### PR TITLE
Fix alignment of call controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -279,7 +279,6 @@ video {
 .videoView .nameIndicator {
 	width: 100%;
 	padding: 0;
-	right: 0;
 }
 /* ellipsize name in 1on1 calls */
 .participants-2 .videoContainer.promoted + .videoContainer-dummy .nameIndicator {


### PR DESCRIPTION
Before // After:
Note that before the controls were not centered below the avatar.
![issue3](https://cloud.githubusercontent.com/assets/24209909/20653109/9a30be68-b507-11e6-943a-3c674a96e3f2.jpg)
cc @nextcloud/designers 