### PR TITLE
Allow to get signaling settings as guests

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -44,6 +44,7 @@ class Capabilities implements ICapability {
 					'audio',
 					'video',
 					'chat',
+					'guest-signaling',
 				],
 			],
 		];

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -85,7 +85,7 @@ class SignalingController extends OCSController {
 	}
 
 	/**
-	 * @NoAdminRequired
+	 * @PublicPage
 	 *
 	 * Only available for logged in users because guests can not use the apps
 	 * right now.
@@ -275,7 +275,6 @@ class SignalingController extends OCSController {
 	 * See sections "Backend validation" in
 	 * https://github.com/nextcloud/spreed/wiki/Spreed-Signaling-API
 	 *
-	 * @NoCSRFRequired
 	 * @PublicPage
 	 *
 	 * @return DataResponse

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -37,6 +37,7 @@ class CapabilitiesTest extends TestCase {
 					'audio',
 					'video',
 					'chat',
+					'guest-signaling',
 				],
 			],
 		], $capabilities->getCapabilities());


### PR DESCRIPTION
Fix #634 

@fancycode this is required, so the mobile apps work for guests.
I couldn't find a reason in the path why it should be disallowed for guests,
as there is special handling on generating the ticket for guests:
https://github.com/nextcloud/spreed/blob/5670fcb9ad2136062ef2aa7f3f51d8cc3a1de3d0/lib/Config.php#L180-L184