### PR TITLE
Make the triangle for opening the sidebar more visible

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -648,7 +648,7 @@ video {
 	top: 0;
 	right: 0;
 	border-width: 24px;
-	border-color: #ebebeb;
+	border-color: $color-border;
 	border-style: solid;
 	border-left-color: transparent;
 	border-top-color: transparent;
@@ -661,7 +661,7 @@ video {
 	top: 2px;
 	right: 0;
 	border-width: 22px;
-	border-color: #fff;
+	border-color: $color-primary;
 	border-style: solid;
 	border-left-color: transparent;
 	border-top-color: transparent;


### PR DESCRIPTION
The white handle with a slight grey border was hardly
visible on the white background when waiting for a call.

Fix #503 

### Default
> ![bildschirmfoto von 2018-01-09 12-08-37](https://user-images.githubusercontent.com/213943/34718175-f895efd6-f535-11e7-932f-4f7f0626c37f.png)

### Black in call
> ![bildschirmfoto von 2018-01-09 12-06-58](https://user-images.githubusercontent.com/213943/34718189-083f54b8-f536-11e7-9583-b5b762634f42.png)

### White theming without call
Unchanged 
