### PR TITLE
fix background going white above 10 participants

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -313,15 +313,7 @@ video {
 	border-top-right-radius: 3px;
 }
 
-#app-content.participants-2,
-#app-content.participants-3,
-#app-content.participants-4,
-#app-content.participants-5,
-#app-content.participants-6,
-#app-content.participants-7,
-#app-content.participants-8,
-#app-content.participants-9,
-#app-content.participants-10,
+.videoContainer.promoted,
 #app-content.screensharing {
 	background-color: #000;
 }


### PR DESCRIPTION
This fixes the background switch issue we encountered today in the company call. It should stay black the whole time but went to white above 10 participants:
![many participants](https://cloud.githubusercontent.com/assets/925062/24658745/e4e29ede-194a-11e7-92d7-15ef0d6f2160.png)


Please review @nextcloud/spreed 