### PR TITLE
Only show client links when the firstrunwizard is enabled

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -57,7 +57,6 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 		<admin>OCA\Spreed\Settings\Admin\StunServer</admin>
 		<admin>OCA\Spreed\Settings\Admin\SignalingServer</admin>
 		<admin-section>OCA\Spreed\Settings\Admin\Section</admin-section>
-		<personal>OCA\Spreed\Settings\Personal</personal>
 	</settings>
 
 	<activity>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -29,10 +29,12 @@ use OCA\Spreed\GuestManager;
 use OCA\Spreed\HookListener;
 use OCA\Spreed\Notification\Notifier;
 use OCA\Spreed\Room;
+use OCA\Spreed\Settings\Personal;
 use OCA\Spreed\Signaling\BackendNotifier;
 use OCA\Spreed\Signaling\Messages;
 use OCP\AppFramework\App;
 use OCP\IServerContainer;
+use OCP\Settings\IManager;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -66,6 +68,7 @@ class Application extends App {
 		$this->registerRoomInvitationHook($dispatcher);
 		$this->registerCallNotificationHook($dispatcher);
 		$this->registerChatHooks($dispatcher);
+		$this->registerClientLinks($server);
 	}
 
 	protected function registerNotifier(IServerContainer $server) {
@@ -80,6 +83,14 @@ class Application extends App {
 				'name' => $l->t('Talk'),
 			];
 		});
+	}
+
+	protected function registerClientLinks(IServerContainer $server) {
+		if ($server->getAppManager()->isEnabledForUser('firstrunwizard')) {
+			/** @var IManager $settingManager */
+			$settingManager = $server->getSettingsManager();
+			$settingManager->registerSetting('personal', Personal::class);
+		}
 	}
 
 	protected function registerInternalSignalingHooks(EventDispatcherInterface $dispatcher) {


### PR DESCRIPTION
As requested in #1043, this will make sure we only show the client links if the firstrunwizard app is enabled.

Fix #1043