### PR TITLE
Fix guest name color in light color themings

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -561,7 +561,7 @@ video {
 }
 
 #guestName:hover {
-	color: #fff;
+	color: #fff !important;
 }
 
 #guestNameInput {
@@ -587,4 +587,9 @@ video {
 /* make blue header bar transparent in shared room */
 #body-public #app-content:not(.participants-1) #header.spreed-public {
 	background: transparent;
+}
+
+/* make guest name white because header bar is transparent*/
+#body-public #app-content:not(.participants-1) #guestName {
+    color: rgba(255, 255, 255, 0.7);
 }


### PR DESCRIPTION
Guest name color in light color themings is black.
![screen shot 2017-05-19 at 12 07 20](https://cloud.githubusercontent.com/assets/4638605/26243556/963cd92e-3c8c-11e7-8edf-de38cec8fb47.png)
When the guest is in a call the top bar becomes transparent and the name is not visible anymore.

Now (in-call):
![screen shot 2017-05-19 at 12 08 05](https://cloud.githubusercontent.com/assets/4638605/26243663/dfd1a380-3c8c-11e7-8702-07ba2aa8e157.png)

