### PR TITLE
Bound video width of promoted speaker

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -197,6 +197,7 @@ video {
 #videos .videoContainer.promoted video {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
+    max-width: 100%;
 }
 #videos .videoContainer video,
 #videos .videoContainer .avatar {


### PR DESCRIPTION
Both ways have their respective pros & cons. I prefer the `After` as it doesn't hide anything.

Before:
![spreedme_bound-video-width-before](https://user-images.githubusercontent.com/31063993/29778078-6a006714-8c0e-11e7-87b0-63eec3fbdbd4.png)

After:
![spreedme_bound-video-width-after](https://user-images.githubusercontent.com/31063993/29778083-6c2fc548-8c0e-11e7-9d28-859caa75ee38.png)
