### PR TITLE
Fixes for header on public page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -518,6 +518,35 @@ video {
 	top: 0;
 }
 
+/* In the public page the header is inside the app-content, so it has to be
+   hidden explicitly. */
+#app-content:-webkit-full-screen #header {
+	display: none !important;
+}
+#app-content:-moz-full-screen #header {
+	display: none !important;
+}
+#app-content:-ms-fullscreen #header {
+	display: none !important;
+}
+#app-content:fullscreen #header {
+	display: none !important;
+}
+
+/* As there is no header the fullscreen button can be moved to the top. */
+#app-content:-webkit-full-screen #video-fullscreen.public {
+	top: 0;
+}
+#app-content:-moz-full-screen #video-fullscreen.public {
+	top: 0;
+}
+#app-content:-ms-fullscreen #video-fullscreen.public {
+	top: 0;
+}
+#app-content:fullscreen #video-fullscreen.public {
+	top: 0;
+}
+
 .localmediaerror h2 {
 	color: red;
 	font-weight: bold;

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -47,13 +47,12 @@ script(
 			<div id="header" class="spreed-public">
 				<div id="header-left">
 					<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="nextcloud" target="_blank">
-						<div class="logo logo-icon svg"></div>
+						<div class="logo logo-icon svg">
+							<h1 class="hidden-visually">
+								<?php p($theme->getName() . ' ' . $l->t('Talk')); ?>
+							</h1>
+						</div>
 					</a>
-					<div class="header-appname-container">
-						<h1 class="header-appname">
-							<?php p($theme->getName()); ?>
-						</h1>
-					</div>
 				</div>
 				<div id="header-right">
 				</div>

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -47,7 +47,7 @@ script(
 			<div id="header" class="spreed-public">
 				<div id="header-left">
 					<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="nextcloud" target="_blank">
-						<div class="logo-icon svg"></div>
+						<div class="logo logo-icon svg"></div>
 					</a>
 					<div class="header-appname-container">
 						<h1 class="header-appname">


### PR DESCRIPTION
This will conflict with #455 (I will rebase as needed depending on which one gets merged first).

This pull request fixes the Nextcloud logo not being shown on the public page, aligns the header markup with the one used in user pages, and hides the header when in fullscreen mode on the public page.
