### PR TITLE
Fix "Participants" text not shown in tab header

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -132,7 +132,8 @@
 	margin: 0 !important;
 }
 
-.icon-contacts-dark,
+.select2-result .icon-contacts-dark.avatar,
+#app-navigation .icon-contacts-dark,
 #app-navigation .app-navigation-entry-link .icon-public,
 .icon-add  {
 	background-color: transparent !important;

--- a/css/style.scss
+++ b/css/style.scss
@@ -133,11 +133,10 @@
 }
 
 .select2-result .icon-contacts-dark.avatar,
+.select2-result .icon-add.avatar,
 #app-navigation .icon-contacts-dark,
 #app-navigation .app-navigation-entry-link .icon-public,
-.icon-add  {
-	background-color: transparent !important;
-	color: transparent !important;
+#app-navigation .icon-add  {
 	border-radius: 0;
 	width: 32px;
 	height: 32px;

--- a/js/app.js
+++ b/js/app.js
@@ -133,7 +133,7 @@
 			});
 
 			$('#select-participants').on("click", function() {
-				$('.select2-drop').find('.avatar').each(function () {
+				$('.select2-drop').find('.avatar[data-user]').each(function () {
 					var element = $(this);
 					if (element.data('user-display-name')) {
 						element.avatar(element.data('user'), 32, undefined, false, undefined, element.data('user-display-name'));
@@ -164,7 +164,7 @@
 			}.bind(this));
 
 			$('#select-participants').on("select2-loaded", function() {
-				$('.select2-drop').find('.avatar').each(function () {
+				$('.select2-drop').find('.avatar[data-user]').each(function () {
 					var element = $(this);
 					if (element.data('user-display-name')) {
 						element.avatar(element.data('user'), 32, undefined, false, undefined, element.data('user-display-name'));


### PR DESCRIPTION
This pull request fixes a regression introduced in 8b247e25e1b5

Before:
![tab-header-participants-before](https://user-images.githubusercontent.com/26858233/43409675-db09c594-9424-11e8-819a-c0795d38a332.png)

After:
![tab-header-participants-after](https://user-images.githubusercontent.com/26858233/43409677-dd3845d4-9424-11e8-9208-f75baff11711.png)
