### PR TITLE
pass if no valid user object was returned

### DIFF
--- a/lib/ContactsMenu/Providers/CallProvider.php
+++ b/lib/ContactsMenu/Providers/CallProvider.php
@@ -76,12 +76,12 @@ class CallProvider implements IProvider {
 		}
 
 		$user = $this->userManager->get($uid);
-		$talkAction = $this->l10n->t('Talk');
-
-		if ($user instanceof IUser) {
-			$talkAction = $this->l10n->t('Talk to %s', [$user->getDisplayName()]);
+		if(!$user instanceof IUser) {
+			// No valid user object
+			return;
 		}
 
+		$talkAction = $this->l10n->t('Talk to %s', [$user->getDisplayName()]);
 		$iconUrl = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('spreed', 'app-dark.svg'));
 		$callUrl = $this->urlGenerator->linkToRouteAbsolute('spreed.Page.index') . '?callUser=' . $user->getUID();
 		$action = $this->actionFactory->newLinkAction($iconUrl, $talkAction, $callUrl);


### PR DESCRIPTION
Fixes:

![screenshot_20180306_161811](https://user-images.githubusercontent.com/2184312/37040374-f7ddbaf6-2159-11e8-8f95-2b5c4056535d.png)

when an invalid user was posted to the provider.

Can happen if an LDAP user is unavailable for whatever reason.