### PR TITLE
Fix working icon position when sending a message

### DIFF
--- a/css/comments.scss
+++ b/css/comments.scss
@@ -28,12 +28,19 @@
 	display: block;
 }
 
-#commentsTabView .newCommentForm .submit {
+#commentsTabView .newCommentForm .submit,
+#commentsTabView .newCommentForm .submitLoading {
 	position: absolute;
+
+	width: 44px;
+	height: 44px;
+
 	bottom: -4px;
 	right: -8px;
 	margin: 0;
-	padding: 13px 22px;;
+}
+
+#commentsTabView .newCommentForm .submit {
 	background-color: transparent;
 	border: none;
 	opacity: .3;
@@ -45,20 +52,6 @@
 
 #commentsTabView .newCommentForm .submitLoading {
 	background-position: left;
-
-	/* Match rules for '#commentsTabView .newCommentForm .submit' to place the
-	   loading icon at the same position as the confirm icon */
-	position: absolute;
-	bottom: 0px;
-	right: 8px;
-	width: 30px;
-	margin: 0;
-	padding: 7px 9px;
-
-	/* Match rules for 'input[type="submit"]' to place the loading icon at the
-	   same position as the confirm icon */
-	min-height: 34px;
-	box-sizing: border-box;
 }
 
 #commentsTabView .newCommentForm .cancel {

--- a/css/comments.scss
+++ b/css/comments.scss
@@ -50,10 +50,6 @@
 	opacity: 1;
 }
 
-#commentsTabView .newCommentForm .submitLoading {
-	background-position: left;
-}
-
 #commentsTabView .newCommentForm .cancel {
 	margin-right: 6px;
 }


### PR DESCRIPTION
This pull request fixes a regression introduced in b458794e6a6430fda9c835ef84ed29c163d45019

The submit icon is hidden when the working icon is shown; in the screenshots below both are shown at the same time for clarity.

Before:
![chat-send-message-icons-before](https://user-images.githubusercontent.com/26858233/39365704-31e50f00-4a32-11e8-9f8e-ad283d0f20ef.png)

After:
![chat-send-message-icons-after](https://user-images.githubusercontent.com/26858233/39365706-33a3912c-4a32-11e8-9a8d-44e63b5a73c0.png)
