### PR TITLE
Add grouping of messages in chat view

### DIFF
--- a/css/comments.css
+++ b/css/comments.css
@@ -190,3 +190,28 @@
 #commentsTabView .comment.grouped {
 	margin-top: -20px;
 }
+
+#commentsTabView .comment.showDate {
+	margin-top: 40px;
+	border-top: 1px solid #dbdbdb;
+	padding-top: 10px;
+}
+
+#commentsTabView .comment.showDate:before {
+	content: attr(data-date);
+
+	position: absolute;
+	top: 0;
+	left: 50%;
+	transform: translateX(-50%) translateY(-50%);
+	padding: 0 7px 0 7px;
+
+	text-align: center;
+
+	color: #878787;
+	background-color: #fff;
+}
+
+#commentsTabView .comment.showDate .authorRow {
+	display: block;
+}

--- a/css/comments.css
+++ b/css/comments.css
@@ -182,3 +182,11 @@
 .app-files .action-comment {
 	padding: 16px 14px;
 }
+
+#commentsTabView .comment.grouped .authorRow {
+	display: none;
+}
+
+#commentsTabView .comment.grouped {
+	margin-top: -20px;
+}

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -97,6 +97,8 @@
 		},
 
 		render: function() {
+			delete this._lastAddedMessageModel;
+
 			this.$el.html(this.template({
 				emptyResultLabel: t('spreed', 'No messages yet, start the conversation!')
 			}));
@@ -147,7 +149,39 @@
 				this.$container.prepend($el);
 			}
 
+			if (this._modelsHaveSameActor(this._lastAddedMessageModel, model) &&
+					this._modelsAreTemporaryNear(this._lastAddedMessageModel, model)) {
+				$el.next().addClass('grouped');
+			}
+
+			// Keeping the model for the last added message is not only
+			// practical, but needed, as the models for previous messages are
+			// removed from the collection each time a new set of messages is
+			// received.
+			this._lastAddedMessageModel = model;
+
 			this._postRenderItem($el);
+		},
+
+		_modelsHaveSameActor: function(model1, model2) {
+			if (!model1 || !model2) {
+				return false;
+			}
+
+			return model1.get('actorId') === model2.get('actorId') &&
+				model1.get('actorType') === model2.get('actorType');
+		},
+
+		_modelsAreTemporaryNear: function(model1, model2, secondsThreshold) {
+			if (!model1 || !model2) {
+				return false;
+			}
+
+			if (_.isUndefined(secondsThreshold)) {
+				secondsThreshold = 120;
+			}
+
+			return Math.abs(model1.get('timestamp') - model2.get('timestamp')) <= secondsThreshold;
 		},
 
 		_postRenderItem: function($el) {

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -154,6 +154,17 @@
 				$el.next().addClass('grouped');
 			}
 
+			// PHP timestamp is second-based; JavaScript timestamp is
+			// millisecond based.
+			model.set('date', new Date(model.get('timestamp') * 1000));
+
+			if (this._lastAddedMessageModel && !this._modelsHaveSameDate(this._lastAddedMessageModel, model)) {
+				// 'LL' formats a localized date including day of month, month
+				// name and year
+				$el.next().attr('data-date', OC.Util.formatDate(this._lastAddedMessageModel.get('date'), 'LL'));
+				$el.next().addClass('showDate');
+			}
+
 			// Keeping the model for the last added message is not only
 			// practical, but needed, as the models for previous messages are
 			// removed from the collection each time a new set of messages is
@@ -182,6 +193,14 @@
 			}
 
 			return Math.abs(model1.get('timestamp') - model2.get('timestamp')) <= secondsThreshold;
+		},
+
+		_modelsHaveSameDate: function(model1, model2) {
+			if (!model1 || !model2) {
+				return false;
+			}
+
+			return model1.get('date').toDateString() === model2.get('date').toDateString();
 		},
 
 		_postRenderItem: function($el) {


### PR DESCRIPTION
Now contiguous chat messages sent by the same user with a difference of less than 120 seconds between each message are grouped together; chat messages sent during the same day are _grouped_ by showing a header with the date.

Just for the record, the threshold of 120 seconds was chosen for no special reason; it simply felt like a reasonable value.

**Before grouping:**
![chat-grouped-messages-before](https://user-images.githubusercontent.com/26858233/32888304-2929e33a-cac7-11e7-91cf-eb7c0bd06bbc.png)

**After grouping:**
![chat-grouped-messages-after](https://user-images.githubusercontent.com/26858233/32888307-2c3872c6-cac7-11e7-93c7-1bd4a753300e.png)

