### PR TITLE
Format mentions (without avatars) in the message list

### DIFF
--- a/css/comments.scss
+++ b/css/comments.scss
@@ -248,6 +248,6 @@
 	display: block;
 }
 
-#commentsTabView .comment .mention-user {
+#commentsTabView .comment .message .mention-user {
 	font-weight: bold;
 }

--- a/css/comments.scss
+++ b/css/comments.scss
@@ -247,3 +247,7 @@
 #commentsTabView .comment.showDate .authorRow {
 	display: block;
 }
+
+#commentsTabView .comment .mention-user {
+	font-weight: bold;
+}

--- a/css/comments.scss
+++ b/css/comments.scss
@@ -249,5 +249,15 @@
 }
 
 #commentsTabView .comment .message .mention-user {
+	/* Make the mention the positioning context of its child contacts menu */
+	position: relative;
+
 	font-weight: bold;
+}
+
+#commentsTabView .comment .message .contactsmenu-popover {
+	/* Override default positioning of the contacts menu from server, as it is
+	 * based on an avatar plus a text instead of only '@' plus a text. */
+	left: -17px;
+	top: 140%;
 }

--- a/css/comments.scss
+++ b/css/comments.scss
@@ -255,6 +255,10 @@
 	font-weight: bold;
 }
 
+#commentsTabView .comment .message .mention-user:not(.current-user) {
+	cursor: pointer;
+}
+
 #commentsTabView .comment .message .contactsmenu-popover {
 	/* Override default positioning of the contacts menu from server, as it is
 	 * based on an avatar plus a text instead of only '@' plus a text. */

--- a/css/style.scss
+++ b/css/style.scss
@@ -630,7 +630,7 @@ video {
 	opacity: .3;
 }
 
-.bubble,
+.bubble:not(.contactsmenu-popover),
 #app-navigation .app-navigation-entry-menu {
 	right: 4px;
 }

--- a/css/style.scss
+++ b/css/style.scss
@@ -24,6 +24,14 @@
 	border: 1px solid #eee;
 }
 
+.contactsmenu-popover li > a > img {
+	/* The app uses border-box sizing, so the size of the icon is the
+	 * width/height plus the padding set by default in the server
+	 * (16px + 11px*2). */
+	width: 38px;
+	height: 38px;
+}
+
 /**
  * Sidebar styles
  */

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -469,7 +469,8 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         `actorId` | string | User id of the message author
         `actorDisplayName` | string | Display name of the message author
         `timestamp` | int | Timestamp in seconds and UTC time zone
-        `message` | string | Message in plain text
+        `message` | string | Message string with placeholders (see [Rich Object String](https://github.com/nextcloud/server/issues/1706))
+        `messageParameters` | array | Message parameters for `message` (see [Rich Object String](https://github.com/nextcloud/server/issues/1706))
 
 ### Sending a new chat message
 

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -53,7 +53,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 ### 3.0 (Initial Talk release)
 * `audio` - audio is supported
 * `video` - video + screensharing is supported
-* `chat` - simple text chat is supported
+* `chat` - simple text chat is supported, superseded by `chat-v2`
 
 ### 3.1
 * `guest-signaling` - Guests can do signaling via api endpoints
@@ -62,7 +62,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 ### 3.2
 * `guest-display-names` - Display names of guests are stored in the database, can be set via API (not WebRTC only) and are used on returned comments/participants/etc.
 * `multi-room-users` - Users can be in multiple rooms at the same time now, therefor signaling now also requires the room/call token on the URL.
-* `chat-v2` - Chat now has a decent offset, the previous `chat` is not available anymore.
+* `chat-v2` - Chat messages are now [Rich Object Strings](https://github.com/nextcloud/server/issues/1706) and pagination is available, the previous `chat` is not available anymore.
 
 
 ## Room management

--- a/js/models/chatmessage.js
+++ b/js/models/chatmessage.js
@@ -48,7 +48,8 @@
 			actorId: '',
 			actorDisplayName: '',
 			timestamp: 0,
-			message: ''
+			message: '',
+			messageParameters: []
 		},
 
 		url: function() {

--- a/js/richobjectstringparser.js
+++ b/js/richobjectstringparser.js
@@ -13,7 +13,7 @@
 
 	OCA.SpreedMe.RichObjectStringParser = {
 
-		_userLocalTemplate: '<span class="mention-user">@{{id}}</span>',
+		_userLocalTemplate: '<span class="mention-user">@{{name}}</span>',
 
 		_unknownTemplate: '<strong>{{name}}</strong>',
 		_unknownLinkTemplate: '<a href="{{link}}">{{name}}</a>',

--- a/js/richobjectstringparser.js
+++ b/js/richobjectstringparser.js
@@ -13,7 +13,7 @@
 
 	OCA.SpreedMe.RichObjectStringParser = {
 
-		_userLocalTemplate: '<span class="mention-user">@{{name}}</span>',
+		_userLocalTemplate: '<span class="mention-user" data-user="{{id}}">@{{name}}</span>',
 
 		_unknownTemplate: '<strong>{{name}}</strong>',
 		_unknownLinkTemplate: '<a href="{{link}}">{{name}}</a>',

--- a/js/richobjectstringparser.js
+++ b/js/richobjectstringparser.js
@@ -1,0 +1,76 @@
+/* global OCA, Handlebars */
+
+/**
+ * @copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ */
+
+(function(OCA, Handlebars) {
+
+	OCA.SpreedMe.RichObjectStringParser = {
+
+		_userLocalTemplate: '<span class="mention-user">@{{id}}</span>',
+
+		_unknownTemplate: '<strong>{{name}}</strong>',
+		_unknownLinkTemplate: '<a href="{{link}}">{{name}}</a>',
+
+		/**
+		 * @param {string} subject
+		 * @param {Object} parameters
+		 * @returns {string}
+		 */
+		parseMessage: function(subject, parameters) {
+			var self = this,
+				regex = /\{([a-z0-9-]+)\}/gi,
+				matches = subject.match(regex);
+
+			_.each(matches, function(parameter) {
+				parameter = parameter.substring(1, parameter.length - 1);
+				var parsed = self.parseParameter(parameters[parameter]);
+
+				subject = subject.replace('{' + parameter + '}', parsed);
+			});
+
+			return subject;
+		},
+
+		/**
+		 * @param {Object} parameter
+		 * @param {string} parameter.type
+		 * @param {string} parameter.id
+		 * @param {string} parameter.name
+		 * @param {string} parameter.link
+		 */
+		parseParameter: function(parameter) {
+			switch (parameter.type) {
+				case 'user':
+					if (!this.userLocalTemplate) {
+						this.userLocalTemplate = Handlebars.compile(this._userLocalTemplate);
+					}
+					if (!parameter.name) {
+						parameter.name = parameter.id;
+					}
+					return this.userLocalTemplate(parameter);
+
+				default:
+					if (!_.isUndefined(parameter.link)) {
+						if (!this.unknownLinkTemplate) {
+							this.unknownLinkTemplate = Handlebars.compile(this._unknownLinkTemplate);
+						}
+						return this.unknownLinkTemplate(parameter);
+					}
+
+					if (!this.unknownTemplate) {
+						this.unknownTemplate = Handlebars.compile(this._unknownTemplate);
+					}
+					return this.unknownTemplate(parameter);
+			}
+		}
+
+	};
+
+})(OCA, Handlebars);

--- a/js/richobjectstringparser.js
+++ b/js/richobjectstringparser.js
@@ -30,8 +30,13 @@
 
 			_.each(matches, function(parameter) {
 				parameter = parameter.substring(1, parameter.length - 1);
-				var parsed = self.parseParameter(parameters[parameter]);
+				if (!parameters.hasOwnProperty(parameter) || !parameters[parameter]) {
+					// Malformed translation?
+					console.error('Potential malformed ROS string: parameter {' + parameter + '} was found in the string but is missing from the parameter list');
+					return;
+				}
 
+				var parsed = self.parseParameter(parameters[parameter]);
 				subject = subject.replace('{' + parameter + '}', parsed);
 			});
 

--- a/js/richobjectstringparser.js
+++ b/js/richobjectstringparser.js
@@ -1,4 +1,4 @@
-/* global OCA, Handlebars */
+/* global OC, OCA, Handlebars */
 
 /**
  * @copyright (c) 2016 Joas Schilling <coding@schilljs.com>
@@ -9,11 +9,11 @@
  * later. See the COPYING file.
  */
 
-(function(OCA, Handlebars) {
+(function(OC, OCA, Handlebars) {
 
 	OCA.SpreedMe.RichObjectStringParser = {
 
-		_userLocalTemplate: '<span class="mention-user" data-user="{{id}}">@{{name}}</span>',
+		_userLocalTemplate: '<span class="mention-user {{#if isCurrentUser}}current-user{{/if}}" data-user="{{id}}">@{{name}}</span>',
 
 		_unknownTemplate: '<strong>{{name}}</strong>',
 		_unknownLinkTemplate: '<a href="{{link}}">{{name}}</a>',
@@ -59,6 +59,9 @@
 					if (!parameter.name) {
 						parameter.name = parameter.id;
 					}
+					if (OC.getCurrentUser().uid === parameter.id) {
+						parameter.isCurrentUser = true;
+					}
 					return this.userLocalTemplate(parameter);
 
 				default:
@@ -78,4 +81,4 @@
 
 	};
 
-})(OCA, Handlebars);
+})(OC, OCA, Handlebars);

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -206,6 +206,8 @@
 
 			var formattedMessage = escapeHTML(commentModel.get('message')).replace(/\n/g, '<br/>');
 			formattedMessage = OCP.Comments.plainToRich(formattedMessage);
+			formattedMessage = OCA.SpreedMe.RichObjectStringParser.parseMessage(
+				formattedMessage, commentModel.get('messageParameters'));
 
 			var data = _.extend({}, commentModel.attributes, {
 				actorDisplayName: actorDisplayName,

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -377,7 +377,11 @@
 		_postRenderMessage: function($el) {
 			$el.find('.mention-user').each(function() {
 				var $this = $(this);
-				$this.contactsMenu($this.data('user'), 0, $this);
+
+				var user = $this.data('user');
+				if (user !== OC.getCurrentUser().uid) {
+					$this.contactsMenu(user, 0, $this);
+				}
 			});
 		},
 

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -375,12 +375,9 @@
 		},
 
 		_postRenderMessage: function($el) {
-			$el.find('.avatar').each(function() {
-				var avatar = $(this);
-				var strong = $(this).next();
-				var appendTo = $(this).parent();
-
-				$.merge(avatar, strong).contactsMenu(avatar.data('user'), 0, appendTo);
+			$el.find('.mention-user').each(function() {
+				var $this = $(this);
+				$this.contactsMenu($this.data('user'), 0, $this);
 			});
 		},
 

--- a/lib/Chat/RichMessageHelper.php
+++ b/lib/Chat/RichMessageHelper.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Chat;
+
+use OCP\Comments\IComment;
+use OCP\Comments\ICommentsManager;
+
+/**
+ * Helper class to get a rich message from a plain text message.
+ */
+class RichMessageHelper {
+
+	/** @var ICommentsManager */
+	private $commentsManager;
+
+	/**
+	 * @param ICommentsManager $commentsManager
+	 */
+	public function __construct(ICommentsManager $commentsManager) {
+		$this->commentsManager = $commentsManager;
+	}
+
+	/**
+	 * Returns the equivalent rich message to the given comment.
+	 *
+	 * The mentions in the comment are replaced by "{mention-$type$index}" in
+	 * the returned rich message; each "mention-$type$index" parameter contains
+	 * the following attributes:
+	 *   -type: the type of the mention ("user")
+	 *   -id: the ID of the user
+	 *   -name: the display name of the user, or an empty string if it could
+	 *     not be resolved.
+	 *
+	 * @param IComment $comment
+	 * @return Array first element, the rich message; second element, the
+	 *         parameters of the rich message (or an empty array if there are no
+	 *         parameters).
+	 */
+	public function getRichMessage(IComment $comment) {
+		$message = $comment->getMessage();
+		$messageParameters = [];
+
+		$mentionTypeCount = [];
+
+		$mentions = $comment->getMentions();
+		foreach ($mentions as $mention) {
+			if (!array_key_exists($mention['type'], $mentionTypeCount)) {
+				$mentionTypeCount[$mention['type']] = 0;
+			}
+			$mentionTypeCount[$mention['type']]++;
+
+			// To keep a limited character set in parameter IDs ([a-zA-Z0-9-])
+			// the mention parameter ID does not include the mention ID (which
+			// could contain characters like '@' for user IDs) but a one-based
+			// index of the mentions of that type.
+			$mentionParameterId = 'mention-' . $mention['type'] . $mentionTypeCount[$mention['type']];
+
+			$message = str_replace('@' . $mention['id'], '{' . $mentionParameterId . '}', $message);
+
+			try {
+				$displayName = $this->commentsManager->resolveDisplayName($mention['type'], $mention['id']);
+			} catch (\OutOfBoundsException $e) {
+				// There is no registered display name resolver for the mention
+				// type, so the client decides what to display.
+				$displayName = '';
+			}
+
+			$messageParameters[$mentionParameterId] = [
+				'type' => $mention['type'],
+				'id' => $mention['id'],
+				'name' => $displayName
+			];
+		}
+
+		return [$message, $messageParameters];
+	}
+
+}

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -24,6 +24,7 @@
 namespace OCA\Spreed\Controller;
 
 use OCA\Spreed\Chat\ChatManager;
+use OCA\Spreed\Chat\RichMessageHelper;
 use OCA\Spreed\Exceptions\ParticipantNotFoundException;
 use OCA\Spreed\Exceptions\RoomNotFoundException;
 use OCA\Spreed\GuestManager;
@@ -64,6 +65,9 @@ class ChatController extends OCSController {
 	/** @var string[] */
 	protected $guestNames;
 
+	/** @var RichMessageHelper */
+	private $richMessageHelper;
+
 	/**
 	 * @param string $appName
 	 * @param string $UserId
@@ -81,7 +85,8 @@ class ChatController extends OCSController {
 								TalkSession $session,
 								Manager $manager,
 								ChatManager $chatManager,
-								GuestManager $guestManager) {
+								GuestManager $guestManager,
+								RichMessageHelper $richMessageHelper) {
 		parent::__construct($appName, $request);
 
 		$this->userId = $UserId;
@@ -90,6 +95,7 @@ class ChatController extends OCSController {
 		$this->manager = $manager;
 		$this->chatManager = $chatManager;
 		$this->guestManager = $guestManager;
+		$this->richMessageHelper = $richMessageHelper;
 	}
 
 	/**
@@ -247,6 +253,8 @@ class ChatController extends OCSController {
 				$displayName = $guestNames[$comment->getActorId()];
 			}
 
+			list($message, $messageParameters) = $this->richMessageHelper->getRichMessage($comment);
+
 			return [
 				'id' => $comment->getId(),
 				'token' => $token,
@@ -254,7 +262,8 @@ class ChatController extends OCSController {
 				'actorId' => $comment->getActorId(),
 				'actorDisplayName' => $displayName,
 				'timestamp' => $comment->getCreationDateTime()->getTimestamp(),
-				'message' => $comment->getMessage()
+				'message' => $message,
+				'messageParameters' => $messageParameters,
 			];
 		}, $comments), Http::STATUS_OK);
 

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -25,6 +25,7 @@ script(
 		'views/roomlistview',
 		'views/sidebarview',
 		'views/tabview',
+		'richobjectstringparser',
 		'simplewebrtc',
 		'webrtc',
 		'signaling',

--- a/templates/index.php
+++ b/templates/index.php
@@ -28,6 +28,7 @@ script(
 		'views/roomlistview',
 		'views/sidebarview',
 		'views/tabview',
+		'richobjectstringparser',
 		'simplewebrtc',
 		'webrtc',
 		'signaling',

--- a/tests/acceptance/features/bootstrap/ChatContext.php
+++ b/tests/acceptance/features/bootstrap/ChatContext.php
@@ -144,6 +144,24 @@ class ChatContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function formattedMentionInChatMessageOf($chatAncestor, $number, $user) {
+		return Locator::forThe()->xpath("span[contains(concat(' ', normalize-space(@class), ' '), ' mention-user ') and normalize-space() = '@$user']")->
+				descendantOf(self::textOfChatMessage($chatAncestor, $number))->
+				describedAs("Formatted mention of $user in chat message $number in the list of received messages");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function formattedLinkInChatMessageTo($chatAncestor, $number, $url) {
+		return Locator::forThe()->xpath("a[normalize-space(@href) = '$url']")->
+				descendantOf(self::textOfChatMessage($chatAncestor, $number))->
+				describedAs("Formatted link to $url in chat message $number in the list of received messages");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function newChatMessageForm($chatAncestor) {
 		return Locator::forThe()->css(".newCommentForm")->
 				descendantOf(self::chatView($chatAncestor))->
@@ -227,6 +245,20 @@ class ChatContext implements Context, ActorAwareInterface {
 		// Author element is not visible for the message, so its text is
 		// returned as an empty string (even if the element has actual text).
 		PHPUnit_Framework_Assert::assertEquals("", $this->actor->find(self::authorOfChatMessage($this->chatAncestor, $number))->getText());
+	}
+
+	/**
+	 * @Then I see that the message :number contains a formatted mention of :user
+	 */
+	public function iSeeThatTheMessageContainsAFormattedMentionOf($number, $user) {
+		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::formattedMentionInChatMessageOf($this->chatAncestor, $number, $user), 10));
+	}
+
+	/**
+	 * @Then I see that the message :number contains a formatted link to :user
+	 */
+	public function iSeeThatTheMessageContainsAFormattedLinkTo($number, $url) {
+		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::formattedLinkInChatMessageTo($this->chatAncestor, $number, $url), 10));
 	}
 
 }

--- a/tests/acceptance/features/chat.feature
+++ b/tests/acceptance/features/chat.feature
@@ -139,6 +139,11 @@ Feature: chat
     And I create a group conversation
     And I see that the chat is shown in the main view
     When I send a new chat message with the text "Hello @admin, check http://www.nextcloud.com"
-    Then I see that the message 1 was sent by "user0" with the text "Hello @admin, check http://www.nextcloud.com"
+    # As the message contains child HTML elements (due to the contacts menu for
+    # the mention) a whitespace appears after the mention when the message is
+    # converted to plain text; it does not appear when the message is rendered
+    # by browsers, it is just an artefact from the conversion algorithm of the
+    # underlying libraries used by the tests.
+    Then I see that the message 1 was sent by "user0" with the text "Hello @admin , check http://www.nextcloud.com"
     And I see that the message 1 contains a formatted mention of "admin"
     And I see that the message 1 contains a formatted link to "http://www.nextcloud.com"

--- a/tests/acceptance/features/chat.feature
+++ b/tests/acceptance/features/chat.feature
@@ -123,3 +123,22 @@ Feature: chat
     And I see that the message 4 was sent by "user0" with the text "Fine thanks"
     And I see that the message 5 was sent with the text "And you?" and grouped with the previous one
     And I see that the message 6 was sent by "admin" with the text "Fine too!"
+
+  Scenario: mention another user
+    Given I am logged in
+    And I have opened the Talk app
+    And I create a group conversation
+    And I see that the chat is shown in the main view
+    When I send a new chat message with the text "Hello @admin"
+    Then I see that the message 1 was sent by "user0" with the text "Hello @admin"
+    And I see that the message 1 contains a formatted mention of "admin"
+
+  Scenario: mention another user and a URL
+    Given I am logged in
+    And I have opened the Talk app
+    And I create a group conversation
+    And I see that the chat is shown in the main view
+    When I send a new chat message with the text "Hello @admin, check http://www.nextcloud.com"
+    Then I see that the message 1 was sent by "user0" with the text "Hello @admin, check http://www.nextcloud.com"
+    And I see that the message 1 contains a formatted mention of "admin"
+    And I see that the message 1 contains a formatted link to "http://www.nextcloud.com"

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -465,6 +465,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 				// TODO test timestamp; it may require using Runkit, php-timecop
 				// or something like that.
 				'message' => (string) $message['message'],
+				'messageParameters' => json_encode($message['messageParameters']),
 			];
 		}, $messages));
 	}

--- a/tests/integration/features/chat/group.feature
+++ b/tests/integration/features/chat/group.feature
@@ -12,8 +12,8 @@ Feature: chat/group
       | invite   | attendees1 |
     When user "participant1" sends message "Message 1" to room "group room" with 201
     Then user "participant1" sees the following messages in room "group room" with 200
-      | room       | actorType | actorId      | actorDisplayName         | message   |
-      | group room | users     | participant1 | participant1-displayname | Message 1 |
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | group room | users     | participant1 | participant1-displayname | Message 1 | []                |
 
   Scenario: invited user can send and receive chat messages to and from group room
     Given user "participant1" creates room "group room"
@@ -21,8 +21,8 @@ Feature: chat/group
       | invite   | attendees1 |
     When user "participant2" sends message "Message 1" to room "group room" with 201
     Then user "participant2" sees the following messages in room "group room" with 200
-      | room       | actorType | actorId      | actorDisplayName         | message   |
-      | group room | users     | participant2 | participant2-displayname | Message 1 |
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | group room | users     | participant2 | participant2-displayname | Message 1 | []                |
 
   Scenario: not invited user can not send nor receive chat messages to nor from group room
     Given user "participant1" creates room "group room"
@@ -48,10 +48,10 @@ Feature: chat/group
     When user "participant1" sends message "Message 1" to room "group room" with 201
     And user "participant2" sends message "Message 2" to room "group room" with 201
     Then user "participant1" sees the following messages in room "group room" with 200
-      | room       | actorType | actorId      | actorDisplayName         | message   |
-      | group room | users     | participant2 | participant2-displayname | Message 2 |
-      | group room | users     | participant1 | participant1-displayname | Message 1 |
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | group room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | group room | users     | participant1 | participant1-displayname | Message 1 | []                |
     And user "participant2" sees the following messages in room "group room" with 200
-      | room       | actorType | actorId      | actorDisplayName         | message   |
-      | group room | users     | participant2 | participant2-displayname | Message 2 |
-      | group room | users     | participant1 | participant1-displayname | Message 1 |
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | group room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | group room | users     | participant1 | participant1-displayname | Message 1 | []                |

--- a/tests/integration/features/chat/one-to-one.feature
+++ b/tests/integration/features/chat/one-to-one.feature
@@ -10,8 +10,8 @@ Feature: chat/one-to-one
       | invite   | participant2 |
     When user "participant1" sends message "Message 1" to room "one-to-one room" with 201
     Then user "participant1" sees the following messages in room "one-to-one room" with 200
-      | room            | actorType | actorId      | actorDisplayName         | message   |
-      | one-to-one room | users     | participant1 | participant1-displayname | Message 1 |
+      | room            | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | one-to-one room | users     | participant1 | participant1-displayname | Message 1 | []                |
 
   Scenario: invited user can send and receive chat messages to and from one-to-one room
     Given user "participant1" creates room "one-to-one room"
@@ -19,8 +19,8 @@ Feature: chat/one-to-one
       | invite   | participant2 |
     When user "participant2" sends message "Message 1" to room "one-to-one room" with 201
     Then user "participant2" sees the following messages in room "one-to-one room" with 200
-      | room            | actorType | actorId      | actorDisplayName         | message   |
-      | one-to-one room | users     | participant2 | participant2-displayname | Message 1 |
+      | room            | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | one-to-one room | users     | participant2 | participant2-displayname | Message 1 | []                |
 
   Scenario: not invited user can not send nor receive chat messages to nor from one-to-one room
     Given user "participant1" creates room "one-to-one room"
@@ -46,10 +46,10 @@ Feature: chat/one-to-one
     When user "participant1" sends message "Message 1" to room "one-to-one room" with 201
     And user "participant2" sends message "Message 2" to room "one-to-one room" with 201
     Then user "participant1" sees the following messages in room "one-to-one room" with 200
-      | room            | actorType | actorId      | actorDisplayName         | message   |
-      | one-to-one room | users     | participant2 | participant2-displayname | Message 2 |
-      | one-to-one room | users     | participant1 | participant1-displayname | Message 1 |
+      | room            | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | one-to-one room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | one-to-one room | users     | participant1 | participant1-displayname | Message 1 | []                |
     And user "participant2" sees the following messages in room "one-to-one room" with 200
-      | room            | actorType | actorId      | actorDisplayName         | message   |
-      | one-to-one room | users     | participant2 | participant2-displayname | Message 2 |
-      | one-to-one room | users     | participant1 | participant1-displayname | Message 1 |
+      | room            | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | one-to-one room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | one-to-one room | users     | participant1 | participant1-displayname | Message 1 | []                |

--- a/tests/integration/features/chat/password.feature
+++ b/tests/integration/features/chat/password.feature
@@ -10,8 +10,8 @@ Feature: chat/password
     And user "participant1" sets password "foobar" for room "public password protected room" with 200
     When user "participant1" sends message "Message 1" to room "public password protected room" with 201
     Then user "participant1" sees the following messages in room "public password protected room" with 200
-      | room                           | actorType | actorId      | actorDisplayName         | message   |
-      | public password protected room | users     | participant1 | participant1-displayname | Message 1 |
+      | room                           | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public password protected room | users     | participant1 | participant1-displayname | Message 1 | []                |
 
   Scenario: invited user can send and receive chat messages to and from public password protected room
     Given user "participant1" creates room "public password protected room"
@@ -20,8 +20,8 @@ Feature: chat/password
     And user "participant1" adds "participant2" to room "public password protected room" with 200
     When user "participant2" sends message "Message 1" to room "public password protected room" with 201
     Then user "participant2" sees the following messages in room "public password protected room" with 200
-      | room                           | actorType | actorId      | actorDisplayName         | message   |
-      | public password protected room | users     | participant2 | participant2-displayname | Message 1 |
+      | room                           | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public password protected room | users     | participant2 | participant2-displayname | Message 1 | []                |
 
   Scenario: not invited but joined with password user can send and receive chat messages to and from public password protected room
     Given user "participant1" creates room "public password protected room"
@@ -31,8 +31,8 @@ Feature: chat/password
       | password | foobar |
     When user "participant3" sends message "Message 1" to room "public password protected room" with 201
     Then user "participant3" sees the following messages in room "public password protected room" with 200
-      | room                           | actorType | actorId      | actorDisplayName         | message   |
-      | public password protected room | users     | participant3 | participant3-displayname | Message 1 |
+      | room                           | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public password protected room | users     | participant3 | participant3-displayname | Message 1 | []                |
 
   Scenario: not invited user can not send nor receive chat messages to and from public password protected room
     Given user "participant1" creates room "public password protected room"
@@ -50,8 +50,8 @@ Feature: chat/password
       | password | foobar |
     When user "guest" sends message "Message 1" to room "public password protected room" with 201
     Then user "guest" sees the following messages in room "public password protected room" with 200
-      | room                           | actorType | actorId | actorDisplayName | message   |
-      | public password protected room | guests    | guest   |                  | Message 1 |
+      | room                           | actorType | actorId | actorDisplayName | message   | messageParameters |
+      | public password protected room | guests    | guest   |                  | Message 1 | []                |
 
   Scenario: not joined guest can not send nor receive chat messages to and from public password protected room
     Given user "participant1" creates room "public password protected room"
@@ -75,26 +75,26 @@ Feature: chat/password
     And user "participant3" sends message "Message 3" to room "public password protected room" with 201
     And user "guest" sends message "Message 4" to room "public password protected room" with 201
     Then user "participant1" sees the following messages in room "public password protected room" with 200
-      | room                           | actorType | actorId      | actorDisplayName         | message   |
-      | public password protected room | guests    | guest        |                          | Message 4 |
-      | public password protected room | users     | participant3 | participant3-displayname | Message 3 |
-      | public password protected room | users     | participant2 | participant2-displayname | Message 2 |
-      | public password protected room | users     | participant1 | participant1-displayname | Message 1 |
+      | room                           | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public password protected room | guests    | guest        |                          | Message 4 | []                |
+      | public password protected room | users     | participant3 | participant3-displayname | Message 3 | []                |
+      | public password protected room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | public password protected room | users     | participant1 | participant1-displayname | Message 1 | []                |
     And user "participant2" sees the following messages in room "public password protected room" with 200
-      | room                           | actorType | actorId      | actorDisplayName         | message   |
-      | public password protected room | guests    | guest        |                          | Message 4 |
-      | public password protected room | users     | participant3 | participant3-displayname | Message 3 |
-      | public password protected room | users     | participant2 | participant2-displayname | Message 2 |
-      | public password protected room | users     | participant1 | participant1-displayname | Message 1 |
+      | room                           | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public password protected room | guests    | guest        |                          | Message 4 | []                |
+      | public password protected room | users     | participant3 | participant3-displayname | Message 3 | []                |
+      | public password protected room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | public password protected room | users     | participant1 | participant1-displayname | Message 1 | []                |
     And user "participant3" sees the following messages in room "public password protected room" with 200
-      | room                           | actorType | actorId      | actorDisplayName         | message   |
-      | public password protected room | guests    | guest        |                          | Message 4 |
-      | public password protected room | users     | participant3 | participant3-displayname | Message 3 |
-      | public password protected room | users     | participant2 | participant2-displayname | Message 2 |
-      | public password protected room | users     | participant1 | participant1-displayname | Message 1 |
+      | room                           | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public password protected room | guests    | guest        |                          | Message 4 | []                |
+      | public password protected room | users     | participant3 | participant3-displayname | Message 3 | []                |
+      | public password protected room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | public password protected room | users     | participant1 | participant1-displayname | Message 1 | []                |
     And user "guest" sees the following messages in room "public password protected room" with 200
-      | room                           | actorType | actorId      | actorDisplayName         | message   |
-      | public password protected room | guests    | guest        |                          | Message 4 |
-      | public password protected room | users     | participant3 | participant3-displayname | Message 3 |
-      | public password protected room | users     | participant2 | participant2-displayname | Message 2 |
-      | public password protected room | users     | participant1 | participant1-displayname | Message 1 |
+      | room                           | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public password protected room | guests    | guest        |                          | Message 4 | []                |
+      | public password protected room | users     | participant3 | participant3-displayname | Message 3 | []                |
+      | public password protected room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | public password protected room | users     | participant1 | participant1-displayname | Message 1 | []                |

--- a/tests/integration/features/chat/public.feature
+++ b/tests/integration/features/chat/public.feature
@@ -9,8 +9,8 @@ Feature: chat/public
       | roomType | 3 |
     When user "participant1" sends message "Message 1" to room "public room" with 201
     Then user "participant1" sees the following messages in room "public room" with 200
-      | room        | actorType | actorId      | actorDisplayName         | message   |
-      | public room | users     | participant1 | participant1-displayname | Message 1 |
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | Message 1 | []                |
 
   Scenario: invited user can send and receive chat messages to and from public room
     Given user "participant1" creates room "public room"
@@ -18,8 +18,8 @@ Feature: chat/public
     And user "participant1" adds "participant2" to room "public room" with 200
     When user "participant2" sends message "Message 1" to room "public room" with 201
     Then user "participant2" sees the following messages in room "public room" with 200
-      | room        | actorType | actorId      | actorDisplayName         | message   |
-      | public room | users     | participant2 | participant2-displayname | Message 1 |
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | users     | participant2 | participant2-displayname | Message 1 | []                |
 
   Scenario: not invited but joined user can send and receive chat messages to and from public room
     Given user "participant1" creates room "public room"
@@ -27,8 +27,8 @@ Feature: chat/public
     And user "participant3" joins room "public room" with 200
     When user "participant3" sends message "Message 1" to room "public room" with 201
     Then user "participant3" sees the following messages in room "public room" with 200
-      | room        | actorType | actorId      | actorDisplayName         | message   |
-      | public room | users     | participant3 | participant3-displayname | Message 1 |
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | users     | participant3 | participant3-displayname | Message 1 | []                |
 
   Scenario: not invited user can not send nor receive chat messages to and from public room
     Given user "participant1" creates room "public room"
@@ -43,8 +43,8 @@ Feature: chat/public
     And user "guest" joins room "public room" with 200
     When user "guest" sends message "Message 1" to room "public room" with 201
     Then user "guest" sees the following messages in room "public room" with 200
-      | room        | actorType | actorId | actorDisplayName | message   |
-      | public room | guests    | guest   |                  | Message 1 |
+      | room        | actorType | actorId | actorDisplayName | message   | messageParameters |
+      | public room | guests    | guest   |                  | Message 1 | []                |
 
   Scenario: not joined guest can not send nor receive chat messages to and from public room
     Given user "participant1" creates room "public room"
@@ -62,17 +62,17 @@ Feature: chat/public
     And user "participant2" sends message "Message 2" to room "public room" with 201
     And user "guest" sends message "Message 3" to room "public room" with 201
     Then user "participant1" sees the following messages in room "public room" with 200
-      | room        | actorType | actorId      | actorDisplayName         | message   |
-      | public room | guests    | guest        |                          | Message 3 |
-      | public room | users     | participant2 | participant2-displayname | Message 2 |
-      | public room | users     | participant1 | participant1-displayname | Message 1 |
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | guests    | guest        |                          | Message 3 | []                |
+      | public room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | public room | users     | participant1 | participant1-displayname | Message 1 | []                |
     And user "participant2" sees the following messages in room "public room" with 200
-      | room        | actorType | actorId      | actorDisplayName         | message   |
-      | public room | guests    | guest        |                          | Message 3 |
-      | public room | users     | participant2 | participant2-displayname | Message 2 |
-      | public room | users     | participant1 | participant1-displayname | Message 1 |
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | guests    | guest        |                          | Message 3 | []                |
+      | public room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | public room | users     | participant1 | participant1-displayname | Message 1 | []                |
     And user "guest" sees the following messages in room "public room" with 200
-      | room        | actorType | actorId      | actorDisplayName         | message   |
-      | public room | guests    | guest        |                          | Message 3 |
-      | public room | users     | participant2 | participant2-displayname | Message 2 |
-      | public room | users     | participant1 | participant1-displayname | Message 1 |
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | guests    | guest        |                          | Message 3 | []                |
+      | public room | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | public room | users     | participant1 | participant1-displayname | Message 1 | []                |

--- a/tests/integration/features/chat/rich-messages.feature
+++ b/tests/integration/features/chat/rich-messages.feature
@@ -1,0 +1,45 @@
+Feature: chat/public
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+
+  Scenario: message without enrichable references has empty parameters
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    When user "participant1" sends message "Message without enrichable references" to room "public room" with 201
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message                               | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | Message without enrichable references | []                |
+
+  Scenario: message with mention to valid user has mention parameter
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    When user "participant1" sends message "Mention to @participant2" to room "public room" with 201
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message                    | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | Mention to {mention-user1} | {"mention-user1":{"type":"user","id":"participant2","name":"participant2-displayname"}} |
+
+  Scenario: message with mention to invalid user has mention parameter
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    When user "participant1" sends message "Mention to @unknownUser" to room "public room" with 201
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message                    | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | Mention to {mention-user1} | {"mention-user1":{"type":"user","id":"unknownUser","name":"Unknown user"}} |
+
+  Scenario: message with duplicated mention has single mention parameter
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    When user "participant1" sends message "Mention to @participant2 and @participant2 again" to room "public room" with 201
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message                                              | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | Mention to {mention-user1} and {mention-user1} again | {"mention-user1":{"type":"user","id":"participant2","name":"participant2-displayname"}} |
+
+  Scenario: message with mentions to several users has mention parameters
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    When user "participant1" sends message "Mention to @participant2, @unknownUser, @participant2 again and @participant3" to room "public room" with 201
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message                                                                                | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | Mention to {mention-user1}, {mention-user2}, {mention-user1} again and {mention-user3} | {"mention-user1":{"type":"user","id":"participant2","name":"participant2-displayname"},"mention-user2":{"type":"user","id":"unknownUser","name":"Unknown user"},"mention-user3":{"type":"user","id":"participant3","name":"participant3-displayname"}} |

--- a/tests/php/Chat/RichMessageHelperTest.php
+++ b/tests/php/Chat/RichMessageHelperTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Tests\php\Chat;
+
+use OCA\Spreed\Chat\RichMessageHelper;
+use OCP\Comments\IComment;
+use OCP\Comments\ICommentsManager;
+
+class RichMessageHelperTest extends \Test\TestCase {
+
+	/** @var \OCP\Comments\ICommentsManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $commentsManager;
+
+	/** @var \OCA\Spreed\Chat\RichMessageHelper */
+	protected $richMessageHelper;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->commentsManager = $this->createMock(ICommentsManager::class);
+
+		$this->richMessageHelper = new RichMessageHelper($this->commentsManager);
+	}
+
+	private function newComment($message, $mentions) {
+		$comment = $this->createMock(IComment::class);
+
+		$comment->method('getMessage')->willReturn($message);
+		$comment->method('getMentions')->willReturn($mentions);
+
+		return $comment;
+	}
+
+	public function testGetRichMessageWithoutEnrichableReferences() {
+		$comment = $this->newComment('Message without enrichable references', []);
+
+		list($message, $messageParameters) = $this->richMessageHelper->getRichMessage($comment);
+
+		$this->assertEquals('Message without enrichable references', $message);
+		$this->assertEquals([], $messageParameters);
+	}
+
+	public function testGetRichMessageWithSingleMention() {
+		$mentions = [
+			['type'=>'user', 'id'=>'testUser'],
+		];
+		$comment = $this->newComment('Mention to @testUser', $mentions);
+
+		$this->commentsManager->expects($this->once())
+			->method('resolveDisplayName')
+			->with('user', 'testUser')
+			->willReturn('testUser display name');
+
+		list($message, $messageParameters) = $this->richMessageHelper->getRichMessage($comment);
+
+		$expectedMessageParameters = [
+			'mention-user1' => [
+				'type' => 'user',
+				'id' => 'testUser',
+				'name' => 'testUser display name'
+			]
+		];
+
+		$this->assertEquals('Mention to {mention-user1}', $message);
+		$this->assertEquals($expectedMessageParameters, $messageParameters);
+	}
+
+	public function testGetRichMessageWithDuplicatedMention() {
+		$mentions = [
+			['type'=>'user', 'id'=>'testUser'],
+		];
+		$comment = $this->newComment('Mention to @testUser and @testUser again', $mentions);
+
+		$this->commentsManager->expects($this->once())
+			->method('resolveDisplayName')
+			->with('user', 'testUser')
+			->willReturn('testUser display name');
+
+		list($message, $messageParameters) = $this->richMessageHelper->getRichMessage($comment);
+
+		$expectedMessageParameters = [
+			'mention-user1' => [
+				'type' => 'user',
+				'id' => 'testUser',
+				'name' => 'testUser display name'
+			]
+		];
+
+		$this->assertEquals('Mention to {mention-user1} and {mention-user1} again', $message);
+		$this->assertEquals($expectedMessageParameters, $messageParameters);
+	}
+
+	public function testGetRichMessageWithSeveralMentions() {
+		$mentions = [
+			['type'=>'user', 'id'=>'testUser1'],
+			['type'=>'user', 'id'=>'testUser2'],
+			['type'=>'user', 'id'=>'testUser3']
+		];
+		$comment = $this->newComment('Mention to @testUser1, @testUser2, @testUser1 again and @testUser3', $mentions);
+
+		$this->commentsManager->expects($this->exactly(3))
+			->method('resolveDisplayName')
+			->withConsecutive(
+				['user', 'testUser1'],
+				['user', 'testUser2'],
+				['user', 'testUser3']
+			)
+			->willReturn(
+				'testUser1 display name',
+				'testUser2 display name',
+				'testUser3 display name'
+			);
+
+		list($message, $messageParameters) = $this->richMessageHelper->getRichMessage($comment);
+
+		$expectedMessageParameters = [
+			'mention-user1' => [
+				'type' => 'user',
+				'id' => 'testUser1',
+				'name' => 'testUser1 display name'
+			],
+			'mention-user2' => [
+				'type' => 'user',
+				'id' => 'testUser2',
+				'name' => 'testUser2 display name'
+			],
+			'mention-user3' => [
+				'type' => 'user',
+				'id' => 'testUser3',
+				'name' => 'testUser3 display name'
+			]
+		];
+
+		$this->assertEquals('Mention to {mention-user1}, {mention-user2}, {mention-user1} again and {mention-user3}', $message);
+		$this->assertEquals($expectedMessageParameters, $messageParameters);
+	}
+
+	public function testGetRichMessageWhenDisplayNameCanNotBeResolved() {
+		$mentions = [
+			['type'=>'user', 'id'=>'testUser'],
+		];
+		$comment = $this->newComment('Mention to @testUser', $mentions);
+
+		$this->commentsManager->expects($this->once())
+			->method('resolveDisplayName')
+			->willThrowException(new \OutOfBoundsException());
+
+		list($message, $messageParameters) = $this->richMessageHelper->getRichMessage($comment);
+
+		$expectedMessageParameters = [
+			'mention-user1' => [
+				'type' => 'user',
+				'id' => 'testUser',
+				'name' => ''
+			]
+		];
+
+		$this->assertEquals('Mention to {mention-user1}', $message);
+		$this->assertEquals($expectedMessageParameters, $messageParameters);
+	}
+
+}


### PR DESCRIPTION
This pull request adds formatted mentions to the message list (but not formatted mentions nor auto-completion in messages being composed); it is based on #517, although in this case avatars are no longer included in the mention ([as decided in #517](https://github.com/nextcloud/spreed/pull/517#issuecomment-357277790)).

It is based on both the mentions shown in the Comments app and the rich formatting of notifications. The backend uses the Comments API to store the messages, so when `receiveMessages` is called the Comments API is used to extract the mentions from the plain text message originally sent. However, unlike the Comments app, the mentions are not returned to the client in its own attribute, but in a generic way using a rich object string. Thanks to this approach it should be easier to extend the formatting in the future with support for other [definition types](https://github.com/nextcloud/server/blob/0913bc2157293acafa186afec4018ad25d7fbb22/lib/public/RichObjectStrings/Definitions.php#L40).

In any case, as the mentions are got using the Comments API this system has its same limitations, like not supporting mentions to users with a space in the name.

Note that links are still formatted in the client using `OCP.Comments.plainToRich`, which formats the plain text links found in the message; this has not been modified, although for consistency it would be good to move the links too to the rich object string system (something for another pull request, though).

Before:
![chat-mention-no-avatar-before](https://user-images.githubusercontent.com/26858233/39135308-f013f990-4718-11e8-9804-9e80833d8aad.png)

After (outdated; now the display name is shown instead of the user name):
![chat-mention-no-avatar-after](https://user-images.githubusercontent.com/26858233/39135299-ea7b06cc-4718-11e8-9bc7-651c6c81b9c7.png)

Formatted mentions are just `span` elements with a `font-weight: bold` style; ~~they include the user name, but not the display name (it is the same as in GitHub, for example). Should the display name be shown too? Note that showing it in a tooltip may not be a good option, as (pending, to be done in another pull request) the contacts menu will be shown when clicking on the mention (like done in the Comments app), and the tooltip and the menu would look bad at the same time.~~ they include _@_ followed by the display name.
