### PR TITLE
Update "name" member on rename so "getName" returns updated name.

### DIFF
--- a/lib/Room.php
+++ b/lib/Room.php
@@ -177,6 +177,7 @@ class Room {
 			->set('name', $query->createNamedParameter($newName))
 			->where($query->expr()->eq('id', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)));
 		$query->execute();
+		$this->name = $newName;
 
 		return true;
 	}


### PR DESCRIPTION
Otherwise `getName` always returns the initial name.