### PR TITLE
Limit unread message counter to "99+"

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -96,11 +96,24 @@
 	height: 32px;
 }
 
-#app-navigation .app-navigation-entry-utils-counter span {
-	padding: 2px 5px;
-	border-radius: 10px;
-	background-color: $color-primary;
-	color: $color-primary-text;
+#app-navigation .app-navigation-entry-utils-counter {
+	overflow: hidden;
+	text-align: right;
+	font-size: 9pt;
+	line-height: 44px;
+	padding: 0 12px; /* Same padding as all li > a in the app-navigation */
+
+	&.highlighted {
+		padding-right: 0;
+		text-align: center;
+
+		span {
+			padding: 2px 5px;
+			border-radius: 10px;
+			background-color: $color-primary;
+			color: $color-primary-text;
+		}
+	}
 }
 
 .public-room {

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -37,7 +37,7 @@
 	var ITEM_TEMPLATE = '<a class="app-navigation-entry-link" href="#{{id}}" data-token="{{token}}"><div class="avatar" data-user="{{name}}" data-user-display-name="{{displayName}}"></div> {{displayName}}</a>'+
 						'<div class="app-navigation-entry-utils">'+
 							'<ul>'+
-								'{{#if unreadMessages}}<li class="app-navigation-entry-utils-counter"><span>{{unreadMessages}}</span></li>{{/if}}'+
+								'{{#if unreadMessages}}<li class="app-navigation-entry-utils-counter highlighted"><span>{{numUnreadMessages}}</span></li>{{/if}}'+
 								'<li class="app-navigation-entry-utils-menu-button"><button></button></li>'+
 							'</ul>'+
 						'</div>'+
@@ -103,7 +103,8 @@
 		templateContext: function() {
 			return {
 				isDeletable: (this.model.get('participantType') === 1 || this.model.get('participantType') === 2) &&
-					(Object.keys(this.model.get('participants')).length > 1 || this.model.get('numGuests') > 0)
+					(Object.keys(this.model.get('participants')).length > 1 || this.model.get('numGuests') > 0),
+				numUnreadMessages: this.model.get('unreadMessages') > 99 ? '99+' : this.model.get('unreadMessages')
 			};
 		},
 		onRender: function() {


### PR DESCRIPTION
CSS is a copy of the server version now

Top is new (84445 is now 99+)
Bottom is old (number is cut off)

> ![bildschirmfoto von 2018-05-03 11-18-59](https://user-images.githubusercontent.com/213943/39568876-ea3de7c6-4ec3-11e8-9c36-d424202b61e7.png)

As per documentation https://docs.nextcloud.com/server/13/developer_manual/design/navigation.html#counter the counter should be limited to 3 digits, but I think for chat messages it does not matter anymore when it's over 100, so we display 99+ when it's more then 99

@Ivansss @mario we limit the number in the UI not the api, so maybe you can limit it too to 99+