### PR TITLE
Fix slow update of "Join/leave call" button

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -661,8 +661,14 @@ var spreedPeerConnectionTable = [];
 		});
 
 		OCA.SpreedMe.webrtc.on('joinedCall', function() {
+			OCA.SpreedMe.app.syncRooms();
+
 			$('#app-content').removeClass('icon-loading');
 			$('.videoView').removeClass('hidden');
+		});
+
+		OCA.SpreedMe.webrtc.on('leftCall', function() {
+			OCA.SpreedMe.app.syncRooms();
 		});
 
 		OCA.SpreedMe.webrtc.on('channelOpen', function(channel) {


### PR DESCRIPTION
Fixes #473

The button is updated when the model changes, but the model was not being synced when the user joined or left a call, so it only changed when it was synced for any other reason.
