### PR TITLE
Fix peer creation when wrong user list was sent to the other peer

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -292,6 +292,21 @@ var spreedPeerConnectionTable = [];
 			webrtc.leaveCall();
 		});
 
+		signaling.on('message', function (message) {
+			if (message.type !== 'offer') {
+				return;
+			}
+
+			var peers = OCA.SpreedMe.webrtc.webrtc.peers;
+			var stalePeer = peers.find(function(peer) {
+				return peer.id === message.from && peer.sid !== message.sid;
+			});
+
+			if (stalePeer) {
+				usersChanged(signaling, [], [stalePeer.id]);
+			}
+		});
+
 		webrtc = new SimpleWebRTC({
 			localVideoEl: 'localVideo',
 			remoteVideosEl: '',


### PR DESCRIPTION
In some circumstances (for example, [if the signaling server provides an incorrect list of users](https://github.com/nextcloud/spreed/pull/1534)) the peer that created the offer can disconnect from the peer that received the offer without causing the peer that received the offer to remove the peer that created the offer.

In that situation, if the peer that created the offer then tried to connect again with the other peer [the other peer created a new `Peer` object](https://github.com/nextcloud/spreed/blob/05905d1972ae35e011ff41c17a914d28bf551140/js/simplewebrtc.js#L18033-L18040) that was used instead of the old one (because the peer that created the offer [removed its original "Peer" object](https://github.com/nextcloud/spreed/blob/339b1dfc05e3ff01c89f58757febb7a7fa97e887/js/webrtc.js#L205) and created a new one, so although [the `id` of the peer is the same](https://github.com/nextcloud/spreed/blob/339b1dfc05e3ff01c89f58757febb7a7fa97e887/js/webrtc.js#L184), [its `sid` is not](https://github.com/nextcloud/spreed/blob/05905d1972ae35e011ff41c17a914d28bf551140/js/simplewebrtc.js#L17657)). However, as the old `Peer` object was not removed, its video element (which was no longer updated) was kept visible, hiding the video element linked to the new "Peer" object ([due to the new video element being prepended to the container](https://github.com/nextcloud/spreed/blob/339b1dfc05e3ff01c89f58757febb7a7fa97e887/js/webrtc.js#L1091)) and making it look frozen.

It is not possible to ensure that the peer that received the offer will always remove the peer that created the offer if the peer that created the offer disconnects from the peer that received the offer, so this is handled instead by removing the stale `Peer` objects when new offers are received.

The bug just described (and fixed in the first commit) happens even if the peer that received the offer disconnects from, but does not remove, the peer that created the offer. The next bug (fixed in the second commit) only happens if the peer that created the offer does not disconnect from the peer that received the offer when the peer that received the offer disconnects from the peer that created the offer.

With latest browser versions when a peer closes the connection with other peer the ICE connection of that other peer is changed to the `closed` state, so those browsers are not affected by this second bug (although they are by the first). However, with older browser versions (at least in Firefox 52 and Chromium 62; I have not checked which versions changed the behaviour) when a peer closes the connection with other peer the other peer is not aware of that; no event or state change happens in the connection, nor the media stream, nor the data channel... anywhere (at least, as far as I could see).

A peer only tried to connect with another peer if its session ID was larger than the session ID of the other peer; otherwise it just waited for the other peer to start the connection instead. [This is done that way to prevent overloading a peer joining a room.](https://github.com/nextcloud/spreed/blob/339b1dfc05e3ff01c89f58757febb7a7fa97e887/js/webrtc.js#L178-L181)

However, in the scenario above, the peer that received the offer just waited for the peer that created the offer to start the connection again. As the peer that created the offer was not aware of the disconnection it did not try to connect again, and thus they never reconnected.

It is not possible to ensure that the peer that created the offer will always disconnect from the peer that received the offer if the peer that received the offer disconnects from the peer that created the offer, so this is handled instead by making that peers with smaller session IDs also start a connection if the peer with the larger session ID did not in a reasonable time.

Besides all those things I have noticed a bug (video is frozen) with pure ICE reconnections (without creating new peer objects) in Firefox (which would happen if testing the second scenario with latest Firefox release; the bug fixed by the second commit would not happen, but this other one would); however, I suspect that it may be related to the shim used by SimpleWebRTC, so I will dig into it again once the change to the new library is done.

@mario @Ivansss You may want (or maybe not :-P ) to check in the apps the forced misbehaviours of the signaling server below to ensure that they work as expected.

### How to test (scenario 1): ###

- Insert the following lines [before users are appended to the list in `SignalingController::getUsersInRoom`](https://github.com/nextcloud/spreed/blob/3471b9fc39ca1e760c44356e03d0acb85b6da64f/lib/Controller/SignalingController.php#L237):
```
	$sessionId = $this->session->getSessionForRoom($room->getToken());
	if ($participant->getSessionId() < $sessionId && !rand(0, 3)) {
		continue;
	}
```
  This will make that, sometimes, the participant that sent the WebRTC offer to another participant disconnects from that participant
- Join a call with user A
- Join the same call with user B
- Wait

**Result with this pull request:**
After several minutes, the peers will have disconnected and reconnected again several times, but the call will still be working.

**Result without this pull request:**
After several minutes, the peers will have disconnected and reconnected again several times; the video for one of the peers will appear to be frozen, but if the DOM is checked it can be seen that there are instead several video elements. Removing all except the first one will show again a working video.



### How to test (scenario 2): ###

- Test with older versions of Firefox (for example, 52) or Chromium (for example, 62), as newer versions would reconnect instead of showing the bug
- Insert the following lines [before users are appended to the list in `SignalingController::getUsersInRoom`](https://github.com/nextcloud/spreed/blob/3471b9fc39ca1e760c44356e03d0acb85b6da64f/lib/Controller/SignalingController.php#L237):
```
	$sessionId = $this->session->getSessionForRoom($room->getToken());
	if ($participant->getSessionId() > $sessionId && !rand(0, 3)) {
		continue;
	}
```
  This will make that, sometimes, the participant that received the WebRTC offer from another participant disconnects from that participant (opposite case from scenario 1)
- Join a call with user A
- Join the same call with user B
- Wait

**Result with this pull request:**
After several minutes, the peers will have disconnected and reconnected again several times, but the call will still be working.

**Result without this pull request:**
After several minutes, one of the peers will have disconnected from the other peer; the peer that disconnected will be waiting for the other peer to reconnect, and the other peer will still be "connected" to that peer but with a frozen video and audio.
