### PR TITLE
Fix the fix for icons in dark mode

### DIFF
--- a/css/files.scss
+++ b/css/files.scss
@@ -163,6 +163,13 @@
 	display: none;
 }
 
+/* Force the white icon during calls, independent from white/dark mode
+ * selection, because it is shown on the black calling screen. */
+#app-sidebar .icon-close.force-icon-white-in-call.icon-shadow {
+	background-image: url(icon-color-path('close', 'actions', 'fff', 1, true));
+	filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
+}
+
 
 
 

--- a/css/style.scss
+++ b/css/style.scss
@@ -312,6 +312,12 @@ input[type="password"] {
 	&.icon-fullscreen {
 		background-image: url(icon-color-path('fullscreen', 'actions', 'fff', 1, true));
 	}
+
+	/* ".force-icon-white-in-call" can be combined with ".icon-shadow" just like
+	 * ".icon-white". */
+	&.icon-shadow {
+		filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
+	}
 }
 
 /* Use white icon for the app navigation toggle when in a call; this can not be

--- a/css/style.scss
+++ b/css/style.scss
@@ -298,32 +298,6 @@ input[type="password"] {
 	}
 }
 
-#app-content:not(.incall):not(.screensharing) .force-icon-white-in-call {
-	/*
-	 * Also force the white icons, when the video of the local participant is shown,
-	 * because the black icons are not visible on videos, especially when your camera is covered.
-	 */
-	&#hideVideo:not(.local-video-disabled) {
-		&.icon-video {
-			background-image: url(icon-color-path('video', 'actions', 'fff', 1, true));
-		}
-		&.icon-video-off {
-			background-image: url(icon-color-path('video-off', 'actions', 'fff', 1, true));
-		}
-	}
-	&#mute:not(.local-video-disabled) {
-		&.icon-audio {
-			background-image: url(icon-color-path('audio', 'actions', 'fff', 1, true));
-		}
-		&.icon-audio-off {
-			background-image: url(icon-color-path('audio-off', 'actions', 'fff', 1, true));
-		}
-	}
-	&#screensharing-button:not(.local-video-disabled) {
-		background-image: url(icon-color-path('screen-off', 'actions', 'fff', 1, true));
-	}
-}
-
 #app-content.incall .force-icon-white-in-call,
 #app-content.screensharing .force-icon-white-in-call,
 #app-content.incall ~ #app-sidebar-wrapper .force-icon-white-in-call,
@@ -337,24 +311,6 @@ input[type="password"] {
 	}
 	&.icon-fullscreen {
 		background-image: url(icon-color-path('fullscreen', 'actions', 'fff', 1, true));
-	}
-	&.icon-audio {
-		background-image: url(icon-color-path('audio', 'actions', 'fff', 1, true));
-	}
-	&.icon-audio-off {
-		background-image: url(icon-color-path('audio-off', 'actions', 'fff', 1, true));
-	}
-	&.icon-video {
-		background-image: url(icon-color-path('video', 'actions', 'fff', 1, true));
-	}
-	&.icon-video-off {
-		background-image: url(icon-color-path('video-off', 'actions', 'fff', 1, true));
-	}
-	&.icon-screen {
-		background-image: url(icon-color-path('screen', 'actions', 'fff', 1, true));
-	}
-	&.icon-screen-off {
-		background-image: url(icon-color-path('screen-off', 'actions', 'fff', 1, true));
 	}
 }
 

--- a/css/style.scss
+++ b/css/style.scss
@@ -314,10 +314,12 @@ input[type="password"] {
 	}
 }
 
-/* Use white icon for the app navigation toggle when in a call */
+/* Use white icon for the app navigation toggle when in a call; this can not be
+ * integrated above because the navigation toggle is created by the core and
+ * does not include the Talk-specific "force-icon-white-in-call" CSS class. */
 #app-content.incall .icon-menu,
 #app-content.screensharing .icon-menu {
-	@include icon-color('menu', 'actions', $color-white, 1, true);
+	background-image: url(icon-color-path('menu', 'actions', 'fff', 1, true));
 	filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
 }
 

--- a/css/style.scss
+++ b/css/style.scss
@@ -298,8 +298,7 @@ input[type="password"] {
 	}
 }
 
-#app-content:not(.incall):not(.screensharing) .force-icon-white-in-call,
-#app-content:not(.incall):not(.screensharing) ~ #app-sidebar-wrapper .force-icon-white-in-call {
+#app-content:not(.incall):not(.screensharing) .force-icon-white-in-call {
 	/*
 	 * Also force the white icons, when the video of the local participant is shown,
 	 * because the black icons are not visible on videos, especially when your camera is covered.

--- a/css/video.scss
+++ b/css/video.scss
@@ -347,7 +347,9 @@ video {
 
 
 
-#app-content:not(.incall):not(.screensharing) .force-icon-white-in-call {
+#app-content:not(.incall):not(.screensharing) .force-icon-white-in-call,
+#talk-sidebar:not(.incall):not(.screensharing) .force-icon-white-in-call,
+#call-container:not(.incall):not(.screensharing) .force-icon-white-in-call {
 	/*
 	 * Also force the white icons, when the video of the local participant is shown,
 	 * because the black icons are not visible on videos, especially when your camera is covered.
@@ -373,8 +375,8 @@ video {
 	}
 }
 
-#app-content.incall .force-icon-white-in-call,
-#app-content.screensharing .force-icon-white-in-call {
+.incall .force-icon-white-in-call,
+.screensharing .force-icon-white-in-call {
 	/*
 	 * Force the white icon, independent from white/dark mode selection,
 	 * because those icons are presented on our black calling-screen.

--- a/css/video.scss
+++ b/css/video.scss
@@ -346,6 +346,63 @@ video {
 
 
 
+
+#app-content:not(.incall):not(.screensharing) .force-icon-white-in-call {
+	/*
+	 * Also force the white icons, when the video of the local participant is shown,
+	 * because the black icons are not visible on videos, especially when your camera is covered.
+	 */
+	&#hideVideo:not(.local-video-disabled) {
+		&.icon-video {
+			background-image: url(icon-color-path('video', 'actions', 'fff', 1, true));
+		}
+		&.icon-video-off {
+			background-image: url(icon-color-path('video-off', 'actions', 'fff', 1, true));
+		}
+	}
+	&#mute:not(.local-video-disabled) {
+		&.icon-audio {
+			background-image: url(icon-color-path('audio', 'actions', 'fff', 1, true));
+		}
+		&.icon-audio-off {
+			background-image: url(icon-color-path('audio-off', 'actions', 'fff', 1, true));
+		}
+	}
+	&#screensharing-button:not(.local-video-disabled) {
+		background-image: url(icon-color-path('screen-off', 'actions', 'fff', 1, true));
+	}
+}
+
+#app-content.incall .force-icon-white-in-call,
+#app-content.screensharing .force-icon-white-in-call {
+	/*
+	 * Force the white icon, independent from white/dark mode selection,
+	 * because those icons are presented on our black calling-screen.
+	 */
+	&.icon-audio {
+		background-image: url(icon-color-path('audio', 'actions', 'fff', 1, true));
+	}
+	&.icon-audio-off {
+		background-image: url(icon-color-path('audio-off', 'actions', 'fff', 1, true));
+	}
+	&.icon-video {
+		background-image: url(icon-color-path('video', 'actions', 'fff', 1, true));
+	}
+	&.icon-video-off {
+		background-image: url(icon-color-path('video-off', 'actions', 'fff', 1, true));
+	}
+	&.icon-screen {
+		background-image: url(icon-color-path('screen', 'actions', 'fff', 1, true));
+	}
+	&.icon-screen-off {
+		background-image: url(icon-color-path('screen-off', 'actions', 'fff', 1, true));
+	}
+}
+
+
+
+
+
 #videos .videoContainer.speaking:not(.videoView) .nameIndicator,
 #videos .videoContainer.videoView.speaking .nameIndicator .icon-audio {
 	animation: pulse 1s;

--- a/css/video.scss
+++ b/css/video.scss
@@ -357,21 +357,26 @@ video {
 	&#hideVideo:not(.local-video-disabled) {
 		&.icon-video {
 			background-image: url(icon-color-path('video', 'actions', 'fff', 1, true));
+			filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
 		}
 		&.icon-video-off {
 			background-image: url(icon-color-path('video-off', 'actions', 'fff', 1, true));
+			filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
 		}
 	}
 	&#mute:not(.local-video-disabled) {
 		&.icon-audio {
 			background-image: url(icon-color-path('audio', 'actions', 'fff', 1, true));
+			filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
 		}
 		&.icon-audio-off {
 			background-image: url(icon-color-path('audio-off', 'actions', 'fff', 1, true));
+			filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
 		}
 	}
 	&#screensharing-button:not(.local-video-disabled) {
 		background-image: url(icon-color-path('screen-off', 'actions', 'fff', 1, true));
+		filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
 	}
 }
 
@@ -398,6 +403,12 @@ video {
 	}
 	&.icon-screen-off {
 		background-image: url(icon-color-path('screen-off', 'actions', 'fff', 1, true));
+	}
+
+	/* ".force-icon-white-in-call" can be combined with ".icon-shadow" just like
+	 * ".icon-white". */
+	&.icon-shadow {
+		filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
 	}
 }
 

--- a/js/filesplugin.js
+++ b/js/filesplugin.js
@@ -207,7 +207,7 @@
 			// waiting for other participants it should be kept black. However,
 			// this would need to hook in "updateParticipantsUI" which is where
 			// the "incall" class is set.
-			$('#app-sidebar .icon-close').addClass('icon-white icon-shadow');
+			$('#app-sidebar .icon-close').addClass('force-icon-white-in-call icon-shadow');
 		},
 
 		_hideCallUi: function() {
@@ -221,7 +221,7 @@
 			});
 
 			// Restore the icon to close the sidebar.
-			$('#app-sidebar .icon-close').removeClass('icon-white icon-shadow');
+			$('#app-sidebar .icon-close').removeClass('force-icon-white-in-call icon-shadow');
 
 			if (!this._$callContainerWrapper || this._$callContainerWrapper.hasClass('hidden')) {
 				return;


### PR DESCRIPTION
Follow up to #1485

This pull request fixes:
- The video buttons in the public share authentication page and in the Files app
- The navigation toggle during a call in the main Talk UI with dark mode
- The close button during a call in the Files app with dark mode
- The shadows on icons forced to white colour
