### PR TITLE
Pass empty list of session ids when notifying about removed guests.

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -266,7 +266,10 @@ class Application extends App {
 			$notifier = $this->getBackendNotifier();
 
 			$room = $event->getSubject();
-			$notifier->participantsModified($room);
+			// TODO: The list of removed session ids should be passed through the event
+			// so the signaling server can optimize forwarding the message.
+			$sessionIds = [];
+			$notifier->participantsModified($room, $sessionIds);
 		});
 		$dispatcher->addListener(GuestManager::class . '::updateName', function(GenericEvent $event) {
 			/** @var BackendNotifier $notifier */


### PR DESCRIPTION
This is just a workaround that fixes #1408, the cleaner solution should be to get the list of session ids from the event and pass it along to the signaling server.
