### PR TITLE
format app description

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -2,24 +2,15 @@
 <info>
 	<id>spreed</id>
 	<name>Spreed video calls</name>
-	<description><![CDATA[Voice over IP conferencing using WebRTC
+	<description><![CDATA[Video & voice calls using WebRTC
 
-👥 **1on1 & group calls!** Just invite people, or create a call with a whole group. :)
+👥 1on1 & group calls! Just invite people, or create a call with a whole group. :)
 
-🔗 **Public rooms!** You can send a link to anyone to have a call with them!
+🔗 Public rooms! You can send a link to anyone to have a call with them!
 
-🚀 **Integration with other Nextcloud apps!** Currently Contacts and users – more to come.
+🚀 Integration with other Nextcloud apps! Currently Contacts and users – more to come.
 
-🙈 **We’re not reinventing the wheel!** Based on the great [simpleWebRTC](https://simplewebrtc.com/) library.
-
-
-And in the works for the [coming versions](https://github.com/nextcloud/spreed/milestones/):
-
-💻 [Screen sharing](https://github.com/nextcloud/spreed/issues/31)
-
-💬 [Chat integration](https://github.com/nextcloud/spreed/issues/35)
-
-✋ [Federated calls](https://github.com/nextcloud/spreed/issues/21), to call people on other Nextclouds
+🙈 We’re not reinventing the wheel! Based on the great simpleWebRTC library.
 	]]></description>
 	<licence>AGPL</licence>
 


### PR DESCRIPTION
Markdown like bolding and linking does not work in the app description in the management, makes the entry look strange.

Also I cut the part »And in the works for the [coming versions]« because that makes the entry wayyy too long.

@nickvergessen @Ivansss please review.