### PR TITLE
Mark messages directly as read when waiting for new messages.

### DIFF
--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -128,15 +128,15 @@ class ChatManager {
 
 		$comments = $this->commentsManager->getForObjectSinceTalkVersion('chat', $chatId, $offset, 'asc', $limit);
 
+		if ($user instanceof IUser) {
+			$this->commentsManager->setReadMark('chat', $chatId, new  \DateTime(), $user);
+		}
+
 		while (empty($comments) && $elapsedTime < $timeout) {
 			sleep(1);
 			$elapsedTime++;
 
 			$comments = $this->commentsManager->getForObjectSinceTalkVersion('chat', $chatId, $offset, 'asc', $limit);
-		}
-
-		if ($user instanceof IUser) {
-			$this->commentsManager->setReadMark('chat', $chatId, new  \DateTime(), $user);
 		}
 
 		return $comments;


### PR DESCRIPTION
**Before:**
Messages already read by the user were marked as 'read' after new messages were sent by the server.
When there were no new messages, this could take 30 seconds (timeout) until the server replied.
If the request was canceled by the user during this time, read messages were not marked as read.

**Now:**
Read messages are directly marked as 'read' when the user request new messages.