### PR TITLE
Show chat view as main view when in a room but not in a call

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -141,6 +141,30 @@
 }
 
 /**
+ * Main view chat styles
+ */
+#app-content-wrapper {
+	height: 100%;
+}
+
+#app-content-wrapper #commentsTabView {
+	width: 100%;
+	height: 100%;
+
+	display: flex;
+	flex-direction: column;
+}
+
+#app-content-wrapper #commentsTabView .comments {
+	overflow-y: auto;
+}
+
+/* Hide all siblings of the chat view when shown as the main view */
+#app-content-wrapper #commentsTabView ~ * {
+	display: none !important;
+}
+
+/**
  * Video styles
  */
 

--- a/css/style.css
+++ b/css/style.css
@@ -690,6 +690,13 @@ video {
 	}
 }
 
+/* The header element contains the header div; as the header div uses a fixed
+   position the header element has no height, so it must be explicitly set to
+   prevent #app-content-wrapper from overlapping with the header element */
+#body-public header {
+	height: 45px;
+}
+
 /* make blue header bar transparent in shared room */
 #body-public #app-content:not(.participants-1) #header.spreed-public {
 	background: transparent;

--- a/css/style.css
+++ b/css/style.css
@@ -153,10 +153,25 @@
 
 	display: flex;
 	flex-direction: column;
+
+	padding-top: 15px;
+}
+
+/* The lateral padding is set for each child instead of for the chat view as a
+   whole to prevent showing the scroll bar padded from the border of the chat
+   view (which could be fixed by using a negative margin and a positive padding
+   in the list of messages) and to ensure that the contacts menu is not clipped
+   due to overflowing the chat view on its left (much harder to fix). */
+#app-content-wrapper #commentsTabView .newCommentRow {
+	padding-left: 15px;
+	padding-right: 15px;
 }
 
 #app-content-wrapper #commentsTabView .comments {
 	overflow-y: auto;
+
+	padding-left: 15px;
+	padding-right: 15px;
 }
 
 /* Hide all siblings of the chat view when shown as the main view */

--- a/js/app.js
+++ b/js/app.js
@@ -509,7 +509,7 @@
 			this._chatView = new OCA.SpreedMe.Views.ChatView({
 				collection: this._messageCollection,
 				id: 'commentsTabView',
-				className: 'chat tab'
+				className: 'chat'
 			});
 
 			this._messageCollection.listenTo(roomChannel, 'leaveCurrentCall', function() {

--- a/js/app.js
+++ b/js/app.js
@@ -396,10 +396,12 @@
 			if (this.activeRoom.get('participantInCall') && this._chatViewInMainView === true) {
 				this._chatView.$el.detach();
 				this._sidebarView.addTab('chat', { label: t('spreed', 'Chat') }, this._chatView);
+				this._chatView.setTooltipContainer(undefined);
 				this._chatViewInMainView = false;
 			} else if (!this.activeRoom.get('participantInCall') && !this._chatViewInMainView) {
 				this._sidebarView.removeTab('chat');
 				this._chatView.$el.prependTo('#app-content-wrapper');
+				this._chatView.setTooltipContainer($('#app'));
 				this._chatViewInMainView = true;
 			}
 		},

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -1,4 +1,4 @@
-/* global autosize, Backbone, Handlebars, OC, OCA */
+/* global autosize, Marionette, Handlebars, OC, OCA */
 
 /**
  *
@@ -21,7 +21,7 @@
  *
  */
 
-(function(OCA, OC, Backbone, Handlebars, autosize) {
+(function(OCA, OC, Marionette, Handlebars, autosize) {
 	'use strict';
 
 	OCA.SpreedMe = OCA.SpreedMe || {};
@@ -57,7 +57,7 @@
 		'    <div class="message">{{{formattedMessage}}}</div>' +
 		'</li>';
 
-	var ChatView = Backbone.View.extend({
+	var ChatView = Marionette.View.extend({
 
 		events: {
 			'submit .newCommentForm': '_onSubmitComment',
@@ -68,11 +68,9 @@
 			this.listenTo(this.collection, 'add', this._onAddModel);
 		},
 
-		template: function(params) {
-			if (!this._template) {
-				this._template = Handlebars.compile(TEMPLATE);
-			}
-			return this._template(params);
+		template: Handlebars.compile(TEMPLATE),
+		templateContext: {
+			emptyResultLabel: t('spreed', 'No messages yet, start the conversation!')
 		},
 
 		addCommentTemplate: function(params) {
@@ -96,12 +94,9 @@
 			return this._commentTemplate(params);
 		},
 
-		render: function() {
+		onRender: function() {
 			delete this._lastAddedMessageModel;
 
-			this.$el.html(this.template({
-				emptyResultLabel: t('spreed', 'No messages yet, start the conversation!')
-			}));
 			this.$el.find('.comments').before(this.addCommentTemplate({}));
 			this.$el.find('.has-tooltip').tooltip();
 			this.$container = this.$el.find('ul.comments');
@@ -111,8 +106,6 @@
 			this.$el.find('.message').on('keydown input change', this._onTypeComment);
 
 			autosize(this.$el.find('.newCommentRow .message'));
-
-			return this;
 		},
 
 		_formatItem: function(commentModel) {
@@ -319,4 +312,4 @@
 
 	OCA.SpreedMe.Views.ChatView = ChatView;
 
-})(OCA, OC, Backbone, Handlebars, autosize);
+})(OCA, OC, Marionette, Handlebars, autosize);

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -98,7 +98,7 @@
 			delete this._lastAddedMessageModel;
 
 			this.$el.find('.comments').before(this.addCommentTemplate({}));
-			this.$el.find('.has-tooltip').tooltip();
+			this.$el.find('.has-tooltip').tooltip({container: this._tooltipContainer});
 			this.$container = this.$el.find('ul.comments');
 			// FIXME handle guest users
 			this.$el.find('.avatar').avatar(OC.getCurrentUser().uid, 32);
@@ -106,6 +106,27 @@
 			this.$el.find('.message').on('keydown input change', this._onTypeComment);
 
 			autosize(this.$el.find('.newCommentRow .message'));
+		},
+
+		/**
+		 * Set the tooltip container.
+		 *
+		 * Depending on the parent elements of the chat view the tooltips may
+		 * need to be appended to a specific element to be properly shown (due
+		 * to how CSS overflows, clipping areas and positioning contexts work).
+		 * If no specific container is ever set, or if it is set to "undefined",
+		 * the tooltip elements will be appended as siblings of the element for
+		 * which they are shown.
+		 *
+		 * @param jQuery tooltipContainer the element to append the tooltip
+		 *        elements to
+		 */
+		setTooltipContainer: function(tooltipContainer) {
+			this._tooltipContainer = tooltipContainer;
+
+			// Update tooltips
+			this.$el.find('.has-tooltip').tooltip('destroy');
+			this.$el.find('.has-tooltip').tooltip({container: this._tooltipContainer});
 		},
 
 		_formatItem: function(commentModel) {
@@ -197,7 +218,7 @@
 		},
 
 		_postRenderItem: function($el) {
-			$el.find('.has-tooltip').tooltip();
+			$el.find('.has-tooltip').tooltip({container: this._tooltipContainer});
 			$el.find('.avatar').each(function() {
 				var $this = $(this);
 				$this.avatar($this.attr('data-username'), 32);

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -59,47 +59,49 @@ script(
 			</div>
 		</header>
 
-		<button id="video-fullscreen" class="icon-fullscreen icon-white icon-shadow public" data-placement="bottom" data-toggle="tooltip" data-original-title="<?php p($l->t('Fullscreen')) ?>"></button>
+		<div id="app-content-wrapper">
+			<button id="video-fullscreen" class="icon-fullscreen icon-white icon-shadow public" data-placement="bottom" data-toggle="tooltip" data-original-title="<?php p($l->t('Fullscreen')) ?>"></button>
 
-		<div id="video-speaking">
+			<div id="video-speaking">
 
-		</div>
-		<div id="videos">
-			<div class="videoView videoContainer hidden" id="localVideoContainer">
-				<video id="localVideo"></video>
-				<div class="avatar-container hidden">
-					<div class="avatar"></div>
-				</div>
-				<div class="nameIndicator">
-					<button id="mute" class="icon-audio icon-white icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Mute audio')) ?>"></button>
-					<button id="hideVideo" class="icon-video icon-white icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Disable video')) ?>"></button>
-					<button id="screensharing-button" class="app-navigation-entry-utils-menu-button icon-screen-off icon-white icon-shadow screensharing-disabled" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Share screen')) ?>"></button>
-					<div id="screensharing-menu" class="app-navigation-entry-menu">
-						<ul>
-							<li>
-								<button id="show-screen-button">
-									<span class="icon-screen"></span>
-									<span><?php p($l->t('Show your screen'));?></span>
-								</button>
-							</li>
-							<li>
-								<button id="stop-screen-button">
-									<span class="icon-screen-off"></span>
-									<span><?php p($l->t('Stop screensharing'));?></span>
-								</button>
-							</li>
-						</ul>
+			</div>
+			<div id="videos">
+				<div class="videoView videoContainer hidden" id="localVideoContainer">
+					<video id="localVideo"></video>
+					<div class="avatar-container hidden">
+						<div class="avatar"></div>
+					</div>
+					<div class="nameIndicator">
+						<button id="mute" class="icon-audio icon-white icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Mute audio')) ?>"></button>
+						<button id="hideVideo" class="icon-video icon-white icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Disable video')) ?>"></button>
+						<button id="screensharing-button" class="app-navigation-entry-utils-menu-button icon-screen-off icon-white icon-shadow screensharing-disabled" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Share screen')) ?>"></button>
+						<div id="screensharing-menu" class="app-navigation-entry-menu">
+							<ul>
+								<li>
+									<button id="show-screen-button">
+										<span class="icon-screen"></span>
+										<span><?php p($l->t('Show your screen'));?></span>
+									</button>
+								</li>
+								<li>
+									<button id="stop-screen-button">
+										<span class="icon-screen-off"></span>
+										<span><?php p($l->t('Stop screensharing'));?></span>
+									</button>
+								</li>
+							</ul>
+						</div>
 					</div>
 				</div>
 			</div>
-		</div>
 
-		<div id="screens"></div>
+			<div id="screens"></div>
 
-		<div id="emptycontent">
-			<div id="emptycontent-icon" class="icon-video"></div>
-			<h2><?php p($l->t('Looking great today! :)')) ?></h2>
-			<p class="uploadmessage"><?php p($l->t('Smile in 3… 2… 1!')) ?></p>
+			<div id="emptycontent">
+				<div id="emptycontent-icon" class="icon-video"></div>
+				<h2><?php p($l->t('Looking great today! :)')) ?></h2>
+				<p class="uploadmessage"><?php p($l->t('Smile in 3… 2… 1!')) ?></p>
+			</div>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
No changes were made to the layout of the chat view in this layout. Therefore, the messages are shown from newest to oldest and the new message input is shown at the top, even when shown as the main view, which is an uncommon layout. A follow up pull request will reverse the layout of the chat view to use a more common one.

In the same way, the local video is now hidden behind the chat view. When the chat view is shown as the main view the local video should appear in a sidebar tab; this will be done in another pull request too.
