### PR TITLE
Cannot use OCP\Util as Util because the name is already in use

### DIFF
--- a/lib/Files/TemplateLoader.php
+++ b/lib/Files/TemplateLoader.php
@@ -24,9 +24,7 @@ declare(strict_types=1);
 
 namespace OCA\Spreed\Files;
 
-use OCP\Util;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Helper class to add the Talk UI to the sidebar of the Files app.
@@ -54,8 +52,8 @@ class TemplateLoader {
 	 * Files app.
 	 */
 	public function loadTalkSidebarForFilesApp() {
-		Util::addStyle('spreed', 'merged-files');
-		Util::addScript('spreed', 'merged-files');
+		\OCP\Util::addStyle('spreed', 'merged-files');
+		\OCP\Util::addScript('spreed', 'merged-files');
 	}
 
 }


### PR DESCRIPTION
Fix #1489 

No problem in master, because this is allowed and valid in 7.1+, but 15 still supports 7.0 where it fails.