### PR TITLE
Fix getting current tab ID when there are no tabs

### DIFF
--- a/js/views/tabview.js
+++ b/js/views/tabview.js
@@ -337,9 +337,14 @@
 		/**
 		 * Returns the ID of the currently selected tab.
 		 *
-		 * @return {string} the ID of the currently selected tab.
+		 * @return {string} the ID of the currently selected tab, or an empty
+		 *                  string if there is none.
 		 */
 		getCurrentTabId: function() {
+			if (this._tabHeadersView === null) {
+				return '';
+			}
+
 			return this._tabHeadersView.getCurrentTabId();
 		},
 


### PR DESCRIPTION
Follow up to #1302 
