### PR TITLE
Open sidebar automatically when joining a room

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -385,6 +385,16 @@
 		updateSidebarWithActiveRoom: function() {
 			this._sidebarView.enable();
 
+			// The sidebar has a width of 27% of the window width and a minimum
+			// width of 300px. Therefore, when the window is 1111px wide or
+			// narrower the sidebar will always be 300px wide, and when that
+			// happens it will overlap with the content area (the narrower the
+			// window the larger the overlap). Due to this the sidebar is opened
+			// automatically only if it will not overlap with the content area.
+			if ($(window).width() > 1111) {
+				this._sidebarView.open();
+			}
+
 			var callInfoView = new OCA.SpreedMe.Views.CallInfoView({
 				model: this.activeRoom,
 				guestNameModel: this._localStorageModel


### PR DESCRIPTION
Fixes #461

The sidebar has a width of 27% of the window width and a minimum width of 300px. Therefore, when the window is 1111px wide or narrower the sidebar will always be 300px wide, and when that happens it will overlap with the content area (the narrower the window the larger the overlap); this will be more evident once the chat view is shown as the main view. Due to this the sidebar is opened automatically only if it will not overlap with the content area.

With this change if the window is wide enough the sidebar will always be opened when joining a room. Should we try to be more _clever_ about that (and take into account that _soon_ the main view will show not only video, but also a chat when not in a call)? For example, if the user joins a room and closes the sidebar without joining a call (so she was just chatting) it may be better to not open the sidebar automatically if she changes to another room. But if she closed the sidebar because she was in a call maybe she expects it to open when joining a new room... or maybe not. It is hard to know what a user expects :-) Due to that I opted for the current approach, which is always consistent, sometimes maybe annoying ;-)
