### PR TITLE
Remove additional non-guideline padding in navigation entries

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -648,10 +648,6 @@ video {
 	display: none;
 }
 
-.participantWithList li > a,
-#app-navigation li > a {
-	padding-right: 44px !important;
-}
 #app-navigation .utils {
 	padding: 0;
 }


### PR DESCRIPTION
Before:
![screenshot from 2018-06-26 15-26-51](https://user-images.githubusercontent.com/925062/41915359-ce7612cc-7955-11e8-94ef-3472ccbfcbbd.png)

After:
![screenshot from 2018-06-26 15-26-35](https://user-images.githubusercontent.com/925062/41915360-cea1a874-7955-11e8-9de1-10497e0ea53f.png)


Please review @nextcloud/talk @nextcloud/designers @MariusBluem 