### PR TITLE
Limit scroll bar in sidebar to chat view

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -900,3 +900,48 @@ video {
 	display: inline-block;
 	padding: 12px 0;
 }
+
+/**
+ * Cascade parent element height to the chat view in the sidebar to limit the
+ * vertical scroll bar only to the list of messages. Otherwise, the vertical
+ * scroll bar would be shown for the whole sidebar and everything would be
+ * moved when scrolling to see overflown messages.
+ *
+ * The list of messages should stretch to fill the available space at the bottom
+ * of the right sidebar, so the height is cascaded using flex boxes.
+ *
+ * It is horrible, I know (but better than using JavaScript ;-) ). Please
+ * improve it if you know how :-)
+ */
+#app-sidebar {
+	display: flex;
+	flex-direction: column;
+}
+
+#app-sidebar .tabs {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+#app-sidebar .tabsContainer {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+#app-sidebar .tab {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+#app-sidebar #commentsTabView {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+#app-sidebar .comments {
+	overflow-y: auto;
+}

--- a/css/style.scss
+++ b/css/style.scss
@@ -945,3 +945,26 @@ video {
 #app-sidebar .comments {
 	overflow-y: auto;
 }
+
+/**
+ * Place the scroll bar of the message list on the right edge of the sidebar,
+ * but keeping the padding of the tab view.
+ *
+ * The padding must be set on the left too to ensure that the contacts menu
+ * shown when clicking on an author name does not overflow the tab (as it would
+ * be hidden).
+ *
+ * The bottom padding is removed to extend the chat view to the bottom edge of
+ * the sidebar.
+ */
+#app-sidebar .tab-chat {
+	padding-left: 0px;
+	padding-right: 0px;
+	padding-bottom: 0px;
+}
+
+#app-sidebar #commentsTabView .newCommentRow,
+#app-sidebar #commentsTabView .comments {
+	padding-left: 15px;
+	padding-right: 15px;
+}

--- a/css/style.scss
+++ b/css/style.scss
@@ -968,3 +968,53 @@ video {
 	padding-left: 15px;
 	padding-right: 15px;
 }
+
+/**
+ * Limiting the scroll bar in the sidebar to the list of chat messages causes
+ * the scroll bar to be removed from the whole sidebar in other tabs too.
+ * Therefore, the scroll bars must be explicitly enabled in the other tab
+ * contents that need them.
+ */
+#app-sidebar #participantsTabView {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+#app-sidebar .participantWithList {
+	overflow-y: auto;
+}
+
+/**
+ * Place the scroll bar of the participants list on the right edge of the
+ * sidebar, but keeping the padding of the tab view.
+ *
+ * The bottom padding is removed to extend the participant view to the bottom
+ * edge of the sidebar.
+ */
+#app-sidebar .tab-participants {
+	padding-right: 0px;
+	padding-bottom: 0px;
+}
+
+#app-sidebar #participantsTabView form,
+#app-sidebar #participantsTabView .participantWithList {
+	padding-right: 15px;
+}
+
+/**
+ * Add a little margin so the participants do not "touch" the form when they are
+ * scrolled, in the same way that the chat messages do not disappear directly
+ * below the new message input.
+ */
+#app-sidebar #participantsTabView form {
+	margin-bottom: 15px;
+}
+
+/**
+ * Add a little margin to the last participant so the list is nicely framed with
+ * the sides when fully scrolled to the bottom.
+ */
+#app-sidebar #participantsTabView .participant:last-child {
+	margin-bottom: 15px;
+}

--- a/js/app.js
+++ b/js/app.js
@@ -320,7 +320,8 @@
 			this._participants = new OCA.SpreedMe.Models.ParticipantCollection();
 			this._participantsView = new OCA.SpreedMe.Views.ParticipantView({
 				room: this.activeRoom,
-				collection: this._participants
+				collection: this._participants,
+				id: 'participantsTabView'
 			});
 
 			this._participantsView.listenTo(this._rooms, 'change:active', function(model, active) {

--- a/js/app.js
+++ b/js/app.js
@@ -396,7 +396,7 @@
 			if (this.activeRoom.get('participantInCall') && this._chatViewInMainView === true) {
 				this._chatView.$el.detach();
 				this._sidebarView.addTab('chat', { label: t('spreed', 'Chat') }, this._chatView);
-				this._chatView.setTooltipContainer(undefined);
+				this._chatView.setTooltipContainer(this._chatView.$el);
 				this._chatViewInMainView = false;
 			} else if (!this.activeRoom.get('participantInCall') && !this._chatViewInMainView) {
 				this._sidebarView.removeTab('chat');

--- a/js/views/sidebarview.js
+++ b/js/views/sidebarview.js
@@ -30,7 +30,7 @@
 	var TEMPLATE =
 		'<div id="app-sidebar-trigger" class="icon-menu-people icon-white icon-shadow">' +
 		'</div>' +
-		'<div id="app-sidebar" class="detailsView scroll-container">' +
+		'<div id="app-sidebar" class="detailsView">' +
 		'	<div class="detailCallInfoContainer">' +
 		'	</div>' +
 		'	<div class="tabs">' +

--- a/js/views/tabview.js
+++ b/js/views/tabview.js
@@ -326,9 +326,16 @@
 		 * @param string tabId the ID of the selected tab.
 		 */
 		onChildviewSelectTabHeader: function(tabId) {
+			if (this._selectedTabExtraClass) {
+				this.getRegion('tabContent').$el.removeClass(this._selectedTabExtraClass);
+			}
+
 			// With Marionette 3.1 "this.detachChildView('tabContent')" would be
 			// used instead of the "preventDestroy" option.
 			this.showChildView('tabContent', this._tabContentViews[tabId], { preventDestroy: true } );
+
+			this._selectedTabExtraClass = 'tab-' + tabId;
+			this.getRegion('tabContent').$el.addClass(this._selectedTabExtraClass);
 		}
 
 	});


### PR DESCRIPTION
Except when almost empty, the message list of the chat view is taller than its available vertical space in the sidebar. Due to this a scroll bar was shown for the whole sidebar, and everything was moved when
scrolling to see overflown messages.

That is a valid approach when messages are shown from newest to oldest and the new message input is above the list of messages, as in that case the call details and the tab headers are near the new message input and the newest messages.

However, once the layout of the chat view is reversed and the messages are shown from oldest to newest with the new message input below the list of messages having to scroll back and forth to see the call details/tab headers or the new message input/newest messages would be a pain.

Therefore now the scroll bar is shown only for the message list, so it can be scrolled without moving the other elements in the sidebar.

Limiting the scroll bar in the sidebar to the list of chat messages causes the scroll bar to be removed from the whole sidebar in other tabs too, so the scroll bars had to be explicitly enabled in the list of participants.

Note that now, due to the scroll bar being shown only for the tabs, the call details are always visible. In short screens this may not leave too much space for the tabs, making them uncomfortable to use. This will be fixed in another pull request.
