### PR TITLE
Add search provider for chat messages

### DIFF
--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -31,6 +31,8 @@
   * [Sending a new chat message](#sending-a-new-chat-message)
   * [Get mention autocomplete suggestions](#get-mention-autocomplete-suggestions)
   * [System messages](#system-messages)
+- [Search](#search)
+  * [Search chat messages](#search-chat-messages)
 - [Guests](#guests)
   * [Set display name](#set-display-name)
 - [Signaling](#signaling)
@@ -594,6 +596,46 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 * `moderator_demoted` - {actor} demoted {user} from moderator
 * `guest_moderator_promoted` - {actor} promoted {user} to moderator
 * `guest_moderator_demoted` - {actor} demoted {user} from moderator
+
+## Search
+
+### Search chat messages
+
+The search uses the server endpoint, so it is not available for guest users.
+
+* Method: `GET`
+* Endpoint: `/index.php/core/search` (from the root, it does not use the base OCS endpoint)
+* Data:
+
+    field | type | Description
+    ------|------|------------
+    `query` | string | The (sub)string to look for in chat messages
+    `inApps` | array | The apps in which perform the search; it should contain a single item with the value 'spreed'
+
+    - Header:
+
+        field | type | Description
+        ------|------|------------
+        `requesttoken` | string | The request token returned by a previous login
+
+* Response:
+    - Status code:
+        + `200 OK`
+
+    - Data:
+        Array of results, each result has at least:
+
+        field | type | Description
+        ------|------|------------
+        `type` | string | 'chat-message'
+        `id` | int | ID of the comment
+        `token` | string | Room token
+        `actorType` | string | `guests` or `users`
+        `actorId` | string | User id of the message author
+        `actorDisplayName` | string | Display name of the message author
+        `timestamp` | int | Timestamp in seconds and UTC time zone
+        `name` | string | Full message string; raw, not a rich object string
+        `relevantMessagePart` | string | Substring of the full message centered on the first match in the message
 
 ## Guests
 

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -148,7 +148,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         `lastMessage` | message | Last message in a room if available, otherwise empty
         `objectType` | string | The type of object that the room is associated with; "share:password" if the room is used to request a password for a share, otherwise empty
         `objectId` | string | Share token if "objectType" is "share:password", otherwise empty
-       
+
 ### Get single room (also for guests)
 
 * Method: `GET`
@@ -573,7 +573,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         `id` | string | The user id which should be sent as `@<id>` in the message
         `label` | string | The displayname of the user
         `source` | string | The type of the user, currently only `users`
-        
+
 ### System messages
 
 * `conversation_created` - {actor} created the conversation
@@ -592,7 +592,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 * `moderator_demoted` - {actor} demoted {user} from moderator
 * `guest_moderator_promoted` - {actor} promoted {user} to moderator
 * `guest_moderator_demoted` - {actor} demoted {user} from moderator
-        
+
 ## Guests
 
 ### Set display name
@@ -610,8 +610,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         + `200 OK`
         + `404 Not Found` When the room is not found or the session does not exist in the room
         + `403 Forbidden` When the user is logged in
-        
-        
+
 ## Signaling
 
 ### Get signaling settings
@@ -628,13 +627,13 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
     `ticket` | string | Ticket for the external signaling server
 
     - STUN server
-    
+
        field | type | Description
        ------|------|------------
        `url` | string | STUN server URL
 
     - TURN server
-    
+
        field | type | Description
        ------|------|------------
        `url` | array | One element array with TURN server URL

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -29,6 +29,8 @@
 - [Chat](#chat)
   * [Receive chat messages of a room](#receive-chat-messages-of-a-room)
   * [Sending a new chat message](#sending-a-new-chat-message)
+  * [Get mention autocomplete suggestions](#get-mention-autocomplete-suggestions)
+  * [System messages](#system-messages)
 - [Guests](#guests)
   * [Set display name](#set-display-name)
 - [Signaling](#signaling)

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -31,6 +31,7 @@ use OCA\Spreed\HookListener;
 use OCA\Spreed\Notification\Notifier;
 use OCA\Spreed\Participant;
 use OCA\Spreed\Room;
+use OCA\Spreed\Search\Provider;
 use OCA\Spreed\Settings\Personal;
 use OCA\Spreed\Signaling\BackendNotifier;
 use OCA\Spreed\Signaling\Messages;
@@ -54,6 +55,8 @@ class Application extends App {
 			$listener = \OC::$server->query(HookListener::class);
 			$listener->deleteUser($user);
 		});
+
+		$server->getSearch()->registerProvider(Provider::class, ['apps' => ['spreed']]);
 
 		$this->registerNotifier($server);
 		$this->getContainer()->registerCapability(Capabilities::class);

--- a/lib/Search/Provider.php
+++ b/lib/Search/Provider.php
@@ -1,0 +1,189 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2018 Joas Schilling <coding@schilljs.com>
+ * @copyright Copyright (c) 2018 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Search;
+
+use OCA\Spreed\Exceptions\ParticipantNotFoundException;
+use OCA\Spreed\GuestManager;
+use OCA\Spreed\Manager;
+use OCP\Comments\IComment;
+use OCP\Comments\ICommentsManager;
+use OCP\IL10N;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Search\Result as BaseResult;
+
+class Provider extends \OCP\Search\Provider {
+
+	/** @var IUserSession */
+	private $userSession;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var ICommentsManager */
+	private $commentsManager;
+
+	/** @var IL10N */
+	private $l;
+
+	/** @var Manager */
+	private $manager;
+
+	/** @var GuestManager */
+	private $guestManager;
+
+	/**
+	 * @param array $options as key => value
+	 */
+	public function __construct($options = array()) {
+		parent::__construct($options);
+
+		// Search providers are instantiated with "new $class($options)" in
+		// "lib/private/Search.php", so the standard dependency injection system
+		// can not be used and needs to be faked instead.
+		$this->userSession = \OC::$server->getUserSession();
+		$this->userManager = \OC::$server->getUserManager();
+		$this->commentsManager = \OC::$server->getCommentsManager();
+		$this->l = \OC::$server->getL10N('spreed');
+		$this->manager = \OC::$server->resolve('\OCA\Spreed\Manager');
+		// GuestManager uses IL10N, which is not registered in the server
+		// container, so it needs to be explicitly constructed instead of
+		// resolved.
+		$this->guestManager = new GuestManager(
+			\OC::$server->getDatabaseConnection(),
+			\OC::$server->getMailer(),
+			\OC::$server->query(\OCP\Defaults::class),
+			\OC::$server->getUserSession(),
+			\OC::$server->getURLGenerator(),
+			\OC::$server->getL10N('spreed'),
+			\OC::$server->getEventDispatcher()
+		);
+	}
+
+	/**
+	 * Search for $query
+	 *
+	 * @param string $query
+	 * @return array An array of OCP\Search\Result's
+	 */
+	public function search($query): array {
+		$user = $this->userSession->getUser();
+		if (!$user instanceof IUser) {
+			return [];
+		}
+
+		$searchableRooms = $this->manager->getRoomsForParticipant($user->getUID());
+
+		$results = [];
+		$numComments = 50;
+		$offset = 0;
+
+		while (\count($results) < $numComments) {
+			/** @var IComment[] $comments */
+			$comments = $this->commentsManager->search($query, 'chat', '', '', $offset, $numComments);
+
+			foreach ($comments as $comment) {
+				$result = $this->getResultForComment($comment, $query, $searchableRooms);
+				if ($result) {
+					$results[] = $result;
+				}
+			}
+
+			if (\count($comments) < $numComments) {
+				// Didn't find more comments when we tried to get, so there are
+				// no more comments.
+				return $results;
+			}
+
+			$offset += $numComments;
+			$numComments = 50 - \count($results);
+		}
+
+		return $results;
+	}
+
+	/**
+	 * @param IComment $comment
+	 * @param BaseResult[] $results
+	 * @param string $query
+	 * @param Room[] $searchableRooms
+	 * @return BaseResult|null
+	 */
+	private function getResultForComment(IComment $comment, string $query, array $searchableRooms) {
+		if ($comment->getActorType() !== 'users' && $comment->getActorType() !== 'guests') {
+			return null;
+		}
+
+		// Ignore system messages
+		if ($comment->getVerb() !== 'comment') {
+			return null;
+		}
+
+		// Ignore rooms that the user is not a participant of
+		$room = $this->getSearchableRoomById($searchableRooms, (int)$comment->getObjectId());
+		if (!$room) {
+			return null;
+		}
+
+		$actorDisplayName = '';
+		if ($comment->getActorType() === 'users') {
+			$user = $this->userManager->get($comment->getActorId());
+			$actorDisplayName = $user instanceof IUser ? $user->getDisplayName() : '';
+		} else if ($comment->getActorType() === 'guests') {
+			try {
+				$actorDisplayName = $this->guestManager->getNameBySessionHash($comment->getActorId());
+			} catch (ParticipantNotFoundException $e) {
+			}
+		}
+
+		try {
+			return new Result(
+				$this->l,
+				$query,
+				$comment,
+				$room->getToken(),
+				$actorDisplayName
+			);
+		} catch (\InvalidArgumentException $e) {
+			return null;
+		}
+	}
+
+	/**
+	 * @param Room[] $searchableRooms
+	 * @param int $roomId
+	 * @return Room|null
+	 */
+	private function getSearchableRoomById(array $searchableRooms, int $roomId) {
+		foreach ($searchableRooms as $room) {
+			if ($room->getId() === $roomId) {
+				return $room;
+			}
+		}
+
+		return null;
+	}
+}

--- a/lib/Search/Result.php
+++ b/lib/Search/Result.php
@@ -1,0 +1,124 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2018 Joas Schilling <coding@schilljs.com>
+ * @copyright Copyright (c) 2018 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Search;
+
+use OCP\Comments\IComment;
+use OCP\IL10N;
+use OCP\Search\Result as BaseResult;
+
+class Result extends BaseResult {
+
+	/** @var IL10N */
+	private $l;
+
+	/** @var string */
+	public $type = 'chat-message';
+
+	/** @var string */
+	public $token;
+
+	/** @var string */
+	public $actorType;
+
+	/** @var string */
+	public $actorId;
+
+	/** @var string */
+	public $actorDisplayName;
+
+	/** @var int */
+	public $timestamp;
+
+	/** @var string */
+	public $relevantMessagePart;
+
+	/**
+	 * @param IL10N $l
+	 * @param string $search
+	 * @param IComment $comment
+	 * @param string $token
+	 * @param string $actorDisplayName
+	 * @throws \InvalidArgumentException
+	 */
+	public function __construct(
+			IL10N $l,
+			string $search,
+			IComment $comment,
+			string $token,
+			string $actorDisplayName
+	) {
+		parent::__construct(
+			(int) $comment->getId(),
+			$comment->getMessage()
+		/* @todo , [link to chat message] */
+		);
+
+		$this->l = $l;
+
+		$this->token = $token;
+
+		$this->actorType = $comment->getActorType();
+		$this->actorId = $comment->getActorId();
+		$this->actorDisplayName = $actorDisplayName;
+
+		$this->timestamp = $comment->getCreationDateTime()->getTimestamp();
+
+		$this->relevantMessagePart = $this->getRelevantMessagePart($comment->getMessage(), $search);
+	}
+
+	/**
+	 * @param string $message
+	 * @param string $search
+	 * @return string
+	 * @throws \InvalidArgumentException
+	 */
+	protected function getRelevantMessagePart(string $message, string $search): string {
+		$start = stripos($message, $search);
+		if ($start === false) {
+			throw new InvalidArgumentException('Chat message section not found');
+		}
+
+		$end = $start + strlen($search);
+
+		if ($start <= 25) {
+			$start = 0;
+			$prefix = '';
+		} else {
+			$start -= 25;
+			$prefix = $this->l->t('…');
+		}
+
+		if ((strlen($message) - $end) <= 25) {
+			$end = strlen($message);
+			$suffix = '';
+		} else {
+			$end += 25;
+			$suffix = $this->l->t('…');
+		}
+
+		return $prefix . substr($message, $start, $end - $start) . $suffix;
+	}
+
+}

--- a/tests/integration/config/behat.yml
+++ b/tests/integration/config/behat.yml
@@ -7,6 +7,12 @@ default:
         - %paths.base%/../features
       contexts:
         - FeatureContext
+        - SearchContext:
+            baseUrl: http://localhost:8080/
+            admin:
+              - admin
+              - admin
+            regularUserPassword: 123456
         - SharingContext:
             baseUrl: http://localhost:8080/
             admin:

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -39,6 +39,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	protected static $tokenToIdentifier;
 	/** @var array[] */
 	protected static $sessionIdToUser;
+	/** @var array[] */
+	protected static $userToSessionId;
 
 	/** @var string */
 	protected $currentUser;
@@ -65,6 +67,10 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		return self::$identifierToToken[$identifier];
 	}
 
+	public static function getSessionIdForUser(string $user) {
+		return self::$userToSessionId[$user];
+	}
+
 	/**
 	 * FeatureContext constructor.
 	 */
@@ -80,6 +86,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		self::$identifierToToken = [];
 		self::$tokenToIdentifier = [];
 		self::$sessionIdToUser = [];
+		self::$userToSessionId = [];
 
 		$this->createdUsers = [];
 		$this->createdGroups = [];
@@ -233,6 +240,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			// database, though, so the ID stored in the database and returned
 			// in chat messages is a hashed version instead.
 			self::$sessionIdToUser[sha1($response['sessionId'])] = $user;
+			self::$userToSessionId[$user] = sha1($response['sessionId']);
 		}
 	}
 
@@ -420,6 +428,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			// database, though, so the ID stored in the database and returned
 			// in chat messages is a hashed version instead.
 			self::$sessionIdToUser[sha1($response['sessionId'])] = $user;
+			self::$userToSessionId[$user] = sha1($response['sessionId']);
 		}
 	}
 

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -381,6 +381,23 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" sets her name to "([^"]*)" in room "([^"]*)" with (\d+)$/
+	 *
+	 * @param string $guest
+	 * @param string $name
+	 * @param string $identifier
+	 * @param string $statusCode
+	 */
+	public function userSetsHerNameToInRoom($user, $name, $identifier, $statusCode) {
+		$this->setCurrentUser($user);
+		$this->sendRequest(
+			'POST', '/apps/spreed/api/v1/guest/' . self::$identifierToToken[$identifier] . '/name',
+			new TableNode([['displayName', $name]])
+		);
+		$this->assertStatusCode($this->response, $statusCode);
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" joins call "([^"]*)" with (\d+)$/
 	 *
 	 * @param string $user

--- a/tests/integration/features/bootstrap/SearchContext.php
+++ b/tests/integration/features/bootstrap/SearchContext.php
@@ -1,0 +1,217 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\TableNode;
+use GuzzleHttp\Client;
+use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Message\ResponseInterface;
+
+class SearchContext implements Context {
+
+	/** @var string */
+	private $baseUrl = '';
+
+	/** @var ResponseInterface */
+	private $response = null;
+
+	public function __construct(string $baseUrl, array $admin, string $regularUserPassword) {
+		$this->baseUrl = $baseUrl;
+		$this->adminUser = $admin;
+		$this->regularUserPassword = $regularUserPassword;
+
+		// In case of CI deployment we take the server url from the environment
+		$testServerUrl = getenv('TEST_SERVER_URL');
+		if ($testServerUrl !== false) {
+			$this->baseUrl = $testServerUrl;
+		}
+	}
+
+	/**
+	 * @When user :user searches for :query in chat messages
+	 *
+	 * @param string $user
+	 * @param string $query
+	 */
+	public function userSearchesForInChatMessages(string $user, string $query) {
+		// Search endpoint is not an OCS endpoint, so a request token must be
+		// provided.
+		list($requestToken, $cookieJar) = $this->loggingInUsingWebAs($user);
+
+		$url = '/index.php/core/search';
+
+		$parameters[] = 'query=' . $query;
+		$parameters[] = 'inApps[]=spreed';
+
+		$url .= '?' . implode('&', $parameters);
+
+		$this->sendingToWithRequestToken('GET', $url, $requestToken, $cookieJar);
+	}
+
+	/**
+	 * @Then the list of search results has :count results
+	 */
+	public function theListOfSearchResultsHasResults(int $count) {
+		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+
+		$searchResults = json_decode($this->response->getBody());
+
+		PHPUnit_Framework_Assert::assertEquals($count, count($searchResults));
+	}
+
+	/**
+	 * @Then search result :number contains
+	 *
+	 * @param int $number
+	 * @param TableNode $body
+	 */
+	public function searchResultXContains(int $number, TableNode $body) {
+		if (!($body instanceof TableNode)) {
+			return;
+		}
+
+		$searchResults = json_decode($this->response->getBody(), $asAssociativeArray = true);
+		$searchResult = $searchResults[$number];
+
+		$defaultExpectedFields = [
+			'type' => 'chat-message',
+			'id' => 'A_NUMBER',
+			'timestamp' => 'A_NUMBER'
+		];
+		$expectedFields = array_merge($defaultExpectedFields, $body->getRowsHash());
+
+		if (array_key_exists('room', $expectedFields)) {
+			$expectedFields['token'] = FeatureContext::getTokenForIdentifier($expectedFields['room']);
+			unset($expectedFields['room']);
+		}
+
+		if (!array_key_exists('actorDisplayName', $expectedFields) &&
+				array_key_exists('actorId', $expectedFields)) {
+			$expectedFields['actorDisplayName'] = $expectedFields['actorId'] . '-displayname';
+		}
+
+		if (array_key_exists('actorType', $expectedFields) &&
+				$expectedFields['actorType'] === 'guests' &&
+				array_key_exists('actorId', $expectedFields)) {
+			$expectedFields['actorId'] = FeatureContext::getSessionIdForUser($expectedFields['actorId']);
+		}
+
+		if (!array_key_exists('relevantMessagePart', $expectedFields) &&
+				array_key_exists('name', $expectedFields)) {
+			$expectedFields['relevantMessagePart'] = $expectedFields['name'];
+		}
+
+		foreach ($expectedFields as $expectedField => $expectedValue) {
+			$this->assertFieldIsInReturnedSearchResult($expectedField, $expectedValue, $searchResult);
+		}
+	}
+
+	/**
+	 * @param string $verb
+	 * @param string $url
+	 * @param string $requestToken
+	 * @param CookieJar $cookieJar
+	 */
+	private function sendingToWithRequestToken(string $verb, string $url, string $requestToken, CookieJar $cookieJar) {
+		$fullUrl = $this->baseUrl . $url;
+
+		$client = new Client();
+		try {
+			$this->response = $client->send($client->createRequest(
+				$verb,
+				$fullUrl,
+				[
+					'cookies' => $cookieJar,
+					'headers' => [
+						'requesttoken' => $requestToken
+					]
+				]
+			));
+		} catch (GuzzleHttp\Exception\ClientException $e) {
+			$this->response = $e->getResponse();
+		}
+	}
+
+	/**
+	 * @param ResponseInterface $response
+	 * @return string
+	 */
+	private function extractRequestTokenFromResponse(ResponseInterface $response): string {
+		return substr(preg_replace('/(.*)data-requesttoken="(.*)">(.*)/sm', '\2', $response->getBody()->getContents()), 0, 89);
+	}
+
+	/**
+	 * @param string $user
+	 */
+	private function loggingInUsingWebAs(string $user) {
+		$loginUrl = $this->baseUrl . '/login';
+
+		$cookieJar = new CookieJar();
+
+		// Request a new session and extract CSRF token
+		$client = new Client();
+		$response = $client->get(
+			$loginUrl,
+			[
+				'cookies' => $cookieJar,
+			]
+		);
+		$requestToken = $this->extractRequestTokenFromResponse($response);
+
+		// Login and extract new token
+		$password = ($user === 'admin') ? $this->adminUser[1] : $this->regularUserPassword;
+		$client = new Client();
+		$response = $client->post(
+			$loginUrl,
+			[
+				'body' => [
+					'user' => $user,
+					'password' => $password,
+					'requesttoken' => $requestToken,
+				],
+				'cookies' => $cookieJar,
+			]
+		);
+		$requestToken = $this->extractRequestTokenFromResponse($response);
+
+		return [$requestToken, $cookieJar];
+	}
+
+	/**
+	 * @param string $field
+	 * @param string $contentExpected
+	 * @param array $returnedSearchResult
+	 */
+	private function assertFieldIsInReturnedSearchResult(string $field, string $contentExpected, array $returnedSearchResult){
+		if (!array_key_exists($field, $returnedSearchResult)) {
+			PHPUnit_Framework_Assert::fail("$field was not found in response");
+		}
+
+		if ($contentExpected === 'A_NUMBER') {
+			PHPUnit_Framework_Assert::assertTrue(is_numeric((string)$returnedSearchResult[$field]), "Field '$field' is not a number: " . $returnedSearchResult[$field]);
+		} else {
+			PHPUnit_Framework_Assert::assertEquals($contentExpected, (string)$returnedSearchResult[$field], "Field '$field' does not match");
+		}
+	}
+
+}

--- a/tests/integration/features/chat/public.feature
+++ b/tests/integration/features/chat/public.feature
@@ -76,3 +76,55 @@ Feature: chat/public
       | public room | guests    | guest        |                          | Message 3 | []                |
       | public room | users     | participant2 | participant2-displayname | Message 2 | []                |
       | public room | users     | participant1 | participant1-displayname | Message 1 | []                |
+
+
+
+  Scenario: everyone in a public room receives a message with the name of the guest that sent it
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    When user "guest" sets her name to "The name of the guest" in room "public room" with 200
+    And user "guest" sends message "Message 1" to room "public room" with 201
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId | actorDisplayName      | message   | messageParameters |
+      | public room | guests    | guest   | The name of the guest | Message 1 | []                |
+    And user "participant2" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId | actorDisplayName      | message   | messageParameters |
+      | public room | guests    | guest   | The name of the guest | Message 1 | []                |
+    And user "guest" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId | actorDisplayName      | message   | messageParameters |
+      | public room | guests    | guest   | The name of the guest | Message 1 | []                |
+
+  Scenario: everyone in a public room receives a message with the updated name of the guest that sent it
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    When user "guest" sets her name to "The name of the guest" in room "public room" with 200
+    And user "guest" sends message "Message 1" to room "public room" with 201
+    And user "guest" sets her name to "The new name of the guest" in room "public room" with 200
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId | actorDisplayName          | message   | messageParameters |
+      | public room | guests    | guest   | The new name of the guest | Message 1 | []                |
+    And user "participant2" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId | actorDisplayName          | message   | messageParameters |
+      | public room | guests    | guest   | The new name of the guest | Message 1 | []                |
+    And user "guest" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId | actorDisplayName          | message   | messageParameters |
+      | public room | guests    | guest   | The new name of the guest | Message 1 | []                |
+
+  Scenario: everyone in a public room receives a message with the name of the guest that sent it before leaving the room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    When user "guest" sets her name to "The name of the guest" in room "public room" with 200
+    And user "guest" sends message "Message 1" to room "public room" with 201
+    And user "guest" leaves room "public room" with 200
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId | actorDisplayName      | message   | messageParameters |
+      | public room | guests    | guest   | The name of the guest | Message 1 | []                |
+    And user "participant2" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId | actorDisplayName      | message   | messageParameters |
+      | public room | guests    | guest   | The name of the guest | Message 1 | []                |

--- a/tests/integration/features/chat/search.feature
+++ b/tests/integration/features/chat/search.feature
@@ -1,0 +1,529 @@
+Feature: search
+
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+
+  Scenario: search my own message in a one to one room
+    Given user "participant1" creates room "one-to-one room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant2" sends message "My first message" to room "one-to-one room" with 201
+    When user "participant2" searches for "first" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | one-to-one room |
+      | name | My first message |
+      | actorType | users |
+      | actorId | participant2 |
+
+  Scenario: search a message of the other user in a one to one room
+    Given user "participant1" creates room "one-to-one room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" sends message "Other's first message" to room "one-to-one room" with 201
+    When user "participant2" searches for "first" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | one-to-one room |
+      | name | Other's first message |
+      | actorType | users |
+      | actorId | participant1 |
+
+  Scenario: search a message in a one to one room not invited to
+    Given user "participant1" creates room "one-to-one room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" sends message "Other's first message" to room "one-to-one room" with 201
+    When user "participant3" searches for "first" in chat messages
+    Then the list of search results has "0" results
+
+
+
+  Scenario: search my own message in a group room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant2" sends message "My first message" to room "group room" with 201
+    When user "participant2" searches for "first" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | group room |
+      | name | My first message |
+      | actorType | users |
+      | actorId | participant2 |
+
+  Scenario: search a message of another user in a group room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" sends message "Other's first message" to room "group room" with 201
+    When user "participant2" searches for "first" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | group room |
+      | name | Other's first message |
+      | actorType | users |
+      | actorId | participant1 |
+
+  Scenario: search a message of another user in a group room sent before being invited to the room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" sends message "Other's first message" to room "group room" with 201
+    And user "participant1" adds "participant2" to room "group room" with 200
+    When user "participant2" searches for "first" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | group room |
+      | name | Other's first message |
+      | actorType | users |
+      | actorId | participant1 |
+
+  Scenario: search a message in a group room not invited to
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" sends message "Other's first message" to room "group room" with 201
+    When user "participant3" searches for "first" in chat messages
+    Then the list of search results has "0" results
+
+
+
+  Scenario: search my own message in a public room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "participant2" sends message "My first message" to room "public room" with 201
+    When user "participant2" searches for "first" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | My first message |
+      | actorType | users |
+      | actorId | participant2 |
+
+  Scenario: search a message of another user in a public room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "participant1" sends message "Other's first message" to room "public room" with 201
+    When user "participant2" searches for "first" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | Other's first message |
+      | actorType | users |
+      | actorId | participant1 |
+
+  Scenario: search a message of another user in a public room sent before being invited to the room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" sends message "Other's first message" to room "public room" with 201
+    And user "participant1" adds "participant2" to room "public room" with 200
+    When user "participant2" searches for "first" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | Other's first message |
+      | actorType | users |
+      | actorId | participant1 |
+
+  Scenario: search a message of a self-joined user in a public room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "participant3" joins room "public room" with 200
+    And user "participant3" sends message "Self-joined's first message" to room "public room" with 201
+    When user "participant2" searches for "first" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | Self-joined's first message |
+      | actorType | users |
+      | actorId | participant3 |
+
+  Scenario: search a message of a guest user in a public room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    And user "guest" sends message "Guest's first message" to room "public room" with 201
+    When user "participant2" searches for "first" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | Guest's first message |
+      | actorType | guests |
+      | actorId | guest |
+      | actorDisplayName | |
+
+  Scenario: search a message of a named guest user currently in a public room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    And user "guest" sets her name to "The name of the guest" in room "public room" with 200
+    And user "guest" sends message "Guest's first message" to room "public room" with 201
+    When user "participant2" searches for "first" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | Guest's first message |
+      | actorType | guests |
+      | actorId | guest |
+      | actorDisplayName | The name of the guest |
+
+  Scenario: search a message of a named guest user with an updated name in a public room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    And user "guest" sets her name to "The name of the guest" in room "public room" with 200
+    And user "guest" sends message "Guest's first message" to room "public room" with 201
+    And user "guest" sets her name to "The new name of the guest" in room "public room" with 200
+    When user "participant2" searches for "first" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | Guest's first message |
+      | actorType | guests |
+      | actorId | guest |
+      | actorDisplayName | The new name of the guest |
+
+  Scenario: search a message of a named guest user no longer in a public room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    And user "guest" sets her name to "The name of the guest" in room "public room" with 200
+    And user "guest" sends message "Guest's first message" to room "public room" with 201
+    And user "guest" leaves room "public room" with 200
+    When user "participant2" searches for "first" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | Guest's first message |
+      | actorType | guests |
+      | actorId | guest |
+      | actorDisplayName | The name of the guest |
+
+  Scenario: search a message in a public room not invited but joined to
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "participant3" joins room "public room" with 200
+    And user "participant1" sends message "Other's first message" to room "public room" with 201
+    When user "participant3" searches for "first" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | Other's first message |
+      | actorType | users |
+      | actorId | participant1 |
+
+  Scenario: search a message in a public room not invited but joined to sent before joining to the room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "participant1" sends message "Other's first message" to room "public room" with 201
+    And user "participant3" joins room "public room" with 200
+    When user "participant3" searches for "first" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | Other's first message |
+      | actorType | users |
+      | actorId | participant1 |
+
+  Scenario: search a message in a public room not invited nor joined to
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "participant1" sends message "Other's first message" to room "public room" with 201
+    When user "participant3" searches for "first" in chat messages
+    Then the list of search results has "0" results
+
+  # The search endpoint is available only to logged in users, so no search for
+  # guests.
+
+
+
+  Scenario: search a message using a substring of a full word
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" sends message "The message to be found" to room "public room" with 201
+    When user "participant1" searches for "essa" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | The message to be found |
+      | actorType | users |
+      | actorId | participant1 |
+
+  Scenario: search a message using a different case
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" sends message "The MESSAGE to be found" to room "public room" with 201
+    When user "participant1" searches for "message" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | The MESSAGE to be found |
+      | actorType | users |
+      | actorId | participant1 |
+
+
+
+  Scenario: search a system message
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    When user "participant1" searches for "created" in chat messages
+    Then the list of search results has "0" results
+
+
+
+  Scenario: search a message with a mention
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" sends message "Mention to @participant2" to room "public room" with 201
+    When user "participant1" searches for "mention" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | Mention to @participant2 |
+      | actorType | users |
+      | actorId | participant1 |
+
+  Scenario: search a mention
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" sends message "Mention to @participant2" to room "public room" with 201
+    When user "participant1" searches for "@participant2" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | Mention to @participant2 |
+      | actorType | users |
+      | actorId | participant1 |
+
+
+
+  Scenario: search a long message ellipsized on the right
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" sends message "A very verbose message that is meant to be used to test the ellipsized message returned when searching for long chat messages" to room "public room" with 201
+    When user "participant1" searches for "verbose" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | A very verbose message that is meant to be used to test the ellipsized message returned when searching for long chat messages |
+      | actorType | users |
+      | actorId | participant1 |
+      | relevantMessagePart | A very verbose message that is meant to… |
+
+  Scenario: search a long message ellipsized on the left
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" sends message "A very verbose message that is meant to be used to test the ellipsized message returned when searching for long chat messages" to room "public room" with 201
+    When user "participant1" searches for "searching" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | A very verbose message that is meant to be used to test the ellipsized message returned when searching for long chat messages |
+      | actorType | users |
+      | actorId | participant1 |
+      | relevantMessagePart | …ed message returned when searching for long chat messages |
+
+  Scenario: search a long message ellipsized on both ends
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" sends message "A very verbose message that is meant to be used to test the ellipsized message returned when searching for long chat messages" to room "public room" with 201
+    When user "participant1" searches for "ellipsized" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | A very verbose message that is meant to be used to test the ellipsized message returned when searching for long chat messages |
+      | actorType | users |
+      | actorId | participant1 |
+      | relevantMessagePart | …t to be used to test the ellipsized message returned when se… |
+
+
+
+  Scenario: search a long message with several matches
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" sends message "A very verbose message that is meant to be used to test the ellipsized message returned when searching for long chat messages" to room "public room" with 201
+    When user "participant1" searches for "message" in chat messages
+    Then the list of search results has "1" results
+    And search result "0" contains
+      | room | public room |
+      | name | A very verbose message that is meant to be used to test the ellipsized message returned when searching for long chat messages |
+      | actorType | users |
+      | actorId | participant1 |
+      | relevantMessagePart | A very verbose message that is meant to be used… |
+
+
+
+  Scenario: search several messages in a one to one room
+    Given user "participant1" creates room "one-to-one room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant2" sends message "My first message to be found" to room "one-to-one room" with 201
+    And user "participant2" sends message "My second message should not be found" to room "one-to-one room" with 201
+    And user "participant1" sends message "Other user's first message to be found" to room "one-to-one room" with 201
+    And user "participant1" sends message "Other user's second message should not be found" to room "one-to-one room" with 201
+    And user "participant2" sends message "My third message to be found" to room "one-to-one room" with 201
+    When user "participant2" searches for "message to be found" in chat messages
+    Then the list of search results has "3" results
+    And search result "0" contains
+      | room | one-to-one room |
+      | name | My third message to be found |
+      | actorType | users |
+      | actorId | participant2 |
+    And search result "1" contains
+      | room | one-to-one room |
+      | name | Other user's first message to be found |
+      | actorType | users |
+      | actorId | participant1 |
+    And search result "2" contains
+      | room | one-to-one room |
+      | name | My first message to be found |
+      | actorType | users |
+      | actorId | participant2 |
+
+  Scenario: search several messages in a group room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    And user "participant1" sends message "Other user's first message to be found" to room "group room" with 201
+    And user "participant2" sends message "My first message should not be found" to room "group room" with 201
+    And user "participant2" sends message "My second message to be found" to room "group room" with 201
+    And user "participant1" sends message "Other user's second message should not be found" to room "group room" with 201
+    And user "participant2" sends message "My third message to be found" to room "group room" with 201
+    And user "participant3" sends message "Yet another user's first message to be found" to room "group room" with 201
+    When user "participant2" searches for "message to be found" in chat messages
+    Then the list of search results has "4" results
+    And search result "0" contains
+      | room | group room |
+      | name | Yet another user's first message to be found |
+      | actorType | users |
+      | actorId | participant3 |
+    And search result "1" contains
+      | room | group room |
+      | name | My third message to be found |
+      | actorType | users |
+      | actorId | participant2 |
+    And search result "2" contains
+      | room | group room |
+      | name | My second message to be found |
+      | actorType | users |
+      | actorId | participant2 |
+    And search result "3" contains
+      | room | group room |
+      | name | Other user's first message to be found |
+      | actorType | users |
+      | actorId | participant1 |
+
+  Scenario: search several messages in a public room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "participant3" joins room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    And user "participant1" sends message "Other user's first message should not be found" to room "public room" with 201
+    And user "participant2" sends message "My first message should not be found" to room "public room" with 201
+    And user "guest" sends message "Guest's first message to be found" to room "public room" with 201
+    And user "participant2" sends message "My second message to be found" to room "public room" with 201
+    And user "participant1" sends message "Other user's second message to be found" to room "public room" with 201
+    And user "participant2" sends message "My third message to be found" to room "public room" with 201
+    And user "participant3" sends message "Self-joined user's first message should not be found" to room "public room" with 201
+    And user "guest" sends message "Guest's second message should not be found" to room "public room" with 201
+    And user "participant3" sends message "Self-joined user's second message to be found" to room "public room" with 201
+    When user "participant2" searches for "message to be found" in chat messages
+    Then the list of search results has "5" results
+    And search result "0" contains
+      | room | public room |
+      | name | Self-joined user's second message to be found |
+      | actorType | users |
+      | actorId | participant3 |
+      | relevantMessagePart | …elf-joined user's second message to be found |
+    And search result "1" contains
+      | room | public room |
+      | name | My third message to be found |
+      | actorType | users |
+      | actorId | participant2 |
+    And search result "2" contains
+      | room | public room |
+      | name | Other user's second message to be found |
+      | actorType | users |
+      | actorId | participant1 |
+    And search result "3" contains
+      | room | public room |
+      | name | My second message to be found |
+      | actorType | users |
+      | actorId | participant2 |
+    And search result "4" contains
+      | room | public room |
+      | name | Guest's first message to be found |
+      | actorType | guests |
+      | actorId | guest |
+      | actorDisplayName | |
+
+
+
+  Scenario: search several messages in several rooms
+    Given user "participant1" creates room "one-to-one room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    And user "participant1" adds "participant3" to room "group room" with 200
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "participant3" joins room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    And user "guest" sends message "Guest's first public message to be found" to room "public room" with 201
+    And user "participant1" sends message "Other user's first group message should not be found" to room "group room" with 201
+    And user "participant1" sends message "Other user's first one-to-one message to be found" to room "one-to-one room" with 201
+    And user "participant2" sends message "My first one-to-one message should not be found" to room "one-to-one room" with 201
+    And user "participant2" sends message "My first public message should not be found" to room "public room" with 201
+    And user "participant1" sends message "Other user's second group message to be found" to room "group room" with 201
+    And user "participant2" sends message "My first group message to be found" to room "group room" with 201
+    And user "participant2" sends message "My second group message should not be found" to room "group room" with 201
+    And user "participant1" sends message "Other user's second one-to-one message should not be found" to room "one-to-one room" with 201
+    And user "participant3" sends message "Self-joined user's first public message to be found" to room "public room" with 201
+    When user "participant2" searches for "message to be found" in chat messages
+    Then the list of search results has "5" results
+    And search result "0" contains
+      | room | public room |
+      | name | Self-joined user's first public message to be found |
+      | actorType | users |
+      | actorId | participant3 |
+      | relevantMessagePart | …ined user's first public message to be found |
+    And search result "1" contains
+      | room | group room |
+      | name | My first group message to be found |
+      | actorType | users |
+      | actorId | participant2 |
+    And search result "2" contains
+      | room | group room |
+      | name | Other user's second group message to be found |
+      | actorType | users |
+      | actorId | participant1 |
+      | relevantMessagePart | …ther user's second group message to be found |
+    And search result "3" contains
+      | room | one-to-one room |
+      | name | Other user's first one-to-one message to be found |
+      | actorType | users |
+      | actorId | participant1 |
+      | relevantMessagePart | … user's first one-to-one message to be found |
+    And search result "4" contains
+      | room | public room |
+      | name | Guest's first public message to be found |
+      | actorType | guests |
+      | actorId | guest |
+      | actorDisplayName | |


### PR DESCRIPTION
This pull request only adds the search provider itself; the WebUI will be added later.

Messages are searched only in rooms that the user is currently a participant of, and system messages are ignored in the search.

As the server endpoint is available only to registered users the search provider can not be used by guests.

@Ivansss @mario Note that this uses the standard search endpoint from the server, which is not an OCS endpoint, and requires a request token to be provided.
