### PR TITLE
Update tooltip when room participants change

### DIFF
--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -83,6 +83,9 @@
 			'change:displayName': function() {
 				this.render();
 			},
+			'change:participants': function() {
+				this.render();
+			},
 			'change:type': function() {
 				this.render();
 				this.checkSharingStatus();


### PR DESCRIPTION
Before, room tooltip was not updated when the room had a room name set.