### PR TITLE
Fix empty content message in Files app when WebRTC is not supported

### DIFF
--- a/js/embedded.js
+++ b/js/embedded.js
@@ -27,6 +27,7 @@
 	OCA.Talk = OCA.Talk || {};
 
 	var roomChannel = Backbone.Radio.channel('rooms');
+	var localMediaChannel = Backbone.Radio.channel('localMedia');
 
 	OCA.Talk.Embedded = Marionette.Application.extend({
 		OWNER: 1,
@@ -139,6 +140,13 @@
 				OCA.SpreedMe.initWebRTC(this);
 				this._mediaControlsView.setWebRtc(OCA.SpreedMe.webrtc);
 			}
+
+			if (!OCA.SpreedMe.webrtc.capabilities.support) {
+				localMediaChannel.trigger('webRtcNotSupported');
+			} else {
+				localMediaChannel.trigger('waitingForPermissions');
+			}
+
 			OCA.SpreedMe.webrtc.startMedia(this.token);
 		},
 		startLocalMedia: function(configuration) {
@@ -149,6 +157,8 @@
 
 			$('.videoView').removeClass('hidden');
 			this.initAudioVideoSettings(configuration);
+
+			localMediaChannel.trigger('startLocalMedia');
 		},
 		startWithoutLocalMedia: function(configuration) {
 			if (this.callbackAfterMedia) {
@@ -158,6 +168,10 @@
 
 			$('.videoView').removeClass('hidden');
 			this.initAudioVideoSettings(configuration);
+
+			if (OCA.SpreedMe.webrtc.capabilities.support) {
+				localMediaChannel.trigger('startWithoutLocalMedia');
+			}
 		},
 		initAudioVideoSettings: function(configuration) {
 			if (configuration.audio !== false) {

--- a/js/filesplugin.js
+++ b/js/filesplugin.js
@@ -156,7 +156,7 @@
 
 			this.$el.append(this._$callContainerWrapper);
 			$('#call-container-wrapper').append('<div id="call-container"></div>');
-			$('#call-container-wrapper').append('<div id="emptycontent"><div id="emptycontent-icon" class="icon-loading"></div><h2></h2><p></p></div>');
+			$('#call-container-wrapper').append('<div id="emptycontent"><div id="emptycontent-icon" class="icon-loading"></div><h2></h2><p class="emptycontent-additional"></p></div>');
 			$('#call-container').append('<div id="videos"><div id="localVideoContainer" class="videoView videoContainer"></div></div>');
 			$('#call-container').append('<div id="screens"></div>');
 

--- a/js/publicshareauth.js
+++ b/js/publicshareauth.js
@@ -63,7 +63,7 @@
 			$('#content').append($('footer'));
 
 			$('body').append('<div id="talk-sidebar" class="disappear"></div>');
-			$('#talk-sidebar').append('<div id="emptycontent"><div id="emptycontent-icon" class="icon-loading"></div><h2></h2><p></p></div>');
+			$('#talk-sidebar').append('<div id="emptycontent"><div id="emptycontent-icon" class="icon-loading"></div><h2></h2><p class="emptycontent-additional"></p></div>');
 			$('#talk-sidebar').append('<div id="call-container"></div>');
 			$('#call-container').append('<div id="videos"><div id="localVideoContainer" class="videoView videoContainer"></div></div>');
 			$('#call-container').append('<div id="screens"></div>');


### PR DESCRIPTION
The `EmptyContentView` expects some events to be triggered in the `localMedia` radio channel while waiting for permissions or when WebRTC is not supported to show the proper message.

**How to test:**
- Open the Files app in IE 11 or any other browser that does not support WebRTC
- Share a file with another user
- Open the _Chat_ tab for that file and start a call

**Results with this pull request:**
The empty content message reads _WebRTC is not supported in your browser :-/_ and below it _Please use a different browser like Firefox or Chrome_

**Results without this pull request:**
The empty content message reads _Waiting for userXXX to join the call  …_
