### PR TITLE
Fix roomDescription for guests

### DIFF
--- a/js/xhrconnection.js
+++ b/js/xhrconnection.js
@@ -43,7 +43,7 @@ var sessionId = '';
 									};
 
 									result.forEach(function(element) {
-										if(OC.getCurrentUser()['uid'] !== element['userId']) {
+										if(sessionId !== element['sessionId']) {
 											roomDescription['clients'][element['sessionId']] = {
 												'video': true
 											};


### PR DESCRIPTION
Check against session ids to create roomDescription when joining a room.
Before guests were adding themselves in roomDescription.