### PR TITLE
Set width of app-sidebar to 250px like app-navigation

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -965,6 +965,7 @@ video {
 #app-sidebar {
 	display: flex;
 	flex-direction: column;
+	width: 250px;
 }
 
 #app-sidebar .tabs {


### PR DESCRIPTION
It was intended from the start to have a set width for the sidebar, and setting it to the same as the navigation seems best. cc @nextcloud/designers @danxuliu 

This helps to have a predictable size of the sidbar and not have elements all over the place. It also makes sure the main view is always the focus.

Doing it here as precursor to moving it into core for Nextcloud 14. (And yes, in the future future future we can do it with flexbox. ;)