### PR TITLE
Use a different display name than the user ID in the integration tests

### DIFF
--- a/tests/integration/features/add-participant.feature
+++ b/tests/integration/features/add-participant.feature
@@ -10,10 +10,10 @@ Feature: public
     And user "participant1" adds "participant2" to room "room" with 200
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 1               | participant1, participant2 |
+      | room | 3    | 1               | participant1-displayname, participant2-displayname |
     And user "participant2" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 3               | participant1, participant2 |
+      | room | 3    | 3               | participant1-displayname, participant2-displayname |
     And user "participant3" is not participant of room "room"
 
   Scenario: User invites a user
@@ -22,18 +22,18 @@ Feature: public
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 1               | participant1, participant2 |
+      | room | 3    | 1               | participant1-displayname, participant2-displayname |
     And user "participant2" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 3               | participant1, participant2 |
+      | room | 3    | 3               | participant1-displayname, participant2-displayname |
     And user "participant3" is not participant of room "room"
     When user "participant2" adds "participant3" to room "room" with 403
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 1               | participant1, participant2 |
+      | room | 3    | 1               | participant1-displayname, participant2-displayname |
     And user "participant2" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 3               | participant1, participant2 |
+      | room | 3    | 3               | participant1-displayname, participant2-displayname |
     And user "participant3" is not participant of room "room"
 
   Scenario: Moderator invites a user
@@ -43,21 +43,21 @@ Feature: public
     When user "participant1" promotes "participant2" in room "room" with 200
     And user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 1               | participant1, participant2 |
+      | room | 3    | 1               | participant1-displayname, participant2-displayname |
     And user "participant2" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 2               | participant1, participant2 |
+      | room | 3    | 2               | participant1-displayname, participant2-displayname |
     And user "participant3" is not participant of room "room"
     When user "participant2" adds "participant3" to room "room" with 200
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 1               | participant1, participant2, participant3 |
+      | room | 3    | 1               | participant1-displayname, participant2-displayname, participant3-displayname |
     And user "participant2" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 2               | participant1, participant2, participant3 |
+      | room | 3    | 2               | participant1-displayname, participant2-displayname, participant3-displayname |
     And user "participant3" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 3               | participant1, participant2, participant3 |
+      | room | 3    | 3               | participant1-displayname, participant2-displayname, participant3-displayname |
 
   Scenario: Stranger invites a user
     Given user "participant1" creates room "room"
@@ -65,6 +65,6 @@ Feature: public
     And user "participant3" adds "participant2" to room "room" with 404
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 1               | participant1 |
+      | room | 3    | 1               | participant1-displayname |
     And user "participant2" is not participant of room "room"
     And user "participant3" is not participant of room "room"

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -385,6 +385,9 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			$this->userExists($user);
 		} catch (\GuzzleHttp\Exception\ClientException $ex) {
 			$this->createUser($user);
+			// Set a display name different than the user ID to be able to
+			// ensure in the tests that the right value was returned.
+			$this->setUserDisplayName($user);
 		}
 		$response = $this->userExists($user);
 		$this->assertStatusCode($response, 200);
@@ -424,6 +427,22 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			],
 		];
 		$client->send($client->createRequest('GET', $userProvisioningUrl . '/' . $user, $options2));
+	}
+
+	private function setUserDisplayName($user) {
+		$userProvisioningUrl = $this->baseUrl . 'ocs/v2.php/cloud/users/' . $user;
+		$client = new Client();
+		$options = [
+			'auth' => ['admin', 'admin'],
+			'body' => [
+				'key' => 'displayname',
+				'value' => $user . '-displayname'
+			],
+			'headers' => [
+				'OCS-APIREQUEST' => 'true',
+			],
+		];
+		$client->send($client->createRequest('PUT', $userProvisioningUrl, $options));
 	}
 
 	/**

--- a/tests/integration/features/delete-room.feature
+++ b/tests/integration/features/delete-room.feature
@@ -9,7 +9,7 @@ Feature: public
       | roomType | 3 |
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 1               | participant1 |
+      | room | 3    | 1               | participant1-displayname |
     And user "participant2" is not participant of room "room"
     And user "participant3" is not participant of room "room"
     When user "participant1" deletes room "room" with 200
@@ -22,7 +22,7 @@ Feature: public
     And user "participant1" promotes "participant2" in room "room" with 200
     And user "participant2" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 2               | participant1, participant2 |
+      | room | 3    | 2               | participant1-displayname, participant2-displayname |
     And user "participant1" is participant of room "room"
     And user "participant2" is participant of room "room"
     When user "participant2" deletes room "room" with 200
@@ -35,7 +35,7 @@ Feature: public
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant2" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 3               | participant1, participant2 |
+      | room | 3    | 3               | participant1-displayname, participant2-displayname |
     And user "participant1" is participant of room "room"
     And user "participant2" is participant of room "room"
     When user "participant2" deletes room "room" with 403

--- a/tests/integration/features/leave-room.feature
+++ b/tests/integration/features/leave-room.feature
@@ -9,7 +9,7 @@ Feature: public
       | roomType | 3 |
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 1               | participant1 |
+      | room | 3    | 1               | participant1-displayname |
     And user "participant2" is not participant of room "room"
     And user "participant3" is not participant of room "room"
     When user "participant1" leaves room "room" with 200
@@ -22,7 +22,7 @@ Feature: public
     And user "participant1" promotes "participant2" in room "room" with 200
     And user "participant2" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 2               | participant1, participant2 |
+      | room | 3    | 2               | participant1-displayname, participant2-displayname |
     And user "participant1" is participant of room "room"
     And user "participant2" is participant of room "room"
     When user "participant2" leaves room "room" with 200
@@ -35,7 +35,7 @@ Feature: public
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant2" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 3               | participant1, participant2 |
+      | room | 3    | 3               | participant1-displayname, participant2-displayname |
     And user "participant1" is participant of room "room"
     And user "participant2" is participant of room "room"
     When user "participant2" leaves room "room" with 200

--- a/tests/integration/features/one-to-one.feature
+++ b/tests/integration/features/one-to-one.feature
@@ -15,10 +15,10 @@ Feature: one-to-one
       | invite   | participant2 |
     Then user "participant1" is participant of the following rooms
       | id    | type | participantType | participants |
-      | room1 | 1    | 1               | participant1, participant2 |
+      | room1 | 1    | 1               | participant1-displayname, participant2-displayname |
     And user "participant2" is participant of the following rooms
       | id    | type | participantType | participants |
-      | room1 | 1    | 1               | participant1, participant2 |
+      | room1 | 1    | 1               | participant1-displayname, participant2-displayname |
     And user "participant3" is participant of the following rooms
     And user "participant1" is participant of room "room1"
     And user "participant2" is participant of room "room1"
@@ -71,7 +71,7 @@ Feature: one-to-one
     When user "participant1" makes room "room6" public with 200
     Then user "participant1" is participant of the following rooms
       | id    | type | participantType | participants |
-      | room6 | 3    | 1               | participant1, participant2 |
+      | room6 | 3    | 1               | participant1-displayname, participant2-displayname |
 
   Scenario: User1 invites user2 to a one2one room and invites user3
     Given user "participant1" creates room "room7"
@@ -83,11 +83,11 @@ Feature: one-to-one
     When user "participant1" adds "participant3" to room "room7" with 200
     Then user "participant1" is participant of the following rooms
       | id    | type | participantType | participants |
-      | room7 | 2    | 1               | participant1, participant2, participant3 |
+      | room7 | 2    | 1               | participant1-displayname, participant2-displayname, participant3-displayname |
     And user "participant3" is participant of room "room7"
     Then user "participant3" is participant of the following rooms
       | id    | type | participantType | participants |
-      | room7 | 2    | 3               | participant1, participant2, participant3 |
+      | room7 | 2    | 3               | participant1-displayname, participant2-displayname, participant3-displayname |
 
   Scenario: User1 invites user2 to a one2one room and promote user2 to moderator
     Given user "participant1" creates room "room8"

--- a/tests/integration/features/promotion-demotion.feature
+++ b/tests/integration/features/promotion-demotion.feature
@@ -10,15 +10,15 @@ Feature: public
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant2" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 3               | participant1, participant2 |
+      | room | 3    | 3               | participant1-displayname, participant2-displayname |
     When user "participant1" promotes "participant2" in room "room" with 200
     And user "participant2" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 2               | participant1, participant2 |
+      | room | 3    | 2               | participant1-displayname, participant2-displayname |
     And user "participant1" demotes "participant2" in room "room" with 200
     And user "participant2" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 3               | participant1, participant2 |
+      | room | 3    | 3               | participant1-displayname, participant2-displayname |
 
   Scenario: Moderator promotes/demotes moderator
     Given user "participant1" creates room "room"
@@ -27,16 +27,16 @@ Feature: public
     And user "participant1" adds "participant3" to room "room" with 200
     And user "participant3" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 3               | participant1, participant2, participant3 |
+      | room | 3    | 3               | participant1-displayname, participant2-displayname, participant3-displayname |
     And user "participant1" promotes "participant2" in room "room" with 200
     When user "participant2" promotes "participant3" in room "room" with 200
     Then user "participant3" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 2               | participant1, participant2, participant3 |
+      | room | 3    | 2               | participant1-displayname, participant2-displayname, participant3-displayname |
     When user "participant2" demotes "participant3" in room "room" with 200
     Then user "participant3" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 3               | participant1, participant2, participant3 |
+      | room | 3    | 3               | participant1-displayname, participant2-displayname, participant3-displayname |
 
   Scenario: User promotes/demotes moderator
     Given user "participant1" creates room "room"
@@ -45,19 +45,19 @@ Feature: public
     And user "participant1" adds "participant3" to room "room" with 200
     And user "participant3" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 3               | participant1, participant2, participant3 |
+      | room | 3    | 3               | participant1-displayname, participant2-displayname, participant3-displayname |
     When user "participant2" promotes "participant3" in room "room" with 403
     Then user "participant3" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 3               | participant1, participant2, participant3 |
+      | room | 3    | 3               | participant1-displayname, participant2-displayname, participant3-displayname |
     When user "participant1" promotes "participant3" in room "room" with 200
     Then user "participant3" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 2               | participant1, participant2, participant3 |
+      | room | 3    | 2               | participant1-displayname, participant2-displayname, participant3-displayname |
     When user "participant2" demotes "participant3" in room "room" with 403
     Then user "participant3" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 2               | participant1, participant2, participant3 |
+      | room | 3    | 2               | participant1-displayname, participant2-displayname, participant3-displayname |
 
   Scenario: Stranger promotes/demotes moderator
     Given user "participant1" creates room "room"
@@ -65,16 +65,16 @@ Feature: public
     And user "participant1" adds "participant3" to room "room" with 200
     And user "participant3" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 3               | participant1, participant3 |
+      | room | 3    | 3               | participant1-displayname, participant3-displayname |
     When user "participant2" promotes "participant3" in room "room" with 404
     Then user "participant3" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 3               | participant1, participant3 |
+      | room | 3    | 3               | participant1-displayname, participant3-displayname |
     When user "participant1" promotes "participant3" in room "room" with 200
     Then user "participant3" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 2               | participant1, participant3 |
+      | room | 3    | 2               | participant1-displayname, participant3-displayname |
     When user "participant2" demotes "participant3" in room "room" with 404
     Then user "participant3" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 2               | participant1, participant3 |
+      | room | 3    | 2               | participant1-displayname, participant3-displayname |

--- a/tests/integration/features/public-private.feature
+++ b/tests/integration/features/public-private.feature
@@ -9,68 +9,68 @@ Feature: public
       | roomType | 3 |
     And user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 1               | participant1 |
+      | room | 3    | 1               | participant1-displayname |
     When user "participant1" makes room "room" private with 200
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 2    | 1               | participant1 |
+      | room | 2    | 1               | participant1-displayname |
     When user "participant1" makes room "room" public with 200
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 1               | participant1 |
+      | room | 3    | 1               | participant1-displayname |
 
   Scenario: Moderator makes room private/public
     Given user "participant1" creates room "room"
       | roomType | 3 |
     And user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 1               | participant1 |
+      | room | 3    | 1               | participant1-displayname |
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant1" promotes "participant2" in room "room" with 200
     When user "participant2" makes room "room" private with 200
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 2    | 1               | participant1, participant2 |
+      | room | 2    | 1               | participant1-displayname, participant2-displayname |
     When user "participant2" makes room "room" public with 200
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 1               | participant1, participant2 |
+      | room | 3    | 1               | participant1-displayname, participant2-displayname |
 
   Scenario: User makes room private/public
     Given user "participant1" creates room "room"
       | roomType | 3 |
     And user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 1               | participant1 |
+      | room | 3    | 1               | participant1-displayname |
     And user "participant1" adds "participant2" to room "room" with 200
     When user "participant2" makes room "room" private with 403
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 1               | participant1, participant2 |
+      | room | 3    | 1               | participant1-displayname, participant2-displayname |
     When user "participant1" makes room "room" private with 200
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 2    | 1               | participant1, participant2 |
+      | room | 2    | 1               | participant1-displayname, participant2-displayname |
     When user "participant2" makes room "room" public with 403
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 2    | 1               | participant1, participant2 |
+      | room | 2    | 1               | participant1-displayname, participant2-displayname |
 
   Scenario: Stranger makes room private/public
     Given user "participant1" creates room "room"
       | roomType | 3 |
     And user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 1               | participant1 |
+      | room | 3    | 1               | participant1-displayname |
     When user "participant2" makes room "room" private with 404
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 3    | 1               | participant1 |
+      | room | 3    | 1               | participant1-displayname |
     When user "participant1" makes room "room" private with 200
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 2    | 1               | participant1 |
+      | room | 2    | 1               | participant1-displayname |
     When user "participant2" makes room "room" public with 404
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
-      | room | 2    | 1               | participant1 |
+      | room | 2    | 1               | participant1-displayname |


### PR DESCRIPTION
This makes possible to ensure that the right value was returned by the server.