### PR TITLE
Load initial chat messages from most recent to oldest.

### DIFF
--- a/js/models/chatmessagecollection.js
+++ b/js/models/chatmessagecollection.js
@@ -51,6 +51,7 @@
 	var ChatMessageCollection = Backbone.Collection.extend({
 
 		model: OCA.SpreedMe.Models.ChatMessage,
+		comparator: 'id',
 
 		initialize: function(models, options) {
 			if (options.token === undefined) {

--- a/js/views/virtuallist.js
+++ b/js/views/virtuallist.js
@@ -285,7 +285,7 @@
 			// If the appended elements are not immediately after the last
 			// loaded element there is nothing to load now; they will be loaded
 			// as needed with the other pending elements.
-			if (this._$firstAppendedElement._previous !== this._$lastLoadedElement) {
+			if (!this._$firstAppendedElement || this._$firstAppendedElement._previous !== this._$lastLoadedElement) {
 				delete this._appendedElementsBuffer;
 
 				return;


### PR DESCRIPTION
This implements #1150.

@danxuliu The sorting of entries is wrong: each chunk is sorted correctly in itself, but the overall list is sorted wrong (most recent are at the top). I'm not familiar with the chat message / virtual list code, so could you please take a look?