### PR TITLE
Fix Strict Standards error in integration tests on PHP 7

### DIFF
--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -95,9 +95,14 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			if (strpos($expectedRoom['participants'], ' [exact order]') === false) {
 				sort($participantNames);
 			} else {
+				// "end(array_keys(..." would generate the Strict Standards
+				// error "Only variables should be passed by reference".
+				$participantNamesKeys = array_keys($participantNames);
+				$lastParticipantKey = end($participantNamesKeys);
+
 				// Append " [exact order]" to the last participant so the
 				// imploded string is the same as the expected one.
-				$participantNames[end(array_keys($participantNames))] .= ' [exact order]';
+				$participantNames[$lastParticipantKey] .= ' [exact order]';
 			}
 
 			return [


### PR DESCRIPTION
Besides returning the last element, `end` also sets the internal pointer of the array to the last element, and for that it receives a reference to the array. Thus, `end(array_keys(...` can not be used, as it would
generate the Strict Standards error _Only variables should be passed by reference_, so the returned value from `array_keys` has to be stored in a variable.
