### PR TITLE
Show autocompletion as soon as "@" is typed

### DIFF
--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -126,9 +126,6 @@
 		_onAutoComplete: function(query, callback) {
 			var self = this;
 
-			if(_.isEmpty(query)) {
-				return;
-			}
 			if(!_.isUndefined(this._autoCompleteRequestTimer)) {
 				clearTimeout(this._autoCompleteRequestTimer);
 			}


### PR DESCRIPTION
In order to show the autocompletion it was needed to type at least another character after _@_, so only the mentions that matched that character were shown. Now the autocompletion is shown as soon as _@_ is typed, which shows all the possible mentions in the room.
