### PR TITLE
Make STUN server configurable through settings.

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,4 +11,7 @@
 		<owncloud min-version="9.1" max-version="9.2" />
 	</dependencies>
 	<namespace>Spreed</namespace>
+	<settings>
+		<admin>OCA\Spreed\Settings\Admin</admin>
+	</settings>
 </info>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -62,6 +62,11 @@ return [
 			'name' => 'api#ping',
 			'url' => '/api/ping',
 			'verb' => 'POST',
+		],
+		[
+			'name' => 'AppSettings#setSpreedSettings',
+			'url' => '/settings',
+			'verb' => 'POST',
 		]
 	],
 ];

--- a/js/settings-admin.js
+++ b/js/settings-admin.js
@@ -1,0 +1,11 @@
+$(document).ready(function(){
+
+	$('#spreed_settings_form').change(function(){
+		OC.msg.startSaving('#spreed_settings_msg');
+		var post = $( "#spreed_settings_form" ).serialize();
+		$.post(OC.generateUrl('/apps/spreed/settings'), post, function(data){
+			OC.msg.finishedSaving('#spreed_settings_msg', data);
+		});
+	});
+
+});

--- a/lib/Controller/AppSettingsController.php
+++ b/lib/Controller/AppSettingsController.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @author Joachim Bauch <mail@joachim-bauch.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IRequest;
+
+class AppSettingsController extends Controller {
+
+	/** @var IL10N */
+	private $l10n;
+	/** @var IConfig */
+	private $config;
+
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param IL10N $l10n
+	 * @param IConfig $config
+	 */
+	public function __construct($appName,
+								IRequest $request,
+								IL10N $l10n,
+								IConfig $config) {
+		parent::__construct($appName, $request);
+		$this->l10n = $l10n;
+		$this->config = $config;
+	}
+
+	/**
+	 * Configure the settings of the Spreed app. The STUN server must be passed
+	 * in the form "stunserver:port", e.g. "stun.domain.invalid:1234".
+	 *
+	 * @param string $stun_server
+	 */
+	public function setSpreedSettings($stun_server) {
+		$stun_server = trim($stun_server);
+		if ($stun_server !== "") {
+			if (substr($stun_server, 0, 5) === "stun:") {
+				$stun_server = substr($stun_server, 5);
+			}
+
+			$parts = explode(":", $stun_server);
+			if (count($parts) > 2) {
+				return array('data' =>
+					array('message' =>
+						(string) $this->l10n->t('Invalid format, must be stunserver:port.')
+					),
+					'status' => 'error'
+				);
+			}
+
+			$options = array(
+				'options' => array(
+					'default' => 0,
+					'max_range' => 65535,
+					'min_range' => 1,
+				),
+			);
+			if (count($parts) == 2 && !filter_var($parts[1], FILTER_VALIDATE_INT, $options)) {
+				return array('data' =>
+					array('message' =>
+						(string) $this->l10n->t('Invalid port specified.')
+					),
+					'status' => 'error'
+				);
+			}
+		}
+
+		$this->config->setAppValue('spreed', 'stun_server', $stun_server);
+
+		return array('data' =>
+			array('message' =>
+				(string) $this->l10n->t('Saved')
+			),
+			'status' => 'success'
+		);
+	}
+
+}

--- a/lib/Controller/SignallingController.php
+++ b/lib/Controller/SignallingController.php
@@ -25,10 +25,15 @@ namespace OCA\Spreed\Controller;
 
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IRequest;
 
+use OCA\Spreed\Util;
+
 class SignallingController extends Controller {
+	/** @var IConfig */
+	private $config;
 	/** @var IDBConnection */
 	private $dbConnection;
 	/** @var string */
@@ -37,14 +42,17 @@ class SignallingController extends Controller {
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
+	 * @param IConfig $config
 	 * @param IDBConnection $connection
 	 * @param string $UserId
 	 */
 	public function __construct($appName,
 								IRequest $request,
+								IConfig $config,
 								IDBConnection $connection,
 								$UserId) {
 		parent::__construct($appName, $request);
+		$this->config = $config;
 		$this->dbConnection = $connection;
 		$this->userId = $UserId;
 	}
@@ -80,12 +88,13 @@ class SignallingController extends Controller {
 
 				break;
 			case 'stunservers':
-				// FIXME: Use non-google servers
-				$response = [
-					[
-						'url' => 'stun:stun.l.google.com:19302',
-					],
-				];
+				$response = [];
+				$stunServer = Util::getStunServer($this->config);
+				if ($stunServer) {
+					array_push($response, [
+						'url' => 'stun:' . $stunServer,
+					]);
+				}
 				break;
 		}
 		return new JSONResponse($response);

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @author Joachim Bauch <mail@joachim-bauch.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Settings;
+
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
+use OCP\Settings\ISettings;
+
+use OCA\Spreed\Util;
+
+class Admin implements ISettings {
+
+    /** @var IConfig */
+    private $config;
+
+    public function __construct(IConfig $config) {
+        $this->config = $config;
+    }
+
+    /**
+     * @return TemplateResponse
+     */
+    public function getForm() {
+        $parameters = [
+            'stunServer' => Util::getStunServer($this->config),
+        ];
+
+        return new TemplateResponse('spreed', 'settings-admin', $parameters, '');
+    }
+
+    /**
+     * @return string the section ID, e.g. 'sharing'
+     */
+    public function getSection() {
+        return 'additional';
+    }
+
+    /**
+     * @return int whether the form should be rather on the top or bottom of
+     * the admin section. The forms are arranged in ascending order of the
+     * priority values. It is required to return a value between 0 and 100.
+     *
+     * E.g.: 70
+     */
+    public function getPriority() {
+        return 30;
+    }
+
+}

--- a/lib/Util.php
+++ b/lib/Util.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @author Joachim Bauch <mail@joachim-bauch.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed;
+
+use OCP\IConfig;
+
+class Util {
+
+    public static function getStunServer(IConfig $config) {
+        return $config->getAppValue('spreed', 'stun_server', 'stun.l.google.com:19302');
+    }
+
+}

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -1,0 +1,20 @@
+<?php
+script('spreed', ['settings-admin']);
+?>
+
+<div id="spreed" class="section">
+    <form id="spreed_settings_form" class="spreed_settings">
+        <h2 class="app-name">Spreed</h2>
+        <span id="spreed_settings_msg" class="msg"></span>
+        <p>
+            <label for="stun_server"><?php p($l->t('STUN server')) ?></label>
+            <!-- TODO(fancycode): Should use CSS style to make input wider. -->
+            <input type="text" style="width:300px" id="stun_server"
+                   name="stun_server" placeholder="stunserver:port"
+                   value="<?php p($_['stunServer']) ?>" />
+            <p>
+                <em><?php p($l->t('The STUN server is used to determine the public address of participants behind a router.')) ?></em>
+            </p>
+        </p>
+    </form>
+</div>


### PR DESCRIPTION
No longer hardcodes the STUN server to `stun.l.google.com:19302` (but still uses it by default if not changed).

Implements the `STUN` part of #2.

cc @LukasReschke