### PR TITLE
Remove notifications when they are done

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -378,6 +378,16 @@ class Application extends App {
 			$notificationHooks->generateCallNotifications($room);
 		};
 		$dispatcher->addListener(Room::class . '::preSessionJoinCall', $listener);
+
+		$listener = function(GenericEvent $event) {
+			/** @var Room $room */
+			$room = $event->getSubject();
+
+			/** @var \OCA\Spreed\Notification\Hooks $notificationHooks */
+			$notificationHooks = $this->getContainer()->query(\OCA\Spreed\Notification\Hooks::class);
+			$notificationHooks->markCallNotificationsRead($room);
+		};
+		$dispatcher->addListener(Room::class . '::postSessionJoinCall', $listener);
 	}
 
 	protected function registerChatHooks(EventDispatcherInterface $dispatcher) {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -356,6 +356,16 @@ class Application extends App {
 			$notificationHooks->generateInvitation($room, $event->getArgument('users'));
 		};
 		$dispatcher->addListener(Room::class . '::postAddUsers', $listener);
+
+		$listener = function(GenericEvent $event) {
+			/** @var Room $room */
+			$room = $event->getSubject();
+
+			/** @var \OCA\Spreed\Notification\Hooks $notificationHooks */
+			$notificationHooks = $this->getContainer()->query(\OCA\Spreed\Notification\Hooks::class);
+			$notificationHooks->markInvitationRead($room);
+		};
+		$dispatcher->addListener(Room::class . '::postJoinRoom', $listener);
 	}
 
 	protected function registerCallNotificationHook(EventDispatcherInterface $dispatcher) {

--- a/lib/Notification/Hooks.php
+++ b/lib/Notification/Hooks.php
@@ -163,4 +163,28 @@ class Hooks {
 			}
 		}
 	}
+
+	/**
+	 * Call notification: "{user} wants to talk with you"
+	 *
+	 * @param Room $room
+	 */
+	public function markCallNotificationsRead(Room $room) {
+		$currentUser = $this->userSession->getUser();
+		if (!$currentUser instanceof IUser) {
+			return;
+		}
+
+		$notification = $this->notificationManager->createNotification();
+		try {
+			$notification->setApp('spreed')
+				->setUser($currentUser->getUID())
+				->setObject('call', $room->getToken())
+				->setSubject('call');
+			$this->notificationManager->markProcessed($notification);
+		} catch (\InvalidArgumentException $e) {
+			$this->logger->logException($e, ['app' => 'spreed']);
+			return;
+		}
+	}
 }

--- a/lib/Notification/Hooks.php
+++ b/lib/Notification/Hooks.php
@@ -58,7 +58,6 @@ class Hooks {
 		}
 		$actorId = $actor->getUID();
 
-
 		$notification = $this->notificationManager->createNotification();
 		$dateTime = new \DateTime();
 		try {
@@ -85,6 +84,30 @@ class Hooks {
 			} catch (\InvalidArgumentException $e) {
 				$this->logger->logException($e, ['app' => 'spreed']);
 			}
+		}
+	}
+
+	/**
+	 * Room invitation: "{actor} invited you to {call}"
+	 *
+	 * @param Room $room
+	 */
+	public function markInvitationRead(Room $room) {
+		$currentUser = $this->userSession->getUser();
+		if (!$currentUser instanceof IUser) {
+			return;
+		}
+
+		$notification = $this->notificationManager->createNotification();
+		try {
+			$notification->setApp('spreed')
+				->setUser($currentUser->getUID())
+				->setObject('room', $room->getToken())
+				->setSubject('invitation');
+			$this->notificationManager->markProcessed($notification);
+		} catch (\InvalidArgumentException $e) {
+			$this->logger->logException($e, ['app' => 'spreed']);
+			return;
 		}
 	}
 


### PR DESCRIPTION
@jancborchardt now I got what you meant, this does now:

* Remove "{actor} invited you to {conversation}" notification when the user opened the conversation
* Remove "{user} wants to talk with you"/"A group call started in {conversation}" notification when the participant joins the call

The notifications already vanished when you clicked on them directly instead of going to the place yourself or used an app.

Ref https://github.com/nextcloud/notifications/issues/250