### PR TITLE
Do not show room names when the user is not part of it

### DIFF
--- a/tests/integration/features/sharing/get.feature
+++ b/tests/integration/features/sharing/get.feature
@@ -320,7 +320,7 @@ Feature: get
       | storage_id             | home::participant1 |
       | file_target            | /welcome (2).txt |
       | share_with             | one-to-one room not invited to |
-      | share_with_displayname | participant3-displayname, participant4-displayname |
+      | share_with_displayname | Private conversation|
 
   Scenario: get all shares and reshares of a user who reshared a file to an owned one-to-one room
     Given user "participant2" creates room "one-to-one room not invited to"
@@ -354,7 +354,7 @@ Feature: get
       | storage_id             | home::participant1 |
       | file_target            | /welcome (2).txt |
       | share_with             | one-to-one room not invited to |
-      | share_with_displayname | participant2-displayname, participant3-displayname |
+      | share_with_displayname | Private conversation |
 
   Scenario: get all shares and reshares of a user who reshared a file to a one-to-one room
     Given user "participant2" creates room "one-to-one room not invited to"
@@ -388,7 +388,7 @@ Feature: get
       | storage_id             | home::participant1 |
       | file_target            | /welcome (2).txt |
       | share_with             | one-to-one room not invited to |
-      | share_with_displayname | participant2-displayname, participant3-displayname |
+      | share_with_displayname | Private conversation |
 
   Scenario: get all shares of a file
     Given user "participant1" creates room "own group room"
@@ -527,7 +527,7 @@ Feature: get
       | storage_id             | home::participant1 |
       | file_target            | /welcome (2).txt |
       | share_with             | one-to-one room not invited to |
-      | share_with_displayname | participant3-displayname, participant4-displayname |
+      | share_with_displayname | Private conversation |
 
   Scenario: get all shares and reshares of a file reshared to a one-to-one room by its owner
     Given user "participant2" creates room "one-to-one room not invited to"
@@ -561,7 +561,7 @@ Feature: get
       | storage_id             | home::participant1 |
       | file_target            | /welcome (2).txt |
       | share_with             | one-to-one room not invited to |
-      | share_with_displayname | participant2-displayname, participant3-displayname |
+      | share_with_displayname | Private conversation |
 
   Scenario: get all shares and reshares of a file reshared to a one-to-one room by its second participant
     Given user "participant2" creates room "one-to-one room not invited to"
@@ -595,7 +595,7 @@ Feature: get
       | storage_id             | home::participant1 |
       | file_target            | /welcome (2).txt |
       | share_with             | one-to-one room not invited to |
-      | share_with_displayname | participant2-displayname, participant3-displayname |
+      | share_with_displayname | Private conversation |
 
   Scenario: get all shares and reshares of a deleted file
     Given user "participant1" creates room "own group room"


### PR DESCRIPTION
Follow up to #1426 

Views:
* Black - Owner of the files
* White - Owner of the rooms

Shares:
* Shared to room "Playdowns"
* Shared to room without a name set
* Shared in one-to-one conversation between test1 and test2

> ![bildschirmfoto von 2019-01-30 12-14-09](https://user-images.githubusercontent.com/213943/51977815-c02f7a80-2488-11e9-8979-133ee7035f1a.png)
