### PR TITLE
Also set a token when it is null

### DIFF
--- a/lib/Migration/Version2000Date20171026140257.php
+++ b/lib/Migration/Version2000Date20171026140257.php
@@ -79,7 +79,8 @@ class Version2000Date20171026140257 extends SimpleMigrationStep {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
 			->from('spreedme_rooms')
-			->where($query->expr()->emptyString('token'));
+			->where($query->expr()->emptyString('token'))
+			->orWhere($query->expr()->isNull('token'));
 		$result = $query->execute();
 
 		$output->startProgress();


### PR DESCRIPTION
Appearantly some rooms had null as a token in the past

Don't know why this should occur, because the table had default value empty string since ever, but this should fix the problem of @tobiasKaminsky 