### PR TITLE
Standalone signaling support

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -59,6 +59,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 	<settings>
 		<admin>OCA\Spreed\Settings\Admin\TurnServer</admin>
 		<admin>OCA\Spreed\Settings\Admin\StunServer</admin>
+		<admin>OCA\Spreed\Settings\Admin\SignalingServer</admin>
 		<admin-section>OCA\Spreed\Settings\Admin\Section</admin-section>
 	</settings>
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -38,7 +38,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 	<bugs>https://github.com/nextcloud/spreed/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/spreed.git</repository>
 
-	<version>2.1.7</version>
+	<version>2.1.8</version>
 
 	<dependencies>
 		<nextcloud min-version="13" max-version="13" />

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -47,6 +47,14 @@ return [
 			],
 		],
 		[
+			'name' => 'Signaling#backend',
+			'url' => '/api/{apiVersion}/signaling/backend',
+			'verb' => 'POST',
+			'requirements' => [
+				'apiVersion' => 'v1',
+			],
+		],
+		[
 			'name' => 'Call#getPeersForCall',
 			'url' => '/api/{apiVersion}/call/{token}',
 			'verb' => 'GET',

--- a/css/settings-admin.scss
+++ b/css/settings-admin.scss
@@ -6,6 +6,7 @@
 	.icon-delete,
 	.icon-checkmark-color,
 	div.stun-server:last-child .icon-add,
+	div.signaling-server:last-child .icon-add,
 	div.turn-server:last-child .icon-add {
 		display: inline-block;
 	}

--- a/js/admin/signaling-server.js
+++ b/js/admin/signaling-server.js
@@ -1,28 +1,127 @@
 /* global OC, OCP, OCA, $, _, Handlebars */
 
-(function(OC, OCP, OCA, $) {
+(function(OC, OCP, OCA, $, _, Handlebars) {
 	'use strict';
 
 	OCA.VideoCalls = OCA.VideoCalls || {};
 	OCA.VideoCalls.Admin = OCA.VideoCalls.Admin || {};
 	OCA.VideoCalls.Admin.SignalingServer = {
 
-		$signaling: undefined,
+		TEMPLATE: '<div class="signaling-server">' +
+		'	<input type="text" class="server" placeholder="wss://signaling.example.org" value="{{server}}">' +
+		'	<input type="checkbox" id="verify{{seed}}" name="verify{{seed}}" class="checkbox verify" value="1" {{#if verify}} checked="checked"{{/if}}>' +
+		'	<label for="verify{{seed}}">' + t('spreed', 'Validate SSL certificate') + '</label>' +
+		'	<a class="icon icon-delete" title="' + t('spreed', 'Delete server') + '"></a>' +
+		'	<a class="icon icon-add" title="' + t('spreed', 'Add new server') + '"></a>' +
+		'	<span class="icon icon-checkmark-color hidden" title="' + t('spreed', 'Saved') + '"></span>' +
+		'</div>',
+		$list: undefined,
+		$secret: undefined,
+		template: undefined,
+		seed: 0,
 
 		init: function() {
-			this.$signaling = $('div.signaling-server');
-			this.$signaling.find('input').on('change', this.saveServer);
+			this.template = Handlebars.compile(this.TEMPLATE);
+			this.$list = $('div.signaling-servers');
+			this.$secret = $('#signaling_secret');
+			this.renderList();
+
+			this.$secret.on('change', this.saveServers.bind(this));
 		},
 
-		saveServer: function() {
-			// this.$signaling.find('input').removeClass('error');
-			// this.$signaling.find('.icon-checkmark-color').addClass('hidden');
+		renderList: function() {
+			var data = this.$list.data('servers');
 
-			// OCP.AppConfig.setValue('spreed', $(this).attr('name'), $(this).value, {
-			// 	success: function() {
-			// 		self.temporaryShowSuccess($server);
-			// 	}
-			// });
+			var hasServers = false;
+			if (!_.isUndefined(data.secret)) {
+				_.each(data.servers, function (server) {
+					this.$list.append(
+						this.renderServer(server)
+					);
+				}.bind(this));
+
+				hasServers = data.servers.length !== 0;
+
+				this.$secret.val(data.secret);
+			}
+
+			if (!hasServers) {
+				this.addNewTemplate();
+			}
+
+			this.$secret.parents('p').first().removeClass('hidden');
+		},
+
+		addNewTemplate: function() {
+			var $server = this.renderServer({
+				validate: true
+			});
+			this.$list.append($server);
+			return $server;
+		},
+
+		deleteServer: function(e) {
+			e.stopPropagation();
+
+			var $server = $(e.currentTarget).parents('div.signaling-server').first();
+			$server.remove();
+
+			this.saveServers();
+
+			if (this.$list.find('div.signaling-server').length === 0) {
+				var $newServer = this.addNewTemplate();
+				this.temporaryShowSuccess($newServer);
+			}
+		},
+
+		saveServers: function() {
+			var servers = [],
+				$error = [],
+				$success = [],
+				self = this,
+				$secret = this.$secret,
+				secret = this.$secret.val().trim();
+
+			this.$list.find('input').removeClass('error');
+			this.$secret.removeClass('error');
+			this.$list.find('.icon-checkmark-color').addClass('hidden');
+
+			this.$list.find('div.signaling-server').each(function() {
+				var $row = $(this),
+					$server = $row.find('input.server'),
+					$verify = $row.find('input.verify'),
+					data = {
+						server: $server.val().trim(),
+						verify: $verify.val() === '1'
+					};
+
+				if (data.server === '') {
+					$error.push($server);
+					return;
+				}
+
+				if (secret === '') {
+					$error.push($secret);
+					return;
+				}
+
+				$success.push($(this));
+				servers.push(data);
+			});
+
+			OCP.AppConfig.setValue('spreed', 'signaling_servers', JSON.stringify({
+				servers: servers,
+				secret: secret
+			}), {
+				success: function() {
+					_.each($error, function($input) {
+						$input.addClass('error');
+					});
+					_.each($success, function($server) {
+						self.temporaryShowSuccess($server);
+					});
+				}
+			});
 		},
 
 		temporaryShowSuccess: function($server) {
@@ -31,12 +130,23 @@
 			setTimeout(function() {
 				$icon.addClass('hidden');
 			}, 2000);
+		},
+
+		renderServer: function(server) {
+			server.seed = this.seed++;
+			var $template = $(this.template(server));
+
+			$template.find('a.icon-add').on('click', this.addNewTemplate.bind(this));
+			$template.find('a.icon-delete').on('click', this.deleteServer.bind(this));
+			$template.find('input').on('change', this.saveServers.bind(this));
+
+			return $template;
 		}
 
 	};
 
 
-})(OC, OCP, OCA, $);
+})(OC, OCP, OCA, $, _, Handlebars);
 
 $(document).ready(function(){
 	OCA.VideoCalls.Admin.SignalingServer.init();

--- a/js/admin/signaling-server.js
+++ b/js/admin/signaling-server.js
@@ -1,0 +1,43 @@
+/* global OC, OCP, OCA, $, _, Handlebars */
+
+(function(OC, OCP, OCA, $) {
+	'use strict';
+
+	OCA.VideoCalls = OCA.VideoCalls || {};
+	OCA.VideoCalls.Admin = OCA.VideoCalls.Admin || {};
+	OCA.VideoCalls.Admin.SignalingServer = {
+
+		$signaling: undefined,
+
+		init: function() {
+			this.$signaling = $('div.signaling-server');
+			this.$signaling.find('input').on('change', this.saveServer);
+		},
+
+		saveServer: function() {
+			// this.$signaling.find('input').removeClass('error');
+			// this.$signaling.find('.icon-checkmark-color').addClass('hidden');
+
+			// OCP.AppConfig.setValue('spreed', $(this).attr('name'), $(this).value, {
+			// 	success: function() {
+			// 		self.temporaryShowSuccess($server);
+			// 	}
+			// });
+		},
+
+		temporaryShowSuccess: function($server) {
+			var $icon = $server.find('.icon-checkmark-color');
+			$icon.removeClass('hidden');
+			setTimeout(function() {
+				$icon.addClass('hidden');
+			}, 2000);
+		}
+
+	};
+
+
+})(OC, OCP, OCA, $);
+
+$(document).ready(function(){
+	OCA.VideoCalls.Admin.SignalingServer.init();
+});

--- a/js/admin/signaling-server.js
+++ b/js/admin/signaling-server.js
@@ -92,7 +92,7 @@
 					$verify = $row.find('input.verify'),
 					data = {
 						server: $server.val().trim(),
-						verify: $verify.val() === '1'
+						verify: !!$verify.prop('checked')
 					};
 
 				if (data.server === '') {

--- a/js/calls.js
+++ b/js/calls.js
@@ -17,6 +17,10 @@
 			selectParticipants.removeClass('error');
 		});
 
+		signaling.on('roomChanged', function() {
+			OCA.SpreedMe.Calls.leaveCurrentCall(false);
+		});
+
 		OCA.SpreedMe.Calls.leaveAllCalls();
 	}
 

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -33,10 +33,6 @@
 		}
 	};
 
-	SignalingBase.prototype.emit = function(/*ev, data*/) {
-		// Override in subclasses.
-	};
-
 	SignalingBase.prototype._trigger = function(ev, args) {
 		var handlers = this.handlers[ev];
 		if (!handlers) {

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -593,13 +593,13 @@
 
 	StandaloneSignaling.prototype.sendHello = function() {
 		var msg;
-		if (this.sessionId) {
+		if (this.resumeId) {
 			console.log("Trying to resume session", this.sessionId);
 			msg = {
 				"type": "hello",
 				"hello": {
 					"version": "1.0",
-					"sessionid": this.sessionId
+					"resumeid": this.resumeId
 				}
 			};
 		} else {
@@ -625,9 +625,9 @@
 	StandaloneSignaling.prototype.helloResponseReceived = function(data) {
 		console.log("Hello response received", data);
 		if (data.type !== "hello") {
-			if (this.sessionId) {
+			if (this.resumeId) {
 				// Resuming the session failed, reconnect as new session.
-				this.sessionId = '';
+				this.resumeId = '';
 				this.sendHello();
 				return;
 			}
@@ -638,9 +638,10 @@
 			return;
 		}
 
-		var resumedSession = !!this.sessionId;
+		var resumedSession = !!this.resumeId;
 		this.connected = true;
 		this.sessionId = data.hello.sessionid;
+		this.resumeId = data.hello.resumeid;
 
 		var messages = this.pendingMessages;
 		this.pendingMessages = [];

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -8,6 +8,7 @@
 		this.sessionId = '';
 		this.currentCallToken = null;
 		this.handlers = {};
+		this.features = {};
 	}
 
 	SignalingBase.prototype.on = function(ev, handler) {
@@ -56,6 +57,10 @@
 	SignalingBase.prototype.disconnect = function() {
 		this.sessionId = '';
 		this.currentCallToken = null;
+	};
+
+	SignalingBase.prototype.hasFeature = function(feature) {
+		return this.features && this.features[feature];
 	};
 
 	SignalingBase.prototype.emit = function(ev, data) {
@@ -642,10 +647,18 @@
 		this.connected = true;
 		this.sessionId = data.hello.sessionid;
 		this.resumeId = data.hello.resumeid;
+		this.features = {};
+		var i;
+		if (data.hello.server && data.hello.server.features) {
+			var features = data.hello.server.features;
+			for (i = 0; i < features.length; i++) {
+				this.features[features[i]] = true;
+			}
+		}
 
 		var messages = this.pendingMessages;
 		this.pendingMessages = [];
-		for (var i = 0; i < messages.length; i++) {
+		for (i = 0; i < messages.length; i++) {
 			var msg = messages[i][0];
 			var callback = messages[i][1];
 			this.doSend(msg, callback);

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -607,7 +607,7 @@
 			};
 		} else {
 			var user = OC.getCurrentUser();
-			var url = OC.generateUrl("/apps/spreed/signalling/backend");
+			var url = OC.generateUrl("/ocs/v2.php/apps/spreed/api/v1/signaling/backend");
 			msg = {
 				"type": "hello",
 				"hello": {

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -439,8 +439,15 @@
 		}.bind(this));
 	};
 
-	function StandaloneSignaling(settings, url) {
+	function StandaloneSignaling(settings, urls) {
 		SignalingBase.prototype.constructor.apply(this, arguments);
+		if (typeof(urls) === "string") {
+			urls = [urls];
+		}
+		// We can connect to any of the servers.
+		var idx = Math.floor(Math.random() * urls.length);
+		// TODO(jojo): Try other server if connection fails.
+		var url = urls[idx];
 		// Make sure we are using websocket urls.
 		if (url.indexOf("https://") === 0) {
 			url = "wss://" + url.substr(8);
@@ -755,9 +762,9 @@
 		} else {
 			settings = {};
 		}
-		var url = settings['server'];
-		if (url)  {
-			return new StandaloneSignaling(settings, url);
+		var urls = settings['server'];
+		if (urls)  {
+			return new StandaloneSignaling(settings, urls);
 		} else {
 			return new InternalSignaling(settings);
 		}

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -801,7 +801,7 @@
 			settings = {};
 		}
 		var urls = settings['server'];
-		if (urls)  {
+		if (urls && urls.length) {
 			return new StandaloneSignaling(settings, urls);
 		} else {
 			return new InternalSignaling(settings);

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -534,7 +534,11 @@
 					}
 					break;
 				case "room":
-					// No special processing required for now.
+					if (this.currentCallToken && data.room.roomid != this.currentCallToken) {
+						this._trigger('roomChanged', [this.currentCallToken, data.room.roomid]);
+						this.joinedUsers = {};
+						this.currentCallToken = null;
+					}
 					break;
 				case "event":
 					this.processEvent(data);

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -534,7 +534,7 @@
 					}
 					break;
 				case "room":
-					if (this.currentCallToken && data.room.roomid != this.currentCallToken) {
+					if (this.currentCallToken && data.room.roomid !== this.currentCallToken) {
 						this._trigger('roomChanged', [this.currentCallToken, data.room.roomid]);
 						this.joinedUsers = {};
 						this.currentCallToken = null;

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -667,6 +667,11 @@
 		}
 
 		this._trigger("connect");
+		if (this.reconnected) {
+			// The list of rooms might have changed while we were not connected,
+			// so perform resync once.
+			this.internalSyncRooms();
+		}
 		if (!resumedSession && this.currentCallToken) {
 			this.joinCall(this.currentCallToken);
 		}

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -3,7 +3,8 @@
 
 	OCA.SpreedMe = OCA.SpreedMe || {};
 
-	function SignalingBase() {
+	function SignalingBase(settings) {
+		this.settings = settings;
 		this.sessionId = '';
 		this.currentCallToken = null;
 		this.handlers = {};
@@ -110,7 +111,7 @@
 	};
 
 	// Connection to the internal signaling server provided by the app.
-	function InternalSignaling() {
+	function InternalSignaling(/*settings*/) {
 		SignalingBase.prototype.constructor.apply(this, arguments);
 		this.spreedArrayConnection = [];
 
@@ -431,7 +432,7 @@
 		}.bind(this));
 	};
 
-	function StandaloneSignaling(url) {
+	function StandaloneSignaling(settings, url) {
 		SignalingBase.prototype.constructor.apply(this, arguments);
 		// Make sure we are using websocket urls.
 		if (url.indexOf("https://") === 0) {
@@ -601,7 +602,6 @@
 		} else {
 			var user = OC.getCurrentUser();
 			var url = OC.generateUrl("/apps/spreed/signalling/backend");
-			var ticket = $("#app").attr("data-signalingticket");
 			msg = {
 				"type": "hello",
 				"hello": {
@@ -610,7 +610,7 @@
 						"url": OC.getProtocol() + "://" + OC.getHost() + url,
 						"params": {
 							"userid": user.uid,
-							"ticket": ticket,
+							"ticket": this.settings.ticket
 						}
 					}
 				}
@@ -753,11 +753,17 @@
 	};
 
 	OCA.SpreedMe.createSignalingConnection = function() {
-		var url = $("#app").attr("data-signalingserver");
-		if (url)  {
-			return new StandaloneSignaling(url);
+		var settings = $("#app #signaling-settings").text();
+		if (settings) {
+			settings = JSON.parse(settings);
 		} else {
-			return new InternalSignaling();
+			settings = {};
+		}
+		var url = settings['server'];
+		if (url)  {
+			return new StandaloneSignaling(settings, url);
+		} else {
+			return new InternalSignaling(settings);
 		}
 	};
 

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -16,6 +16,20 @@
 		} else {
 			this.handlers[ev].push(handler);
 		}
+
+		switch (ev) {
+			case 'stunservers':
+			case 'turnservers':
+				var servers = this.settings[ev] || [];
+				if (servers.length) {
+					// The caller expects the handler to be called when the data
+					// is available, so defer to simulate a delayed response.
+					_.defer(function() {
+						handler(servers);
+					});
+				}
+				break;
+		}
 	};
 
 	SignalingBase.prototype.emit = function(/*ev, data*/) {
@@ -155,13 +169,6 @@
 			case 'connect':
 				// A connection is established if we can perform a request
 				// through it.
-				this._sendMessageWithCallback(ev);
-				break;
-
-			case 'stunservers':
-			case 'turnservers':
-				// Values are not pushed by the server but have to be explicitly
-				// requested.
 				this._sendMessageWithCallback(ev);
 				break;
 		}
@@ -545,17 +552,6 @@
 			this.socket = null;
 		}
 		SignalingBase.prototype.disconnect.apply(this, arguments);
-	};
-
-	StandaloneSignaling.prototype.on = function(ev/*, handler*/) {
-		SignalingBase.prototype.on.apply(this, arguments);
-
-		switch (ev) {
-			case "stunservers":
-			case "turnservers":
-				// TODO(fancycode): Implement getting STUN/TURN settings.
-				break;
-		}
 	};
 
 	StandaloneSignaling.prototype.sendCallMessage = function(data) {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -112,12 +112,13 @@ class Application extends App {
 			// so they can update the room properties.
 			$notifier->roomModified($room);
 		});
-		$dispatcher->addListener(Room::class . '::preDeleteRoom', function(GenericEvent $event) {
+		$dispatcher->addListener(Room::class . '::postDeleteRoom', function(GenericEvent $event) {
 			/** @var BackendNotifier $notifier */
 			$notifier = $this->getContainer()->query(BackendNotifier::class);
 
 			$room = $event->getSubject();
-			$notifier->roomDeleted($room);
+			$participants = $event->getArgument('participants');
+			$notifier->roomDeleted($room, $participants);
 		});
 		$dispatcher->addListener(Room::class . '::postRemoveUser', function(GenericEvent $event) {
 			/** @var BackendNotifier $notifier */

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -88,8 +88,6 @@ class Application extends App {
 		$dispatcher->addListener(Room::class . '::postRemoveBySession', $listener);
 		$dispatcher->addListener(Room::class . '::postUserDisconnectRoom', $listener);
 
-
-		$dispatcher = $this->getContainer()->getServer()->getEventDispatcher();
 		$dispatcher->addListener(Room::class . '::postAddUsers', function(GenericEvent $event) {
 			/** @var BackendNotifier $notifier */
 			$notifier = $this->getContainer()->query(BackendNotifier::class);

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -22,6 +22,7 @@
 namespace OCA\Spreed\AppInfo;
 
 use OCA\Spreed\Activity\Hooks;
+use OCA\Spreed\BackendNotifier;
 use OCA\Spreed\Chat\ChatManager;
 use OCA\Spreed\HookListener;
 use OCA\Spreed\Notification\Notifier;
@@ -86,6 +87,39 @@ class Application extends App {
 		$dispatcher->addListener(Room::class . '::postRemoveUser', $listener);
 		$dispatcher->addListener(Room::class . '::postRemoveBySession', $listener);
 		$dispatcher->addListener(Room::class . '::postUserDisconnectRoom', $listener);
+
+
+		$dispatcher = $this->getContainer()->getServer()->getEventDispatcher();
+		$dispatcher->addListener(Room::class . '::postAddUsers', function(GenericEvent $event) {
+			/** @var BackendNotifier $notifier */
+			$notifier = $this->getContainer()->query(BackendNotifier::class);
+
+			$room = $event->getSubject();
+			$participants= $event->getArgument('users');
+			$notifier->roomInvited($room, $participants);
+		});
+		$dispatcher->addListener(Room::class . '::postSetName', function(GenericEvent $event) {
+			/** @var BackendNotifier $notifier */
+			$notifier = $this->getContainer()->query(BackendNotifier::class);
+
+			$room = $event->getSubject();
+			$notifier->roomModified($room);
+		});
+		$dispatcher->addListener(Room::class . '::preDeleteRoom', function(GenericEvent $event) {
+			/** @var BackendNotifier $notifier */
+			$notifier = $this->getContainer()->query(BackendNotifier::class);
+
+			$room = $event->getSubject();
+			$notifier->roomDeleted($room);
+		});
+		$dispatcher->addListener(Room::class . '::postRemoveUser', function(GenericEvent $event) {
+			/** @var BackendNotifier $notifier */
+			$notifier = $this->getContainer()->query(BackendNotifier::class);
+
+			$room = $event->getSubject();
+			$user = $event->getArgument('user');
+			$notifier->roomsDisinvited($room, [$user->getUID()]);
+		});
 	}
 
 	protected function registerActivityHooks(EventDispatcherInterface $dispatcher) {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -105,6 +105,15 @@ class Application extends App {
 			$room = $event->getSubject();
 			$notifier->roomModified($room);
 		});
+		$dispatcher->addListener(Room::class . '::postSetParticipantType', function(GenericEvent $event) {
+			/** @var BackendNotifier $notifier */
+			$notifier = $this->getContainer()->query(BackendNotifier::class);
+
+			$room = $event->getSubject();
+			// The type of a participant has changed, notify all participants
+			// so they can update the room properties.
+			$notifier->roomModified($room);
+		});
 		$dispatcher->addListener(Room::class . '::preDeleteRoom', function(GenericEvent $event) {
 			/** @var BackendNotifier $notifier */
 			$notifier = $this->getContainer()->query(BackendNotifier::class);

--- a/lib/BackendNotifier.php
+++ b/lib/BackendNotifier.php
@@ -21,17 +21,18 @@
  *
  */
 
-namespace OCA\Spreed\Controller;
+namespace OCA\Spreed;
 
 use OCA\Spreed\Config;
 use OCA\Spreed\Room;
-use OCP\AppFramework\Controller;
 use OCP\Http\Client\IClientService;
 use OCP\ILogger;
 use OCP\IRequest;
 use OCP\Security\ISecureRandom;
 
-class BackendController extends Controller {
+class BackendNotifier{
+	/** @var Manager */
+	private $manager;
 	/** @var Config */
 	private $config;
 	/** @var ILogger */
@@ -42,19 +43,18 @@ class BackendController extends Controller {
 	private $secureRandom;
 
 	/**
-	 * @param string $appName
-	 * @param IRequest $request
+	 * @param Manager $manager
 	 * @param IConfig $config
 	 * @param ILogger $logger
 	 * @param IClientService $clientService
+	 * @param ISecureRandom $secureRandom
 	 */
-	public function __construct($appName,
-								IRequest $request,
+	public function __construct(Manager $manager,
 								Config $config,
 								ILogger $logger,
 								IClientService $clientService,
 								ISecureRandom $secureRandom) {
-		parent::__construct($appName, $request);
+		$this->manager = $manager;
 		$this->config = $config;
 		$this->logger = $logger;
 		$this->clientService = $clientService;

--- a/lib/BackendNotifier.php
+++ b/lib/BackendNotifier.php
@@ -74,11 +74,8 @@ class BackendNotifier{
 		}
 
 		// We can use any server of the available backends.
-		$signaling = $signaling[array_rand($signaling)];
-		if (substr($signaling, -1) === '/') {
-			$signaling = substr($signaling, 0, strlen($signaling) - 1);
-		}
-		$url = $signaling . $url;
+		$signaling['server'] = rtrim($signaling['server'], '/');
+		$url = rtrim($signaling['server'], '/') . $url;
 		if (substr($url, 0, 6) === 'wss://') {
 			$url = 'https://' . substr($url, 6);
 		} else if (substr($url, 0, 5) === 'ws://') {
@@ -99,10 +96,10 @@ class BackendNotifier{
 			'headers' => $headers,
 			'body' => $body,
 		];
-		if ($this->config->allowInsecureSignaling()) {
+		if (!$signaling['verify']) {
 			$params['verify'] = false;
 		}
-		$response = $client->post($url, $params);
+		$client->post($url, $params);
 	}
 
 	/**

--- a/lib/BackendNotifier.php
+++ b/lib/BackendNotifier.php
@@ -192,12 +192,16 @@ class BackendNotifier{
 	 *
 	 * @param Room $room
 	 */
-	public function roomDeleted($room) {
+	public function roomDeleted($room, $participants) {
 		$this->logger->info("Room deleted: " . $room->getToken());
+		$userIds = [];
+		foreach ($participants['users'] as $participant => $data) {
+			array_push($userIds, $participant);
+		}
 		$this->backendRequest('/api/v1/room/' . $room->getToken(), [
 			'type' => 'delete',
 			'delete' => [
-				'userids' => $this->getRoomUserIds($room),
+				'userids' => $userIds,
 			],
 		]);
 	}

--- a/lib/BackendNotifier.php
+++ b/lib/BackendNotifier.php
@@ -68,12 +68,13 @@ class BackendNotifier{
 	 * @param array $data
 	 */
 	private function backendRequest($url, $data) {
-		$signaling = $this->config->getSignalingServer();
-		if (empty($signaling)) {
+		$servers = $this->config->getSignalingServers();
+		if (empty($servers)) {
 			return;
 		}
 
 		// We can use any server of the available backends.
+		$signaling = $servers[mt_rand(0, count($servers) - 1)];
 		$signaling['server'] = rtrim($signaling['server'], '/');
 		$url = rtrim($signaling['server'], '/') . $url;
 		if (substr($url, 0, 6) === 'wss://') {

--- a/lib/BackendNotifier.php
+++ b/lib/BackendNotifier.php
@@ -122,10 +122,14 @@ class BackendNotifier{
 	 * The given users are now invited to a room.
 	 *
 	 * @param Room $room
-	 * @param array $userIds
+	 * @param array $users
 	 */
-	public function roomInvited($room, $userIds) {
-		$this->logger->info("Now invited to " . $room->getToken() . ": " + print_r($userIds, true));
+	public function roomInvited($room, $users) {
+		$this->logger->info("Now invited to " . $room->getToken() . ": " + print_r($users, true));
+		$userIds = [];
+		foreach ($users as $user) {
+			array_push($userIds, $user["userId"]);
+		}
 		$this->backendRequest('/api/v1/room/' . $room->getToken(), [
 			'type' => 'invite',
 			'invite' => [

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -23,6 +23,8 @@ namespace OCA\Spreed;
 
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
+use OCP\IUser;
+use OCP\Security\ISecureRandom;
 
 class Config {
 
@@ -32,14 +34,21 @@ class Config {
 	/** @var ITimeFactory */
 	protected $timeFactory;
 
+	/** @var ISecureRandom */
+	private $secureRandom;
+
 	/**
 	 * Config constructor.
 	 *
 	 * @param IConfig $config
+	 * @param ISecureRandom $secureRandom
 	 * @param ITimeFactory $timeFactory
 	 */
-	public function __construct(IConfig $config, ITimeFactory $timeFactory) {
+	public function __construct(IConfig $config,
+								ISecureRandom $secureRandom,
+								ITimeFactory $timeFactory) {
 		$this->config = $config;
+		$this->secureRandom = $secureRandom;
 		$this->timeFactory = $timeFactory;
 	}
 
@@ -94,6 +103,77 @@ class Config {
 			'password' => $password,
 			'protocols' => $server['protocols'],
 		);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSignalingServer() {
+		return $this->config->getAppValue('spreed', 'signaling_server', '');
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSignalingSecret() {
+		return $this->config->getAppValue('spreed', 'signaling_secret', '');
+	}
+
+	/**
+	 * @param string $userId
+	 * @return string
+	 */
+	public function getSignalingTicket($userId) {
+		if (empty($userId)) {
+			$secret = $this->config->getAppValue('spreed', 'signaling_ticket_secret', '');
+		} else {
+			$secret = $this->config->getUserValue($userId, 'spreed', 'signaling_ticket_secret', '');
+		}
+		if (empty($secret)) {
+			// Create secret lazily on first access.
+			// TODO(fancycode): Is there a possibility for a race condition?
+			$secret = $this->secureRandom->generate(255);
+			if (empty($userId)) {
+				$this->config->setAppValue('spreed', 'signaling_ticket_secret', $secret);
+			} else {
+				$this->config->setUserValue($userId, 'spreed', 'signaling_ticket_secret', $secret);
+			}
+		}
+
+		// Format is "random:timestamp:userid:checksum" and "checksum" is the
+		// SHA256-HMAC of "random:timestamp:userid" with the per-user secret.
+		$random = $this->secureRandom->generate(16);
+		$timestamp = $this->timeFactory->getTime();
+		$data = $random . ':' . $timestamp . ':' . $userId;
+		$hash = hash_hmac('sha256', $data, $secret);
+		return $data . ':' . $hash;
+	}
+
+	/**
+	 * @param string $userId
+	 * @param string $ticket
+	 * @return bool
+	 */
+	public function validateSignalingTicket($userId, $ticket) {
+		if (empty($userId)) {
+			$secret = $this->config->getAppValue('spreed', 'signaling_ticket_secret', '');
+		} else {
+			$secret = $this->config->getUserValue($userId, 'spreed', 'signaling_ticket_secret', '');
+		}
+		if (empty($secret)) {
+			return false;
+		}
+
+		$lastcolon = strrpos($ticket, ':');
+		if ($lastcolon === false) {
+			// Immediately reject invalid formats.
+			return false;
+		}
+
+		// TODO(fancycode): Should we reject tickets that are too old?
+		$data = substr($ticket, 0, $lastcolon);
+		$hash = hash_hmac('sha256', $data, $secret);
+		return hash_equals($hash, substr($ticket, $lastcolon + 1));
 	}
 
 }

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -120,6 +120,13 @@ class Config {
 	}
 
 	/**
+	 * @return bool
+	 */
+	public function allowInsecureSignaling() {
+		return ($this->config->getAppValue('spreed', 'signaling_skip_verify_cert', '') != '');
+	}
+
+	/**
 	 * @param string $userId
 	 * @return string
 	 */

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -123,7 +123,8 @@ class Config {
 	 * @return bool
 	 */
 	public function allowInsecureSignaling() {
-		return ($this->config->getAppValue('spreed', 'signaling_skip_verify_cert', '') != '');
+		$skip_verify = $this->config->getAppValue('spreed', 'signaling_skip_verify_cert', '');
+		return !empty($skip_verify);
 	}
 
 	/**

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -109,7 +109,11 @@ class Config {
 	 * @return string
 	 */
 	public function getSignalingServer() {
-		return $this->config->getAppValue('spreed', 'signaling_server', '');
+		$server = $this->config->getAppValue('spreed', 'signaling_server', '');
+		if ($server === '') {
+			return [];
+		}
+		return explode('\n', $server);
 	}
 
 	/**

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -106,20 +106,19 @@ class Config {
 	}
 
 	/**
+	 * Returns list of signaling servers. Each entry contains the URL of the
+	 * server and a flag whether the certificate should be verified.
+	 *
 	 * @return array
 	 */
-	public function getSignalingServer() {
+	public function getSignalingServers() {
 		$config = $this->config->getAppValue('spreed', 'signaling_servers');
 		$signaling = json_decode($config, true);
-
 		if (!is_array($signaling)) {
 			return [];
 		}
 
-		// For now we use a random server from the list
-		$server = $signaling['servers'][mt_rand(0, count($servers) - 1)];
-
-		return explode('\n', $server);
+		return $signaling['servers'];
 	}
 
 	/**

--- a/lib/Controller/BackendController.php
+++ b/lib/Controller/BackendController.php
@@ -93,11 +93,14 @@ class BackendController extends Controller {
 		$headers['Spreed-Signaling-Random'] = $random;
 		$headers['Spreed-Signaling-Checksum'] = $hash;
 
-		$response = $client->post($url, [
+		$params = [
 			'headers' => $headers,
 			'body' => $body,
-			'verify' => false,
-		]);
+		];
+		if ($this->config->allowInsecureSignaling()) {
+			$params['verify'] = false;
+		}
+		$response = $client->post($url, $params);
 	}
 
 	/**

--- a/lib/Controller/BackendController.php
+++ b/lib/Controller/BackendController.php
@@ -73,6 +73,8 @@ class BackendController extends Controller {
 			return;
 		}
 
+		// We can use any server of the available backends.
+		$signaling = $signaling[array_rand($signaling)];
 		if (substr($signaling, -1) === '/') {
 			$signaling = substr($signaling, 0, strlen($signaling) - 1);
 		}

--- a/lib/Controller/BackendController.php
+++ b/lib/Controller/BackendController.php
@@ -104,6 +104,21 @@ class BackendController extends Controller {
 	}
 
 	/**
+	 * Return list of userids that are invited to a room.
+	 *
+	 * @param Room $room
+	 * @return array
+	 */
+	private function getRoomUserIds($room) {
+		$participants = $room->getParticipants();
+		$userIds = [];
+		foreach ($participants['users'] as $participant => $data) {
+			array_push($userIds, $participant);
+		}
+		return $userIds;
+	}
+
+	/**
 	 * The given users are now invited to a room.
 	 *
 	 * @param Room $room
@@ -115,6 +130,9 @@ class BackendController extends Controller {
 			'type' => 'invite',
 			'invite' => [
 				'userids' => $userIds,
+				// TODO(fancycode): We should try to get rid of "alluserids" and
+				// find a better way to notify existing users to update the room.
+				'alluserids' => $this->getRoomUserIds($room),
 				'properties' => [
 					'name' => $room->getName(),
 					'type' => $room->getType(),
@@ -135,6 +153,13 @@ class BackendController extends Controller {
 			'type' => 'disinvite',
 			'disinvite' => [
 				'userids' => $userIds,
+				// TODO(fancycode): We should try to get rid of "alluserids" and
+				// find a better way to notify existing users to update the room.
+				'alluserids' => $this->getRoomUserIds($room),
+				'properties' => [
+					'name' => $room->getName(),
+					'type' => $room->getType(),
+				],
 			],
 		]);
 	}
@@ -146,15 +171,10 @@ class BackendController extends Controller {
 	 */
 	public function roomModified($room) {
 		$this->logger->info("Room modified: " . $room->getToken());
-		$participants = $room->getParticipants();
-		$userIds = [];
-		foreach ($participants['users'] as $participant => $data) {
-			array_push($userIds, $participant);
-		}
 		$this->backendRequest('/api/v1/room/' . $room->getToken(), [
 			'type' => 'update',
 			'update' => [
-				'userids' => $userIds,
+				'userids' => $this->getRoomUserIds($room),
 				'properties' => [
 					'name' => $room->getName(),
 					'type' => $room->getType(),
@@ -170,15 +190,10 @@ class BackendController extends Controller {
 	 */
 	public function roomDeleted($room) {
 		$this->logger->info("Room deleted: " . $room->getToken());
-		$participants = $room->getParticipants();
-		$userIds = [];
-		foreach ($participants['users'] as $participant => $data) {
-			array_push($userIds, $participant);
-		}
 		$this->backendRequest('/api/v1/room/' . $room->getToken(), [
 			'type' => 'delete',
 			'delete' => [
-				'userids' => $userIds,
+				'userids' => $this->getRoomUserIds($room),
 			],
 		]);
 	}

--- a/lib/Controller/BackendController.php
+++ b/lib/Controller/BackendController.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Joachim Bauch <bauch@struktur.de>
+ *
+ * @author Joachim Bauch <bauch@struktur.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Controller;
+
+use OCA\Spreed\Config;
+use OCA\Spreed\Room;
+use OCP\AppFramework\Controller;
+use OCP\Http\Client\IClientService;
+use OCP\ILogger;
+use OCP\IRequest;
+use OCP\Security\ISecureRandom;
+
+class BackendController extends Controller {
+	/** @var Config */
+	private $config;
+	/** @var ILogger */
+	private $logger;
+	/** @var IClientService */
+	private $clientService;
+	/** @var ISecureRandom */
+	private $secureRandom;
+
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param IConfig $config
+	 * @param ILogger $logger
+	 * @param IClientService $clientService
+	 */
+	public function __construct($appName,
+								IRequest $request,
+								Config $config,
+								ILogger $logger,
+								IClientService $clientService,
+								ISecureRandom $secureRandom) {
+		parent::__construct($appName, $request);
+		$this->config = $config;
+		$this->logger = $logger;
+		$this->clientService = $clientService;
+		$this->secureRandom = $secureRandom;
+	}
+
+	/**
+	 * Perform a request to the signaling backend.
+	 *
+	 * @param string $url
+	 * @param array $data
+	 */
+	private function backendRequest($url, $data) {
+		$signaling = $this->config->getSignalingServer();
+		if (empty($signaling)) {
+			return;
+		}
+
+		if (substr($signaling, -1) === '/') {
+			$signaling = substr($signaling, 0, strlen($signaling) - 1);
+		}
+		$url = $signaling . $url;
+		if (substr($url, 0, 6) === 'wss://') {
+			$url = 'https://' . substr($url, 6);
+		} else if (substr($url, 0, 5) === 'ws://') {
+			$url = 'http://' . substr($url, 5);
+		}
+		$client = $this->clientService->newClient();
+		$body = json_encode($data);
+		$headers = [
+			'Content-Type' => 'application/json',
+		];
+
+		$random = $this->secureRandom->generate(64);
+		$hash = hash_hmac('sha256', $random . $body, $this->config->getSignalingSecret());
+		$headers['Spreed-Signaling-Random'] = $random;
+		$headers['Spreed-Signaling-Checksum'] = $hash;
+
+		$response = $client->post($url, [
+			'headers' => $headers,
+			'body' => $body,
+			'verify' => false,
+		]);
+	}
+
+	/**
+	 * The given users are now invited to a room.
+	 *
+	 * @param Room $room
+	 * @param array $userIds
+	 */
+	public function roomInvited($room, $userIds) {
+		$this->logger->info("Now invited to " . $room->getToken() . ": " + print_r($userIds, true));
+		$this->backendRequest('/api/v1/room/' . $room->getToken(), [
+			'type' => 'invite',
+			'invite' => [
+				'userids' => $userIds,
+				'properties' => [
+					'name' => $room->getName(),
+					'type' => $room->getType(),
+				],
+			],
+		]);
+	}
+
+	/**
+	 * The given users are no longer invited to a room.
+	 *
+	 * @param Room $room
+	 * @param array $userIds
+	 */
+	public function roomsDisinvited($room, $userIds) {
+		$this->logger->info("No longer invited to " . $room->getToken() . ": " + print_r($userIds, true));
+		$this->backendRequest('/api/v1/room/' . $room->getToken(), [
+			'type' => 'disinvite',
+			'disinvite' => [
+				'userids' => $userIds,
+			],
+		]);
+	}
+
+	/**
+	 * The given room has been modified.
+	 *
+	 * @param Room $room
+	 */
+	public function roomModified($room) {
+		$this->logger->info("Room modified: " . $room->getToken());
+		$participants = $room->getParticipants();
+		$userIds = [];
+		foreach ($participants['users'] as $participant => $data) {
+			array_push($userIds, $participant);
+		}
+		$this->backendRequest('/api/v1/room/' . $room->getToken(), [
+			'type' => 'update',
+			'update' => [
+				'userids' => $userIds,
+				'properties' => [
+					'name' => $room->getName(),
+					'type' => $room->getType(),
+				],
+			],
+		]);
+	}
+
+	/**
+	 * The given room has been deleted.
+	 *
+	 * @param Room $room
+	 */
+	public function roomDeleted($room) {
+		$this->logger->info("Room deleted: " . $room->getToken());
+		$participants = $room->getParticipants();
+		$userIds = [];
+		foreach ($participants['users'] as $participant => $data) {
+			array_push($userIds, $participant);
+		}
+		$this->backendRequest('/api/v1/room/' . $room->getToken(), [
+			'type' => 'delete',
+			'delete' => [
+				'userids' => $userIds,
+			],
+		]);
+	}
+
+}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -162,8 +162,10 @@ class PageController extends Controller {
 
 		$params = [
 			'token' => $token,
-			'signaling-server' => $this->config->getSignalingServer(),
-			'signaling-ticket' => $this->config->getSignalingTicket($this->userId),
+			'signaling-settings' => [
+				'server' => $this->config->getSignalingServer(),
+				'ticket' => $this->config->getSignalingTicket($this->userId),
+			],
 		];
 		$response = new TemplateResponse($this->appName, 'index', $params);
 		$csp = new ContentSecurityPolicy();
@@ -202,8 +204,10 @@ class PageController extends Controller {
 
 		$params = [
 			'token' => $token,
-			'signaling-server' => $this->config->getSignalingServer(),
-			'signaling-ticket' => $this->config->getSignalingTicket($this->userId),
+			'signaling-settings' => [
+				'server' => $this->config->getSignalingServer(),
+				'ticket' => $this->config->getSignalingTicket($this->userId),
+			],
 		];
 		$response = new TemplateResponse($this->appName, 'index-public', $params, 'base');
 		$csp = new ContentSecurityPolicy();

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -116,8 +116,14 @@ class PageController extends Controller {
 				];
 			}
 		}
+
+		$signaling = $this->config->getSignalingServer();
+		if (!empty($signaling)) {
+			$signaling = $signaling['server'];
+		}
+
 		return [
-			'server' => $this->config->getSignalingServer(),
+			'server' => $signaling,
 			'ticket' => $this->config->getSignalingTicket($this->userId),
 			'stunservers' => $stun,
 			'turnservers' => $turn,

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -117,8 +117,9 @@ class PageController extends Controller {
 			}
 		}
 
-		$signaling = $this->config->getSignalingServer();
-		if (!empty($signaling)) {
+		$servers = $this->config->getSignalingServers();
+		if (!empty($servers)) {
+			$signaling = $servers[mt_rand(0, count($servers) - 1)];
 			$signaling = $signaling['server'];
 		}
 

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -26,6 +26,7 @@ namespace OCA\Spreed\Controller;
 use OC\HintException;
 use OCA\Spreed\Exceptions\ParticipantNotFoundException;
 use OCA\Spreed\Exceptions\RoomNotFoundException;
+use OCA\Spreed\Config;
 use OCA\Spreed\Manager;
 use OCA\Spreed\Participant;
 use OCA\Spreed\Room;
@@ -55,6 +56,8 @@ class PageController extends Controller {
 	private $url;
 	/** @var IManager */
 	private $notificationManager;
+	/** @var Config */
+	private $config;
 
 	/**
 	 * @param string $appName
@@ -66,6 +69,7 @@ class PageController extends Controller {
 	 * @param Manager $manager
 	 * @param IURLGenerator $url
 	 * @param IManager $notificationManager
+	 * @param Config $config
 	 */
 	public function __construct($appName,
 								IRequest $request,
@@ -75,7 +79,8 @@ class PageController extends Controller {
 								ILogger $logger,
 								Manager $manager,
 								IURLGenerator $url,
-								IManager $notificationManager) {
+								IManager $notificationManager,
+								Config $config) {
 		parent::__construct($appName, $request);
 		$this->api = $api;
 		$this->session = $session;
@@ -84,6 +89,7 @@ class PageController extends Controller {
 		$this->manager = $manager;
 		$this->url = $url;
 		$this->notificationManager = $notificationManager;
+		$this->config = $config;
 	}
 
 	/**
@@ -156,6 +162,8 @@ class PageController extends Controller {
 
 		$params = [
 			'token' => $token,
+			'signaling-server' => $this->config->getSignalingServer(),
+			'signaling-ticket' => $this->config->getSignalingTicket($this->userId),
 		];
 		$response = new TemplateResponse($this->appName, 'index', $params);
 		$csp = new ContentSecurityPolicy();
@@ -194,6 +202,8 @@ class PageController extends Controller {
 
 		$params = [
 			'token' => $token,
+			'signaling-server' => $this->config->getSignalingServer(),
+			'signaling-ticket' => $this->config->getSignalingTicket($this->userId),
 		];
 		$response = new TemplateResponse($this->appName, 'index-public', $params, 'base');
 		$csp = new ContentSecurityPolicy();

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -63,6 +63,8 @@ class RoomController extends OCSController {
 	private $activityManager;
 	/** @var IL10N */
 	private $l10n;
+	/** @var BackendController */
+	private $backend;
 
 	/**
 	 * @param string $appName
@@ -76,6 +78,7 @@ class RoomController extends OCSController {
 	 * @param INotificationManager $notificationManager
 	 * @param IActivityManager $activityManager
 	 * @param IL10N $l10n
+	 * @param BackendController $backend
 	 */
 	public function __construct($appName,
 								$UserId,
@@ -87,7 +90,8 @@ class RoomController extends OCSController {
 								Manager $manager,
 								INotificationManager $notificationManager,
 								IActivityManager $activityManager,
-								IL10N $l10n) {
+								IL10N $l10n,
+								BackendController $backend) {
 		parent::__construct($appName, $request);
 		$this->session = $session;
 		$this->userId = $UserId;
@@ -98,6 +102,7 @@ class RoomController extends OCSController {
 		$this->notificationManager = $notificationManager;
 		$this->activityManager = $activityManager;
 		$this->l10n = $l10n;
+		$this->backend = $backend;
 	}
 
 	/**
@@ -350,6 +355,11 @@ class RoomController extends OCSController {
 
 			$this->createNotification($currentUser, $targetUser, $room);
 
+			$this->backend->roomInvited($room, [
+				$currentUser->getUID(),
+				$targetUser->getUID(),
+			]);
+
 			return new DataResponse(['token' => $room->getToken()], Http::STATUS_CREATED);
 		}
 	}
@@ -419,6 +429,8 @@ class RoomController extends OCSController {
 			'participantType' => Participant::OWNER,
 		]);
 
+		$this->backend->roomInvited($room, [$this->userId]);
+
 		return new DataResponse(['token' => $room->getToken()], Http::STATUS_CREATED);
 	}
 
@@ -450,6 +462,8 @@ class RoomController extends OCSController {
 		if (!$room->setName($roomName)) {
 			return new DataResponse([], Http::STATUS_METHOD_NOT_ALLOWED);
 		}
+
+		$this->backend->roomModified($room);
 		return new DataResponse([]);
 	}
 
@@ -473,6 +487,7 @@ class RoomController extends OCSController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
+		$this->backend->roomDeleted($room);
 		$room->deleteRoom();
 
 		return new DataResponse([]);
@@ -561,6 +576,7 @@ class RoomController extends OCSController {
 				'userId' => $newUser->getUID(),
 			]);
 			$this->createNotification($currentUser, $newUser, $room);
+			$this->backend->roomInvited($room, [$newUser->getUID()]);
 
 			return new DataResponse(['type' => $room->getType()]);
 		}
@@ -569,6 +585,7 @@ class RoomController extends OCSController {
 			'userId' => $newUser->getUID(),
 		]);
 		$this->createNotification($currentUser, $newUser, $room);
+		$this->backend->roomInvited($room, [$newUser->getUID()]);
 
 		return new DataResponse([]);
 	}
@@ -596,6 +613,7 @@ class RoomController extends OCSController {
 
 		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
 			$room->deleteRoom();
+			$this->backend->roomDeleted($room);
 			return new DataResponse([]);
 		}
 
@@ -615,6 +633,7 @@ class RoomController extends OCSController {
 		}
 
 		$room->removeUser($targetUser);
+		$this->backend->roomsDisinvited($room, [$targetUser->getUID()]);
 		return new DataResponse([]);
 	}
 
@@ -636,6 +655,7 @@ class RoomController extends OCSController {
 
 		if ($room->getType() === Room::ONE_TO_ONE_CALL || $room->getNumberOfParticipants() === 1) {
 			$room->deleteRoom();
+			$this->backend->roomDeleted($room);
 		} else {
 			$currentUser = $this->userManager->get($this->userId);
 			if (!$currentUser instanceof IUser) {
@@ -643,6 +663,7 @@ class RoomController extends OCSController {
 			}
 
 			$room->removeUser($currentUser);
+			$this->backend->roomsDisinvited($room, [$currentUser->getUID()]);
 		}
 
 		return new DataResponse([]);

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -63,8 +63,6 @@ class RoomController extends OCSController {
 	private $activityManager;
 	/** @var IL10N */
 	private $l10n;
-	/** @var BackendController */
-	private $backend;
 
 	/**
 	 * @param string $appName
@@ -78,7 +76,6 @@ class RoomController extends OCSController {
 	 * @param INotificationManager $notificationManager
 	 * @param IActivityManager $activityManager
 	 * @param IL10N $l10n
-	 * @param BackendController $backend
 	 */
 	public function __construct($appName,
 								$UserId,
@@ -90,8 +87,7 @@ class RoomController extends OCSController {
 								Manager $manager,
 								INotificationManager $notificationManager,
 								IActivityManager $activityManager,
-								IL10N $l10n,
-								BackendController $backend) {
+								IL10N $l10n) {
 		parent::__construct($appName, $request);
 		$this->session = $session;
 		$this->userId = $UserId;
@@ -102,7 +98,6 @@ class RoomController extends OCSController {
 		$this->notificationManager = $notificationManager;
 		$this->activityManager = $activityManager;
 		$this->l10n = $l10n;
-		$this->backend = $backend;
 	}
 
 	/**
@@ -352,13 +347,7 @@ class RoomController extends OCSController {
 				'userId' => $targetUser->getUID(),
 				'participantType' => Participant::OWNER,
 			]);
-
 			$this->createNotification($currentUser, $targetUser, $room);
-
-			$this->backend->roomInvited($room, [
-				$currentUser->getUID(),
-				$targetUser->getUID(),
-			]);
 
 			return new DataResponse(['token' => $room->getToken()], Http::STATUS_CREATED);
 		}
@@ -429,8 +418,6 @@ class RoomController extends OCSController {
 			'participantType' => Participant::OWNER,
 		]);
 
-		$this->backend->roomInvited($room, [$this->userId]);
-
 		return new DataResponse(['token' => $room->getToken()], Http::STATUS_CREATED);
 	}
 
@@ -463,7 +450,6 @@ class RoomController extends OCSController {
 			return new DataResponse([], Http::STATUS_METHOD_NOT_ALLOWED);
 		}
 
-		$this->backend->roomModified($room);
 		return new DataResponse([]);
 	}
 
@@ -487,7 +473,6 @@ class RoomController extends OCSController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		$this->backend->roomDeleted($room);
 		$room->deleteRoom();
 
 		return new DataResponse([]);
@@ -576,7 +561,6 @@ class RoomController extends OCSController {
 				'userId' => $newUser->getUID(),
 			]);
 			$this->createNotification($currentUser, $newUser, $room);
-			$this->backend->roomInvited($room, [$newUser->getUID()]);
 
 			return new DataResponse(['type' => $room->getType()]);
 		}
@@ -585,7 +569,6 @@ class RoomController extends OCSController {
 			'userId' => $newUser->getUID(),
 		]);
 		$this->createNotification($currentUser, $newUser, $room);
-		$this->backend->roomInvited($room, [$newUser->getUID()]);
 
 		return new DataResponse([]);
 	}
@@ -613,7 +596,6 @@ class RoomController extends OCSController {
 
 		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
 			$room->deleteRoom();
-			$this->backend->roomDeleted($room);
 			return new DataResponse([]);
 		}
 
@@ -633,7 +615,6 @@ class RoomController extends OCSController {
 		}
 
 		$room->removeUser($targetUser);
-		$this->backend->roomsDisinvited($room, [$targetUser->getUID()]);
 		return new DataResponse([]);
 	}
 
@@ -655,7 +636,6 @@ class RoomController extends OCSController {
 
 		if ($room->getType() === Room::ONE_TO_ONE_CALL || $room->getNumberOfParticipants() === 1) {
 			$room->deleteRoom();
-			$this->backend->roomDeleted($room);
 		} else {
 			$currentUser = $this->userManager->get($this->userId);
 			if (!$currentUser instanceof IUser) {
@@ -663,7 +643,6 @@ class RoomController extends OCSController {
 			}
 
 			$room->removeUser($currentUser);
-			$this->backend->roomsDisinvited($room, [$currentUser->getUID()]);
 		}
 
 		return new DataResponse([]);

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -30,10 +30,13 @@ use OCA\Spreed\Room;
 use OCA\Spreed\Signaling\Messages;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\OCSController;
 use OCP\IDBConnection;
 use OCP\IRequest;
 use OCP\ISession;
+use OCP\IUser;
+use OCP\IUserManager;
 
 class SignalingController extends OCSController {
 	/** @var Config */
@@ -48,6 +51,8 @@ class SignalingController extends OCSController {
 	private $messages;
 	/** @var string|null */
 	private $userId;
+	/** @var IUserManager */
+	private $userManager;
 
 	/**
 	 * @param string $appName
@@ -66,6 +71,7 @@ class SignalingController extends OCSController {
 								Manager $manager,
 								IDBConnection $connection,
 								Messages $messages,
+								IUserManager $userManager,
 								$UserId) {
 		parent::__construct($appName, $request);
 		$this->config = $config;
@@ -73,6 +79,7 @@ class SignalingController extends OCSController {
 		$this->dbConnection = $connection;
 		$this->manager = $manager;
 		$this->messages = $messages;
+		$this->userManager = $userManager;
 		$this->userId = $UserId;
 	}
 
@@ -83,6 +90,10 @@ class SignalingController extends OCSController {
 	 * @return DataResponse
 	 */
 	public function signaling($messages) {
+		if ($this->config->getSignalingServer() !== '') {
+			throw new \Exception('Internal signaling disabled.');
+		}
+
 		$response = [];
 		$messages = json_decode($messages, true);
 		foreach($messages as $message) {
@@ -137,6 +148,10 @@ class SignalingController extends OCSController {
 	 * @return DataResponse
 	 */
 	public function pullMessages() {
+		if ($this->config->getSignalingServer() !== '') {
+			throw new \Exception('Internal signaling disabled.');
+		}
+
 		$data = [];
 		$seconds = 30;
 		$sessionId = '';
@@ -221,4 +236,143 @@ class SignalingController extends OCSController {
 
 		return $usersInRoom;
 	}
+
+	/*
+	 * Check if the current request is coming from an allowed backend.
+	 *
+	 * The backends are sending the custom header "Spreed-Signaling-Random"
+	 * containing at least 32 bytes random data, and the header
+	 * "Spreed-Signaling-Checksum", which is the SHA256-HMAC of the random data
+	 * and the body of the request, calculated with the shared secret from the
+	 * configuration.
+	 *
+	 * @return bool
+	 */
+	private function validateBackendRequest($data) {
+		$random = $_SERVER['HTTP_SPREED_SIGNALING_RANDOM'];
+		if (empty($random) || strlen($random) < 32) {
+			return false;
+		}
+		$checksum = $_SERVER['HTTP_SPREED_SIGNALING_CHECKSUM'];
+		if (empty($checksum)) {
+			return false;
+		}
+		$hash = hash_hmac('sha256', $random . $data, $this->config->getSignalingSecret());
+		return hash_equals($hash, strtolower($checksum));
+	}
+
+	/**
+	 * Backend API to query information required for standalone signaling
+	 * servers.
+	 *
+	 * See sections "Backend validation" in
+	 * https://github.com/nextcloud/spreed/wiki/Spreed-Signaling-API
+	 *
+	 * @NoCSRFRequired
+	 * @PublicPage
+	 *
+	 * @param string $message
+	 * @return JSONResponse
+	 */
+	public function backend() {
+		$json = file_get_contents('php://input');
+		if (!$this->validateBackendRequest($json)) {
+			return new JSONResponse([
+				'type' => 'error',
+				'error' => [
+					'code' => 'invalid_request',
+					'message' => 'The request could not be authenticated.',
+				],
+			]);
+		}
+
+		$message = json_decode($json, true);
+		switch ($message['type']) {
+			case 'auth':
+				// Query authentication information about a user.
+				return $this->backendAuth($message['auth']);
+			case 'room':
+				// Query information about a room.
+				return $this->backendRoom($message['room']);
+			default:
+				return new JSONResponse([
+					'type' => 'error',
+					'error' => [
+						'code' => 'unknown_type',
+						'message' => 'The given type ' . print_r($message, true) . ' is not supported.',
+					],
+				]);
+		}
+	}
+
+	private function backendAuth($auth) {
+		$params = $auth['params'];
+		$userId = $params['userid'];
+		if (!$this->config->validateSignalingTicket($userId, $params['ticket'])) {
+			return new JSONResponse([
+				'type' => 'error',
+				'error' => [
+					'code' => 'invalid_ticket',
+					'message' => 'The given ticket is not valid for this user.',
+				],
+			]);
+		}
+
+		if (!empty($userId)) {
+			$user = $this->userManager->get($userId);
+			if (!$user instanceof IUser) {
+				return new JSONResponse([
+					'type' => 'error',
+					'error' => [
+						'code' => 'no_such_user',
+						'message' => 'The given user does not exist.',
+					],
+				]);
+			}
+		}
+
+		$response = [
+			'type' => 'auth',
+			'auth' => [
+				'version' => '1.0',
+			],
+		];
+		if (!empty($userId)) {
+			$response['auth']['userid'] = $user->getUID();
+			$response['auth']['user'] = [
+				'displayname' => $user->getDisplayName(),
+			];
+		}
+		return new JSONResponse($response);
+	}
+
+	private function backendRoom($room) {
+		$roomId = $room['roomid'];
+		$userId = $room['userid'];
+		try {
+			$room = $this->manager->getRoomForParticipantByToken($roomId, $userId);
+		} catch (RoomNotFoundException $e) {
+			return new JSONResponse([
+				'type' => 'error',
+				'error' => [
+					'code' => 'no_such_room',
+					'message' => 'The user is not invited to this room.',
+				],
+			]);
+		}
+
+		$response = [
+			'type' => 'room',
+			'room' => [
+				'version' => '1.0',
+				'roomid' => $room->getToken(),
+				'properties' => [
+					'name' => $room->getName(),
+					'type' => $room->getType(),
+				],
+			],
+		];
+		return new JSONResponse($response);
+	}
+
 }

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -361,6 +361,12 @@ class SignalingController extends OCSController {
 			]);
 		}
 
+		if (!empty($userId)) {
+			// Rooms get sorted by last ping time for users, so make sure to
+			// update when a user joins a room.
+			$room->ping($userId, '0', time());
+		}
+
 		$response = [
 			'type' => 'room',
 			'room' => [

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -90,7 +90,8 @@ class SignalingController extends OCSController {
 	 * @return DataResponse
 	 */
 	public function signaling($messages) {
-		if ($this->config->getSignalingServer() !== '') {
+		$signaling = $this->config->getSignalingServer();
+		if (!empty($signaling)) {
 			throw new \Exception('Internal signaling disabled.');
 		}
 
@@ -124,7 +125,8 @@ class SignalingController extends OCSController {
 	 * @return DataResponse
 	 */
 	public function pullMessages() {
-		if ($this->config->getSignalingServer() !== '') {
+		$signaling = $this->config->getSignalingServer();
+		if (!empty($signaling)) {
 			throw new \Exception('Internal signaling disabled.');
 		}
 

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -92,7 +92,7 @@ class SignalingController extends OCSController {
 	public function signaling($messages) {
 		$signaling = $this->config->getSignalingServer();
 		if (!empty($signaling)) {
-			throw new \Exception('Internal signaling disabled.');
+			return new DataResponse('Internal signaling disabled.', Http::STATUS_BAD_REQUEST);
 		}
 
 		$response = [];
@@ -127,7 +127,7 @@ class SignalingController extends OCSController {
 	public function pullMessages() {
 		$signaling = $this->config->getSignalingServer();
 		if (!empty($signaling)) {
-			throw new \Exception('Internal signaling disabled.');
+			return new DataResponse('Internal signaling disabled.', Http::STATUS_BAD_REQUEST);
 		}
 
 		$data = [];

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -113,30 +113,6 @@ class SignalingController extends OCSController {
 					$this->messages->addMessage($message['sessionId'], $decodedMessage['to'], json_encode($decodedMessage));
 
 					break;
-				case 'stunservers':
-					$response = [];
-					$stunServer = $this->config->getStunServer();
-					if ($stunServer) {
-						$response[] = [
-							'url' => 'stun:' . $stunServer,
-						];
-					}
-					break;
-				case 'turnservers':
-					$response = [];
-					$turnSettings = $this->config->getTurnSettings();
-					if (!empty($turnSettings['server'])) {
-						$protocols = explode(',', $turnSettings['protocols']);
-						foreach ($protocols as $proto) {
-							$response[] = [
-								'url' => ['turn:' . $turnSettings['server'] . '?transport=' . $proto],
-								'urls' => ['turn:' . $turnSettings['server'] . '?transport=' . $proto],
-								'username' => $turnSettings['username'],
-								'credential' => $turnSettings['password'],
-							];
-						}
-					}
-					break;
 			}
 		}
 

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -215,7 +215,7 @@ class SignalingController extends OCSController {
 		return $usersInRoom;
 	}
 
-	/*
+	/**
 	 * Check if the current request is coming from an allowed backend.
 	 *
 	 * The backends are sending the custom header "Spreed-Signaling-Random"
@@ -249,7 +249,6 @@ class SignalingController extends OCSController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 *
-	 * @param string $message
 	 * @return JSONResponse
 	 */
 	public function backend() {

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -90,7 +90,7 @@ class SignalingController extends OCSController {
 	 * @return DataResponse
 	 */
 	public function signaling($messages) {
-		$signaling = $this->config->getSignalingServer();
+		$signaling = $this->config->getSignalingServers();
 		if (!empty($signaling)) {
 			return new DataResponse('Internal signaling disabled.', Http::STATUS_BAD_REQUEST);
 		}
@@ -125,7 +125,7 @@ class SignalingController extends OCSController {
 	 * @return DataResponse
 	 */
 	public function pullMessages() {
-		$signaling = $this->config->getSignalingServer();
+		$signaling = $this->config->getSignalingServers();
 		if (!empty($signaling)) {
 			return new DataResponse('Internal signaling disabled.', Http::STATUS_BAD_REQUEST);
 		}

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -219,7 +219,10 @@ class Room {
 	}
 
 	public function deleteRoom() {
-		$this->dispatcher->dispatch(self::class . '::preDeleteRoom', new GenericEvent($this));
+		$participants = $this->getParticipants();
+		$this->dispatcher->dispatch(self::class . '::preDeleteRoom', new GenericEvent($this, [
+			'participants' => $participants,
+		]));
 		$query = $this->db->getQueryBuilder();
 
 		// Delete all participants
@@ -232,7 +235,9 @@ class Room {
 			->where($query->expr()->eq('id', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)));
 		$query->execute();
 
-		$this->dispatcher->dispatch(self::class . '::postDeleteRoom', new GenericEvent($this));
+		$this->dispatcher->dispatch(self::class . '::postDeleteRoom', new GenericEvent($this, [
+			'participants' => $participants,
+		]));
 	}
 
 	/**

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -430,7 +430,7 @@ class Room {
 	 * @param int $participantType
 	 */
 	public function setParticipantType($participant, $participantType) {
-		$this->dispatcher->dispatch(self::class . '::preChangeParticipantType', new GenericEvent($this, [
+		$this->dispatcher->dispatch(self::class . '::preSetParticipantType', new GenericEvent($this, [
 			'user' => $participant,
 			'newType' => $participantType,
 		]));
@@ -442,7 +442,7 @@ class Room {
 			->andWhere($query->expr()->eq('userId', $query->createNamedParameter($participant)));
 		$query->execute();
 
-		$this->dispatcher->dispatch(self::class . '::postChangeParticipantType', new GenericEvent($this, [
+		$this->dispatcher->dispatch(self::class . '::postSetParticipantType', new GenericEvent($this, [
 			'user' => $participant,
 			'newType' => $participantType,
 		]));

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -220,7 +220,6 @@ class Room {
 
 	public function deleteRoom() {
 		$this->dispatcher->dispatch(self::class . '::preDeleteRoom', new GenericEvent($this));
-
 		$query = $this->db->getQueryBuilder();
 
 		// Delete all participants
@@ -241,7 +240,8 @@ class Room {
 	 * @return bool True when the change was valid, false otherwise
 	 */
 	public function setName($newName) {
-		if ($newName === $this->getName()) {
+		$oldName = $this->getName();
+		if ($newName === $oldName) {
 			return true;
 		}
 
@@ -351,6 +351,7 @@ class Room {
 	 * @return bool True when the change was valid, false otherwise
 	 */
 	public function changeType($newType) {
+		$newType = (int) $newType;
 		if ($newType === $this->getType()) {
 			return true;
 		}
@@ -372,7 +373,7 @@ class Room {
 			->where($query->expr()->eq('id', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)));
 		$query->execute();
 
-		$this->type = (int) $newType;
+		$this->type = $newType;
 
 		if ($oldType === self::PUBLIC_CALL) {
 			// Kick all guests and users that were not invited

--- a/lib/Settings/Admin/SignalingServer.php
+++ b/lib/Settings/Admin/SignalingServer.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @author Joachim Bauch <mail@joachim-bauch.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Settings\Admin;
+
+
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
+use OCP\Settings\ISettings;
+
+class SignalingServer implements ISettings {
+
+	/** @var IConfig */
+	private $config;
+
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	/**
+	 * @return TemplateResponse
+	 */
+	public function getForm() {
+		$parameters = [
+			'signalingServer' => $this->config->getAppValue('spreed', 'signaling_server'),
+			'signalingSecret' => $this->config->getAppValue('spreed', 'signaling_secret'),
+		];
+
+		return new TemplateResponse('spreed', 'settings/admin/signaling-server', $parameters, '');
+	}
+
+	/**
+	 * @return string the section ID, e.g. 'sharing'
+	 */
+	public function getSection() {
+		return 'videocalls';
+	}
+
+	/**
+	 * @return int whether the form should be rather on the top or bottom of
+	 * the admin section. The forms are arranged in ascending order of the
+	 * priority values. It is required to return a value between 0 and 100.
+	 *
+	 * E.g.: 70
+	 */
+	public function getPriority() {
+		return 75;
+	}
+
+}

--- a/lib/Settings/Admin/SignalingServer.php
+++ b/lib/Settings/Admin/SignalingServer.php
@@ -40,9 +40,7 @@ class SignalingServer implements ISettings {
 	 */
 	public function getForm() {
 		$parameters = [
-			'signalingServer' => $this->config->getAppValue('spreed', 'signaling_server'),
-			'signalingSecret' => $this->config->getAppValue('spreed', 'signaling_secret'),
-			'signalingSkipVerifyCert' => $this->config->getAppValue('spreed', 'signaling_skip_verify_cert'),
+			'signalingServers' => $this->config->getAppValue('spreed', 'signaling_servers'),
 		];
 
 		return new TemplateResponse('spreed', 'settings/admin/signaling-server', $parameters, '');

--- a/lib/Settings/Admin/SignalingServer.php
+++ b/lib/Settings/Admin/SignalingServer.php
@@ -42,6 +42,7 @@ class SignalingServer implements ISettings {
 		$parameters = [
 			'signalingServer' => $this->config->getAppValue('spreed', 'signaling_server'),
 			'signalingSecret' => $this->config->getAppValue('spreed', 'signaling_secret'),
+			'signalingSkipVerifyCert' => $this->config->getAppValue('spreed', 'signaling_skip_verify_cert'),
 		];
 
 		return new TemplateResponse('spreed', 'settings/admin/signaling-server', $parameters, '');

--- a/lib/Settings/Admin/SignalingServer.php
+++ b/lib/Settings/Admin/SignalingServer.php
@@ -50,7 +50,7 @@ class SignalingServer implements ISettings {
 	 * @return string the section ID, e.g. 'sharing'
 	 */
 	public function getSection() {
-		return 'videocalls';
+		return 'talk';
 	}
 
 	/**

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -33,7 +33,7 @@ script(
 <div id="notification-container">
 	<div id="notification" style="display: none;"></div>
 </div>
-<div id="app" class="nc-enable-screensharing-extension" data-token="<?php p($_['token']) ?>">
+<div id="app" class="nc-enable-screensharing-extension" data-token="<?php p($_['token']) ?>" data-signalingServer="<?php p($_['signaling-server']) ?>" data-signalingTicket="<?php p($_['signaling-ticket']) ?>">
 	<div id="app-content" class="participants-1">
 
 		<header>

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -33,7 +33,10 @@ script(
 <div id="notification-container">
 	<div id="notification" style="display: none;"></div>
 </div>
-<div id="app" class="nc-enable-screensharing-extension" data-token="<?php p($_['token']) ?>" data-signalingServer="<?php p($_['signaling-server']) ?>" data-signalingTicket="<?php p($_['signaling-ticket']) ?>">
+<div id="app" class="nc-enable-screensharing-extension" data-token="<?php p($_['token']) ?>">
+	<script type="text/json" id="signaling-settings">
+	<?php echo json_encode($_['signaling-settings']) ?>
+	</script>
 	<div id="app-content" class="participants-1">
 
 		<header>

--- a/templates/index.php
+++ b/templates/index.php
@@ -33,7 +33,10 @@ script(
 );
 ?>
 
-<div id="app" class="nc-enable-screensharing-extension" data-token="<?php p($_['token']) ?>" data-signalingServer="<?php p($_['signaling-server']) ?>" data-signalingTicket="<?php p($_['signaling-ticket']) ?>">
+<div id="app" class="nc-enable-screensharing-extension" data-token="<?php p($_['token']) ?>">
+	<script type="text/json" id="signaling-settings">
+	<?php echo json_encode($_['signaling-settings']) ?>
+	</script>
 	<div id="app-navigation" class="icon-loading">
 		<form id="oca-spreedme-add-room">
 			<input id="select-participants" class="select2-offscreen" type="text" placeholder="<?php p($l->t('Choose person …')) ?>"/>

--- a/templates/index.php
+++ b/templates/index.php
@@ -33,7 +33,7 @@ script(
 );
 ?>
 
-<div id="app" class="nc-enable-screensharing-extension" data-token="<?php p($_['token']) ?>">
+<div id="app" class="nc-enable-screensharing-extension" data-token="<?php p($_['token']) ?>" data-signalingServer="<?php p($_['signaling-server']) ?>" data-signalingTicket="<?php p($_['signaling-ticket']) ?>">
 	<div id="app-navigation" class="icon-loading">
 		<form id="oca-spreedme-add-room">
 			<input id="select-participants" class="select2-offscreen" type="text" placeholder="<?php p($l->t('Choose person …')) ?>"/>

--- a/templates/settings/admin/signaling-server.php
+++ b/templates/settings/admin/signaling-server.php
@@ -1,0 +1,24 @@
+<?php
+/** @var array $_ */
+/** @var \OCP\IL10N $l */
+script('spreed', ['admin/signaling-server']);
+style('spreed', ['settings-admin']);
+?>
+
+<div class="videocalls section signaling-server">
+	<h3><?php p($l->t('Signaling server')) ?></h3>
+	<p class="settings-hint"><?php p($l->t('An external signaling server can optionally be used for larger installations. Leave empty to use the internal signaling server.')) ?></p>
+
+	<p>
+		<label for="signaling_server"><?php p($l->t('External signaling server')) ?></label>
+		<input type="text" id="signaling_server"
+			   name="signaling_server" placeholder="wss://signaling.example.org"
+			   value="<?php p($_['signalingServer']) ?>" />
+	</p>
+	<p>
+		<label for="signaling_secret"><?php p($l->t('Shared secret')) ?></label>
+		<input type="text" id="signaling_secret"
+			   name="signaling_secret" placeholder="shared secret"
+			   value="<?php p($_['signalingSecret']) ?>" />
+	</p>
+</div>

--- a/templates/settings/admin/signaling-server.php
+++ b/templates/settings/admin/signaling-server.php
@@ -9,21 +9,13 @@ style('spreed', ['settings-admin']);
 	<h3><?php p($l->t('Signaling server')) ?></h3>
 	<p class="settings-hint"><?php p($l->t('An external signaling server can optionally be used for larger installations. Leave empty to use the internal signaling server.')) ?></p>
 
-	<p>
-		<label for="signaling_server"><?php p($l->t('External signaling server')) ?></label>
-		<input type="text" id="signaling_server"
-			   name="signaling_server" placeholder="wss://signaling.example.org"
-			   value="<?php p($_['signalingServer']) ?>" />
-	</p>
-	<p>
-		<input type="checkbox" id="signaling_skip_verify_cert" name="signaling_skip_verify_cert" class="checkbox" value="1" <?php p($_['signalingSkipVerifyCert'] ? 'checked="checked"' : '') ?>>
-		<label for="signaling_skip_verify_cert"><?php p($l->t('Allow invalid certificates when connecting to the external signaling server? Only enable this if required for development!')) ?>
-		</label>
-	</p>
-	<p>
+	<div class="signaling-servers" data-servers="<?php p($_['signalingServers']) ?>">
+	</div>
+
+	<p class="hidden">
 		<label for="signaling_secret"><?php p($l->t('Shared secret')) ?></label>
 		<input type="text" id="signaling_secret"
-			   name="signaling_secret" placeholder="shared secret"
+			   name="signaling_secret" placeholder="<?php p($l->t('Shared secret')) ?>"
 			   value="<?php p($_['signalingSecret']) ?>" />
 	</p>
 </div>

--- a/templates/settings/admin/signaling-server.php
+++ b/templates/settings/admin/signaling-server.php
@@ -16,6 +16,11 @@ style('spreed', ['settings-admin']);
 			   value="<?php p($_['signalingServer']) ?>" />
 	</p>
 	<p>
+		<input type="checkbox" id="signaling_skip_verify_cert" name="signaling_skip_verify_cert" class="checkbox" value="1" <?php p($_['signalingSkipVerifyCert'] ? 'checked="checked"' : '') ?>>
+		<label for="signaling_skip_verify_cert"><?php p($l->t('Allow invalid certificates when connecting to the external signaling server? Only enable this if required for development!')) ?>
+		</label>
+	</p>
+	<p>
 		<label for="signaling_secret"><?php p($l->t('Shared secret')) ?></label>
 		<input type="text" id="signaling_secret"
 			   name="signaling_secret" placeholder="shared secret"

--- a/templates/settings/admin/signaling-server.php
+++ b/templates/settings/admin/signaling-server.php
@@ -15,7 +15,6 @@ style('spreed', ['settings-admin']);
 	<p class="hidden">
 		<label for="signaling_secret"><?php p($l->t('Shared secret')) ?></label>
 		<input type="text" id="signaling_secret"
-			   name="signaling_secret" placeholder="<?php p($l->t('Shared secret')) ?>"
-			   value="<?php p($_['signalingSecret']) ?>" />
+			   name="signaling_secret" placeholder="<?php p($l->t('Shared secret')) ?>" />
 	</p>
 </div>

--- a/tests/php/ConfigTest.php
+++ b/tests/php/ConfigTest.php
@@ -23,6 +23,7 @@ namespace OCA\Spreed\Tests\php;
 use OCA\Spreed\Config;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
+use OCP\Security\ISecureRandom;
 use Test\TestCase;
 
 class ConfigTest extends TestCase {
@@ -35,6 +36,8 @@ class ConfigTest extends TestCase {
 
 		/** @var \PHPUnit_Framework_MockObject_MockObject|ITimeFactory $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
+		/** @var \PHPUnit_Framework_MockObject_MockObject|ISecureRandom $secureRandom */
+		$secureRandom = $this->createMock(ISecureRandom::class);
 		/** @var \PHPUnit_Framework_MockObject_MockObject|IConfig $config */
 		$config = $this->createMock(IConfig::class);
 		$config
@@ -43,8 +46,7 @@ class ConfigTest extends TestCase {
 			->with('spreed', 'stun_servers', json_encode(['stun.nextcloud.com:443']))
 			->willReturn(json_encode($servers));
 
-		$helper = new Config($config, $timeFactory);
-
+		$helper = new Config($config, $secureRandom, $timeFactory);
 		$this->assertTrue(in_array($helper->getStunServer(), $servers, true));
 	}
 
@@ -76,7 +78,9 @@ class ConfigTest extends TestCase {
 			->method('getTime')
 			->willReturn(1479743025);
 
-		$helper = new Config($config, $timeFactory);
+		/** @var \PHPUnit_Framework_MockObject_MockObject|ISecureRandom $secureRandom */
+		$secureRandom = $this->createMock(ISecureRandom::class);
+		$helper = new Config($config, $secureRandom, $timeFactory);
 
 		//
 		$server = $helper->getTurnSettings();


### PR DESCRIPTION
This PR adds support for using a standalone signaling server.

See https://github.com/nextcloud/spreed/wiki/Spreed-Signaling-API for the documentation of message formats. In a follow-up PR, the same messages will be implemented for the PHP backend, so there is only one API that clients need to implement.

@nickvergessen @Ivansss 