### PR TITLE
Fix wording and icons for screensharing options

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -839,6 +839,7 @@ video {
 
 @include icon-black-white('menu-people', 'spreed', 1);
 @include icon-black-white('no-password', 'spreed', 1);
+@include icon-black-white('share-window', 'spreed', 1);
 
 #app-sidebar .close {
 	position: absolute;

--- a/img/share-window.svg
+++ b/img/share-window.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M19 4H5c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H5V6h14v12z"/></svg>

--- a/js/app.js
+++ b/js/app.js
@@ -265,12 +265,16 @@
 				// The parent CSS of the menu list items is using "display:block !important",
 				// so we need to also hide with "!important".
 				if (webrtc.getLocalScreen()) {
-					$('#show-window-entry').attr('style','display:none !important');
+					$('#share-screen-entry').attr('style','display:none !important');
+					$('#share-window-entry').attr('style','display:none !important');
+					$('#show-screen-entry').show();
 					$('#stop-screen-entry').show();
 					$('#screensharing-menu').toggleClass('open');
 				} else {
 					if (splitShare) {
-						$('#show-window-entry').show();
+						$('#share-screen-entry').show();
+						$('#share-window-entry').show();
+						$('#show-screen-entry').attr('style','display:none !important');
 						$('#stop-screen-entry').attr('style','display:none !important');
 						$('#screensharing-menu').toggleClass('open');
 						return;
@@ -280,27 +284,28 @@
 				}
 			}.bind(this));
 
+			$("#share-screen-button").on('click', function() {
+				var webrtc = OCA.SpreedMe.webrtc;
+				if (!webrtc.getLocalScreen()) {
+					this.startShareScreen('screen');
+				}
+				$('#screensharing-menu').toggleClass('open', false);
+			}.bind(this));
+
+			$("#share-window-button").on('click', function() {
+				var webrtc = OCA.SpreedMe.webrtc;
+				if (!webrtc.getLocalScreen()) {
+					this.startShareScreen('window');
+				}
+				$('#screensharing-menu').toggleClass('open', false);
+			}.bind(this));
+
 			$("#show-screen-button").on('click', function() {
 				var webrtc = OCA.SpreedMe.webrtc;
 				if (webrtc.getLocalScreen()) {
 					var currentUser = OCA.SpreedMe.webrtc.connection.getSessionid();
 					OCA.SpreedMe.sharedScreens.switchScreenToId(currentUser);
-				} else {
-					this.startShareScreen('screen');
 				}
-
-				$('#screensharing-menu').toggleClass('open', false);
-			}.bind(this));
-
-			$("#show-window-button").on('click', function() {
-				var webrtc = OCA.SpreedMe.webrtc;
-				if (webrtc.getLocalScreen()) {
-					var currentUser = OCA.SpreedMe.webrtc.connection.getSessionid();
-					OCA.SpreedMe.sharedScreens.switchScreenToId(currentUser);
-				} else {
-					this.startShareScreen('window');
-				}
-
 				$('#screensharing-menu').toggleClass('open', false);
 			}.bind(this));
 

--- a/js/publicshareauth.js
+++ b/js/publicshareauth.js
@@ -82,7 +82,7 @@
 				'			<li id="share-screen-entry">' +
 				'				<button id="share-screen-button">' +
 				'					<span class="icon-screen"></span>' +
-				'					<span>' + t('spreed', 'Share your screen') + '</span>' +
+				'					<span>' + t('spreed', 'Share whole screen') + '</span>' +
 				'				</button>' +
 				'			</li>' +
 				'			<li id="share-window-entry">' +

--- a/js/publicshareauth.js
+++ b/js/publicshareauth.js
@@ -79,13 +79,25 @@
 				'	<button id="screensharing-button" class="app-navigation-entry-utils-menu-button icon-screen-off icon-white icon-shadow screensharing-disabled" data-placement="top" data-toggle="tooltip" data-original-title="' + t('spreed', 'Share screen') + '"></button>' +
 				'	<div id="screensharing-menu" class="app-navigation-entry-menu">' +
 				'		<ul>' +
-				'			<li>' +
+				'			<li id="share-screen-entry">' +
+				'				<button id="share-screen-button">' +
+				'					<span class="icon-screen"></span>' +
+				'					<span>' + t('spreed', 'Share your screen') + '</span>' +
+				'				</button>' +
+				'			</li>' +
+				'			<li id="share-window-entry">' +
+				'				<button id="share-window-button">' +
+				'					<span class="icon-share-window"></span>' +
+				'					<span>' + t('spreed', 'Share a single window') + '</span>' +
+				'				</button>' +
+				'			</li>' +
+				'			<li id="show-screen-entry">' +
 				'				<button id="show-screen-button">' +
 				'					<span class="icon-screen"></span>' +
 				'					<span>' + t('spreed', 'Show your screen') + '</span>' +
 				'				</button>' +
 				'			</li>' +
-				'			<li>' +
+				'			<li id="stop-screen-entry">' +
 				'				<button id="stop-screen-button">' +
 				'					<span class="icon-screen-off"></span>' +
 				'					<span>' + t('spreed', 'Stop screensharing') + '</span>' +

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -72,16 +72,22 @@ script(
 					<button id="screensharing-button" class="app-navigation-entry-utils-menu-button icon-screen-off icon-white icon-shadow screensharing-disabled" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Share screen')) ?>"></button>
 					<div id="screensharing-menu" class="app-navigation-entry-menu">
 						<ul>
-							<li>
-								<button id="show-screen-button">
+							<li id="share-screen-entry">
+								<button id="share-screen-button">
 									<span class="icon-screen"></span>
 									<span><?php p($l->t('Share your screen'));?></span>
 								</button>
 							</li>
-							<li id="show-window-entry">
-								<button id="show-window-button">
+							<li id="share-window-entry">
+								<button id="share-window-button">
 									<span class="icon-share-window"></span>
 									<span><?php p($l->t('Share a single window'));?></span>
+								</button>
+							</li>
+							<li id="show-screen-entry">
+								<button id="show-screen-button">
+									<span class="icon-screen"></span>
+									<span><?php p($l->t('Show your screen'));?></span>
 								</button>
 							</li>
 							<li id="stop-screen-entry">

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -75,7 +75,7 @@ script(
 							<li id="share-screen-entry">
 								<button id="share-screen-button">
 									<span class="icon-screen"></span>
-									<span><?php p($l->t('Share your screen'));?></span>
+									<span><?php p($l->t('Share whole screen'));?></span>
 								</button>
 							</li>
 							<li id="share-window-entry">

--- a/templates/index-public.php
+++ b/templates/index-public.php
@@ -75,13 +75,13 @@ script(
 							<li>
 								<button id="show-screen-button">
 									<span class="icon-screen"></span>
-									<span><?php p($l->t('Show your screen'));?></span>
+									<span><?php p($l->t('Share your screen'));?></span>
 								</button>
 							</li>
 							<li id="show-window-entry">
 								<button id="show-window-button">
-									<span class="icon-screen"></span>
-									<span><?php p($l->t('Show a single window'));?></span>
+									<span class="icon-share-window"></span>
+									<span><?php p($l->t('Share a single window'));?></span>
 								</button>
 							</li>
 							<li id="stop-screen-entry">

--- a/templates/index.php
+++ b/templates/index.php
@@ -82,13 +82,13 @@ script(
 						<li>
 							<button id="show-screen-button">
 								<span class="icon-screen"></span>
-								<span><?php p($l->t('Show your screen'));?></span>
+								<span><?php p($l->t('Share your screen'));?></span>
 							</button>
 						</li>
 						<li id="show-window-entry">
 							<button id="show-window-button">
-								<span class="icon-screen"></span>
-								<span><?php p($l->t('Show a single window'));?></span>
+								<span class="icon-share-window"></span>
+								<span><?php p($l->t('Share a single window'));?></span>
 							</button>
 						</li>
 						<li id="stop-screen-entry">

--- a/templates/index.php
+++ b/templates/index.php
@@ -79,16 +79,22 @@ script(
 				<button id="screensharing-button" class="app-navigation-entry-utils-menu-button icon-screen-off icon-white icon-shadow screensharing-disabled" data-placement="top" data-toggle="tooltip" data-original-title="<?php p($l->t('Share screen')) ?>"></button>
 				<div id="screensharing-menu" class="app-navigation-entry-menu">
 					<ul>
-						<li>
-							<button id="show-screen-button">
+						<li id="share-screen-entry">
+							<button id="share-screen-button">
 								<span class="icon-screen"></span>
 								<span><?php p($l->t('Share your screen'));?></span>
 							</button>
 						</li>
-						<li id="show-window-entry">
-							<button id="show-window-button">
+						<li id="share-window-entry">
+							<button id="share-window-button">
 								<span class="icon-share-window"></span>
 								<span><?php p($l->t('Share a single window'));?></span>
+							</button>
+						</li>
+						<li id="show-screen-entry">
+							<button id="show-screen-button">
+								<span class="icon-screen"></span>
+								<span><?php p($l->t('Show your screen'));?></span>
 							</button>
 						</li>
 						<li id="stop-screen-entry">

--- a/templates/index.php
+++ b/templates/index.php
@@ -82,7 +82,7 @@ script(
 						<li id="share-screen-entry">
 							<button id="share-screen-button">
 								<span class="icon-screen"></span>
-								<span><?php p($l->t('Share your screen'));?></span>
+								<span><?php p($l->t('Share whole screen'));?></span>
 							</button>
 						</li>
 						<li id="share-window-entry">


### PR DESCRIPTION
**Before**:

![screen shot 2018-12-03 at 12 21 19](https://user-images.githubusercontent.com/4638605/49371050-76c7e680-f6f6-11e8-8717-a04ec46f19ac.png)

**After**:

![screen shot 2018-12-03 at 12 19 38](https://user-images.githubusercontent.com/4638605/49371063-80514e80-f6f6-11e8-87e6-9fbeba98ffcf.png)

When the user is sharing a screen or window:

![screen shot 2018-12-03 at 12 22 41](https://user-images.githubusercontent.com/4638605/49371098-9b23c300-f6f6-11e8-807c-ef425081f646.png)
