### PR TITLE
Fix tab header icons not shown

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -821,7 +821,8 @@ video {
 
 	a {
 		padding-left: 32px;
-		background: no-repeat 12px;
+		background-position: 12px;
+		background-repeat: no-repeat;
 		color: $color-main-text;
 		opacity: .5;
 	}


### PR DESCRIPTION
This pull request fixes a regression introduced in ac9a9494d48615a6f74162b0ca157bc4102f3617

Although in that commit the same change that caused this regression (replacing individual `background-XXX` properties with the general `background` property) was applied too to `.participantWithList li > a` in that case it does not seem to have caused any problem (the `background` property in that element it looks like dead code without any effect, by the way).

Before:
![tab-header-icon-before](https://user-images.githubusercontent.com/26858233/40794075-6e98f1b4-64fe-11e8-9ecd-5bee4e9de256.png)

After:
![tab-header-icon-after](https://user-images.githubusercontent.com/26858233/40794079-71a8c67c-64fe-11e8-809f-f3d87ae2e2bb.png)
