### PR TITLE
Fix guest's avatar

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -621,7 +621,8 @@
 			} else if (guestName) {
 				avatar.imageplaceholder(guestName, undefined, 128);
 			} else {
-				avatar.avatar(null, 128);
+				avatar.imageplaceholder('?', undefined, 128);
+				avatar.css('background-color', '#b9b9b9');
 				OC.Notification.showTemporary(t('spreed', 'You can set your name on the top right of this page so other participants can identify you better.'));
 			}
 
@@ -666,7 +667,8 @@
 			if (savedGuestName) {
 				avatar.imageplaceholder(savedGuestName, undefined, 128);
 			} else {
-				avatar.avatar(null, 128);
+				avatar.imageplaceholder('?', undefined, 128);
+				avatar.css('background-color', '#b9b9b9');
 			}
 		},
 		initShareRoomClipboard: function () {


### PR DESCRIPTION
This `avatar(null, 128)` no longer works because of this change https://github.com/nextcloud/server/commit/54c68519ce1cab9baaf86a29c7172811767d97c4
null is converted to string and then an avatar with an 'N' is generated.

Before:
![screen shot 2017-09-19 at 18 42 20](https://user-images.githubusercontent.com/4638605/30604202-6a5cf322-9d6a-11e7-8a20-ecd0bd8fc15c.png)

Now:
![screen shot 2017-09-19 at 18 42 50](https://user-images.githubusercontent.com/4638605/30604208-6f16ee86-9d6a-11e7-8455-353c575d458d.png)
