### PR TITLE
Add button to share files from Talk UI

### DIFF
--- a/css/comments.scss
+++ b/css/comments.scss
@@ -22,31 +22,45 @@
 }
 
 #commentsTabView .newCommentForm .message {
-	width: calc(100% - 32px);
+	width: calc(100% - 36px);
 	margin-left: 36px;
 	padding-right: 30px;
 	display: block;
 }
 
 #commentsTabView .newCommentForm .submit,
-#commentsTabView .newCommentForm .submitLoading {
+#commentsTabView .newCommentForm .submitLoading,
+#commentsTabView .newCommentForm .share,
+#commentsTabView .newCommentForm .shareLoading {
 	position: absolute;
 
 	width: 44px;
 	height: 44px;
 
 	bottom: -4px;
-	right: -8px;
 	margin: 0;
 }
 
-#commentsTabView .newCommentForm .submit {
+#commentsTabView .newCommentForm .submit,
+#commentsTabView .newCommentForm .submitLoading {
+	right: 0;
+}
+
+#commentsTabView .newCommentForm .share,
+#commentsTabView .newCommentForm .shareLoading {
+	right: -44px;
+}
+
+#commentsTabView .newCommentForm .submit,
+#commentsTabView .newCommentForm .share {
 	background-color: transparent;
 	border: none;
 	opacity: .3;
 }
 #commentsTabView .newCommentForm .submit:hover,
-#commentsTabView .newCommentForm .submit:focus {
+#commentsTabView .newCommentForm .submit:focus,
+#commentsTabView .newCommentForm .share:hover,
+#commentsTabView .newCommentForm .share:focus {
 	opacity: 1;
 }
 


### PR DESCRIPTION
The button, which is shown next to the area to write new messages, shows a file picker and then shares the chosen file with the room.

Note that currently new files can not be uploaded through the file picker; only those already in the Nextcloud account of the user can be chosen.

Also, currently only registered users can share files with a room, so the button is hidden for guests.