### PR TITLE
Allow to give calls a name

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -90,7 +90,9 @@ pipeline:
       # Pre-setup steps
       - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
       - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
-      - cd ../server/apps/$APP_NAME
+      - cd ../server/
+      - ./occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
 
       # Run phpunit tests
       - cd tests/php/
@@ -113,7 +115,9 @@ pipeline:
       # Pre-setup steps
       - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
       - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
-      - cd ../server/apps/$APP_NAME
+      - cd ../server/
+      - ./occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
 
       # Run phpunit tests
       - cd tests/php/
@@ -134,7 +138,9 @@ pipeline:
       # Pre-setup steps
       - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
       - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
-      - cd ../server/apps/$APP_NAME
+      - cd ../server/
+      - ./occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
 
       # Run phpunit tests
       - cd tests/php/

--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -59,7 +59,8 @@
 			<field>
 				<name>name</name>
 				<type>text</type>
-				<notnull>true</notnull>
+				<default/>
+				<notnull>false</notnull>
 				<length>255</length>
 			</field>
 			<field>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 	<screenshot>https://raw.githubusercontent.com/nextcloud/spreed/master/docs/spreed-in-action.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/spreed/master/docs/inviting-people.png</screenshot>
 
-	<version>1.1.3</version>
+	<version>1.1.4</version>
 	<dependencies>
 		<nextcloud min-version="11" max-version="12" />
 	</dependencies>
@@ -41,7 +41,14 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 		<prevent_group_restriction />
 	</types>
 	<namespace>Spreed</namespace>
+
 	<settings>
 		<admin>OCA\Spreed\Settings\Admin</admin>
 	</settings>
+
+	<repair-steps>
+		<post-migration>
+			<step>OCA\Spreed\Migration\EmptyNameInsteadOfRandom</step>
+		</post-migration>
+	</repair-steps>
 </info>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -60,6 +60,12 @@ return [
 			'requirements' => ['roomId' => '\d+'],
 		],
 		[
+			'name' => 'api#renameRoom',
+			'url' => '/api/room/{roomId}',
+			'verb' => 'PUT',
+			'requirements' => ['roomId' => '\d+'],
+		],
+		[
 			'name' => 'api#addParticipantToRoom',
 			'url' => '/api/room/{roomId}',
 			'verb' => 'POST',

--- a/css/style.css
+++ b/css/style.css
@@ -90,7 +90,8 @@
 	display: block !important;
 }
 
-.private-room {
+.private-room,
+.hidden-important {
 	display: none !important;
 }
 
@@ -109,6 +110,26 @@
     top: 0;
     padding: 16px;
 	opacity: .5;
+}
+
+.rename-input {
+	margin-top: 0px !important;
+	margin-bottom: 4px !important;
+}
+
+.icon-confirm.rename-confirm {
+	background-size: 16px;
+	background-color: transparent;
+	border: none;
+	position: absolute;
+	right: -5px;
+	top: 38px;
+	padding: 16px;
+	opacity: .5;
+}
+
+.icon-confirm.rename-confirm:hover  {
+	opacity: 1;
 }
 
 

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -197,7 +197,8 @@
 			this.ui.personSelectorInput.select2('open');
 		},
 		showRenameInput: function() {
-			var currentRoomName = this.model.get('name');
+			var currentRoomName = this.model.get('name'),
+				self = this;
 
 			this.$el.find('.rename-element').removeClass('hidden-important');
 			this.$el.find('.rename-room-button').addClass('hidden-important');
@@ -207,6 +208,14 @@
 			}
 
 			this.$el.find('.rename-input').focus();
+			this.$el.keyup(function(e) {
+				if (e.keyCode === 13) {
+					self.confirmRoomRename();
+				} else if (e.keyCode === 27) {
+					self.$el.find('.rename-element').addClass('hidden-important');
+					self.$el.find('.rename-room-button').removeClass('hidden-important');
+				}
+			});
 		},
 		confirmRoomRename: function() {
 			var currentRoomName = this.model.get('name');

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -43,6 +43,16 @@
 										'<span>'+t('spreed', 'Add person')+'</span>'+
 									'</button>'+
 								'</li>'+
+								'{{#isNameEditable}}'+
+								'<li>'+
+									'<button class="rename-room-button">'+
+										'<span class="icon-rename"></span>'+
+										'<span>'+t('spreed', 'Rename')+'</span>'+
+									'</button>'+
+								'</li>'+
+								'<input class="hidden-important rename-element rename-input" maxlength="200" type="text"/>'+
+								'<button class="icon-confirm hidden-important rename-element rename-confirm"></button>'+
+								'{{/isNameEditable}}'+
 								'<li>'+
 									'<button class="share-link-button">'+
 										'<span class="icon-public"></span>'+
@@ -74,6 +84,7 @@
 				this.render();
 			},
 			'change:type': function() {
+				this.render();
 				this.checkSharingStatus();
 			}
 		},
@@ -126,6 +137,8 @@
 		events: {
 			'click .app-navigation-entry-utils-menu-button button': 'toggleMenu',
 			'click .app-navigation-entry-menu .add-person-button': 'addPerson',
+			'click .app-navigation-entry-menu .rename-room-button': 'showRenameInput',
+			'click .app-navigation-entry-menu .rename-confirm': 'confirmRoomRename',
 			'click .app-navigation-entry-menu .share-link-button': 'shareGroup',
 			'click .app-navigation-entry-menu .leave-group-button': 'leaveGroup',
 			'click .icon-delete': 'unshareGroup',
@@ -182,6 +195,45 @@
 			this.ui.menuList.attr('style', 'display: none !important');
 			this.ui.personSelectorForm.toggleClass('hidden');
 			this.ui.personSelectorInput.select2('open');
+		},
+		showRenameInput: function() {
+			var currentRoomName = this.model.get('name');
+
+			this.$el.find('.rename-element').removeClass('hidden-important');
+			this.$el.find('.rename-room-button').addClass('hidden-important');
+
+			if (currentRoomName) {
+				this.$el.find('.rename-input').val(currentRoomName);
+			}
+
+			this.$el.find('.rename-input').focus();
+		},
+		confirmRoomRename: function() {
+			var currentRoomName = this.model.get('name');
+			var newRoomName = $.trim(this.$el.find('.rename-input').val());
+
+			this.$el.find('.rename-element').addClass('hidden-important');
+			this.$el.find('.rename-room-button').removeClass('hidden-important');
+
+			if (currentRoomName !== newRoomName) {
+				console.log('Changing room name to: '+newRoomName+' from: '+currentRoomName);
+				this.renameRoom(newRoomName);
+			}
+		},
+		renameRoom: function(roomName) {
+			var app = OCA.SpreedMe.app;
+
+			// This should be the only case
+			if ((this.model.get('type') !== 1) && (roomName.length <= 200)) {
+				$.ajax({
+					url: OC.generateUrl('/apps/spreed/api/room/') + this.model.get('id'),
+					type: 'PUT',
+					data: 'roomName='+roomName,
+					success: function() {
+						app.syncRooms();
+					}
+				});
+			}
 		},
 		shareGroup: function() {
 			var app = OCA.SpreedMe.app;

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -305,7 +305,24 @@
 			$('#emptycontent p').text(messageAdditional);
 		},
 		addTooltip: function () {
-			var htmlstring = escapeHTML(this.model.get('displayName')).replace(/\, /g, '<br>');
+			var participants = [];
+			$.each(this.model.get('participants'), function(participantId, participantName) {
+				if (participantId !== oc_current_user) {
+					participants.push(escapeHTML(participantName));
+				}
+			});
+
+			if (this.model.get('guestList') !== '') {
+				participants.push(this.model.get('guestList'));
+			}
+
+			if (participants.length === 0) {
+				participants.push(t('spreed', 'You'));
+			} else {
+				participants.push(t('spreed', 'and you'));
+			}
+
+			var htmlstring = participants.join('<br>');
 
 			this.ui.room.tooltip({
 				placement: 'bottom',

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -202,24 +202,26 @@ class ApiController extends Controller {
 
 			case Room::GROUP_CALL:
 			case Room::PUBLIC_CALL:
-				/// As name of the room use the names of the other participants
-				if ($this->userId === null) {
-					$participantList[] = $this->l10n->t('You');
+				if ($room->getName() === '') {
+					// As name of the room use the names of the other participants
+					if ($this->userId === null) {
+						$participantList[] = $this->l10n->t('You');
 
-					if ($numGuestParticipants !== 0 && $room->getType() === Room::PUBLIC_CALL) {
-						$participantList[] = $this->l10n->n('%n other guest', '%n other guests', $numGuestParticipants);
-					}
-				} else if ($numOtherParticipants === 0) {
-					$participantList = [$this->l10n->t('You')];
+						if ($numGuestParticipants !== 0 && $room->getType() === Room::PUBLIC_CALL) {
+							$participantList[] = $this->l10n->n('%n other guest', '%n other guests', $numGuestParticipants);
+						}
+					} else if ($numOtherParticipants === 0) {
+						$participantList = [$this->l10n->t('You')];
 
-					if ($numGuestParticipants !== 0 && $room->getType() === Room::PUBLIC_CALL) {
+						if ($numGuestParticipants !== 0 && $room->getType() === Room::PUBLIC_CALL) {
+							$participantList[] = $this->l10n->n('%n guest', '%n guests', $numGuestParticipants);
+						}
+					} else if ($numGuestParticipants !== 0 && $room->getType() === Room::PUBLIC_CALL) {
 						$participantList[] = $this->l10n->n('%n guest', '%n guests', $numGuestParticipants);
 					}
-				} else if ($numGuestParticipants !== 0 && $room->getType() === Room::PUBLIC_CALL) {
-					$participantList[] = $this->l10n->n('%n guest', '%n guests', $numGuestParticipants);
-				}
 
-				$roomData['displayName'] = implode($this->l10n->t(', '), $participantList);
+					$roomData['displayName'] = implode($this->l10n->t(', '), $participantList);
+				}
 				break;
 
 			default:

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -363,6 +363,26 @@ class ApiController extends Controller {
 	 * @NoAdminRequired
 	 *
 	 * @param int $roomId
+	 * @param string $roomName
+	 * @return JSONResponse
+	 */
+	public function renameRoom($roomId, $roomName) {
+		try {
+			$room = $this->manager->getRoomForParticipant($roomId, $this->userId);
+		} catch (RoomNotFoundException $e) {
+			return new JSONResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if (!$room->setName($roomName)) {
+			return new JSONResponse([], Http::STATUS_METHOD_NOT_ALLOWED);
+		}
+		return new JSONResponse([]);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param int $roomId
 	 * @param string $newParticipant
 	 * @return JSONResponse
 	 */

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -373,6 +373,10 @@ class ApiController extends Controller {
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 
+		if (strlen($roomName) > 200) {
+			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
 		if (!$room->setName($roomName)) {
 			return new JSONResponse([], Http::STATUS_METHOD_NOT_ALLOWED);
 		}

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -159,6 +159,7 @@ class ApiController extends Controller {
 			'type' => $room->getType(),
 			'name' => $room->getName(),
 			'displayName' => $room->getName(),
+			'isNameEditable' => ($room->getType() !== Room::ONE_TO_ONE_CALL),
 			'count' => $room->getNumberOfParticipants(time() - 30),
 			'lastPing' => isset($participants['users'][$this->userId]['lastPing']) ? $participants['users'][$this->userId]['lastPing'] : 0,
 			'sessionId' => isset($participants['users'][$this->userId]['sessionId']) ? $participants['users'][$this->userId]['sessionId'] : '0',

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -107,7 +107,7 @@ class Manager {
 	}
 
 	/**
-	 * @param int $id
+	 * @param int $roomId
 	 * @return Room
 	 * @throws RoomNotFoundException
 	 */
@@ -189,9 +189,6 @@ class Manager {
 	 * @return Room
 	 */
 	private function createRoom($type, $name = '') {
-		if ($name === '') {
-			$name = $this->secureRandom->generate(12);
-		}
 
 		$query = $this->db->getQueryBuilder();
 		$query->insert('spreedme_rooms')

--- a/lib/Migration/EmptyNameInsteadOfRandom.php
+++ b/lib/Migration/EmptyNameInsteadOfRandom.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Migration;
+
+
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class EmptyNameInsteadOfRandom implements IRepairStep {
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	/** @var IConfig */
+	protected $config;
+
+	/** @var IGroupManager */
+	protected $groupManager;
+
+	/**
+	 * @param IDBConnection $connection
+	 * @param IConfig $config
+	 * @param IGroupManager $groupManager
+	 */
+	public function __construct(IDBConnection $connection, IConfig $config, IGroupManager $groupManager) {
+		$this->connection = $connection;
+		$this->config = $config;
+		$this->groupManager = $groupManager;
+	}
+
+	/**
+	 * Returns the step's name
+	 *
+	 * @return string
+	 * @since 9.1.0
+	 */
+	public function getName() {
+		return 'Remove random call names';
+	}
+
+	/**
+	 * Run repair step.
+	 * Must throw exception on error.
+	 *
+	 * @since 9.1.0
+	 * @param IOutput $output
+	 * @throws \Exception in case of failure
+	 */
+	public function run(IOutput $output) {
+		if (!version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '1.1.4', '<')) {
+			return;
+		}
+
+		$update = $this->connection->getQueryBuilder();
+		$update->update('spreedme_rooms')
+			->set('name', $update->createNamedParameter(''))
+			->where($update->expr()->eq('id', $update->createParameter('room_id')));
+
+		$query = $this->connection->getQueryBuilder();
+		$query->select('*')
+			->from('spreedme_rooms');
+		$result = $query->execute();
+
+		$output->startProgress();
+		while ($row = $result->fetch()) {
+			$output->advance();
+
+			if (strlen($row['name']) !== 12 || $this->groupManager->groupExists($row['name'])) {
+				continue;
+			}
+
+			$update->setParameter('room_id', (int) $row['id'], IQueryBuilder::PARAM_INT)
+				->execute();
+		}
+		$output->finishProgress();
+	}
+}

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -100,6 +100,28 @@ class Room {
 	}
 
 	/**
+	 * @param string $newName Currently it is only allowed to rename: Room::GROUP_CALL, Room::PUBLIC_CALL
+	 * @return bool True when the change was valid, false otherwise
+	 */
+	public function setName($newName) {
+		if ($newName === $this->getName()) {
+			return true;
+		}
+
+		if ($this->getType() === self::ONE_TO_ONE_CALL) {
+			return false;
+		}
+
+		$query = $this->db->getQueryBuilder();
+		$query->update('spreedme_rooms')
+			->set('name', $query->createNamedParameter($newName))
+			->where($query->expr()->eq('id', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)));
+		$query->execute();
+
+		return true;
+	}
+
+	/**
 	 * @param int $newType Currently it is only allowed to change to: Room::GROUP_CALL, Room::PUBLIC_CALL
 	 * @return bool True when the change was valid, false otherwise
 	 */

--- a/tests/php/Migration/EmptyNameInsteadOfRandomTest.php
+++ b/tests/php/Migration/EmptyNameInsteadOfRandomTest.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Tests\php\Migration;
+
+
+use OCA\Spreed\Migration\EmptyNameInsteadOfRandom;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\Migration\IOutput;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class EmptyNameInsteadOfRandomTest extends TestCase {
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	protected $config;
+
+	/** @var IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $groupManager;
+
+	/** @var EmptyNameInsteadOfRandom */
+	protected $step;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->config = $this->createMock(IConfig::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+
+		$this->step = new EmptyNameInsteadOfRandom($this->connection, $this->config, $this->groupManager);
+		$this->clearRoomsTable();
+	}
+
+	protected function tearDown() {
+		$this->clearRoomsTable();
+		parent::tearDown();
+	}
+
+	protected function clearRoomsTable() {
+		$query = $this->connection->getQueryBuilder();
+		$query->delete('spreedme_rooms')
+			->execute();
+	}
+
+	public function testGetName() {
+		$this->assertInternalType('string', $this->step->getName());
+		$this->assertNotEmpty($this->step->getName());
+	}
+
+	public function dataRun() {
+		return [
+			['1.1.4', null, null, null],
+			['1.1.3', 'abcdefghijkl', true, 'abcdefghijkl'],
+			['1.1.2', 'abcdefghijkl', false, ''],
+			['1.1.1', 'admin', null, 'admin'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataRun
+	 * @param string $version
+	 * @param string|null $originalName
+	 * @param bool|null $isGroup
+	 * @param string|null $updatedName
+	 */
+	public function testRun($version, $originalName, $isGroup, $updatedName) {
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('spreed', 'installed_version', '0.0.0')
+			->willReturn($version);
+
+		if ($originalName === null || $isGroup === null) {
+			$this->groupManager->expects($this->never())
+				->method('groupExists');
+		} else {
+			$this->groupManager->expects($this->once())
+				->method('groupExists')
+				->with($originalName)
+				->willReturn($isGroup);
+		}
+
+		$query = $this->connection->getQueryBuilder();
+		$query->insert('spreedme_rooms')
+			->values([
+				'name' => $query->createNamedParameter($originalName),
+				'type' => $query->createNamedParameter(1)
+			]);
+		$query->execute();
+		$id = $query->getLastInsertId();
+
+		$this->step->run($this->createMock(IOutput::class));
+
+		$query = $this->connection->getQueryBuilder();
+		$query->select('*')
+			->from('spreedme_rooms')
+			->where($query->expr()->eq('id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+		$result = $query->execute();
+		$row = $result->fetch();
+		$result->closeCursor();
+
+		$this->assertSame($updatedName, $row['name']);
+	}
+}


### PR DESCRIPTION
I think our "Ivan Sein, Roel..." call name is pretty useless for everybody. Instead it would make sense, when it's called "Company Call".
This PR adds an endpoint which allows to set a name for calls. The participant list is still used, when there was no room name set manually.

- [x] On hover the participant list should be displayed instead of the room name again
- [x] UI needs an option to rename a channel

@Ivansss can you help?