### PR TITLE
Fix position of contacts menu shown on mentions

### DIFF
--- a/css/comments.scss
+++ b/css/comments.scss
@@ -327,10 +327,8 @@ body:not(#body-public) #commentsTabView .comment:not(.newCommentRow) .message .m
 }
 
 #commentsTabView .comment .message .contactsmenu-popover {
-	/* Override default positioning of the contacts menu from server, as it is
-	 * based on an avatar plus a text instead of only '@' plus a text. */
-	left: -12px;
-	top: 140%;
+	left: -6px;
+	top: 24px;
 }
 
 #commentsTabView .comment .message .filePreviewContainer .filePreview {


### PR DESCRIPTION
See nextcloud/server#11258

**Before:**
![talk-mentions-contacts-menu-before](https://user-images.githubusercontent.com/26858233/45611397-9d637300-ba5f-11e8-8d7c-8dfe1e751a9d.png)

**After:**
![talk-mentions-contacts-menu-after](https://user-images.githubusercontent.com/26858233/45611392-9b011900-ba5f-11e8-9058-be4cda5c80d8.png)
