### PR TITLE
show header on public shared room page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -415,3 +415,8 @@ video {
 		opacity: 1;
 	}
 }
+
+/* make blue header bar transparent in shared room */
+#body-public #app-content:not(.participants-1) #header.spreed-public {
+	background: transparent;
+}

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -27,6 +27,22 @@ script(
 <div id="app" data-roomId="<?php p($_['roomId']) ?>">
 	<div id="app-content" class="participants-1">
 
+		<header>
+			<div id="header" class="spreed-public">
+				<a href="<?php print_unescaped(link_to('', 'index.php')); ?>"
+					 title="" id="nextcloud">
+					<div class="logo-icon svg">
+					</div>
+				</a>
+
+				<div class="header-appname-container">
+					<h1 class="header-appname">
+						<?php p($theme->getName()); ?>
+					</h1>
+				</div>
+			</div>
+		</header>
+
 		<div id="video-speaking">
 
 		</div>


### PR DESCRIPTION
Displays the Nextcloud logo in a blue header bar when entering a public call page. When another caller joins, the bar goes from blue to transparent so more of the video area is visible.