### PR TITLE
Make acceptance test for two users chatting more robust

### DIFF
--- a/tests/acceptance/features/chat.feature
+++ b/tests/acceptance/features/chat.feature
@@ -102,13 +102,17 @@ Feature: chat
     When I act as John
     And I send a new chat message with the text "Hello"
     And I act as Jane
+    And I see that the message 1 was sent by "admin" with the text "Hello"
     And I send a new chat message with the text "Hi!"
     And I act as John
+    And I see that the message 2 was sent by "user0" with the text "Hi!"
     And I send a new chat message with the text "How are you?"
     And I act as Jane
+    And I see that the message 3 was sent by "admin" with the text "How are you?"
     And I send a new chat message with the text "Fine thanks"
     And I send a new chat message with the text "And you?"
     And I act as John
+    And I see that the message 5 was sent with the text "And you?" and grouped with the previous one
     And I send a new chat message with the text "Fine too!"
     Then I see that the message 1 was sent by "admin" with the text "Hello"
     And I see that the message 2 was sent by "user0" with the text "Hi!"


### PR DESCRIPTION
The chat between two users was tested by a sequence of one user sending a message and immediately after that the other user sending another message. Most of the time the messages were processed in the server in the order in which they were sent, but sometimes it could happen that a previous message took longer than usual to get to the server and then the next message from the other user was processed before it; in those cases the test failed due to the messages not matching the expected order. Now each user waits for the last message of the other user to be received before sending the next message.
