### PR TITLE
Fix rendering of the participant list

### DIFF
--- a/js/models/participantcollection.js
+++ b/js/models/participantcollection.js
@@ -31,6 +31,14 @@
 		room: undefined,
 
 		/**
+		 * Returns the unique identifier for each participant model in the
+		 * collection.
+		 */
+		modelId: function (attrs) {
+			return attrs['userId']? ('userId-' + attrs['userId']) : ('sessionId' + attrs['sessionId']);
+		},
+
+		/**
 		 * @param {OCA.SpreedMe.Models.Room} room
 		 * @returns {Array}
 		 */

--- a/js/views/participantlistview.js
+++ b/js/views/participantlistview.js
@@ -79,19 +79,19 @@
 		childView: Marionette.View.extend({
 			tagName: 'li',
 			modelEvents: {
-				'change:active': function() {
+				'change:sessionId': function() {
+					// The sessionId is used to know if the user is online.
 					this.render();
 				},
 				'change:displayName': function() {
 					this.render();
 				},
-				'change:participants': function() {
+				'change:participantType': function() {
 					this.render();
 				},
-				'change:type': function() {
+				'change:inCall': function() {
 					this.render();
-					this.checkSharingStatus();
-				}
+				},
 			},
 			initialize: function() {
 				this.listenTo(uiChannel, 'document:click', function(event) {

--- a/js/views/participantlistview.js
+++ b/js/views/participantlistview.js
@@ -30,7 +30,7 @@
 	var uiChannel = Backbone.Radio.channel('ui');
 
 	var ITEM_TEMPLATE = '' +
-		'<a class="participant-entry-link {{#if isOffline}}participant-offline{{/if}}" href="#" data-sessionId="{{sessionId}}">' +
+		'<a class="participant-entry-link" href="#" data-sessionId="{{sessionId}}">' +
 			'<div class="avatar"></div>' +
 			' {{name}}' +
 			'{{#if participantIsOwner}}<span class="participant-moderator-indicator">(' + t('spreed', 'moderator') + ')</span>{{/if}}' +
@@ -145,6 +145,8 @@
 
 				if (!this.model.isOnline()) {
 					this.$el.addClass('participant-offline');
+				} else {
+					this.$el.removeClass('participant-offline');
 				}
 
 				this.toggleMenuClass();

--- a/js/views/participantlistview.js
+++ b/js/views/participantlistview.js
@@ -184,7 +184,11 @@
 						participant: participantId
 					},
 					success: function() {
-						self.render();
+						self.model.set('participantType', OCA.SpreedMe.app.MODERATOR);
+						// When an attribute that affects the order of a
+						// collection is set the collection has to be explicitly
+						// sorted again.
+						self.model.collection.sort();
 					},
 					error: function() {
 						console.log('Error while promoting user to moderator');
@@ -206,7 +210,11 @@
 						participant: participantId
 					},
 					success: function() {
-						self.render();
+						self.model.set('participantType', OCA.SpreedMe.app.USER);
+						// When an attribute that affects the order of a
+						// collection is set the collection has to be explicitly
+						// sorted again.
+						self.model.collection.sort();
 					},
 					error: function() {
 						console.log('Error while demoting moderator');
@@ -234,7 +242,7 @@
 						participant: participantId
 					},
 					success: function() {
-						self.render();
+						self.model.collection.remove(self.model);
 					},
 					error: function() {
 						console.log('Error while removing user from room');

--- a/js/views/participantlistview.js
+++ b/js/views/participantlistview.js
@@ -75,6 +75,7 @@
 	OCA.SpreedMe.Views.ParticipantListView = Marionette.CollectionView.extend({
 		tagName: 'ul',
 		className: 'participantWithList',
+		reorderOnSort: true,
 
 		childView: Marionette.View.extend({
 			tagName: 'li',

--- a/js/views/participantlistview.js
+++ b/js/views/participantlistview.js
@@ -75,20 +75,7 @@
 	OCA.SpreedMe.Views.ParticipantListView = Marionette.CollectionView.extend({
 		tagName: 'ul',
 		className: 'participantWithList',
-		collectionEvents: {
-			'update': function() {
-				this.render();
-			},
-			'reset': function() {
-				this.render();
-			},
-			'sort': function() {
-				this.render();
-			},
-			'sync': function() {
-				this.render();
-			}
-		},
+
 		childView: Marionette.View.extend({
 			tagName: 'li',
 			modelEvents: {


### PR DESCRIPTION
The participant list was rendered again on every collection event, even if nothing had changed; besides being unnecessary it also caused some flickering and it could also cause the participant menu to be suddenly closed while a moderator had it open to perform some action, like promoting another user.

This pull request fixes it so the participant list is rendered again only when something has actually changed. Moreover, instead of rendering the full list only the specific views of the participants that changed are rendered again.
