### PR TITLE
Disable call button while joining or leaving a call

### DIFF
--- a/css/files.scss
+++ b/css/files.scss
@@ -1,6 +1,28 @@
 #talkChatTabView .call-button {
 	text-align: center;
 	margin-bottom: 10px;
+
+	button {
+		padding-left: 26px;
+		padding-right: 26px;
+	}
+
+	.icon-loading-small {
+		/* Prevent the text from being moved when the icon is shown. */
+		position: absolute;
+
+		margin-left: 5px;
+		margin-top: 1px;
+
+		/* Unset the background image set by the server for loading icons inside
+		 * buttons, as in this case the pure CSS icon can be used instead of the
+		 * image. */
+		background-image: unset;
+
+		&.hidden {
+			display: none;
+		}
+	}
 }
 
 #talkChatTabView .file-not-shared button {

--- a/css/style.scss
+++ b/css/style.scss
@@ -743,6 +743,23 @@
 				width: 100%;
 				padding: 12px;
 			}
+
+			.icon-loading-small {
+				/* Prevent the text from being moved when the icon is shown. */
+				position: absolute;
+
+				margin-left: 5px;
+				margin-top: 1px;
+
+				/* Unset the background image set by the server for loading
+				 * icons inside buttons, as in this case the pure CSS icon can
+				 * be used instead of the image. */
+				background-image: unset;
+
+				&.hidden {
+					display: none;
+				}
+			}
 		}
 	}
 

--- a/js/connection.js
+++ b/js/connection.js
@@ -112,6 +112,8 @@
 				return;
 			}
 
+			roomsChannel.trigger('joinCall', token);
+
 			var self = this;
 			this.app.callbackAfterMedia = function(configuration) {
 				var flags = OCA.SpreedMe.app.FLAG_IN_CALL;
@@ -130,6 +132,8 @@
 			this.app.setupWebRTC();
 		},
 		leaveCurrentCall: function() {
+			roomsChannel.trigger('leaveCurrentCall');
+
 			this.app.signaling.leaveCurrentCall();
 			this.app.signaling.syncRooms();
 			$(this.app.mainCallElementSelector).removeClass('incall');

--- a/js/views/callbutton.js
+++ b/js/views/callbutton.js
@@ -56,6 +56,7 @@
 		ui: {
 			'joinCallButton': 'button.join-call',
 			'leaveCallButton': 'button.leave-call',
+			'workingIcon': '.icon-loading-small',
 		},
 
 		events: {
@@ -96,10 +97,12 @@
 
 		_waitForCallToBeJoined: function() {
 			this.getUI('joinCallButton').prop('disabled', true);
+			this.getUI('workingIcon').removeClass('hidden');
 		},
 
 		_waitForCallToBeLeft: function() {
 			this.getUI('leaveCallButton').prop('disabled', true);
+			this.getUI('workingIcon').removeClass('hidden');
 		},
 
 	});

--- a/js/views/callbutton.js
+++ b/js/views/callbutton.js
@@ -30,6 +30,8 @@
 	OCA.SpreedMe.Views = OCA.SpreedMe.Views || {};
 	OCA.Talk.Views = OCA.Talk.Views || {};
 
+	var roomsChannel = Backbone.Radio.channel('rooms');
+
 	var CallButton  = Marionette.View.extend({
 
 		className: 'call-button',
@@ -76,6 +78,12 @@
 		 */
 		initialize: function(options) {
 			this._connection = options.connection;
+
+			// While joining or leaving a call the button is disabled; it will
+			// be rendered again and thus enabled once the operation finishes
+			// and the model changes.
+			this.listenTo(roomsChannel, 'joinCall', this._waitForCallToBeJoined);
+			this.listenTo(roomsChannel, 'leaveCurrentCall', this._waitForCallToBeLeft);
 		},
 
 		joinCall: function() {
@@ -84,6 +92,14 @@
 
 		leaveCall: function() {
 			this._connection.leaveCurrentCall();
+		},
+
+		_waitForCallToBeJoined: function() {
+			this.getUI('joinCallButton').prop('disabled', true);
+		},
+
+		_waitForCallToBeLeft: function() {
+			this.getUI('leaveCallButton').prop('disabled', true);
 		},
 
 	});

--- a/js/views/templates.js
+++ b/js/views/templates.js
@@ -5,7 +5,7 @@ templates['callbutton'] = template({"1":function(container,depth0,helpers,partia
 
   return "<button class=\"leave-call primary\">"
     + container.escapeExpression(((helper = (helper = helpers.leaveCallText || (depth0 != null ? depth0.leaveCallText : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"leaveCallText","hash":{},"data":data}) : helper)))
-    + "</button>\n";
+    + "<span class=\"icon icon-loading-small hidden\"></span></button>\n";
 },"3":function(container,depth0,helpers,partials,data) {
     var stack1;
 
@@ -15,13 +15,13 @@ templates['callbutton'] = template({"1":function(container,depth0,helpers,partia
 
   return "<button class=\"join-call call-ongoing primary\">"
     + container.escapeExpression(((helper = (helper = helpers.joinCallText || (depth0 != null ? depth0.joinCallText : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"joinCallText","hash":{},"data":data}) : helper)))
-    + "</button>\n";
+    + "<span class=\"icon icon-loading-small hidden\"></span></button>\n";
 },"6":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "<button class=\"join-call primary\">"
     + container.escapeExpression(((helper = (helper = helpers.startCallText || (depth0 != null ? depth0.startCallText : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"startCallText","hash":{},"data":data}) : helper)))
-    + "</button>\n";
+    + "<span class=\"icon icon-loading-small hidden\"></span></button>\n";
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     var stack1;
 

--- a/js/views/templates/callbutton.handlebars
+++ b/js/views/templates/callbutton.handlebars
@@ -1,9 +1,9 @@
 {{#if isInCall}}
-<button class="leave-call primary">{{leaveCallText}}</button>
+<button class="leave-call primary">{{leaveCallText}}<span class="icon icon-loading-small hidden"></span></button>
 {{else}}
 	{{#if hasCall}}
-<button class="join-call call-ongoing primary">{{joinCallText}}</button>
+<button class="join-call call-ongoing primary">{{joinCallText}}<span class="icon icon-loading-small hidden"></span></button>
 	{{else}}
-<button class="join-call primary">{{startCallText}}</button>
+<button class="join-call primary">{{startCallText}}<span class="icon icon-loading-small hidden"></span></button>
 	{{/if}}
 {{/if}}


### PR DESCRIPTION
Joining or leaving a call is not an immediate action; in some cases a few seconds can pass before the action is finished, so during that time the button should be disabled, both to prevent further actions from the user and to give her feedback that the action is still going on.

In addition to disabling the button a working/loading icon was added to the button when it is disabled for a stronger feedback. However, I am not sure if the icon is really needed or if just disabling the button would be enough. Also, there is something that I do not like about the icon... but I do not know what it is :-P

@nextcloud/designers 

Main Talk UI, button enabled:
![talk-call-button-enabled](https://user-images.githubusercontent.com/26858233/49796806-fa5c8580-fd3d-11e8-8d72-94d20f87abcc.png)

Main Talk UI, button disabled:
![talk-call-button-disabled](https://user-images.githubusercontent.com/26858233/49796804-f7619500-fd3d-11e8-888d-627ddc260f06.png)

Chat tab in Files app, before:
![files-call-button-before](https://user-images.githubusercontent.com/26858233/49796819-06484780-fd3e-11e8-96a0-5c1e34fc1eab.png)

Chat tab in Files app, after, button enabled (padding added to make room for the icon):
![files-call-button-after-enabled](https://user-images.githubusercontent.com/26858233/49796829-09433800-fd3e-11e8-9559-cfbbe4a285a2.png)

Chat tab in Files app, after, button disabled:
![files-call-button-after-disabled](https://user-images.githubusercontent.com/26858233/49796832-0ba59200-fd3e-11e8-86e3-5ac89992aace.png)
