### PR TITLE
Fix protocols for TURN server not saved

### DIFF
--- a/js/admin/turn-server.js
+++ b/js/admin/turn-server.js
@@ -133,6 +133,7 @@
 			$template.find('a.icon-add').on('click', this.addNewTemplate.bind(this));
 			$template.find('a.icon-delete').on('click', this.deleteServer.bind(this));
 			$template.find('input').on('change', this.saveServers.bind(this));
+			$template.find('select').on('change', this.saveServers.bind(this));
 
 			return $template;
 		}


### PR DESCRIPTION
Fixes #531

The TURN server values are now (tried to be) saved when the protocols are changed, like it is done when the server URL or the secret are changed.

Note that, just like with the server URL or the secret, all the required fields must be filled for the saving to succeed. Otherwise no value will be saved.
