### PR TITLE
Ensure all properties of rooms are set

### DIFF
--- a/js/models/room.js
+++ b/js/models/room.js
@@ -40,11 +40,30 @@
 	 */
 	var Room = Backbone.Model.extend({
 		defaults: {
-			name: '',
+			id: '',
 			token: '',
+			name: '',
+			type: 0,
+			displayName: '',
+			objectType: '',
+			objectId: '',
+			participantType: 0,
+			participantFlags: 0,
 			count: 0,
-			active: false,
-			lastPing: 0
+			hasPassword: false,
+			hasCall: false,
+			lastActivity: 0,
+			unreadMessages: 0,
+			unreadMention: false,
+			isFavorite: false,
+			notificationLevel: 0,
+			lastPing: 0,
+			sessionId: '0',
+			participants: [],
+			numGuests: 0,
+			guestList: '',
+			lastMessage: [],
+			active: false
 		},
 		url: function() {
 			return OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.get('token');


### PR DESCRIPTION
Fix #1537 

Actual fix is https://github.com/nextcloud/server/pull/14178 but we can't help that.
This PR just fixes a follow up problem that occurs afterwards.
> Uncaught TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at n.setEmptyContentMessageWhenWaitingForOthersToJoinTheCall (VM2488 emptycontentview.js:174)