### PR TITLE
Fix menu position for rooms and participants

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -658,11 +658,6 @@ video {
 	opacity: .3;
 }
 
-.bubble:not(.contactsmenu-popover),
-#app-navigation .app-navigation-entry-menu {
-	right: 4px;
-}
-
 #app-navigation .app-navigation-entry-menu li {
 	width: auto !important;
 	float: inherit;


### PR DESCRIPTION
Before:
![menu-position-rooms-before](https://user-images.githubusercontent.com/26858233/41036509-935b0f3c-6990-11e8-9160-4450dde1cca1.png)
![menu-position-participants-before](https://user-images.githubusercontent.com/26858233/41036513-95250584-6990-11e8-9267-16cc5df0e11b.png)

After:
![menu-position-rooms-after](https://user-images.githubusercontent.com/26858233/41036515-972a36d8-6990-11e8-9a2c-86a0a099ed70.png)
![menu-position-participants-after](https://user-images.githubusercontent.com/26858233/41036520-98bc63d6-6990-11e8-9efc-cb868ffe346f.png)
