### PR TITLE
Adjust UI to layout changes in server

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -4,12 +4,14 @@
  * overridden with a full set of flex containers to cascade parent element
  * height to the main view to limit the vertical scroll bar only to it (same
  * thing done for the sidebar and the chat view). */
-#body-user {
+#body-user,
+#body-public {
 	display: flex;
 	flex-direction: column;
 }
 
-#body-user #header {
+#body-user #header,
+#body-public #header {
 	/* Override fixed position from server to include it in the flex layout */
 	position: static;
 	flex-shrink: 0;
@@ -53,14 +55,6 @@
 	overflow: hidden;
 
 	flex-grow: 1;
-}
-
-#body-public {
-	height: 100%;
-}
-
-#body-public #app-content {
-	overflow: hidden;
 }
 
 .app-spreed #app-navigation {
@@ -809,27 +803,9 @@ video {
 	}
 }
 
-/* The header element contains the header div; as the header div uses a fixed
-   position the header element has no height, and as #app-content-wrapper uses a
-   "100%" height its contents must be padded to prevent them from overlapping
-   with the header element */
-#body-public #app-content-wrapper {
-	padding-top: 45px;
-}
-
 /* make blue header bar transparent in shared room */
 #body-public #app-content:not(.participants-1) #header.spreed-public {
 	background: transparent;
-}
-
-/* Correctly position icons below header in public chat. */
-#body-public {
-	#app-sidebar-trigger {
-		top: 45px;
-	}
-	#video-fullscreen {
-		top: 89px;
-	}
 }
 
 /* As the header is hidden (except for the logo), move the fullscreen button and

--- a/css/style.scss
+++ b/css/style.scss
@@ -36,6 +36,10 @@
 
 	flex-grow: 1;
 
+	/* Does not change anything in normal mode, but ensures that the element
+	 * will stretch to the full width in full screen mode. */
+	width: 100%;
+
 	/* Override margin used in server, as the header is part of the flex layout
 	 * and thus the content does not need to be pushed down. */
 	margin-top: 0;
@@ -593,91 +597,63 @@ video {
 
 /* Fullscreen handling */
 
-/**
- * Different browsers handle fullscreen elements with a margin in different
- * ways: Firefox ignores the margin and uses the full width, while Chromium uses
- * a strange mix which is neither the full width nor the full margin. Due to
- * this the margin is removed to unify the appearance across browsers; visually,
- * this causes the sidebar to slide on the content instead of "pushing" it to
- * the left.
- */
-#app-content:-webkit-full-screen {
-	width: 100%;
-	margin-right: 0;
-
-	&.participants-1 {
-		background: #fff;
-	}
-}
-#app-content:-moz-full-screen {
-	width: 100%;
-	margin-right: 0;
-
-	&.participants-1 {
-		background: #fff;
-	}
-}
-#app-content:-ms-fullscreen {
-	width: 100%;
-	margin-right: 0;
-
-	&.participants-1 {
-		background: #fff;
-	}
-}
-#app-content:fullscreen {
-	width: 100%;
-	margin-right: 0;
-
-	&.participants-1 {
-		background: #fff;
-	}
-}
-
 /* No switching between rooms in fullscreen, focus on the current call. */
-#app-content:-webkit-full-screen #app-navigation-toggle {
+#content:-webkit-full-screen #app-navigation-toggle {
 	display: none !important;
 }
-#app-content:-moz-full-screen #app-navigation-toggle {
+#content:-moz-full-screen #app-navigation-toggle {
 	display: none !important;
 }
-#app-content:-ms-fullscreen #app-navigation-toggle {
+#content:-ms-fullscreen #app-navigation-toggle {
 	display: none !important;
 }
-#app-content:fullscreen #app-navigation-toggle {
+#content:fullscreen #app-navigation-toggle {
 	display: none !important;
 }
 
-/**
- * In fullscreen mode there is no header, so the sidebar has to be moved to the
- * top.
- */
-#app-content:-webkit-full-screen #app-sidebar {
-	top: 0;
+#content:-webkit-full-screen #app-navigation {
+	display: none;
 }
-#app-content:-moz-full-screen #app-sidebar {
-	top: 0;
+#content:-moz-full-screen #app-navigation {
+	display: none;
 }
-#app-content:-ms-fullscreen #app-sidebar {
-	top: 0;
+#content:-ms-fullscreen #app-navigation {
+	display: none;
 }
-#app-content:fullscreen #app-sidebar {
-	top: 0;
+#content:fullscreen #app-navigation {
+	display: none;
 }
 
-/* In the public page the header is inside the app-content, so it has to be
-   hidden explicitly. */
-#app-content:-webkit-full-screen #header {
-	display: none !important;
+#content:-webkit-full-screen #app-content {
+	margin-left: 0;
 }
-#app-content:-moz-full-screen #header {
-	display: none !important;
+#content:-moz-full-screen #app-content {
+	margin-left: 0;
 }
-#app-content:-ms-fullscreen #header {
-	display: none !important;
+#content:-ms-fullscreen #app-content {
+	margin-left: 0;
 }
-#app-content:fullscreen #header {
-	display: none !important;
+#content:fullscreen #app-content {
+	margin-left: 0;
+}
+
+/* Set the background of the content to the same colour as the app content and
+ * the app sidebar to prevent a black background from appearing when the sidebar
+ * is shown or hidden.
+ * During a call the background of the app content is black, but as the
+ * background of the content has the same colour of the sidebar and is a
+ * placeholder on its position it looks acceptable. */
+#content:-webkit-full-screen {
+	background-color: var(--color-main-background);
+}
+#content:-moz-full-screen {
+	background-color: var(--color-main-background);
+}
+#content:-ms-fullscreen {
+	background-color: var(--color-main-background);
+}
+#content:fullscreen {
+	background-color: var(--color-main-background);
 }
 
 
@@ -758,6 +734,16 @@ video {
 	/* Higher than the z-index of the app-content */
 	z-index: 1050;
 	cursor: pointer;
+}
+
+/* Override server definitions to ensure that the sidebar is vertically
+ * stretched, as the header is part of the flex layout and its height does not
+ * need to be removed from the sidebar (specially in fullscreen mode where there
+ * is no header). */
+#app-sidebar {
+	position: static;
+	height: unset;
+	top: 0;
 }
 
 .icon-menu-people {

--- a/css/style.scss
+++ b/css/style.scss
@@ -757,8 +757,8 @@ video {
 	position: absolute;
 	top: 0;
 	right: 0;
-	/* Higher than the z-index of the emptycontent */
-	z-index: 50;
+	/* Higher than the z-index of the app-content */
+	z-index: 1050;
 	cursor: pointer;
 }
 

--- a/css/style.scss
+++ b/css/style.scss
@@ -57,15 +57,7 @@
 	flex-grow: 1;
 }
 
-.app-spreed #app-navigation {
-	padding-top: 45px;
-	padding-bottom: 0;
-}
-
 #oca-spreedme-add-room {
-	position: absolute;
-	width: 249px;
-	top: 0;
 	border-bottom: 1px solid $color-border;
 }
 

--- a/css/style.scss
+++ b/css/style.scss
@@ -753,10 +753,16 @@ video {
 	display: inline-block;
 }
 
+/* The sidebar wrapper contains the trigger for the sidebar and the sidebar
+ * itself placed in columns. To prevent the trigger from taking up space for the
+ * app content the trigger width is removed from the wrapper by pushing its left
+ * margin. */
+#app-sidebar-wrapper {
+	display: flex;
+	margin-left: -44px;
+}
+
 #app-sidebar-trigger {
-	position: absolute;
-	top: 0;
-	right: 0;
 	/* Higher than the z-index of the app-content */
 	z-index: 1050;
 	cursor: pointer;

--- a/css/style.scss
+++ b/css/style.scss
@@ -1,8 +1,64 @@
+/* The standard layout defined in the server includes a fixed header with a
+ * sticky sidebar. This causes the scroll bar for the main area to appear to the
+ * right of the sidebar, which looks confusing for the chat. Thus that layout is
+ * overridden with a full set of flex containers to cascade parent element
+ * height to the main view to limit the vertical scroll bar only to it (same
+ * thing done for the sidebar and the chat view). */
+#body-user {
+	display: flex;
+	flex-direction: column;
+}
+
+#body-user #header {
+	/* Override fixed position from server to include it in the flex layout */
+	position: static;
+	flex-shrink: 0;
+}
+
+#content-wrapper {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+
+	flex-grow: 1;
+
+	/* Override "min-height: 100%" set in server, as the header is part of the
+	 * flex layout and thus the whole body is not available for the content. */
+	min-height: 0;
+}
+
+#content {
+	display: flex;
+	flex-direction: row;
+	overflow: hidden;
+
+	flex-grow: 1;
+
+	/* Override margin used in server, as the header is part of the flex layout
+	 * and thus the content does not need to be pushed down. */
+	margin-top: 0;
+}
+
+#app-content {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+
+	flex-grow: 1;
+}
+
+#app-content-wrapper {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+
+	flex-grow: 1;
+}
+
 #body-public {
 	height: 100%;
 }
 
-.app-spreed #app-content,
 #body-public #app-content {
 	overflow: hidden;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -557,7 +557,7 @@
 		},
 		initialize: function() {
 			this._sidebarView = new OCA.SpreedMe.Views.SidebarView();
-			$('#app-content').append(this._sidebarView.$el);
+			$('#content').append(this._sidebarView.$el);
 
 			if (OC.getCurrentUser().uid) {
 				this._rooms = new OCA.SpreedMe.Models.RoomCollection();

--- a/js/app.js
+++ b/js/app.js
@@ -697,7 +697,7 @@
 			}
 		},
 		enableFullscreen: function() {
-			var fullscreenElem = document.getElementById('app-content');
+			var fullscreenElem = document.getElementById('content');
 
 			if (fullscreenElem.requestFullscreen) {
 				fullscreenElem.requestFullscreen();

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -36,6 +36,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Http\Template\PublicTemplateResponse;
 use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -220,7 +221,8 @@ class PageController extends Controller {
 			'token' => $token,
 			'signaling-settings' => $this->config->getSettings($this->userId),
 		];
-		$response = new TemplateResponse($this->appName, 'index-public', $params, 'base');
+		$response = new PublicTemplateResponse($this->appName, 'index-public', $params);
+		$response->setFooterVisible(false);
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedConnectDomain('*');
 		$csp->addAllowedMediaDomain('blob:');

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -46,67 +46,52 @@ script(
 	<script type="text/json" id="signaling-settings">
 	<?php echo json_encode($_['signaling-settings']) ?>
 	</script>
-	<div id="app-content" class="participants-1">
+</div>
 
-		<header>
-			<div id="header" class="spreed-public">
-				<div id="header-left">
-					<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="nextcloud" target="_blank">
-						<div class="logo logo-icon svg">
-							<h1 class="hidden-visually">
-								<?php p($theme->getName() . ' ' . $l->t('Talk')); ?>
-							</h1>
-						</div>
-					</a>
+<div id="app-content" class="participants-1">
+
+	<div id="app-content-wrapper">
+		<button id="video-fullscreen" class="icon-fullscreen icon-white icon-shadow public" data-placement="bottom" data-toggle="tooltip" data-original-title="<?php p($l->t('Fullscreen (f)')) ?>"></button>
+
+		<div id="video-speaking">
+
+		</div>
+		<div id="videos">
+			<div class="videoView videoContainer hidden" id="localVideoContainer">
+				<video id="localVideo"></video>
+				<div class="avatar-container hidden">
+					<div class="avatar"></div>
 				</div>
-				<div id="header-right">
-				</div>
-			</div>
-		</header>
-
-		<div id="app-content-wrapper">
-			<button id="video-fullscreen" class="icon-fullscreen icon-white icon-shadow public" data-placement="bottom" data-toggle="tooltip" data-original-title="<?php p($l->t('Fullscreen (f)')) ?>"></button>
-
-			<div id="video-speaking">
-
-			</div>
-			<div id="videos">
-				<div class="videoView videoContainer hidden" id="localVideoContainer">
-					<video id="localVideo"></video>
-					<div class="avatar-container hidden">
-						<div class="avatar"></div>
-					</div>
-					<div class="nameIndicator">
-						<button id="mute" class="icon-audio icon-white icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Mute audio (m)')) ?>"></button>
-						<button id="hideVideo" class="icon-video icon-white icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Disable video (v)')) ?>"></button>
-						<button id="screensharing-button" class="app-navigation-entry-utils-menu-button icon-screen-off icon-white icon-shadow screensharing-disabled" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Share screen')) ?>"></button>
-						<div id="screensharing-menu" class="app-navigation-entry-menu">
-							<ul>
-								<li>
-									<button id="show-screen-button">
-										<span class="icon-screen"></span>
-										<span><?php p($l->t('Show your screen'));?></span>
-									</button>
-								</li>
-								<li>
-									<button id="stop-screen-button">
-										<span class="icon-screen-off"></span>
-										<span><?php p($l->t('Stop screensharing'));?></span>
-									</button>
-								</li>
-							</ul>
-						</div>
+				<div class="nameIndicator">
+					<button id="mute" class="icon-audio icon-white icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Mute audio (m)')) ?>"></button>
+					<button id="hideVideo" class="icon-video icon-white icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Disable video (v)')) ?>"></button>
+					<button id="screensharing-button" class="app-navigation-entry-utils-menu-button icon-screen-off icon-white icon-shadow screensharing-disabled" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Share screen')) ?>"></button>
+					<div id="screensharing-menu" class="app-navigation-entry-menu">
+						<ul>
+							<li>
+								<button id="show-screen-button">
+									<span class="icon-screen"></span>
+									<span><?php p($l->t('Show your screen'));?></span>
+								</button>
+							</li>
+							<li>
+								<button id="stop-screen-button">
+									<span class="icon-screen-off"></span>
+									<span><?php p($l->t('Stop screensharing'));?></span>
+								</button>
+							</li>
+						</ul>
 					</div>
 				</div>
 			</div>
+		</div>
 
-			<div id="screens"></div>
+		<div id="screens"></div>
 
-			<div id="emptycontent">
-				<div id="emptycontent-icon" class="icon-video"></div>
-				<h2><?php p($l->t('Join a conversation or start a new one')) ?></h2>
-				<p class="uploadmessage"></p>
-			</div>
+		<div id="emptycontent">
+			<div id="emptycontent-icon" class="icon-video"></div>
+			<h2><?php p($l->t('Join a conversation or start a new one')) ?></h2>
+			<p class="uploadmessage"></p>
 		</div>
 	</div>
 </div>

--- a/templates/index.php
+++ b/templates/index.php
@@ -46,53 +46,55 @@ script(
 	<script type="text/json" id="signaling-settings">
 	<?php echo json_encode($_['signaling-settings']) ?>
 	</script>
-	<div id="app-navigation" class="icon-loading">
-		<form id="oca-spreedme-add-room">
-			<input id="select-participants" class="select2-offscreen" type="text" placeholder="<?php p($l->t('New conversation …')) ?>"/>
-		</form>
-		<ul id="spreedme-room-list" class="with-icon">
-		</ul>
-	</div>
+</div>
 
-	<div id="app-content" class="participants-1">
+<div id="app-navigation" class="icon-loading">
+	<form id="oca-spreedme-add-room">
+		<input id="select-participants" class="select2-offscreen" type="text" placeholder="<?php p($l->t('New conversation …')) ?>"/>
+	</form>
+	<ul id="spreedme-room-list" class="with-icon">
+	</ul>
+</div>
 
-		<div id="app-content-wrapper">
+<div id="app-content" class="participants-1">
+
+	<div id="app-content-wrapper">
 		<button id="video-fullscreen" class="icon-fullscreen icon-white icon-shadow hidden" data-placement="bottom" data-toggle="tooltip" data-original-title="<?php p($l->t('Fullscreen (f)')) ?>"></button>
 
 		<div id="video-speaking">
 
-		</div>
-		<div id="videos">
-			<div class="videoView videoContainer hidden" id="localVideoContainer">
-				<video id="localVideo"></video>
-				<div class="avatar-container hidden">
-					<div class="avatar"></div>
-				</div>
-				<div class="nameIndicator">
-					<button id="mute" class="icon-audio icon-white icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Mute audio (m)')) ?>"></button>
-					<button id="hideVideo" class="icon-video icon-white icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Disable video (v)')) ?>"></button>
-					<button id="screensharing-button" class="app-navigation-entry-utils-menu-button icon-screen-off icon-white icon-shadow screensharing-disabled" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Share screen')) ?>"></button>
-					<div id="screensharing-menu" class="app-navigation-entry-menu">
-						<ul>
-							<li>
-								<button id="show-screen-button">
-									<span class="icon-screen"></span>
-									<span><?php p($l->t('Show your screen'));?></span>
-								</button>
-							</li>
-							<li>
-								<button id="stop-screen-button">
-									<span class="icon-screen-off"></span>
-									<span><?php p($l->t('Stop screensharing'));?></span>
-								</button>
-							</li>
-						</ul>
-					</div>
+	</div>
+	<div id="videos">
+		<div class="videoView videoContainer hidden" id="localVideoContainer">
+			<video id="localVideo"></video>
+			<div class="avatar-container hidden">
+				<div class="avatar"></div>
+			</div>
+			<div class="nameIndicator">
+				<button id="mute" class="icon-audio icon-white icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Mute audio (m)')) ?>"></button>
+				<button id="hideVideo" class="icon-video icon-white icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Disable video (v)')) ?>"></button>
+				<button id="screensharing-button" class="app-navigation-entry-utils-menu-button icon-screen-off icon-white icon-shadow screensharing-disabled" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Share screen')) ?>"></button>
+				<div id="screensharing-menu" class="app-navigation-entry-menu">
+					<ul>
+						<li>
+							<button id="show-screen-button">
+								<span class="icon-screen"></span>
+								<span><?php p($l->t('Show your screen'));?></span>
+							</button>
+						</li>
+						<li>
+							<button id="stop-screen-button">
+								<span class="icon-screen-off"></span>
+								<span><?php p($l->t('Stop screensharing'));?></span>
+							</button>
+						</li>
+					</ul>
 				</div>
 			</div>
 		</div>
+	</div>
 
-		<div id="screens"></div>
+	<div id="screens"></div>
 
 		<div id="emptycontent">
 			<div id="emptycontent-icon" class="icon-video"></div>
@@ -102,8 +104,8 @@ script(
 				<input id="shareRoomInput" class="share-room-input hidden" readonly="readonly" type="text"/>
 				<div id="shareRoomClipboardButton" class="shareRoomClipboard icon-clippy hidden" data-clipboard-target="#shareRoomInput"></div>
 			</div>
-		</div>
 
 		</div>
+
 	</div>
 </div>

--- a/tests/acceptance/features/bootstrap/ConversationInfoContext.php
+++ b/tests/acceptance/features/bootstrap/ConversationInfoContext.php
@@ -42,6 +42,15 @@ class ConversationInfoContext implements Context, ActorAwareInterface {
 	public static function conversationNameEditableTextLabel() {
 		return Locator::forThe()->css(".room-name")->
 				descendantOf(self::conversationInfoContainer())->
+				describedAs("Conversation name editable text label in conversation info");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function conversationNameLabel() {
+		return Locator::forThe()->css(".label")->
+				descendantOf(self::conversationNameEditableTextLabel())->
 				describedAs("Conversation name label in conversation info");
 	}
 
@@ -67,7 +76,7 @@ class ConversationInfoContext implements Context, ActorAwareInterface {
 	 * @Given I rename the conversation to :newConversationName
 	 */
 	public function iRenameTheConversationTo($newConversationName) {
-		$this->actor->find(self::conversationNameEditableTextLabel(), 10)->click();
+		$this->actor->find(self::conversationNameLabel(), 10)->click();
 		$this->actor->find(self::editConversationNameButton(), 2)->click();
 		$this->actor->find(self::conversationNameTextInput(), 2)->setValue($newConversationName . "\r");
 	}


### PR DESCRIPTION
This pull request fixes the several issues in the UI of Talk caused by the layout changes in the server (nextcloud/server#9982 and follow ups).

Note that this takes into account the changes in the server only up to Nextcloud 14 Beta 1; other layout changes were introduced after Beta 1, but those will be tackled in other pull requests.

Other known issues that will be fixed in other pull requests:
- Colour of fullscreen and sidebar trigger icons (the issue was not caused by the layout changes, but by a different server change)
- Header no longer hidden during calls in public page
- In fullscreen mode the sidebar now "pushes" the content to the left instead of sliding over it; while this is great in large screens it is problematic in narrow screens, and in those screens the old behaviour of sliding over the content should be introduced again.
- The acceptance test _delete a one-to-one conversation_ fails; it seems to be a legit failure (the conversation is not closed for participant B when participant A deletes it) and a regression in Talk unrelated to these changes or the layout changes in the server.
