### PR TITLE
Fix Chat tab not shown in Files app if Sharing tab was not opened

### DIFF
--- a/js/filesplugin.js
+++ b/js/filesplugin.js
@@ -251,6 +251,9 @@
 			}
 
 			var shareTypes = fileInfo.get('shareTypes').filter(function(shareType) {
+				// shareType could be an integer or a string depending on
+				// whether the Sharing tab was opened or not.
+				shareType = parseInt(shareType);
 				return shareType === OC.Share.SHARE_TYPE_USER ||
 						shareType === OC.Share.SHARE_TYPE_GROUP ||
 						shareType === OC.Share.SHARE_TYPE_CIRCLE ||


### PR DESCRIPTION
This pull request fixes a bug introduced when `eslint` issues were fixed in #1323 (it complained that a strict comparison was not being used, and now I have remembered why a strict comparison was not being used :-P ).

When the details view is opened for a file the `shareTypes` of the FileInfo are initially strings; they are converted to integers only once the _Sharing_ tab has been opened. Thus, now the `shareTypes` are always "casted" to integers before performing a strict comparison against the `SHARE_TYPE_XXX` constants.

**How to test**
- In the Files app, share a file with another user
- Reload the Files app
- Open the details view for the shared file

**Results with this pull request**
The header of the _Chat_ tab is visible.

**Results without this pull request**
The header of the _Chat_ tab is hidden. If the _Sharing_ tab is opened, and the details view is closed and then open again the header of the _Chat_ tab will be visible.
