### PR TITLE
Add support for sending the password for a link share by Nextcloud Talk

### DIFF
--- a/lib/Controller/PublicShareAuthController.php
+++ b/lib/Controller/PublicShareAuthController.php
@@ -81,9 +81,6 @@ class PublicShareAuthController extends OCSController {
 	 * a guest or user on behalf of a registered user, the sharer, who will be
 	 * the owner of the room.
 	 *
-	 * If there is already a room for requesting the password of the given share
-	 * no new room is created; the existing room is returned instead.
-	 *
 	 * The share must have "send password by Talk" enabled; an error is returned
 	 * otherwise.
 	 *

--- a/lib/Controller/PublicShareAuthController.php
+++ b/lib/Controller/PublicShareAuthController.php
@@ -32,7 +32,6 @@ use OCP\AppFramework\OCSController;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
-use OCP\Notification\IManager as NotificationManager;
 use OCP\Share\IManager as ShareManager;
 use OCP\Share\Exceptions\ShareNotFound;
 
@@ -40,8 +39,6 @@ class PublicShareAuthController extends OCSController {
 
 	/** @var IUserManager */
 	private $userManager;
-	/** @var NotificationManager */
-	private $notificationManager;
 	/** @var ShareManager */
 	private $shareManager;
 	/** @var Manager */
@@ -51,7 +48,6 @@ class PublicShareAuthController extends OCSController {
 	 * @param string $appName
 	 * @param IRequest $request
 	 * @param IUserManager $userManager
-	 * @param NotificationManager $notificationManager
 	 * @param ShareManager $shareManager
 	 * @param Manager $manager
 	 */
@@ -59,13 +55,11 @@ class PublicShareAuthController extends OCSController {
 			string $appName,
 			IRequest $request,
 			IUserManager $userManager,
-			NotificationManager $notificationManager,
 			ShareManager $shareManager,
 			Manager $manager
 	) {
 		parent::__construct($appName, $request);
 		$this->userManager = $userManager;
-		$this->notificationManager = $notificationManager;
 		$this->shareManager = $shareManager;
 		$this->manager = $manager;
 	}

--- a/lib/Controller/PublicShareAuthController.php
+++ b/lib/Controller/PublicShareAuthController.php
@@ -32,6 +32,7 @@ use OCP\AppFramework\OCSController;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\Share;
 use OCP\Share\IManager as ShareManager;
 use OCP\Share\Exceptions\ShareNotFound;
 
@@ -100,8 +101,14 @@ class PublicShareAuthController extends OCSController {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
+		if ($share->getShareType() === Share::SHARE_TYPE_EMAIL) {
+			$roomName = $share->getSharedWith();
+		} else {
+			$roomName = trim($share->getTarget(), '/');
+		}
+
 		// Create the room
-		$room = $this->manager->createPublicRoom($share->getSharedWith(), 'share:password', $shareToken);
+		$room = $this->manager->createPublicRoom($roomName, 'share:password', $shareToken);
 		$room->addUsers([
 			'userId' => $sharerUser->getUID(),
 			'participantType' => Participant::OWNER,

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -227,7 +227,7 @@ class RoomController extends OCSController {
 
 		if ($room->getObjectType() === 'share:password') {
 			// FIXME use an event
-			$roomData['displayName'] = $this->l10n->t('Password request by %s', [$room->getName()]);
+			$roomData['displayName'] = $this->l10n->t('Password request: %s', [$room->getName()]);
 		}
 
 		$currentUser = $this->userManager->get($this->userId);

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -465,16 +465,10 @@ class Notifier implements INotifier {
 		}
 
 		try {
-			$segments = explode('/', $share->getNode()->getPath(), 4);
-			if (!isset($segments[3])) {
-				throw new \OCP\Files\NotFoundException('File not in /user/files/');
-			}
 			$file = [
-				'type' => 'file',
+				'type' => 'highlight',
 				'id' => $share->getNodeId(),
 				'name' => $share->getNode()->getName(),
-				'path' => $segments[3],
-				'link' => $this->url->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileid' => $share->getNodeId()]),
 			];
 		} catch (\OCP\Files\NotFoundException $e) {
 			throw new \InvalidArgumentException('Unknown file');

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -37,6 +37,7 @@ use OCP\L10N\IFactory;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 use OCP\RichObjectStrings\Definitions;
+use OCP\Share;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager as IShareManager;
 
@@ -463,19 +464,24 @@ class Notifier implements INotifier {
 			throw new \InvalidArgumentException('Unknown share');
 		}
 
-		$sharedWith = $share->getSharedWith();
+		if ($share->getShareType() === Share::SHARE_TYPE_EMAIL) {
+			$sharedWith = $share->getSharedWith();
 
-		$notification
-			->setParsedSubject(str_replace('{email}', $sharedWith, $l->t('{email} requested the password to access a share')))
-			->setRichSubject(
-				$l->t('{email} requested the password to access a share'), [
-					'email' => [
-						'type' => 'email',
-						'id' => $sharedWith,
-						'name' => $sharedWith,
+			$notification
+				->setParsedSubject(str_replace('{email}', $sharedWith, $l->t('{email} requested the password to access a share')))
+				->setRichSubject(
+					$l->t('{email} requested the password to access a share'), [
+						'email' => [
+							'type' => 'email',
+							'id' => $sharedWith,
+							'name' => $sharedWith,
+						]
 					]
-				]
-			);
+				);
+		} else {
+			$notification
+				->setParsedSubject($l->t('Someone requested the password to access a share'));
+		}
 
 		return $notification;
 	}


### PR DESCRIPTION
Requires #1267 
Required by nextcloud/server#11875

Regarding Talk the differences between protecting the password of an e-mail share or a link share are minimal; despite that, this pull request is required by the server changes. The reason is that link shares do not have a value in their `sharedWith` field (when got with the OCS enpoint they do, [although it is set by the `ShareAPIController`](https://github.com/nextcloud/server/blob/ea21aa3f7a12c5d1bd80eea329de3eb695fde4e5/apps/files_sharing/lib/Controller/ShareAPIController.php#L211), internally they have none), so without those changes when the room for the link share was created [the name of the room was set to `null`](https://github.com/nextcloud/spreed/blob/f81f5e0a7c17601a039f820b4d0fa59a561fe993/lib/Controller/PublicShareAuthController.php#L113). [When the call activity is generated the room name is expected to be a string](https://github.com/nextcloud/spreed/blob/bb9d9ab65eaf7f154568cd0cd2565489d48dc6ca/lib/Activity/Hooks.php#L94), but as the name was `null` PHP complained, no proper HTTP response was sent and the UI broke.

~~TODO:~~
- [x] The room name should be fixed. Currently it is set to the e-mail address or the target of the share (depending on the type of share), and [in the `RoomController` it is composed and returned as _Password request by {roomName}_](https://github.com/nextcloud/spreed/blob/e3d985da600404442973fcf1cb4cd04534cec023/lib/Controller/RoomController.php#L230).

  This was done [to show the room name in the language of the sharer](https://github.com/nextcloud/spreed/commit/55a983fd9f87cd61608e2283a798c6ccdffe5a0e), but now that the name needs to be different depending on the share type it would require to get the share object to check its type every time a room is formatted.

  It would be better to set the name once (and update it when needed, for example if the file name of a link share changes) than adding those extra queries, for example, every time that the list of rooms is got.

- [x] The notification sent for a link share should probably include the name of the file in its message; _Someone requested the password to access a share_ is too vague.
