### PR TITLE
Give user better feedback when launching Spreed

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -303,6 +303,22 @@
 				});
 			}
 		},
+		setEmptyContentMessage: function(icon, message, messageAdditional) {
+			//Remove previous icon, avatar or link from emptycontent
+			var emptyContentIcon = document.getElementById('emptycontent-icon');
+			emptyContentIcon.removeAttribute('class');
+			emptyContentIcon.innerHTML = '';
+			$('#shareRoomInput').addClass('hidden');
+			$('#shareRoomClipboardButton').addClass('hidden');
+
+			$('#emptycontent-icon').addClass(icon);
+			$('#emptycontent h2').text(message);
+			if (messageAdditional) {
+				$('#emptycontent p').text(messageAdditional);
+			} else {
+				$('#emptycontent p').text('');
+			}
+		},
 		showPublicRoomMessage: function(participants) {
 			var message, messageAdditional;
 
@@ -353,14 +369,27 @@
 			$(document).on('click', this.onDocumentClick);
 		},
 		onStart: function() {
+			this.setEmptyContentMessage(
+				'icon-video-off',
+				t('spreed', 'Waiting for camera and microphone permissions'),
+				t('spreed', 'Please, give your browser access to use your camera and microphone in order to use this app.')
+			);
+
+			OCA.SpreedMe.initWebRTC();
+		},
+		startSpreed: function () {
 			console.log('Starting spreed …');
 			var self = this;
+
+			this.setEmptyContentMessage(
+				'icon-video',
+				t('spreed', 'Looking great today! :)'),
+				t('spreed', 'Time to call your friends')
+			);
 
 			if (!oc_current_user) {
 				this.initGuestName();
 			}
-
-			OCA.SpreedMe.initWebRTC();
 
 			if (oc_current_user) {
 				OCA.SpreedMe.initRooms();
@@ -369,6 +398,7 @@
 
 			this._registerPageEvents();
 			this.initShareRoomClipboard();
+
 			var roomId = parseInt($('#app').attr('data-roomId'), 10);
 			if (roomId) {
 				OCA.SpreedMe.Rooms.join(roomId);

--- a/js/app.js
+++ b/js/app.js
@@ -377,7 +377,7 @@
 
 			OCA.SpreedMe.initWebRTC();
 		},
-		startSpreed: function () {
+		startSpreed: function(configuration) {
 			console.log('Starting spreed …');
 			var self = this;
 
@@ -423,8 +423,7 @@
 
 			this._startPing();
 
-			//Show avatar until we receive local video stream and then decide if show video or not.
-			this.hideVideo();
+			this.initAudioVideoSettings(configuration);
 		},
 		onDocumentClick: function(event) {
 			var uiChannel = Backbone.Radio.channel('ui');

--- a/js/rooms.js
+++ b/js/rooms.js
@@ -112,21 +112,17 @@
 			});
 		},
 		showRoomDeletedMessage: function(deleter) {
-			//Remove previous icon, avatar or link from emptycontent
-			var emptyContentIcon = document.getElementById('emptycontent-icon');
-			emptyContentIcon.removeAttribute('class');
-			emptyContentIcon.innerHTML = '';
-			$('#shareRoomInput').addClass('hidden');
-			$('#shareRoomClipboardButton').addClass('hidden');
-
 			if (deleter) {
-				$('#emptycontent-icon').addClass('icon-video');
-				$('#emptycontent h2').text(t('spreed', 'Looking great today! :)'));
-				$('#emptycontent p').text(t('spreed', 'Time to call your friends'));
+				OCA.SpreedMe.app.setEmptyContentMessage(
+					'icon-video',
+					t('spreed', 'Looking great today! :)'),
+					t('spreed', 'Time to call your friends')
+				);
 			} else {
-				$('#emptycontent-icon').addClass('icon-video-off');
-				$('#emptycontent h2').text(t('spreed', 'This call has ended'));
-				$('#emptycontent p').text('');
+				OCA.SpreedMe.app.setEmptyContentMessage(
+					'icon-video-off',
+					t('spreed', 'This call has ended')
+				);
 			}
 		}
 	};

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -270,6 +270,7 @@ var spreedMappingTable = [];
 
 		OCA.SpreedMe.webrtc.on('localMediaStarted', function (configuration) {
 			OCA.SpreedMe.app.initAudioVideoSettings(configuration);
+			OCA.SpreedMe.app.startSpreed();
 		});
 
 		OCA.SpreedMe.webrtc.on('localMediaError', function(error) {
@@ -293,16 +294,14 @@ var spreedMappingTable = [];
 				messageAdditional = error.message || error.name;
 			}
 
-			//Remove previous icon, avatar or link from emptycontent
-			var emptyContentIcon = document.getElementById('emptycontent-icon');
-			emptyContentIcon.removeAttribute('class');
-			emptyContentIcon.innerHTML = '';
-			$('#shareRoomInput').addClass('hidden');
-			$('#shareRoomClipboardButton').addClass('hidden');
+			OCA.SpreedMe.app.setEmptyContentMessage(
+				'icon-video-off',
+				message,
+				messageAdditional
+			);
 
-			$('#emptycontent-icon').addClass('icon-video-off');
-			$('#emptycontent h2').text(message);
-			$('#emptycontent p').text(messageAdditional);
+			// Hide rooms sidebar
+			$('#app-navigation').hide();
 		});
 
 		if(!OCA.SpreedMe.webrtc.capabilities.support) {
@@ -312,16 +311,11 @@ var spreedMappingTable = [];
 			message = t('spreed', 'WebRTC is not supported in your browser :-/');
 			messageAdditional = t('spreed', 'Please use a different browser like Firefox or Chrome');
 
-			//Remove previous icon, avatar or link from emptycontent
-			var emptyContentIcon = document.getElementById('emptycontent-icon');
-			emptyContentIcon.removeAttribute('class');
-			emptyContentIcon.innerHTML = '';
-			$('#shareRoomInput').addClass('hidden');
-			$('#shareRoomClipboardButton').addClass('hidden');
-
-			$('#emptycontent-icon').addClass('icon-video-off');
-			$('#emptycontent h2').text(message);
-			$('#emptycontent p').text(messageAdditional);
+			OCA.SpreedMe.app.setEmptyContentMessage(
+				'icon-video-off',
+				message,
+				messageAdditional
+			);
 		}
 
 		OCA.SpreedMe.webrtc.on('joinedRoom', function(name) {

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -269,8 +269,7 @@ var spreedMappingTable = [];
 		});
 
 		OCA.SpreedMe.webrtc.on('localMediaStarted', function (configuration) {
-			OCA.SpreedMe.app.initAudioVideoSettings(configuration);
-			OCA.SpreedMe.app.startSpreed();
+			OCA.SpreedMe.app.startSpreed(configuration);
 		});
 
 		OCA.SpreedMe.webrtc.on('localMediaError', function(error) {


### PR DESCRIPTION
Improve the feedback given to the user when Spreed app is launched.
Wait to microphone and camera permission before joining a room (it also shows a message to the user).

- Fix #214 