### PR TITLE
Change default STUN server (#86)

### DIFF
--- a/lib/Util.php
+++ b/lib/Util.php
@@ -31,7 +31,7 @@ class Util {
 	 * @return string
 	 */
 	public static function getStunServer(IConfig $config) {
-		return $config->getAppValue('spreed', 'stun_server', 'stun.l.google.com:19302');
+		return $config->getAppValue('spreed', 'stun_server', 'stun.nextcloud.com:443');
 	}
 
 	/**

--- a/tests/php/UtilTest.php
+++ b/tests/php/UtilTest.php
@@ -38,7 +38,7 @@ class UtilTest extends TestCase {
 		$config
 			->expects($this->once())
 			->method('getAppValue')
-			->with('spreed', 'stun_server', 'stun.l.google.com:19302')
+			->with('spreed', 'stun_server', 'stun.nextcloud.com:443')
 			->willReturn('88.198.160.129');
 
 		$this->assertSame('88.198.160.129', $this->util->getStunServer($config));


### PR DESCRIPTION
We should use our own server by default, not the external one from Google.

@Ivansss @nickvergessen