### PR TITLE
Fix room polling not stopped when leaving the current room

### DIFF
--- a/js/signaling.js
+++ b/js/signaling.js
@@ -540,8 +540,11 @@
 		this._startPullingMessages();
 	};
 
-	OCA.Talk.Signaling.Internal.prototype._doLeaveRoom = function(/*token*/) {
-		// Nothing to do anymore
+	OCA.Talk.Signaling.Internal.prototype._doLeaveRoom = function(token) {
+		if (token === this.currentRoomToken && !this.roomCollection) {
+			window.clearInterval(this.roomPoller);
+			this.roomPoller = null;
+		}
 	};
 
 	OCA.Talk.Signaling.Internal.prototype.sendCallMessage = function(data) {


### PR DESCRIPTION
When setting a room in the internal signaling a poller is started that synchronizes the room data periodically; that poller should be stopped when the room is left.

Note, however, that the poller should not be stopped when leaving the current room if it was initialized for a room collection instead.

**How to test:**
- As userA, share a link with the password protected by Talk
- As userB, open the link and request the password to start the call
- As userA, join the room in Talk and then leave so the room is deleted
- As userB, see the developer console of the browser

**Result with this pull request:**
Once the UI is updated saying that the conversation has ended the requests to the room stop.

**Result without this pull request:**
Requests to the room go on slowly but endlessly.

@fancycode Is something similar needed for the standalone server?
