### PR TITLE
Remove guest name input from sidebar as it already is in chat

### DIFF
--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -33,9 +33,6 @@
 		'{{#if showShareLink}}' +
 		'	<div class="clipboard-button"><span class="icon icon-clippy"></span></div>' +
 		'{{/if}}' +
-		'{{#if isGuest}}' +
-		'	<div class="guest-name"></div>' +
-		'{{/if}}' +
 		'{{#if participantInCall}}' +
 		'	<div>' +
 		'		<button class="leave-call primary">' + t('spreed', 'Leave call') + '</button>' +


### PR DESCRIPTION
No need to duplicate that, especially as there it just flies around in the middle of other controls.

Not needed since we already have it in the chat input, where it’s much more relevant.