### PR TITLE
Notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 
 # Karma/jasmine coverage data
 coverage
+tests/php/coverage-html
+tests/php/clover.xml

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -29,6 +29,21 @@
 		'href' => $g->linkToRoute('spreed.page.index'),
 		'icon' => $g->imagePath('spreed', 'app.svg'),
 		'name' => $l->t('Calls'),
+	];
+});
 
+
+$manager = \OC::$server->getNotificationManager();
+$manager->registerNotifier(function() {
+	return new \OCA\Spreed\Notification\Notifier(
+		\OC::$server->getL10NFactory(),
+		\OC::$server->getURLGenerator(),
+		\OC::$server->getUserManager()
+	);
+}, function() {
+	$l = \OC::$server->getL10N('spreed');
+	return [
+		'id' => 'spreed',
+		'name' => $l->t('Spreed'),
 	];
 });

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -35,13 +35,10 @@
 
 $manager = \OC::$server->getNotificationManager();
 $manager->registerNotifier(function() {
-	return new \OCA\Spreed\Notification\Notifier(
-		\OC::$server->getL10NFactory(),
-		\OC::$server->getURLGenerator(),
-		\OC::$server->getUserManager()
-	);
+	return \OC::$server->query('OCA\Spreed\Notification\Notifier');
 }, function() {
 	$l = \OC::$server->getL10N('spreed');
+
 	return [
 		'id' => 'spreed',
 		'name' => $l->t('Spreed'),

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -33,6 +33,7 @@ use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\Notification\IManager;
 use OCP\Security\ISecureRandom;
 
 class ApiController extends Controller {
@@ -46,6 +47,8 @@ class ApiController extends Controller {
 	private $userManager;
 	/** @var ISecureRandom */
 	private $secureRandom;
+	/** @var IManager */
+	private $notificationManager;
 
 	/**
 	 * @param string $appName
@@ -55,6 +58,7 @@ class ApiController extends Controller {
 	 * @param IL10N $l10n
 	 * @param IUserManager $userManager
 	 * @param ISecureRandom $secureRandom
+	 * @param IManager $notificationManager
 	 */
 	public function __construct($appName,
 								$UserId,
@@ -62,13 +66,15 @@ class ApiController extends Controller {
 								IDBConnection $dbConnection,
 								IL10N $l10n,
 								IUserManager $userManager,
-								ISecureRandom $secureRandom) {
+								ISecureRandom $secureRandom,
+								IManager $notificationManager) {
 		parent::__construct($appName, $request);
 		$this->userId = $UserId;
 		$this->dbConnection = $dbConnection;
 		$this->l10n = $l10n;
 		$this->userManager = $userManager;
 		$this->secureRandom = $secureRandom;
+		$this->notificationManager = $notificationManager;
 	}
 
 	/**
@@ -267,14 +273,13 @@ class ApiController extends Controller {
 					->execute();
 			}
 
-			$notification = \OC::$server->getNotificationManager()->createNotification();
+			$notification = $this->notificationManager->createNotification();
 			$notification->setApp('spreed')
 				->setUser($targetUser->getUID())
 				->setDateTime(new \DateTime())
 				->setObject('one2one', $roomId)
 				->setSubject('invitation', [$this->userId]);
-
-			\OC::$server->getNotificationManager()->notify($notification);
+			$this->notificationManager->notify($notification);
 
 			return new JSONResponse(['roomId' => $roomId], Http::STATUS_CREATED);
 		}
@@ -287,6 +292,12 @@ class ApiController extends Controller {
 	 * @return JSONResponse
 	 */
 	public function ping($currentRoom) {
+		$notification = $this->notificationManager->createNotification();
+		$notification->setApp('spreed')
+			->setUser($this->userId)
+			->setObject('one2one', $currentRoom);
+		$this->notificationManager->markProcessed($notification);
+
 		$qb = $this->dbConnection->getQueryBuilder();
 		$qb->update('spreedme_room_participants')
 			->set('lastPing', $qb->createNamedParameter(time()))

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -218,7 +218,7 @@ class ApiController extends Controller {
 	}
 
 	/**
-	 * Initiates a one-to-one video call from the urrent user to the recipient
+	 * Initiates a one-to-one video call from the current user to the recipient
 	 *
 	 * @NoAdminRequired
 	 *
@@ -266,6 +266,15 @@ class ApiController extends Controller {
 					)
 					->execute();
 			}
+
+			$notification = \OC::$server->getNotificationManager()->createNotification();
+			$notification->setApp('spreed')
+				->setUser($targetUser->getUID())
+				->setDateTime(new \DateTime())
+				->setObject('one2one', $roomId)
+				->setSubject('invitation', [$this->userId]);
+
+			\OC::$server->getNotificationManager()->notify($notification);
 
 			return new JSONResponse(['roomId' => $roomId], Http::STATUS_CREATED);
 		}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Notification;
+
+
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use OCP\Notification\INotification;
+use OCP\Notification\INotifier;
+
+class Notifier implements INotifier {
+
+	/** @var IFactory */
+	protected $lFactory;
+
+	/** @var IURLGenerator */
+	protected $url;
+
+	/** @var IUserManager */
+	protected $userManager;
+
+	/**
+	 * @param IFactory $lFactory
+	 * @param IURLGenerator $url
+	 * @param IUserManager $userManager
+	 */
+	public function __construct(IFactory $lFactory, IURLGenerator $url, IUserManager $userManager) {
+		$this->lFactory = $lFactory;
+		$this->url = $url;
+		$this->userManager = $userManager;
+	}
+
+	/**
+	 * @param INotification $notification
+	 * @param string $languageCode The code of the language that should be used to prepare the notification
+	 * @return INotification
+	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
+	 * @since 9.0.0
+	 */
+	public function prepare(INotification $notification, $languageCode) {
+		if ($notification->getApp() !== 'spreed') {
+			throw new \InvalidArgumentException('Incorrect app');
+		}
+
+		$l = $this->lFactory->get('spreed', $languageCode);
+
+		if ($notification->getSubject() === 'invitation') {
+			$parameters = $notification->getSubjectParameters();
+			$uid = $parameters[0];
+			$notification
+				->setIcon($this->url->getAbsoluteURL($this->url->imagePath('spreed', 'app.svg')))
+				->setLink($this->url->linkToRouteAbsolute('spreed.page.index') . '#' . $notification->getObjectId());
+
+			if ($notification->getObjectType() === 'one2one') {
+				$user = $this->userManager->get($uid);
+				if ($user instanceof IUser) {
+					$notification
+						->setParsedSubject(
+							$l->t('%s wants to have a call with you', [$user->getDisplayName()])
+						)
+						->setRichSubject(
+							$l->t('{user} wants to have a call with you'), [
+								'user' => [
+									'type' => 'user',
+									'id' => $uid,
+									'name' => $user->getDisplayName(),
+								]
+							]
+						)
+					;
+				} else {
+					throw new \InvalidArgumentException('Calling user does not exist anymore');
+				}
+			} else {
+				throw new \InvalidArgumentException('Unknown object type');
+			}
+		} else {
+			throw new \InvalidArgumentException('Unknown subject');
+		}
+
+		return $notification;
+	}
+}

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Tests\php;
+
+use OCA\Spreed\Notification\Notifier;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use OCP\Notification\INotification;
+
+class NotifierTest extends \Test\TestCase {
+
+	/** @var IFactory|\PHPUnit_Framework_MockObject_MockObject */
+	protected $lFactory;
+	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
+	protected $url;
+	/** @var IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $userManager;
+	/** @var Notifier */
+	protected $notifier;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->lFactory = $this->createMock(IFactory::class);
+		$this->url = $this->createMock(IURLGenerator::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+
+		$this->notifier = new Notifier(
+			$this->lFactory,
+			$this->url,
+			$this->userManager
+		);
+	}
+
+	public function dataPrepare() {
+		return [
+			['admin', 'Admin', 'Admin wants to have a call with you'],
+			['test', 'Test user', 'Test user wants to have a call with you'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataPrepare
+	 * @param string $uid
+	 * @param string $displayName
+	 * @param string $parsedSubject
+	 */
+	public function testPrepare($uid, $displayName, $parsedSubject) {
+		$n = $this->createMock(INotification::class);
+		$l = $this->createMock(IL10N::class);
+		$l->expects($this->exactly(2))
+			->method('t')
+			->will($this->returnCallback(function($text, $parameters = []) {
+				return vsprintf($text, $parameters);
+			}));
+
+		$this->lFactory->expects($this->once())
+			->method('get')
+			->with('spreed', 'de')
+			->willReturn($l);
+
+		$u = $this->createMock(IUser::class);
+		$u->expects($this->exactly(2))
+			->method('getDisplayName')
+			->willReturn($displayName);
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with($uid)
+			->willReturn($u);
+
+		$n->expects($this->once())
+			->method('setIcon')
+			->willReturnSelf();
+		$n->expects($this->once())
+			->method('setLink')
+			->willReturnSelf();
+		$n->expects($this->once())
+			->method('setParsedSubject')
+			->with($parsedSubject)
+			->willReturnSelf();
+		$n->expects($this->once())
+			->method('setRichSubject')
+			->with('{user} wants to have a call with you',[
+				'user' => [
+					'type' => 'user',
+					'id' => $uid,
+					'name' => $displayName,
+				]
+			])
+			->willReturnSelf();
+
+		$n->expects($this->once())
+			->method('getApp')
+			->willReturn('spreed');
+		$n->expects($this->once())
+			->method('getSubject')
+			->willReturn('invitation');
+		$n->expects($this->once())
+			->method('getSubjectParameters')
+			->willReturn([$uid]);
+		$n->expects($this->once())
+			->method('getObjectType')
+			->willReturn('one2one');
+
+		$this->notifier->prepare($n, 'de');
+	}
+
+	public function dataPrepareThrows() {
+		return [
+			['Incorrect app', 'invalid-app', null, null, null],
+			['Unknown subject', 'spreed', 'invalid-subject', null, null],
+			['Unknown object type', 'spreed', 'invitation', ['admin'], 'invalid-object-type'],
+			['Calling user does not exist anymore', 'spreed', 'invitation', ['admin'], 'one2one'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataPrepareThrows
+	 *
+	 * @expectedException \InvalidArgumentException
+	 *
+	 * @param string $message
+	 * @param string $app
+	 * @param string|null $subject
+	 * @param array|null $params
+	 * @param string|null $objectType
+	 */
+	public function testPrepareThrows($message, $app, $subject, $params, $objectType) {
+		$n = $this->createMock(INotification::class);
+		$l = $this->createMock(IL10N::class);
+
+		$this->lFactory->expects($subject === null ? $this->never() : $this->once())
+			->method('get')
+			->with('spreed', 'de')
+			->willReturn($l);
+
+		$n->expects($params === null ? $this->never() : $this->once())
+			->method('setIcon')
+			->willReturnSelf();
+		$n->expects($params === null ? $this->never() : $this->once())
+			->method('setLink')
+			->willReturnSelf();
+
+		$n->expects($this->once())
+			->method('getApp')
+			->willReturn($app);
+		$n->expects($subject === null ? $this->never() : $this->once())
+			->method('getSubject')
+			->willReturn($subject);
+		$n->expects($params === null ? $this->never() : $this->once())
+			->method('getSubjectParameters')
+			->willReturn($params);
+		$n->expects($objectType === null ? $this->never() : $this->once())
+			->method('getObjectType')
+			->willReturn($objectType);
+
+		$this->setExpectedException(\InvalidArgumentException::class, $message);
+		$this->notifier->prepare($n, 'de');
+	}
+}

--- a/tests/php/UtilTest.php
+++ b/tests/php/UtilTest.php
@@ -18,7 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-namespace OCA\Spreed\Tests\Settings;
+namespace OCA\Spreed\Tests\php;
+
 use OCA\Spreed\Util;
 use OCP\IConfig;
 use Test\TestCase;


### PR DESCRIPTION
### Todo
- [ ] The link behind the notification (Notifier `->setLink(` ) should open the room directly (no endpoint available) => @LukasReschke will do this in a different PR
- [x] Opening a room should dismiss the notification
- [x] Add unit tests for the `prepare()` method.

cc @Ivansss @LukasReschke 