### PR TITLE
Split API controller and clarify method names

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -55,7 +55,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 	<navigations>
 		<navigation>
 			<name>Video calls</name>
-			<route>spreed.page.index</route>
+			<route>spreed.Page.index</route>
 			<order>3</order>
 		</navigation>
 	</navigations>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -24,7 +24,7 @@
 return [
 	'routes' => [
 		[
-			'name' => 'page#index',
+			'name' => 'Page#index',
 			'url' => '/',
 			'verb' => 'GET',
 		],
@@ -46,25 +46,13 @@ return [
 	],
 	'ocs' => [
 		[
-			'name' => 'api#getRooms',
+			'name' => 'Call#getRooms',
 			'url' => '/api/{apiVersion}/room',
 			'verb' => 'GET',
 			'requirements' => ['apiVersion' => 'v1'],
 		],
 		[
-			'name' => 'api#makePublic',
-			'url' => '/api/{apiVersion}/room/public',
-			'verb' => 'POST',
-			'requirements' => ['apiVersion' => 'v1'],
-		],
-		[
-			'name' => 'api#makePrivate',
-			'url' => '/api/{apiVersion}/room/public',
-			'verb' => 'DELETE',
-			'requirements' => ['apiVersion' => 'v1'],
-		],
-		[
-			'name' => 'api#getRoom',
+			'name' => 'Call#getRoom',
 			'url' => '/api/{apiVersion}/room/{token}',
 			'verb' => 'GET',
 			'requirements' => [
@@ -73,34 +61,7 @@ return [
 			],
 		],
 		[
-			'name' => 'api#renameRoom',
-			'url' => '/api/{apiVersion}/room/{roomId}',
-			'verb' => 'PUT',
-			'requirements' => [
-				'apiVersion' => 'v1',
-				'roomId' => '\d+'
-			],
-		],
-		[
-			'name' => 'api#addParticipantToRoom',
-			'url' => '/api/{apiVersion}/room/{roomId}',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v1',
-				'roomId' => '\d+'
-			],
-		],
-		[
-			'name' => 'api#leaveRoom',
-			'url' => '/api/{apiVersion}/room/{roomId}',
-			'verb' => 'DELETE',
-			'requirements' => [
-				'apiVersion' => 'v1',
-				'roomId' => '\d+'
-			],
-		],
-		[
-			'name' => 'api#getPeersInRoom',
+			'name' => 'Call#getPeersInRoom',
 			'url' => '/api/{apiVersion}/room/{token}/peers',
 			'verb' => 'GET',
 			'requirements' => [
@@ -109,7 +70,7 @@ return [
 			],
 		],
 		[
-			'name' => 'api#joinRoom',
+			'name' => 'Call#joinRoom',
 			'url' => '/api/{apiVersion}/room/{token}/join',
 			'verb' => 'POST',
 			'requirements' => [
@@ -118,7 +79,7 @@ return [
 			],
 		],
 		[
-			'name' => 'api#ping',
+			'name' => 'Call#ping',
 			'url' => '/api/{apiVersion}/ping',
 			'verb' => 'POST',
 			'requirements' => [
@@ -127,28 +88,68 @@ return [
 			],
 		],
 		[
-			'name' => 'api#leave',
+			'name' => 'Call#leave',
 			'url' => '/api/{apiVersion}/leave',
 			'verb' => 'DELETE',
 			'requirements' => ['apiVersion' => 'v1'],
 		],
+
 		[
-			'name' => 'api#createOneToOneRoom',
+			'name' => 'Room#createOneToOneRoom',
 			'url' => '/api/{apiVersion}/oneToOne',
 			'verb' => 'PUT',
 			'requirements' => ['apiVersion' => 'v1'],
 		],
 		[
-			'name' => 'api#createGroupRoom',
+			'name' => 'Room#createGroupRoom',
 			'url' => '/api/{apiVersion}/group',
 			'verb' => 'PUT',
 			'requirements' => ['apiVersion' => 'v1'],
 		],
 		[
-			'name' => 'api#createPublicRoom',
+			'name' => 'Room#createPublicRoom',
 			'url' => '/api/{apiVersion}/public',
 			'verb' => 'PUT',
 			'requirements' => ['apiVersion' => 'v1'],
+		],
+		[
+			'name' => 'Room#renameRoom',
+			'url' => '/api/{apiVersion}/room/{roomId}',
+			'verb' => 'PUT',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'roomId' => '\d+'
+			],
+		],
+		[
+			'name' => 'Room#makePublic',
+			'url' => '/api/{apiVersion}/room/public',
+			'verb' => 'POST',
+			'requirements' => ['apiVersion' => 'v1'],
+		],
+		[
+			'name' => 'Room#makePrivate',
+			'url' => '/api/{apiVersion}/room/public',
+			'verb' => 'DELETE',
+			'requirements' => ['apiVersion' => 'v1'],
+		],
+		[
+			'name' => 'Room#addParticipantToRoom',
+			'url' => '/api/{apiVersion}/room/{roomId}',
+			'verb' => 'POST',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'roomId' => '\d+'
+			],
+		],
+		[
+			'name' => 'Room#leaveRoom',
+			'url' => '/api/{apiVersion}/room/{roomId}',
+			'verb' => 'DELETE',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'roomId' => '\d+'
+			],
 		],
 	],
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -70,7 +70,7 @@ return [
 			],
 		],
 		[
-			'name' => 'Call#joinRoom',
+			'name' => 'Call#joinCall',
 			'url' => '/api/{apiVersion}/room/{token}/join',
 			'verb' => 'POST',
 			'requirements' => [
@@ -88,7 +88,7 @@ return [
 			],
 		],
 		[
-			'name' => 'Call#leave',
+			'name' => 'Call#leaveCall',
 			'url' => '/api/{apiVersion}/leave',
 			'verb' => 'DELETE',
 			'requirements' => ['apiVersion' => 'v1'],
@@ -143,7 +143,7 @@ return [
 			],
 		],
 		[
-			'name' => 'Room#leaveRoom',
+			'name' => 'Room#removeSelfFromRoom',
 			'url' => '/api/{apiVersion}/room/{roomId}',
 			'verb' => 'DELETE',
 			'requirements' => [

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -79,7 +79,7 @@ return [
 			],
 		],
 		[
-			'name' => 'Call#ping',
+			'name' => 'Call#pingCall',
 			'url' => '/api/{apiVersion}/ping',
 			'verb' => 'POST',
 			'requirements' => [

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -123,19 +123,19 @@ return [
 		],
 		[
 			'name' => 'Room#makePublic',
-			'url' => '/api/{apiVersion}/room/public',
+			'url' => '/api/{apiVersion}/room/{roomId}/public',
 			'verb' => 'POST',
 			'requirements' => ['apiVersion' => 'v1'],
 		],
 		[
 			'name' => 'Room#makePrivate',
-			'url' => '/api/{apiVersion}/room/public',
+			'url' => '/api/{apiVersion}/room/{roomId}/public',
 			'verb' => 'DELETE',
 			'requirements' => ['apiVersion' => 'v1'],
 		],
 		[
 			'name' => 'Room#addParticipantToRoom',
-			'url' => '/api/{apiVersion}/room/{roomId}',
+			'url' => '/api/{apiVersion}/room/{roomId}/participants',
 			'verb' => 'POST',
 			'requirements' => [
 				'apiVersion' => 'v1',
@@ -144,7 +144,7 @@ return [
 		],
 		[
 			'name' => 'Room#removeSelfFromRoom',
-			'url' => '/api/{apiVersion}/room/{roomId}',
+			'url' => '/api/{apiVersion}/room/{roomId}/participants/self',
 			'verb' => 'DELETE',
 			'requirements' => [
 				'apiVersion' => 'v1',

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -89,6 +89,12 @@ return [
 			'requirements' => ['apiVersion' => 'v1'],
 		],
 		[
+			'name' => 'Room#createRoom',
+			'url' => '/api/{apiVersion}/room',
+			'verb' => 'POST',
+			'requirements' => ['apiVersion' => 'v1'],
+		],
+		[
 			'name' => 'Room#getRoom',
 			'url' => '/api/{apiVersion}/room/{token}',
 			'verb' => 'GET',
@@ -98,48 +104,48 @@ return [
 			],
 		],
 		[
-			'name' => 'Room#createRoom',
-			'url' => '/api/{apiVersion}/room',
-			'verb' => 'POST',
-			'requirements' => ['apiVersion' => 'v1'],
-		],
-		[
 			'name' => 'Room#renameRoom',
-			'url' => '/api/{apiVersion}/room/{roomId}',
+			'url' => '/api/{apiVersion}/room/{token}',
 			'verb' => 'PUT',
 			'requirements' => [
 				'apiVersion' => 'v1',
-				'roomId' => '\d+'
+				'token' => '^[a-z0-9]{4,30}$',
 			],
 		],
 		[
 			'name' => 'Room#makePublic',
-			'url' => '/api/{apiVersion}/room/{roomId}/public',
-			'verb' => 'POST',
-			'requirements' => ['apiVersion' => 'v1'],
-		],
-		[
-			'name' => 'Room#makePrivate',
-			'url' => '/api/{apiVersion}/room/{roomId}/public',
-			'verb' => 'DELETE',
-			'requirements' => ['apiVersion' => 'v1'],
-		],
-		[
-			'name' => 'Room#addParticipantToRoom',
-			'url' => '/api/{apiVersion}/room/{roomId}/participants',
+			'url' => '/api/{apiVersion}/room/{token}/public',
 			'verb' => 'POST',
 			'requirements' => [
 				'apiVersion' => 'v1',
-				'roomId' => '\d+'
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
+		[
+			'name' => 'Room#makePrivate',
+			'url' => '/api/{apiVersion}/room/{token}/public',
+			'verb' => 'DELETE',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
+		[
+			'name' => 'Room#addParticipantToRoom',
+			'url' => '/api/{apiVersion}/room/{token}/participants',
+			'verb' => 'POST',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
 			],
 		],
 		[
 			'name' => 'Room#removeSelfFromRoom',
-			'url' => '/api/{apiVersion}/room/{roomId}/participants/self',
+			'url' => '/api/{apiVersion}/room/{token}/participants/self',
 			'verb' => 'DELETE',
 			'requirements' => [
 				'apiVersion' => 'v1',
-				'roomId' => '\d+'
+				'token' => '^[a-z0-9]{4,30}$',
 			],
 		],
 	],

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -29,12 +29,12 @@ return [
 			'verb' => 'GET',
 		],
 		[
-			'name' => 'signalling#signalling',
+			'name' => 'Signalling#signalling',
 			'url' => '/signalling',
 			'verb' => 'POST',
 		],
 		[
-			'name' => 'signalling#pullMessages',
+			'name' => 'Signalling#pullMessages',
 			'url' => '/messages',
 			'verb' => 'GET',
 		],

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -47,7 +47,7 @@ return [
 	'ocs' => [
 		[
 			'name' => 'Call#getPeersForCall',
-			'url' => '/api/{apiVersion}/room/{token}/peers',
+			'url' => '/api/{apiVersion}/call/{token}',
 			'verb' => 'GET',
 			'requirements' => [
 				'apiVersion' => 'v1',
@@ -56,7 +56,7 @@ return [
 		],
 		[
 			'name' => 'Call#joinCall',
-			'url' => '/api/{apiVersion}/room/{token}/join',
+			'url' => '/api/{apiVersion}/call/{token}',
 			'verb' => 'POST',
 			'requirements' => [
 				'apiVersion' => 'v1',
@@ -65,8 +65,8 @@ return [
 		],
 		[
 			'name' => 'Call#pingCall',
-			'url' => '/api/{apiVersion}/ping',
-			'verb' => 'POST',
+			'url' => '/api/{apiVersion}/call/{token}',
+			'verb' => 'PUT',
 			'requirements' => [
 				'apiVersion' => 'v1',
 				'token' => '^[a-z0-9]{4,30}$',
@@ -74,7 +74,7 @@ return [
 		],
 		[
 			'name' => 'Call#leaveCall',
-			'url' => '/api/{apiVersion}/leave',
+			'url' => '/api/{apiVersion}/call',
 			'verb' => 'DELETE',
 			'requirements' => ['apiVersion' => 'v1'],
 		],

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -95,21 +95,9 @@ return [
 			],
 		],
 		[
-			'name' => 'Room#createOneToOneRoom',
-			'url' => '/api/{apiVersion}/oneToOne',
-			'verb' => 'PUT',
-			'requirements' => ['apiVersion' => 'v1'],
-		],
-		[
-			'name' => 'Room#createGroupRoom',
-			'url' => '/api/{apiVersion}/group',
-			'verb' => 'PUT',
-			'requirements' => ['apiVersion' => 'v1'],
-		],
-		[
-			'name' => 'Room#createPublicRoom',
-			'url' => '/api/{apiVersion}/public',
-			'verb' => 'PUT',
+			'name' => 'Room#createRoom',
+			'url' => '/api/{apiVersion}/room',
+			'verb' => 'POST',
 			'requirements' => ['apiVersion' => 'v1'],
 		],
 		[

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -74,9 +74,12 @@ return [
 		],
 		[
 			'name' => 'Call#leaveCall',
-			'url' => '/api/{apiVersion}/call',
+			'url' => '/api/{apiVersion}/call/{token}',
 			'verb' => 'DELETE',
-			'requirements' => ['apiVersion' => 'v1'],
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
 		],
 
 		[

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -46,21 +46,6 @@ return [
 	],
 	'ocs' => [
 		[
-			'name' => 'Call#getRooms',
-			'url' => '/api/{apiVersion}/room',
-			'verb' => 'GET',
-			'requirements' => ['apiVersion' => 'v1'],
-		],
-		[
-			'name' => 'Call#getRoom',
-			'url' => '/api/{apiVersion}/room/{token}',
-			'verb' => 'GET',
-			'requirements' => [
-				'apiVersion' => 'v1',
-				'token' => '^[a-z0-9]{4,30}$',
-			],
-		],
-		[
 			'name' => 'Call#getPeersInRoom',
 			'url' => '/api/{apiVersion}/room/{token}/peers',
 			'verb' => 'GET',
@@ -94,6 +79,21 @@ return [
 			'requirements' => ['apiVersion' => 'v1'],
 		],
 
+		[
+			'name' => 'Room#getRooms',
+			'url' => '/api/{apiVersion}/room',
+			'verb' => 'GET',
+			'requirements' => ['apiVersion' => 'v1'],
+		],
+		[
+			'name' => 'Room#getRoom',
+			'url' => '/api/{apiVersion}/room/{token}',
+			'verb' => 'GET',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
 		[
 			'name' => 'Room#createOneToOneRoom',
 			'url' => '/api/{apiVersion}/oneToOne',

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -46,7 +46,7 @@ return [
 	],
 	'ocs' => [
 		[
-			'name' => 'Call#getPeersInRoom',
+			'name' => 'Call#getPeersForCall',
 			'url' => '/api/{apiVersion}/room/{token}/peers',
 			'verb' => 'GET',
 			'requirements' => [

--- a/js/rooms.js
+++ b/js/rooms.js
@@ -33,9 +33,12 @@
 		createOneToOneVideoCall: function(recipientUserId) {
 			console.log(recipientUserId);
 			$.ajax({
-				url: OC.linkToOCS('apps/spreed/api/v1', 2) + 'oneToOne',
-				type: 'PUT',
-				data: 'targetUserName='+recipientUserId,
+				url: OC.linkToOCS('apps/spreed/api/v1', 2) + 'room',
+				type: 'POST',
+				data: {
+					invite: recipientUserId,
+					roomType: 1
+				},
 				beforeSend: function (request) {
 					request.setRequestHeader('Accept', 'application/json');
 				},
@@ -45,9 +48,12 @@
 		createGroupVideoCall: function(groupId) {
 			console.log(groupId);
 			$.ajax({
-				url: OC.linkToOCS('apps/spreed/api/v1', 2) + 'group',
-				type: 'PUT',
-				data: 'targetGroupName='+groupId,
+				url: OC.linkToOCS('apps/spreed/api/v1', 2) + 'room',
+				type: 'POST',
+				data: {
+					invite: groupId,
+					roomType: 2
+				},
 				beforeSend: function (request) {
 					request.setRequestHeader('Accept', 'application/json');
 				},
@@ -57,8 +63,11 @@
 		createPublicVideoCall: function() {
 			console.log("Creating a new public room.");
 			$.ajax({
-				url: OC.linkToOCS('apps/spreed/api/v1', 2) + 'public',
-				type: 'PUT',
+				url: OC.linkToOCS('apps/spreed/api/v1', 2) + 'room',
+				type: 'POST',
+				data: {
+					roomType: 3
+				},
 				beforeSend: function (request) {
 					request.setRequestHeader('Accept', 'application/json');
 				},

--- a/js/rooms.js
+++ b/js/rooms.js
@@ -94,7 +94,7 @@
 				beforeSend: function (request) {
 					request.setRequestHeader('Accept', 'application/json');
 				},
-				url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + token + '/peers'
+				url: OC.linkToOCS('apps/spreed/api/v1/call', 2) + token
 			});
 		},
 		ping: function() {
@@ -102,12 +102,10 @@
 				return;
 			}
 
-			$.post(
-				OC.linkToOCS('apps/spreed/api/v1', 2) + 'ping',
-				{
-					token: OCA.SpreedMe.Rooms.currentRoom()
-				}
-			).done(function() {
+			$.ajax({
+				url: OC.linkToOCS('apps/spreed/api/v1/call', 2) + OCA.SpreedMe.Rooms.currentRoom(),
+				method: 'PUT'
+			}).done(function() {
 				pingFails = 0;
 			}).fail(function(xhr) {
 				// If there is an error when pinging, retry for 3 times.
@@ -121,7 +119,7 @@
 		},
 		leaveAllRooms: function() {
 			$.ajax({
-				url: OC.linkToOCS('apps/spreed/api/v1', 2) + 'leave',
+				url: OC.linkToOCS('apps/spreed/api/v1/call', 2),
 				method: 'DELETE',
 				async: false
 			});

--- a/js/rooms.js
+++ b/js/rooms.js
@@ -127,8 +127,13 @@
 			});
 		},
 		leaveAllRooms: function() {
+			var token = OCA.SpreedMe.Rooms.currentRoom();
+			if (!token) {
+				return;
+			}
+
 			$.ajax({
-				url: OC.linkToOCS('apps/spreed/api/v1/call', 2),
+				url: OC.linkToOCS('apps/spreed/api/v1/call', 2) + token,
 				method: 'DELETE',
 				async: false
 			});

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -113,7 +113,7 @@
 				// their signalling information.
 				var callback = arguments[2];
 				$.ajax({
-					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + data + '/join',
+					url: OC.linkToOCS('apps/spreed/api/v1/call', 2) + data,
 					type: 'POST',
 					beforeSend: function (request) {
 						request.setRequestHeader('Accept', 'application/json');

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -265,9 +265,8 @@
 			// This should be the only case
 			if (this.model.get('type') !== ROOM_TYPE_PUBLIC_CALL) {
 				$.ajax({
-					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + 'public',
+					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('id') + '/public',
 					type: 'POST',
-					data: 'roomId='+this.model.get('id'),
 					success: function() {
 						app.syncRooms();
 					}
@@ -280,9 +279,8 @@
 			// This should be the only case
 			if (this.model.get('type') === ROOM_TYPE_PUBLIC_CALL) {
 				$.ajax({
-					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + 'public',
+					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('id') + '/public',
 					type: 'DELETE',
-					data: 'roomId='+this.model.get('id'),
 					success: function() {
 						app.syncRooms();
 					}
@@ -300,7 +298,7 @@
 			this.$el.slideUp();
 
 			$.ajax({
-				url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('id'),
+				url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('id') + '/participants/self',
 				type: 'DELETE'
 			});
 		},
@@ -526,7 +524,7 @@
 				var app = OCA.SpreedMe.app;
 
 				$.post(
-					OC.linkToOCS('apps/spreed/api/v1/room', 2) + _this.model.get('id'),
+					OC.linkToOCS('apps/spreed/api/v1/room', 2) + _this.model.get('id') + '/participants',
 					{
 						newParticipant: e.val
 					}

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -250,7 +250,7 @@
 			// This should be the only case
 			if ((this.model.get('type') !== ROOM_TYPE_ONE_TO_ONE) && (roomName.length <= 200)) {
 				$.ajax({
-					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('id'),
+					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('token'),
 					type: 'PUT',
 					data: 'roomName='+roomName,
 					success: function() {
@@ -265,7 +265,7 @@
 			// This should be the only case
 			if (this.model.get('type') !== ROOM_TYPE_PUBLIC_CALL) {
 				$.ajax({
-					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('id') + '/public',
+					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('token') + '/public',
 					type: 'POST',
 					success: function() {
 						app.syncRooms();
@@ -279,7 +279,7 @@
 			// This should be the only case
 			if (this.model.get('type') === ROOM_TYPE_PUBLIC_CALL) {
 				$.ajax({
-					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('id') + '/public',
+					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('token') + '/public',
 					type: 'DELETE',
 					success: function() {
 						app.syncRooms();
@@ -298,7 +298,7 @@
 			this.$el.slideUp();
 
 			$.ajax({
-				url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('id') + '/participants/self',
+				url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('token') + '/participants/self',
 				type: 'DELETE'
 			});
 		},
@@ -524,7 +524,7 @@
 				var app = OCA.SpreedMe.app;
 
 				$.post(
-					OC.linkToOCS('apps/spreed/api/v1/room', 2) + _this.model.get('id') + '/participants',
+					OC.linkToOCS('apps/spreed/api/v1/room', 2) + _this.model.get('token') + '/participants',
 					{
 						newParticipant: e.val
 					}

--- a/lib/ContactsMenu/Providers/CallProvider.php
+++ b/lib/ContactsMenu/Providers/CallProvider.php
@@ -71,7 +71,7 @@ class CallProvider implements IProvider {
 		}
 
 		$iconUrl = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'actions/video.svg'));
-		$callUrl = $this->urlGenerator->linkToRouteAbsolute('spreed.page.index') . '?callUser=' . $uid;
+		$callUrl = $this->urlGenerator->linkToRouteAbsolute('spreed.Page.index') . '?callUser=' . $uid;
 		$action = $this->actionFactory->newLinkAction($iconUrl, $this->l10n->t('Video call'), $callUrl);
 		$entry->addAction($action);
 	}

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -71,7 +71,7 @@ class CallController extends OCSController {
 	 * @param string $token
 	 * @return DataResponse
 	 */
-	public function getPeersInRoom($token) {
+	public function getPeersForCall($token) {
 		try {
 			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
 		} catch (RoomNotFoundException $e) {

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -125,10 +125,7 @@ class CallController extends OCSController {
 		/** @var array[] $participants */
 		$participants = $room->getParticipants();
 		$sortParticipants = function(array $participant1, array $participant2) {
-			if ($participant1['lastPing'] === $participant2['lastPing']) {
-				return 0;
-			}
-			return ($participant1['lastPing'] > $participant2['lastPing']) ? -1 : 1;
+			return $participant2['lastPing'] - $participant1['lastPing'];
 		};
 		uasort($participants['users'], $sortParticipants);
 		uasort($participants['guests'], $sortParticipants);
@@ -312,7 +309,7 @@ class CallController extends OCSController {
 	 * @param string $token
 	 * @return DataResponse
 	 */
-	public function ping($token) {
+	public function pingCall($token) {
 		try {
 			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
 		} catch (RoomNotFoundException $e) {

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -163,10 +163,12 @@ class CallController extends OCSController {
 	 * @PublicPage
 	 * @UseSession
 	 *
+	 * @param string $token
 	 * @return DataResponse
 	 */
-	public function leaveCall() {
+	public function leaveCall($token) {
 		if ($this->userId !== null) {
+			// TODO: Currently we ignore $token, should be fixed at some point
 			$this->manager->disconnectUserFromAllRooms($this->userId);
 		} else {
 			$sessionId = $this->session->get('spreed-session');

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -27,28 +27,19 @@ namespace OCA\Spreed\Controller;
 
 use OCA\Spreed\Exceptions\RoomNotFoundException;
 use OCA\Spreed\Manager;
-use OCA\Spreed\Room;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
-use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IRequest;
 use OCP\ISession;
-use OCP\IUser;
 use OCP\IUserManager;
 
 class CallController extends OCSController {
 	/** @var string */
 	private $userId;
-	/** @var IL10N */
-	private $l10n;
-	/** @var IUserManager */
-	private $userManager;
 	/** @var ISession */
 	private $session;
-	/** @var ILogger */
-	private $logger;
 	/** @var Manager */
 	private $manager;
 
@@ -56,7 +47,6 @@ class CallController extends OCSController {
 	 * @param string $appName
 	 * @param string $UserId
 	 * @param IRequest $request
-	 * @param IL10N $l10n
 	 * @param IUserManager $userManager
 	 * @param ISession $session
 	 * @param ILogger $logger
@@ -65,167 +55,14 @@ class CallController extends OCSController {
 	public function __construct($appName,
 								$UserId,
 								IRequest $request,
-								IL10N $l10n,
 								IUserManager $userManager,
 								ISession $session,
 								ILogger $logger,
 								Manager $manager) {
 		parent::__construct($appName, $request);
 		$this->userId = $UserId;
-		$this->l10n = $l10n;
-		$this->userManager = $userManager;
 		$this->session = $session;
-		$this->logger = $logger;
 		$this->manager = $manager;
-	}
-
-	/**
-	 * Get all currently existent rooms which the user has joined
-	 *
-	 * @NoAdminRequired
-	 *
-	 * @return DataResponse
-	 */
-	public function getRooms() {
-		$rooms = $this->manager->getRoomsForParticipant($this->userId);
-
-		$return = [];
-		foreach ($rooms as $room) {
-			try {
-				$return[] = $this->formatRoom($room);
-			} catch (RoomNotFoundException $e) {
-			}
-		}
-
-		return new DataResponse($return);
-	}
-
-	/**
-	 * @PublicPage
-	 *
-	 * @param string $token
-	 * @return DataResponse
-	 */
-	public function getRoom($token) {
-		try {
-			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
-			return new DataResponse($this->formatRoom($room));
-		} catch (RoomNotFoundException $e) {
-			return new DataResponse([], Http::STATUS_NOT_FOUND);
-		}
-	}
-
-	/**
-	 * @param Room $room
-	 * @return array
-	 * @throws RoomNotFoundException
-	 */
-	protected function formatRoom(Room $room) {
-		// Sort by lastPing
-		/** @var array[] $participants */
-		$participants = $room->getParticipants();
-		$sortParticipants = function(array $participant1, array $participant2) {
-			return $participant2['lastPing'] - $participant1['lastPing'];
-		};
-		uasort($participants['users'], $sortParticipants);
-		uasort($participants['guests'], $sortParticipants);
-
-		$participantList = [];
-		foreach ($participants['users'] as $participant => $lastPing) {
-			$user = $this->userManager->get($participant);
-			if ($user instanceof IUser) {
-				$participantList[$participant] = $user->getDisplayName();
-			}
-		}
-
-		$roomData = [
-			'id' => $room->getId(),
-			'token' => $room->getToken(),
-			'type' => $room->getType(),
-			'name' => $room->getName(),
-			'displayName' => $room->getName(),
-			'isNameEditable' => $room->getType() !== Room::ONE_TO_ONE_CALL,
-			'count' => $room->getNumberOfParticipants(time() - 30),
-			'lastPing' => isset($participants['users'][$this->userId]['lastPing']) ? $participants['users'][$this->userId]['lastPing'] : 0,
-			'sessionId' => isset($participants['users'][$this->userId]['sessionId']) ? $participants['users'][$this->userId]['sessionId'] : '0',
-			'participants' => $participantList,
-		];
-
-		$activeGuests = array_filter($participants['guests'], function($data) {
-			return $data['lastPing'] > time() - 30;
-		});
-
-		$numActiveGuests = count($activeGuests);
-		if ($numActiveGuests !== count($participants['guests'])) {
-			$room->cleanGuestParticipants();
-		}
-
-		if ($this->userId !== null) {
-			unset($participantList[$this->userId]);
-			$numOtherParticipants = count($participantList);
-			$numGuestParticipants = $numActiveGuests;
-		} else {
-			$numOtherParticipants = count($participantList);
-			$numGuestParticipants = $numActiveGuests - 1;
-		}
-
-		$guestString = '';
-		switch ($room->getType()) {
-			case Room::ONE_TO_ONE_CALL:
-				// As name of the room use the name of the other person participating
-				if ($numOtherParticipants === 1) {
-					// Only one other participant
-					reset($participantList);
-					$roomData['name'] = key($participantList);
-					$roomData['displayName'] = $participantList[$roomData['name']];
-				} else {
-					// Invalid user count, there must be exactly 2 users in each one2one room
-					$this->logger->warning('one2one room found with invalid participant count. Leaving room for everyone', [
-						'app' => 'spreed',
-					]);
-					$room->deleteRoom();
-				}
-				break;
-
-			/** @noinspection PhpMissingBreakStatementInspection */
-			case Room::PUBLIC_CALL:
-				if ($this->userId === null && $numGuestParticipants) {
-					$guestString = $this->l10n->n('%n other guest', '%n other guests', $numGuestParticipants);
-				} else if ($numGuestParticipants) {
-					$guestString = $this->l10n->n('%n guest', '%n guests', $numGuestParticipants);
-				}
-
-				// no break;
-
-			case Room::GROUP_CALL:
-				if ($room->getName() === '') {
-					// As name of the room use the names of the other participants
-					if ($this->userId === null) {
-						$participantList[] = $this->l10n->t('You');
-					} else if ($numOtherParticipants === 0) {
-						$participantList = [$this->l10n->t('You')];
-					}
-
-					if ($guestString !== '') {
-						$participantList[] = $guestString;
-					}
-
-					$roomData['displayName'] = implode($this->l10n->t(', '), $participantList);
-				}
-				break;
-
-			default:
-				// Invalid room type
-				$this->logger->warning('Invalid room type found. Leaving room for everyone', [
-					'app' => 'spreed',
-				]);
-				$room->deleteRoom();
-				throw new RoomNotFoundException();
-		}
-
-		$roomData['guestList'] = $guestString;
-
-		return $roomData;
 	}
 
 	/**

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -275,31 +275,12 @@ class CallController extends OCSController {
 
 	/**
 	 * @PublicPage
-	 *
-	 * @param string $token
-	 * @return DataResponse
-	 */
-	public function ping($token) {
-		try {
-			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
-		} catch (RoomNotFoundException $e) {
-			return new DataResponse([], Http::STATUS_NOT_FOUND);
-		}
-
-		$sessionId = $this->session->get('spreed-session');
-		$room->ping($this->userId, $sessionId, time());
-
-		return new DataResponse();
-	}
-
-	/**
-	 * @PublicPage
 	 * @UseSession
 	 *
 	 * @param string $token
 	 * @return DataResponse
 	 */
-	public function joinRoom($token) {
+	public function joinCall($token) {
 		try {
 			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
 		} catch (RoomNotFoundException $e) {
@@ -327,11 +308,30 @@ class CallController extends OCSController {
 
 	/**
 	 * @PublicPage
+	 *
+	 * @param string $token
+	 * @return DataResponse
+	 */
+	public function ping($token) {
+		try {
+			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
+		} catch (RoomNotFoundException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		$sessionId = $this->session->get('spreed-session');
+		$room->ping($this->userId, $sessionId, time());
+
+		return new DataResponse();
+	}
+
+	/**
+	 * @PublicPage
 	 * @UseSession
 	 *
 	 * @return DataResponse
 	 */
-	public function leave() {
+	public function leaveCall() {
 		if ($this->userId !== null) {
 			$this->manager->disconnectUserFromAllRooms($this->userId);
 		} else {

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -32,7 +32,6 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
-use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -42,10 +41,8 @@ use OCP\Security\ISecureRandom;
 class PageController extends Controller {
 	/** @var string */
 	private $userId;
-	/** @var ManagementController */
+	/** @var RoomController */
 	private $api;
-	/** @var IL10N */
-	private $l10n;
 	/** @var ILogger */
 	private $logger;
 	/** @var Manager */
@@ -60,9 +57,8 @@ class PageController extends Controller {
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
-	 * @param ManagementController $api
+	 * @param RoomController $api
 	 * @param string $UserId
-	 * @param IL10N $l10n
 	 * @param ILogger $logger
 	 * @param Manager $manager
 	 * @param ISecureRandom $secureRandom
@@ -71,9 +67,8 @@ class PageController extends Controller {
 	 */
 	public function __construct($appName,
 								IRequest $request,
-								ManagementController $api,
+								RoomController $api,
 								$UserId,
-								IL10N $l10n,
 								ILogger $logger,
 								Manager $manager,
 								ISecureRandom $secureRandom,
@@ -82,7 +77,6 @@ class PageController extends Controller {
 		parent::__construct($appName, $request);
 		$this->userId = $UserId;
 		$this->api = $api;
-		$this->l10n = $l10n;
 		$this->logger = $logger;
 		$this->manager = $manager;
 		$this->secureRandom = $secureRandom;

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -42,7 +42,7 @@ use OCP\Security\ISecureRandom;
 class PageController extends Controller {
 	/** @var string */
 	private $userId;
-	/** @var ApiController */
+	/** @var ManagementController */
 	private $api;
 	/** @var IL10N */
 	private $l10n;
@@ -60,7 +60,7 @@ class PageController extends Controller {
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
-	 * @param ApiController $api
+	 * @param ManagementController $api
 	 * @param string $UserId
 	 * @param IL10N $l10n
 	 * @param ILogger $logger
@@ -71,7 +71,7 @@ class PageController extends Controller {
 	 */
 	public function __construct($appName,
 								IRequest $request,
-								ApiController $api,
+								ManagementController $api,
 								$UserId,
 								IL10N $l10n,
 								ILogger $logger,
@@ -132,7 +132,7 @@ class PageController extends Controller {
 			$response = $this->api->createOneToOneRoom($callUser);
 			if ($response->getStatus() !== Http::STATUS_NOT_FOUND) {
 				$data = $response->getData();
-				return new RedirectResponse($this->url->linkToRoute('spreed.pagecontroller.showCall', ['token' => $data['token']]));
+				return new RedirectResponse($this->url->linkToRoute('spreed.Page.showCall', ['token' => $data['token']]));
 			}
 		}
 
@@ -161,7 +161,7 @@ class PageController extends Controller {
 			}
 		} catch (RoomNotFoundException $e) {
 			return new RedirectResponse($this->url->linkToRoute('core.login.showLoginForm', [
-				'redirect_url' => $this->url->linkToRoute('spreed.page.index', ['token' => $token]),
+				'redirect_url' => $this->url->linkToRoute('spreed.Page.index', ['token' => $token]),
 			]));
 		}
 
@@ -190,13 +190,13 @@ class PageController extends Controller {
 				if ($room->getType() !== Room::PUBLIC_CALL) {
 					throw new RoomNotFoundException();
 				}
-				return new RedirectResponse($this->url->linkToRoute('spreed.page.index', ['token' => $token]));
+				return new RedirectResponse($this->url->linkToRoute('spreed.Page.index', ['token' => $token]));
 			} catch (RoomNotFoundException $e) {
 				return new RedirectResponse($this->url->linkToRoute('core.login.showLoginForm', [
-					'redirect_url' => $this->url->linkToRoute('spreed.page.index', ['token' => $token]),
+					'redirect_url' => $this->url->linkToRoute('spreed.Page.index', ['token' => $token]),
 				]));
 			}
 		}
-		return new RedirectResponse($this->url->linkToRoute('spreed.page.index', ['token' => $token]));
+		return new RedirectResponse($this->url->linkToRoute('spreed.Page.index', ['token' => $token]));
 	}
 }

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -123,7 +123,7 @@ class PageController extends Controller {
 				$token = '';
 			}
 		} else {
-			$response = $this->api->createOneToOneRoom($callUser);
+			$response = $this->api->createRoom(Room::ONE_TO_ONE_CALL, $callUser);
 			if ($response->getStatus() !== Http::STATUS_NOT_FOUND) {
 				$data = $response->getData();
 				return new RedirectResponse($this->url->linkToRoute('spreed.Page.showCall', ['token' => $data['token']]));

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -238,7 +238,7 @@ class RoomController extends OCSController {
 	 * @param int $roomId
 	 * @return DataResponse
 	 */
-	public function leaveRoom($roomId) {
+	public function removeSelfFromRoom($roomId) {
 		try {
 			$room = $this->manager->getRoomForParticipant($roomId, $this->userId);
 		} catch (RoomNotFoundException $e) {

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -246,10 +246,32 @@ class RoomController extends OCSController {
 	 *
 	 * @NoAdminRequired
 	 *
+	 * @param int $roomType
+	 * @param string $invite
+	 * @return DataResponse
+	 */
+	public function createRoom($roomType, $invite = '') {
+		switch ((int) $roomType) {
+			case Room::ONE_TO_ONE_CALL:
+				return $this->createOneToOneRoom($invite);
+			case Room::GROUP_CALL:
+				return $this->createGroupRoom($invite);
+			case Room::PUBLIC_CALL:
+				return $this->createPublicRoom();
+		}
+
+		return new DataResponse([], Http::STATUS_BAD_REQUEST);
+	}
+
+	/**
+	 * Initiates a one-to-one video call from the current user to the recipient
+	 *
+	 * @NoAdminRequired
+	 *
 	 * @param string $targetUserName
 	 * @return DataResponse
 	 */
-	public function createOneToOneRoom($targetUserName) {
+	protected function createOneToOneRoom($targetUserName) {
 		// Get the user
 		$targetUser = $this->userManager->get($targetUserName);
 		$currentUser = $this->userManager->get($this->userId);
@@ -280,7 +302,7 @@ class RoomController extends OCSController {
 	 * @param string $targetGroupName
 	 * @return DataResponse
 	 */
-	public function createGroupRoom($targetGroupName) {
+	protected function createGroupRoom($targetGroupName) {
 		$targetGroup = $this->groupManager->get($targetGroupName);
 		$currentUser = $this->userManager->get($this->userId);
 
@@ -312,7 +334,7 @@ class RoomController extends OCSController {
 	 *
 	 * @return DataResponse
 	 */
-	public function createPublicRoom() {
+	protected function createPublicRoom() {
 		$currentUser = $this->userManager->get($this->userId);
 
 		// Create the room

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1,0 +1,340 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Lukas Reschke <lukas@statuscode.ch>
+ * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Lukas Reschke <lukas@statuscode.ch>
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Controller;
+
+use OCA\Spreed\Exceptions\RoomNotFoundException;
+use OCA\Spreed\Manager;
+use OCA\Spreed\Room;
+use OCP\Activity\IManager as IActivityManager;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
+use OCP\ILogger;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\Notification\IManager as INotificationManager;
+
+class RoomController extends OCSController {
+	/** @var string */
+	private $userId;
+	/** @var IUserManager */
+	private $userManager;
+	/** @var IGroupManager */
+	private $groupManager;
+	/** @var ILogger */
+	private $logger;
+	/** @var Manager */
+	private $manager;
+	/** @var INotificationManager */
+	private $notificationManager;
+	/** @var IActivityManager */
+	private $activityManager;
+
+	/**
+	 * @param string $appName
+	 * @param string $UserId
+	 * @param IRequest $request
+	 * @param IUserManager $userManager
+	 * @param IGroupManager $groupManager
+	 * @param ILogger $logger
+	 * @param Manager $manager
+	 * @param INotificationManager $notificationManager
+	 * @param IActivityManager $activityManager
+	 */
+	public function __construct($appName,
+								$UserId,
+								IRequest $request,
+								IUserManager $userManager,
+								IGroupManager $groupManager,
+								ILogger $logger,
+								Manager $manager,
+								INotificationManager $notificationManager,
+								IActivityManager $activityManager) {
+		parent::__construct($appName, $request);
+		$this->userId = $UserId;
+		$this->userManager = $userManager;
+		$this->groupManager = $groupManager;
+		$this->logger = $logger;
+		$this->manager = $manager;
+		$this->notificationManager = $notificationManager;
+		$this->activityManager = $activityManager;
+	}
+
+	/**
+	 * Initiates a one-to-one video call from the current user to the recipient
+	 *
+	 * @NoAdminRequired
+	 *
+	 * @param string $targetUserName
+	 * @return DataResponse
+	 */
+	public function createOneToOneRoom($targetUserName) {
+		// Get the user
+		$targetUser = $this->userManager->get($targetUserName);
+		$currentUser = $this->userManager->get($this->userId);
+		if(!($targetUser instanceof IUser)) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		// If room exists: Reuse that one, otherwise create a new one.
+		try {
+			$room = $this->manager->getOne2OneRoom($this->userId, $targetUser->getUID());
+			return new DataResponse(['token' => $room->getToken()], Http::STATUS_OK);
+		} catch (RoomNotFoundException $e) {
+			$room = $this->manager->createOne2OneRoom();
+			$room->addUser($currentUser);
+
+			$room->addUser($targetUser);
+			$this->createNotification($currentUser, $targetUser, $room);
+
+			return new DataResponse(['token' => $room->getToken()], Http::STATUS_CREATED);
+		}
+	}
+
+	/**
+	 * Initiates a group video call from the selected group
+	 *
+	 * @NoAdminRequired
+	 *
+	 * @param string $targetGroupName
+	 * @return DataResponse
+	 */
+	public function createGroupRoom($targetGroupName) {
+		$targetGroup = $this->groupManager->get($targetGroupName);
+		$currentUser = $this->userManager->get($this->userId);
+
+		if(!($targetGroup instanceof IGroup)) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		$usersInGroup = $targetGroup->getUsers();
+		// If the user who is creating this call is not part of this group add them
+		if (!$targetGroup->inGroup($currentUser)) {
+			$usersInGroup[] = $currentUser;
+		}
+
+		// Create the room
+		$room = $this->manager->createGroupRoom($targetGroup->getGID());
+		foreach ($usersInGroup as $user) {
+			$room->addUser($user);
+
+			if ($currentUser->getUID() !== $user->getUID()) {
+				$this->createNotification($currentUser, $user, $room);
+			}
+		}
+
+		return new DataResponse(['token' => $room->getToken()], Http::STATUS_CREATED);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @return DataResponse
+	 */
+	public function createPublicRoom() {
+		$currentUser = $this->userManager->get($this->userId);
+
+		// Create the room
+		$room = $this->manager->createPublicRoom();
+		$room->addUser($currentUser);
+
+		return new DataResponse(['token' => $room->getToken()], Http::STATUS_CREATED);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param int $roomId
+	 * @param string $roomName
+	 * @return DataResponse
+	 */
+	public function renameRoom($roomId, $roomName) {
+		try {
+			$room = $this->manager->getRoomForParticipant($roomId, $this->userId);
+		} catch (RoomNotFoundException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if (strlen($roomName) > 200) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
+		if (!$room->setName($roomName)) {
+			return new DataResponse([], Http::STATUS_METHOD_NOT_ALLOWED);
+		}
+		return new DataResponse([]);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param int $roomId
+	 * @param string $newParticipant
+	 * @return DataResponse
+	 */
+	public function addParticipantToRoom($roomId, $newParticipant) {
+		try {
+			$room = $this->manager->getRoomForParticipant($roomId, $this->userId);
+		} catch (RoomNotFoundException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		$participants = $room->getParticipants();
+		if (isset($participants['users'][$newParticipant])) {
+			return new DataResponse([]);
+		}
+
+		$currentUser = $this->userManager->get($this->userId);
+		$newUser = $this->userManager->get($newParticipant);
+		if (!$newUser instanceof IUser) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
+			// In case a user is added to a one2one call, we change the call to a group call
+			$room->changeType(Room::GROUP_CALL);
+
+			$room->addUser($newUser);
+			$this->createNotification($currentUser, $newUser, $room);
+
+			return new DataResponse(['type' => $room->getType()]);
+		}
+
+		$room->addUser($newUser);
+		$this->createNotification($currentUser, $newUser, $room);
+
+		return new DataResponse([]);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param int $roomId
+	 * @return DataResponse
+	 */
+	public function leaveRoom($roomId) {
+		try {
+			$room = $this->manager->getRoomForParticipant($roomId, $this->userId);
+		} catch (RoomNotFoundException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if ($room->getType() === Room::ONE_TO_ONE_CALL || $room->getNumberOfParticipants() === 1) {
+			$room->deleteRoom();
+		} else {
+			$currentUser = $this->userManager->get($this->userId);
+			$room->removeUser($currentUser);
+		}
+
+		return new DataResponse([]);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param int $roomId
+	 * @return DataResponse
+	 */
+	public function makePublic($roomId) {
+		try {
+			$room = $this->manager->getRoomForParticipant($roomId, $this->userId);
+		} catch (RoomNotFoundException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if ($room->getType() !== Room::PUBLIC_CALL) {
+			$room->changeType(Room::PUBLIC_CALL);
+		}
+
+		return new DataResponse();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param int $roomId
+	 * @return DataResponse
+	 */
+	public function makePrivate($roomId) {
+		try {
+			$room = $this->manager->getRoomForParticipant($roomId, $this->userId);
+		} catch (RoomNotFoundException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if ($room->getType() === Room::PUBLIC_CALL) {
+			$room->changeType(Room::GROUP_CALL);
+		}
+
+		return new DataResponse();
+	}
+
+	/**
+	 * @param IUser $actor
+	 * @param IUser $user
+	 * @param Room $room
+	 */
+	protected function createNotification(IUser $actor, IUser $user, Room $room) {
+		$notification = $this->notificationManager->createNotification();
+		$dateTime = new \DateTime();
+		try {
+			$notification->setApp('spreed')
+				->setUser($user->getUID())
+				->setDateTime($dateTime)
+				->setObject('room', $room->getId())
+				->setSubject('invitation', [$actor->getUID()]);
+			$this->notificationManager->notify($notification);
+		} catch (\InvalidArgumentException $e) {
+			// Error while creating the notification
+			$this->logger->logException($e, ['app' => 'spreed']);
+		}
+
+		$event = $this->activityManager->generateEvent();
+		try {
+			$event->setApp('spreed')
+				->setType('spreed')
+				->setAuthor($actor->getUID())
+				->setAffectedUser($user->getUID())
+				->setObject('room', $room->getId(), $room->getName())
+				->setTimestamp($dateTime->getTimestamp())
+				->setSubject('invitation', [
+					'user' => $actor->getUID(),
+					'room' => $room->getId(),
+					'name' => $room->getName(),
+				]);
+			$this->activityManager->publish($event);
+		} catch (\InvalidArgumentException $e) {
+			// Error while creating the activity
+			$this->logger->logException($e, ['app' => 'spreed']);
+		} catch (\BadMethodCallException $e) {
+			// Error while sending the activity
+			$this->logger->logException($e, ['app' => 'spreed']);
+		}
+	}
+}

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -32,6 +32,7 @@ use OCP\Activity\IManager as IActivityManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
+use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUser;
@@ -55,6 +56,8 @@ class RoomController extends OCSController {
 	private $notificationManager;
 	/** @var IActivityManager */
 	private $activityManager;
+	/** @var IL10N */
+	private $l10n;
 
 	/**
 	 * @param string $appName
@@ -66,6 +69,7 @@ class RoomController extends OCSController {
 	 * @param Manager $manager
 	 * @param INotificationManager $notificationManager
 	 * @param IActivityManager $activityManager
+	 * @param IL10N $l10n
 	 */
 	public function __construct($appName,
 								$UserId,
@@ -75,7 +79,8 @@ class RoomController extends OCSController {
 								ILogger $logger,
 								Manager $manager,
 								INotificationManager $notificationManager,
-								IActivityManager $activityManager) {
+								IActivityManager $activityManager,
+								IL10N $l10n) {
 		parent::__construct($appName, $request);
 		$this->userId = $UserId;
 		$this->userManager = $userManager;
@@ -84,6 +89,156 @@ class RoomController extends OCSController {
 		$this->manager = $manager;
 		$this->notificationManager = $notificationManager;
 		$this->activityManager = $activityManager;
+		$this->l10n = $l10n;
+	}
+
+	/**
+	 * Get all currently existent rooms which the user has joined
+	 *
+	 * @NoAdminRequired
+	 *
+	 * @return DataResponse
+	 */
+	public function getRooms() {
+		$rooms = $this->manager->getRoomsForParticipant($this->userId);
+
+		$return = [];
+		foreach ($rooms as $room) {
+			try {
+				$return[] = $this->formatRoom($room);
+			} catch (RoomNotFoundException $e) {
+			}
+		}
+
+		return new DataResponse($return);
+	}
+
+	/**
+	 * @PublicPage
+	 *
+	 * @param string $token
+	 * @return DataResponse
+	 */
+	public function getRoom($token) {
+		try {
+			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
+			return new DataResponse($this->formatRoom($room));
+		} catch (RoomNotFoundException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+	}
+
+	/**
+	 * @param Room $room
+	 * @return array
+	 * @throws RoomNotFoundException
+	 */
+	protected function formatRoom(Room $room) {
+		// Sort by lastPing
+		/** @var array[] $participants */
+		$participants = $room->getParticipants();
+		$sortParticipants = function(array $participant1, array $participant2) {
+			return $participant2['lastPing'] - $participant1['lastPing'];
+		};
+		uasort($participants['users'], $sortParticipants);
+		uasort($participants['guests'], $sortParticipants);
+
+		$participantList = [];
+		foreach ($participants['users'] as $participant => $lastPing) {
+			$user = $this->userManager->get($participant);
+			if ($user instanceof IUser) {
+				$participantList[$participant] = $user->getDisplayName();
+			}
+		}
+
+		$roomData = [
+			'id' => $room->getId(),
+			'token' => $room->getToken(),
+			'type' => $room->getType(),
+			'name' => $room->getName(),
+			'displayName' => $room->getName(),
+			'isNameEditable' => $room->getType() !== Room::ONE_TO_ONE_CALL,
+			'count' => $room->getNumberOfParticipants(time() - 30),
+			'lastPing' => isset($participants['users'][$this->userId]['lastPing']) ? $participants['users'][$this->userId]['lastPing'] : 0,
+			'sessionId' => isset($participants['users'][$this->userId]['sessionId']) ? $participants['users'][$this->userId]['sessionId'] : '0',
+			'participants' => $participantList,
+		];
+
+		$activeGuests = array_filter($participants['guests'], function($data) {
+			return $data['lastPing'] > time() - 30;
+		});
+
+		$numActiveGuests = count($activeGuests);
+		if ($numActiveGuests !== count($participants['guests'])) {
+			$room->cleanGuestParticipants();
+		}
+
+		if ($this->userId !== null) {
+			unset($participantList[$this->userId]);
+			$numOtherParticipants = count($participantList);
+			$numGuestParticipants = $numActiveGuests;
+		} else {
+			$numOtherParticipants = count($participantList);
+			$numGuestParticipants = $numActiveGuests - 1;
+		}
+
+		$guestString = '';
+		switch ($room->getType()) {
+			case Room::ONE_TO_ONE_CALL:
+				// As name of the room use the name of the other person participating
+				if ($numOtherParticipants === 1) {
+					// Only one other participant
+					reset($participantList);
+					$roomData['name'] = key($participantList);
+					$roomData['displayName'] = $participantList[$roomData['name']];
+				} else {
+					// Invalid user count, there must be exactly 2 users in each one2one room
+					$this->logger->warning('one2one room found with invalid participant count. Leaving room for everyone', [
+						'app' => 'spreed',
+					]);
+					$room->deleteRoom();
+				}
+				break;
+
+			/** @noinspection PhpMissingBreakStatementInspection */
+			case Room::PUBLIC_CALL:
+				if ($this->userId === null && $numGuestParticipants) {
+					$guestString = $this->l10n->n('%n other guest', '%n other guests', $numGuestParticipants);
+				} else if ($numGuestParticipants) {
+					$guestString = $this->l10n->n('%n guest', '%n guests', $numGuestParticipants);
+				}
+
+			// no break;
+
+			case Room::GROUP_CALL:
+				if ($room->getName() === '') {
+					// As name of the room use the names of the other participants
+					if ($this->userId === null) {
+						$participantList[] = $this->l10n->t('You');
+					} else if ($numOtherParticipants === 0) {
+						$participantList = [$this->l10n->t('You')];
+					}
+
+					if ($guestString !== '') {
+						$participantList[] = $guestString;
+					}
+
+					$roomData['displayName'] = implode($this->l10n->t(', '), $participantList);
+				}
+				break;
+
+			default:
+				// Invalid room type
+				$this->logger->warning('Invalid room type found. Leaving room for everyone', [
+					'app' => 'spreed',
+				]);
+				$room->deleteRoom();
+				throw new RoomNotFoundException('The room type is unknown');
+		}
+
+		$roomData['guestList'] = $guestString;
+
+		return $roomData;
 	}
 
 	/**

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -347,13 +347,13 @@ class RoomController extends OCSController {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * @param int $roomId
+	 * @param string $token
 	 * @param string $roomName
 	 * @return DataResponse
 	 */
-	public function renameRoom($roomId, $roomName) {
+	public function renameRoom($token, $roomName) {
 		try {
-			$room = $this->manager->getRoomForParticipant($roomId, $this->userId);
+			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
 		} catch (RoomNotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
@@ -371,13 +371,13 @@ class RoomController extends OCSController {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * @param int $roomId
+	 * @param string $token
 	 * @param string $newParticipant
 	 * @return DataResponse
 	 */
-	public function addParticipantToRoom($roomId, $newParticipant) {
+	public function addParticipantToRoom($token, $newParticipant) {
 		try {
-			$room = $this->manager->getRoomForParticipant($roomId, $this->userId);
+			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
 		} catch (RoomNotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
@@ -412,12 +412,12 @@ class RoomController extends OCSController {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * @param int $roomId
+	 * @param string $token
 	 * @return DataResponse
 	 */
-	public function removeSelfFromRoom($roomId) {
+	public function removeSelfFromRoom($token) {
 		try {
-			$room = $this->manager->getRoomForParticipant($roomId, $this->userId);
+			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
 		} catch (RoomNotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
@@ -435,12 +435,12 @@ class RoomController extends OCSController {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * @param int $roomId
+	 * @param string $token
 	 * @return DataResponse
 	 */
-	public function makePublic($roomId) {
+	public function makePublic($token) {
 		try {
-			$room = $this->manager->getRoomForParticipant($roomId, $this->userId);
+			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
 		} catch (RoomNotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
@@ -455,12 +455,12 @@ class RoomController extends OCSController {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * @param int $roomId
+	 * @param string $token
 	 * @return DataResponse
 	 */
-	public function makePrivate($roomId) {
+	public function makePrivate($token) {
 		try {
-			$room = $this->manager->getRoomForParticipant($roomId, $this->userId);
+			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
 		} catch (RoomNotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -92,7 +92,7 @@ class Notifier implements INotifier {
 			$uid = $parameters[0];
 			$notification
 				->setIcon($this->url->getAbsoluteURL($this->url->imagePath('spreed', 'app.svg')))
-				->setLink($this->url->linkToRouteAbsolute('spreed.page.index') . '?token=' . $room->getToken());
+				->setLink($this->url->linkToRouteAbsolute('spreed.Page.index') . '?token=' . $room->getToken());
 
 			if ($notification->getObjectType() === 'room') {
 				$user = $this->userManager->get($uid);


### PR DESCRIPTION
## New mapping

`/api`

- `/{apiVersion}`
  - `/call`
    - `/{token}` - `GET` connected peers
    - `/{token}` - `POST` to join a call
    - `/{token}` - `PUT` your "I'm still here"
    - `/{token}` - `DELETE` when you leave the app or close the browser
  - `/room` - `POST` create a room
  - `/room` - `GET` all rooms
    - `/{token}` - `GET` room publicly
    - `/{token}` - `DELETE` delete a room #353 
    - `/{token}` - `PUT` rename a call
      - `/public` - `POST` make a call public
      - `/public` - `DELETE` make a call private
      - `/moderators` - `POST` promote a participant to be a moderator #353 
      - `/moderators` - `DELETE` demote a moderator #353 
      - `/participants` - `POST` add a participant
      - `/participants` - `DELETE` remove a participant #353 
        - `/self` - `DELETE` remove yourself from a room
