### PR TITLE
Fix browser history

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -572,7 +572,7 @@
 					return;
 				}
 
-				OC.Util.History.pushState({}, OC.generateUrl('/apps/spreed'));
+				OC.Util.History.replaceState({}, OC.generateUrl('/apps/spreed'));
 			});
 
 			this._mediaControlsView = new OCA.SpreedMe.Views.MediaControlsView({

--- a/js/app.js
+++ b/js/app.js
@@ -558,6 +558,10 @@
 					return;
 				}
 
+				if (this._popingState) {
+					return;
+				}
+
 				OC.Util.History.pushState({
 					token: token
 				}, OC.generateUrl('/call/' + token));
@@ -680,7 +684,9 @@
 		},
 		_onPopState: function(params) {
 			if (!_.isUndefined(params.token)) {
+				this._popingState = true;
 				this.connection.joinRoom(params.token);
+				delete this._popingState;
 			}
 		},
 		onDocumentClick: function(event) {

--- a/js/app.js
+++ b/js/app.js
@@ -553,6 +553,24 @@
 				$('#emptycontent').show();
 			});
 
+			this.listenTo(roomChannel, 'joinRoom', function(token) {
+				if (OCA.Talk.PublicShareAuth) {
+					return;
+				}
+
+				OC.Util.History.pushState({
+					token: token
+				}, OC.generateUrl('/call/' + token));
+			});
+
+			this.listenTo(roomChannel, 'leaveCurrentRoom', function() {
+				if (OCA.Talk.PublicShareAuth) {
+					return;
+				}
+
+				OC.Util.History.pushState({}, OC.generateUrl('/apps/spreed'));
+			});
+
 			this._mediaControlsView = new OCA.SpreedMe.Views.MediaControlsView({
 				app: this,
 				webrtc: OCA.SpreedMe.webrtc,

--- a/js/connection.js
+++ b/js/connection.js
@@ -88,11 +88,7 @@
 			this.app.token = token;
 			this.app.signaling.joinRoom(token);
 
-			if (!OCA.Talk.PublicShareAuth) {
-				OC.Util.History.pushState({
-					token: token
-				}, OC.generateUrl('/call/' + token));
-			}
+			roomsChannel.trigger('joinRoom', token);
 
 			this.app.syncAndSetActiveRoom(token);
 			$('#video-fullscreen').removeClass('hidden');
@@ -100,9 +96,7 @@
 		leaveCurrentRoom: function() {
 			$('#video-fullscreen').addClass('hidden');
 			this.app.signaling.leaveCurrentRoom();
-			if (!OCA.Talk.PublicShareAuth) {
-				OC.Util.History.pushState({}, OC.generateUrl('/apps/spreed'));
-			}
+
 			$(this.app.mainCallElementSelector).removeClass('incall');
 
 			roomsChannel.trigger('leaveCurrentRoom');


### PR DESCRIPTION
Fixes #1445 

Also fixes the browser history in the main Talk UI in these two scenarios:

**Scenario 1:**
- Join conversation 1
- Join conversation 2
- Go back in history

Result with this pull request:
It is possible to go forward in history to the conversation 2 again.

Result without this pull request:
It is not possible to go forward in history.



**Scenario 2:**
- Join conversation 1
- Join conversation 2
- Leave conversation 2
- Go back in history

Result with this pull request:
Conversation 1 is loaded.

Result without this pull request:
The whole Talk UI is reloaded.
