### PR TITLE
🆕 Read marker handling based on ID and settable via API

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>7.0.0-dev.1</version>
+	<version>7.0.0-dev.2</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -121,6 +121,15 @@ return [
 			],
 		],
 		[
+			'name' => 'Chat#setReadMarker',
+			'url' => '/api/{apiVersion}/chat/{token}/read',
+			'verb' => 'POST',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
+		[
 			'name' => 'Chat#mentions',
 			'url' => '/api/{apiVersion}/chat/{token}/mentions',
 			'verb' => 'GET',

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -32,3 +32,7 @@ title: Capabilities
 ## 6.0
 * `locked-one-to-one-rooms` - One-to-one conversations are now locked to the users. Neither guests nor other participants can be added, so the options to do that should be hidden as well. Also a user can only leave a one-to-one conversation (not delete). It will be deleted when the other participant left too. If the other participant posts a new chat message or starts a call, the left-participant will be re-added.
 * `read-only-rooms` - Conversations can be in `read-only` mode which means people can not do calls or write chat messages.
+
+
+## 7.0
+* `chat-read-marker` - The chat can be optionally marked read by clients manually, independent from the loading of the chat messages.

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -63,6 +63,24 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
     - Data:
         The full message array of the new message, as defined in [Receive chat messages of a conversation](#receive-chat-messages-of-a-conversation)
 
+## Mark chat as read
+
+* Method: `POST`
+* Endpoint: `/chat/{token}/read`
+* Data:
+
+    field | type | Description
+    ------|------|------------
+    `lastReadMessage` | int | The last read message ID
+
+* Response:
+    - Header:
+        + `200 OK`
+        + `404 Not Found` When the room could not be found for the participant,
+        or the participant is a guest.
+
+
+
 ## Get mention autocomplete suggestions
 
 * Method: `GET`

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -14,6 +14,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
     `limit` | int | Number of chat messages to receive (100 by default, 200 at most)
     `timeout` | int | `$lookIntoFuture = 1` only, Number of seconds to wait for new messages (30 by default, 60 at most)
     `lastKnownMessageId` | int | Serves as an offset for the query. The lastKnownMessageId for the next page is available in the `X-Chat-Last-Given` header.
+    `setReadMarker` | int | `1` to automatically set the read timer after fetching the messages, use `0` when your client calls `Mark chat as read` manually. (Default: `1`)
 
 * Response:
     - Status code:

--- a/docs/conversation.md
+++ b/docs/conversation.md
@@ -64,6 +64,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         `notificationLevel` | int | The notification level for the user (one of `Participant::NOTIFY_*` (1-3))
         `unreadMessages` | int | Number of unread chat messages in the conversation (only available with `chat-v2` capability)
         `unreadMention` | bool | Flag if the user was mentioned since their last visit
+        `lastReadMessage` | int | ID of the last read message in a room
         `lastMessage` | message | Last message in a conversation if available, otherwise empty
         `objectType` | string | The type of object that the conversation is associated with; "share:password" if the conversation is used to request a password for a share, otherwise empty
         `objectId` | string | Share token if "objectType" is "share:password", otherwise empty

--- a/docs/conversation.md
+++ b/docs/conversation.md
@@ -64,7 +64,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         `notificationLevel` | int | The notification level for the user (one of `Participant::NOTIFY_*` (1-3))
         `unreadMessages` | int | Number of unread chat messages in the conversation (only available with `chat-v2` capability)
         `unreadMention` | bool | Flag if the user was mentioned since their last visit
-        `lastReadMessage` | int | ID of the last read message in a room
+        `lastReadMessage` | int | ID of the last read message in a room (only available with `chat-read-marker` capability)
         `lastMessage` | message | Last message in a conversation if available, otherwise empty
         `objectType` | string | The type of object that the conversation is associated with; "share:password" if the conversation is used to request a password for a share, otherwise empty
         `objectId` | string | Share token if "objectType" is "share:password", otherwise empty

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -78,6 +78,7 @@ class Capabilities implements IPublicCapability {
 					'invite-groups-and-mails',
 					'locked-one-to-one-rooms',
 					'read-only-rooms',
+					'chat-read-marker',
 				],
 				'config' => [
 					'chat' => [

--- a/lib/Chat/CommentsManager.php
+++ b/lib/Chat/CommentsManager.php
@@ -95,4 +95,43 @@ class CommentsManager extends Manager {
 
 		return $lastComments;
 	}
+
+	public function getNumberOfCommentsForObjectSinceComment(string $objectType, string $objectId, int $lastRead, string $verb = ''): int {
+		$query = $this->dbConn->getQueryBuilder();
+		$query->selectAlias($query->createFunction('COUNT(' . $query->getColumnName('id') . ')'), 'num_messages')
+			->from('comments')
+			->where($query->expr()->eq('object_type', $query->createNamedParameter($objectType)))
+			->andWhere($query->expr()->eq('object_id', $query->createNamedParameter($objectId)))
+			->andWhere($query->expr()->gt('id', $query->createNamedParameter($lastRead)));
+
+		if ($verb !== '') {
+			$query->andWhere($query->expr()->eq('verb', $query->createNamedParameter($verb)));
+		}
+
+		$result = $query->execute();
+		$data = $result->fetch();
+		$result->closeCursor();
+
+		return (int) ($data['num_messages'] ?? 0);
+	}
+
+	public function getLastCommentBeforeDate(string $objectType, string $objectId, \DateTime $beforeDate, string $verb = ''): int {
+		$query = $this->dbConn->getQueryBuilder();
+		$query->select('id')
+			->from('comments')
+			->where($query->expr()->eq('object_type', $query->createNamedParameter($objectType)))
+			->andWhere($query->expr()->eq('object_id', $query->createNamedParameter($objectId)))
+			->andWhere($query->expr()->lt('creation_timestamp', $query->createNamedParameter($beforeDate, IQueryBuilder::PARAM_DATE)))
+			->orderBy('creation_timestamp', 'desc');
+
+		if ($verb !== '') {
+			$query->andWhere($query->expr()->eq('verb', $query->createNamedParameter($verb)));
+		}
+
+		$result = $query->execute();
+		$data = $result->fetch();
+		$result->closeCursor();
+
+		return (int) ($data['id'] ?? 0);
+	}
 }

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -213,6 +213,8 @@ class ChatController extends AEnvironmentAwareController {
 	 * @param int $limit Number of chat messages to receive (100 by default, 200 at most)
 	 * @param int $lastKnownMessageId The last known message (serves as offset)
 	 * @param int $timeout Number of seconds to wait for new messages (30 by default, 30 at most)
+	 * @param int $setReadMarker Automatically set the last read marker when 1,
+	 *                           if your client does this itself via chat/{token}/read set to 0
 	 * @return DataResponse an array of chat messages, "404 Not found" if the
 	 *         room token was not valid or "304 Not modified" if there were no messages;
 	 *         each chat message is an array with
@@ -220,7 +222,7 @@ class ChatController extends AEnvironmentAwareController {
 	 *         'actorDisplayName', 'timestamp' (in seconds and UTC timezone) and
 	 *         'message'.
 	 */
-	public function receiveMessages(int $lookIntoFuture, int $limit = 100, int $lastKnownMessageId = 0, int $timeout = 30): DataResponse {
+	public function receiveMessages(int $lookIntoFuture, int $limit = 100, int $lastKnownMessageId = 0, int $timeout = 30, int $setReadMarker = 1): DataResponse {
 		$limit = min(200, $limit);
 		$timeout = min(30, $timeout);
 
@@ -267,7 +269,9 @@ class ChatController extends AEnvironmentAwareController {
 		$newLastKnown = end($comments);
 		if ($newLastKnown instanceof IComment) {
 			$response->addHeader('X-Chat-Last-Given', $newLastKnown->getId());
-			$this->participant->setLastReadMessage((int) $newLastKnown->getId());
+			if ($setReadMarker === 1) {
+				$this->participant->setLastReadMessage((int) $newLastKnown->getId());
+			}
 		}
 
 		return $response;

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -267,9 +267,22 @@ class ChatController extends AEnvironmentAwareController {
 		$newLastKnown = end($comments);
 		if ($newLastKnown instanceof IComment) {
 			$response->addHeader('X-Chat-Last-Given', $newLastKnown->getId());
+			$this->participant->setLastReadMessage((int) $newLastKnown->getId());
 		}
 
 		return $response;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @RequireParticipant
+	 *
+	 * @param int $lastReadMessage
+	 * @return DataResponse
+	 */
+	public function setReadMarker(int $lastReadMessage): DataResponse {
+		$this->participant->setLastReadMessage($lastReadMessage);
+		return new DataResponse();
 	}
 
 	/**

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -154,11 +154,6 @@ class Manager {
 	 * @return Participant
 	 */
 	public function createParticipantObject(Room $room, array $row): Participant {
-		$lastMention = null;
-		if (!empty($row['last_mention'])) {
-			$lastMention = $this->timeFactory->getDateTime($row['last_mention']);
-		}
-
 		$lastJoinedCall = null;
 		if (!empty($row['last_joined_call'])) {
 			$lastJoinedCall = $this->timeFactory->getDateTime($row['last_joined_call']);
@@ -174,7 +169,8 @@ class Manager {
 			(int) $row['in_call'],
 			(int) $row['notification_level'],
 			(bool) $row['favorite'],
-			$lastMention,
+			(int) $row['last_read_message'],
+			(int) $row['last_mention_message'],
 			$lastJoinedCall
 		);
 	}

--- a/lib/Migration/Version7000Date20190724121136.php
+++ b/lib/Migration/Version7000Date20190724121136.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2018 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Spreed\Migration;
+
+use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\DBAL\Types\Type;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version7000Date20190724121136 extends SimpleMigrationStep {
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param \Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 * @throws SchemaException
+	 * @since 13.0.0
+	 */
+	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('talk_participants');
+		if (!$table->hasColumn('last_read_message')) {
+			$table->addColumn('last_read_message', Type::BIGINT, [
+				'default' => 0,
+				'notnull' => false,
+			]);
+			$table->addColumn('last_mention_message', Type::BIGINT, [
+				'default' => 0,
+				'notnull' => false,
+			]);
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param \Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @since 13.0.0
+	 */
+	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+		$query = $this->connection->getQueryBuilder();
+		$query->select('m.user_id', 'm.object_id')
+			->selectAlias($query->createFunction('MAX(' . $query->getColumnName('c.id') . ')'), 'last_comment')
+			->from('comments_read_markers', 'm')
+			->leftJoin('m', 'comments', 'c', $query->expr()->andX(
+				$query->expr()->eq('c.object_id', 'm.object_id'),
+				$query->expr()->eq('c.object_type', 'm.object_type'),
+				$query->expr()->eq('c.creation_timestamp', 'm.marker_datetime')
+			))
+			->where($query->expr()->eq('m.object_type', $query->createNamedParameter('chat')))
+			->groupBy('m.user_id', 'm.object_id');
+
+		$update = $this->connection->getQueryBuilder();
+		$update->update('talk_participants')
+			->set('last_read_message', $update->createParameter('message_id'))
+			->where($update->expr()->eq('user_id', $update->createParameter('user_id')))
+			->andWhere($update->expr()->eq('room_id', $update->createParameter('room_id')));
+
+		$result = $query->execute();
+		while ($row = $result->fetch()) {
+			$update->setParameter('message_id', (int) $row['last_comment'], IQueryBuilder::PARAM_INT)
+				->setParameter('user_id', $row['user_id'])
+				->setParameter('room_id', (int) $row['object_id'], IQueryBuilder::PARAM_INT);
+			$update->execute();
+		}
+		$result->closeCursor();
+
+		/**
+		 * The above query only works if the user read in the same exact second
+		 * as the comment was posted (author only), we set the read marker to -1
+		 * for all users and in case of -1 we calculate the marker on the next request.
+		 */
+		$default = $this->connection->getQueryBuilder();
+		$default->update('talk_participants')
+			->set('last_read_message', $default->createNamedParameter(-1))
+			->where($default->expr()->isNotNull('user_id'))
+			->andWhere($default->expr()->eq('last_read_message', $default->createNamedParameter(0)));
+		$default->execute();
+	}
+}

--- a/lib/Migration/Version7000Date20190724121137.php
+++ b/lib/Migration/Version7000Date20190724121137.php
@@ -50,7 +50,7 @@ class Version7000Date20190724121137 extends SimpleMigrationStep {
 			->selectAlias($query->createFunction('MAX(' . $query->getColumnName('c.id') . ')'), 'last_mention_message')
 			->from('talk_participants', 'p')
 			->leftJoin('p', 'comments', 'c', $query->expr()->andX(
-				$query->expr()->eq('c.object_id', 'p.room_id'),
+				$query->expr()->eq('c.object_id', $query->expr()->castColumn('p.room_id', IQueryBuilder::PARAM_STR)),
 				$query->expr()->eq('c.object_type', $query->createNamedParameter('chat')),
 				$query->expr()->eq('c.creation_timestamp', 'p.last_mention')
 			))

--- a/lib/Migration/Version7000Date20190724121137.php
+++ b/lib/Migration/Version7000Date20190724121137.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Spreed\Migration;
+
+use Doctrine\DBAL\Schema\SchemaException;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version7000Date20190724121137 extends SimpleMigrationStep {
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param \Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @since 13.0.0
+	 */
+	public function preSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+		$query = $this->connection->getQueryBuilder();
+		$query->select('p.user_id', 'p.room_id')
+			->selectAlias($query->createFunction('MAX(' . $query->getColumnName('c.id') . ')'), 'last_mention_message')
+			->from('talk_participants', 'p')
+			->leftJoin('p', 'comments', 'c', $query->expr()->andX(
+				$query->expr()->eq('c.object_id', 'p.room_id'),
+				$query->expr()->eq('c.object_type', $query->createNamedParameter('chat')),
+				$query->expr()->eq('c.creation_timestamp', 'p.last_mention')
+			))
+			->where($query->expr()->isNotNull('p.user_id'))
+			->groupBy('p.user_id', 'p.room_id');
+
+		$update = $this->connection->getQueryBuilder();
+		$update->update('talk_participants')
+			->set('last_mention_message', $update->createParameter('message_id'))
+			->where($update->expr()->eq('user_id', $update->createParameter('user_id')))
+			->andWhere($update->expr()->eq('room_id', $update->createParameter('room_id')));
+
+		$result = $query->execute();
+		while ($row = $result->fetch()) {
+			$update->setParameter('message_id', (int) $row['last_mention_message'], IQueryBuilder::PARAM_INT)
+				->setParameter('user_id', $row['user_id'])
+				->setParameter('room_id', (int) $row['room_id'], IQueryBuilder::PARAM_INT);
+			$update->execute();
+		}
+		$result->closeCursor();
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param \Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 * @throws SchemaException
+	 * @since 13.0.0
+	 */
+	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('talk_participants');
+		if ($table->hasColumn('last_mention')) {
+			$table->dropColumn('last_mention');
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Participant.php
+++ b/lib/Participant.php
@@ -63,8 +63,10 @@ class Participant {
 	protected $notificationLevel;
 	/** @var bool */
 	private $isFavorite;
-	/** @var \DateTime|null */
-	private $lastMention;
+	/** @var int */
+	private $lastReadMessage;
+	/** @var int */
+	private $lastMentionMessage;
 	/** @var \DateTime|null */
 	private $lastJoinedCall;
 
@@ -77,7 +79,8 @@ class Participant {
 								int $inCall,
 								int $notificationLevel,
 								bool $isFavorite,
-								\DateTime $lastMention = null,
+								int $lastReadMessage,
+								int $lastMentionMessage,
 								\DateTime $lastJoinedCall = null) {
 		$this->db = $db;
 		$this->room = $room;
@@ -88,7 +91,8 @@ class Participant {
 		$this->inCall = $inCall;
 		$this->notificationLevel = $notificationLevel;
 		$this->isFavorite = $isFavorite;
-		$this->lastMention = $lastMention;
+		$this->lastReadMessage = $lastReadMessage;
+		$this->lastMentionMessage = $lastMentionMessage;
 		$this->lastJoinedCall = $lastJoinedCall;
 	}
 
@@ -122,13 +126,6 @@ class Participant {
 
 	public function getInCallFlags(): int {
 		return $this->inCall;
-	}
-
-	/**
-	 * @return \DateTime|null
-	 */
-	public function getLastMention(): ?\DateTime {
-		return $this->lastMention;
 	}
 
 	/**
@@ -183,6 +180,46 @@ class Participant {
 		$query->execute();
 
 		$this->notificationLevel = $notificationLevel;
+		return true;
+	}
+
+	public function getLastReadMessage(): int {
+		return $this->lastReadMessage;
+	}
+
+	public function setLastReadMessage(int $messageId): bool {
+		if (!$this->user) {
+			return false;
+		}
+
+		$query = $this->db->getQueryBuilder();
+		$query->update('talk_participants')
+			->set('last_read_message', $query->createNamedParameter($messageId, IQueryBuilder::PARAM_INT))
+			->where($query->expr()->eq('user_id', $query->createNamedParameter($this->user)))
+			->andWhere($query->expr()->eq('room_id', $query->createNamedParameter($this->room->getId())));
+		$query->execute();
+
+		$this->lastReadMessage = $messageId;
+		return true;
+	}
+
+	public function getLastMentionMessage(): int {
+		return $this->lastMentionMessage;
+	}
+
+	public function setLastMentionMessage(int $messageId): bool {
+		if (!$this->user) {
+			return false;
+		}
+
+		$query = $this->db->getQueryBuilder();
+		$query->update('talk_participants')
+			->set('last_mention_message', $query->createNamedParameter($messageId, IQueryBuilder::PARAM_INT))
+			->where($query->expr()->eq('user_id', $query->createNamedParameter($this->user)))
+			->andWhere($query->expr()->eq('room_id', $query->createNamedParameter($this->room->getId())));
+		$query->execute();
+
+		$this->lastMentionMessage = $messageId;
 		return true;
 	}
 }

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -1112,10 +1112,10 @@ class Room {
 		return (int) ($row['num_participants'] ?? 0);
 	}
 
-	public function markUsersAsMentioned(array $userIds, \DateTime $time): void {
+	public function markUsersAsMentioned(array $userIds, int $messageId): void {
 		$query = $this->db->getQueryBuilder();
 		$query->update('talk_participants')
-			->set('last_mention', $query->createNamedParameter($time, 'datetime'))
+			->set('last_mention_message', $query->createNamedParameter($messageId, IQueryBuilder::PARAM_INT))
 			->where($query->expr()->eq('room_id', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->in('user_id', $query->createNamedParameter($userIds, IQueryBuilder::PARAM_STR_ARRAY)));
 		$query->execute();

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -524,6 +524,11 @@ class Room {
 			'users' => $participants,
 		]));
 
+		$lastMessage = 0;
+		if ($this->getLastMessage() instanceof IComment) {
+			$lastMessage = (int) $this->getLastMessage()->getId();
+		}
+
 		$query = $this->db->getQueryBuilder();
 		$query->insert('talk_participants')
 			->values(
@@ -533,6 +538,7 @@ class Room {
 					'participant_type' => $query->createParameter('participant_type'),
 					'room_id' => $query->createNamedParameter($this->getId()),
 					'last_ping' => $query->createNamedParameter(0, IQueryBuilder::PARAM_INT),
+					'last_read_message' => $query->createNamedParameter($lastMessage, IQueryBuilder::PARAM_INT),
 				]
 			);
 
@@ -779,6 +785,11 @@ class Room {
 			throw new InvalidPasswordException();
 		}
 
+		$lastMessage = 0;
+		if ($this->getLastMessage() instanceof IComment) {
+			$lastMessage = (int) $this->getLastMessage()->getId();
+		}
+
 		$sessionId = $this->secureRandom->generate(255);
 		while (!$this->db->insertIfNotExist('*PREFIX*talk_participants', [
 			'user_id' => '',
@@ -786,6 +797,7 @@ class Room {
 			'last_ping' => 0,
 			'session_id' => $sessionId,
 			'participant_type' => Participant::GUEST,
+			'last_read_message' => $lastMessage,
 		], ['session_id'])) {
 			$sessionId = $this->secureRandom->generate(255);
 		}

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -89,6 +89,7 @@ class CapabilitiesTest extends TestCase {
 					'invite-groups-and-mails',
 					'locked-one-to-one-rooms',
 					'read-only-rooms',
+					'chat-read-marker',
 				],
 				'config' => [
 					'chat' => [
@@ -142,6 +143,7 @@ class CapabilitiesTest extends TestCase {
 					'invite-groups-and-mails',
 					'locked-one-to-one-rooms',
 					'read-only-rooms',
+					'chat-read-marker',
 				],
 				'config' => [
 					'chat' => [

--- a/tests/php/Chat/ChatManagerTest.php
+++ b/tests/php/Chat/ChatManagerTest.php
@@ -218,6 +218,20 @@ class ChatManagerTest extends TestCase {
 		$this->assertEquals($expected, $comments);
 	}
 
+	public function testGetUnreadCount() {
+		/** @var Room|MockObject $chat */
+		$chat = $this->createMock(Room::class);
+		$chat->expects($this->once())
+			->method('getId')
+			->willReturn(23);
+
+		$this->commentsManager->expects($this->once())
+			->method('getNumberOfCommentsForObjectSinceComment')
+			->with('chat', 23, 42, 'comment');
+
+		$this->chatManager->getUnreadCount($chat, 42);
+	}
+
 	public function testDeleteMessages() {
 
 		$chat = $this->createMock(Room::class);


### PR DESCRIPTION
- [x] Fix writing of last_mention_message
- [x] Add endpoint to set the last_read_message
- [x] Adjust unit tests
- [ ] Correctly set the read marker from the web UI
- [ ] Fix the loading of the chat messages as described in #1164 
- [x] People added later should have the marker set to `!== 0` so they are at the bottom and not the start.

Rel #1164 
Rel #1788