### PR TITLE
gitignore: Ignore 'package-lock.json'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-# Exclude npm deps
+# Exclude npm stuff
 build
 node_modules
+package-lock.json
 
 # Karma/jasmine coverage data
 coverage


### PR DESCRIPTION
This file is installed by npm as of version 5 when running
"npm install"