### PR TITLE
Fix new multi-session signaling endpoints.

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -51,7 +51,7 @@ return [
 		],
 		[
 			'name' => 'Signaling#signaling',
-			'url' => '/api/{apiVersion}/signaling/messages/{token}',
+			'url' => '/api/{apiVersion}/signaling/{token}/messages',
 			'verb' => 'POST',
 			'requirements' => [
 				'apiVersion' => 'v1',
@@ -60,7 +60,7 @@ return [
 		],
 		[
 			'name' => 'Signaling#pullMessages',
-			'url' => '/api/{apiVersion}/signaling/messages/{token}',
+			'url' => '/api/{apiVersion}/signaling/{token}/messages',
 			'verb' => 'GET',
 			'requirements' => [
 				'apiVersion' => 'v1',

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -34,24 +34,6 @@ return [
 		 * Signaling
 		 */
 		[
-			'name' => 'Signaling#signaling',
-			'url' => '/api/{apiVersion}/signaling/{token}',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v1',
-				'token' => '^[a-z0-9]{4,30}$',
-			],
-		],
-		[
-			'name' => 'Signaling#pullMessages',
-			'url' => '/api/{apiVersion}/signaling/{token}',
-			'verb' => 'GET',
-			'requirements' => [
-				'apiVersion' => 'v1',
-				'token' => '^[a-z0-9]{4,30}$',
-			],
-		],
-		[
 			'name' => 'Signaling#getSettings',
 			'url' => '/api/{apiVersion}/signaling/settings',
 			'verb' => 'GET',
@@ -65,6 +47,24 @@ return [
 			'verb' => 'POST',
 			'requirements' => [
 				'apiVersion' => 'v1',
+			],
+		],
+		[
+			'name' => 'Signaling#signaling',
+			'url' => '/api/{apiVersion}/signaling/messages/{token}',
+			'verb' => 'POST',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
+		[
+			'name' => 'Signaling#pullMessages',
+			'url' => '/api/{apiVersion}/signaling/messages/{token}',
+			'verb' => 'GET',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
 			],
 		],
 

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -51,7 +51,7 @@ return [
 		],
 		[
 			'name' => 'Signaling#signaling',
-			'url' => '/api/{apiVersion}/signaling/{token}/messages',
+			'url' => '/api/{apiVersion}/signaling/{token}',
 			'verb' => 'POST',
 			'requirements' => [
 				'apiVersion' => 'v1',
@@ -60,7 +60,7 @@ return [
 		],
 		[
 			'name' => 'Signaling#pullMessages',
-			'url' => '/api/{apiVersion}/signaling/{token}/messages',
+			'url' => '/api/{apiVersion}/signaling/{token}',
 			'verb' => 'GET',
 			'requirements' => [
 				'apiVersion' => 'v1',

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -341,7 +341,7 @@
 	OCA.Talk.Signaling.Internal.prototype._sendMessages = function(messages) {
 		var defer = $.Deferred();
 		$.ajax({
-			url: OC.linkToOCS('apps/spreed/api/v1/signaling/messages', 2) + this.currentRoomToken,
+			url: OC.linkToOCS('apps/spreed/api/v1/signaling', 2) + this.currentRoomToken + '/messages',
 			type: 'POST',
 			data: {messages: JSON.stringify(messages)},
 			beforeSend: function (request) {
@@ -417,7 +417,7 @@
 		// Connect to the messages endpoint and pull for new messages
 		this.pullMessagesRequest =
 		$.ajax({
-			url: OC.linkToOCS('apps/spreed/api/v1/signaling/messages', 2) + this.currentRoomToken,
+			url: OC.linkToOCS('apps/spreed/api/v1/signaling', 2) + this.currentRoomToken + '/messages',
 			type: 'GET',
 			dataType: 'json',
 			beforeSend: function (request) {

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -341,7 +341,7 @@
 	OCA.Talk.Signaling.Internal.prototype._sendMessages = function(messages) {
 		var defer = $.Deferred();
 		$.ajax({
-			url: OC.linkToOCS('apps/spreed/api/v1/signaling', 2) + this.currentRoomToken + '/messages',
+			url: OC.linkToOCS('apps/spreed/api/v1/signaling', 2) + this.currentRoomToken,
 			type: 'POST',
 			data: {messages: JSON.stringify(messages)},
 			beforeSend: function (request) {
@@ -417,7 +417,7 @@
 		// Connect to the messages endpoint and pull for new messages
 		this.pullMessagesRequest =
 		$.ajax({
-			url: OC.linkToOCS('apps/spreed/api/v1/signaling', 2) + this.currentRoomToken + '/messages',
+			url: OC.linkToOCS('apps/spreed/api/v1/signaling', 2) + this.currentRoomToken,
 			type: 'GET',
 			dataType: 'json',
 			beforeSend: function (request) {

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -341,7 +341,7 @@
 	OCA.Talk.Signaling.Internal.prototype._sendMessages = function(messages) {
 		var defer = $.Deferred();
 		$.ajax({
-			url: OC.linkToOCS('apps/spreed/api/v1/signaling', 2) + this.currentRoomToken,
+			url: OC.linkToOCS('apps/spreed/api/v1/signaling/messages', 2) + this.currentRoomToken,
 			type: 'POST',
 			data: {messages: JSON.stringify(messages)},
 			beforeSend: function (request) {
@@ -417,7 +417,7 @@
 		// Connect to the messages endpoint and pull for new messages
 		this.pullMessagesRequest =
 		$.ajax({
-			url: OC.linkToOCS('apps/spreed/api/v1/signaling', 2) + this.currentRoomToken,
+			url: OC.linkToOCS('apps/spreed/api/v1/signaling/messages', 2) + this.currentRoomToken,
 			type: 'GET',
 			dataType: 'json',
 			beforeSend: function (request) {

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -450,7 +450,11 @@ class Manager {
 		$i = 0;
 		while ($i < 1000) {
 			try {
-				return $this->generateNewToken($query, $entropy, $chars);
+				$token = $this->generateNewToken($query, $entropy, $chars);
+				if (\in_array($token, ['settings', 'backend'], true)) {
+					throw new \OutOfBoundsException('Reserved word');
+				}
+				return $token;
 			} catch (\OutOfBoundsException $e) {
 				$i++;
 				if ($entropy >= 30 || $i >= 999) {


### PR DESCRIPTION
Follows #748 
getSettings endpoint could not be used because `signaling/settings` was wrongly treated as `signaling/{token}` (pullingMessages).