### PR TITLE
Fix room name input width

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -705,6 +705,8 @@
 	.room-name {
 		display: block;
 
+		flex-grow: 1;
+
 		/* Limit the room name to the container width and prevent it from
 		 * wrapping the full label when using a flex display; this is needed for
 		 * the edit button and the ellipsis in the name to work as expected. */


### PR DESCRIPTION
Follow up to #1387

After moving the room name into a flex container the room name input no longer expanded to fill the whole width of the sidebar.
