### PR TITLE
Add acceptance tests for requesting the password of a link share

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -269,6 +269,8 @@ matrix:
     - TESTS: acceptance
       TESTS_ACCEPTANCE: conversation
     - TESTS: acceptance
+      TESTS_ACCEPTANCE: public-share-auth
+    - TESTS: acceptance
       TESTS_ACCEPTANCE: room-shares
 
 services:

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -17,6 +17,7 @@ default:
         - FilesAppContext
         - FilesAppSharingContext
         - LoginPageContext
+        - PublicShareContext
 
         # Talk app contexts
         - ChatContext
@@ -25,6 +26,7 @@ default:
         - FilesAppChatTabContext
         - FilesAppRoomSharingContext
         - ParticipantListContext
+        - PublicSharePasswordRequestContext
         - TalkAppContext
 
   extensions:

--- a/tests/acceptance/features/bootstrap/PublicSharePasswordRequestContext.php
+++ b/tests/acceptance/features/bootstrap/PublicSharePasswordRequestContext.php
@@ -26,6 +26,7 @@ use Behat\Behat\Context\Context;
 class PublicSharePasswordRequestContext implements Context, ActorAwareInterface {
 
 	use ActorAware;
+	use ChatAncestorSetter;
 
 	/**
 	 * @return Locator
@@ -33,6 +34,23 @@ class PublicSharePasswordRequestContext implements Context, ActorAwareInterface 
 	public static function requestPasswordButton() {
 		return Locator::forThe()->button("Request password")->
 				describedAs("Request password button in the public share authentication page");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function talkSidebar() {
+		return Locator::forThe()->css("#talk-sidebar")->
+				describedAs("Talk sidebar in the public share authentication page");
+	}
+
+	/**
+	 * @When I request the password
+	 */
+	public function iRequestThePassword() {
+		$this->actor->find(self::requestPasswordButton(), 10)->click();
+
+		$this->setChatAncestorForActor(self::talkSidebar(), $this->actor);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/PublicSharePasswordRequestContext.php
+++ b/tests/acceptance/features/bootstrap/PublicSharePasswordRequestContext.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use Behat\Behat\Context\Context;
+
+class PublicSharePasswordRequestContext implements Context, ActorAwareInterface {
+
+	use ActorAware;
+
+	/**
+	 * @return Locator
+	 */
+	public static function requestPasswordButton() {
+		return Locator::forThe()->button("Request password")->
+				describedAs("Request password button in the public share authentication page");
+	}
+
+	/**
+	 * @Then I see that the request password button is shown
+	 */
+	public function iSeeThatTheRequestPasswordButtonIsShown() {
+		if (!WaitFor::elementToBeEventuallyShown(
+				$this->actor,
+				self::requestPasswordButton(),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("The request password button is not shown yet after $timeout seconds");
+		}
+	}
+
+	/**
+	 * @Then I see that the request password button is not shown
+	 */
+	public function iSeeThatTheRequestPasswordButtonIsNotShown() {
+		try {
+			// Wait a little before deciding that the button is not shown, as
+			// the button would be loaded after the page has loaded.
+			PHPUnit_Framework_Assert::assertFalse(
+					$this->actor->find(self::requestPasswordButton(), 5)->isVisible());
+		} catch (NoSuchElementException $exception) {
+		}
+	}
+
+}

--- a/tests/acceptance/features/public-share-auth.feature
+++ b/tests/acceptance/features/public-share-auth.feature
@@ -25,3 +25,58 @@ Feature: public share auth
     And I visit the shared link I wrote down
     Then I see that the current page is the Authenticate page for the shared link I wrote down
     And I see that the request password button is not shown
+
+
+
+  Scenario: chat in the authentication page of a link share with a password protected by Talk
+    Given I act as John
+    And I am logged in
+    And I share the link for "welcome.txt" protected by the password "abcdef"
+    And I set the password of the shared link as protected by Talk
+    And I see that the password of the link share is protected by Talk
+    And I write down the shared link
+    And I act as Jane
+    And I visit the shared link I wrote down
+    And I see that the current page is the Authenticate page for the shared link I wrote down
+    When I request the password
+    And I send a new chat message with the text "Hello"
+    And I see that the message 1 was sent by "Guest" with the text "Hello"
+    And I act as John
+    And I have opened the Talk app
+    And I open the "Password request: welcome.txt" conversation
+    And I send a new chat message with the text "Hi!"
+    Then I see that the message 1 was sent by "Guest" with the text "Hello"
+    And I see that the message 2 was sent by "user0" with the text "Hi!"
+    And I act as Jane
+    And I see that the message 1 was sent by "Guest" with the text "Hello"
+    And I see that the message 2 was sent by "user0" with the text "Hi!"
+
+  Scenario: access a link share with a password protected by Talk after a chat
+    Given I act as John
+    And I am logged in
+    And I share the link for "welcome.txt" protected by the password "abcdef"
+    And I set the password of the shared link as protected by Talk
+    And I see that the password of the link share is protected by Talk
+    And I write down the shared link
+    And I act as Jane
+    And I visit the shared link I wrote down
+    And I see that the current page is the Authenticate page for the shared link I wrote down
+    And I request the password
+    And I send a new chat message with the text "Hello"
+    And I see that the message 1 was sent by "Guest" with the text "Hello"
+    And I act as John
+    And I have opened the Talk app
+    And I open the "Password request: welcome.txt" conversation
+    And I send a new chat message with the text "Hi!"
+    When I act as Jane
+    And I see that the message 2 was sent by "user0" with the text "Hi!"
+    And I authenticate with password "abcdef"
+    Then I see that the current page is the shared link I wrote down
+    And I see that the shared file preview shows the text "Welcome to your Nextcloud account!"
+    And I act as John
+    And I see that the "Password request: welcome.txt" conversation is not shown in the list
+    # This fails when run without any timeout multiplier, as currently the empty
+    # content message is shown after receiving several 404 errors instead of on
+    # the first one.
+    And I see that the "This conversation has ended" empty content message is shown in the main view
+    And I see that the sidebar is closed

--- a/tests/acceptance/features/public-share-auth.feature
+++ b/tests/acceptance/features/public-share-auth.feature
@@ -1,0 +1,27 @@
+Feature: public share auth
+
+  Scenario: try to access a link share with a password protected by Talk
+    Given I act as John
+    And I am logged in
+    And I share the link for "welcome.txt" protected by the password "abcdef"
+    And I set the password of the shared link as protected by Talk
+    And I see that the password of the link share is protected by Talk
+    And I write down the shared link
+    When I act as Jane
+    And I visit the shared link I wrote down
+    Then I see that the current page is the Authenticate page for the shared link I wrote down
+    And I see that the request password button is shown
+
+  Scenario: try to access a link share with a password no longer protected by Talk
+    Given I act as John
+    And I am logged in
+    And I share the link for "welcome.txt" protected by the password "abcdef"
+    And I set the password of the shared link as protected by Talk
+    And I see that the password of the link share is protected by Talk
+    And I set the password of the shared link as not protected by Talk
+    And I see that the password of the link share is not protected by Talk
+    And I write down the shared link
+    When I act as Jane
+    And I visit the shared link I wrote down
+    Then I see that the current page is the Authenticate page for the shared link I wrote down
+    And I see that the request password button is not shown


### PR DESCRIPTION
[The last scenario fails when the acceptance tests are run without any timeout multiplier](https://github.com/nextcloud/spreed/commit/ad26f2ce9b0ff1b43582b65c93cae7efbf7d22c7#diff-c8c885284913c6339176f4ce788ece13R78); this is not a problem when run in Drone, as a multiplier is used in that case which causes the tests to wait for longer for the conversation to be finished.

The scenario will pass without requiring a timeout multiplier once #1342 is fixed.
 