### PR TITLE
Participant types

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,7 +42,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 	<bugs>https://github.com/nextcloud/spreed/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/spreed.git</repository>
 
-	<version>2.1.1</version>
+	<version>2.1.2</version>
 
 	<dependencies>
 		<nextcloud min-version="13" max-version="13" />

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -140,6 +140,15 @@ return [
 			],
 		],
 		[
+			'name' => 'Room#removeParticipantFromRoom',
+			'url' => '/api/{apiVersion}/room/{token}/participants',
+			'verb' => 'DELETE',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
+		[
 			'name' => 'Room#removeSelfFromRoom',
 			'url' => '/api/{apiVersion}/room/{token}/participants/self',
 			'verb' => 'DELETE',

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -148,6 +148,24 @@ return [
 				'token' => '^[a-z0-9]{4,30}$',
 			],
 		],
+		[
+			'name' => 'Room#promoteModerator',
+			'url' => '/api/{apiVersion}/room/{token}/moderators',
+			'verb' => 'POST',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
+		[
+			'name' => 'Room#demoteModerator',
+			'url' => '/api/{apiVersion}/room/{token}/moderators',
+			'verb' => 'DELETE',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
 	],
 ];
 

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -113,6 +113,15 @@ return [
 			],
 		],
 		[
+			'name' => 'Room#deleteRoom',
+			'url' => '/api/{apiVersion}/room/{token}',
+			'verb' => 'DELETE',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
+		[
 			'name' => 'Room#makePublic',
 			'url' => '/api/{apiVersion}/room/{token}/public',
 			'verb' => 'POST',

--- a/css/style.css
+++ b/css/style.css
@@ -525,6 +525,10 @@ video {
 	overflow: hidden;
 }
 
+#app-navigation .app-navigation-entry-menu input.first-option {
+	margin-top: 5px;
+}
+
 #app-navigation .app-navigation-entry-menu li span {
 	display: inline-block;
 	height: 36px;

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -48,7 +48,7 @@
 										'<span>'+t('spreed', 'Add person')+'</span>'+
 									'</button>'+
 								'</li>'+
-								'{{#isNameEditable}}'+
+								'{{#if isNameEditable}}'+
 								'<li>'+
 									'<button class="rename-room-button">'+
 										'<span class="icon-rename"></span>'+
@@ -57,7 +57,7 @@
 								'</li>'+
 								'<input class="hidden-important rename-element rename-input" maxlength="200" type="text"/>'+
 								'<button class="icon-confirm hidden-important rename-element rename-confirm"></button>'+
-								'{{/isNameEditable}}'+
+								'{{/if}}'+
 								'<li>'+
 									'<button class="share-link-button">'+
 										'<span class="icon-public"></span>'+
@@ -68,11 +68,19 @@
 									'<div class="icon-delete private-room"></div>'+
 								'</li>'+
 								'<li>'+
-									'<button class="leave-group-button">'+
-										'<span class="icon-close"></span>'+
-										'<span>'+t('spreed', 'Leave call')+'</span>'+
+									'<button class="leave-room-button">'+
+										'<span class="{{#if isDeletable}}icon-close{{else}}icon-delete{{/if}}"></span>'+
+										'<span>{{#if isDeletable}}'+t('spreed', 'Leave call')+'{{else}}'+t('spreed', 'Delete call')+'{{/if}}</span>'+
 									'</button>'+
 								'</li>'+
+								'{{#if isDeletable}}'+
+								'<li>'+
+									'<button class="delete-room-button">'+
+										'<span class="icon-delete"></span>'+
+										'<span>'+t('spreed', 'Delete call')+'</span>'+
+									'</button>'+
+								'</li>'+
+								'{{/if}}'+
 							'</ul>'+
 							'<form class="oca-spreedme-add-person hidden">'+
 								'<input class="add-person-input" type="text" placeholder="Type name..."/>'+
@@ -148,7 +156,8 @@
 			'click .app-navigation-entry-menu .rename-room-button': 'showRenameInput',
 			'click .app-navigation-entry-menu .rename-confirm': 'confirmRoomRename',
 			'click .app-navigation-entry-menu .share-link-button': 'shareGroup',
-			'click .app-navigation-entry-menu .leave-group-button': 'leaveGroup',
+			'click .app-navigation-entry-menu .leave-room-button': 'leaveRoom',
+			'click .app-navigation-entry-menu .delete-room-button': 'deleteRoom',
 			'click .icon-delete': 'unshareGroup',
 			'click .app-navigation-entry-link': 'joinRoom'
 		},
@@ -287,7 +296,7 @@
 				});
 			}
 		},
-		leaveGroup: function() {
+		leaveRoom: function() {
 			//If user is in that room, it should leave that room first.
 			if (this.model.get('active')) {
 				OCA.SpreedMe.Rooms.leaveCurrentRoom();
@@ -299,6 +308,26 @@
 
 			$.ajax({
 				url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('token') + '/participants/self',
+				type: 'DELETE'
+			});
+		},
+		deleteRoom: function() {
+			if (this.model.get('participantType') !== 1 &&
+				this.model.get('participantType') !== 2) {
+				return;
+			}
+
+			//If user is in that room, it should leave that room first.
+			if (this.model.get('active')) {
+				OCA.SpreedMe.Rooms.leaveCurrentRoom();
+				OCA.SpreedMe.Rooms.showRoomDeletedMessage(true);
+				OC.Util.History.pushState({}, OC.generateUrl('/apps/spreed'));
+			}
+
+			this.$el.slideUp();
+
+			$.ajax({
+				url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('token'),
 				type: 'DELETE'
 			});
 		},

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -327,10 +327,10 @@
 				case ROOM_TYPE_ONE_TO_ONE:
 					var waitingParticipantId, waitingParticipantName;
 
-					$.each(participants, function(participantId, participantName) {
+					$.each(participants, function(participantId, data) {
 						if (oc_current_user !== participantId) {
 							waitingParticipantId = participantId;
-							waitingParticipantName = participantName;
+							waitingParticipantName = data.name;
 						}
 					});
 
@@ -386,9 +386,9 @@
 		},
 		addTooltip: function () {
 			var participants = [];
-			$.each(this.model.get('participants'), function(participantId, participantName) {
+			$.each(this.model.get('participants'), function(participantId, data) {
 				if (participantId !== oc_current_user) {
-					participants.push(escapeHTML(participantName));
+					participants.push(escapeHTML(data.name));
 				}
 			});
 

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -42,6 +42,7 @@
 						'</div>'+
 						'<div class="app-navigation-entry-menu">'+
 							'<ul class="app-navigation-entry-menu-list">'+
+								'{{#if canModerate}}'+
 								'<li>'+
 									'<button class="add-person-button">'+
 										'<span class="icon-add"></span>'+
@@ -67,6 +68,13 @@
 									'<div class="clipboardButton icon-clippy private-room" data-clipboard-target="#shareInput-{{id}}"></div>'+
 									'<div class="icon-delete private-room"></div>'+
 								'</li>'+
+								'{{/if}}'+
+								'{{#if showShareLink}}'+
+								'<li>'+
+									'<input id="shareInput-{{id}}" class="share-link-input private-room first-option" readonly="readonly" type="text"/>'+
+									'<div class="clipboardButton icon-clippy private-room" data-clipboard-target="#shareInput-{{id}}"></div>'+
+								'</li>'+
+								'{{/if}}'+
 								'<li>'+
 									'<button class="leave-room-button">'+
 										'<span class="{{#if isDeletable}}icon-close{{else}}icon-delete{{/if}}"></span>'+
@@ -82,9 +90,11 @@
 								'</li>'+
 								'{{/if}}'+
 							'</ul>'+
+							'{{#if canModerate}}'+
 							'<form class="oca-spreedme-add-person hidden">'+
 								'<input class="add-person-input" type="text" placeholder="Type name..."/>'+
 							'</form>'+
+							'{{/if}}'+
 						'</div>';
 
 	var RoomItenView = Marionette.View.extend({
@@ -115,6 +125,15 @@
 					this.toggleMenuClass();
 				}
 			});
+		},
+		templateContext: function() {
+			var canModerate = this.model.get('participantType') === 1 || this.model.get('participantType') === 2;
+			return {
+				canModerate: canModerate,
+				showShareLink: !canModerate && this.model.get('type') === ROOM_TYPE_PUBLIC_CALL,
+				isNameEditable: canModerate && this.model.get('type') !== ROOM_TYPE_ONE_TO_ONE,
+				isDeletable: canModerate && (Object.keys(this.model.get('participants')).length > 2 || this.model.get('numGuests') > 0)
+			}
 		},
 		onRender: function() {
 			var roomURL, completeURL;

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -133,7 +133,7 @@
 				showShareLink: !canModerate && this.model.get('type') === ROOM_TYPE_PUBLIC_CALL,
 				isNameEditable: canModerate && this.model.get('type') !== ROOM_TYPE_ONE_TO_ONE,
 				isDeletable: canModerate && (Object.keys(this.model.get('participants')).length > 2 || this.model.get('numGuests') > 0)
-			}
+			};
 		},
 		onRender: function() {
 			var roomURL, completeURL;

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -162,24 +162,6 @@ class RoomController extends OCSController {
 			$participantType = Participant::GUEST;
 		}
 
-		$canModerate = $participantType === Participant::MODERATOR || $participantType === Participant::OWNER;
-
-		$roomData = [
-			'id' => $room->getId(),
-			'token' => $room->getToken(),
-			'type' => $room->getType(),
-			'name' => $room->getName(),
-			'displayName' => $room->getName(),
-			'isNameEditable' => $room->getType() !== Room::ONE_TO_ONE_CALL,
-			'isModerator' => $participantType === Participant::MODERATOR,
-			'isOwner' => $participantType === Participant::OWNER,
-			'isDeletable' => $canModerate && (count($participantList) > 2 || !empty($participants['guests'])),
-			'count' => $room->getNumberOfParticipants(time() - 30),
-			'lastPing' => isset($participants['users'][$this->userId]['lastPing']) ? $participants['users'][$this->userId]['lastPing'] : 0,
-			'sessionId' => isset($participants['users'][$this->userId]['sessionId']) ? $participants['users'][$this->userId]['sessionId'] : '0',
-			'participants' => $participantList,
-		];
-
 		$activeGuests = array_filter($participants['guests'], function($data) {
 			return $data['lastPing'] > time() - 30;
 		});
@@ -188,6 +170,20 @@ class RoomController extends OCSController {
 		if ($numActiveGuests !== count($participants['guests'])) {
 			$room->cleanGuestParticipants();
 		}
+
+		$roomData = [
+			'id' => $room->getId(),
+			'token' => $room->getToken(),
+			'type' => $room->getType(),
+			'name' => $room->getName(),
+			'displayName' => $room->getName(),
+			'participantType' => $participantType,
+			'count' => $room->getNumberOfParticipants(time() - 30),
+			'lastPing' => isset($participants['users'][$this->userId]['lastPing']) ? $participants['users'][$this->userId]['lastPing'] : 0,
+			'sessionId' => isset($participants['users'][$this->userId]['sessionId']) ? $participants['users'][$this->userId]['sessionId'] : '0',
+			'participants' => $participantList,
+			'numGuests' => $numActiveGuests,
+		];
 
 		if ($this->userId !== null) {
 			unset($participantList[$this->userId]);

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -592,6 +592,10 @@ class RoomController extends OCSController {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
+		if ($this->userId === $participant) {
+			return new DataResponse([], Http::STATUS_FORBIDDEN);
+		}
+
 		if (!in_array($currentParticipant->getParticipantType(), [Participant::OWNER, Participant::MODERATOR], true)) {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -354,8 +354,15 @@ class RoomController extends OCSController {
 	public function renameRoom($token, $roomName) {
 		try {
 			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
+			$participant = $room->getParticipant($this->userId);
 		} catch (RoomNotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		} catch (\RuntimeException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if (!in_array($participant->getParticipantType(), [Participant::OWNER, Participant::MODERATOR], true)) {
+			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		if (strlen($roomName) > 200) {
@@ -378,8 +385,15 @@ class RoomController extends OCSController {
 	public function addParticipantToRoom($token, $newParticipant) {
 		try {
 			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
+			$participant = $room->getParticipant($this->userId);
 		} catch (RoomNotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		} catch (\RuntimeException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if (!in_array($participant->getParticipantType(), [Participant::OWNER, Participant::MODERATOR], true)) {
+			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		$participants = $room->getParticipants();
@@ -441,8 +455,15 @@ class RoomController extends OCSController {
 	public function makePublic($token) {
 		try {
 			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
+			$participant = $room->getParticipant($this->userId);
 		} catch (RoomNotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		} catch (\RuntimeException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if (!in_array($participant->getParticipantType(), [Participant::OWNER, Participant::MODERATOR], true)) {
+			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		if ($room->getType() !== Room::PUBLIC_CALL) {
@@ -461,8 +482,15 @@ class RoomController extends OCSController {
 	public function makePrivate($token) {
 		try {
 			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
+			$participant = $room->getParticipant($this->userId);
 		} catch (RoomNotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		} catch (\RuntimeException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if (!in_array($participant->getParticipantType(), [Participant::OWNER, Participant::MODERATOR], true)) {
+			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		if ($room->getType() === Room::PUBLIC_CALL) {

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -501,6 +501,78 @@ class RoomController extends OCSController {
 	}
 
 	/**
+	 * @NoAdminRequired
+	 *
+	 * @param string $token
+	 * @param string $participant
+	 * @return DataResponse
+	 */
+	public function promoteModerator($token, $participant) {
+		try {
+			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
+			$currentParticipant = $room->getParticipant($this->userId);
+		} catch (RoomNotFoundException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		} catch (\RuntimeException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if (!in_array($currentParticipant->getParticipantType(), [Participant::OWNER, Participant::MODERATOR], true)) {
+			return new DataResponse([], Http::STATUS_FORBIDDEN);
+		}
+
+		try {
+			$targetParticipant = $room->getParticipant($participant);
+		} catch (\RuntimeException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if (!in_array($targetParticipant->getParticipantType(), [Participant::OWNER, Participant::MODERATOR], true)) {
+			return new DataResponse([''], Http::STATUS_PRECONDITION_FAILED);
+		}
+
+		$room->setParticipantType($participant, Participant::MODERATOR);
+
+		return new DataResponse();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param string $token
+	 * @param string $participant
+	 * @return DataResponse
+	 */
+	public function demoteModerator($token, $participant) {
+		try {
+			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
+			$currentParticipant = $room->getParticipant($this->userId);
+		} catch (RoomNotFoundException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		} catch (\RuntimeException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if (!in_array($currentParticipant->getParticipantType(), [Participant::OWNER, Participant::MODERATOR], true)) {
+			return new DataResponse([], Http::STATUS_FORBIDDEN);
+		}
+
+		try {
+			$targetParticipant = $room->getParticipant($participant);
+		} catch (\RuntimeException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if ($targetParticipant->getParticipantType() !== Participant::MODERATOR) {
+			return new DataResponse([''], Http::STATUS_PRECONDITION_FAILED);
+		}
+
+		$room->setParticipantType($participant, Participant::USER);
+
+		return new DataResponse();
+	}
+
+	/**
 	 * @param IUser $actor
 	 * @param IUser $user
 	 * @param Room $room

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -286,9 +286,9 @@ class RoomController extends OCSController {
 			return new DataResponse(['token' => $room->getToken()], Http::STATUS_OK);
 		} catch (RoomNotFoundException $e) {
 			$room = $this->manager->createOne2OneRoom();
-			$room->addParticipant($currentUser, Participant::OWNER);
+			$room->addParticipant($currentUser->getUID(), Participant::OWNER);
 
-			$room->addParticipant($targetUser, Participant::OWNER);
+			$room->addParticipant($targetUser->getUID(), Participant::OWNER);
 			$this->createNotification($currentUser, $targetUser, $room);
 
 			return new DataResponse(['token' => $room->getToken()], Http::STATUS_CREATED);
@@ -313,7 +313,7 @@ class RoomController extends OCSController {
 
 		// Create the room
 		$room = $this->manager->createGroupRoom($targetGroup->getGID());
-		$room->addParticipant($currentUser, Participant::OWNER);
+		$room->addParticipant($currentUser->getUID(), Participant::OWNER);
 
 		$usersInGroup = $targetGroup->getUsers();
 		foreach ($usersInGroup as $user) {
@@ -335,11 +335,9 @@ class RoomController extends OCSController {
 	 * @return DataResponse
 	 */
 	protected function createPublicRoom() {
-		$currentUser = $this->userManager->get($this->userId);
-
 		// Create the room
 		$room = $this->manager->createPublicRoom();
-		$room->addParticipant($currentUser, Participant::OWNER);
+		$room->addParticipant($this->userId, Participant::OWNER);
 
 		return new DataResponse(['token' => $room->getToken()], Http::STATUS_CREATED);
 	}

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -225,7 +225,9 @@ class RoomController extends OCSController {
 			case Room::GROUP_CALL:
 				if ($room->getName() === '') {
 					// As name of the room use the names of the other participants
-					$participantList = array_values($participantList);
+					$participantList = array_map(function($participant) {
+						return $participant['name'];
+					}, $participantList);
 					if ($this->userId === null) {
 						$participantList[] = $this->l10n->t('You');
 					} else if ($numOtherParticipants === 0) {

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -67,7 +67,11 @@ class Manager {
 		$result = $query->execute();
 		$rooms = [];
 		while ($row = $result->fetch()) {
-			$rooms[] = new Room($this->db, $this->secureRandom, (int) $row['id'], (int) $row['type'], $row['token'], $row['name']);
+			$room = new Room($this->db, $this->secureRandom, (int) $row['id'], (int) $row['type'], $row['token'], $row['name']);
+			if ($participant !== null && isset($row['userId'])) {
+				$room->setParticipant(new Participant($this->db, $room, $row['userId'], (int) $row['participantType'], (int) $row['lastPing'], $row['sessionId']));
+			}
+			$rooms[] = $room;
 		}
 		$result->closeCursor();
 
@@ -106,6 +110,9 @@ class Manager {
 		}
 
 		$room = new Room($this->db, $this->secureRandom, (int) $row['id'], (int) $row['type'], $row['token'], $row['name']);
+		if ($participant !== null && isset($row['userId'])) {
+			$room->setParticipant(new Participant($this->db, $room, $row['userId'], (int) $row['participantType'], (int) $row['lastPing'], $row['sessionId']));
+		}
 
 		if ($participant === null && $room->getType() !== Room::PUBLIC_CALL) {
 			throw new RoomNotFoundException();
@@ -147,6 +154,9 @@ class Manager {
 		}
 
 		$room = new Room($this->db, $this->secureRandom, (int) $row['id'], (int) $row['type'], $row['token'], $row['name']);
+		if ($participant !== null && isset($row['userId'])) {
+			$room->setParticipant(new Participant($this->db, $room, $row['userId'], (int) $row['participantType'], (int) $row['lastPing'], $row['sessionId']));
+		}
 
 		if ($room->getType() === Room::PUBLIC_CALL) {
 			return $room;

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -69,7 +69,8 @@ class Manager {
 		while ($row = $result->fetch()) {
 			$room = new Room($this->db, $this->secureRandom, (int) $row['id'], (int) $row['type'], $row['token'], $row['name']);
 			if ($participant !== null && isset($row['userId'])) {
-				$room->setParticipant(new Participant($this->db, $room, $row['userId'], (int) $row['participantType'], (int) $row['lastPing'], $row['sessionId']));
+				$room->setParticipant($row['userId'],
+					new Participant($this->db, $room, $row['userId'], (int) $row['participantType'], (int) $row['lastPing'], $row['sessionId']));
 			}
 			$rooms[] = $room;
 		}
@@ -111,7 +112,8 @@ class Manager {
 
 		$room = new Room($this->db, $this->secureRandom, (int) $row['id'], (int) $row['type'], $row['token'], $row['name']);
 		if ($participant !== null && isset($row['userId'])) {
-			$room->setParticipant(new Participant($this->db, $room, $row['userId'], (int) $row['participantType'], (int) $row['lastPing'], $row['sessionId']));
+			$room->setParticipant($row['userId'],
+				new Participant($this->db, $room, $row['userId'], (int) $row['participantType'], (int) $row['lastPing'], $row['sessionId']));
 		}
 
 		if ($participant === null && $room->getType() !== Room::PUBLIC_CALL) {
@@ -155,7 +157,8 @@ class Manager {
 
 		$room = new Room($this->db, $this->secureRandom, (int) $row['id'], (int) $row['type'], $row['token'], $row['name']);
 		if ($participant !== null && isset($row['userId'])) {
-			$room->setParticipant(new Participant($this->db, $room, $row['userId'], (int) $row['participantType'], (int) $row['lastPing'], $row['sessionId']));
+			$room->setParticipant($row['userId'],
+				new Participant($this->db, $room, $row['userId'], (int) $row['participantType'], (int) $row['lastPing'], $row['sessionId']));
 		}
 
 		if ($room->getType() === Room::PUBLIC_CALL) {

--- a/lib/Migration/Version2001002Date20170707115443.php
+++ b/lib/Migration/Version2001002Date20170707115443.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Spreed\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version2001002Date20170707115443 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param \Closure $schemaClosure The `\Closure` returns a `Schema`
+	 * @param array $options
+	 * @since 13.0.0
+	 */
+	public function preSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param \Closure $schemaClosure The `\Closure` returns a `Schema`
+	 * @param array $options
+	 * @return null|Schema
+	 * @since 13.0.0
+	 */
+	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options) {
+		/** @var Schema $schema */
+		$schema = $schemaClosure();
+		$table = $schema->getTable('spreedme_room_participants');
+
+		$table->addColumn('participantType', Type::SMALLINT, [
+			'notnull' => true,
+			'length' => 6,
+		]);
+
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param \Closure $schemaClosure The `\Closure` returns a `Schema`
+	 * @param array $options
+	 * @since 13.0.0
+	 */
+	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+	}
+}

--- a/lib/Migration/Version2001002Date20170707115443.php
+++ b/lib/Migration/Version2001002Date20170707115443.php
@@ -67,6 +67,7 @@ class Version2001002Date20170707115443 extends SimpleMigrationStep {
 		$table->addColumn('participantType', Type::SMALLINT, [
 			'notnull' => true,
 			'length' => 6,
+			'default' => 0,
 		]);
 
 		return $schema;

--- a/lib/Participant.php
+++ b/lib/Participant.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed;
+
+class Participant {
+	const OWNER = 1;
+	const MODERATOR = 2;
+	const USER = 3;
+	const GUEST = 4;
+}

--- a/lib/Participant.php
+++ b/lib/Participant.php
@@ -23,9 +23,57 @@
 
 namespace OCA\Spreed;
 
+use OCP\IDBConnection;
+
 class Participant {
 	const OWNER = 1;
 	const MODERATOR = 2;
 	const USER = 3;
 	const GUEST = 4;
+
+	/** @var IDBConnection */
+	protected $db;
+	/** @var Room */
+	protected $room;
+	/** @var string */
+	protected $user;
+	/** @var int */
+	protected $participantType;
+	/** @var int */
+	protected $lastPing;
+	/** @var string */
+	protected $sessionId;
+
+	/**
+	 * @param IDBConnection $db
+	 * @param Room $room
+	 * @param string $user
+	 * @param int $participantType
+	 * @param int $lastPing
+	 * @param string $sessionId
+	 */
+	public function __construct(IDBConnection $db, Room $room, $user, $participantType, $lastPing, $sessionId) {
+		$this->db = $db;
+		$this->room = $room;
+		$this->user = $user;
+		$this->participantType = $participantType;
+		$this->lastPing = $lastPing;
+		$this->sessionId = $sessionId;
+	}
+
+	public function getUser() {
+		return $this->user;
+	}
+
+	public function getParticipantType() {
+		return $this->participantType;
+	}
+
+	public function getLastPing() {
+		return $this->lastPing;
+	}
+
+	public function getSessionId() {
+		return $this->sessionId;
+	}
 }

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -368,6 +368,7 @@ class Room {
 				$users[$row['userId']] = [
 					'lastPing' => (int) $row['lastPing'],
 					'sessionId' => $row['sessionId'],
+					'participantType' => (int) $row['participantType'],
 				];
 			} else {
 				$guests[] = [

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -171,14 +171,15 @@ class Room {
 	 * @param IUser $user
 	 */
 	public function addUser(IUser $user) {
-		$this->addParticipant($user->getUID());
+		$this->addParticipant($user->getUID(), Participant::USER);
 	}
 
 	/**
 	 * @param string $participant
+	 * @param int $participantType
 	 * @param string $sessionId
 	 */
-	public function addParticipant($participant, $sessionId = '0') {
+	public function addParticipant($participant, $participantType, $sessionId = '0') {
 		$query = $this->db->getQueryBuilder();
 		$query->insert('spreedme_room_participants')
 			->values(
@@ -187,6 +188,7 @@ class Room {
 					'roomId' => $query->createNamedParameter($this->getId()),
 					'lastPing' => $query->createNamedParameter(0, IQueryBuilder::PARAM_INT),
 					'sessionId' => $query->createNamedParameter($sessionId),
+					'participantType' => $query->createNamedParameter($participantType, IQueryBuilder::PARAM_INT),
 				]
 			);
 		$query->execute();
@@ -249,6 +251,7 @@ class Room {
 			'roomId' => $this->getId(),
 			'lastPing' => 0,
 			'sessionId' => $sessionId,
+			'participantType' => Participant::GUEST,
 		], ['sessionId'])) {
 			$sessionId = $this->secureRandom->generate(255);
 		}


### PR DESCRIPTION
- [x] Depends on #352 
- [x] Depends on #349 
- [x] Set both participants as owner for new 1on1 calls
- [x] Set creator as owner for new group/public calls
- [x] Migration step to set owner on existing calls
- [x] Endpoint to promote/demote participant to/from moderator
- [x] Endpoint to remove a user from a room
- [ ] UI to promotion/demotion
- [ ] UI to remove a user from a room

Fix #297 

@jancborchardt we need a UI to allow to promote users to moderators, demote them again and in the future also to remove users from a room. Do you have a good idea for a UI here? I think it would be nice if this was possible while being in a call, but it should also work when there is no call atm (to prepare it) and when the user is not part of the current call, which I think makes this a bit tricky. But maybe you have an idea?

When there is a call for participants I would suggest a dropdown on the name of the user, or a little triangle behind it.

@Ivansss what do you think, how should we set the owner on update for group rooms etc. I mean for 1on1 rooms we just set both as owners, when there is only one user in a room it's also easy. But what do we do with public/group rooms where there is more than one user? We don't know which user created it.