### PR TITLE
Improve design of emptycontent view

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -736,7 +736,7 @@ video {
 	font-weight: bold;
 }
 
-.localmediaerror .uploadmessage {
+.localmediaerror .emptycontent-additional {
 	display: none;
 }
 

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -90,9 +90,9 @@ script(
 		<div id="screens"></div>
 
 		<div id="emptycontent">
-			<div id="emptycontent-icon" class="icon-video"></div>
+			<div id="emptycontent-icon" class="icon-talk"></div>
 			<h2><?php p($l->t('Join a conversation or start a new one')) ?></h2>
-			<p class="uploadmessage"></p>
+			<p class="emptycontent-additional">👋 Say hi to your friends and colleagues!</p>
 		</div>
 	</div>
 </div>

--- a/templates/index.php
+++ b/templates/index.php
@@ -97,9 +97,9 @@ script(
 	<div id="screens"></div>
 
 		<div id="emptycontent">
-			<div id="emptycontent-icon" class="icon-video"></div>
+			<div id="emptycontent-icon" class="icon-talk"></div>
 			<h2><?php p($l->t('Join a conversation or start a new one')) ?></h2>
-			<p class="uploadmessage"></p>
+			<p class="emptycontent-additional">👋 Say hi to your friends and colleagues!</p>
 			<div id="shareRoomContainer" class="" style="display: inline-flex">
 				<input id="shareRoomInput" class="share-room-input hidden" readonly="readonly" type="text"/>
 				<div id="shareRoomClipboardButton" class="shareRoomClipboard icon-clippy hidden" data-clipboard-target="#shareRoomInput"></div>


### PR DESCRIPTION
Before: a bit bland, boring and with outdated icon ;)
![talk emptycontent before](https://user-images.githubusercontent.com/925062/47826340-ae4e1680-dd77-11e8-9994-77bd0706e2fc.png)

After: nice and friendly, like a communication app should be :slightly_smiling_face: 
![talk emptycontent view after](https://user-images.githubusercontent.com/925062/47826341-ae4e1680-dd77-11e8-8086-fe1ac6091ee2.png)

Please review @nextcloud/designers – also I’m sure we can improve more!