### PR TITLE
Add a relative prefix to the date divider in the chat

### DIFF
--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -208,11 +208,11 @@
 			// millisecond based.
 			model.set('date', new Date(model.get('timestamp') * 1000));
 
-			if (this._lastAddedMessageModel && !this._modelsHaveSameDate(this._lastAddedMessageModel, model)) {
+			if (!this._lastAddedMessageModel || !this._modelsHaveSameDate(this._lastAddedMessageModel, model)) {
 				if (this._oldestOnTopLayout) {
 					$el.attr('data-date', this._getDateSeparator(model.get('date')));
 					$el.addClass('showDate');
-				} else {
+				} else if (this._lastAddedMessageModel) {
 					$el.next().attr('data-date', this._getDateSeparator(this._lastAddedMessageModel.get('date')));
 					$el.next().addClass('showDate');
 				}

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -52,7 +52,7 @@
 		'    <div class="authorRow">' +
 		'        <div class="avatar" {{#if actorId}}data-username="{{actorId}}"{{/if}}> </div>' +
 		'        <div class="author">{{actorDisplayName}}</div>' +
-		'        <div class="date has-tooltip live-relative-timestamp" data-timestamp="{{timestamp}}" title="{{altDate}}">{{date}}</div>' +
+		'        <div class="date has-tooltip{{#if relativeDate}} live-relative-timestamp{{/if}}" data-timestamp="{{timestamp}}" title="{{altDate}}">{{date}}</div>' +
 		'    </div>' +
 		'    <div class="message">{{{formattedMessage}}}</div>' +
 		'</li>';
@@ -142,7 +142,8 @@
 		_formatItem: function(commentModel) {
 			// PHP timestamp is second-based; JavaScript timestamp is
 			// millisecond based.
-			var timestamp = commentModel.get('timestamp') * 1000;
+			var timestamp = commentModel.get('timestamp') * 1000,
+				relativeDate = moment(timestamp, 'x').diff(moment()) > -86400000;
 
 			var actorDisplayName = commentModel.get('actorDisplayName');
 			if (commentModel.attributes.actorType === 'guests') {
@@ -159,7 +160,8 @@
 			var data = _.extend({}, commentModel.attributes, {
 				actorDisplayName: actorDisplayName,
 				timestamp: timestamp,
-				date: moment(timestamp, 'x').diff(moment()) > -86400000 ? OC.Util.relativeModifiedDate(timestamp) : OC.Util.formatDate(timestamp, 'LT'),
+				date: relativeDate ? OC.Util.relativeModifiedDate(timestamp) : OC.Util.formatDate(timestamp, 'LTS'),
+				relativeDate: relativeDate,
 				altDate: OC.Util.formatDate(timestamp),
 				formattedMessage: formattedMessage
 			});

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -159,8 +159,8 @@
 			var data = _.extend({}, commentModel.attributes, {
 				actorDisplayName: actorDisplayName,
 				timestamp: timestamp,
-				date: OC.Util.relativeModifiedDate(timestamp),
-				altDate: OC.Util.formatDate(timestamp, 'LL LTS'),
+				date: moment(timestamp, 'x').diff(moment()) > -86400000 ? OC.Util.relativeModifiedDate(timestamp) : OC.Util.formatDate(timestamp, 'LT'),
+				altDate: OC.Util.formatDate(timestamp),
 				formattedMessage: formattedMessage
 			});
 			return data;

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -1,4 +1,4 @@
-/* global autosize, Marionette, Handlebars, OC, OCA, OCP */
+/* global autosize, Handlebars, Marionette, moment, OC, OCA, OCP */
 
 /**
  *
@@ -21,7 +21,7 @@
  *
  */
 
-(function(OCA, OC, OCP, Marionette, Handlebars, autosize) {
+(function(OCA, OC, OCP, Marionette, Handlebars, autosize, moment) {
 	'use strict';
 
 	OCA.SpreedMe = OCA.SpreedMe || {};
@@ -209,13 +209,11 @@
 			model.set('date', new Date(model.get('timestamp') * 1000));
 
 			if (this._lastAddedMessageModel && !this._modelsHaveSameDate(this._lastAddedMessageModel, model)) {
-				// 'LL' formats a localized date including day of month, month
-				// name and year
 				if (this._oldestOnTopLayout) {
-					$el.attr('data-date', OC.Util.formatDate(model.get('date'), 'LL'));
+					$el.attr('data-date', this._getDateSeparator(model.get('date')));
 					$el.addClass('showDate');
 				} else {
-					$el.next().attr('data-date', OC.Util.formatDate(this._lastAddedMessageModel.get('date'), 'LL'));
+					$el.next().attr('data-date', this._getDateSeparator(this._lastAddedMessageModel.get('date')));
 					$el.next().addClass('showDate');
 				}
 			}
@@ -240,6 +238,33 @@
 				// the new one).
 				this.$container.scrollTop(this.$container.scrollTop() + (newFirstVisibleCommentTop - firstVisibleCommentTop));
 			}
+		},
+
+		_getDateSeparator: function(timestamp) {
+			var date = moment(timestamp, 'x'),
+				today = moment(),
+				dayOfYear = OC.Util.formatDate(date, 'YYYY-DDD'),
+				dayOfYearToday = OC.Util.formatDate(today, 'YYYY-DDD');
+
+			var relativePrefix = '';
+			if (dayOfYear === dayOfYearToday) {
+				relativePrefix = t('spreed', 'Today');
+			} else {
+				var yesterday = OC.Util.formatDate(today.subtract(1, 'd'), 'YYYY-DDD');
+
+				if (dayOfYear === yesterday) {
+					relativePrefix = t('spreed', 'Yesterday');
+				} else {
+					relativePrefix = date.fromNow();
+				}
+			}
+
+			return t('spreed', '{relativeDate}, {absoluteDate}', {
+				relativeDate: relativePrefix,
+				// 'LL' formats a localized date including day of month, month
+				// name and year
+				absoluteDate: OC.Util.formatDate(timestamp, 'LL')
+			});
 		},
 
 		_modelsHaveSameActor: function(model1, model2) {
@@ -391,4 +416,4 @@
 
 	OCA.SpreedMe.Views.ChatView = ChatView;
 
-})(OCA, OC, OCP, Marionette, Handlebars, autosize);
+})(OCA, OC, OCP, Marionette, Handlebars, autosize, moment);


### PR DESCRIPTION
@jancborchardt it's not exactly the steps you mentioned, but instead its automatically done by momentjs.
I think it's good enough, but since "a month ago" is repeating with each day in the past, I'd also be fine with only showing relative until it's no longer displayed as "days ago".
No one needs relative dates for "7 months ago".


> ![ug-test_-_gesprach_-_nextcloud_-_2018-01-15_16 10 07](https://user-images.githubusercontent.com/213943/34949010-182e20e2-fa0f-11e7-99e9-ac48f43fd1e7.png)

Fix #559 