### PR TITLE
Add lock icon to password popover.

### DIFF
--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -54,7 +54,7 @@
 		'				<div class="popovermenu password-menu menu-left">' +
 		'					<ul>' +
 		'						<li>' +
-		'							<span class="menuitem icon-triangle-e password-option">' +
+		'							<span class="menuitem {{#if hasPassword}}icon-password"{{else}}icon-no-password{{/if}} password-option">' +
 		'								<form class="password-form">' +
 		'									<input class="password-input" required maxlength="200" type="password"' +
 		'				  						placeholder="{{#if hasPassword}}' + t('spreed', 'Change password') + '{{else}}' + t('spreed', 'Set password') + '{{/if}}">'+


### PR DESCRIPTION
Before:

![screen shot 2018-04-20 at 12 26 27](https://user-images.githubusercontent.com/4638605/39046373-36735faa-4496-11e8-8f64-f2e11a0387cd.png)

Now:

![screen shot 2018-04-20 at 12 27 07](https://user-images.githubusercontent.com/4638605/39046382-3cb5bbf6-4496-11e8-86f1-1139723a7cd6.png)

![screen shot 2018-04-20 at 12 32 47](https://user-images.githubusercontent.com/4638605/39046610-0980d6d4-4497-11e8-8572-f8b76be0675b.png)


As an icon is required in popover menu (as discussed in https://github.com/nextcloud/spreed/pull/647#issuecomment-376143749), I think a lock icon makes more sense than a triangle.
It looks like something could be disclosed with the triangle.
