### PR TITLE
Open header link of public call page in new tab to not throw people out of call

### DIFF
--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -34,7 +34,7 @@ script(
 		<header>
 			<div id="header" class="spreed-public">
 				<div id="header-left">
-					<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="nextcloud">
+					<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="nextcloud" target="_blank">
 						<div class="logo-icon svg"></div>
 					</a>
 					<div class="header-appname-container">


### PR DESCRIPTION
We just had this issue in a call ;) Please review @rullzer @juliushaertl 