### PR TITLE
[WIP] Add screensharing support.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -320,7 +320,7 @@ video {
 }
 
 #app-content.screensharing #localScreenContainer {
-	max-height: calc(100% - 200px);
+	height: calc(100% - 200px);
 	overflow: scroll;
 	background-color: transparent;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -323,6 +323,17 @@ video {
 	padding: 12px 35%;
 }
 
+#video-fullscreen {
+	position: absolute;
+	right: 0px;
+	z-index: 90;
+}
+
+#video-fullscreen.public {
+	top: 45px;
+}
+
+#video-fullscreen,
 .nameIndicator button {
 	background-color: transparent;
 	border: none;

--- a/css/style.css
+++ b/css/style.css
@@ -338,7 +338,7 @@ video {
 	text-align: center;
 	font-size: 20px;
 	white-space: nowrap;
-	overflow: hidden;
+	overflow: visible;
 	text-overflow: ellipsis;
 }
 .videoView .nameIndicator {

--- a/css/style.css
+++ b/css/style.css
@@ -308,18 +308,15 @@ video {
 #app-content.participants-7,
 #app-content.participants-8,
 #app-content.participants-9,
-#app-content.participants-10 {
-	background-color: #000;
-}
-
+#app-content.participants-10,
 #app-content.screensharing {
-	background-color: #ddd;
+	background-color: #000;
 }
 
 #app-content.screensharing .videoContainer video {
 	max-height: 200px;
 	background-color: transparent;
-	box-shadow: 0 0 0 0;
+	box-shadow: 0;
 }
 
 #app-content.screensharing #localScreenContainer {

--- a/css/style.css
+++ b/css/style.css
@@ -341,8 +341,10 @@ video {
 	height: 44px;
 	background-size: 25px;
 }
+
 .nameIndicator button.audio-disabled,
-.nameIndicator button.video-disabled {
+.nameIndicator button.video-disabled,
+.nameIndicator button.screensharing-disabled {
 	opacity: .7;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -248,6 +248,14 @@ video {
 	display: block !important;
 }
 
+.participants-1 #video-fullscreen {
+	display: none;
+}
+
+.participants-1 #toggleScreensharing {
+	display: none;
+}
+
 /* big speaker video */
 .participants-1 .videoContainer,
 .participants-2 .videoContainer,

--- a/css/style.css
+++ b/css/style.css
@@ -139,6 +139,9 @@
     background-position-y: 8px !important;
 }
 
+/**
+ * Video styles
+ */
 
 #videos {
 	position: absolute;
@@ -307,6 +310,22 @@ video {
 #app-content.participants-9,
 #app-content.participants-10 {
 	background-color: #000;
+}
+
+#app-content.screensharing {
+	background-color: #ddd;
+}
+
+#app-content.screensharing .videoContainer video {
+	max-height: 200px;
+	background-color: transparent;
+	box-shadow: 0 0 0 0;
+}
+
+#app-content.screensharing #localScreenContainer {
+	max-height: calc(100% - 200px);
+	overflow: scroll;
+	background-color: transparent;
 }
 
 .nameIndicator {

--- a/js/app.js
+++ b/js/app.js
@@ -210,6 +210,49 @@
 				}
 			});
 
+			var screensharingStopped = function() {
+				console.log("Screensharing now stopped");
+			};
+
+			OCA.SpreedMe.webrtc.on('localScreenStopped', function() {
+				screensharingStopped();
+			});
+
+			$('#toogleScreensharing').click(function() {
+				var webrtc = OCA.SpreedMe.webrtc;
+				if (!webrtc.capabilities.supportScreenSharing) {
+					console.log("Screensharing is not supported");
+					return;
+				}
+
+				if (webrtc.getLocalScreen()) {
+					webrtc.stopScreenShare();
+					screensharingStopped();
+				} else {
+					webrtc.shareScreen(function(err) {
+						if (err) {
+							switch (err.name) {
+								case "HTTPS_REQUIRED":
+									console.log("Need HTTPS for screensharing.");
+									break;
+								case "PERMISSION_DENIED":
+								case "CEF_GETSCREENMEDIA_CANCELED":  // Experimental, may go away in the future.
+									console.log("User cancelled screensharing request.");
+									break;
+								case "EXTENSION_UNAVAILABLE":
+									console.log("Need to install extension to make screensharing work.");
+									break;
+								default:
+									console.log("Could not start screensharing", err.name, err);
+									break;
+							}
+						} else {
+							console.log("Screensharing now started");
+						}
+					});
+				}
+			});
+
 			$("#guestName").on('click', function() {
 				$('#guestName').addClass('hidden');
 				$("#guestNameInput").removeClass('hidden');

--- a/js/app.js
+++ b/js/app.js
@@ -155,6 +155,11 @@
 				});
 			});
 
+			// Initialize button tooltips
+			$('[data-toggle="tooltip"]').tooltip({trigger: 'hover'}).click(function() {
+				$(this).tooltip('hide');
+			});
+
 			$('#hideVideo').click(function() {
 				if(!OCA.SpreedMe.app.videoWasEnabledAtLeastOnce) {
 					// don't allow clicking the video toggle
@@ -173,6 +178,7 @@
 					localStorage.setItem("videoDisabled", true);
 				}
 			});
+
 			$('#mute').click(function() {
 				if (OCA.SpreedMe.webrtc.webrtc.isAudioEnabled()) {
 					OCA.SpreedMe.app.disableAudio();
@@ -197,6 +203,7 @@
 					} else if (fullscreenElem.msRequestFullscreen) {
 						fullscreenElem.msRequestFullscreen();
 					}
+					$(this).attr('data-original-title', 'Exit fullscreen');
 				} else {
 					if (document.exitFullscreen) {
 						document.exitFullscreen();
@@ -207,12 +214,13 @@
 					} else if (document.msExitFullscreen) {
 						document.msExitFullscreen();
 					}
+					$(this).attr('data-original-title', 'Fullscreen');
 				}
 			});
 
 			var screensharingStopped = function() {
 				console.log("Screensharing now stopped");
-				$('#toggleScreensharing').data('title', 'Enable screensharing')
+				$('#toggleScreensharing').attr('data-original-title', 'Enable screensharing')
 					.addClass('screensharing-disabled icon-screen-off-white')
 					.removeClass('icon-screen-white');
 			};
@@ -235,7 +243,7 @@
 					webrtc.shareScreen(function(err) {
 						if (!err) {
 							OC.Notification.showTemporary(t('spreed', 'Screensharing is about to start…'));
-							$('#toggleScreensharing').data('title', 'Stop screensharing')
+							$('#toggleScreensharing').attr('data-original-title', 'Stop screensharing')
 								.removeClass('screensharing-disabled icon-screen-off-white')
 								.addClass('icon-screen-white');
 							return;
@@ -470,7 +478,7 @@
 		},
 		enableAudio: function() {
 			OCA.SpreedMe.webrtc.unmute();
-			$('#mute').data('title', 'Mute audio')
+			$('#mute').attr('data-original-title', 'Mute audio')
 				.removeClass('audio-disabled icon-audio-off-white')
 				.addClass('icon-audio-white');
 
@@ -478,7 +486,7 @@
 		},
 		disableAudio: function() {
 			OCA.SpreedMe.webrtc.mute();
-			$('#mute').data('title', 'Enable audio')
+			$('#mute').attr('data-original-title', 'Enable audio')
 				.addClass('audio-disabled icon-audio-off-white')
 				.removeClass('icon-audio-white');
 
@@ -490,9 +498,10 @@
 			var localVideo = $hideVideoButton.closest('.videoView').find('#localVideo');
 
 			OCA.SpreedMe.webrtc.resumeVideo();
-			$hideVideoButton.data('title', 'Disable video')
+			$hideVideoButton.attr('data-original-title', 'Disable video')
 				.removeClass('video-disabled icon-video-off-white')
 				.addClass('icon-video-white');
+
 			avatarContainer.hide();
 			localVideo.show();
 
@@ -503,7 +512,7 @@
 			var avatarContainer = $hideVideoButton.closest('.videoView').find('.avatar-container');
 			var localVideo = $hideVideoButton.closest('.videoView').find('#localVideo');
 
-			$hideVideoButton.data('title', 'Enable video')
+			$hideVideoButton.attr('data-original-title', 'Enable video')
 				.addClass('video-disabled icon-video-off-white')
 				.removeClass('icon-video-white');
 

--- a/js/app.js
+++ b/js/app.js
@@ -212,6 +212,9 @@
 
 			var screensharingStopped = function() {
 				console.log("Screensharing now stopped");
+				$('#toogleScreensharing').data('title', 'Enable screensharing')
+					.addClass('screensharing-disabled icon-screen-off-white')
+					.removeClass('icon-screen-white');
 			};
 
 			OCA.SpreedMe.webrtc.on('localScreenStopped', function() {
@@ -232,6 +235,9 @@
 					webrtc.shareScreen(function(err) {
 						if (!err) {
 							OC.Notification.showTemporary(t('spreed', 'Screensharing is about to start…'));
+							$('#toogleScreensharing').data('title', 'Stop screensharing')
+								.removeClass('screensharing-disabled icon-screen-off-white')
+								.addClass('icon-screen-white');
 							return;
 						}
 

--- a/js/app.js
+++ b/js/app.js
@@ -211,7 +211,7 @@
 			});
 
 			var screensharingStopped = function() {
-				console.log("Screensharing now stopped");
+				// No need to notify the user.
 			};
 
 			OCA.SpreedMe.webrtc.on('localScreenStopped', function() {
@@ -221,7 +221,7 @@
 			$('#toogleScreensharing').click(function() {
 				var webrtc = OCA.SpreedMe.webrtc;
 				if (!webrtc.capabilities.supportScreenSharing) {
-					console.log("Screensharing is not supported");
+					OC.Notification.showTemporary(t('spreed', 'Screensharing is not supported by your browser.'));
 					return;
 				}
 
@@ -230,24 +230,28 @@
 					screensharingStopped();
 				} else {
 					webrtc.shareScreen(function(err) {
-						if (err) {
-							switch (err.name) {
-								case "HTTPS_REQUIRED":
-									console.log("Need HTTPS for screensharing.");
-									break;
-								case "PERMISSION_DENIED":
-								case "CEF_GETSCREENMEDIA_CANCELED":  // Experimental, may go away in the future.
-									console.log("User cancelled screensharing request.");
-									break;
-								case "EXTENSION_UNAVAILABLE":
-									console.log("Need to install extension to make screensharing work.");
-									break;
-								default:
-									console.log("Could not start screensharing", err.name, err);
-									break;
-							}
-						} else {
-							console.log("Screensharing now started");
+						if (!err) {
+							OC.Notification.showTemporary(t('spreed', 'Screensharing is about to start…'));
+							return;
+						}
+
+						switch (err.name) {
+							case "HTTPS_REQUIRED":
+								OC.Notification.showTemporary(t('spreed', 'Screensharing requires the page to be loaded through HTTPS.'));
+								break;
+							case "PERMISSION_DENIED":
+							case "NotAllowedError":
+							case "CEF_GETSCREENMEDIA_CANCELED":  // Experimental, may go away in the future.
+								OC.Notification.showTemporary(t('spreed', 'The screensharing request has been cancelled.'));
+								break;
+							case "EXTENSION_UNAVAILABLE":
+								// TODO(fancycode): Show popup with links to Chrome/Firefox extensions.
+								OC.Notification.showTemporary(t('spreed', 'An extension is required to start screensharing.'));
+								break;
+							default:
+								OC.Notification.showTemporary(t('spreed', 'An error occurred while starting screensharing.'));
+								console.log("Could not start screensharing", err);
+								break;
 						}
 					});
 				}

--- a/js/app.js
+++ b/js/app.js
@@ -211,7 +211,7 @@
 			});
 
 			var screensharingStopped = function() {
-				// No need to notify the user.
+				console.log("Screensharing now stopped");
 			};
 
 			OCA.SpreedMe.webrtc.on('localScreenStopped', function() {

--- a/js/app.js
+++ b/js/app.js
@@ -212,7 +212,7 @@
 
 			var screensharingStopped = function() {
 				console.log("Screensharing now stopped");
-				$('#toogleScreensharing').data('title', 'Enable screensharing')
+				$('#toggleScreensharing').data('title', 'Enable screensharing')
 					.addClass('screensharing-disabled icon-screen-off-white')
 					.removeClass('icon-screen-white');
 			};
@@ -221,7 +221,7 @@
 				screensharingStopped();
 			});
 
-			$('#toogleScreensharing').click(function() {
+			$('#toggleScreensharing').click(function() {
 				var webrtc = OCA.SpreedMe.webrtc;
 				if (!webrtc.capabilities.supportScreenSharing) {
 					OC.Notification.showTemporary(t('spreed', 'Screensharing is not supported by your browser.'));
@@ -235,7 +235,7 @@
 					webrtc.shareScreen(function(err) {
 						if (!err) {
 							OC.Notification.showTemporary(t('spreed', 'Screensharing is about to start…'));
-							$('#toogleScreensharing').data('title', 'Stop screensharing')
+							$('#toggleScreensharing').data('title', 'Stop screensharing')
 								.removeClass('screensharing-disabled icon-screen-off-white')
 								.addClass('icon-screen-white');
 							return;

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -153,6 +153,16 @@ var spreedMappingTable = [];
 		var spreedListofSpeakers = {};
 		var latestSpeakerId = null;
 		var screenSharingActive = false;
+
+		window.addEventListener('resize', function() {
+			if (screenSharingActive) {
+				$('#localScreenContainer').children('video').each(function() {
+					$(this).width('100%');
+					$(this).height($('#localScreenContainer').height());
+				});
+			}
+		});
+
 		OCA.SpreedMe.speakers = {
 			showStatus: function() {
 				var data = [];
@@ -544,10 +554,10 @@ var spreedMappingTable = [];
 
 		// Local screen added.
 		OCA.SpreedMe.webrtc.on('localScreenAdded', function (video) {
-			video.onclick = function () {
-				video.style.width = video.videoWidth + 'px';
-				video.style.height = video.videoHeight + 'px';
-			};
+			var initialHeight = $('#app-content').height() - 200;
+
+			video.style.width = '100%';
+			video.style.height = initialHeight + 'px';
 
 			OCA.SpreedMe.speakers.unpromoteLatestSpeaker();
 

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -39,6 +39,30 @@ var spreedMappingTable = [];
 				appContentElement.attr('class', '').addClass(participantsClass);
 			}
 
+			//Send shared screen to new participants
+			var webrtc = OCA.SpreedMe.webrtc;
+			if (webrtc.getLocalScreen()) {
+				var newUsers = currentUsersInRoom.diff(previousUsersInRoom);
+				var currentUser = webrtc.connection.getSessionid();
+				newUsers.forEach(function(user) {
+					if (user !== currentUser) {
+						var peer = webrtc.webrtc.createPeer({
+								id: user,
+								type: 'screen',
+								sharemyscreen: true,
+								enableDataChannels: false,
+								receiveMedia: {
+									offerToReceiveAudio: 0,
+									offerToReceiveVideo: 0
+								},
+								broadcaster: currentUser,
+						});
+						webrtc.emit('createdPeer', peer);
+						peer.start();
+					}
+				});
+			}
+
 			var disconnectedUsers = previousUsersInRoom.diff(currentUsersInRoom);
 			disconnectedUsers.forEach(function(user) {
 				console.log('XXX Remove peer', user);

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -24,7 +24,7 @@ script(
 );
 ?>
 
-<div id="app" data-roomId="<?php p($_['roomId']) ?>">
+<div id="app" class="nc-enable-screensharing-extension" data-roomId="<?php p($_['roomId']) ?>">
 	<div id="app-content" class="participants-1">
 
 		<header>

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -62,10 +62,13 @@ script(
 					<button id="mute" class="icon-audio-white" data-title="<?php p($l->t('Mute audio')) ?>"></button>
 					<button id="hideVideo" class="icon-video-white" data-title="<?php p($l->t('Pause video')) ?>"></button>
 					<button id="video-fullscreen" class="icon-fullscreen-white" data-title="<?php p($l->t('Fullscreen')) ?>"></button>
+					<button id="toogleScreensharing" class="icon-view-play" data-title="<?php p($l->t('Toggle screensharing')) ?>"></button>
 				</div>
 			</div>
 		</div>
 
+		<div id="localScreenContainer">
+		</div>
 
 		<div id="emptycontent">
 			<div id="emptycontent-icon" class="icon-video"></div>

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -68,8 +68,7 @@ script(
 			</div>
 		</div>
 
-		<div id="localScreenContainer">
-		</div>
+		<div id="localScreenContainer"></div>
 
 		<div id="emptycontent">
 			<div id="emptycontent-icon" class="icon-video"></div>

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -49,7 +49,7 @@ script(
 			</div>
 		</header>
 
-		<button id="video-fullscreen" class="icon-fullscreen-white public" data-title="<?php p($l->t('Fullscreen')) ?>"></button>
+		<button id="video-fullscreen" class="icon-fullscreen-white public" data-placement="bottom" data-toggle="tooltip" data-original-title="<?php p($l->t('Fullscreen')) ?>"></button>
 
 		<div id="video-speaking">
 
@@ -61,9 +61,9 @@ script(
 					<div class="avatar"></div>
 				</div>
 				<div class="nameIndicator">
-					<button id="mute" class="icon-audio-white" data-title="<?php p($l->t('Mute audio')) ?>"></button>
-					<button id="hideVideo" class="icon-video-white" data-title="<?php p($l->t('Pause video')) ?>"></button>
-					<button id="toggleScreensharing" class="icon-screen-off-white screensharing-disabled" data-title="<?php p($l->t('Toggle screensharing')) ?>"></button>
+					<button id="mute" class="icon-audio-white" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Mute audio')) ?>"></button>
+					<button id="hideVideo" class="icon-video-white" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Disable video')) ?>"></button>
+					<button id="toggleScreensharing" class="icon-screen-off-white screensharing-disabled" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Share screen')) ?>"></button>
 				</div>
 			</div>
 		</div>

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -63,7 +63,7 @@ script(
 				<div class="nameIndicator">
 					<button id="mute" class="icon-audio-white" data-title="<?php p($l->t('Mute audio')) ?>"></button>
 					<button id="hideVideo" class="icon-video-white" data-title="<?php p($l->t('Pause video')) ?>"></button>
-					<button id="toogleScreensharing" class="icon-view-play" data-title="<?php p($l->t('Toggle screensharing')) ?>"></button>
+					<button id="toogleScreensharing" class="icon-screen-off-white screensharing-disabled" data-title="<?php p($l->t('Toggle screensharing')) ?>"></button>
 				</div>
 			</div>
 		</div>

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -49,6 +49,8 @@ script(
 			</div>
 		</header>
 
+		<button id="video-fullscreen" class="icon-fullscreen-white public" data-title="<?php p($l->t('Fullscreen')) ?>"></button>
+
 		<div id="video-speaking">
 
 		</div>
@@ -61,7 +63,6 @@ script(
 				<div class="nameIndicator">
 					<button id="mute" class="icon-audio-white" data-title="<?php p($l->t('Mute audio')) ?>"></button>
 					<button id="hideVideo" class="icon-video-white" data-title="<?php p($l->t('Pause video')) ?>"></button>
-					<button id="video-fullscreen" class="icon-fullscreen-white" data-title="<?php p($l->t('Fullscreen')) ?>"></button>
 					<button id="toogleScreensharing" class="icon-view-play" data-title="<?php p($l->t('Toggle screensharing')) ?>"></button>
 				</div>
 			</div>

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -63,7 +63,7 @@ script(
 				<div class="nameIndicator">
 					<button id="mute" class="icon-audio-white" data-title="<?php p($l->t('Mute audio')) ?>"></button>
 					<button id="hideVideo" class="icon-video-white" data-title="<?php p($l->t('Pause video')) ?>"></button>
-					<button id="toogleScreensharing" class="icon-screen-off-white screensharing-disabled" data-title="<?php p($l->t('Toggle screensharing')) ?>"></button>
+					<button id="toggleScreensharing" class="icon-screen-off-white screensharing-disabled" data-title="<?php p($l->t('Toggle screensharing')) ?>"></button>
 				</div>
 			</div>
 		</div>

--- a/templates/index.php
+++ b/templates/index.php
@@ -35,6 +35,8 @@ script(
 
 	<div id="app-content" class="participants-1">
 
+		<button id="video-fullscreen" class="icon-fullscreen-white" data-title="<?php p($l->t('Fullscreen')) ?>"></button>
+
 		<div id="video-speaking">
 
 		</div>
@@ -47,7 +49,6 @@ script(
 				<div class="nameIndicator">
 					<button id="mute" class="icon-audio-white" data-title="<?php p($l->t('Mute audio')) ?>"></button>
 					<button id="hideVideo" class="icon-video-white" data-title="<?php p($l->t('Pause video')) ?>"></button>
-					<button id="video-fullscreen" class="icon-fullscreen-white" data-title="<?php p($l->t('Fullscreen')) ?>"></button>
 					<button id="toogleScreensharing" class="icon-view-play" data-title="<?php p($l->t('Toggle screensharing')) ?>"></button>
 				</div>
 			</div>

--- a/templates/index.php
+++ b/templates/index.php
@@ -24,7 +24,7 @@ script(
 );
 ?>
 
-<div id="app" data-roomId="<?php p($_['roomId']) ?>">
+<div id="app" class="nc-enable-screensharing-extension" data-roomId="<?php p($_['roomId']) ?>">
 	<div id="app-navigation" class="icon-loading">
 		<form id="oca-spreedme-add-room">
 			<input id="edit-roomname" type="text" placeholder="<?php p($l->t('Choose person …')) ?>"/>

--- a/templates/index.php
+++ b/templates/index.php
@@ -35,7 +35,7 @@ script(
 
 	<div id="app-content" class="participants-1">
 
-		<button id="video-fullscreen" class="icon-fullscreen-white" data-title="<?php p($l->t('Fullscreen')) ?>"></button>
+		<button id="video-fullscreen" class="icon-fullscreen-white" data-placement="bottom" data-toggle="tooltip" data-original-title="<?php p($l->t('Fullscreen')) ?>"></button>
 
 		<div id="video-speaking">
 
@@ -47,9 +47,9 @@ script(
 					<div class="avatar"></div>
 				</div>
 				<div class="nameIndicator">
-					<button id="mute" class="icon-audio-white" data-title="<?php p($l->t('Mute audio')) ?>"></button>
-					<button id="hideVideo" class="icon-video-white" data-title="<?php p($l->t('Pause video')) ?>"></button>
-					<button id="toggleScreensharing" class="icon-screen-off-white screensharing-disabled" data-title="<?php p($l->t('Toggle screensharing')) ?>"></button>
+					<button id="mute" class="icon-audio-white" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Mute audio')) ?>"></button>
+					<button id="hideVideo" class="icon-video-white" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Disable video')) ?>"></button>
+					<button id="toggleScreensharing" class="icon-screen-off-white screensharing-disabled" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Share screen')) ?>"></button>
 				</div>
 			</div>
 		</div>

--- a/templates/index.php
+++ b/templates/index.php
@@ -54,8 +54,7 @@ script(
 			</div>
 		</div>
 
-		<div id="localScreenContainer">
-		</div>
+		<div id="localScreenContainer"></div>
 
 		<div id="emptycontent">
 			<div id="emptycontent-icon" class="icon-video"></div>

--- a/templates/index.php
+++ b/templates/index.php
@@ -49,7 +49,7 @@ script(
 				<div class="nameIndicator">
 					<button id="mute" class="icon-audio-white" data-title="<?php p($l->t('Mute audio')) ?>"></button>
 					<button id="hideVideo" class="icon-video-white" data-title="<?php p($l->t('Pause video')) ?>"></button>
-					<button id="toogleScreensharing" class="icon-view-play" data-title="<?php p($l->t('Toggle screensharing')) ?>"></button>
+					<button id="toogleScreensharing" class="icon-screen-off-white screensharing-disabled" data-title="<?php p($l->t('Toggle screensharing')) ?>"></button>
 				</div>
 			</div>
 		</div>

--- a/templates/index.php
+++ b/templates/index.php
@@ -49,7 +49,7 @@ script(
 				<div class="nameIndicator">
 					<button id="mute" class="icon-audio-white" data-title="<?php p($l->t('Mute audio')) ?>"></button>
 					<button id="hideVideo" class="icon-video-white" data-title="<?php p($l->t('Pause video')) ?>"></button>
-					<button id="toogleScreensharing" class="icon-screen-off-white screensharing-disabled" data-title="<?php p($l->t('Toggle screensharing')) ?>"></button>
+					<button id="toggleScreensharing" class="icon-screen-off-white screensharing-disabled" data-title="<?php p($l->t('Toggle screensharing')) ?>"></button>
 				</div>
 			</div>
 		</div>

--- a/templates/index.php
+++ b/templates/index.php
@@ -48,10 +48,13 @@ script(
 					<button id="mute" class="icon-audio-white" data-title="<?php p($l->t('Mute audio')) ?>"></button>
 					<button id="hideVideo" class="icon-video-white" data-title="<?php p($l->t('Pause video')) ?>"></button>
 					<button id="video-fullscreen" class="icon-fullscreen-white" data-title="<?php p($l->t('Fullscreen')) ?>"></button>
+					<button id="toogleScreensharing" class="icon-view-play" data-title="<?php p($l->t('Toggle screensharing')) ?>"></button>
 				</div>
 			</div>
 		</div>
 
+		<div id="localScreenContainer">
+		</div>
 
 		<div id="emptycontent">
 			<div id="emptycontent-icon" class="icon-video"></div>


### PR DESCRIPTION
This PR adds support for screensharing (#31).

Currently more a tech demo :see_no_evil: various parts still need implementation:
- [X] Chrome support (see https://github.com/nextcloud/spreed-screensharing-chrome-extension for the required extension)
- [X] Firefox support (see https://github.com/nextcloud/spreed-screensharing-firefox-addon for the required extension)
- [x] Add custom icon to toggle screensharing (currently shows a `play` icon below the avatar)
- [x] Better layout of the streams (currently only renders stacked below the other videos)
- [x] Feedback to the user about why it could not be started (currently logs through `console.log` in `app.js`)

cc @jancborchardt for ui, @nickvergessen @LukasReschke, @Ivansss for general review