### PR TITLE
Fix pointer cursor not shown on message authors

### DIFF
--- a/css/comments.scss
+++ b/css/comments.scss
@@ -153,6 +153,12 @@
 	position: relative;
 }
 
+#commentsTabView .comment .authorRow .avatar:not(.currentUser),
+#commentsTabView .comment .authorRow .avatar:not(.currentUser) img,
+#commentsTabView .comment .authorRow .author:not(.currentUser) {
+	cursor: pointer;
+}
+
 .atwho-view-ul * .avatar-name-wrapper {
 	white-space: nowrap;
 }

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -54,8 +54,8 @@
 	var COMMENT_TEMPLATE =
 		'<li class="comment" data-id="{{id}}">' +
 		'    <div class="authorRow">' +
-		'        <div class="avatar" data-user-id="{{actorId}}" data-displayname="{{actorDisplayName}}"> </div>' +
-		'        <div class="author">{{actorDisplayName}}</div>' +
+		'        <div class="avatar{{#if isUserAuthor}} currentUser{{/if}}" data-user-id="{{actorId}}" data-displayname="{{actorDisplayName}}"> </div>' +
+		'        <div class="author{{#if isUserAuthor}} currentUser{{/if}}">{{actorDisplayName}}</div>' +
 		'        <div class="date has-tooltip{{#if relativeDate}} live-relative-timestamp{{/if}}" data-timestamp="{{timestamp}}" title="{{altDate}}">{{date}}</div>' +
 		'    </div>' +
 		'    <div class="message">{{{formattedMessage}}}</div>' +
@@ -120,6 +120,11 @@
 			if (!this._commentTemplate) {
 				this._commentTemplate = Handlebars.compile(COMMENT_TEMPLATE);
 			}
+
+			params = _.extend({
+				isUserAuthor: OC.getCurrentUser().uid === params.actorId,
+			}, params);
+
 			return this._commentTemplate(params);
 		},
 


### PR DESCRIPTION
Clicking on a message author shows the contacts menu (provided the author is not the current user); in those cases the cursor should be a pointer so the user knows that an interaction with those elements is possible.

Note that the changes in the CSS file will conflict with the changes done in #812; see [the equivalent CSS file from the Comments app](https://github.com/nextcloud/server/blob/0489643f506f314af8dd76444a7b2f0f375ad80b/apps/comments/css/comments.scss#L137-L156) for reference on how to solve the conflict (it is not exactly the same, but you can get an idea ;-) ).
