### PR TITLE
Fix wording for 'Leave conversation'

### DIFF
--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -47,7 +47,7 @@
 								'<li>'+
 									'<button class="remove-room-button">'+
 										'<span class="{{#if isDeletable}}icon-close{{else}}icon-delete{{/if}}"></span>'+
-										'<span>'+t('spreed', 'Remove conversation from list')+'</span>'+
+										'<span>'+t('spreed', 'Leave conversation')+'</span>'+
 									'</button>'+
 								'</li>'+
 								'{{/if}}'+

--- a/tests/acceptance/features/bootstrap/ConversationListContext.php
+++ b/tests/acceptance/features/bootstrap/ConversationListContext.php
@@ -102,8 +102,8 @@ class ConversationListContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
-	public static function removeConversationFromListMenuItemFor($conversation) {
-		return self::conversationMenuItemFor($conversation, "Remove conversation from list");
+	public static function leaveConversationMenuItemFor($conversation) {
+		return self::conversationMenuItemFor($conversation, "Leave conversation");
 	}
 
 	/**
@@ -163,11 +163,11 @@ class ConversationListContext implements Context, ActorAwareInterface {
 	}
 
 	/**
-	 * @Given I remove the :conversation conversation from the list
+	 * @Given I leave the :conversation conversation
 	 */
 	public function iRemoveTheConversationFromTheList($conversation) {
 		$this->actor->find(self::conversationMenuButtonFor($conversation), 10)->click();
-		$this->actor->find(self::removeConversationFromListMenuItemFor($conversation), 2)->click();
+		$this->actor->find(self::leaveConversationMenuItemFor($conversation), 2)->click();
 	}
 
 	/**

--- a/tests/acceptance/features/conversation.feature
+++ b/tests/acceptance/features/conversation.feature
@@ -44,12 +44,12 @@ Feature: conversation
     And I see that the "admin" conversation is not active
     And I see that the number of participants shown in the list is "1"
 
-  Scenario: remove a conversation from the list
+  Scenario: leave a conversation
     Given I am logged in
     And I have opened the Talk app
     And I create a group conversation
     And I see that the "You" conversation is active
-    When I remove the "You" conversation from the list
+    When I leave the "You" conversation
     Then I see that the "You" conversation is not shown in the list
     And I see that the "Join a conversation or start a new one" empty content message is shown in the main view
     And I see that the sidebar is closed
@@ -79,12 +79,12 @@ Feature: conversation
     And I see that the "This conversation has ended" empty content message is shown in the main view
     And I see that the sidebar is closed
 
-  Scenario: create a new conversation after removing the active one
+  Scenario: create a new conversation after leaving the active one
     Given I am logged in
     And I have opened the Talk app
     And I create a group conversation
     And I see that the "You" conversation is active
-    And I remove the "You" conversation from the list
+    And I leave the "You" conversation
     And I see that the "You" conversation is not shown in the list
     And I see that the "Join a conversation or start a new one" empty content message is shown in the main view
     And I see that the sidebar is closed
@@ -95,7 +95,7 @@ Feature: conversation
     And I see that the number of participants shown in the list is "1"
     And I see that "user0" is shown in the list of participants as a moderator
 
-  Scenario: change to another conversation after removing the active one
+  Scenario: change to another conversation after leaving the active one
     Given I am logged in
     And I have opened the Talk app
     And I create a one-to-one conversation with "admin"
@@ -105,7 +105,7 @@ Feature: conversation
     And I see that the "admin" conversation is not active
     And I see that the "You" conversation is active
     And I see that the number of participants shown in the list is "1"
-    And I remove the "You" conversation from the list
+    And I leave the "You" conversation
     And I see that the "You" conversation is not shown in the list
     And I see that the "Join a conversation or start a new one" empty content message is shown in the main view
     And I see that the sidebar is closed


### PR DESCRIPTION
I had the same confusion as @diplodata in https://github.com/nextcloud/spreed/issues/849 where I wasn’t sure what the difference was between "Remove conversation from list" and "Delete conversation".

So now "Remove conversation from list" is "Leave conversation". :) 