### PR TITLE
Fix UI when leaving current call

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -575,6 +575,11 @@
 				this.stopReceivingMessages();
 			});
 
+			this.listenTo(roomChannel, 'leaveCurrentRoom', function() {
+				this._chatView.$el.detach();
+				this._chatViewInMainView = false;
+			});
+
 			$(document).on('click', this.onDocumentClick);
 			OC.Util.History.addOnPopStateHandler(_.bind(this._onPopState, this));
 		},

--- a/js/app.js
+++ b/js/app.js
@@ -560,7 +560,7 @@
 				this.initGuestName();
 			}
 
-			this._sidebarView.listenTo(roomChannel, 'leaveCurrentCall', function() {
+			this._sidebarView.listenTo(roomChannel, 'leaveCurrentRoom', function() {
 				this.disable();
 			});
 
@@ -571,7 +571,7 @@
 				guestNameModel: this._localStorageModel
 			});
 
-			this._messageCollection.listenTo(roomChannel, 'leaveCurrentCall', function() {
+			this._messageCollection.listenTo(roomChannel, 'leaveCurrentRoom', function() {
 				this.stopReceivingMessages();
 			});
 

--- a/js/app.js
+++ b/js/app.js
@@ -420,13 +420,13 @@
 
 					self.setPageTitle(self.activeRoom.get('displayName'));
 
-					self.updateChatViewPlacement();
-					self.listenTo(self.activeRoom, 'change:participantInCall', self.updateChatViewPlacement);
+					self.updateContentsLayout();
+					self.listenTo(self.activeRoom, 'change:participantInCall', self.updateContentsLayout);
 
 					self.updateSidebarWithActiveRoom();
 				});
 		},
-		updateChatViewPlacement: function() {
+		updateContentsLayout: function() {
 			if (!this.activeRoom) {
 				// This should never happen, but just in case
 				return;
@@ -448,6 +448,18 @@
 				this._chatView.setTooltipContainer($('#app'));
 				this._chatView.focusChatInput();
 				this._chatViewInMainView = true;
+			}
+
+			if (this.activeRoom.get('participantInCall')) {
+				$('#video-speaking').show();
+				$('#videos').show();
+				$('#screens').show();
+				$('#emptycontent').hide();
+			} else {
+				$('#video-speaking').hide();
+				$('#videos').hide();
+				$('#screens').hide();
+				$('#emptycontent').show();
 			}
 		},
 		updateSidebarWithActiveRoom: function() {
@@ -578,6 +590,11 @@
 			this.listenTo(roomChannel, 'leaveCurrentRoom', function() {
 				this._chatView.$el.detach();
 				this._chatViewInMainView = false;
+
+				$('#video-speaking').hide();
+				$('#videos').hide();
+				$('#screens').hide();
+				$('#emptycontent').show();
 			});
 
 			$(document).on('click', this.onDocumentClick);

--- a/js/connection.js
+++ b/js/connection.js
@@ -109,8 +109,6 @@
 			this.app.callbackAfterMedia = function() {
 				self.app.signaling.joinCall(token);
 				self.app.signaling.syncRooms();
-
-				$('#emptycontent').hide();
 			};
 
 			this.app.setupWebRTC();

--- a/js/connection.js
+++ b/js/connection.js
@@ -98,7 +98,7 @@
 			OC.Util.History.pushState({}, OC.generateUrl('/apps/spreed'));
 			$('#app-content').removeClass('incall');
 			this.showRoomDeletedMessage(deleter);
-			roomsChannel.trigger('leaveCurrentCall');
+			roomsChannel.trigger('leaveCurrentRoom');
 		},
 		joinCall: function(token) {
 			if (this.app.signaling.currentCallToken === token) {

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -210,7 +210,6 @@
 				return;
 			}
 
-			OCA.SpreedMe.app._chatView.$el.detach();
 			OCA.SpreedMe.app.connection.leaveCurrentRoom(true);
 			OC.Util.History.pushState({}, OC.generateUrl('/apps/spreed'));
 		},

--- a/tests/acceptance/features/bootstrap/ConversationListContext.php
+++ b/tests/acceptance/features/bootstrap/ConversationListContext.php
@@ -107,6 +107,13 @@ class ConversationListContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @return Locator
+	 */
+	public static function deleteConversationMenuItemFor($conversation) {
+		return self::conversationMenuItemFor($conversation, "Delete conversation");
+	}
+
+	/**
 	 * @Given I create a group conversation
 	 */
 	public function iCreateAGroupConversation() {
@@ -161,6 +168,14 @@ class ConversationListContext implements Context, ActorAwareInterface {
 	public function iRemoveTheConversationFromTheList($conversation) {
 		$this->actor->find(self::conversationMenuButtonFor($conversation), 10)->click();
 		$this->actor->find(self::removeConversationFromListMenuItemFor($conversation), 2)->click();
+	}
+
+	/**
+	 * @Given I delete the :conversation conversation
+	 */
+	public function iDeleteTheConversation($conversation) {
+		$this->actor->find(self::conversationMenuButtonFor($conversation), 10)->click();
+		$this->actor->find(self::deleteConversationMenuItemFor($conversation), 2)->click();
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/ConversationListContext.php
+++ b/tests/acceptance/features/bootstrap/ConversationListContext.php
@@ -179,7 +179,17 @@ class ConversationListContext implements Context, ActorAwareInterface {
 	 * @Then I see that the :conversation conversation is active
 	 */
 	public function iSeeThatTheConversationIsActive($conversation) {
-		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::activeConversationListItemFor($conversation), 10)->isVisible());
+		// The active conversation list item may be hidden but exist in the DOM
+		// during the lapse between removing the conversation and getting the
+		// updated conversation list from the server, so it has to be explictly
+		// waited for it to be visible instead of relying on the implicit wait
+		// made to find the element.
+		if (!WaitFor::elementToBeEventuallyShown(
+				$this->actor,
+				self::activeConversationListItemFor($conversation),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("The $conversation conversation is not active yet after $timeout seconds");
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/TalkAppContext.php
+++ b/tests/acceptance/features/bootstrap/TalkAppContext.php
@@ -103,9 +103,9 @@ class TalkAppContext implements Context, ActorAwareInterface {
 	}
 
 	/**
-	 * @Then I see that the empty content message is shown in the main view
+	 * @Then I see that the :text empty content message is shown in the main view
 	 */
-	public function iSeeThatTheEmptyContentMessageIsShownInTheMainView() {
+	public function iSeeThatTheEmptyContentMessageIsShownInTheMainView($text) {
 		// The empty content always exists in the DOM, so it has to be explictly
 		// waited for it to be visible instead of relying on the implicit wait
 		// made to find the element.
@@ -115,6 +115,8 @@ class TalkAppContext implements Context, ActorAwareInterface {
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
 			PHPUnit_Framework_Assert::fail("The empty content was not shown yet after $timeout seconds");
 		}
+
+		PHPUnit_Framework_Assert::assertEquals($text, $this->actor->find(self::emptyContent())->getText());
 	}
 
 	/**

--- a/tests/acceptance/features/conversation.feature
+++ b/tests/acceptance/features/conversation.feature
@@ -51,5 +51,5 @@ Feature: conversation
     And I see that the "You" conversation is active
     When I remove the "You" conversation from the list
     Then I see that the "You" conversation is not shown in the list
-    And I see that the empty content message is shown in the main view
+    And I see that the "Join a conversation or start a new one" empty content message is shown in the main view
     And I see that the sidebar is closed

--- a/tests/acceptance/features/conversation.feature
+++ b/tests/acceptance/features/conversation.feature
@@ -53,3 +53,66 @@ Feature: conversation
     Then I see that the "You" conversation is not shown in the list
     And I see that the "Join a conversation or start a new one" empty content message is shown in the main view
     And I see that the sidebar is closed
+
+  Scenario: delete a one-to-one conversation
+    Given I act as John
+    And I am logged in
+    And I have opened the Talk app
+    And I create a one-to-one conversation with "admin"
+    And I see that the "admin" conversation is active
+    And I see that the chat is shown in the main view
+    And I see that the sidebar is open
+    And I act as Jane
+    And I am logged in as the admin
+    And I have opened the Talk app
+    And I open the "user0" conversation
+    And I see that the "user0" conversation is active
+    And I see that the chat is shown in the main view
+    And I see that the sidebar is open
+    When I act as John
+    And I delete the "admin" conversation
+    Then I see that the "admin" conversation is not shown in the list
+    And I see that the "Join a conversation or start a new one" empty content message is shown in the main view
+    And I see that the sidebar is closed
+    And I act as Jane
+    And I see that the "user0" conversation is not shown in the list
+    And I see that the "This call has ended" empty content message is shown in the main view
+    And I see that the sidebar is closed
+
+  Scenario: create a new conversation after removing the active one
+    Given I am logged in
+    And I have opened the Talk app
+    And I create a group conversation
+    And I see that the "You" conversation is active
+    And I remove the "You" conversation from the list
+    And I see that the "You" conversation is not shown in the list
+    And I see that the "Join a conversation or start a new one" empty content message is shown in the main view
+    And I see that the sidebar is closed
+    When I create a group conversation
+    Then I see that the "You" conversation is active
+    And I see that the chat is shown in the main view
+    And I see that the sidebar is open
+    And I see that the number of participants shown in the list is "1"
+    And I see that "user0" is shown in the list of participants as a moderator
+
+  Scenario: change to another conversation after removing the active one
+    Given I am logged in
+    And I have opened the Talk app
+    And I create a one-to-one conversation with "admin"
+    And I see that the "admin" conversation is active
+    And I see that the number of participants shown in the list is "2"
+    And I create a group conversation
+    And I see that the "admin" conversation is not active
+    And I see that the "You" conversation is active
+    And I see that the number of participants shown in the list is "1"
+    And I remove the "You" conversation from the list
+    And I see that the "You" conversation is not shown in the list
+    And I see that the "Join a conversation or start a new one" empty content message is shown in the main view
+    And I see that the sidebar is closed
+    When I open the "admin" conversation
+    Then I see that the "admin" conversation is active
+    And I see that the chat is shown in the main view
+    And I see that the sidebar is open
+    And I see that the number of participants shown in the list is "2"
+    And I see that "user0" is shown in the list of participants as a moderator
+    And I see that "admin" is shown in the list of participants as a moderator


### PR DESCRIPTION
Requires #871 

This pull request fixes the call UI being shown after leaving the current call.

Note that the fix just shows and hides the HTML elements when needed; a proper fix would require to introduce view objects for the call UI and things like that, but for the time being this is good enough ;-)

Unfortunately acceptance tests could not be provided; as far as I know it is not possible to grant media permissions from WebDriver (although there are some tricks to grant them beforehand when using Mozilla Firefox, but they are cumbersome to apply with Behat/Mink :-( ).

**How to test:**
- Create a conversation with another user
- Join the call with both users
- Delete the conversation

**Expected result:**
The empty content message is shown.

**Actual result:**
The local video container and the avatar of the other user are shown; the empty content message is not shown.
