### PR TITLE
Allow apps to get the signaling information

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -47,6 +47,14 @@ return [
 			],
 		],
 		[
+			'name' => 'Signaling#getSettings',
+			'url' => '/api/{apiVersion}/signaling/settings',
+			'verb' => 'GET',
+			'requirements' => [
+				'apiVersion' => 'v1',
+			],
+		],
+		[
 			'name' => 'Signaling#backend',
 			'url' => '/api/{apiVersion}/signaling/backend',
 			'verb' => 'POST',

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -52,6 +52,43 @@ class Config {
 		$this->timeFactory = $timeFactory;
 	}
 
+	public function getSettings($userId) {
+		$stun = [];
+		$stunServer = $this->getStunServer();
+		if ($stunServer) {
+			$stun[] = [
+				'url' => 'stun:' . $stunServer,
+			];
+		}
+		$turn = [];
+		$turnSettings = $this->getTurnSettings();
+		if (!empty($turnSettings['server'])) {
+			$protocols = explode(',', $turnSettings['protocols']);
+			foreach ($protocols as $proto) {
+				$turn[] = [
+					'url' => ['turn:' . $turnSettings['server'] . '?transport=' . $proto],
+					'urls' => ['turn:' . $turnSettings['server'] . '?transport=' . $proto],
+					'username' => $turnSettings['username'],
+					'credential' => $turnSettings['password'],
+				];
+			}
+		}
+
+		$signaling = [];
+		$servers = $this->getSignalingServers();
+		if (!empty($servers)) {
+			$signaling = $servers[mt_rand(0, count($servers) - 1)];
+			$signaling = $signaling['server'];
+		}
+
+		return [
+			'server' => $signaling,
+			'ticket' => $this->getSignalingTicket($userId),
+			'stunservers' => $stun,
+			'turnservers' => $turn,
+		];
+	}
+
 	/**
 	 * @return string
 	 */

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -93,46 +93,6 @@ class PageController extends Controller {
 	}
 
 	/**
-	 * @return array
-	 */
-	private function getSignalingSettings() {
-		$stun = [];
-		$stunServer = $this->config->getStunServer();
-		if ($stunServer) {
-			$stun[] = [
-				'url' => 'stun:' . $stunServer,
-			];
-		}
-		$turn = [];
-		$turnSettings = $this->config->getTurnSettings();
-		if (!empty($turnSettings['server'])) {
-			$protocols = explode(',', $turnSettings['protocols']);
-			foreach ($protocols as $proto) {
-				$turn[] = [
-					'url' => ['turn:' . $turnSettings['server'] . '?transport=' . $proto],
-					'urls' => ['turn:' . $turnSettings['server'] . '?transport=' . $proto],
-					'username' => $turnSettings['username'],
-					'credential' => $turnSettings['password'],
-				];
-			}
-		}
-
-		$signaling = [];
-		$servers = $this->config->getSignalingServers();
-		if (!empty($servers)) {
-			$signaling = $servers[mt_rand(0, count($servers) - 1)];
-			$signaling = $signaling['server'];
-		}
-
-		return [
-			'server' => $signaling,
-			'ticket' => $this->config->getSignalingTicket($this->userId),
-			'stunservers' => $stun,
-			'turnservers' => $turn,
-		];
-	}
-
-	/**
 	 * @PublicPage
 	 * @NoCSRFRequired
 	 * @UseSession
@@ -204,7 +164,7 @@ class PageController extends Controller {
 
 		$params = [
 			'token' => $token,
-			'signaling-settings' => $this->getSignalingSettings(),
+			'signaling-settings' => $this->config->getSettings($this->userId),
 		];
 		$response = new TemplateResponse($this->appName, 'index', $params);
 		$csp = new ContentSecurityPolicy();
@@ -243,7 +203,7 @@ class PageController extends Controller {
 
 		$params = [
 			'token' => $token,
-			'signaling-settings' => $this->getSignalingSettings(),
+			'signaling-settings' => $this->config->getSettings($this->userId),
 		];
 		$response = new TemplateResponse($this->appName, 'index-public', $params, 'base');
 		$csp = new ContentSecurityPolicy();

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -84,6 +84,18 @@ class SignalingController extends OCSController {
 	}
 
 	/**
+	 * @NoAdminRequired
+	 *
+	 * Only available for logged in users because guests can not use the apps
+	 * right now.
+	 *
+	 * @return DataResponse
+	 */
+	public function getSettings() {
+		return new DataResponse($this->config->getSettings($this->userId));
+	}
+
+	/**
 	 * @PublicPage
 	 *
 	 * @param string $messages


### PR DESCRIPTION
"Regression" from 6ee066ab0825517fb992cf9377e7b0fc46005827

call `GET ocs/v2.php/apps/spreed/api/v1/signaling/settings` to get the stun, turn and other required config