### PR TITLE
Only sync and set active room after user has joined room.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -618,6 +618,8 @@
 					return;
 				}
 
+				this.syncAndSetActiveRoom(token);
+
 				this.inRoom = true;
 				if (this.pendingNickChange) {
 					this.setGuestName(this.pendingNickChange);

--- a/js/app.js
+++ b/js/app.js
@@ -613,7 +613,11 @@
 			this.connection = new OCA.Talk.Connection(this);
 			this.token = $('#app').attr('data-token');
 
-			this.signaling.on('joinRoom', function(/* token */) {
+			this.signaling.on('joinRoom', function(token) {
+				if (this.token !== token) {
+					return;
+				}
+
 				this.inRoom = true;
 				if (this.pendingNickChange) {
 					this.setGuestName(this.pendingNickChange);

--- a/js/connection.js
+++ b/js/connection.js
@@ -19,12 +19,6 @@
 			selectParticipants.removeClass('error');
 		});
 
-		this.app.signaling.on('joinRoom', function(joinedToken) {
-			if (joinedToken === this.app.token) {
-				this.app.syncAndSetActiveRoom(joinedToken);
-			}
-		}.bind(this));
-
 		this.app.signaling.on('roomChanged', function() {
 			this.leaveCurrentRoom();
 		}.bind(this));

--- a/js/connection.js
+++ b/js/connection.js
@@ -19,6 +19,12 @@
 			selectParticipants.removeClass('error');
 		});
 
+		this.app.signaling.on('joinRoom', function(joinedToken) {
+			if (joinedToken === this.app.token) {
+				this.app.syncAndSetActiveRoom(joinedToken);
+			}
+		}.bind(this));
+
 		this.app.signaling.on('roomChanged', function() {
 			this.leaveCurrentRoom();
 		}.bind(this));
@@ -94,7 +100,6 @@
 
 			roomsChannel.trigger('joinRoom', token);
 
-			this.app.syncAndSetActiveRoom(token);
 			$('#video-fullscreen').removeClass('hidden');
 		},
 		leaveCurrentRoom: function() {

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -65,12 +65,7 @@
 		},
 
 		syncAndSetActiveRoom: function(token) {
-			this.signaling.syncRooms()
-				.then(function() {
-					if (OC.getCurrentUser().uid) {
-						roomChannel.trigger('active', token);
-					}
-				});
+			this.signaling.syncRooms();
 		},
 
 		initialize: function() {

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -81,8 +81,6 @@
 			var self = this;
 			this.signaling.syncRooms()
 				.then(function() {
-					self.stopListening(self.activeRoom, 'change:participantFlags');
-
 					if (OC.getCurrentUser().uid) {
 						roomChannel.trigger('active', token);
 

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -64,10 +64,6 @@
 			});
 		},
 
-		syncAndSetActiveRoom: function(token) {
-			this.signaling.syncRooms();
-		},
-
 		initialize: function() {
 			if (!OC.getCurrentUser().uid) {
 				this.initGuestName();

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -97,7 +97,11 @@
 			this.signaling = OCA.Talk.Signaling.createConnection();
 			this.connection = new OCA.Talk.Connection(this);
 
-			this.signaling.on('joinRoom', function(/* token */) {
+			this.signaling.on('joinRoom', function(token) {
+				if (this.token !== token) {
+					return;
+				}
+
 				this.inRoom = true;
 				if (this.pendingNickChange) {
 					this.setGuestName(this.pendingNickChange);

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -57,9 +57,6 @@
 		/** property {String} selector */
 		mainCallElementSelector: '#call-container',
 
-		/** @property {OCA.SpreedMe.Models.RoomCollection} _rooms  */
-		_rooms: null,
-
 		_registerPageEvents: function() {
 			// Initialize button tooltips
 			$('[data-toggle="tooltip"]').tooltip({trigger: 'hover'}).click(function() {
@@ -67,38 +64,17 @@
 			});
 		},
 
-		/**
-		 * @param {string} token
-		 */
-		_setRoomActive: function(token) {
-			if (OC.getCurrentUser().uid) {
-				this._rooms.forEach(function(room) {
-					room.set('active', room.get('token') === token);
-				});
-			}
-		},
 		syncAndSetActiveRoom: function(token) {
-			var self = this;
 			this.signaling.syncRooms()
 				.then(function() {
 					if (OC.getCurrentUser().uid) {
 						roomChannel.trigger('active', token);
-
-						self._rooms.forEach(function(room) {
-							if (room.get('token') === token) {
-								self.activeRoom = room;
-								self._chatView.setRoom(room);
-							}
-						});
 					}
 				});
 		},
 
 		initialize: function() {
-			if (OC.getCurrentUser().uid) {
-				this._rooms = new OCA.SpreedMe.Models.RoomCollection();
-				this.listenTo(roomChannel, 'active', this._setRoomActive);
-			} else {
+			if (!OC.getCurrentUser().uid) {
 				this.initGuestName();
 			}
 


### PR DESCRIPTION
This fixes a race condition when (as logged in user) joining a public room that has been created by another user. It can happen that the list of rooms is fetched before the "join room" request finished, so the room is not included in the list, causing `syncAndSetActiveRoom` (https://github.com/nextcloud/spreed/blob/master/js/app.js#L324) to fail.

As a solution, `syncAndSetActiveRoom` is only called when the room was joined to make sure it is included in the list of rooms.