### PR TITLE
Work around fetching participants before setting the room

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -354,7 +354,11 @@
 			});
 
 			this.signaling.on('participantListChanged', function() {
-				this._participants.fetch();
+				// The "participantListChanged" event can be triggered by the
+				// signaling before the room is set in the collection.
+				if (this._participants.url) {
+					this._participants.fetch();
+				}
 			}.bind(this));
 
 			this._participantsView.listenTo(this._rooms, 'change:active', function(model, active) {


### PR DESCRIPTION
Fixes #1113 

The room data currently comes from both the signaling and queries to the server, and each one of those sources have its own set of events. Due to this, when entering a room the list of participants can sometimes be tried to be fetched before the room was set for the list of participants.

This commit works around that problem by fetching the participant list only when a URL was set; the real fix (proper synchronization between the events from both sources) would require a much deeper overhaul of the architecture.

In order to test this and consistently cause `participantListChanged` to be triggered before the room is set [`this.setRoom(model)`](https://github.com/nextcloud/spreed/blob/85d3514991aadd4b31d8f5f306c337c3784215e8/js/app.js#L362) can be wrapped with a timeout, like `setTimeout(function() { this.setRoom(model); }.bind(this), 2000);`.