### PR TITLE
Add button to expand tabs in the sidebar

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -947,6 +947,18 @@ video {
 	padding: 12px 0;
 }
 
+.elementExpanderButton {
+	width: 44px;
+	height: 44px;
+	opacity: 0.5;
+	cursor: pointer;
+}
+
+.elementExpanderButton:hover,
+.elementExpanderButton:focus {
+	opacity: 1;
+}
+
 /**
  * Cascade parent element height to the chat view in the sidebar to limit the
  * vertical scroll bar only to the list of messages. Otherwise, the vertical
@@ -1063,4 +1075,29 @@ video {
  */
 #app-sidebar #participantsTabView .participant:last-child {
 	margin-bottom: 15px;
+}
+
+/**
+ * Place the expander button of tabs to the right border of the sidebar,
+ * "floating" over the tab contents.
+ */
+#app-sidebar .tab .elementExpanderButton {
+	position: absolute;
+	right: 0;
+	z-index: 5;
+
+	/* The tab header has some margin that can be used to move the expander
+	   button away from the tab contents, as it should not look like part of the
+	   contents nor interfere with its use. */
+	margin-top: -22px;
+}
+
+#app-sidebar .expanded {
+	margin-top: 15px;
+}
+
+#app-sidebar .expanded .elementExpanderButton {
+	/* Ignore the margin of the expanded element and place the button in the top
+	   right corner at the same place of the close button (now hidden). */
+	margin-top: -15px;
 }

--- a/js/views/elementexpanderbutton.js
+++ b/js/views/elementexpanderbutton.js
@@ -1,0 +1,129 @@
+/* global Backbone, OCA */
+
+/**
+ *
+ * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+(function(OCA, Backbone) {
+	'use strict';
+
+	OCA.SpreedMe = OCA.SpreedMe || {};
+	OCA.SpreedMe.Views = OCA.SpreedMe.Views || {};
+
+	/**
+	 * Helper button to expand an element in an ancestor.
+	 *
+	 * The expander works directly on HTML elements and it does not take into
+	 * account Backbone or Marionette views; it simply traverses the ancestors
+	 * of the given $expandableElement hiding their siblings until $container is
+	 * reached.
+	 *
+	 * The button is automatically prepended to the $expandableElement when
+	 * created. Clicking on the button will expand the element and clicking
+	 * again will restore it. The button can be removed by calling "remove()" on
+	 * the expander object.
+	 */
+	var ElementExpanderButton = Backbone.View.extend({
+
+		tagName: 'a',
+		className:'elementExpanderButton icon-fullscreen',
+
+		events: {
+			'click': '_onClick',
+		},
+
+		initialize: function(options) {
+			if (!('$expandableElement' in options)) {
+				throw 'Missing parameter "$expandableElement"';
+			}
+			if (!('$container' in options)) {
+				throw 'Missing parameter "$container"';
+			}
+
+			this._$expandableElement = options.$expandableElement;
+			this._$container = options.$container;
+
+			this._expanded = false;
+			this._hiddenElements = new Array();
+
+			this.render().$el.prependTo(this._$expandableElement);
+		},
+
+		render: function() {
+			this.$el.attr('href', '#');
+
+			if (this._expanded) {
+				this.$el.html('<span class="hidden-visually">' + t('spreed', 'Restore') + '</span>');
+			} else {
+				this.$el.html('<span class="hidden-visually">' + t('spreed', 'Expand') + '</span>');
+			}
+
+			return this;
+		},
+
+		_onClick: function() {
+			if (!this._expanded) {
+				this._expand();
+			} else {
+				this._restore();
+			}
+		},
+
+		_expand: function() {
+			var self = this;
+
+			this._$expandableElement.parents().each(function(index, parent) {
+				var $parent = $(parent);
+				if ($parent.is(self._$container)) {
+					return false;
+				}
+
+				$parent.siblings().each(function(index, sibling) {
+					var $sibling = $(sibling);
+					self._hiddenElements.push($sibling);
+					$sibling.hide();
+				});
+			});
+
+			this._$expandableElement.addClass('expanded');
+
+			this.$el.find('span').text(t('spreed', 'Restore'));
+
+			this._expanded = true;
+		},
+
+		_restore: function() {
+			this._hiddenElements.forEach(function($element) {
+				$element.show();
+			});
+			this._hiddenElements = [];
+
+			this._$expandableElement.removeClass('expanded');
+
+			this.$el.find('span').text(t('spreed', 'Expand'));
+
+			this._expanded = false;
+		}
+
+	});
+
+	OCA.SpreedMe.Views.ElementExpanderButton = ElementExpanderButton;
+
+})(OCA, Backbone);

--- a/js/views/sidebarview.js
+++ b/js/views/sidebarview.js
@@ -178,6 +178,12 @@
 		 */
 		addTab: function(tabId, tabHeaderOptions, tabContentView) {
 			this._tabView.addTab(tabId, tabHeaderOptions, tabContentView);
+
+			var elementExpanderButton = new OCA.SpreedMe.Views.ElementExpanderButton({
+				$expandableElement: tabContentView.$el,
+				$container: this.$el
+			});
+			tabContentView.elementExpanderButton = elementExpanderButton;
 		},
 
 		/**
@@ -198,7 +204,14 @@
 		 * @return Marionette.View the content view of the removed tab.
 		 */
 		removeTab: function(tabId) {
-			return this._tabView.removeTab(tabId);
+			var contentView = this._tabView.removeTab(tabId);
+
+			if (typeof contentView !== 'undefined') {
+				contentView.elementExpanderButton.remove();
+				delete contentView.elementExpanderButton;
+			}
+
+			return contentView;
 		}
 
 	});

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -21,6 +21,7 @@ script(
 		'views/callinfoview',
 		'views/chatview',
 		'views/editabletextlabel',
+		'views/elementexpanderbutton',
 		'views/roomlistview',
 		'views/sidebarview',
 		'views/tabview',

--- a/templates/index.php
+++ b/templates/index.php
@@ -22,6 +22,7 @@ script(
 		'views/callinfoview',
 		'views/chatview',
 		'views/editabletextlabel',
+		'views/elementexpanderbutton',
 		'views/participantlistview',
 		'views/participantview',
 		'views/roomlistview',


### PR DESCRIPTION
Due to the scroll bar being shown only for the tabs the call details are always visible. In short screens this may not leave too much space for the tabs, making them uncomfortable to use.

To improve that now a button is added automatically to every tab added to the sidebar; clicking on the button toggles the associated tab between its normal size and an expanded size that fills the whole sidebar.

I have tried other approaches, like hiding the call details when scrolling in one direction and showing it back when scrolling on the opposite direction, but in the end the button one was the simplest, most reliable and less bug/quirk prone.
