### PR TITLE
Fixed wrong peer type for regular (video) streams.

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -496,7 +496,7 @@ var spreedMappingTable = [];
 		OCA.SpreedMe.webrtc.on('nick', function(data) {
 			var el = document.getElementById('container_' + OCA.SpreedMe.webrtc.getDomId({
 					id: data.id,
-					type: 'type',
+					type: 'video',
 					broadcaster: false
 				}));
 			var $el = $(el);
@@ -513,7 +513,7 @@ var spreedMappingTable = [];
 		OCA.SpreedMe.webrtc.on('mute', function(data) {
 			var el = document.getElementById('container_' + OCA.SpreedMe.webrtc.getDomId({
 					id: data.id,
-					type: 'type',
+					type: 'video',
 					broadcaster: false
 				}));
 			var $el = $(el);
@@ -544,7 +544,7 @@ var spreedMappingTable = [];
 		OCA.SpreedMe.webrtc.on('unmute', function(data) {
 			var el = document.getElementById('container_' + OCA.SpreedMe.webrtc.getDomId({
 					id: data.id,
-					type: 'type',
+					type: 'video',
 					broadcaster: false
 				}));
 			var $el = $(el);

--- a/js/xhrconnection.js
+++ b/js/xhrconnection.js
@@ -45,7 +45,7 @@ var sessionId = '';
 									result.forEach(function(element) {
 										if(OC.getCurrentUser()['uid'] !== element['userId']) {
 											roomDescription['clients'][element['sessionId']] = {
-												'type': 'video'
+												'video': true
 											};
 										}
 									});


### PR DESCRIPTION
`simplewebrtc.js` is getting the type from the keys in https://github.com/nextcloud/spreed/blob/dc8d7ee32e001794150ae66fffa914a4682cf848/js/simplewebrtc.js#L14149 so the key should be `video`, not `type`.

@nickvergessen @LukasReschke