### PR TITLE
Return 0 if element does not exists

### DIFF
--- a/lib/Room.php
+++ b/lib/Room.php
@@ -192,7 +192,7 @@ class Room {
 		$row = $result->fetchAll();
 		$result->closeCursor();
 
-		return (int) $row['num_participants'];
+		return isset($row['num_participants']) ? (int) $row['num_participants'] : 0;
 	}
 
 	/**


### PR DESCRIPTION
This can return an empty result set in which case this spams the error log every second with a horrible amount of errors such as the following:

> Undefined index: num_participants at /media/psf/stable9/apps/spreed/lib/Room.php#195

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>

cc @Ivansss @nickvergessen 