### PR TITLE
Improve performance of the list of chat messages

### DIFF
--- a/css/comments.scss
+++ b/css/comments.scss
@@ -77,6 +77,14 @@
 	color: grey;
 }
 
+/* Internal wrappers used by the virtual list. */
+#commentsTabView .comments .wrapper-background,
+#commentsTabView .comments .wrapper {
+	position: absolute;
+	left: 0;
+	right: 0;
+}
+
 #commentsTabView .comment {
 	position: relative;
 	margin-bottom: 30px;

--- a/css/style.scss
+++ b/css/style.scss
@@ -225,10 +225,6 @@
 	flex-direction: column;
 }
 
-#app-content-wrapper #commentsTabView .comment:first-child {
-	padding-top: 15px;
-}
-
 /* The lateral padding is set for each child instead of for the chat view as a
    whole to prevent showing the scroll bar padded from the border of the chat
    view (which could be fixed by using a negative margin and a positive padding
@@ -249,6 +245,15 @@
 
 	padding-left: 44px;
 	padding-right: 44px;
+}
+
+
+#app-content-wrapper #commentsTabView .comments .wrapper-background,
+#app-content-wrapper #commentsTabView .comments .wrapper {
+	/* Padding is not respected in the comment wrapper due to its absolute
+	 * positioning, so it must be set through its position. */
+	left: 44px;
+	right: 44px;
 }
 
 /* Hide all siblings of the chat view when shown as the main view */
@@ -1221,6 +1226,14 @@ video {
 #app-sidebar #commentsTabView .comments {
 	padding-left: 15px;
 	padding-right: 15px;
+}
+
+#app-sidebar #commentsTabView .comments .wrapper-background,
+#app-sidebar #commentsTabView .comments .wrapper {
+	/* Padding is not respected in the comment wrapper due to its absolute
+	 * positioning, so it must be set through its position. */
+	left: 15px;
+	right: 15px;
 }
 
 #app-sidebar #commentsTabView .newCommentForm {

--- a/js/app.js
+++ b/js/app.js
@@ -472,18 +472,16 @@
 			var flags = this.activeRoom.get('participantFlags') || 0;
 			var inCall = flags & OCA.SpreedMe.app.FLAG_IN_CALL !== 0;
 			if (inCall && this._chatViewInMainView === true) {
-				this._chatView.saveScrollPosition();
 				this._chatView.$el.detach();
 				this._sidebarView.addTab('chat', { label: t('spreed', 'Chat'), icon: 'icon-comment', priority: 100 }, this._chatView);
 				this._sidebarView.selectTab('chat');
-				this._chatView.restoreScrollPosition();
+				this._chatView.reloadMessageList();
 				this._chatView.setTooltipContainer(this._chatView.$el);
 				this._chatViewInMainView = false;
 			} else if (!inCall && !this._chatViewInMainView) {
-				this._chatView.saveScrollPosition();
 				this._sidebarView.removeTab('chat');
 				this._chatView.$el.prependTo('#app-content-wrapper');
-				this._chatView.restoreScrollPosition();
+				this._chatView.reloadMessageList();
 				this._chatView.setTooltipContainer($('#app'));
 				this._chatView.focusChatInput();
 				this._chatViewInMainView = true;
@@ -670,6 +668,45 @@
 
 				this._chatView.restoreScrollPosition();
 			}.bind(this));
+
+			// Opening or closing the sidebar changes the width of the main
+			// view, so if the chat view is in the main view it needs to be
+			// reloaded.
+			var reloadMessageListOnSidebarVisibilityChange = function() {
+				if (!this._chatViewInMainView) {
+					return;
+				}
+
+				this._chatView.reloadMessageList();
+			}.bind(this);
+			this._chatView.listenTo(this._sidebarView, 'opened', reloadMessageListOnSidebarVisibilityChange);
+			this._chatView.listenTo(this._sidebarView, 'closed', reloadMessageListOnSidebarVisibilityChange);
+
+			// Resizing the window can change the size of the chat view, both
+			// when it is in the main view and in the sidebar, so the chat view
+			// needs to be reloaded. The initial reload is not very heavy, so
+			// the handler is not debounced for a snappier feel and to reduce
+			// flickering.
+			// However, resizing the window below certain width causes the
+			// navigation bar to be hidden; an explicit handling is needed in
+			// this case because the app navigation (or, more specifically, its
+			// Snap object) adds a transition to the app content, so the reload
+			// needs to be delayed to give the transition time to end and thus
+			// give the app content time to get its final size.
+			var reloadMessageListOnWindowResize = function() {
+				var chatView = this._chatView;
+
+				if ($(window).width() >= 768 || !this._chatViewInMainView) {
+					chatView.reloadMessageList();
+
+					return;
+				}
+
+				setTimeout(function() {
+					chatView.reloadMessageList();
+				}, 300);
+			}.bind(this);
+			$(window).resize(reloadMessageListOnWindowResize);
 
 			this._messageCollection.listenTo(roomChannel, 'leaveCurrentRoom', function() {
 				this.stopReceivingMessages();

--- a/js/models/chatmessagecollection.js
+++ b/js/models/chatmessagecollection.js
@@ -97,7 +97,9 @@
 		},
 
 		_messagesReceived: function(messages) {
+			this.trigger('add:start');
 			this.set(messages);
+			this.trigger('add:end');
 		},
 
 		receiveMessages: function() {

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -425,8 +425,8 @@
 			this._postRenderItem(model, $el);
 
 			if (scrollToNew) {
-				var newestCommentHiddenHeight = (this._getCommentTopPosition($newestComment) + this._getCommentOuterHeight($newestComment)) - this.$container.outerHeight();
-				this.$container.scrollTop(this.$container.scrollTop() + newestCommentHiddenHeight + $el.outerHeight(true));
+				var newestCommentHiddenHeight = (this._getCommentTopPosition($el) + this._getCommentOuterHeight($el)) - this.$container.outerHeight();
+				this.$container.scrollTop(this.$container.scrollTop() + newestCommentHiddenHeight);
 			}
 		},
 

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -388,18 +388,14 @@
 			return data;
 		},
 
-		_onAddModel: function(model, collection, options) {
+		_onAddModel: function(model) {
 			this.$el.find('.emptycontent').toggleClass('hidden', true);
 
 			var $newestComment = this.$container.children('.comment').last();
 			var scrollToNew = $newestComment.length > 0 && this._getCommentTopPosition($newestComment) < this.$container.outerHeight();
 
 			var $el = $(this.commentTemplate(this._formatItem(model)));
-			if (!_.isUndefined(options.at) && collection.length > 1) {
-				this.$container.find('li').eq(options.at).before($el);
-			} else {
-				this.$container.append($el);
-			}
+			this.$container.append($el);
 
 			if (this._modelsHaveSameActor(this._lastAddedMessageModel, model) &&
 					this._modelsAreTemporaryNear(this._lastAddedMessageModel, model) &&

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -239,6 +239,8 @@
 		onRender: function() {
 			delete this._lastAddedMessageModel;
 
+			this._$newestComment = $();
+
 			this.$el.find('.emptycontent').after(this.addCommentTemplate({}));
 
 			this.$el.find('.has-tooltip').tooltip({container: this._tooltipContainer});
@@ -391,11 +393,11 @@
 		_onAddModel: function(model) {
 			this.$el.find('.emptycontent').toggleClass('hidden', true);
 
-			var $newestComment = this.$container.children('.comment').last();
-			var scrollToNew = $newestComment.length > 0 && this._getCommentTopPosition($newestComment) < this.$container.outerHeight();
+			var scrollToNew = this._$newestComment.length > 0 && this._getCommentTopPosition(this._$newestComment) < this.$container.outerHeight();
 
 			var $el = $(this.commentTemplate(this._formatItem(model)));
 			this.$container.append($el);
+			this._$newestComment = $el;
 
 			if (this._modelsHaveSameActor(this._lastAddedMessageModel, model) &&
 					this._modelsAreTemporaryNear(this._lastAddedMessageModel, model) &&
@@ -425,7 +427,7 @@
 			this._postRenderItem(model, $el);
 
 			if (scrollToNew) {
-				var newestCommentHiddenHeight = (this._getCommentTopPosition($el) + this._getCommentOuterHeight($el)) - this.$container.outerHeight();
+				var newestCommentHiddenHeight = (this._getCommentTopPosition(this._$newestComment) + this._getCommentOuterHeight(this._$newestComment)) - this.$container.outerHeight();
 				this.$container.scrollTop(this.$container.scrollTop() + newestCommentHiddenHeight);
 			}
 		},

--- a/js/views/virtuallist.js
+++ b/js/views/virtuallist.js
@@ -180,6 +180,22 @@
 
 	VirtualList.prototype = {
 
+		getFirstElement: function() {
+			return this._$firstElement;
+		},
+
+		getFirstVisibleElement: function() {
+			return this._$firstVisibleElement;
+		},
+
+		getLastElement: function() {
+			return this._$lastElement;
+		},
+
+		getLastVisibleElement: function() {
+			return this._$lastVisibleElement;
+		},
+
 		prependElementStart: function() {
 			this._prependedElementsBuffer = document.createDocumentFragment();
 

--- a/js/views/virtuallist.js
+++ b/js/views/virtuallist.js
@@ -884,6 +884,57 @@
 			this._$wrapper.appendTo(this._$container);
 		},
 
+		/**
+		 * Scroll the list to the given element.
+		 *
+		 * The element will be aligned with the top of the list (or as far as
+		 * possible, in case the element is at the bottom).
+		 *
+		 * @param {jQuery} $element the element of the list to scroll to.
+		 */
+		scrollTo: function($element) {
+			if (!this._isLoaded($element)) {
+				return;
+			}
+
+			this._$container.scrollTop($element._top);
+
+			// The visible elements are updated when the scroll event is
+			// handled. However, as the scroll event is asynchronous, it is not
+			// guaranteed that it will be handled before this method returns; as
+			// the caller could expect that the visibility of elements is
+			// updated when scrolling programatically this must be explicitly
+			// done.
+			// Note that, although the event is handled asynchronously (and in
+			// some cases several scrolls can be merged in a single event) the
+			// value returned by scrollTop() is always the expected one
+			// immediately after setting it with scrollTop(value).
+			this.updateVisibleElements();
+		},
+
+		/**
+		 * Returns whether the given element is loaded or not.
+		 *
+		 * @param {jQuery} $element the element to check.
+		 * @return true if the element is loaded, false otherwise.
+		 */
+		_isLoaded: function($element) {
+			if (!this._$firstLoadedElement || !this._$lastLoadedElement) {
+				return false;
+			}
+
+			var $currentElement = this._$firstLoadedElement;
+			while ($currentElement !== this._$lastLoadedElement._next) {
+				if ($currentElement === $element) {
+					return true;
+				}
+
+				$currentElement = $currentElement._next;
+			}
+
+			return false;
+		},
+
 	};
 
 	OCA.SpreedMe.Views.VirtualList = VirtualList;

--- a/js/views/virtuallist.js
+++ b/js/views/virtuallist.js
@@ -387,7 +387,7 @@
 			this._$wrapper.appendTo(this._$container);
 
 			// Reset wrapper background
-			this._$wrapperBackground.height(0);
+			this._setWrapperBackgroundHeight(0);
 
 			this._loadInitialElements($initialElement);
 
@@ -559,10 +559,7 @@
 
 			var wrapperHeightDifference = this._getElementHeight($wrapper) - previousWrapperHeight;
 
-			// Although getting the height with jQuery < 3.X rounds to the
-			// nearest integer setting the height respects the given float
-			// number.
-			this._$wrapperBackground.height(this._getElementHeight(this._$wrapperBackground) + wrapperHeightDifference);
+			this._setWrapperBackgroundHeight(this._getElementHeight(this._$wrapperBackground) + wrapperHeightDifference);
 
 			// Note that the order of "first/last" is not the same for the main
 			// elements and the elements passed to this method.
@@ -640,10 +637,7 @@
 
 			var wrapperHeightDifference = this._getElementHeight($wrapper) - previousWrapperHeight;
 
-			// Although getting the height with jQuery < 3.X rounds to the
-			// nearest integer setting the height respects the given float
-			// number.
-			this._$wrapperBackground.height(this._getElementHeight(this._$wrapperBackground) + wrapperHeightDifference);
+			this._setWrapperBackgroundHeight(this._getElementHeight(this._$wrapperBackground) + wrapperHeightDifference);
 
 			if (!this._$firstLoadedElement) {
 				this._$firstLoadedElement = $firstElementToLoad;
@@ -782,6 +776,21 @@
 			var marginBottom = Math.max(0, parseFloat($element.css('margin-bottom')));
 
 			return this._getElementOuterHeightWithoutMargins($element) + marginTop + marginBottom;
+		},
+
+		_setWrapperBackgroundHeight: function(height) {
+			// Although getting the height with jQuery < 3.X rounds to the
+			// nearest integer setting the height respects the given float
+			// number.
+			this._$wrapperBackground.height(height);
+
+			// If the container is scrollable set its "tabindex" attribute so it
+			// is included in the sequential keyboard navigation.
+			if (this._getElementHeight(this._$wrapperBackground) > this._getElementHeight(this._$container)) {
+				this._$container.attr('tabindex', 0);
+			} else {
+				this._$container.removeAttr('tabindex');
+			}
 		},
 
 		/**

--- a/js/views/virtuallist.js
+++ b/js/views/virtuallist.js
@@ -1,0 +1,417 @@
+/* global _, $ */
+
+/**
+ *
+ * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+(function(_, $) {
+
+	'use strict';
+
+	OCA.SpreedMe = OCA.SpreedMe || {};
+	OCA.SpreedMe.Views = OCA.SpreedMe.Views || {};
+
+	/**
+	 * Virtual list of DOM elements.
+	 *
+	 * The virtual list makes possible to create a list with an "unlimited"*
+	 * number of elements. Despite the browser optimizations there is a limit in
+	 * the number of elements that can be added to a document before the browser
+	 * becomes sluggish when the document is further modified (due to having to
+	 * layout/reflow a high number of elements); the virtual list solves that by
+	 * keeping in the document only those elements that are currently visible,
+	 * and refreshing them as needed when the list is scrolled.
+	 *
+	 * *The actual limit depends, among other things, on the maximum height for
+	 * an element supported by the browser, the available memory to hold the
+	 * elements, and the performance traversing linked lists, although it should
+	 * be high enough for most common uses.
+	 *
+	 * The virtual list receives the container of the list (the element that the
+	 * list elements would have been appended to if the virtual list was not
+	 * used) in its constructor.
+	 *
+	 * The CSS style of the container must have a "visible" or (preferred) an
+	 * "auto" value for its "overflow-y" property. Similarly, the positioning of
+	 * the ".wrapper-background" and ".wrapper" elements child of the container
+	 * must be set to "absolute".
+	 *
+	 * Elements are appended to the virtual list by first notifying the list
+	 * that elements are going to be appended, then appending the elements, and
+	 * finally processing the appended elements. Thus, even if there is only one
+	 * element to add, first "appendElementStart()" must be called, followed by
+	 * one or more calls to "appendElement()" each one with a single element,
+	 * and followed by a final call to "appendElementEnd()".
+	 *
+	 * The elements in the list can have different heights, and they can
+	 * partially overlap their previous or next element due to the use of a
+	 * negative top margin, but their top position must not exceed the top
+	 * position of its previous element, and their bottom position must not
+	 * exceed the bottom position of its next element.
+	 *
+	 * It is assumed that the position and size of an element will not change
+	 * once added to the list.
+	 *
+	 *
+	 *
+	 * Internal description:
+	 * ---------------------
+	 *
+	 * Feast your eyes on this glorious ASCII art representation of the virtual
+	 * list:
+	 *
+	 * ············· - List start / Wrapper background start - Top position = 0
+	 * ·           ·
+	 * · _ _ _ _ _ · _ Wrapper start - Top position ~= scroll position
+	 * :___________: _
+	 * | ~~~     | |   Viewport start / Container top
+	 * | ~~      |||
+	 * | ~~      | |
+	 * | ~~~~~   | |   Viewport end / Container bottom
+	 * :¯¯¯¯¯¯¯¯¯¯¯: ¯
+	 * · ¯ ¯ ¯ ¯ ¯ · ¯ Wrapper end
+	 * ·           ·
+	 * ·           ·
+	 * ·           ·
+	 * ·           ·
+	 * ············· - List end / Wrapper background end
+	 *
+	 * When the children of an element are larger than its parent and the parent
+	 * can not grow any further the parent becomes a viewport for its children:
+	 * it can only show a partial area of the children, but it provides an
+	 * scroll bar to move the viewport up and down.
+	 *
+	 * The virtual list is based on that behaviour. In order to reduce the
+	 * elements in the document, when the virtual list is set for a container,
+	 * only those children of the container that are currently visible in the
+	 * viewport are actually in the document; whenever the container is scrolled
+	 * the elements are added and removed as needed.
+	 *
+	 * Specifically, the visible elements are added to and removed from a direct
+	 * child of the container, a wrapper that only holds the visible elements.
+	 *
+	 * Besides the wrapper, the container has another direct children, a
+	 * background element that simulates the full length of the list; although
+	 * the background is empty its height is set to the height of all the
+	 * elements in the list, so when the list is longer than the container the
+	 * background causes the scroll bar to appear in the container as if it
+	 * contained the real list.
+	 *
+	 * Both the background and the wrapper have an absolute position; this
+	 * absolute position makes possible for the wrapper to move freely over the
+	 * background, and also limits the layout calculations only to the wrapper
+	 * itself when adding and removing the visible elements (although for better
+	 * performance the updates are also done off-line, that is, with the wrapper
+	 * detached from the document so only two reflows, one when it is detached
+	 * and one when it is attached again, are done no matter the number of
+	 * updated elements).
+	 *
+	 * Whenever the container is scrolled the elements are updated in the
+	 * wrapper as needed; the top position of the wrapper is set so its elements
+	 * are at the same distance from the top of the background as they would be
+	 * if all their previous elements were in the document.
+	 *
+	 * In order to know where the elements should be in the full list as well as
+	 * whether they are visible or not their position and size must have been
+	 * calculated before. Thus, when elements are added to the virtual list they
+	 * are briefly added to the document in a temporal wrapper; the position of
+	 * this temporal wrapper is set based on the already added elements, so the
+	 * browser can layout the new elements and their real position and size can
+	 * be cached.
+	 */
+	var VirtualList = function($container) {
+		this._$container = $container;
+
+		this._$firstElement = null;
+		this._$lastElement = null;
+		this._$firstVisibleElement = null;
+		this._$lastVisibleElement = null;
+
+		this._$wrapperBackground = $('<div class="wrapper-background"></div>');
+		this._$wrapperBackground.height(0);
+
+		this._$wrapper = $('<div class="wrapper"></div>');
+		this._$wrapper._top = 0;
+
+		this._$container.append(this._$wrapperBackground);
+		this._$container.append(this._$wrapper);
+
+		var self = this;
+		this._$container.on('scroll', function() {
+			self.updateVisibleElements();
+		});
+	};
+
+	VirtualList.prototype = {
+
+		appendElementStart: function() {
+			this._appendedElementsBuffer = document.createDocumentFragment();
+
+			delete this._$firstAppendedElement;
+		},
+
+		appendElement: function($element) {
+			// ParentNode.append() is not compatible with older browsers.
+			this._appendedElementsBuffer.appendChild($element.get(0));
+
+			if (this._$lastElement) {
+				this._$lastElement._next = $element;
+			}
+			$element._previous = this._$lastElement;
+			$element._next = null;
+			this._$lastElement = $element;
+
+			if (!this._$firstElement) {
+				this._$firstElement = $element;
+			}
+
+			if (!this._$firstAppendedElement) {
+				this._$firstAppendedElement = $element;
+			}
+		},
+
+		appendElementEnd: function() {
+			var $wrapper = $('<div class="wrapper"></div>');
+			$wrapper._top = 0;
+
+			if (this._$firstAppendedElement._previous) {
+				$wrapper.css('top', this._$firstAppendedElement._previous._topRaw);
+				$wrapper._top = this._$firstAppendedElement._previous._topRaw;
+
+				// Include the previous element, as it may change the
+				// position of the newest element due to collapsing margins
+				$wrapper.append(this._$firstAppendedElement._previous.clone());
+			}
+
+			this._$container.append($wrapper);
+
+			var previousWrapperHeight = $wrapper.height();
+
+			$wrapper.append(this._appendedElementsBuffer);
+			delete this._appendedElementsBuffer;
+
+			var wrapperHeightDifference = $wrapper.height() - previousWrapperHeight;
+
+			this._$wrapperBackground.height(this._$wrapperBackground.height() + wrapperHeightDifference);
+
+			while (this._$firstAppendedElement) {
+				this._updateCache(this._$firstAppendedElement, $wrapper);
+
+				this._$firstAppendedElement = this._$firstAppendedElement._next;
+			}
+
+			// Remove the temporal wrapper used to layout and get the height of
+			// the added items.
+			$wrapper.detach();
+			$wrapper.children().detach();
+			$wrapper.remove();
+
+			this.updateVisibleElements();
+		},
+
+		/**
+		 * Updates the cached position and size of the given element.
+		 *
+		 * The element must be a child of a wrapper currently in the container
+		 * (although it can be a temporal wrapper, it does not need to be the
+		 * main one); detached elements can not be used, as the values to cache
+		 * would be invalid in that case.
+		 *
+		 * The element top position is relative to the wrapper, and the wrapper
+		 * top position plus the element top position is expected to place the
+		 * element at the proper offset from the top of the container.
+		 *
+		 * @param {jQuery} $element the element to update its cache.
+		 * @param {jQuery} $wrapper the parent wrapper of the element.
+		 */
+		_updateCache: function($element, $wrapper) {
+			$element._height = this._getElementOuterHeight($element);
+
+			// The top position of an element must be got from the element
+			// itself; it can not be based on the top position and height of the
+			// previous element, because the browser may merge/collapse the
+			// margins.
+			$element._top = $wrapper._top + this._getElementTopPosition($element);
+			$element._topRaw = $element._top;
+			var marginTop = parseFloat($element.css('margin-top'));
+			if (marginTop < 0) {
+				$element._topRaw -= marginTop;
+			}
+		},
+
+		/**
+		 * Returns the top position, from the top margin, of the given element.
+		 *
+		 * The returned value takes into account a negative top margin, which
+		 * pulls up the element closer to the previous element.
+		 *
+		 * @param jQuery $element the jQuery element to get its height.
+		 */
+		_getElementTopPosition: function($element) {
+			// When the margin is positive, jQuery returns the proper top
+			// position of the element (that is, including the top margin).
+			// However, when it is negative, jQuery returns where the top
+			// position of the element would be if there was no margin, so in
+			// those cases the top position returned by jQuery is below the
+			// actual top position of the element.
+			var marginTop = parseInt($element.css('margin-top'));
+			if (marginTop >= 0) {
+				return $element.position().top;
+			}
+
+			return $element.position().top + marginTop;
+		},
+
+		/**
+		 * Returns the full outer height, with margins, of the given element.
+		 *
+		 * The returned value includes the height, the padding, the border and
+		 * the margin; negative margins are not taken into account, as they do
+		 * not affect the visible height of the element; they only pull up the
+		 * element (negative top margin) or its next element (negative bottom
+		 * margin), but without modifying its visible height.
+		 *
+		 * @param jQuery $element the jQuery element to get its height.
+		 */
+		_getElementOuterHeight: function($element) {
+			// When the margin is positive, jQuery returns the proper outer
+			// height of the element. However, when it is negative, it
+			// substracts the negative margin from the overall height of the
+			// element, so in those cases the outer height returned by jQuery is
+			// smaller than the actual height.
+			var marginTop = parseInt($element.css('margin-top'));
+			if (marginTop >= 0) {
+				return $element.outerHeight(true);
+			}
+
+			return $element.outerHeight(true) - marginTop;
+		},
+
+		/**
+		 * Updates the visible elements.
+		 *
+		 * Elements no longer in the viewport are removed, while elements now in
+		 * the viewport are added.
+		 */
+		updateVisibleElements: function() {
+			if (!this._$firstVisibleElement && !this._$firstElement) {
+				return;
+			}
+
+			if (!this._$firstVisibleElement) {
+				this._$firstVisibleElement = this._$firstElement;
+				this._$lastVisibleElement = this._$firstVisibleElement;
+
+				this._$wrapper.append(this._$firstVisibleElement);
+			}
+
+			var visibleAreaTop = this._$container.scrollTop();
+			var visibleAreaBottom = visibleAreaTop + this._$container.outerHeight();
+
+			var firstVisibleElementIsStillPartiallyVisible =
+					this._$firstVisibleElement._top <= visibleAreaTop &&
+					this._$firstVisibleElement._top + this._$firstVisibleElement._height > visibleAreaTop;
+			var lastVisibleElementIsStillPartiallyVisible =
+					this._$lastVisibleElement._top < visibleAreaBottom &&
+					this._$lastVisibleElement._top + this._$lastVisibleElement._height >= visibleAreaBottom;
+			// The first element could be being pulled up into its previous
+			// element due to a negative top margin, so it is necessary to
+			// ensure that the previous element is not visible even if the first
+			// one "crosses" the top of the visible area.
+			var previousElementToFirstVisibleElementIsNotVisibleYet =
+					!this._$firstVisibleElement._previous ||
+					this._$firstVisibleElement._previous._top + this._$firstVisibleElement._previous._height <= visibleAreaTop;
+			// The next element could be pulled up into the last visible element
+			// due to a negative top margin, so it is necessary to ensure that
+			// it is not visible even if the last one "crosses" the bottom of
+			// the visible area.
+			var nextElementToLastVisibleElementIsNotVisibleYet =
+					!this._$lastVisibleElement._next ||
+					this._$lastVisibleElement._next._top >= visibleAreaBottom;
+
+			if (firstVisibleElementIsStillPartiallyVisible &&
+					lastVisibleElementIsStillPartiallyVisible &&
+					previousElementToFirstVisibleElementIsNotVisibleYet &&
+					nextElementToLastVisibleElementIsNotVisibleYet) {
+				return;
+			} else {
+				this._$wrapper.detach();
+			}
+
+			// The currently visible area does not contain any of the visible
+			// elements.
+			if (this._$firstVisibleElement._top >= visibleAreaBottom ||
+					this._$lastVisibleElement._top + this._$lastVisibleElement._height <= visibleAreaTop) {
+				// Remove all visible elements.
+				while (this._$firstVisibleElement !== this._$lastVisibleElement._next) {
+					this._$firstVisibleElement.detach();
+					this._$firstVisibleElement = this._$firstVisibleElement._next;
+				}
+
+				// Show the new first visible element.
+				this._$firstVisibleElement = this._$firstElement;
+				while (this._$firstVisibleElement._top + this._$firstVisibleElement._height <= visibleAreaTop) {
+					this._$firstVisibleElement = this._$firstVisibleElement._next;
+				}
+
+				this._$firstVisibleElement.prependTo(this._$wrapper);
+
+				this._$lastVisibleElement = this._$firstVisibleElement;
+			}
+
+			// Remove leading elements no longer visible.
+			while (this._$firstVisibleElement._top + this._$firstVisibleElement._height <= visibleAreaTop) {
+				this._$firstVisibleElement.detach();
+				this._$firstVisibleElement = this._$firstVisibleElement._next;
+			}
+
+			// Prepend leading elements now visible.
+			while (this._$firstVisibleElement._previous &&
+					this._$firstVisibleElement._previous._top + this._$firstVisibleElement._previous._height > visibleAreaTop) {
+				this._$firstVisibleElement._previous.prependTo(this._$wrapper);
+				this._$firstVisibleElement = this._$firstVisibleElement._previous;
+			}
+
+			// Align wrapper with the top raw position (without negative
+			// margins) of the first visible element.
+			this._$wrapper._top = this._$firstVisibleElement._topRaw;
+			this._$wrapper.css('top', this._$wrapper._top);
+
+			// Remove trailing elements no longer visible.
+			while (this._$lastVisibleElement._top >= visibleAreaBottom) {
+				this._$lastVisibleElement.detach();
+				this._$lastVisibleElement = this._$lastVisibleElement._previous;
+			}
+
+			// Append trailing elements now visible.
+			while (this._$lastVisibleElement._next &&
+					this._$lastVisibleElement._next._top < visibleAreaBottom) {
+				this._$lastVisibleElement._next.appendTo(this._$wrapper);
+				this._$lastVisibleElement = this._$lastVisibleElement._next;
+			}
+
+			this._$wrapper.appendTo(this._$container);
+		},
+
+	};
+
+	OCA.SpreedMe.Views.VirtualList = VirtualList;
+
+})(_, $);

--- a/lib/PublicShareAuth/TemplateLoader.php
+++ b/lib/PublicShareAuth/TemplateLoader.php
@@ -97,6 +97,7 @@ class TemplateLoader {
 		Util::addScript('spreed', 'views/roomlistview');
 		Util::addScript('spreed', 'views/sidebarview');
 		Util::addScript('spreed', 'views/tabview');
+		Util::addScript('spreed', 'views/virtuallist');
 		Util::addScript('spreed', 'richobjectstringparser');
 		Util::addScript('spreed', 'simplewebrtc');
 		Util::addScript('spreed', 'webrtc');

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -32,6 +32,7 @@ script(
 		'views/roomlistview',
 		'views/sidebarview',
 		'views/tabview',
+		'views/virtuallist',
 		'richobjectstringparser',
 		'simplewebrtc',
 		'webrtc',

--- a/templates/index.php
+++ b/templates/index.php
@@ -31,6 +31,7 @@ script(
 		'views/roomlistview',
 		'views/sidebarview',
 		'views/tabview',
+		'views/virtuallist',
 		'richobjectstringparser',
 		'simplewebrtc',
 		'webrtc',

--- a/tests/acceptance/features/bootstrap/ChatContext.php
+++ b/tests/acceptance/features/bootstrap/ChatContext.php
@@ -99,9 +99,18 @@ class ChatContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function chatMessagesWrapper($chatAncestor) {
+		return Locator::forThe()->css(".wrapper")->
+				descendantOf(self::chatMessagesList($chatAncestor))->
+				describedAs("Wrapper for visible messages in the list of received chat messages");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function chatMessage($chatAncestor, $number) {
 		return Locator::forThe()->xpath("li[not(contains(concat(' ', normalize-space(@class), ' '), ' systemMessage '))][$number]")->
-				descendantOf(self::chatMessagesList($chatAncestor))->
+				descendantOf(self::chatMessagesWrapper($chatAncestor))->
 				describedAs("Chat message $number in the list of received messages");
 	}
 
@@ -110,7 +119,7 @@ class ChatContext implements Context, ActorAwareInterface {
 	 */
 	public static function groupedChatMessage($chatAncestor, $number) {
 		return Locator::forThe()->xpath("li[not(contains(concat(' ', normalize-space(@class), ' '), ' systemMessage '))][position() = $number and contains(concat(' ', normalize-space(@class), ' '), ' grouped ')]")->
-				descendantOf(self::chatMessagesList($chatAncestor))->
+				descendantOf(self::chatMessagesWrapper($chatAncestor))->
 				describedAs("Grouped chat message $number in the list of received messages");
 	}
 


### PR DESCRIPTION
Requires #1302

It seemed that this day was never going to come, but finally, here it is :-D
:fireworks: :fireworks: :fireworks: :fireworks: :fireworks:  **This pull request is ready for review!!!** :fireworks: :fireworks: :fireworks: :fireworks: :fireworks:

Each time a new element or a group of elements is added to the document the browser needs to layout it (calculate its position and height), but if the elements use a static or relative positioning (they are part of the flow of the document) it needs to reflow the document too (layout other existing elements again that could be affected or affect the new elements).

When joining a room all the chat messages in the room were loaded and added one by one to the document. Each time a new message was added to the list all the other messages already in the list had to be layout again, and thus the document was reflown again and again each time with a higher number of elements.

Instead of adding each message on its own when several of them were received an initial improvement is to add them all at once. This way, instead of one reflow for each element only one reflow for the whole set is needed. However, this only helps up to some point; once the number of elements in the list is very high even a single reflow takes a _lot_ of time, so not only the initial load, but also regular chat is sluggish.

The only way to improve the performance is thus limit the number of elements in the list. The virtual list does that while giving the user the impression that the list contains all the messages. How? By keeping in the document only the elements that are actually visible, removing those that are out of view, and updating them as needed when the user scrolls the list. For more information please refer to the documentation in the code itself ;-)

Of course, despite its benefits, this approach also comes with its own issues :-)
- As the elements in the virtual list are removed when they are no longer visible, the selected text in a message disappears when the message is scrolled out of view. It could be probably solved by not removing the elements during a scroll if they are selected, but for the time being it is a limitation of this new implementation; I will try to solve that later in a different pull request.
- Firefox has subpixel accuracy for the position and size of the elements, but surprisingly the scroll position is handled as an integer. Due to this it is not possible to keep exactly the same scroll position when elements are prepended to the list, and several prepends in a row (for example, when the list is reloaded) cause a wiggly effect and a small drift from the proper scroll position. Unfortunately I do not know how to solve that, although it is only a nuisance more than a problem.
- It happened to me that when scrolling the list by keeping a key pressed Chromium stopped sending scroll events... and then when key was released sent them all of a sudden. I would say that it was just a strange (and not reproducible) Chromium bug more than a problem with the virtual list itself.
- Scrolling while the list is being reloaded in the responsive view of Chromium shows the wrong elements. The problem seems to be that when the scroll even is handled calling `scrollTop()` returns the scroll position when the event was triggered instead of the current one (as done in the normal view of Chromium or in Firefox), so when the visible elements are updated the wrong ones end being shown. I do not know how that could be fixed, but it should not be a very big problem, as once the reload ends the scrolling shows the right elements, and again it actually looks like a bug in Chromium, and only in its responsive view.

I have developed and tested the virtual list with the desktop versions of Firefox and Chromium; tests with the mobile versions are appreciated ;-) (And by the way, adding so much code without unit, integration or acceptance tests make me dizzy :-P ).



**How to test (setup):**
To notice the performance improvement it is necessary to use a room with a large number of messages. A naive way to get a room with a large number of messages would be to modify the `ChatController` to include the following code before `$creationDateTime = new \DateTime('now', new \DateTimeZone('UTC'));` in `sendMessage`:
```
	$numberOfMessages = 10000;
	$baseTime = new \DateTime('now', new \DateTimeZone('UTC'));
	$baseTimeTimestamp = $baseTime->getTimestamp() - $numberOfMessages;
	$currentMessage = 1;
	for ($i=0; $i<$numberOfMessages; $i++) {

			$creationDateTime = new \DateTime();
			$creationDateTime->setTimestamp($baseTimeTimestamp + $i);

			try {
					$comment = $this->chatManager->sendMessage($room, $actorType, $actorId, (string)$currentMessage, $creationDateTime);
			} catch (MessageTooLongException $e) {
					return new DataResponse([], Http::STATUS_REQUEST_ENTITY_TOO_LARGE);
			} catch (\Exception $e) {
					return new DataResponse([], Http::STATUS_BAD_REQUEST);
			}
			$currentMessage++;
	}
```

With that code, whenever a new message is sent to the controller (simply typing in the UI, for example) 10000 extra messages would be added too to that room.

That code should be used only during the setup of the room; for the actual test of the virtual list it should be removed, as otherwise even with a virtual list sending a new message would take time.



**How to test:**
- Enter a room with a large number of messages
- Send new messages
- Resize the window
- Scroll the list

**Result before this pull request:**
Go for a walk while the messages are loaded when entering a room and hope that the browser has not crashed when you return; make some stretches whenever a new message is added or the window is resized; wait a little when scrolling the list

**Result after this pull request:**
Make some stretches while the messages are loaded when entering a room*; enjoy an immediate update whenever a new message is added, the window is resized or when scrolling the list

*When entering the room the browser becomes slightly unresponsive; this is mainly caused by the continuous load of messages by the model without any throttling, but this was not fixed because it will no longer happen once the messages are loaded on request in a later pull request.
