### PR TITLE
Fix page title not updated when room name is updated

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -325,6 +325,7 @@
 			var self = this;
 			this.signaling.syncRooms()
 				.then(function() {
+					self.stopListening(self.activeRoom, 'change:displayName');
 					self.stopListening(self.activeRoom, 'change:participantFlags');
 
 					var participants;
@@ -350,6 +351,9 @@
 					self._emptyContentView.setActiveRoom(self.activeRoom);
 
 					self.setPageTitle(self.activeRoom.get('displayName'));
+					self.listenTo(self.activeRoom, 'change:displayName', function(model, value) {
+						self.setPageTitle(value);
+					});
 
 					self.updateContentsLayout();
 					self.listenTo(self.activeRoom, 'change:participantFlags', self.updateContentsLayout);

--- a/js/app.js
+++ b/js/app.js
@@ -576,6 +576,8 @@
 					return;
 				}
 
+				this.setPageTitle(null);
+
 				OC.Util.History.replaceState({}, OC.generateUrl('/apps/spreed'));
 			});
 


### PR DESCRIPTION
**Scenario 1**
**How to test:**
- Create a new room / Open in a room as a moderator
- Change room name

**Result with this pull request:**
The page title is updated with the new name.

**Result without this pull request:**
The page title keeps showing the old name.

**Scenario 2**
**How to test:**
- Join a room
- Leave or delete the room

**Result with this pull request:**
The page title is set to the default Talk title.

**Result without this pull request:**
The page title keeps showing the name of the left or deleted room.
