### PR TITLE
Remove support for newest on top chat layout

### DIFF
--- a/css/comments.scss
+++ b/css/comments.scss
@@ -70,15 +70,6 @@
 	overflow-wrap: break-word;
 }
 
-#commentsTabView.oldestOnTopLayout .comment {
-	margin-top: 30px;
-	margin-bottom: 0;
-}
-
-#commentsTabView.oldestOnTopLayout .comment:first-child {
-	margin-top: 0;
-}
-
 #commentsTabView .comment .avatar,
 .atwho-view-ul * .avatar{
 	width: 32px;
@@ -224,10 +215,6 @@ body:not(#body-public) #commentsTabView .comment .authorRow:not(.currentUser):no
 
 #commentsTabView .comment.grouped {
 	margin-top: -20px;
-}
-
-#commentsTabView.oldestOnTopLayout .comment.grouped {
-	margin-top: 10px;
 }
 
 #commentsTabView .comment.showDate {

--- a/js/app.js
+++ b/js/app.js
@@ -564,7 +564,6 @@
 			this._chatView = new OCA.SpreedMe.Views.ChatView({
 				collection: this._messageCollection,
 				id: 'commentsTabView',
-				oldestOnTopLayout: true,
 				guestNameModel: this._localStorageModel
 			});
 

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -65,9 +65,7 @@
 
 		groupedMessages: 0,
 
-		className: function() {
-			return 'chat' + (this._oldestOnTopLayout? ' oldestOnTopLayout': '');
-		},
+		className: 'chat',
 
 		ui: {
 			'guestName': 'div.guest-name'


### PR DESCRIPTION
When [the oldest on top layout was added](https://github.com/nextcloud/spreed/pull/561) it was enabled by default, although the original newest on top layout was also kept as an option. However, the newest on top layout has not been used since then, and it is not expected to be used ever again. To make the chat view more maintainable and ease adding new features this pull request removes the original newest on top chat layout.

This pull request also removes the unused CSS rules for `.oldestOnTopLayout` elements (yes, oldest on top, not the layout that is being removed but the layout that is being kept); due to a stupid mistake the CSS class was never added, so the CSS rules were not used :facepalm:
