### PR TITLE
Use the token instead of the id to identify the room objects

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -269,7 +269,7 @@ class Application extends App {
 
 			/** @var ChatManager $chatManager */
 			$chatManager = $this->getContainer()->query(ChatManager::class);
-			$chatManager->deleteMessages((string) $room->getId());
+			$chatManager->deleteMessages($room);
 		};
 		$dispatcher->addListener(Room::class . '::postDeleteRoom', $listener);
 	}

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -151,7 +151,7 @@ class ChatManager {
 	 * @param Room $chat
 	 */
 	public function deleteMessages(Room $chat) {
-		$this->commentsManager->deleteCommentsAtObject('chat', $chat->getId());
+		$this->commentsManager->deleteCommentsAtObject('chat', (string) $chat->getId());
 
 		$this->notifier->removePendingNotificationsForRoom($chat);
 	}

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -209,7 +209,7 @@ class ChatController extends OCSController {
 
 		$creationDateTime = new \DateTime('now', new \DateTimeZone('UTC'));
 
-		$comment = $this->chatManager->sendMessage((string) $room->getId(), $actorType, $actorId, $message, $creationDateTime);
+		$comment = $this->chatManager->sendMessage($room, $actorType, $actorId, $message, $creationDateTime);
 
 		$this->dispatcher->dispatch(ChatManager::class . '::sendMessage', new GenericEvent($room, [
 			'actorType' => $actorType,
@@ -266,9 +266,9 @@ class ChatController extends OCSController {
 
 		if ($lookIntoFuture) {
 			$currentUser = $this->userManager->get($this->userId);
-			$comments = $this->chatManager->waitForNewMessages((string) $room->getId(), $lastKnownMessageId, $limit, $timeout, $currentUser);
+			$comments = $this->chatManager->waitForNewMessages($room, $lastKnownMessageId, $limit, $timeout, $currentUser);
 		} else {
-			$comments = $this->chatManager->getHistory((string) $room->getId(), $lastKnownMessageId, $limit);
+			$comments = $this->chatManager->getHistory($room, $lastKnownMessageId, $limit);
 		}
 
 		if (empty($comments)) {

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -195,7 +195,7 @@ class RoomController extends OCSController {
 
 		$currentUser = $this->userManager->get($this->userId);
 		if ($currentUser instanceof IUser) {
-			$roomData['unreadMessages'] = $this->chatManager->getUnreadCount($room->getId(), $currentUser);
+			$roomData['unreadMessages'] = $this->chatManager->getUnreadCount($room, $currentUser);
 		}
 
 		// Sort by lastPing

--- a/lib/Notification/Hooks.php
+++ b/lib/Notification/Hooks.php
@@ -68,7 +68,7 @@ class Hooks {
 		try {
 			$notification->setApp('spreed')
 				->setDateTime($dateTime)
-				->setObject('room', $room->getId())
+				->setObject('room', $room->getToken())
 				->setSubject('invitation', [
 					'actorId' => $actor->getUID(),
 				]);
@@ -111,7 +111,7 @@ class Hooks {
 		try {
 			// Remove all old notifications for this room
 			$notification->setApp('spreed')
-				->setObject('room', $room->getId());
+				->setObject('room', $room->getToken());
 			$this->notificationManager->markProcessed($notification);
 
 			$notification->setObject('call', $room->getId());

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -81,7 +81,7 @@ class Notifier implements INotifier {
 		$l = $this->lFactory->get('spreed', $languageCode);
 
 		try {
-			$room = $this->manager->getRoomByToken((int) $notification->getObjectId());
+			$room = $this->manager->getRoomByToken($notification->getObjectId());
 		} catch (RoomNotFoundException $e) {
 			try {
 				// Before 3.2.3 the id was passed in notifications

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -33,7 +33,6 @@ use OCP\L10N\IFactory;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 use OCP\RichObjectStrings\Definitions;
-use OCP\RichObjectStrings\InvalidObjectExeption;
 
 class Notifier implements INotifier {
 
@@ -82,10 +81,15 @@ class Notifier implements INotifier {
 		$l = $this->lFactory->get('spreed', $languageCode);
 
 		try {
-			$room = $this->manager->getRoomById((int) $notification->getObjectId());
+			$room = $this->manager->getRoomByToken((int) $notification->getObjectId());
 		} catch (RoomNotFoundException $e) {
-			// Room does not exist
-			throw new \InvalidArgumentException('Invalid room');
+			try {
+				// Before 3.2.3 the id was passed in notifications
+				$room = $this->manager->getRoomById((int) $notification->getObjectId());
+			} catch (RoomNotFoundException $e) {
+				// Room does not exist
+				throw new \InvalidArgumentException('Invalid room');
+			}
 		}
 
 		$notification

--- a/tests/php/Chat/NotifierTest.php
+++ b/tests/php/Chat/NotifierTest.php
@@ -93,7 +93,7 @@ class NotifierTest extends \Test\TestCase {
 		return $comment;
 	}
 
-	private function newNotification($comment) {
+	private function newNotification($room, $comment) {
 		$notification = $this->createMock(INotification::class);
 
 		$notification->expects($this->once())
@@ -103,7 +103,7 @@ class NotifierTest extends \Test\TestCase {
 
 		$notification->expects($this->once())
 			->method('setObject')
-			->with('chat', $comment->getObjectId())
+			->with('chat', $room->getToken())
 			->willReturnSelf();
 
 		$notification->expects($this->once())
@@ -125,7 +125,12 @@ class NotifierTest extends \Test\TestCase {
 	public function testNotifyMentionedUsers() {
 		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'Mention @anotherUser');
 
-		$notification = $this->newNotification($comment);
+		$room = $this->createMock(Room::class);
+		$room->expects($this->any())
+			->method('getToken')
+			->willReturn('Token123');
+
+		$notification = $this->newNotification($room, $comment);
 
 		$this->notificationManager->expects($this->once())
 			->method('createNotification')
@@ -141,7 +146,6 @@ class NotifierTest extends \Test\TestCase {
 			->with($comment->getMessage())
 			->willReturnSelf();
 
-		$room = $this->createMock(Room::class);
 		$this->manager->expects($this->once())
 			->method('getRoomById')
 			->with('roomId')
@@ -158,13 +162,18 @@ class NotifierTest extends \Test\TestCase {
 			->method('notify')
 			->with($notification);
 
-		$this->notifier->notifyMentionedUsers($comment);
+		$this->notifier->notifyMentionedUsers($room, $comment);
 	}
 
 	public function testNotifyMentionedUsersByGuest() {
 		$comment = $this->newComment(108, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000016), 'Mention @anotherUser');
 
-		$notification = $this->newNotification($comment);
+		$room = $this->createMock(Room::class);
+		$room->expects($this->any())
+			->method('getToken')
+			->willReturn('Token123');
+
+		$notification = $this->newNotification($room, $comment);
 
 		$this->notificationManager->expects($this->once())
 			->method('createNotification')
@@ -180,7 +189,6 @@ class NotifierTest extends \Test\TestCase {
 			->with($comment->getMessage())
 			->willReturnSelf();
 
-		$room = $this->createMock(Room::class);
 		$this->manager->expects($this->once())
 			->method('getRoomById')
 			->with('roomId')
@@ -197,14 +205,19 @@ class NotifierTest extends \Test\TestCase {
 			->method('notify')
 			->with($notification);
 
-		$this->notifier->notifyMentionedUsers($comment);
+		$this->notifier->notifyMentionedUsers($room, $comment);
 	}
 
 	public function testNotifyMentionedUsersWithLongMessageStartMention() {
 		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016),
 			'123456789 @anotherUserWithOddLengthName 123456789-123456789-123456789-123456789-123456789-123456789');
 
-		$notification = $this->newNotification($comment);
+		$room = $this->createMock(Room::class);
+		$room->expects($this->any())
+			->method('getToken')
+			->willReturn('Token123');
+
+		$notification = $this->newNotification($room, $comment);
 
 		$this->notificationManager->expects($this->once())
 			->method('createNotification')
@@ -220,7 +233,6 @@ class NotifierTest extends \Test\TestCase {
 			->with('123456789 @anotherUserWithOddLengthName 123456789-123456789-1234', ['ellipsisEnd'])
 			->willReturnSelf();
 
-		$room = $this->createMock(Room::class);
 		$this->manager->expects($this->once())
 			->method('getRoomById')
 			->with('roomId')
@@ -237,14 +249,19 @@ class NotifierTest extends \Test\TestCase {
 			->method('notify')
 			->with($notification);
 
-		$this->notifier->notifyMentionedUsers($comment);
+		$this->notifier->notifyMentionedUsers($room, $comment);
 	}
 
 	public function testNotifyMentionedUsersWithLongMessageMiddleMention() {
 		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016),
 			'123456789-123456789-123456789-1234 @anotherUserWithOddLengthName 6789-123456789-123456789-123456789');
 
-		$notification = $this->newNotification($comment);
+		$room = $this->createMock(Room::class);
+		$room->expects($this->any())
+			->method('getToken')
+			->willReturn('Token123');
+
+		$notification = $this->newNotification($room, $comment);
 
 		$this->notificationManager->expects($this->once())
 			->method('createNotification')
@@ -260,7 +277,6 @@ class NotifierTest extends \Test\TestCase {
 			->with('89-123456789-1234 @anotherUserWithOddLengthName 6789-123456789-1', ['ellipsisStart', 'ellipsisEnd'])
 			->willReturnSelf();
 
-		$room = $this->createMock(Room::class);
 		$this->manager->expects($this->once())
 			->method('getRoomById')
 			->with('roomId')
@@ -277,14 +293,19 @@ class NotifierTest extends \Test\TestCase {
 			->method('notify')
 			->with($notification);
 
-		$this->notifier->notifyMentionedUsers($comment);
+		$this->notifier->notifyMentionedUsers($room, $comment);
 	}
 
 	public function testNotifyMentionedUsersWithLongMessageEndMention() {
 		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016),
 			'123456789-123456789-123456789-123456789-123456789-123456789 @anotherUserWithOddLengthName 123456789');
 
-		$notification = $this->newNotification($comment);
+		$room = $this->createMock(Room::class);
+		$room->expects($this->any())
+			->method('getToken')
+			->willReturn('Token123');
+
+		$notification = $this->newNotification($room, $comment);
 
 		$this->notificationManager->expects($this->once())
 			->method('createNotification')
@@ -300,7 +321,6 @@ class NotifierTest extends \Test\TestCase {
 			->with('6789-123456789-123456789 @anotherUserWithOddLengthName 123456789', ['ellipsisStart'])
 			->willReturnSelf();
 
-		$room = $this->createMock(Room::class);
 		$this->manager->expects($this->once())
 			->method('getRoomById')
 			->with('roomId')
@@ -317,35 +337,50 @@ class NotifierTest extends \Test\TestCase {
 			->method('notify')
 			->with($notification);
 
-		$this->notifier->notifyMentionedUsers($comment);
+		$this->notifier->notifyMentionedUsers($room, $comment);
 	}
 
 	public function testNotifyMentionedUsersToSelf() {
 		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'Mention @testUser');
 
+		$room = $this->createMock(Room::class);
+		$room->expects($this->any())
+			->method('getToken')
+			->willReturn('Token123');
+
 		$this->notificationManager->expects($this->never())
 			->method('createNotification');
 
 		$this->notificationManager->expects($this->never())
 			->method('notify');
 
-		$this->notifier->notifyMentionedUsers($comment);
+		$this->notifier->notifyMentionedUsers($room, $comment);
 	}
 
 	public function testNotifyMentionedUsersToUnknownUser() {
 		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'Mention @unknownUser');
 
+		$room = $this->createMock(Room::class);
+		$room->expects($this->any())
+			->method('getToken')
+			->willReturn('Token123');
+
 		$this->notificationManager->expects($this->never())
 			->method('createNotification');
 
 		$this->notificationManager->expects($this->never())
 			->method('notify');
 
-		$this->notifier->notifyMentionedUsers($comment);
+		$this->notifier->notifyMentionedUsers($room, $comment);
 	}
 
 	public function testNotifyMentionedUsersToUserNotInvitedToChat() {
 		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'Mention @userNotInOneToOneChat');
+
+		$room = $this->createMock(Room::class);
+		$room->expects($this->any())
+			->method('getToken')
+			->willReturn('Token123');
 
 		$this->notificationManager->expects($this->never())
 			->method('createNotification');
@@ -367,11 +402,16 @@ class NotifierTest extends \Test\TestCase {
 		$this->notificationManager->expects($this->never())
 			->method('notify');
 
-		$this->notifier->notifyMentionedUsers($comment);
+		$this->notifier->notifyMentionedUsers($room, $comment);
 	}
 
 	public function testNotifyMentionedUsersNoMentions() {
 		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'No mentions');
+
+		$room = $this->createMock(Room::class);
+		$room->expects($this->any())
+			->method('getToken')
+			->willReturn('Token123');
 
 		$this->notificationManager->expects($this->never())
 			->method('createNotification');
@@ -379,14 +419,19 @@ class NotifierTest extends \Test\TestCase {
 		$this->notificationManager->expects($this->never())
 			->method('notify');
 
-		$this->notifier->notifyMentionedUsers($comment);
+		$this->notifier->notifyMentionedUsers($room, $comment);
 	}
 
 	public function testNotifyMentionedUsersSeveralMentions() {
 		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'Mention @anotherUser, and @unknownUser, and @testUser, and @userAbleToJoin');
 
-		$anotherUserNotification = $this->newNotification($comment);
-		$userAbleToJoinNotification = $this->newNotification($comment);
+		$room = $this->createMock(Room::class);
+		$room->expects($this->any())
+			->method('getToken')
+			->willReturn('Token123');
+
+		$anotherUserNotification = $this->newNotification($room, $comment);
+		$userAbleToJoinNotification = $this->newNotification($room, $comment);
 
 		$this->notificationManager->expects($this->exactly(2))
 			->method('createNotification')
@@ -415,7 +460,6 @@ class NotifierTest extends \Test\TestCase {
 			->with('notherUser, and @unknownUser, and @testUser, and @userAbleToJoin')
 			->willReturnSelf();
 
-		$room = $this->createMock(Room::class);
 		$this->manager->expects($this->exactly(2))
 			->method('getRoomById')
 			->with('roomId')
@@ -435,11 +479,16 @@ class NotifierTest extends \Test\TestCase {
 				[ $userAbleToJoinNotification ]
 			);
 
-		$this->notifier->notifyMentionedUsers($comment);
+		$this->notifier->notifyMentionedUsers($room, $comment);
 	}
 
 	public function testRemovePendingNotificationsForRoom() {
 		$notification = $this->createMock(INotification::class);
+
+		$room = $this->createMock(Room::class);
+		$room->expects($this->any())
+			->method('getToken')
+			->willReturn('Token123');
 
 		$this->notificationManager->expects($this->once())
 			->method('createNotification')
@@ -453,9 +502,9 @@ class NotifierTest extends \Test\TestCase {
 		$notification->expects($this->exactly(3))
 			->method('setObject')
 			->withConsecutive(
-				['chat', 'testChatId'],
-				['room', 'testChatId'],
-				['call', 'testChatId']
+				['chat', 'Token123'],
+				['room', 'Token123'],
+				['call', 'Token123']
 			)
 			->willReturnSelf();
 
@@ -463,7 +512,7 @@ class NotifierTest extends \Test\TestCase {
 			->method('markProcessed')
 			->with($notification);
 
-		$this->notifier->removePendingNotificationsForRoom('testChatId');
+		$this->notifier->removePendingNotificationsForRoom($room);
 	}
 
 }

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -158,13 +158,9 @@ class ChatControllerTest extends \Test\TestCase {
 		$this->manager->expects($this->never())
 			->method('getRoomForParticipantByToken');
 
-		$this->room->expects($this->once())
-			->method('getId')
-			->willReturn(1234);
-
 		$this->chatManager->expects($this->once())
 			->method('sendMessage')
-			->with('1234',
+			->with($this->room,
 				   'users',
 				   $this->userId,
 				   'testMessage',
@@ -197,13 +193,9 @@ class ChatControllerTest extends \Test\TestCase {
 			->method('getParticipant')
 			->with($this->userId);
 
-		$this->room->expects($this->once())
-			->method('getId')
-			->willReturn(1234);
-
 		$this->chatManager->expects($this->once())
 			->method('sendMessage')
-			->with('1234',
+			->with($this->room,
 				   'users',
 				   $this->userId,
 				   'testMessage',
@@ -263,13 +255,9 @@ class ChatControllerTest extends \Test\TestCase {
 		$this->manager->expects($this->never())
 			->method('getRoomForParticipantByToken');
 
-		$this->room->expects($this->once())
-			->method('getId')
-			->willReturn(1234);
-
 		$this->chatManager->expects($this->once())
 			->method('sendMessage')
-			->with('1234',
+			->with($this->room,
 				   'guests',
 				   sha1('testSpreedSession'),
 				   'testMessage',
@@ -347,15 +335,11 @@ class ChatControllerTest extends \Test\TestCase {
 		$this->manager->expects($this->never())
 			->method('getRoomForParticipantByToken');
 
-		$this->room->expects($this->once())
-			->method('getId')
-			->willReturn(1234);
-
 		$offset = 23;
 		$limit = 4;
 		$this->chatManager->expects($this->once())
 			->method('getHistory')
-			->with('1234', $offset, $limit)
+			->with($this->room, $offset, $limit)
 			->willReturn([
 				$comment4 = $this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
 				$comment3 = $this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
@@ -415,15 +399,11 @@ class ChatControllerTest extends \Test\TestCase {
 			->method('getParticipant')
 			->with($this->userId);
 
-		$this->room->expects($this->once())
-			->method('getId')
-			->willReturn(1234);
-
 		$offset = 23;
 		$limit = 4;
 		$this->chatManager->expects($this->once())
 			->method('getHistory')
-			->with('1234', $offset, $limit)
+			->with($this->room, $offset, $limit)
 			->willReturn([
 				$comment4 = $this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
 				$comment3 = $this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
@@ -512,15 +492,11 @@ class ChatControllerTest extends \Test\TestCase {
 		$this->manager->expects($this->never())
 			->method('getRoomForParticipantByToken');
 
-		$this->room->expects($this->once())
-			->method('getId')
-			->willReturn(1234);
-
 		$offset = 23;
 		$limit = 4;
 		$this->chatManager->expects($this->once())
 			->method('getHistory')
-			->with('1234', $offset, $limit)
+			->with($this->room, $offset, $limit)
 			->willReturn([
 				$comment4 = $this->newComment(111, 'users', 'testUser', new \DateTime('@' . 1000000016), 'testMessage4'),
 				$comment3 = $this->newComment(110, 'users', 'testUnknownUser', new \DateTime('@' . 1000000015), 'testMessage3'),
@@ -627,10 +603,6 @@ class ChatControllerTest extends \Test\TestCase {
 		$this->manager->expects($this->never())
 			->method('getRoomForParticipantByToken');
 
-		$this->room->expects($this->once())
-			->method('getId')
-			->willReturn(1234);
-
 		$testUser = $this->createMock(IUser::class);
 		$testUser->expects($this->any())
 			->method('getUID')
@@ -644,7 +616,7 @@ class ChatControllerTest extends \Test\TestCase {
 		$timeout = 10;
 		$this->chatManager->expects($this->once())
 			->method('waitForNewMessages')
-			->with('1234', $offset, $limit, $timeout, $testUser)
+			->with($this->room, $offset, $limit, $timeout, $testUser)
 			->willReturn([
 				$comment1 = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000004), 'testMessage1'),
 				$comment2 = $this->newComment(109, 'guests', 'testSpreedSession', new \DateTime('@' . 1000000008), 'testMessage2'),
@@ -695,10 +667,6 @@ class ChatControllerTest extends \Test\TestCase {
 		$this->manager->expects($this->never())
 			->method('getRoomForParticipantByToken');
 
-		$this->room->expects($this->once())
-			->method('getId')
-			->willReturn(1234);
-
 		$testUser = $this->createMock(IUser::class);
 		$testUser->expects($this->any())
 			->method('getUID')
@@ -709,7 +677,7 @@ class ChatControllerTest extends \Test\TestCase {
 		$timeout = 3;
 		$this->chatManager->expects($this->once())
 			->method('waitForNewMessages')
-			->with('1234', $offset, $limit, $timeout, $testUser)
+			->with($this->room, $offset, $limit, $timeout, $testUser)
 			->willReturn([]);
 
 		$this->userManager->expects($this->any())
@@ -737,10 +705,6 @@ class ChatControllerTest extends \Test\TestCase {
 		$this->manager->expects($this->never())
 			->method('getRoomForParticipantByToken');
 
-		$this->room->expects($this->once())
-			->method('getId')
-			->willReturn(1234);
-
 		$testUser = $this->createMock(IUser::class);
 		$testUser->expects($this->any())
 			->method('getUID')
@@ -752,7 +716,7 @@ class ChatControllerTest extends \Test\TestCase {
 		$limit = 4;
 		$this->chatManager->expects($this->once())
 			->method('waitForNewMessages')
-			->with('1234', $offset, $limit, $maximumTimeout, $testUser)
+			->with($this->room, $offset, $limit, $maximumTimeout, $testUser)
 			->willReturn([]);
 
 		$this->userManager->expects($this->any())

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -93,7 +93,7 @@ class NotifierTest extends \Test\TestCase {
 			->method('getType')
 			->willReturn(Room::ONE_TO_ONE_CALL);
 		$this->manager->expects($this->once())
-			->method('getRoomById')
+			->method('getRoomByToken')
 			->willReturn($room);
 
 		$this->lFactory->expects($this->once())
@@ -180,7 +180,7 @@ class NotifierTest extends \Test\TestCase {
 			->method('getName')
 			->willReturn($name);
 		$this->manager->expects($this->once())
-			->method('getRoomById')
+			->method('getRoomByToken')
 			->willReturn($room);
 
 		$this->lFactory->expects($this->once())
@@ -398,7 +398,7 @@ class NotifierTest extends \Test\TestCase {
 				->willReturn('testRoomId');
 		}
 		$this->manager->expects($this->once())
-			->method('getRoomById')
+			->method('getRoomByToken')
 			->willReturn($room);
 
 		$this->lFactory->expects($this->once())
@@ -499,15 +499,18 @@ class NotifierTest extends \Test\TestCase {
 
 		if ($validRoom === null) {
 			$this->manager->expects($this->never())
-				->method('getRoomById');
+				->method('getRoomByToken');
 		} else if ($validRoom === true) {
 			$room = $this->createMock(Room::class);
 			$room->expects($this->never())
 				->method('getType');
 			$this->manager->expects($this->once())
-				->method('getRoomById')
+				->method('getRoomByToken')
 				->willReturn($room);
 		} else if ($validRoom === false) {
+			$this->manager->expects($this->once())
+				->method('getRoomByToken')
+				->willThrowException(new RoomNotFoundException());
 			$this->manager->expects($this->once())
 				->method('getRoomById')
 				->willThrowException(new RoomNotFoundException());


### PR DESCRIPTION
Changes the object id from room id to the token, so you can query the room to get the full information for it

Fix #1001