### PR TITLE
Fix "removeTabHeader" on Internet Explorer

### DIFF
--- a/js/views/tabview.js
+++ b/js/views/tabview.js
@@ -179,7 +179,9 @@
 			// Remove the dummy target element that was replaced by the view
 			// when it was shown and that is restored back when the region is
 			// removed.
-			removedRegion.el.remove();
+			if (removedRegion.el.parentNode) {
+				removedRegion.el.parentNode.removeChild(removedRegion.el);
+			}
 		},
 
 		selectTabHeader: function(tabId) {


### PR DESCRIPTION
Internet explorer does not support the `ChildNode.remove()` method, so the node needs to be removed through its parent (which is also supported by the rest of browsers).

**How to test:**
- Use Internet Explorer 11
- Login to Talk
- Join a call in a room
- Leave the call

**Result with this pull request:**
The chat view is removed from the sidebar and goes back to the main view.

**Result without this pull request:**
An error is logged in the developer console and the chat view is not shown again in the main view.
