### PR TITLE
Fix "private const" on PHP 7.0

### DIFF
--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -43,7 +43,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 class SignalingController extends OCSController {
 
 	/** @var int */
-	private const PULL_MESSAGES_TIMEOUT = 30;
+	const PULL_MESSAGES_TIMEOUT = 30;
 
 	/** @var Config */
 	private $config;


### PR DESCRIPTION
Follow up to #1543 

`private const` is only valid starting with PHP 7.1.
