### PR TITLE
Notify standalone signaling server about sessions to remove from room.

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -147,6 +147,14 @@ class Application extends App {
 			$user = $event->getArgument('user');
 			$notifier->roomsDisinvited($room, [$user->getUID()]);
 		});
+		$dispatcher->addListener(Room::class . '::postRemoveBySession', function(GenericEvent $event) {
+			/** @var BackendNotifier $notifier */
+			$notifier = $this->getBackendNotifier();
+
+			$room = $event->getSubject();
+			$participant = $event->getArgument('participant');
+			$notifier->roomSessionsRemoved($room, [$participant->getSessionId()]);
+		});
 		$dispatcher->addListener(Room::class . '::postSessionJoinCall', function(GenericEvent $event) {
 			/** @var BackendNotifier $notifier */
 			$notifier = $this->getBackendNotifier();

--- a/lib/Signaling/BackendNotifier.php
+++ b/lib/Signaling/BackendNotifier.php
@@ -176,6 +176,30 @@ class BackendNotifier{
 	}
 
 	/**
+	 * The given sessions have been removed from a room.
+	 *
+	 * @param Room $room
+	 * @param array $sessionIds
+	 * @throws \Exception
+	 */
+	public function roomSessionsRemoved($room, $sessionIds) {
+		$this->logger->info('Removed from ' . $room->getToken() . ': ' . print_r($sessionIds, true), ['app' => 'spreed']);
+		$this->backendRequest('/api/v1/room/' . $room->getToken(), [
+			'type' => 'disinvite',
+			'disinvite' => [
+				'sessionids' => $sessionIds,
+				// TODO(fancycode): We should try to get rid of 'alluserids' and
+				// find a better way to notify existing users to update the room.
+				'alluserids' => $this->getRoomUserIds($room),
+				'properties' => [
+					'name' => $room->getName(),
+					'type' => $room->getType(),
+				],
+			],
+		]);
+	}
+
+	/**
 	 * The given room has been modified.
 	 *
 	 * @param Room $room


### PR DESCRIPTION
Btw, that is the expected behaviour when a user is removed? For now I can simply reconnect and will be in the room again.