### PR TITLE
Improve password protection UX and UI.

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -737,6 +737,10 @@ video {
 	background-image: url('../img/menu-people.svg?v=1');
 }
 
+.icon-no-password {
+	background-image: url('../img/no-password.svg?v=1');
+}
+
 #app-sidebar .close {
 	position: absolute;
 	top: 0;

--- a/css/style.scss
+++ b/css/style.scss
@@ -923,11 +923,13 @@ video {
 }
 
 .detailCallInfoContainer .clipboard-button,
+.detailCallInfoContainer .password-button,
 .detailCallInfoContainer .editable-text-label:hover .edit-button {
 	display: inline-block;
 }
 
 .detailCallInfoContainer .clipboard-button .icon,
+.detailCallInfoContainer .password-button .icon,
 .detailCallInfoContainer .editable-text-label .edit-button .icon {
 	cursor: pointer;
 	padding: 22px;

--- a/img/no-password.svg
+++ b/img/no-password.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" version="1.1" viewBox="0 0 71 100"><path stroke-width=".16" d="m8 0c-2.2091 0-4 1.7909-4 4v3h-1v7h10v-7h-1-2-2-2v-3c0-1.1046 0.8954-2 2-2s2 0.8954 2 2v1h2v-1c0-2.2091-1.791-4-4-4z" transform="matrix(6.25,0,0,6.25,-14.5,0)"/></svg>

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -284,10 +284,6 @@
 
 		confirmPassword: function() {
 			var newPassword = this.ui.passwordInput.val().trim();
-
-			console.log('Setting room password to "' + newPassword + '".');
-			console.log('Setting room password to "' + this.model.get('hasPassword') + '".');
-
 			$.ajax({
 				url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('token') + '/password',
 				type: 'PUT',
@@ -304,8 +300,6 @@
 					OC.Notification.show(t('spreed', 'Error occurred while setting password'), {type: 'error'});
 				}
 			});
-
-			console.log('.rename-option');
 		},
 
 		keyUpPassword: function(e) {

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -51,6 +51,7 @@
 		'		<label for="link-checkbox">' + t('spreed', 'Share link') + '</label>' +
 		'		{{#if isPublic}}' +
 		'			<div class="clipboard-button"><span class="icon icon-clippy"></span></div>' +
+		'			<div class="password-button"><span class="icon icon-password"></span></div>' +
 		'			<div class="password-option">' +
 		'				<input class="password-input" maxlength="200" type="password"' +
 		'				  placeholder="{{#if hasPassword}}' + t('spreed', 'Change password') + '{{else}}' + t('spreed', 'Set password') + '{{/if}}">'+
@@ -88,6 +89,7 @@
 			'joinCallButton': 'button.join-call',
 			'leaveCallButton': 'button.leave-call',
 
+			'passwordButton': '.password-button',
 			'passwordOption': '.password-option',
 			'passwordInput': '.password-input',
 			'passwordConfirm': '.password-confirm'
@@ -102,6 +104,7 @@
 			'change @ui.linkCheckbox': 'toggleLinkCheckbox',
 
 			'keyup @ui.passwordInput': 'keyUpPassword',
+			'click @ui.passwordButton': 'showPasswordInput',
 			'click @ui.passwordConfirm': 'confirmPassword',
 			'click @ui.joinCallButton': 'joinCall',
 			'click @ui.leaveCallButton': 'leaveCall'
@@ -210,6 +213,14 @@
 				title: t('spreed', 'Copy')
 			});
 			this.initClipboard();
+
+			this.ui.passwordOption.hide();
+			this.ui.passwordButton.tooltip({
+				placement: 'bottom',
+				trigger: 'hover',
+				title: (this.model.get('hasPassword')) ? t('spreed', 'Change password') : t('spreed', 'Set password')
+			});
+
 		},
 
 		_canModerate: function() {
@@ -265,6 +276,12 @@
 		/**
 		 * Password
 		 */
+		showPasswordInput: function() {
+			this.ui.passwordButton.hide();
+			this.ui.passwordOption.show();
+			this.ui.passwordInput.focus();
+		},
+
 		confirmPassword: function() {
 			var newPassword = this.ui.passwordInput.val().trim();
 
@@ -284,6 +301,9 @@
 				}.bind(this)
 			});
 
+			this.ui.passwordOption.hide();
+			this.ui.passwordButton.show();
+
 			console.log('.rename-option');
 		},
 
@@ -294,6 +314,8 @@
 			} else if (e.keyCode === 27) {
 				// ESC
 				this.ui.passwordInput.val('');
+				this.ui.passwordOption.hide();
+				this.ui.passwordButton.show();
 			}
 		},
 

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -51,7 +51,7 @@
 		'		<label for="link-checkbox">' + t('spreed', 'Share link') + '</label>' +
 		'		{{#if isPublic}}' +
 		'			<div class="clipboard-button"><span class="icon icon-clippy"></span></div>' +
-		'			<div class="password-button"><span class="icon icon-password"></span></div>' +
+		'			<div class="password-button"><span class="icon {{#if hasPassword}}icon-password"{{else}}icon-no-password{{/if}}"></span></div>' +
 		'			<div class="password-option">' +
 		'				<input class="password-input" maxlength="200" type="password"' +
 		'				  placeholder="{{#if hasPassword}}' + t('spreed', 'Change password') + '{{else}}' + t('spreed', 'Set password') + '{{/if}}">'+

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -296,13 +296,14 @@
 				},
 				success: function() {
 					this.ui.passwordInput.val('');
-
+					this.ui.passwordOption.hide();
+					this.ui.passwordButton.show();
 					OCA.SpreedMe.app.syncRooms();
-				}.bind(this)
+				}.bind(this),
+				error: function() {
+					OC.Notification.show(t('spreed', 'Error occurred while setting password'), {type: 'error'});
+				}
 			});
-
-			this.ui.passwordOption.hide();
-			this.ui.passwordButton.show();
 
 			console.log('.rename-option');
 		},


### PR DESCRIPTION
Password input caught to much attention in the right side bar.

![screen shot 2018-01-22 at 17 07 00](https://user-images.githubusercontent.com/4638605/35230619-d4348b14-ff96-11e7-8a3a-ac3fb9b8d240.png)

It will be hidden by default and a password button will replace it.

![screen shot 2018-01-22 at 16 58 35](https://user-images.githubusercontent.com/4638605/35230662-f4bab0d4-ff96-11e7-8c2d-6ddfdb9b59a5.png)

@jancborchardt It would be nice to have an **'opened lock' icon** so we can show it when the room has no password set.

Also, we could have a new combined icon (public + password) for the left side bar, so a user could see directly which public calls are password protected without being in that room.

Something like this:
![screen shot 2018-01-22 at 16 58 52](https://user-images.githubusercontent.com/4638605/35230929-b6735226-ff97-11e7-9f2c-08aa3ca61a32.png)



