### PR TITLE
Adjust tab header icons to changes in server

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -539,6 +539,9 @@
 	margin-top: 0;
 	margin-bottom: 10px;
 	min-height: 44px;
+
+	/* Prevent the chat view from vertically compressing the tab headers */
+	flex-shrink: 0;
 }
 
 .tabHeaders .tabHeader {
@@ -549,19 +552,18 @@
 	border-bottom: 1px solid $color-border;
 	margin-bottom: 0;
 
-	a {
-		padding-left: 32px;
-		background-position: 12px;
-		background-repeat: no-repeat;
+	.icon, a {
 		color: $color-main-text;
 		opacity: .5;
 	}
 }
 
-.tabHeaders .tabHeader.selected a,
-.tabHeaders .tabHeader:hover a,
-.tabHeaders .tabHeader:focus a {
-	opacity: 1;
+.tabHeaders .tabHeader.selected,
+.tabHeaders .tabHeader:hover,
+.tabHeaders .tabHeader:focus {
+	.icon, a {
+		opacity: 1;
+	}
 }
 /* END: move padding fixes and icons-for-tabs capability into core */
 

--- a/js/views/tabview.js
+++ b/js/views/tabview.js
@@ -29,7 +29,8 @@
 	OCA.SpreedMe.Views = OCA.SpreedMe.Views || {};
 
 	var TEMPLATE_TAB_HEADER_VIEW =
-		'<a href="#" class="{{icon}}">{{label}}</a>';
+		'<span class="icon {{icon}}"></span>' +
+		'<a href="#">{{label}}</a>';
 
 	var TEMPLATE_TAB_VIEW =
 		'<div class="tabHeaders">' +


### PR DESCRIPTION
In Nextcloud 15 icons were added to the tab headers in the sidebar; due to the shared CSS rules this broke the position of icons in the tab headers of Talk.

For consistency with the server, the tab header icons were not fixed to their previous position (to the left of the label), but to the same position used in the sidebar of the server (above the label).

![tab-header-icon](https://user-images.githubusercontent.com/26858233/49937724-f8c6c500-fed7-11e8-9d74-e616b72add61.png)
