### PR TITLE
cast userids to string to avoid issues with  numerical IDs

### DIFF
--- a/lib/Activity/Hooks.php
+++ b/lib/Activity/Hooks.php
@@ -78,7 +78,7 @@ class Hooks {
 
 		$duration = $this->timeFactory->getTime() - $activeSince->getTimestamp();
 		$participants = $room->getParticipants($activeSince->getTimestamp());
-		$userIds = array_keys($participants['users']);
+		$userIds = array_map('strval', array_keys($participants['users']));
 
 		if (empty($userIds) || (count($userIds) === 1 && $room->getActiveGuests() === 0)) {
 			// Single user pinged or guests only => no activity


### PR DESCRIPTION
Related to https://github.com/nextcloud/server/pull/8355 

This would blow up further in line 109, because `setAffectedUser()` only accepts strings. 

I could not test this on my dev setup unfortunately. 