### PR TITLE
Participant list whitespace

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -1057,6 +1057,7 @@ video {
 
 #app-sidebar .participantWithList {
 	overflow-y: auto;
+	padding-top: 8px;
 }
 
 #app-sidebar .participantWithList .participant:last-child {
@@ -1079,15 +1080,6 @@ video {
 #app-sidebar #participantsTabView form,
 #app-sidebar #participantsTabView .participantWithList {
 	margin-right: 15px;
-}
-
-/**
- * Add a little margin so the participants do not "touch" the form when they are
- * scrolled, in the same way that the chat messages do not disappear directly
- * below the new message input.
- */
-#app-sidebar #participantsTabView form {
-	margin-bottom: 15px;
 }
 
 /**

--- a/css/style.scss
+++ b/css/style.scss
@@ -1077,9 +1077,15 @@ video {
 	padding-bottom: 0;
 }
 
-#app-sidebar #participantsTabView form,
-#app-sidebar #participantsTabView .participantWithList {
+/* Form needs margin, participant list needs padding
+ * So the form has margin from the right side, but the scroll bar of the
+ * participant list is directly on the right.
+ */
+#app-sidebar #participantsTabView form {
 	margin-right: 15px;
+}
+#app-sidebar #participantsTabView .participantWithList {
+	padding-right: 15px;
 }
 
 /**


### PR DESCRIPTION
- Reduce whitespace between participant list and "Add" input because they belong closer together
- Make it so that the participant list scrolls below the input field and there’s no white "block"
- Fix the participant list scrollbar not being on the very right

Before:
![screenshot from 2018-06-21 08-33-04](https://user-images.githubusercontent.com/925062/41701775-f475f392-752d-11e8-9488-f709db4dbf84.png)

After:
![screenshot from 2018-06-21 08-31-53](https://user-images.githubusercontent.com/925062/41701776-f4a13b2e-752d-11e8-9dcc-62c24f3e682c.png)
