### PR TITLE
Fix appearance of author row when showing the date

### DIFF
--- a/css/comments.scss
+++ b/css/comments.scss
@@ -250,7 +250,7 @@
 }
 
 #commentsTabView .comment.showDate .authorRow {
-	display: block;
+	display: inline-flex;
 }
 
 #commentsTabView .comment .message .mention-user {


### PR DESCRIPTION
When a message shows the date separator its author row is explicitly shown. This is needed to ensure that the author row will always be shown in that case, even if the message is a grouped message. In normal messages (those that are not grouped and do not show the date separator) [now the author row is shown using "display: inline-flex"](https://github.com/nextcloud/spreed/pull/812/commits/85cd8181e5c5c0a58f89d67a492b97b10631fdc2#diff-e2a9b39888965cc9ac080ee77638d6d3R155), so the same value should be used too for messages that show the date separator.

Before (issue is in first message; second message is a non-grouped message, shown for reference):
![chat-grouped-author-date-before](https://user-images.githubusercontent.com/26858233/39423893-61db5eb4-4c74-11e8-8594-227b4ad27dd0.png)

After (the difference is subtle, but it is there :-P ):
![chat-grouped-author-date-after](https://user-images.githubusercontent.com/26858233/39423903-6995aa4c-4c74-11e8-8109-66d31641bc77.png)
