### PR TITLE
paste only plaintext into the chat input field

### DIFF
--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -77,6 +77,7 @@
 
 		events: {
 			'submit .newCommentForm': '_onSubmitComment',
+			'paste div.message': '_onPaste'
 		},
 
 		initialize: function() {
@@ -155,6 +156,18 @@
 					}
 				});
 			}.bind(this), 400);
+		},
+
+		/**
+		 * Limit pasting to plain text
+		 *
+		 * @param e
+		 * @private
+		 */
+		_onPaste: function (e) {
+			e.preventDefault();
+			var text = e.originalEvent.clipboardData.getData("text/plain");
+			document.execCommand('insertText', false, text);
 		},
 
 		template: Handlebars.compile(TEMPLATE),


### PR DESCRIPTION
When some marked-up content is in the clipboard, it will be formatted as HTML on paste into  the chat input field. The patch fixes it, according to how it is done in [file comments](https://github.com/nextcloud/server/blob/master/apps/comments/js/commentstabview.js#L757-L761). Since we accept plain text only as comment/chat data, it should be inserted as plain text directly.

Before:

![screenshot_20180704_003545](https://user-images.githubusercontent.com/2184312/42247688-31ae4996-7f22-11e8-805a-c0fbb2075302.png)

After:

![screenshot_20180704_003611](https://user-images.githubusercontent.com/2184312/42247712-40fc4da8-7f22-11e8-9540-9c440823d588.png)

Actually, it also affects what is exactly provided as chat message: 

![screenshot_20180704_004003](https://user-images.githubusercontent.com/2184312/42247826-cae45132-7f22-11e8-8885-5ac923ae214b.png)


(above before the patch, below after)

