### PR TITLE
Run integration tests on MySQL and PostgreSQL too

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -166,6 +166,9 @@ matrix:
     - TESTS: php7.1-integration
       DB: mysql
       DATABASEHOST: mysql-5.7
+    - TESTS: php7.1-integration
+      DB: pgsql
+      DATABASEHOST: postgres-10
     - TESTS: jsunit
 
 services:
@@ -179,3 +182,11 @@ services:
     when:
       matrix:
         DATABASEHOST: mysql-5.7
+  postgres-10:
+    image: postgres:10
+    environment:
+      - POSTGRES_USER=oc_autotest
+      - POSTGRES_PASSWORD=
+    when:
+      matrix:
+        DATABASEHOST: postgres-10

--- a/.drone.yml
+++ b/.drone.yml
@@ -127,7 +127,6 @@ pipeline:
     environment:
       - APP_NAME=spreed
       - CORE_BRANCH=master
-      - DB=sqlite
     commands:
       # Pre-setup steps
       - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
@@ -163,4 +162,5 @@ matrix:
     - TESTS: php7.1
     - TESTS: php7.2
     - TESTS: php7.1-integration
+      DB: sqlite
     - TESTS: jsunit

--- a/.drone.yml
+++ b/.drone.yml
@@ -163,4 +163,19 @@ matrix:
     - TESTS: php7.2
     - TESTS: php7.1-integration
       DB: sqlite
+    - TESTS: php7.1-integration
+      DB: mysql
+      DATABASEHOST: mysql-5.7
     - TESTS: jsunit
+
+services:
+  mysql-5.7:
+    image: mysql:5.7
+    environment:
+      - MYSQL_ROOT_PASSWORD=owncloud
+      - MYSQL_USER=oc_autotest
+      - MYSQL_PASSWORD=owncloud
+      - MYSQL_DATABASE=oc_autotest
+    when:
+      matrix:
+        DATABASEHOST: mysql-5.7

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -421,6 +421,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			new TableNode([['message', $message]])
 		);
 		$this->assertStatusCode($this->response, $statusCode);
+		sleep(1); // make sure Postgres manages the order of the messages
 	}
 
 	/**


### PR DESCRIPTION
Fixes #443

Requires nextcloud/travis_ci#5

The _before_install.sh_ script uses the `$DATABASEHOST` environment variable to either create the database or wait for it to be up, and also to set the database host during the installation. Drone services are located by other Drone containers by their name, so the `$DATABASEHOST` must be set to the name of the database service; in the case of SQLite `$DATABASEHOST` is ignored, so there is no need to set it.

~~By the way, it seems that there is a bug with the order of received chat messages in PostgreSQL :-O I will try to take a look.~~ @nickvergessen addressed that in the last commit.
