### PR TITLE
Send initial screensharing stream to participants that don't publish video.

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -1232,15 +1232,17 @@ var spreedPeerConnectionTable = [];
 			var signaling = OCA.SpreedMe.app.signaling;
 
 			var currentSessionId = signaling.getSessionid();
-			OCA.SpreedMe.webrtc.getPeers(null, 'video').forEach(function (existingPeer) {
-				if (existingPeer.id === currentSessionId) {
+			for (var sessionId in usersInCallMapping) {
+				if (!usersInCallMapping.hasOwnProperty(sessionId)) {
+					continue;
+				} else if (sessionId === currentSessionId) {
 					// Running with MCU, no need to create screensharing
 					// subscriber for client itself.
-					return;
+					continue;
 				}
 
-				createScreensharingPeer(signaling, existingPeer.id);
-			});
+				createScreensharingPeer(signaling, sessionId);
+			}
 		});
 
 		OCA.SpreedMe.webrtc.on('localScreenStopped', function() {


### PR DESCRIPTION
Previously the screensharing stream was only sent to other participants that had a `video` peer. Participants without a camera/microphone and using the MCU don't have such a peer on the sender side.

How to reproduce:
- Setup standalone signaling / MCU.
- Join call with user A that has camera / microphone.
- Join call with user B that doesn't have camera / microphone (or doesn't allow access).
- Start screensharing with user A.

Before: No screen is visible for user B.
After: User B sees the screen of user A.