### PR TITLE
Add support for Talk sidebar in Files app

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -320,6 +320,19 @@ return [
 		],
 
 		/**
+		 * Files
+		 */
+		[
+			'name' => 'Files#getRoom',
+			'url' => '/api/{apiVersion}/file/{fileId}',
+			'verb' => 'GET',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'fileId' => '.+'
+			],
+		],
+
+		/**
 		 * Guest
 		 */
 		[

--- a/css/chat.scss
+++ b/css/chat.scss
@@ -1,0 +1,357 @@
+/*
+ * Copyright (c) 2016
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+#chatTabView .comments,
+#chatTabView .emptycontent {
+	flex-grow: 1;
+}
+
+#chatTabView .emptycontent {
+	margin-top: 0;
+}
+
+#chatTabView .newCommentForm {
+	position: relative;
+}
+
+#chatTabView .newCommentForm .message {
+	width: calc(100% - 36px);
+	margin-left: 36px;
+	padding-right: 30px;
+	display: block;
+}
+
+#chatTabView .newCommentForm .submit,
+#chatTabView .newCommentForm .submitLoading,
+#chatTabView .newCommentForm .share,
+#chatTabView .newCommentForm .shareLoading {
+	position: absolute;
+
+	width: 44px;
+	height: 44px;
+
+	bottom: -4px;
+	margin: 0;
+}
+
+#chatTabView .newCommentForm .submit,
+#chatTabView .newCommentForm .submitLoading {
+	right: 0;
+}
+
+#chatTabView .newCommentForm .share,
+#chatTabView .newCommentForm .shareLoading {
+	right: -44px;
+}
+
+#chatTabView .newCommentForm .submit,
+#chatTabView .newCommentForm .share {
+	background-color: transparent;
+	border: none;
+	opacity: .3;
+}
+#chatTabView .newCommentForm .submit:hover,
+#chatTabView .newCommentForm .submit:focus,
+#chatTabView .newCommentForm .share:hover,
+#chatTabView .newCommentForm .share:focus {
+	opacity: 1;
+}
+
+#chatTabView .newCommentForm .cancel {
+	margin-right: 6px;
+}
+
+#chatTabView .newCommentForm div.message {
+	resize: none;
+}
+
+#chatTabView .newCommentForm div.message:empty:before {
+	content: attr(data-placeholder);
+	color: grey;
+}
+
+/* Internal wrappers used by the virtual list. */
+#chatTabView .comments .wrapper-background,
+#chatTabView .comments .wrapper {
+	position: absolute;
+	left: 0;
+	right: 0;
+}
+
+#chatTabView .comment {
+	position: relative;
+	margin-bottom: 30px;
+	word-wrap: break-word;
+	overflow-wrap: break-word;
+}
+
+#chatTabView .comment .avatar,
+.atwho-view-ul * .avatar{
+	width: 32px;
+	height: 32px;
+	line-height: 32px;
+	margin-right: 5px;
+}
+
+#chatTabView .comment .message .avatar,
+.atwho-view-ul * .avatar
+{
+	display: inline-block;
+}
+
+#activityTabView li.comment.collapsed .activitymessage,
+#chatTabView .comment.collapsed .message {
+	white-space: pre-wrap;
+}
+
+#activityTabView li.comment.collapsed .activitymessage,
+#chatTabView .comment.collapsed .message {
+	max-height: 70px;
+	overflow: hidden;
+}
+
+#activityTabView li.comment .message-overlay,
+#chatTabView .comment .message-overlay {
+	display: none;
+}
+
+#activityTabView li.comment.collapsed .message-overlay,
+#chatTabView .comment.collapsed .message-overlay {
+	display: block;
+	position: absolute;
+	z-index: 2;
+	height: 50px;
+	pointer-events: none;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: -moz-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
+	background: -webkit-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
+	background: -o-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
+	background: -ms-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
+	background: linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
+	filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr='#00FFFFFF', endColorstr='#FFFFFFFF');
+	background-repeat: no-repeat;
+}
+
+#chatTabView .authorRow>div {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+#chatTabView .authorRow>div.hidden {
+	display: none !important;
+}
+
+.atwho-view-ul * .avatar-name-wrapper,
+#chatTabView .comment .authorRow {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	width: 100%;
+}
+
+#chatTabView .comment .authorRow .contactsmenu-popover {
+	top: 32px;
+}
+
+body:not(#body-public) #chatTabView .comment .authorRow:not(.currentUser):not(.guestUser) {
+	.avatar,
+	.avatar img,
+	.author {
+		cursor: pointer;
+	}
+}
+
+.atwho-view-ul .avatar-name-wrapper,
+.atwho-view-ul .avatar-name-wrapper .avatar,
+.atwho-view-ul .avatar-name-wrapper .avatar img {
+	cursor: pointer;
+}
+
+.atwho-view-ul * .avatar-name-wrapper {
+	white-space: nowrap;
+}
+
+#chatTabView .comment .author,
+#chatTabView .comment .date {
+	color: var(--color-text-maxcontrast);
+}
+#chatTabView .comment .author {
+	margin-left: 5px;
+}
+#chatTabView .comment .date {
+	/* "margin-left: auto" aligns the block to the right, while
+	 * "text-align: right" aligns the text inside the block to the right, for
+	 * example, when it uses two lines due to a limited width. */
+	margin-left: auto;
+	text-align: right;
+}
+
+#chatTabView .comments li .message {
+	padding-left: 40px;
+}
+
+#chatTabView .comment .action {
+	opacity: 0;
+	vertical-align: middle;
+	display: inline-block;
+}
+
+#chatTabView .comment:hover .action {
+	opacity: 0.3;
+}
+
+#chatTabView .comment .action:hover {
+	opacity: 1;
+}
+
+#chatTabView .comment .action.delete {
+	position: absolute;
+	right: 0;
+}
+
+#chatTabView .comment.disabled {
+	opacity: 0.3;
+}
+
+#chatTabView .comment.disabled .action {
+	visibility: hidden;
+}
+
+#chatTabView .message.error {
+	color: #e9322d;
+	border-color: #e9322d;
+	box-shadow: 0 0 6px #f8b9b7;
+}
+
+.app-files .action-comment {
+	padding: 16px 14px;
+}
+
+#chatTabView .comment.grouped .authorRow {
+	display: none;
+}
+
+#chatTabView .comment.grouped {
+	margin-top: -20px;
+}
+
+#chatTabView .comment.showDate {
+	margin-top: 40px;
+	border-top: 1px solid #dbdbdb;
+	padding-top: 10px;
+}
+
+#chatTabView .comment.showDate:before {
+	content: attr(data-date);
+
+	position: absolute;
+	top: 0;
+	left: 50%;
+	transform: translateX(-50%) translateY(-50%);
+	padding: 0 7px 0 7px;
+
+	text-align: center;
+
+	color: #878787;
+	background-color: #fff;
+}
+
+#chatTabView .comment.showDate .authorRow {
+	display: inline-flex;
+}
+
+#chatTabView .comment .message .mention-user {
+	/* Make the mention the positioning context of its child contacts menu */
+	position: relative;
+
+	display: inline;
+	vertical-align: top;
+	background-color: var(--color-background-dark);
+	border-radius: 50vh;
+	padding: 1px 7px 1px 1px;
+
+	/* Ensure that the avatar and the user name will be kept together;
+	 * otherwise a line break could be added between them when the wrapper
+	 * is close to the right border of the message. */
+	white-space: nowrap;
+
+	.avatar {
+		img {
+			vertical-align: top;
+		}
+		height: 16px;
+		width: 16px;
+		vertical-align: middle;
+		padding: 1px;
+		margin-top: -2px;
+		margin-left: 0;
+		margin-right: 2px;
+	}
+}
+
+#chatTabView .comment:not(.systemMessage) .message .mention-user {
+	font-weight: bold;
+
+	&.currentUser {
+		background-color: var(--color-primary);
+		color: var(--color-primary-text);
+	}
+}
+
+#chatTabView .comment.systemMessage .message .mention-user {
+	color: var(--color-main-text);
+}
+
+/* System messages have no author, so the author row only contains the date.
+ * Instead of showing the date on its own row and the message below it the
+ * message and the date are merged in a single row using flexboxes. */
+#chatTabView .comment.systemMessage {
+	display: flex;
+	flex-direction: row;
+}
+
+#chatTabView .comment.systemMessage .authorRow {
+	order: 1;
+	flex-grow: 0;
+	width: auto;
+	padding-left: 10px;
+}
+
+#chatTabView .comment.systemMessage .message {
+	order: 0;
+	flex-grow: 1;
+	color: var(--color-text-maxcontrast);
+}
+
+body:not(#body-public) #chatTabView .comment:not(.newCommentRow) .message .mention-user:not(.currentUser),
+body:not(#body-public) #chatTabView .comment:not(.newCommentRow) .message .mention-user:not(.currentUser) .avatar,
+body:not(#body-public) #chatTabView .comment:not(.newCommentRow) .message .mention-user:not(.currentUser) .avatar img {
+	cursor: pointer;
+}
+
+#chatTabView .comment .message .contactsmenu-popover {
+	left: -6px;
+	top: 24px;
+}
+
+#chatTabView .comment .message .filePreviewContainer .filePreview {
+	/* The file preview can not be a block; otherwise it would fill the whole
+	 * width of the container and the loading icon would not be centered on the
+	 * image. */
+	display: inline-block;
+}
+
+#chatTabView .comment .message .filePreviewContainer strong {
+	/* As the file preview is an inline block the name is set as a block to
+	 * force it to be on its own line below the preview. */
+	display: block;
+}

--- a/css/files.scss
+++ b/css/files.scss
@@ -1,0 +1,106 @@
+/**
+ * Cascade parent element height to the chat view in the sidebar to limit the
+ * vertical scroll bar only to the list of messages. Otherwise, the vertical
+ * scroll bar would be shown for the whole sidebar and everything would be
+ * moved when scrolling to see overflown messages.
+ *
+ * The list of messages should stretch to fill the available space at the bottom
+ * of the right sidebar, so the height is cascaded using flex boxes.
+ *
+ * It is horrible, I know (but better than using JavaScript ;-) ). Please
+ * improve it if you know how :-)
+ */
+#app-sidebar {
+	display: flex;
+	flex-direction: column;
+}
+
+#app-sidebar .detailFileInfoContainer {
+	flex-shrink: 0;
+}
+
+#app-sidebar .tabsContainer {
+	display: flex;
+	flex-direction: column;
+
+	flex-grow: 1;
+}
+
+#app-sidebar .tab {
+	display: flex;
+	flex-direction: column;
+
+	flex-grow: 1;
+}
+
+#app-sidebar .tabsContainer.with-inner-scroll-bars,
+#app-sidebar .tabsContainer.with-inner-scroll-bars .tab {
+	overflow: hidden;
+}
+
+#app-sidebar .tab.hidden {
+	display: none;
+}
+
+#app-sidebar #chatTabView {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+
+	flex-grow: 1;
+}
+
+#app-sidebar #chatTabView .comments {
+	overflow-y: auto;
+
+	/* Needed for proper calculation of comment positions in the scrolling
+	   container (as otherwise the comment position is calculated with respect
+	   to the closest ancestor with a relative position) */
+	position: relative;
+}
+
+/**
+ * Place the scroll bar of the message list on the right edge of the sidebar,
+ * but keeping the padding of the tab view.
+ *
+ * The padding must be set on the left too to ensure that the contacts menu
+ * shown when clicking on an author name does not overflow the tab (as it would
+ * be hidden).
+ *
+ * The bottom padding is removed to extend the chat view to the bottom edge of
+ * the sidebar.
+ */
+#app-sidebar .tab-chat {
+	padding-left: 0;
+	padding-right: 0;
+	padding-bottom: 0;
+}
+
+/* Hack needed to overcome the padding of the tab container and move the scroll
+ * bar of the messages list to the right border of the sidebar. */
+#app-sidebar .tabsContainer.with-inner-scroll-bars .tab {
+	padding-right: 0px;
+}
+
+#app-sidebar #chatTabView .comments {
+	padding-right: 15px;
+}
+
+#app-sidebar #chatTabView .comments .wrapper-background,
+#app-sidebar #chatTabView .comments .wrapper {
+	/* Padding is not respected in the comment wrapper due to its absolute
+	 * positioning, so it must be set through its position. */
+	right: 15px;
+}
+
+#app-sidebar #chatTabView .newCommentRow {
+	/* The details view in the Files app has a bottom padding of 15px, so the
+	 * general bottom margin used for comments should be reduced for the new
+	 * comment form. */
+	margin-bottom: 5px;
+}
+
+#app-sidebar #chatTabView .newCommentForm {
+	/* Make room to show the "Add" button when chat is shown in the sidebar. */
+	margin-right: 44px;
+}

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -1,0 +1,604 @@
+/* global Marionette, Backbone, OCA */
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+(function(OC, OCA, Marionette, Backbone, _, $) {
+	'use strict';
+
+	OCA.Talk = OCA.Talk || {};
+
+	var roomChannel = Backbone.Radio.channel('rooms');
+
+	OCA.Talk.Embedded = Marionette.Application.extend({
+		OWNER: 1,
+		MODERATOR: 2,
+		USER: 3,
+		GUEST: 4,
+		USERSELFJOINED: 5,
+
+		/* Must stay in sync with values in "lib/Room.php". */
+		FLAG_DISCONNECTED: 0,
+		FLAG_IN_CALL: 1,
+		FLAG_WITH_AUDIO: 2,
+		FLAG_WITH_VIDEO: 4,
+
+		/** @property {OCA.SpreedMe.Models.Room} activeRoom  */
+		activeRoom: null,
+
+		/** @property {String} token  */
+		token: null,
+
+		/** @property {OCA.Talk.Connection} connection  */
+		connection: null,
+
+		/** @property {OCA.Talk.Signaling.base} signaling  */
+		signaling: null,
+
+		/** @property {OCA.SpreedMe.Models.RoomCollection} _rooms  */
+		_rooms: null,
+		/** @property {OCA.SpreedMe.Views.RoomListView} _roomsView  */
+		_roomsView: null,
+		/** @property {OCA.SpreedMe.Models.ParticipantCollection} _participants  */
+		_participants: null,
+		/** @property {OCA.SpreedMe.Views.ParticipantView} _participantsView  */
+		_participantsView: null,
+		/** @property {boolean} videoWasEnabledAtLeastOnce  */
+		videoWasEnabledAtLeastOnce: false,
+		displayedGuestNameHint: false,
+		audioDisabled: localStorage.getItem("audioDisabled"),
+		audioNotFound: false,
+		videoDisabled: localStorage.getItem("videoDisabled"),
+		videoNotFound: false,
+		fullscreenDisabled: true,
+		_searchTerm: '',
+		guestNick: null,
+		_currentEmptyContent: null,
+		_lastEmptyContent: null,
+		_registerPageEvents: function() {
+			// Initialize button tooltips
+			$('[data-toggle="tooltip"]').tooltip({trigger: 'hover'}).click(function() {
+				$(this).tooltip('hide');
+			});
+
+// 			this.registerLocalVideoButtonHandlers();
+		},
+
+// 		registerLocalVideoButtonHandlers: function() {
+// 			$('#hideVideo').click(function() {
+// 				if(!OCA.SpreedMe.app.videoWasEnabledAtLeastOnce) {
+// 					// don't allow clicking the video toggle
+// 					// when no video ever was streamed (that
+// 					// means that permission wasn't granted
+// 					// yet or there is no video available at
+// 					// all)
+// 					console.log('video can not be enabled - there was no stream available before');
+// 					return;
+// 				}
+// 				if ($(this).hasClass('video-disabled')) {
+// 					OCA.SpreedMe.app.enableVideo();
+// 					localStorage.removeItem("videoDisabled");
+// 				} else {
+// 					OCA.SpreedMe.app.disableVideo();
+// 					localStorage.setItem("videoDisabled", true);
+// 				}
+// 			});
+// 
+// 			$('#mute').click(function() {
+// 				if (OCA.SpreedMe.webrtc.webrtc.isAudioEnabled()) {
+// 					OCA.SpreedMe.app.disableAudio();
+// 					localStorage.setItem("audioDisabled", true);
+// 				} else {
+// 					OCA.SpreedMe.app.enableAudio();
+// 					localStorage.removeItem("audioDisabled");
+// 				}
+// 			});
+// 
+// 			$('#video-fullscreen').click(function() {
+// 				if (this.fullscreenDisabled) {
+// 					this.enableFullscreen();
+// 				} else {
+// 					this.disableFullscreen();
+// 				}
+// 			}.bind(this));
+// 
+// 			$('#screensharing-button').click(function() {
+// 				var webrtc = OCA.SpreedMe.webrtc;
+// 				if (!webrtc.capabilities.supportScreenSharing) {
+// 					if (window.location.protocol === 'https:') {
+// 						OC.Notification.showTemporary(t('spreed', 'Screensharing is not supported by your browser.'));
+// 					} else {
+// 						OC.Notification.showTemporary(t('spreed', 'Screensharing requires the page to be loaded through HTTPS.'));
+// 					}
+// 					return;
+// 				}
+// 
+// 				if (webrtc.getLocalScreen()) {
+// 					$('#screensharing-menu').toggleClass('open');
+// 				} else {
+// 					var screensharingButton = $(this);
+// 					screensharingButton.prop('disabled', true);
+// 					webrtc.shareScreen(function(err) {
+// 						screensharingButton.prop('disabled', false);
+// 						if (!err) {
+// 							$('#screensharing-button').attr('data-original-title', t('spreed', 'Screensharing options'))
+// 								.removeClass('screensharing-disabled icon-screen-off')
+// 								.addClass('icon-screen');
+// 							return;
+// 						}
+// 
+// 						switch (err.name) {
+// 							case "HTTPS_REQUIRED":
+// 								OC.Notification.showTemporary(t('spreed', 'Screensharing requires the page to be loaded through HTTPS.'));
+// 								break;
+// 							case "PERMISSION_DENIED":
+// 							case "NotAllowedError":
+// 							case "CEF_GETSCREENMEDIA_CANCELED":  // Experimental, may go away in the future.
+// 								break;
+// 							case "FF52_REQUIRED":
+// 								OC.Notification.showTemporary(t('spreed', 'Sharing your screen only works with Firefox version 52 or newer.'));
+// 								break;
+// 							case "EXTENSION_UNAVAILABLE":
+// 								var  extensionURL = null;
+// 								if (!!window.chrome && !!window.chrome.webstore) {// Chrome
+// 									extensionURL = 'https://chrome.google.com/webstore/detail/screensharing-for-nextclo/kepnpjhambipllfmgmbapncekcmabkol';
+// 								}
+// 
+// 								if (extensionURL) {
+// 									var text = t('spreed', 'Screensharing extension is required to share your screen.');
+// 									var element = $('<a>').attr('href', extensionURL).attr('target','_blank').text(text);
+// 
+// 									OC.Notification.showTemporary(element, {isHTML: true});
+// 								} else {
+// 									OC.Notification.showTemporary(t('spreed', 'Please use a different browser like Firefox or Chrome to share your screen.'));
+// 								}
+// 								break;
+// 							default:
+// 								OC.Notification.showTemporary(t('spreed', 'An error occurred while starting screensharing.'));
+// 								console.log("Could not start screensharing", err);
+// 								break;
+// 						}
+// 					});
+// 				}
+// 			});
+// 
+// 			$("#show-screen-button").on('click', function() {
+// 				var currentUser = OCA.SpreedMe.webrtc.connection.getSessionid();
+// 				OCA.SpreedMe.sharedScreens.switchScreenToId(currentUser);
+// 
+// 				$('#screensharing-menu').toggleClass('open', false);
+// 			});
+// 
+// 			$("#stop-screen-button").on('click', function() {
+// 				OCA.SpreedMe.webrtc.stopScreenShare();
+// 			});
+// 		},
+
+		/**
+		 * @param {string} token
+		 */
+		// TODO
+		_setRoomActive: function(token) {
+			if (OC.getCurrentUser().uid) {
+				this._rooms.forEach(function(room) {
+					room.set('active', room.get('token') === token);
+				});
+			}
+		},
+		// TODO
+		syncAndSetActiveRoom: function(token) {
+			var self = this;
+			this.signaling.syncRooms()
+				.then(function() {
+					self.stopListening(self.activeRoom, 'change:participantFlags');
+
+					var participants;
+					if (OC.getCurrentUser().uid) {
+						roomChannel.trigger('active', token);
+
+						self._rooms.forEach(function(room) {
+							if (room.get('token') === token) {
+								self.activeRoom = room;
+							}
+						});
+						participants = self.activeRoom.get('participants');
+					}
+					// Disable video when entering a room with more than 5 participants.
+					if (participants && Object.keys(participants).length > 5) {
+						self.disableVideo();
+					}
+
+// 					self.updateContentsLayout();
+// 					self.listenTo(self.activeRoom, 'change:participantFlags', self.updateContentsLayout);
+// 
+// 					self.updateSidebarWithActiveRoom();
+				});
+		},
+		// TODO
+		updateContentsLayout: function() {
+			if (!this.activeRoom) {
+				// This should never happen, but just in case
+				return;
+			}
+
+// 			var flags = this.activeRoom.get('participantFlags') || 0;
+// 			var inCall = flags & OCA.SpreedMe.app.FLAG_IN_CALL !== 0;
+// 			if (inCall && this._chatViewInMainView === true) {
+// 				this._chatView.saveScrollPosition();
+// 				this._chatView.$el.detach();
+// 				this._sidebarView.addTab('chat', { label: t('spreed', 'Chat'), icon: 'icon-comment', priority: 100 }, this._chatView);
+// 				this._sidebarView.selectTab('chat');
+// 				this._chatView.restoreScrollPosition();
+// 				this._chatView.setTooltipContainer(this._chatView.$el);
+// 				this._chatViewInMainView = false;
+// 			} else if (!inCall && !this._chatViewInMainView) {
+// 				this._chatView.saveScrollPosition();
+// 				this._sidebarView.removeTab('chat');
+// 				this._chatView.$el.prependTo('#app-content-wrapper');
+// 				this._chatView.restoreScrollPosition();
+// 				this._chatView.setTooltipContainer($('#app'));
+// 				this._chatView.focusChatInput();
+// 				this._chatViewInMainView = true;
+// 			}
+// 
+// 			if (inCall) {
+// 				$('#video-speaking').show();
+// 				$('#videos').show();
+// 				$('#screens').show();
+// 				$('#emptycontent').hide();
+// 			} else {
+// 				$('#video-speaking').hide();
+// 				$('#videos').hide();
+// 				$('#screens').hide();
+// 				$('#emptycontent').show();
+// 			}
+		},
+		// TODO
+		updateSidebarWithActiveRoom: function() {
+// 			this._sidebarView.enable();
+
+// 			// The sidebar has a width of 27% of the window width and a minimum
+// 			// width of 300px. Therefore, when the window is 1111px wide or
+// 			// narrower the sidebar will always be 300px wide, and when that
+// 			// happens it will overlap with the content area (the narrower the
+// 			// window the larger the overlap). Due to this the sidebar is opened
+// 			// automatically only if it will not overlap with the content area.
+// 			if ($(window).width() > 1111) {
+// 				this._sidebarView.open();
+// 			}
+
+			var callInfoView = new OCA.SpreedMe.Views.CallInfoView({
+				model: this.activeRoom,
+				// TODO
+// 				guestNameModel: this._localStorageModel
+			});
+// 			this._sidebarView.setCallInfoView(callInfoView);
+
+			this._messageCollection.setRoomToken(this.activeRoom.get('token'));
+			this._messageCollection.receiveMessages();
+		},
+
+		/**
+		 *
+		 * @param {string|Object} icon
+		 * @param {string} icon.userId
+		 * @param {string} icon.displayName
+		 * @param {string} message
+		 * @param {string} [messageAdditional]
+		 * @param {string} [url]
+		 */
+		// TODO
+		setEmptyContentMessage: function(icon, message, messageAdditional, url) {
+			console.log("Set empty content message: " + message);
+// 			var $icon = $('#emptycontent-icon'),
+// 				$emptyContent = $('#emptycontent');
+// 
+// 			//Remove previous icon and avatar from emptycontent
+// 			$icon.removeAttr('class').attr('class', '');
+// 			$icon.html('');
+// 
+// 			if (url) {
+// 				$('#shareRoomInput').removeClass('hidden').val(url);
+// 				$('#shareRoomClipboardButton').removeClass('hidden');
+// 			} else {
+// 				$('#shareRoomInput').addClass('hidden');
+// 				$('#shareRoomClipboardButton').addClass('hidden');
+// 			}
+// 
+// 			if (typeof icon === 'string') {
+// 				$icon.addClass(icon);
+// 			} else {
+// 				var $avatar = $('<div>');
+// 				$avatar.addClass('avatar room-avatar');
+// 				if (icon.userId !== icon.displayName) {
+// 					$avatar.avatar(icon.userId, 128, undefined, false, undefined, icon.displayName);
+// 				} else {
+// 					$avatar.avatar(icon.userId, 128);
+// 				}
+// 				$icon.append($avatar);
+// 			}
+// 
+// 			$emptyContent.find('h2').html(message);
+// 			$emptyContent.find('p').text(messageAdditional ? messageAdditional : '');
+// 			this._lastEmptyContent = this._currentEmptyContent;
+// 			this._currentEmptyContent = arguments;
+		},
+		// TODO
+		restoreEmptyContent: function() {
+			console.log("Restore empty content");
+// 			this.setEmptyContentMessage.apply(this, this._lastEmptyContent);
+		},
+		// TODO
+		initialize: function() {
+			// TODO
+// 			this._sidebarView = new OCA.SpreedMe.Views.SidebarView();
+// 			$('#content').append(this._sidebarView.$el);
+
+			// TODO
+			if (OC.getCurrentUser().uid) {
+				this._rooms = new OCA.SpreedMe.Models.RoomCollection();
+				this.listenTo(roomChannel, 'active', this._setRoomActive);
+			}
+
+			// TODO
+// 			this._sidebarView.listenTo(roomChannel, 'leaveCurrentRoom', function() {
+// 				this.disable();
+// 			});
+
+			this._messageCollection = new OCA.SpreedMe.Models.ChatMessageCollection(null, {token: null});
+			this._chatView = new OCA.SpreedMe.Views.ChatView({
+				collection: this._messageCollection,
+				id: 'chatTabView'
+				// TODO
+// 				guestNameModel: this._localStorageModel
+			});
+
+			this._messageCollection.listenTo(roomChannel, 'leaveCurrentRoom', function() {
+				this.stopReceivingMessages();
+			});
+
+			// TODO
+			this.listenTo(roomChannel, 'leaveCurrentRoom', function() {
+				this._chatView.$el.detach();
+			});
+// 			this.listenTo(roomChannel, 'leaveCurrentRoom', function() {
+// 				this._chatView.$el.detach();
+// 				this._chatViewInMainView = false;
+// 
+// 				$('#video-speaking').hide();
+// 				$('#videos').hide();
+// 				$('#screens').hide();
+// 				$('#emptycontent').show();
+// 			});
+
+			$(document).on('click', this.onDocumentClick);
+		},
+		// TODO
+		onStart: function() {
+			this.signaling = OCA.Talk.Signaling.createConnection();
+			this.connection = new OCA.Talk.Connection(this);
+
+			this.signaling.on('joinRoom', function(/* token */) {
+				this.inRoom = true;
+			}.bind(this));
+
+			$(window).unload(function () {
+				this.connection.leaveCurrentRoom(false);
+				this.signaling.disconnect();
+			}.bind(this));
+
+			this._registerPageEvents();
+		},
+		// TODO
+		setupWebRTC: function() {
+			if (!OCA.SpreedMe.webrtc) {
+				OCA.SpreedMe.initWebRTC(this);
+			}
+			OCA.SpreedMe.webrtc.startMedia(this.token);
+		},
+		// TODO
+		startLocalMedia: function(configuration) {
+			if (this.callbackAfterMedia) {
+				this.callbackAfterMedia(configuration);
+				this.callbackAfterMedia = null;
+			}
+
+			$('.videoView').removeClass('hidden');
+			this.initAudioVideoSettings(configuration);
+			this.restoreEmptyContent();
+		},
+		// TODO
+		startWithoutLocalMedia: function(isAudioEnabled, isVideoEnabled) {
+			if (this.callbackAfterMedia) {
+				this.callbackAfterMedia(null);
+				this.callbackAfterMedia = null;
+			}
+
+			$('.videoView').removeClass('hidden');
+
+			this.disableAudio();
+			if (!isAudioEnabled) {
+				this.hasNoAudio();
+			}
+
+			this.disableVideo();
+			if (!isVideoEnabled) {
+				this.hasNoVideo();
+			}
+		},
+		// TODO
+		onDocumentClick: function(event) {
+			var uiChannel = Backbone.Radio.channel('ui');
+
+			uiChannel.trigger('document:click', event);
+		},
+		// TODO
+		initAudioVideoSettings: function(configuration) {
+			if (this.audioDisabled) {
+				this.disableAudio();
+			}
+
+			if (configuration.video !== false) {
+				if (this.videoDisabled) {
+					this.disableVideo();
+				}
+			} else {
+				this.videoWasEnabledAtLeastOnce = false;
+				this.disableVideo();
+			}
+		},
+		// TODO
+		enableAudioButton: function() {
+			$('#mute').attr('data-original-title', t('spreed', 'Mute audio (m)'))
+				.removeClass('audio-disabled icon-audio-off')
+				.addClass('icon-audio');
+		},
+		// TODO
+		enableAudio: function() {
+			if (this.audioNotFound || !OCA.SpreedMe.webrtc) {
+				return;
+			}
+			OCA.SpreedMe.webrtc.unmute();
+			this.enableAudioButton();
+			this.audioDisabled = false;
+		},
+		// TODO
+		disableAudioButton: function() {
+			$('#mute').attr('data-original-title', t('spreed', 'Unmute audio (m)'))
+				.addClass('audio-disabled icon-audio-off')
+				.removeClass('icon-audio');
+		},
+		// TODO
+		disableAudio: function() {
+			if (this.audioNotFound || !OCA.SpreedMe.webrtc) {
+				return;
+			}
+			OCA.SpreedMe.webrtc.mute();
+			this.disableAudioButton();
+			this.audioDisabled = true;
+		},
+		// TODO
+		hasAudio: function() {
+			$('#mute').removeClass('no-audio-available');
+			this.enableAudioButton();
+			this.audioNotFound = false;
+		},
+		// TODO
+		hasNoAudio: function() {
+			$('#mute').removeClass('audio-disabled icon-audio')
+				.addClass('no-audio-available icon-audio-off')
+				.attr('data-original-title', t('spreed', 'No audio'));
+			this.audioDisabled = true;
+			this.audioNotFound = true;
+		},
+		// TODO
+		enableVideoUI: function() {
+			var $hideVideoButton = $('#hideVideo');
+			var $audioMuteButton = $('#mute');
+			var $screensharingButton = $('#screensharing-button');
+			var avatarContainer = $hideVideoButton.closest('.videoView').find('.avatar-container');
+			var localVideo = $hideVideoButton.closest('.videoView').find('#localVideo');
+
+			$hideVideoButton.attr('data-original-title', t('spreed', 'Disable video (v)'))
+				.removeClass('local-video-disabled video-disabled icon-video-off')
+				.addClass('icon-video');
+			$audioMuteButton.removeClass('local-video-disabled');
+			$screensharingButton.removeClass('local-video-disabled');
+
+			avatarContainer.hide();
+			localVideo.show();
+		},
+		// TODO
+		enableVideo: function() {
+			if (this.videoNotFound || !OCA.SpreedMe.webrtc) {
+				return;
+			}
+
+			OCA.SpreedMe.webrtc.resumeVideo();
+			this.enableVideoUI();
+			this.videoDisabled = false;
+		},
+		// TODO
+		hideVideo: function() {
+			var $hideVideoButton = $('#hideVideo');
+			var $audioMuteButton = $('#mute');
+			var $screensharingButton = $('#screensharing-button');
+			var avatarContainer = $hideVideoButton.closest('.videoView').find('.avatar-container');
+			var localVideo = $hideVideoButton.closest('.videoView').find('#localVideo');
+
+			if (!$hideVideoButton.hasClass('no-video-available')) {
+				$hideVideoButton.attr('data-original-title', t('spreed', 'Enable video (v)'))
+					.addClass('local-video-disabled video-disabled icon-video-off')
+					.removeClass('icon-video');
+				$audioMuteButton.addClass('local-video-disabled');
+				$screensharingButton.addClass('local-video-disabled');
+			}
+
+			var avatar = avatarContainer.find('.avatar');
+			var guestName = localStorage.getItem("nick");
+			if (OC.getCurrentUser().uid) {
+				avatar.avatar(OC.getCurrentUser().uid, 128);
+			} else {
+				avatar.imageplaceholder('?', guestName, 128);
+				avatar.css('background-color', '#b9b9b9');
+				if (this.displayedGuestNameHint === false) {
+					OC.Notification.showTemporary(t('spreed', 'Set your name in the chat window so other participants can identify you better.'));
+					this.displayedGuestNameHint = true;
+				}
+			}
+
+			avatarContainer.removeClass('hidden');
+			avatarContainer.show();
+			localVideo.hide();
+		},
+		// TODO
+		disableVideo: function() {
+			if (this.videoNotFound || !OCA.SpreedMe.webrtc) {
+				return;
+			}
+
+			OCA.SpreedMe.webrtc.pauseVideo();
+			this.hideVideo();
+			this.videoDisabled = true;
+		},
+		// TODO
+		hasVideo: function() {
+			$('#hideVideo').removeClass('no-video-available');
+			this.enableVideoUI();
+			this.videoNotFound = false;
+		},
+		// TODO
+		hasNoVideo: function() {
+			$('#hideVideo').removeClass('icon-video')
+				.addClass('no-video-available icon-video-off')
+				.attr('data-original-title', t('spreed', 'No Camera'));
+			this.videoDisabled = true;
+			this.videoNotFound = true;
+		},
+		// TODO
+		disableScreensharingButton: function() {
+			$('#screensharing-button').attr('data-original-title', t('spreed', 'Enable screensharing'))
+					.addClass('screensharing-disabled icon-screen-off')
+					.removeClass('icon-screen');
+			$('#screensharing-menu').toggleClass('open', false);
+		},
+	});
+
+})(OC, OCA, Marionette, Backbone, _, $);

--- a/js/filesplugin.js
+++ b/js/filesplugin.js
@@ -1,0 +1,249 @@
+/**
+ *
+ * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+(function(OC, OCA) {
+
+	'use strict';
+
+	OCA.Talk = OCA.Talk || {};
+
+	/**
+	 * Tab view for Talk chat in the details view of the Files app.
+	 *
+	 * This view shows the chat for the Talk room associated with the file. The
+	 * tab is shown only for those files in which the Talk sidebar is supported,
+	 * otherwise it is hidden.
+	 */
+	OCA.Talk.TalkChatDetailTabView = OCA.Files.DetailTabView.extend({
+
+		id: 'talkChatTabView',
+
+		/**
+		 * Higher priority than other tabs.
+		 */
+		order: -10,
+
+		/**
+		 * Returns a CSS class to force scroll bars in the chat view instead of
+		 * in the whole sidebar.
+		 */
+		getTabsContainerExtraClasses: function() {
+			return 'with-inner-scroll-bars';
+		},
+
+		getLabel: function() {
+			return t('spreed', 'Chat');
+		},
+
+		getIcon: function() {
+			return 'icon-talk';
+		},
+
+		/**
+		 * Returns whether the Talk tab can be displayed for the file.
+		 *
+		 * @param OCA.Files.FileInfoModel fileInfo
+		 * @return True if the tab can be displayed, false otherwise.
+		 * @see OCA.Talk.FilesPlugin.isTalkSidebarSupportedForFile
+		 */
+		canDisplay: function(fileInfo) {
+			if (OCA.Talk.FilesPlugin.isTalkSidebarSupportedForFile(fileInfo)) {
+				return true;
+			}
+
+			// If the Talk tab can not be displayed then the current room is
+			// left; this must be done here because "setFileInfo" will not get
+			// called with the new file if the tab can not be displayed.
+			delete this._currentFileId;
+			OCA.Talk.FilesPlugin.leaveCurrentRoom();
+			// TODO Not needed when changing to another room as the new one
+			// will override the values of the previous one, but needed when
+			// there is no room to stop the signaling from pinging the
+			// previous room; this should probably be fixed anyways in the
+			// signaling.
+			OCA.SpreedMe.app.signaling.disconnect();
+
+			return false;
+		},
+
+		/**
+		 * Sets the FileInfoModel for the currently selected file.
+		 *
+		 * Rooms are associated to the id of the file, so the chat can not be
+		 * loaded until the file info is set and the token for the room is got.
+		 *
+		 * @param OCA.Files.FileInfoModel fileInfo
+		 */
+		setFileInfo: function(fileInfo) {
+			this.model = fileInfo;
+
+			if (!fileInfo || fileInfo.get('id') === undefined) {
+				// This should never happen, except during the initial setup of
+				// the Files app.
+				// TODO disconnect from the previous room just in case?
+
+				return;
+			}
+
+			// TODO join the room again due to the room model not keeping
+			// previous messages, as due to that when the chat is rendered again
+			// the previous messages are gone.
+// 			if (this._currentFileId === fileInfo.get('id')) {
+// 				// "setFileInfo" may have been called due to the parent view
+// 				// being rendered again. In that case the chat view needs to be
+// 				// rendered again too, as the references to its elements are no
+// 				// longer valid.
+// 				OCA.SpreedMe.app._chatView.render();
+// 				return;
+// 			}
+
+			// TODO if id changed probably stop Talk until the new room is
+			// fetch; replace chat by a loading spinner
+
+			this._currentFileId = fileInfo.get('id');
+
+		// TODO probably move to a model
+			$.ajax({
+				url: OC.linkToOCS('apps/spreed/api/v1', 2) + 'file/' + fileInfo.get('id'),
+				type: 'GET',
+				beforeSend: function(request) {
+					request.setRequestHeader('Accept', 'application/json');
+				},
+				success: function(ocsResponse) {
+					OCA.Talk.FilesPlugin.joinRoom(ocsResponse.ocs.data.token);
+				},
+				error: function() {
+					// TODO show error somehow, maybe in the empty content of
+					// the chat?
+					OCA.Talk.FilesPlugin.leaveCurrentRoom();
+				}
+			});
+
+			// TODO
+			OCA.SpreedMe.app._chatView.$el.appendTo(this.$el);
+			OCA.SpreedMe.app._chatView.setTooltipContainer($('#app-sidebar'));
+		},
+
+	});
+
+	var roomsChannel = Backbone.Radio.channel('rooms');
+
+	/**
+	 * @namespace
+	 */
+	OCA.Talk.FilesPlugin = {
+		ignoreLists: [
+			'files_trashbin',
+			'files.public'
+		],
+
+		attach: function(fileList) {
+			var self = this;
+			if (this.ignoreLists.indexOf(fileList.id) >= 0) {
+				return;
+			}
+
+			this.setupSignalingEventHandlers();
+
+			fileList.registerTabView(new OCA.Talk.TalkChatDetailTabView());
+		},
+
+		/**
+		 * Returns whether the Talk tab can be displayed for the file.
+		 *
+		 * @return True if the file is shared with the current user or by the
+		 *         current user to another user (as a user, group...), false
+		 *         otherwise.
+		 */
+		isTalkSidebarSupportedForFile: function(fileInfo) {
+			if (!fileInfo) {
+				return false;
+			}
+
+			if (fileInfo.get('shareOwnerId')) {
+				// Shared with me
+				// TODO How to check that it is not a remote share? At least for
+				// local shares "shareTypes" is not defined when shared with me.
+				return true;
+			}
+
+			if (!fileInfo.get('shareTypes')) {
+				return false;
+			}
+
+			var shareTypes = fileInfo.get('shareTypes').filter(function(shareType) {
+				return shareType == OC.Share.SHARE_TYPE_USER ||
+						shareType == OC.Share.SHARE_TYPE_GROUP ||
+						shareType == OC.Share.SHARE_TYPE_CIRCLE ||
+						shareType == OC.Share.SHARE_TYPE_ROOM;
+			});
+
+			if (shareTypes.length === 0) {
+				return false;
+			}
+
+			return true;
+		},
+
+		// TODO probably move to embedded
+		setupSignalingEventHandlers: function() {
+			var self = this;
+
+			OCA.SpreedMe.app.signaling.on('joinRoom', function(joinedRoomToken) {
+				if (OCA.SpreedMe.app.token !== joinedRoomToken) {
+					return;
+				}
+
+				OCA.SpreedMe.app.signaling.syncRooms().then(function() {
+					OCA.SpreedMe.app._messageCollection.setRoomToken(OCA.SpreedMe.app.activeRoom.get('token'));
+					OCA.SpreedMe.app._messageCollection.receiveMessages();
+				});
+			});
+		},
+
+		// TODO probably move to embedded
+		joinRoom: function(token) {
+			// TODO disconnect from previous room?
+
+			OCA.SpreedMe.app.activeRoom = new OCA.SpreedMe.Models.Room({token: token});
+			OCA.SpreedMe.app.signaling.setRoom(OCA.SpreedMe.app.activeRoom);
+
+			OCA.SpreedMe.app.token = token;
+			OCA.SpreedMe.app.signaling.joinRoom(token);
+		},
+
+		// TODO probably move to embedded
+		leaveCurrentRoom: function() {
+			OCA.SpreedMe.app.signaling.leaveCurrentRoom();
+
+			roomsChannel.trigger('leaveCurrentRoom');
+
+			OCA.SpreedMe.app.token = null;
+			OCA.SpreedMe.app.activeRoom = null;
+		}
+
+	};
+
+	OCA.SpreedMe.app = new OCA.Talk.Embedded();
+	OCA.SpreedMe.app.start();
+
+	OC.Plugins.register('OCA.Files.FileList', OCA.Talk.FilesPlugin);
+})(OC, OCA);

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -93,6 +93,10 @@ class Application extends App {
 		/** @var \OCA\Spreed\Files\Listener $filesListener */
 		$filesListener = $this->getContainer()->query(\OCA\Spreed\Files\Listener::class);
 		$filesListener->register();
+
+		/** @var \OCA\Spreed\Files\TemplateLoader $filesTemplateLoader */
+		$filesTemplateLoader = $this->getContainer()->query(\OCA\Spreed\Files\TemplateLoader::class);
+		$filesTemplateLoader->register();
 	}
 
 	protected function registerNotifier(IServerContainer $server) {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -89,6 +89,10 @@ class Application extends App {
 		/** @var \OCA\Spreed\PublicShareAuth\TemplateLoader $shareAuthTemplateLoader */
 		$shareAuthTemplateLoader = $this->getContainer()->query(\OCA\Spreed\PublicShareAuth\TemplateLoader::class);
 		$shareAuthTemplateLoader->register();
+
+		/** @var \OCA\Spreed\Files\Listener $filesListener */
+		$filesListener = $this->getContainer()->query(\OCA\Spreed\Files\Listener::class);
+		$filesListener->register();
 	}
 
 	protected function registerNotifier(IServerContainer $server) {

--- a/lib/BackgroundJob/RemoveEmptyRooms.php
+++ b/lib/BackgroundJob/RemoveEmptyRooms.php
@@ -64,7 +64,7 @@ class RemoveEmptyRooms extends TimedJob {
 		if ($room->getType() === Room::ONE_TO_ONE_CALL && $room->getNumberOfParticipants(false) <= 1) {
 			$room->deleteRoom();
 			$this->numDeletedRooms++;
-		} else if ($room->getNumberOfParticipants(false) === 0) {
+		} else if ($room->getNumberOfParticipants(false) === 0 && $room->getObjectType() !== 'file') {
 			$room->deleteRoom();
 			$this->numDeletedRooms++;
 		}

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+/**
+ *
+ * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Controller;
+
+use OCA\Spreed\Exceptions\RoomNotFoundException;
+use OCA\Spreed\Files\Util;
+use OCA\Spreed\Manager;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\AppFramework\OCSController;
+use OCP\IL10N;
+use OCP\IRequest;
+
+class FilesController extends OCSController {
+
+	/** @var string */
+	private $currentUser;
+	/** @var Manager */
+	private $manager;
+	/** @var Util */
+	private $util;
+	/** @var IL10N */
+	private $l;
+
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param string $userId
+	 * @param Manager $manager
+	 * @param Util $util
+	 * @param IL10N $l10n
+	 */
+	public function __construct(
+			string $appName,
+			IRequest $request,
+			string $userId,
+			Manager $manager,
+			Util $util,
+			IL10N $l10n
+	) {
+		parent::__construct($appName, $request);
+		$this->currentUser = $userId;
+		$this->manager = $manager;
+		$this->util = $util;
+		$this->l = $l10n;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * Returns the token of the room associated to the given file id.
+	 *
+	 * If there is no room associated to the given file id a new room is
+	 * created; the new room is a public room associated with a "file" object
+	 * with the given file id. Unlike normal rooms in which the owner is the
+	 * user that created the room these are special rooms without owner or any
+	 * other persistent participant.
+	 *
+	 * In any case, to create or even get the token of the room, the file must
+	 * be shared and the user must have direct access to that file; an error
+	 * is returned otherwise. A user has direct access to a file if she has
+	 * access to it through a user, group, circle or room share (but not through
+	 * a link share, for example), or if she is the owner of such a file.
+	 *
+	 * @param string $fileId
+	 * @return DataResponse the status code is "200 OK" if a room is returned,
+	 *         or "404 Not found" if the given file id was invalid.
+	 */
+	public function getRoom(string $fileId): DataResponse {
+		$share = $this->util->getAnyDirectShareOfFileAccessibleByUser($fileId, $this->currentUser);
+		if (!$share) {
+			throw new OCSNotFoundException($this->l->t('File is not shared, or shared but not with the user'));
+		}
+
+		try {
+			$room = $this->manager->getRoomByObject('file', $fileId);
+		} catch (RoomNotFoundException $e) {
+			$room = $this->manager->createPublicRoom('', 'file', $fileId);
+		}
+
+		return new DataResponse([
+			'token' => $room->getToken()
+		]);
+	}
+
+}

--- a/lib/Files/Listener.php
+++ b/lib/Files/Listener.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+
+/**
+ *
+ * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Files;
+
+use OCA\Spreed\Room;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * Custom behaviour for rooms for files.
+ *
+ * The rooms for files are intended to give the users a way to talk about a
+ * specific shared file, for example, when collaboratively editing it. The room
+ * is persistent and can be accessed simultaneously by any user with direct
+ * access (user, group, circle and room share, but not link share, for example)
+ * to that file. The room has no owner, and there are no persistent participants
+ * (it is a public room that users join and leave on each session).
+ *
+ * These rooms are associated to a "file" object, and their custom behaviour is
+ * provided by calling the methods of this class as a response to different room
+ * events.
+ */
+class Listener {
+
+	/** @var EventDispatcherInterface */
+	protected $dispatcher;
+	/** @var Util */
+	protected $util;
+
+	public function __construct(EventDispatcherInterface $dispatcher, Util $util) {
+		$this->dispatcher = $dispatcher;
+		$this->util = $util;
+	}
+
+	public function register() {
+		$listener = function(GenericEvent $event) {
+			/** @var Room $room */
+			$room = $event->getSubject();
+			$this->preventUsersWithoutDirectAccessToTheFileFromJoining($room, $event->getArgument('userId'));
+		};
+		$this->dispatcher->addListener(Room::class . '::preJoinRoom', $listener);
+
+		$listener = function(GenericEvent $event) {
+			/** @var Room $room */
+			$room = $event->getSubject();
+			$this->preventGuestsFromJoining($room);
+		};
+		$this->dispatcher->addListener(Room::class . '::preJoinRoomGuest', $listener);
+	}
+
+	/**
+	 * Prevents users from joining if they do not have direct access to the
+	 * file.
+	 *
+	 * A user has direct access to a file if she received the file through a
+	 * user, group, circle or room share (but not through a link share, for
+	 * example), or if she is the owner of such a file.
+	 *
+	 * This method should be called before a user joins a room.
+	 *
+	 * @param Room $room
+	 * @param string $userId
+	 * @throws \Exception
+	 */
+	public function preventUsersWithoutDirectAccessToTheFileFromJoining(Room $room, string $userId) {
+		if ($room->getObjectType() !== 'file') {
+			return;
+		}
+
+		$share = $this->util->getAnyDirectShareOfFileAccessibleByUser($room->getObjectId(), $userId);
+		if (!$share) {
+			throw new \Exception('User does not have direct access to the file');
+		}
+	}
+
+	/**
+	 * Prevents guests from joining the room.
+	 *
+	 * This method should be called before a guest joins a room.
+	 *
+	 * @param Room $room
+	 * @throws \Exception
+	 */
+	public function preventGuestsFromJoining(Room $room) {
+		if ($room->getObjectType() !== 'file') {
+			return;
+		}
+
+		throw new \Exception('Guests are not allowed in rooms for files');
+	}
+
+}

--- a/lib/Files/Listener.php
+++ b/lib/Files/Listener.php
@@ -68,6 +68,14 @@ class Listener {
 			$this->preventGuestsFromJoining($room);
 		};
 		$this->dispatcher->addListener(Room::class . '::preJoinRoomGuest', $listener);
+
+		// TODO listen to share deletion to remove the conversation when the
+		// file is no longer shared? Also note that if a user share is
+		// transfered to the other user the share is removed
+
+		// TODO right now there are no owners or persistent participants of the
+		// room, but if there were, listen to file ownership transfer to change
+		// the room owner/participant when needed
 	}
 
 	/**
@@ -91,6 +99,8 @@ class Listener {
 
 		$share = $this->util->getAnyDirectShareOfFileAccessibleByUser($room->getObjectId(), $userId);
 		if (!$share) {
+			// TODO the exception message is shown as an error in Nextcloud
+			// logs, how to prevent that?
 			throw new \Exception('User does not have direct access to the file');
 		}
 	}

--- a/lib/Files/TemplateLoader.php
+++ b/lib/Files/TemplateLoader.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+/**
+ *
+ * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Files;
+
+use OCP\Util;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * Helper class to add the Talk UI to the sidebar of the Files app.
+ */
+class TemplateLoader {
+
+	/** @var EventDispatcherInterface */
+	protected $dispatcher;
+
+	public function __construct(EventDispatcherInterface $dispatcher) {
+		$this->dispatcher = $dispatcher;
+	}
+
+	public function register() {
+		$listener = function() {
+			$this->loadTalkSidebarForFilesApp();
+		};
+		$this->dispatcher->addListener('OCA\Files::loadAdditionalScripts', $listener);
+	}
+
+	/**
+	 * Loads the Talk UI in the sidebar of the Files app.
+	 *
+	 * This method should be called when loading additional scripts for the
+	 * Files app.
+	 */
+	public function loadTalkSidebarForFilesApp() {
+		Util::addStyle('spreed', 'files');
+		Util::addStyle('spreed', 'chat');
+		Util::addStyle('spreed', 'autocomplete');
+
+		Util::addScript('spreed', 'vendor/backbone/backbone-min');
+		Util::addScript('spreed', 'vendor/backbone.radio/build/backbone.radio.min');
+		Util::addScript('spreed', 'vendor/backbone.marionette/lib/backbone.marionette.min');
+		Util::addScript('spreed', 'vendor/jshashes/hashes.min');
+		Util::addScript('spreed', 'vendor/Caret.js/dist/jquery.caret.min');
+		Util::addScript('spreed', 'vendor/At.js/dist/js/jquery.atwho.min');
+		Util::addScript('spreed', 'models/chatmessage');
+		Util::addScript('spreed', 'models/chatmessagecollection');
+		Util::addScript('spreed', 'models/localstoragemodel');
+		Util::addScript('spreed', 'models/room');
+		Util::addScript('spreed', 'models/roomcollection');
+		Util::addScript('spreed', 'models/participant');
+		Util::addScript('spreed', 'models/participantcollection');
+		Util::addScript('spreed', 'views/callinfoview');
+		Util::addScript('spreed', 'views/chatview');
+		Util::addScript('spreed', 'views/editabletextlabel');
+		Util::addScript('spreed', 'views/participantlistview');
+		Util::addScript('spreed', 'views/participantview');
+		Util::addScript('spreed', 'views/roomlistview');
+		Util::addScript('spreed', 'views/sidebarview');
+		Util::addScript('spreed', 'views/tabview');
+		Util::addScript('spreed', 'views/virtuallist');
+		Util::addScript('spreed', 'richobjectstringparser');
+		Util::addScript('spreed', 'simplewebrtc');
+		Util::addScript('spreed', 'webrtc');
+		Util::addScript('spreed', 'signaling');
+		Util::addScript('spreed', 'connection');
+		Util::addScript('spreed', 'embedded');
+		Util::addScript('spreed', 'filesplugin');
+	}
+
+}

--- a/lib/Files/Util.php
+++ b/lib/Files/Util.php
@@ -1,0 +1,139 @@
+<?php
+declare(strict_types=1);
+
+/**
+ *
+ * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Files;
+
+use OCP\Files\IRootFolder;
+use OCP\Files\Node;
+use OCP\Share\IManager as ShareManager;
+
+class Util {
+
+	/** @var IRootFolder */
+	private $rootFolder;
+	/** @var ShareManager */
+	private $shareManager;
+
+	/**
+	 * @param IRootFolder $rootFolder
+	 * @param ShareManager $shareManager
+	 */
+	public function __construct(
+			IRootFolder $rootFolder,
+			ShareManager $shareManager
+	) {
+		$this->rootFolder = $rootFolder;
+		$this->shareManager = $shareManager;
+	}
+
+	/**
+	 * Returns any share of the file that the user has direct access to.
+	 *
+	 * A user has direct access to a share and, thus, to a file, if she received
+	 * the file through a user, group, circle or room share (but not through a
+	 * public link, for example), or if she is the owner of such a share.
+	 *
+	 * @param string $fileId
+	 * @param string $userId
+	 * @return IShare|null
+	 */
+	public function getAnyDirectShareOfFileAccessibleByUser(string $fileId, string $userId) {
+		$userFolder = $this->rootFolder->getUserFolder($userId);
+		$fileById = $userFolder->getById($fileId);
+		if (empty($fileById)) {
+			return null;
+		}
+
+		foreach ($fileById as $node) {
+			$share = $this->getAnyDirectShareOfNodeAccessibleByUser($node, $userId);
+			if ($share) {
+				return $share;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns any share of the node that the user has direct access to.
+	 *
+	 * @param Node $node
+	 * @param string $userId
+	 * @return IShare|null
+	 */
+	private function getAnyDirectShareOfNodeAccessibleByUser(Node $node, string $userId) {
+		$reshares = false;
+		$limit = 1;
+
+		$shares = $this->shareManager->getSharesBy($userId, \OCP\Share::SHARE_TYPE_USER, $node, $reshares, $limit);
+		if (\count($shares) > 0) {
+			return $shares[0];
+		}
+
+		$shares = $this->shareManager->getSharesBy($userId, \OCP\Share::SHARE_TYPE_GROUP, $node, $reshares, $limit);
+		if (\count($shares) > 0) {
+			return $shares[0];
+		}
+
+		$shares = $this->shareManager->getSharesBy($userId, \OCP\Share::SHARE_TYPE_CIRCLE, $node, $reshares, $limit);
+		if (\count($shares) > 0) {
+			return $shares[0];
+		}
+
+		$shares = $this->shareManager->getSharesBy($userId, \OCP\Share::SHARE_TYPE_ROOM, $node, $reshares, $limit);
+		if (\count($shares) > 0) {
+			return $shares[0];
+		}
+
+		// If the node is not shared then there is no need for further checks.
+		// Note that "isShared()" returns false for owned shares, so the check
+		// can not be moved above.
+		if (!$node->isShared()) {
+			return null;
+		}
+
+		$shares = $this->shareManager->getSharedWith($userId, \OCP\Share::SHARE_TYPE_USER, $node, $limit);
+		if (\count($shares) > 0) {
+			return $shares[0];
+		}
+
+		$shares = $this->shareManager->getSharedWith($userId, \OCP\Share::SHARE_TYPE_GROUP, $node, $limit);
+		if (\count($shares) > 0) {
+			return $shares[0];
+		}
+
+		$shares = $this->shareManager->getSharedWith($userId, \OCP\Share::SHARE_TYPE_CIRCLE, $node, $limit);
+		if (\count($shares) > 0) {
+			return $shares[0];
+		}
+
+		$shares = $this->shareManager->getSharedWith($userId, \OCP\Share::SHARE_TYPE_ROOM, $node, $limit);
+		if (\count($shares) > 0) {
+			return $shares[0];
+		}
+
+		return null;
+	}
+
+}

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -299,6 +299,30 @@ class Manager {
 	}
 
 	/**
+	 * @param string $objectType
+	 * @param string $objectId
+	 * @return Room
+	 * @throws RoomNotFoundException
+	 */
+	public function getRoomByObject(string $objectType, string $objectId): Room {
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from('talk_rooms')
+			->where($query->expr()->eq('object_type', $query->createNamedParameter($objectType)))
+			->andWhere($query->expr()->eq('object_id', $query->createNamedParameter($objectId)));
+
+		$result = $query->execute();
+		$row = $result->fetch();
+		$result->closeCursor();
+
+		if ($row === false) {
+			throw new RoomNotFoundException();
+		}
+
+		return $this->createRoomObject($row);
+	}
+
+	/**
 	 * @param string|null $userId
 	 * @param string $sessionId
 	 * @return Room


### PR DESCRIPTION
:construction: :construction: :construction: :warning: :warning: :warning:  **WIP: DO NOT MERGE** :warning: :warning: :warning: :construction: :construction: :construction:

Requires nextcloud/server#11647

This pull request adds initial support for the Talk sidebar in the Files app.

It is currently a work in progress; the code is not ready for review yet, although feedback about the feature itself is welcome.

In the Files app, when the user shows the details view for a file shared with other users, now a _Chat_ tab is shown (call support will be added in another pull request). This chat is accessible by all the users that have access to that file (through a user, group, circle or room share), and although it is shown in the main Files app it is mainly targeted to communicate while collaboratively editing the file (like with Collabora Online, which [now uses the sidebar of the Files app](https://github.com/nextcloud/richdocuments/pull/223)).

![talk-sidebar-files-chat](https://user-images.githubusercontent.com/26858233/46604947-24a08580-caf8-11e8-850a-4c632108e250.png)

Note that there is a single room for each file, no matter which or how many shares it has; there are no separate rooms based on the shares, like two different rooms for two different user shares, another room for a group share, etc. In the same way that all the users can collaboratively edit the file the room is also accessible by all of them.

However, for the time being, only registered users have access to the room for a file, and only if they have direct access to the file (through a user, group, circle or room share); the Talk sidebar is not shown in the public share page, and neither guests nor users can join the room even if they know its token and they can access the file due to a link share. This restriction could be addressed in a later pull request but, for simplicity, this initial version enforces it.

The rooms associated to files are persistent public rooms, but without any persistent participant; all the users join and leave in each session, so the rooms are not added to the room list. They only appear there when the user is currently in the room, that is, when she has the _Chat_ tab is open for the file in the Files app.

In a similar way notifications are sent to the user only when she is currently in the room. This is the expected behaviour in my opinion (except for mentions, which should be notified even if not currently in the room); if some people is working on a file in general it would not make sense to notify everyone with access to that file for example that a conversation started if they are not already working on it.

Pending:
- [ ] Rooms for files are never removed yet. A new `BackgroundJob` should be added for that; it would check whether the file associated to a room exists or not and, if it does not exist, remove the room.
  - Another approach would be to listen to file deletion events, but that would introduce a lot of unneeded overhead, as once the file is deleted the room would be no longer accessible anyway (so it does not really matter if it lives a bit longer), and this would make file deletion slower due to the extra database queries.

Enhancements for future pull requests:
- Add support for calls
- The autocomplete should show all the users that can access the room instead of only those that are currently active in the room (although those currently active in the room should have higher priority).
  - Mentions should be notified (if the user has access to the file) even when not currently in the room.
- Do not create the room if it is not needed. Right now the room is created just by opening the _Chat_ tab; it would be better to create it only if any user actually wrote anything in the room. The PHP changes are trivial, although the JavaScript ones are more involved.
