### PR TITLE
 Fix multiple mentions which are used directly behind each others 

### DIFF
--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -646,7 +646,10 @@
 			} while(oldHtml !== html);
 			$comment.html(html);
 
-			return $comment.text();
+			var message = $comment.text();
+
+			// Little hack to replace the non-breaking space resulting from the editable div content with normal spaces
+			return decodeURI(encodeURI(message).replace(/%C2%A0/g, '%20'));
 		},
 
 		_onSubmitComment: function(e) {

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -637,15 +637,7 @@
 				}
 			});
 
-			var oldHtml;
-			var html = $comment.html();
-			do {
-				// replace works one by one
-				oldHtml = html;
-				html = oldHtml.replace("<br>", "\n");	// preserve line breaks
-			} while(oldHtml !== html);
-			$comment.html(html);
-
+			$comment.html($comment.html().replace(/<br>/g, "\n"));
 			var message = $comment.text();
 
 			// Little hack to replace the non-breaking space resulting from the editable div content with normal spaces


### PR DESCRIPTION
The editable div inserts non-breaking spaces (url encode %C2%A0) after a mention.
When two mentions are right behind each others, the later one is not matched by the
regex later, because the lookahead on the @ finds only non-breaking content.
Manually adding a space in between the two mentions solves this already.

But instead we replace them with normal spaces before sending them to the server.


Fix #1380 