### PR TITLE
Restart EventSource if no spreed session

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -2,7 +2,6 @@
 /* global SimpleWebRTC, OC, OCA: false */
 
 var webrtc;
-var spreedEventSource;
 var spreedMappingTable = [];
 
 (function(OCA, OC) {
@@ -15,7 +14,7 @@ var spreedMappingTable = [];
 	 */
 	function openEventSource() {
 		// Connect to the messages endpoint and pull for new messages
-		spreedEventSource = new OC.EventSource(OC.generateUrl('/apps/spreed/messages'));
+		var messageEventSource = new OC.EventSource(OC.generateUrl('/apps/spreed/messages'));
 		var previousUsersInRoom = [];
 		Array.prototype.diff = function(a) {
 			return this.filter(function(i) {
@@ -23,7 +22,7 @@ var spreedMappingTable = [];
 			});
 		};
 
-		spreedEventSource.listen('usersInRoom', function(users) {
+		messageEventSource.listen('usersInRoom', function(users) {
 			var currentUsersInRoom = [];
 			users.forEach(function(user) {
 				currentUsersInRoom.push(user['sessionId']);
@@ -74,7 +73,7 @@ var spreedMappingTable = [];
 			previousUsersInRoom = currentUsersInRoom;
 		});
 
-		spreedEventSource.listen('message', function(message) {
+		messageEventSource.listen('message', function(message) {
 			message = JSON.parse(message);
 			var peers = self.webrtc.getPeers(message.from, message.roomType);
 			var peer;
@@ -111,7 +110,7 @@ var spreedMappingTable = [];
 				});
 			}
 		});
-		spreedEventSource.listen('__internal__', function(data) {
+		messageEventSource.listen('__internal__', function(data) {
 			if (data === 'close') {
 				console.log('signaling connection closed - will reopen');
 				setTimeout(openEventSource, 0);
@@ -369,8 +368,6 @@ var spreedMappingTable = [];
 		OCA.SpreedMe.webrtc.on('joinedRoom', function(name) {
 			$('#app-content').removeClass('icon-loading');
 			$('.videoView').removeClass('hidden');
-			spreedEventSource.close();
-			openEventSource();
 			OCA.SpreedMe.app.syncAndSetActiveRoom(name);
 		});
 

--- a/lib/Controller/SignallingController.php
+++ b/lib/Controller/SignallingController.php
@@ -153,6 +153,7 @@ class SignallingController extends Controller {
 					// User is not active anywhere
 					$eventSource->send('usersInRoom', []);
 					$currentParticipant = false;
+					break;
 				} else {
 					$qb = $this->dbConnection->getQueryBuilder();
 					$qb->select('*')
@@ -220,7 +221,8 @@ class SignallingController extends Controller {
 			$this->dbConnection->close();
 			sleep(1);
 		}
-		exit();
+
+		$eventSource->close();
 	}
 
 	/**


### PR DESCRIPTION
This fixes what wanted to be fixed in #255 

$sessionId = $this->session->get('spreed-session');
https://github.com/nextcloud/spreed/blob/master/lib/Controller/SignallingController.php#L150
sessionId is never updated because it is inside a while loop that never ends.
This makes guests sometimes never able to join a call (If they didn't get the spreed-session before EventSource was started). Now, if this happens, the EventSource will be restarted until it get the current spreed-session.

PR #255 has been reverted because it was causing loses of some signaling messages when the EventSource was restarted. 