### PR TITLE
Fix call info not being rendered when a password is set

### DIFF
--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -229,6 +229,8 @@
 					password: newPassword
 				},
 				success: function() {
+					this.ui.passwordInput.val('');
+
 					OCA.SpreedMe.app.syncRooms();
 				}.bind(this)
 			});


### PR DESCRIPTION
When the `CallInfoView` is rendered the values set in the input fields but not saved yet are lost. Therefore, instead of directly rendering the view when the attributes of the model change it is first checked if an edition is being performed and, it is, then the view is rendered once the edition is finished.

`renderWhenInactive` assumes that the password is not being edited when the field has no value. However, when the user set a password the field was not automatically emptied, and thus the rendering was blocked (unless the user manually emptied the field). To prevent this, now, once the password is successfully set, the field is automatically emptied.
