### PR TITLE
Allow to mention everyone in the conversation 

### DIFF
--- a/css/chatview.scss
+++ b/css/chatview.scss
@@ -294,8 +294,9 @@ body:not(#body-public) #chatView .comment .authorRow:not(.currentUser):not(.gues
 		margin-right: 2px;
 
 		&.icon {
-			height: 18px !important;
-			width: 18px !important;
+			margin-top: -2px;
+			margin-left: 1px;
+			background-color: var(--color-background-darker);
 		}
 	}
 }

--- a/css/chatview.scss
+++ b/css/chatview.scss
@@ -265,6 +265,7 @@ body:not(#body-public) #chatView .comment .authorRow:not(.currentUser):not(.gues
 	display: inline-flex;
 }
 
+#chatView .comment .message .mention-call,
 #chatView .comment .message .mention-user {
 	/* Make the mention the positioning context of its child contacts menu */
 	position: relative;
@@ -291,9 +292,15 @@ body:not(#body-public) #chatView .comment .authorRow:not(.currentUser):not(.gues
 		margin-top: -4px;
 		margin-left: 0;
 		margin-right: 2px;
+
+		&.icon {
+			height: 18px !important;
+			width: 18px !important;
+		}
 	}
 }
 
+#chatView .comment:not(.systemMessage) .message .mention-call,
 #chatView .comment:not(.systemMessage) .message .mention-user {
 	font-weight: bold;
 
@@ -303,6 +310,7 @@ body:not(#body-public) #chatView .comment .authorRow:not(.currentUser):not(.gues
 	}
 }
 
+#chatView .comment.systemMessage .message .mention-call,
 #chatView .comment.systemMessage .message .mention-user {
 	color: var(--color-main-text);
 }

--- a/css/style.scss
+++ b/css/style.scss
@@ -169,6 +169,7 @@ input[type="password"] {
 }
 
 .select2-result .avatar.icon,
+.atwho-view-ul .avatar.icon,
 #app-navigation .app-navigation-entry-link .avatar.icon {
 	border-radius: 50%;
 	width: 32px;

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -86,7 +86,11 @@
 						// highlighting loads the avatars.
 						var $li = $(li);
 						var $avatar = $li.find('.avatar');
-						$avatar.avatar($avatar.data('user-id'), 32);
+						if ($avatar.data('user-id') === 'all') {
+							$avatar.addClass('avatar icon icon-contacts');
+						} else {
+							$avatar.avatar($avatar.data('user-id'), 32);
+						}
 						return $li;
 					},
 					sorter: function (q, items) { return items; }
@@ -506,7 +510,11 @@
 
 			var setAvatar = function($element, size) {
 				if ($element.data('user-id')) {
-					$element.avatar($element.data('user-id'), size, undefined, false, undefined, $element.data('user-display-name'));
+					if ($element.data('user-id') === 'all') {
+						$element.addClass('avatar icon icon-contacts');
+					} else {
+						$element.avatar($element.data('user-id'), size, undefined, false, undefined, $element.data('user-display-name'));
+					}
 				} else {
 					$element.imageplaceholder('?', $element.data('displayname'), size);
 					$element.css('background-color', '#b9b9b9');
@@ -557,7 +565,7 @@
 				var $avatar = $this.find('.avatar');
 
 				var user = $avatar.data('user-id');
-				if (user !== OC.getCurrentUser().uid) {
+				if (user !== 'all' && user !== OC.getCurrentUser().uid) {
 					$this.contactsMenu(user, 0, $this);
 				}
 			});

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -372,7 +372,7 @@
 				actorDisplayName === '') {
 				actorDisplayName = t('spreed', 'Guest');
 			}
-			if (actorDisplayName == null) {
+			if (actorDisplayName === null) {
 				actorDisplayName = t('spreed', '[Unknown user name]');
 			}
 
@@ -565,7 +565,7 @@
 				var $avatar = $this.find('.avatar');
 
 				var user = $avatar.data('user-id');
-				if (user !== 'all' && user !== OC.getCurrentUser().uid) {
+				if (user !== OC.getCurrentUser().uid) {
 					$this.contactsMenu(user, 0, $this);
 				}
 			});

--- a/js/views/richobjectstringparser.js
+++ b/js/views/richobjectstringparser.js
@@ -59,6 +59,13 @@
 					}
 					return this.userLocalTemplate(parameter);
 
+				case 'call':
+					if (!this.callTemplate) {
+						this.callTemplate = OCA.Talk.Views.Templates['richobjectstringparser_call'];
+					}
+
+					return this.callTemplate(parameter);
+
 				case 'file':
 					if (!this.filePreviewTemplate) {
 						this.filePreviewTemplate = OCA.Talk.Views.Templates['richobjectstringparser_filepreview'];

--- a/js/views/templates.js
+++ b/js/views/templates.js
@@ -132,6 +132,13 @@ templates['mediacontrolsview'] = template({"compiler":[7,">= 4.0.0"],"main":func
     + alias4(((helper = (helper = helpers.stopScreenButtonTitle || (depth0 != null ? depth0.stopScreenButtonTitle : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"stopScreenButtonTitle","hash":{},"data":data}) : helper)))
     + "</span>\n			</button>\n		</li>\n	</ul>\n</div>\n";
 },"useData":true});
+templates['richobjectstringparser_call'] = template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
+    var helper;
+
+  return "<span class=\"atwho-inserted\" contenteditable=\"false\"><span class=\"mention-call avatar-name-wrapper currentUser\"><span class=\"avatar icon icon-contacts\"></span><strong>"
+    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"name","hash":{},"data":data}) : helper)))
+    + "</strong></span></span>\n";
+},"useData":true});
 templates['richobjectstringparser_filepreview'] = template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 

--- a/js/views/templates.js
+++ b/js/views/templates.js
@@ -135,7 +135,7 @@ templates['mediacontrolsview'] = template({"compiler":[7,">= 4.0.0"],"main":func
 templates['richobjectstringparser_call'] = template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     var helper;
 
-  return "<span class=\"atwho-inserted\" contenteditable=\"false\"><span class=\"mention-call avatar-name-wrapper currentUser\"><span class=\"avatar icon icon-contacts\"></span><strong>"
+  return "<span class=\"atwho-inserted\" contenteditable=\"false\"><span class=\"mention-call avatar-name-wrapper currentUser\"><span class=\"avatar icon icon-contacts\" data-user-id=\"all\"></span><strong>"
     + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"name","hash":{},"data":data}) : helper)))
     + "</strong></span></span>\n";
 },"useData":true});

--- a/js/views/templates/richobjectstringparser_call.handlebars
+++ b/js/views/templates/richobjectstringparser_call.handlebars
@@ -3,4 +3,4 @@
     after the mention, and thus causing the mention to "touch" the following
     text; "~" from Handlebars can not be used because it is not recursive, it
     only applies to a single level }}
-<span class="atwho-inserted" contenteditable="false"><span class="mention-call avatar-name-wrapper currentUser"><span class="avatar icon icon-contacts"></span><strong>{{name}}</strong></span></span>
+<span class="atwho-inserted" contenteditable="false"><span class="mention-call avatar-name-wrapper currentUser"><span class="avatar icon icon-contacts" data-user-id="all"></span><strong>{{name}}</strong></span></span>

--- a/js/views/templates/richobjectstringparser_call.handlebars
+++ b/js/views/templates/richobjectstringparser_call.handlebars
@@ -1,0 +1,6 @@
+{{! The browser merges two consecutive spaces, so the spaces inside the mention
+    are removed to prevent a trailing space from being merged with the space
+    after the mention, and thus causing the mention to "touch" the following
+    text; "~" from Handlebars can not be used because it is not recursive, it
+    only applies to a single level }}
+<span class="atwho-inserted" contenteditable="false"><span class="mention-call avatar-name-wrapper currentUser"><span class="avatar icon icon-contacts"></span><strong>{{name}}</strong></span></span>

--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -84,6 +84,12 @@ class Notifier {
 			return [];
 		}
 
+		$mentionedAll = array_search('all', $mentionedUserIds, true);
+
+		if ($mentionedAll !== false) {
+			$mentionedUserIds = $chat->getParticipantUserIds();
+		}
+
 		$notification = $this->createNotification($chat, $comment, 'mention');
 		foreach ($mentionedUserIds as $mentionedUserId) {
 			if ($this->shouldUserBeNotified($mentionedUserId, $comment)) {

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -361,6 +361,15 @@ class ChatController extends OCSController {
 		]);
 
 		$results = $this->prepareResultArray($results);
+
+		if ($search === '' || strpos('all', $search) !== false) {
+			array_unshift($results, [
+				'id' => 'all',
+				'label' => $this->l->t('Everyone'),
+				'source' => 'groups',
+			]);
+		}
+
 		return new DataResponse($results);
 	}
 

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -44,7 +44,6 @@ use OCP\Comments\IComment;
 use OCP\Comments\MessageTooLongException;
 use OCP\IL10N;
 use OCP\IRequest;
-use OCP\IUser;
 use OCP\IUserManager;
 
 class ChatController extends OCSController {
@@ -365,8 +364,8 @@ class ChatController extends OCSController {
 		if ($search === '' || strpos('all', $search) !== false) {
 			array_unshift($results, [
 				'id' => 'all',
-				'label' => $this->l->t('Everyone'),
-				'source' => 'groups',
+				'label' => $room->getName() ?: $this->l->t('Conversation'),
+				'source' => 'calls',
 			]);
 		}
 


### PR DESCRIPTION
`@all` now creates a notification for everyone and shows up as `<group icon> Everyone` in the chat.

Known issues: In the notification the avatar is `E` for everyone, instead of the group icon. But that would require fixing in the notifications app, and I'm not sure what the best way for this is atm. We could go with ROS group instead of user, but that would complicate the JS on our site a lot, because we would need to render those two the same and even then the icon would not be shown in the notification.

Fix #1412 