### PR TITLE
Notify users mentioned in chat messages

### DIFF
--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -90,6 +90,7 @@ class ChatManager {
 	 * maximum time to wait must be set using the $timeout parameter.
 	 *
 	 * @param string $chatId
+	 * @param string $userId
 	 * @param int $timeout the maximum number of seconds to wait for messages
 	 * @param int $offset optional, starting point
 	 * @param \DateTime|null $notOlderThan optional, the date and time of the
@@ -98,7 +99,7 @@ class ChatManager {
 	 *         creation date and message are relevant), or an empty array if the
 	 *         timeout expired.
 	 */
-	public function receiveMessages($chatId, $timeout, $offset = 0, \DateTime $notOlderThan = null) {
+	public function receiveMessages($chatId, $userId, $timeout, $offset = 0, \DateTime $notOlderThan = null) {
 		$comments = [];
 
 		$commentsFound = false;
@@ -113,6 +114,8 @@ class ChatManager {
 				$elapsedTime++;
 			}
 		}
+
+		$this->notifier->markMentionNotificationsRead($chatId, $userId);
 
 		if ($commentsFound) {
 			// The limit and offset of getForObject can not be based on the

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -23,6 +23,7 @@
 
 namespace OCA\Spreed\Chat;
 
+use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
 
 /**

--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Chat;
+
+use OCP\Comments\IComment;
+use OCP\Notification\IManager as INotificationManager;
+use OCP\Notification\INotification;
+use OCP\IUserManager;
+
+/**
+ * Helper class for notifications related to user mentions in chat messages.
+ *
+ * This class uses the NotificationManager to create and remove the
+ * notifications as needed; OCA\Spreed\Notification\Notifier is the one that
+ * prepares the notifications for display.
+ */
+class Notifier {
+
+	/** @var INotificationManager */
+	private $notificationManager;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/**
+	 * @param INotificationManager $notificationManager
+	 * @param IUserManager $userManager
+	 */
+	public function __construct(INotificationManager $notificationManager,
+								IUserManager $userManager) {
+		$this->notificationManager = $notificationManager;
+		$this->userManager = $userManager;
+	}
+
+	/**
+	 * Notifies the user mentioned in the comment.
+	 *
+	 * The comment must be a chat message comment. That is, its "objectId" must
+	 * be the room ID.
+	 *
+	 * @param IComment $comment
+	 */
+	public function notifyMentionedUsers(IComment $comment) {
+		$mentionedUserIds = $this->getMentionedUserIds($comment);
+		if (empty($mentionedUserIds)) {
+			return;
+		}
+
+		foreach ($mentionedUserIds as $mentionedUserId) {
+			if ($this->shouldUserBeNotified($mentionedUserId, $comment)) {
+				$notification = $this->createNotification($comment, $mentionedUserId);
+
+				$this->notificationManager->notify($notification);
+			}
+		}
+	}
+
+	/**
+	 * Removes all the pending notifications for the room with the given ID.
+	 *
+	 * @param string $roomId
+	 */
+	public function removePendingNotificationsForRoom($roomId) {
+		$notification = $this->notificationManager->createNotification();
+
+		$notification
+			->setApp('spreed')
+			->setObject('room', $roomId);
+
+		$this->notificationManager->markProcessed($notification);
+	}
+
+	/**
+	 * Returns the IDs of the users mentioned in the given comment.
+	 *
+	 * @param IComment $comment
+	 * @return string[] the mentioned user IDs
+	 */
+	private function getMentionedUserIds(IComment $comment) {
+		$mentions = $comment->getMentions();
+
+		if (empty($mentions)) {
+			return [];
+		}
+
+		$userIds = [];
+		foreach ($mentions as $mention) {
+			if ($mention['type'] === 'user') {
+				$userIds[] = $mention['id'];
+			}
+		}
+
+		return $userIds;
+	}
+
+	/**
+	 * Creates a notification for the given chat message comment and mentioned
+	 * user ID.
+	 *
+	 * @param IComment $comment
+	 * @param string $mentionedUserId
+	 * @return INotification
+	 */
+	private function createNotification(IComment $comment, $mentionedUserId) {
+		$notification = $this->notificationManager->createNotification();
+		$notification
+			->setApp('spreed')
+			->setObject('room', $comment->getObjectId())
+			->setUser($mentionedUserId)
+			->setSubject('mention', [
+				'userType' => $comment->getActorType(),
+				'userId' => $comment->getActorId(),
+				])
+			->setDateTime($comment->getCreationDateTime());
+
+		return $notification;
+	}
+
+	private function shouldUserBeNotified($userId, IComment $comment) {
+		if ($userId === $comment->getActorId()) {
+			// Do not notify the user if she mentioned herself
+			return false;
+		}
+
+		if (!$this->userManager->userExists($userId)) {
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -105,6 +105,29 @@ class Notifier {
 	}
 
 	/**
+	 * Removes all the pending mention notifications for the room
+	 *
+	 * @param string $roomId
+	 * @param string $userId
+	 */
+	public function markMentionNotificationsRead($roomId, $userId) {
+
+		if ($userId === null || $userId === '') {
+			return;
+		}
+
+		$notification = $this->notificationManager->createNotification();
+
+		$notification
+			->setApp('spreed')
+			->setObject('room', $roomId)
+			->setSubject('mention')
+			->setUser($userId);
+
+		$this->notificationManager->markProcessed($notification);
+	}
+
+	/**
 	 * Returns the IDs of the users mentioned in the given comment.
 	 *
 	 * @param IComment $comment

--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -226,13 +226,13 @@ class Notifier {
 
 		try {
 			$room = $this->manager->getRoomById($comment->getObjectId());
-			$participant = $room->getParticipant($userId);
+			$room->getParticipant($userId);
 		} catch (RoomNotFoundException $e) {
 			return false;
 		} catch (ParticipantNotFoundException $e) {
 			return false;
 		}
 
-		return $participant->getSessionId() === '0';
+		return true;
 	}
 }

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -206,7 +206,7 @@ class ChatController extends OCSController {
 			$timeout = $maximumTimeout;
 		}
 
-		$comments = $this->chatManager->receiveMessages((string) $room->getId(), $timeout, $offset, $notOlderThan);
+		$comments = $this->chatManager->receiveMessages((string) $room->getId(), $this->userId, $timeout, $offset, $notOlderThan);
 
 		return new DataResponse(array_map(function(IComment $comment) use ($token) {
 			$displayName = null;

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -147,6 +147,18 @@ class Notifier implements INotifier {
 			];
 		}
 
+		$messageParameters = $notification->getMessageParameters();
+
+		$parsedMessage = $notification->getMessage();
+		if (in_array('ellipsisStart', $messageParameters) && !in_array('ellipsisEnd', $messageParameters)) {
+			$parsedMessage = $l->t('… %s', $parsedMessage);
+		} else if (!in_array('ellipsisStart', $messageParameters) && in_array('ellipsisEnd', $messageParameters)) {
+			$parsedMessage = $l->t('%s …', $parsedMessage);
+		} else if (in_array('ellipsisStart', $messageParameters) && in_array('ellipsisEnd', $messageParameters)) {
+			$parsedMessage = $l->t('… %s …', $parsedMessage);
+		}
+		$notification->setParsedMessage($parsedMessage);
+
 		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
 			$notification
 				->setParsedSubject(

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -92,14 +92,136 @@ class Notifier implements INotifier {
 			->setIcon($this->url->getAbsoluteURL($this->url->imagePath('spreed', 'app.svg')))
 			->setLink($this->url->linkToRouteAbsolute('spreed.Page.index') . '?token=' . $room->getToken());
 
-		if ($notification->getSubject() === 'invitation') {
+		$subject = $notification->getSubject();
+		if ($subject === 'invitation') {
 			return $this->parseInvitation($notification, $room, $l);
 		}
-		if ($notification->getSubject() === 'call') {
+		if ($subject === 'call') {
 			return $this->parseCall($notification, $room, $l);
+		}
+		if ($subject === 'mention') {
+			return $this->parseMention($notification, $room, $l);
 		}
 
 		throw new \InvalidArgumentException('Unknown subject');
+	}
+
+	/**
+	 * @param INotification $notification
+	 * @param Room $room
+	 * @param IL10N $l
+	 * @return INotification
+	 * @throws \InvalidArgumentException
+	 */
+	protected function parseMention(INotification $notification, Room $room, IL10N $l) {
+		if ($notification->getObjectType() !== 'room') {
+			throw new \InvalidArgumentException('Unknown object type');
+		}
+
+		$subjectParameters = $notification->getSubjectParameters();
+
+		$richSubjectUser = null;
+		$isGuest = false;
+		if ($subjectParameters['userType'] === 'users') {
+			$userId = $subjectParameters['userId'];
+			$user = $this->userManager->get($userId);
+
+			if ($user instanceof IUser) {
+				$richSubjectUser = [
+					'type' => 'user',
+					'id' => $userId,
+					'name' => $user->getDisplayName(),
+				];
+			}
+		} else {
+			$isGuest = true;
+		}
+
+		$richSubjectCall = null;
+		if ($room->getName() !== '') {
+			$richSubjectCall = [
+				'type' => 'call',
+				'id' => $room->getId(),
+				'name' => $room->getName(),
+				'call-type' => $this->getRoomType($room),
+			];
+		}
+
+		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
+			$notification
+				->setParsedSubject(
+					$l->t('%s mentioned you in a private chat', [$user->getDisplayName()])
+				)
+				->setRichSubject(
+					$l->t('{user} mentioned you in a private chat'), [
+						'user' => $richSubjectUser
+					]
+				);
+
+		} else if (in_array($room->getType(), [Room::GROUP_CALL, Room::PUBLIC_CALL], true)) {
+			if ($richSubjectUser && $richSubjectCall) {
+				$notification
+					->setParsedSubject(
+						$l->t('%s mentioned you in a group chat: %s', [$user->getDisplayName(), $room->getName()])
+					)
+					->setRichSubject(
+						$l->t('{user} mentioned you in a group chat: {call}'), [
+							'user' => $richSubjectUser,
+							'call' => $richSubjectCall
+						]
+					);
+			} else if ($richSubjectUser && !$richSubjectCall) {
+				$notification
+					->setParsedSubject(
+						$l->t('%s mentioned you in a group chat', [$user->getDisplayName()])
+					)
+					->setRichSubject(
+						$l->t('{user} mentioned you in a group chat'), [
+							'user' => $richSubjectUser
+						]
+					);
+			} else if (!$richSubjectUser && !$isGuest && $richSubjectCall) {
+				$notification
+					->setParsedSubject(
+						$l->t('A (now) deleted user mentioned you in a group chat: %s', [$room->getName()])
+					)
+					->setRichSubject(
+						$l->t('A (now) deleted user mentioned you in a group chat: {call}'), [
+							'call' => $richSubjectCall
+						]
+					);
+			} else if (!$richSubjectUser && !$isGuest && !$richSubjectCall) {
+				$notification
+					->setParsedSubject(
+						$l->t('A (now) deleted user mentioned you in a group chat')
+					)
+					->setRichSubject(
+						$l->t('A (now) deleted user mentioned you in a group chat')
+					);
+			} else if (!$richSubjectUser && $isGuest && $richSubjectCall) {
+				$notification
+					->setParsedSubject(
+						$l->t('A guest mentioned you in a group chat: %s', [$room->getName()])
+					)
+					->setRichSubject(
+						$l->t('A guest mentioned you in a group chat: {call}'), [
+							'call' => $richSubjectCall
+						]
+					);
+			} else if (!$richSubjectUser && $isGuest && !$richSubjectCall) {
+				$notification
+					->setParsedSubject(
+						$l->t('A guest mentioned you in a group chat')
+					)
+					->setRichSubject(
+						$l->t('A guest mentioned you in a group chat')
+					);
+			}
+		} else {
+			throw new \InvalidArgumentException('Unknown room type');
+		}
+
+		return $notification;
 	}
 
 	/**

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -89,7 +89,7 @@ class Notifier implements INotifier {
 		}
 
 		$notification
-			->setIcon($this->url->getAbsoluteURL($this->url->imagePath('spreed', 'app.svg')))
+			->setIcon($this->url->getAbsoluteURL($this->url->imagePath('spreed', 'app-dark.svg')))
 			->setLink($this->url->linkToRouteAbsolute('spreed.Page.index') . '?token=' . $room->getToken());
 
 		$subject = $notification->getSubject();

--- a/tests/php/Chat/ChatManagerTest.php
+++ b/tests/php/Chat/ChatManagerTest.php
@@ -121,8 +121,12 @@ class ChatManagerTest extends \Test\TestCase {
 				$this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage1')
 			]);
 
+		$this->notifier->expects($this->once())
+			->method('markMentionNotificationsRead')
+			->with('testChatId', 'userId');
+
 		$timeout = 42;
-		$comments = $this->chatManager->receiveMessages('testChatId', $timeout, $offset, $notOlderThan);
+		$comments = $this->chatManager->receiveMessages('testChatId', 'userId', $timeout, $offset, $notOlderThan);
 		$expected = [
 				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000042), 'testMessage3'),
 				$this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000023), 'testMessage2')
@@ -154,8 +158,12 @@ class ChatManagerTest extends \Test\TestCase {
 				$this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage1')
 			]);
 
+		$this->notifier->expects($this->once())
+			->method('markMentionNotificationsRead')
+			->with('testChatId', 'userId');
+
 		$timeout = 42;
-		$comments = $this->chatManager->receiveMessages('testChatId', $timeout, $offset, $notOlderThan);
+		$comments = $this->chatManager->receiveMessages('testChatId', 'userId', $timeout, $offset, $notOlderThan);
 		$expected = [
 				$this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000108), 'testMessage4'),
 				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000042), 'testMessage3'),
@@ -185,8 +193,12 @@ class ChatManagerTest extends \Test\TestCase {
 				$this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage1')
 			]);
 
+		$this->notifier->expects($this->once())
+			->method('markMentionNotificationsRead')
+			->with('testChatId', 'userId');
+
 		$timeout = 42;
-		$comments = $this->chatManager->receiveMessages('testChatId', $timeout, $offset, $notOlderThan);
+		$comments = $this->chatManager->receiveMessages('testChatId', 'userId', $timeout, $offset, $notOlderThan);
 		$expected = [
 				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000042), 'testMessage3'),
 				$this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000023), 'testMessage2'),

--- a/tests/php/Chat/ChatManagerTest.php
+++ b/tests/php/Chat/ChatManagerTest.php
@@ -24,6 +24,7 @@
 namespace OCA\Spreed\Tests\php\Chat;
 
 use OCA\Spreed\Chat\ChatManager;
+use OCA\Spreed\Chat\Notifier;
 use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
 
@@ -31,6 +32,9 @@ class ChatManagerTest extends \Test\TestCase {
 
 	/** @var OCP\Comments\ICommentsManager|\PHPUnit_Framework_MockObject_MockObject */
 	protected $commentsManager;
+
+	/** @var \OCA\Spreed\Chat\Notifier|\PHPUnit_Framework_MockObject_MockObject */
+	protected $notifier;
 
 	/** @var \OCA\Spreed\Chat\ChatManager */
 	protected $chatManager;
@@ -40,7 +44,10 @@ class ChatManagerTest extends \Test\TestCase {
 
 		$this->commentsManager = $this->createMock(ICommentsManager::class);
 
-		$this->chatManager = new ChatManager($this->commentsManager);
+		$this->notifier = $this->createMock(Notifier::class);
+
+		$this->chatManager = new ChatManager($this->commentsManager,
+											 $this->notifier);
 	}
 
 	private function newComment($id, $actorType, $actorId, $creationDateTime, $message) {
@@ -85,6 +92,10 @@ class ChatManagerTest extends \Test\TestCase {
 
 		$this->commentsManager->expects($this->once())
 			->method('save')
+			->with($comment);
+
+		$this->notifier->expects($this->once())
+			->method('notifyMentionedUsers')
 			->with($comment);
 
 		$this->chatManager->sendMessage('testChatId', 'users', 'testUser', 'testMessage', $creationDateTime);
@@ -189,6 +200,10 @@ class ChatManagerTest extends \Test\TestCase {
 		$this->commentsManager->expects($this->once())
 			->method('deleteCommentsAtObject')
 			->with('chat', 'testChatId');
+
+		$this->notifier->expects($this->once())
+			->method('removePendingNotificationsForRoom')
+			->with('testChatId');
 
 		$this->chatManager->deleteMessages('testChatId');
 	}

--- a/tests/php/Chat/NotifierTest.php
+++ b/tests/php/Chat/NotifierTest.php
@@ -125,6 +125,11 @@ class NotifierTest extends \Test\TestCase {
 			->with('anotherUser')
 			->willReturnSelf();
 
+		$notification->expects($this->once())
+			->method('setMessage')
+			->with($comment->getMessage())
+			->willReturnSelf();
+
 		$this->notificationManager->expects($this->once())
 			->method('notify')
 			->with($notification);
@@ -144,6 +149,92 @@ class NotifierTest extends \Test\TestCase {
 		$notification->expects($this->once())
 			->method('setUser')
 			->with('anotherUser')
+			->willReturnSelf();
+
+		$notification->expects($this->once())
+			->method('setMessage')
+			->with($comment->getMessage())
+			->willReturnSelf();
+
+		$this->notificationManager->expects($this->once())
+			->method('notify')
+			->with($notification);
+
+		$this->notifier->notifyMentionedUsers($comment);
+	}
+
+	public function testNotifyMentionedUsersWithLongMessageStartMention() {
+		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016),
+			'123456789 @anotherUserWithOddLengthName 123456789-123456789-123456789-123456789-123456789-123456789');
+
+		$notification = $this->newNotification($comment);
+
+		$this->notificationManager->expects($this->once())
+			->method('createNotification')
+			->willReturn($notification);
+
+		$notification->expects($this->once())
+			->method('setUser')
+			->with('anotherUserWithOddLengthName')
+			->willReturnSelf();
+
+		$notification->expects($this->once())
+			->method('setMessage')
+			->with('123456789 @anotherUserWithOddLengthName 123456789-123456789-1234', ['ellipsisEnd'])
+			->willReturnSelf();
+
+		$this->notificationManager->expects($this->once())
+			->method('notify')
+			->with($notification);
+
+		$this->notifier->notifyMentionedUsers($comment);
+	}
+
+	public function testNotifyMentionedUsersWithLongMessageMiddleMention() {
+		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016),
+			'123456789-123456789-123456789-1234 @anotherUserWithOddLengthName 6789-123456789-123456789-123456789');
+
+		$notification = $this->newNotification($comment);
+
+		$this->notificationManager->expects($this->once())
+			->method('createNotification')
+			->willReturn($notification);
+
+		$notification->expects($this->once())
+			->method('setUser')
+			->with('anotherUserWithOddLengthName')
+			->willReturnSelf();
+
+		$notification->expects($this->once())
+			->method('setMessage')
+			->with('89-123456789-1234 @anotherUserWithOddLengthName 6789-123456789-1', ['ellipsisStart', 'ellipsisEnd'])
+			->willReturnSelf();
+
+		$this->notificationManager->expects($this->once())
+			->method('notify')
+			->with($notification);
+
+		$this->notifier->notifyMentionedUsers($comment);
+	}
+
+	public function testNotifyMentionedUsersWithLongMessageEndMention() {
+		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016),
+			'123456789-123456789-123456789-123456789-123456789-123456789 @anotherUserWithOddLengthName 123456789');
+
+		$notification = $this->newNotification($comment);
+
+		$this->notificationManager->expects($this->once())
+			->method('createNotification')
+			->willReturn($notification);
+
+		$notification->expects($this->once())
+			->method('setUser')
+			->with('anotherUserWithOddLengthName')
+			->willReturnSelf();
+
+		$notification->expects($this->once())
+			->method('setMessage')
+			->with('6789-123456789-123456789 @anotherUserWithOddLengthName 123456789', ['ellipsisStart'])
 			->willReturnSelf();
 
 		$this->notificationManager->expects($this->once())
@@ -207,9 +298,19 @@ class NotifierTest extends \Test\TestCase {
 			->with('anotherUser')
 			->willReturnSelf();
 
+		$anotherUserNotification->expects($this->once())
+			->method('setMessage')
+			->with('Mention @anotherUser, and @unknownUser, and @testUser, and @user')
+			->willReturnSelf();
+
 		$userAbleToJoinNotification->expects($this->once())
 			->method('setUser')
 			->with('userAbleToJoin')
+			->willReturnSelf();
+
+		$userAbleToJoinNotification->expects($this->once())
+			->method('setMessage')
+			->with('notherUser, and @unknownUser, and @testUser, and @userAbleToJoin')
 			->willReturnSelf();
 
 		$this->notificationManager->expects($this->exactly(2))

--- a/tests/php/Chat/NotifierTest.php
+++ b/tests/php/Chat/NotifierTest.php
@@ -148,9 +148,6 @@ class NotifierTest extends \Test\TestCase {
 			->willReturn($room);
 
 		$participant = $this->createMock(Participant::class);
-		$participant->expects($this->once())
-			->method('getSessionId')
-			->willReturn('0');
 
 		$room->expects($this->once())
 			->method('getParticipant')
@@ -160,35 +157,6 @@ class NotifierTest extends \Test\TestCase {
 		$this->notificationManager->expects($this->once())
 			->method('notify')
 			->with($notification);
-
-		$this->notifier->notifyMentionedUsers($comment);
-	}
-
-	public function testNotifyMentionedUsersActive() {
-		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'Mention @anotherUser');
-
-		$this->notificationManager->expects($this->never())
-			->method('createNotification');
-
-		$this->notificationManager->expects($this->never())
-			->method('notify');
-
-
-		$room = $this->createMock(Room::class);
-		$this->manager->expects($this->once())
-			->method('getRoomById')
-			->with('roomId')
-			->willReturn($room);
-
-		$participant = $this->createMock(Participant::class);
-		$participant->expects($this->once())
-			->method('getSessionId')
-			->willReturn('1');
-
-		$room->expects($this->once())
-			->method('getParticipant')
-			->with('anotherUser')
-			->willReturn($participant);
 
 		$this->notifier->notifyMentionedUsers($comment);
 	}
@@ -219,9 +187,6 @@ class NotifierTest extends \Test\TestCase {
 			->willReturn($room);
 
 		$participant = $this->createMock(Participant::class);
-		$participant->expects($this->once())
-			->method('getSessionId')
-			->willReturn('0');
 
 		$room->expects($this->once())
 			->method('getParticipant')
@@ -262,9 +227,6 @@ class NotifierTest extends \Test\TestCase {
 			->willReturn($room);
 
 		$participant = $this->createMock(Participant::class);
-		$participant->expects($this->once())
-			->method('getSessionId')
-			->willReturn('0');
 
 		$room->expects($this->once())
 			->method('getParticipant')
@@ -305,9 +267,6 @@ class NotifierTest extends \Test\TestCase {
 			->willReturn($room);
 
 		$participant = $this->createMock(Participant::class);
-		$participant->expects($this->once())
-			->method('getSessionId')
-			->willReturn('0');
 
 		$room->expects($this->once())
 			->method('getParticipant')
@@ -348,9 +307,6 @@ class NotifierTest extends \Test\TestCase {
 			->willReturn($room);
 
 		$participant = $this->createMock(Participant::class);
-		$participant->expects($this->once())
-			->method('getSessionId')
-			->willReturn('0');
 
 		$room->expects($this->once())
 			->method('getParticipant')
@@ -466,9 +422,6 @@ class NotifierTest extends \Test\TestCase {
 			->willReturn($room);
 
 		$participant = $this->createMock(Participant::class);
-		$participant->expects($this->exactly(2))
-			->method('getSessionId')
-			->willReturn('0');
 
 		$room->expects($this->exactly(2))
 			->method('getParticipant')

--- a/tests/php/Chat/NotifierTest.php
+++ b/tests/php/Chat/NotifierTest.php
@@ -1,0 +1,249 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Tests\php\Chat;
+
+use OCA\Spreed\Chat\Notifier;
+use OCP\Comments\IComment;
+use OCP\Notification\IManager as INotificationManager;
+use OCP\Notification\INotification;
+use OCP\IUserManager;
+
+class NotifierTest extends \Test\TestCase {
+
+	/** @var \OCP\Notification\IManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $notificationManager;
+
+	/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $userManager;
+
+	/** @var \OCA\Spreed\Chat\Notifier */
+	protected $notifier;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->notificationManager = $this->createMock(INotificationManager::class);
+
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->userManager
+			->method('userExists')
+			->will($this->returnCallback(function($userId) {
+				if ($userId === 'unknownUser') {
+					return false;
+				}
+
+				return true;
+			}));
+
+		$this->notifier = new Notifier($this->notificationManager,
+									   $this->userManager);
+	}
+
+	private function newComment($id, $actorType, $actorId, $creationDateTime, $message) {
+		// $mentionMatches[0] contains the whole matches, while
+		// $mentionMatches[1] contains the matched subpattern.
+		$mentionMatches = [];
+		preg_match_all('/@([a-zA-Z0-9]+)/', $message, $mentionMatches);
+
+		$mentions = array_map(function($mentionMatch) {
+			return [ 'type' => 'user', 'id' => $mentionMatch ];
+		}, $mentionMatches[1]);
+
+		$comment = $this->createMock(IComment::class);
+
+		$comment->method('getId')->willReturn($id);
+		$comment->method('getActorType')->willReturn($actorType);
+		$comment->method('getActorId')->willReturn($actorId);
+		$comment->method('getCreationDateTime')->willReturn($creationDateTime);
+		$comment->method('getMessage')->willReturn($message);
+		$comment->method('getMentions')->willReturn($mentions);
+
+		return $comment;
+	}
+
+	private function newNotification($comment) {
+		$notification = $this->createMock(INotification::class);
+
+		$notification->expects($this->once())
+			->method('setApp')
+			->with('spreed')
+			->willReturnSelf();
+
+		$notification->expects($this->once())
+			->method('setObject')
+			->with('room', $comment->getObjectId())
+			->willReturnSelf();
+
+		$notification->expects($this->once())
+			->method('setSubject')
+			->with('mention', [
+				'userType' => $comment->getActorType(),
+				'userId' => $comment->getActorId(),
+			])
+			->willReturnSelf();
+
+		$notification->expects($this->once())
+			->method('setDateTime')
+			->with($comment->getCreationDateTime())
+			->willReturnSelf();
+
+		return $notification;
+	}
+
+	public function testNotifyMentionedUsers() {
+		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'Mention @anotherUser');
+
+		$notification = $this->newNotification($comment);
+
+		$this->notificationManager->expects($this->once())
+			->method('createNotification')
+			->willReturn($notification);
+
+		$notification->expects($this->once())
+			->method('setUser')
+			->with('anotherUser')
+			->willReturnSelf();
+
+		$this->notificationManager->expects($this->once())
+			->method('notify')
+			->with($notification);
+
+		$this->notifier->notifyMentionedUsers($comment);
+	}
+
+	public function testNotifyMentionedUsersByGuest() {
+		$comment = $this->newComment(108, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000016), 'Mention @anotherUser');
+
+		$notification = $this->newNotification($comment);
+
+		$this->notificationManager->expects($this->once())
+			->method('createNotification')
+			->willReturn($notification);
+
+		$notification->expects($this->once())
+			->method('setUser')
+			->with('anotherUser')
+			->willReturnSelf();
+
+		$this->notificationManager->expects($this->once())
+			->method('notify')
+			->with($notification);
+
+		$this->notifier->notifyMentionedUsers($comment);
+	}
+
+	public function testNotifyMentionedUsersToSelf() {
+		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'Mention @testUser');
+
+		$this->notificationManager->expects($this->never())
+			->method('createNotification');
+
+		$this->notificationManager->expects($this->never())
+			->method('notify');
+
+		$this->notifier->notifyMentionedUsers($comment);
+	}
+
+	public function testNotifyMentionedUsersToUnknownUser() {
+		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'Mention @unknownUser');
+
+		$this->notificationManager->expects($this->never())
+			->method('createNotification');
+
+		$this->notificationManager->expects($this->never())
+			->method('notify');
+
+		$this->notifier->notifyMentionedUsers($comment);
+	}
+
+	public function testNotifyMentionedUsersNoMentions() {
+		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'No mentions');
+
+		$this->notificationManager->expects($this->never())
+			->method('createNotification');
+
+		$this->notificationManager->expects($this->never())
+			->method('notify');
+
+		$this->notifier->notifyMentionedUsers($comment);
+	}
+
+	public function testNotifyMentionedUsersSeveralMentions() {
+		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'Mention @anotherUser, and @unknownUser, and @testUser, and @userAbleToJoin');
+
+		$anotherUserNotification = $this->newNotification($comment);
+		$userAbleToJoinNotification = $this->newNotification($comment);
+
+		$this->notificationManager->expects($this->exactly(2))
+			->method('createNotification')
+			->will($this->onConsecutiveCalls(
+				$anotherUserNotification,
+				$userAbleToJoinNotification
+			));
+
+		$anotherUserNotification->expects($this->once())
+			->method('setUser')
+			->with('anotherUser')
+			->willReturnSelf();
+
+		$userAbleToJoinNotification->expects($this->once())
+			->method('setUser')
+			->with('userAbleToJoin')
+			->willReturnSelf();
+
+		$this->notificationManager->expects($this->exactly(2))
+			->method('notify')
+			->withConsecutive(
+				[ $anotherUserNotification ],
+				[ $userAbleToJoinNotification ]
+			);
+
+		$this->notifier->notifyMentionedUsers($comment);
+	}
+
+	public function testRemovePendingNotificationsForRoom() {
+		$notification = $this->createMock(INotification::class);
+
+		$this->notificationManager->expects($this->once())
+			->method('createNotification')
+			->willReturn($notification);
+
+		$notification->expects($this->once())
+			->method('setApp')
+			->with('spreed')
+			->willReturnSelf();
+
+		$notification->expects($this->once())
+			->method('setObject')
+			->with('room', 'testChatId')
+			->willReturnSelf();
+
+		$this->notificationManager->expects($this->once())
+			->method('markProcessed')
+			->with($notification);
+
+		$this->notifier->removePendingNotificationsForRoom('testChatId');
+	}
+
+}

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -319,7 +319,7 @@ class ChatControllerTest extends \Test\TestCase {
 		$timestamp = 1000000000;
 		$this->chatManager->expects($this->once())
 			->method('receiveMessages')
-			->with('1234', $timeout, $offset, new \DateTime('@' . $timestamp))
+			->with('1234', $this->userId, $timeout, $offset, new \DateTime('@' . $timestamp))
 			->willReturn([
 				$this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
 				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
@@ -377,7 +377,7 @@ class ChatControllerTest extends \Test\TestCase {
 		$timestamp = 1000000000;
 		$this->chatManager->expects($this->once())
 			->method('receiveMessages')
-			->with('1234', $timeout, $offset, new \DateTime('@' . $timestamp))
+			->with('1234', $this->userId, $timeout, $offset, new \DateTime('@' . $timestamp))
 			->willReturn([
 				$this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
 				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
@@ -465,7 +465,7 @@ class ChatControllerTest extends \Test\TestCase {
 		$timestamp = 1000000000;
 		$this->chatManager->expects($this->once())
 			->method('receiveMessages')
-			->with('1234', $timeout, $offset, new \DateTime('@' . $timestamp))
+			->with('1234', null, $timeout, $offset, new \DateTime('@' . $timestamp))
 			->willReturn([
 				$this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
 				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
@@ -546,7 +546,7 @@ class ChatControllerTest extends \Test\TestCase {
 		$timestamp = 1000000000;
 		$this->chatManager->expects($this->once())
 			->method('receiveMessages')
-			->with('1234', $timeout, $offset, new \DateTime('@' . $timestamp))
+			->with('1234', $this->userId, $timeout, $offset, new \DateTime('@' . $timestamp))
 			->willReturn([]);
 
 		$response = $this->controller->receiveMessages('testToken', $offset, $timestamp, $timeout);
@@ -579,7 +579,7 @@ class ChatControllerTest extends \Test\TestCase {
 		$timestamp = 1000000000;
 		$this->chatManager->expects($this->once())
 			->method('receiveMessages')
-			->with('1234', $maximumTimeout, $offset, new \DateTime('@' . $timestamp))
+			->with('1234', $this->userId, $maximumTimeout, $offset, new \DateTime('@' . $timestamp))
 			->willReturn([]);
 
 		$response = $this->controller->receiveMessages('testToken', $offset, $timestamp, $timeout);

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -262,97 +262,104 @@ class NotifierTest extends \Test\TestCase {
 	public function dataPrepareMention() {
 		return [
 			[
-				Room::ONE_TO_ONE_CALL, ['userType' => 'users', 'userId' => 'testUser'],           'Test user', '',
+				Room::ONE_TO_ONE_CALL, ['userType' => 'users', 'userId' => 'testUser'],           ['ellipsisStart', 'ellipsisEnd'], 'Test user', '',
 				'Test user mentioned you in a private chat',
 				['{user} mentioned you in a private chat',
 					['user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user']]
-				]
+				],
+				'… message …'
 			],
 			// If the user is deleted in a one to one chat the chat is also
 			// deleted, and that in turn would delete the pending notification.
 			[
-				Room::GROUP_CALL,      ['userType' => 'users', 'userId' => 'testUser'],           'Test user', '',
+				Room::GROUP_CALL,      ['userType' => 'users', 'userId' => 'testUser'],           [], 'Test user', '',
 				'Test user mentioned you in a group chat',
 				['{user} mentioned you in a group chat',
 					['user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user']]
-				]
+				],
+				'message'
 			],
 			[
-				Room::GROUP_CALL,      ['userType' => 'users', 'userId' => 'testUser'],           null,        '',
+				Room::GROUP_CALL,      ['userType' => 'users', 'userId' => 'testUser'],           ['ellipsisStart'], null,        '',
 				'A (now) deleted user mentioned you in a group chat',
 				['A (now) deleted user mentioned you in a group chat',
 					[]
 				],
-				true
-			],
+				'… message',
+				true],
 			[
-				Room::GROUP_CALL,      ['userType' => 'users', 'userId' => 'testUser'],           'Test user', 'Room name',
+				Room::GROUP_CALL,      ['userType' => 'users', 'userId' => 'testUser'],           ['ellipsisEnd'], 'Test user', 'Room name',
 				'Test user mentioned you in a group chat: Room name',
 				['{user} mentioned you in a group chat: {call}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
 						'call' => ['type' => 'call', 'id' => 'testRoomId', 'name' => 'Room name', 'call-type' => 'group']
 					]
-				]
+				],
+				'message …'
 			],
 			[
-				Room::GROUP_CALL,      ['userType' => 'users', 'userId' => 'testUser'],           null,        'Room name',
+				Room::GROUP_CALL,      ['userType' => 'users', 'userId' => 'testUser'],           ['ellipsisStart', 'ellipsisEnd'], null,        'Room name',
 				'A (now) deleted user mentioned you in a group chat: Room name',
 				['A (now) deleted user mentioned you in a group chat: {call}',
 					[
 						'call' => ['type' => 'call', 'id' => 'testRoomId', 'name' => 'Room name', 'call-type' => 'group']
 					]
 				],
-				true
-			],
+				'… message …',
+				true],
 			[
-				Room::PUBLIC_CALL,     ['userType' => 'users', 'userId' => 'testUser'],           'Test user', '',
+				Room::PUBLIC_CALL,     ['userType' => 'users', 'userId' => 'testUser'],           [], 'Test user', '',
 				'Test user mentioned you in a group chat',
 				['{user} mentioned you in a group chat',
 					['user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user']]
-				]
+				],
+				'message'
 			],
 			[
-				Room::PUBLIC_CALL,     ['userType' => 'users', 'userId' => 'testUser'],           null,        '',
+				Room::PUBLIC_CALL,     ['userType' => 'users', 'userId' => 'testUser'],           ['ellipsisStart'], null,        '',
 				'A (now) deleted user mentioned you in a group chat',
 				['A (now) deleted user mentioned you in a group chat',
 					[]
 				],
-				true
-			],
+				'… message',
+				true],
 			[
-				Room::PUBLIC_CALL,     ['userType' => 'guests', 'userId' => 'testSpreedSession'], null,        '',
+				Room::PUBLIC_CALL,     ['userType' => 'guests', 'userId' => 'testSpreedSession'], ['ellipsisEnd'], null,        '',
 				'A guest mentioned you in a group chat',
 				['A guest mentioned you in a group chat',
 					[]
-				]
+				],
+				'message …'
 			],
 			[
-				Room::PUBLIC_CALL,     ['userType' => 'users', 'userId' => 'testUser'],           'Test user', 'Room name',
+				Room::PUBLIC_CALL,     ['userType' => 'users', 'userId' => 'testUser'],           ['ellipsisStart', 'ellipsisEnd'], 'Test user', 'Room name',
 				'Test user mentioned you in a group chat: Room name',
 				['{user} mentioned you in a group chat: {call}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
 						'call' => ['type' => 'call', 'id' => 'testRoomId', 'name' => 'Room name', 'call-type' => 'public']
 					]
-				]
+				],
+				'… message …'
 			],
 			[
-				Room::PUBLIC_CALL,     ['userType' => 'users', 'userId' => 'testUser'],           null,    'Room name',
+				Room::PUBLIC_CALL,     ['userType' => 'users', 'userId' => 'testUser'],           [], null,    'Room name',
 				'A (now) deleted user mentioned you in a group chat: Room name',
 				['A (now) deleted user mentioned you in a group chat: {call}',
 					[
 						'call' => ['type' => 'call', 'id' => 'testRoomId', 'name' => 'Room name', 'call-type' => 'public']
 					]
 				],
-				true
-			],
+				'message',
+				true],
 			[
-				Room::PUBLIC_CALL,     ['userType' => 'guests', 'userId' => 'testSpreedSession'], null,    'Room name',
+				Room::PUBLIC_CALL,     ['userType' => 'guests', 'userId' => 'testSpreedSession'], ['ellipsisStart', 'ellipsisEnd'], null,    'Room name',
 				'A guest mentioned you in a group chat: Room name',
 				['A guest mentioned you in a group chat: {call}',
 					['call' => ['type' => 'call', 'id' => 'testRoomId', 'name' => 'Room name', 'call-type' => 'public']]
-				]
+				],
+				'… message …'
 			]
 		];
 	}
@@ -361,16 +368,18 @@ class NotifierTest extends \Test\TestCase {
 	 * @dataProvider dataPrepareMention
 	 * @param int $roomType
 	 * @param array $subjectParameters
+	 * @param array $messageParameters
 	 * @param string $displayName
 	 * @param string $roomName
 	 * @param string $parsedSubject
 	 * @param array $richSubject
+	 * @param string $parsedMessage
 	 * @param bool $deletedUser
 	 */
-	public function testPrepareMention($roomType, $subjectParameters, $displayName, $roomName, $parsedSubject, $richSubject, $deletedUser = false) {
+	public function testPrepareMention($roomType, $subjectParameters, $messageParameters, $displayName, $roomName, $parsedSubject, $richSubject, $parsedMessage, $deletedUser = false) {
 		$notification = $this->createMock(INotification::class);
 		$l = $this->createMock(IL10N::class);
-		$l->expects($this->exactly(2))
+		$l->expects($this->atLeast(2))
 			->method('t')
 			->will($this->returnCallback(function($text, $parameters = []) {
 				return vsprintf($text, $parameters);
@@ -434,6 +443,10 @@ class NotifierTest extends \Test\TestCase {
 			->method('setRichSubject')
 			->with($richSubject[0], $richSubject[1])
 			->willReturnSelf();
+		$notification->expects($this->once())
+			->method('setParsedMessage')
+			->with($parsedMessage)
+			->willReturnSelf();
 
 		$notification->expects($this->once())
 			->method('getApp')
@@ -447,6 +460,12 @@ class NotifierTest extends \Test\TestCase {
 		$notification->expects($this->once())
 			->method('getObjectType')
 			->willReturn('room');
+		$notification->expects($this->once())
+			->method('getMessage')
+			->willReturn('message');
+		$notification->expects($this->once())
+			->method('getMessageParameters')
+			->willReturn($messageParameters);
 
 		$this->assertEquals($notification, $this->notifier->prepare($notification, 'de'));
 	}

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -259,6 +259,198 @@ class NotifierTest extends \Test\TestCase {
 		$this->notifier->prepare($n, 'de');
 	}
 
+	public function dataPrepareMention() {
+		return [
+			[
+				Room::ONE_TO_ONE_CALL, ['userType' => 'users', 'userId' => 'testUser'],           'Test user', '',
+				'Test user mentioned you in a private chat',
+				['{user} mentioned you in a private chat',
+					['user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user']]
+				]
+			],
+			// If the user is deleted in a one to one chat the chat is also
+			// deleted, and that in turn would delete the pending notification.
+			[
+				Room::GROUP_CALL,      ['userType' => 'users', 'userId' => 'testUser'],           'Test user', '',
+				'Test user mentioned you in a group chat',
+				['{user} mentioned you in a group chat',
+					['user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user']]
+				]
+			],
+			[
+				Room::GROUP_CALL,      ['userType' => 'users', 'userId' => 'testUser'],           null,        '',
+				'A (now) deleted user mentioned you in a group chat',
+				['A (now) deleted user mentioned you in a group chat',
+					[]
+				],
+				true
+			],
+			[
+				Room::GROUP_CALL,      ['userType' => 'users', 'userId' => 'testUser'],           'Test user', 'Room name',
+				'Test user mentioned you in a group chat: Room name',
+				['{user} mentioned you in a group chat: {call}',
+					[
+						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
+						'call' => ['type' => 'call', 'id' => 'testRoomId', 'name' => 'Room name', 'call-type' => 'group']
+					]
+				]
+			],
+			[
+				Room::GROUP_CALL,      ['userType' => 'users', 'userId' => 'testUser'],           null,        'Room name',
+				'A (now) deleted user mentioned you in a group chat: Room name',
+				['A (now) deleted user mentioned you in a group chat: {call}',
+					[
+						'call' => ['type' => 'call', 'id' => 'testRoomId', 'name' => 'Room name', 'call-type' => 'group']
+					]
+				],
+				true
+			],
+			[
+				Room::PUBLIC_CALL,     ['userType' => 'users', 'userId' => 'testUser'],           'Test user', '',
+				'Test user mentioned you in a group chat',
+				['{user} mentioned you in a group chat',
+					['user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user']]
+				]
+			],
+			[
+				Room::PUBLIC_CALL,     ['userType' => 'users', 'userId' => 'testUser'],           null,        '',
+				'A (now) deleted user mentioned you in a group chat',
+				['A (now) deleted user mentioned you in a group chat',
+					[]
+				],
+				true
+			],
+			[
+				Room::PUBLIC_CALL,     ['userType' => 'guests', 'userId' => 'testSpreedSession'], null,        '',
+				'A guest mentioned you in a group chat',
+				['A guest mentioned you in a group chat',
+					[]
+				]
+			],
+			[
+				Room::PUBLIC_CALL,     ['userType' => 'users', 'userId' => 'testUser'],           'Test user', 'Room name',
+				'Test user mentioned you in a group chat: Room name',
+				['{user} mentioned you in a group chat: {call}',
+					[
+						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
+						'call' => ['type' => 'call', 'id' => 'testRoomId', 'name' => 'Room name', 'call-type' => 'public']
+					]
+				]
+			],
+			[
+				Room::PUBLIC_CALL,     ['userType' => 'users', 'userId' => 'testUser'],           null,    'Room name',
+				'A (now) deleted user mentioned you in a group chat: Room name',
+				['A (now) deleted user mentioned you in a group chat: {call}',
+					[
+						'call' => ['type' => 'call', 'id' => 'testRoomId', 'name' => 'Room name', 'call-type' => 'public']
+					]
+				],
+				true
+			],
+			[
+				Room::PUBLIC_CALL,     ['userType' => 'guests', 'userId' => 'testSpreedSession'], null,    'Room name',
+				'A guest mentioned you in a group chat: Room name',
+				['A guest mentioned you in a group chat: {call}',
+					['call' => ['type' => 'call', 'id' => 'testRoomId', 'name' => 'Room name', 'call-type' => 'public']]
+				]
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider dataPrepareMention
+	 * @param int $roomType
+	 * @param array $subjectParameters
+	 * @param string $displayName
+	 * @param string $roomName
+	 * @param string $parsedSubject
+	 * @param array $richSubject
+	 * @param bool $deletedUser
+	 */
+	public function testPrepareMention($roomType, $subjectParameters, $displayName, $roomName, $parsedSubject, $richSubject, $deletedUser = false) {
+		$notification = $this->createMock(INotification::class);
+		$l = $this->createMock(IL10N::class);
+		$l->expects($this->exactly(2))
+			->method('t')
+			->will($this->returnCallback(function($text, $parameters = []) {
+				return vsprintf($text, $parameters);
+			}));
+
+		$room = $this->createMock(Room::class);
+		$room->expects($this->atLeastOnce())
+			->method('getType')
+			->willReturn($roomType);
+		$room->expects($this->atLeastOnce())
+			->method('getName')
+			->willReturn($roomName);
+		if ($roomName !== '') {
+			$room->expects($this->atLeastOnce())
+				->method('getId')
+				->willReturn('testRoomId');
+		}
+		$this->manager->expects($this->once())
+			->method('getRoomById')
+			->willReturn($room);
+
+		$this->lFactory->expects($this->once())
+			->method('get')
+			->with('spreed', 'de')
+			->willReturn($l);
+
+		$user = $this->createMock(IUser::class);
+		if ($subjectParameters['userType'] === 'users' && !$deletedUser) {
+			$user->expects($this->exactly(2))
+				->method('getDisplayName')
+				->willReturn($displayName);
+			$this->userManager->expects($this->once())
+				->method('get')
+				->with($subjectParameters['userId'])
+				->willReturn($user);
+		} else if ($subjectParameters['userType'] === 'users' && $deletedUser) {
+			$user->expects($this->never())
+				->method('getDisplayName');
+			$this->userManager->expects($this->once())
+				->method('get')
+				->with($subjectParameters['userId'])
+				->willReturn(null);
+		} else {
+			$user->expects($this->never())
+				->method('getDisplayName');
+			$this->userManager->expects($this->never())
+				->method('get');
+		}
+
+		$notification->expects($this->once())
+			->method('setIcon')
+			->willReturnSelf();
+		$notification->expects($this->once())
+			->method('setLink')
+			->willReturnSelf();
+		$notification->expects($this->once())
+			->method('setParsedSubject')
+			->with($parsedSubject)
+			->willReturnSelf();
+		$notification->expects($this->once())
+			->method('setRichSubject')
+			->with($richSubject[0], $richSubject[1])
+			->willReturnSelf();
+
+		$notification->expects($this->once())
+			->method('getApp')
+			->willReturn('spreed');
+		$notification->expects($this->once())
+			->method('getSubject')
+			->willReturn('mention');
+		$notification->expects($this->once())
+			->method('getSubjectParameters')
+			->willReturn($subjectParameters);
+		$notification->expects($this->once())
+			->method('getObjectType')
+			->willReturn('room');
+
+		$this->assertEquals($notification, $this->notifier->prepare($notification, 'de'));
+	}
+
 	public function dataPrepareThrows() {
 		return [
 			['Incorrect app', 'invalid-app', null, null, null, null],
@@ -266,6 +458,7 @@ class NotifierTest extends \Test\TestCase {
 			['Unknown subject', 'spreed', true, 'invalid-subject', null, null],
 			['Unknown object type', 'spreed', true, 'invitation', null, 'invalid-object-type'],
 			['Calling user does not exist anymore', 'spreed', true, 'invitation', ['admin'], 'room'],
+			['Unknown object type', 'spreed', true, 'mention', null, 'invalid-object-type'],
 		];
 	}
 


### PR DESCRIPTION
This pull request adds notifications for users mentioned in a chat; the notification links to the Talk room, and includes an ellipsized version of the original message centered around the mention (as the length of the notification message can be at most 64 bytes).

The rich subject of the notifications use `call` instead of `room` or `chat` due to `call` being already available in [lib/public/RichObjectStrings/Definitions.php](https://github.com/nextcloud/server/blob/a089e084116e88b3cad35b2f3a294445d78d8a3d/lib/public/RichObjectStrings/Definitions.php#L155) (in Nextcloud server). Unlike with the current code for invitation notifications, no checks are made on whether `call` is available or not, as the chat will be available only from Nextcloud 13 and onwards (I think so :-P ).

A mentioned user is notified only if she is able to participate in the room in which she was mentioned, that is, if she is already a participant of the room if the message was written in a private chat (a one to one chat, a group chat, or a password protected public chat), or in any case if the message was written in a public chat. When a room is deleted all the pending notifications for that room are also removed.

**Still missing** is not sending a notification to a user when she is mentioned in the chat room in which she is currently active. It is related to #459, but I will need some guidance here @nickvergessen @ivansss (and if you want to implement it yourselves please feel free to do it ;-) ).

Finally, **there are no integration tests yet**, although they can be added at a later time.
