### PR TITLE
Fix appearance of message list in public share authentication page

### DIFF
--- a/css/publicshareauth.scss
+++ b/css/publicshareauth.scss
@@ -201,6 +201,20 @@ input#request-password-button:disabled ~ .icon {
 	padding-right: 15px;
 }
 
+#talk-sidebar #commentsTabView .comments .wrapper-background,
+#talk-sidebar #commentsTabView .comments .wrapper {
+	/* Padding is not respected in the comment wrapper due to its absolute
+	 * positioning, so it must be set through its position. */
+	left: 15px;
+	right: 15px;
+}
+
+#talk-sidebar #commentsTabView .comments .wrapper {
+	/* Reset the rules set for ".wrapper" elements by "guest.scss" in server, as
+	 * they affect too the virtual list wrapper when they should not. */
+	width: auto;
+	margin-top: 0;
+}
 
 
 /* Unset conflicting rules from guest.css for the sidebar */


### PR DESCRIPTION
Follow up to #1271

[_guest.scss_ in server sets the `width` and `margin-top` properties of `.wrapper` elements](https://github.com/nextcloud/server/blob/256f989a71dec7f74d18d53ffeb9d91a8dd56c7b/core/css/guest.css#L98-L101) to position the main content of the public share authentication page. However, as the selector used in the rule is too broad it is also applied to the internal wrapper of the virtual list, so the properties need to be reset in that case.

Besides that, the padding of the message list is ignored [when using the virtual list](https://github.com/nextcloud/spreed/blob/902ec4a68f0cd3110e5849c3d429ed34ab3e6091/css/comments.scss#L83), so that padding needs to be applied through the `left` and `right` properties of the internal wrapper of the virtual list.

**Before:**
![talk-sidebar-publicshareauth-wrapper-before](https://user-images.githubusercontent.com/26858233/49092175-b491be80-f261-11e8-9299-4b0a4e9c004b.png)

**After:**
![talk-sidebar-publicshareauth-wrapper-after](https://user-images.githubusercontent.com/26858233/49092190-bd829000-f261-11e8-8db5-028baf1956e0.png)
