### PR TITLE
Fix SQLite random issues where you can only connect to the newest room

### DIFF
--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -258,18 +258,16 @@ class Manager {
 
 		$query = $this->db->getQueryBuilder();
 		$query->select('*')
-			->from('talk_rooms', 'r')
-			->leftJoin('r', 'talk_participants', 'p', $query->expr()->andX(
-				$query->expr()->eq('p.sessionId', $query->createNamedParameter($sessionId)),
-				$query->expr()->eq('p.roomId', 'r.id')
-			))
+			->from('talk_participants', 'p')
+			->leftJoin('p', 'talk_rooms', 'r', $query->expr()->eq('p.roomId', 'r.id'))
+			->where($query->expr()->eq('p.sessionId', $query->createNamedParameter($sessionId)))
 			->setMaxResults(1);
 
 		$result = $query->execute();
 		$row = $result->fetch();
 		$result->closeCursor();
 
-		if ($row === false) {
+		if ($row === false || !$row['id']) {
 			throw new RoomNotFoundException();
 		}
 


### PR DESCRIPTION
The problem is, that SQLite does the LIMIT before the LEFT JOIN.
This means it would always take the latest room and then try to
match your session against it. However, we wanted to first match
the LEFT JOIN and then limit the result set to 1 row.

By changing the FROM to the participant table, we will always match
the correct participant (if there is one) and then left join the
room just like we intended to.

Signed-off-by: Joas Schilling <coding@schilljs.com>