### PR TITLE
Always notify in one2one rooms

### DIFF
--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -27,7 +27,6 @@ use OCA\Spreed\Room;
 use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
-use OCP\IDBConnection;
 use OCP\IUser;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -118,6 +117,9 @@ class ChatManager {
 			$notifiedUsers = $this->notifier->notifyMentionedUsers($chat, $comment);
 			if (!empty($notifiedUsers)) {
 				$chat->markUsersAsMentioned($notifiedUsers, $creationDateTime);
+			} else if ($chat->getType() === Room::ONE_TO_ONE_CALL) {
+				// User was not mentioned, send a normal notification
+				$this->notifier->notifyOtherParticipant($chat, $comment);
 			}
 
 			$this->dispatcher->dispatch(self::class . '::sendMessage', new GenericEvent($chat, [

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -97,7 +97,7 @@ class Notifier implements INotifier {
 		if ($subject === 'call') {
 			return $this->parseCall($notification, $room, $l);
 		}
-		if ($subject === 'mention') {
+		if ($subject === 'mention' ||  $subject === 'chat') {
 			return $this->parseMention($notification, $room, $l);
 		}
 
@@ -157,7 +157,16 @@ class Notifier implements INotifier {
 		}
 		$notification->setParsedMessage($parsedMessage);
 
-		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
+		if ($notification->getSubject() === 'chat') {
+			$notification
+				->setParsedSubject(str_replace('{user}', $user->getDisplayName(), $l->t('{user} sent you a private message')))
+				->setRichSubject(
+					$l->t('{user} sent you a private message'), [
+						'user' => $richSubjectUser
+					]
+				);
+
+		} else if ($room->getType() === Room::ONE_TO_ONE_CALL) {
 			$notification
 				->setParsedSubject(
 					$l->t('%s mentioned you in a private conversation', [$user->getDisplayName()])

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -451,7 +451,7 @@ class NotifierTest extends \Test\TestCase {
 		$notification->expects($this->once())
 			->method('getApp')
 			->willReturn('spreed');
-		$notification->expects($this->once())
+		$notification->expects($this->exactly(2))
 			->method('getSubject')
 			->willReturn('mention');
 		$notification->expects($this->once())


### PR DESCRIPTION
- [x] Based on #1067 

Notification is only send, when you don't have an active session for the room.
Or should we still do this, so you beep-boop when you have the tab open somewhere in the background? @mario @jancborchardt 

Fix #875

