### PR TITLE
Fix sorting of chat messages with same timestamp

### DIFF
--- a/js/models/chatmessagecollection.js
+++ b/js/models/chatmessagecollection.js
@@ -90,8 +90,16 @@
 			// messages sorted from oldest to newest, is to sort the models
 			// passed to "set" from oldest to newest.
 			if (models !== undefined && models !== null && models.ocs !== undefined && models.ocs.data !== undefined) {
-				models.ocs.data = _.sortBy(models.ocs.data, function(model) {
-					return model.timestamp;
+				models.ocs.data = _.sortBy(models.ocs.data, function(model, index) {
+					// The timestamp is in seconds, so when sent extremely fast
+					// two or more messages can have the same timestamp. The ID
+					// is a string, and although currently it contains an
+					// integer which is always incremented from the previous
+					// message that is an internal implementation detail that
+					// can not be relied on. Due to all that the sorting is
+					// based on the reversed position of the model in the set
+					// returned by the server.
+					return (models.ocs.data.length - 1 - index);
 				});
 			}
 


### PR DESCRIPTION
The timestamp is in seconds, so when sent extremely fast two or more messages can have the same timestamp. As a stable sorting algorithm is used and the messages were sorted only by timestamp, when two or more messages had the same timestamp the relative order between them was the same as the one returned by the server. Due to this those messages were sorted from newest to oldest between them, while the rest were sorted from oldest to newest. The solution is to sort the models by their reversed position in the set returned by the server.
