### PR TITLE
Activities for calls

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,7 +42,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 	<bugs>https://github.com/nextcloud/spreed/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/spreed.git</repository>
 
-	<version>2.1.6</version>
+	<version>2.1.7</version>
 
 	<dependencies>
 		<nextcloud min-version="13" max-version="13" />
@@ -72,7 +72,8 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 		</settings>
 
 		<providers>
-			<provider>OCA\Spreed\Activity\Provider</provider>
+			<provider>OCA\Spreed\Activity\Provider\Invitation</provider>
+			<provider>OCA\Spreed\Activity\Provider\Call</provider>
 		</providers>
 	</activity>
 

--- a/lib/Activity/Hooks.php
+++ b/lib/Activity/Hooks.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Activity;
+
+use OCA\Spreed\Room;
+use OCP\Activity\IManager;
+use OCP\AppFramework\Utility\ITimeFactory;
+
+class Hooks {
+
+	/** @var IManager */
+	protected $activityManager;
+
+	/** @var ITimeFactory */
+	protected $timeFactory;
+
+	/**
+	 * @param IManager $activityManager
+	 * @param ITimeFactory $timeFactory
+	 */
+	public function __construct(IManager $activityManager, ITimeFactory $timeFactory) {
+		$this->activityManager = $activityManager;
+		$this->timeFactory = $timeFactory;
+	}
+
+	public function setActive(Room $room, $isGuest) {
+		$room->setActiveSince(new \DateTime(), $isGuest);
+	}
+
+	public function generateActivity(Room $room) {
+		$activeSince = $room->getActiveSince();
+		if (!$activeSince instanceof \DateTime || $room->hasActiveSessions()) {
+			return false;
+		}
+
+		$duration = $this->timeFactory->getTime() - $activeSince->getTimestamp();
+		$participants = $room->getParticipants($activeSince->getTimestamp());
+		$userIds = array_keys($participants['users']);
+
+		if (empty($userIds) || (count($userIds) === 1 && $room->getActiveGuests() === 0)) {
+			// Single user pinged or guests only => no activity
+			$room->resetActiveSince();
+			return false;
+		}
+
+		$event = $this->activityManager->generateEvent();
+		$event->setApp('spreed')
+			->setType('spreed')
+			->setAuthor('')
+			->setObject('room', $room->getId(), $room->getName())
+			->setTimestamp(time())
+			->setSubject('call', [
+				'room' => $room->getId(),
+				'users' => $userIds,
+				'guests' => $room->getActiveGuests(),
+				'duration' => $duration,
+			]);
+
+		foreach ($userIds as $userId) {
+			$event->setAffectedUser($userId);
+			$this->activityManager->publish($event);
+		}
+
+		$room->resetActiveSince();
+	}
+
+}

--- a/lib/Activity/Provider/Base.php
+++ b/lib/Activity/Provider/Base.php
@@ -27,6 +27,7 @@ use OCA\Spreed\Room;
 use OCP\Activity\IEvent;
 use OCP\Activity\IManager;
 use OCP\Activity\IProvider;
+use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -104,10 +105,11 @@ abstract class Base implements IProvider {
 	}
 
 	/**
+	 * @param IL10N $l
 	 * @param Room $room
 	 * @return array
 	 */
-	protected function getRoom(Room $room) {
+	protected function getRoom(IL10N $l, Room $room) {
 		switch ($room->getType()) {
 			case Room::ONE_TO_ONE_CALL:
 				$stringType = 'one2one';
@@ -124,8 +126,22 @@ abstract class Base implements IProvider {
 		return [
 			'type' => 'call',
 			'id' => $room->getId(),
-			'name' => $room->getName(),
+			'name' => $room->getName() ?: $l->t('a call'),
 			'call-type' => $stringType,
+		];
+	}
+
+	/**
+	 * @param IL10N $l
+	 * @param int $roomId
+	 * @return array
+	 */
+	protected function getFormerRoom(IL10N $l, $roomId) {
+		return [
+			'type' => 'call',
+			'id' => $roomId,
+			'name' => $l->t('a call'),
+			'call-type' => Room::UNKNOWN_CALL,
 		];
 	}
 

--- a/lib/Activity/Provider/Base.php
+++ b/lib/Activity/Provider/Base.php
@@ -76,6 +76,7 @@ abstract class Base implements IProvider {
 		if ($event->getApp() !== 'spreed') {
 			throw new \InvalidArgumentException();
 		}
+
 		if ($this->activityManager->getRequirePNG()) {
 			$event->setIcon($this->url->getAbsoluteURL($this->url->imagePath('spreed', 'app-dark.png')));
 		} else {

--- a/lib/Activity/Provider/Call.php
+++ b/lib/Activity/Provider/Call.php
@@ -38,20 +38,23 @@ class Call extends Base {
 	 */
 	public function parse($language, IEvent $event, IEvent $previousEvent = null) {
 		$event = parent::preParse($event);
-		$l = $this->languageFactory->get('spreed', $language);
 
-		try {
+		if ($event->getSubject() === 'call') {
+			$l = $this->languageFactory->get('spreed', $language);
 			$parameters = $event->getSubjectParameters();
-			$room = $this->manager->getRoomById((int) $parameters['room']);
 
-			if ($event->getSubject() === 'call') {
-				$result = $this->parseCall($event, $l, $room);
-				$result['subject'] .= ' ' . $this->getDuration($l, $parameters['duration']);
-				$this->setSubjects($event, $result['subject'], $result['params']);
-			} else {
-				throw new \InvalidArgumentException();
-			}
-		} catch (RoomNotFoundException $e) {
+//			$roomParameter = $this->getFormerRoom($l, (int) $parameters['room']);
+//			try {
+//				$room = $this->manager->getRoomById((int) $parameters['room']);
+//				$roomParameter = $this->getRoom($l, $room);
+//			} catch (RoomNotFoundException $e) {
+//			}
+
+			$result = $this->parseCall($event, $l);
+			$result['subject'] .= ' ' . $this->getDuration($l, $parameters['duration']);
+//			$result['params']['call'] = $roomParameter;
+			$this->setSubjects($event, $result['subject'], $result['params']);
+		} else {
 			throw new \InvalidArgumentException();
 		}
 
@@ -73,7 +76,7 @@ class Call extends Base {
 		return $l->t('(Duration %s)', $duration);
 	}
 
-	protected function parseCall(IEvent $event, IL10N $l, Room $room) {
+	protected function parseCall(IEvent $event, IL10N $l) {
 		$parameters = $event->getSubjectParameters();
 
 		$currentUser = array_search($this->activityManager->getCurrentUserId(), $parameters['users'], true);
@@ -83,63 +86,48 @@ class Call extends Base {
 		unset($parameters['users'][$currentUser]);
 		sort($parameters['users']);
 
-		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
-			$otherUser = array_pop($parameters['users']);
-
-			if ($otherUser === '') {
-				throw new \InvalidArgumentException('Unknown case');
-			}
-
-			return [
-				'subject' => $l->t('You had a private call with {user}'),
-				'params' => [
-					'user' => $this->getUser($otherUser),
-				],
-			];
-		}
-
 		$numUsers = count($parameters['users']);
 		$displayedUsers = $numUsers;
 		switch ($numUsers) {
 			case 0:
-				$subject = $l->t('You had a call with {user1}');
+				$subject = $l->t('You attended a call with {user1}');
 				$subject = str_replace('{user1}', $l->n('%n guest', '%n guests', $parameters['guests']), $subject);
 				break;
 			case 1:
 				if ($parameters['guests'] === 0) {
-					$subject = $l->t('You had a call with {user1}');
+					$subject = $l->t('You attended a call with {user1}');
 				} else {
-					$subject = $l->t('You had a call with {user1} and {user2}');
+					$subject = $l->t('You attended a call with {user1} and {user2}');
 					$subject = str_replace('{user2}', $l->n('%n guest', '%n guests', $parameters['guests']), $subject);
 				}
 				break;
 			case 2:
 				if ($parameters['guests'] === 0) {
-					$subject = $l->t('You had a call with {user1} and {user2}');
+					$subject = $l->t('You attended a call with {user1} and {user2}');
 				} else {
-					$subject = $l->t('You had a call with {user1}, {user2} and {user3}');
+					$subject = $l->t('You attended a call with {user1}, {user2} and {user3}');
 					$subject = str_replace('{user3}', $l->n('%n guest', '%n guests', $parameters['guests']), $subject);
 				}
 				break;
 			case 3:
 				if ($parameters['guests'] === 0) {
-					$subject = $l->t('You had a call with {user1}, {user2} and {user3}');
+					$subject = $l->t('You attended a call with {user1}, {user2} and {user3}');
 				} else {
-					$subject = $l->t('You had a call with {user1}, {user2}, {user3} and {user4}');
+					$subject = $l->t('You attended a call with {user1}, {user2}, {user3} and {user4}');
 					$subject = str_replace('{user4}', $l->n('%n guest', '%n guests', $parameters['guests']), $subject);
 				}
 				break;
 			case 4:
 				if ($parameters['guests'] === 0) {
-					$subject = $l->t('You had a call with {user1}, {user2}, {user3} and {user4}');
+					$subject = $l->t('You attended a call with {user1}, {user2}, {user3} and {user4}');
 				} else {
-					$subject = $l->t('You had a call with {user1}, {user2}, {user3}, {user4} and {user5}');
+					$subject = $l->t('You attended a call with {user1}, {user2}, {user3}, {user4} and {user5}');
 					$subject = str_replace('{user5}', $l->n('%n guest', '%n guests', $parameters['guests']), $subject);
 				}
 				break;
 			case 5:
 			default:
-				$subject = $l->t('You had a call with {user1}, {user2}, {user3}, {user4} and {user5}');
+				$subject = $l->t('You attended a call with {user1}, {user2}, {user3}, {user4} and {user5}');
 				if ($numUsers === 5 && $parameters['guests'] === 0) {
 					$displayedUsers = 5;
 				} else {

--- a/lib/Activity/Provider/Call.php
+++ b/lib/Activity/Provider/Call.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Activity\Provider;
+
+use OCA\Spreed\Exceptions\RoomNotFoundException;
+use OCA\Spreed\Room;
+use OCP\Activity\IEvent;
+use OCP\IL10N;
+
+class Call extends Base {
+
+	/**
+	 * @param string $language
+	 * @param IEvent $event
+	 * @param IEvent|null $previousEvent
+	 * @return IEvent
+	 * @throws \InvalidArgumentException
+	 * @since 11.0.0
+	 */
+	public function parse($language, IEvent $event, IEvent $previousEvent = null) {
+		$event = parent::preParse($event);
+		$l = $this->languageFactory->get('spreed', $language);
+
+		try {
+			$parameters = $event->getSubjectParameters();
+			$room = $this->manager->getRoomById((int) $parameters['room']);
+
+			if ($event->getSubject() === 'call') {
+				$result = $this->parseCall($event, $l, $room);
+				$result['subject'] .= ' ' . $this->getDuration($l, $parameters['duration']);
+				$this->setSubjects($event, $result['subject'], $result['params']);
+			} else {
+				throw new \InvalidArgumentException();
+			}
+		} catch (RoomNotFoundException $e) {
+			throw new \InvalidArgumentException();
+		}
+
+		return $event;
+	}
+
+	protected function getDuration(IL10N $l, $seconds) {
+		$hours = floor($seconds / 3600);
+		$seconds %= 3600;
+		$minutes = floor($seconds / 60);
+		$seconds %= 60;
+
+		if ($hours > 0) {
+			$duration = sprintf('%1$d:%2$02d:%3$02d', $hours, $minutes, $seconds);
+		} else {
+			$duration = sprintf('%1$d:%2$02d', $minutes, $seconds);
+		}
+
+		return $l->t('(Duration %s)', $duration);
+	}
+
+	protected function parseCall(IEvent $event, IL10N $l, Room $room) {
+		$parameters = $event->getSubjectParameters();
+
+		$currentUser = array_search($this->activityManager->getCurrentUserId(), $parameters['users'], true);
+		if ($currentUser === false) {
+			throw new \InvalidArgumentException('Unknown case');
+		}
+		unset($parameters['users'][$currentUser]);
+		sort($parameters['users']);
+
+		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
+			$otherUser = array_pop($parameters['users']);
+
+			if ($otherUser === '') {
+				throw new \InvalidArgumentException('Unknown case');
+			}
+
+			return [
+				'subject' => $l->t('You had a private call with {user}'),
+				'params' => [
+					'user' => $this->getUser($otherUser),
+				],
+			];
+		}
+
+		$numUsers = count($parameters['users']);
+		$displayedUsers = $numUsers;
+		switch ($numUsers) {
+			case 0:
+				$subject = $l->t('You had a call with {user1}');
+				$subject = str_replace('{user1}', $l->n('%n guest', '%n guests', $parameters['guests']), $subject);
+				break;
+			case 1:
+				if ($parameters['guests'] === 0) {
+					$subject = $l->t('You had a call with {user1}');
+				} else {
+					$subject = $l->t('You had a call with {user1} and {user2}');
+					$subject = str_replace('{user2}', $l->n('%n guest', '%n guests', $parameters['guests']), $subject);
+				}
+				break;
+			case 2:
+				if ($parameters['guests'] === 0) {
+					$subject = $l->t('You had a call with {user1} and {user2}');
+				} else {
+					$subject = $l->t('You had a call with {user1}, {user2} and {user3}');
+					$subject = str_replace('{user3}', $l->n('%n guest', '%n guests', $parameters['guests']), $subject);
+				}
+				break;
+			case 3:
+				if ($parameters['guests'] === 0) {
+					$subject = $l->t('You had a call with {user1}, {user2} and {user3}');
+				} else {
+					$subject = $l->t('You had a call with {user1}, {user2}, {user3} and {user4}');
+					$subject = str_replace('{user4}', $l->n('%n guest', '%n guests', $parameters['guests']), $subject);
+				}
+				break;
+			case 4:
+				if ($parameters['guests'] === 0) {
+					$subject = $l->t('You had a call with {user1}, {user2}, {user3} and {user4}');
+				} else {
+					$subject = $l->t('You had a call with {user1}, {user2}, {user3}, {user4} and {user5}');
+					$subject = str_replace('{user5}', $l->n('%n guest', '%n guests', $parameters['guests']), $subject);
+				}
+				break;
+			case 5:
+			default:
+				$subject = $l->t('You had a call with {user1}, {user2}, {user3}, {user4} and {user5}');
+				if ($numUsers === 5 && $parameters['guests'] === 0) {
+					$displayedUsers = 5;
+				} else {
+					$displayedUsers = 4;
+					$numOthers = $parameters['guests'] + $numUsers - $displayedUsers;
+					$subject = str_replace('{user5}', $l->n('%n other', '%n others', $numOthers), $subject);
+				}
+		}
+
+		$params = [];
+		for ($i = 1; $i <= $displayedUsers; $i++) {
+			$params['user' . $i] = $this->getUser($parameters['users'][$i - 1]);
+		}
+
+		return [
+			'subject' => $subject,
+			'params' => $params,
+		];
+	}
+
+}

--- a/lib/Activity/Provider/Invitation.php
+++ b/lib/Activity/Provider/Invitation.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Activity\Provider;
+
+use OCA\Spreed\Exceptions\RoomNotFoundException;
+use OCA\Spreed\Room;
+use OCP\Activity\IEvent;
+use OCP\IL10N;
+
+class Invitation extends Base {
+
+	/**
+	 * @param string $language
+	 * @param IEvent $event
+	 * @param IEvent|null $previousEvent
+	 * @return IEvent
+	 * @throws \InvalidArgumentException
+	 * @since 11.0.0
+	 */
+	public function parse($language, IEvent $event, IEvent $previousEvent = null) {
+		$event = parent::preParse($event);
+		$l = $this->languageFactory->get('spreed', $language);
+
+		try {
+			$parameters = $event->getSubjectParameters();
+			$room = $this->manager->getRoomById((int) $parameters['room']);
+
+			if ($event->getSubject() === 'invitation') {
+				$result = $this->parseInvitation($event, $l, $room);
+				$this->setSubjects($event, $result['subject'], $result['params']);
+			} else {
+				throw new \InvalidArgumentException();
+			}
+		} catch (RoomNotFoundException $e) {
+			throw new \InvalidArgumentException();
+		}
+
+		return $event;
+	}
+
+	protected function parseInvitation(IEvent $event, IL10N $l, Room $room) {
+		$parameters = $event->getSubjectParameters();
+
+		if ($room->getName() === '') {
+			if ($room->getType() === Room::ONE_TO_ONE_CALL) {
+				$subject = $l->t('{actor} invited you to a private call');
+			} else {
+				$subject = $l->t('{actor} invited you to a group call');
+			}
+
+			return [
+				'subject' => $subject,
+				'params' => $this->getParameters($parameters),
+			];
+		}
+
+		return [
+			'subject' => $l->t('{actor} invited you to the call {call}'),
+			'params' => $this->getParameters($parameters, $room),
+		];
+	}
+
+	/**
+	 * @param array $parameters
+	 * @param Room $room
+	 * @return array
+	 */
+	protected function getParameters(array $parameters, Room $room = null) {
+		if ($room === null) {
+			return [
+				'actor' => $this->getUser($parameters['user']),
+			];
+		}
+
+		return [
+			'actor' => $this->getUser($parameters['user']),
+			'call' => $this->getRoom($room),
+		];
+	}
+
+}

--- a/lib/Activity/Provider/Invitation.php
+++ b/lib/Activity/Provider/Invitation.php
@@ -38,19 +38,20 @@ class Invitation extends Base {
 	 */
 	public function parse($language, IEvent $event, IEvent $previousEvent = null) {
 		$event = parent::preParse($event);
-		$l = $this->languageFactory->get('spreed', $language);
 
-		try {
+		if ($event->getSubject() === 'invitation') {
 			$parameters = $event->getSubjectParameters();
-			$room = $this->manager->getRoomById((int) $parameters['room']);
-
-			if ($event->getSubject() === 'invitation') {
-				$result = $this->parseInvitation($event, $l, $room);
-				$this->setSubjects($event, $result['subject'], $result['params']);
-			} else {
+			try {
+				$room = $this->manager->getRoomById((int) $parameters['room']);
+			} catch (RoomNotFoundException $e) {
 				throw new \InvalidArgumentException();
 			}
-		} catch (RoomNotFoundException $e) {
+
+			$l = $this->languageFactory->get('spreed', $language);
+
+			$result = $this->parseInvitation($event, $l, $room);
+			$this->setSubjects($event, $result['subject'], $result['params']);
+		} else {
 			throw new \InvalidArgumentException();
 		}
 

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -65,7 +65,12 @@ class Manager {
 	 * @return Room
 	 */
 	protected function createRoomObject(array $row) {
-		return new Room($this->db, $this->secureRandom, $this->dispatcher, $this->hasher, (int) $row['id'], (int) $row['type'], $row['token'], $row['name'], $row['password']);
+		$activeSince = null;
+		if (!empty($row['activeSince'])) {
+			$activeSince = new \DateTime($row['activeSince']);
+		}
+
+		return new Room($this->db, $this->secureRandom, $this->dispatcher, $this->hasher, (int) $row['id'], (int) $row['type'], $row['token'], $row['name'], $row['password'], (int) $row['activeGuests'], $activeSince);
 	}
 
 	/**
@@ -358,13 +363,7 @@ class Manager {
 		$query->execute();
 		$roomId = $query->getLastInsertId();
 
-		return $this->createRoomObject([
-			'id' => $roomId,
-			'type' => $type,
-			'token' => $token,
-			'name' => $name,
-			'password' => '',
-		]);
+		return $this->getRoomById($roomId);
 	}
 
 	/**

--- a/lib/Migration/Version2001Date20171009132424.php
+++ b/lib/Migration/Version2001Date20171009132424.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Spreed\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version2001Date20171009132424 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param \Closure $schemaClosure The `\Closure` returns a `Schema`
+	 * @param array $options
+	 * @return null|Schema
+	 * @since 13.0.0
+	 */
+	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options) {
+		/** @var Schema $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('spreedme_rooms');
+		$table->addColumn('activeSince', Type::DATETIME, [
+			'notnull' => false,
+		]);
+		$table->addColumn('activeGuests', Type::INTEGER, [
+			'notnull' => true,
+			'length' => 4,
+			'default' => 0,
+			'unsigned' => true,
+		]);
+
+		return $schema;
+	}
+
+}

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -59,6 +59,10 @@ class Room {
 	private $name;
 	/** @var string */
 	private $password;
+	/** @var int */
+	private $activeGuests;
+	/** @var \DateTime|null */
+	private $activeSince;
 
 	/** @var string */
 	protected $currentUser;
@@ -77,8 +81,10 @@ class Room {
 	 * @param string $token
 	 * @param string $name
 	 * @param string $password
+	 * @param int $activeGuests
+	 * @param \DateTime|null $activeSince
 	 */
-	public function __construct(IDBConnection $db, ISecureRandom $secureRandom, EventDispatcherInterface $dispatcher, IHasher $hasher, $id, $type, $token, $name, $password) {
+	public function __construct(IDBConnection $db, ISecureRandom $secureRandom, EventDispatcherInterface $dispatcher, IHasher $hasher, $id, $type, $token, $name, $password, $activeGuests, \DateTime $activeSince = null) {
 		$this->db = $db;
 		$this->secureRandom = $secureRandom;
 		$this->dispatcher = $dispatcher;
@@ -88,6 +94,8 @@ class Room {
 		$this->token = $token;
 		$this->name = $name;
 		$this->password = $password;
+		$this->activeGuests = $activeGuests;
+		$this->activeSince = $activeSince;
 	}
 
 	/**
@@ -116,6 +124,20 @@ class Room {
 	 */
 	public function getName() {
 		return $this->name;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getActiveGuests() {
+		return $this->activeGuests;
+	}
+
+	/**
+	 * @return \DateTime|null
+	 */
+	public function getActiveSince() {
+		return $this->activeSince;
 	}
 
 	/**
@@ -275,6 +297,52 @@ class Room {
 		]));
 
 		return true;
+	}
+
+	/**
+	 * @param \DateTime $since
+	 * @param bool $isGuest
+	 * @return bool
+	 */
+	public function setActiveSince(\DateTime $since, $isGuest) {
+
+		if ($isGuest && $this->getType() === self::PUBLIC_CALL) {
+			$query = $this->db->getQueryBuilder();
+			$query->update('spreedme_rooms')
+				->set('activeGuests', $query->createFunction($query->getColumnName('activeGuests') . ' + 1'))
+				->where($query->expr()->eq('id', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)));
+			$query->execute();
+
+			$this->activeGuests++;
+		}
+
+		if ($this->activeSince instanceof \DateTime) {
+			return false;
+		}
+
+		$query = $this->db->getQueryBuilder();
+		$query->update('spreedme_rooms')
+			->set('activeSince', $query->createNamedParameter($since, 'datetime'))
+			->where($query->expr()->eq('id', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->isNull('activeSince'));
+		$query->execute();
+
+		$this->activeSince = $since;
+
+		return true;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function resetActiveSince() {
+		$query = $this->db->getQueryBuilder();
+		$query->update('spreedme_rooms')
+			->set('activeGuests', $query->createNamedParameter(0))
+			->set('activeSince', $query->createNamedParameter(null, 'datetime'))
+			->where($query->expr()->eq('id', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)));
+		$query->execute();
+
 	}
 
 	/**
@@ -599,6 +667,23 @@ class Room {
 		$result->closeCursor();
 
 		return $sessions;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function hasActiveSessions() {
+		$query = $this->db->getQueryBuilder();
+		$query->select('sessionId')
+			->from('spreedme_room_participants')
+			->where($query->expr()->eq('roomId', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->neq('sessionId', $query->createNamedParameter('0')))
+			->setMaxResults(1);
+		$result = $query->execute();
+		$row = $result->fetch();
+		$result->closeCursor();
+
+		return (bool) $row;
 	}
 
 	/**

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -36,6 +36,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Room {
+	const UNKNOWN_CALL = -1;
 	const ONE_TO_ONE_CALL = 1;
 	const GROUP_CALL = 2;
 	const PUBLIC_CALL = 3;

--- a/tests/php/Activity/Provider/BaseTest.php
+++ b/tests/php/Activity/Provider/BaseTest.php
@@ -19,10 +19,10 @@
  *
  */
 
-namespace OCA\Spreed\Tests\php\Activity;
+namespace OCA\Spreed\Tests\php\Activity\Provider;
 
 
-use OCA\Spreed\Activity\Provider;
+use OCA\Spreed\Activity\Provider\Base;
 use OCA\Spreed\Manager;
 use OCA\Spreed\Room;
 use OCP\Activity\IEvent;
@@ -34,11 +34,11 @@ use OCP\L10N\IFactory;
 use Test\TestCase;
 
 /**
- * Class ProviderTest
+ * Class BaseTest
  *
  * @package OCA\Spreed\Tests\php\Activity
  */
-class ProviderTest extends TestCase {
+class BaseTest extends TestCase {
 
 	/** @var IFactory|\PHPUnit_Framework_MockObject_MockObject */
 	protected $l10nFactory;
@@ -63,41 +63,74 @@ class ProviderTest extends TestCase {
 
 	/**
 	 * @param string[] $methods
-	 * @return Provider|\PHPUnit_Framework_MockObject_MockObject
+	 * @return Base|\PHPUnit_Framework_MockObject_MockObject
 	 */
 	protected function getProvider(array $methods = []) {
-		if (!empty($methods)) {
-			return $this->getMockBuilder(Provider::class)
-				->setConstructorArgs([
-					$this->l10nFactory,
-					$this->url,
-					$this->activityManager,
-					$this->userManager,
-					$this->manager,
-				])
-				->setMethods($methods)
-				->getMock();
-		}
-		return new Provider(
-			$this->l10nFactory,
-			$this->url,
-			$this->activityManager,
-			$this->userManager,
-			$this->manager
-		);
+		$methods[] = 'parse';
+		return $this->getMockBuilder(Base::class)
+			->setConstructorArgs([
+				$this->l10nFactory,
+				$this->url,
+				$this->activityManager,
+				$this->userManager,
+				$this->manager,
+			])
+			->setMethods($methods)
+			->getMock();
+	}
+
+
+	public function dataPreParse() {
+		return [
+			[true, 'app-dark.png'],
+			[false, 'app-dark.svg'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataPreParse
+	 *
+	 */
+	public function testPreParse($png, $imagePath) {
+		/** @var IEvent|\PHPUnit_Framework_MockObject_MockObject $event */
+		$event = $this->createMock(IEvent::class);
+		$event->expects($this->once())
+			->method('getApp')
+			->willReturn('spreed');
+
+		$this->activityManager->expects($this->once())
+			->method('getRequirePNG')
+			->willReturn($png);
+
+		$this->url->expects($this->once())
+			->method('imagePath')
+			->with('spreed', $imagePath)
+			->willReturn('imagePath');
+		$this->url->expects($this->once())
+			->method('getAbsoluteURL')
+			->with('imagePath')
+			->willReturn('getAbsoluteURL');
+
+		$event->expects($this->once())
+			->method('setIcon')
+			->with('getAbsoluteURL')
+			->willReturnSelf();
+
+		$provider = $this->getProvider();
+		$this->assertSame($event, static::invokePrivate($provider, 'preParse', [$event]));
 	}
 
 	/**
 	 * @expectedException \InvalidArgumentException
 	 */
-	public function testParseThrows() {
+	public function testPreParseThrows() {
 		/** @var IEvent|\PHPUnit_Framework_MockObject_MockObject $event */
 		$event = $this->createMock(IEvent::class);
 		$event->expects($this->once())
 			->method('getApp')
 			->willReturn('activity');
 		$provider = $this->getProvider();
-		$provider->parse('en', $event, null);
+		static::invokePrivate($provider, 'preParse', [$event]);
 	}
 
 	public function dataSetSubject() {
@@ -129,43 +162,6 @@ class ProviderTest extends TestCase {
 			->willReturnSelf();
 
 		self::invokePrivate($provider, 'setSubjects', [$event, $subject, $parameters]);
-	}
-
-	public function dataGetParameters() {
-		return [
-			['test', true, ['actor' => 'array(user)', 'call' => 'array(room)']],
-			['admin', false, ['actor' => 'array(user)']],
-		];
-	}
-
-	/**
-	 * @dataProvider dataGetParameters
-	 *
-	 * @param string $user
-	 * @param bool $isRoom
-	 * @param array $expected
-	 */
-	public function testGetParameters($user, $isRoom, array $expected) {
-		$provider = $this->getProvider(['getUser', 'getRoom']);
-
-		$provider->expects($this->once())
-			->method('getUser')
-			->with($user)
-			->willReturn('array(user)');
-
-		if ($isRoom) {
-			$room = $this->createMock(Room::class);
-			$provider->expects($this->once())
-				->method('getRoom')
-				->with($room)
-				->willReturn('array(room)');
-		} else {
-			$room = null;
-			$provider->expects($this->never())
-				->method('getRoom');
-		}
-
-		$this->assertEquals($expected, self::invokePrivate($provider, 'getParameters', [['user' => $user], $room]));
 	}
 
 	public function dataGetRoom() {

--- a/tests/php/Activity/Provider/BaseTest.php
+++ b/tests/php/Activity/Provider/BaseTest.php
@@ -27,6 +27,7 @@ use OCA\Spreed\Manager;
 use OCA\Spreed\Room;
 use OCP\Activity\IEvent;
 use OCP\Activity\IManager;
+use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -166,9 +167,12 @@ class BaseTest extends TestCase {
 
 	public function dataGetRoom() {
 		return [
-			[Room::ONE_TO_ONE_CALL, 23, 'private-call', 'one2one'],
-			[Room::GROUP_CALL, 42, 'group-call', 'group'],
-			[Room::PUBLIC_CALL, 128, 'public-call', 'public'],
+			[Room::ONE_TO_ONE_CALL, 23, 'private-call', 'private-call', 'one2one'],
+			[Room::GROUP_CALL, 42, 'group-call', 'group-call', 'group'],
+			[Room::PUBLIC_CALL, 128, 'public-call', 'public-call', 'public'],
+			[Room::ONE_TO_ONE_CALL, 23, '', 'a call', 'one2one'],
+			[Room::GROUP_CALL, 42, '', 'a call', 'group'],
+			[Room::PUBLIC_CALL, 128, '', 'a call', 'public'],
 		];
 	}
 
@@ -178,9 +182,10 @@ class BaseTest extends TestCase {
 	 * @param int $type
 	 * @param int $id
 	 * @param string $name
+	 * @param string $expectedName
 	 * @param string $expectedType
 	 */
-	public function testGetRoom($type, $id, $name, $expectedType) {
+	public function testGetRoom($type, $id, $name, $expectedName, $expectedType) {
 		$provider = $this->getProvider();
 
 		$room = $this->createMock(Room::class);
@@ -194,12 +199,19 @@ class BaseTest extends TestCase {
 			->method('getName')
 			->willReturn($name);
 
+		$l = $this->createMock(IL10N::class);
+		$l->expects($this->any())
+			->method('t')
+			->willReturnCallback(function($text, $parameters = []) {
+				return vsprintf($text, $parameters);
+			});
+
 		$this->assertEquals([
 			'type' => 'call',
 			'id' => $id,
-			'name' => $name,
+			'name' => $expectedName,
 			'call-type' => $expectedType,
-		], self::invokePrivate($provider, 'getRoom', [$room]));
+		], self::invokePrivate($provider, 'getRoom', [$l, $room]));
 	}
 
 	public function dataGetUser() {

--- a/tests/php/Activity/Provider/InvitationTest.php
+++ b/tests/php/Activity/Provider/InvitationTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Tests\php\Activity\Provider;
+
+
+use OCA\Spreed\Activity\Provider\Invitation;
+use OCA\Spreed\Manager;
+use OCA\Spreed\Room;
+use OCP\Activity\IEvent;
+use OCP\Activity\IManager;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use Test\TestCase;
+
+/**
+ * Class InvitationTest
+ *
+ * @package OCA\Spreed\Tests\php\Activity
+ */
+class InvitationTest extends TestCase {
+
+	/** @var IFactory|\PHPUnit_Framework_MockObject_MockObject */
+	protected $l10nFactory;
+	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
+	protected $url;
+	/** @var IManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $activityManager;
+	/** @var IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $userManager;
+	/** @var Manager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $manager;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->l10nFactory = $this->createMock(IFactory::class);
+		$this->url = $this->createMock(IURLGenerator::class);
+		$this->activityManager = $this->createMock(IManager::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->manager = $this->createMock(Manager::class);
+	}
+
+	/**
+	 * @param string[] $methods
+	 * @return Invitation|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	protected function getProvider(array $methods = []) {
+		if (!empty($methods)) {
+			return $this->getMockBuilder(Invitation::class)
+				->setConstructorArgs([
+					$this->l10nFactory,
+					$this->url,
+					$this->activityManager,
+					$this->userManager,
+					$this->manager,
+				])
+				->setMethods($methods)
+				->getMock();
+		}
+		return new Invitation(
+			$this->l10nFactory,
+			$this->url,
+			$this->activityManager,
+			$this->userManager,
+			$this->manager
+		);
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testParseThrows() {
+		/** @var IEvent|\PHPUnit_Framework_MockObject_MockObject $event */
+		$event = $this->createMock(IEvent::class);
+		$event->expects($this->once())
+			->method('getApp')
+			->willReturn('activity');
+		$provider = $this->getProvider();
+		$provider->parse('en', $event, null);
+	}
+
+	public function dataGetParameters() {
+		return [
+			['test', true, ['actor' => 'array(user)', 'call' => 'array(room)']],
+			['admin', false, ['actor' => 'array(user)']],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetParameters
+	 *
+	 * @param string $user
+	 * @param bool $isRoom
+	 * @param array $expected
+	 */
+	public function testGetParameters($user, $isRoom, array $expected) {
+		$provider = $this->getProvider(['getUser', 'getRoom']);
+
+		$provider->expects($this->once())
+			->method('getUser')
+			->with($user)
+			->willReturn('array(user)');
+
+		if ($isRoom) {
+			$room = $this->createMock(Room::class);
+			$provider->expects($this->once())
+				->method('getRoom')
+				->with($room)
+				->willReturn('array(room)');
+		} else {
+			$room = null;
+			$provider->expects($this->never())
+				->method('getRoom');
+		}
+
+		$this->assertEquals($expected, self::invokePrivate($provider, 'getParameters', [['user' => $user], $room]));
+	}
+
+}


### PR DESCRIPTION
Fix #236  

> ![bildschirmfoto vom 2017-10-10 17-10-55](https://user-images.githubusercontent.com/213943/31394357-62b054e6-adde-11e7-9954-b520a0c8abf7.png)

Should add the room name to the activity so it's clickable.
But I just noticed this is also missing for invitations, so I will do it in a follow up PR.
