### PR TITLE
Do not allow to restrict the app to a group

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,10 +33,13 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 	<screenshot>https://raw.githubusercontent.com/nextcloud/spreed/master/docs/spreed-in-action.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/spreed/master/docs/inviting-people.png</screenshot>
 
-	<version>1.1.2</version>
+	<version>1.1.3</version>
 	<dependencies>
 		<nextcloud min-version="11" max-version="12" />
 	</dependencies>
+	<types>
+		<prevent_group_restriction />
+	</types>
 	<namespace>Spreed</namespace>
 	<settings>
 		<admin>OCA\Spreed\Settings\Admin</admin>


### PR DESCRIPTION
This breaks public calls as well as calls to users which are not in the group

Fix #201 
