### PR TITLE
Add proper chat message offset support

### DIFF
--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -61,7 +61,8 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 
 ### 3.2
 * `guest-display-names` - Display names of guests are stored in the database, can be set via API (not WebRTC only) and are used on returned comments/participants/etc.
-* `multi-room-users` - Users can be in multiple rooms at the same time now, therefor signaling now also requires the room/call token on the URL
+* `multi-room-users` - Users can be in multiple rooms at the same time now, therefor signaling now also requires the room/call token on the URL.
+* `chat-v2` - Chat now has a decent offset, the previous `chat` is not available anymore.
 
 
 ## Room management
@@ -441,14 +442,21 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 
     field | type | Description
     ------|------|------------
-    `offset` | int | Ignores the first N messages
-    `notOlderThanTimestamp` | int | Timestamp in seconds and UTC time zone
-    `timeout` | int | Number of seconds to wait for new messages (30 by default, 60 at most)
+    `lookIntoFuture` | int | `1` Poll and wait for new message or `0` get history of a room
+    `limit` | int | Number of chat messages to receive (100 by default, 200 at most)
+    `timeout` | int | `$lookIntoFuture = 1` only, Number of seconds to wait for new messages (30 by default, 60 at most)
+    `lastKnownMessageId` | int | Serves as an offset for the query. The lastKnownMessageId for the next page is available in the `X-Chat-Last-Given` header.
 
 * Response:
-    - Header:
+    - Status code:
         + `200 OK`
         + `404 Not Found` When the room could not be found for the participant
+
+    - Header:
+
+        field | type | Description
+        ------|------|------------
+        `X-Chat-Last-Given` | int | Offset (lastKnownMessageId) for the next page.
 
     - Data:
         Array of messages, each message has at least:
@@ -456,6 +464,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         field | type | Description
         ------|------|------------
         `id` | int | ID of the comment
+        `token` | string | Room token
         `actorType` | string | `guests` or `users`
         `actorId` | string | User id of the message author
         `actorDisplayName` | string | Display name of the message author

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -43,7 +43,7 @@ class Capabilities implements IPublicCapability {
 				'features' => [
 					'audio',
 					'video',
-					'chat',
+					'chat-v2',
 					'guest-signaling',
 					'empty-group-room',
 					'guest-display-names',

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -102,14 +102,14 @@ class ChatManager {
 	 *
 	 * @param string $chatId
 	 * @param int $offset Last known message id
-	 * @param int $timeout
 	 * @param int $limit
+	 * @param int $timeout
 	 * @param string $userId
 	 * @return IComment[] the messages found (only the id, actor type and id,
 	 *         creation date and message are relevant), or an empty array if the
 	 *         timeout expired.
 	 */
-	public function waitForNewMessages($chatId, $offset, $timeout, $limit, $userId) {
+	public function waitForNewMessages($chatId, $offset, $limit, $timeout, $userId) {
 		$this->notifier->markMentionNotificationsRead($chatId, $userId);
 		$elapsedTime = 0;
 

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -45,10 +45,10 @@ class ChatManager {
 	private $notifier;
 
 	/**
-	 * @param ICommentsManager $commentsManager
+	 * @param CommentsManager $commentsManager
 	 * @param Notifier $notifier
 	 */
-	public function __construct(ICommentsManager $commentsManager,
+	public function __construct(CommentsManager $commentsManager,
 								Notifier $notifier) {
 		$this->commentsManager = $commentsManager;
 		$this->notifier = $notifier;

--- a/lib/Chat/CommentsManager.php
+++ b/lib/Chat/CommentsManager.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Chat;
+
+
+use OC\Comments\Comment;
+use OC\Comments\Manager;
+use OCP\Comments\IComment;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+
+class CommentsManager extends Manager {
+
+	/**
+	 * @param string $objectType
+	 * @param string $objectId
+	 * @param int $lastKnownCommentId
+	 * @param string $sortDirection
+	 * @param int $limit
+	 * @return array
+	 */
+	public function getForObjectSinceTalkVersion(
+		$objectType,
+		$objectId,
+		$lastKnownCommentId,
+		$sortDirection = 'asc',
+		$limit = 30
+	) {
+		$comments = [];
+
+		$query = $this->dbConn->getQueryBuilder();
+		$query->select('*')
+			->from('comments')
+			->where($query->expr()->eq('object_type', $query->createNamedParameter($objectType)))
+			->andWhere($query->expr()->eq('object_id', $query->createNamedParameter($objectId)))
+			->orderBy('creation_timestamp', $sortDirection === 'desc' ? 'DESC' : 'ASC')
+			->addOrderBy('id', $sortDirection === 'desc' ? 'DESC' : 'ASC');
+
+		if ($limit > 0) {
+			$query->setMaxResults($limit);
+		}
+
+		$lastKnownComment = $this->getLastKnownCommentTalkVersion(
+			$objectType,
+			$objectId,
+			$lastKnownCommentId
+		);
+		if ($lastKnownComment instanceof IComment) {
+			$query->andWhere(
+				$query->expr()->lte(
+					'creation_timestamp',
+					$query->createNamedParameter($lastKnownComment->getCreationDateTime()->getTimestamp()
+				)),
+				$query->expr()->lte(
+					'id',
+					$query->createNamedParameter($lastKnownComment->getId()
+				))
+
+			);
+		}
+
+		$resultStatement = $query->execute();
+		while ($data = $resultStatement->fetch()) {
+			$comment = new Comment($this->normalizeDatabaseData($data));
+			$this->cache($comment);
+			$comments[] = $comment;
+		}
+		$resultStatement->closeCursor();
+
+		return $comments;
+	}
+
+	/**
+	 * @param string $objectType
+	 * @param string $objectId
+	 * @param int $id
+	 * @return Comment|null
+	 */
+	protected function getLastKnownCommentTalkVersion($objectType,
+													$objectId,
+													$id) {
+		$query = $this->dbConn->getQueryBuilder();
+		$query->select('*')
+			->from('comments')
+			->where($query->expr()->eq('object_type', $query->createNamedParameter($objectType)))
+			->andWhere($query->expr()->eq('object_id', $query->createNamedParameter($objectId)))
+			->andWhere($query->expr()->eq('id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+
+		$result = $query->execute();
+		$row = $result->fetch();
+		$result->closeCursor();
+
+		if ($row) {
+			$comment = new Comment($this->normalizeDatabaseData($row));
+			$this->cache($comment);
+			return $comment;
+		}
+
+		return null;
+	}
+}

--- a/lib/Chat/CommentsManager.php
+++ b/lib/Chat/CommentsManager.php
@@ -64,17 +64,44 @@ class CommentsManager extends Manager {
 			$lastKnownCommentId
 		);
 		if ($lastKnownComment instanceof IComment) {
-			$query->andWhere(
-				$query->expr()->lte(
-					'creation_timestamp',
-					$query->createNamedParameter($lastKnownComment->getCreationDateTime()->getTimestamp()
-				)),
-				$query->expr()->lte(
-					'id',
-					$query->createNamedParameter($lastKnownComment->getId()
-				))
-
-			);
+			$lastKnownCommentDateTime = $lastKnownComment->getCreationDateTime();
+			if ($sortDirection === 'desc') {
+				$query->andWhere(
+					$query->expr()->orX(
+						$query->expr()->lt(
+							'creation_timestamp',
+							$query->createNamedParameter($lastKnownCommentDateTime, IQueryBuilder::PARAM_DATE),
+							IQueryBuilder::PARAM_DATE
+						),
+						$query->expr()->andX(
+							$query->expr()->eq(
+								'creation_timestamp',
+								$query->createNamedParameter($lastKnownCommentDateTime, IQueryBuilder::PARAM_DATE),
+								IQueryBuilder::PARAM_DATE
+							),
+							$query->expr()->lt('id', $query->createNamedParameter($lastKnownCommentId))
+						)
+					)
+				);
+			} else {
+				$query->andWhere(
+					$query->expr()->orX(
+						$query->expr()->gt(
+							'creation_timestamp',
+							$query->createNamedParameter($lastKnownCommentDateTime, IQueryBuilder::PARAM_DATE),
+							IQueryBuilder::PARAM_DATE
+						),
+						$query->expr()->andX(
+							$query->expr()->eq(
+								'creation_timestamp',
+								$query->createNamedParameter($lastKnownCommentDateTime, IQueryBuilder::PARAM_DATE),
+								IQueryBuilder::PARAM_DATE
+							),
+							$query->expr()->gt('id', $query->createNamedParameter($lastKnownCommentId))
+						)
+					)
+				);
+			}
 		}
 
 		$resultStatement = $query->execute();

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -200,9 +200,9 @@ class ChatController extends OCSController {
 	 *
 	 * @param string $token the room token
 	 * @param int $lookIntoFuture Polling for new messages (1) or getting the history of the chat (0)
+	 * @param int $limit Number of chat messages to receive (100 by default, 200 at most)
 	 * @param int $lastKnownMessageId The last known message (serves as offset)
 	 * @param int $timeout Number of seconds to wait for new messages (30 by default, 60 at most)
-	 * @param int $limit Number of chat messages to receive (100 by default, 200 at most)
 	 * @return DataResponse an array of chat messages, "404 Not found" if the
 	 *         room token was not valid or "304 Not modified" if there were no messages;
 	 *         each chat message is an array with
@@ -210,7 +210,7 @@ class ChatController extends OCSController {
 	 *         'actorDisplayName', 'timestamp' (in seconds and UTC timezone) and
 	 *         'message'.
 	 */
-	public function receiveMessages($token, $lookIntoFuture, $lastKnownMessageId = 0, $timeout = 30, $limit = 100) {
+	public function receiveMessages($token, $lookIntoFuture, $limit = 100, $lastKnownMessageId = 0, $timeout = 30) {
 		$room = $this->getRoom($token);
 		if ($room === null) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
@@ -219,7 +219,7 @@ class ChatController extends OCSController {
 		$timeout = min(60, $timeout);
 
 		if ($lookIntoFuture) {
-			$comments = $this->chatManager->waitForNewMessages((string) $room->getId(), $lastKnownMessageId, $timeout, $limit, $this->userId);
+			$comments = $this->chatManager->waitForNewMessages((string) $room->getId(), $lastKnownMessageId, $limit, $timeout, $this->userId);
 		} else {
 			$comments = $this->chatManager->getHistory((string) $room->getId(), $lastKnownMessageId, $limit);
 		}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -441,13 +441,12 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	 * @Then /^user "([^"]*)" sees the following messages in room "([^"]*)" with (\d+)$/
 	 *
 	 * @param string $user
-	 * @param string $message
 	 * @param string $identifier
 	 * @param string $statusCode
 	 */
 	public function userSeesTheFollowingMessagesInRoom($user, $identifier, $statusCode, TableNode $formData = null) {
 		$this->setCurrentUser($user);
-		$this->sendRequest('GET', '/apps/spreed/api/v1/chat/' . self::$identifierToToken[$identifier]);
+		$this->sendRequest('GET', '/apps/spreed/api/v1/chat/' . self::$identifierToToken[$identifier] . '?lookIntoFuture=0');
 		$this->assertStatusCode($this->response, $statusCode);
 
 		$messages = $this->getDataFromResponse($this->response);

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -38,7 +38,7 @@ class CapabilitiesTest extends TestCase {
 				'features' => [
 					'audio',
 					'video',
-					'chat',
+					'chat-v2',
 					'guest-signaling',
 					'empty-group-room',
 					'guest-display-names',


### PR DESCRIPTION
The offset now is based on the last known chat message instead of limit-offset,
so new messages don't mess up requests to get the history of a room

Todo:
- [x] Make offset the last comment id instead of limit-offset
- [x] Change capabilities
- [x] Adjust the JS pulling of chat messages