### PR TITLE
Fix name not shown for registered users without microphone nor camera

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -386,7 +386,9 @@ var spreedPeerConnectionTable = [];
 				spreedPeerConnectionTable[peer.id] = 0;
 
 				peer.pc.on('iceConnectionStateChange', function () {
+					var userId = spreedMappingTable[peer.id];
 					var avatar = $(newContainer).find('.avatar');
+					var nameIndicator = $(newContainer).find('.nameIndicator');
 					var mediaIndicator = $(newContainer).find('.mediaIndicator');
 					avatar.removeClass('icon-loading');
 					mediaIndicator.find('.iceFailedIndicator').addClass('not-failed');
@@ -400,6 +402,12 @@ var spreedPeerConnectionTable = [];
 						case 'completed': // on caller side
 							console.log('Connection established.');
 							avatar.css('opacity', '1');
+							// Ensure that the peer name is shown, as the name
+							// indicator for registered users without microphone
+							// nor camera will not be updated later.
+							if (userId && userId.length) {
+								nameIndicator.text(peer.nick);
+							}
 							// Send the current information about the video and microphone state
 							if (!OCA.SpreedMe.webrtc.webrtc.isVideoEnabled()) {
 								OCA.SpreedMe.webrtc.emit('videoOff');


### PR DESCRIPTION
When the peer is a registered user [her name is shown](https://github.com/nextcloud/spreed/blob/86f131021f23b6bde312b8260ac80f1a1a491a94/js/webrtc.js#L802) when [a stream is added for that peer](https://github.com/nextcloud/spreed/blob/a6a97da84be30908bf806c68f5afe00fc66e178d/js/simplewebrtc.js#L18226). However, if the peer has no microphone nor camera then no stream is added, and thus the name was not shown. Now the name is shown too when the connection is established to guarantee that it will be shown even if no stream is added.

In the case of guest users [the name is shown](https://github.com/nextcloud/spreed/blob/86f131021f23b6bde312b8260ac80f1a1a491a94/js/webrtc.js#L806) when a stream is added for that peer, but [also](https://github.com/nextcloud/spreed/blob/86f131021f23b6bde312b8260ac80f1a1a491a94/js/webrtc.js#L976) when [a `nickChanged` message is received](https://github.com/nextcloud/spreed/blob/86f131021f23b6bde312b8260ac80f1a1a491a94/js/webrtc.js#L775-L778). That message [is sent when the peers are connected](https://github.com/nextcloud/spreed/blob/86f131021f23b6bde312b8260ac80f1a1a491a94/js/webrtc.js#L414-L417), so the name of the guest user was already properly set even if the user has no microphone nor camera.

**How to test:**
- As user A, start a call with user B
- As user B, join the call with user A without granting permissions for microphone nor camera

**Expected result**
The display name of user B appears below her avatar in user A's screen

**Actual result**
User B's name does not appear in user A's screen
