### PR TITLE
Fix update of CSS classes during screensharing

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -25,13 +25,18 @@ var spreedPeerConnectionTable = [];
 
 		var $appContentElement = $('#app-content'),
 			participantsClass = 'participants-' + currentUsersNo,
+			hadScreensharing = $appContentElement.hasClass('screensharing'),
 			hadSidebar = $appContentElement.hasClass('with-app-sidebar');
-		if (!$appContentElement.hasClass(participantsClass) && !$appContentElement.hasClass('screensharing')) {
+		if (!$appContentElement.hasClass(participantsClass)) {
 			$appContentElement.attr('class', '').addClass(participantsClass);
 			if (currentUsersNo > 1) {
 				$appContentElement.addClass('incall');
 			} else {
 				$appContentElement.removeClass('incall');
+			}
+
+			if (hadScreensharing) {
+				$appContentElement.addClass('screensharing');
 			}
 
 			if (hadSidebar) {


### PR DESCRIPTION
During screensharing the `participants-X` and `incall` CSS classes were not updated, which could led to inconsistencies in the UI (for example, if another participant joined or left the call during screensharing).

How to test:
- Start call with user A
- Join call with user B
- Share screen with user A
- Leave call with user B
- Stop screen sharing with user A

Expected result:
The screen turns white again and the message _Waiting for user B to join the call …_ is shown.

Actual result:
The screen stays black. Note that, eventually, the proper UI will be restored due to the signaling, but it is not immediate as it should be.
