### PR TITLE
Fix slower active users not included in user list returned by signaling

### DIFF
--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -41,6 +41,10 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 class SignalingController extends OCSController {
+
+	/** @var int */
+	private const PULL_MESSAGES_TIMEOUT = 30;
+
 	/** @var Config */
 	private $config;
 	/** @var TalkSession */
@@ -154,7 +158,7 @@ class SignalingController extends OCSController {
 		}
 
 		$data = [];
-		$seconds = 30;
+		$seconds = self::PULL_MESSAGES_TIMEOUT;
 
 		try {
 			$sessionId = $this->session->getSessionForRoom($token);
@@ -222,10 +226,11 @@ class SignalingController extends OCSController {
 	 */
 	protected function getUsersInRoom(Room $room, int $pingTimestamp): array {
 		$usersInRoom = [];
-		// Get participants active in the last 30 seconds, or since the last
-		// signaling ping of the current user if it was done more than 30
-		// seconds ago.
-		$timestamp = min(time() - 30, $pingTimestamp);
+		// Get participants active in the last 40 seconds (an extra time is used
+		// to include other participants pinging almost at the same time as the
+		// current user), or since the last signaling ping of the current user
+		// if it was done more than 40 seconds ago.
+		$timestamp = min(time() - (self::PULL_MESSAGES_TIMEOUT + 10), $pingTimestamp);
 		// "- 1" is needed because only the participants whose last ping is
 		// greater than the given timestamp are returned.
 		$participants = $room->getParticipants($timestamp - 1);


### PR DESCRIPTION
Follow up to #1522

When a user requests the signaling messages from the internal signaling server first the last ping of the user is updated. Then, after waiting for at most 30 seconds, the list of users active in the room is returned.

That list was based on the users whose last ping happened around 30 seconds ago or less (it could be a bit longer than 30 seconds, but the described problem remains in that case too); if other user pulled the messages slightly before the current user and that other user did not pull the messages again (or the chat messages, as that updates the last ping too) before the user list was returned that other user was not included in the list, as her last ping happened more than 30 seconds ago.

Now the elapsed time since the last ping for users returned in the list is longer than the timeout used for pulling messages (and chat messages) to ensure (up to a point) that active users will be included in the list even if it took a bit longer for them to pull messages again.

Unfortunately I have not found any easy and consistent way to reproduce the bug, so I can not provide a step by step testing scenario, except for "leave a call between two peers running for a lot of time until the bug happens" :-(
