### PR TITLE
Add global Content Security Policy for signaling servers

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -35,7 +35,9 @@ use OCA\Spreed\Settings\Personal;
 use OCA\Spreed\Signaling\BackendNotifier;
 use OCA\Spreed\Signaling\Messages;
 use OCP\AppFramework\App;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\IServerContainer;
+use OCP\Security\IContentSecurityPolicyManager;
 use OCP\Settings\IManager;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -65,6 +67,7 @@ class Application extends App {
 			$this->registerInternalSignalingHooks($dispatcher);
 		} else {
 			$this->registerSignalingBackendHooks($dispatcher);
+			$this->addContentSecurityPolicyForSignalingServers($servers);
 		}
 		$this->registerCallActivityHooks($dispatcher);
 		$this->registerRoomActivityHooks($dispatcher);
@@ -411,5 +414,30 @@ class Application extends App {
 			$roomShareProvider->deleteInRoom($room->getToken());
 		};
 		$dispatcher->addListener(Room::class . '::postDeleteRoom', $listener);
+	}
+
+	protected function addContentSecurityPolicyForSignalingServers(array $servers) {
+		$csp = new ContentSecurityPolicy();
+		foreach ($servers as $server) {
+			$csp->addAllowedConnectDomain($this->getWebSocketDomainForSignalingServer($server['server']));
+		}
+		$cspManager = $this->getContainer()->query(IContentSecurityPolicyManager::class);
+		$cspManager->addDefaultPolicy($csp);
+	}
+
+	protected function getWebSocketDomainForSignalingServer(string $url): string {
+		// Copied from Standalone constructor in "js/signaling.js".
+
+		if (strpos($url, 'https://') === 0) {
+			$url = 'wss://' . substr($url, 8);
+		} else if (strpos($url, 'http://') === 0) {
+			$url = 'ws://' . substr($url, 7);
+		}
+		if (substr($url, -1) === "/") {
+			$url = substr($url, 0, -1);
+		}
+		$url = $url . '/spreed';
+
+		return $url;
 	}
 }


### PR DESCRIPTION
The default Content Security Policy restricts connections only to the same domain of the page, so the domains of the web sockets used to connect to the standalone signaling servers must be explicitly allowed.

This has to be done for Nextcloud as a whole, as Talk is embedded in other apps by loading additional scripts in the browser, and thus it is not possible to set the Content Security Policy in the controllers that serve those apps.

@nickvergessen Can we remove `addAllowedConnectDomain('*')` from the [PageController](https://github.com/nextcloud/spreed/blob/3473a762763e98c0813823f801234030db97593e/lib/Controller/PageController.php) and [the ShareController in the server](https://github.com/nextcloud/server/commit/3febeb6ca71421135fd699374f8c979891b68186)? Or are all the domains allowed for any special reason?
