### PR TITLE
Show again participants without streams in a call

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -363,7 +363,6 @@ var spreedPeerConnectionTable = [];
 				var user = usersInCallMapping[id];
 				if (user && !userHasStreams(user)) {
 					console.log("User has no stream", id);
-					return;
 				}
 
 				// Indicator for username


### PR DESCRIPTION
Participants without streams were removed from the main call view [in a previous commit](https://github.com/nextcloud/spreed/pull/914/commits/d4929b7525f506a7a0a10bac5c499045751bc696#diff-df9e9621f81056c7ff54db096571cab0R366). However, as those participants are still listening in the call and they can also share their screen even if the have no
microphone or camera now they are shown again like any other participant in the call.
