### PR TITLE
Use special icons for rooms associated to objects

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -126,12 +126,15 @@
 .select2-result .icon-contacts.avatar,
 .select2-result .icon-public-white.avatar,
 .select2-result .icon-mail.avatar,
-#app-navigation .icon-contacts,
 #app-navigation .app-navigation-entry-link .icon {
 	border-radius: 50%;
 	width: 32px;
 	height: 32px;
 	background-color: var(--color-background-darker);
+}
+
+.icon-file-white {
+	@include icon-color('file', 'filetypes', $color-white, 1, true);
 }
 
 #app-navigation .favorite-mark {

--- a/css/style.scss
+++ b/css/style.scss
@@ -176,34 +176,8 @@
 	}
 }
 
-.public-room {
-	display: block !important;
-}
-
-.private-room,
 .hidden-important {
 	display: none !important;
-}
-
-.icon-clippy.public-room {
-	background-size: 16px;
-	position: absolute;
-	right: 0;
-	bottom: 0;
-	padding: 16px;
-}
-
-.icon-delete.public-room {
-	background-size: 16px;
-	position: absolute;
-	right: 0;
-	top: 4px;
-	padding: 16px;
-	opacity: .5;
-}
-
-.icon-clippy.public-room {
-	background-position-y: 8px !important;
 }
 
 /**

--- a/css/style.scss
+++ b/css/style.scss
@@ -127,7 +127,7 @@
 .select2-result .icon-public-white.avatar,
 .select2-result .icon-mail.avatar,
 #app-navigation .icon-contacts,
-#app-navigation .app-navigation-entry-link .icon-public-white {
+#app-navigation .app-navigation-entry-link .icon {
 	border-radius: 50%;
 	width: 32px;
 	height: 32px;

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -211,8 +211,6 @@
 		},
 		checkSharingStatus: function() {
 			if (this.model.get('type') === OCA.SpreedMe.app.ROOM_TYPE_ONE_TO_ONE) { // 1on1
-				this.$el.find('.public-room').removeClass('public-room').addClass('private-room');
-
 				_.each(this.$el.find('.avatar'), function(a) {
 					if ($(a).data('user-display-name')) {
 						$(a).avatar($(a).data('user'), 32, undefined, false, undefined, $(a).data('user-display-name'));
@@ -221,14 +219,10 @@
 					}
 				});
 			} else if (this.model.get('type') === OCA.SpreedMe.app.ROOM_TYPE_GROUP) { // Group
-				this.$el.find('.public-room').removeClass('public-room').addClass('private-room');
-
 				_.each(this.$el.find('.avatar'), function(a) {
 					$(a).removeClass('icon-public-white').addClass('icon-contacts');
 				});
 			} else if (this.model.get('type') === OCA.SpreedMe.app.ROOM_TYPE_PUBLIC) { // Public room
-				this.$el.find('.private-room').removeClass('private-room').addClass('public-room');
-
 				_.each(this.$el.find('.avatar'), function(a) {
 					$(a).removeClass('icon-contacts').addClass('icon-public-white');
 				});

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -156,9 +156,9 @@
 		templateContext: function() {
 			var icon = '';
 			if (this.model.get('type') === OCA.SpreedMe.app.ROOM_TYPE_GROUP) {
-				icon = 'icon-contacts';
+				icon = 'icon icon-contacts';
 			} else if (this.model.get('type') === OCA.SpreedMe.app.ROOM_TYPE_PUBLIC) {
-				icon = 'icon-public-white';
+				icon = 'icon icon-public-white';
 			}
 
 			// If a room is a one2one room it can not be removed from the list, only be deleted for both participants.

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -155,7 +155,11 @@
 		},
 		templateContext: function() {
 			var icon = '';
-			if (this.model.get('type') === OCA.SpreedMe.app.ROOM_TYPE_GROUP) {
+			if (this.model.get('objectType') === 'file') {
+				icon = 'icon icon-file-white';
+			} else if (this.model.get('objectType') === 'share:password') {
+				icon = 'icon icon-password-white';
+			} else if (this.model.get('type') === OCA.SpreedMe.app.ROOM_TYPE_GROUP) {
 				icon = 'icon icon-contacts';
 			} else if (this.model.get('type') === OCA.SpreedMe.app.ROOM_TYPE_PUBLIC) {
 				icon = 'icon icon-public-white';

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -30,7 +30,7 @@
 	var uiChannel = Backbone.Radio.channel('ui');
 
 	var ITEM_TEMPLATE = '<a class="app-navigation-entry-link" href="#{{id}}" data-token="{{token}}">' +
-							'<div class="avatar" data-user="{{name}}" data-user-display-name="{{displayName}}"></div>' +
+							'<div class="avatar {{icon}}" data-user="{{name}}" data-user-display-name="{{displayName}}"></div>' +
 							'{{#if isFavorite}}'+
 							// The favorite mark can not be a child of the
 							// avatar, as it would be removed when the avatar is
@@ -154,9 +154,17 @@
 			});
 		},
 		templateContext: function() {
+			var icon = '';
+			if (this.model.get('type') === OCA.SpreedMe.app.ROOM_TYPE_GROUP) {
+				icon = 'icon-contacts';
+			} else if (this.model.get('type') === OCA.SpreedMe.app.ROOM_TYPE_PUBLIC) {
+				icon = 'icon-public-white';
+			}
+
 			// If a room is a one2one room it can not be removed from the list, only be deleted for both participants.
 			var isRemovable = this.model.get('type') !== 1;
 			return {
+				icon: icon,
 				canFavorite: this.model.get('participantType') !== 5,
 				notifyAlways: this.model.get('notificationLevel') === OCA.SpreedMe.app.NOTIFY_ALWAYS,
 				notifyMention: this.model.get('notificationLevel') === OCA.SpreedMe.app.NOTIFY_MENTION,
@@ -170,7 +178,7 @@
 		onRender: function() {
 			var roomURL;
 
-			this.checkSharingStatus();
+			this.setAvatarIfNeeded();
 
 			roomURL = OC.generateUrl('/call/' + this.model.get('token'));
 			this.$el.find('.app-navigation-entry-link').attr('href', roomURL);
@@ -209,24 +217,18 @@
 		toggleMenuClass: function() {
 			this.ui.menu.toggleClass('open', this.menuShown);
 		},
-		checkSharingStatus: function() {
-			if (this.model.get('type') === OCA.SpreedMe.app.ROOM_TYPE_ONE_TO_ONE) { // 1on1
-				_.each(this.$el.find('.avatar'), function(a) {
-					if ($(a).data('user-display-name')) {
-						$(a).avatar($(a).data('user'), 32, undefined, false, undefined, $(a).data('user-display-name'));
-					} else {
-						$(a).avatar($(a).data('user'), 32);
-					}
-				});
-			} else if (this.model.get('type') === OCA.SpreedMe.app.ROOM_TYPE_GROUP) { // Group
-				_.each(this.$el.find('.avatar'), function(a) {
-					$(a).removeClass('icon-public-white').addClass('icon-contacts');
-				});
-			} else if (this.model.get('type') === OCA.SpreedMe.app.ROOM_TYPE_PUBLIC) { // Public room
-				_.each(this.$el.find('.avatar'), function(a) {
-					$(a).removeClass('icon-contacts').addClass('icon-public-white');
-				});
+		setAvatarIfNeeded: function() {
+			if (this.model.get('type') !== OCA.SpreedMe.app.ROOM_TYPE_ONE_TO_ONE) {
+				return;
 			}
+
+			_.each(this.$el.find('.avatar'), function(a) {
+				if ($(a).data('user-display-name')) {
+					$(a).avatar($(a).data('user'), 32, undefined, false, undefined, $(a).data('user-display-name'));
+				} else {
+					$(a).avatar($(a).data('user'), 32);
+				}
+			});
 		},
 		removeRoom: function() {
 			this.$el.slideUp();


### PR DESCRIPTION
In the room list now rooms for password requests use the password icon and rooms for files use the file icon.

**Before:**
![room-list-icon-before](https://user-images.githubusercontent.com/26858233/49616555-84f55b80-f9b1-11e8-846f-18868d794f96.png)

**After:**
![room-list-icon-after](https://user-images.githubusercontent.com/26858233/49616560-87f04c00-f9b1-11e8-9444-78bebd6b2b17.png)

@mario @Ivansss Probably something to be updated in the mobile apps too.

@nextcloud/designers 