### PR TITLE
Join the call only aftrer media access was done

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -618,7 +618,7 @@
 			if (!OCA.SpreedMe.webrtc) {
 				OCA.SpreedMe.initWebRTC(this);
 			}
-			OCA.SpreedMe.webrtc.startMedia();
+			OCA.SpreedMe.webrtc.startMedia(this.token);
 		},
 		startLocalMedia: function(configuration) {
 			if (this.callbackAfterMedia) {

--- a/js/app.js
+++ b/js/app.js
@@ -618,13 +618,24 @@
 			if (!OCA.SpreedMe.webrtc) {
 				OCA.SpreedMe.initWebRTC(this);
 			}
+			OCA.SpreedMe.webrtc.startMedia();
 		},
 		startLocalMedia: function(configuration) {
+			if (this.callbackAfterMedia) {
+				this.callbackAfterMedia();
+				this.callbackAfterMedia = null;
+			}
+
 			$('.videoView').removeClass('hidden');
 			this.initAudioVideoSettings(configuration);
 			this.restoreEmptyContent();
 		},
 		startWithoutLocalMedia: function(isAudioEnabled, isVideoEnabled) {
+			if (this.callbackAfterMedia) {
+				this.callbackAfterMedia();
+				this.callbackAfterMedia = null;
+			}
+
 			$('.videoView').removeClass('hidden');
 
 			this.disableAudio();

--- a/js/connection.js
+++ b/js/connection.js
@@ -105,12 +105,15 @@
 				return;
 			}
 
-			this.app.signaling.joinCall(token);
-			this.app.signaling.syncRooms();
+			var self = this;
+			this.app.callbackAfterMedia = function() {
+				self.app.signaling.joinCall(token);
+				self.app.signaling.syncRooms();
+
+				$('#emptycontent').hide();
+			};
 
 			this.app.setupWebRTC();
-
-			$('#emptycontent').hide();
 		},
 		leaveCurrentCall: function() {
 			this.app.signaling.leaveCurrentCall();

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -188,15 +188,6 @@ var spreedPeerConnectionTable = [];
 		app.signaling.on('leaveCall', function () {
 			webrtc.leaveCall();
 		});
-		app.signaling.on('joinCall', function (token) {
-			app.setEmptyContentMessage(
-				'icon-video-off',
-				t('spreed', 'Waiting for camera and microphone permissions'),
-				t('spreed', 'Please, give your browser access to use your camera and microphone in order to use this app.')
-			);
-
-			webrtc.joinCall(token);
-		});
 
 		webrtc = new SimpleWebRTC({
 			localVideoEl: 'localVideo',
@@ -218,6 +209,16 @@ var spreedPeerConnectionTable = [];
 			nick: OC.getCurrentUser().displayName
 		});
 		OCA.SpreedMe.webrtc = webrtc;
+
+		OCA.SpreedMe.webrtc.startMedia = function (token) {
+			app.setEmptyContentMessage(
+				'icon-video-off',
+				t('spreed', 'Waiting for camera and microphone permissions'),
+				t('spreed', 'Please, give your browser access to use your camera and microphone in order to use this app.')
+			);
+
+			webrtc.joinCall(token);
+		};
 
 		var spreedListofSpeakers = {};
 		var spreedListofSharedScreens = {};


### PR DESCRIPTION
When we delayed the media access, we were all fast with testing.
Before this patch, when there was already at least one user in the
call and you took longer to accept the media request than webrtc
took to init everything, you would always send a black video signal
and no sound, because the data was not there, when connections were
established with the other users. Now we first request the media and
send the join call to the server afterwards.

Fix #850 