### PR TITLE
Override default CSP for now to allow JavaScript "eval"

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -179,6 +179,7 @@ class PageController extends Controller {
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedConnectDomain('*');
 		$csp->addAllowedMediaDomain('blob:');
+		$csp->allowEvalScript(true);
 		$response->setContentSecurityPolicy($csp);
 		return $response;
 	}


### PR DESCRIPTION
By default in [Nextcloud 15 the Content Security Policy prevents the use of JavaScript `eval` function](https://github.com/nextcloud/server/commit/5b61ef9213df0ff67ebd5b9c88a8e1562f367351). This is used in several places in Talk, so for now this restriction is lifted until the code is moved away from `eval`.

Note that this only fixes the main UI of Talk; the Settings page and the _Request password by Talk_ UI in the authentication page of shares are currently broken with current server master. The Settings page will be fixed by @rullzer, while the _Request password by Talk_ UI will be fixed later when the rest of the Talk UI is moved away from `eval`.
