### PR TITLE
Fix scrolling on participants list

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -1044,10 +1044,14 @@ video {
 #app-sidebar #participantsTabView {
 	display: flex;
 	flex-direction: column;
+	overflow: hidden;
 }
 
 #app-sidebar .participantWithList {
 	overflow-y: auto;
+}
+
+#app-sidebar .participantWithList .participant:last-child {
 	/* Add room for the popovermenu on last user */
 	padding-bottom: 64px;
 }


### PR DESCRIPTION
Fixes #851, which is a regression introduced in #745.

When using Firefox, the participants tab view requires its overflow to be hidden to limit its size to the size of its parents. Otherwise, the participants tab view grows to fit its children; if that happens then no scroll bar is shown for the participants list, as the participants list is tall enough to fit all its items (even if they are not visible because they are in the overflow area). In Chromium, on the other hand, the participants tab view size is always limited by its parents, no matter if the overflow is hidden or not.

In a similar way, once the overflow is hidden the bottom padding added to the participants list has to be added to its last item instead. Firefox only takes into account the bottom padding in the participants list when the list has not overflown the participants tab view; it needs to be added to the last item to be taken into account also when the participants list is taller than the participants tab view. Chromium, on the other hand, always takes into account the padding, no matter if it is added to the participants list or to its last item.
