### PR TITLE
Streamline empty content messages

### DIFF
--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -111,8 +111,10 @@
 			this.$el.find('.app-navigation-entry-link').attr('href', roomURL);
 
 			if (this.model.get('active')) {
+				if (!this.$el.hasClass('active')) {
+					this.addRoomMessage();
+				}
 				this.$el.addClass('active');
-				this.addRoomMessage();
 			} else {
 				this.$el.removeClass('active');
 			}
@@ -169,10 +171,6 @@
 					$(a).removeClass('icon-contacts-dark').addClass('icon-public');
 				});
 			}
-
-			if (this.model.get('active')) {
-				this.addRoomMessage();
-			}
 		},
 		leaveRoom: function() {
 			// If user is in that room, it should leave the associated call first.
@@ -216,59 +214,40 @@
 			}, OC.generateUrl('/call/' + token));
 		},
 		addRoomMessage: function() {
-			var message = '',
-				messageAdditional = '',
-				participants = this.model.get('participants'),
-				hasCall = this.model.get('hasCall'),
-				isInCall = this.model.get('participantInCall');
-
-			//Remove previous icon, avatar or link from emptycontent
-			var $emptyContentIcon = $('#emptycontent-icon');
-			$emptyContentIcon.attr('class', '')
-				.empty();
-			$('#shareRoomInput').addClass('hidden');
-			$('#shareRoomClipboardButton').addClass('hidden');
-
+			console.log('addRoomMessage');
+			var participants = this.model.get('participants');
 
 			switch(this.model.get('type')) {
 				case ROOM_TYPE_ONE_TO_ONE:
-					var waitingParticipantId = '',
-						waitingParticipantName = '';
+					var participantId = '',
+						participantName = '';
 
-					_.each(participants, function(data, participantId) {
-						if (OC.getCurrentUser().uid !== participantId) {
-							waitingParticipantId = participantId;
-							waitingParticipantName = data.name;
+					_.each(participants, function(data, userId) {
+						if (OC.getCurrentUser().uid !== userId) {
+							participantId = userId;
+							participantName = data.name;
 						}
 					});
 
-					// Avatar for username
-					var avatar = document.createElement('div');
-					avatar.className = 'avatar room-avatar';
-
-					$emptyContentIcon.append(avatar);
-
-					$emptyContentIcon.find('.avatar').each(function () {
-						if (waitingParticipantName && (waitingParticipantId !== waitingParticipantName)) {
-							$(this).avatar(waitingParticipantId, 128, undefined, false, undefined, waitingParticipantName);
-						} else {
-							$(this).avatar(waitingParticipantId, 128);
-						}
-					});
-
-					message = t('spreed', 'Waiting for {participantName} to join the room …', {participantName: waitingParticipantName});
-					if (hasCall) {
-						if (isInCall) {
-							message = t('spreed', 'Waiting for {participantName} to join the call …', {participantName: waitingParticipantName});
-						} else {
-							message = t('spreed', '{participantName} is waiting for you to join the call …', {participantName: waitingParticipantName});
-						}
-					}
+					OCA.SpreedMe.app.setEmptyContentMessage(
+						{ userId: participantId, displayName: participantName},
+						t('spreed', 'Waiting for {participantName} to join the call …', {participantName: participantName})
+					);
 					break;
 				case ROOM_TYPE_PUBLIC_CALL:
 				case ROOM_TYPE_GROUP_CALL:
-					message = t('spreed', 'Waiting for others to join the room …');
+					var icon = '',
+						message = '',
+						messageAdditional = '',
+						url = '';
 
+					if (this.model.get('type') === ROOM_TYPE_PUBLIC_CALL) {
+						icon = 'icon-public';
+					} else {
+						icon = 'icon-contacts-dark';
+					}
+
+					message = t('spreed', 'Waiting for others to join the call …');
 					if (OC.getCurrentUser().uid !== null && Object.keys(participants).length === 1) {
 						message = t('spreed', 'No other people in this call');
 						if (this.model.get('participantType') === 0 || this.model.get('participantType') === 1) {
@@ -276,93 +255,17 @@
 						}
 					}
 
-					if (hasCall) {
-						$emptyContentIcon.addClass('icon-video');
-						if (isInCall) {
-							message = t('spreed', 'Waiting for others to join the call …');
-
-						} else {
-							var others = [];
-							_.each(participants, function(data) {
-								if (data.call) {
-									others.push(data.name);
-								}
-							});
-
-							if (others.length === 1) {
-								message = t('spreed', '{participantName} is waiting for you to join the call …', {participantName: others[0]});
-							} else {
-								message = t('spreed', 'Call in progress …');
-								switch (others.length) {
-									case 0:
-										break;
-									case 2:
-										messageAdditional = t('spreed', 'Join {participant1} and {participant2}', {
-											participant1: others[0],
-											participant2: others[1]
-										});
-										break;
-									case 3:
-										messageAdditional = t('spreed', 'Join {participant1}, {participant2} and {participant3}', {
-											participant1: others[0],
-											participant2: others[1],
-											participant3: others[2]
-										});
-										break;
-									case 4:
-										messageAdditional = t('spreed', 'Join {participant1}, {participant2}, {participant3} and {participant4}', {
-											participant1: others[0],
-											participant2: others[1],
-											participant3: others[2],
-											participant4: others[3]
-										});
-										break;
-									case 5:
-										messageAdditional = t('spreed', 'Join {participant1}, {participant2}, {participant3}, {participant4} and {participant5}', {
-											participant1: others[0],
-											participant2: others[1],
-											participant3: others[2],
-											participant4: others[3],
-											participant5: others[4]
-										});
-										break;
-									default:
-										messageAdditional = t('spreed', 'Join {participant1}, {participant2}, {participant3}, {participant4}, …', {
-											participant1: others[0],
-											participant2: others[1],
-											participant3: others[2],
-											participant4: others[3]
-										});
-										break;
-								}
-							}
-						}
-					} else {
-						if (this.model.get('type') === ROOM_TYPE_PUBLIC_CALL) {
-							$emptyContentIcon.addClass('icon-public');
-						} else {
-							$emptyContentIcon.addClass('icon-contacts-dark');
-						}
-					}
-
 					if (messageAdditional === '' && this.model.get('type') === ROOM_TYPE_PUBLIC_CALL) {
 						messageAdditional = t('spreed', 'Share this link to invite others!');
-
-						//Add link
-						var url = window.location.protocol + '//' + window.location.host + OC.generateUrl('/call/' + this.model.get('token'));
-						$('#shareRoomInput').val(url);
-						$('#shareRoomInput').removeClass('hidden');
-						$('#shareRoomClipboardButton').removeClass('hidden');
-
+						url = window.location.protocol + '//' + window.location.host + OC.generateUrl('/call/' + this.model.get('token'));
 					}
+
+					OCA.SpreedMe.app.setEmptyContentMessage(icon, message, messageAdditional, url);
 					break;
 				default:
 					console.log("Unknown room type", this.model.get('type'));
-					break;
+					return;
 			}
-
-			$('#emptycontent h2').html(message);
-			$('#emptycontent p').text(messageAdditional);
 		},
 		addTooltip: function () {
 			var participants = [];

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -189,16 +189,14 @@ var spreedPeerConnectionTable = [];
 			webrtc.leaveCall();
 		});
 		app.signaling.on('joinCall', function (token) {
+			app.setEmptyContentMessage(
+				'icon-video-off',
+				t('spreed', 'Waiting for camera and microphone permissions'),
+				t('spreed', 'Please, give your browser access to use your camera and microphone in order to use this app.')
+			);
+
 			webrtc.joinCall(token);
 		});
-
-		var nick = OC.getCurrentUser().displayName;
-
-		app.setEmptyContentMessage(
-			'icon-video-off',
-			t('spreed', 'Waiting for camera and microphone permissions'),
-			t('spreed', 'Please, give your browser access to use your camera and microphone in order to use this app.')
-		);
 
 		webrtc = new SimpleWebRTC({
 			localVideoEl: 'localVideo',
@@ -217,7 +215,7 @@ var spreedPeerConnectionTable = [];
 			detectSpeakingEvents: true,
 			connection: app.signaling,
 			enableDataChannels: true,
-			nick: nick
+			nick: OC.getCurrentUser().displayName
 		});
 
 
@@ -640,6 +638,7 @@ var spreedPeerConnectionTable = [];
 		});
 
 		OCA.SpreedMe.webrtc.on('localMediaStarted', function (configuration) {
+			console.log('localMediaStarted');
 			app.startLocalMedia(configuration);
 		});
 
@@ -652,7 +651,6 @@ var spreedPeerConnectionTable = [];
 					messageAdditional = t('spreed', 'Please adjust your configuration');
 				} else {
 					message = t('spreed', 'Access to microphone & camera was denied');
-					$('#emptycontent p').hide();
 				}
 			} else if(!OCA.SpreedMe.webrtc.capabilities.support) {
 				console.log('WebRTC not supported');
@@ -669,22 +667,14 @@ var spreedPeerConnectionTable = [];
 				message,
 				messageAdditional
 			);
-
-			// Hide rooms sidebar
-			$('#app-navigation').hide();
 		});
 
 		if(!OCA.SpreedMe.webrtc.capabilities.support) {
 			console.log('WebRTC not supported');
-			var message, messageAdditional;
-
-			message = t('spreed', 'WebRTC is not supported in your browser :-/');
-			messageAdditional = t('spreed', 'Please use a different browser like Firefox or Chrome');
-
 			OCA.SpreedMe.app.setEmptyContentMessage(
 				'icon-video-off',
-				message,
-				messageAdditional
+				t('spreed', 'WebRTC is not supported in your browser :-/'),
+				t('spreed', 'Please use a different browser like Firefox or Chrome')
 			);
 		}
 


### PR DESCRIPTION
The empty content message is now only shown when you are the only one in the call and are waiting for other people. Otherwise you see the chat or the call screen. So we can simplify this a bit.
Also fixed:
* Show previous message again, after media permissions was requested (including avatar in 1on1 calls)
* Always show message for media permission, not only on first connection
