### PR TITLE
Add support for room shares

### DIFF
--- a/js/richobjectstringparser.js
+++ b/js/richobjectstringparser.js
@@ -16,7 +16,7 @@
 		_userLocalTemplate: '<span class="mention-user {{#if isCurrentUser}}current-user{{/if}}" data-user="{{id}}">@{{name}}</span>',
 
 		_unknownTemplate: '<strong>{{name}}</strong>',
-		_unknownLinkTemplate: '<a href="{{link}}">{{name}}</a>',
+		_unknownLinkTemplate: '<a href="{{link}}" class="external" target="_blank" rel="noopener noreferrer"><strong>{{name}}</strong></a>',
 
 		/**
 		 * @param {string} subject

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -29,6 +29,7 @@ use OCA\Spreed\Config;
 use OCA\Spreed\GuestManager;
 use OCA\Spreed\HookListener;
 use OCA\Spreed\Notification\Notifier;
+use OCA\Spreed\Participant;
 use OCA\Spreed\Room;
 use OCA\Spreed\Settings\Personal;
 use OCA\Spreed\Signaling\BackendNotifier;
@@ -70,6 +71,7 @@ class Application extends App {
 		$this->registerRoomInvitationHook($dispatcher);
 		$this->registerCallNotificationHook($dispatcher);
 		$this->registerChatHooks($dispatcher);
+		$this->registerRoomHooks($dispatcher);
 		$this->registerClientLinks($server);
 
 		/** @var Listener $systemMessageListener */
@@ -318,6 +320,40 @@ class Application extends App {
 			/** @var ChatManager $chatManager */
 			$chatManager = $this->getContainer()->query(ChatManager::class);
 			$chatManager->deleteMessages($room);
+		};
+		$dispatcher->addListener(Room::class . '::postDeleteRoom', $listener);
+	}
+
+	protected function registerRoomHooks(EventDispatcherInterface $dispatcher) {
+		$listener = function(GenericEvent $event)  {
+			/** @var Room $room */
+			$room = $event->getSubject();
+
+			if ($event->getArgument('selfJoin')) {
+				/** @var \OCA\Spreed\Share\RoomShareProvider $roomShareProvider */
+				$roomShareProvider = $this->getContainer()->query(\OCA\Spreed\Share\RoomShareProvider::class);
+				$roomShareProvider->deleteInRoom($room->getToken(), $event->getArgument('userId'));
+			}
+		};
+		$dispatcher->addListener(Room::class . '::postUserDisconnectRoom', $listener);
+
+		$listener = function(GenericEvent $event) {
+			/** @var Room $room */
+			$room = $event->getSubject();
+
+			/** @var \OCA\Spreed\Share\RoomShareProvider $roomShareProvider */
+			$roomShareProvider = $this->getContainer()->query(\OCA\Spreed\Share\RoomShareProvider::class);
+			$roomShareProvider->deleteInRoom($room->getToken(), $event->getArgument('user')->getUID());
+		};
+		$dispatcher->addListener(Room::class . '::postRemoveUser', $listener);
+
+		$listener = function(GenericEvent $event) {
+			/** @var Room $room */
+			$room = $event->getSubject();
+
+			/** @var \OCA\Spreed\Share\RoomShareProvider $roomShareProvider */
+			$roomShareProvider = $this->getContainer()->query(\OCA\Spreed\Share\RoomShareProvider::class);
+			$roomShareProvider->deleteInRoom($room->getToken());
 		};
 		$dispatcher->addListener(Room::class . '::postDeleteRoom', $listener);
 	}

--- a/lib/Share/Helper/DeletedShareAPIController.php
+++ b/lib/Share/Helper/DeletedShareAPIController.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+/**
+ *
+ * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Share\Helper;
+
+use OCA\Spreed\Exceptions\RoomNotFoundException;
+use OCA\Spreed\Manager;
+use OCA\Spreed\Room;
+use OCP\IUserManager;
+use OCP\Share\IShare;
+
+/**
+ * Helper of OCA\Files_Sharing\Controller\DeletedShareAPIController for room
+ * shares.
+ *
+ * The methods of this class are called from the DeletedShareAPIController to
+ * perform actions or checks specific to room shares.
+ */
+class DeletedShareAPIController {
+
+	/** @var string */
+	private $userId;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var Manager */
+	private $manager;
+
+	/**
+	 * DeletedShareAPIController constructor.
+	 *
+	 * @param string $UserId
+	 * @param IUserManager $userManager
+	 * @param Manager $manager
+	 */
+	public function __construct(
+			string $UserId,
+			IUserManager $userManager,
+			Manager $manager
+	) {
+		$this->userId = $UserId;
+		$this->userManager = $userManager;
+		$this->manager = $manager;
+	}
+
+	/**
+	 * Formats the specific fields of a room share for OCS output.
+	 *
+	 * The returned fields override those set by the main
+	 * DeletedShareAPIController.
+	 *
+	 * @param IShare $share
+	 * @return array
+	 */
+	public function formatShare(IShare $share): array {
+		$result = [];
+
+		try {
+			$room = $this->manager->getRoomByToken($share->getSharedWith());
+		} catch (RoomNotFoundException $e) {
+			return $result;
+		}
+
+		// The display name of one-to-one rooms is set to the display name of
+		// the other participant.
+		$roomName = $room->getName();
+		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
+			$participantsList = $room->getParticipants()['users'];
+			unset($participantsList[$this->userId]);
+
+			$roomName = $this->userManager->get(key($participantsList))->getDisplayName();
+		}
+
+		$result['share_with_displayname'] = $roomName;
+
+		return $result;
+	}
+
+}

--- a/lib/Share/Helper/ShareAPIController.php
+++ b/lib/Share/Helper/ShareAPIController.php
@@ -1,0 +1,182 @@
+<?php
+declare(strict_types=1);
+
+/**
+ *
+ * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Share\Helper;
+
+use OCA\Spreed\Exceptions\ParticipantNotFoundException;
+use OCA\Spreed\Exceptions\RoomNotFoundException;
+use OCA\Spreed\Manager;
+use OCA\Spreed\Room;
+use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\IL10N;
+use OCP\IUserManager;
+use OCP\Share\IShare;
+
+/**
+ * Helper of OCA\Files_Sharing\Controller\ShareAPIController for room shares.
+ *
+ * The methods of this class are called from the ShareAPIController to perform
+ * actions or checks specific to room shares.
+ */
+class ShareAPIController {
+
+	/** @var string */
+	private $userId;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var Manager */
+	private $manager;
+
+	/** @var IL10N */
+	private $l;
+
+	/**
+	 * ShareAPIController constructor.
+	 *
+	 * @param string $UserId
+	 * @param IUserManager $userManager
+	 * @param Manager $manager
+	 * @param IL10N $l10n
+	 */
+	public function __construct(
+			string $UserId,
+			IUserManager $userManager,
+			Manager $manager,
+			IL10N $l10n
+	) {
+		$this->userId = $UserId;
+		$this->userManager = $userManager;
+		$this->manager = $manager;
+		$this->l = $l10n;
+	}
+
+	/**
+	 * Formats the specific fields of a room share for OCS output.
+	 *
+	 * The returned fields override those set by the main ShareAPIController.
+	 *
+	 * @param IShare $share
+	 * @return array
+	 */
+	public function formatShare(IShare $share): array {
+		$result = [];
+
+		try {
+			$room = $this->manager->getRoomByToken($share->getSharedWith());
+		} catch (RoomNotFoundException $e) {
+			return $result;
+		}
+
+		// The display name of one-to-one rooms is set to the display name of
+		// the other participant.
+		$roomName = $room->getName();
+		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
+			$participantsList = $room->getParticipants()['users'];
+			unset($participantsList[$this->userId]);
+
+			$roomName = $this->userManager->get(key($participantsList))->getDisplayName();
+		}
+
+		$result['share_with_displayname'] = $roomName;
+
+		return $result;
+	}
+
+	/**
+	 * Prepares the given share to be passed to OC\Share20\Manager::createShare.
+	 *
+	 * @param IShare $share
+	 * @param string $shareWith
+	 * @param int $permissions
+	 * @param string $expireDate
+	 */
+	public function createShare(IShare $share, string $shareWith, int $permissions, string $expireDate) {
+		$share->setSharedWith($shareWith);
+		$share->setPermissions($permissions);
+
+		if ($expireDate !== '') {
+			try {
+				$expireDate = $this->parseDate($expireDate);
+				$share->setExpirationDate($expireDate);
+			} catch (\Exception $e) {
+				throw new OCSNotFoundException($this->l->t('Invalid date, date format must be YYYY-MM-DD'));
+			}
+		}
+	}
+
+	/**
+	 * Make sure that the passed date is valid ISO 8601
+	 * So YYYY-MM-DD
+	 * If not throw an exception
+	 *
+	 * Copied from \OCA\Files_Sharing\Controller\ShareAPIController::parseDate.
+	 *
+	 * @param string $expireDate
+	 * @return \DateTime
+	 * @throws \Exception
+	 */
+	private function parseDate(string $expireDate): \DateTime {
+		try {
+			$date = new \DateTime($expireDate);
+		} catch (\Exception $e) {
+			throw new \Exception('Invalid date. Format must be YYYY-MM-DD');
+		}
+
+		if ($date === false) {
+			throw new \Exception('Invalid date. Format must be YYYY-MM-DD');
+		}
+
+		$date->setTime(0, 0, 0);
+
+		return $date;
+	}
+
+	/**
+	 * Returns whether the given user can access the given room share or not.
+	 *
+	 * A user can access a room share only if she is a participant of the room.
+	 *
+	 * @param IShare $share
+	 * @param string $user
+	 * @return bool
+	 */
+	public function canAccessShare(IShare $share, string $user): bool {
+		try {
+			$room = $this->manager->getRoomByToken($share->getSharedWith());
+		} catch (RoomNotFoundException $e) {
+			return false;
+		}
+
+		try {
+			$room->getParticipant($user);
+		} catch (ParticipantNotFoundException $e) {
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/lib/Share/Helper/ShareAPIController.php
+++ b/lib/Share/Helper/ShareAPIController.php
@@ -102,6 +102,10 @@ class ShareAPIController {
 
 		$result['share_with_displayname'] = $roomName;
 
+		if ($room->getType() === Room::PUBLIC_CALL) {
+			$result['token'] = $share->getToken();
+		}
+
 		return $result;
 	}
 

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -388,7 +388,22 @@ class RoomShareProvider implements IShareProvider {
 	 * @throws ShareNotFound
 	 */
 	public function getShareById($id, $recipientId = null) {
-		throw new \Exception("Not implemented");
+		$qb = $this->dbConnection->getQueryBuilder();
+
+		$qb->select('*')
+			->from('share')
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)))
+			->andWhere($qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_ROOM)));
+
+		$cursor = $qb->execute();
+		$data = $cursor->fetch();
+		$cursor->closeCursor();
+
+		if ($data === false) {
+			throw new ShareNotFound();
+		}
+
+		return $this->createShareObject($data);
 	}
 
 	/**

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -1,0 +1,245 @@
+<?php
+declare(strict_types=1);
+
+/**
+ *
+ * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Share;
+
+use OCP\Files\Folder;
+use OCP\Files\Node;
+use OCP\Share\Exceptions\GenericShareException;
+use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\IShare;
+use OCP\Share\IShareProvider;
+
+/**
+ * Share provider for room shares.
+ *
+ * Files are shared with a room identified by its token; only users currently in
+ * the room can share with and access the shared files (although the access
+ * checks are not enforced by the provider, but done on a higher layer).
+ *
+ * Like in group shares, a recipient can move or delete a share without
+ * modifying the share for the other users in the room.
+ */
+class RoomShareProvider implements IShareProvider {
+
+	/**
+	 * Return the identifier of this provider.
+	 *
+	 * @return string Containing only [a-zA-Z0-9]
+	 */
+	public function identifier() {
+		return 'ocRoomShare';
+	}
+
+	/**
+	 * Create a share
+	 *
+	 * @param IShare $share
+	 * @return IShare The share object
+	 */
+	public function create(IShare $share) {
+		throw new \Exception("Not implemented");
+	}
+
+	/**
+	 * Update a share
+	 *
+	 * @param IShare $share
+	 * @return IShare The share object
+	 */
+	public function update(IShare $share) {
+		throw new \Exception("Not implemented");
+	}
+
+	/**
+	 * Delete a share
+	 *
+	 * @param IShare $share
+	 */
+	public function delete(IShare $share) {
+		throw new \Exception("Not implemented");
+	}
+
+	/**
+	 * Unshare a file from self as recipient.
+	 * If a user unshares a room share from their self then the original room
+	 * share should still exist.
+	 *
+	 * @param IShare $share
+	 * @param string $recipient UserId of the recipient
+	 */
+	public function deleteFromSelf(IShare $share, $recipient) {
+		throw new \Exception("Not implemented");
+	}
+
+	/**
+	 * Restore a share for a given recipient. The implementation could be provider independant.
+	 *
+	 * @param IShare $share
+	 * @param string $recipient
+	 * @return IShare The restored share object
+	 * @throws GenericShareException In case the share could not be restored
+	 */
+	public function restore(IShare $share, string $recipient): IShare {
+		throw new \Exception("Not implemented");
+	}
+
+	/**
+	 * Move a share as a recipient.
+	 * This is updating the share target. Thus the mount point of the recipient.
+	 * This may require special handling. If a user moves a group share
+	 * the target should only be changed for them.
+	 *
+	 * @param IShare $share
+	 * @param string $recipient userId of recipient
+	 * @return IShare
+	 */
+	public function move(IShare $share, $recipient) {
+		throw new \Exception("Not implemented");
+	}
+
+	/**
+	 * Get all shares by the given user in a folder
+	 *
+	 * @param string $userId
+	 * @param Folder $node
+	 * @param bool $reshares Also get the shares where $user is the owner instead of just the shares where $user is the initiator
+	 * @return IShare[]
+	 */
+	public function getSharesInFolder($userId, Folder $node, $reshares) {
+		throw new \Exception("Not implemented");
+	}
+
+	/**
+	 * Get all shares by the given user
+	 *
+	 * @param string $userId
+	 * @param int $shareType
+	 * @param Node|null $node
+	 * @param bool $reshares Also get the shares where $user is the owner instead of just the shares where $user is the initiator
+	 * @param int $limit The maximum number of shares to be returned, -1 for all shares
+	 * @param int $offset
+	 * @return IShare[]
+	 */
+	public function getSharesBy($userId, $shareType, $node, $reshares, $limit, $offset) {
+		throw new \Exception("Not implemented");
+	}
+
+	/**
+	 * Get share by id
+	 *
+	 * @param int $id
+	 * @param string|null $recipientId
+	 * @return IShare
+	 * @throws ShareNotFound
+	 */
+	public function getShareById($id, $recipientId = null) {
+		throw new \Exception("Not implemented");
+	}
+
+	/**
+	 * Get shares for a given path
+	 *
+	 * @param Node $path
+	 * @return IShare[]
+	 */
+	public function getSharesByPath(Node $path) {
+		throw new \Exception("Not implemented");
+	}
+
+	/**
+	 * Get shared with the given user
+	 *
+	 * @param string $userId get shares where this user is the recipient
+	 * @param int $shareType
+	 * @param Node|null $node
+	 * @param int $limit The max number of entries returned, -1 for all
+	 * @param int $offset
+	 * @return IShare[]
+	 */
+	public function getSharedWith($userId, $shareType, $node, $limit, $offset) {
+		throw new \Exception("Not implemented");
+	}
+
+	/**
+	 * Get a share by token
+	 *
+	 * Note that token here refers to share token, not room token.
+	 *
+	 * @param string $token
+	 * @return IShare
+	 * @throws ShareNotFound
+	 */
+	public function getShareByToken($token) {
+		throw new \Exception("Not implemented");
+	}
+
+	/**
+	 * A user is deleted from the system
+	 * So clean up the relevant shares.
+	 *
+	 * @param string $uid
+	 * @param int $shareType
+	 */
+	public function userDeleted($uid, $shareType) {
+		throw new \Exception("Not implemented");
+	}
+
+	/**
+	 * A group is deleted from the system.
+	 * We have to clean up all shares to this group.
+	 * Providers not handling group shares should just return
+	 *
+	 * @param string $gid
+	 */
+	public function groupDeleted($gid) {
+		throw new \Exception("Not implemented");
+	}
+
+	/**
+	 * A user is deleted from a group
+	 * We have to clean up all the related user specific group shares
+	 * Providers not handling group shares should just return
+	 *
+	 * @param string $uid
+	 * @param string $gid
+	 */
+	public function userDeletedFromGroup($uid, $gid) {
+		throw new \Exception("Not implemented");
+	}
+
+	/**
+	 * Get the access list to the array of provided nodes.
+	 *
+	 * @see IManager::getAccessList() for sample docs
+	 *
+	 * @param Node[] $nodes The list of nodes to get access for
+	 * @param bool $currentAccess If current access is required (like for removed shares that might get revived later)
+	 * @return array
+	 */
+	public function getAccessList($nodes, $currentAccess) {
+		throw new \Exception("Not implemented");
+	}
+
+}

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -83,6 +83,7 @@ class RoomShareProvider implements IShareProvider {
 
 	/**
 	 * Unshare a file from self as recipient.
+	 *
 	 * If a user unshares a room share from their self then the original room
 	 * share should still exist.
 	 *
@@ -107,8 +108,9 @@ class RoomShareProvider implements IShareProvider {
 
 	/**
 	 * Move a share as a recipient.
+	 *
 	 * This is updating the share target. Thus the mount point of the recipient.
-	 * This may require special handling. If a user moves a group share
+	 * This may require special handling. If a user moves a room share
 	 * the target should only be changed for them.
 	 *
 	 * @param IShare $share

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -766,7 +766,7 @@ class RoomShareProvider implements IShareProvider {
 	 * @throws ShareNotFound
 	 */
 	public function getShareByToken($token) {
-		throw new \Exception("Not implemented");
+		throw new ShareNotFound();
 	}
 
 	/**

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
  *
  * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
  *
+ * Code copied from "lib/private/Share20/DefaultShareProvider.php" and
+ * "apps/sharebymail/lib/ShareByMailProvider.php" at d805959e819e64 in Nextcloud
+ * server repository.
+ *
  * @license GNU AGPL version 3 or any later version
  *
  * This program is free software: you can redistribute it and/or modify

--- a/tests/integration/config/behat.yml
+++ b/tests/integration/config/behat.yml
@@ -7,6 +7,12 @@ default:
         - %paths.base%/../features
       contexts:
         - FeatureContext
+        - SharingContext:
+            baseUrl: http://localhost:8080/
+            admin:
+              - admin
+              - admin
+            regularUserPassword: 123456
 
   extensions:
       jarnaiz\JUnitFormatter\JUnitFormatterExtension:

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -61,6 +61,10 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	/** @var array */
 	protected $createdGroups = [];
 
+	public static function getTokenForIdentifier(string $identifier) {
+		return self::$identifierToToken[$identifier];
+	}
+
 	/**
 	 * FeatureContext constructor.
 	 */
@@ -73,6 +77,10 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	 * @BeforeScenario
 	 */
 	public function setUp() {
+		self::$identifierToToken = [];
+		self::$tokenToIdentifier = [];
+		self::$sessionIdToUser = [];
+
 		$this->createdUsers = [];
 		$this->createdGroups = [];
 	}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -632,6 +632,25 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->createdUsers[] = $user;
 	}
 
+	/**
+	 * @Given /^user "([^"]*)" is deleted$/
+	 * @param string $user
+	 */
+	public function userIsDeleted($user) {
+		$deleted = false;
+
+		$this->deleteUser($user);
+		try {
+			$this->userExists($user);
+		} catch (\GuzzleHttp\Exception\ClientException $ex) {
+			$deleted = true;
+		}
+
+		if (!$deleted) {
+			PHPUnit_Framework_Assert::fail("User $user exists");
+		}
+	}
+
 	private function deleteUser($user) {
 		$userProvisioningUrl = $this->baseUrl . 'ocs/v2.php/cloud/users/' . $user;
 		$client = new Client();

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -55,12 +55,38 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	/** @var string */
 	protected $lastEtag;
 
+	/** @var array */
+	protected $createdUsers = [];
+
+	/** @var array */
+	protected $createdGroups = [];
+
 	/**
 	 * FeatureContext constructor.
 	 */
 	public function __construct() {
 		$this->cookieJars = [];
 		$this->baseUrl = getenv('TEST_SERVER_URL');
+	}
+
+	/**
+	 * @BeforeScenario
+	 */
+	public function setUp() {
+		$this->createdUsers = [];
+		$this->createdGroups = [];
+	}
+
+	/**
+	 * @AfterScenario
+	 */
+	public function tearDown() {
+		foreach ($this->createdUsers as $user) {
+			$this->deleteUser($user);
+		}
+		foreach ($this->createdGroups as $group) {
+			$this->deleteGroup($group);
+		}
 	}
 
 	/**
@@ -594,6 +620,22 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			],
 		];
 		$client->send($client->createRequest('GET', $userProvisioningUrl . '/' . $user, $options2));
+
+		$this->createdUsers[] = $user;
+	}
+
+	private function deleteUser($user) {
+		$userProvisioningUrl = $this->baseUrl . 'ocs/v2.php/cloud/users/' . $user;
+		$client = new Client();
+		$options = [
+			'auth' => ['admin', 'admin'],
+			'headers' => [
+				'OCS-APIREQUEST' => 'true',
+			],
+		];
+		$client->send($client->createRequest('DELETE', $userProvisioningUrl, $options));
+
+		unset($this->createdUsers[array_search($user, $this->createdUsers)]);
 	}
 
 	private function setUserDisplayName($user) {
@@ -650,6 +692,22 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			],
 		];
 		$client->send($client->createRequest('POST', $userProvisioningUrl, $options));
+
+		$this->createdGroups[] = $group;
+	}
+
+	private function deleteGroup($group) {
+		$userProvisioningUrl = $this->baseUrl . 'ocs/v2.php/cloud/groups/' . $group;
+		$client = new Client();
+		$options = [
+			'auth' => ['admin', 'admin'],
+			'headers' => [
+				'OCS-APIREQUEST' => 'true',
+			],
+		];
+		$client->send($client->createRequest('DELETE', $userProvisioningUrl, $options));
+
+		unset($this->createdGroups[array_search($group, $this->createdGroups)]);
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -297,6 +297,19 @@ class SharingContext implements Context {
 	}
 
 	/**
+	 * @When user :user gets deleted shares
+	 *
+	 * @param string $user
+	 */
+	public function userGetsDeletedShares(string $user) {
+		$this->currentUser = $user;
+
+		$url = '/apps/files_sharing/api/v1/deletedshares';
+
+		$this->sendingTo('GET', $url);
+	}
+
+	/**
 	 * @Then the OCS status code should be :statusCode
 	 *
 	 * @param int $statusCode
@@ -509,6 +522,10 @@ class SharingContext implements Context {
 	 * @param \SimpleXMLElement $returnedShare
 	 */
 	private function assertFieldIsInReturnedShare(string $field, string $contentExpected, \SimpleXMLElement $returnedShare){
+		if ($contentExpected === 'IGNORE') {
+			return;
+		}
+
 		if (!array_key_exists($field, $returnedShare)) {
 			PHPUnit_Framework_Assert::fail("$field was not found in response");
 		}

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -191,6 +191,19 @@ class SharingContext implements Context {
 	}
 
 	/**
+	 * @When user :user restores last share
+	 *
+	 * @param string $user
+	 */
+	public function userRestoresLastShareWithOcs(string $user) {
+		$this->currentUser = $user;
+
+		$url = '/apps/files_sharing/api/v1/deletedshares/ocRoomShare:' . $this->getLastShareId();
+
+		$this->sendingTo('POST', $url);
+	}
+
+	/**
 	 * @When user :user gets last share
 	 */
 	public function userGetsLastShare(string $user) {

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -1,0 +1,330 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\TableNode;
+use GuzzleHttp\Client;
+use GuzzleHttp\Message\ResponseInterface;
+
+class SharingContext implements Context {
+
+	/** @var string */
+	private $baseUrl = '';
+
+	/** @var ResponseInterface */
+	private $response = null;
+
+	/** @var string */
+	private $currentUser = '';
+
+	/** @var string */
+	private $regularUserPassword;
+
+	/** @var \SimpleXMLElement */
+	private $lastCreatedShareData = null;
+
+	public function __construct(string $baseUrl, array $admin, string $regularUserPassword) {
+		$this->baseUrl = $baseUrl;
+		$this->adminUser = $admin;
+		$this->regularUserPassword = $regularUserPassword;
+
+		// in case of ci deployment we take the server url from the environment
+		$testServerUrl = getenv('TEST_SERVER_URL');
+		if ($testServerUrl !== false) {
+			$this->baseUrl = $testServerUrl;
+		}
+	}
+
+	/**
+	 * @When user :user shares :path with user :sharee
+	 *
+	 * @param string $user
+	 * @param string $path
+	 * @param string $sharee
+	 * @param TableNode|null $body
+	 */
+	public function userSharesWithUser(string $user, string $path, string $sharee, TableNode $body = null) {
+		$this->userSharesWith($user, $path, 0 /*Share::SHARE_TYPE_USER*/, $sharee, $body);
+	}
+
+	/**
+	 * @When user :user shares :path with user :sharee with OCS :statusCode
+	 *
+	 * @param string $user
+	 * @param string $path
+	 * @param string $sharee
+	 * @param int $statusCode
+	 */
+	public function userSharesWithUserWithOcs(string $user, string $path, string $sharee, int $statusCode) {
+		$this->userSharesWithUser($user, $path, $sharee);
+		$this->theOCSStatusCodeShouldBe($statusCode);
+	}
+
+	/**
+	 * @When user :user shares :path with room :room
+	 *
+	 * @param string $user
+	 * @param string $path
+	 * @param string $room
+	 * @param TableNode|null $body
+	 */
+	public function userSharesWithRoom(string $user, string $path, string $room, TableNode $body = null) {
+		$this->userSharesWith($user, $path, 10 /*Share::SHARE_TYPE_ROOM*/, FeatureContext::getTokenForIdentifier($room), $body);
+	}
+
+	/**
+	 * @When user :user shares :path with room :room with OCS :statusCode
+	 *
+	 * @param string $user
+	 * @param string $path
+	 * @param string $room
+	 * @param int $statusCode
+	 */
+	public function userSharesWithRoomWithOcs(string $user, string $path, string $room, int $statusCode) {
+		$this->userSharesWithRoom($user, $path, $room);
+		$this->theOCSStatusCodeShouldBe($statusCode);
+	}
+
+	/**
+	 * @When user :user gets last share
+	 */
+	public function userGetsLastShare(string $user) {
+		$this->currentUser = $user;
+
+		$url = '/apps/files_sharing/api/v1/shares/' . $this->getLastShareId();
+
+		$this->sendingTo('GET', $url);
+	}
+
+	/**
+	 * @When user :user gets all shares
+	 *
+	 * @param string $user
+	 */
+	public function userGetsAllShares(string $user) {
+		$this->currentUser = $user;
+
+		$url = '/apps/files_sharing/api/v1/shares';
+
+		$this->sendingTo('GET', $url);
+	}
+
+	/**
+	 * @Then the OCS status code should be :statusCode
+	 *
+	 * @param int $statusCode
+	 */
+	public function theOCSStatusCodeShouldBe(int $statusCode) {
+		$meta = $this->getXmlResponse()->meta[0];
+
+		PHPUnit_Framework_Assert::assertEquals($statusCode, (int)$meta->statuscode, 'Response message: ' . (string)$meta->message);
+	}
+
+	/**
+	 * @Then the HTTP status code should be :statusCode
+	 *
+	 * @param int $statusCode
+	 */
+	public function theHTTPStatusCodeShouldBe(int $statusCode) {
+		PHPUnit_Framework_Assert::assertEquals($statusCode, $this->response->getStatusCode());
+	}
+
+	/**
+	 * @Then the list of returned shares has :count shares
+	 */
+	public function theListOfReturnedSharesHasShares(int $count) {
+		$this->theHTTPStatusCodeShouldBe(200);
+		$this->theOCSStatusCodeShouldBe(100);
+
+		$returnedShares = $this->getXmlResponse()->data[0];
+
+		PHPUnit_Framework_Assert::assertEquals($count, count($returnedShares->element));
+	}
+
+	/**
+	 * @Then share is returned with
+	 *
+	 * @param TableNode $body
+	 */
+	public function shareIsReturnedWith(TableNode $body) {
+		$this->shareXIsReturnedWith(0, $body);
+	}
+
+	/**
+	 * @Then share :number is returned with
+	 *
+	 * @param int $number
+	 * @param TableNode $body
+	 */
+	public function shareXIsReturnedWith(int $number, TableNode $body) {
+		$this->theHTTPStatusCodeShouldBe(200);
+		$this->theOCSStatusCodeShouldBe(100);
+
+		if (!($body instanceof TableNode)) {
+			return;
+		}
+
+		$returnedShare = $this->getXmlResponse()->data[0];
+		if ($returnedShare->element) {
+			$returnedShare = $returnedShare->element[$number];
+		}
+
+		$defaultExpectedFields = [
+			'id' => 'A_NUMBER',
+			'share_type' => '10', // Share::SHARE_TYPE_ROOM,
+			'permissions' => '19',
+			'stime' => 'A_NUMBER',
+			'parent' => '',
+			'expiration' => '',
+			'token' => '',
+			'storage' => 'A_NUMBER',
+			'item_source' => 'A_NUMBER',
+			'file_source' => 'A_NUMBER',
+			'file_parent' => 'A_NUMBER',
+			'mail_send' => '0'
+		];
+		$expectedFields = array_merge($defaultExpectedFields, $body->getRowsHash());
+
+		if (!array_key_exists('uid_file_owner', $expectedFields) &&
+				array_key_exists('uid_owner', $expectedFields)) {
+			$expectedFields['uid_file_owner'] = $expectedFields['uid_owner'];
+		}
+		if (!array_key_exists('displayname_file_owner', $expectedFields) &&
+				array_key_exists('displayname_owner', $expectedFields)) {
+			$expectedFields['displayname_file_owner'] = $expectedFields['displayname_owner'];
+		}
+
+		if (array_key_exists('share_type', $expectedFields) &&
+				$expectedFields['share_type'] == 10 /* Share::SHARE_TYPE_ROOM */ &&
+				array_key_exists('share_with', $expectedFields)) {
+			$expectedFields['share_with'] = FeatureContext::getTokenForIdentifier($expectedFields['share_with']);
+		}
+
+		foreach ($expectedFields as $field => $value) {
+			$this->assertFieldIsInReturnedShare($field, $value, $returnedShare);
+		}
+	}
+
+	/**
+	 * @param string $user
+	 * @param string $path
+	 * @param string $shareType
+	 * @param string $shareWith
+	 * @param TableNode|null $body
+	 */
+	private function userSharesWith(string $user, string $path, string $shareType, string $shareWith, TableNode $body = null) {
+		$this->currentUser = $user;
+
+		$url = '/apps/files_sharing/api/v1/shares';
+
+		$parameters = [];
+		$parameters[] = 'path=' . $path;
+		$parameters[] = 'shareType=' . $shareType;
+		$parameters[] = 'shareWith=' . $shareWith;
+
+		if ($body instanceof TableNode) {
+			foreach ($body->getRowsHash() as $key => $value) {
+				if ($key === 'expireDate' && $value !== 'invalid date'){
+					$value = date('Y-m-d', strtotime($value));
+				}
+				$parameters[] = $key . '=' . $value;
+			}
+		}
+
+		$url .= '?' . implode('&', $parameters);
+
+		$this->sendingTo('POST', $url);
+
+		$this->lastCreatedShareData = $this->getXmlResponse();
+	}
+
+	/**
+	 * @param string $verb
+	 * @param string $url
+	 * @param TableNode $body
+	 */
+	private function sendingTo(string $verb, string $url, TableNode $body = null) {
+		$fullUrl = $this->baseUrl . "ocs/v1.php" . $url;
+		$client = new Client();
+		$options = [];
+		if ($this->currentUser === 'admin') {
+			$options['auth'] = $this->adminUser;
+		} else {
+			$options['auth'] = [$this->currentUser, $this->regularUserPassword];
+		}
+		$options['headers'] = [
+			'OCS_APIREQUEST' => 'true'
+		];
+		if ($body instanceof TableNode) {
+			$fd = $body->getRowsHash();
+			if (array_key_exists('expireDate', $fd)){
+				$fd['expireDate'] = date('Y-m-d', strtotime($fd['expireDate']));
+			}
+			$options['body'] = $fd;
+		}
+
+		try {
+			$this->response = $client->send($client->createRequest($verb, $fullUrl, $options));
+		} catch (GuzzleHttp\Exception\ClientException $ex) {
+			$this->response = $ex->getResponse();
+		}
+	}
+
+	/**
+	 * @return string
+	 */
+	private function getLastShareId(): string {
+		return (string)$this->lastCreatedShareData->data[0]->id;
+	}
+
+	/**
+	 * @return SimpleXMLElement
+	 */
+	private function getXmlResponse(): \SimpleXMLElement {
+		return simplexml_load_string($this->response->getBody());
+	}
+
+	/**
+	 * @param string $field
+	 * @param string $contentExpected
+	 * @param \SimpleXMLElement $returnedShare
+	 */
+	private function assertFieldIsInReturnedShare(string $field, string $contentExpected, \SimpleXMLElement $returnedShare){
+		if (!array_key_exists($field, $returnedShare)) {
+			PHPUnit_Framework_Assert::fail("$field was not found in response");
+		}
+
+		if ($field === 'expiration' && !empty($contentExpected)){
+			$contentExpected = date('Y-m-d', strtotime($contentExpected)) . " 00:00:00";
+		}
+
+		if ($contentExpected === 'A_NUMBER') {
+			PHPUnit_Framework_Assert::assertTrue(is_numeric((string)$returnedShare->$field), "Field '$field' is not a number: " . $returnedShare->$field);
+		} else if (strpos($contentExpected, 'REGEXP ') === 0) {
+			PHPUnit_Framework_Assert::assertRegExp(substr($contentExpected, strlen('REGEXP ')), (string)$returnedShare->$field, "Field '$field' does not match");
+		} else {
+			PHPUnit_Framework_Assert::assertEquals($contentExpected, (string)$returnedShare->$field, "Field '$field' does not match");
+		}
+	}
+
+}

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -167,6 +167,30 @@ class SharingContext implements Context {
 	}
 
 	/**
+	 * @When user :user deletes last share
+	 *
+	 * @param string $user
+	 */
+	public function userDeletesLastShare(string $user) {
+		$this->currentUser = $user;
+
+		$url = '/apps/files_sharing/api/v1/shares/' . $this->getLastShareId();
+
+		$this->sendingTo('DELETE', $url);
+	}
+
+	/**
+	 * @When user :user deletes last share with OCS :statusCode
+	 *
+	 * @param string $user
+	 * @param int $statusCode
+	 */
+	public function userDeletesLastShareWithOcs(string $user, int $statusCode) {
+		$this->userDeletesLastShare($user);
+		$this->theOCSStatusCodeShouldBe($statusCode);
+	}
+
+	/**
 	 * @When user :user gets last share
 	 */
 	public function userGetsLastShare(string $user) {

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -153,6 +153,20 @@ class SharingContext implements Context {
 	}
 
 	/**
+	 * @When user :user updates last share with
+	 *
+	 * @param string $user
+	 * @param TableNode $body
+	 */
+	public function userUpdatesLastShareWith(string $user, TableNode $body) {
+		$this->currentUser = $user;
+
+		$url = '/apps/files_sharing/api/v1/shares/' . $this->getLastShareId();
+
+		$this->sendingTo('PUT', $url, $body);
+	}
+
+	/**
 	 * @When user :user gets last share
 	 */
 	public function userGetsLastShare(string $user) {

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -177,6 +177,19 @@ class SharingContext implements Context {
 	}
 
 	/**
+	 * @When user :user gets all received shares
+	 *
+	 * @param string $user
+	 */
+	public function userGetsAllReceivedShares(string $user) {
+		$this->currentUser = $user;
+
+		$url = '/apps/files_sharing/api/v1/shares?shared_with_me=true';
+
+		$this->sendingTo('GET', $url);
+	}
+
+	/**
 	 * @Then the OCS status code should be :statusCode
 	 *
 	 * @param int $statusCode

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -177,6 +177,61 @@ class SharingContext implements Context {
 	}
 
 	/**
+	 * @When user :user gets all shares and reshares
+	 *
+	 * @param string $user
+	 */
+	public function userGetsAllSharesAndReshares(string $user) {
+		$this->currentUser = $user;
+
+		$url = '/apps/files_sharing/api/v1/shares?reshares=true';
+
+		$this->sendingTo('GET', $url);
+	}
+
+	/**
+	 * @When user :user gets all shares for :path
+	 *
+	 * @param string $user
+	 * @param string $path
+	 */
+	public function userGetsAllSharesFor(string $user, string $path) {
+		$this->currentUser = $user;
+
+		$url = '/apps/files_sharing/api/v1/shares?path=' . $path;
+
+		$this->sendingTo('GET', $url);
+	}
+
+	/**
+	 * @When user :user gets all shares and reshares for :path
+	 *
+	 * @param string $user
+	 * @param string $path
+	 */
+	public function userGetsAllSharesAndResharesFor(string $user, string $path) {
+		$this->currentUser = $user;
+
+		$url = '/apps/files_sharing/api/v1/shares?reshares=true&path=' . $path;
+
+		$this->sendingTo('GET', $url);
+	}
+
+	/**
+	 * @When user :user gets all shares for :path and its subfiles
+	 *
+	 * @param string $user
+	 * @param string $path
+	 */
+	public function userGetsAllSharesForAndItsSubfiles(string $user, string $path) {
+		$this->currentUser = $user;
+
+		$url = '/apps/files_sharing/api/v1/shares?subfiles=true&path=' . $path;
+
+		$this->sendingTo('GET', $url);
+	}
+
+	/**
 	 * @When user :user gets all received shares
 	 *
 	 * @param string $user
@@ -185,6 +240,20 @@ class SharingContext implements Context {
 		$this->currentUser = $user;
 
 		$url = '/apps/files_sharing/api/v1/shares?shared_with_me=true';
+
+		$this->sendingTo('GET', $url);
+	}
+
+	/**
+	 * @When user :user gets all received shares for :path
+	 *
+	 * @param string $user
+	 * @param string $path
+	 */
+	public function userGetsAllReceivedSharesFor(string $user, string $path) {
+		$this->currentUser = $user;
+
+		$url = '/apps/files_sharing/api/v1/shares?shared_with_me=true&path=' . $path;
 
 		$this->sendingTo('GET', $url);
 	}

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -753,6 +753,10 @@ class SharingContext implements Context {
 
 		if ($contentExpected === 'A_NUMBER') {
 			PHPUnit_Framework_Assert::assertTrue(is_numeric((string)$returnedShare->$field), "Field '$field' is not a number: " . $returnedShare->$field);
+		} else if ($contentExpected === 'A_TOKEN') {
+			// A token is composed by 15 characters from
+			// ISecureRandom::CHAR_HUMAN_READABLE.
+			PHPUnit_Framework_Assert::assertRegExp('/^[abcdefgijkmnopqrstwxyzABCDEFGHJKLMNPQRSTWXYZ23456789]{15}$/', (string)$returnedShare->$field, "Field '$field' is not a token");
 		} else if (strpos($contentExpected, 'REGEXP ') === 0) {
 			PHPUnit_Framework_Assert::assertRegExp(substr($contentExpected, strlen('REGEXP ')), (string)$returnedShare->$field, "Field '$field' does not match");
 		} else {

--- a/tests/integration/features/sharing/create.feature
+++ b/tests/integration/features/sharing/create.feature
@@ -1,0 +1,301 @@
+Feature: create
+
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+
+  Scenario: create share with an owned one-to-one room
+    Given user "participant1" creates room "own one-to-one room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    When user "participant1" shares "welcome.txt" with room "own one-to-one room"
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own one-to-one room |
+      | share_with_displayname | participant2-displayname |
+
+  Scenario: create share with a one-to-one room invited to
+    Given user "participant2" creates room "one-to-one room invited to"
+      | roomType | 1 |
+      | invite   | participant1 |
+    When user "participant1" shares "welcome.txt" with room "one-to-one room invited to"
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | one-to-one room invited to |
+      | share_with_displayname | participant2-displayname |
+
+  Scenario: create share with a one-to-one room not invited to
+    Given user "participant2" creates room "one-to-one room not invited to"
+      | roomType | 1 |
+      | invite   | participant3 |
+    When user "participant1" shares "welcome.txt" with room "one-to-one room not invited to"
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+
+  Scenario: create share with an owned group room
+    Given user "participant1" creates room "own group room"
+      | roomType | 2 |
+    And user "participant1" renames room "own group room" to "Own group room" with 200
+    When user "participant1" shares "welcome.txt" with room "own group room"
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own group room |
+      | share_with_displayname | Own group room |
+
+  Scenario: create share with a group room invited to
+    Given user "participant2" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
+    And user "participant2" adds "participant1" to room "group room invited to" with 200
+    When user "participant1" shares "welcome.txt" with room "group room invited to"
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+
+  Scenario: create share with a group room not invited to
+    Given user "participant2" creates room "group room not invited to"
+      | roomType | 2 |
+    When user "participant1" shares "welcome.txt" with room "group room not invited to"
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+
+  Scenario: create share with a group room no longer invited to
+    Given user "participant2" creates room "group room no longer invited to"
+      | roomType | 2 |
+    And user "participant2" adds "participant1" to room "group room no longer invited to" with 200
+    And user "participant2" removes "participant1" from room "group room no longer invited to" with 200
+    When user "participant1" shares "welcome.txt" with room "group room no longer invited to"
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+
+  Scenario: create share with an owned public room
+    Given user "participant1" creates room "own public room"
+      | roomType | 3 |
+    And user "participant1" renames room "own public room" to "Own public room" with 200
+    When user "participant1" shares "welcome.txt" with room "own public room"
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own public room |
+      | share_with_displayname | Own public room |
+
+  Scenario: create share with a public room invited to
+    Given user "participant2" creates room "public room invited to"
+      | roomType | 3 |
+    And user "participant2" renames room "public room invited to" to "Public room invited to" with 200
+    And user "participant2" adds "participant1" to room "public room invited to" with 200
+    When user "participant1" shares "welcome.txt" with room "public room invited to"
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | public room invited to |
+      | share_with_displayname | Public room invited to |
+
+  Scenario: create share with a public room self joined to
+    Given user "participant2" creates room "public room self joined to"
+      | roomType | 3 |
+    And user "participant2" renames room "public room self joined to" to "Public room self joined to" with 200
+    And user "participant1" joins room "public room self joined to" with 200
+    When user "participant1" shares "welcome.txt" with room "public room self joined to"
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | public room self joined to |
+      | share_with_displayname | Public room self joined to |
+
+  Scenario: create share with a public room not joined to
+    Given user "participant2" creates room "public room not joined to"
+      | roomType | 3 |
+    When user "participant1" shares "welcome.txt" with room "public room not joined to"
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+
+  Scenario: create share with a public room no longer joined to
+    Given user "participant2" creates room "public room no longer joined to"
+      | roomType | 3 |
+    And user "participant1" joins room "public room no longer joined to" with 200
+    And user "participant1" leaves room "public room no longer joined to" with 200
+    When user "participant1" shares "welcome.txt" with room "public room no longer joined to"
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+
+
+
+  Scenario: create share with an expiration date
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    When user "participant1" shares "welcome.txt" with room "group room"
+      | expireDate | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+      | expiration             | +3 days |
+
+  Scenario: create share with an invalid expiration date
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    When user "participant1" shares "welcome.txt" with room "group room"
+      | expireDate | invalid date |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+
+  Scenario: create share with specific permissions
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    When user "participant1" shares "welcome.txt" with room "group room"
+      | permissions | 1 |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+      | permissions            | 1 |
+
+
+
+  Scenario: create share again with another room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant1" creates room "another group room"
+      | roomType | 2 |
+    And user "participant1" renames room "another group room" to "Another group room" with 200
+    When user "participant1" shares "welcome.txt" with room "another group room"
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | another group room |
+      | share_with_displayname | Another group room |
+
+  Scenario: create share again with same room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant1" shares "welcome.txt" with room "group room"
+    Then the OCS status code should be "403"
+    And the HTTP status code should be "401"
+
+
+
+  Scenario: create share with a room that includes a user who already received that share through another room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant1" creates room "another group room"
+      | roomType | 2 |
+    And user "participant1" renames room "another group room" to "Another group room" with 200
+    And user "participant1" adds "participant2" to room "another group room" with 200
+    When user "participant1" shares "welcome.txt" with room "another group room"
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | another group room |
+      | share_with_displayname | Another group room |
+
+  Scenario: create share with a user who already received that share through a room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant1" shares "welcome.txt" with user "participant2"
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | participant2 |
+      | share_with_displayname | participant2-displayname |
+      | share_type             | 0 |
+      | mail_send              | 1 |
+
+  Scenario: create share with a room including a user who already received that share directly
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    When user "participant1" shares "welcome.txt" with room "group room"
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |

--- a/tests/integration/features/sharing/create.feature
+++ b/tests/integration/features/sharing/create.feature
@@ -20,6 +20,17 @@ Feature: create
       | file_target            | /welcome.txt |
       | share_with             | own one-to-one room |
       | share_with_displayname | participant2-displayname |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | own one-to-one room |
+      | share_with_displayname | participant1-displayname |
 
   Scenario: create share with a one-to-one room invited to
     Given user "participant2" creates room "one-to-one room invited to"
@@ -36,6 +47,17 @@ Feature: create
       | file_target            | /welcome.txt |
       | share_with             | one-to-one room invited to |
       | share_with_displayname | participant2-displayname |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | one-to-one room invited to |
+      | share_with_displayname | participant1-displayname |
 
   Scenario: create share with a one-to-one room not invited to
     Given user "participant2" creates room "one-to-one room not invited to"
@@ -46,11 +68,16 @@ Feature: create
     And the HTTP status code should be "200"
     And user "participant1" gets all shares
     And the list of returned shares has 0 shares
+    And user "participant2" gets all received shares
+    And the list of returned shares has 0 shares
+    And user "participant3" gets all received shares
+    And the list of returned shares has 0 shares
 
   Scenario: create share with an owned group room
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
     And user "participant1" renames room "own group room" to "Own group room" with 200
+    And user "participant1" adds "participant2" to room "own group room" with 200
     When user "participant1" shares "welcome.txt" with room "own group room"
     Then share is returned with
       | uid_owner              | participant1 |
@@ -60,6 +87,17 @@ Feature: create
       | mimetype               | text/plain |
       | storage_id             | home::participant1 |
       | file_target            | /welcome.txt |
+      | share_with             | own group room |
+      | share_with_displayname | Own group room |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
       | share_with             | own group room |
       | share_with_displayname | Own group room |
 
@@ -79,6 +117,17 @@ Feature: create
       | file_target            | /welcome.txt |
       | share_with             | group room invited to |
       | share_with_displayname | Group room invited to |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
 
   Scenario: create share with a group room not invited to
     Given user "participant2" creates room "group room not invited to"
@@ -87,6 +136,8 @@ Feature: create
     Then the OCS status code should be "404"
     And the HTTP status code should be "200"
     And user "participant1" gets all shares
+    And the list of returned shares has 0 shares
+    And user "participant2" gets all received shares
     And the list of returned shares has 0 shares
 
   Scenario: create share with a group room no longer invited to
@@ -99,11 +150,15 @@ Feature: create
     And the HTTP status code should be "200"
     And user "participant1" gets all shares
     And the list of returned shares has 0 shares
+    And user "participant2" gets all received shares
+    And the list of returned shares has 0 shares
 
   Scenario: create share with an owned public room
     Given user "participant1" creates room "own public room"
       | roomType | 3 |
     And user "participant1" renames room "own public room" to "Own public room" with 200
+    And user "participant1" adds "participant2" to room "own public room" with 200
+    And user "participant3" joins room "own public room" with 200
     When user "participant1" shares "welcome.txt" with room "own public room"
     Then share is returned with
       | uid_owner              | participant1 |
@@ -115,12 +170,35 @@ Feature: create
       | file_target            | /welcome.txt |
       | share_with             | own public room |
       | share_with_displayname | Own public room |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | own public room |
+      | share_with_displayname | Own public room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | own public room |
+      | share_with_displayname | Own public room |
 
   Scenario: create share with a public room invited to
     Given user "participant2" creates room "public room invited to"
       | roomType | 3 |
     And user "participant2" renames room "public room invited to" to "Public room invited to" with 200
     And user "participant2" adds "participant1" to room "public room invited to" with 200
+    And user "participant3" joins room "public room invited to" with 200
     When user "participant1" shares "welcome.txt" with room "public room invited to"
     Then share is returned with
       | uid_owner              | participant1 |
@@ -132,12 +210,35 @@ Feature: create
       | file_target            | /welcome.txt |
       | share_with             | public room invited to |
       | share_with_displayname | Public room invited to |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room invited to |
+      | share_with_displayname | Public room invited to |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room invited to |
+      | share_with_displayname | Public room invited to |
 
   Scenario: create share with a public room self joined to
     Given user "participant2" creates room "public room self joined to"
       | roomType | 3 |
     And user "participant2" renames room "public room self joined to" to "Public room self joined to" with 200
     And user "participant1" joins room "public room self joined to" with 200
+    And user "participant3" joins room "public room self joined to" with 200
     When user "participant1" shares "welcome.txt" with room "public room self joined to"
     Then share is returned with
       | uid_owner              | participant1 |
@@ -149,6 +250,28 @@ Feature: create
       | file_target            | /welcome.txt |
       | share_with             | public room self joined to |
       | share_with_displayname | Public room self joined to |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room self joined to |
+      | share_with_displayname | Public room self joined to |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room self joined to |
+      | share_with_displayname | Public room self joined to |
 
   Scenario: create share with a public room not joined to
     Given user "participant2" creates room "public room not joined to"
@@ -157,6 +280,8 @@ Feature: create
     Then the OCS status code should be "404"
     And the HTTP status code should be "200"
     And user "participant1" gets all shares
+    And the list of returned shares has 0 shares
+    And user "participant2" gets all received shares
     And the list of returned shares has 0 shares
 
   Scenario: create share with a public room no longer joined to
@@ -169,6 +294,8 @@ Feature: create
     And the HTTP status code should be "200"
     And user "participant1" gets all shares
     And the list of returned shares has 0 shares
+    And user "participant2" gets all received shares
+    And the list of returned shares has 0 shares
 
 
 
@@ -176,6 +303,7 @@ Feature: create
     Given user "participant1" creates room "group room"
       | roomType | 2 |
     And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
     When user "participant1" shares "welcome.txt" with room "group room"
       | expireDate | +3 days |
     Then share is returned with
@@ -186,6 +314,18 @@ Feature: create
       | mimetype               | text/plain |
       | storage_id             | home::participant1 |
       | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
       | share_with             | group room |
       | share_with_displayname | Group room |
       | expiration             | +3 days |
@@ -200,11 +340,14 @@ Feature: create
     And the HTTP status code should be "200"
     And user "participant1" gets all shares
     And the list of returned shares has 0 shares
+    And user "participant2" gets all received shares
+    And the list of returned shares has 0 shares
 
   Scenario: create share with specific permissions
     Given user "participant1" creates room "group room"
       | roomType | 2 |
     And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
     When user "participant1" shares "welcome.txt" with room "group room"
       | permissions | 1 |
     Then share is returned with
@@ -218,6 +361,18 @@ Feature: create
       | share_with             | group room |
       | share_with_displayname | Group room |
       | permissions            | 1 |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+      | permissions            | 1 |
 
 
 
@@ -225,10 +380,12 @@ Feature: create
     Given user "participant1" creates room "group room"
       | roomType | 2 |
     And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant1" creates room "another group room"
       | roomType | 2 |
     And user "participant1" renames room "another group room" to "Another group room" with 200
+    And user "participant1" adds "participant3" to room "another group room" with 200
     When user "participant1" shares "welcome.txt" with room "another group room"
     Then share is returned with
       | uid_owner              | participant1 |
@@ -262,11 +419,36 @@ Feature: create
       | file_target            | /welcome.txt |
       | share_with             | another group room |
       | share_with_displayname | Another group room |
+    And user "participant2" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | another group room |
+      | share_with_displayname | Another group room |
 
   Scenario: create share again with same room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
     And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     When user "participant1" shares "welcome.txt" with room "group room"
     Then the OCS status code should be "403"
@@ -281,6 +463,18 @@ Feature: create
       | mimetype               | text/plain |
       | storage_id             | home::participant1 |
       | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
       | share_with             | group room |
       | share_with_displayname | Group room |
 
@@ -307,6 +501,28 @@ Feature: create
       | file_target            | /welcome.txt |
       | share_with             | another group room |
       | share_with_displayname | Another group room |
+    And user "participant2" gets all received shares
+    And the list of returned shares has 2 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And share 1 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | another group room |
+      | share_with_displayname | Another group room |
 
   Scenario: create share with a user who already received that share through a room
     Given user "participant1" creates room "group room"
@@ -327,6 +543,29 @@ Feature: create
       | share_with_displayname | participant2-displayname |
       | share_type             | 0 |
       | mail_send              | 1 |
+    And user "participant2" gets all received shares
+    And the list of returned shares has 2 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant2 |
+      | share_with_displayname | participant2-displayname |
+      | share_type             | 0 |
+    And share 1 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
 
   Scenario: create share with a room including a user who already received that share directly
     Given user "participant1" creates room "group room"
@@ -343,5 +582,28 @@ Feature: create
       | mimetype               | text/plain |
       | storage_id             | home::participant1 |
       | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets all received shares
+    And the list of returned shares has 2 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant2 |
+      | share_with_displayname | participant2-displayname |
+      | share_type             | 0 |
+    And share 1 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
       | share_with             | group room |
       | share_with_displayname | Group room |

--- a/tests/integration/features/sharing/create.feature
+++ b/tests/integration/features/sharing/create.feature
@@ -299,6 +299,132 @@ Feature: create
 
 
 
+  Scenario: create share with a room of a received share whose owner is in the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant2" shares "welcome.txt" with user "participant1" with OCS 100
+    When user "participant1" shares "welcome (2).txt" with room "group room"
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant2 |
+      | displayname_file_owner | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant2 |
+      | displayname_file_owner | participant2-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant2 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant2 |
+      | displayname_file_owner | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  Scenario: create share with a room of a received share whose owner is not in the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant2" shares "welcome.txt" with user "participant1" with OCS 100
+    When user "participant1" shares "welcome (2).txt" with room "group room"
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant2 |
+      | displayname_file_owner | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant2 |
+      | displayname_file_owner | participant2-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant2 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant2 |
+      | displayname_file_owner | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  Scenario: create share with a room of a received share without reshare permissions
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant2" shares "welcome.txt" with user "participant1"
+      | permissions            | 1 |
+    And share is returned with
+      | permissions            | 1 |
+      | share_type             | 0 |
+      | mail_send              | 1 |
+    When user "participant1" shares "welcome (2).txt" with room "group room"
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant1" gets all shares
+    And the list of returned shares has 0 shares
+    And user "participant1" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | permissions            | 1 |
+      | share_type             | 0 |
+    And user "participant2" gets all shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | permissions            | 1 |
+      | share_type             | 0 |
+    And user "participant2" gets all received shares
+    And the list of returned shares has 0 shares
+    And user "participant3" gets all received shares
+    And the list of returned shares has 0 shares
+
+
+
   Scenario: create share with an expiration date
     Given user "participant1" creates room "group room"
       | roomType | 2 |
@@ -465,6 +591,42 @@ Feature: create
       | file_target            | /welcome.txt |
       | share_with             | group room |
       | share_with_displayname | Group room |
+    And user "participant2" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  Scenario: create share again with same room by a sharee
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant2" shares "welcome (2).txt" with room "group room"
+    Then the OCS status code should be "403"
+    And the HTTP status code should be "401"
+    And user "participant1" gets all shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets all shares
+    And the list of returned shares has 0 shares
     And user "participant2" gets all received shares
     And the list of returned shares has 1 shares
     And share 0 is returned with

--- a/tests/integration/features/sharing/create.feature
+++ b/tests/integration/features/sharing/create.feature
@@ -44,6 +44,8 @@ Feature: create
     When user "participant1" shares "welcome.txt" with room "one-to-one room not invited to"
     Then the OCS status code should be "404"
     And the HTTP status code should be "200"
+    And user "participant1" gets all shares
+    And the list of returned shares has 0 shares
 
   Scenario: create share with an owned group room
     Given user "participant1" creates room "own group room"
@@ -84,6 +86,8 @@ Feature: create
     When user "participant1" shares "welcome.txt" with room "group room not invited to"
     Then the OCS status code should be "404"
     And the HTTP status code should be "200"
+    And user "participant1" gets all shares
+    And the list of returned shares has 0 shares
 
   Scenario: create share with a group room no longer invited to
     Given user "participant2" creates room "group room no longer invited to"
@@ -93,6 +97,8 @@ Feature: create
     When user "participant1" shares "welcome.txt" with room "group room no longer invited to"
     Then the OCS status code should be "404"
     And the HTTP status code should be "200"
+    And user "participant1" gets all shares
+    And the list of returned shares has 0 shares
 
   Scenario: create share with an owned public room
     Given user "participant1" creates room "own public room"
@@ -150,6 +156,8 @@ Feature: create
     When user "participant1" shares "welcome.txt" with room "public room not joined to"
     Then the OCS status code should be "404"
     And the HTTP status code should be "200"
+    And user "participant1" gets all shares
+    And the list of returned shares has 0 shares
 
   Scenario: create share with a public room no longer joined to
     Given user "participant2" creates room "public room no longer joined to"
@@ -159,6 +167,8 @@ Feature: create
     When user "participant1" shares "welcome.txt" with room "public room no longer joined to"
     Then the OCS status code should be "404"
     And the HTTP status code should be "200"
+    And user "participant1" gets all shares
+    And the list of returned shares has 0 shares
 
 
 
@@ -188,6 +198,8 @@ Feature: create
       | expireDate | invalid date |
     Then the OCS status code should be "404"
     And the HTTP status code should be "200"
+    And user "participant1" gets all shares
+    And the list of returned shares has 0 shares
 
   Scenario: create share with specific permissions
     Given user "participant1" creates room "group room"
@@ -228,6 +240,28 @@ Feature: create
       | file_target            | /welcome.txt |
       | share_with             | another group room |
       | share_with_displayname | Another group room |
+    And user "participant1" gets all shares
+    And the list of returned shares has 2 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And share 1 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | another group room |
+      | share_with_displayname | Another group room |
 
   Scenario: create share again with same room
     Given user "participant1" creates room "group room"
@@ -237,6 +271,18 @@ Feature: create
     When user "participant1" shares "welcome.txt" with room "group room"
     Then the OCS status code should be "403"
     And the HTTP status code should be "401"
+    And user "participant1" gets all shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
 
 
 

--- a/tests/integration/features/sharing/create.feature
+++ b/tests/integration/features/sharing/create.feature
@@ -170,6 +170,7 @@ Feature: create
       | file_target            | /welcome.txt |
       | share_with             | own public room |
       | share_with_displayname | Own public room |
+      | token                  | A_TOKEN |
     And user "participant2" gets last share
     And share is returned with
       | uid_owner              | participant1 |
@@ -181,6 +182,7 @@ Feature: create
       | file_target            | /welcome (2).txt |
       | share_with             | own public room |
       | share_with_displayname | Own public room |
+      | token                  | A_TOKEN |
     And user "participant3" gets last share
     And share is returned with
       | uid_owner              | participant1 |
@@ -192,6 +194,7 @@ Feature: create
       | file_target            | /welcome (2).txt |
       | share_with             | own public room |
       | share_with_displayname | Own public room |
+      | token                  | A_TOKEN |
 
   Scenario: create share with a public room invited to
     Given user "participant2" creates room "public room invited to"
@@ -210,6 +213,7 @@ Feature: create
       | file_target            | /welcome.txt |
       | share_with             | public room invited to |
       | share_with_displayname | Public room invited to |
+      | token                  | A_TOKEN |
     And user "participant2" gets last share
     And share is returned with
       | uid_owner              | participant1 |
@@ -221,6 +225,7 @@ Feature: create
       | file_target            | /welcome (2).txt |
       | share_with             | public room invited to |
       | share_with_displayname | Public room invited to |
+      | token                  | A_TOKEN |
     And user "participant3" gets last share
     And share is returned with
       | uid_owner              | participant1 |
@@ -232,6 +237,7 @@ Feature: create
       | file_target            | /welcome (2).txt |
       | share_with             | public room invited to |
       | share_with_displayname | Public room invited to |
+      | token                  | A_TOKEN |
 
   Scenario: create share with a public room self joined to
     Given user "participant2" creates room "public room self joined to"
@@ -250,6 +256,7 @@ Feature: create
       | file_target            | /welcome.txt |
       | share_with             | public room self joined to |
       | share_with_displayname | Public room self joined to |
+      | token                  | A_TOKEN |
     And user "participant2" gets last share
     And share is returned with
       | uid_owner              | participant1 |
@@ -261,6 +268,7 @@ Feature: create
       | file_target            | /welcome (2).txt |
       | share_with             | public room self joined to |
       | share_with_displayname | Public room self joined to |
+      | token                  | A_TOKEN |
     And user "participant3" gets last share
     And share is returned with
       | uid_owner              | participant1 |
@@ -272,6 +280,7 @@ Feature: create
       | file_target            | /welcome (2).txt |
       | share_with             | public room self joined to |
       | share_with_displayname | Public room self joined to |
+      | token                  | A_TOKEN |
 
   Scenario: create share with a public room not joined to
     Given user "participant2" creates room "public room not joined to"

--- a/tests/integration/features/sharing/delete.feature
+++ b/tests/integration/features/sharing/delete.feature
@@ -249,3 +249,91 @@ Feature: delete
       | share_with             | participant2 |
       | share_with_displayname | participant2-displayname |
       | share_type             | 0 |
+
+
+
+  Scenario: delete received share
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant2" deletes last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+
+
+  Scenario: delete share received directly and through a room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant2" deletes last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant2 |
+      | share_with_displayname | participant2-displayname |
+      | share_type             | 0 |

--- a/tests/integration/features/sharing/delete.feature
+++ b/tests/integration/features/sharing/delete.feature
@@ -1,0 +1,251 @@
+Feature: delete
+
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+
+  Scenario: delete share with an owned one-to-one room
+    Given user "participant1" creates room "own one-to-one room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" shares "welcome.txt" with room "own one-to-one room" with OCS 100
+    When user "participant1" deletes last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: delete share with a one-to-one room invited to
+    Given user "participant2" creates room "one-to-one room invited to"
+      | roomType | 1 |
+      | invite   | participant1 |
+    And user "participant1" shares "welcome.txt" with room "one-to-one room invited to" with OCS 100
+    When user "participant1" deletes last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: delete share with an owned group room
+    Given user "participant1" creates room "own group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "own group room" with 200
+    And user "participant1" shares "welcome.txt" with room "own group room" with OCS 100
+    When user "participant1" deletes last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: delete share with a group room invited to
+    Given user "participant2" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant2" adds "participant1" to room "group room invited to" with 200
+    And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
+    When user "participant1" deletes last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: delete share with an owned public room
+    Given user "participant1" creates room "own public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "own public room" with 200
+    And user "participant3" joins room "own public room" with 200
+    And user "participant1" shares "welcome.txt" with room "own public room" with OCS 100
+    When user "participant1" deletes last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+    And user "participant3" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: delete share with a public room invited to
+    Given user "participant2" creates room "public room invited to"
+      | roomType | 3 |
+    And user "participant2" adds "participant1" to room "public room invited to" with 200
+    And user "participant3" joins room "public room invited to" with 200
+    And user "participant1" shares "welcome.txt" with room "public room invited to" with OCS 100
+    When user "participant1" deletes last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+    And user "participant3" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: delete share with a public room self joined to
+    Given user "participant2" creates room "public room self joined to"
+      | roomType | 3 |
+    And user "participant1" joins room "public room self joined to" with 200
+    And user "participant3" joins room "public room self joined to" with 200
+    And user "participant1" shares "welcome.txt" with room "public room self joined to" with OCS 100
+    When user "participant1" deletes last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+    And user "participant3" gets last share
+    And the OCS status code should be "404"
+
+
+
+  Scenario: delete (unknown) share with a one-to-one room not invited to
+    Given user "participant2" creates room "one-to-one room not invited to"
+      | roomType | 1 |
+      | invite   | participant3 |
+    And user "participant2" shares "welcome.txt" with room "one-to-one room not invited to" with OCS 100
+    When user "participant1" deletes last share
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant2 |
+      | file_target            | /welcome.txt |
+      | share_with             | one-to-one room not invited to |
+      | share_with_displayname | participant3-displayname |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | one-to-one room not invited to |
+      | share_with_displayname | participant2-displayname |
+
+  Scenario: delete (unknown) share with a group room not invited to
+    Given user "participant2" creates room "group room not invited to"
+      | roomType | 2 |
+    And user "participant2" renames room "group room not invited to" to "Group room not invited to" with 200
+    And user "participant2" adds "participant3" to room "group room not invited to" with 200
+    And user "participant2" shares "welcome.txt" with room "group room not invited to" with OCS 100
+    When user "participant1" deletes last share
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant2 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room not invited to |
+      | share_with_displayname | Group room not invited to |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room not invited to |
+      | share_with_displayname | Group room not invited to |
+
+  Scenario: delete (unknown) share with a public room not joined to
+    Given user "participant2" creates room "public room not joined to"
+      | roomType | 3 |
+    And user "participant2" renames room "public room not joined to" to "Public room not joined to" with 200
+    And user "participant2" adds "participant3" to room "public room not joined to" with 200
+    And user "participant2" shares "welcome.txt" with room "public room not joined to" with OCS 100
+    When user "participant1" deletes last share
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant2 |
+      | file_target            | /welcome.txt |
+      | share_with             | public room not joined to |
+      | share_with_displayname | Public room not joined to |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room not joined to |
+      | share_with_displayname | Public room not joined to |
+
+
+
+  Scenario: delete share with a user who also received that share through a room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    When user "participant1" deletes last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "participant2" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  Scenario: delete share with a room including a user who also received that share directly
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant1" deletes last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "participant2" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant2 |
+      | share_with_displayname | participant2-displayname |
+      | share_type             | 0 |

--- a/tests/integration/features/sharing/delete.feature
+++ b/tests/integration/features/sharing/delete.feature
@@ -190,6 +190,7 @@ Feature: delete
       | file_target            | /welcome.txt |
       | share_with             | public room not joined to |
       | share_with_displayname | Public room not joined to |
+      | token                  | A_TOKEN |
     And user "participant3" gets last share
     And share is returned with
       | uid_owner              | participant2 |
@@ -201,6 +202,7 @@ Feature: delete
       | file_target            | /welcome (2).txt |
       | share_with             | public room not joined to |
       | share_with_displayname | Public room not joined to |
+      | token                  | A_TOKEN |
 
 
 

--- a/tests/integration/features/sharing/get.feature
+++ b/tests/integration/features/sharing/get.feature
@@ -54,3 +54,14 @@ Feature: get
       | file_target            | /welcome.txt |
       | share_with             | group room |
       | share_with_displayname | New room name |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | New room name |

--- a/tests/integration/features/sharing/get.feature
+++ b/tests/integration/features/sharing/get.feature
@@ -88,6 +88,60 @@ Feature: get
 
 
 
+  Scenario: get an expired share
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room"
+      | expireDate | -3 days |
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+      | expiration             | -3 days |
+    When user "participant1" gets last share
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+    And the HTTP status code should be "200"
+
+  Scenario: get an expired share moved by the sharee
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" moves file "/welcome (2).txt" to "/renamed.txt" with 201
+    And user "participant1" updates last share with
+      | expireDate | -3 days |
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+      | expiration             | -3 days |
+    When user "participant1" gets last share
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+    And the HTTP status code should be "200"
+
+
+
   Scenario: get all shares of a user
     Given user "participant1" creates room "own group room"
       | roomType | 2 |

--- a/tests/integration/features/sharing/get.feature
+++ b/tests/integration/features/sharing/get.feature
@@ -731,3 +731,21 @@ Feature: get
     Then the response contains a share-types DAV property with
       | 0 |
       | 10 |
+
+
+
+  Scenario: get recent files including a share
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" creates folder "/test"
+    And user "participant1" creates folder "/test/subfolder"
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant1" shares "test/subfolder" with room "group room" with OCS 100
+    And user "participant1" shares "test/subfolder" with user "participant3" with OCS 100
+    When user "participant1" gets recent files
+    Then the response contains a share-types file property for "/welcome.txt" with
+      | 10 |
+    And the response contains a share-types file property for "/test" with
+    And the response contains a share-types file property for "/test/subfolder" with
+      | 0 |
+      | 10 |

--- a/tests/integration/features/sharing/get.feature
+++ b/tests/integration/features/sharing/get.feature
@@ -619,3 +619,115 @@ Feature: get
     And the list of returned shares has 0 shares
     And user "participant3" gets deleted shares
     And the list of returned shares has 0 shares
+
+
+
+  Scenario: get DAV properties for a share
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant1" gets the share-type DAV property for "/welcome.txt"
+    Then the response contains a share-types DAV property with
+      | 10 |
+
+  Scenario: get DAV properties for a folder with a share
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" creates folder "/test"
+    And user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
+    And user "participant1" shares "/test/renamed.txt" with room "group room" with OCS 100
+    When user "participant1" gets the share-type DAV property for "/test"
+    Then the response contains a share-types DAV property with
+      | 10 |
+
+  Scenario: get DAV properties for a received share
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant2" gets the share-type DAV property for "/welcome (2).txt"
+    Then the response contains a share-types DAV property with
+
+  Scenario: get DAV properties for a room share reshared with a user
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant2" creates room "another group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    When user "participant1" gets the share-type DAV property for "/welcome.txt"
+    Then the response contains a share-types DAV property with
+      | 10 |
+
+  Scenario: get DAV properties for a user share reshared with a room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant2" creates room "another group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with room "group room" with OCS 100
+    When user "participant1" gets the share-type DAV property for "/welcome.txt"
+    Then the response contains a share-types DAV property with
+      | 0 |
+
+  Scenario: get DAV properties for a room share reshared with a user as the resharer
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant2" creates room "another group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    When user "participant2" gets the share-type DAV property for "/welcome (2).txt"
+    Then the response contains a share-types DAV property with
+      | 0 |
+
+  Scenario: get DAV properties for a user share reshared with a room as the resharer
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant2" creates room "another group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with room "group room" with OCS 100
+    When user "participant2" gets the share-type DAV property for "/welcome (2).txt"
+    Then the response contains a share-types DAV property with
+      | 10 |
+
+  # Reshares are taken into account only for the files in the folder, not the
+  # folder itself.
+  Scenario: get DAV properties for a reshared folder
+    Given user "participant2" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" creates folder "/test"
+    And user "participant1" shares "/test" with user "participant2" with OCS 100
+    And user "participant2" shares "/test" with room "group room" with OCS 100
+    When user "participant1" gets the share-type DAV property for "/test"
+    Then the response contains a share-types DAV property with
+      | 0 |
+
+  Scenario: get DAV properties for a folder with a reshare
+    Given user "participant2" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" creates folder "/test"
+    And user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
+    And user "participant1" shares "/test/renamed.txt" with user "participant2" with OCS 100
+    And user "participant2" shares "renamed.txt" with room "group room" with OCS 100
+    When user "participant1" gets the share-type DAV property for "/test"
+    Then the response contains a share-types DAV property with
+      | 0 |
+      | 10 |
+
+  Scenario: get DAV properties for a folder with a reshared folder
+    Given user "participant2" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" creates folder "/test"
+    And user "participant1" creates folder "/test/subfolder"
+    And user "participant1" shares "/test/subfolder" with user "participant2" with OCS 100
+    And user "participant2" shares "subfolder" with room "group room" with OCS 100
+    When user "participant1" gets the share-type DAV property for "/test"
+    Then the response contains a share-types DAV property with
+      | 0 |
+      | 10 |

--- a/tests/integration/features/sharing/get.feature
+++ b/tests/integration/features/sharing/get.feature
@@ -23,6 +23,24 @@ Feature: get
       | share_with             | group room |
       | share_with_displayname | Group room |
 
+  Scenario: get a received share
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant2" gets last share
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
 
 
   Scenario: get a share using a user not invited to the room

--- a/tests/integration/features/sharing/get.feature
+++ b/tests/integration/features/sharing/get.feature
@@ -3,6 +3,8 @@ Feature: get
   Background:
     Given user "participant1" exists
     Given user "participant2" exists
+    Given user "participant3" exists
+    Given user "participant4" exists
 
 
 
@@ -83,3 +85,442 @@ Feature: get
       | file_target            | /welcome (2).txt |
       | share_with             | group room |
       | share_with_displayname | New room name |
+
+
+
+  Scenario: get all shares of a user
+    Given user "participant1" creates room "own group room"
+      | roomType | 2 |
+    And user "participant1" renames room "own group room" to "Own group room" with 200
+    And user "participant2" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
+    And user "participant2" adds "participant1" to room "group room invited to" with 200
+    And user "participant1" creates room "own one-to-one room"
+      | roomType | 1 |
+      | invite   | participant3 |
+    And user "participant3" creates room "one-to-one room not invited to"
+      | roomType | 1 |
+      | invite   | participant4 |
+    And user "participant1" creates folder "/test"
+    And user "participant1" shares "welcome.txt" with room "own group room" with OCS 100
+    And user "participant1" shares "test" with room "group room invited to" with OCS 100
+    And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
+    And user "participant1" shares "test" with room "own one-to-one room" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
+    When user "participant1" gets all shares
+    Then the list of returned shares has 4 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own group room |
+      | share_with_displayname | Own group room |
+    And share 1 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /test |
+      | item_type              | folder |
+      | mimetype               | httpd/unix-directory |
+      | storage_id             | home::participant1 |
+      | file_target            | /test |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 31 |
+    And share 2 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+    And share 3 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /test |
+      | item_type              | folder |
+      | mimetype               | httpd/unix-directory |
+      | storage_id             | home::participant1 |
+      | file_target            | /test |
+      | share_with             | own one-to-one room |
+      | share_with_displayname | participant3-displayname |
+      | permissions            | 31 |
+
+  Scenario: get all shares and reshares of a user
+    Given user "participant1" creates room "own group room"
+      | roomType | 2 |
+    And user "participant1" renames room "own group room" to "Own group room" with 200
+    And user "participant2" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
+    And user "participant2" adds "participant1" to room "group room invited to" with 200
+    And user "participant1" creates room "own one-to-one room"
+      | roomType | 1 |
+      | invite   | participant3 |
+    And user "participant3" creates room "one-to-one room not invited to"
+      | roomType | 1 |
+      | invite   | participant4 |
+    And user "participant1" creates folder "/test"
+    And user "participant1" shares "welcome.txt" with room "own group room" with OCS 100
+    And user "participant1" shares "test" with room "group room invited to" with OCS 100
+    And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
+    And user "participant1" shares "test" with room "own one-to-one room" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
+    When user "participant1" gets all shares and reshares
+    Then the list of returned shares has 6 shares
+    And share 0 is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant3 |
+      | share_with_displayname | participant3-displayname |
+      | share_type             | 0 |
+    And share 1 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own group room |
+      | share_with_displayname | Own group room |
+    And share 2 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /test |
+      | item_type              | folder |
+      | mimetype               | httpd/unix-directory |
+      | storage_id             | home::participant1 |
+      | file_target            | /test |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 31 |
+    And share 3 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+    And share 4 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /test |
+      | item_type              | folder |
+      | mimetype               | httpd/unix-directory |
+      | storage_id             | home::participant1 |
+      | file_target            | /test |
+      | share_with             | own one-to-one room |
+      | share_with_displayname | participant3-displayname |
+      | permissions            | 31 |
+    And share 5 is returned with
+      | uid_owner              | participant3 |
+      | displayname_owner      | participant3-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | one-to-one room not invited to |
+      | share_with_displayname | participant3-displayname |
+
+  Scenario: get all shares of a file
+    Given user "participant1" creates room "own group room"
+      | roomType | 2 |
+    And user "participant1" renames room "own group room" to "Own group room" with 200
+    And user "participant2" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
+    And user "participant2" adds "participant1" to room "group room invited to" with 200
+    And user "participant1" creates room "own one-to-one room"
+      | roomType | 1 |
+      | invite   | participant3 |
+    And user "participant3" creates room "one-to-one room not invited to"
+      | roomType | 1 |
+      | invite   | participant4 |
+    And user "participant1" creates folder "/test"
+    And user "participant1" shares "welcome.txt" with room "own group room" with OCS 100
+    And user "participant1" shares "test" with room "group room invited to" with OCS 100
+    And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
+    And user "participant1" shares "test" with room "own one-to-one room" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
+    When user "participant1" gets all shares for "/welcome.txt"
+    Then the list of returned shares has 2 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own group room |
+      | share_with_displayname | Own group room |
+    And share 1 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+
+  Scenario: get all shares and reshares of a file
+    Given user "participant1" creates room "own group room"
+      | roomType | 2 |
+    And user "participant1" renames room "own group room" to "Own group room" with 200
+    And user "participant2" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
+    And user "participant2" adds "participant1" to room "group room invited to" with 200
+    And user "participant1" creates room "own one-to-one room"
+      | roomType | 1 |
+      | invite   | participant3 |
+    And user "participant3" creates room "one-to-one room not invited to"
+      | roomType | 1 |
+      | invite   | participant4 |
+    And user "participant1" creates folder "/test"
+    And user "participant1" shares "welcome.txt" with room "own group room" with OCS 100
+    And user "participant1" shares "test" with room "group room invited to" with OCS 100
+    And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
+    And user "participant1" shares "test" with room "own one-to-one room" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
+    When user "participant1" gets all shares and reshares for "/welcome.txt"
+    Then the list of returned shares has 4 shares
+    And share 0 is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant3 |
+      | share_with_displayname | participant3-displayname |
+      | share_type             | 0 |
+    And share 1 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own group room |
+      | share_with_displayname | Own group room |
+    And share 2 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+    And share 3 is returned with
+      | uid_owner              | participant3 |
+      | displayname_owner      | participant3-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | one-to-one room not invited to |
+      | share_with_displayname | participant3-displayname |
+
+  Scenario: get all shares of a folder
+    Given user "participant1" creates room "own group room"
+      | roomType | 2 |
+    And user "participant1" renames room "own group room" to "Own group room" with 200
+    And user "participant2" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
+    And user "participant2" adds "participant1" to room "group room invited to" with 200
+    And user "participant1" creates room "own one-to-one room"
+      | roomType | 1 |
+      | invite   | participant3 |
+    And user "participant3" creates room "one-to-one room not invited to"
+      | roomType | 1 |
+      | invite   | participant4 |
+    And user "participant1" creates folder "/test"
+    And user "participant1" creates folder "/test/subfolder"
+    And user "participant1" creates folder "/test/subfolder/subsubfolder"
+    And user "participant1" creates folder "/test2"
+    And user "participant1" shares "welcome.txt" with room "own group room" with OCS 100
+    And user "participant1" shares "test/subfolder" with room "group room invited to" with OCS 100
+    And user "participant1" shares "test/subfolder/subsubfolder" with room "group room invited to" with OCS 100
+    And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
+    And user "participant1" shares "test2" with room "own one-to-one room" with OCS 100
+    And user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
+    And user "participant2" shares "subfolder" with user "participant3" with OCS 100
+    And user "participant3" shares "subfolder" with room "one-to-one room not invited to" with OCS 100
+    # Only direct children are taken into account
+    When user "participant1" gets all shares for "/test" and its subfiles
+    Then the list of returned shares has 3 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /test/renamed.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own group room |
+      | share_with_displayname | Own group room |
+    And share 1 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /test/renamed.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+    And share 2 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /test/subfolder |
+      | item_type              | folder |
+      | mimetype               | httpd/unix-directory |
+      | storage_id             | home::participant1 |
+      | file_target            | /subfolder |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 31 |
+
+
+
+  Scenario: get all received shares of a user
+    Given user "participant1" creates room "own group room"
+      | roomType | 2 |
+    And user "participant1" renames room "own group room" to "Own group room" with 200
+    And user "participant1" adds "participant2" to room "own group room" with 200
+    And user "participant2" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
+    And user "participant2" adds "participant1" to room "group room invited to" with 200
+    And user "participant2" adds "participant3" to room "group room invited to" with 200
+    And user "participant1" creates room "own one-to-one room"
+      | roomType | 1 |
+      | invite   | participant3 |
+    And user "participant3" creates folder "/test"
+    And user "participant2" shares "welcome.txt" with room "own group room" with OCS 100
+    And user "participant3" shares "test" with room "group room invited to" with OCS 100
+    And user "participant2" shares "welcome.txt" with room "group room invited to" with OCS 100
+    And user "participant3" shares "test" with room "own one-to-one room" with OCS 100
+    When user "participant1" gets all received shares
+    Then the list of returned shares has 4 shares
+    And share 0 is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | own group room |
+      | share_with_displayname | Own group room |
+    And share 1 is returned with
+      | uid_owner              | participant3 |
+      | displayname_owner      | participant3-displayname |
+      | path                   | /test |
+      | item_type              | folder |
+      | mimetype               | httpd/unix-directory |
+      | storage_id             | shared::/test |
+      | file_target            | /test |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 31 |
+    And share 2 is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+    And share 3 is returned with
+      | uid_owner              | participant3 |
+      | displayname_owner      | participant3-displayname |
+      | path                   | /test |
+      | item_type              | folder |
+      | mimetype               | httpd/unix-directory |
+      | storage_id             | shared::/test |
+      | file_target            | /test |
+      | share_with             | own one-to-one room |
+      | share_with_displayname | participant3-displayname |
+      | permissions            | 31 |
+
+  Scenario: get all received shares of a file
+    Given user "participant1" creates room "own group room"
+      | roomType | 2 |
+    And user "participant1" renames room "own group room" to "Own group room" with 200
+    And user "participant1" adds "participant2" to room "own group room" with 200
+    And user "participant2" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
+    And user "participant2" adds "participant1" to room "group room invited to" with 200
+    And user "participant2" adds "participant3" to room "group room invited to" with 200
+    And user "participant1" creates room "own one-to-one room"
+      | roomType | 1 |
+      | invite   | participant3 |
+    And user "participant3" creates folder "/test"
+    And user "participant2" shares "welcome.txt" with room "own group room" with OCS 100
+    And user "participant3" shares "test" with room "group room invited to" with OCS 100
+    And user "participant2" shares "welcome.txt" with room "group room invited to" with OCS 100
+    And user "participant3" shares "test" with room "own one-to-one room" with OCS 100
+    When user "participant1" gets all received shares for "/welcome (2).txt"
+    Then the list of returned shares has 2 shares
+    And share 0 is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | own group room |
+      | share_with_displayname | Own group room |
+    And share 1 is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |

--- a/tests/integration/features/sharing/get.feature
+++ b/tests/integration/features/sharing/get.feature
@@ -1,0 +1,56 @@
+Feature: get
+
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+
+
+
+  Scenario: get a share
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant1" gets last share
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+
+
+  Scenario: get a share using a user not invited to the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant2" gets last share
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+
+
+
+  Scenario: get a share after changing the room name
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant1" renames room "group room" to "New room name" with 200
+    When user "participant1" gets last share
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | New room name |

--- a/tests/integration/features/sharing/get.feature
+++ b/tests/integration/features/sharing/get.feature
@@ -578,3 +578,44 @@ Feature: get
       | file_target            | /welcome (2).txt |
       | share_with             | group room invited to |
       | share_with_displayname | Group room invited to |
+
+
+
+  Scenario: get deleted shares when deleting an own share
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant1" deletes last share
+    When user "participant1" gets deleted shares
+    Then the list of returned shares has 0 shares
+    And user "participant2" gets deleted shares
+    And the list of returned shares has 0 shares
+
+  Scenario: get deleted shares when deleting a received share
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" deletes last share
+    When user "participant2" gets deleted shares
+    Then the list of returned shares has 1 shares
+    And share 0 is returned with
+      | id                     | REGEXP /ocRoomShare:[0-9]+/ |
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+      | permissions            | 0 |
+      | mail_send              | IGNORE |
+    And user "participant1" gets deleted shares
+    And the list of returned shares has 0 shares
+    And user "participant3" gets deleted shares
+    And the list of returned shares has 0 shares

--- a/tests/integration/features/sharing/hooks.feature
+++ b/tests/integration/features/sharing/hooks.feature
@@ -419,3 +419,270 @@ Feature: hooks
       | share_with             | participant3 |
       | share_with_displayname | participant3-displayname |
       | share_type             | 0 |
+
+
+
+  Scenario: add sharer again to group room after sharing a file and the sharer was removed from the room
+    Given user "participant2" creates room "group room"
+      | roomType | 2 |
+    And user "participant2" adds "participant1" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" removes "participant1" from room "group room" with 200
+    When user "participant2" adds "participant1" to room "group room" with 200
+    Then user "participant1" gets all shares
+    And the list of returned shares has 0 shares
+    And user "participant2" gets all received shares
+    And the list of returned shares has 0 shares
+
+  Scenario: add sharer again to group room after sharing a file and the sharer removed herself from the room
+    Given user "participant2" creates room "group room"
+      | roomType | 2 |
+    And user "participant2" adds "participant1" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant1" removes themselves from room "group room" with 200
+    When user "participant2" adds "participant1" to room "group room" with 200
+    Then user "participant1" gets all shares
+    And the list of returned shares has 0 shares
+    And user "participant2" gets all received shares
+    And the list of returned shares has 0 shares
+
+  Scenario: join public room again after sharing a file and the sharer left the room
+    Given user "participant2" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" joins room "public room" with 200
+    And user "participant1" shares "welcome.txt" with room "public room" with OCS 100
+    And user "participant1" leaves room "public room" with 200
+    When user "participant1" joins room "public room" with 200
+    Then user "participant1" gets all shares
+    And the list of returned shares has 0 shares
+    And user "participant2" gets all received shares
+    And the list of returned shares has 0 shares
+
+
+
+  Scenario: add sharer again to group room after sharing a file and a receiver reshared it and the sharer was removed from the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant2" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant1" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant1" removes "participant2" from room "group room" with 200
+    When user "participant1" adds "participant2" to room "group room" with 200
+    Then user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant1" gets all shares
+    And the list of returned shares has 0 shares
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant2 |
+      | displayname_file_owner | participant2-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant2 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant3 |
+      | share_with_displayname | participant3-displayname |
+      | share_type             | 0 |
+    And user "participant2" gets all shares
+    And the list of returned shares has 0 shares
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant2 |
+      | displayname_file_owner | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant3 |
+      | share_with_displayname | participant3-displayname |
+      | share_type             | 0 |
+
+
+
+  Scenario: add sharee again to group room after a file was shared and the sharee was removed from the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant1" removes "participant2" from room "group room" with 200
+    When user "participant1" adds "participant2" to room "group room" with 200
+    Then user "participant2" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  Scenario: add sharee again to group room after a file was shared and moved by the sharee and the sharee was removed from the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" moves file "welcome (2).txt" to "renamed.txt"
+    And user "participant1" removes "participant2" from room "group room" with 200
+    When user "participant1" adds "participant2" to room "group room" with 200
+    Then user "participant2" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  Scenario: add sharee again to group room after a file was shared and the sharee removed herself from the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" removes themselves from room "group room" with 200
+    When user "participant1" adds "participant2" to room "group room" with 200
+    Then user "participant2" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  Scenario: add sharee again to group room after a file was shared and moved by the sharee and the sharee removed herself from the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" moves file "welcome (2).txt" to "renamed.txt"
+    And user "participant2" removes themselves from room "group room" with 200
+    When user "participant1" adds "participant2" to room "group room" with 200
+    Then user "participant2" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  Scenario: join sharee again to public room after a file was shared and the sharee left the room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" renames room "public room" to "Public room" with 200
+    And user "participant2" joins room "public room" with 200
+    And user "participant1" shares "welcome.txt" with room "public room" with OCS 100
+    And user "participant2" leaves room "public room" with 200
+    When user "participant2" joins room "public room" with 200
+    Then user "participant2" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room |
+      | share_with_displayname | Public room |
+
+  Scenario: join sharee again to public room after a file was shared and moved by the sharee and the sharee left the room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" renames room "public room" to "Public room" with 200
+    And user "participant2" joins room "public room" with 200
+    And user "participant1" shares "welcome.txt" with room "public room" with OCS 100
+    And user "participant2" moves file "welcome (2).txt" to "renamed.txt"
+    And user "participant2" leaves room "public room" with 200
+    When user "participant2" joins room "public room" with 200
+    Then user "participant2" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room |
+      | share_with_displayname | Public room |
+
+
+
+  Scenario: add sharee again to group room after a file was shared and the sharee reshared it and the sharee was removed from the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant1" removes "participant2" from room "group room" with 200
+    When user "participant1" adds "participant2" to room "group room" with 200
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant3 |
+      | share_with_displayname | participant3-displayname |
+      | share_type             | 0 |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant3 |
+      | share_with_displayname | participant3-displayname |
+      | share_type             | 0 |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant3 |
+      | share_with_displayname | participant3-displayname |
+      | share_type             | 0 |

--- a/tests/integration/features/sharing/hooks.feature
+++ b/tests/integration/features/sharing/hooks.feature
@@ -857,3 +857,142 @@ Feature: hooks
       | file_target            | /welcome (2).txt |
       | share_with             | yet another group room |
       | share_with_displayname | Yet another group room |
+
+
+
+  Scenario: delete user after sharing a file
+    Given user "participant1" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room invited to" with 200
+    And user "participant2" shares "welcome.txt" with room "group room invited to" with OCS 100
+    When user "participant2" is deleted
+    Then user "participant1" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: delete user after receiving a shared a file
+    Given user "participant1" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant1" renames room "group room invited to" to "Group room invited to" with 200
+    And user "participant1" adds "participant2" to room "group room invited to" with 200
+    And user "participant1" adds "participant3" to room "group room invited to" with 200
+    And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
+    When user "participant2" is deleted
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+
+  Scenario: delete user after receiving and moving a shared a file
+    Given user "participant1" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant1" renames room "group room invited to" to "Group room invited to" with 200
+    And user "participant1" adds "participant2" to room "group room invited to" with 200
+    And user "participant1" adds "participant3" to room "group room invited to" with 200
+    And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
+    And user "participant2" moves file "welcome (2).txt" to "renamed.txt"
+    When user "participant2" is deleted
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+
+  Scenario: delete user after resharing a file
+    Given user "participant1" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant1" renames room "group room invited to" to "Group room invited to" with 200
+    And user "participant1" adds "participant2" to room "group room invited to" with 200
+    And user "participant1" adds "participant3" to room "group room invited to" with 200
+    And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with user "participant4" with OCS 100
+    When user "participant2" is deleted
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2 |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant4 |
+      | share_with_displayname | participant4-displayname |
+      | share_type             | 0 |
+    And user "participant1" gets all shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+    And user "participant3" gets last share
+    And the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant3" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+    And user "participant4" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2 |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant4 |
+      | share_with_displayname | participant4-displayname |
+      | share_type             | 0 |

--- a/tests/integration/features/sharing/hooks.feature
+++ b/tests/integration/features/sharing/hooks.feature
@@ -1,0 +1,421 @@
+Feature: hooks
+
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+    Given user "participant4" exists
+
+  # Entering a room does not really require any hook to work, but conceptually
+  # these tests belong here.
+  Scenario: invite user to group room after a file was shared
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant1" adds "participant2" to room "group room" with 200
+    Then user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  Scenario: join public room after a file was shared
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" renames room "public room" to "Public room" with 200
+    And user "participant1" shares "welcome.txt" with room "public room" with OCS 100
+    And user "participant2" joins room "public room" with 200
+    Then user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room |
+      | share_with_displayname | Public room |
+
+
+
+  Scenario: remove sharer from group room after sharing a file
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant2" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant1" removes "participant2" from room "group room" with 200
+    Then user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: remove herself from group room after sharing a file
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant2" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant2" removes themselves from room "group room" with 200
+    Then user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: leave group room after sharing a file
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant2" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant2" leaves room "group room" with 200
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant2 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  Scenario: leave public room invited to after sharing a file
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" renames room "public room" to "Public room" with 200
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "participant2" shares "welcome.txt" with room "public room" with OCS 100
+    When user "participant2" leaves room "public room" with 200
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room |
+      | share_with_displayname | Public room |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant2 |
+      | file_target            | /welcome.txt |
+      | share_with             | public room |
+      | share_with_displayname | Public room |
+
+  Scenario: leave public room self joined to after sharing a file
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant2" joins room "public room" with 200
+    And user "participant2" shares "welcome.txt" with room "public room" with OCS 100
+    When user "participant2" leaves room "public room" with 200
+    Then user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: remove sharer from group room with other shares after sharing a file
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" creates folder "test"
+    And user "participant1" shares "test" with room "group room" with OCS 100
+    And user "participant2" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant1" removes "participant2" from room "group room" with 200
+    Then user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+    And user "participant1" gets all shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /test |
+      | item_type              | folder |
+      | mimetype               | httpd/unix-directory |
+      | storage_id             | home::participant1 |
+      | file_target            | /test |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+      | permissions            | 31 |
+
+
+
+  Scenario: remove sharer from group room after sharing a file and a receiver reshared it
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant2" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant1" shares "welcome (2).txt" with user "participant3" with OCS 100
+    When user "participant1" removes "participant2" from room "group room" with 200
+    Then user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant1" gets all shares
+    And the list of returned shares has 0 shares
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant2 |
+      | displayname_file_owner | participant2-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant2 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant3 |
+      | share_with_displayname | participant3-displayname |
+      | share_type             | 0 |
+    And user "participant2" gets all shares
+    And the list of returned shares has 0 shares
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant2 |
+      | displayname_file_owner | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant3 |
+      | share_with_displayname | participant3-displayname |
+      | share_type             | 0 |
+
+
+
+  Scenario: remove sharee from group room after a file was shared
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant1" removes "participant2" from room "group room" with 200
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: remove sharee from group room after a file was shared and the sharee moved it
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" moves file "welcome (2).txt" to "renamed.txt"
+    When user "participant1" removes "participant2" from room "group room" with 200
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: remove herself from group room after a file was shared
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant2" removes themselves from room "group room" with 200
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: remove herself from group room after a file was shared and the sharee moved it
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" moves file "welcome (2).txt" to "renamed.txt"
+    When user "participant2" removes themselves from room "group room" with 200
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: leave public room self joined to after a file was shared
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" renames room "public room" to "Public room" with 200
+    And user "participant2" joins room "public room" with 200
+    And user "participant1" shares "welcome.txt" with room "public room" with OCS 100
+    When user "participant2" leaves room "public room" with 200
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | public room |
+      | share_with_displayname | Public room |
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: leave public room self joined to after a file was shared and the sharee moved it
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" renames room "public room" to "Public room" with 200
+    And user "participant2" joins room "public room" with 200
+    And user "participant1" shares "welcome.txt" with room "public room" with OCS 100
+    And user "participant2" moves file "welcome (2).txt" to "renamed.txt"
+    When user "participant2" leaves room "public room" with 200
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | public room |
+      | share_with_displayname | Public room |
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: remove sharee from group room with other sharees after a file was shared and the sharees moved it
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" moves file "welcome (2).txt" to "renamed.txt"
+    And user "participant3" moves file "welcome (2).txt" to "renamed too.txt"
+    When user "participant1" removes "participant2" from room "group room" with 200
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /renamed too.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/renamed too.txt |
+      | file_target            | /renamed too.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+
+
+  Scenario: remove sharee from group room after a file was shared and the sharee reshared it
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    When user "participant1" removes "participant2" from room "group room" with 200
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant3 |
+      | share_with_displayname | participant3-displayname |
+      | share_type             | 0 |
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+    And user "participant2" gets all shares
+    And the list of returned shares has 0 shares
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant3 |
+      | share_with_displayname | participant3-displayname |
+      | share_type             | 0 |

--- a/tests/integration/features/sharing/hooks.feature
+++ b/tests/integration/features/sharing/hooks.feature
@@ -686,3 +686,174 @@ Feature: hooks
       | share_with             | participant3 |
       | share_with_displayname | participant3-displayname |
       | share_type             | 0 |
+
+
+
+  Scenario: delete one-to-one room after sharing a file
+    Given user "participant1" creates room "own one-to-one room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" shares "welcome.txt" with room "own one-to-one room" with OCS 100
+    When user "participant1" deletes room "own one-to-one room" with 200
+    Then user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: delete group room after sharing a file
+    Given user "participant1" creates room "own group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "own group room" with 200
+    And user "participant1" shares "welcome.txt" with room "own group room" with OCS 100
+    When user "participant1" deletes room "own group room" with 200
+    Then user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: delete public room after sharing a file
+    Given user "participant1" creates room "own public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "own public room" with 200
+    And user "participant3" joins room "own public room" with 200
+    And user "participant1" shares "welcome.txt" with room "own public room" with OCS 100
+    When user "participant1" deletes room "own public room" with 200
+    Then user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+    And user "participant3" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: delete room after a file was shared and the sharee moved it
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" moves file "welcome (2).txt" to "renamed.txt"
+    When user "participant1" deletes room "group room" with 200
+    Then user "participant1" gets last share
+    And the OCS status code should be "404"
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: delete room after a file was shared and the sharee reshared it
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    When user "participant1" deletes room "group room" with 200
+    Then user "participant1" gets all shares
+    And the list of returned shares has 0 shares
+    And user "participant2" gets all shares
+    And the list of returned shares has 0 shares
+    And user "participant2" gets all received shares
+    And the list of returned shares has 0 shares
+    And user "participant3" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant3 |
+      | share_with_displayname | participant3-displayname |
+      | share_type             | 0 |
+
+  Scenario: delete room after a file was shared and the sharee moved and reshared it
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" moves file "welcome (2).txt" to "renamed.txt"
+    And user "participant2" shares "renamed.txt" with user "participant3" with OCS 100
+    When user "participant1" deletes room "group room" with 200
+    Then user "participant1" gets all shares
+    And the list of returned shares has 0 shares
+    And user "participant2" gets all shares
+    And the list of returned shares has 0 shares
+    And user "participant2" gets all received shares
+    And the list of returned shares has 0 shares
+    And user "participant3" gets all received shares
+    And the list of returned shares has 1 shares
+    And share 0 is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /renamed.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/renamed.txt |
+      | file_target            | /renamed.txt |
+      | share_with             | participant3 |
+      | share_with_displayname | participant3-displayname |
+      | share_type             | 0 |
+
+  Scenario: delete room after sharing a file with several rooms
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" creates room "another group room"
+      | roomType | 2 |
+    And user "participant1" renames room "another group room" to "Another group room" with 200
+    And user "participant1" creates room "yet another group room"
+      | roomType | 2 |
+    And user "participant1" renames room "yet another group room" to "Yet another group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant2" to room "another group room" with 200
+    And user "participant1" adds "participant2" to room "yet another group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant1" shares "welcome.txt" with room "another group room" with OCS 100
+    And user "participant1" shares "welcome.txt" with room "yet another group room" with OCS 100
+    When user "participant1" deletes room "group room" with 200
+    Then user "participant1" gets all shares
+    And the list of returned shares has 2 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | another group room |
+      | share_with_displayname | Another group room |
+    And share 1 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | yet another group room |
+      | share_with_displayname | Yet another group room |
+    And user "participant2" gets all received shares
+    And the list of returned shares has 2 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | another group room |
+      | share_with_displayname | Another group room |
+    And share 1 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | yet another group room |
+      | share_with_displayname | Yet another group room |

--- a/tests/integration/features/sharing/hooks.feature
+++ b/tests/integration/features/sharing/hooks.feature
@@ -43,6 +43,7 @@ Feature: hooks
       | file_target            | /welcome (2).txt |
       | share_with             | public room |
       | share_with_displayname | Public room |
+      | token                  | A_TOKEN |
 
 
 
@@ -116,6 +117,7 @@ Feature: hooks
       | file_target            | /welcome (2).txt |
       | share_with             | public room |
       | share_with_displayname | Public room |
+      | token                  | A_TOKEN |
     And user "participant2" gets last share
     And share is returned with
       | uid_owner              | participant2 |
@@ -127,6 +129,7 @@ Feature: hooks
       | file_target            | /welcome.txt |
       | share_with             | public room |
       | share_with_displayname | Public room |
+      | token                  | A_TOKEN |
 
   Scenario: leave public room self joined to after sharing a file
     Given user "participant1" creates room "public room"
@@ -318,6 +321,7 @@ Feature: hooks
       | file_target            | /welcome.txt |
       | share_with             | public room |
       | share_with_displayname | Public room |
+      | token                  | A_TOKEN |
     And user "participant2" gets last share
     And the OCS status code should be "404"
 
@@ -340,6 +344,7 @@ Feature: hooks
       | file_target            | /welcome.txt |
       | share_with             | public room |
       | share_with_displayname | Public room |
+      | token                  | A_TOKEN |
     And user "participant2" gets last share
     And the OCS status code should be "404"
 
@@ -611,6 +616,7 @@ Feature: hooks
       | file_target            | /welcome (2).txt |
       | share_with             | public room |
       | share_with_displayname | Public room |
+      | token                  | A_TOKEN |
 
   Scenario: join sharee again to public room after a file was shared and moved by the sharee and the sharee left the room
     Given user "participant1" creates room "public room"
@@ -633,6 +639,7 @@ Feature: hooks
       | file_target            | /welcome (2).txt |
       | share_with             | public room |
       | share_with_displayname | Public room |
+      | token                  | A_TOKEN |
 
 
 

--- a/tests/integration/features/sharing/move.feature
+++ b/tests/integration/features/sharing/move.feature
@@ -51,6 +51,163 @@ Feature: move
 
 
 
+  # When an own share is moved into a received shared folder the ownership of
+  # the share is handed over to the folder owner.
+  Scenario: move share to received shared folder from a user in the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant3" creates folder "/test"
+    And user "participant3" shares "/test" with user "participant1" with OCS 100
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant3 |
+      | displayname_file_owner | participant3-displayname |
+      | path                   | /test/renamed.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/test |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant3 |
+      | displayname_file_owner | participant3-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant3 |
+      | displayname_file_owner | participant3-displayname |
+      | path                   | /test/renamed.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant3 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  Scenario: move share to received shared folder from a user not in the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant4" creates folder "/test"
+    And user "participant4" shares "/test" with user "participant1" with OCS 100
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant4 |
+      | displayname_file_owner | participant4-displayname |
+      | path                   | /test/renamed.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/test |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant4 |
+      | displayname_file_owner | participant4-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant4 |
+      | displayname_file_owner | participant4-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  Scenario: move share to received shared folder which is also a received shared folder
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant3" creates folder "/test"
+    And user "participant3" shares "/test" with user "participant4" with OCS 100
+    And user "participant4" shares "/test" with user "participant1" with OCS 100
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant3 |
+      | displayname_file_owner | participant3-displayname |
+      | path                   | /test/renamed.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/test |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant3 |
+      | displayname_file_owner | participant3-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant3 |
+      | displayname_file_owner | participant3-displayname |
+      | path                   | /test/renamed.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant3 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant4" gets last share
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+
+
+
   Scenario: move received share to another folder
     Given user "participant1" creates room "group room"
       | roomType | 2 |
@@ -80,6 +237,112 @@ Feature: move
       | mimetype               | text/plain |
       | storage_id             | shared::/test/renamed.txt |
       | file_target            | /test/renamed.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+
+
+  # Received shares can not be moved into other shares (general limitation of
+  # the sharing system, not related to room shares).
+  Scenario: move received share to shared folder
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant3" creates folder "/test"
+    And user "participant3" shares "/test" with user "participant2" with OCS 100
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant3" moves file "/welcome (2).txt" to "/test/renamed.txt"
+    Then the HTTP status code should be "403"
+
+  # Received shares can be moved into other received shares, though. However,
+  # they are moved back to the default share folder.
+  Scenario: move received share to received shared folder from a user in the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant3" creates folder "/test"
+    And user "participant3" shares "/test" with user "participant2" with OCS 100
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant2" moves file "/welcome (2).txt" to "/test/renamed.txt"
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /renamed.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/renamed.txt |
+      | file_target            | /renamed.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  Scenario: move received share to received shared folder from a user not in the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant4" creates folder "/test"
+    And user "participant4" shares "/test" with user "participant2" with OCS 100
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant2" moves file "/welcome (2).txt" to "/test/renamed.txt"
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /renamed.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/renamed.txt |
+      | file_target            | /renamed.txt |
       | share_with             | group room |
       | share_with_displayname | Group room |
     And user "participant3" gets last share

--- a/tests/integration/features/sharing/move.feature
+++ b/tests/integration/features/sharing/move.feature
@@ -1,0 +1,95 @@
+Feature: move
+
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+    Given user "participant4" exists
+
+  Scenario: move share to another folder
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant1" creates folder "/test"
+    When user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /test/renamed.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+
+
+  Scenario: move received share to another folder
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" creates folder "/test"
+    When user "participant2" moves file "/welcome (2).txt" to "/test/renamed.txt" with 201
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /test/renamed.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/test/renamed.txt |
+      | file_target            | /test/renamed.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |

--- a/tests/integration/features/sharing/restore.feature
+++ b/tests/integration/features/sharing/restore.feature
@@ -1,0 +1,153 @@
+Feature: delete
+
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+
+  Scenario: restore deleted share
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" deletes last share
+    When user "participant2" restores last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "participant2" gets deleted shares
+    And the list of returned shares has 0 shares
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  Scenario: restore share deleted after moving it
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" moves file "/welcome (2).txt" to "/renamed.txt" with 201
+    And user "participant2" deletes last share
+    When user "participant2" restores last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "participant2" gets deleted shares
+    And the list of returned shares has 0 shares
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /renamed.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/renamed.txt |
+      | file_target            | /renamed.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  Scenario: restore deleted share after owner updated it
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" deletes last share
+    And user "participant1" updates last share with
+      | permissions | 1 |
+    When user "participant2" restores last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "participant2" gets deleted shares
+    And the list of returned shares has 0 shares
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+      | permissions            | 1 |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+      | permissions | 1 |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+      | permissions | 1 |

--- a/tests/integration/features/sharing/transfer-ownership.feature
+++ b/tests/integration/features/sharing/transfer-ownership.feature
@@ -1,0 +1,140 @@
+Feature: transfer-ownership
+
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+
+  Scenario: transfer ownership of a file shared with a room to a user in the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When transfering ownership from "participant1" to "participant2"
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome.txt |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | REGEXP /\/transferred from participant1 on .*\/welcome.txt/ |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant2 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  Scenario: transfer ownership of a file reshared with a room to a user in the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant3" shares "welcome.txt" with user "participant1" with OCS 100
+    And user "participant1" shares "welcome (2).txt" with room "group room" with OCS 100
+    When transfering ownership from "participant1" to "participant2"
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant3 |
+      | displayname_file_owner | participant3-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant3 |
+      | displayname_file_owner | participant3-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant3 |
+      | displayname_file_owner | participant3-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant3 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+
+  # This is a special case in which even if the (now) sharer is not in a room
+  # the room share is valid and other participants can access that share.
+  Scenario: transfer ownership of a file shared with a room to a user not in the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When transfering ownership from "participant1" to "participant2"
+    Then user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome.txt |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | REGEXP /\/transferred from participant1 on .*\/welcome.txt/ |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant2 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |

--- a/tests/integration/features/sharing/update.feature
+++ b/tests/integration/features/sharing/update.feature
@@ -1,0 +1,1101 @@
+Feature: update
+
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+
+  Scenario: update share with an owned one-to-one room
+    Given user "participant1" creates room "own one-to-one room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" shares "welcome.txt" with room "own one-to-one room" with OCS 100
+    When user "participant1" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own one-to-one room |
+      | share_with_displayname | participant2-displayname |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own one-to-one room |
+      | share_with_displayname | participant2-displayname |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | own one-to-one room |
+      | share_with_displayname | participant1-displayname |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+
+  Scenario: update share with a one-to-one room invited to
+    Given user "participant2" creates room "one-to-one room invited to"
+      | roomType | 1 |
+      | invite   | participant1 |
+    And user "participant1" shares "welcome.txt" with room "one-to-one room invited to" with OCS 100
+    When user "participant1" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | one-to-one room invited to |
+      | share_with_displayname | participant2-displayname |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | one-to-one room invited to |
+      | share_with_displayname | participant2-displayname |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | one-to-one room invited to |
+      | share_with_displayname | participant1-displayname |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+
+  Scenario: update share with an owned group room
+    Given user "participant1" creates room "own group room"
+      | roomType | 2 |
+    And user "participant1" renames room "own group room" to "Own group room" with 200
+    And user "participant1" adds "participant2" to room "own group room" with 200
+    And user "participant1" shares "welcome.txt" with room "own group room" with OCS 100
+    When user "participant1" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own group room |
+      | share_with_displayname | Own group room |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own group room |
+      | share_with_displayname | Own group room |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | own group room |
+      | share_with_displayname | Own group room |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+
+  Scenario: update share with a group room invited to
+    Given user "participant2" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
+    And user "participant2" adds "participant1" to room "group room invited to" with 200
+    And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
+    When user "participant1" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+
+  Scenario: update share with an owned public room
+    Given user "participant1" creates room "own public room"
+      | roomType | 3 |
+    And user "participant1" renames room "own public room" to "Own public room" with 200
+    And user "participant1" adds "participant2" to room "own public room" with 200
+    And user "participant3" joins room "own public room" with 200
+    And user "participant1" shares "welcome.txt" with room "own public room" with OCS 100
+    When user "participant1" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own public room |
+      | share_with_displayname | Own public room |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own public room |
+      | share_with_displayname | Own public room |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | own public room |
+      | share_with_displayname | Own public room |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | own public room |
+      | share_with_displayname | Own public room |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+
+  Scenario: update share with a public room invited to
+    Given user "participant2" creates room "public room invited to"
+      | roomType | 3 |
+    And user "participant2" renames room "public room invited to" to "Public room invited to" with 200
+    And user "participant2" adds "participant1" to room "public room invited to" with 200
+    And user "participant3" joins room "public room invited to" with 200
+    And user "participant1" shares "welcome.txt" with room "public room invited to" with OCS 100
+    When user "participant1" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | public room invited to |
+      | share_with_displayname | Public room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | public room invited to |
+      | share_with_displayname | Public room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room invited to |
+      | share_with_displayname | Public room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room invited to |
+      | share_with_displayname | Public room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+
+  Scenario: update share with a public room self joined to
+    Given user "participant2" creates room "public room self joined to"
+      | roomType | 3 |
+    And user "participant2" renames room "public room self joined to" to "Public room self joined to" with 200
+    And user "participant1" joins room "public room self joined to" with 200
+    And user "participant3" joins room "public room self joined to" with 200
+    And user "participant1" shares "welcome.txt" with room "public room self joined to" with OCS 100
+    When user "participant1" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | public room self joined to |
+      | share_with_displayname | Public room self joined to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | public room self joined to |
+      | share_with_displayname | Public room self joined to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room self joined to |
+      | share_with_displayname | Public room self joined to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room self joined to |
+      | share_with_displayname | Public room self joined to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+
+
+
+  Scenario: update (unknown) share with a one-to-one room not invited to
+    Given user "participant2" creates room "one-to-one room not invited to"
+      | roomType | 1 |
+      | invite   | participant3 |
+    And user "participant2" shares "welcome.txt" with room "one-to-one room not invited to" with OCS 100
+    When user "participant1" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant2 |
+      | file_target            | /welcome.txt |
+      | share_with             | one-to-one room not invited to |
+      | share_with_displayname | participant3-displayname |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | one-to-one room not invited to |
+      | share_with_displayname | participant2-displayname |
+
+  Scenario: update (unknown) share with a group room not invited to
+    Given user "participant2" creates room "group room not invited to"
+      | roomType | 2 |
+    And user "participant2" renames room "group room not invited to" to "Group room not invited to" with 200
+    And user "participant2" adds "participant3" to room "group room not invited to" with 200
+    And user "participant2" shares "welcome.txt" with room "group room not invited to" with OCS 100
+    When user "participant1" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant2 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room not invited to |
+      | share_with_displayname | Group room not invited to |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room not invited to |
+      | share_with_displayname | Group room not invited to |
+
+  Scenario: update (unknown) share with a public room not joined to
+    Given user "participant2" creates room "public room not joined to"
+      | roomType | 3 |
+    And user "participant2" renames room "public room not joined to" to "Public room not joined to" with 200
+    And user "participant2" adds "participant3" to room "public room not joined to" with 200
+    And user "participant2" shares "welcome.txt" with room "public room not joined to" with OCS 100
+    When user "participant1" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant2 |
+      | file_target            | /welcome.txt |
+      | share_with             | public room not joined to |
+      | share_with_displayname | Public room not joined to |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room not joined to |
+      | share_with_displayname | Public room not joined to |
+
+
+
+  Scenario: update received share with an owned one-to-one room
+    Given user "participant2" creates room "own one-to-one room"
+      | roomType | 1 |
+      | invite   | participant1 |
+    And user "participant1" shares "welcome.txt" with room "own one-to-one room" with OCS 100
+    When user "participant2" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | own one-to-one room |
+      | share_with_displayname | participant1-displayname |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own one-to-one room |
+      | share_with_displayname | participant2-displayname |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | own one-to-one room |
+      | share_with_displayname | participant1-displayname |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+
+  Scenario: update received share with a one-to-one room invited to
+    Given user "participant1" creates room "one-to-one room invited to"
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" shares "welcome.txt" with room "one-to-one room invited to" with OCS 100
+    When user "participant2" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | one-to-one room invited to |
+      | share_with_displayname | participant1-displayname |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | one-to-one room invited to |
+      | share_with_displayname | participant2-displayname |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | one-to-one room invited to |
+      | share_with_displayname | participant1-displayname |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+
+  Scenario: update received share with an owned group room
+    Given user "participant2" creates room "own group room"
+      | roomType | 2 |
+    And user "participant2" renames room "own group room" to "Own group room" with 200
+    And user "participant2" adds "participant1" to room "own group room" with 200
+    And user "participant1" shares "welcome.txt" with room "own group room" with OCS 100
+    When user "participant2" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | own group room |
+      | share_with_displayname | Own group room |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own group room |
+      | share_with_displayname | Own group room |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | own group room |
+      | share_with_displayname | Own group room |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+
+  Scenario: update received share with a group room invited to
+    Given user "participant1" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant1" renames room "group room invited to" to "Group room invited to" with 200
+    And user "participant1" adds "participant2" to room "group room invited to" with 200
+    And user "participant1" adds "participant3" to room "group room invited to" with 200
+    And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
+    When user "participant2" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+
+  Scenario: update received share with a group room no longer invited to
+    Given user "participant1" creates room "group room no longer invited to"
+      | roomType | 2 |
+    And user "participant1" renames room "group room no longer invited to" to "Group room no longer invited to" with 200
+    And user "participant1" adds "participant2" to room "group room no longer invited to" with 200
+    And user "participant1" adds "participant3" to room "group room no longer invited to" with 200
+    And user "participant1" shares "welcome.txt" with room "group room no longer invited to" with OCS 100
+    And user "participant1" removes "participant2" from room "group room no longer invited to" with 200
+    When user "participant2" updates last share with
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room no longer invited to |
+      | share_with_displayname | Group room no longer invited to |
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room no longer invited to |
+      | share_with_displayname | Group room no longer invited to |
+
+  Scenario: update received share with an owned public room
+    Given user "participant2" creates room "own public room"
+      | roomType | 3 |
+    And user "participant2" renames room "own public room" to "Own public room" with 200
+    And user "participant2" adds "participant1" to room "own public room" with 200
+    And user "participant3" joins room "own public room" with 200
+    And user "participant1" shares "welcome.txt" with room "own public room" with OCS 100
+    When user "participant2" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | own public room |
+      | share_with_displayname | Own public room |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | own public room |
+      | share_with_displayname | Own public room |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | own public room |
+      | share_with_displayname | Own public room |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | own public room |
+      | share_with_displayname | Own public room |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+
+  Scenario: update received share with a public room invited to
+    Given user "participant1" creates room "public room invited to"
+      | roomType | 3 |
+    And user "participant1" renames room "public room invited to" to "Public room invited to" with 200
+    And user "participant1" adds "participant2" to room "public room invited to" with 200
+    And user "participant3" joins room "public room invited to" with 200
+    And user "participant1" shares "welcome.txt" with room "public room invited to" with OCS 100
+    When user "participant2" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room invited to |
+      | share_with_displayname | Public room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | public room invited to |
+      | share_with_displayname | Public room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room invited to |
+      | share_with_displayname | Public room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room invited to |
+      | share_with_displayname | Public room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+
+  Scenario: update received share with a public room self joined to
+    Given user "participant1" creates room "public room self joined to"
+      | roomType | 3 |
+    And user "participant1" renames room "public room self joined to" to "Public room self joined to" with 200
+    And user "participant2" joins room "public room self joined to" with 200
+    And user "participant3" joins room "public room self joined to" with 200
+    And user "participant1" shares "welcome.txt" with room "public room self joined to" with OCS 100
+    When user "participant2" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room self joined to |
+      | share_with_displayname | Public room self joined to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | public room self joined to |
+      | share_with_displayname | Public room self joined to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room self joined to |
+      | share_with_displayname | Public room self joined to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room self joined to |
+      | share_with_displayname | Public room self joined to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+
+  Scenario: update received share with a public room no longer joined to
+    Given user "participant1" creates room "public room no longer joined to"
+      | roomType | 3 |
+    And user "participant1" renames room "public room no longer joined to" to "Public room no longer joined to" with 200
+    And user "participant2" joins room "public room no longer joined to" with 200
+    And user "participant3" joins room "public room no longer joined to" with 200
+    And user "participant1" shares "welcome.txt" with room "public room no longer joined to" with OCS 100
+    And user "participant2" leaves room "public room no longer joined to" with 200
+    When user "participant2" updates last share with
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | public room no longer joined to |
+      | share_with_displayname | Public room no longer joined to |
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room no longer joined to |
+      | share_with_displayname | Public room no longer joined to |
+
+
+
+  Scenario: update received share after moving it
+    Given user "participant1" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant1" renames room "group room invited to" to "Group room invited to" with 200
+    And user "participant1" adds "participant2" to room "group room invited to" with 200
+    And user "participant1" adds "participant3" to room "group room invited to" with 200
+    And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
+    And user "participant2" creates folder "/test"
+    And user "participant2" moves file "/welcome (2).txt" to "/test/renamed.txt" with 201
+    When user "participant2" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /test/renamed.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/test/renamed.txt |
+      | file_target            | /test/renamed.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /test/renamed.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/test/renamed.txt |
+      | file_target            | /test/renamed.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+
+  Scenario: update received share with a room no longer invited to after moving it
+    Given user "participant1" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant1" renames room "group room invited to" to "Group room invited to" with 200
+    And user "participant1" adds "participant2" to room "group room invited to" with 200
+    And user "participant1" adds "participant3" to room "group room invited to" with 200
+    And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
+    And user "participant2" creates folder "/test"
+    And user "participant2" moves file "/welcome (2).txt" to "/test/renamed.txt" with 201
+    And user "participant1" removes "participant2" from room "group room invited to" with 200
+    When user "participant2" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant3" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+
+
+
+  Scenario: update received share with increased permissions
+    Given user "participant1" creates room "group room invited to"
+      | roomType | 2 |
+    And user "participant1" renames room "group room invited to" to "Group room invited to" with 200
+    And user "participant1" adds "participant2" to room "group room invited to" with 200
+    And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
+    And user "participant1" updates last share with
+      | permissions            | 1 |
+    When user "participant2" updates last share with
+      | permissions            | 19 |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 1 |
+    And user "participant2" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome (2).txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | shared::/welcome (2).txt |
+      | file_target            | /welcome (2).txt |
+      | share_with             | group room invited to |
+      | share_with_displayname | Group room invited to |
+      | permissions            | 1 |

--- a/tests/integration/features/sharing/update.feature
+++ b/tests/integration/features/sharing/update.feature
@@ -1099,3 +1099,69 @@ Feature: update
       | share_with             | group room invited to |
       | share_with_displayname | Group room invited to |
       | permissions            | 1 |
+
+
+
+  Scenario: update share after sharee deleted it
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" deletes last share with OCS 100
+    When user "participant1" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+      | permissions            | 1 |
+      | expiration             | +3 days |
+    And user "participant2" gets last share
+    And the OCS status code should be "404"
+
+  Scenario: update received share after deleting it
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" renames room "group room" to "Group room" with 200
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    And user "participant2" deletes last share with OCS 100
+    When user "participant2" updates last share with
+      | permissions            | 1 |
+      | expireDate             | +3 days |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    And user "participant1" gets last share
+    And share is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome.txt |
+      | share_with             | group room |
+      | share_with_displayname | Group room |
+    And user "participant2" gets last share
+    And the OCS status code should be "404"

--- a/tests/integration/features/sharing/update.feature
+++ b/tests/integration/features/sharing/update.feature
@@ -215,6 +215,7 @@ Feature: update
       | file_target            | /welcome.txt |
       | share_with             | own public room |
       | share_with_displayname | Own public room |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant1" gets last share
@@ -228,6 +229,7 @@ Feature: update
       | file_target            | /welcome.txt |
       | share_with             | own public room |
       | share_with_displayname | Own public room |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant2" gets last share
@@ -241,6 +243,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | own public room |
       | share_with_displayname | Own public room |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant3" gets last share
@@ -254,6 +257,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | own public room |
       | share_with_displayname | Own public room |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
 
@@ -277,6 +281,7 @@ Feature: update
       | file_target            | /welcome.txt |
       | share_with             | public room invited to |
       | share_with_displayname | Public room invited to |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant1" gets last share
@@ -290,6 +295,7 @@ Feature: update
       | file_target            | /welcome.txt |
       | share_with             | public room invited to |
       | share_with_displayname | Public room invited to |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant2" gets last share
@@ -303,6 +309,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | public room invited to |
       | share_with_displayname | Public room invited to |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant3" gets last share
@@ -316,6 +323,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | public room invited to |
       | share_with_displayname | Public room invited to |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
 
@@ -339,6 +347,7 @@ Feature: update
       | file_target            | /welcome.txt |
       | share_with             | public room self joined to |
       | share_with_displayname | Public room self joined to |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant1" gets last share
@@ -352,6 +361,7 @@ Feature: update
       | file_target            | /welcome.txt |
       | share_with             | public room self joined to |
       | share_with_displayname | Public room self joined to |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant2" gets last share
@@ -365,6 +375,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | public room self joined to |
       | share_with_displayname | Public room self joined to |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant3" gets last share
@@ -378,6 +389,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | public room self joined to |
       | share_with_displayname | Public room self joined to |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
 
@@ -472,6 +484,7 @@ Feature: update
       | file_target            | /welcome.txt |
       | share_with             | public room not joined to |
       | share_with_displayname | Public room not joined to |
+      | token                  | A_TOKEN |
     And user "participant3" gets last share
     And share is returned with
       | uid_owner              | participant2 |
@@ -483,6 +496,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | public room not joined to |
       | share_with_displayname | Public room not joined to |
+      | token                  | A_TOKEN |
 
 
 
@@ -749,6 +763,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | own public room |
       | share_with_displayname | Own public room |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant1" gets last share
@@ -762,6 +777,7 @@ Feature: update
       | file_target            | /welcome.txt |
       | share_with             | own public room |
       | share_with_displayname | Own public room |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant2" gets last share
@@ -775,6 +791,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | own public room |
       | share_with_displayname | Own public room |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant3" gets last share
@@ -788,6 +805,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | own public room |
       | share_with_displayname | Own public room |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
 
@@ -811,6 +829,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | public room invited to |
       | share_with_displayname | Public room invited to |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant1" gets last share
@@ -824,6 +843,7 @@ Feature: update
       | file_target            | /welcome.txt |
       | share_with             | public room invited to |
       | share_with_displayname | Public room invited to |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant2" gets last share
@@ -837,6 +857,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | public room invited to |
       | share_with_displayname | Public room invited to |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant3" gets last share
@@ -850,6 +871,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | public room invited to |
       | share_with_displayname | Public room invited to |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
 
@@ -873,6 +895,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | public room self joined to |
       | share_with_displayname | Public room self joined to |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant1" gets last share
@@ -886,6 +909,7 @@ Feature: update
       | file_target            | /welcome.txt |
       | share_with             | public room self joined to |
       | share_with_displayname | Public room self joined to |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant2" gets last share
@@ -899,6 +923,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | public room self joined to |
       | share_with_displayname | Public room self joined to |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
     And user "participant3" gets last share
@@ -912,6 +937,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | public room self joined to |
       | share_with_displayname | Public room self joined to |
+      | token                  | A_TOKEN |
       | permissions            | 1 |
       | expiration             | +3 days |
 
@@ -939,6 +965,7 @@ Feature: update
       | file_target            | /welcome.txt |
       | share_with             | public room no longer joined to |
       | share_with_displayname | Public room no longer joined to |
+      | token                  | A_TOKEN |
     And user "participant2" gets last share
     And the OCS status code should be "404"
     And the HTTP status code should be "200"
@@ -953,6 +980,7 @@ Feature: update
       | file_target            | /welcome (2).txt |
       | share_with             | public room no longer joined to |
       | share_with_displayname | Public room no longer joined to |
+      | token                  | A_TOKEN |
 
 
 

--- a/tests/integration/spreedcheats/lib/Controller/ApiController.php
+++ b/tests/integration/spreedcheats/lib/Controller/ApiController.php
@@ -59,6 +59,14 @@ class ApiController extends OCSController {
 		$query = $this->db->getQueryBuilder();
 		$query->delete('talk_participants')->execute();
 
+		$query = $this->db->getQueryBuilder();
+		$query->delete('share')
+			->where($query->expr()->orX(
+				$query->expr()->eq('share_type', $query->createNamedParameter(\OCP\Share::SHARE_TYPE_ROOM)),
+				$query->expr()->eq('share_type', $query->createNamedParameter(11 /*RoomShareProvider::SHARE_TYPE_USERROOM*/))
+			))
+			->execute();
+
 		return new DataResponse();
 	}
 }


### PR DESCRIPTION
Talk part of nextcloud/server#10255

First of all sorry for the massive size of this pull request. If it is any comfort to you it is basically a big specification of integration tests with some code in between :-P

This pull request, with its server counterpart, makes possible to share a file or folder into a Talk room. The integration test will need to be launched again once the server part is merged.

Room shares are heavily based on (read, copy-pasted from :-P ) group shares, although with some differences. In the same way that a user must be a participant of a room to send a message to it a user must be a participant of a room to share a file with it (in the case of group shares enforcing that is enabled in the settings). Similarly, when a user leaves a room she has no longer access to the shares in the room; for consistency, her own shares are also removed.

This Talk part adds a new `IShareProvider`, `RoomShareProvider`, which provides the core operations (create, update, delete...) for each share type. To try to make it more manageable for review each operation is added incrementally in its own commit, followed by commits that add the integration tests that verify that operation.

Due to the current architecture of the sharing system it is not enough to provide an `IShareProvider` to add a new type of share; the controllers for the sharing API also need to be modified to support each type of share. Due to this, and to keep the server isolated from the Talk details (for example, whether a file can be shared with certain type of room or not, or how to generate the display name for a room share), the controllers just delegate those checks or actions to helper classes defined in Talk.

Note that this pull request just adds the core implementation of room shares. Other features, like sending a message in the chat to inform the rest of the users that a file was shared, show the name of the participants as the display name of the share when the room has no name set, or making possible to share files from the Talk UI itself will be added in other pull requests. In any case, all those changes are Talk specific; no changes are needed in the server for them.

Also note that this pull request implements room shares, but not search for room collaborators (so even if room shares are implemented you can not test them from the UI); this is implemented in #1051
