### PR TITLE
Fix empty guest display name

### DIFF
--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -321,7 +321,7 @@
 
 			var actorDisplayName = commentModel.get('actorDisplayName');
 			if (commentModel.get('actorType') === 'guests' &&
-				actorDisplayName === null) {
+				actorDisplayName === '') {
 				actorDisplayName = t('spreed', 'Guest');
 			}
 			if (actorDisplayName == null) {


### PR DESCRIPTION
Fix #817 
After this change https://github.com/nextcloud/spreed/pull/807 we should not check any more for null values.