### PR TITLE
Allow to repost the last comment

### DIFF
--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -624,7 +624,6 @@
 
 			// Pressing Arrow-up/down in an empty/unchanged input brings back the last sent messages
 			if (this.lastComments.length !== 0 && !$field.atwho('isSelecting')) {
-				console.log('key');
 
 				if (ev.keyCode === 38 || ev.keyCode === 40) {
 					this._loopThroughLastComments(ev, $field);


### PR DESCRIPTION
Navigate with Arrow-Up and Arrow-Down through the last messages you sent.

> ![messagenavigation](https://user-images.githubusercontent.com/213943/52411472-4f1d4200-2adc-11e9-941e-8638adf9f901.gif)

This is especially helpful with #1453  where you can not always copy the last message you where typing.