### PR TITLE
Add icon to go to the file associated to a room

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -661,9 +661,52 @@
  */
 .detailCallInfoContainer,
 .authorRow {
+	.room-name-container {
+		display: flex;
+
+		/* Prevent the room name from overlapping the button to close the
+		 * sidebar. */
+		margin-right: 29px;
+
+		a {
+			opacity: .6;
+
+			&:hover,
+			&:focus,
+			&:active {
+				opacity: 1;
+			}
+
+			/* The container height is 42px (line height of 30px and bottom
+			 * margin of 12px, both defined for h2 in the server), so clear the
+			 * extra height of the link below the icon; this limits the
+			 * clickable area to 44x44px, as otherwise it was too near the call
+			 * button. */
+			margin-bottom: 5px;
+
+			.icon {
+				display: block;
+
+				width: 44px;
+				height: 44px;
+
+				background-size: 24px;
+
+				/* Pull up the icon slightly to align it vertically with the
+				 * label, which has a line height of 30px (defined in the
+				 * server). */
+				margin-top: -7px;
+			}
+		}
+	}
+
 	.room-name {
 		display: block;
-		margin-right: 29px;
+
+		/* Limit the room name to the container width and prevent it from
+		 * wrapping the full label when using a flex display; this is needed for
+		 * the edit button and the ellipsis in the name to work as expected. */
+		overflow: hidden;
 
 		.label {
 			white-space: nowrap;

--- a/css/style.scss
+++ b/css/style.scss
@@ -134,7 +134,7 @@
 }
 
 .icon-file-white {
-	@include icon-color('file', 'filetypes', $color-white, 1, true);
+	@include icon-color('text', 'filetypes', $color-white, 1, true);
 }
 
 #app-navigation .favorite-mark {

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -77,7 +77,6 @@
 		templateContext: function() {
 			var canModerate = this._canModerate();
 			return $.extend(this.model.toJSON(), {
-				isGuest: this.model.get('participantType') === 4,
 				canModerate: canModerate,
 				canFullModerate: this._canFullModerate(),
 				isPublic: this.model.get('type') === 3,

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -29,7 +29,14 @@
 	OCA.SpreedMe.Views = OCA.SpreedMe.Views || {};
 
 	var TEMPLATE =
-		'<div class="room-name"></div>' +
+		'<div class="room-name-container">' +
+		'	<div class="room-name"></div>' +
+		'	{{#if isRoomForFile}}' +
+		'	<a class="file-link" href="{{fileLink}}" target="_blank" rel="noopener noreferrer" data-original-title="{{fileLinkTitle}}">' +
+		'		<span class="icon icon-file"></span>' +
+		'	</a>' +
+		'	{{/if}}' +
+		'</div>' +
 		'<div class="call-controls-container">' +
 		'	<div class="call-button"></div>' +
 		'{{#if canModerate}}' +
@@ -77,6 +84,9 @@
 		templateContext: function() {
 			var canModerate = this._canModerate();
 			return $.extend(this.model.toJSON(), {
+				isRoomForFile: this.model.get('objectType') === 'file',
+				fileLink: OC.generateUrl('/f/{fileId}', { fileId: this.model.get('objectId') }),
+				fileLinkTitle: t('spreed', 'Go to file'),
 				canModerate: canModerate,
 				canFullModerate: this._canFullModerate(),
 				isPublic: this.model.get('type') === 3,
@@ -87,6 +97,7 @@
 
 		ui: {
 			'roomName': 'div.room-name',
+			'fileLink': '.file-link',
 			'shareLinkOptions': '.share-link-options',
 			'clipboardButton': '.clipboard-button',
 			'linkCheckbox': '.link-checkbox',
@@ -221,6 +232,10 @@
 				trigger: 'hover',
 				title: (this.model.get('hasPassword')) ? t('spreed', 'Change password') : t('spreed', 'Set password')
 			});
+
+			// Set the body as the container to show the tooltip in front of the
+			// header.
+			this.ui.fileLink.tooltip({container: $('body')});
 
 			var self = this;
 			OC.registerMenu($(this.ui.passwordButton), $(this.ui.passwordMenu), function() {


### PR DESCRIPTION
As the rooms associated to a file are also shown in the regular Talk UI now an icon is shown next to the room name to easily go to the file when clicking on it.

![room-name-file-icon](https://user-images.githubusercontent.com/26858233/49932906-95826600-feca-11e8-8aef-f8257291f8c5.png)

For consistency with the server and between the room list and the new icon [the icon in the room list for rooms associated to a file](https://github.com/nextcloud/spreed/pull/1346) is now the _text_ icon instead of the _file_ icon.

![room-list-file-icon](https://user-images.githubusercontent.com/26858233/49932919-a16e2800-feca-11e8-9624-fb2e0b5e13e6.png)

@nextcloud/designers 
