### PR TITLE
Allow calling "RoomController::formatLastMessage" without a current user.

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -365,7 +365,7 @@ class RoomController extends OCSController {
 	 * @param IUser $currentUser
 	 * @return array
 	 */
-	protected function formatLastMessage(IComment $lastMessage, IUser $currentUser): array {
+	protected function formatLastMessage(IComment $lastMessage, IUser $currentUser = null): array {
 		list($message, $messageParameters) = $this->messageParser->parseMessage($lastMessage, $this->l10n, $currentUser);
 
 		$displayName = '';


### PR DESCRIPTION
This fails with the new type hinting which expects a "IUser" object.

Error is
```
{"reqId":"9M8MFWmKeN2if6H4LCso","level":3,"time":"2018-09-28T12:40:23+00:00","remoteAddr":"10.1.1.31","user":"--","app":"PHP","method":"GET","url":"\/ocs\/v2.php\/apps\/spreed\/api\/v1\/room\/p27wbszi","message":"TypeError: Argument 2 passed to OCA\\Spreed\\Controller\\RoomController::formatLastMessage() must implement interface OCP\\IUser, null given, called in \/apps\/spreed\/lib\/Controller\/RoomController.php on line 279 at \/apps\/spreed\/lib\/Controller\/RoomController.php#368","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/69.0.3497.100 Safari\/537.36","version":"15.0.0.0"}
```