### PR TITLE
Fix colour and opacity of icons shown over main content

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -459,6 +459,13 @@ video {
 		filter: none;
 	}
 
+	&.icon-menu-people {
+		background-image: var(--icon-menu-people-000);
+	}
+	&.icon-fullscreen {
+		background-image: var(--icon-fullscreen-000);
+	}
+
 	&.icon-menu-people,
 	&.icon-fullscreen {
 		filter: none;
@@ -747,9 +754,7 @@ video {
 	top: 0;
 }
 
-.icon-menu-people {
-	background-image: url('../img/menu-people.svg?v=1');
-}
+@include icon-black-white('menu-people', 'spreed', 1);
 
 .icon-no-password {
 	background-image: url('../img/no-password.svg?v=1');

--- a/css/style.scss
+++ b/css/style.scss
@@ -449,6 +449,16 @@ video {
 	background-color: #000;
 }
 
+#app-content ~ #app-sidebar-wrapper .icon-menu-people,
+#app-content .icon-fullscreen {
+	opacity: .5;
+
+	&:hover,
+	&:focus {
+		opacity: 1;
+	}
+}
+
 /* Use dark icons when not in a call (= white background) */
 #app-content:not(.incall):not(.screensharing) .icon-white.icon-shadow,
 #app-content:not(.incall):not(.screensharing) ~ #app-sidebar-wrapper .icon-white.icon-shadow {
@@ -469,12 +479,6 @@ video {
 	&.icon-menu-people,
 	&.icon-fullscreen {
 		filter: none;
-		opacity: .5;
-
-		&:hover,
-		&:focus {
-			opacity: 1;
-		}
 	}
 }
 

--- a/css/style.scss
+++ b/css/style.scss
@@ -583,6 +583,15 @@ video {
 	opacity: .7;
 }
 
+.nameIndicator button.audio-disabled:not(.no-audio-available),
+.nameIndicator button.video-disabled:not(.no-video-available),
+.nameIndicator button.screensharing-disabled {
+	&:hover,
+	&:focus {
+		opacity: 1;
+	}
+}
+
 .nameIndicator button.no-audio-available,
 .nameIndicator button.no-video-available {
 	opacity: .7;

--- a/css/style.scss
+++ b/css/style.scss
@@ -631,8 +631,16 @@ video {
 	display: none;
 }
 
-.muteIndicator.audio-off {
+.muteIndicator.audio-off,
+.hideRemoteVideo.icon-video-off {
 	opacity: .7;
+}
+
+.hideRemoteVideo.icon-video-off {
+	&:hover,
+	&:focus {
+		opacity: 1;
+	}
 }
 
 .iceFailedIndicator {

--- a/css/style.scss
+++ b/css/style.scss
@@ -466,15 +466,15 @@ video {
 	 * use dark icons.
 	 * There is no need to override "icon-video" and "icon-screensharing", as
 	 * they will never be shown with dark icons. */
-	&#hideVideo.video-disabled,
-	&#mute.video-disabled,
-	&#screensharing-button.video-disabled {
+	&#hideVideo.local-video-disabled,
+	&#mute.local-video-disabled,
+	&#screensharing-button.local-video-disabled {
 		filter: none;
 	}
-	&#hideVideo.video-disabled {
+	&#hideVideo.local-video-disabled {
 		background-image: var(--icon-video-off-000);
 	}
-	&#mute.video-disabled {
+	&#mute.local-video-disabled {
 		&.icon-audio-off {
 			background-image: var(--icon-audio-off-000);
 		}
@@ -482,7 +482,7 @@ video {
 			background-image: var(--icon-audio-000);
 		}
 	}
-	&#screensharing-button.video-disabled {
+	&#screensharing-button.local-video-disabled {
 		background-image: var(--icon-screen-off-000);
 	}
 

--- a/css/style.scss
+++ b/css/style.scss
@@ -450,7 +450,8 @@ video {
 }
 
 /* Use dark icons when not in a call (= white background) */
-#app-content:not(.incall):not(.screensharing) .icon-white.icon-shadow {
+#app-content:not(.incall):not(.screensharing) .icon-white.icon-shadow,
+#app-content:not(.incall):not(.screensharing) ~ #app-sidebar-wrapper .icon-white.icon-shadow {
 	/* Still use white icons outside of calls when local video shows */
 	&#hideVideo.video-disabled,
 	&#mute.video-disabled,

--- a/css/style.scss
+++ b/css/style.scss
@@ -482,6 +482,13 @@ video {
 	}
 }
 
+/* Use white icon for the app navigation toggle when in a call */
+#app-content.incall .icon-menu,
+#app-content.screensharing .icon-menu {
+	@include icon-color('menu', 'actions', $color-white, 1, true);
+	filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
+}
+
 #app-content.screensharing #screens {
 	position: absolute;
 	width: 100%;

--- a/css/style.scss
+++ b/css/style.scss
@@ -462,11 +462,28 @@ video {
 /* Use dark icons when not in a call (= white background) */
 #app-content:not(.incall):not(.screensharing) .icon-white.icon-shadow,
 #app-content:not(.incall):not(.screensharing) ~ #app-sidebar-wrapper .icon-white.icon-shadow {
-	/* Still use white icons outside of calls when local video shows */
+	/* Still use white icons outside of calls when local video shows; otherwise
+	 * use dark icons.
+	 * There is no need to override "icon-video" and "icon-screensharing", as
+	 * they will never be shown with dark icons. */
 	&#hideVideo.video-disabled,
 	&#mute.video-disabled,
 	&#screensharing-button.video-disabled {
 		filter: none;
+	}
+	&#hideVideo.video-disabled {
+		background-image: var(--icon-video-off-000);
+	}
+	&#mute.video-disabled {
+		&.icon-audio-off {
+			background-image: var(--icon-audio-off-000);
+		}
+		&.icon-audio {
+			background-image: var(--icon-audio-000);
+		}
+	}
+	&#screensharing-button.video-disabled {
+		background-image: var(--icon-screen-off-000);
 	}
 
 	&.icon-menu-people {

--- a/js/app.js
+++ b/js/app.js
@@ -773,10 +773,10 @@
 			var localVideo = $hideVideoButton.closest('.videoView').find('#localVideo');
 
 			$hideVideoButton.attr('data-original-title', t('spreed', 'Disable video (v)'))
-				.removeClass('video-disabled icon-video-off')
+				.removeClass('local-video-disabled video-disabled icon-video-off')
 				.addClass('icon-video');
-			$audioMuteButton.removeClass('video-disabled');
-			$screensharingButton.removeClass('video-disabled');
+			$audioMuteButton.removeClass('local-video-disabled');
+			$screensharingButton.removeClass('local-video-disabled');
 
 			avatarContainer.hide();
 			localVideo.show();
@@ -799,10 +799,10 @@
 
 			if (!$hideVideoButton.hasClass('no-video-available')) {
 				$hideVideoButton.attr('data-original-title', t('spreed', 'Enable video (v)'))
-					.addClass('video-disabled icon-video-off')
+					.addClass('local-video-disabled video-disabled icon-video-off')
 					.removeClass('icon-video');
-				$audioMuteButton.addClass('video-disabled');
-				$screensharingButton.addClass('video-disabled');
+				$audioMuteButton.addClass('local-video-disabled');
+				$screensharingButton.addClass('local-video-disabled');
 			}
 
 			var avatar = avatarContainer.find('.avatar');


### PR DESCRIPTION
This pull request fixes the colour and the opacity of the icons shown on the content (the app navigation toggle, the sidebar trigger, the fullscreen button and the media buttons).

@nextcloud/designers Note that each group of icons uses its own opacity: the app navigation toggle (which comes from the server) uses 0.6, the sidebar trigger and the fullscreen button use 0.5, and the media buttons use 0.7. I have respected the opacity that was being used for them because I was not sure if those different values were on purpose due to their different function, or it is just something that should be fixed (but, if that is the case, it can wait to a different pull request ;-) ).

Before, no call:
![content-icons-no-call-before](https://user-images.githubusercontent.com/26858233/43471777-20221f24-94ec-11e8-887f-fddcf0bb9803.png)

After, no call:
![content-icons-no-call-after](https://user-images.githubusercontent.com/26858233/43472120-f62cdb68-94ec-11e8-9800-23d64073a145.png)

Before, call:
![content-icons-call-before](https://user-images.githubusercontent.com/26858233/43472168-1e6da76a-94ed-11e8-98ea-bcc3ddd127cd.png)

After, call:
![content-icons-call-after](https://user-images.githubusercontent.com/26858233/43472052-c794612c-94ec-11e8-8265-85bf86a33d77.png)
