### PR TITLE
Fix signaling settings not loaded when requesting the password by Talk

### DIFF
--- a/js/publicshareauth.js
+++ b/js/publicshareauth.js
@@ -208,7 +208,16 @@
 	};
 
 	OCA.SpreedMe.app = new OCA.Talk.Application();
-	OCA.SpreedMe.app.start();
 
-	OCA.Talk.PublicShareAuth.init();
+	OCA.SpreedMe.app.on('start', function() {
+		OCA.Talk.PublicShareAuth.init();
+	});
+
+	// Unlike in the regular Talk app when Talk is embedded the signaling
+	// settings are not initially included in the HTML, so they need to be
+	// explicitly loaded before starting the app.
+	OCA.Talk.Signaling.loadSettings().then(function() {
+		OCA.SpreedMe.app.start();
+	});
+
 })(OCA);

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -8,6 +8,47 @@
 		Internal: {},
 		Standalone: {},
 
+		/**
+		* Loads the signaling settings.
+		*
+		* The signaling settings are set in the DOM element in which
+		* "createConnection" expects to find them; if the DOM element already
+		* exists it is assumed that the settings are already loaded.
+		*
+		* @return Deferred a Deferred object that will be resolved once the
+		*         settings are loaded.
+		*/
+		loadSettings: function() {
+			var deferred = $.Deferred();
+
+			if ($('#app #signaling-settings').length > 0) {
+				deferred.resolve();
+
+				return deferred.promise();
+			}
+
+			if ($('#app').length === 0) {
+				$('body').append('<div id="app"></div>');
+			}
+			$('#app').append('<script type="text/json" id="signaling-settings"></script>');
+
+			$.ajax({
+				url: OC.linkToOCS('apps/spreed/api/v1/signaling/', 2) + 'settings',
+				type: 'GET',
+				dataType: 'json',
+				success: function (result) {
+					$('#app #signaling-settings').text(JSON.stringify(result.ocs.data));
+
+					deferred.resolve();
+				},
+				error: function (xhr, textStatus, errorThrown) {
+					deferred.reject(xhr, textStatus, errorThrown);
+				}
+			});
+
+			return deferred.promise();
+		},
+
 		createConnection: function() {
 			var settings = $("#app #signaling-settings").text();
 			if (settings) {

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -33,7 +33,7 @@
 			$('#app').append('<script type="text/json" id="signaling-settings"></script>');
 
 			$.ajax({
-				url: OC.linkToOCS('apps/spreed/api/v1/signaling/', 2) + 'settings',
+				url: OC.linkToOCS('apps/spreed/api/v1/signaling', 2) + 'settings',
 				type: 'GET',
 				dataType: 'json',
 				success: function (result) {

--- a/lib/PublicShareAuth/TemplateLoader.php
+++ b/lib/PublicShareAuth/TemplateLoader.php
@@ -103,7 +103,6 @@ class TemplateLoader {
 		Util::addScript('spreed', 'signaling');
 		Util::addScript('spreed', 'connection');
 		Util::addScript('spreed', 'app');
-		Util::addScript('spreed', 'init');
 		Util::addScript('spreed', 'publicshareauth');
 	}
 


### PR DESCRIPTION
In the normal Talk UI [the signaling settings are included by the PageController](https://github.com/nextcloud/spreed/blob/3473a762763e98c0813823f801234030db97593e/lib/Controller/PageController.php#L176) in [the HTML returned by the server](https://github.com/nextcloud/spreed/blob/9bc30ef6ba4d0baa422b7aacf8247afda4ad72ab/templates/index.php#L47). However, when Talk is embedded in other pages (like in the public share authentication page) Talk can alter the HTML returned by the server [only to include the JavaScript files that will load its UI in the browser](https://github.com/nextcloud/spreed/blob/e6678362b42ae367fd71d7f34b3d58ce2784ca02/lib/PublicShareAuth/TemplateLoader.php#L74-L108).

When the signaling connection is created, which [is done when the app is started](https://github.com/nextcloud/spreed/blob/6275900baa7085dbe8f8dd6f5629cdb7720f7b75/js/app.js#L652), it is expected that [the signaling settings are provided in a specific DOM element](https://github.com/nextcloud/spreed/blob/0d9ed544440e9ba86baeecda5aa58b37556bdf3c/js/signaling.js#L12), so now, when Talk is embedded in the public share authentication page, the settings are fetched from the server with an AJAX call, added to the DOM, and only then the app is started and the _Request password_ button shown.
