### PR TITLE
Trigger "usersLeft" event for remaining users when leaving room.

### DIFF
--- a/js/signaling.js
+++ b/js/signaling.js
@@ -719,6 +719,11 @@
 			}
 		}, function(data) {
 			console.log("Left", data);
+			// Any users we previously had in the room also "left" for us.
+			var leftUsers = _.keys(this.joinedUsers);
+			if (leftUsers.length) {
+				this._trigger("usersLeft", [leftUsers]);
+			}
 			this.joinedUsers = {};
 			this.currentCallToken = null;
 		}.bind(this));


### PR DESCRIPTION
This fixes a UI issue with the standalone signaling where the interface didn't switch back to the "Looking good" view when leaving a room.
