### PR TITLE
Fix split "being in a room" from "calling"

### DIFF
--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -145,22 +145,27 @@ class CallController extends OCSController {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
-		if ($this->userId !== null) {
+		if ($this->userId === null) {
 			if (!$this->session->exists('spreed-session')) {
 				return new DataResponse([], Http::STATUS_NOT_FOUND);
 			}
-			$sessionId = $this->session->get('spreed-session');
+
+			try {
+				$participant = $room->getParticipantBySession($this->session->get('spreed-session'));
+			} catch (ParticipantNotFoundException $e) {
+				return new DataResponse([], Http::STATUS_NOT_FOUND);
+			}
 		} else {
 			try {
 				$participant = $room->getParticipant($this->userId);
 			} catch (ParticipantNotFoundException $e) {
 				return new DataResponse([], Http::STATUS_NOT_FOUND);
 			}
+		}
 
-			$sessionId = $participant->getSessionId();
-			if ($sessionId === '0') {
-				return new DataResponse([], Http::STATUS_NOT_FOUND);
-			}
+		$sessionId = $participant->getSessionId();
+		if ($sessionId === '0') {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
 		$room->changeInCall($sessionId, true);
@@ -205,22 +210,27 @@ class CallController extends OCSController {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
-		if ($this->userId !== null) {
+		if ($this->userId === null) {
 			if (!$this->session->exists('spreed-session')) {
 				return new DataResponse();
 			}
-			$sessionId = $this->session->get('spreed-session');
+
+			try {
+				$participant = $room->getParticipantBySession($this->session->get('spreed-session'));
+			} catch (ParticipantNotFoundException $e) {
+				return new DataResponse([], Http::STATUS_NOT_FOUND);
+			}
 		} else {
 			try {
 				$participant = $room->getParticipant($this->userId);
 			} catch (ParticipantNotFoundException $e) {
 				return new DataResponse([], Http::STATUS_NOT_FOUND);
 			}
+		}
 
-			$sessionId = $participant->getSessionId();
-			if ($sessionId === '0') {
-				return new DataResponse([], Http::STATUS_NOT_FOUND);
-			}
+		$sessionId = $participant->getSessionId();
+		if ($sessionId === '0') {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
 		$room->changeInCall($sessionId, false);

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -120,6 +120,11 @@ class CallController extends OCSController {
 		}
 
 		foreach ($participants['guests'] as $data) {
+			if (!$data['inCall']) {
+				// User is not active in call
+				continue;
+			}
+
 			$result[] = [
 				'userId' => '',
 				'token' => $token,

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -202,7 +202,7 @@ class Room {
 	 * @throws ParticipantNotFoundException When the user is not a participant
 	 */
 	public function getParticipantBySession($sessionId) {
-		if (!is_string($sessionId) || $sessionId === '') {
+		if (!is_string($sessionId) || $sessionId === '' || $sessionId === '0') {
 			throw new ParticipantNotFoundException('Not a user');
 		}
 

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -164,6 +164,32 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" joins room "([^"]*)" with (\d+)$/
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 * @param string $statusCode
+	 * @param TableNode|null $formData
+	 */
+	public function userJoinsRoom($user, $identifier, $statusCode, TableNode $formData = null) {
+		$this->setCurrentUser($user);
+		$this->sendRequest(
+			'POST', '/apps/spreed/api/v1/room/' . self::$identifierToToken[$identifier] . '/participants/active',
+			$formData
+		);
+		$this->assertStatusCode($this->response, $statusCode);
+
+		$response = $this->getDataFromResponse($this->response);
+		if (array_key_exists('sessionId', $response)) {
+			// In the chat guest users are identified by their sessionId. The
+			// sessionId is larger than the size of the actorId column in the
+			// database, though, so the ID stored in the database and returned
+			// in chat messages is a hashed version instead.
+			self::$sessionIdToUser[sha1($response['sessionId'])] = $user;
+		}
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" leaves room "([^"]*)" with (\d+)$/
 	 *
 	 * @param string $user

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -190,6 +190,19 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" exits room "([^"]*)" with (\d+)$/
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 * @param string $statusCode
+	 */
+	public function userExitsRoom($user, $identifier, $statusCode) {
+		$this->setCurrentUser($user);
+		$this->sendRequest('DELETE', '/apps/spreed/api/v1/room/' . self::$identifierToToken[$identifier] . '/participants/active');
+		$this->assertStatusCode($this->response, $statusCode);
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" leaves room "([^"]*)" with (\d+)$/
 	 *
 	 * @param string $user

--- a/tests/integration/features/callapi/group.feature
+++ b/tests/integration/features/callapi/group.feature
@@ -19,7 +19,13 @@ Feature: callapi/group
     And user "participant2" is participant of room "room"
     Then user "participant1" sees 0 peers in call "room" with 200
     And user "participant2" sees 0 peers in call "room" with 200
+    Then user "participant1" joins room "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant2" sees 0 peers in call "room" with 200
     Then user "participant1" joins call "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant2" sees 1 peers in call "room" with 200
+    Then user "participant2" joins room "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant2" sees 1 peers in call "room" with 200
     And user "participant2" joins call "room" with 200
@@ -30,7 +36,13 @@ Feature: callapi/group
     Then user "participant1" leaves call "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant2" sees 1 peers in call "room" with 200
+    Then user "participant1" exits room "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant2" sees 1 peers in call "room" with 200
     Then user "participant2" leaves call "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant2" sees 0 peers in call "room" with 200
+    Then user "participant2" exits room "room" with 200
     Then user "participant1" sees 0 peers in call "room" with 200
     And user "participant2" sees 0 peers in call "room" with 200
 
@@ -41,7 +53,13 @@ Feature: callapi/group
     Then user "participant1" is participant of room "room"
     Then user "participant3" is not participant of room "room"
     And user "participant3" sees 0 peers in call "room" with 404
+    Then user "participant1" joins room "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant2" sees 0 peers in call "room" with 200
     Then user "participant1" joins call "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant3" sees 0 peers in call "room" with 404
+    And user "participant3" joins room "room" with 404
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
     And user "participant3" joins call "room" with 404
@@ -50,7 +68,10 @@ Feature: callapi/group
     And user "participant3" pings call "room" with 404
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
-    Then user "participant3" leaves call "room" with 200
+    Then user "participant3" leaves call "room" with 404
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant3" sees 0 peers in call "room" with 404
+    Then user "participant3" exits room "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
     Then user "participant1" leaves call "room" with 200
@@ -63,7 +84,11 @@ Feature: callapi/group
       | invite   | attendees1 |
     Then user "participant1" is participant of room "room"
     And user "guest" sees 0 peers in call "room" with 404
+    Then user "participant1" joins room "room" with 200
     Then user "participant1" joins call "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "guest" sees 0 peers in call "room" with 404
+    And user "guest" joins room "room" with 404
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404
     And user "guest" joins call "room" with 404
@@ -72,7 +97,10 @@ Feature: callapi/group
     And user "guest" pings call "room" with 404
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404
-    Then user "guest" leaves call "room" with 200
+    Then user "guest" leaves call "room" with 404
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "guest" sees 0 peers in call "room" with 404
+    Then user "guest" exits room "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404
     Then user "participant1" leaves call "room" with 200

--- a/tests/integration/features/callapi/one-to-one.feature
+++ b/tests/integration/features/callapi/one-to-one.feature
@@ -17,7 +17,13 @@ Feature: callapi/one-to-one
     And user "participant2" is participant of room "room"
     Then user "participant1" sees 0 peers in call "room" with 200
     And user "participant2" sees 0 peers in call "room" with 200
+    Then user "participant1" joins room "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant2" sees 0 peers in call "room" with 200
     Then user "participant1" joins call "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant2" sees 1 peers in call "room" with 200
+    And user "participant2" joins room "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant2" sees 1 peers in call "room" with 200
     And user "participant2" joins call "room" with 200
@@ -28,7 +34,13 @@ Feature: callapi/one-to-one
     Then user "participant1" leaves call "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant2" sees 1 peers in call "room" with 200
+    Then user "participant1" exits room "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant2" sees 1 peers in call "room" with 200
     Then user "participant2" leaves call "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant2" sees 0 peers in call "room" with 200
+    Then user "participant2" exits room "room" with 200
     Then user "participant1" sees 0 peers in call "room" with 200
     And user "participant2" sees 0 peers in call "room" with 200
 
@@ -39,7 +51,13 @@ Feature: callapi/one-to-one
     Then user "participant1" is participant of room "room"
     Then user "participant3" is not participant of room "room"
     And user "participant3" sees 0 peers in call "room" with 404
+    Then user "participant1" joins room "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant3" sees 0 peers in call "room" with 404
     Then user "participant1" joins call "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant3" sees 0 peers in call "room" with 404
+    And user "participant3" joins room "room" with 404
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
     And user "participant3" joins call "room" with 404
@@ -48,10 +66,16 @@ Feature: callapi/one-to-one
     And user "participant3" pings call "room" with 404
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
-    Then user "participant3" leaves call "room" with 200
+    Then user "participant3" leaves call "room" with 404
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant3" sees 0 peers in call "room" with 404
+    Then user "participant3" exits room "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
     Then user "participant1" leaves call "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant3" sees 0 peers in call "room" with 404
+    Then user "participant1" exits room "room" with 200
     Then user "participant1" sees 0 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
 
@@ -61,7 +85,13 @@ Feature: callapi/one-to-one
       | invite   | participant2 |
     Then user "participant1" is participant of room "room"
     And user "guest" sees 0 peers in call "room" with 404
+    Then user "participant1" joins room "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "guest" sees 0 peers in call "room" with 404
     Then user "participant1" joins call "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "guest" sees 0 peers in call "room" with 404
+    And user "guest" joins room "room" with 404
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404
     And user "guest" joins call "room" with 404
@@ -70,9 +100,15 @@ Feature: callapi/one-to-one
     And user "guest" pings call "room" with 404
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404
-    Then user "guest" leaves call "room" with 200
+    Then user "guest" leaves call "room" with 404
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "guest" sees 0 peers in call "room" with 404
+    Then user "guest" exits room "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404
     Then user "participant1" leaves call "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "guest" sees 0 peers in call "room" with 404
+    Then user "participant1" exits room "room" with 200
     Then user "participant1" sees 0 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404

--- a/tests/integration/features/callapi/password.feature
+++ b/tests/integration/features/callapi/password.feature
@@ -18,7 +18,13 @@ Feature: callapi/public
     And user "participant2" is participant of room "room"
     Then user "participant1" sees 0 peers in call "room" with 200
     And user "participant2" sees 0 peers in call "room" with 200
+    Then user "participant1" joins room "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant2" sees 0 peers in call "room" with 200
     Then user "participant1" joins call "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant2" sees 1 peers in call "room" with 200
+    And user "participant2" joins room "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant2" sees 1 peers in call "room" with 200
     And user "participant2" joins call "room" with 200
@@ -41,19 +47,31 @@ Feature: callapi/public
     Then user "participant1" is participant of room "room"
     Then user "participant3" is not participant of room "room"
     And user "participant3" sees 0 peers in call "room" with 404
+    Then user "participant1" joins room "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant3" sees 0 peers in call "room" with 404
     Then user "participant1" joins call "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
-    And user "participant3" joins call "room" with 403
+    And user "participant3" joins room "room" with 403
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant3" sees 0 peers in call "room" with 404
+    And user "participant3" joins call "room" with 404
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
     And user "participant3" pings call "room" with 404
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
-    Then user "participant3" leaves call "room" with 200
+    Then user "participant3" leaves call "room" with 404
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant3" sees 0 peers in call "room" with 404
+    Then user "participant3" exits room "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
     Then user "participant1" leaves call "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant3" sees 0 peers in call "room" with 404
+    Then user "participant1" exits room "room" with 200
     Then user "participant1" sees 0 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
 
@@ -65,11 +83,17 @@ Feature: callapi/public
     Then user "participant1" is participant of room "room"
     Then user "participant3" is not participant of room "room"
     And user "participant3" sees 0 peers in call "room" with 404
+    Then user "participant1" joins room "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant3" sees 0 peers in call "room" with 404
     Then user "participant1" joins call "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
-    And user "participant3" joins call "room" with 200
+    And user "participant3" joins room "room" with 200
       | password | foobar |
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant3" sees 1 peers in call "room" with 200
+    And user "participant3" joins call "room" with 200
     Then user "participant1" sees 2 peers in call "room" with 200
     And user "participant3" sees 2 peers in call "room" with 200
     And user "participant3" pings call "room" with 200
@@ -77,8 +101,14 @@ Feature: callapi/public
     And user "participant3" sees 2 peers in call "room" with 200
     Then user "participant3" leaves call "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant3" sees 1 peers in call "room" with 200
+    Then user "participant3" exits room "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
     Then user "participant1" leaves call "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant3" sees 0 peers in call "room" with 404
+    Then user "participant1" exits room "room" with 200
     Then user "participant1" sees 0 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
 
@@ -89,10 +119,16 @@ Feature: callapi/public
     And user "participant1" adds "participant2" to room "room" with 200
     Then user "participant1" is participant of room "room"
     And user "guest" sees 0 peers in call "room" with 404
+    Then user "participant1" joins room "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant3" sees 0 peers in call "room" with 404
     Then user "participant1" joins call "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404
-    And user "guest" joins call "room" with 403
+    And user "guest" joins room "room" with 403
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "guest" sees 0 peers in call "room" with 404
+    And user "guest" joins call "room" with 404
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404
     And user "guest" pings call "room" with 404
@@ -112,11 +148,17 @@ Feature: callapi/public
     And user "participant1" adds "participant2" to room "room" with 200
     Then user "participant1" is participant of room "room"
     And user "guest" sees 0 peers in call "room" with 404
+    Then user "participant1" joins room "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant3" sees 0 peers in call "room" with 404
     Then user "participant1" joins call "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404
-    And user "guest" joins call "room" with 200
+    And user "guest" joins room "room" with 200
       | password | foobar |
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "guest" sees 1 peers in call "room" with 200
+    And user "guest" joins call "room" with 200
     Then user "participant1" sees 2 peers in call "room" with 200
     And user "guest" sees 2 peers in call "room" with 200
     And user "guest" pings call "room" with 200
@@ -124,7 +166,13 @@ Feature: callapi/public
     And user "guest" sees 2 peers in call "room" with 200
     Then user "guest" leaves call "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
+    And user "guest" sees 1 peers in call "room" with 200
+    Then user "guest" exits room "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404
     Then user "participant1" leaves call "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "guest" sees 0 peers in call "room" with 404
+    Then user "participant1" exits room "room" with 200
     Then user "participant1" sees 0 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404

--- a/tests/integration/features/callapi/public.feature
+++ b/tests/integration/features/callapi/public.feature
@@ -17,7 +17,13 @@ Feature: callapi/public
     And user "participant2" is participant of room "room"
     Then user "participant1" sees 0 peers in call "room" with 200
     And user "participant2" sees 0 peers in call "room" with 200
+    Then user "participant1" joins room "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant2" sees 0 peers in call "room" with 200
     Then user "participant1" joins call "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant2" sees 1 peers in call "room" with 200
+    Then user "participant2" joins room "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant2" sees 1 peers in call "room" with 200
     And user "participant2" joins call "room" with 200
@@ -28,7 +34,13 @@ Feature: callapi/public
     Then user "participant1" leaves call "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant2" sees 1 peers in call "room" with 200
+    Then user "participant1" exits room "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant2" sees 1 peers in call "room" with 200
     Then user "participant2" leaves call "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant2" sees 0 peers in call "room" with 200
+    Then user "participant2" exits room "room" with 200
     Then user "participant1" sees 0 peers in call "room" with 200
     And user "participant2" sees 0 peers in call "room" with 200
 
@@ -39,9 +51,15 @@ Feature: callapi/public
     Then user "participant1" is participant of room "room"
     Then user "participant3" is not participant of room "room"
     And user "participant3" sees 0 peers in call "room" with 404
+    Then user "participant1" joins room "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant2" sees 0 peers in call "room" with 200
     Then user "participant1" joins call "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
+    Then user "participant3" joins room "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant3" sees 1 peers in call "room" with 200
     And user "participant3" joins call "room" with 200
     Then user "participant1" sees 2 peers in call "room" with 200
     And user "participant3" sees 2 peers in call "room" with 200
@@ -50,8 +68,14 @@ Feature: callapi/public
     And user "participant3" sees 2 peers in call "room" with 200
     Then user "participant3" leaves call "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
+    And user "participant3" sees 1 peers in call "room" with 200
+    Then user "participant3" exits room "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
     Then user "participant1" leaves call "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant3" sees 0 peers in call "room" with 404
+    Then user "participant1" exits room "room" with 200
     Then user "participant1" sees 0 peers in call "room" with 200
     And user "participant3" sees 0 peers in call "room" with 404
 
@@ -61,9 +85,15 @@ Feature: callapi/public
     And user "participant1" adds "participant2" to room "room" with 200
     Then user "participant1" is participant of room "room"
     And user "guest" sees 0 peers in call "room" with 404
+    Then user "participant1" joins room "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant2" sees 0 peers in call "room" with 200
     Then user "participant1" joins call "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404
+    Then user "guest" joins room "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
+    And user "guest" sees 1 peers in call "room" with 200
     And user "guest" joins call "room" with 200
     Then user "participant1" sees 2 peers in call "room" with 200
     And user "guest" sees 2 peers in call "room" with 200
@@ -72,7 +102,13 @@ Feature: callapi/public
     And user "guest" sees 2 peers in call "room" with 200
     Then user "guest" leaves call "room" with 200
     Then user "participant1" sees 1 peers in call "room" with 200
+    And user "guest" sees 1 peers in call "room" with 200
+    Then user "guest" exits room "room" with 200
+    Then user "participant1" sees 1 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404
     Then user "participant1" leaves call "room" with 200
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "guest" sees 0 peers in call "room" with 404
+    Then user "participant1" exits room "room" with 200
     Then user "participant1" sees 0 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404

--- a/tests/integration/features/chat/password.feature
+++ b/tests/integration/features/chat/password.feature
@@ -27,7 +27,7 @@ Feature: chat/password
     Given user "participant1" creates room "public password protected room"
       | roomType | 3 |
     And user "participant1" sets password "foobar" for room "public password protected room" with 200
-    And user "participant3" joins call "public password protected room" with 200
+    And user "participant3" joins room "public password protected room" with 200
       | password | foobar |
     When user "participant3" sends message "Message 1" to room "public password protected room" with 201
     Then user "participant3" sees the following messages in room "public password protected room" with 200
@@ -46,7 +46,7 @@ Feature: chat/password
     Given user "participant1" creates room "public password protected room"
       | roomType | 3 |
     And user "participant1" sets password "foobar" for room "public password protected room" with 200
-    And user "guest" joins call "public password protected room" with 200
+    And user "guest" joins room "public password protected room" with 200
       | password | foobar |
     When user "guest" sends message "Message 1" to room "public password protected room" with 201
     Then user "guest" sees the following messages in room "public password protected room" with 200
@@ -66,9 +66,9 @@ Feature: chat/password
       | roomType | 3 |
     And user "participant1" sets password "foobar" for room "public password protected room" with 200
     And user "participant1" adds "participant2" to room "public password protected room" with 200
-    And user "participant3" joins call "public password protected room" with 200
+    And user "participant3" joins room "public password protected room" with 200
       | password | foobar |
-    And user "guest" joins call "public password protected room" with 200
+    And user "guest" joins room "public password protected room" with 200
       | password | foobar |
     When user "participant1" sends message "Message 1" to room "public password protected room" with 201
     And user "participant2" sends message "Message 2" to room "public password protected room" with 201

--- a/tests/integration/features/chat/public.feature
+++ b/tests/integration/features/chat/public.feature
@@ -24,7 +24,7 @@ Feature: chat/public
   Scenario: not invited but joined user can send and receive chat messages to and from public room
     Given user "participant1" creates room "public room"
       | roomType | 3 |
-    And user "participant3" joins call "public room" with 200
+    And user "participant3" joins room "public room" with 200
     When user "participant3" sends message "Message 1" to room "public room" with 201
     Then user "participant3" sees the following messages in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message   |
@@ -40,7 +40,7 @@ Feature: chat/public
   Scenario: joined guest can send and receive chat messages to and from public room
     Given user "participant1" creates room "public room"
       | roomType | 3 |
-    And user "guest" joins call "public room" with 200
+    And user "guest" joins room "public room" with 200
     When user "guest" sends message "Message 1" to room "public room" with 201
     Then user "guest" sees the following messages in room "public room" with 200
       | room        | actorType | actorId | actorDisplayName | message   |
@@ -57,7 +57,7 @@ Feature: chat/public
     Given user "participant1" creates room "public room"
       | roomType | 3 |
     And user "participant1" adds "participant2" to room "public room" with 200
-    And user "guest" joins call "public room" with 200
+    And user "guest" joins room "public room" with 200
     When user "participant1" sends message "Message 1" to room "public room" with 201
     And user "participant2" sends message "Message 2" to room "public room" with 201
     And user "guest" sends message "Message 3" to room "public room" with 201

--- a/tests/integration/features/set-password.feature
+++ b/tests/integration/features/set-password.feature
@@ -11,12 +11,12 @@ Feature: public
       | id   | type | participantType | participants |
       | room | 3    | 1               | participant1-displayname |
     When user "participant1" sets password "foobar" for room "room" with 200
-    Then user "participant3" joins call "room" with 403
-    Then user "participant3" joins call "room" with 200
+    Then user "participant3" joins room "room" with 403
+    Then user "participant3" joins room "room" with 200
       | password | foobar |
     And user "participant3" leaves call "room" with 200
     When user "participant1" sets password "" for room "room" with 200
-    Then user "participant3" joins call "room" with 200
+    Then user "participant3" joins room "room" with 200
 
   Scenario: Moderator sets a room password
     Given user "participant1" creates room "room"
@@ -27,12 +27,12 @@ Feature: public
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant1" promotes "participant2" in room "room" with 200
     When user "participant2" sets password "foobar" for room "room" with 200
-    Then user "participant3" joins call "room" with 403
-    Then user "participant3" joins call "room" with 200
+    Then user "participant3" joins room "room" with 403
+    Then user "participant3" joins room "room" with 200
       | password | foobar |
     And user "participant3" leaves call "room" with 200
     When user "participant2" sets password "" for room "room" with 200
-    Then user "participant3" joins call "room" with 200
+    Then user "participant3" joins room "room" with 200
 
   Scenario: User sets a room password
     Given user "participant1" creates room "room"
@@ -42,15 +42,15 @@ Feature: public
       | room | 3    | 1               | participant1-displayname |
     And user "participant1" adds "participant2" to room "room" with 200
     When user "participant2" sets password "foobar" for room "room" with 403
-    Then user "participant3" joins call "room" with 200
+    Then user "participant3" joins room "room" with 200
     And user "participant3" leaves call "room" with 200
     When user "participant1" sets password "foobar" for room "room" with 200
-    Then user "participant3" joins call "room" with 403
-    Then user "participant3" joins call "room" with 200
+    Then user "participant3" joins room "room" with 403
+    Then user "participant3" joins room "room" with 200
       | password | foobar |
     And user "participant3" leaves call "room" with 200
     When user "participant2" sets password "" for room "room" with 403
-    Then user "participant3" joins call "room" with 403
+    Then user "participant3" joins room "room" with 403
 
   Scenario: Stranger sets a room password
     Given user "participant1" creates room "room"
@@ -59,12 +59,12 @@ Feature: public
       | id   | type | participantType | participants |
       | room | 3    | 1               | participant1-displayname |
     When user "participant2" sets password "foobar" for room "room" with 404
-    Then user "participant3" joins call "room" with 200
+    Then user "participant3" joins room "room" with 200
     And user "participant3" leaves call "room" with 200
     When user "participant1" sets password "foobar" for room "room" with 200
-    Then user "participant3" joins call "room" with 403
-    Then user "participant3" joins call "room" with 200
+    Then user "participant3" joins room "room" with 403
+    Then user "participant3" joins room "room" with 200
       | password | foobar |
     And user "participant3" leaves call "room" with 200
     When user "participant2" sets password "" for room "room" with 404
-    Then user "participant3" joins call "room" with 403
+    Then user "participant3" joins room "room" with 403


### PR DESCRIPTION
This is a follow up for #459.

This pull request fixes the arguments passed to `Participant` constructor (which fixes joining a room as a guest from the UI) and the integration tests for setting a password and chatting, as they should join a room instead of a call since the changes introduced in the previous pull request.

The integration tests are not fully fixed yet, though. It seems that it is no longer possible to join a call without joining the room first, not even for the creator or someone who was invited to the room. The question is, should directly joining a call automatically make the participant to join the room too? Or should it be kept like now, in which the participant must join the room explicitly? @Ivansss @nickvergessen Please fix the code and/or the integration tests as needed.

Fix #465 