### PR TITLE
Make the unread count more obvious

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -96,6 +96,13 @@
 	height: 32px;
 }
 
+#app-navigation .app-navigation-entry-utils-counter span {
+	padding: 2px 5px;
+	border-radius: 10px;
+	background-color: $color-primary;
+	color: $color-primary-text;
+}
+
 .public-room {
 	display: block !important;
 }

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -37,7 +37,7 @@
 	var ITEM_TEMPLATE = '<a class="app-navigation-entry-link" href="#{{id}}" data-token="{{token}}"><div class="avatar" data-user="{{name}}" data-user-display-name="{{displayName}}"></div> {{displayName}}</a>'+
 						'<div class="app-navigation-entry-utils">'+
 							'<ul>'+
-								'{{#if unreadMessages}}<li class="app-navigation-entry-utils-counter">{{unreadMessages}}</li>{{/if}}'+
+								'{{#if unreadMessages}}<li class="app-navigation-entry-utils-counter"><span>{{unreadMessages}}</span></li>{{/if}}'+
 								'<li class="app-navigation-entry-utils-menu-button"><button></button></li>'+
 							'</ul>'+
 						'</div>'+


### PR DESCRIPTION
> ![talk_-_nextcloud_-_2018-04-26_15 33 23](https://user-images.githubusercontent.com/213943/39308997-426734e6-4967-11e8-8441-31b72a1c15f2.png)

Let's do it

cc @skjnldsv maybe we can add something like this to the navigation directly. Yes blue may be unwanted for number of users in a group, but for unread count it sounds more important.