### PR TITLE
Fetch another batch of initial messages if a whole batch was received.

### DIFF
--- a/js/signaling.js
+++ b/js/signaling.js
@@ -74,6 +74,7 @@
 		this.features = {};
 		this.pendingChatRequests = [];
 		this._lastChatMessagesFetch = null;
+		this.chatBatchSize = 100;
 	}
 
 	OCA.Talk.Signaling.Base = Base;
@@ -362,6 +363,7 @@
 	OCA.Talk.Signaling.Base.prototype._getChatRequestData = function(lastKnownMessageId) {
 		return {
 			lastKnownMessageId: lastKnownMessageId,
+			limit: this.chatBatchSize,
 			lookIntoFuture: 1
 		};
 	};
@@ -430,7 +432,9 @@
 
 		this._waitTimeUntilRetry = 1;
 
-		if (this.receiveMessagesAgain) {
+		// Fetch more messages if PHP backend or a whole batch has been received
+		// (more messages might be available in this case).
+		if (this.receiveMessagesAgain || (messages && messages.length === this.chatBatchSize)) {
 			this._receiveChatMessages();
 		}
 


### PR DESCRIPTION
Fixes #1395 where only the first batch was loaded initially.