### PR TITLE
Use dedicated event name to trigger when refreshing the participant list

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -360,8 +360,7 @@
 				id: 'participantsTabView'
 			});
 
-			this.signaling.on('usersChanged', function() {
-				// Also refresh the participant list when the users change
+			this.signaling.on('participantListChanged', function() {
 				this._participants.fetch();
 			}.bind(this));
 

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -428,7 +428,7 @@
 					switch(message.type) {
 						case "usersInRoom":
 							this._trigger('usersInRoom', [message.data]);
-							this._trigger("usersChanged");
+							this._trigger("participantListChanged");
 							break;
 						case "message":
 							if (typeof(message.data) === 'string') {
@@ -881,7 +881,7 @@
 						this._trigger("usersLeft", [leftUsers]);
 					}
 					this._trigger("usersJoined", [joinedUsers]);
-					this._trigger("usersChanged");
+					this._trigger("participantListChanged");
 				}
 				break;
 			case "leave":
@@ -892,7 +892,7 @@
 						delete this.joinedUsers[leftSessionIds[i]];
 					}
 					this._trigger("usersLeft", [leftSessionIds]);
-					this._trigger("usersChanged");
+					this._trigger("participantListChanged");
 				}
 				break;
 			default:
@@ -945,6 +945,7 @@
 		switch (data.event.type) {
 			case "update":
 				this._trigger("usersChanged", [data.event.update.users]);
+				this._trigger("participantListChanged");
 				this.internalSyncRooms();
 				break;
 			default:


### PR DESCRIPTION
This avoids a conflict (introduced by #864) with the existing ´usersChanged` event which is triggered when the `inCall` status of a user has changed.
