### PR TITLE
Fix size of sidebar trigger and fullscreen icons

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -538,6 +538,9 @@ video {
 	margin: 0;
 	width: 44px;
 	height: 44px;
+}
+
+.nameIndicator button {
 	background-size: 24px;
 }
 


### PR DESCRIPTION
Fixes #904

Note that the screenshots below were taken on top of #1091, so when testing this branch you will not see some of the icons (anyway, I have used different pull requests for them because they are independent issues).

Before:
![icons-size-before](https://user-images.githubusercontent.com/26858233/43472291-647bf95a-94ed-11e8-9916-1918fb21d956.png)

After:
![icons-size-after](https://user-images.githubusercontent.com/26858233/43472294-672df11c-94ed-11e8-9394-7ef61380666a.png)

Note that the size of the media icons was not reduced; in my opinion it does not look good (in fact I would have increased the size of the app navigation toggle instead of reducing the others, but that is a different matter ;-) ):
![icons-size-all](https://user-images.githubusercontent.com/26858233/43472297-6921a482-94ed-11e8-8167-859322d828da.png)