### PR TITLE
More design work & clean up to reduce possible height of room details

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -735,12 +735,14 @@ video {
 	position: absolute;
 	top: 0;
 	right: 0;
-	/* The app uses border-box sizing, so the padding is 15px like in the Files
-	 * app plus 8px of half the size of the icon */
-	padding: 23px;
-	opacity: 0.5;
+	padding: 22px;
+	opacity: .5;
 	/* Higher index than the trigger to hide it when the sidebar is open */
 	z-index: 20;
+}
+#app-sidebar .close:hover,
+#app-sidebar .close:focus {
+	opacity: 1;
 }
 
 #videos .videoContainer.speaking:not(.videoView) .nameIndicator,

--- a/css/style.scss
+++ b/css/style.scss
@@ -126,9 +126,9 @@
 	background-color: transparent;
 	border: none;
 	position: absolute;
-	right: 0;
-	bottom: 3px;
-	padding: 16px;
+	right: -6px;
+	top: -5px;
+	padding: 22px;
 	opacity: .5;
 }
 .icon-confirm.password-confirm:hover,
@@ -904,15 +904,25 @@ video {
  */
 
 .detailCallInfoContainer .room-name {
-	display: inline-block;
+	display: block;
+	width: calc(100% - 29px); /* 44px close button - 15px container padding */
 }
 
-.detailCallInfoContainer h3,
-.detailCallInfoContainer .guest-name p {
+.detailCallInfoContainer h3 {
 	display: inline-block;
+	width: 100%;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
+}
+
+.detailCallInfoContainer .room-name:hover h3,
+.detailCallInfoContainer .room-name:focus h3 {
+	width: calc(100% - 44px); /* minus the edit button */
 }
 
 .detailCallInfoContainer .guest-name p {
+	display: inline-block;
     padding: 9px 0;
 }
 
@@ -929,20 +939,45 @@ video {
 .detailCallInfoContainer .editable-text-label .edit-button .icon {
 	cursor: pointer;
 	padding: 22px;
-	vertical-align: middle;
 	margin-left: -5px;
 	margin-top: -5px;
+	opacity: .5;
+}
+
+.detailCallInfoContainer .clipboard-button .icon:hover,
+.detailCallInfoContainer .clipboard-button .icon:focus,
+.detailCallInfoContainer .editable-text-label .edit-button .icon:hover,
+.detailCallInfoContainer .editable-text-label .edit-button .icon:focus {
+	opacity: 1;
+}
+
+.detailCallInfoContainer .clipboard-button .icon {
+	vertical-align: middle;
 }
 
 .detailCallInfoContainer .editable-text-label .input-wrapper,
 .detailCallInfoContainer .password-option {
 	position: relative;
 	display: inline-block;
+	width: 100%;
 }
 
 .detailCallInfoContainer .editable-text-label input,
 .detailCallInfoContainer .password-input {
 	width: 100%;
+	padding-right: 38px; /* 44px for submit button - 6px neg. margin overhang */
+	text-overflow: ellipsis;
+}
+
+/* Adjust styles to fit h3 and prevent jumping */
+.detailCallInfoContainer .editable-text-label input {
+	margin: 3px 0 10px !important;
+	font-size: 15px;
+	font-weight: 300;
+}
+.detailCallInfoContainer .editable-text-label input + .icon-confirm.confirm-button {
+	top: 0;
+	right: -3px;
 }
 
 .detailCallInfoContainer #link-checkbox+label {

--- a/css/style.scss
+++ b/css/style.scss
@@ -937,6 +937,9 @@ video {
 	flex-grow: 1;
 	flex-basis: 50%;
 }
+.detailCallInfoContainer .container-call {
+	flex-grow: 0;
+}
 
 .detailCallInfoContainer .join-call,
 .detailCallInfoContainer .leaveCall {

--- a/css/style.scss
+++ b/css/style.scss
@@ -929,6 +929,21 @@ video {
     padding: 9px 0;
 }
 
+.detailCallInfoContainer .container-call-link {
+	display: flex;
+}
+.detailCallInfoContainer .container-call,
+.detailCallInfoContainer .container-link {
+	flex-grow: 1;
+	flex-basis: 50%;
+}
+
+.detailCallInfoContainer .join-call,
+.detailCallInfoContainer .leaveCall {
+	width: calc(100% - 12px);
+}
+
+
 .detailCallInfoContainer .editable-text-label .edit-button {
 	display: none;
 }
@@ -958,11 +973,14 @@ video {
 	vertical-align: middle;
 }
 
-.detailCallInfoContainer .editable-text-label .input-wrapper,
-.detailCallInfoContainer .password-option {
+.detailCallInfoContainer .editable-text-label .input-wrapper {
 	position: relative;
 	display: inline-block;
 	width: 100%;
+}
+
+.detailCallInfoContainer .password-option {
+	position: relative;
 }
 
 .detailCallInfoContainer .editable-text-label input,

--- a/css/style.scss
+++ b/css/style.scss
@@ -954,6 +954,7 @@ video {
 .detailCallInfoContainer .clipboard-button,
 .detailCallInfoContainer .editable-text-label:hover .edit-button {
 	display: inline-block;
+	vertical-align: top;
 }
 
 .detailCallInfoContainer .clipboard-button .icon,
@@ -994,14 +995,15 @@ video {
 }
 
 /* Adjust styles to fit h3 and prevent jumping */
-.detailCallInfoContainer .editable-text-label input {
+.detailCallInfoContainer .editable-text-label.room-name input {
 	margin: 3px 0 10px !important;
 	font-size: 15px;
 	font-weight: 300;
-}
-.detailCallInfoContainer .editable-text-label input + .icon-confirm.confirm-button {
-	top: 0;
-	right: -3px;
+
+	+ .icon-confirm.confirm-button {
+		top: 0;
+		right: -3px;
+	}
 }
 
 .detailCallInfoContainer #link-checkbox+label {

--- a/css/style.scss
+++ b/css/style.scss
@@ -1103,7 +1103,7 @@ video {
  * below the new message input.
  */
 #app-sidebar #participantsTabView form {
-	margin-bottom: 15px;
+	margin-bottom: 10px;
 }
 
 /**

--- a/css/style.scss
+++ b/css/style.scss
@@ -737,7 +737,7 @@ video {
 	top: 0;
 	right: 0;
 	padding: 22px;
-	opacity: .5;
+	opacity: .3;
 	/* Higher index than the trigger to hide it when the sidebar is open */
 	z-index: 20;
 }

--- a/css/style.scss
+++ b/css/style.scss
@@ -16,12 +16,13 @@
 	position: absolute;
 	width: 249px;
 	top: 0;
-	border-bottom: 1px solid #eee;
+	border-bottom: 1px solid $color-border;
 }
 
 .oca-spreedme-add-person {
 	width: 100%;
-	border: 1px solid #eee;
+	border: 1px solid $color-border;
+	border-radius: $border-radius;
 }
 
 /**

--- a/css/style.scss
+++ b/css/style.scss
@@ -907,8 +907,8 @@ video {
  */
 
 .detailCallInfoContainer .room-name {
-	display: block;
-	width: calc(100% - 29px); /* 44px close button - 15px container padding */
+	display: inline-block;
+	width: calc(100% - 73px); /* 44px rename/copy + 44px close - 15px padding */
 }
 
 .detailCallInfoContainer h3 {
@@ -919,14 +919,15 @@ video {
 	overflow: hidden;
 }
 
-.detailCallInfoContainer .room-name:hover h3,
-.detailCallInfoContainer .room-name:focus h3 {
-	width: calc(100% - 44px); /* minus the edit button */
-}
+.detailCallInfoContainer .guest-name {
+	.label {
+		display: inline-block;
+	    padding: 9px 0;
+	}
 
-.detailCallInfoContainer .guest-name p {
-	display: inline-block;
-    padding: 9px 0;
+	.edit-button {
+		height: 0;
+	}
 }
 
 .detailCallInfoContainer .container-call-link {
@@ -962,7 +963,6 @@ video {
 	cursor: pointer;
 	padding: 22px;
 	margin-left: -5px;
-	margin-top: -5px;
 	opacity: .5;
 }
 
@@ -994,15 +994,24 @@ video {
 	text-overflow: ellipsis;
 }
 
-/* Adjust styles to fit h3 and prevent jumping */
-.detailCallInfoContainer .editable-text-label.room-name input {
-	margin: 3px 0 10px !important;
-	font-size: 15px;
-	font-weight: 300;
+/* Fit to h3 and prevent jumping. TODO: convert HTML to be flexbox-capable */
+.detailCallInfoContainer .editable-text-label.room-name {
+	.edit-button {
+		position: absolute;
+		right: 44px;
+		top: 16px;
+	}
 
-	+ .icon-confirm.confirm-button {
-		top: 0;
-		right: -3px;
+	input {
+		width: calc(100% + 44px);
+		margin: 3px 0 10px !important;
+		font-size: 15px;
+		font-weight: 300;
+
+		+ .icon-confirm.confirm-button {
+			top: 0;
+			right: -47px;
+		}
 	}
 }
 

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -209,7 +209,7 @@
 			this.ui.clipboardButton.tooltip({
 				placement: 'bottom',
 				trigger: 'hover',
-				title: t('spreed', 'Copy')
+				title: t('spreed', 'Copy link')
 			});
 			this.initClipboard();
 		},

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -36,17 +36,18 @@
 		'{{#if isGuest}}' +
 		'	<div class="guest-name"></div>' +
 		'{{/if}}' +
+		'	<div class="container-call-link">' +
 		'{{#if participantInCall}}' +
-		'	<div>' +
+		'	<div class="container-call">' +
 		'		<button class="leave-call primary">' + t('spreed', 'Leave call') + '</button>' +
 		'	</div>' +
 		'{{else}}' +
-		'	<div>' +
+		'	<div class="container-call">' +
 		'		<button class="join-call primary">' + t('spreed', 'Join call') + '</button>' +
 		'	</div>' +
 		'{{/if}}' +
 		'{{#if canModerate}}' +
-		'	<div>' +
+		'	<div class="container-link">' +
 		'		<input name="link-checkbox" id="link-checkbox" class="checkbox link-checkbox" value="1" {{#if isPublic}} checked="checked"{{/if}} type="checkbox">' +
 		'		<label for="link-checkbox">' + t('spreed', 'Share link') + '</label>' +
 		'		{{#if isPublic}}' +
@@ -58,7 +59,8 @@
 		'			</div>' +
 		'		{{/if}}' +
 		'	</div>' +
-		'{{/if}}';
+		'{{/if}}' +
+		'</div>';
 
 	var CallInfoView  = Marionette.View.extend({
 


### PR DESCRIPTION
- Cleaning up the h3 and rename style to not jump on rename 
- Put »Join call« and »Share link« on one line, proper layout and saving space :)

@danxuliu if you think it’s necessary or can do it, we could also move the Password input into a 3-dot menu popover (icon right next to copy link). But this is already much better. :)

![screenshot from 2018-01-10 10-21-05](https://user-images.githubusercontent.com/925062/34764927-41c3597c-f5f0-11e7-9282-26a7730decae.png) - ![screenshot from 2018-01-10 10-21-45](https://user-images.githubusercontent.com/925062/34764925-419b1192-f5f0-11e7-9783-cf4a426c25b7.png)


Ref https://github.com/nextcloud/spreed/pull/558#issuecomment-356522526