### PR TITLE
Fix submit button in public share authentication page

### DIFF
--- a/css/publicshareauth.scss
+++ b/css/publicshareauth.scss
@@ -232,3 +232,9 @@ input#request-password-button:disabled ~ .icon {
 #talk-sidebar input.icon-confirm[type="submit"] {
 	top: unset;
 }
+
+/* Unset conflicting rules from guest.css for the sidebar */
+#talk-sidebar input[type="submit"].hidden,
+#talk-sidebar input.icon-confirm[type="submit"].hidden {
+	display: none;
+}

--- a/css/publicshareauth.scss
+++ b/css/publicshareauth.scss
@@ -226,3 +226,9 @@ input#request-password-button:disabled ~ .icon {
 	width: unset;
 	margin: 0;
 }
+
+/* Unset conflicting rules from publicshareauth.css (core) for the sidebar */
+#talk-sidebar input[type="submit"],
+#talk-sidebar input.icon-confirm[type="submit"] {
+	top: unset;
+}


### PR DESCRIPTION
**Before:**
![publicshareauth-submit-before](https://user-images.githubusercontent.com/26858233/51834661-49b14200-22fb-11e9-84df-223d6ab4c442.png)

**After:**
![publicshareauth-submit-after](https://user-images.githubusercontent.com/26858233/51834670-4f0e8c80-22fb-11e9-8908-f06f05faecf9.png)

**Before:**
![publicshareauth-submit-sending-before](https://user-images.githubusercontent.com/26858233/51834663-4b7b0580-22fb-11e9-961e-324ccf5080c7.png)

**After:**
![publicshareauth-submit-sending-after](https://user-images.githubusercontent.com/26858233/51834672-50d85000-22fb-11e9-8ebf-a931c62f921c.png)

