### PR TITLE
End pending signaling when user is no longer in the room

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -148,9 +148,10 @@ class Application extends App {
 			// When "addMessageForAllParticipants" is called the participant is
 			// no longer in the room, so the message needs to be explicitly
 			// added for the participant.
-			$sessionId = $event->getArgument('sessionId');
-			if ($sessionId !== null && $sessionId !== '' && $sessionId !== '0') {
-				$messages->addMessage($sessionId, $sessionId, 'refresh-participant-list');
+			/** @var Participant $participant */
+			$participant = $event->getArgument('participant');
+			if ($participant->getSessionId() !== '0') {
+				$messages->addMessage($participant->getSessionId(), $participant->getSessionId(), 'refresh-participant-list');
 			}
 		};
 
@@ -159,9 +160,6 @@ class Application extends App {
 		$dispatcher->addListener(Room::class . '::postUserDisconnectRoom', $listener);
 
 		$listener = function(GenericEvent $event) {
-			/** @var Room $room */
-			$room = $event->getSubject();
-
 			/** @var Messages $messages */
 			$messages = $this->getContainer()->query(Messages::class);
 			$participants = $event->getArgument('participants');

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -157,6 +157,23 @@ class Application extends App {
 		$dispatcher->addListener(Room::class . '::postRemoveUser', $listener);
 		$dispatcher->addListener(Room::class . '::postRemoveBySession', $listener);
 		$dispatcher->addListener(Room::class . '::postUserDisconnectRoom', $listener);
+
+		$listener = function(GenericEvent $event) {
+			/** @var Room $room */
+			$room = $event->getSubject();
+
+			/** @var Messages $messages */
+			$messages = $this->getContainer()->query(Messages::class);
+			$participants = $event->getArgument('participants');
+			foreach ($participants['users'] as $participant) {
+				$messages->addMessage($participant['sessionId'], $participant['sessionId'], 'refresh-participant-list');
+			}
+			foreach ($participants['guests'] as $participant) {
+				$messages->addMessage($participant['sessionId'], $participant['sessionId'], 'refresh-participant-list');
+			}
+		};
+
+		$dispatcher->addListener(Room::class . '::postDeleteRoom', $listener);
 	}
 
 	protected function getBackendNotifier() {


### PR DESCRIPTION
When there was a ping call [the current room was left as soon as the ping returned with an error 404](https://github.com/nextcloud/spreed/blob/db5861e3902bb895e874f911e9e8d2c43e28682a/js/signaling.js#L660-L667).

Since [the ping was removed](https://github.com/nextcloud/spreed/commit/3e326172f7ce6254cd4a1cd980eb1412f809a992#diff-b203a312c79675f92005f11eb2d9a086R583) the current room is left after receiving three signaling errors in a row, each one with a pause of five seconds before the next request.

However, the biggest delay comes from the signaling not being ended when the user is no longer in the room. When a participant is removed or disconnected from a room the `refresh-participant-list` signaling message is added to all the participants in that room. However, the participant just removed or disconnected is no longer in the room, and thus the participant did not receive the message. This pull request fixes that, as well as adding the `refresh-participant-list` message to all the participants in a room just deleted.

Note, however, that the participant will never receive that message from the signaling endpoint, [but a 404 error due to no longer being in the room](https://github.com/nextcloud/spreed/blob/021dc333dc73e168633eef6c260c1e77e11dde56/lib/Controller/SignalingController.php#L197-L204). In any case, [this ends the pending signaling request](https://github.com/nextcloud/spreed/blob/021dc333dc73e168633eef6c260c1e77e11dde56/lib/Controller/SignalingController.php#L177) as soon as the participant is removed or disconnected or the room is deleted instead of keep waiting until the timeout ends.

Besides that, I am not sure if the current room should be left as soon as a 404 error is returned by the signaling (by appending `jqXHR.status === 404 || ` to the [condition to stop retrying](https://github.com/nextcloud/spreed/blob/9c0c1da64a43e84edb74c696fb6ac991a0f9c700/js/signaling.js#L631), or if there could be any case in which retrying would return a different response.

**How to test**
**Scenario 1**
- As userA, create a group room and add userB
- As userB, join to the group room
- As userA, remove userB from the group room

**Scenario 2**
- As userA, create a group room and add userB
- As userA, create a different room and join it
- As userB, join to the group room
- As userA, remove the group room **without joining to it** (otherwise the user will be removed from the room before deleting it, and thus the `refresh-participants-list` message will be sent for userB due to the change in the participants instead of due to `postDeleteRoom` which is the scenario tested here).

**Result with this pull request**
The UI will show _This conversation has ended_ after 15-20 seconds (if the change mentioned above regarding the error 404 is added then the UI will be updated almost immediately).

**Result without this pull request**
The UI will show _This conversation has ended_ after up to 45 seconds.
