### PR TITLE
Fix TURN credential generation.

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -131,12 +131,14 @@ class Config {
 
 		// Credentials are valid for 24h
 		// FIXME add the TTL to the response and properly reconnect then
-		$username = $this->timeFactory->getTime() + 86400;
+		$timestamp = $this->timeFactory->getTime() + 86400;
+		$rnd = $this->secureRandom->generate(16);
+		$username = (string) $timestamp . ':' . $rnd;
 		$password = base64_encode(hash_hmac('sha1', $username, $server['secret'], true));
 
 		return array(
 			'server' => $server['server'],
-			'username' => (string) $username,
+			'username' => $username,
 			'password' => $password,
 			'protocols' => $server['protocols'],
 		);

--- a/tests/php/ConfigTest.php
+++ b/tests/php/ConfigTest.php
@@ -80,6 +80,11 @@ class ConfigTest extends TestCase {
 
 		/** @var \PHPUnit_Framework_MockObject_MockObject|ISecureRandom $secureRandom */
 		$secureRandom = $this->createMock(ISecureRandom::class);
+		$secureRandom
+			->expects($this->once())
+			->method('generate')
+			->with(16)
+			->willReturn('abcdefghijklmnop');
 		$helper = new Config($config, $secureRandom, $timeFactory);
 
 		//
@@ -87,15 +92,15 @@ class ConfigTest extends TestCase {
 		if ($server['server'] === 'turn.example.org') {
 			$this->assertSame([
 				'server' => 'turn.example.org',
-				'username' => '1479829425',
-				'password' => 'ZY8fZQxAw/24gT0XYnMlcepUFlI=',
+				'username' => '1479829425:abcdefghijklmnop',
+				'password' => '4VJLVbihLzuxgMfDrm5C3zy8kLQ=',
 				'protocols' => 'udp,tcp',
 			], $server);
 		} else {
 			$this->assertSame([
 				'server' => 'turn2.example.com',
-				'username' => '1479829425',
-				'password' => 'VoqRpE4ktQ85TqFps8Qt+scEEvE=',
+				'username' => '1479829425:abcdefghijklmnop',
+				'password' => 'Ol9DEqnvyN4g+IAM+vFnqhfWUTE=',
 				'protocols' => 'tcp',
 			], $server);
 		}


### PR DESCRIPTION
The temporary username must consist of the timestamp and a random username, see https://github.com/coturn/coturn/wiki/turnserver#turn-rest-api (and https://tools.ietf.org/html/draft-uberti-behave-turn-rest-00#section-2.2) for details on the format.