### PR TITLE
Fix position of local container children in older Firefox versions

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -394,6 +394,7 @@ video {
 	max-height: 100% !important;
 	bottom: 0;
 	border-top-right-radius: 3px;
+	right: 0;
 }
 
 .videoContainer.promoted,
@@ -462,11 +463,13 @@ video {
 .participants-1 .videoView .nameIndicator,
 .participants-2 .videoView .nameIndicator {
 	left: initial;
+	right: 0;
 }
 
 .participants-1 .videoView .avatar-container,
 .participants-2 .videoView .avatar-container {
 	left: initial;
+	right: 0;
 }
 
 /* ellipsize name in 1on1 calls */


### PR DESCRIPTION
Before:
![local-video-position-before](https://user-images.githubusercontent.com/26858233/41715086-a0258bd4-7552-11e8-8d3c-326aa9dfa4eb.png)

After:
![local-video-position-after](https://user-images.githubusercontent.com/26858233/41715089-a224f870-7552-11e8-8c3c-e08cd0ebe284.png)
