### PR TITLE
Remove https:// prefix from TURN URL placeholder

### DIFF
--- a/js/admin/stun-server.js
+++ b/js/admin/stun-server.js
@@ -68,8 +68,17 @@
 			this.$list.find('.icon-checkmark-color').addClass('hidden');
 
 			this.$list.find('input').each(function() {
-				var server = this.value,
-					parts = server.split(':');
+				var server = this.value;
+				
+				// Remove HTTP or HTTPS protocol, if provided
+				if (server.startsWith('https://')) {
+					server = server.substr(8);
+				} else if (server.startsWith('http://')) {
+					server = data.server.substr(7);
+				}
+				
+				var parts = server.split(':');
+				
 				if (parts.length !== 2) {
 					$(this).addClass('error');
 				} else {

--- a/js/admin/stun-server.js
+++ b/js/admin/stun-server.js
@@ -74,7 +74,7 @@
 				if (server.startsWith('https://')) {
 					server = server.substr(8);
 				} else if (server.startsWith('http://')) {
-					server = data.server.substr(7);
+					server = server.substr(7);
 				}
 				
 				var parts = server.split(':');

--- a/js/admin/turn-server.js
+++ b/js/admin/turn-server.js
@@ -8,7 +8,7 @@
 	OCA.VideoCalls.Admin.TurnServer = {
 
 		TEMPLATE: '<div class="turn-server">' +
-		'	<input type="text" class="server" placeholder="https://turn.example.org" value="{{server}}">' +
+		'	<input type="text" class="server" placeholder="turn.example.org" value="{{server}}">' +
 		'	<input type="text" class="secret" placeholder="' + t('spreed', 'Shared secret') + '" value="{{secret}}">' +
 		'	<select class="protocols" title="' + t('spreed', 'TURN server protocols') + '">' +
 		'	{{#select protocols}}' +

--- a/js/admin/turn-server.js
+++ b/js/admin/turn-server.js
@@ -98,6 +98,14 @@
 					}
 					return;
 				}
+				
+				// remove HTTP/HTTPS prefix if provided
+				if (data.server.startsWith('https://')) {
+					data.server = data.server.substr(8);
+				} else if (data.server.startsWith('http://')) {
+					data.server = data.server.substr(7);
+				}
+				
 				if (data.secret === '') {
 					$error.push($secret);
 					return;


### PR DESCRIPTION
Closes #600

The `https://` protocol is not used (to my knowledge) in TURN connections, rather it is the turn protocol. So, this placeholder should not include HTTPS prefix, as it may mislead end users.