### PR TITLE
Fix postgres issue when updating

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>3.0.0</version>
+	<version>3.0.1</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/lib/Migration/Version2000Date20171026140256.php
+++ b/lib/Migration/Version2000Date20171026140256.php
@@ -22,6 +22,7 @@
  */
 namespace OCA\Spreed\Migration;
 
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -60,6 +61,11 @@ class Version2000Date20171026140256 extends SimpleMigrationStep {
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 
 		if (!version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '1.1.4', '<')) {
+			return;
+		}
+
+		if ($this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
+			// Couldn't install prior anyway, so we can skip this update step as well
 			return;
 		}
 

--- a/lib/Migration/Version2000Date20171026140256.php
+++ b/lib/Migration/Version2000Date20171026140256.php
@@ -59,7 +59,7 @@ class Version2000Date20171026140256 extends SimpleMigrationStep {
 	 */
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 
-		if (!version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '2.0.0', '<')) {
+		if (version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '2.0.0', '<')) {
 			// Migrations only work after 2.0.0
 			return;
 		}

--- a/lib/Migration/Version2000Date20171026140256.php
+++ b/lib/Migration/Version2000Date20171026140256.php
@@ -22,7 +22,6 @@
  */
 namespace OCA\Spreed\Migration;
 
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -60,12 +59,8 @@ class Version2000Date20171026140256 extends SimpleMigrationStep {
 	 */
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 
-		if (!version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '1.1.4', '<')) {
-			return;
-		}
-
-		if ($this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
-			// Couldn't install prior anyway, so we can skip this update step as well
+		if (!version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '2.0.0', '<')) {
+			// Migrations only work after 2.0.0
 			return;
 		}
 

--- a/lib/Migration/Version2000Date20171026140257.php
+++ b/lib/Migration/Version2000Date20171026140257.php
@@ -22,6 +22,7 @@
  */
 namespace OCA\Spreed\Migration;
 
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -62,6 +63,11 @@ class Version2000Date20171026140257 extends SimpleMigrationStep {
 	 * @since 13.0.0
 	 */
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+
+		if ($this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
+			// Couldn't install prior anyway, so we can skip this update step as well
+			return;
+		}
 
 		$chars = str_replace(['l', '0', '1'], '', ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
 		$entropy = (int) $this->config->getAppValue('spreed', 'token_entropy', 8);

--- a/lib/Migration/Version2000Date20171026140257.php
+++ b/lib/Migration/Version2000Date20171026140257.php
@@ -63,7 +63,7 @@ class Version2000Date20171026140257 extends SimpleMigrationStep {
 	 */
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 
-		if (!version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '2.0.0', '<')) {
+		if (version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '2.0.0', '<')) {
 			// Migrations only work after 2.0.0
 			return;
 		}

--- a/lib/Migration/Version2000Date20171026140257.php
+++ b/lib/Migration/Version2000Date20171026140257.php
@@ -22,7 +22,6 @@
  */
 namespace OCA\Spreed\Migration;
 
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -64,8 +63,8 @@ class Version2000Date20171026140257 extends SimpleMigrationStep {
 	 */
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 
-		if ($this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
-			// Couldn't install prior anyway, so we can skip this update step as well
+		if (!version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '2.0.0', '<')) {
+			// Migrations only work after 2.0.0
 			return;
 		}
 

--- a/lib/Migration/Version2001Date20170707115443.php
+++ b/lib/Migration/Version2001Date20170707115443.php
@@ -22,6 +22,7 @@
  */
 namespace OCA\Spreed\Migration;
 
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
 use OCA\Spreed\Participant;
@@ -127,9 +128,15 @@ class Version2001Date20170707115443 extends SimpleMigrationStep {
 	protected function makeOne2OneParticipantsOwners(array $one2oneRooms) {
 		$update = $this->db->getQueryBuilder();
 
-		$update->update('spreedme_room_participants')
-			->set('participantType', $update->createNamedParameter(Participant::OWNER))
-			->where($update->expr()->in('roomId', $update->createNamedParameter($one2oneRooms, IQueryBuilder::PARAM_INT_ARRAY)));
+		if (!$this->db->getDatabasePlatform() instanceof PostgreSqlPlatform) {
+			$update->update('spreedme_room_participants')
+				->set('participantType', $update->createNamedParameter(Participant::OWNER))
+				->where($update->expr()->in('roomId', $update->createNamedParameter($one2oneRooms, IQueryBuilder::PARAM_INT_ARRAY)));
+		} else {
+			$update->update('spreedme_room_participants')
+				->set('participanttype', $update->createNamedParameter(Participant::OWNER))
+				->where($update->expr()->in('roomId', $update->createNamedParameter($one2oneRooms, IQueryBuilder::PARAM_INT_ARRAY)));
+		}
 
 		return $update->execute();
 	}
@@ -141,9 +148,15 @@ class Version2001Date20170707115443 extends SimpleMigrationStep {
 	protected function makeGroupParticipantsModerators(array $one2oneRooms) {
 		$update = $this->db->getQueryBuilder();
 
-		$update->update('spreedme_room_participants')
-			->set('participantType', $update->createNamedParameter(Participant::MODERATOR))
-			->where($update->expr()->nonEmptyString('userId'));
+		if (!$this->db->getDatabasePlatform() instanceof PostgreSqlPlatform) {
+			$update->update('spreedme_room_participants')
+				->set('participantType', $update->createNamedParameter(Participant::MODERATOR))
+				->where($update->expr()->nonEmptyString('userId'));
+		} else {
+			$update->update('spreedme_room_participants')
+				->set('participanttype', $update->createNamedParameter(Participant::MODERATOR))
+				->where($update->expr()->nonEmptyString('userId'));
+		}
 
 		if (!empty($one2oneRooms)) {
 			$update->andWhere($update->expr()->notIn('roomId', $update->createNamedParameter($one2oneRooms, IQueryBuilder::PARAM_INT_ARRAY)));

--- a/lib/Migration/Version2001Date20170707115443.php
+++ b/lib/Migration/Version2001Date20170707115443.php
@@ -81,7 +81,7 @@ class Version2001Date20170707115443 extends SimpleMigrationStep {
 	 */
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 
-		if (!version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '2.0.0', '<')) {
+		if (version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '2.0.0', '<')) {
 			// Migrations only work after 2.0.0
 			return;
 		}

--- a/lib/Migration/Version2001Date20170707115443.php
+++ b/lib/Migration/Version2001Date20170707115443.php
@@ -22,12 +22,12 @@
  */
 namespace OCA\Spreed\Migration;
 
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
 use OCA\Spreed\Participant;
 use OCA\Spreed\Room;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
@@ -37,11 +37,16 @@ class Version2001Date20170707115443 extends SimpleMigrationStep {
 	/** @var IDBConnection */
 	protected $db;
 
+	/** @var IConfig */
+	protected $config;
+
 	/**
 	 * @param IDBConnection $db
+	 * @param IConfig $config
 	 */
-	public function __construct(IDBConnection $db) {
+	public function __construct(IDBConnection $db, IConfig $config) {
 		$this->db = $db;
+		$this->config = $config;
 	}
 
 	/**
@@ -75,8 +80,8 @@ class Version2001Date20170707115443 extends SimpleMigrationStep {
 	 */
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 
-		if ($this->db->getDatabasePlatform() instanceof PostgreSqlPlatform) {
-			// Couldn't install prior anyway, so we can skip this update step as well
+		if (!version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '2.0.0', '<')) {
+			// Migrations only work after 2.0.0
 			return;
 		}
 

--- a/lib/Migration/Version2001Date20170707115443.php
+++ b/lib/Migration/Version2001Date20170707115443.php
@@ -22,6 +22,7 @@
  */
 namespace OCA\Spreed\Migration;
 
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
 use OCA\Spreed\Participant;
@@ -73,6 +74,12 @@ class Version2001Date20170707115443 extends SimpleMigrationStep {
 	 * @since 13.0.0
 	 */
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+
+		if ($this->db->getDatabasePlatform() instanceof PostgreSqlPlatform) {
+			// Couldn't install prior anyway, so we can skip this update step as well
+			return;
+		}
+
 		$query = $this->db->getQueryBuilder();
 
 		$query->selectAlias($query->createFunction('COUNT(*)'), 'num_rooms')

--- a/lib/Migration/Version2001Date20171026134605.php
+++ b/lib/Migration/Version2001Date20171026134605.php
@@ -23,6 +23,7 @@
 namespace OCA\Spreed\Migration;
 
 use Doctrine\DBAL\Exception\TableNotFoundException;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -152,6 +153,12 @@ class Version2001Date20171026134605 extends SimpleMigrationStep {
 	 * @since 13.0.0
 	 */
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+
+		if ($this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
+			// Couldn't install prior anyway, so we can skip this update step as well
+			return;
+		}
+
 		$roomIdMap = $this->copyRooms();
 		$this->copyParticipants($roomIdMap);
 		$this->fixNotifications($roomIdMap);

--- a/lib/Migration/Version2001Date20171026134605.php
+++ b/lib/Migration/Version2001Date20171026134605.php
@@ -252,7 +252,7 @@ class Version2001Date20171026134605 extends SimpleMigrationStep {
 			if (!$this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
 				$insert->setParameter('participantType', (int) $row['participantType'], IQueryBuilder::PARAM_INT);
 			} else {
-				$insert->setParameter('participanType', (int) $row['participanttype'], IQueryBuilder::PARAM_INT);
+				$insert->setParameter('participantType', (int) $row['participanttype'], IQueryBuilder::PARAM_INT);
 			}
 			$insert->execute();
 		}

--- a/lib/Migration/Version2001Date20171026134605.php
+++ b/lib/Migration/Version2001Date20171026134605.php
@@ -160,7 +160,7 @@ class Version2001Date20171026134605 extends SimpleMigrationStep {
 	 */
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 
-		if (!version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '2.0.0', '<')) {
+		if (version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '2.0.0', '<')) {
 			// Migrations only work after 2.0.0
 			return;
 		}

--- a/lib/Migration/Version2001Date20171026134605.php
+++ b/lib/Migration/Version2001Date20171026134605.php
@@ -23,10 +23,10 @@
 namespace OCA\Spreed\Migration;
 
 use Doctrine\DBAL\Exception\TableNotFoundException;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
@@ -36,11 +36,16 @@ class Version2001Date20171026134605 extends SimpleMigrationStep {
 	/** @var IDBConnection */
 	protected $connection;
 
+	/** @var IConfig */
+	protected $config;
+
 	/**
 	 * @param IDBConnection $connection
+	 * @param IConfig $config
 	 */
-	public function __construct(IDBConnection $connection) {
+	public function __construct(IDBConnection $connection, IConfig $config) {
 		$this->connection = $connection;
+		$this->config = $config;
 	}
 
 	/**
@@ -154,8 +159,8 @@ class Version2001Date20171026134605 extends SimpleMigrationStep {
 	 */
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 
-		if ($this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
-			// Couldn't install prior anyway, so we can skip this update step as well
+		if (!version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '2.0.0', '<')) {
+			// Migrations only work after 2.0.0
 			return;
 		}
 

--- a/lib/Migration/Version2001Date20180103144447.php
+++ b/lib/Migration/Version2001Date20180103144447.php
@@ -22,9 +22,9 @@
  */
 namespace OCA\Spreed\Migration;
 
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
@@ -34,11 +34,16 @@ class Version2001Date20180103144447 extends SimpleMigrationStep {
 	/** @var IDBConnection */
 	protected $connection;
 
+	/** @var IConfig */
+	protected $config;
+
 	/**
 	 * @param IDBConnection $connection
+	 * @param IConfig $config
 	 */
-	public function __construct(IDBConnection $connection) {
+	public function __construct(IDBConnection $connection, IConfig $config) {
 		$this->connection = $connection;
+		$this->config = $config;
 	}
 
 
@@ -113,8 +118,8 @@ class Version2001Date20180103144447 extends SimpleMigrationStep {
 	 */
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 
-		if ($this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
-			// Couldn't install prior anyway, so we can skip this update step as well
+		if (!version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '2.0.0', '<')) {
+			// Migrations only work after 2.0.0
 			return;
 		}
 

--- a/lib/Migration/Version2001Date20180103144447.php
+++ b/lib/Migration/Version2001Date20180103144447.php
@@ -119,7 +119,7 @@ class Version2001Date20180103144447 extends SimpleMigrationStep {
 	 */
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 
-		if (!version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '2.0.0', '<')) {
+		if (version_compare($this->config->getAppValue('spreed', 'installed_version', '0.0.0'), '2.0.0', '<')) {
 			// Migrations only work after 2.0.0
 			return;
 		}

--- a/lib/Migration/Version2001Date20180103144447.php
+++ b/lib/Migration/Version2001Date20180103144447.php
@@ -22,6 +22,7 @@
  */
 namespace OCA\Spreed\Migration;
 
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
 use OCP\IConfig;
@@ -123,21 +124,39 @@ class Version2001Date20180103144447 extends SimpleMigrationStep {
 			return;
 		}
 
-		$update = $this->connection->getQueryBuilder();
-		$update->update('talk_rooms')
-			->set('active_since', 'activeSince')
-			->set('active_guests', 'activeGuests');
-		$update->execute();
+		if (!$this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
+			$update = $this->connection->getQueryBuilder();
+			$update->update('talk_rooms')
+				->set('active_since', 'activeSince')
+				->set('active_guests', 'activeGuests');
+			$update->execute();
 
-		$update = $this->connection->getQueryBuilder();
-		$update->update('talk_participants')
-			->set('user_id', 'userId')
-			->set('room_id', 'roomId')
-			->set('last_ping', 'lastPing')
-			->set('session_id', 'sessionId')
-			->set('participant_type', 'participantType')
-			->set('in_call', 'inCall');
-		$update->execute();
+			$update = $this->connection->getQueryBuilder();
+			$update->update('talk_participants')
+				->set('user_id', 'userId')
+				->set('room_id', 'roomId')
+				->set('last_ping', 'lastPing')
+				->set('session_id', 'sessionId')
+				->set('participant_type', 'participantType')
+				->set('in_call', 'inCall');
+			$update->execute();
+		} else {
+			$update = $this->connection->getQueryBuilder();
+			$update->update('talk_rooms')
+				->set('active_since', 'activesince')
+				->set('active_guests', 'activeguests');
+			$update->execute();
+
+			$update = $this->connection->getQueryBuilder();
+			$update->update('talk_participants')
+				->set('user_id', 'userid')
+				->set('room_id', 'roomid')
+				->set('last_ping', 'lastping')
+				->set('session_id', 'sessionid')
+				->set('participant_type', 'participanttype')
+				->set('in_call', 'incall');
+			$update->execute();
+		}
 
 	}
 }


### PR DESCRIPTION
~~Postgres could not be used in 12. It installed the tables with wrong names
so we need to ignore it on the update steps. The wrong tables will be
dropped and new tables will be created with further migrations.
But we shouldn't try to migrate data from the old and broken layout.~~



Fix #578 
Fix #543 