### PR TITLE
Fix ICE servers configuration

### DIFF
--- a/js/simplewebrtc.js
+++ b/js/simplewebrtc.js
@@ -18064,8 +18064,8 @@
 		}
 
 		connection.on('stunservers', function (args) {
-			// resets/overrides the config
-			self.webrtc.config.peerConnectionConfig.iceServers = args;
+			// appends to the config
+			self.webrtc.config.peerConnectionConfig.iceServers = self.webrtc.config.peerConnectionConfig.iceServers.concat(args);
 			self.emit('stunservers', args);
 		});
 		connection.on('turnservers', function (args) {

--- a/js/simplewebrtc.js
+++ b/js/simplewebrtc.js
@@ -18402,7 +18402,7 @@
 			debug: false,
 			// makes the entire PC config overridable
 			peerConnectionConfig: {
-				iceServers: [{'urls': 'stun:stun.l.google.com:19302'}]
+				iceServers: []
 			},
 			peerConnectionConstraints: {
 				optional: []


### PR DESCRIPTION
- [x] Fix problem with 'stunservers' and 'turnservers' events:
Sometimes 'stunservers' event is received after 'turnservers' event.
This causes that only the STUN server is set as ICE servers (TURN servers are overwritten).

- [x] Also remove Google's default STUN server