### PR TITLE
Add basic backend for chat

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -84,6 +84,25 @@ return [
 		],
 
 		[
+			'name' => 'Chat#receiveMessages',
+			'url' => '/api/{apiVersion}/chat/{token}',
+			'verb' => 'GET',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
+		[
+			'name' => 'Chat#sendMessage',
+			'url' => '/api/{apiVersion}/chat/{token}',
+			'verb' => 'POST',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
+
+		[
 			'name' => 'Room#getRooms',
 			'url' => '/api/{apiVersion}/room',
 			'verb' => 'GET',

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Chat;
+
+use OCP\Comments\ICommentsManager;
+
+/**
+ * Basic polling chat manager.
+ *
+ * sendMessage() saves a comment using the ICommentsManager, while
+ * receiveMessages() tries to read comments from ICommentsManager (with a little
+ * wait between reads) until comments are found or until the timeout expires.
+ */
+class ChatManager {
+
+	/** @var ICommentsManager */
+	private $commentsManager;
+
+	/**
+	 * @param ICommentsManager $commentsManager
+	 */
+	public function __construct(ICommentsManager $commentsManager) {
+		$this->commentsManager = $commentsManager;
+	}
+
+	/**
+	 * Sends a new message to the given chat.
+	 *
+	 * @param string $chatId
+	 * @param string $actorType
+	 * @param string $actorId
+	 * @param string $message
+	 * @param \DateTime $creationDateTime
+	 */
+	public function sendMessage($chatId, $actorType, $actorId, $message, \DateTime $creationDateTime) {
+		$comment = $this->commentsManager->create($actorType, $actorId, 'chat', $chatId);
+		$comment->setMessage($message);
+		$comment->setCreationDateTime($creationDateTime);
+		// A verb ('comment', 'like'...) must be provided to be able to save a
+		// comment
+		$comment->setVerb('comment');
+
+		$this->commentsManager->save($comment);
+	}
+
+	/**
+	 * Receives the messages from the given chat.
+	 *
+	 * It is possible to limit the returned messages to those not older than
+	 * certain date and time setting the $notOlderThan parameter. In the same
+	 * way it is possible to ignore the first N messages setting the $offset
+	 * parameter. Both parameters are optional; if not set all the messages from
+	 * the chat are returned.
+	 *
+	 * In any case, receiveMessages will wait (hang) until there is at least one
+	 * message to be returned. It will not wait indefinitely, though; the
+	 * maximum time to wait must be set using the $timeout parameter.
+	 *
+	 * @param string $chatId
+	 * @param int $timeout the maximum number of seconds to wait for messages
+	 * @param int $offset optional, starting point
+	 * @param \DateTime|null $notOlderThan optional, the date and time of the
+	 *        oldest message that may be returned
+	 * @return IComment[] the messages found (only the id, actor type and id,
+	 *         creation date and message are relevant), or an empty array if the
+	 *         timeout expired.
+	 */
+	public function receiveMessages($chatId, $timeout, $offset = 0, \DateTime $notOlderThan = null) {
+		$comments = [];
+
+		$commentsFound = false;
+		$elapsedTime = 0;
+		while (!$commentsFound && $elapsedTime < $timeout) {
+			$numberOfComments = $this->commentsManager->getNumberOfCommentsForObject('chat', $chatId, $notOlderThan);
+
+			if ($numberOfComments > $offset) {
+				$commentsFound = true;
+			} else {
+				sleep(1);
+				$elapsedTime++;
+			}
+		}
+
+		if ($commentsFound) {
+			// The limit and offset of getForObject can not be based on the
+			// number of comments, as more comments may have been added between
+			// that call and this one (very unlikely, yet possible).
+			$comments = $this->commentsManager->getForObject('chat', $chatId, $noLimit = 0, $noOffset = 0, $notOlderThan);
+
+			// The comments are ordered from newest to oldest, so get all the
+			// comments before the $offset elements from the end of the array.
+			$length = null;
+			if ($offset) {
+				$length = -$offset;
+			}
+			$comments = array_slice($comments, $noOffset, $length);
+		}
+
+		return $comments;
+	}
+
+}

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Controller;
+
+use OCA\Spreed\Chat\ChatManager;
+use OCA\Spreed\Exceptions\RoomNotFoundException;
+use OCA\Spreed\Manager;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IUserManager;
+
+class ChatController extends OCSController {
+
+	/** @var string */
+	private $userId;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var ISession */
+	private $session;
+
+	/** @var Manager */
+	private $manager;
+
+	/** @var ChatManager */
+	private $chatManager;
+
+	/**
+	 * @param string $appName
+	 * @param string $UserId
+	 * @param IRequest $request
+	 * @param IUserManager $userManager
+	 * @param ISession $session
+	 * @param Manager $manager
+	 * @param ChatManager $chatManager
+	 */
+	public function __construct($appName,
+								$UserId,
+								IRequest $request,
+								IUserManager $userManager,
+								ISession $session,
+								Manager $manager,
+								ChatManager $chatManager) {
+		parent::__construct($appName, $request);
+
+		$this->userId = $UserId;
+		$this->userManager = $userManager;
+		$this->session = $session;
+		$this->manager = $manager;
+		$this->chatManager = $chatManager;
+	}
+
+	/**
+	 * @PublicPage
+	 *
+	 * Sends a new chat message to the given room.
+	 *
+	 * The author and timestamp are automatically set to the current user/guest
+	 * and time.
+	 *
+	 * @param string $token the room token
+	 * @param string $message the message to send
+	 * @return DataResponse the status code is "201 Created" if successful, and
+	 *         "404 Not found" if the room or session for a guest user was not
+	 *         found".
+	 */
+	public function sendMessage($token, $message) {
+		try {
+			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
+		} catch (RoomNotFoundException $exception) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if ($this->userId === null) {
+			$actorType = 'guests';
+			$actorId = $this->session->get('spreed-session');
+		} else {
+			$actorType = 'users';
+			$actorId = $this->userId;
+		}
+
+		if (!$actorId) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		$creationDateTime = new \DateTime('now', new \DateTimeZone('UTC'));
+
+		$this->chatManager->sendMessage($token, $actorType, $actorId, $message, $creationDateTime);
+
+		return new DataResponse([], Http::STATUS_CREATED);
+	}
+
+	/**
+	 * @PublicPage
+	 *
+	 * Receives the chat messages from the given room.
+	 *
+	 * It is possible to limit the returned messages to those not older than
+	 * certain date and time setting the $notOlderThan parameter. In the same
+	 * way it is possible to ignore the first N messages setting the $offset
+	 * parameter. Both parameters are optional; if not set all the messages from
+	 * the chat are returned.
+	 *
+	 * If there are currently no messages the response will not be sent
+	 * immediately. Instead, HTTP connection will be kept open waiting for new
+	 * messages to arrive and, when they do, then the response will be sent. The
+	 * connection will not be kept open indefinitely, though; the number of
+	 * seconds to wait for new messages to arrive can be set using the timeout
+	 * parameter; the default timeout is 30 seconds, maximum timeout is 60
+	 * seconds. If the timeout ends then a successful but empty response will be
+	 * sent.
+	 *
+	 * @param string $token the room token
+	 * @param int offset optional, the first N messages to ignore
+	 * @param int notOlderThanTimestamp optional, timestamp in seconds and UTC
+	 *        time zone
+	 * @param int timeout optional, the number of seconds to wait for new
+	 *        messages (30 by default, 60 at most)
+	 * @return DataResponse an array of chat messages, or "404 Not found" if the
+	 *         room token was not valid; each chat message is an array with
+	 *         fields 'id', 'token', 'actoryType', 'actorId',
+	 *         'actorDisplayName', 'timestamp' (in seconds and UTC timezone) and
+	 *         'message'.
+	 */
+	public function receiveMessages($token, $offset = 0, $notOlderThanTimestamp = 0, $timeout = 30) {
+		try {
+			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
+		} catch (RoomNotFoundException $exception) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		$notOlderThan = null;
+		if ($notOlderThanTimestamp > 0) {
+			$notOlderThan = new \DateTime();
+			$notOlderThan->setTimestamp($notOlderThanTimestamp);
+			$notOlderThan->setTimeZone(new \DateTimeZone('UTC'));
+		}
+
+		$maximumTimeout = 60;
+		if ($timeout > $maximumTimeout) {
+			$timeout = $maximumTimeout;
+		}
+
+		$comments = $this->chatManager->receiveMessages($token, $timeout, $offset, $notOlderThan);
+
+		$userManager = $this->userManager;
+
+		return new DataResponse(array_map(function($comment) use ($token, $userManager) {
+			$displayName = null;
+			if ($comment->getActorType() === 'users') {
+				$user = $userManager->get($comment->getActorId());
+				$displayName = is_null($user) ? null : $user->getDisplayName();
+			}
+
+			return [
+				'id' => $comment->getId(),
+				'token' => $token,
+				'actorType' => $comment->getActorType(),
+				'actorId' => $comment->getActorId(),
+				'actorDisplayName' => $displayName,
+				'timestamp' => $comment->getCreationDateTime()->getTimestamp(),
+				'message' => $comment->getMessage()
+			];
+		}, $comments));
+	}
+
+}

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -99,6 +99,12 @@ class ChatController extends OCSController {
 		if ($this->userId === null) {
 			$actorType = 'guests';
 			$actorId = $this->session->get('spreed-session');
+			// The character limit for actorId is 64, but the spreed-session is
+			// 256 characters long, so it has to be hashed to get an ID that
+			// fits (except if there is no session, as the actorId should be
+			// empty in that case but sha1('') would generate a hash too
+			// instead of returning an empty string).
+			$actorId = $actorId? sha1($actorId): $actorId;
 		} else {
 			$actorType = 'users';
 			$actorId = $this->userId;

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -116,7 +116,7 @@ class ChatController extends OCSController {
 
 		$creationDateTime = new \DateTime('now', new \DateTimeZone('UTC'));
 
-		$this->chatManager->sendMessage($token, $actorType, $actorId, $message, $creationDateTime);
+		$this->chatManager->sendMessage(strval($room->getId()), $actorType, $actorId, $message, $creationDateTime);
 
 		return new DataResponse([], Http::STATUS_CREATED);
 	}
@@ -172,7 +172,7 @@ class ChatController extends OCSController {
 			$timeout = $maximumTimeout;
 		}
 
-		$comments = $this->chatManager->receiveMessages($token, $timeout, $offset, $notOlderThan);
+		$comments = $this->chatManager->receiveMessages(strval($room->getId()), $timeout, $offset, $notOlderThan);
 
 		$userManager = $this->userManager;
 

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -37,6 +37,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	protected static $identifierToToken;
 	/** @var array[] */
 	protected static $tokenToIdentifier;
+	/** @var array[] */
+	protected static $sessionIdToUser;
 
 	/** @var string */
 	protected $currentUser;
@@ -320,6 +322,11 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			$formData
 		);
 		$this->assertStatusCode($this->response, $statusCode);
+
+		$response = $this->getDataFromResponse($this->response);
+		if (array_key_exists('sessionId', $response)) {
+			self::$sessionIdToUser[$response['sessionId']] = $user;
+		}
 	}
 
 	/**
@@ -354,6 +361,56 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		} else {
 			PHPUnit_Framework_Assert::assertEquals((int) $numPeers, 0);
 		}
+	}
+
+	/**
+	 * @Then /^user "([^"]*)" sends message "([^"]*)" to room "([^"]*)" with (\d+)$/
+	 *
+	 * @param string $user
+	 * @param string $message
+	 * @param string $identifier
+	 * @param string $statusCode
+	 */
+	public function userSendsMessageToRoom($user, $message, $identifier, $statusCode) {
+		$this->setCurrentUser($user);
+		$this->sendRequest(
+			'POST', '/apps/spreed/api/v1/chat/' . self::$identifierToToken[$identifier],
+			new TableNode([['message', $message]])
+		);
+		$this->assertStatusCode($this->response, $statusCode);
+	}
+
+	/**
+	 * @Then /^user "([^"]*)" sees the following messages in room "([^"]*)" with (\d+)$/
+	 *
+	 * @param string $user
+	 * @param string $message
+	 * @param string $identifier
+	 * @param string $statusCode
+	 */
+	public function userSeesTheFollowingMessagesInRoom($user, $identifier, $statusCode, TableNode $formData = null) {
+		$this->setCurrentUser($user);
+		$this->sendRequest('GET', '/apps/spreed/api/v1/chat/' . self::$identifierToToken[$identifier]);
+		$this->assertStatusCode($this->response, $statusCode);
+
+		$messages = $this->getDataFromResponse($this->response);
+		if ($formData === null) {
+			PHPUnit_Framework_Assert::assertEmpty($messages);
+			return;
+		}
+
+		PHPUnit_Framework_Assert::assertCount(count($formData->getHash()), $messages, 'Message count does not match');
+		PHPUnit_Framework_Assert::assertEquals($formData->getHash(), array_map(function($message) {
+			return [
+				'room' => self::$tokenToIdentifier[$message['token']],
+				'actorType' => (string) $message['actorType'],
+				'actorId' => ($message['actorType'] == 'guests')? self::$sessionIdToUser[$message['actorId']]: (string) $message['actorId'],
+				'actorDisplayName' => (string) $message['actorDisplayName'],
+				// TODO test timestamp; it may require using Runkit, php-timecop
+				// or something like that.
+				'message' => (string) $message['message'],
+			];
+		}, $messages));
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -325,7 +325,11 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 
 		$response = $this->getDataFromResponse($this->response);
 		if (array_key_exists('sessionId', $response)) {
-			self::$sessionIdToUser[$response['sessionId']] = $user;
+			// In the chat guest users are identified by their sessionId. The
+			// sessionId is larger than the size of the actorId column in the
+			// database, though, so the ID stored in the database and returned
+			// in chat messages is a hashed version instead.
+			self::$sessionIdToUser[sha1($response['sessionId'])] = $user;
 		}
 	}
 

--- a/tests/integration/features/chat/group.feature
+++ b/tests/integration/features/chat/group.feature
@@ -1,0 +1,57 @@
+Feature: chat/group
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+    And group "attendees1" exists
+    And user "participant2" is member of group "attendees1"
+
+  Scenario: owner can send and receive chat messages to and from group room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | invite   | attendees1 |
+    When user "participant1" sends message "Message 1" to room "group room" with 201
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message   |
+      | group room | users     | participant1 | participant1-displayname | Message 1 |
+
+  Scenario: invited user can send and receive chat messages to and from group room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | invite   | attendees1 |
+    When user "participant2" sends message "Message 1" to room "group room" with 201
+    Then user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message   |
+      | group room | users     | participant2 | participant2-displayname | Message 1 |
+
+  Scenario: not invited user can not send nor receive chat messages to nor from group room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | invite   | attendees1 |
+    When user "participant3" sends message "Message 1" to room "group room" with 404
+    And user "participant1" sends message "Message 2" to room "group room" with 201
+    Then user "participant3" sees the following messages in room "group room" with 404
+
+  Scenario: guest can not send nor receive chat messages to nor from group room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | invite   | attendees1 |
+    And user "guest" joins call "group room" with 404
+    When user "guest" sends message "Message 1" to room "group room" with 404
+    And user "participant1" sends message "Message 2" to room "group room" with 201
+    Then user "guest" sees the following messages in room "group room" with 404
+
+  Scenario: everyone in a group room can receive messages from everyone in that room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | invite   | attendees1 |
+    When user "participant1" sends message "Message 1" to room "group room" with 201
+    And user "participant2" sends message "Message 2" to room "group room" with 201
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message   |
+      | group room | users     | participant2 | participant2-displayname | Message 2 |
+      | group room | users     | participant1 | participant1-displayname | Message 1 |
+    And user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message   |
+      | group room | users     | participant2 | participant2-displayname | Message 2 |
+      | group room | users     | participant1 | participant1-displayname | Message 1 |

--- a/tests/integration/features/chat/one-to-one.feature
+++ b/tests/integration/features/chat/one-to-one.feature
@@ -1,0 +1,55 @@
+Feature: chat/one-to-one
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+
+  Scenario: owner can send and receive chat messages to and from one-to-one room
+    Given user "participant1" creates room "one-to-one room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    When user "participant1" sends message "Message 1" to room "one-to-one room" with 201
+    Then user "participant1" sees the following messages in room "one-to-one room" with 200
+      | room            | actorType | actorId      | actorDisplayName         | message   |
+      | one-to-one room | users     | participant1 | participant1-displayname | Message 1 |
+
+  Scenario: invited user can send and receive chat messages to and from one-to-one room
+    Given user "participant1" creates room "one-to-one room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    When user "participant2" sends message "Message 1" to room "one-to-one room" with 201
+    Then user "participant2" sees the following messages in room "one-to-one room" with 200
+      | room            | actorType | actorId      | actorDisplayName         | message   |
+      | one-to-one room | users     | participant2 | participant2-displayname | Message 1 |
+
+  Scenario: not invited user can not send nor receive chat messages to nor from one-to-one room
+    Given user "participant1" creates room "one-to-one room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    When user "participant3" sends message "Message 1" to room "one-to-one room" with 404
+    And user "participant1" sends message "Message 2" to room "one-to-one room" with 201
+    Then user "participant3" sees the following messages in room "one-to-one room" with 404
+
+  Scenario: guest can not send nor receive chat messages to nor from one-to-one room
+    Given user "participant1" creates room "one-to-one room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "guest" joins call "one-to-one room" with 404
+    When user "guest" sends message "Message 1" to room "one-to-one room" with 404
+    And user "participant1" sends message "Message 2" to room "one-to-one room" with 201
+    Then user "guest" sees the following messages in room "one-to-one room" with 404
+
+  Scenario: everyone in a one-to-one room can receive messages from everyone in that room
+    Given user "participant1" creates room "one-to-one room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    When user "participant1" sends message "Message 1" to room "one-to-one room" with 201
+    And user "participant2" sends message "Message 2" to room "one-to-one room" with 201
+    Then user "participant1" sees the following messages in room "one-to-one room" with 200
+      | room            | actorType | actorId      | actorDisplayName         | message   |
+      | one-to-one room | users     | participant2 | participant2-displayname | Message 2 |
+      | one-to-one room | users     | participant1 | participant1-displayname | Message 1 |
+    And user "participant2" sees the following messages in room "one-to-one room" with 200
+      | room            | actorType | actorId      | actorDisplayName         | message   |
+      | one-to-one room | users     | participant2 | participant2-displayname | Message 2 |
+      | one-to-one room | users     | participant1 | participant1-displayname | Message 1 |

--- a/tests/integration/features/chat/password.feature
+++ b/tests/integration/features/chat/password.feature
@@ -1,0 +1,100 @@
+Feature: chat/password
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+
+  Scenario: owner can send and receive chat messages to and from public password protected room
+    Given user "participant1" creates room "public password protected room"
+      | roomType | 3 |
+    And user "participant1" sets password "foobar" for room "public password protected room" with 200
+    When user "participant1" sends message "Message 1" to room "public password protected room" with 201
+    Then user "participant1" sees the following messages in room "public password protected room" with 200
+      | room                           | actorType | actorId      | actorDisplayName         | message   |
+      | public password protected room | users     | participant1 | participant1-displayname | Message 1 |
+
+  Scenario: invited user can send and receive chat messages to and from public password protected room
+    Given user "participant1" creates room "public password protected room"
+      | roomType | 3 |
+    And user "participant1" sets password "foobar" for room "public password protected room" with 200
+    And user "participant1" adds "participant2" to room "public password protected room" with 200
+    When user "participant2" sends message "Message 1" to room "public password protected room" with 201
+    Then user "participant2" sees the following messages in room "public password protected room" with 200
+      | room                           | actorType | actorId      | actorDisplayName         | message   |
+      | public password protected room | users     | participant2 | participant2-displayname | Message 1 |
+
+  Scenario: not invited but joined with password user can send and receive chat messages to and from public password protected room
+    Given user "participant1" creates room "public password protected room"
+      | roomType | 3 |
+    And user "participant1" sets password "foobar" for room "public password protected room" with 200
+    And user "participant3" joins call "public password protected room" with 200
+      | password | foobar |
+    When user "participant3" sends message "Message 1" to room "public password protected room" with 201
+    Then user "participant3" sees the following messages in room "public password protected room" with 200
+      | room                           | actorType | actorId      | actorDisplayName         | message   |
+      | public password protected room | users     | participant3 | participant3-displayname | Message 1 |
+
+  Scenario: not invited user can not send nor receive chat messages to and from public password protected room
+    Given user "participant1" creates room "public password protected room"
+      | roomType | 3 |
+    And user "participant1" sets password "foobar" for room "public password protected room" with 200
+    When user "participant3" sends message "Message 1" to room "public password protected room" with 404
+    And user "participant1" sends message "Message 2" to room "public password protected room" with 201
+    Then user "participant3" sees the following messages in room "public password protected room" with 404
+
+  Scenario: joined with password guest can send and receive chat messages to and from public password protected room
+    Given user "participant1" creates room "public password protected room"
+      | roomType | 3 |
+    And user "participant1" sets password "foobar" for room "public password protected room" with 200
+    And user "guest" joins call "public password protected room" with 200
+      | password | foobar |
+    When user "guest" sends message "Message 1" to room "public password protected room" with 201
+    Then user "guest" sees the following messages in room "public password protected room" with 200
+      | room                           | actorType | actorId | actorDisplayName | message   |
+      | public password protected room | guests    | guest   |                  | Message 1 |
+
+  Scenario: not joined guest can not send nor receive chat messages to and from public password protected room
+    Given user "participant1" creates room "public password protected room"
+      | roomType | 3 |
+    And user "participant1" sets password "foobar" for room "public password protected room" with 200
+    When user "guest" sends message "Message 1" to room "public password protected room" with 404
+    And user "participant1" sends message "Message 2" to room "public password protected room" with 201
+    Then user "guest" sees the following messages in room "public password protected room" with 404
+
+  Scenario: everyone in a public password protected room can receive messages from everyone in that room
+    Given user "participant1" creates room "public password protected room"
+      | roomType | 3 |
+    And user "participant1" sets password "foobar" for room "public password protected room" with 200
+    And user "participant1" adds "participant2" to room "public password protected room" with 200
+    And user "participant3" joins call "public password protected room" with 200
+      | password | foobar |
+    And user "guest" joins call "public password protected room" with 200
+      | password | foobar |
+    When user "participant1" sends message "Message 1" to room "public password protected room" with 201
+    And user "participant2" sends message "Message 2" to room "public password protected room" with 201
+    And user "participant3" sends message "Message 3" to room "public password protected room" with 201
+    And user "guest" sends message "Message 4" to room "public password protected room" with 201
+    Then user "participant1" sees the following messages in room "public password protected room" with 200
+      | room                           | actorType | actorId      | actorDisplayName         | message   |
+      | public password protected room | guests    | guest        |                          | Message 4 |
+      | public password protected room | users     | participant3 | participant3-displayname | Message 3 |
+      | public password protected room | users     | participant2 | participant2-displayname | Message 2 |
+      | public password protected room | users     | participant1 | participant1-displayname | Message 1 |
+    And user "participant2" sees the following messages in room "public password protected room" with 200
+      | room                           | actorType | actorId      | actorDisplayName         | message   |
+      | public password protected room | guests    | guest        |                          | Message 4 |
+      | public password protected room | users     | participant3 | participant3-displayname | Message 3 |
+      | public password protected room | users     | participant2 | participant2-displayname | Message 2 |
+      | public password protected room | users     | participant1 | participant1-displayname | Message 1 |
+    And user "participant3" sees the following messages in room "public password protected room" with 200
+      | room                           | actorType | actorId      | actorDisplayName         | message   |
+      | public password protected room | guests    | guest        |                          | Message 4 |
+      | public password protected room | users     | participant3 | participant3-displayname | Message 3 |
+      | public password protected room | users     | participant2 | participant2-displayname | Message 2 |
+      | public password protected room | users     | participant1 | participant1-displayname | Message 1 |
+    And user "guest" sees the following messages in room "public password protected room" with 200
+      | room                           | actorType | actorId      | actorDisplayName         | message   |
+      | public password protected room | guests    | guest        |                          | Message 4 |
+      | public password protected room | users     | participant3 | participant3-displayname | Message 3 |
+      | public password protected room | users     | participant2 | participant2-displayname | Message 2 |
+      | public password protected room | users     | participant1 | participant1-displayname | Message 1 |

--- a/tests/integration/features/chat/public.feature
+++ b/tests/integration/features/chat/public.feature
@@ -1,0 +1,72 @@
+Feature: chat/public
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+
+  Scenario: owner can send and receive chat messages to and from public room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    When user "participant1" sends message "Message 1" to room "public room" with 201
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message   |
+      | public room | users     | participant1 | participant1-displayname | Message 1 |
+
+  Scenario: invited user can send and receive chat messages to and from public room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    When user "participant2" sends message "Message 1" to room "public room" with 201
+    Then user "participant2" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message   |
+      | public room | users     | participant2 | participant2-displayname | Message 1 |
+
+  Scenario: not invited user can send and receive chat messages to and from public room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    When user "participant3" sends message "Message 1" to room "public room" with 201
+    Then user "participant3" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message   |
+      | public room | users     | participant3 | participant3-displayname | Message 1 |
+
+  Scenario: joined guest can send and receive chat messages to and from public room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "guest" joins call "public room" with 200
+    When user "guest" sends message "Message 1" to room "public room" with 201
+    Then user "guest" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId | actorDisplayName | message   |
+      | public room | guests    | guest   |                  | Message 1 |
+
+  Scenario: not joined guest can not send messages to public room, but she can receive them
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    When user "guest" sends message "Message 1" to room "public room" with 404
+    And user "participant1" sends message "Message 2" to room "public room" with 201
+    Then user "guest" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message   |
+      | public room | users     | participant1 | participant1-displayname | Message 2 |
+
+  Scenario: everyone in a public room can receive messages from everyone in that room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "guest" joins call "public room" with 200
+    When user "participant1" sends message "Message 1" to room "public room" with 201
+    And user "participant2" sends message "Message 2" to room "public room" with 201
+    And user "guest" sends message "Message 3" to room "public room" with 201
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message   |
+      | public room | guests    | guest        |                          | Message 3 |
+      | public room | users     | participant2 | participant2-displayname | Message 2 |
+      | public room | users     | participant1 | participant1-displayname | Message 1 |
+    And user "participant2" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message   |
+      | public room | guests    | guest        |                          | Message 3 |
+      | public room | users     | participant2 | participant2-displayname | Message 2 |
+      | public room | users     | participant1 | participant1-displayname | Message 1 |
+    And user "guest" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message   |
+      | public room | guests    | guest        |                          | Message 3 |
+      | public room | users     | participant2 | participant2-displayname | Message 2 |
+      | public room | users     | participant1 | participant1-displayname | Message 1 |

--- a/tests/integration/features/chat/public.feature
+++ b/tests/integration/features/chat/public.feature
@@ -21,13 +21,21 @@ Feature: chat/public
       | room        | actorType | actorId      | actorDisplayName         | message   |
       | public room | users     | participant2 | participant2-displayname | Message 1 |
 
-  Scenario: not invited user can send and receive chat messages to and from public room
+  Scenario: not invited but joined user can send and receive chat messages to and from public room
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+    And user "participant3" joins call "public room" with 200
     When user "participant3" sends message "Message 1" to room "public room" with 201
     Then user "participant3" sees the following messages in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message   |
       | public room | users     | participant3 | participant3-displayname | Message 1 |
+
+  Scenario: not invited user can not send nor receive chat messages to and from public room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    When user "participant3" sends message "Message 1" to room "public room" with 404
+    And user "participant1" sends message "Message 2" to room "public room" with 201
+    Then user "participant3" sees the following messages in room "public room" with 404
 
   Scenario: joined guest can send and receive chat messages to and from public room
     Given user "participant1" creates room "public room"
@@ -38,14 +46,12 @@ Feature: chat/public
       | room        | actorType | actorId | actorDisplayName | message   |
       | public room | guests    | guest   |                  | Message 1 |
 
-  Scenario: not joined guest can not send messages to public room, but she can receive them
+  Scenario: not joined guest can not send nor receive chat messages to and from public room
     Given user "participant1" creates room "public room"
       | roomType | 3 |
     When user "guest" sends message "Message 1" to room "public room" with 404
     And user "participant1" sends message "Message 2" to room "public room" with 201
-    Then user "guest" sees the following messages in room "public room" with 200
-      | room        | actorType | actorId      | actorDisplayName         | message   |
-      | public room | users     | participant1 | participant1-displayname | Message 2 |
+    Then user "guest" sees the following messages in room "public room" with 404
 
   Scenario: everyone in a public room can receive messages from everyone in that room
     Given user "participant1" creates room "public room"

--- a/tests/php/Chat/ChatManagerTest.php
+++ b/tests/php/Chat/ChatManagerTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Tests\php\Chat;
+
+use OCA\Spreed\Chat\ChatManager;
+use OCP\Comments\IComment;
+use OCP\Comments\ICommentsManager;
+
+class ChatManagerTest extends \Test\TestCase {
+
+	/** @var OCP\Comments\ICommentsManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $commentsManager;
+
+	/** @var \OCA\Spreed\Chat\ChatManager */
+	protected $chatManager;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->commentsManager = $this->createMock(ICommentsManager::class);
+
+		$this->chatManager = new ChatManager($this->commentsManager);
+	}
+
+	private function newComment($id, $actorType, $actorId, $creationDateTime, $message) {
+		$comment = $this->createMock(IComment::class);
+
+		$comment->method('getId')->willReturn($id);
+		$comment->method('getActorType')->willReturn($actorType);
+		$comment->method('getActorId')->willReturn($actorId);
+		$comment->method('getCreationDateTime')->willReturn($creationDateTime);
+		$comment->method('getMessage')->willReturn($message);
+
+		// Used for equals comparison
+		$comment->id = $id;
+		$comment->actorType = $actorType;
+		$comment->actorId = $actorId;
+		$comment->creationDateTime = $creationDateTime;
+		$comment->message = $message;
+
+		return $comment;
+	}
+
+	public function testSendMessage() {
+		$comment = $this->createMock(IComment::class);
+
+		$this->commentsManager->expects($this->once())
+			->method('create')
+			->with('users', 'testUser', 'chat', 'testChatId')
+			->willReturn($comment);
+
+		$comment->expects($this->once())
+			->method('setMessage')
+			->with('testMessage');
+
+		$creationDateTime = new \DateTime();
+		$comment->expects($this->once())
+			->method('setCreationDateTime')
+			->with($creationDateTime);
+
+		$comment->expects($this->once())
+			->method('setVerb')
+			->with('comment');
+
+		$this->commentsManager->expects($this->once())
+			->method('save')
+			->with($comment);
+
+		$this->chatManager->sendMessage('testChatId', 'users', 'testUser', 'testMessage', $creationDateTime);
+	}
+
+	public function testReceiveMessages() {
+		$notOlderThan = new \DateTime('@1000000000');
+
+		$offset = 1;
+		$this->commentsManager->expects($this->once())
+			->method('getNumberOfCommentsForObject')
+			->with('chat', 'testChatId', $notOlderThan)
+			->willReturn($offset + 2);
+
+		$limit = 0;
+		$getForObjectOffset = 0;
+		$this->commentsManager->expects($this->once())
+			->method('getForObject')
+			->with('chat', 'testChatId', $limit, $getForObjectOffset, $notOlderThan)
+			->willReturn([
+				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000042), 'testMessage3'),
+				$this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000023), 'testMessage2'),
+				$this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage1')
+			]);
+
+		$timeout = 42;
+		$comments = $this->chatManager->receiveMessages('testChatId', $timeout, $offset, $notOlderThan);
+		$expected = [
+				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000042), 'testMessage3'),
+				$this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000023), 'testMessage2')
+		];
+
+		$this->assertEquals($expected, $comments);
+	}
+
+	public function testReceiveMessagesMoreCommentsThanExpected() {
+		$notOlderThan = new \DateTime('@1000000000');
+
+		$offset = 1;
+		$this->commentsManager->expects($this->once())
+			->method('getNumberOfCommentsForObject')
+			->with('chat', 'testChatId', $notOlderThan)
+			->willReturn($offset + 2);
+
+		// An extra comment was added between the call to
+		// getNumberOfCommentsForObject and the call to getForObject
+		$limit = 0;
+		$getForObjectOffset = 0;
+		$this->commentsManager->expects($this->once())
+			->method('getForObject')
+			->with('chat', 'testChatId', $limit, $getForObjectOffset, $notOlderThan)
+			->willReturn([
+				$this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000108), 'testMessage4'),
+				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000042), 'testMessage3'),
+				$this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000023), 'testMessage2'),
+				$this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage1')
+			]);
+
+		$timeout = 42;
+		$comments = $this->chatManager->receiveMessages('testChatId', $timeout, $offset, $notOlderThan);
+		$expected = [
+				$this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000108), 'testMessage4'),
+				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000042), 'testMessage3'),
+				$this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000023), 'testMessage2')
+		];
+
+		$this->assertEquals($expected, $comments);
+	}
+
+	public function testReceiveMessagesNoOffset() {
+		$notOlderThan = new \DateTime('@1000000000');
+
+		$offset = 0;
+		$this->commentsManager->expects($this->once())
+			->method('getNumberOfCommentsForObject')
+			->with('chat', 'testChatId', $notOlderThan)
+			->willReturn($offset + 3);
+
+		$limit = 0;
+		$getForObjectOffset = 0;
+		$this->commentsManager->expects($this->once())
+			->method('getForObject')
+			->with('chat', 'testChatId', $limit, $getForObjectOffset, $notOlderThan)
+			->willReturn([
+				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000042), 'testMessage3'),
+				$this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000023), 'testMessage2'),
+				$this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage1')
+			]);
+
+		$timeout = 42;
+		$comments = $this->chatManager->receiveMessages('testChatId', $timeout, $offset, $notOlderThan);
+		$expected = [
+				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000042), 'testMessage3'),
+				$this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000023), 'testMessage2'),
+				$this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage1')
+		];
+
+		$this->assertEquals($expected, $comments);
+	}
+
+}

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -25,6 +25,7 @@ namespace OCA\Spreed\Tests\php\Controller;
 
 use OCA\Spreed\Chat\ChatManager;
 use OCA\Spreed\Controller\ChatController;
+use OCA\Spreed\Exceptions\ParticipantNotFoundException;
 use OCA\Spreed\Exceptions\RoomNotFoundException;
 use OCA\Spreed\Manager;
 use OCA\Spreed\Room;
@@ -107,17 +108,22 @@ class ChatControllerTest extends \Test\TestCase {
 	}
 
 	public function testSendMessageByUser() {
+		$this->session->expects($this->once())
+			->method('get')
+			->with('spreed-session')
+			->willReturn('testSpreedSession');
+
 		$this->manager->expects($this->once())
-			->method('getRoomForParticipantByToken')
-			->with('testToken', $this->userId)
+			->method('getRoomForSession')
+			->with($this->userId, 'testSpreedSession')
 			->willReturn($this->room);
+
+		$this->manager->expects($this->never())
+			->method('getRoomForParticipantByToken');
 
 		$this->room->expects($this->once())
 			->method('getId')
 			->willReturn(1234);
-
-		$this->session->expects($this->never())
-			->method('get');
 
 		$this->chatManager->expects($this->once())
 			->method('sendMessage')
@@ -134,9 +140,16 @@ class ChatControllerTest extends \Test\TestCase {
 		$this->assertEquals($expected, $response);
 	}
 
-	public function testSendMessageByGuest() {
-		$this->userId = null;
-		$this->recreateChatController();
+	public function testSendMessageByUserNotJoinedButInRoom() {
+		$this->session->expects($this->once())
+			->method('get')
+			->with('spreed-session')
+			->willReturn(null);
+
+		$this->manager->expects($this->once())
+			->method('getRoomForSession')
+			->with($this->userId, null)
+			->will($this->throwException(new RoomNotFoundException()));
 
 		$this->manager->expects($this->once())
 			->method('getRoomForParticipantByToken')
@@ -144,13 +157,78 @@ class ChatControllerTest extends \Test\TestCase {
 			->willReturn($this->room);
 
 		$this->room->expects($this->once())
+			->method('getParticipant')
+			->with($this->userId);
+
+		$this->room->expects($this->once())
 			->method('getId')
 			->willReturn(1234);
 
+		$this->chatManager->expects($this->once())
+			->method('sendMessage')
+			->with('1234',
+				   'users',
+				   $this->userId,
+				   'testMessage',
+				   $this->newMessageDateTimeConstraint
+			);
+
+		$response = $this->controller->sendMessage('testToken', 'testMessage');
+		$expected = new DataResponse([], Http::STATUS_CREATED);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testSendMessageByUserNotJoinedNorInRoom() {
 		$this->session->expects($this->once())
 			->method('get')
 			->with('spreed-session')
+			->willReturn(null);
+
+		$this->manager->expects($this->once())
+			->method('getRoomForSession')
+			->with($this->userId, null)
+			->will($this->throwException(new RoomNotFoundException()));
+
+		$this->manager->expects($this->once())
+			->method('getRoomForParticipantByToken')
+			->with('testToken', $this->userId)
+			->willReturn($this->room);
+
+		$this->room->expects($this->once())
+			->method('getParticipant')
+			->with($this->userId)
+			->will($this->throwException(new ParticipantNotFoundException()));
+
+		$this->chatManager->expects($this->never())
+			->method('sendMessage');
+
+		$response = $this->controller->sendMessage('testToken', 'testMessage');
+		$expected = new DataResponse([], Http::STATUS_NOT_FOUND);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testSendMessageByGuest() {
+		$this->userId = null;
+		$this->recreateChatController();
+
+		$this->session->expects($this->any())
+			->method('get')
+			->with('spreed-session')
 			->willReturn('testSpreedSession');
+
+		$this->manager->expects($this->once())
+			->method('getRoomForSession')
+			->with($this->userId, 'testSpreedSession')
+			->willReturn($this->room);
+
+		$this->manager->expects($this->never())
+			->method('getRoomForParticipantByToken');
+
+		$this->room->expects($this->once())
+			->method('getId')
+			->willReturn(1234);
 
 		$this->chatManager->expects($this->once())
 			->method('sendMessage')
@@ -171,15 +249,18 @@ class ChatControllerTest extends \Test\TestCase {
 		$this->userId = null;
 		$this->recreateChatController();
 
-		$this->manager->expects($this->once())
-			->method('getRoomForParticipantByToken')
-			->with('testToken', $this->userId)
-			->willReturn($this->room);
-
 		$this->session->expects($this->once())
 			->method('get')
 			->with('spreed-session')
 			->willReturn(null);
+
+		$this->manager->expects($this->once())
+			->method('getRoomForSession')
+			->with($this->userId, null)
+			->will($this->throwException(new RoomNotFoundException()));
+
+		$this->manager->expects($this->never())
+			->method('getRoomForParticipantByToken');
 
 		$this->chatManager->expects($this->never())
 			->method('sendMessage');
@@ -191,13 +272,20 @@ class ChatControllerTest extends \Test\TestCase {
 	}
 
 	public function testSendMessageToInvalidRoom() {
+		$this->session->expects($this->once())
+			->method('get')
+			->with('spreed-session')
+			->willReturn(null);
+
+		$this->manager->expects($this->once())
+			->method('getRoomForSession')
+			->with($this->userId, null)
+			->will($this->throwException(new RoomNotFoundException()));
+
 		$this->manager->expects($this->once())
 			->method('getRoomForParticipantByToken')
 			->with('testToken', $this->userId)
 			->will($this->throwException(new RoomNotFoundException()));
-
-		$this->session->expects($this->never())
-			->method('get');
 
 		$this->chatManager->expects($this->never())
 			->method('sendMessage');
@@ -209,17 +297,22 @@ class ChatControllerTest extends \Test\TestCase {
 	}
 
 	public function testReceiveMessagesByUser() {
+		$this->session->expects($this->once())
+			->method('get')
+			->with('spreed-session')
+			->willReturn('testSpreedSession');
+
 		$this->manager->expects($this->once())
-			->method('getRoomForParticipantByToken')
-			->with('testToken', $this->userId)
+			->method('getRoomForSession')
+			->with($this->userId, 'testSpreedSession')
 			->willReturn($this->room);
+
+		$this->manager->expects($this->never())
+			->method('getRoomForParticipantByToken');
 
 		$this->room->expects($this->once())
 			->method('getId')
 			->willReturn(1234);
-
-		$this->session->expects($this->never())
-			->method('get');
 
 		$timeout = 42;
 		$offset = 23;
@@ -251,6 +344,97 @@ class ChatControllerTest extends \Test\TestCase {
 			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>null, 'timestamp'=>1000000008, 'message'=>'testMessage2'],
 			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000004, 'message'=>'testMessage1']
 		], Http::STATUS_OK);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testReceiveMessagesByUserNotJoinedButInRoom() {
+		$this->session->expects($this->once())
+			->method('get')
+			->with('spreed-session')
+			->willReturn(null);
+
+		$this->manager->expects($this->once())
+			->method('getRoomForSession')
+			->with($this->userId, null)
+			->will($this->throwException(new RoomNotFoundException()));
+
+		$this->manager->expects($this->once())
+			->method('getRoomForParticipantByToken')
+			->with('testToken', $this->userId)
+			->willReturn($this->room);
+
+		$this->room->expects($this->once())
+			->method('getParticipant')
+			->with($this->userId);
+
+		$this->room->expects($this->once())
+			->method('getId')
+			->willReturn(1234);
+
+		$timeout = 42;
+		$offset = 23;
+		$timestamp = 1000000000;
+		$this->chatManager->expects($this->once())
+			->method('receiveMessages')
+			->with('1234', $timeout, $offset, new \DateTime('@' . $timestamp))
+			->willReturn([
+				$this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
+				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
+				$this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000008), 'testMessage2'),
+				$this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000004), 'testMessage1')
+			]);
+
+		$testUser = $this->createMock(IUser::class);
+		$testUser->expects($this->exactly(2))
+			->method('getDisplayName')
+			->willReturn('Test User');
+
+		$this->userManager->expects($this->exactly(3))
+			->method('get')
+			->withConsecutive(['testUser'], ['testUnknownUser'], ['testUser'])
+			->willReturn($testUser, null, $testUser);
+
+		$response = $this->controller->receiveMessages('testToken', $offset, $timestamp, $timeout);
+		$expected = new DataResponse([
+			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000016, 'message'=>'testMessage4'],
+			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>null, 'timestamp'=>1000000015, 'message'=>'testMessage3'],
+			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>null, 'timestamp'=>1000000008, 'message'=>'testMessage2'],
+			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000004, 'message'=>'testMessage1']
+		], Http::STATUS_OK);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testReceiveMessagesByUserNotJoinedNorInRoom() {
+		$this->session->expects($this->once())
+			->method('get')
+			->with('spreed-session')
+			->willReturn(null);
+
+		$this->manager->expects($this->once())
+			->method('getRoomForSession')
+			->with($this->userId, null)
+			->will($this->throwException(new RoomNotFoundException()));
+
+		$this->manager->expects($this->once())
+			->method('getRoomForParticipantByToken')
+			->with('testToken', $this->userId)
+			->willReturn($this->room);
+
+		$this->room->expects($this->once())
+			->method('getParticipant')
+			->with($this->userId)
+			->will($this->throwException(new ParticipantNotFoundException()));
+
+		$timeout = 42;
+		$offset = 23;
+		$timestamp = 1000000000;
+		$this->chatManager->expects($this->never())
+			->method('receiveMessages');
+
+		$response = $this->controller->receiveMessages('testToken', $offset, $timestamp, $timeout);
+		$expected = new DataResponse([], Http::STATUS_NOT_FOUND);
 
 		$this->assertEquals($expected, $response);
 	}
@@ -259,17 +443,22 @@ class ChatControllerTest extends \Test\TestCase {
 		$this->userId = null;
 		$this->recreateChatController();
 
+		$this->session->expects($this->any())
+			->method('get')
+			->with('spreed-session')
+			->willReturn('testSpreedSession');
+
 		$this->manager->expects($this->once())
-			->method('getRoomForParticipantByToken')
-			->with('testToken', $this->userId)
+			->method('getRoomForSession')
+			->with($this->userId, 'testSpreedSession')
 			->willReturn($this->room);
+
+		$this->manager->expects($this->never())
+			->method('getRoomForParticipantByToken');
 
 		$this->room->expects($this->once())
 			->method('getId')
 			->willReturn(1234);
-
-		$this->session->expects($this->never())
-			->method('get');
 
 		$timeout = 42;
 		$offset = 23;
@@ -305,18 +494,52 @@ class ChatControllerTest extends \Test\TestCase {
 		$this->assertEquals($expected, $response);
 	}
 
-	public function testReceiveMessagesTimeoutExpired() {
+	public function testReceiveMessagesByGuestNotJoined() {
+		$this->userId = null;
+		$this->recreateChatController();
+
+		$this->session->expects($this->once())
+			->method('get')
+			->with('spreed-session')
+			->willReturn(null);
+
 		$this->manager->expects($this->once())
-			->method('getRoomForParticipantByToken')
-			->with('testToken', $this->userId)
+			->method('getRoomForSession')
+			->with($this->userId, null)
+			->will($this->throwException(new RoomNotFoundException()));
+
+		$this->manager->expects($this->never())
+			->method('getRoomForParticipantByToken');
+
+		$timeout = 42;
+		$offset = 23;
+		$timestamp = 1000000000;
+		$this->chatManager->expects($this->never())
+			->method('receiveMessages');
+
+		$response = $this->controller->receiveMessages('testToken', $offset, $timestamp, $timeout);
+		$expected = new DataResponse([], Http::STATUS_NOT_FOUND);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testReceiveMessagesTimeoutExpired() {
+		$this->session->expects($this->once())
+			->method('get')
+			->with('spreed-session')
+			->willReturn('testSpreedSession');
+
+		$this->manager->expects($this->once())
+			->method('getRoomForSession')
+			->with($this->userId, 'testSpreedSession')
 			->willReturn($this->room);
+
+		$this->manager->expects($this->never())
+			->method('getRoomForParticipantByToken');
 
 		$this->room->expects($this->once())
 			->method('getId')
 			->willReturn(1234);
-
-		$this->session->expects($this->never())
-			->method('get');
 
 		$timeout = 42;
 		$offset = 23;
@@ -333,17 +556,22 @@ class ChatControllerTest extends \Test\TestCase {
 	}
 
 	public function testReceiveMessagesTimeoutTooLarge() {
+		$this->session->expects($this->once())
+			->method('get')
+			->with('spreed-session')
+			->willReturn('testSpreedSession');
+
 		$this->manager->expects($this->once())
-			->method('getRoomForParticipantByToken')
-			->with('testToken', $this->userId)
+			->method('getRoomForSession')
+			->with($this->userId, 'testSpreedSession')
 			->willReturn($this->room);
+
+		$this->manager->expects($this->never())
+			->method('getRoomForParticipantByToken');
 
 		$this->room->expects($this->once())
 			->method('getId')
 			->willReturn(1234);
-
-		$this->session->expects($this->never())
-			->method('get');
 
 		$timeout = 100000;
 		$maximumTimeout = 60;
@@ -361,13 +589,20 @@ class ChatControllerTest extends \Test\TestCase {
 	}
 
 	public function testReceiveMessagesFromInvalidRoom() {
+		$this->session->expects($this->once())
+			->method('get')
+			->with('spreed-session')
+			->willReturn(null);
+
+		$this->manager->expects($this->once())
+			->method('getRoomForSession')
+			->with($this->userId, null)
+			->will($this->throwException(new RoomNotFoundException()));
+
 		$this->manager->expects($this->once())
 			->method('getRoomForParticipantByToken')
 			->with('testToken', $this->userId)
 			->will($this->throwException(new RoomNotFoundException()));
-
-		$this->session->expects($this->never())
-			->method('get');
 
 		$timeout = 42;
 		$offset = 23;

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -1,0 +1,347 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Tests\php\Controller;
+
+use OCA\Spreed\Chat\ChatManager;
+use OCA\Spreed\Controller\ChatController;
+use OCA\Spreed\Exceptions\RoomNotFoundException;
+use OCA\Spreed\Manager;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\Comments\IComment;
+use OCP\ISession;
+use OCP\IUser;
+use OCP\IUserManager;
+
+class ChatControllerTest extends \Test\TestCase {
+
+	/** @var string */
+	private $userId;
+
+	/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $userManager;
+
+	/** @var \OCP\ISession|\PHPUnit_Framework_MockObject_MockObject */
+	private $session;
+
+	/** @var \OCA\Spreed\Manager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $manager;
+
+	/** @var \OCA\Spreed\Chat\ChatManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $chatManager;
+
+	/** @var \OCA\Spreed\Controller\ChatController */
+	private $controller;
+
+	/** @var \PHPUnit_Framework_Constraint_Callback */
+	private $newMessageDateTimeConstraint;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->userId = 'testUser';
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->session = $this->createMock(ISession::class);
+		$this->manager = $this->createMock(Manager::class);
+		$this->chatManager = $this->createMock(ChatManager::class);
+
+		$this->recreateChatController();
+
+		// Verifies that the difference of the given DateTime and now is at most
+		// five seconds, and that it uses the UTC time zone.
+		$this->newMessageDateTimeConstraint = $this->callback(function(\DateTime $dateTime) {
+			return abs((new \DateTime())->getTimestamp() - $dateTime->getTimestamp()) <= 5 &&
+				(new \DateTimeZone('UTC'))->getName() === $dateTime->getTimezone()->getName();
+		});
+	}
+
+	private function recreateChatController() {
+		$this->controller = new ChatController(
+			'spreed',
+			$this->userId,
+			$this->createMock(\OCP\IRequest::class),
+			$this->userManager,
+			$this->session,
+			$this->manager,
+			$this->chatManager
+		);
+	}
+
+	private function newComment($id, $actorType, $actorId, $creationDateTime, $message) {
+		$comment = $this->createMock(IComment::class);
+
+		$comment->method('getId')->willReturn($id);
+		$comment->method('getActorType')->willReturn($actorType);
+		$comment->method('getActorId')->willReturn($actorId);
+		$comment->method('getCreationDateTime')->willReturn($creationDateTime);
+		$comment->method('getMessage')->willReturn($message);
+
+		return $comment;
+	}
+
+	public function testSendMessageByUser() {
+		$this->manager->expects($this->once())
+			->method('getRoomForParticipantByToken')
+			->with('testToken', $this->userId);
+
+		$this->session->expects($this->never())
+			->method('get');
+
+		$this->chatManager->expects($this->once())
+			->method('sendMessage')
+			->with('testToken',
+				   'users',
+				   $this->userId,
+				   'testMessage',
+				   $this->newMessageDateTimeConstraint
+			);
+
+		$response = $this->controller->sendMessage('testToken', 'testMessage');
+		$expected = new DataResponse([], Http::STATUS_CREATED);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testSendMessageByGuest() {
+		$this->userId = null;
+		$this->recreateChatController();
+
+		$this->manager->expects($this->once())
+			->method('getRoomForParticipantByToken')
+			->with('testToken', $this->userId);
+
+		$this->session->expects($this->once())
+			->method('get')
+			->with('spreed-session')
+			->willReturn('testSpreedSession');
+
+		$this->chatManager->expects($this->once())
+			->method('sendMessage')
+			->with('testToken',
+				   'guests',
+				   'testSpreedSession',
+				   'testMessage',
+				   $this->newMessageDateTimeConstraint
+			);
+
+		$response = $this->controller->sendMessage('testToken', 'testMessage');
+		$expected = new DataResponse([], Http::STATUS_CREATED);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testSendMessageByGuestNotJoined() {
+		$this->userId = null;
+		$this->recreateChatController();
+
+		$this->manager->expects($this->once())
+			->method('getRoomForParticipantByToken')
+			->with('testToken', $this->userId);
+
+		$this->session->expects($this->once())
+			->method('get')
+			->with('spreed-session')
+			->willReturn(null);
+
+		$this->chatManager->expects($this->never())
+			->method('sendMessage');
+
+		$response = $this->controller->sendMessage('testToken', 'testMessage');
+		$expected = new DataResponse([], Http::STATUS_NOT_FOUND);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testSendMessageToInvalidRoom() {
+		$this->manager->expects($this->once())
+			->method('getRoomForParticipantByToken')
+			->with('testToken', $this->userId)
+			->will($this->throwException(new RoomNotFoundException()));
+
+		$this->session->expects($this->never())
+			->method('get');
+
+		$this->chatManager->expects($this->never())
+			->method('sendMessage');
+
+		$response = $this->controller->sendMessage('testToken', 'testMessage');
+		$expected = new DataResponse([], Http::STATUS_NOT_FOUND);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testReceiveMessagesByUser() {
+		$this->manager->expects($this->once())
+			->method('getRoomForParticipantByToken')
+			->with('testToken', $this->userId);
+
+		$this->session->expects($this->never())
+			->method('get');
+
+		$timeout = 42;
+		$offset = 23;
+		$timestamp = 1000000000;
+		$this->chatManager->expects($this->once())
+			->method('receiveMessages')
+			->with('testToken', $timeout, $offset, new \DateTime('@' . $timestamp))
+			->willReturn([
+				$this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
+				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
+				$this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000008), 'testMessage2'),
+				$this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000004), 'testMessage1')
+			]);
+
+		$testUser = $this->createMock(IUser::class);
+		$testUser->expects($this->exactly(2))
+			->method('getDisplayName')
+			->willReturn('Test User');
+
+		$this->userManager->expects($this->exactly(3))
+			->method('get')
+			->withConsecutive(['testUser'], ['testUnknownUser'], ['testUser'])
+			->willReturn($testUser, null, $testUser);
+
+		$response = $this->controller->receiveMessages('testToken', $offset, $timestamp, $timeout);
+		$expected = new DataResponse([
+			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000016, 'message'=>'testMessage4'],
+			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>null, 'timestamp'=>1000000015, 'message'=>'testMessage3'],
+			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>null, 'timestamp'=>1000000008, 'message'=>'testMessage2'],
+			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000004, 'message'=>'testMessage1']
+		], Http::STATUS_OK);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testReceiveMessagesByGuest() {
+		$this->userId = null;
+		$this->recreateChatController();
+
+		$this->manager->expects($this->once())
+			->method('getRoomForParticipantByToken')
+			->with('testToken', $this->userId);
+
+		$this->session->expects($this->never())
+			->method('get');
+
+		$timeout = 42;
+		$offset = 23;
+		$timestamp = 1000000000;
+		$this->chatManager->expects($this->once())
+			->method('receiveMessages')
+			->with('testToken', $timeout, $offset, new \DateTime('@' . $timestamp))
+			->willReturn([
+				$this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
+				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
+				$this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000008), 'testMessage2'),
+				$this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000004), 'testMessage1')
+			]);
+
+		$testUser = $this->createMock(IUser::class);
+		$testUser->expects($this->exactly(2))
+			->method('getDisplayName')
+			->willReturn('Test User');
+
+		$this->userManager->expects($this->exactly(3))
+			->method('get')
+			->withConsecutive(['testUser'], ['testUnknownUser'], ['testUser'])
+			->willReturn($testUser, null, $testUser);
+
+		$response = $this->controller->receiveMessages('testToken', $offset, $timestamp, $timeout);
+		$expected = new DataResponse([
+			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000016, 'message'=>'testMessage4'],
+			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>null, 'timestamp'=>1000000015, 'message'=>'testMessage3'],
+			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>null, 'timestamp'=>1000000008, 'message'=>'testMessage2'],
+			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000004, 'message'=>'testMessage1']
+		], Http::STATUS_OK);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testReceiveMessagesTimeoutExpired() {
+		$this->manager->expects($this->once())
+			->method('getRoomForParticipantByToken')
+			->with('testToken', $this->userId);
+
+		$this->session->expects($this->never())
+			->method('get');
+
+		$timeout = 42;
+		$offset = 23;
+		$timestamp = 1000000000;
+		$this->chatManager->expects($this->once())
+			->method('receiveMessages')
+			->with('testToken', $timeout, $offset, new \DateTime('@' . $timestamp))
+			->willReturn([]);
+
+		$response = $this->controller->receiveMessages('testToken', $offset, $timestamp, $timeout);
+		$expected = new DataResponse([], Http::STATUS_OK);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testReceiveMessagesTimeoutTooLarge() {
+		$this->manager->expects($this->once())
+			->method('getRoomForParticipantByToken')
+			->with('testToken', $this->userId);
+
+		$this->session->expects($this->never())
+			->method('get');
+
+		$timeout = 100000;
+		$maximumTimeout = 60;
+		$offset = 23;
+		$timestamp = 1000000000;
+		$this->chatManager->expects($this->once())
+			->method('receiveMessages')
+			->with('testToken', $maximumTimeout, $offset, new \DateTime('@' . $timestamp))
+			->willReturn([]);
+
+		$response = $this->controller->receiveMessages('testToken', $offset, $timestamp, $timeout);
+		$expected = new DataResponse([], Http::STATUS_OK);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testReceiveMessagesFromInvalidRoom() {
+		$this->manager->expects($this->once())
+			->method('getRoomForParticipantByToken')
+			->with('testToken', $this->userId)
+			->will($this->throwException(new RoomNotFoundException()));
+
+		$this->session->expects($this->never())
+			->method('get');
+
+		$timeout = 42;
+		$offset = 23;
+		$timestamp = 1000000000;
+		$this->chatManager->expects($this->never())
+			->method('receiveMessages');
+
+		$response = $this->controller->receiveMessages('testToken', $offset, $timestamp, $timeout);
+		$expected = new DataResponse([], Http::STATUS_NOT_FOUND);
+
+		$this->assertEquals($expected, $response);
+	}
+
+}

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -27,6 +27,7 @@ use OCA\Spreed\Chat\ChatManager;
 use OCA\Spreed\Controller\ChatController;
 use OCA\Spreed\Exceptions\RoomNotFoundException;
 use OCA\Spreed\Manager;
+use OCA\Spreed\Room;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\Comments\IComment;
@@ -51,6 +52,9 @@ class ChatControllerTest extends \Test\TestCase {
 	/** @var \OCA\Spreed\Chat\ChatManager|\PHPUnit_Framework_MockObject_MockObject */
 	protected $chatManager;
 
+	/** @var \OCA\Spreed\Room|\PHPUnit_Framework_MockObject_MockObject */
+	protected $room;
+
 	/** @var \OCA\Spreed\Controller\ChatController */
 	private $controller;
 
@@ -65,6 +69,8 @@ class ChatControllerTest extends \Test\TestCase {
 		$this->session = $this->createMock(ISession::class);
 		$this->manager = $this->createMock(Manager::class);
 		$this->chatManager = $this->createMock(ChatManager::class);
+
+		$this->room = $this->createMock(Room::class);
 
 		$this->recreateChatController();
 
@@ -103,14 +109,19 @@ class ChatControllerTest extends \Test\TestCase {
 	public function testSendMessageByUser() {
 		$this->manager->expects($this->once())
 			->method('getRoomForParticipantByToken')
-			->with('testToken', $this->userId);
+			->with('testToken', $this->userId)
+			->willReturn($this->room);
+
+		$this->room->expects($this->once())
+			->method('getId')
+			->willReturn(1234);
 
 		$this->session->expects($this->never())
 			->method('get');
 
 		$this->chatManager->expects($this->once())
 			->method('sendMessage')
-			->with('testToken',
+			->with('1234',
 				   'users',
 				   $this->userId,
 				   'testMessage',
@@ -129,7 +140,12 @@ class ChatControllerTest extends \Test\TestCase {
 
 		$this->manager->expects($this->once())
 			->method('getRoomForParticipantByToken')
-			->with('testToken', $this->userId);
+			->with('testToken', $this->userId)
+			->willReturn($this->room);
+
+		$this->room->expects($this->once())
+			->method('getId')
+			->willReturn(1234);
 
 		$this->session->expects($this->once())
 			->method('get')
@@ -138,7 +154,7 @@ class ChatControllerTest extends \Test\TestCase {
 
 		$this->chatManager->expects($this->once())
 			->method('sendMessage')
-			->with('testToken',
+			->with('1234',
 				   'guests',
 				   sha1('testSpreedSession'),
 				   'testMessage',
@@ -157,7 +173,8 @@ class ChatControllerTest extends \Test\TestCase {
 
 		$this->manager->expects($this->once())
 			->method('getRoomForParticipantByToken')
-			->with('testToken', $this->userId);
+			->with('testToken', $this->userId)
+			->willReturn($this->room);
 
 		$this->session->expects($this->once())
 			->method('get')
@@ -194,7 +211,12 @@ class ChatControllerTest extends \Test\TestCase {
 	public function testReceiveMessagesByUser() {
 		$this->manager->expects($this->once())
 			->method('getRoomForParticipantByToken')
-			->with('testToken', $this->userId);
+			->with('testToken', $this->userId)
+			->willReturn($this->room);
+
+		$this->room->expects($this->once())
+			->method('getId')
+			->willReturn(1234);
 
 		$this->session->expects($this->never())
 			->method('get');
@@ -204,7 +226,7 @@ class ChatControllerTest extends \Test\TestCase {
 		$timestamp = 1000000000;
 		$this->chatManager->expects($this->once())
 			->method('receiveMessages')
-			->with('testToken', $timeout, $offset, new \DateTime('@' . $timestamp))
+			->with('1234', $timeout, $offset, new \DateTime('@' . $timestamp))
 			->willReturn([
 				$this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
 				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
@@ -239,7 +261,12 @@ class ChatControllerTest extends \Test\TestCase {
 
 		$this->manager->expects($this->once())
 			->method('getRoomForParticipantByToken')
-			->with('testToken', $this->userId);
+			->with('testToken', $this->userId)
+			->willReturn($this->room);
+
+		$this->room->expects($this->once())
+			->method('getId')
+			->willReturn(1234);
 
 		$this->session->expects($this->never())
 			->method('get');
@@ -249,7 +276,7 @@ class ChatControllerTest extends \Test\TestCase {
 		$timestamp = 1000000000;
 		$this->chatManager->expects($this->once())
 			->method('receiveMessages')
-			->with('testToken', $timeout, $offset, new \DateTime('@' . $timestamp))
+			->with('1234', $timeout, $offset, new \DateTime('@' . $timestamp))
 			->willReturn([
 				$this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
 				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
@@ -281,7 +308,12 @@ class ChatControllerTest extends \Test\TestCase {
 	public function testReceiveMessagesTimeoutExpired() {
 		$this->manager->expects($this->once())
 			->method('getRoomForParticipantByToken')
-			->with('testToken', $this->userId);
+			->with('testToken', $this->userId)
+			->willReturn($this->room);
+
+		$this->room->expects($this->once())
+			->method('getId')
+			->willReturn(1234);
 
 		$this->session->expects($this->never())
 			->method('get');
@@ -291,7 +323,7 @@ class ChatControllerTest extends \Test\TestCase {
 		$timestamp = 1000000000;
 		$this->chatManager->expects($this->once())
 			->method('receiveMessages')
-			->with('testToken', $timeout, $offset, new \DateTime('@' . $timestamp))
+			->with('1234', $timeout, $offset, new \DateTime('@' . $timestamp))
 			->willReturn([]);
 
 		$response = $this->controller->receiveMessages('testToken', $offset, $timestamp, $timeout);
@@ -303,7 +335,12 @@ class ChatControllerTest extends \Test\TestCase {
 	public function testReceiveMessagesTimeoutTooLarge() {
 		$this->manager->expects($this->once())
 			->method('getRoomForParticipantByToken')
-			->with('testToken', $this->userId);
+			->with('testToken', $this->userId)
+			->willReturn($this->room);
+
+		$this->room->expects($this->once())
+			->method('getId')
+			->willReturn(1234);
 
 		$this->session->expects($this->never())
 			->method('get');
@@ -314,7 +351,7 @@ class ChatControllerTest extends \Test\TestCase {
 		$timestamp = 1000000000;
 		$this->chatManager->expects($this->once())
 			->method('receiveMessages')
-			->with('testToken', $maximumTimeout, $offset, new \DateTime('@' . $timestamp))
+			->with('1234', $maximumTimeout, $offset, new \DateTime('@' . $timestamp))
 			->willReturn([]);
 
 		$response = $this->controller->receiveMessages('testToken', $offset, $timestamp, $timeout);

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -140,7 +140,7 @@ class ChatControllerTest extends \Test\TestCase {
 			->method('sendMessage')
 			->with('testToken',
 				   'guests',
-				   'testSpreedSession',
+				   sha1('testSpreedSession'),
 				   'testMessage',
 				   $this->newMessageDateTimeConstraint
 			);


### PR DESCRIPTION
This pull request adds a basic backend for the chat; the frontend will be added in later pull requests.

The backend provides two controller methods: `sendMessage` and `receiveMessages`. `receiveMessages` uses a long-polling approach: it returns immediately only if there are messages available; otherwise it keeps the HTTP connection open and waits for new messages, returning them as soon as they are available (in which case a new HTTP request must be done by the client). The HTTP connection is not kept open indefinitely, though; the default timeout is 30 seconds, and the maximum timeout that can be set is 60 seconds (I have used those values because they _felt_ right; they are not related to typical values for web server timeouts or anything like that).

Note that, at this time, chat messages are never removed; a later pull request will ensure that when a room is deleted all its chat messages are also deleted.

Internally for chat messages the Comments API is used; only a subset of its features is needed (for example, there is no need for parent-child relationships in chat messages), but it fits well with the chat messages anyway and is already mature code, so using it seemed like the best approach. The Comments API is not used directly by the `ChatController`, though; the `ChatManager` class sits between them and is the one that takes care of calling the Comments API as needed and also of waiting for new messages to be available when trying to receive them.

The `ChatManager` uses polling to the Comments API (and this, in turn, to the database): it queries the Comments API to see if there are available messages; if there are it returns them, and if not, it sleeps for a second and queries it again, repeating this process until there are messages or the timeout expires. The good thing about this approach is that it just works; there is no need to install specific extensions, or to configure anything. The bad thing is the stress caused to the server. Therefore, the idea is to create another `ChatManager` that will use interprocess communication to notify and wake up other PHP process when there are messages available, thus eliminating the need to poll the database.

That more advanced `ChatManager` will not be a replacement but a complement for the current `ChatManager` though; the more advanced one will be used if possible but, if not (for example if it requires PHP extensions that are not installed), it will fallback to the basic one. Given that other `ChatManager` related classes/interfaces/files will be added in the future the `ChatManager` was placed on its own `Chat` directory.

Finally, although unit and integration tests are provided for the backend, for the time being there are no tests that truly verify that the long-polling works as expected; I will try to come with something later, as asynchronous tests would be really useful for the more advanced `ChatManager` version.
