### PR TITLE
Use a newer version of the nextcloudci/php7.1 Docker image in Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -126,15 +126,12 @@ pipeline:
       matrix:
         TESTS: php7.0
   php7.1:
-    image: nextcloudci/php7.1:php7.1-3
+    image: nextcloudci/php7.1:php7.1-15
     environment:
       - APP_NAME=spreed
       - CORE_BRANCH=master
       - DB=sqlite
     commands:
-      # FIXME: Move into Docker image
-      - yum -y install wget
-
       # Pre-setup steps
       - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
       - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
@@ -149,15 +146,12 @@ pipeline:
       matrix:
         TESTS: php7.1
   php7.1-integration:
-    image: nextcloudci/php7.1:php7.1-3
+    image: nextcloudci/php7.1:php7.1-15
     environment:
       - APP_NAME=spreed
       - CORE_BRANCH=master
       - DB=sqlite
     commands:
-      # FIXME: Move into Docker image
-      - yum -y install wget
-
       # Pre-setup steps
       - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
       - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB


### PR DESCRIPTION
The _php7.1_ and _php7.1-integration_ tests seem to be running in Drone, but in fact they are not; although there are no errors, if you take a closer look to their output you can see that the tests themselves are not run either (see, for example, [_php7.1_ log for pull request 100](https://drone.nextcloud.com/nextcloud/spreed/100/29) and [_php7.1-integration_ log for pull request 100](https://drone.nextcloud.com/nextcloud/spreed/100/31).

As the _spreed_ repository only contains the app, in order to run the tests Drone downloads and executes https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh, which downloads the server and prepares the environment as needed, and then downloads and executes https://raw.githubusercontent.com/nextcloud/travis_ci/master/core_install.sh, which installs the Nextcloud server as needed depending on the desired database to be used for the test.

The problem comes from the `more ./tests/autoconfig-oracle.php` command in [_core_install.sh_](https://github.com/nextcloud/travis_ci/blob/de668360c208c17f7293260be5280cc236494fb8/core_install.sh#L105) (introduced in commit [Try fixing OCI](https://github.com/nextcloud/travis_ci/commit/bdcc363c5dc58c454de968e02f9cfb4c9d42692a) from pull request [Allow apps to test on oracle](https://github.com/nextcloud/travis_ci/pull/3), although I do not understand the rationale of that command there; @nickvergessen, any insights?); for some strange reason, when executed without a TTY on a CentOS based Docker image it breaks the execution of the remaining Drone commands (which include running the tests), although no error is issued and thus the tests wrongly seem to have been successfully run in the general Drone view.

When executed on a Debian based image, though, everything works as expected; I was not able to determine why it fails in the CentOS image (_more_ belongs to the _util-linux_ package; the source code for the release 2.23.2 of _util-linux_, which is the one used in the _nextcloudci/php7.1:php7.1-3_ image, can be found [here](https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/tree/text-utils/more.c?h=v2.23.2) if you want to investigate ;-) ), but simply using a newer _nextcloudci/php7.1_ image based on Debian is enough to make the tests work in Drone, and also removes the need of installing _wget_ each time the tests are run as it is already included in the image.
