### PR TITLE
Fix local audio and video not disabled when not available

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -971,10 +971,12 @@ var spreedPeerConnectionTable = [];
 			}
 
 			if (!OCA.SpreedMe.webrtc.webrtc.isAudioEnabled()) {
+				app.disableAudio();
 				app.hasNoAudio();
 			}
 
 			if (!OCA.SpreedMe.webrtc.webrtc.isVideoEnabled()) {
+				app.disableVideo();
 				app.hasNoVideo();
 			}
 		});


### PR DESCRIPTION
When the streams are initialized and there is no audio or no video the `audio/videoNotFound` flag is set. This flag prevents the audio or video from being enabled later, and it is also used to discard calls to `disableAudio/Video`, as there would be no need to disable them if they were not found. However, in that last case, it is necessary to explicitly disable them before the flag is set.

The most evident problem of not disabling the video before setting `videoNotFound` can be seen when joining a call with microphone but without camera, as in that case an empty video would be shown instead of the avatar of the local user.

Before:
![local-video-before](https://user-images.githubusercontent.com/26858233/41034636-7d530510-698a-11e8-80cd-17cf4ef4fd6d.png)

After:
![local-video-after](https://user-images.githubusercontent.com/26858233/41034640-7fa16f6e-698a-11e8-92c8-21a5c5c61e92.png)
