### PR TITLE
Fix room name in CallInfoView for "share:password" rooms

### DIFF
--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -156,9 +156,14 @@
 		},
 
 		initialize: function() {
+			var nameAttribute = 'name';
+			if (this.model.get('objectType') === 'share:password') {
+				nameAttribute = 'displayName';
+			}
+
 			this._nameEditableTextLabel = new OCA.SpreedMe.Views.EditableTextLabel({
 				model: this.model,
-				modelAttribute: 'name',
+				modelAttribute: nameAttribute,
 				modelSaveOptions: {
 					patch: true,
 					success: function() {
@@ -246,6 +251,11 @@
 		},
 
 		_updateNameEditability: function() {
+			if (this.model.get('objectType') === 'share:password') {
+				this._nameEditableTextLabel.disableEdition();
+				return;
+			}
+
 			if (this._canModerate() && this.model.get('type') !== 1) {
 				this._nameEditableTextLabel.enableEdition();
 			} else {


### PR DESCRIPTION
The name of rooms for requesting a password by Talk [is generated by the server](https://github.com/nextcloud/spreed/blob/e3d985da600404442973fcf1cb4cd04534cec023/lib/Controller/RoomController.php#L230) each time a room or the list of rooms is fetched, and it should not be editable by the user. Moreover, the `name` attribute is the raw name from which the `displayName` attribute is generated, and thus the later is the one that should be shown for `share:password` rooms.
