### PR TITLE
Adjust UI to further layout changes in server

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -17,24 +17,18 @@
 	flex-shrink: 0;
 }
 
-#content-wrapper {
-	display: flex;
-	flex-direction: column;
-	overflow: hidden;
-
-	flex-grow: 1;
-
-	/* Override "min-height: 100%" set in server, as the header is part of the
-	 * flex layout and thus the whole body is not available for the content. */
-	min-height: 0;
-}
-
 #content {
 	display: flex;
 	flex-direction: row;
 	overflow: hidden;
 
 	flex-grow: 1;
+
+	/* Override "min-height: 100%" and "padding-top: 50px" set in server, as the
+	 * header is part of the flex layout and thus the whole body is not
+	 * available for the content. */
+	min-height: 0;
+	padding-top: 0;
 
 	/* Does not change anything in normal mode, but ensures that the element
 	 * will stretch to the full width in full screen mode. */

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -39,9 +39,6 @@ script(
 );
 ?>
 
-<div id="notification-container">
-	<div id="notification" style="display: none;"></div>
-</div>
 <div id="app" class="nc-enable-screensharing-extension" data-token="<?php p($_['token']) ?>">
 	<script type="text/json" id="signaling-settings">
 	<?php echo json_encode($_['signaling-settings']) ?>


### PR DESCRIPTION
This pull request is a follow up to #1085 that adjust the UI again to the layout changes introduced in the server after Beta 1.

Basically it fixes the scrolling of the main view and removes a duplicated element (because it is now provided by the server).

Will this be the last pull request with fixes due to changes of the layout in the server before NC 14? He, who knows... :-P
