### PR TITLE
Add TURN server to personal settings.

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -46,3 +46,5 @@ $manager->registerNotifier(function() {
 });
 
 \OCP\Util::connectHook('OC_User', 'post_deleteUser', \OCA\Spreed\Util::class, 'deleteUser');
+
+OC_App::registerPersonal('spreed', 'personal');

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -47,4 +47,4 @@ $manager->registerNotifier(function() {
 
 \OCP\Util::connectHook('OC_User', 'post_deleteUser', \OCA\Spreed\Util::class, 'deleteUser');
 
-OC_App::registerPersonal('spreed', 'personal');
+\OCP\App::registerPersonal('spreed', 'personal');

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <info>
 	<id>spreed</id>
-	<name>Spreed.ME video calls</name>
+	<name>Spreed video calls</name>
 	<description>Voice over IP conferencing using WebRTC</description>
 	<licence>AGPLv3+</licence>
 	<author>Lukas Reschke, Jan-Christoph Borchardt, Morris Jobke</author>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -83,7 +83,12 @@ return [
 		],
 		[
 			'name' => 'AppSettings#setSpreedSettings',
-			'url' => '/settings',
+			'url' => '/settings/admin',
+			'verb' => 'POST',
+		],
+		[
+			'name' => 'PersonalSettings#setSpreedSettings',
+			'url' => '/settings/personal',
 			'verb' => 'POST',
 		],
 		[

--- a/js/settings-admin.js
+++ b/js/settings-admin.js
@@ -3,7 +3,7 @@ $(document).ready(function(){
 	$('#spreed_settings_form').change(function(){
 		OC.msg.startSaving('#spreed_settings_msg');
 		var post = $( "#spreed_settings_form" ).serialize();
-		$.post(OC.generateUrl('/apps/spreed/settings'), post, function(data){
+		$.post(OC.generateUrl('/apps/spreed/settings/admin'), post, function(data){
 			OC.msg.finishedSaving('#spreed_settings_msg', data);
 		});
 	});

--- a/js/settings-personal.js
+++ b/js/settings-personal.js
@@ -1,0 +1,11 @@
+$(document).ready(function(){
+
+    $('#spreed_settings_form').change(function(){
+        OC.msg.startSaving('#spreed_settings_msg');
+        var post = $("#spreed_settings_form").serialize();
+        $.post(OC.generateUrl('/apps/spreed/settings/personal'), post, function(data){
+            OC.msg.finishedSaving('#spreed_settings_msg', data);
+        });
+    });
+
+});

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -19,7 +19,18 @@
  *
  */
 
-$app = new \OCA\Spreed\AppInfo\Application();
-/** @var OCA\Spreed\Controller\PersonalSettingsController */
-$controller = $app->getContainer()->query('PersonalSettingsController');
-return $controller->displayPanel()->render();
+namespace OCA\Spreed\AppInfo;
+
+use OCP\AppFramework\App;
+use OCA\Spreed\Controller\PersonalSettingsController;
+
+class Application extends App {
+
+    public function __construct () {
+        parent::__construct('spreed');
+        $container = $this->getContainer();
+
+        $container->registerAlias('PersonalSettingsController', PersonalSettingsController::class);
+    }
+
+}

--- a/lib/Controller/PersonalSettingsController.php
+++ b/lib/Controller/PersonalSettingsController.php
@@ -28,7 +28,6 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
-use OCP\IUserSession;
 
 class PersonalSettingsController extends Controller {
 
@@ -37,26 +36,26 @@ class PersonalSettingsController extends Controller {
 	/** @var IConfig */
 	private $config;
 	/**
-	 * @var bool|IUser
+	 * @var string
 	 */
-	private $user;
+	private $userId;
 
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
 	 * @param IL10N $l10n
 	 * @param IConfig $config
-	 * @param IUserSession $userSession
+	 * @param string $userId
 	 */
 	public function __construct($appName,
 								IRequest $request,
 								IL10N $l10n,
 								IConfig $config,
-								IUserSession $userSession) {
+								$userId) {
 		parent::__construct($appName, $request);
 		$this->l10n = $l10n;
 		$this->config = $config;
-		$this->user = $userSession && $userSession->isLoggedIn() ? $userSession->getUser() : false;
+		$this->userId = $userId;
 	}
 
 	/**
@@ -65,7 +64,7 @@ class PersonalSettingsController extends Controller {
 	 * @return TemplateResponse
 	 */
 	public function displayPanel() {
-		$settings = Util::getTurnSettings($this->config, $this->user->getUID());
+		$settings = Util::getTurnSettings($this->config, $this->userId);
 		return new TemplateResponse('spreed', 'settings-personal', [
 			'turnSettings' => $settings,
 		], '');
@@ -82,7 +81,7 @@ class PersonalSettingsController extends Controller {
 	 * @param string $turn_protocols
 	 */
 	public function setSpreedSettings($turn_server, $turn_username, $turn_password, $turn_protocols) {
-		if (!$this->user) {
+		if (!$this->userId) {
 			return array('data' =>
 				array('message' =>
 					(string) $this->l10n->t('Not logged in.')
@@ -136,7 +135,7 @@ class PersonalSettingsController extends Controller {
 			'protocols' => $turn_protocols
 		);
 
-		$this->config->setUserValue($this->user->getUID(),
+		$this->config->setUserValue($this->userId,
 			'spreed',
 			'turn_settings',
 			json_encode($turn_settings));

--- a/lib/Controller/PersonalSettingsController.php
+++ b/lib/Controller/PersonalSettingsController.php
@@ -21,7 +21,10 @@
 
 namespace OCA\Spreed\Controller;
 
+use OCA\Spreed\Util;
+
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -54,6 +57,18 @@ class PersonalSettingsController extends Controller {
 		$this->l10n = $l10n;
 		$this->config = $config;
 		$this->user = $userSession && $userSession->isLoggedIn() ? $userSession->getUser() : false;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @return TemplateResponse
+	 */
+	public function displayPanel() {
+		$settings = Util::getTurnSettings($this->config, $this->user->getUID());
+		return new TemplateResponse('spreed', 'settings-personal', [
+			'turnSettings' => $settings,
+		], '');
 	}
 
 	/**

--- a/lib/Controller/PersonalSettingsController.php
+++ b/lib/Controller/PersonalSettingsController.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * @author Joachim Bauch <mail@joachim-bauch.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+class PersonalSettingsController extends Controller {
+
+	/** @var IL10N */
+	private $l10n;
+	/** @var IConfig */
+	private $config;
+	/**
+	 * @var bool|IUser
+	 */
+	private $user;
+
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param IL10N $l10n
+	 * @param IConfig $config
+	 * @param IUserSession $userSession
+	 */
+	public function __construct($appName,
+								IRequest $request,
+								IL10N $l10n,
+								IConfig $config,
+								IUserSession $userSession) {
+		parent::__construct($appName, $request);
+		$this->l10n = $l10n;
+		$this->config = $config;
+		$this->user = $userSession && $userSession->isLoggedIn() ? $userSession->getUser() : false;
+	}
+
+	/**
+	 * Configure the personal settings of the Spreed app. The TURN server must
+	 * be passed in the form "turnserver:port", e.g. "turn.domain.invalid:1234".
+	 *
+	 * @NoAdminRequired
+	 * @param string $turn_server
+	 * @param string $turn_username
+	 * @param string $turn_password
+	 * @param string $turn_protocols
+	 */
+	public function setSpreedSettings($turn_server, $turn_username, $turn_password, $turn_protocols) {
+		if (!$this->user) {
+			return array('data' =>
+				array('message' =>
+					(string) $this->l10n->t('Not logged in.')
+				),
+				'status' => 'error'
+			);
+		}
+
+		$turn_server = trim($turn_server);
+		if ($turn_server !== "") {
+			$parts = explode(":", $turn_server);
+			if (count($parts) > 2) {
+				return array('data' =>
+					array('message' =>
+						(string) $this->l10n->t('Invalid format, must be turnserver:port.')
+					),
+					'status' => 'error'
+				);
+			}
+
+			$options = array(
+				'options' => array(
+					'default' => 0,
+					'max_range' => 65535,
+					'min_range' => 1,
+				),
+			);
+			if (count($parts) === 2 && !filter_var($parts[1], FILTER_VALIDATE_INT, $options)) {
+				return array('data' =>
+					array('message' =>
+						(string) $this->l10n->t('Invalid port specified.')
+					),
+					'status' => 'error'
+				);
+			}
+		}
+
+		if (empty($turn_server) || empty($turn_username) || empty($turn_password)) {
+			return array('data' =>
+				array('message' =>
+					(string) $this->l10n->t('All fields have to be filled out.')
+				),
+				'status' => 'error'
+			);
+		}
+
+		$turn_settings = array(
+			'server' => $turn_server,
+			'username' => $turn_username,
+			'password' => $turn_password,
+			'protocols' => $turn_protocols
+		);
+
+		$this->config->setUserValue($this->user->getUID(),
+			'spreed',
+			'turn_settings',
+			json_encode($turn_settings));
+		return array('data' =>
+			array('message' =>
+				(string) $this->l10n->t('Saved')
+			),
+			'status' => 'success'
+		);
+	}
+
+}

--- a/lib/Controller/SignallingController.php
+++ b/lib/Controller/SignallingController.php
@@ -103,6 +103,20 @@ class SignallingController extends Controller {
 						]);
 					}
 					break;
+				case 'turnservers':
+					$response = [];
+					$turnSettings = Util::getTurnSettings($this->config, $this->userId);
+					if (!empty($turnSettings)) {
+						$protocols = explode(",", $turnSettings['protocols']);
+						foreach ($protocols as $proto) {
+							array_push($response, [
+								'url' => 'turn:' . $turnSettings['server'] . '?transport=' . $proto,
+								'username' => $turnSettings['username'],
+								'credential' => $turnSettings['password'],
+							]);
+						}
+					}
+					break;
 			}
 		}
 

--- a/lib/Util.php
+++ b/lib/Util.php
@@ -50,4 +50,13 @@ class Util {
 			}
 		}
 	}
+
+    public static function getTurnSettings(IConfig $config, $uid) {
+        $value = $config->getUserValue($uid, 'spreed', 'turn_settings');
+        if (empty($value)) {
+            return array();
+        }
+        return json_decode($value, true);
+    }
+
 }

--- a/personal.php
+++ b/personal.php
@@ -1,0 +1,11 @@
+<?php
+
+use OCA\Spreed\Util;
+
+$tmpl = new OCP\Template('spreed', 'settings-personal');
+$config = \OC::$server->getConfig();
+$uid = \OC::$server->getUserSession()->getUser()->getUID();
+
+$settings = Util::getTurnSettings($config, $uid);
+$tmpl->assign('turnSettings', $settings);
+return $tmpl->fetchPage();

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -4,7 +4,7 @@ script('spreed', ['settings-admin']);
 
 <div id="spreed" class="section">
     <form id="spreed_settings_form" class="spreed_settings">
-        <h2 class="app-name">Spreed</h2>
+        <h2 class="app-name">Spreed video calls</h2>
         <span id="spreed_settings_msg" class="msg"></span>
         <p>
             <label for="stun_server"><?php p($l->t('STUN server')) ?></label>

--- a/templates/settings-personal.php
+++ b/templates/settings-personal.php
@@ -1,0 +1,45 @@
+<?php
+script('spreed', ['settings-personal']);
+?>
+
+<div id="spreedSettings" class="section">
+    <form id="spreed_settings_form" class="spreed_settings">
+        <h2><?php p($l->t('Spreed')); ?></h2>
+        <p>
+            <?php p($l->t('The TURN server is used to relay audio/video streams in cases where the participants can\'t connect directly to each other.')) ?>
+        </p>
+        <span id="spreed_settings_msg" class="msg"></span>
+        <p>
+            <label for="turn_server"><?php p($l->t('TURN server')) ?></label>
+            <input type="text" id="turn_server"
+                   name="turn_server" placeholder="turnserver:port"
+                   value="<?php p($_['turnSettings']['server']) ?>" />
+        </p>
+        <p>
+            <label for="turn_username"><?php p($l->t('Username')) ?></label>
+            <input type="text" id="turn_username"
+                   name="turn_username" placeholder="username"
+                   value="<?php p($_['turnSettings']['username']) ?>" />
+        </p>
+        <p>
+            <label for="turn_password"><?php p($l->t('Password')) ?></label>
+            <input type="text" id="turn_password"
+                   name="turn_password" placeholder="password"
+                   value="<?php p($_['turnSettings']['password']) ?>" />
+        </p>
+        <p>
+            <label for="turn_protocols"><?php p($l->t('Protocols')) ?></label>
+            <select id="turn_protocols" name="turn_protocols">
+                <option value="udp,tcp"
+                    <?php p($_['turnSettings']['protocols'] === 'udp,tcp' ? 'selected' : '') ?>>
+                    udp and tcp</option>
+                <option value="udp"
+                    <?php p($_['turnSettings']['protocols'] === 'udp' ? 'selected' : '') ?>>
+                    udp only</option>
+                <option value="tcp"
+                    <?php p($_['turnSettings']['protocols'] === 'tcp' ? 'selected' : '') ?>>
+                    tcp only</option>
+            </select>
+        </p>
+    </form>
+</div>

--- a/templates/settings-personal.php
+++ b/templates/settings-personal.php
@@ -4,7 +4,7 @@ script('spreed', ['settings-personal']);
 
 <div id="spreedSettings" class="section">
     <form id="spreed_settings_form" class="spreed_settings">
-        <h2><?php p($l->t('Spreed')); ?></h2>
+        <h2><?php p($l->t('Spreed video calls')); ?></h2>
         <p>
             <?php p($l->t('The TURN server is used to relay audio/video streams in cases where the participants can\'t connect directly to each other.')) ?>
         </p>

--- a/tests/php/PersonalSettingsControllerTest.php
+++ b/tests/php/PersonalSettingsControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @author Joachim Bauch <mail@joachim-bauch.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Tests\php;
+
+use OCA\Spreed\Controller\PersonalSettingsController;
+use OCA\Spreed\Util;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IRequest;
+use Test\TestCase;
+
+/**
+ * Unittests for PersonalSettingsController.
+ *
+ * @group DB
+ *
+ */
+class PersonalSettingsControllerTest extends TestCase {
+
+    const TEST_PERSONAL_SETTINGS_USER = "test-personal-settings-user";
+
+    /** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+    private $config;
+    /** @var string */
+    private $userId;
+    /** @var PersonalSettingsController */
+    private $controller;
+
+    protected function setUp() {
+        parent::setUp();
+
+        $this->userId = self::TEST_PERSONAL_SETTINGS_USER;
+
+        $this->config = \OC::$server->getConfig();
+        $this->controller = new PersonalSettingsController(
+            'spreed',
+            $this->createMock(IRequest::class),
+            $this->createMock(IL10N::class),
+            $this->config,
+            $this->userId
+        );
+    }
+
+    protected function tearDown() {
+        parent::tearDown();
+    }
+
+    public function testSetPersonalSettings() {
+        $server = "server.domain.invalid:12345";
+        $username = "foo";
+        $password = "bar";
+        $protocols = "udp,tcp";
+        $response = $this->controller->setSpreedSettings($server, $username, $password, $protocols);
+        $this->assertEquals('success', $response['status']);
+
+        $settings = Util::getTurnSettings($this->config, $this->userId);
+        $this->assertEquals($server, $settings['server']);
+        $this->assertEquals($username, $settings['username']);
+        $this->assertEquals($password, $settings['password']);
+        $this->assertEquals($protocols, $settings['protocols']);
+    }
+
+}


### PR DESCRIPTION
This implements the second part of #2 to add TURN support. For now each user
has to have an account on the TURN server. Support for shared credentials will
be added in a separate PR.

@nickvergessen @LukasReschke 