### PR TITLE
Add the call name to the notification when the call has a name

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -31,6 +31,8 @@ use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\RichObjectStrings\Definitions;
+use OCP\RichObjectStrings\InvalidObjectExeption;
 
 class Notifier implements INotifier {
 
@@ -46,17 +48,22 @@ class Notifier implements INotifier {
 	/** @var Manager */
 	protected $manager;
 
+	/** @var Definitions */
+	protected $definitions;
+
 	/**
 	 * @param IFactory $lFactory
 	 * @param IURLGenerator $url
 	 * @param IUserManager $userManager
 	 * @param Manager $manager
+	 * @param Definitions $definitions
 	 */
-	public function __construct(IFactory $lFactory, IURLGenerator $url, IUserManager $userManager, Manager $manager) {
+	public function __construct(IFactory $lFactory, IURLGenerator $url, IUserManager $userManager, Manager $manager, Definitions $definitions) {
 		$this->lFactory = $lFactory;
 		$this->url = $url;
 		$this->userManager = $userManager;
 		$this->manager = $manager;
+		$this->definitions = $definitions;
 	}
 
 	/**
@@ -107,20 +114,50 @@ class Notifier implements INotifier {
 						;
 					} else if ($room->getType() === Room::GROUP_CALL ||
 						$room->getType() === Room::PUBLIC_CALL) {
-						$notification
-							->setParsedSubject(
-								$l->t('%s invited you to a group call', [$user->getDisplayName()])
-							)
-							->setRichSubject(
-								$l->t('{user} invited you to a group call'), [
-									'user' => [
-										'type' => 'user',
-										'id' => $uid,
-										'name' => $user->getDisplayName(),
+						$callTypeIsSupported = false;
+						try {
+							$this->definitions->getDefinition('call');
+							$callTypeIsSupported = true;
+						} catch (InvalidObjectExeption $e) {
+							// Before 11.0.2 this is not supported
+						}
+
+						if ($callTypeIsSupported && $room->getName() !== '') {
+							$notification
+								->setParsedSubject(
+									$l->t('%s invited you to a group call: %s', [$user->getDisplayName(), $room->getName()])
+								)
+								->setRichSubject(
+									$l->t('{user} invited you to a group call: {call}'), [
+										'user' => [
+											'type' => 'user',
+											'id' => $uid,
+											'name' => $user->getDisplayName(),
+										],
+										'call' => [
+											'type' => 'call',
+											'id' => $room->getId(),
+											'name' => $room->getName(),
+										],
 									]
-								]
-							)
-						;
+								)
+							;
+						} else {
+							$notification
+								->setParsedSubject(
+									$l->t('%s invited you to a group call', [$user->getDisplayName()])
+								)
+								->setRichSubject(
+									$l->t('{user} invited you to a group call'), [
+										'user' => [
+											'type' => 'user',
+											'id' => $uid,
+											'name' => $user->getDisplayName(),
+										]
+									]
+								)
+							;
+						}
 					} else {
 						throw new \InvalidArgumentException('Unknown room type');
 					}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -138,6 +138,7 @@ class Notifier implements INotifier {
 											'type' => 'call',
 											'id' => $room->getId(),
 											'name' => $room->getName(),
+											'call-type' => $this->getRoomType($room),
 										],
 									]
 								)
@@ -172,5 +173,23 @@ class Notifier implements INotifier {
 		}
 
 		return $notification;
+	}
+
+	/**
+	 * @param Room $room
+	 * @return string
+	 * @throws \InvalidArgumentException
+	 */
+	protected function getRoomType(Room $room) {
+		switch ($room->getType()) {
+			case Room::ONE_TO_ONE_CALL:
+				return 'one2one';
+			case Room::GROUP_CALL:
+				return 'group';
+			case Room::PUBLIC_CALL:
+				return 'public';
+			default:
+				throw new \InvalidArgumentException('Unknown room type');
+		}
 	}
 }

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -237,6 +237,7 @@ class NotifierTest extends \Test\TestCase {
 						'type' => 'call',
 						'id' => $roomId,
 						'name' => $name,
+						'call-type' => 'public',
 					],
 				])
 				->willReturnSelf();

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -31,6 +31,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Notification\INotification;
+use OCP\RichObjectStrings\Definitions;
 
 class NotifierTest extends \Test\TestCase {
 
@@ -42,6 +43,8 @@ class NotifierTest extends \Test\TestCase {
 	protected $userManager;
 	/** @var Manager|\PHPUnit_Framework_MockObject_MockObject */
 	protected $manager;
+	/** @var Definitions|\PHPUnit_Framework_MockObject_MockObject */
+	protected $definitions;
 	/** @var Notifier */
 	protected $notifier;
 
@@ -52,12 +55,14 @@ class NotifierTest extends \Test\TestCase {
 		$this->url = $this->createMock(IURLGenerator::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->manager = $this->createMock(Manager::class);
+		$this->definitions = $this->createMock(Definitions::class);
 
 		$this->notifier = new Notifier(
 			$this->lFactory,
 			$this->url,
 			$this->userManager,
-			$this->manager
+			$this->manager,
+			$this->definitions
 		);
 	}
 
@@ -144,8 +149,8 @@ class NotifierTest extends \Test\TestCase {
 
 	public function dataPrepareGroup() {
 		return [
-			[Room::GROUP_CALL, 'admin', 'Admin', 'Admin invited you to a group call'],
-			[Room::PUBLIC_CALL, 'test', 'Test user', 'Test user invited you to a group call'],
+			[Room::GROUP_CALL, 'admin', 'Admin', '', 'Admin invited you to a group call'],
+			[Room::PUBLIC_CALL, 'test', 'Test user', 'Name', 'Test user invited you to a group call: Name'],
 		];
 	}
 
@@ -154,9 +159,11 @@ class NotifierTest extends \Test\TestCase {
 	 * @param int $type
 	 * @param string $uid
 	 * @param string $displayName
+	 * @param string $name
 	 * @param string $parsedSubject
 	 */
-	public function testPrepareGroup($type, $uid, $displayName, $parsedSubject) {
+	public function testPrepareGroup($type, $uid, $displayName, $name, $parsedSubject) {
+		$roomId = $type;
 		$n = $this->createMock(INotification::class);
 		$l = $this->createMock(IL10N::class);
 		$l->expects($this->exactly(2))
@@ -169,6 +176,9 @@ class NotifierTest extends \Test\TestCase {
 		$room->expects($this->atLeastOnce())
 			->method('getType')
 			->willReturn($type);
+		$room->expects($this->atLeastOnce())
+			->method('getName')
+			->willReturn($name);
 		$this->manager->expects($this->once())
 			->method('getRoomById')
 			->willReturn($room);
@@ -197,16 +207,40 @@ class NotifierTest extends \Test\TestCase {
 			->method('setParsedSubject')
 			->with($parsedSubject)
 			->willReturnSelf();
-		$n->expects($this->once())
-			->method('setRichSubject')
-			->with('{user} invited you to a group call',[
-				'user' => [
-					'type' => 'user',
-					'id' => $uid,
-					'name' => $displayName,
-				]
-			])
-			->willReturnSelf();
+
+		if ($name === '') {
+			$room->expects($this->never())
+				->method('getId');
+			$n->expects($this->once())
+				->method('setRichSubject')
+				->with('{user} invited you to a group call',[
+					'user' => [
+						'type' => 'user',
+						'id' => $uid,
+						'name' => $displayName,
+					]
+				])
+				->willReturnSelf();
+		} else {
+			$room->expects($this->once())
+				->method('getId')
+				->willReturn($roomId);
+			$n->expects($this->once())
+				->method('setRichSubject')
+				->with('{user} invited you to a group call: {call}', [
+					'user' => [
+						'type' => 'user',
+						'id' => $uid,
+						'name' => $displayName,
+					],
+					'call' => [
+						'type' => 'call',
+						'id' => $roomId,
+						'name' => $name,
+					],
+				])
+				->willReturnSelf();
+		}
 
 		$n->expects($this->once())
 			->method('getApp')


### PR DESCRIPTION
Doesn't work before 12.0 and where ever we backport the [definitions change](https://github.com/nextcloud/server/pull/3106).
So no need to rush it for 1.2