### PR TITLE
Fix call activity

### DIFF
--- a/lib/Activity/Hooks.php
+++ b/lib/Activity/Hooks.php
@@ -59,10 +59,9 @@ class Hooks {
 	 * Mark the user as (in)active for a call
 	 *
 	 * @param Room $room
-	 * @param bool $isGuest
 	 */
-	public function setActive(Room $room, $isGuest) {
-		$room->setActiveSince(new \DateTime(), $isGuest);
+	public function setActive(Room $room) {
+		$room->setActiveSince(new \DateTime(), !$this->userSession->isLoggedIn());
 	}
 
 	/**
@@ -73,7 +72,7 @@ class Hooks {
 	 */
 	public function generateCallActivity(Room $room) {
 		$activeSince = $room->getActiveSince();
-		if (!$activeSince instanceof \DateTime || $room->hasActiveSessions()) {
+		if (!$activeSince instanceof \DateTime || $room->hasSessionsInCall()) {
 			return false;
 		}
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -135,16 +135,15 @@ class Application extends App {
 	}
 
 	protected function registerCallActivityHooks(EventDispatcherInterface $dispatcher) {
-		$listener = function(GenericEvent $event, $eventName) {
+		$listener = function(GenericEvent $event) {
 			/** @var Room $room */
 			$room = $event->getSubject();
 
 			/** @var Hooks $hooks */
 			$hooks = $this->getContainer()->query(Hooks::class);
-			$hooks->setActive($room, $eventName === Room::class . '::postGuestEnterRoom');
+			$hooks->setActive($room);
 		};
-		$dispatcher->addListener(Room::class . '::postUserEnterRoom', $listener);
-		$dispatcher->addListener(Room::class . '::postGuestEnterRoom', $listener);
+		$dispatcher->addListener(Room::class . '::postSessionJoinCall', $listener);
 
 		$listener = function(GenericEvent $event) {
 			/** @var Room $room */
@@ -156,7 +155,7 @@ class Application extends App {
 		};
 		$dispatcher->addListener(Room::class . '::postRemoveBySession', $listener);
 		$dispatcher->addListener(Room::class . '::postRemoveUser', $listener);
-		$dispatcher->addListener(Room::class . '::postUserDisconnectRoom', $listener);
+		$dispatcher->addListener(Room::class . '::postSessionLeaveCall', $listener);
 	}
 
 	protected function registerRoomInvitationHook(EventDispatcherInterface $dispatcher) {

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -729,12 +729,12 @@ class Room {
 	/**
 	 * @return bool
 	 */
-	public function hasActiveSessions() {
+	public function hasSessionsInCall() {
 		$query = $this->db->getQueryBuilder();
 		$query->select('sessionId')
 			->from('talk_participants')
 			->where($query->expr()->eq('roomId', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)))
-			->andWhere($query->expr()->neq('sessionId', $query->createNamedParameter('0')))
+			->andWhere($query->expr()->eq('inCall', $query->createNamedParameter(1, IQueryBuilder::PARAM_INT)))
 			->setMaxResults(1);
 		$result = $query->execute();
 		$row = $result->fetch();


### PR DESCRIPTION
Only last commit is relevant, because it is:
- [x] Based on #476 

Regression from #459 

Before joining a room would start the call and the call would only end when there is no one in the room and someone is removed from a room 💔 