### PR TITLE
Limit size of own video on mobile so other participant is still visible

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -322,6 +322,12 @@ video {
 	left: initial;
 	z-index: 10;
 }
+@media only screen and (max-width: 768px) {
+	.participants-1 .videoView,
+	.participants-2 .videoView {
+		max-height: 35%;
+	}
+}
 .participants-1 .videoView video,
 .participants-2 .videoView video {
 	position: absolute;


### PR DESCRIPTION
Otherwise it looks like this where the other person is overlapped by your own video:
![video calls mobile android firefox](https://user-images.githubusercontent.com/925062/27915374-674800a8-6266-11e7-8245-67cb749e382a.png)

So it’s now limited to 30% height.