### PR TITLE
Fix vertical position of contacts menu on author row

### DIFF
--- a/css/comments.scss
+++ b/css/comments.scss
@@ -150,6 +150,10 @@
 	width: 100%;
 }
 
+#commentsTabView .comment .authorRow .contactsmenu-popover {
+	top: 32px;
+}
+
 body:not(#body-public) #commentsTabView .comment .authorRow:not(.currentUser):not(.guestUser) {
 	.avatar,
 	.avatar img,


### PR DESCRIPTION
Before:
![contactsmenu-author-row-before](https://user-images.githubusercontent.com/26858233/48279002-87ff3980-e44f-11e8-96f9-fa8e353cc3f8.png)

After:
![contactsmenu-author-row-after](https://user-images.githubusercontent.com/26858233/48278974-774ec380-e44f-11e8-83f9-b29487285f46.png)
