### PR TITLE
Ensure that "object_type" and "object_id" are strings

### DIFF
--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -107,7 +107,7 @@ class Manager {
 			]));
 		}
 
-		return new Room($this, $this->db, $this->secureRandom, $this->dispatcher, $this->hasher, (int) $row['id'], (int) $row['type'], $row['token'], $row['name'], $row['password'], (int) $row['active_guests'], $activeSince, $lastActivity, $lastMessage, $row['object_type'], $row['object_id']);
+		return new Room($this, $this->db, $this->secureRandom, $this->dispatcher, $this->hasher, (int) $row['id'], (int) $row['type'], $row['token'], $row['name'], $row['password'], (int) $row['active_guests'], $activeSince, $lastActivity, $lastMessage, (string) $row['object_type'], (string) $row['object_id']);
 	}
 
 	/**


### PR DESCRIPTION
[As `object_type` and `object_id` are nullable](https://github.com/nextcloud/spreed/blob/29a72c3ededd44ffb44d5bcb02763aabd1f041ea/lib/Migration/Version3003Date20180720162342.php#L41-L50) the row returned by the database can contain a null value in those fields. However, those fields are nullable only due to some Oracle limitations; conceptually they should be empty strings, so an explicit cast to string is now used when creating the room object.

An example of those fields being returned as null could be seen in rooms created in Talk 3.x and then updated to Talk 4.x (although rooms created in Talk 4.x should be fine, as [by default an empty string is stored in the database when the room is created](https://github.com/nextcloud/spreed/blob/1edb5226bb103ba8143a5a5a0cda00f49ccc5d56/lib/Manager.php#L411)).