### PR TITLE
Add basic frontend for chat

### DIFF
--- a/css/comments.css
+++ b/css/comments.css
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2016
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+#commentsTabView .emptycontent {
+	margin-top: 0;
+}
+
+#commentsTabView .newCommentForm {
+	position: relative;
+	margin-bottom: 20px;
+}
+
+#commentsTabView .newCommentForm .message {
+	width: calc(100% - 81px); /* 36 (left margin) + 30 (right padding) + 15 (right padding of surrounding box) */
+	margin-left: 36px;
+	padding-right: 30px;
+	display: block;
+}
+
+#commentsTabView .newCommentForm .submit {
+	position: absolute;
+	bottom: 0px;
+	right: 8px;
+	width: 30px;
+	margin: 0;
+	padding: 7px 9px;
+	background-color: transparent;
+	border: none;
+	opacity: .3;
+}
+#commentsTabView .newCommentForm .submit:hover,
+#commentsTabView .newCommentForm .submit:focus {
+	opacity: 1;
+}
+
+#commentsTabView .newCommentForm .submitLoading {
+	background-position: left;
+}
+
+#commentsTabView .newCommentForm .cancel {
+	margin-right: 6px;
+}
+
+#commentsTabView .newCommentForm div.message {
+	resize: none;
+}
+
+#commentsTabView .newCommentForm div.message:empty:before {
+	content: attr(data-placeholder);
+	color: grey;
+}
+
+#commentsTabView .comment {
+	position: relative;
+	margin-bottom: 30px;
+}
+
+#commentsTabView .comment .avatar,
+.atwho-view-ul * .avatar{
+	width: 32px;
+	height: 32px;
+	line-height: 32px;
+}
+
+#commentsTabView .comment .message .avatar,
+.atwho-view-ul * .avatar
+{
+	display: inline-block;
+}
+
+#activityTabView li.comment.collapsed .activitymessage,
+#commentsTabView .comment.collapsed .message {
+	white-space: pre-wrap;
+}
+
+#activityTabView li.comment.collapsed .activitymessage,
+#commentsTabView .comment.collapsed .message {
+	max-height: 70px;
+	overflow: hidden;
+}
+
+#activityTabView li.comment .message-overlay,
+#commentsTabView .comment .message-overlay {
+	display: none;
+}
+
+#activityTabView li.comment.collapsed .message-overlay,
+#commentsTabView .comment.collapsed .message-overlay {
+	display: block;
+	position: absolute;
+	z-index: 2;
+	height: 50px;
+	pointer-events: none;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: -moz-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
+	background: -webkit-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
+	background: -o-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
+	background: -ms-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
+	background: linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
+	filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr='#00FFFFFF', endColorstr='#FFFFFFFF');
+	background-repeat: no-repeat;
+}
+
+#commentsTabView .authorRow>div {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+#commentsTabView .authorRow>div.hidden {
+	display: none !important;
+}
+
+#commentsTabView .comments li .message .avatar-name-wrapper,
+.atwho-view-ul * .avatar-name-wrapper,
+#commentsTabView .comment .authorRow {
+	position: relative;
+	cursor: pointer;
+}
+
+.atwho-view-ul * .avatar-name-wrapper {
+	white-space: nowrap;
+}
+
+#commentsTabView .comment .author,
+#commentsTabView .comment .date {
+	opacity: .5;
+}
+#commentsTabView .comment .author {
+	margin-left: 5px;
+}
+#commentsTabView .comment .date {
+	position: absolute;
+	right: 0;
+	top: 5px;
+}
+
+#commentsTabView .comments li .message {
+	padding-left: 40px;
+}
+
+#commentsTabView .comment .action {
+	opacity: 0;
+	vertical-align: middle;
+	display: inline-block;
+}
+
+#commentsTabView .comment:hover .action {
+	opacity: 0.3;
+}
+
+#commentsTabView .comment .action:hover {
+	opacity: 1;
+}
+
+#commentsTabView .comment .action.delete {
+	position: absolute;
+	right: 0;
+}
+
+#commentsTabView .comment.disabled {
+	opacity: 0.3;
+}
+
+#commentsTabView .comment.disabled .action {
+	visibility: hidden;
+}
+
+#commentsTabView .message.error {
+	color: #e9322d;
+	border-color: #e9322d;
+	box-shadow: 0 0 6px #f8b9b7;
+}
+
+.app-files .action-comment {
+	padding: 16px 14px;
+}

--- a/css/comments.css
+++ b/css/comments.css
@@ -123,7 +123,6 @@
 .atwho-view-ul * .avatar-name-wrapper,
 #commentsTabView .comment .authorRow {
 	position: relative;
-	cursor: pointer;
 }
 
 .atwho-view-ul * .avatar-name-wrapper {

--- a/js/app.js
+++ b/js/app.js
@@ -391,6 +391,9 @@
 				guestNameModel: this._localStorageModel
 			});
 			this._sidebarView.setCallInfoView(callInfoView);
+
+			this._messageCollection.setRoomToken(this.activeRoom.get('token'));
+			this._messageCollection.receiveMessages();
 		},
 		setPageTitle: function(title){
 			if (title) {
@@ -470,6 +473,19 @@
 
 			this._sidebarView.listenTo(roomChannel, 'leaveCurrentCall', function() {
 				this.disable();
+			});
+
+			this._messageCollection = new OCA.SpreedMe.Models.ChatMessageCollection(null, {token: null});
+			this._chatView = new OCA.SpreedMe.Views.ChatView({
+				collection: this._messageCollection,
+				id: 'commentsTabView',
+				className: 'chat tab'
+			});
+
+			this._sidebarView.addTab('chat', { label: t('spreed', 'Chat') }, this._chatView);
+
+			this._messageCollection.listenTo(roomChannel, 'leaveCurrentCall', function() {
+				this.stopReceivingMessages();
 			});
 
 			$(document).on('click', this.onDocumentClick);

--- a/js/models/chatmessage.js
+++ b/js/models/chatmessage.js
@@ -1,0 +1,81 @@
+/* global Backbone, OC, OCA */
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+(function(OCA, OC, Backbone) {
+	'use strict';
+
+	OCA.SpreedMe = OCA.SpreedMe || {};
+	OCA.SpreedMe.Models = OCA.SpreedMe.Models || {};
+
+	/**
+	 * Model for chat messages.
+	 *
+	 * ChatMessage can be used as the model of a ChatMessageCollection or as a
+	 * standalone model. When used as a standalone model the room token must be
+	 * provided in the constructor options (as "token").
+	 *
+	 * In any case, "create" is the only synchronization method allowed; chat
+	 * messages can not be edited nor deleted, and they can not be got
+	 * individually either, but as a list through ChatMessageCollection.
+	 *
+	 * To send a new message create a standalone ChatMessage object and call
+	 * "save".
+	 */
+	var ChatMessage = Backbone.Model.extend({
+
+		defaults: {
+			actorType: '',
+			actorId: '',
+			actorDisplayName: '',
+			timestamp: 0,
+			message: ''
+		},
+
+		url: function() {
+			if (this.token === undefined) {
+				throw 'Missing parameter token';
+			}
+
+			return OC.linkToOCS('apps/spreed/api/v1/chat', 2) + this.token;
+		},
+
+		initialize: function(options) {
+			// Only needed in standalone mode; when used as the model of a
+			// ChatMessageCollection the synchronization is performed by the
+			// collection instead.
+			this.token = options.token;
+		},
+
+		sync: function(method, model, options) {
+			if (method !== 'create') {
+				throw 'Synchronization method not supported by ChatMessage: ' + method;
+			}
+
+			return Backbone.Model.prototype.sync.call(this, method, model, options);
+		}
+
+	});
+
+	OCA.SpreedMe.Models.ChatMessage = ChatMessage;
+
+})(OCA, OC, Backbone);

--- a/js/models/chatmessagecollection.js
+++ b/js/models/chatmessagecollection.js
@@ -41,7 +41,8 @@
 	 * To get the messages from the server "receiveMessages" should be used. It
 	 * will enable polling to the server and automatically update the collection
 	 * when new messages are received. Once enabled, the polling will go on
-	 * indefinitely.
+	 * indefinitely. Due to this "stopReceivingMessages" must be called once
+	 * the ChatMessageCollection is no longer needed.
 	 */
 	var ChatMessageCollection = Backbone.Collection.extend({
 
@@ -96,6 +97,8 @@
 		},
 
 		receiveMessages: function() {
+			this.receiveMessagesAgain = true;
+
 			this.fetch({
 				data: {
 					// The notOlderThan parameter could be used to limit the
@@ -118,14 +121,22 @@
 			});
 		},
 
+		stopReceivingMessages: function() {
+			this.receiveMessagesAgain = false;
+		},
+
 		_successfulFetch: function(collection, response) {
 			this.offset += response.ocs.data.length;
 
-			this.receiveMessages();
+			if (this.receiveMessagesAgain) {
+				this.receiveMessages();
+			}
 		},
 
 		_failedFetch: function() {
-			this.receiveMessages();
+			if (this.receiveMessagesAgain) {
+				this.receiveMessages();
+			}
 		}
 
 	});

--- a/js/models/chatmessagecollection.js
+++ b/js/models/chatmessagecollection.js
@@ -58,6 +58,8 @@
 			this.url = OC.linkToOCS('apps/spreed/api/v1/chat', 2) + this.token;
 
 			this.offset = 0;
+
+			this._waitTimeUntilRetry = 1;
 		},
 
 		parse: function(result) {
@@ -128,6 +130,8 @@
 		_successfulFetch: function(collection, response) {
 			this.offset += response.ocs.data.length;
 
+			this._waitTimeUntilRetry = 1;
+
 			if (this.receiveMessagesAgain) {
 				this.receiveMessages();
 			}
@@ -135,7 +139,12 @@
 
 		_failedFetch: function() {
 			if (this.receiveMessagesAgain) {
-				this.receiveMessages();
+				_.delay(_.bind(this.receiveMessages, this), this._waitTimeUntilRetry * 1000);
+
+				// Increase the wait time until retry to at most 64 seconds.
+				if (this._waitTimeUntilRetry < 64) {
+					this._waitTimeUntilRetry *= 2;
+				}
 			}
 		}
 

--- a/js/models/chatmessagecollection.js
+++ b/js/models/chatmessagecollection.js
@@ -1,0 +1,63 @@
+/* global Backbone, OC, OCA */
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+(function(OCA, OC, Backbone) {
+	'use strict';
+
+	OCA.SpreedMe = OCA.SpreedMe || {};
+	OCA.SpreedMe.Models = OCA.SpreedMe.Models || {};
+
+	/**
+	 * Collection for chat messages.
+	 *
+	 * The ChatMessageCollection gives read access to all the chat messages from
+	 * a specific chat room. The room token must be provided in the constructor
+	 * options (as "token").
+	 *
+	 * "read" is the only synchronization method allowed; chat messages can not
+	 * be edited nor deleted, and to send a new message a standalone ChatMessage
+	 * should be used instead.
+	 */
+	var ChatMessageCollection = Backbone.Collection.extend({
+
+		model: OCA.SpreedMe.Models.ChatMessage,
+
+		initialize: function(models, options) {
+			if (options.token === undefined) {
+				throw 'Missing parameter token';
+			}
+
+			this.token = options.token;
+
+			this.url = OC.linkToOCS('apps/spreed/api/v1/chat', 2) + this.token;
+		},
+
+		parse: function(result) {
+			return result.ocs.data;
+		}
+
+	});
+
+	OCA.SpreedMe.Models.ChatMessageCollection = ChatMessageCollection;
+
+})(OCA, OC, Backbone);

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -1,0 +1,268 @@
+/* global autosize, Backbone, Handlebars, OC, OCA */
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+(function(OCA, OC, Backbone, Handlebars, autosize) {
+	'use strict';
+
+	OCA.SpreedMe = OCA.SpreedMe || {};
+	OCA.SpreedMe.Views = OCA.SpreedMe.Views || {};
+
+	var TEMPLATE =
+		'<ul class="comments">' +
+		'</ul>' +
+		'<div class="emptycontent"><div class="icon-comment"></div>' +
+		'<p>{{emptyResultLabel}}</p></div>' +
+		'<div class="loading hidden" style="height: 50px"></div>';
+
+	var ADD_COMMENT_TEMPLATE =
+		'<div class="newCommentRow comment" data-id="{{id}}">' +
+		'    <div class="authorRow">' +
+		'        <div class="avatar" data-username="{{actorId}}"></div>' +
+		'        <div class="author">{{actorDisplayName}}</div>' +
+		'    </div>' +
+		'    <form class="newCommentForm">' +
+		'        <div contentEditable="true" class="message" data-placeholder="{{newMessagePlaceholder}}">{{message}}</div>' +
+		'        <input class="submit icon-confirm" type="submit" value="" />' +
+		'        <div class="submitLoading icon-loading-small hidden"></div>'+
+		'    </form>' +
+		'</div>';
+
+	var COMMENT_TEMPLATE =
+		'<li class="comment" data-id="{{id}}">' +
+		'    <div class="authorRow">' +
+		'        <div class="avatar" {{#if actorId}}data-username="{{actorId}}"{{/if}}> </div>' +
+		'        <div class="author">{{actorDisplayName}}</div>' +
+		'        <div class="date has-tooltip live-relative-timestamp" data-timestamp="{{timestamp}}" title="{{altDate}}">{{date}}</div>' +
+		'    </div>' +
+		'    <div class="message">{{{formattedMessage}}}</div>' +
+		'</li>';
+
+	var ChatView = Backbone.View.extend({
+
+		events: {
+			'submit .newCommentForm': '_onSubmitComment',
+		},
+
+		initialize: function() {
+			this.listenTo(this.collection, 'reset', this.render);
+			this.listenTo(this.collection, 'add', this._onAddModel);
+		},
+
+		template: function(params) {
+			if (!this._template) {
+				this._template = Handlebars.compile(TEMPLATE);
+			}
+			return this._template(params);
+		},
+
+		addCommentTemplate: function(params) {
+			if (!this._addCommentTemplate) {
+				this._addCommentTemplate = Handlebars.compile(ADD_COMMENT_TEMPLATE);
+			}
+			// FIXME handle guest users
+			var currentUser = OC.getCurrentUser();
+			return this._addCommentTemplate(_.extend({
+				actorId: currentUser.uid,
+				actorDisplayName: currentUser.displayName,
+				newMessagePlaceholder: t('spreed', 'New message…'),
+				submitText: t('spreed', 'Send')
+			}, params));
+		},
+
+		commentTemplate: function(params) {
+			if (!this._commentTemplate) {
+				this._commentTemplate = Handlebars.compile(COMMENT_TEMPLATE);
+			}
+			return this._commentTemplate(params);
+		},
+
+		render: function() {
+			this.$el.html(this.template({
+				emptyResultLabel: t('spreed', 'No messages yet, start the conversation!')
+			}));
+			this.$el.find('.comments').before(this.addCommentTemplate({}));
+			this.$el.find('.has-tooltip').tooltip();
+			this.$container = this.$el.find('ul.comments');
+			// FIXME handle guest users
+			this.$el.find('.avatar').avatar(OC.getCurrentUser().uid, 32);
+			this.delegateEvents();
+			this.$el.find('.message').on('keydown input change', this._onTypeComment);
+
+			autosize(this.$el.find('.newCommentRow .message'));
+
+			return this;
+		},
+
+		_formatItem: function(commentModel) {
+			// PHP timestamp is second-based; JavaScript timestamp is
+			// millisecond based.
+			var timestamp = commentModel.get('timestamp') * 1000;
+
+			var actorDisplayName = commentModel.get('actorDisplayName');
+			if (commentModel.attributes.actorType === 'guests') {
+				// FIXME get guest name from WebRTC or something like that
+				actorDisplayName = 'Guest';
+			}
+			if (actorDisplayName == null) {
+				actorDisplayName = t('spreed', '[Unknown user name]');
+			}
+
+			var data = _.extend({}, commentModel.attributes, {
+				actorDisplayName: actorDisplayName,
+				timestamp: timestamp,
+				date: OC.Util.relativeModifiedDate(timestamp),
+				altDate: OC.Util.formatDate(timestamp, 'LL LTS'),
+				formattedMessage: escapeHTML(commentModel.get('message')).replace(/\n/g, '<br/>')
+			});
+			return data;
+		},
+
+		_onAddModel: function(model, collection, options) {
+			this.$el.find('.emptycontent').toggleClass('hidden', true);
+
+			var $el = $(this.commentTemplate(this._formatItem(model)));
+			if (!_.isUndefined(options.at) && collection.length > 1) {
+				this.$container.find('li').eq(options.at).before($el);
+			} else {
+				this.$container.prepend($el);
+			}
+
+			this._postRenderItem($el);
+		},
+
+		_postRenderItem: function($el) {
+			$el.find('.has-tooltip').tooltip();
+			$el.find('.avatar').each(function() {
+				var $this = $(this);
+				$this.avatar($this.attr('data-username'), 32);
+			});
+
+			// FIXME do not show contacts menu for guest users
+			var username = $el.find('.avatar').data('username');
+			if (username !== oc_current_user) {
+				$el.find('.authorRow .avatar, .authorRow .author').contactsMenu(
+					username, 0, $el.find('.authorRow'));
+			}
+
+			var $message = $el.find('.message');
+			this._postRenderMessage($message);
+		},
+
+		_postRenderMessage: function($el) {
+			$el.find('.avatar').each(function() {
+				var avatar = $(this);
+				var strong = $(this).next();
+				var appendTo = $(this).parent();
+
+				$.merge(avatar, strong).contactsMenu(avatar.data('user'), 0, appendTo);
+			});
+		},
+
+		_onTypeComment: function(ev) {
+			var $field = $(ev.target);
+			var $submitButton = $field.data('submitButtonEl');
+			if (!$submitButton) {
+				$submitButton = $field.closest('form').find('.submit');
+				$field.data('submitButtonEl', $submitButton);
+			}
+
+			//submits form on ctrl+Enter or cmd+Enter
+			if (ev.keyCode === 13 && (ev.ctrlKey || ev.metaKey)) {
+				$submitButton.click();
+			}
+		},
+
+		_commentBodyHTML2Plain: function($el) {
+			var $comment = $el.clone();
+
+			var oldHtml;
+			var html = $comment.html();
+			do {
+				// replace works one by one
+				oldHtml = html;
+				html = oldHtml.replace("<br>", "\n");	// preserve line breaks
+				console.warn(html);
+			} while(oldHtml !== html);
+			$comment.html(html);
+
+			return $comment.text();
+		},
+
+		_onSubmitComment: function(e) {
+			var self = this;
+			var $form = $(e.target);
+			var comment = null;
+			var $submit = $form.find('.submit');
+			var $loading = $form.find('.submitLoading');
+			var $commentField = $form.find('.message');
+			var message = $commentField.text().trim();
+
+			if (!message.length) {
+				return false;
+			}
+
+			$commentField.prop('disabled', true);
+			$submit.addClass('hidden');
+			$loading.removeClass('hidden');
+
+			message = this._commentBodyHTML2Plain($commentField);
+
+			comment = new OCA.SpreedMe.Models.ChatMessage({
+				token: this.collection.token,
+				message: message
+			});
+			comment.save({}, {
+				success: function(model) {
+					self._onSubmitSuccess(model, $form);
+				},
+				error: function() {
+					self._onSubmitError($form);
+				}
+			});
+
+			return false;
+		},
+
+		_onSubmitSuccess: function(model, $form) {
+			$form.find('.submit').removeClass('hidden');
+			$form.find('.submitLoading').addClass('hidden');
+			$form.find('.message').text('').prop('disabled', false);
+
+			// The new message does not need to be explicitly added to the list
+			// of messages; it will be automatically fetched from the server
+			// thanks to the auto-refresh of the list.
+		},
+
+		_onSubmitError: function($form) {
+			$form.find('.submit').removeClass('hidden');
+			$form.find('.submitLoading').addClass('hidden');
+			$form.find('.message').prop('disabled', false);
+
+			OC.Notification.show(t('spreed', 'Error occurred while sending message'), {type: 'error'});
+		},
+
+	});
+
+	OCA.SpreedMe.Views.ChatView = ChatView;
+
+})(OCA, OC, Backbone, Handlebars, autosize);

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -6,16 +6,20 @@ vendor_script('select2/select2');
 vendor_style('select2/select2');
 
 style('spreed', 'style');
+style('spreed', 'comments');
 script(
 	'spreed',
 	[
 		'vendor/backbone/backbone-min',
 		'vendor/backbone.radio/build/backbone.radio.min',
 		'vendor/backbone.marionette/lib/backbone.marionette.min',
+		'models/chatmessage',
+		'models/chatmessagecollection',
 		'models/localstoragemodel',
 		'models/room',
 		'models/roomcollection',
 		'views/callinfoview',
+		'views/chatview',
 		'views/editabletextlabel',
 		'views/roomlistview',
 		'views/sidebarview',

--- a/templates/index.php
+++ b/templates/index.php
@@ -6,17 +6,21 @@ vendor_script('select2/select2');
 vendor_style('select2/select2');
 
 style('spreed', 'style');
+style('spreed', 'comments');
 script(
 	'spreed',
 	[
 		'vendor/backbone/backbone-min',
 		'vendor/backbone.radio/build/backbone.radio.min',
 		'vendor/backbone.marionette/lib/backbone.marionette.min',
+		'models/chatmessage',
+		'models/chatmessagecollection',
 		'models/room',
 		'models/roomcollection',
 		'models/participant',
 		'models/participantcollection',
 		'views/callinfoview',
+		'views/chatview',
 		'views/editabletextlabel',
 		'views/participantlistview',
 		'views/participantview',


### PR DESCRIPTION
This pull request adds a basic web frontend for the chat to the right sidebar. The UI is based on the Comments app, although without some of its more advanced features like mentions or autocompletion.

The CSS file is a direct copy of the CSS file from the Comments app; in the future it could be worth extracting the common parts between the Comments app and Nextcloud Talk, but for now... A copy is fine ;-)

The ChatView has some minor problems with the avatars of guest users; they should be addressed in a future pull request.
