### PR TITLE
Simplify notification wording

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -195,20 +195,20 @@ class Notifier implements INotifier {
 			} else if (!$richSubjectUser && !$isGuest && $richSubjectCall) {
 				$notification
 					->setParsedSubject(
-						$l->t('You were mentioned in a group conversation by a user that has since been deleted: %s', [$room->getName()])
+						$l->t('You were mentioned in a group conversation by a deleted user: %s', [$room->getName()])
 					)
 					->setRichSubject(
-						$l->t('You were mentioned in a group conversation by a user that has since been deleted: {call}'), [
+						$l->t('You were mentioned in a group conversation by a deleted user: {call}'), [
 							'call' => $richSubjectCall
 						]
 					);
 			} else if (!$richSubjectUser && !$isGuest && !$richSubjectCall) {
 				$notification
 					->setParsedSubject(
-						$l->t('You were mentioned in a group conversation by a user that has since been deleted')
+						$l->t('You were mentioned in a group conversation by a deleted user')
 					)
 					->setRichSubject(
-						$l->t('You were mentioned in a group conversation by a user that has since been deleted')
+						$l->t('You were mentioned in a group conversation by a deleted user')
 					);
 			} else if (!$richSubjectUser && $isGuest && $richSubjectCall) {
 				$notification

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -281,8 +281,8 @@ class NotifierTest extends \Test\TestCase {
 			],
 			[
 				Room::GROUP_CALL,      ['userType' => 'users', 'userId' => 'testUser'],           ['ellipsisStart'], null,        '',
-				'You were mentioned in a group conversation by a user that has since been deleted',
-				['You were mentioned in a group conversation by a user that has since been deleted',
+				'You were mentioned in a group conversation by a deleted user',
+				['You were mentioned in a group conversation by a deleted user',
 					[]
 				],
 				'… message',
@@ -300,8 +300,8 @@ class NotifierTest extends \Test\TestCase {
 			],
 			[
 				Room::GROUP_CALL,      ['userType' => 'users', 'userId' => 'testUser'],           ['ellipsisStart', 'ellipsisEnd'], null,        'Room name',
-				'You were mentioned in a group conversation by a user that has since been deleted: Room name',
-				['You were mentioned in a group conversation by a user that has since been deleted: {call}',
+				'You were mentioned in a group conversation by a deleted user: Room name',
+				['You were mentioned in a group conversation by a deleted user: {call}',
 					[
 						'call' => ['type' => 'call', 'id' => 'testRoomId', 'name' => 'Room name', 'call-type' => 'group']
 					]
@@ -318,8 +318,8 @@ class NotifierTest extends \Test\TestCase {
 			],
 			[
 				Room::PUBLIC_CALL,     ['userType' => 'users', 'userId' => 'testUser'],           ['ellipsisStart'], null,        '',
-				'You were mentioned in a group conversation by a user that has since been deleted',
-				['You were mentioned in a group conversation by a user that has since been deleted',
+				'You were mentioned in a group conversation by a deleted user',
+				['You were mentioned in a group conversation by a deleted user',
 					[]
 				],
 				'… message',
@@ -345,8 +345,8 @@ class NotifierTest extends \Test\TestCase {
 			],
 			[
 				Room::PUBLIC_CALL,     ['userType' => 'users', 'userId' => 'testUser'],           [], null,    'Room name',
-				'You were mentioned in a group conversation by a user that has since been deleted: Room name',
-				['You were mentioned in a group conversation by a user that has since been deleted: {call}',
+				'You were mentioned in a group conversation by a deleted user: Room name',
+				['You were mentioned in a group conversation by a deleted user: {call}',
 					[
 						'call' => ['type' => 'call', 'id' => 'testRoomId', 'name' => 'Room name', 'call-type' => 'public']
 					]


### PR DESCRIPTION
[As suggested by @jancborchardt](https://github.com/nextcloud/spreed/pull/500#issuecomment-356440981); although the meaning is not exactly the same (personally I would add back the _now_) the new wording is simpler and thus easier to understand.
