### PR TITLE
Add support for right sidebar in public page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -115,13 +115,13 @@
 }
 
 .password-input,
-.rename-input {
+.room-name input {
 	margin-top: 0 !important;
 	margin-bottom: 4px !important;
 }
 
 .icon-confirm.password-confirm,
-.icon-confirm.rename-confirm {
+.icon-confirm.confirm-button {
 	background-size: 16px;
 	background-color: transparent;
 	border: none;
@@ -132,7 +132,7 @@
 	opacity: .5;
 }
 .icon-confirm.password-confirm:hover,
-.icon-confirm.rename-confirm:hover  {
+.icon-confirm.confirm-button:hover  {
 	opacity: 1;
 }
 
@@ -752,31 +752,31 @@ video {
 	display: inline-block;
 }
 
-.detailCallInfoContainer .rename-button {
+.detailCallInfoContainer .room-name .edit-button {
 	display: none;
 }
 
 .detailCallInfoContainer .clipboard-button,
-.detailCallInfoContainer:hover .rename-button {
+.detailCallInfoContainer:hover .room-name .edit-button {
 	display: inline-block;
 }
 
 .detailCallInfoContainer .clipboard-button .icon,
-.detailCallInfoContainer .rename-button .icon {
+.detailCallInfoContainer .room-name .edit-button .icon {
 	cursor: pointer;
 	width: 16px;
 	height: 16px;
 	margin: -2px 10px;
 }
 
-.detailCallInfoContainer .rename-option,
+.detailCallInfoContainer .room-name .input-wrapper,
 .detailCallInfoContainer .password-option {
 	position: relative;
 	max-width: calc(100% - 72px);
 	display: inline-block;
 }
 
-.detailCallInfoContainer .rename-input,
+.detailCallInfoContainer .room-name input,
 .detailCallInfoContainer .password-input {
 	width: 100%;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -721,9 +721,12 @@ video {
  * Sidebar details view
  */
 
+.detailCallInfoContainer .room-name {
+	display: inline-block;
+}
+
 .detailCallInfoContainer h3,
 .detailCallInfoContainer .guest-name p {
-	max-width: calc(100% - 72px);
 	display: inline-block;
 }
 
@@ -747,7 +750,6 @@ video {
 .detailCallInfoContainer .editable-text-label .input-wrapper,
 .detailCallInfoContainer .password-option {
 	position: relative;
-	max-width: calc(100% - 72px);
 	display: inline-block;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -628,6 +628,14 @@ video {
 	background: transparent;
 }
 
+/* As the header is hidden (except for the logo), move the fullscreen button and
+ * sidebar to the top during calls */
+#body-public #app-content:not(.participants-1) #app-sidebar,
+#body-public #app-content:not(.participants-1) #video-fullscreen {
+	top: 0;
+	z-index: 3000;
+}
+
 /**
  * Right sidebar
  */

--- a/css/style.css
+++ b/css/style.css
@@ -115,7 +115,7 @@
 }
 
 .password-input,
-.room-name input {
+.editable-text-label input {
 	margin-top: 0 !important;
 	margin-bottom: 4px !important;
 }
@@ -623,43 +623,9 @@ video {
 	}
 }
 
-#guestName {
-    padding: 7px 30px 6px 10px;
-    cursor: pointer;
-}
-
-#guestName:hover {
-	color: #fff !important;
-}
-
-#guestNameInput {
-    margin-top: 7px;
-    margin-right: -10px;
-    padding-right: 22px;
-}
-
-#guestNameConfirm {
-	position: relative;
-	height: 20px;
-	right: 16px;
-	line-height: 14px;
-	background-color: transparent;
-	border: none;
-	opacity: .5;
-}
-
-#guestNameConfirm:hover {
-	opacity: 1;
-}
-
 /* make blue header bar transparent in shared room */
 #body-public #app-content:not(.participants-1) #header.spreed-public {
 	background: transparent;
-}
-
-/* make guest name white because header bar is transparent*/
-#body-public #app-content:not(.participants-1) #guestName {
-    color: rgba(255, 255, 255, 0.7);
 }
 
 /**
@@ -747,36 +713,37 @@ video {
  * Sidebar details view
  */
 
-.detailCallInfoContainer h3 {
+.detailCallInfoContainer h3,
+.detailCallInfoContainer .guest-name p {
 	max-width: calc(100% - 72px);
 	display: inline-block;
 }
 
-.detailCallInfoContainer .room-name .edit-button {
+.detailCallInfoContainer .editable-text-label .edit-button {
 	display: none;
 }
 
 .detailCallInfoContainer .clipboard-button,
-.detailCallInfoContainer:hover .room-name .edit-button {
+.detailCallInfoContainer:hover .editable-text-label .edit-button {
 	display: inline-block;
 }
 
 .detailCallInfoContainer .clipboard-button .icon,
-.detailCallInfoContainer .room-name .edit-button .icon {
+.detailCallInfoContainer .editable-text-label .edit-button .icon {
 	cursor: pointer;
 	width: 16px;
 	height: 16px;
 	margin: -2px 10px;
 }
 
-.detailCallInfoContainer .room-name .input-wrapper,
+.detailCallInfoContainer .editable-text-label .input-wrapper,
 .detailCallInfoContainer .password-option {
 	position: relative;
 	max-width: calc(100% - 72px);
 	display: inline-block;
 }
 
-.detailCallInfoContainer .room-name input,
+.detailCallInfoContainer .editable-text-label input,
 .detailCallInfoContainer .password-input {
 	width: 100%;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -309,37 +309,6 @@
 				OCA.SpreedMe.webrtc.stopScreenShare();
 				screensharingStopped();
 			});
-
-			$("#guestName").on('click', function() {
-				$('#guestName').addClass('hidden');
-				$("#guestNameInput").removeClass('hidden');
-				$("#guestNameConfirm").removeClass('hidden');
-				$("#guestNameInput").focus();
-			});
-
-			$('#guestNameConfirm').click(function () {
-				OCA.SpreedMe.app.changeGuestName();
-				$('#guestName').toggleClass('hidden');
-				$("#guestNameInput").toggleClass('hidden');
-				$("#guestNameConfirm").toggleClass('hidden');
-			});
-
-			$("#guestNameInput").keyup(function (e) {
-				var hide = false;
-
-				if (e.keyCode === 13) { // send new gues name on "enter"
-					hide = true;
-					OCA.SpreedMe.app.changeGuestName();
-				} else if (e.keyCode === 27) { // hide input filed again in ESC
-					hide = true;
-				}
-
-				if (hide) {
-					$('#guestName').toggleClass('hidden');
-					$("#guestNameInput").toggleClass('hidden');
-					$("#guestNameConfirm").toggleClass('hidden');
-				}
-			});
 		},
 		_showRoomList: function() {
 			this._roomsView = new OCA.SpreedMe.Views.RoomListView({
@@ -646,7 +615,7 @@
 			} else if (OCA.SpreedMe.app.displayedGuestNameHint === false) {
 				avatar.imageplaceholder('?', undefined, 128);
 				avatar.css('background-color', '#b9b9b9');
-				OC.Notification.showTemporary(t('spreed', 'You can set your name on the top right of this page so other participants can identify you better.'));
+				OC.Notification.showTemporary(t('spreed', 'You can set your name on the right sidebar so other participants can identify you better.'));
 				OCA.SpreedMe.app.displayedGuestNameHint = true;
 			}
 
@@ -665,12 +634,8 @@
 				var avatar = $('#localVideoContainer').find('.avatar');
 
 				if (value) {
-					$('#guestName').text(value);
-
 					avatar.imageplaceholder(value, undefined, 128);
 				} else {
-					$('#guestName').text(t('spreed', 'Guest'));
-
 					avatar.imageplaceholder('?', undefined, 128);
 					avatar.css('background-color', '#b9b9b9');
 				}
@@ -683,20 +648,8 @@
 			var nick = this._localStorageModel.get('nick');
 
 			if (nick) {
-				$('#guestName').text(nick);
-				$('#guestNameInput').val(nick);
 				OCA.SpreedMe.app.guestNick = nick;
 			}
-		},
-		changeGuestName: function() {
-			var guestName = $.trim($('#guestNameInput').val());
-			var lastSavedNick = this._localStorageModel.get('nick');
-
-			if (guestName !== lastSavedNick) {
-				this._localStorageModel.save('nick', guestName);
-			}
-
-			$('#guestNameInput').val(guestName);
 		},
 		initShareRoomClipboard: function () {
 			$('body').find('.shareRoomClipboard').tooltip({

--- a/js/app.js
+++ b/js/app.js
@@ -379,7 +379,18 @@
 					}
 
 					self.setPageTitle(self.activeRoom.get('displayName'));
+
+					self.updateSidebarWithActiveRoom();
 				});
+		},
+		updateSidebarWithActiveRoom: function() {
+			this._sidebarView.enable();
+
+			var callInfoView = new OCA.SpreedMe.Views.CallInfoView({
+				model: this.activeRoom,
+				guestNameModel: this._localStorageModel
+			});
+			this._sidebarView.setCallInfoView(callInfoView);
 		},
 		setPageTitle: function(title){
 			if (title) {
@@ -455,17 +466,6 @@
 			if (oc_current_user) {
 				this._rooms = new OCA.SpreedMe.Models.RoomCollection();
 				this.listenTo(roomChannel, 'active', this._setRoomActive);
-
-				this._sidebarView.listenTo(this._rooms, 'change:active', function(model, active) {
-					if (active) {
-						this.enable();
-
-						var callInfoView = new OCA.SpreedMe.Views.CallInfoView({
-							model: model,
-						});
-						this.setCallInfoView(callInfoView);
-					}
-				});
 			}
 
 			this._sidebarView.listenTo(roomChannel, 'leaveCurrentCall', function() {

--- a/js/models/localstoragemodel.js
+++ b/js/models/localstoragemodel.js
@@ -1,0 +1,69 @@
+/* global Backbone, OCA */
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+(function(OCA, Backbone) {
+	'use strict';
+
+	OCA.SpreedMe = OCA.SpreedMe || {};
+	OCA.SpreedMe.Models = OCA.SpreedMe.Models || {};
+
+	/**
+	 * Model for the local storage of the browser.
+	 *
+	 * This makes possible to use the local storage of the browser as a Backbone
+	 * model, for example, with a Marionette view.
+	 *
+	 * The local storage keys to handle must be specified in the "attributes"
+	 * parameter of the constructor.
+	 */
+	var LocalStorageModel = Backbone.Model.extend({
+		isNew: function() {
+			return false;
+		},
+		sync: function(method, model, options) {
+			if (method !== 'read' && method !== 'update') {
+				throw 'Method not supported by LocalStorageModel: ' + method;
+			}
+
+			var response = {};
+
+			if (method === 'read') {
+				response = _.clone(model.attributes);
+				_.each(response, function(value, attribute) {
+					response[attribute] = localStorage.getItem(attribute);
+				});
+			} else {
+				_.each(model.attributes, function(value, attribute) {
+					localStorage.setItem(attribute, value);
+				});
+			}
+
+			if (_.isFunction(options.success)) {
+				options.success.call(this, response);
+			}
+		}
+	});
+
+	OCA.SpreedMe.Models.LocalStorageModel = LocalStorageModel;
+
+})(OCA, Backbone);

--- a/js/models/room.js
+++ b/js/models/room.js
@@ -26,6 +26,13 @@
 	OCA.SpreedMe = OCA.SpreedMe || {};
 	OCA.SpreedMe.Models = OCA.SpreedMe.Models || {};
 
+	/**
+	 * Model for rooms.
+	 *
+	 * Room can be used as the model of a RoomCollection or as a standalone
+	 * model. When used as a standalone model the token must be provided in the
+	 * constructor options.
+	 */
 	var Room = Backbone.Model.extend({
 		defaults: {
 			name: '',
@@ -33,6 +40,16 @@
 			count: 0,
 			active: false,
 			lastPing: 0
+		},
+		url: function() {
+			return OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.get('token');
+		},
+		parse: function(result) {
+			// When the model is created by a RoomCollection "Room.parse" will
+			// be called with the result already parsed by
+			// "RoomCollection.parse", so the given result is already the
+			// attributes hash to be set on the model.
+			return (result.ocs === undefined)? result : result.ocs.data;
 		}
 	});
 

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -75,10 +75,30 @@
 		return this.syncRooms();
 	};
 
+	/**
+	 * Sets a single room to be synced.
+	 *
+	 * If there is a RoomCollection set the synchronization will be performed on
+	 * the RoomCollection instead and the given room will be ignored; setting a
+	 * single room is intended to be used only on public pages.
+	 *
+	 * @param OCA.SpreedMe.Models.Room room the room to sync.
+	 */
+	SignalingBase.prototype.setRoom = function(room) {
+		this.room = room;
+		return this.syncRooms();
+	};
+
 	SignalingBase.prototype.syncRooms = function() {
 		var defer = $.Deferred();
 		if (this.roomCollection && oc_current_user) {
 			this.roomCollection.fetch({
+				success: function(data) {
+					defer.resolve(data);
+				}
+			});
+		} else if (this.room) {
+			this.room.fetch({
 				success: function(data) {
 					defer.resolve(data);
 				}
@@ -261,6 +281,11 @@
 	InternalSignaling.prototype.setRoomCollection = function(/*rooms*/) {
 		this._pollForRoomChanges();
 		return SignalingBase.prototype.setRoomCollection.apply(this, arguments);
+	};
+
+	InternalSignaling.prototype.setRoom = function(/*room*/) {
+		this._pollForRoomChanges();
+		return SignalingBase.prototype.setRoom.apply(this, arguments);
 	};
 
 	InternalSignaling.prototype._pollForRoomChanges = function() {

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -33,6 +33,9 @@
 		'{{#if showShareLink}}' +
 		'	<div class="clipboard-button"><span class="icon icon-clippy"></span></div>' +
 		'{{/if}}' +
+		'{{#if isGuest}}' +
+		'	<div class="guest-name"></div>' +
+		'{{/if}}' +
 		'{{#if canModerate}}' +
 		'	<div>' +
 		'		<input name="link-checkbox" id="link-checkbox" class="checkbox link-checkbox" value="1" {{#if isPublic}} checked="checked"{{/if}} type="checkbox">' +
@@ -59,6 +62,7 @@
 		templateContext: function() {
 			var canModerate = this._canModerate();
 			return $.extend(this.model.toJSON(), {
+				isGuest: this.model.get('participantType') === 4,
 				canModerate: canModerate,
 				isPublic: this.model.get('type') === 3,
 				showShareLink: !canModerate && this.model.get('type') === 3,
@@ -71,13 +75,16 @@
 			'clipboardButton': '.clipboard-button',
 			'linkCheckbox': '.link-checkbox',
 
+			'guestName': 'div.guest-name',
+
 			'passwordOption': '.password-option',
 			'passwordInput': '.password-input',
 			'passwordConfirm': '.password-confirm'
 		},
 
 		regions: {
-			'roomName': '@ui.roomName'
+			'roomName': '@ui.roomName',
+			'guestName': '@ui.guestName'
 		},
 
 		events: {
@@ -127,6 +134,18 @@
 			});
 
 			this._updateNameEditability();
+
+			this._guestNameEditableTextLabel = new OCA.SpreedMe.Views.EditableTextLabel({
+				model: this.getOption('guestNameModel'),
+				modelAttribute: 'nick',
+
+				extraClassNames: 'guest-name',
+				labelTagName: 'p',
+				labelPlaceholder: t('spreed', 'Guest'),
+				inputMaxLength: '20',
+				inputPlaceholder: t('spreed', 'Name'),
+				buttonTitle: t('spreed', 'Rename')
+			});
 		},
 
 		renderWhenInactive: function() {
@@ -149,6 +168,7 @@
 			// rendered, as the element of the region does not exist yet at that
 			// time and without that option the call would fail otherwise.
 			this.getRegion('roomName').reset({ preventDestroy: true, allowMissingEl: true });
+			this.getRegion('guestName').reset({ preventDestroy: true, allowMissingEl: true });
 		},
 
 		onRender: function() {
@@ -160,6 +180,7 @@
 			// Attach the child view again (or for the first time) after the
 			// template has been rendered.
 			this.showChildView('roomName', this._nameEditableTextLabel, { replaceElement: true } );
+			this.showChildView('guestName', this._guestNameEditableTextLabel, { replaceElement: true, allowMissingEl: true } );
 
 			var roomURL = OC.generateUrl('/call/' + this.model.get('token')),
 				completeURL = window.location.protocol + '//' + window.location.host + roomURL;

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -164,12 +164,12 @@
 		confirmRename: function() {
 			var newRoomName = this.ui.renameInput.val().trim();
 
-			if (newRoomName === this.model.get('name')) {
+			if (newRoomName === this.model.get('displayName')) {
 				this.hideRenameInput();
 				return;
 			}
 
-			console.log('Changing room name from "' + this.model.get('name') + '" to "' + newRoomName + '".');
+			console.log('Changing room name from "' + this.model.get('displayName') + '" to "' + newRoomName + '".');
 
 			$.ajax({
 				url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('token'),
@@ -194,7 +194,7 @@
 			} else if (e.keyCode === 27) {
 				// ESC
 				this.hideRenameInput();
-				this.ui.renameInput.val(this.model.get('name'));
+				this.ui.renameInput.val(this.model.get('displayName'));
 			}
 		},
 

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -141,7 +141,7 @@
 
 				extraClassNames: 'guest-name',
 				labelTagName: 'p',
-				labelPlaceholder: t('spreed', 'Guest'),
+				labelPlaceholder: t('spreed', 'Your name …'),
 				inputMaxLength: '20',
 				inputPlaceholder: t('spreed', 'Name'),
 				buttonTitle: t('spreed', 'Rename')

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -171,16 +171,22 @@
 
 			console.log('Changing room name from "' + this.model.get('displayName') + '" to "' + newRoomName + '".');
 
-			$.ajax({
-				url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('token'),
-				type: 'PUT',
-				data: {
-					roomName: newRoomName
-				},
+			this.model.save('displayName', newRoomName, {
+				patch: true,
 				success: function() {
+					// Saving the "displayName" will have triggered a
+					// "change:displayName" event. However, as the input was
+					// still shown the rendering will have been enqueued until
+					// the input is hidden, so the room name text has to be
+					// explicitly set before hiding the input to prevent briefly
+					// showing the old value.
 					this.ui.roomName.text(newRoomName);
 					this.hideRenameInput();
-					OCA.SpreedMe.app.syncRooms();
+
+					// Renaming a room by setting "displayName" causes "name" to
+					// change too in the server, so the model has to be fetched
+					// again to get the changes.
+					this.model.fetch();
 				}.bind(this)
 			});
 

--- a/js/views/editabletextlabel.js
+++ b/js/views/editabletextlabel.js
@@ -1,0 +1,194 @@
+/* global Marionette, Handlebars */
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+(function(OCA, Marionette, Handlebars) {
+	'use strict';
+
+	OCA.SpreedMe = OCA.SpreedMe || {};
+	OCA.SpreedMe.Views = OCA.SpreedMe.Views || {};
+
+	var TEMPLATE =
+		'<div class="label-wrapper">' +
+		'	<{{labelTagName}} class="label">{{text}}</{{labelTagName}}>' +
+		'	{{#if editionEnabled}}' +
+		'		<div class="edit-button"><span class="icon icon-rename" {{#if buttonTitle}} title="{{buttonTitle}}" {{/if}}></span></div>' +
+		'	{{/if}}' +
+		'</div>' +
+		'{{#if editionEnabled}}' +
+		'	<div class="input-wrapper hidden-important">' +
+		'		<input {{#if inputMaxLength}} maxlength="{{inputMaxLength}}" {{/if}} type="text" value="{{text}}" {{#if inputPlaceholder}} placeholder="{{inputPlaceholder}}" {{/if}}>'+
+		'		<div class="icon icon-confirm confirm-button"></div>'+
+		'	</div>' +
+		'{{/if}}';
+
+	/**
+	 * View for an editable text label.
+	 *
+	 * In its main state, an EditableTextLabel shows text in a label (an HTML
+	 * element that can contain a line of text, like "<h1>" or "<p>"). The text
+	 * comes from an attribute in a Backbone model and is automatically updated
+	 * when the attribute changes.
+	 *
+	 * It also provides an edition state in which a text input field replaces
+	 * the label, making possible to edit and save the attribute of the model.
+	 * The EditableTextLabel can be make read-only by calling
+	 * "disableEdition()", or read-write by calling "enableEdition()".
+	 *
+	 * The EditableTextLabel works on a single attribute of a model; they must
+	 * be set in the constructor using the "model" and "modelAttribute" options
+	 * (the first is the Backbone model to get the attribute from, the second is
+	 * the name of the attribute). The "modelSaveOptions" option can be set if
+	 * needed to control the options passed to "Model.save", and
+	 * "extraClassNames", "labelTagName", "inputMaxLength", "inputPlaceholder"
+	 * and "buttonTitle" can be used to customize some elements of the view.
+	 */
+	var EditableTextLabel = Marionette.View.extend({
+
+		className: function() {
+			return 'editable-text-label' + (this.getOption('extraClassNames')? ' ' + this.getOption('extraClassNames') : '');
+		},
+
+		labelTagName: 'p',
+
+		buttonTitle: t('spreed', 'Edit'),
+
+		ui: {
+			labelWrapper: '.label-wrapper',
+			label: '.label',
+			editButton: '.edit-button',
+			inputWrapper: '.input-wrapper',
+			input: 'input',
+			confirmButton: '.confirm-button',
+		},
+
+		events: {
+			'click @ui.editButton': 'showInput',
+			'keyup @ui.input': 'handleInputKeyUp',
+			'click @ui.confirmButton': 'confirmEdit',
+		},
+
+		modelEvents: function() {
+			var modelEvents = {};
+			modelEvents['change:' + this.modelAttribute] = 'updateText';
+
+			return modelEvents;
+		},
+
+		template: Handlebars.compile(TEMPLATE),
+
+		templateContext: function() {
+			return {
+				text: this.model.get(this.modelAttribute),
+
+				editionEnabled: this._editionEnabled,
+
+				labelTagName: this.getOption('labelTagName'),
+				inputMaxLength: this.getOption('inputMaxLength'),
+				inputPlaceholder: this.getOption('inputPlaceholder'),
+				buttonTitle: this.getOption('buttonTitle')
+			};
+		},
+
+		initialize: function(options) {
+			this.mergeOptions(options, ['model', 'modelAttribute', 'modelSaveOptions']);
+
+			this._editionEnabled = true;
+		},
+
+		enableEdition: function() {
+			if (this._editionEnabled) {
+				return;
+			}
+
+			this._editionEnabled = true;
+
+			this.render();
+		},
+
+		disableEdition: function() {
+			if (!this._editionEnabled) {
+				return;
+			}
+
+			this._editionEnabled = false;
+
+			this.render();
+		},
+
+		updateText: function() {
+			this.getUI('label').text(this.model.get(this.modelAttribute));
+		},
+
+		showInput: function() {
+			this.getUI('inputWrapper').removeClass('hidden-important');
+			this.getUI('labelWrapper').addClass('hidden-important');
+
+			this.getUI('input').focus();
+		},
+
+		hideInput: function() {
+			this.getUI('labelWrapper').removeClass('hidden-important');
+			this.getUI('inputWrapper').addClass('hidden-important');
+		},
+
+		handleInputKeyUp: function(event) {
+			if (event.keyCode === 13) {
+				// Enter
+				this.confirmEdit();
+			} else if (event.keyCode === 27) {
+				// ESC
+				this.discardEdit();
+			}
+		},
+
+		confirmEdit: function() {
+			var newText = this.getUI('input').val().trim();
+
+			if (newText === this.model.get(this.modelAttribute)) {
+				this.hideInput();
+
+				return;
+			}
+
+			var options = _.clone(this.modelSaveOptions || {});
+			options.success = _.bind(function() {
+				this.hideInput();
+
+				if (_.isFunction(this.modelSaveOptions.success)) {
+					this.modelSaveOptions.success.apply(this, arguments);
+				}
+			}, this);
+
+			this.model.save(this.modelAttribute, newText, options);
+		},
+
+		discardEdit: function() {
+			this.hideInput();
+			this.getUI('input').val(this.model.get(this.modelAttribute));
+		}
+
+	});
+
+	OCA.SpreedMe.Views.EditableTextLabel = EditableTextLabel;
+
+})(OCA, Marionette, Handlebars);

--- a/js/views/editabletextlabel.js
+++ b/js/views/editabletextlabel.js
@@ -36,7 +36,7 @@
 		'</div>' +
 		'{{#if editionEnabled}}' +
 		'	<div class="input-wrapper hidden-important">' +
-		'		<input {{#if inputMaxLength}} maxlength="{{inputMaxLength}}" {{/if}} type="text" value="{{text}}" {{#if inputPlaceholder}} placeholder="{{inputPlaceholder}}" {{/if}}>'+
+		'		<input {{#if inputMaxLength}} maxlength="{{inputMaxLength}}" {{/if}} type="text" value="{{inputValue}}" {{#if inputPlaceholder}} placeholder="{{inputPlaceholder}}" {{/if}}>'+
 		'		<div class="icon icon-confirm confirm-button"></div>'+
 		'	</div>' +
 		'{{/if}}';
@@ -59,8 +59,9 @@
 	 * (the first is the Backbone model to get the attribute from, the second is
 	 * the name of the attribute). The "modelSaveOptions" option can be set if
 	 * needed to control the options passed to "Model.save", and
-	 * "extraClassNames", "labelTagName", "inputMaxLength", "inputPlaceholder"
-	 * and "buttonTitle" can be used to customize some elements of the view.
+	 * "extraClassNames", "labelTagName", "labelPlaceholder", "inputMaxLength",
+	 * "inputPlaceholder" and "buttonTitle" can be used to customize some
+	 * elements of the view.
 	 */
 	var EditableTextLabel = Marionette.View.extend({
 
@@ -98,12 +99,15 @@
 
 		templateContext: function() {
 			return {
-				text: this.model.get(this.modelAttribute),
+				text: this._getText(),
 
 				editionEnabled: this._editionEnabled,
 
 				labelTagName: this.getOption('labelTagName'),
 				inputMaxLength: this.getOption('inputMaxLength'),
+				// The text of the label is not used as input value as it could
+				// contain a placeholder text.
+				inputValue: this.model.get(this.modelAttribute),
 				inputPlaceholder: this.getOption('inputPlaceholder'),
 				buttonTitle: this.getOption('buttonTitle')
 			};
@@ -135,8 +139,12 @@
 			this.render();
 		},
 
+		_getText: function() {
+			return this.model.get(this.modelAttribute) || this.getOption('labelPlaceholder') || '';
+		},
+
 		updateText: function() {
-			this.getUI('label').text(this.model.get(this.modelAttribute));
+			this.getUI('label').text(this._getText());
 		},
 
 		showInput: function() {

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -12,6 +12,7 @@ script(
 		'vendor/backbone/backbone-min',
 		'vendor/backbone.radio/build/backbone.radio.min',
 		'vendor/backbone.marionette/lib/backbone.marionette.min',
+		'models/localstoragemodel',
 		'models/room',
 		'models/roomcollection',
 		'views/callinfoview',

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -49,11 +49,6 @@ script(
 					</div>
 				</div>
 				<div id="header-right">
-					<div id="settings">
-						<div id="guestName"><?php p($l->t('Guest')) ?></div>
-						<input id="guestNameInput" class="hidden" type="text" maxlength="20" placeholder="<?php p($l->t('Guest')) ?>">
-						<button id="guestNameConfirm" class="icon-confirm hidden"></button>
-					</div>
 				</div>
 			</div>
 		</header>

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -15,6 +15,7 @@ script(
 		'models/room',
 		'models/roomcollection',
 		'views/callinfoview',
+		'views/editabletextlabel',
 		'views/roomlistview',
 		'views/sidebarview',
 		'views/tabview',

--- a/templates/index.php
+++ b/templates/index.php
@@ -17,6 +17,7 @@ script(
 		'models/participant',
 		'models/participantcollection',
 		'views/callinfoview',
+		'views/editabletextlabel',
 		'views/participantlistview',
 		'views/participantview',
 		'views/roomlistview',


### PR DESCRIPTION
This pull request adds the right sidebar also to the public page. Right now the right sidebar in the public page does not provide much value, but this is a preparatory step to later add a chat tab in the sidebar.

The guest name is now shown in the sidebar too instead of in the header as before. This made possible to move the _Enter/Exit fullscreen_ button to the top right corner (which in my opinion looks better), extend the sidebar to the top (as the header is hidden during calls in the public page), and reduce the UI elements shown during calls.

The room name and the guest name had a lot of similar code, so it was refactored into a new view, `EditableTextLabel`. An `EditableTextLabel` shows a single text attribute from a Backbone model and, optionally, also makes possible to edit it. As the guest name is stored in the local storage of the browser a new Backbone model that acts as a bridge between the local storage and Marionette views was introduced (`LocalStorageModel`).
