### PR TITLE
Fix interaction with participant menu

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -937,6 +937,10 @@ video {
 	opacity: .4;
 	margin-left: 5px;
 	margin-bottom: -4px;
+
+	&.hidden {
+		display: none;
+	}
 }
 
 .participantWithList .participant-offline {
@@ -989,7 +993,8 @@ video {
 	height: 44px;
 }
 
-.participantWithList .participant-entry-utils button {
+.participantWithList .participant-entry-utils button,
+.participantWithList .participant-entry-utils button + .icon-loading-small {
 	height: 100%;
 	width: 100%;
 	margin: 0;

--- a/js/views/participantlistview.js
+++ b/js/views/participantlistview.js
@@ -100,8 +100,7 @@
 					if (!target.closest('.popovermenu').is(this.ui.menu) && !target.is(this.ui.menuButton)) {
 						// Close the menu when clicking outside it or the button
 						// that toggles it.
-						this.menuShown = false;
-						this.toggleMenuClass();
+						this.closeMenu();
 					}
 				});
 			},
@@ -171,6 +170,10 @@
 			},
 			toggleMenuClass: function() {
 				this.ui.menu.toggleClass('open', this.menuShown);
+			},
+			closeMenu: function(e) {
+				this.menuShown = false;
+				this.toggleMenuClass();
 			},
 			promoteToModerator: function() {
 				if (this.model.get('participantType') !== OCA.SpreedMe.app.USER) {

--- a/js/views/participantlistview.js
+++ b/js/views/participantlistview.js
@@ -193,7 +193,7 @@
 						self.model.collection.sort();
 					},
 					error: function() {
-						console.log('Error while promoting user to moderator');
+						OC.Notification.showTemporary(t('spreed', 'Error while promoting user to moderator'), {type: 'error'});
 					}
 				});
 			},
@@ -219,7 +219,7 @@
 						self.model.collection.sort();
 					},
 					error: function() {
-						console.log('Error while demoting moderator');
+						OC.Notification.showTemporary(t('spreed', 'Error while demoting moderator'), {type: 'error'});
 					}
 				});
 			},
@@ -247,7 +247,7 @@
 						self.model.collection.remove(self.model);
 					},
 					error: function() {
-						console.log('Error while removing user from room');
+						OC.Notification.showTemporary(t('spreed', 'Error while removing user from room'), {type: 'error'});
 					}
 				});
 			}

--- a/js/views/participantlistview.js
+++ b/js/views/participantlistview.js
@@ -97,8 +97,9 @@
 			initialize: function() {
 				this.listenTo(uiChannel, 'document:click', function(event) {
 					var target = $(event.target);
-					if (!this.$el.is(target.closest('.participant'))) {
-						// Click was not triggered by this element -> close menu
+					if (!target.closest('.popovermenu').is(this.ui.menu) && !target.is(this.ui.menuButton)) {
+						// Close the menu when clicking outside it or the button
+						// that toggles it.
 						this.menuShown = false;
 						this.toggleMenuClass();
 					}

--- a/js/views/participantlistview.js
+++ b/js/views/participantlistview.js
@@ -180,6 +180,8 @@
 					return;
 				}
 
+				this.closeMenu();
+
 				var participantId = this.model.get('userId'),
 					self = this;
 
@@ -206,6 +208,8 @@
 					return;
 				}
 
+				this.closeMenu();
+
 				var participantId = this.model.get('userId'),
 					self = this;
 
@@ -231,6 +235,8 @@
 				if (this.model.get('participantType') === OCA.SpreedMe.app.OWNER) {
 					return;
 				}
+
+				this.closeMenu();
 
 				var self = this,
 					participantId = this.model.get('userId'),

--- a/js/views/participantlistview.js
+++ b/js/views/participantlistview.js
@@ -40,7 +40,10 @@
 		'{{#if canModerate}}' +
 			'<div class="participant-entry-utils">'+
 				'<ul>'+
-					'<li class="participant-entry-utils-menu-button"><button class="icon icon-more"></button></li>'+
+					'<li class="participant-entry-utils-menu-button">' +
+						'<button class="icon icon-more"></button>' +
+						'<span class="icon icon-loading-small hidden"></span>' +
+					'</li>' +
 				'</ul>'+
 			'</div>'+
 			'<div class="popovermenu bubble menu">'+
@@ -159,7 +162,9 @@
 			},
 			ui: {
 				'participant': 'li.participant',
-				'menu': '.popovermenu'
+				'menu': '.popovermenu',
+				'menuButton': '.participant-entry-utils-menu-button button',
+				'menuButtonIconLoading': '.participant-entry-utils-menu-button .icon-loading-small'
 			},
 			template: Handlebars.compile(ITEM_TEMPLATE),
 			menuShown: false,
@@ -181,6 +186,8 @@
 				}
 
 				this.closeMenu();
+				this.ui.menuButton.addClass('hidden');
+				this.ui.menuButtonIconLoading.removeClass('hidden');
 
 				var participantId = this.model.get('userId'),
 					self = this;
@@ -199,6 +206,9 @@
 						self.model.collection.sort();
 					},
 					error: function() {
+						self.ui.menuButtonIconLoading.addClass('hidden');
+						self.ui.menuButton.removeClass('hidden');
+
 						OC.Notification.showTemporary(t('spreed', 'Error while promoting user to moderator'), {type: 'error'});
 					}
 				});
@@ -209,6 +219,8 @@
 				}
 
 				this.closeMenu();
+				this.ui.menuButton.addClass('hidden');
+				this.ui.menuButtonIconLoading.removeClass('hidden');
 
 				var participantId = this.model.get('userId'),
 					self = this;
@@ -227,6 +239,9 @@
 						self.model.collection.sort();
 					},
 					error: function() {
+						self.ui.menuButtonIconLoading.addClass('hidden');
+						self.ui.menuButton.removeClass('hidden');
+
 						OC.Notification.showTemporary(t('spreed', 'Error while demoting moderator'), {type: 'error'});
 					}
 				});
@@ -237,6 +252,8 @@
 				}
 
 				this.closeMenu();
+				this.ui.menuButton.addClass('hidden');
+				this.ui.menuButtonIconLoading.removeClass('hidden');
 
 				var self = this,
 					participantId = this.model.get('userId'),
@@ -257,6 +274,9 @@
 						self.model.collection.remove(self.model);
 					},
 					error: function() {
+						self.ui.menuButtonIconLoading.addClass('hidden');
+						self.ui.menuButton.removeClass('hidden');
+
 						OC.Notification.showTemporary(t('spreed', 'Error while removing user from room'), {type: 'error'});
 					}
 				});

--- a/js/views/participantlistview.js
+++ b/js/views/participantlistview.js
@@ -176,7 +176,7 @@
 			toggleMenuClass: function() {
 				this.ui.menu.toggleClass('open', this.menuShown);
 			},
-			closeMenu: function(e) {
+			closeMenu: function() {
 				this.menuShown = false;
 				this.toggleMenuClass();
 			},


### PR DESCRIPTION
The participant menu is now closed when clicking anywhere once shown; before it was kept shown when clicking on the participant or when performing an action through an item in the menu itself, which was a strange behaviour for a menu.

Moreover, while waiting for the server response after clicking on an item of the menu now the menu toggle is replaced by a working icon; the button is shown again when the operation finishes, either successfully or with a failure. This lets the user know that the operation is still in progress while also preventing her from doing any further operation on that participant while there is one in progress.
