### PR TITLE
🔵 Use theming color as group and shared call colors instead of bland grey

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -135,7 +135,7 @@
 	border-radius: 50%;
 	width: 32px;
 	height: 32px;
-	background-color: var(--color-background-darker);
+	background-color: var(--color-primary);
 }
 
 #app-navigation .favorite-mark {

--- a/js/views/participantview.js
+++ b/js/views/participantview.js
@@ -146,7 +146,7 @@
 				},
 				formatResult: function (element) {
 					if (element.type === 'email') {
-						return '<span><div class="avatar icon-mail"></div>' + escapeHTML(element.displayName) + '</span>';
+						return '<span><div class="avatar icon-mail icon-white"></div>' + escapeHTML(element.displayName) + '</span>';
 					}
 
 					return '<span><div class="avatar" data-user="' + escapeHTML(element.id) + '" data-user-display-name="' + escapeHTML(element.displayName) + '"></div>' + escapeHTML(element.displayName) + '</span>';


### PR DESCRIPTION
We might have discussed this, I think @Ivansss it was us? :) This makes it look much nicer instead of the default grey color:

![grey placeholder icon](https://user-images.githubusercontent.com/925062/47777181-7a7ddd00-dcf4-11e8-97b0-cc29497085bf.png)
![placeholder color to primary](https://user-images.githubusercontent.com/925062/47777182-7a7ddd00-dcf4-11e8-87ff-c3742632d8ee.png)

Also much nicer in the dropdowns:
![blue avatars in dropdown](https://user-images.githubusercontent.com/925062/47777179-79e54680-dcf4-11e8-9160-e8c9b7e65c6c.png)

And for the email sharing, the icon is changed to white to fit better:
![email avatars blue](https://user-images.githubusercontent.com/925062/47777178-79e54680-dcf4-11e8-82b1-c546b37db82f.png)

Please review @nextcloud/talk :tada: 

Could you also adjust that in the mobile Talk apps cc @Ivansss @mario?