### PR TITLE
Fix sidebar in fullscreen mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -480,6 +480,44 @@ video {
 	display: none !important;
 }
 
+/**
+ * Different browsers handle fullscreen elements with a margin in different
+ * ways: Firefox ignores the margin and uses the full width, while Chromium uses
+ * a strange mix which is neither the full width nor the full margin. Due to
+ * this the margin is removed to unify the appearance across browsers; visually,
+ * this causes the sidebar to slide on the content instead of "pushing" it to
+ * the left.
+ */
+#app-content:-webkit-full-screen {
+	margin-right: 0;
+}
+#app-content:-moz-full-screen {
+	margin-right: 0;
+}
+#app-content:-ms-fullscreen {
+	margin-right: 0;
+}
+#app-content:fullscreen {
+	margin-right: 0;
+}
+
+/**
+ * In fullscreen mode there is no header, so the sidebar has to be moved to the
+ * top.
+ */
+#app-content:-webkit-full-screen #app-sidebar {
+	top: 0;
+}
+#app-content:-moz-full-screen #app-sidebar {
+	top: 0;
+}
+#app-content:-ms-fullscreen #app-sidebar {
+	top: 0;
+}
+#app-content:fullscreen #app-sidebar {
+	top: 0;
+}
+
 .localmediaerror h2 {
 	color: red;
 	font-weight: bold;


### PR DESCRIPTION
This will conflict with #456 (I will rebase as needed depending on which one gets merged first).

In normal mode (and a wide screen), when the sidebar is opened a `margin-right` is applied to the app content to make room for the sidebar. In fullscreen mode the element set as fullscreen is the app
content, but it seems that different browsers handle fullscreen elements with a margin in different ways: Firefox ignores the margin and uses the full width, while Chromium uses a strange mix which is neither the full width nor the full margin. Due to this, now the margin is removed in fullscreen mode to unify the appearance across browsers.

As there is no margin, the sidebar now visually seems to slide on the app content instead of _pushing_ it to the left (which is the same behaviour shown in normal mode and narrow screens). Fortunately, this
behaviour fits well with the fullscreen mode, as the video is arguably the reason to enter in fullscreen mode while the sidebar in this case is probably just a temporal view that is closed most of the time.

Also, note that making the app content and the sidebar behave in fullscreen mode like they do in normal mode is currently not possible (or at least I have not found a way to do it).

The problem is that the slide gesture for the navigation bar is enabled too when in fullscreen mode; it is not noticeable because the element that gets translated by that gesture is the same set in fullscreen (the app content), so the browser simply refuses to move it. However, if the element set in fullscreen was changed to a different one (like a wrapper, so the app content handles the margin in the usual way) then the app content would be moved by that gesture. For the time being the gesture can not be disabled either, as it is initialized in core but no means are provided to enable or disable it by apps. 

Anyway, as I said I do not see this as a problem, as the sidebar sliding on the content while in fullscreen mode seems to be a nice behaviour ;-)
