### PR TITLE
fix wording to 'new shared call'

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -35,6 +35,7 @@
 		_roomsView: null,
 		/** @property {boolean} _videoWasEnabledAtLeastOnce  */
 		_videoWasEnabledAtLeastOnce: false,
+		_searchTerm: '',
 		_registerPageEvents: function() {
 			$('#edit-roomname').select2({
 				ajax: {
@@ -42,6 +43,7 @@
 					dataType: 'json',
 					quietMillis: 100,
 					data: function (term) {
+						OCA.SpreedMe.app._searchTerm = term;
 						return {
 							format: 'json',
 							search: term,
@@ -57,9 +59,6 @@
 						}
 
 						var results = [];
-
-						//Add custom entry to create a new empty room
-						results.push({ id: "create-public-room", displayName: t('spreed', 'New shared call'), type: "createPublicRoom"});
 
 						$.each(response.ocs.data.exact.users, function(id, user) {
 							if (oc_current_user === user.value.shareWith) {
@@ -79,6 +78,13 @@
 						$.each(response.ocs.data.groups, function(id, group) {
 							results.push({ id: group.value.shareWith, displayName: group.label + ' ' + t('spreed', '(group)'), type: "group"});
 						});
+
+						//Add custom entry to create a new empty room
+						if (OCA.SpreedMe.app._searchTerm === '') {
+							results.unshift({ id: "create-public-room", displayName: t('spreed', 'New shared call'), type: "createPublicRoom"});
+						} else {
+							results.push({ id: "create-public-room", displayName: t('spreed', 'New shared call'), type: "createPublicRoom"});
+						}
 
 						return {
 							results: results,

--- a/js/app.js
+++ b/js/app.js
@@ -81,9 +81,9 @@
 
 						//Add custom entry to create a new empty room
 						if (OCA.SpreedMe.app._searchTerm === '') {
-							results.unshift({ id: "create-public-room", displayName: t('spreed', 'New shared call'), type: "createPublicRoom"});
+							results.unshift({ id: "create-public-room", displayName: t('spreed', 'New public room'), type: "createPublicRoom"});
 						} else {
-							results.push({ id: "create-public-room", displayName: t('spreed', 'New shared call'), type: "createPublicRoom"});
+							results.push({ id: "create-public-room", displayName: t('spreed', 'New public room'), type: "createPublicRoom"});
 						}
 
 						return {

--- a/js/app.js
+++ b/js/app.js
@@ -59,7 +59,7 @@
 						var results = [];
 
 						//Add custom entry to create a new empty room
-						results.push({ id: "create-public-room", displayName: t('spreed', 'Create a new public room'), type: "createPublicRoom"});
+						results.push({ id: "create-public-room", displayName: t('spreed', 'New shared call'), type: "createPublicRoom"});
 
 						$.each(response.ocs.data.exact.users, function(id, user) {
 							if (oc_current_user === user.value.shareWith) {

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -55,7 +55,7 @@
 								'<li>'+
 									'<button class="leave-group-button">'+
 										'<span class="icon-close"></span>'+
-										'<span>'+t('spreedme', 'Leave group')+'</span>'+
+										'<span>'+t('spreedme', 'Leave call')+'</span>'+
 									'</button>'+
 								'</li>'+
 							'</ul>'+


### PR DESCRIPTION
We do not use the terms »Room« or »Public« anywhere. So »New shared call« is better than the long »Create a new public room«.

- [x] Fix #134 

Please review @nextcloud/designers @LukasReschke @nickvergessen @MorrisJobke 