### PR TITLE
Disable 'Enable video' button if no camera is connected

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -420,6 +420,15 @@ video {
 	opacity: .7;
 }
 
+.nameIndicator button.video-available {
+	opacity: .7;
+	cursor: not-allowed;
+ }
+
+.nameIndicator button.video-available:active {
+	background-color: transparent;
+}
+
 .mediaIndicator {
 	position: absolute;
 	width: 100%;

--- a/css/style.css
+++ b/css/style.css
@@ -420,12 +420,12 @@ video {
 	opacity: .7;
 }
 
-.nameIndicator button.video-available {
+.nameIndicator button.no-video-available {
 	opacity: .7;
 	cursor: not-allowed;
  }
 
-.nameIndicator button.video-available:active {
+.nameIndicator button.no-video-available:active {
 	background-color: transparent;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -682,7 +682,7 @@ video {
 }
 
 #videos .videoContainer.speaking:not(.videoView) .nameIndicator,
-#videos .videoContainer.videoView.speaking .nameIndicator .icon-audio-white {
+#videos .videoContainer.videoView.speaking .nameIndicator .icon-audio {
 	animation: pulse 1s;
 	animation-iteration-count: infinite;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -229,8 +229,8 @@
 			var screensharingStopped = function() {
 				console.log("Screensharing now stopped");
 				$('#screensharing-button').attr('data-original-title', t('spreed', 'Enable screensharing'))
-					.addClass('screensharing-disabled icon-screen-off-white')
-					.removeClass('icon-screen-white');
+					.addClass('screensharing-disabled icon-screen-off')
+					.removeClass('icon-screen');
 				$('#screensharing-menu').toggleClass('open', false);
 			};
 
@@ -258,8 +258,8 @@
 						screensharingButton.prop('disabled', false);
 						if (!err) {
 							$('#screensharing-button').attr('data-original-title', t('spreed', 'Screensharing options'))
-								.removeClass('screensharing-disabled icon-screen-off-white')
-								.addClass('icon-screen-white');
+								.removeClass('screensharing-disabled icon-screen-off')
+								.addClass('icon-screen');
 							return;
 						}
 
@@ -596,16 +596,16 @@
 		enableAudio: function() {
 			OCA.SpreedMe.webrtc.unmute();
 			$('#mute').attr('data-original-title', t('spreed', 'Mute audio'))
-				.removeClass('audio-disabled icon-audio-off-white')
-				.addClass('icon-audio-white');
+				.removeClass('audio-disabled icon-audio-off')
+				.addClass('icon-audio');
 
 			OCA.SpreedMe.app.audioDisabled = false;
 		},
 		disableAudio: function() {
 			OCA.SpreedMe.webrtc.mute();
 			$('#mute').attr('data-original-title', t('spreed', 'Enable audio'))
-				.addClass('audio-disabled icon-audio-off-white')
-				.removeClass('icon-audio-white');
+				.addClass('audio-disabled icon-audio-off')
+				.removeClass('icon-audio');
 
 			OCA.SpreedMe.app.audioDisabled = true;
 		},
@@ -616,8 +616,8 @@
 
 			OCA.SpreedMe.webrtc.resumeVideo();
 			$hideVideoButton.attr('data-original-title', t('spreed', 'Disable video'))
-				.removeClass('video-disabled icon-video-off-white')
-				.addClass('icon-video-white');
+				.removeClass('video-disabled icon-video-off')
+				.addClass('icon-video');
 
 			avatarContainer.hide();
 			localVideo.show();
@@ -631,8 +631,8 @@
 
 			if (!$hideVideoButton.hasClass('no-video-available')) {
 				$hideVideoButton.attr('data-original-title', t('spreed', 'Enable video'))
-					.addClass('video-disabled icon-video-off-white')
-					.removeClass('icon-video-white');
+					.addClass('video-disabled icon-video-off')
+					.removeClass('icon-video');
 			}
 
 			var avatar = avatarContainer.find('.avatar');

--- a/js/app.js
+++ b/js/app.js
@@ -629,9 +629,11 @@
 			var avatarContainer = $hideVideoButton.closest('.videoView').find('.avatar-container');
 			var localVideo = $hideVideoButton.closest('.videoView').find('#localVideo');
 
-			$hideVideoButton.attr('data-original-title', t('spreed', 'Enable video'))
-				.addClass('video-disabled icon-video-off-white')
-				.removeClass('icon-video-white');
+			if (!$hideVideoButton.hasClass('video-available')) {
+				$hideVideoButton.attr('data-original-title', t('spreed', 'Enable video'))
+				 .addClass('video-disabled icon-video-off-white')
+				 .removeClass('icon-video-white');
+			}
 
 			var avatar = avatarContainer.find('.avatar');
 			var guestName = localStorage.getItem("nick");

--- a/js/app.js
+++ b/js/app.js
@@ -629,7 +629,7 @@
 			var avatarContainer = $hideVideoButton.closest('.videoView').find('.avatar-container');
 			var localVideo = $hideVideoButton.closest('.videoView').find('#localVideo');
 
-			if (!$hideVideoButton.hasClass('video-available')) {
+			if (!$hideVideoButton.hasClass('no-video-available')) {
 				$hideVideoButton.attr('data-original-title', t('spreed', 'Enable video'))
 				 .addClass('video-disabled icon-video-off-white')
 				 .removeClass('icon-video-white');

--- a/js/app.js
+++ b/js/app.js
@@ -631,8 +631,8 @@
 
 			if (!$hideVideoButton.hasClass('no-video-available')) {
 				$hideVideoButton.attr('data-original-title', t('spreed', 'Enable video'))
-				 .addClass('video-disabled icon-video-off-white')
-				 .removeClass('icon-video-white');
+					.addClass('video-disabled icon-video-off-white')
+					.removeClass('icon-video-white');
 			}
 
 			var avatar = avatarContainer.find('.avatar');

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -956,8 +956,8 @@ var spreedPeerConnectionTable = [];
 			}
 
 			var $hideVideoButton = $('#hideVideo');
-			if(OCA.SpreedMe.webrtc.webrtc.localStream.getVideoTracks() < 1) {
-				$hideVideoButton.removeClass('video-disabled icon-video-off-white')
+			if(OCA.SpreedMe.webrtc.webrtc.localStream.getVideoTracks().length < 1) {
+				$hideVideoButton.removeClass('video-disabled')
 				.addClass('no-video-available icon-video-off-white')
 				.attr('data-original-title', t('spreed', 'No Camera'));
 			}

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -955,11 +955,10 @@ var spreedPeerConnectionTable = [];
 				OCA.SpreedMe.app.enableVideo();
 			}
 
-			var availableStream = $(OCA.SpreedMe.webrtc.webrtc.localStream.getVideoTracks());
 			var $hideVideoButton = $('#hideVideo');
-			if(availableStream.length < 1 || availableStream.length == undefined) {
+			if(OCA.SpreedMe.webrtc.webrtc.localStream.getVideoTracks() < 1) {
 				$hideVideoButton.removeClass('video-disabled icon-video-off-white')
-				.addClass('video-available icon-video-off-white')
+				.addClass('no-video-available icon-video-off-white')
 				.attr('data-original-title', t('spreed', 'No Camera'));
 			}
 		});

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -954,6 +954,14 @@ var spreedPeerConnectionTable = [];
 			if (!OCA.SpreedMe.app.videoDisabled) {
 				OCA.SpreedMe.app.enableVideo();
 			}
+
+			var availableStream = $(OCA.SpreedMe.webrtc.webrtc.localStream.getVideoTracks());
+			var $hideVideoButton = $('#hideVideo');
+			if(availableStream.length < 1 || availableStream.length == undefined) {
+				$hideVideoButton.removeClass('video-disabled icon-video-off-white')
+				.addClass('video-available icon-video-off-white')
+				.attr('data-original-title', t('spreed', 'No Camera'));
+			}
 		});
 	}
 

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -241,15 +241,15 @@ var spreedPeerConnectionTable = [];
 				mediaIndicator.className = 'mediaIndicator';
 
 				var muteIndicator = document.createElement('button');
-				muteIndicator.className = 'muteIndicator icon-audio-off-white audio-on';
+				muteIndicator.className = 'muteIndicator icon-white icon-shadow icon-audio-off audio-on';
 				muteIndicator.disabled = true;
 
 				var screenSharingIndicator = document.createElement('button');
-				screenSharingIndicator.className = 'screensharingIndicator icon-screen-white screen-off';
+				screenSharingIndicator.className = 'screensharingIndicator icon-white icon-shadow icon-screen screen-off';
 				screenSharingIndicator.setAttribute('data-original-title', t('spreed', 'Show screen'));
 
 				var iceFailedIndicator = document.createElement('button');
-				iceFailedIndicator.className = 'iceFailedIndicator icon-error-white not-failed';
+				iceFailedIndicator.className = 'iceFailedIndicator icon-white icon-shadow icon-error not-failed';
 				iceFailedIndicator.disabled = true;
 
 				$(screenSharingIndicator).tooltip({
@@ -956,10 +956,10 @@ var spreedPeerConnectionTable = [];
 			}
 
 			var $hideVideoButton = $('#hideVideo');
-			if(OCA.SpreedMe.webrtc.webrtc.localStream.getVideoTracks().length < 1) {
-				$hideVideoButton.removeClass('video-disabled')
-				.addClass('no-video-available icon-video-off-white')
-				.attr('data-original-title', t('spreed', 'No Camera'));
+			if (OCA.SpreedMe.webrtc.webrtc.localStream.getVideoTracks().length === 0) {
+				$hideVideoButton.removeClass('video-disabled icon-video')
+					.addClass('no-video-available icon-video-off')
+					.attr('data-original-title', t('spreed', 'No Camera'));
 			}
 		});
 	}


### PR DESCRIPTION
If theres no cam available, this fix will toggle the video icon into the disabled mode. This is solved by query the hardware from navigator.getUserMedia API. 

This Fix is based on:
Disable 'Enable video' button if no camera is connected [#441](https://github.com/nextcloud/spreed/issues/441)

![selection_033](https://user-images.githubusercontent.com/22152652/32615743-d8594910-c570-11e7-93e7-8569123632e3.png)
