### PR TITLE
Keep light style icons when screensharing is active.

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -386,7 +386,7 @@ video {
 }
 
 /* Use dark icons when not in a call (= white background) */
-#app-content:not(.incall) .icon-white.icon-shadow {
+#app-content:not(.incall):not(.screensharing) .icon-white.icon-shadow {
 	/* Still use white icons outside of calls when local video shows */
 	&#hideVideo.video-disabled,
 	&#mute.video-disabled {


### PR DESCRIPTION
Fix #599 