### PR TITLE
Disable contacts menu for mentions in the public view

### DIFF
--- a/css/comments.scss
+++ b/css/comments.scss
@@ -257,7 +257,7 @@ body:not(#body-public) #commentsTabView .comment .authorRow:not(.currentUser):no
 	color: $color-primary-text;
 }
 
-#commentsTabView .comment .message .mention-user:not(.current-user) {
+body:not(#body-public) #commentsTabView .comment:not(.newCommentRow) .message .mention-user:not(.current-user) {
 	cursor: pointer;
 }
 

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -412,6 +412,11 @@
 		},
 
 		_postRenderMessage: function($el) {
+			// Contacts menu is not shown in public view.
+			if (!OC.getCurrentUser().uid) {
+				return;
+			}
+
 			$el.find('.mention-user').each(function() {
 				var $this = $(this);
 


### PR DESCRIPTION
The contacts menu can be shown only in user sessions; in the public view it just fails and shows an error message instead of any useful option, so now it is disabled for mentions in the public view.

Accordingly, now the cursor is a pointer on mentions only if the contacts menu can be shown for that mention.
