### PR TITLE
Add 'Guest' as name indicator for guests.

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -334,7 +334,11 @@ var spreedMappingTable = [];
 				// Indicator for username
 				var userIndicator = document.createElement('div');
 				userIndicator.className = 'nameIndicator';
-				userIndicator.textContent = peer.nick;
+				if (peer.nick) {
+					userIndicator.textContent = peer.nick;
+				} else {
+					userIndicator.textContent = t('spreed', 'Guest');
+				}
 
 				// Avatar for username
 				var avatar = document.createElement('div');


### PR DESCRIPTION
By now, it's only adding 'Guest' if 'nick' property of the peer is empty. 

Another option would be to create a random string/number and add it to guest when creating the peer.
https://github.com/nextcloud/spreed/blob/master/js/webrtc.js#L116