### PR TITLE
Add reason for removing participant from room

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -891,7 +891,7 @@ class RoomController extends OCSController {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
-		$room->removeUser($targetUser);
+		$room->removeUser($targetUser, Room::PARTICIPANT_REMOVED);
 		return new DataResponse([]);
 	}
 
@@ -919,7 +919,7 @@ class RoomController extends OCSController {
 				return new DataResponse([], Http::STATUS_NOT_FOUND);
 			}
 
-			$room->removeUser($currentUser);
+			$room->removeUser($currentUser, Room::PARTICIPANT_LEFT);
 		}
 
 		return new DataResponse([]);
@@ -965,7 +965,7 @@ class RoomController extends OCSController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		$room->removeParticipantBySession($targetParticipant);
+		$room->removeParticipantBySession($targetParticipant, Room::PARTICIPANT_REMOVED);
 		return new DataResponse([]);
 	}
 
@@ -1110,7 +1110,7 @@ class RoomController extends OCSController {
 
 			if ($this->userId === null) {
 				$participant = $room->getParticipantBySession($sessionId);
-				$room->removeParticipantBySession($participant);
+				$room->removeParticipantBySession($participant, Room::PARTICIPANT_LEFT);
 			} else {
 				$participant = $room->getParticipant($this->userId);
 				$room->leaveRoom($participant->getUser());

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -28,6 +28,7 @@ use OCA\Spreed\Config;
 use OCA\Spreed\Exceptions\RoomNotFoundException;
 use OCA\Spreed\Exceptions\ParticipantNotFoundException;
 use OCA\Spreed\Manager;
+use OCA\Spreed\Participant;
 use OCA\Spreed\Room;
 use OCA\Spreed\Signaling\Messages;
 use OCA\Spreed\TalkSession;
@@ -399,7 +400,7 @@ class SignalingController extends OCSController {
 			}
 		}
 
-		if ($participant === null) {
+		if (!$participant instanceof Participant) {
 			// User was not invited to the room, check for access to public room.
 			try {
 				$participant = $room->getParticipantBySession($sessionId);
@@ -422,8 +423,8 @@ class SignalingController extends OCSController {
 		} else if ($action === 'leave') {
 			if (!empty($userId)) {
 				$room->leaveRoom($userId);
-			} else if ($participant !== null) {
-				$room->removeParticipantBySession($participant);
+			} else if ($participant instanceof Participant) {
+				$room->removeParticipantBySession($participant, Room::PARTICIPANT_LEFT);
 			}
 		}
 

--- a/lib/Listener.php
+++ b/lib/Listener.php
@@ -51,7 +51,7 @@ class Listener {
 			if ($room->getType() === Room::ONE_TO_ONE_CALL || $room->getNumberOfParticipants() === 1) {
 				$room->deleteRoom();
 			} else {
-				$room->removeUser($user);
+				$room->removeUser($user, Room::PARTICIPANT_REMOVED);
 			}
 		}
 	}

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -27,6 +27,7 @@ use OCA\Spreed\Chat\CommentsManager;
 use OCA\Spreed\Config;
 use OCA\Spreed\Manager;
 use OCA\Spreed\Participant;
+use OCA\Spreed\Room;
 use OCA\Spreed\Signaling\BackendNotifier;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Http\Client\IClientService;
@@ -203,7 +204,7 @@ class BackendNotifierTest extends \Test\TestCase {
 		$testUser->expects($this->any())
 			->method('getUID')
 			->willReturn($this->userId);
-		$room->removeUser($testUser);
+		$room->removeUser($testUser, Room::PARTICIPANT_REMOVED);
 
 		$requests = $this->controller->getRequests();
 		$bodies = array_map(function($request) use ($room) {


### PR DESCRIPTION
The removeParticipantBySession function is called when a user is removed by a moderator and also when the user leaves by themselves, for a hook that performs an action when a user is removed there needs to be a flag to indicate that the moderator removed the user.  I have added a $reason parameter which can be 'remove' for a moderator and 'leave' if the user just left.