### PR TITLE
 Split "room" from "call" when using the standalone signaling server.

### DIFF
--- a/js/signaling.js
+++ b/js/signaling.js
@@ -625,6 +625,9 @@
 						this._trigger('roomChanged', [this.currentRoomToken, data.room.roomid]);
 						this.joinedUsers = {};
 						this.currentRoomToken = null;
+					} else {
+						// TODO(fancycode): Only fetch properties of room that was modified.
+						this.internalSyncRooms();
 					}
 					break;
 				case "event":

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -701,13 +701,13 @@
 			};
 		} else {
 			var user = OC.getCurrentUser();
-			var url = OC.generateUrl("/ocs/v2.php/apps/spreed/api/v1/signaling/backend");
+			var url = OC.linkToOCS('apps/spreed/api/v1/signaling', 2) + 'backend';
 			msg = {
 				"type": "hello",
 				"hello": {
 					"version": "1.0",
 					"auth": {
-						"url": OC.getProtocol() + "://" + OC.getHost() + url,
+						"url": url,
 						"params": {
 							"userid": user.uid,
 							"ticket": this.settings.ticket

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -12,6 +12,7 @@ var spreedPeerConnectionTable = [];
 	OCA.SpreedMe = OCA.SpreedMe || {};
 
 	var previousUsersInRoom = [];
+	var usersInCallMapping = {};
 
 	function updateParticipantsUI(currentUsersNo) {
 		'use strict';
@@ -110,6 +111,49 @@ var spreedPeerConnectionTable = [];
 		updateParticipantsUI(previousUsersInRoom.length + 1);
 	}
 
+	function usersInCallChanged(users) {
+		// The passed list are the users that are currently in the room,
+		// i.e. that are in the call and should call each other.
+		var currentSessionId = webrtc.connection.getSessionid();
+		var currentUsersInRoom = [];
+		var userMapping = {};
+		var selfInCall = false;
+		var sessionId;
+		for (sessionId in users) {
+			if (!users.hasOwnProperty(sessionId)) {
+				continue;
+			}
+			var user = users[sessionId];
+			if (!user.inCall) {
+				continue;
+			}
+
+			if (sessionId === currentSessionId) {
+				selfInCall = true;
+				continue;
+			}
+
+			currentUsersInRoom.push(sessionId);
+			userMapping[sessionId] = user;
+		}
+
+		if (!selfInCall) {
+			// Own session is no longer in the call, disconnect from all others.
+			usersChanged([], previousUsersInRoom);
+			return;
+		}
+
+		var newSessionIds = currentUsersInRoom.diff(previousUsersInRoom);
+		var disconnectedSessionIds = previousUsersInRoom.diff(currentUsersInRoom);
+		var newUsers = [];
+		newSessionIds.forEach(function(sessionId) {
+			newUsers.push(userMapping[sessionId]);
+		});
+		if (newUsers.length || disconnectedSessionIds.length) {
+			usersChanged(newUsers, disconnectedSessionIds);
+		}
+	}
+
 	function initWebRTC() {
 		'use strict';
 		Array.prototype.diff = function(a) {
@@ -119,47 +163,26 @@ var spreedPeerConnectionTable = [];
 		};
 
 		var signaling = OCA.SpreedMe.createSignalingConnection();
-		signaling.on('usersJoined', function(users) {
-			usersChanged(users, []);
-		});
 		signaling.on('usersLeft', function(users) {
+			users.forEach(function(user) {
+				delete usersInCallMapping[user];
+			});
 			usersChanged([], users);
 		});
-		signaling.on('usersInRoom', function(users) {
-			// The passed list are the users that are currently in the room,
-			// i.e. that are in the call and should call each other.
-			var currentSessionId = webrtc.connection.getSessionid();
-			var currentUsersInRoom = [];
-			var userMapping = {};
-			var selfInCall = false;
+		signaling.on('usersChanged', function(users) {
 			users.forEach(function(user) {
-				if (!user['inCall']) {
-					return;
-				}
-
-				var sessionId = user['sessionId'] || user.sessionid;
-				if (sessionId === currentSessionId) {
-					selfInCall = true;
-					return;
-				}
-
-				currentUsersInRoom.push(sessionId);
-				userMapping[sessionId] = user;
+				var sessionId = user.sessionId || user.sessionid;
+				usersInCallMapping[sessionId] = user;
 			});
-
-			if (!selfInCall) {
-				return;
-			}
-
-			var newSessionIds = currentUsersInRoom.diff(previousUsersInRoom);
-			var disconnectedSessionIds = previousUsersInRoom.diff(currentUsersInRoom);
-			var newUsers = [];
-			newSessionIds.forEach(function(sessionId) {
-				newUsers.push(userMapping[sessionId]);
+			usersInCallChanged(usersInCallMapping);
+		});
+		signaling.on('usersInRoom', function(users) {
+			usersInCallMapping = {};
+			users.forEach(function(user) {
+				var sessionId = user.sessionId || user.sessionid;
+				usersInCallMapping[sessionId] = user;
 			});
-			if (newUsers.length || disconnectedSessionIds.length) {
-				usersChanged(newUsers, disconnectedSessionIds);
-			}
+			usersInCallChanged(usersInCallMapping);
 		});
 
 		var nick = OC.getCurrentUser()['displayName'];

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -92,10 +92,14 @@ class Application extends App {
 		$dispatcher->addListener(Room::class . '::postSessionLeaveCall', $listener);
 	}
 
+	protected function getBackendNotifier() {
+		return $this->getContainer()->query(BackendNotifier::class);
+	}
+
 	protected function registerSignalingBackendHooks(EventDispatcherInterface $dispatcher) {
 		$dispatcher->addListener(Room::class . '::postAddUsers', function(GenericEvent $event) {
 			/** @var BackendNotifier $notifier */
-			$notifier = $this->getContainer()->query(BackendNotifier::class);
+			$notifier = $this->getBackendNotifier();
 
 			$room = $event->getSubject();
 			$participants= $event->getArgument('users');
@@ -103,14 +107,14 @@ class Application extends App {
 		});
 		$dispatcher->addListener(Room::class . '::postSetName', function(GenericEvent $event) {
 			/** @var BackendNotifier $notifier */
-			$notifier = $this->getContainer()->query(BackendNotifier::class);
+			$notifier = $this->getBackendNotifier();
 
 			$room = $event->getSubject();
 			$notifier->roomModified($room);
 		});
 		$dispatcher->addListener(Room::class . '::postSetParticipantType', function(GenericEvent $event) {
 			/** @var BackendNotifier $notifier */
-			$notifier = $this->getContainer()->query(BackendNotifier::class);
+			$notifier = $this->getBackendNotifier();
 
 			$room = $event->getSubject();
 			// The type of a participant has changed, notify all participants
@@ -119,7 +123,7 @@ class Application extends App {
 		});
 		$dispatcher->addListener(Room::class . '::postDeleteRoom', function(GenericEvent $event) {
 			/** @var BackendNotifier $notifier */
-			$notifier = $this->getContainer()->query(BackendNotifier::class);
+			$notifier = $this->getBackendNotifier();
 
 			$room = $event->getSubject();
 			$participants = $event->getArgument('participants');
@@ -127,7 +131,7 @@ class Application extends App {
 		});
 		$dispatcher->addListener(Room::class . '::postRemoveUser', function(GenericEvent $event) {
 			/** @var BackendNotifier $notifier */
-			$notifier = $this->getContainer()->query(BackendNotifier::class);
+			$notifier = $this->getBackendNotifier();
 
 			$room = $event->getSubject();
 			$user = $event->getArgument('user');
@@ -135,7 +139,7 @@ class Application extends App {
 		});
 		$dispatcher->addListener(Room::class . '::postSessionJoinCall', function(GenericEvent $event) {
 			/** @var BackendNotifier $notifier */
-			$notifier = $this->getContainer()->query(BackendNotifier::class);
+			$notifier = $this->getBackendNotifier();
 
 			$room = $event->getSubject();
 			$sessionId = $event->getArgument('sessionId');
@@ -143,7 +147,7 @@ class Application extends App {
 		});
 		$dispatcher->addListener(Room::class . '::postSessionLeaveCall', function(GenericEvent $event) {
 			/** @var BackendNotifier $notifier */
-			$notifier = $this->getContainer()->query(BackendNotifier::class);
+			$notifier = $this->getBackendNotifier();
 
 			$room = $event->getSubject();
 			$sessionId = $event->getArgument('sessionId');

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -133,6 +133,22 @@ class Application extends App {
 			$user = $event->getArgument('user');
 			$notifier->roomsDisinvited($room, [$user->getUID()]);
 		});
+		$dispatcher->addListener(Room::class . '::postSessionJoinCall', function(GenericEvent $event) {
+			/** @var BackendNotifier $notifier */
+			$notifier = $this->getContainer()->query(BackendNotifier::class);
+
+			$room = $event->getSubject();
+			$sessionId = $event->getArgument('sessionId');
+			$notifier->roomInCallChanged($room, true, [$sessionId]);
+		});
+		$dispatcher->addListener(Room::class . '::postSessionLeaveCall', function(GenericEvent $event) {
+			/** @var BackendNotifier $notifier */
+			$notifier = $this->getContainer()->query(BackendNotifier::class);
+
+			$room = $event->getSubject();
+			$sessionId = $event->getArgument('sessionId');
+			$notifier->roomInCallChanged($room, false, [$sessionId]);
+		});
 	}
 
 	protected function registerCallActivityHooks(EventDispatcherInterface $dispatcher) {

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -32,7 +32,6 @@ use OCA\Spreed\Room;
 use OCA\Spreed\Signaling\Messages;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
-use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\OCSController;
 use OCP\IDBConnection;
 use OCP\IRequest;
@@ -279,12 +278,12 @@ class SignalingController extends OCSController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 *
-	 * @return JSONResponse
+	 * @return DataResponse
 	 */
 	public function backend() {
 		$json = $this->getInputStream();
 		if (!$this->validateBackendRequest($json)) {
-			return new JSONResponse([
+			return new DataResponse([
 				'type' => 'error',
 				'error' => [
 					'code' => 'invalid_request',
@@ -305,7 +304,7 @@ class SignalingController extends OCSController {
 				// Ping sessions connected to a room.
 				return $this->backendPing($message['ping']);
 			default:
-				return new JSONResponse([
+				return new DataResponse([
 					'type' => 'error',
 					'error' => [
 						'code' => 'unknown_type',
@@ -319,7 +318,7 @@ class SignalingController extends OCSController {
 		$params = $auth['params'];
 		$userId = $params['userid'];
 		if (!$this->config->validateSignalingTicket($userId, $params['ticket'])) {
-			return new JSONResponse([
+			return new DataResponse([
 				'type' => 'error',
 				'error' => [
 					'code' => 'invalid_ticket',
@@ -331,7 +330,7 @@ class SignalingController extends OCSController {
 		if (!empty($userId)) {
 			$user = $this->userManager->get($userId);
 			if (!$user instanceof IUser) {
-				return new JSONResponse([
+				return new DataResponse([
 					'type' => 'error',
 					'error' => [
 						'code' => 'no_such_user',
@@ -353,7 +352,7 @@ class SignalingController extends OCSController {
 				'displayname' => $user->getDisplayName(),
 			];
 		}
-		return new JSONResponse($response);
+		return new DataResponse($response);
 	}
 
 	private function backendRoom($roomRequest) {
@@ -364,7 +363,7 @@ class SignalingController extends OCSController {
 		try {
 			$room = $this->manager->getRoomByToken($roomId);
 		} catch (RoomNotFoundException $e) {
-			return new JSONResponse([
+			return new DataResponse([
 				'type' => 'error',
 				'error' => [
 					'code' => 'no_such_room',
@@ -389,7 +388,7 @@ class SignalingController extends OCSController {
 				$participant = $room->getParticipantBySession($sessionId);
 			} catch (ParticipantNotFoundException $e) {
 				// Return generic error to avoid leaking which rooms exist.
-				return new JSONResponse([
+				return new DataResponse([
 					'type' => 'error',
 					'error' => [
 						'code' => 'no_such_room',
@@ -414,14 +413,14 @@ class SignalingController extends OCSController {
 				],
 			],
 		];
-		return new JSONResponse($response);
+		return new DataResponse($response);
 	}
 
 	private function backendPing($request) {
 		try {
 			$room = $this->manager->getRoomByToken($request['roomid']);
 		} catch (RoomNotFoundException $e) {
-			return new JSONResponse([
+			return new DataResponse([
 				'type' => 'error',
 				'error' => [
 					'code' => 'no_such_room',
@@ -446,7 +445,7 @@ class SignalingController extends OCSController {
 				'roomid' => $room->getToken(),
 			],
 		];
-		return new JSONResponse($response);
+		return new DataResponse($response);
 	}
 
 }

--- a/lib/Signaling/BackendNotifier.php
+++ b/lib/Signaling/BackendNotifier.php
@@ -208,11 +208,33 @@ class BackendNotifier{
 	 */
 	public function roomInCallChanged($room, $inCall, $sessionIds) {
 		$this->logger->info('Room in-call status changed: ' . $room->getToken() . ' ' . $inCall . ' ' . print_r($sessionIds, true));
+		$changed = [];
+		$users = [];
+		$participants = $room->getParticipants();
+		foreach ($participants['users'] as $userId => $participant) {
+			if ($participant['inCall']) {
+				$users[] = $participant;
+			}
+			if (in_array($participant['sessionId'], $sessionIds)) {
+				$participant['userId'] = $userId;
+				$changed[] = $participant;
+			}
+		}
+		foreach ($participants['guests'] as $participant) {
+			if ($participant['inCall']) {
+				$users[] = $participant;
+			}
+			if (in_array($participant['sessionId'], $sessionIds)) {
+				$changed[] = $participant;
+			}
+		}
+
 		$this->backendRequest('/api/v1/room/' . $room->getToken(), [
 			'type' => 'incall',
 			'incall' => [
 				'incall' => $inCall,
-				'sessionids' => $sessionIds,
+				'changed' => $changed,
+				'users' => $users
 			],
 		]);
 	}

--- a/lib/Signaling/BackendNotifier.php
+++ b/lib/Signaling/BackendNotifier.php
@@ -106,7 +106,7 @@ class BackendNotifier{
 			'headers' => $headers,
 			'body' => $body,
 		];
-		if (!empty($signaling['verify'])) {
+		if (empty($signaling['verify'])) {
 			$params['verify'] = false;
 		}
 		$this->doRequest($url, $params);

--- a/lib/Signaling/BackendNotifier.php
+++ b/lib/Signaling/BackendNotifier.php
@@ -198,4 +198,23 @@ class BackendNotifier{
 		]);
 	}
 
+	/**
+	 * The "in-call" status of the given session ids has changed..
+	 *
+	 * @param Room $room
+	 * @param bool $inCall
+	 * @param array $sessionids
+	 * @throws \Exception
+	 */
+	public function roomInCallChanged($room, $inCall, $sessionIds) {
+		$this->logger->info('Room in-call status changed: ' . $room->getToken() . ' ' . $inCall . ' ' . print_r($sessionIds, true));
+		$this->backendRequest('/api/v1/room/' . $room->getToken(), [
+			'type' => 'incall',
+			'incall' => [
+				'incall' => $inCall,
+				'sessionids' => $sessionIds,
+			],
+		]);
+	}
+
 }

--- a/tests/php/Controller/SignalingControllerTest.php
+++ b/tests/php/Controller/SignalingControllerTest.php
@@ -1,0 +1,619 @@
+<?php
+/**
+ *
+ * @copyright Copyright (c) 2018, Joachim Bauch (bauch@struktur.de)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Tests\php\Controller;
+
+use OCA\Spreed\Config;
+use OCA\Spreed\Controller\SignalingController;
+use OCA\Spreed\Exceptions\ParticipantNotFoundException;
+use OCA\Spreed\Exceptions\RoomNotFoundException;
+use OCA\Spreed\Manager;
+use OCA\Spreed\Participant;
+use OCA\Spreed\Room;
+use OCA\Spreed\Signaling\Messages;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\ISession;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Security\ISecureRandom;
+
+class CustomInputSignalingController extends SignalingController {
+
+	private $inputStream;
+
+	public function setInputStream($data) {
+		$this->inputStream = $data;
+	}
+
+	protected function getInputStream() {
+		return $this->inputStream;
+	}
+
+}
+
+/**
+ * @group DB
+ */
+class SignalingControllerTest extends \Test\TestCase {
+
+	/** @var OCA\Spreed\Config */
+	private $config;
+
+	/** @var \OCP\ISession|\PHPUnit_Framework_MockObject_MockObject */
+	private $session;
+
+	/** @var \OCA\Spreed\Manager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $manager;
+
+	/** @var \OCP\IDBConnection|\PHPUnit_Framework_MockObject_MockObject */
+	protected $dbConnection;
+
+	/** @var \OCA\Spreed\Signaling\Messages|\PHPUnit_Framework_MockObject_MockObject */
+	protected $messages;
+
+	/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $userManager;
+
+	/** @var string */
+	private $userId;
+
+	/** @var CustomInputSignalingController */
+	private $controller;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->userId = 'testUser';
+		$secureRandom = \OC::$server->getSecureRandom();
+		$timeFactory = $this->createMock(ITimeFactory::class);
+		$config = \OC::$server->getConfig();
+		$config->setAppValue('spreed', 'signaling_servers', json_encode([
+			'secret' => 'MySecretValue',
+		]));
+		$config->setAppValue('spreed', 'signaling_ticket_secret', 'the-app-ticket-secret');
+		$config->setUserValue($this->userId, 'spreed', 'signaling_ticket_secret', 'the-user-ticket-secret');
+		$this->config = new Config($config, $secureRandom, $timeFactory);
+		$this->session = $this->createMock(ISession::class);
+		$this->dbConnection = \OC::$server->getDatabaseConnection();
+		$this->manager = $this->createMock(Manager::class);
+		$this->messages = $this->createMock(Messages::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->recreateSignalingController();
+	}
+
+	private function recreateSignalingController() {
+		$this->controller = new CustomInputSignalingController(
+			'spreed',
+			$this->createMock(\OCP\IRequest::class),
+			$this->config,
+			$this->session,
+			$this->manager,
+			$this->dbConnection,
+			$this->messages,
+			$this->userManager,
+			$this->userId
+		);
+	}
+
+	private function validateBackendRandom($data, $random, $checksum) {
+		if (empty($random) || strlen($random) < 32) {
+			return false;
+		}
+		if (empty($checksum)) {
+			return false;
+		}
+		$hash = hash_hmac('sha256', $random . $data, $this->config->getSignalingSecret());
+		return hash_equals($hash, strtolower($checksum));
+	}
+
+	private function calculateBackendChecksum($data, $random) {
+		if (empty($random) || strlen($random) < 32) {
+			return false;
+		}
+		$hash = hash_hmac('sha256', $random . $data, $this->config->getSignalingSecret());
+		return $hash;
+	}
+
+	public function testBackendChecksums() {
+		// Test checksum generation / validation with the example from the API documentation.
+		$data = '{"type":"auth","auth":{"version":"1.0","params":{"hello":"world"}}}';
+		$random = 'afb6b872ab03e3376b31bf0af601067222ff7990335ca02d327071b73c0119c6';
+		$checksum = '3c4a69ff328299803ac2879614b707c807b4758cf19450755c60656cac46e3bc';
+		$this->assertEquals($checksum, $this->calculateBackendChecksum($data, $random));
+		$this->assertTrue($this->validateBackendRandom($data, $random, $checksum));
+	}
+
+	private function performBackendRequest($data) {
+		if (!is_string($data)) {
+			$data = json_encode($data);
+		}
+		$random = 'afb6b872ab03e3376b31bf0af601067222ff7990335ca02d327071b73c0119c6';
+		$checksum = $this->calculateBackendChecksum($data, $random);
+		$_SERVER['HTTP_SPREED_SIGNALING_RANDOM'] = $random;
+		$_SERVER['HTTP_SPREED_SIGNALING_CHECKSUM'] = $checksum;
+		$this->controller->setInputStream($data);
+		return $this->controller->backend();
+	}
+
+	public function testBackendChecksumValidation() {
+		$data = '{}';
+
+		// Random and checksum missing.
+		$this->controller->setInputStream($data);
+		$result = $this->controller->backend();
+		$this->assertSame([
+			'type' => 'error',
+			'error' => [
+				'code' => 'invalid_request',
+				'message' => 'The request could not be authenticated.',
+			],
+		], $result->getData());
+
+		// Invalid checksum.
+		$this->controller->setInputStream($data);
+		$random = 'afb6b872ab03e3376b31bf0af601067222ff7990335ca02d327071b73c0119c6';
+		$checksum = $this->calculateBackendChecksum('{"foo": "bar"}', $random);
+		$_SERVER['HTTP_SPREED_SIGNALING_RANDOM'] = $random;
+		$_SERVER['HTTP_SPREED_SIGNALING_CHECKSUM'] = $checksum;
+		$result = $this->controller->backend();
+		$this->assertSame([
+			'type' => 'error',
+			'error' => [
+				'code' => 'invalid_request',
+				'message' => 'The request could not be authenticated.',
+			],
+		], $result->getData());
+
+		// Short random
+		$this->controller->setInputStream($data);
+		$random = '12345';
+		$checksum = $this->calculateBackendChecksum($data, $random);
+		$_SERVER['HTTP_SPREED_SIGNALING_RANDOM'] = $random;
+		$_SERVER['HTTP_SPREED_SIGNALING_CHECKSUM'] = $checksum;
+		$result = $this->controller->backend();
+		$this->assertSame([
+			'type' => 'error',
+			'error' => [
+				'code' => 'invalid_request',
+				'message' => 'The request could not be authenticated.',
+			],
+		], $result->getData());
+	}
+
+	public function testBackendUnsupportedType() {
+		$result = $this->performBackendRequest([
+			'type' => 'unsupported-type',
+		]);
+		$this->assertSame([
+			'type' => 'error',
+			'error' => [
+				'code' => 'unknown_type',
+				'message' => 'The given type {"type":"unsupported-type"} is not supported.',
+			],
+		], $result->getData());
+	}
+
+	public function testBackendAuth() {
+		// Check validating of tickets.
+		$result = $this->performBackendRequest([
+			'type' => 'auth',
+			'auth' => [
+				'params' => [
+					'userid' => $this->userId,
+					'ticket' => 'invalid-ticket',
+				],
+			],
+		]);
+		$this->assertSame([
+			'type' => 'error',
+			'error' => [
+				'code' => 'invalid_ticket',
+				'message' => 'The given ticket is not valid for this user.',
+			],
+		], $result->getData());
+
+		// Check validating ticket for passed user.
+		$result = $this->performBackendRequest([
+			'type' => 'auth',
+			'auth' => [
+				'params' => [
+					'userid' => 'invalid-userid',
+					'ticket' => $this->config->getSignalingTicket($this->userId),
+				],
+			],
+		]);
+		$this->assertSame([
+			'type' => 'error',
+			'error' => [
+				'code' => 'invalid_ticket',
+				'message' => 'The given ticket is not valid for this user.',
+			],
+		], $result->getData());
+
+		// Check validating of existing users.
+		$result = $this->performBackendRequest([
+			'type' => 'auth',
+			'auth' => [
+				'params' => [
+					'userid' => 'unknown-userid',
+					'ticket' => $this->config->getSignalingTicket('unknown-userid'),
+				],
+			],
+		]);
+		$this->assertSame([
+			'type' => 'error',
+			'error' => [
+				'code' => 'no_such_user',
+				'message' => 'The given user does not exist.',
+			],
+		], $result->getData());
+
+		// Check successfull authentication of users.
+		$testUser = $this->createMock(IUser::class);
+		$testUser->expects($this->once())
+			->method('getDisplayName')
+			->willReturn('Test User');
+		$testUser->expects($this->once())
+			->method('getUID')
+			->willReturn($this->userId);
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with($this->userId)
+			->willReturn($testUser);
+		$result = $this->performBackendRequest([
+			'type' => 'auth',
+			'auth' => [
+				'params' => [
+					'userid' => $this->userId,
+					'ticket' => $this->config->getSignalingTicket($this->userId),
+				],
+			],
+		]);
+		$this->assertSame([
+			'type' => 'auth',
+			'auth' => [
+				'version' => '1.0',
+				'userid' => $this->userId,
+				'user' => [
+					'displayname' => 'Test User',
+				],
+			],
+		], $result->getData());
+
+		// Check successfull authentication of anonymous participants.
+		$result = $this->performBackendRequest([
+			'type' => 'auth',
+			'auth' => [
+				'params' => [
+					'userid' => '',
+					'ticket' => $this->config->getSignalingTicket(''),
+				],
+			],
+		]);
+		$this->assertSame([
+			'type' => 'auth',
+			'auth' => [
+				'version' => '1.0',
+			],
+		], $result->getData());
+	}
+
+	public function testBackendRoomUnknown() {
+		$roomToken = 'the-room';
+		$room = $this->createMock(Room::class);
+		$this->manager->expects($this->once())
+			->method('getRoomByToken')
+			->with($roomToken)
+			->willThrowException(new RoomNotFoundException());
+
+		$result = $this->performBackendRequest([
+			'type' => 'room',
+			'room' => [
+				'roomid' => $roomToken,
+				'userid' => $this->userId,
+				'sessionid' => '',
+			],
+		]);
+		$this->assertSame([
+			'type' => 'error',
+			'error' => [
+				'code' => 'no_such_room',
+				'message' => 'The user is not invited to this room.',
+			],
+		], $result->getData());
+	}
+
+	public function testBackendRoomInvited() {
+		$roomToken = 'the-room';
+		$roomName = 'the-room-name';
+		$room = $this->createMock(Room::class);
+		$this->manager->expects($this->once())
+			->method('getRoomByToken')
+			->with($roomToken)
+			->willReturn($room);
+
+		$participant = $this->createMock(Participant::class);
+		$room->expects($this->once())
+			->method('getName')
+			->willReturn($roomName);
+		$room->expects($this->once())
+			->method('getParticipant')
+			->with($this->userId)
+			->willReturn($participant);
+		$room->expects($this->once())
+			->method('getToken')
+			->willReturn($roomToken);
+		$room->expects($this->once())
+			->method('getType')
+			->willReturn(Room::ONE_TO_ONE_CALL);
+
+		$result = $this->performBackendRequest([
+			'type' => 'room',
+			'room' => [
+				'roomid' => $roomToken,
+				'userid' => $this->userId,
+				'sessionid' => '',
+			],
+		]);
+		$this->assertSame([
+			'type' => 'room',
+			'room' => [
+				'version' => '1.0',
+				'roomid' => $roomToken,
+				'properties' => [
+					'name' => $roomName,
+					'type' => Room::ONE_TO_ONE_CALL,
+				],
+			],
+		], $result->getData());
+	}
+
+	public function testBackendRoomAnonymousPublic() {
+		$roomToken = 'the-room';
+		$roomName = 'the-room-name';
+		$sessionId = 'the-session';
+		$room = $this->createMock(Room::class);
+		$this->manager->expects($this->once())
+			->method('getRoomByToken')
+			->with($roomToken)
+			->willReturn($room);
+
+		$participant = $this->createMock(Participant::class);
+		$room->expects($this->once())
+			->method('getName')
+			->willReturn($roomName);
+		$room->expects($this->once())
+			->method('getParticipantBySession')
+			->with($sessionId)
+			->willReturn($participant);
+		$room->expects($this->once())
+			->method('getToken')
+			->willReturn($roomToken);
+		$room->expects($this->once())
+			->method('getType')
+			->willReturn(Room::PUBLIC_CALL);
+
+		$result = $this->performBackendRequest([
+			'type' => 'room',
+			'room' => [
+				'roomid' => $roomToken,
+				'userid' => '',
+				'sessionid' => $sessionId,
+			],
+		]);
+		$this->assertSame([
+			'type' => 'room',
+			'room' => [
+				'version' => '1.0',
+				'roomid' => $roomToken,
+				'properties' => [
+					'name' => $roomName,
+					'type' => Room::PUBLIC_CALL,
+				],
+			],
+		], $result->getData());
+	}
+
+	public function testBackendRoomInvitedPublic() {
+		$roomToken = 'the-room';
+		$roomName = 'the-room-name';
+		$sessionId = 'the-session';
+		$room = $this->createMock(Room::class);
+		$this->manager->expects($this->once())
+			->method('getRoomByToken')
+			->with($roomToken)
+			->willReturn($room);
+
+		$participant = $this->createMock(Participant::class);
+		$room->expects($this->once())
+			->method('getName')
+			->willReturn($roomName);
+		$room->expects($this->once())
+			->method('getParticipant')
+			->with($this->userId)
+			->willThrowException(new ParticipantNotFoundException());
+		$room->expects($this->once())
+			->method('getParticipantBySession')
+			->with($sessionId)
+			->willReturn($participant);
+		$room->expects($this->once())
+			->method('getToken')
+			->willReturn($roomToken);
+		$room->expects($this->once())
+			->method('getType')
+			->willReturn(Room::PUBLIC_CALL);
+
+		$result = $this->performBackendRequest([
+			'type' => 'room',
+			'room' => [
+				'roomid' => $roomToken,
+				'userid' => $this->userId,
+				'sessionid' => $sessionId,
+			],
+		]);
+		$this->assertSame([
+			'type' => 'room',
+			'room' => [
+				'version' => '1.0',
+				'roomid' => $roomToken,
+				'properties' => [
+					'name' => $roomName,
+					'type' => Room::PUBLIC_CALL,
+				],
+			],
+		], $result->getData());
+	}
+
+	public function testBackendRoomAnonymousOneToOne() {
+		$roomToken = 'the-room';
+		$sessionId = 'the-session';
+		$room = $this->createMock(Room::class);
+		$this->manager->expects($this->once())
+			->method('getRoomByToken')
+			->with($roomToken)
+			->willReturn($room);
+
+		$participant = $this->createMock(Participant::class);
+		$room->expects($this->once())
+			->method('getParticipantBySession')
+			->willThrowException(new ParticipantNotFoundException());
+
+		$result = $this->performBackendRequest([
+			'type' => 'room',
+			'room' => [
+				'roomid' => $roomToken,
+				'userid' => '',
+				'sessionid' => $sessionId,
+			],
+		]);
+		$this->assertSame([
+			'type' => 'error',
+			'error' => [
+				'code' => 'no_such_room',
+				'message' => 'The user is not invited to this room.',
+			],
+		], $result->getData());
+	}
+
+	public function testBackendPingUnknownRoom() {
+		$roomToken = 'the-room';
+		$room = $this->createMock(Room::class);
+		$this->manager->expects($this->once())
+			->method('getRoomByToken')
+			->with($roomToken)
+			->willThrowException(new RoomNotFoundException());
+
+		$result = $this->performBackendRequest([
+			'type' => 'ping',
+			'ping' => [
+				'roomid' => $roomToken,
+				'entries' => [
+					[
+						'userid' => $this->userId,
+					],
+				],
+			],
+		]);
+		$this->assertSame([
+			'type' => 'error',
+			'error' => [
+				'code' => 'no_such_room',
+				'message' => 'No such room.',
+			],
+		], $result->getData());
+	}
+
+	public function testBackendPingUser() {
+		$roomToken = 'the-room';
+		$sessionId = 'the-session';
+		$room = $this->createMock(Room::class);
+		$this->manager->expects($this->once())
+			->method('getRoomByToken')
+			->with($roomToken)
+			->willReturn($room);
+		$room->expects($this->once())
+			->method('getToken')
+			->willReturn($roomToken);
+		$room->expects($this->once())
+			->method('ping')
+			->with($this->userId, $sessionId);
+
+		$result = $this->performBackendRequest([
+			'type' => 'ping',
+			'ping' => [
+				'roomid' => $roomToken,
+				'entries' => [
+					[
+						'userid' => $this->userId,
+						'sessionid' => $sessionId,
+					],
+				],
+			],
+		]);
+		$this->assertSame([
+			'type' => 'room',
+			'room' => [
+				'version' => '1.0',
+				'roomid' => $roomToken,
+			],
+		], $result->getData());
+	}
+
+	public function testBackendPingAnonymous() {
+		$roomToken = 'the-room';
+		$sessionId = 'the-session';
+		$room = $this->createMock(Room::class);
+		$this->manager->expects($this->once())
+			->method('getRoomByToken')
+			->with($roomToken)
+			->willReturn($room);
+		$room->expects($this->once())
+			->method('getToken')
+			->willReturn($roomToken);
+		$room->expects($this->once())
+			->method('ping')
+			->with('', $sessionId);
+
+		$result = $this->performBackendRequest([
+			'type' => 'ping',
+			'ping' => [
+				'roomid' => $roomToken,
+				'entries' => [
+					[
+						'userid' => '',
+						'sessionid' => $sessionId,
+					],
+				],
+			],
+		]);
+		$this->assertSame([
+			'type' => 'room',
+			'room' => [
+				'version' => '1.0',
+				'roomid' => $roomToken,
+			],
+		], $result->getData());
+	}
+
+}

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -1,0 +1,347 @@
+<?php
+/**
+ *
+ * @copyright Copyright (c) 2018, Joachim Bauch (bauch@struktur.de)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Tests\php\Signaling;
+
+use OCA\Spreed\AppInfo\Application;
+use OCA\Spreed\Config;
+use OCA\Spreed\Manager;
+use OCA\Spreed\Participant;
+use OCA\Spreed\Signaling\BackendNotifier;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Http\Client\IClientService;
+use OCP\ILogger;
+use OCP\IUser;
+use OCP\Security\IHasher;
+
+class CustomBackendNotifier extends BackendNotifier {
+
+    private $lastRequest;
+
+    public function getLastRequest() {
+        return $this->lastRequest;
+    }
+
+    public function clearLastRequest() {
+        $this->lastRequest = null;
+    }
+
+    protected function doRequest($url, $params) {
+        $this->lastRequest = [
+            'url' => $url,
+            'params' => $params,
+        ];
+    }
+
+}
+
+class CustomApplication extends Application {
+
+    private $notifier;
+
+    public function setBackendNotifier($notifier) {
+        $this->notifier = $notifier;
+    }
+
+    protected function getBackendNotifier() {
+        return $this->notifier;
+    }
+
+}
+
+/**
+ * @group DB
+ */
+class BackendNotifierTest extends \Test\TestCase {
+
+    /** @var OCA\Spreed\Config */
+    private $config;
+
+    /** @var ISecureRandom */
+    private $secureRandom;
+
+    /** @var CustomBackendNotifier */
+    private $controller;
+
+    /** @var Manager */
+    private $manager;
+
+    /** @var string */
+    private $userId;
+
+    public function setUp() {
+        parent::setUp();
+        // Make sure necessary database tables are set up.
+        \OC_App::updateApp('spreed');
+
+        $this->userId = 'testUser';
+        $this->secureRandom = \OC::$server->getSecureRandom();
+        $timeFactory = $this->createMock(ITimeFactory::class);
+        $config = \OC::$server->getConfig();
+        $this->signalingSecret = 'the-signaling-secret';
+        $this->baseUrl = 'https://localhost/signaling';
+        $config->setAppValue('spreed', 'signaling_servers', json_encode([
+            'secret' => $this->signalingSecret,
+            'servers' => [
+                [
+                    'server' => $this->baseUrl,
+                ],
+            ],
+        ]));
+
+        $this->config = new Config($config, $this->secureRandom, $timeFactory);
+        $this->recreateBackendNotifier();
+
+        $app = new CustomApplication();
+        $app->setBackendNotifier($this->controller);
+        $app->register();
+
+        \OC::$server->registerService(BackendNotifier::class, function() {
+            return $this->controller;
+        });
+
+        $dbConnection = \OC::$server->getDatabaseConnection();
+        $dispatcher = \OC::$server->getEventDispatcher();
+        $this->manager = new Manager($dbConnection, $config, $this->secureRandom, $dispatcher, $this->createMock(IHasher::class));
+    }
+
+    private function recreateBackendNotifier() {
+        $this->controller = new CustomBackendNotifier(
+            $this->config,
+            $this->createMock(ILogger::class),
+            $this->createMock(IClientService::class),
+            $this->secureRandom
+        );
+    }
+
+    private function calculateBackendChecksum($data, $random) {
+        if (empty($random) || strlen($random) < 32) {
+            return false;
+        }
+        $hash = hash_hmac('sha256', $random . $data, $this->signalingSecret);
+        return $hash;
+    }
+
+    private function validateBackendRequest($expectedUrl, $request) {
+        $this->assertTrue(isset($request));
+        $this->assertEquals($expectedUrl, $request['url']);
+        $headers = $request['params']['headers'];
+        $this->assertEquals('application/json', $headers['Content-Type']);
+        $random = $headers['Spreed-Signaling-Random'];
+        $checksum = $headers['Spreed-Signaling-Checksum'];
+        $body = $request['params']['body'];
+        $this->assertEquals($this->calculateBackendChecksum($body, $random), $checksum);
+        return $body;
+    }
+
+    public function testRoomInvite() {
+        $room = $this->manager->createPublicRoom();
+        $room->addUsers([
+            'userId' => $this->userId,
+        ]);
+
+        $request = $this->controller->getLastRequest();
+        $body = $this->validateBackendRequest($this->baseUrl . '/api/v1/room/' . $room->getToken(), $request);
+        $this->assertSame([
+            'type' => 'invite',
+            'invite' => [
+                'userids' => [
+                    $this->userId,
+                ],
+                'alluserids' => [
+                    $this->userId,
+                ],
+                'properties' => [
+                    'name' => $room->getName(),
+                    'type' => $room->getType(),
+                ],
+            ],
+        ], json_decode($body, true));
+    }
+
+    public function testRoomDisinvite() {
+        $room = $this->manager->createPublicRoom();
+        $room->addUsers([
+            'userId' => $this->userId,
+        ]);
+        $this->controller->clearLastRequest();
+        $testUser = $this->createMock(IUser::class);
+        $testUser
+            ->method('getUID')
+            ->willReturn($this->userId);
+        $room->removeUser($testUser);
+
+        $request = $this->controller->getLastRequest();
+        $body = $this->validateBackendRequest($this->baseUrl . '/api/v1/room/' . $room->getToken(), $request);
+        $this->assertSame([
+            'type' => 'disinvite',
+            'disinvite' => [
+                'userids' => [
+                    $this->userId,
+                ],
+                'alluserids' => [
+                ],
+                'properties' => [
+                    'name' => $room->getName(),
+                    'type' => $room->getType(),
+                ],
+            ],
+        ], json_decode($body, true));
+    }
+
+    public function testRoomNameChanged() {
+        $room = $this->manager->createPublicRoom();
+        $room->setName('Test room');
+
+        $request = $this->controller->getLastRequest();
+        $body = $this->validateBackendRequest($this->baseUrl . '/api/v1/room/' . $room->getToken(), $request);
+        $this->assertSame([
+            'type' => 'update',
+            'update' => [
+                'userids' => [
+                ],
+                'properties' => [
+                    'name' => $room->getName(),
+                    'type' => $room->getType(),
+                ],
+            ],
+        ], json_decode($body, true));
+    }
+
+    public function testRoomDelete() {
+        $room = $this->manager->createPublicRoom();
+        $room->addUsers([
+            'userId' => $this->userId,
+        ]);
+        $room->deleteRoom();
+
+        $request = $this->controller->getLastRequest();
+        $body = $this->validateBackendRequest($this->baseUrl . '/api/v1/room/' . $room->getToken(), $request);
+        $this->assertSame([
+            'type' => 'delete',
+            'delete' => [
+                'userids' => [
+                    $this->userId,
+                ],
+            ],
+        ], json_decode($body, true));
+    }
+
+    public function testRoomInCallChanged() {
+        $room = $this->manager->createPublicRoom();
+        $userSession = 'user-session';
+        $room->addUsers([
+            'userId' => $this->userId,
+            'sessionId' => $userSession,
+        ]);
+        $room->changeInCall($userSession, true);
+
+        $request = $this->controller->getLastRequest();
+        $body = $this->validateBackendRequest($this->baseUrl . '/api/v1/room/' . $room->getToken(), $request);
+        $this->assertSame([
+            'type' => 'incall',
+            'incall' => [
+                'incall' => true,
+                'changed' => [
+                    [
+                        'inCall' => true,
+                        'lastPing' => 0,
+                        'sessionId' => $userSession,
+                        'participantType' => Participant::USER,
+                        'userId' => $this->userId,
+                    ],
+                ],
+                'users' => [
+                    [
+                        'inCall' => true,
+                        'lastPing' => 0,
+                        'sessionId' => $userSession,
+                        'participantType' => Participant::USER,
+                    ],
+                ],
+            ],
+        ], json_decode($body, true));
+
+        $this->controller->clearLastRequest();
+        $guestSession = $room->enterRoomAsGuest('');
+        $room->changeInCall($guestSession, true);
+        $request = $this->controller->getLastRequest();
+        $body = $this->validateBackendRequest($this->baseUrl . '/api/v1/room/' . $room->getToken(), $request);
+        $this->assertSame([
+            'type' => 'incall',
+            'incall' => [
+                'incall' => true,
+                'changed' => [
+                    [
+                        'inCall' => true,
+                        'lastPing' => 0,
+                        'sessionId' => $guestSession,
+                        'participantType' => Participant::GUEST,
+                    ],
+                ],
+                'users' => [
+                    [
+                        'inCall' => true,
+                        'lastPing' => 0,
+                        'sessionId' => $userSession,
+                        'participantType' => Participant::USER,
+                    ],
+                    [
+                        'inCall' => true,
+                        'lastPing' => 0,
+                        'sessionId' => $guestSession,
+                        'participantType' => Participant::GUEST,
+                    ],
+                ],
+            ],
+        ], json_decode($body, true));
+
+        $this->controller->clearLastRequest();
+        $room->changeInCall($userSession, false);
+        $request = $this->controller->getLastRequest();
+        $body = $this->validateBackendRequest($this->baseUrl . '/api/v1/room/' . $room->getToken(), $request);
+        $this->assertSame([
+            'type' => 'incall',
+            'incall' => [
+                'incall' => false,
+                'changed' => [
+                    [
+                        'inCall' => false,
+                        'lastPing' => 0,
+                        'sessionId' => $userSession,
+                        'participantType' => Participant::USER,
+                        'userId' => $this->userId,
+                    ],
+                ],
+                'users' => [
+                    [
+                        'inCall' => true,
+                        'lastPing' => 0,
+                        'sessionId' => $guestSession,
+                        'participantType' => Participant::GUEST,
+                    ],
+                ],
+            ],
+        ], json_decode($body, true));
+    }
+
+}


### PR DESCRIPTION
This is a follow-up to #459 