### PR TITLE
Fix opacity of submit buttons

### DIFF
--- a/css/authenticate.css
+++ b/css/authenticate.css
@@ -5,21 +5,43 @@ form fieldset {
 
 #password {
 	margin-right: 0 !important;
-	border-top-right-radius: 0;
-	border-bottom-right-radius: 0;
 	height: 45px;
 	box-sizing: border-box;
 	flex: 1 1 auto;
 	width: 100% !important;
 	min-width: 0; /* FF hack for to override default value */
+
+	/* The padding needs to be set here instead of for "input[type="password"]"
+	 * elements to prevent being overriden by a more specific rule in the
+	 * server. */
+	padding-right: 44px;
+}
+
+input[type="password"]:focus + .icon-confirm:not(:disabled) {
+	opacity: .6;
+}
+
+input[type="password"] + .icon-confirm {
+	position: absolute;
+	right: 15px;
+
+	border: none;
+	/* Needed to override an important rule set in the server. */
+	background-color: transparent !important;
+
+	opacity: .3;
+}
+
+input[type="password"] + .icon-confirm:hover:not(:disabled),
+input[type="password"] + .icon-confirm:focus:not(:disabled),
+input[type="password"] + .icon-confirm:active:not(:disabled) {
+	opacity: 1;
 }
 
 input[type='submit'] {
 	width: 45px;
 	height: 45px;
 	margin-left: 0 !important;
-	border-top-left-radius: 0;
-	border-bottom-left-radius: 0;
 }
 
 fieldset > p {

--- a/css/chatview.scss
+++ b/css/chatview.scss
@@ -51,6 +51,9 @@
 	right: -44px;
 }
 
+#chatView .newCommentForm .message:focus + .submit:not(:hover):not(:focus) {
+	opacity: .6;
+}
 #chatView .newCommentForm .submit,
 #chatView .newCommentForm .share {
 	background-color: transparent;

--- a/css/style.scss
+++ b/css/style.scss
@@ -91,7 +91,7 @@ input[type="text"] {
 	 * the input just like clicking on the icon would do. To hint this behaviour
 	 * the opacity of the confirm icon is slightly increased in this case.
 	 */
-	&:focus + .icon-confirm {
+	&:focus + .icon-confirm:not(:disabled) {
 		opacity: .6;
 	}
 
@@ -108,9 +108,9 @@ input[type="text"] {
 
 		opacity: .3;
 
-		&:hover,
-		&:focus,
-		&:active {
+		&:hover:not(:disabled),
+		&:focus:not(:disabled),
+		&:active:not(:disabled) {
 			opacity: 1;
 		}
 	}

--- a/css/style.scss
+++ b/css/style.scss
@@ -72,6 +72,52 @@
 	height: 38px;
 }
 
+
+
+/**
+ * Confirm icon inside input field.
+ *
+ * The input and the icon should be direct children of a wrapper with a relative
+ * position. The input is expected to be as wide as its wrapper.
+ *
+ * It is assumed that the icon will have the standard width for buttons in
+ * inputs of 34px. However, further adjustments may be needed for the input and
+ * the padding depending on the context where they are used.
+ */
+input[type="text"] {
+	padding-right: 34px;
+
+	/* When the input is focused it is expected that pressing enter will confirm
+	 * the input just like clicking on the icon would do. To hint this behaviour
+	 * the opacity of the confirm icon is slightly increased in this case.
+	 */
+	&:focus + .icon-confirm {
+		opacity: .6;
+	}
+
+	& + .icon-confirm {
+		position: absolute;
+		top: 0;
+		/* Compensate for right margin of inputs set in the server. */
+		right: 3px;
+
+		/* Border and background color are removed to show only the icon inside
+		* the input. */
+		border: none;
+		background-color: transparent;
+
+		opacity: .3;
+
+		&:hover,
+		&:focus,
+		&:active {
+			opacity: 1;
+		}
+	}
+}
+
+
+
 /**
  * Sidebar styles
  */
@@ -693,31 +739,10 @@
 			margin-top: -2px;
 
 			input[type="text"] {
-				padding-right: 34px;
-
-				&:focus + .icon-confirm {
-					opacity: .6;
-				}
-
 				& + .icon-confirm {
-					position: absolute;
-					top: 0;
-					/* Compensate for right margin of inputs set in the
-					 * server. */
-					right: 3px;
-
-					border: none;
 					/* Needed to override an important rule set in the
 					 * server. */
 					background-color: transparent !important;
-
-					opacity: .3;
-
-					&:hover,
-					&:focus,
-					&:active {
-						opacity: 1;
-					}
 				}
 			}
 		}

--- a/css/style.scss
+++ b/css/style.scss
@@ -686,12 +686,40 @@
 			}
 		}
 		.input-wrapper {
-			display: flex;
-			align-items: center;
+			position: relative;
 
 			/* Pull up the wrapper slightly to prevent elements below it from
 			 * moving when it is shown. */
 			margin-top: -2px;
+
+			input[type="text"] {
+				padding-right: 34px;
+
+				&:focus + .icon-confirm {
+					opacity: .6;
+				}
+
+				& + .icon-confirm {
+					position: absolute;
+					top: 0;
+					/* Compensate for right margin of inputs set in the
+					 * server. */
+					right: 3px;
+
+					border: none;
+					/* Needed to override an important rule set in the
+					 * server. */
+					background-color: transparent !important;
+
+					opacity: .3;
+
+					&:hover,
+					&:focus,
+					&:active {
+						opacity: 1;
+					}
+				}
+			}
 		}
 		.label {
 			margin-left: 5px;
@@ -759,31 +787,20 @@
 				margin: 4px 0 4px 0 !important;
 				font-size: 15px;
 				font-weight: 300;
-				padding-right: 44px;
 				text-overflow: ellipsis;
 			}
 
 			.icon-confirm.confirm-button {
-				position: absolute;
-				right: 0;
-				top: 1px;
 				padding: 12px 21px;
 				margin: 0;
-				background-color: transparent !important;
-				border: none;
 			}
 
-			.username:focus + .icon-confirm.confirm-button {
-				opacity: .6;
-			}
+			input[type="text"] {
+				padding-right: 44px;
 
-			.username + .icon-confirm.confirm-button {
-				opacity: .3;
-
-				&:hover,
-				&:focus,
-				&:active {
-					opacity: 1;
+				& + .icon-confirm {
+					top: 1px;
+					right: 0;
 				}
 			}
 		}

--- a/css/style.scss
+++ b/css/style.scss
@@ -736,6 +736,14 @@
 				margin: 0;
 				background-color: transparent !important;
 				border: none;
+
+				opacity: .3;
+
+				&:hover,
+				&:focus,
+				&:active {
+					opacity: 1;
+				}
 			}
 		}
 	}

--- a/css/style.scss
+++ b/css/style.scss
@@ -663,6 +663,41 @@
  */
 .detailCallInfoContainer,
 .authorRow {
+	.editable-text-label {
+		.label-wrapper {
+			display: flex;
+			align-items: center;
+			.edit-button {
+				display: none;
+
+				/* Use the same bottom margin as h2 (defined in the server) to
+				 * align the button vertically with the label. */
+				margin-bottom: 12px;
+
+				.icon {
+					background-color: transparent;
+					border: none;
+					padding: 13px 22px;
+					margin: 0;
+				}
+			}
+			&:hover .edit-button {
+				display: block;
+			}
+		}
+		.input-wrapper {
+			display: flex;
+			align-items: center;
+
+			/* Pull up the wrapper slightly to prevent elements below it from
+			 * moving when it is shown. */
+			margin-top: -2px;
+		}
+		.label {
+			margin-left: 5px;
+		}
+	}
+
 	.room-name-container {
 		display: flex;
 
@@ -757,40 +792,6 @@
 	.guest-name p {
 		display: inline-block;
 		padding: 9px 0;
-	}
-	.editable-text-label {
-		.label-wrapper {
-			display: flex;
-			align-items: center;
-			.edit-button {
-				display: none;
-
-				/* Use the same bottom margin as h2 (defined in the server) to
-				 * align the button vertically with the label. */
-				margin-bottom: 12px;
-
-				.icon {
-					background-color: transparent;
-					border: none;
-					padding: 13px 22px;
-					margin: 0;
-				}
-			}
-			&:hover .edit-button {
-				display: block;
-			}
-		}
-		.input-wrapper {
-			display: flex;
-			align-items: center;
-
-			/* Pull up the wrapper slightly to prevent elements below it from
-			 * moving when it is shown. */
-			margin-top: -2px;
-		}
-		.label {
-			margin-left: 5px;
-		}
 	}
 
 	.call-controls-container {

--- a/css/style.scss
+++ b/css/style.scss
@@ -899,17 +899,24 @@ input[type="password"] {
 		.password-button {
 			position: relative;
 
-			.password-form {
-				position: relative;
+			.menuitem {
+				/* Override rule for menu items from server, as in this case
+				 * only the button in the password field is clickable, so the
+				 * pointer cursor should not be used for the whole item. */
+				cursor: default;
 
-				.password-confirm {
-					/* Inputs in menu items do not have a right margin, so it
-					 * does not need to be compensated. */
-					right: 0;
+				.password-form {
+					position: relative;
 
-					/* Needed to override an important rule set in the
-					 * server. */
-					background-color: transparent !important;
+					.password-confirm {
+						/* Inputs in menu items do not have a right margin, so
+						 * it does not need to be compensated. */
+						right: 0;
+
+						/* Needed to override an important rule set in the
+						 * server. */
+						background-color: transparent !important;
+					}
 				}
 			}
 		}

--- a/css/style.scss
+++ b/css/style.scss
@@ -731,7 +731,7 @@
 			.icon-confirm.confirm-button {
 				position: absolute;
 				right: 0;
-				top: 2px;
+				top: 1px;
 				padding: 12px 21px;
 				margin: 0;
 				background-color: transparent !important;

--- a/css/style.scss
+++ b/css/style.scss
@@ -84,7 +84,8 @@
  * inputs of 34px. However, further adjustments may be needed for the input and
  * the padding depending on the context where they are used.
  */
-input[type="text"] {
+input[type="text"],
+input[type="password"] {
 	padding-right: 34px;
 
 	/* When the input is focused it is expected that pressing enter will confirm
@@ -897,6 +898,20 @@ input[type="text"] {
 		}
 		.password-button {
 			position: relative;
+
+			.password-form {
+				position: relative;
+
+				.password-confirm {
+					/* Inputs in menu items do not have a right margin, so it
+					 * does not need to be compensated. */
+					right: 0;
+
+					/* Needed to override an important rule set in the
+					 * server. */
+					background-color: transparent !important;
+				}
+			}
 		}
 	}
 }

--- a/css/style.scss
+++ b/css/style.scss
@@ -736,7 +736,13 @@
 				margin: 0;
 				background-color: transparent !important;
 				border: none;
+			}
 
+			.username:focus + .icon-confirm.confirm-button {
+				opacity: .6;
+			}
+
+			.username + .icon-confirm.confirm-button {
 				opacity: .3;
 
 				&:hover,


### PR DESCRIPTION
The opacity of the submit button for the room name now follows the opacity of the submit button to send new messages (low opacity by default, full opacity when hovered, focused or active).

Additionally, the opacity of the submit button is slightly increased when its input field is focused; this was made to hint that when the input field for the room name is focused pressing enter sets the room name without having to explicitly click on the submit button, although I am not sure if this is a good approach or not. In any case I added it in a separate commit to be easily dropped or reverted if needed ;-)

**Update:** all this was done too for the submit buttons of guest names, passwords, password in the authentication page and new chat messages.

@nextcloud/designers 

**Before:**
![room-name-submit-before](https://user-images.githubusercontent.com/26858233/49931204-a92bcd80-fec6-11e8-8457-a0612fae5302.png)

**After, default:**
![room-name-submit-after-default](https://user-images.githubusercontent.com/26858233/49931209-ab8e2780-fec6-11e8-8937-659d9024c841.png)

**After, hovered:**
![room-name-submit-after-hovered](https://user-images.githubusercontent.com/26858233/49931216-ae891800-fec6-11e8-83cb-f391c13c5ec5.png)

**After, default opacity when field is focused:**
![room-name-submit-after-field-focused-default](https://user-images.githubusercontent.com/26858233/49931224-b3e66280-fec6-11e8-9dca-813945d2659f.png)

**After, increased opacity when field is focused:**
![room-name-submit-after-field-focused-increased](https://user-images.githubusercontent.com/26858233/49931237-bc3e9d80-fec6-11e8-9598-e3f8ee430840.png)
