### PR TITLE
Format mentions in the message list

### DIFF
--- a/js/models/chatmessage.js
+++ b/js/models/chatmessage.js
@@ -48,7 +48,8 @@
 			actorId: '',
 			actorDisplayName: '',
 			timestamp: 0,
-			message: ''
+			message: '',
+			messageParameters: []
 		},
 
 		url: function() {

--- a/js/richobjectstringparser.js
+++ b/js/richobjectstringparser.js
@@ -1,0 +1,76 @@
+/* global OCA, Handlebars */
+
+/**
+ * @copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ */
+
+(function(OCA, Handlebars) {
+
+	OCA.SpreedMe.RichObjectStringParser = {
+
+		_userLocalTemplate: '<span class="avatar-name-wrapper" data-user="{{id}}"><div class="avatar" data-user="{{id}}" data-user-display-name="{{name}}"></div><strong>{{name}}</strong></span>',
+
+		_unknownTemplate: '<strong>{{name}}</strong>',
+		_unknownLinkTemplate: '<a href="{{link}}">{{name}}</a>',
+
+		/**
+		 * @param {string} subject
+		 * @param {Object} parameters
+		 * @returns {string}
+		 */
+		parseMessage: function(subject, parameters) {
+			var self = this,
+				regex = /\{([a-z0-9-]+)\}/gi,
+				matches = subject.match(regex);
+
+			_.each(matches, function(parameter) {
+				parameter = parameter.substring(1, parameter.length - 1);
+				var parsed = self.parseParameter(parameters[parameter]);
+
+				subject = subject.replace('{' + parameter + '}', parsed);
+			});
+
+			return subject;
+		},
+
+		/**
+		 * @param {Object} parameter
+		 * @param {string} parameter.type
+		 * @param {string} parameter.id
+		 * @param {string} parameter.name
+		 * @param {string} parameter.link
+		 */
+		parseParameter: function(parameter) {
+			switch (parameter.type) {
+				case 'user':
+					if (!this.userLocalTemplate) {
+						this.userLocalTemplate = Handlebars.compile(this._userLocalTemplate);
+					}
+					if (!parameter.name) {
+						parameter.name = parameter.id;
+					}
+					return this.userLocalTemplate(parameter);
+
+				default:
+					if (!_.isUndefined(parameter.link)) {
+						if (!this.unknownLinkTemplate) {
+							this.unknownLinkTemplate = Handlebars.compile(this._unknownLinkTemplate);
+						}
+						return this.unknownLinkTemplate(parameter);
+					}
+
+					if (!this.unknownTemplate) {
+						this.unknownTemplate = Handlebars.compile(this._unknownTemplate);
+					}
+					return this.unknownTemplate(parameter);
+			}
+		}
+
+	};
+
+})(OCA, Handlebars);

--- a/js/richobjectstringparser.js
+++ b/js/richobjectstringparser.js
@@ -30,8 +30,13 @@
 
 			_.each(matches, function(parameter) {
 				parameter = parameter.substring(1, parameter.length - 1);
-				var parsed = self.parseParameter(parameters[parameter]);
+				if (!parameters.hasOwnProperty(parameter) || !parameters[parameter]) {
+					// Malformed translation?
+					console.error('Potential malformed ROS string: parameter {' + parameter + '} was found in the string but is missing from the parameter list');
+					return;
+				}
 
+				var parsed = self.parseParameter(parameters[parameter]);
 				subject = subject.replace('{' + parameter + '}', parsed);
 			});
 

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -205,7 +205,8 @@
 			}
 
 			var formattedMessage = escapeHTML(commentModel.get('message')).replace(/\n/g, '<br/>');
-			formattedMessage = OCP.Comments.plainToRich(formattedMessage);
+			formattedMessage = OCA.SpreedMe.RichObjectStringParser.parseMessage(
+				formattedMessage, commentModel.get('messageParameters'));
 
 			var data = _.extend({}, commentModel.attributes, {
 				actorDisplayName: actorDisplayName,

--- a/lib/Chat/RichMessageHelper.php
+++ b/lib/Chat/RichMessageHelper.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Chat;
+
+use OCP\Comments\IComment;
+use OCP\Comments\ICommentsManager;
+
+/**
+ * Helper class to get a rich message from a plain text message.
+ */
+class RichMessageHelper {
+
+	/** @var ICommentsManager */
+	private $commentsManager;
+
+	/**
+	 * @param ICommentsManager $commentsManager
+	 */
+	public function __construct(ICommentsManager $commentsManager) {
+		$this->commentsManager = $commentsManager;
+	}
+
+	/**
+	 * Returns the equivalent rich message to the given comment.
+	 *
+	 * The mentions in the comment are replaced by "{mention-$type$index}" in
+	 * the returned rich message; each "mention-$type$index" parameter contains
+	 * the following attributes:
+	 *   -type: the type of the mention ("user")
+	 *   -id: the ID of the user
+	 *   -name: the display name of the user, or an empty string if it could
+	 *     not be resolved.
+	 *
+	 * @param IComment $comment
+	 * @return Array first element, the rich message; second element, the
+	 *         parameters of the rich message (or an empty array if there are no
+	 *         parameters).
+	 */
+	public function getRichMessage(IComment $comment) {
+		$message = $comment->getMessage();
+		$messageParameters = [];
+
+		$mentionTypeCount = [];
+
+		$mentions = $comment->getMentions();
+		foreach ($mentions as $mention) {
+			if (!array_key_exists($mention['type'], $mentionTypeCount)) {
+				$mentionTypeCount[$mention['type']] = 0;
+			}
+			$mentionTypeCount[$mention['type']]++;
+
+			// To keep a limited character set in parameter IDs ([a-zA-Z0-9-])
+			// the mention parameter ID does not include the mention ID (which
+			// could contain characters like '@' for user IDs) but a one-based
+			// index of the mentions of that type.
+			$mentionParameterId = 'mention-' . $mention['type'] . $mentionTypeCount[$mention['type']];
+
+			$message = str_replace('@' . $mention['id'], '{' . $mentionParameterId . '}', $message);
+
+			try {
+				$displayName = $this->commentsManager->resolveDisplayName($mention['type'], $mention['id']);
+			} catch (\OutOfBoundsException $e) {
+				// There is no registered display name resolver for the mention
+				// type, so the client decides what to display.
+				$displayName = '';
+			}
+
+			$messageParameters[$mentionParameterId] = [
+				'type' => $mention['type'],
+				'id' => $mention['id'],
+				'name' => $displayName
+			];
+		}
+
+		return [$message, $messageParameters];
+	}
+
+}

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -24,6 +24,7 @@
 namespace OCA\Spreed\Controller;
 
 use OCA\Spreed\Chat\ChatManager;
+use OCA\Spreed\Chat\RichMessageHelper;
 use OCA\Spreed\Exceptions\ParticipantNotFoundException;
 use OCA\Spreed\Exceptions\RoomNotFoundException;
 use OCA\Spreed\GuestManager;
@@ -64,6 +65,9 @@ class ChatController extends OCSController {
 	/** @var string[] */
 	protected $guestNames;
 
+	/** @var RichMessageHelper */
+	private $richMessageHelper;
+
 	/**
 	 * @param string $appName
 	 * @param string $UserId
@@ -81,7 +85,8 @@ class ChatController extends OCSController {
 								TalkSession $session,
 								Manager $manager,
 								ChatManager $chatManager,
-								GuestManager $guestManager) {
+								GuestManager $guestManager,
+								RichMessageHelper $richMessageHelper) {
 		parent::__construct($appName, $request);
 
 		$this->userId = $UserId;
@@ -90,6 +95,7 @@ class ChatController extends OCSController {
 		$this->manager = $manager;
 		$this->chatManager = $chatManager;
 		$this->guestManager = $guestManager;
+		$this->richMessageHelper = $richMessageHelper;
 	}
 
 	/**
@@ -247,6 +253,8 @@ class ChatController extends OCSController {
 				$displayName = $guestNames[$comment->getActorId()];
 			}
 
+			list($message, $messageParameters) = $this->richMessageHelper->getRichMessage($comment);
+
 			return [
 				'id' => $comment->getId(),
 				'token' => $token,
@@ -254,7 +262,8 @@ class ChatController extends OCSController {
 				'actorId' => $comment->getActorId(),
 				'actorDisplayName' => $displayName,
 				'timestamp' => $comment->getCreationDateTime()->getTimestamp(),
-				'message' => $comment->getMessage()
+				'message' => $message,
+				'messageParameters' => $messageParameters,
 			];
 		}, $comments), Http::STATUS_OK);
 

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -25,6 +25,7 @@ script(
 		'views/roomlistview',
 		'views/sidebarview',
 		'views/tabview',
+		'richobjectstringparser',
 		'simplewebrtc',
 		'webrtc',
 		'signaling',

--- a/templates/index.php
+++ b/templates/index.php
@@ -28,6 +28,7 @@ script(
 		'views/roomlistview',
 		'views/sidebarview',
 		'views/tabview',
+		'richobjectstringparser',
 		'simplewebrtc',
 		'webrtc',
 		'signaling',

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -465,6 +465,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 				// TODO test timestamp; it may require using Runkit, php-timecop
 				// or something like that.
 				'message' => (string) $message['message'],
+				'messageParameters' => json_encode($message['messageParameters']),
 			];
 		}, $messages));
 	}

--- a/tests/integration/features/chat/group.feature
+++ b/tests/integration/features/chat/group.feature
@@ -12,8 +12,8 @@ Feature: chat/group
       | invite   | attendees1 |
     When user "participant1" sends message "Message 1" to room "group room" with 201
     Then user "participant1" sees the following messages in room "group room" with 200
-      | room       | actorType | actorId      | actorDisplayName         | message   |
-      | group room | users     | participant1 | participant1-displayname | Message 1 |
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | group room | users     | participant1 | participant1-displayname | Message 1 | []                |
 
   Scenario: invited user can send and receive chat messages to and from group room
     Given user "participant1" creates room "group room"
@@ -21,8 +21,8 @@ Feature: chat/group
       | invite   | attendees1 |
     When user "participant2" sends message "Message 1" to room "group room" with 201
     Then user "participant2" sees the following messages in room "group room" with 200
-      | room       | actorType | actorId      | actorDisplayName         | message   |
-      | group room | users     | participant2 | participant2-displayname | Message 1 |
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | group room | users     | participant2 | participant2-displayname | Message 1 | []                |
 
   Scenario: not invited user can not send nor receive chat messages to nor from group room
     Given user "participant1" creates room "group room"
@@ -48,10 +48,10 @@ Feature: chat/group
     When user "participant1" sends message "Message 1" to room "group room" with 201
     And user "participant2" sends message "Message 2" to room "group room" with 201
     Then user "participant1" sees the following messages in room "group room" with 200
-      | room       | actorType | actorId      | actorDisplayName         | message   |
-      | group room | users     | participant2 | participant2-displayname | Message 2 |
-      | group room | users     | participant1 | participant1-displayname | Message 1 |
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | group room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | group room | users     | participant1 | participant1-displayname | Message 1 | []                |
     And user "participant2" sees the following messages in room "group room" with 200
-      | room       | actorType | actorId      | actorDisplayName         | message   |
-      | group room | users     | participant2 | participant2-displayname | Message 2 |
-      | group room | users     | participant1 | participant1-displayname | Message 1 |
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | group room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | group room | users     | participant1 | participant1-displayname | Message 1 | []                |

--- a/tests/integration/features/chat/one-to-one.feature
+++ b/tests/integration/features/chat/one-to-one.feature
@@ -10,8 +10,8 @@ Feature: chat/one-to-one
       | invite   | participant2 |
     When user "participant1" sends message "Message 1" to room "one-to-one room" with 201
     Then user "participant1" sees the following messages in room "one-to-one room" with 200
-      | room            | actorType | actorId      | actorDisplayName         | message   |
-      | one-to-one room | users     | participant1 | participant1-displayname | Message 1 |
+      | room            | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | one-to-one room | users     | participant1 | participant1-displayname | Message 1 | []                |
 
   Scenario: invited user can send and receive chat messages to and from one-to-one room
     Given user "participant1" creates room "one-to-one room"
@@ -19,8 +19,8 @@ Feature: chat/one-to-one
       | invite   | participant2 |
     When user "participant2" sends message "Message 1" to room "one-to-one room" with 201
     Then user "participant2" sees the following messages in room "one-to-one room" with 200
-      | room            | actorType | actorId      | actorDisplayName         | message   |
-      | one-to-one room | users     | participant2 | participant2-displayname | Message 1 |
+      | room            | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | one-to-one room | users     | participant2 | participant2-displayname | Message 1 | []                |
 
   Scenario: not invited user can not send nor receive chat messages to nor from one-to-one room
     Given user "participant1" creates room "one-to-one room"
@@ -46,10 +46,10 @@ Feature: chat/one-to-one
     When user "participant1" sends message "Message 1" to room "one-to-one room" with 201
     And user "participant2" sends message "Message 2" to room "one-to-one room" with 201
     Then user "participant1" sees the following messages in room "one-to-one room" with 200
-      | room            | actorType | actorId      | actorDisplayName         | message   |
-      | one-to-one room | users     | participant2 | participant2-displayname | Message 2 |
-      | one-to-one room | users     | participant1 | participant1-displayname | Message 1 |
+      | room            | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | one-to-one room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | one-to-one room | users     | participant1 | participant1-displayname | Message 1 | []                |
     And user "participant2" sees the following messages in room "one-to-one room" with 200
-      | room            | actorType | actorId      | actorDisplayName         | message   |
-      | one-to-one room | users     | participant2 | participant2-displayname | Message 2 |
-      | one-to-one room | users     | participant1 | participant1-displayname | Message 1 |
+      | room            | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | one-to-one room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | one-to-one room | users     | participant1 | participant1-displayname | Message 1 | []                |

--- a/tests/integration/features/chat/password.feature
+++ b/tests/integration/features/chat/password.feature
@@ -10,8 +10,8 @@ Feature: chat/password
     And user "participant1" sets password "foobar" for room "public password protected room" with 200
     When user "participant1" sends message "Message 1" to room "public password protected room" with 201
     Then user "participant1" sees the following messages in room "public password protected room" with 200
-      | room                           | actorType | actorId      | actorDisplayName         | message   |
-      | public password protected room | users     | participant1 | participant1-displayname | Message 1 |
+      | room                           | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public password protected room | users     | participant1 | participant1-displayname | Message 1 | []                |
 
   Scenario: invited user can send and receive chat messages to and from public password protected room
     Given user "participant1" creates room "public password protected room"
@@ -20,8 +20,8 @@ Feature: chat/password
     And user "participant1" adds "participant2" to room "public password protected room" with 200
     When user "participant2" sends message "Message 1" to room "public password protected room" with 201
     Then user "participant2" sees the following messages in room "public password protected room" with 200
-      | room                           | actorType | actorId      | actorDisplayName         | message   |
-      | public password protected room | users     | participant2 | participant2-displayname | Message 1 |
+      | room                           | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public password protected room | users     | participant2 | participant2-displayname | Message 1 | []                |
 
   Scenario: not invited but joined with password user can send and receive chat messages to and from public password protected room
     Given user "participant1" creates room "public password protected room"
@@ -31,8 +31,8 @@ Feature: chat/password
       | password | foobar |
     When user "participant3" sends message "Message 1" to room "public password protected room" with 201
     Then user "participant3" sees the following messages in room "public password protected room" with 200
-      | room                           | actorType | actorId      | actorDisplayName         | message   |
-      | public password protected room | users     | participant3 | participant3-displayname | Message 1 |
+      | room                           | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public password protected room | users     | participant3 | participant3-displayname | Message 1 | []                |
 
   Scenario: not invited user can not send nor receive chat messages to and from public password protected room
     Given user "participant1" creates room "public password protected room"
@@ -50,8 +50,8 @@ Feature: chat/password
       | password | foobar |
     When user "guest" sends message "Message 1" to room "public password protected room" with 201
     Then user "guest" sees the following messages in room "public password protected room" with 200
-      | room                           | actorType | actorId | actorDisplayName | message   |
-      | public password protected room | guests    | guest   |                  | Message 1 |
+      | room                           | actorType | actorId | actorDisplayName | message   | messageParameters |
+      | public password protected room | guests    | guest   |                  | Message 1 | []                |
 
   Scenario: not joined guest can not send nor receive chat messages to and from public password protected room
     Given user "participant1" creates room "public password protected room"
@@ -75,26 +75,26 @@ Feature: chat/password
     And user "participant3" sends message "Message 3" to room "public password protected room" with 201
     And user "guest" sends message "Message 4" to room "public password protected room" with 201
     Then user "participant1" sees the following messages in room "public password protected room" with 200
-      | room                           | actorType | actorId      | actorDisplayName         | message   |
-      | public password protected room | guests    | guest        |                          | Message 4 |
-      | public password protected room | users     | participant3 | participant3-displayname | Message 3 |
-      | public password protected room | users     | participant2 | participant2-displayname | Message 2 |
-      | public password protected room | users     | participant1 | participant1-displayname | Message 1 |
+      | room                           | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public password protected room | guests    | guest        |                          | Message 4 | []                |
+      | public password protected room | users     | participant3 | participant3-displayname | Message 3 | []                |
+      | public password protected room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | public password protected room | users     | participant1 | participant1-displayname | Message 1 | []                |
     And user "participant2" sees the following messages in room "public password protected room" with 200
-      | room                           | actorType | actorId      | actorDisplayName         | message   |
-      | public password protected room | guests    | guest        |                          | Message 4 |
-      | public password protected room | users     | participant3 | participant3-displayname | Message 3 |
-      | public password protected room | users     | participant2 | participant2-displayname | Message 2 |
-      | public password protected room | users     | participant1 | participant1-displayname | Message 1 |
+      | room                           | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public password protected room | guests    | guest        |                          | Message 4 | []                |
+      | public password protected room | users     | participant3 | participant3-displayname | Message 3 | []                |
+      | public password protected room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | public password protected room | users     | participant1 | participant1-displayname | Message 1 | []                |
     And user "participant3" sees the following messages in room "public password protected room" with 200
-      | room                           | actorType | actorId      | actorDisplayName         | message   |
-      | public password protected room | guests    | guest        |                          | Message 4 |
-      | public password protected room | users     | participant3 | participant3-displayname | Message 3 |
-      | public password protected room | users     | participant2 | participant2-displayname | Message 2 |
-      | public password protected room | users     | participant1 | participant1-displayname | Message 1 |
+      | room                           | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public password protected room | guests    | guest        |                          | Message 4 | []                |
+      | public password protected room | users     | participant3 | participant3-displayname | Message 3 | []                |
+      | public password protected room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | public password protected room | users     | participant1 | participant1-displayname | Message 1 | []                |
     And user "guest" sees the following messages in room "public password protected room" with 200
-      | room                           | actorType | actorId      | actorDisplayName         | message   |
-      | public password protected room | guests    | guest        |                          | Message 4 |
-      | public password protected room | users     | participant3 | participant3-displayname | Message 3 |
-      | public password protected room | users     | participant2 | participant2-displayname | Message 2 |
-      | public password protected room | users     | participant1 | participant1-displayname | Message 1 |
+      | room                           | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public password protected room | guests    | guest        |                          | Message 4 | []                |
+      | public password protected room | users     | participant3 | participant3-displayname | Message 3 | []                |
+      | public password protected room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | public password protected room | users     | participant1 | participant1-displayname | Message 1 | []                |

--- a/tests/integration/features/chat/public.feature
+++ b/tests/integration/features/chat/public.feature
@@ -9,8 +9,8 @@ Feature: chat/public
       | roomType | 3 |
     When user "participant1" sends message "Message 1" to room "public room" with 201
     Then user "participant1" sees the following messages in room "public room" with 200
-      | room        | actorType | actorId      | actorDisplayName         | message   |
-      | public room | users     | participant1 | participant1-displayname | Message 1 |
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | Message 1 | []                |
 
   Scenario: invited user can send and receive chat messages to and from public room
     Given user "participant1" creates room "public room"
@@ -18,8 +18,8 @@ Feature: chat/public
     And user "participant1" adds "participant2" to room "public room" with 200
     When user "participant2" sends message "Message 1" to room "public room" with 201
     Then user "participant2" sees the following messages in room "public room" with 200
-      | room        | actorType | actorId      | actorDisplayName         | message   |
-      | public room | users     | participant2 | participant2-displayname | Message 1 |
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | users     | participant2 | participant2-displayname | Message 1 | []                |
 
   Scenario: not invited but joined user can send and receive chat messages to and from public room
     Given user "participant1" creates room "public room"
@@ -27,8 +27,8 @@ Feature: chat/public
     And user "participant3" joins room "public room" with 200
     When user "participant3" sends message "Message 1" to room "public room" with 201
     Then user "participant3" sees the following messages in room "public room" with 200
-      | room        | actorType | actorId      | actorDisplayName         | message   |
-      | public room | users     | participant3 | participant3-displayname | Message 1 |
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | users     | participant3 | participant3-displayname | Message 1 | []                |
 
   Scenario: not invited user can not send nor receive chat messages to and from public room
     Given user "participant1" creates room "public room"
@@ -43,8 +43,8 @@ Feature: chat/public
     And user "guest" joins room "public room" with 200
     When user "guest" sends message "Message 1" to room "public room" with 201
     Then user "guest" sees the following messages in room "public room" with 200
-      | room        | actorType | actorId | actorDisplayName | message   |
-      | public room | guests    | guest   |                  | Message 1 |
+      | room        | actorType | actorId | actorDisplayName | message   | messageParameters |
+      | public room | guests    | guest   |                  | Message 1 | []                |
 
   Scenario: not joined guest can not send nor receive chat messages to and from public room
     Given user "participant1" creates room "public room"
@@ -62,17 +62,17 @@ Feature: chat/public
     And user "participant2" sends message "Message 2" to room "public room" with 201
     And user "guest" sends message "Message 3" to room "public room" with 201
     Then user "participant1" sees the following messages in room "public room" with 200
-      | room        | actorType | actorId      | actorDisplayName         | message   |
-      | public room | guests    | guest        |                          | Message 3 |
-      | public room | users     | participant2 | participant2-displayname | Message 2 |
-      | public room | users     | participant1 | participant1-displayname | Message 1 |
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | guests    | guest        |                          | Message 3 | []                |
+      | public room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | public room | users     | participant1 | participant1-displayname | Message 1 | []                |
     And user "participant2" sees the following messages in room "public room" with 200
-      | room        | actorType | actorId      | actorDisplayName         | message   |
-      | public room | guests    | guest        |                          | Message 3 |
-      | public room | users     | participant2 | participant2-displayname | Message 2 |
-      | public room | users     | participant1 | participant1-displayname | Message 1 |
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | guests    | guest        |                          | Message 3 | []                |
+      | public room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | public room | users     | participant1 | participant1-displayname | Message 1 | []                |
     And user "guest" sees the following messages in room "public room" with 200
-      | room        | actorType | actorId      | actorDisplayName         | message   |
-      | public room | guests    | guest        |                          | Message 3 |
-      | public room | users     | participant2 | participant2-displayname | Message 2 |
-      | public room | users     | participant1 | participant1-displayname | Message 1 |
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | guests    | guest        |                          | Message 3 | []                |
+      | public room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | public room | users     | participant1 | participant1-displayname | Message 1 | []                |

--- a/tests/integration/features/chat/rich-messages.feature
+++ b/tests/integration/features/chat/rich-messages.feature
@@ -1,0 +1,45 @@
+Feature: chat/public
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+
+  Scenario: message without enrichable references has empty parameters
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    When user "participant1" sends message "Message without enrichable references" to room "public room" with 201
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message                               | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | Message without enrichable references | []                |
+
+  Scenario: message with mention to valid user has mention parameter
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    When user "participant1" sends message "Mention to @participant2" to room "public room" with 201
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message                    | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | Mention to {mention-user1} | {"mention-user1":{"type":"user","id":"participant2","name":"participant2-displayname"}} |
+
+  Scenario: message with mention to invalid user has mention parameter
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    When user "participant1" sends message "Mention to @unknownUser" to room "public room" with 201
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message                    | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | Mention to {mention-user1} | {"mention-user1":{"type":"user","id":"unknownUser","name":"Unknown user"}} |
+
+  Scenario: message with duplicated mention has single mention parameter
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    When user "participant1" sends message "Mention to @participant2 and @participant2 again" to room "public room" with 201
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message                                              | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | Mention to {mention-user1} and {mention-user1} again | {"mention-user1":{"type":"user","id":"participant2","name":"participant2-displayname"}} |
+
+  Scenario: message with mentions to several users has mention parameters
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    When user "participant1" sends message "Mention to @participant2, @unknownUser, @participant2 again and @participant3" to room "public room" with 201
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message                                                                                | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | Mention to {mention-user1}, {mention-user2}, {mention-user1} again and {mention-user3} | {"mention-user1":{"type":"user","id":"participant2","name":"participant2-displayname"},"mention-user2":{"type":"user","id":"unknownUser","name":"Unknown user"},"mention-user3":{"type":"user","id":"participant3","name":"participant3-displayname"}} |

--- a/tests/php/Chat/RichMessageHelperTest.php
+++ b/tests/php/Chat/RichMessageHelperTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Tests\php\Chat;
+
+use OCA\Spreed\Chat\RichMessageHelper;
+use OCP\Comments\IComment;
+use OCP\Comments\ICommentsManager;
+
+class RichMessageHelperTest extends \Test\TestCase {
+
+	/** @var \OCP\Comments\ICommentsManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $commentsManager;
+
+	/** @var \OCA\Spreed\Chat\RichMessageHelper */
+	protected $richMessageHelper;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->commentsManager = $this->createMock(ICommentsManager::class);
+
+		$this->richMessageHelper = new RichMessageHelper($this->commentsManager);
+	}
+
+	private function newComment($message, $mentions) {
+		$comment = $this->createMock(IComment::class);
+
+		$comment->method('getMessage')->willReturn($message);
+		$comment->method('getMentions')->willReturn($mentions);
+
+		return $comment;
+	}
+
+	public function testGetRichMessageWithoutEnrichableReferences() {
+		$comment = $this->newComment('Message without enrichable references', []);
+
+		list($message, $messageParameters) = $this->richMessageHelper->getRichMessage($comment);
+
+		$this->assertEquals('Message without enrichable references', $message);
+		$this->assertEquals([], $messageParameters);
+	}
+
+	public function testGetRichMessageWithSingleMention() {
+		$mentions = [
+			['type'=>'user', 'id'=>'testUser'],
+		];
+		$comment = $this->newComment('Mention to @testUser', $mentions);
+
+		$this->commentsManager->expects($this->once())
+			->method('resolveDisplayName')
+			->with('user', 'testUser')
+			->willReturn('testUser display name');
+
+		list($message, $messageParameters) = $this->richMessageHelper->getRichMessage($comment);
+
+		$expectedMessageParameters = [
+			'mention-user1' => [
+				'type' => 'user',
+				'id' => 'testUser',
+				'name' => 'testUser display name'
+			]
+		];
+
+		$this->assertEquals('Mention to {mention-user1}', $message);
+		$this->assertEquals($expectedMessageParameters, $messageParameters);
+	}
+
+	public function testGetRichMessageWithDuplicatedMention() {
+		$mentions = [
+			['type'=>'user', 'id'=>'testUser'],
+		];
+		$comment = $this->newComment('Mention to @testUser and @testUser again', $mentions);
+
+		$this->commentsManager->expects($this->once())
+			->method('resolveDisplayName')
+			->with('user', 'testUser')
+			->willReturn('testUser display name');
+
+		list($message, $messageParameters) = $this->richMessageHelper->getRichMessage($comment);
+
+		$expectedMessageParameters = [
+			'mention-user1' => [
+				'type' => 'user',
+				'id' => 'testUser',
+				'name' => 'testUser display name'
+			]
+		];
+
+		$this->assertEquals('Mention to {mention-user1} and {mention-user1} again', $message);
+		$this->assertEquals($expectedMessageParameters, $messageParameters);
+	}
+
+	public function testGetRichMessageWithSeveralMentions() {
+		$mentions = [
+			['type'=>'user', 'id'=>'testUser1'],
+			['type'=>'user', 'id'=>'testUser2'],
+			['type'=>'user', 'id'=>'testUser3']
+		];
+		$comment = $this->newComment('Mention to @testUser1, @testUser2, @testUser1 again and @testUser3', $mentions);
+
+		$this->commentsManager->expects($this->exactly(3))
+			->method('resolveDisplayName')
+			->withConsecutive(
+				['user', 'testUser1'],
+				['user', 'testUser2'],
+				['user', 'testUser3']
+			)
+			->willReturn(
+				'testUser1 display name',
+				'testUser2 display name',
+				'testUser3 display name'
+			);
+
+		list($message, $messageParameters) = $this->richMessageHelper->getRichMessage($comment);
+
+		$expectedMessageParameters = [
+			'mention-user1' => [
+				'type' => 'user',
+				'id' => 'testUser1',
+				'name' => 'testUser1 display name'
+			],
+			'mention-user2' => [
+				'type' => 'user',
+				'id' => 'testUser2',
+				'name' => 'testUser2 display name'
+			],
+			'mention-user3' => [
+				'type' => 'user',
+				'id' => 'testUser3',
+				'name' => 'testUser3 display name'
+			]
+		];
+
+		$this->assertEquals('Mention to {mention-user1}, {mention-user2}, {mention-user1} again and {mention-user3}', $message);
+		$this->assertEquals($expectedMessageParameters, $messageParameters);
+	}
+
+	public function testGetRichMessageWhenDisplayNameCanNotBeResolved() {
+		$mentions = [
+			['type'=>'user', 'id'=>'testUser'],
+		];
+		$comment = $this->newComment('Mention to @testUser', $mentions);
+
+		$this->commentsManager->expects($this->once())
+			->method('resolveDisplayName')
+			->willThrowException(new \OutOfBoundsException());
+
+		list($message, $messageParameters) = $this->richMessageHelper->getRichMessage($comment);
+
+		$expectedMessageParameters = [
+			'mention-user1' => [
+				'type' => 'user',
+				'id' => 'testUser',
+				'name' => ''
+			]
+		];
+
+		$this->assertEquals('Mention to {mention-user1}', $message);
+		$this->assertEquals($expectedMessageParameters, $messageParameters);
+	}
+
+}

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -24,6 +24,7 @@
 namespace OCA\Spreed\Tests\php\Controller;
 
 use OCA\Spreed\Chat\ChatManager;
+use OCA\Spreed\Chat\RichMessageHelper;
 use OCA\Spreed\Controller\ChatController;
 use OCA\Spreed\Exceptions\ParticipantNotFoundException;
 use OCA\Spreed\Exceptions\RoomNotFoundException;
@@ -58,6 +59,10 @@ class ChatControllerTest extends \Test\TestCase {
 	/** @var GuestManager|\PHPUnit_Framework_MockObject_MockObject */
 	protected $guestManager;
 
+
+	/** @var \OCA\Spreed\Chat\RichMessageHelper|\PHPUnit_Framework_MockObject_MockObject */
+	protected $richMessageHelper;
+
 	/** @var Room|\PHPUnit_Framework_MockObject_MockObject */
 	protected $room;
 
@@ -76,6 +81,7 @@ class ChatControllerTest extends \Test\TestCase {
 		$this->manager = $this->createMock(Manager::class);
 		$this->chatManager = $this->createMock(ChatManager::class);
 		$this->guestManager = $this->createMock(GuestManager::class);
+		$this->richMessageHelper = $this->createMock(RichMessageHelper::class);
 
 		$this->room = $this->createMock(Room::class);
 
@@ -98,7 +104,8 @@ class ChatControllerTest extends \Test\TestCase {
 			$this->session,
 			$this->manager,
 			$this->chatManager,
-			$this->guestManager
+			$this->guestManager,
+			$this->richMessageHelper
 		);
 	}
 
@@ -327,10 +334,10 @@ class ChatControllerTest extends \Test\TestCase {
 			->method('getHistory')
 			->with('1234', $offset, $limit)
 			->willReturn([
-				$this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
-				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
-				$this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000008), 'testMessage2'),
-				$this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000004), 'testMessage1')
+				$comment4 = $this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
+				$comment3 = $this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
+				$comment2 = $this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000008), 'testMessage2'),
+				$comment1 = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000004), 'testMessage1')
 			]);
 
 		$testUser = $this->createMock(IUser::class);
@@ -344,11 +351,22 @@ class ChatControllerTest extends \Test\TestCase {
 			->willReturn($testUser, null, $testUser);
 
 		$response = $this->controller->receiveMessages('testToken', 0, $limit, $offset);
+
+		$this->richMessageHelper->expects($this->exactly(4))
+			->method('getRichMessage')
+			->withConsecutive($comment4, $comment3, $comment2, $comment1)
+			->willReturn(
+				['testMessage4', ['testMessageParameters4']],
+				['testMessage3', ['testMessageParameters3']],
+				['testMessage2', ['testMessageParameters2']],
+				['testMessage1', ['testMessageParameters1']]
+			);
+
 		$expected = new DataResponse([
-			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000016, 'message'=>'testMessage4'],
-			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>null, 'timestamp'=>1000000015, 'message'=>'testMessage3'],
-			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>null, 'timestamp'=>1000000008, 'message'=>'testMessage2'],
-			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000004, 'message'=>'testMessage1']
+			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000016, 'message'=>'testMessage4', 'messageParameters'=>['testMessageParameters4']],
+			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>null, 'timestamp'=>1000000015, 'message'=>'testMessage3', 'messageParameters'=>['testMessageParameters3']],
+			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>null, 'timestamp'=>1000000008, 'message'=>'testMessage2', 'messageParameters'=>['testMessageParameters2']],
+			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000004, 'message'=>'testMessage1', 'messageParameters'=>['testMessageParameters1']]
 		], Http::STATUS_OK);
 		$expected->addHeader('X-Chat-Last-Given', 108);
 
@@ -385,10 +403,10 @@ class ChatControllerTest extends \Test\TestCase {
 			->method('getHistory')
 			->with('1234', $offset, $limit)
 			->willReturn([
-				$this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
-				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
-				$this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000008), 'testMessage2'),
-				$this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000004), 'testMessage1')
+				$comment4 = $this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
+				$comment3 = $this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
+				$comment2 = $this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000008), 'testMessage2'),
+				$comment1 = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000004), 'testMessage1')
 			]);
 
 		$testUser = $this->createMock(IUser::class);
@@ -401,12 +419,24 @@ class ChatControllerTest extends \Test\TestCase {
 			->withConsecutive(['testUser'], ['testUnknownUser'], ['testUser'])
 			->willReturn($testUser, null, $testUser);
 
+
 		$response = $this->controller->receiveMessages('testToken', 0, $limit, $offset);
+
+		$this->richMessageHelper->expects($this->exactly(4))
+			->method('getRichMessage')
+			->withConsecutive($comment4, $comment3, $comment2, $comment1)
+			->willReturn(
+				['testMessage4', ['testMessageParameters4']],
+				['testMessage3', ['testMessageParameters3']],
+				['testMessage2', ['testMessageParameters2']],
+				['testMessage1', ['testMessageParameters1']]
+			);
+
 		$expected = new DataResponse([
-			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000016, 'message'=>'testMessage4'],
-			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>null, 'timestamp'=>1000000015, 'message'=>'testMessage3'],
-			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>null, 'timestamp'=>1000000008, 'message'=>'testMessage2'],
-			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000004, 'message'=>'testMessage1']
+			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000016, 'message'=>'testMessage4', 'messageParameters'=>['testMessageParameters4']],
+			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>null, 'timestamp'=>1000000015, 'message'=>'testMessage3', 'messageParameters'=>['testMessageParameters3']],
+			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>null, 'timestamp'=>1000000008, 'message'=>'testMessage2', 'messageParameters'=>['testMessageParameters2']],
+			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000004, 'message'=>'testMessage1', 'messageParameters'=>['testMessageParameters1']]
 		], Http::STATUS_OK);
 		$expected->addHeader('X-Chat-Last-Given', 108);
 
@@ -472,10 +502,10 @@ class ChatControllerTest extends \Test\TestCase {
 			->method('getHistory')
 			->with('1234', $offset, $limit)
 			->willReturn([
-				$this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
-				$this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
-				$this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000008), 'testMessage2'),
-				$this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000004), 'testMessage1')
+				$comment4 = $this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
+				$comment3 = $this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
+				$comment2 = $this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000008), 'testMessage2'),
+				$comment1 = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000004), 'testMessage1')
 			]);
 
 		$testUser = $this->createMock(IUser::class);
@@ -488,12 +518,24 @@ class ChatControllerTest extends \Test\TestCase {
 			->withConsecutive(['testUser'], ['testUnknownUser'], ['testUser'])
 			->willReturn($testUser, null, $testUser);
 
+
 		$response = $this->controller->receiveMessages('testToken', 0, $limit, $offset);
+
+		$this->richMessageHelper->expects($this->exactly(4))
+			->method('getRichMessage')
+			->withConsecutive($comment4, $comment3, $comment2, $comment1)
+			->willReturn(
+				['testMessage4', ['testMessageParameters4']],
+				['testMessage3', ['testMessageParameters3']],
+				['testMessage2', ['testMessageParameters2']],
+				['testMessage1', ['testMessageParameters1']]
+			);
+
 		$expected = new DataResponse([
-			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000016, 'message'=>'testMessage4'],
-			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>null, 'timestamp'=>1000000015, 'message'=>'testMessage3'],
-			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>null, 'timestamp'=>1000000008, 'message'=>'testMessage2'],
-			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000004, 'message'=>'testMessage1']
+			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000016, 'message'=>'testMessage4', 'messageParameters'=>['testMessageParameters4']],
+			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>null, 'timestamp'=>1000000015, 'message'=>'testMessage3', 'messageParameters'=>['testMessageParameters3']],
+			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>null, 'timestamp'=>1000000008, 'message'=>'testMessage2', 'messageParameters'=>['testMessageParameters2']],
+			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'Test User', 'timestamp'=>1000000004, 'message'=>'testMessage1', 'messageParameters'=>['testMessageParameters1']]
 		], Http::STATUS_OK);
 		$expected->addHeader('X-Chat-Last-Given', 108);
 


### PR DESCRIPTION
This pull request adds formatted mentions to the message list (but not formatted mentions nor auto-completion in messages being composed).

It is based on both the mentions shown in the Comments app and the rich formatting of notifications. The backend uses the Comments API to store the messages, so when `receiveMessages` is called the Comments API is used to extract the mentions from the plain text message originally sent. However, unlike the Comments app, the mentions are not returned to the client in its own attribute, but in a generic way using a rich object string. Thanks to this approach it should be easier to extend the formatting in the future with support for other [definition types](https://github.com/nextcloud/server/blob/0913bc2157293acafa186afec4018ad25d7fbb22/lib/public/RichObjectStrings/Definitions.php#L40).

Before:
![chat-mention-before](https://user-images.githubusercontent.com/26858233/33662908-f8106fc2-da8d-11e7-8e4e-c700030d44f6.png)

After:
![chat-mention-after](https://user-images.githubusercontent.com/26858233/33662911-fba7d44a-da8d-11e7-89bf-b42a7671f887.png)

In any case, as the mentions are got using the Comments API this system has its same limitations, like not supporting mentions to users with a space in the name.

Moreover, the Comments app needs to be enabled for mentions to fully work. Otherwise, no [display name resolver for `user`](https://github.com/nextcloud/server/blob/0eebff152a177dd59ed8773df26f1679f8a88e90/apps/comments/appinfo/app.php#L63) would have been registered and thus it would not be possible (using the Comments API) to get the display name for a mention (in this case the id of the user is shown instead as can be seen below).

After, Comments app disabled:
![chat-mention-after-comments-disabled](https://user-images.githubusercontent.com/26858233/33662913-fd9025f0-da8d-11e7-8f21-75a8a45226cd.png)

@blizzz What would be the proper way to not depend on the Comments app? Register a `user` display name resolver too for Nextcloud Talk and [catch the exception](https://github.com/nextcloud/server/blob/0eebff152a177dd59ed8773df26f1679f8a88e90/lib/private/Comments/Manager.php#L827) if the Comments app was enabled and thus the resolver was already registered? Or should the `user` display name resolver be moved from the Comments app to the libraries? Any other option?

Finally note that currently there are some issues with the contacts menu; these will be fixed in another pull request once formatted mentions are added to messages being composed too.
