### PR TITLE
Removing black incall background

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -30,11 +30,6 @@ var spreedPeerConnectionTable = [];
 			hadSidebar = $appContentElement.hasClass('with-app-sidebar');
 		if (!$appContentElement.hasClass(participantsClass)) {
 			$appContentElement.attr('class', '').addClass(participantsClass);
-			if (currentUsersNo > 1) {
-				$appContentElement.addClass('incall');
-			} else {
-				$appContentElement.removeClass('incall');
-			}
 
 			if (hadScreensharing) {
 				$appContentElement.addClass('screensharing');


### PR DESCRIPTION
The black background applied by the incall style causes the chat window to have a black background sometimes.  The background is not necessary as the video window has a black background anyway.