### PR TITLE
Fix display name of reshare with one-to-one room not invited to

### DIFF
--- a/lib/Share/Helper/ShareAPIController.php
+++ b/lib/Share/Helper/ShareAPIController.php
@@ -92,7 +92,9 @@ class ShareAPIController {
 		}
 
 		// The display name of one-to-one rooms is set to the display name of
-		// the other participant.
+		// the other participant, except on reshares to rooms that the user is
+		// not invited to, in which case the display name of both participants
+		// is used.
 		$roomName = $room->getName();
 		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
 			$userIds = $room->getParticipantUserIds();
@@ -100,7 +102,7 @@ class ShareAPIController {
 				if ($this->userId !== $userId) {
 					$user = $this->userManager->get($userId);
 					if ($user instanceof IUser) {
-						$roomName = $user->getDisplayName();
+						$roomName = $roomName? $roomName . $this->l->t(', ') . $user->getDisplayName(): $user->getDisplayName();
 					}
 				}
 			}

--- a/tests/integration/features/sharing/get.feature
+++ b/tests/integration/features/sharing/get.feature
@@ -320,7 +320,75 @@ Feature: get
       | storage_id             | home::participant1 |
       | file_target            | /welcome (2).txt |
       | share_with             | one-to-one room not invited to |
+      | share_with_displayname | participant3-displayname, participant4-displayname |
+
+  Scenario: get all shares and reshares of a user who reshared a file to an owned one-to-one room
+    Given user "participant2" creates room "one-to-one room not invited to"
+      | roomType | 1 |
+      | invite   | participant3 |
+    And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
+    When user "participant1" gets all shares and reshares
+    Then the list of returned shares has 2 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant2 |
+      | share_with_displayname | participant2-displayname |
+      | share_type             | 0 |
+    And share 1 is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | one-to-one room not invited to |
+      | share_with_displayname | participant2-displayname, participant3-displayname |
+
+  Scenario: get all shares and reshares of a user who reshared a file to a one-to-one room
+    Given user "participant2" creates room "one-to-one room not invited to"
+      | roomType | 1 |
+      | invite   | participant3 |
+    And user "participant1" shares "welcome.txt" with user "participant3" with OCS 100
+    And user "participant3" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
+    When user "participant1" gets all shares and reshares
+    Then the list of returned shares has 2 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant3 |
       | share_with_displayname | participant3-displayname |
+      | share_type             | 0 |
+    And share 1 is returned with
+      | uid_owner              | participant3 |
+      | displayname_owner      | participant3-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | one-to-one room not invited to |
+      | share_with_displayname | participant2-displayname, participant3-displayname |
 
   Scenario: get all shares of a file
     Given user "participant1" creates room "own group room"
@@ -459,7 +527,75 @@ Feature: get
       | storage_id             | home::participant1 |
       | file_target            | /welcome (2).txt |
       | share_with             | one-to-one room not invited to |
+      | share_with_displayname | participant3-displayname, participant4-displayname |
+
+  Scenario: get all shares and reshares of a file reshared to a one-to-one room by its owner
+    Given user "participant2" creates room "one-to-one room not invited to"
+      | roomType | 1 |
+      | invite   | participant3 |
+    And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
+    When user "participant1" gets all shares and reshares for "/welcome.txt"
+    Then the list of returned shares has 2 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant2 |
+      | share_with_displayname | participant2-displayname |
+      | share_type             | 0 |
+    And share 1 is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | one-to-one room not invited to |
+      | share_with_displayname | participant2-displayname, participant3-displayname |
+
+  Scenario: get all shares and reshares of a file reshared to a one-to-one room by its second participant
+    Given user "participant2" creates room "one-to-one room not invited to"
+      | roomType | 1 |
+      | invite   | participant3 |
+    And user "participant1" shares "welcome.txt" with user "participant3" with OCS 100
+    And user "participant3" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
+    When user "participant1" gets all shares and reshares for "/welcome.txt"
+    Then the list of returned shares has 2 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant3 |
       | share_with_displayname | participant3-displayname |
+      | share_type             | 0 |
+    And share 1 is returned with
+      | uid_owner              | participant3 |
+      | displayname_owner      | participant3-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | one-to-one room not invited to |
+      | share_with_displayname | participant2-displayname, participant3-displayname |
 
   Scenario: get all shares and reshares of a deleted file
     Given user "participant1" creates room "own group room"


### PR DESCRIPTION
The display name of reshares with one-to-one rooms not invited to was always set to the display name of the last participant. However, this happens since 4afa2d7946f121d07610eeb0165b20ee135fb819; before that the first participant was always used. Now the name of both participants in the room is used instead, which also fixes the integration tests that were broken in 4afa2d7946f121d07610eeb0165b20ee135fb819.
