### PR TITLE
Allow null sessions when getting participant by session

### DIFF
--- a/lib/Room.php
+++ b/lib/Room.php
@@ -176,7 +176,7 @@ class Room {
 	}
 
 	/**
-	 * @param string $userId
+	 * @param string|null $userId
 	 * @return Participant
 	 * @throws ParticipantNotFoundException When the user is not a participant
 	 */
@@ -211,7 +211,7 @@ class Room {
 	}
 
 	/**
-	 * @param string $sessionId
+	 * @param string|null $sessionId
 	 * @return Participant
 	 * @throws ParticipantNotFoundException When the user is not a participant
 	 */

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -215,7 +215,7 @@ class Room {
 	 * @return Participant
 	 * @throws ParticipantNotFoundException When the user is not a participant
 	 */
-	public function getParticipantBySession(string $sessionId): Participant {
+	public function getParticipantBySession(?string $sessionId): Participant {
 		if (!is_string($sessionId) || $sessionId === '' || $sessionId === '0') {
 			throw new ParticipantNotFoundException('Not a user');
 		}


### PR DESCRIPTION
Follow up to #1532  

Otherwise, due to the strict types, a type error is thrown instead of a `ParticipantNotFoundException`.

 @nickvergessen Is it needed to change the PHPDoc of [`getParticipant`](https://github.com/nextcloud/spreed/blob/d702aa08415ff8c664b35b1767a55ebad9ddaeba/lib/Room.php#L179) and [`getParticipantBySession`](https://github.com/nextcloud/spreed/blob/d702aa08415ff8c664b35b1767a55ebad9ddaeba/lib/Room.php#L214) from `@param string xxxId` to `@param string|null xxxId`?
