### PR TITLE
Fix call info rendering blocked for normal (not moderator) users

### DIFF
--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -165,7 +165,7 @@
 		},
 
 		renderWhenInactive: function() {
-			if (this.ui.passwordInput.val() === '') {
+			if (this.ui.passwordInput.length === 0 || this.ui.passwordInput.val() === '') {
 				this.render();
 				return;
 			}


### PR DESCRIPTION
When there is no password input field its value is undefined, so the rendering never finished when calling `renderWhenInactive` due to the strict equal comparison.

This is a prerequisite for, but does not fixes, the [slow update of the _Join/leave call_ button](https://github.com/nextcloud/spreed/issues/473) (that will come in a different pull request).
