### PR TITLE
Make rooms for files in shared folders accessible to shared folder users

### DIFF
--- a/css/files.scss
+++ b/css/files.scss
@@ -268,9 +268,8 @@
 	padding-right: 0px;
 }
 
-#app-sidebar .tabsContainer .tab .app-not-started-placeholder {
-	/* Make the placeholder take the full tab height until the app is
-	 * started. */
+#app-sidebar .tabsContainer .tab .ui-not-ready-placeholder {
+	/* Make the placeholder take the full tab height until the UI is ready. */
 	flex-grow: 1;
 }
 

--- a/css/files.scss
+++ b/css/files.scss
@@ -273,6 +273,14 @@
 	flex-grow: 1;
 }
 
+/* Hide other UI elements when there is a "UI not ready" placeholder. */
+#app-sidebar .tabsContainer .tab .ui-not-ready-placeholder ~ div,
+/* #chatView needs to be set explicitly to override the display property of
+ * "#app-sidebar #chatView". */
+#app-sidebar .tabsContainer .tab .ui-not-ready-placeholder ~ #chatView {
+	display: none;
+}
+
 #app-sidebar #chatView .comments {
 	padding-right: 15px;
 }

--- a/js/filesplugin.js
+++ b/js/filesplugin.js
@@ -325,6 +325,8 @@
 				return;
 			}
 
+			this.$el.prepend('<div class="ui-not-ready-placeholder icon-loading"></div>');
+
 			OCA.Talk.FilesPlugin.isTalkSidebarSupportedForFile(fileInfo).then(function(supported) {
 				if (supported) {
 					this._setFileInfoWhenTalkSidebarIsSupportedForFile(fileInfo);
@@ -344,6 +346,8 @@
 
 		_setFileInfoWhenTalkSidebarIsSupportedForFile: function(fileInfo) {
 			if (this.model === fileInfo) {
+				this.$el.find('.ui-not-ready-placeholder').remove();
+
 				// If the tab was hidden and it is being shown again at this
 				// point the tab has not been made visible yet, so the
 				// operations need to be delayed. However, the scroll position
@@ -388,6 +392,18 @@
 
 				return;
 			}
+
+			// Keep the placeholder visible until the messages for the new room
+			// have been received to prevent showing the messages of the
+			// previous room.
+			// The message collection is updated by the signaling, so there are
+			// no "sync" events to listen to. Moreover, this relies on the fact
+			// that the rooms are never empty (as there will be always at least
+			// a system message for the creation of the room) and thus at least
+			// one model will be always added, triggering the "update" event.
+			OCA.SpreedMe.app._messageCollection.once('update', function() {
+				this.$el.find('.ui-not-ready-placeholder').remove();
+			}, this);
 
 			this._roomForFileModel.join(this.model.get('id'));
 

--- a/js/filesplugin.js
+++ b/js/filesplugin.js
@@ -266,7 +266,7 @@
 			this.listenTo(roomsChannel, 'joinedRoom', this.setActiveRoom);
 			this.listenTo(roomsChannel, 'leaveCurrentRoom', this.setActiveRoom);
 
-			this.$el.append('<div class="app-not-started-placeholder icon-loading"></div>');
+			this.$el.append('<div class="ui-not-ready-placeholder icon-loading"></div>');
 		},
 
 		/**
@@ -457,7 +457,7 @@
 		setAppStarted: function() {
 			this._appStarted = true;
 
-			this.$el.find('.app-not-started-placeholder').remove();
+			this.$el.find('.ui-not-ready-placeholder').remove();
 
 			// Set again the file info now that the app has started.
 			if (this.model !== null) {

--- a/js/filesplugin.js
+++ b/js/filesplugin.js
@@ -467,7 +467,7 @@
 			// Force initial rendering; changes in the room state will
 			// automatically render the button again from now on.
 			this._callButton.render();
-			this._callButton.$el.prependTo(this.$el);
+			this._callButton.$el.insertBefore(OCA.SpreedMe.app._chatView.$el);
 		},
 
 		setAppStarted: function() {

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -84,8 +84,9 @@ class FilesController extends OCSController {
 	 * In any case, to create or even get the token of the room, the file must
 	 * be shared and the user must have direct access to that file; an error
 	 * is returned otherwise. A user has direct access to a file if she has
-	 * access to it through a user, group, circle or room share (but not through
-	 * a link share, for example), or if she is the owner of such a file.
+	 * access to it (or to an ancestor) through a user, group, circle or room
+	 * share (but not through a link share, for example), or if she is the owner
+	 * of such a file.
 	 *
 	 * @param string $fileId
 	 * @return DataResponse the status code is "200 OK" if a room is returned,

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -31,8 +31,10 @@ use OCA\Spreed\Manager;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
+use OCP\Files\NotFoundException;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\Share\IShare;
 
 class FilesController extends OCSController {
 
@@ -91,6 +93,7 @@ class FilesController extends OCSController {
 	 * @param string $fileId
 	 * @return DataResponse the status code is "200 OK" if a room is returned,
 	 *         or "404 Not found" if the given file id was invalid.
+	 * @throws OCSNotFoundException
 	 */
 	public function getRoom(string $fileId): DataResponse {
 		$share = $this->util->getAnyDirectShareOfFileAccessibleByUser($fileId, $this->currentUser);
@@ -101,8 +104,12 @@ class FilesController extends OCSController {
 		try {
 			$room = $this->manager->getRoomByObject('file', $fileId);
 		} catch (RoomNotFoundException $e) {
-			$node = $share->getNode();
-			$room = $this->manager->createPublicRoom($node->getName(), 'file', $fileId);
+			try {
+				$name = $this->getFileName($share, $fileId);
+			} catch (NotFoundException $e) {
+				throw new OCSNotFoundException($this->l->t('File is not shared, or shared but not with the user'));
+			}
+			$room = $this->manager->createPublicRoom($name, 'file', $fileId);
 		}
 
 		try {
@@ -114,6 +121,34 @@ class FilesController extends OCSController {
 		return new DataResponse([
 			'token' => $room->getToken()
 		]);
+	}
+
+	/**
+	 * Returns the name of the file in the share.
+	 *
+	 * If the given share itself is a file its name is returned; otherwise the
+	 * file is looked for in the given shared folder and its name is returned.
+	 *
+	 * @param IShare $share
+	 * @param string $fileId
+	 * @return string
+	 * @throws NotFoundException
+	 */
+	private function getFileName(IShare $share, string $fileId): string {
+		$node = $share->getNode();
+
+		if ($node->getType() === \OCP\Files\FileInfo::TYPE_FILE) {
+			return $node->getName();
+		}
+
+		$fileById = $node->getById($fileId);
+
+		if (empty($fileById)) {
+			throw new NotFoundException('File not found in share');
+		}
+
+		$file = array_shift($fileById);
+		return $file->getName();
 	}
 
 }

--- a/lib/Files/Listener.php
+++ b/lib/Files/Listener.php
@@ -36,9 +36,9 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * specific shared file, for example, when collaboratively editing it. The room
  * is persistent and can be accessed simultaneously by any user with direct
  * access (user, group, circle and room share, but not link share, for example)
- * to that file. The room has no owner, although self joined users become
- * persistent participants automatically when they join until they explicitly
- * leave or no longer have access to the file.
+ * to that file (or to an ancestor). The room has no owner, although self joined
+ * users become persistent participants automatically when they join until they
+ * explicitly leave or no longer have access to the file.
  *
  * These rooms are associated to a "file" object, and their custom behaviour is
  * provided by calling the methods of this class as a response to different room
@@ -84,9 +84,9 @@ class Listener {
 	 * Prevents users from joining if they do not have direct access to the
 	 * file.
 	 *
-	 * A user has direct access to a file if she received the file through a
-	 * user, group, circle or room share (but not through a link share, for
-	 * example), or if she is the owner of such a file.
+	 * A user has direct access to a file if she received the file (or an
+	 * ancestor) through a user, group, circle or room share (but not through a
+	 * link share, for example), or if she is the owner of such a file.
 	 *
 	 * This method should be called before a user joins a room.
 	 *


### PR DESCRIPTION
Fixes #1338 

Before rooms for files could be created only for files that were explicitly shared. Now, if a file is inside a shared folder, a room can be created for that room too even if the file itself is not explicitly shared. In that case the room is accessible to the same users that can access to the shared folder; if the file is later shared with someone else that user will be able to join the room too.

Unfortunately, the FileInfo that is used in the Files app to know whether a file is shared or not does not provide information about files that are inside a folder shared by the current user (although it does when the files are in a folder shared by a different user to the current user). When that information is not available now a query is made to the server to get that information.

Additionally, the Chat tab now shows a loading icon while the UI is not ready (that is, while waiting to know if the file is shared or not, or while getting the new chat messages when changing to a different room).
