### PR TITLE
fix select2 styles for Spreed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -31,12 +31,6 @@
 #select2-drop {
 	margin-top: -44px !important;
 }
-
-.select2-search input {
-	width: 100%;
-	box-sizing: border-box;
-}
-
 #oca-spreedme-add-room .select2-container,
 .oca-spreedme-add-person .select2-container {
 	width: 100%;
@@ -44,16 +38,24 @@
 	border: none;
 	padding: 9px;
 }
+#oca-spreedme-add-room .select2-container .select2-choice,
+.oca-spreedme-add-person .select2-container .select2-choice {
+    border: none;
+}
 #oca-spreedme-add-room .select2-arrow,
 .oca-spreedme-add-person .select2-arrow {
 	display: none !important;
 }
-.select2-search input {
-	padding: 13px 12px !important;
+#select2-drop .select2-search input {
+	padding: 13px 12px 13px 43px !important;
 	width: 100%;
 	box-sizing: border-box;
 	margin: 0;
+	border: none;
 	background-image: none !important;
+}
+#select2-drop .select2-results .select2-result {
+	padding: 0;
 }
 
 #app-navigation .avatar,


### PR DESCRIPTION
One issue is that we have no app namespace on the body or HTML so we can not namespace the select2 styles, as the #select2-drop is in the body.

Will this mess with the other apps because CSS is loaded everywhere? If so, we need namespacing on the body. Like id="app-appname" as we currently do on `id="content"` with `class="app-appname"`.
cc @skjnldsv @nextcloud/javascript @nextcloud/designers 