### PR TITLE
Give audio-white and audio-off-white shadow via CSS

### DIFF
--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -71,7 +71,7 @@ script(
 					<div class="avatar"></div>
 				</div>
 				<div class="nameIndicator">
-					<button id="mute" class="icon-audio-white" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Mute audio')) ?>"></button>
+					<button id="mute" class="icon-audio-white icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Mute audio')) ?>"></button>
 					<button id="hideVideo" class="icon-video-white" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Disable video')) ?>"></button>
 					<button id="screensharing-button" class="app-navigation-entry-utils-menu-button icon-screen-off-white screensharing-disabled" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Share screen')) ?>"></button>
 					<div id="screensharing-menu" class="app-navigation-entry-menu">

--- a/templates/index.php
+++ b/templates/index.php
@@ -64,7 +64,7 @@ script(
 					<div class="avatar"></div>
 				</div>
 				<div class="nameIndicator">
-					<button id="mute" class="icon-audio-white" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Mute audio')) ?>"></button>
+					<button id="mute" class="icon-audio-white icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Mute audio')) ?>"></button>
 					<button id="hideVideo" class="icon-video-white" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Disable video')) ?>"></button>
 					<button id="screensharing-button" class="app-navigation-entry-utils-menu-button icon-screen-off-white screensharing-disabled" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Share screen')) ?>"></button>
 					<div id="screensharing-menu" class="app-navigation-entry-menu">


### PR DESCRIPTION
Fixes regression https://github.com/nextcloud/server/issues/7243

audio-white and audio-off-white should be visible in Talk app when video is disabled (thanks to shadow).

This introduces new class `.icon-shadow` that can be use on any icon. Other icons that (still) have SVG shadow filters will be migrated to this solution in a subsequent PR, because only this one is critical.

To be reviewed and merged with https://github.com/nextcloud/server/pull/7247