### PR TITLE
Changes to allow hooks to set the participant type

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -452,6 +452,10 @@
 								self.activeRoom = room;
 							}
 						});
+
+						if (self.activeRoom === null) {
+							self.activeRoom = new OCA.SpreedMe.Models.Room({ token: self.token });
+						}
 						participants = self.activeRoom.get('participants');
 					} else {
 						// The public page supports only a single room, so the

--- a/js/app.js
+++ b/js/app.js
@@ -648,10 +648,22 @@
 			$(document).on('click', this.onDocumentClick);
 			OC.Util.History.addOnPopStateHandler(_.bind(this._onPopState, this));
 		},
+		GetURLParameter: function(sParam) {
+			var sPageURL = window.location.search.substring(1);
+			var sURLVariables = sPageURL.split('&');
+			for (var i = 0; i < sURLVariables.length; i++)
+			{
+				var sParameterName = sURLVariables[i].split('=');
+				if (sParameterName[0] == sParam) {
+				    return sParameterName[1];
+				}
+			}
+		},
 		onStart: function() {
 			this.signaling = OCA.Talk.Signaling.createConnection();
 			this.connection = new OCA.Talk.Connection(this);
 			this.token = $('#app').attr('data-token');
+			this.password = this.GetURLParameter('password');
 
 			this.signaling.on('joinRoom', function(/* token */) {
 				this.inRoom = true;
@@ -702,7 +714,7 @@
 			this.initShareRoomClipboard();
 
 			if (this.token) {
-				this.connection.joinRoom(this.token);
+				this.connection.joinRoom(this.token, this.password);
 			}
 		},
 		setupWebRTC: function() {

--- a/js/connection.js
+++ b/js/connection.js
@@ -82,14 +82,14 @@
 				success: _.bind(this._createCallSuccessHandle, this)
 			});
 		},
-		joinRoom: function(token) {
+		joinRoom: function(token, password) {
 			if (this.app.signaling.currentRoomToken === token) {
 				return;
 			}
 
 			this.app.signaling.leaveCurrentRoom();
 			this.app.token = token;
-			this.app.signaling.joinRoom(token);
+			this.app.signaling.joinRoom(token, password);
 			this.app.syncAndSetActiveRoom(token);
 			$('#video-fullscreen').removeClass('hidden');
 		},

--- a/js/views/tabview.js
+++ b/js/views/tabview.js
@@ -133,7 +133,11 @@
 			// _.map creates an array, so "currentPriorities" will contain a
 			// "length" property.
 			var currentPriorities = _.map(this._tabIds, _.bind(function(tabId) {
-				return this.getRegion(tabId).currentView.getOption('priority');
+				var region = this.getRegion(tabId);
+				if (typeof region !== 'undefined') {
+					return region.currentView.getOption('priority');
+				}
+				return 0;
 			}, this));
 
 			var index = _.findIndex(currentPriorities, function(currentPriority) {


### PR DESCRIPTION
Changes to allow hooks to set the participant type and a fix when swing/hiding tab views.  The hook when a user joins or a guest joins allows setting the participant type to allow assigning moderator status.  The password also needs to always be sent and tested when a user or guest joins the room to verify they are allowed to access the meeting in the verifyPassword hook (permissions may be changed after a user joins).