### PR TITLE
Display the guest nick for guests on the Chat input

### DIFF
--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -79,8 +79,12 @@
 			if (!this._addCommentTemplate) {
 				this._addCommentTemplate = Handlebars.compile(ADD_COMMENT_TEMPLATE);
 			}
-			// FIXME handle guest users
+
 			var currentUser = OC.getCurrentUser();
+			if (currentUser.uid === null) {
+				currentUser.displayName = OCA.SpreedMe.app.guestNick || '';
+			}
+
 			return this._addCommentTemplate(_.extend({
 				actorId: currentUser.uid,
 				actorDisplayName: currentUser.displayName,


### PR DESCRIPTION
Sadly enough, this seems to not work. The problem is that the chat stuff is set up, before OCA.SpreedMe.app exists, this is due to
https://github.com/nextcloud/spreed/blob/2b596e396dba92f8fe6990d1b57e55ebcdfa853e/js/init.js#L23
It first creates the object, before assigning it to the variable.

Any idea @danxuliu 

Fix #493 