### PR TITLE
Fix pointer cursor shown for guests and in new message form

### DIFF
--- a/css/comments.scss
+++ b/css/comments.scss
@@ -146,10 +146,12 @@
 	width: 100%;
 }
 
-#commentsTabView .comment .authorRow .avatar:not(.currentUser),
-#commentsTabView .comment .authorRow .avatar:not(.currentUser) img,
-#commentsTabView .comment .authorRow .author:not(.currentUser) {
-	cursor: pointer;
+#commentsTabView .comment .authorRow:not(.currentUser) {
+	.avatar,
+	.avatar img,
+	.author {
+		cursor: pointer;
+	}
 }
 
 .atwho-view-ul .avatar-name-wrapper,

--- a/css/comments.scss
+++ b/css/comments.scss
@@ -146,7 +146,7 @@
 	width: 100%;
 }
 
-#commentsTabView .comment .authorRow:not(.currentUser) {
+#commentsTabView .comment .authorRow:not(.currentUser):not(.guestUser) {
 	.avatar,
 	.avatar img,
 	.author {

--- a/css/comments.scss
+++ b/css/comments.scss
@@ -146,7 +146,7 @@
 	width: 100%;
 }
 
-#commentsTabView .comment .authorRow:not(.currentUser):not(.guestUser) {
+body:not(#body-public) #commentsTabView .comment .authorRow:not(.currentUser):not(.guestUser) {
 	.avatar,
 	.avatar img,
 	.author {

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -36,7 +36,7 @@
 
 	var ADD_COMMENT_TEMPLATE =
 		'<div class="newCommentRow comment">' +
-		'    <div class="authorRow">' +
+		'    <div class="authorRow currentUser">' +
 		'        <div class="avatar" data-username="{{actorId}}"></div>' +
 		'        {{#if actorId}}' +
 		'            <div class="author">{{actorDisplayName}}</div>' +

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -53,7 +53,7 @@
 
 	var COMMENT_TEMPLATE =
 		'<li class="comment" data-id="{{id}}">' +
-		'    <div class="authorRow{{#if isUserAuthor}} currentUser{{/if}}">' +
+		'    <div class="authorRow{{#if isUserAuthor}} currentUser{{/if}}{{#if isGuest}} guestUser{{/if}}">' +
 		'        <div class="avatar" data-user-id="{{actorId}}" data-displayname="{{actorDisplayName}}"> </div>' +
 		'        <div class="author">{{actorDisplayName}}</div>' +
 		'        <div class="date has-tooltip{{#if relativeDate}} live-relative-timestamp{{/if}}" data-timestamp="{{timestamp}}" title="{{altDate}}">{{date}}</div>' +
@@ -183,7 +183,9 @@
 			}
 
 			params = _.extend({
+				// TODO isUserAuthor is not properly set for guests
 				isUserAuthor: OC.getCurrentUser().uid === params.actorId,
+				isGuest: params.actorType === 'guests',
 			}, params);
 
 			return this._commentTemplate(params);

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -53,9 +53,9 @@
 
 	var COMMENT_TEMPLATE =
 		'<li class="comment" data-id="{{id}}">' +
-		'    <div class="authorRow">' +
-		'        <div class="avatar{{#if isUserAuthor}} currentUser{{/if}}" data-user-id="{{actorId}}" data-displayname="{{actorDisplayName}}"> </div>' +
-		'        <div class="author{{#if isUserAuthor}} currentUser{{/if}}">{{actorDisplayName}}</div>' +
+		'    <div class="authorRow{{#if isUserAuthor}} currentUser{{/if}}">' +
+		'        <div class="avatar" data-user-id="{{actorId}}" data-displayname="{{actorDisplayName}}"> </div>' +
+		'        <div class="author">{{actorDisplayName}}</div>' +
 		'        <div class="date has-tooltip{{#if relativeDate}} live-relative-timestamp{{/if}}" data-timestamp="{{timestamp}}" title="{{altDate}}">{{date}}</div>' +
 		'    </div>' +
 		'    <div class="message">{{{formattedMessage}}}</div>' +


### PR DESCRIPTION
Follow-up to #814.

Now the default cursor is shown instead of the pointer cursor on guest users, on any user in the public view, and on the user shown in the new message form, as in those cases the contacts menu does not appear when clicking on the users.
