### PR TITLE
Unpromote latest speaker if no users remain in call when removing video.

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -511,8 +511,9 @@ var spreedPeerConnectionTable = [];
 				if (mostRecentId !== null) {
 					OCA.SpreedMe.speakers.switchVideoToId(mostRecentId);
 				} else if (enforce === true) {
-					// if there is no mostRecentId is available there is no user left in call
+					// if there is no mostRecentId available, there is no user left in call
 					// remove the remaining dummy container then too
+					OCA.SpreedMe.speakers.unpromoteLatestSpeaker();
 					$('.videoContainer-dummy').remove();
 				}
 			}


### PR DESCRIPTION
If the same user joins the call again, the video would otherwise not be promoted automatically because the id is still stored in `latestSpeakerId`.
