### PR TITLE
Fix position of input and edit button for room name

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -724,6 +724,10 @@
 		.input-wrapper {
 			display: flex;
 			align-items: center;
+
+			/* Pull up the wrapper slightly to prevent elements below it from
+			 * moving when it is shown. */
+			margin-top: -2px;
 		}
 		.label {
 			margin-left: 5px;

--- a/css/style.scss
+++ b/css/style.scss
@@ -706,6 +706,10 @@
 			.edit-button {
 				display: none;
 
+				/* Use the same bottom margin as h2 (defined in the server) to
+				 * align the button vertically with the label. */
+				margin-bottom: 12px;
+
 				.icon {
 					background-color: transparent;
 					border: none;


### PR DESCRIPTION
**Before, edit button:**
![room-name-edit-before](https://user-images.githubusercontent.com/26858233/49932230-d11c3080-fec8-11e8-9869-14cb0c666a8c.png)

**After, edit button:**
![room-name-edit-after](https://user-images.githubusercontent.com/26858233/49932240-d4172100-fec8-11e8-8593-6b092ca8141e.png)

**Before, input field:**
![room-name-input-before](https://user-images.githubusercontent.com/26858233/49932197-bd70ca00-fec8-11e8-8ac6-1f59567a269e.png)

**After, input field:** (hard to see, but now the elements below it are not moved when the input field is shown)
![room-name-input-after](https://user-images.githubusercontent.com/26858233/49931931-3facbe80-fec8-11e8-954c-55b83d3bc6ea.png)
