### PR TITLE
Fix the update of the EditableTextLabel input

### DIFF
--- a/js/views/editabletextlabel.js
+++ b/js/views/editabletextlabel.js
@@ -148,6 +148,8 @@
 		},
 
 		showInput: function() {
+			this.getUI('input').val(this.model.get(this.modelAttribute));
+
 			this.getUI('inputWrapper').removeClass('hidden-important');
 			this.getUI('labelWrapper').addClass('hidden-important');
 
@@ -165,7 +167,7 @@
 				this.confirmEdit();
 			} else if (event.keyCode === 27) {
 				// ESC
-				this.discardEdit();
+				this.hideInput();
 			}
 		},
 
@@ -189,11 +191,6 @@
 
 			this.model.save(this.modelAttribute, newText, options);
 		},
-
-		discardEdit: function() {
-			this.hideInput();
-			this.getUI('input').val(this.model.get(this.modelAttribute));
-		}
 
 	});
 


### PR DESCRIPTION
The value of the input was not properly updated when the model attribute changed.

For example:
- Moderators A and B join a room
- Moderator A changes the name of the room
- The room name label is updated in the browser of moderator B. However, if moderator B tries to change the name of the room the old name is shown in the input.

Instead of updating the value of the input when the name of the room changes now it is always updated before the input element is shown.
