### PR TITLE
Remove unneeded database connection from SignalingController

### DIFF
--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -33,7 +33,6 @@ use OCA\Spreed\TalkSession;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
-use OCP\IDBConnection;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -45,8 +44,6 @@ class SignalingController extends OCSController {
 	private $session;
 	/** @var Manager */
 	private $manager;
-	/** @var IDBConnection */
-	private $dbConnection;
 	/** @var Messages */
 	private $messages;
 	/** @var string|null */
@@ -60,7 +57,6 @@ class SignalingController extends OCSController {
 	 * @param Config $config
 	 * @param TalkSession $session
 	 * @param Manager $manager
-	 * @param IDBConnection $connection
 	 * @param Messages $messages
 	 * @param IUserManager $userManager
 	 * @param string $UserId
@@ -70,14 +66,12 @@ class SignalingController extends OCSController {
 								Config $config,
 								TalkSession $session,
 								Manager $manager,
-								IDBConnection $connection,
 								Messages $messages,
 								IUserManager $userManager,
 								$UserId) {
 		parent::__construct($appName, $request);
 		$this->config = $config;
 		$this->session = $session;
-		$this->dbConnection = $connection;
 		$this->manager = $manager;
 		$this->messages = $messages;
 		$this->userManager = $userManager;
@@ -178,7 +172,6 @@ class SignalingController extends OCSController {
 				break;
 			}
 
-			$this->dbConnection->close();
 			if (empty($data)) {
 				$seconds--;
 			} else {

--- a/tests/php/Controller/SignalingControllerTest.php
+++ b/tests/php/Controller/SignalingControllerTest.php
@@ -32,7 +32,6 @@ use OCA\Spreed\Room;
 use OCA\Spreed\Signaling\Messages;
 use OCA\Spreed\TalkSession;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\IUserManager;
 
@@ -64,9 +63,6 @@ class SignalingControllerTest extends \Test\TestCase {
 	/** @var Manager|\PHPUnit_Framework_MockObject_MockObject */
 	protected $manager;
 
-	/** @var IDBConnection|\PHPUnit_Framework_MockObject_MockObject */
-	protected $dbConnection;
-
 	/** @var Messages|\PHPUnit_Framework_MockObject_MockObject */
 	protected $messages;
 
@@ -93,7 +89,6 @@ class SignalingControllerTest extends \Test\TestCase {
 		$config->setUserValue($this->userId, 'spreed', 'signaling_ticket_secret', 'the-user-ticket-secret');
 		$this->config = new Config($config, $secureRandom, $timeFactory);
 		$this->session = $this->createMock(TalkSession::class);
-		$this->dbConnection = \OC::$server->getDatabaseConnection();
 		$this->manager = $this->createMock(Manager::class);
 		$this->messages = $this->createMock(Messages::class);
 		$this->userManager = $this->createMock(IUserManager::class);
@@ -107,7 +102,6 @@ class SignalingControllerTest extends \Test\TestCase {
 			$this->config,
 			$this->session,
 			$this->manager,
-			$this->dbConnection,
 			$this->messages,
 			$this->userManager,
 			$this->userId


### PR DESCRIPTION
Looks like a leftover from [a previous cleanup](https://github.com/nextcloud/spreed/commit/9da1bf3343a2c7557087e6d2bb075f5532ab3b50).
