### PR TITLE
Fix editable text label for guest names

### DIFF
--- a/css/publicshareauth.scss
+++ b/css/publicshareauth.scss
@@ -227,6 +227,10 @@ input#request-password-button:disabled ~ .icon {
 	margin: 0;
 }
 
+#talk-sidebar .button {
+	display: unset;
+}
+
 /* Unset conflicting rules from publicshareauth.css (core) for the sidebar */
 #talk-sidebar input[type="submit"],
 #talk-sidebar input.icon-confirm[type="submit"] {

--- a/css/publicshareauth.scss
+++ b/css/publicshareauth.scss
@@ -231,10 +231,39 @@ input#request-password-button:disabled ~ .icon {
 	display: unset;
 }
 
+/* Restore rules from input.scss overriden by guest.css for the sidebar */
+#talk-sidebar input:not([type='range']) {
+	margin: 3px 3px 3px 0;
+	padding: 7px 6px;
+	font-size: 13px;
+	border: 1px solid var(--color-border-dark);
+	box-sizing: border-box;
+
+	&:not(:disabled):not(.primary) {
+		&:hover,
+		&:focus {
+			border-color: var(--color-primary-element);
+		}
+	}
+}
+
+#talk-sidebar input[type="text"],
+#talk-sidebar input[type="password"] {
+	width: 130px;
+
+	padding-right: 34px;
+}
+
 /* Unset conflicting rules from publicshareauth.css (core) for the sidebar */
 #talk-sidebar input[type="submit"],
 #talk-sidebar input.icon-confirm[type="submit"] {
 	top: unset;
+}
+
+#talk-sidebar .guest-name input.icon-confirm[type="submit"] {
+	top: -5px;
+	right: 0px;
+	border: none;
 }
 
 /* Unset conflicting rules from guest.css for the sidebar */

--- a/css/style.scss
+++ b/css/style.scss
@@ -734,10 +734,6 @@ input[type="password"] {
 			.edit-button {
 				display: none;
 
-				/* Use the same bottom margin as h2 (defined in the server) to
-				 * align the button vertically with the label. */
-				margin-bottom: 12px;
-
 				.icon {
 					background-color: transparent;
 					border: none;
@@ -751,10 +747,6 @@ input[type="password"] {
 		}
 		.input-wrapper {
 			position: relative;
-
-			/* Pull up the wrapper slightly to prevent elements below it from
-			 * moving when it is shown. */
-			margin-top: -2px;
 
 			input[type="text"] {
 				& + .icon-confirm {
@@ -818,14 +810,26 @@ input[type="password"] {
 		 * the edit button and the ellipsis in the name to work as expected. */
 		overflow: hidden;
 
-		.label {
-			white-space: nowrap;
-			text-overflow: ellipsis;
-			overflow: hidden;
+		.label-wrapper {
+			.label {
+				white-space: nowrap;
+				text-overflow: ellipsis;
+				overflow: hidden;
+			}
+
+			.edit-button {
+				/* Use the same bottom margin as h2 (defined in the server) to
+				 * align the button vertically with the label. */
+				margin-bottom: 12px;
+			}
 		}
 
 		.input-wrapper {
 			position: relative;
+
+			/* Pull up the wrapper slightly to prevent elements below it from
+			 * moving when it is shown. */
+			margin-top: -2px;
 
 			.username {
 				width: 100%;


### PR DESCRIPTION
This pull request fixes the edit button for guest names in public chats and in the public share authentication page, and the input for guest names in the public share authentication page.

**Edit button, before:**
![guest-name-edit-before](https://user-images.githubusercontent.com/26858233/52212256-5bab5b80-288c-11e9-962e-23118f65ab75.png)

**Edit button, after:**
![guest-name-edit-after](https://user-images.githubusercontent.com/26858233/52212266-5e0db580-288c-11e9-9fec-4bd27126d41a.png)

**Input, before:**
![guest-name-input-before](https://user-images.githubusercontent.com/26858233/52212271-5fd77900-288c-11e9-8872-0d1c411b2949.png)

**Input, after:**
![guest-name-input-after](https://user-images.githubusercontent.com/26858233/52212277-6239d300-288c-11e9-9891-2f10e3db2abf.png)
