### PR TITLE
Fix scrolling in chat view

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -433,14 +433,18 @@
 			}
 
 			if (this.activeRoom.get('participantInCall') && this._chatViewInMainView === true) {
+				this._chatView.saveScrollPosition();
 				this._chatView.$el.detach();
 				this._sidebarView.addTab('chat', { label: t('spreed', 'Chat'), icon: 'icon-comment', priority: 100 }, this._chatView);
 				this._sidebarView.selectTab('chat');
+				this._chatView.restoreScrollPosition();
 				this._chatView.setTooltipContainer(this._chatView.$el);
 				this._chatViewInMainView = false;
 			} else if (!this.activeRoom.get('participantInCall') && !this._chatViewInMainView) {
+				this._chatView.saveScrollPosition();
 				this._sidebarView.removeTab('chat');
 				this._chatView.$el.prependTo('#app-content-wrapper');
+				this._chatView.restoreScrollPosition();
 				this._chatView.setTooltipContainer($('#app'));
 				this._chatView.focusChatInput();
 				this._chatViewInMainView = true;

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -289,7 +289,7 @@
 			this.$el.find('.emptycontent').toggleClass('hidden', true);
 
 			var $newestComment = this.$container.children('.comment').last();
-			var scrollToNew = $newestComment.length > 0 && this._getCommentTopPosition($newestComment) < this.$container.outerHeight(true);
+			var scrollToNew = $newestComment.length > 0 && this._getCommentTopPosition($newestComment) < this.$container.outerHeight();
 
 			var $el = $(this.commentTemplate(this._formatItem(model)));
 			if (!_.isUndefined(options.at) && collection.length > 1) {
@@ -326,7 +326,7 @@
 			this._postRenderItem(model, $el);
 
 			if (scrollToNew) {
-				var newestCommentHiddenHeight = (this._getCommentTopPosition($newestComment) + this._getCommentOuterHeight($newestComment)) - this.$container.outerHeight(true);
+				var newestCommentHiddenHeight = (this._getCommentTopPosition($newestComment) + this._getCommentOuterHeight($newestComment)) - this.$container.outerHeight();
 				this.$container.scrollTop(this.$container.scrollTop() + newestCommentHiddenHeight + $el.outerHeight(true));
 			}
 		},

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -289,7 +289,7 @@
 			this.$el.find('.emptycontent').toggleClass('hidden', true);
 
 			var $newestComment = this.$container.children('.comment').last();
-			var scrollToNew = $newestComment.length > 0 && $newestComment.position().top < this.$container.outerHeight(true);
+			var scrollToNew = $newestComment.length > 0 && this._getCommentTopPosition($newestComment) < this.$container.outerHeight(true);
 
 			var $el = $(this.commentTemplate(this._formatItem(model)));
 			if (!_.isUndefined(options.at) && collection.length > 1) {
@@ -326,9 +326,40 @@
 			this._postRenderItem(model, $el);
 
 			if (scrollToNew) {
-				var newestCommentHiddenHeight = ($newestComment.position().top + $newestComment.outerHeight(true)) - this.$container.outerHeight(true);
+				var newestCommentHiddenHeight = (this._getCommentTopPosition($newestComment) + this._getCommentOuterHeight($newestComment)) - this.$container.outerHeight(true);
 				this.$container.scrollTop(this.$container.scrollTop() + newestCommentHiddenHeight + $el.outerHeight(true));
 			}
+		},
+
+		_getCommentTopPosition: function($element) {
+			// When the margin is positive, jQuery returns the proper top
+			// position of the element (that is, including the top margin).
+			// However, when it is negative, jQuery returns where the top
+			// position of the element would be if there was no margin. Grouped
+			// messages use a negative top margin to "pull them up" closer to
+			// the previous message, so in those cases the top position returned
+			// by jQuery is below the actual top position of the element.
+			var marginTop = parseInt($element.css('margin-top'));
+			if (marginTop >= 0) {
+				return $element.position().top;
+			}
+
+			return $element.position().top + marginTop;
+		},
+
+		_getCommentOuterHeight: function($element) {
+			// When the margin is positive, jQuery returns the proper outer
+			// height of the element. However, when it is negative, it
+			// substracts the negative margin from the overall height of the
+			// element. Grouped messages use a negative top margin to "pull them
+			// up" closer to the previous message, so in those cases the outer
+			// height returned by jQuery is smaller than the actual height.
+			var marginTop = parseInt($element.css('margin-top'));
+			if (marginTop >= 0) {
+				return $element.outerHeight(true);
+			}
+
+			return $element.outerHeight(true) - marginTop;
 		},
 
 		_getDateSeparator: function(timestamp) {


### PR DESCRIPTION
Follow-up to #564.

This pull request fixes the chat view not scrolling to the new message if the last message was grouped and partially visible. More important, it also fixes the scroll position not being kept when the chat view is switched between the main view and the sidebar.

**How to test (chat view not scrolling to new message):**
- Open a conversation and write enough messages to show the scroll bar.
- Write two messages quickly, so the second one is grouped with the previous one.
- Scroll so the last message (the grouped one) is slightly visible.
- Write another message.

Expected result:
- The chat view automatically scrolls to the new message.

Actual result:
- The chat view does not scroll.

**How to test (scroll position kept when switching the chat view):**
- Open a conversation and write enough messages to show the scroll bar.
- Scroll back so both the first and last messages are hidden.
- Join a call.
- Leave the call.

Expected result:
- The last message that was partially visible is now the last message fully visible.

Actual result:
- The chat view is scrolled to the top.
