### PR TITLE
Fix last local media state not remembered when the UI is reloaded

### DIFF
--- a/js/views/mediacontrolsview.js
+++ b/js/views/mediacontrolsview.js
@@ -91,7 +91,7 @@
 				this.disableAudio();
 			}
 
-			this._videoDisabled = localStorage.getItem("videoDisabled");
+			this.videoDisabled = localStorage.getItem("videoDisabled");
 		},
 
 		setWebRtc: function(webrtc) {

--- a/js/views/mediacontrolsview.js
+++ b/js/views/mediacontrolsview.js
@@ -87,10 +87,7 @@
 			this._audioNotFound = false;
 			this._videoNotFound = false;
 
-			if (localStorage.getItem("audioDisabled")) {
-				this.disableAudio();
-			}
-
+			this.audioDisabled = localStorage.getItem("audioDisabled");
 			this.videoDisabled = localStorage.getItem("videoDisabled");
 		},
 


### PR DESCRIPTION
This pull request fixes a regression introduced in c4c047a3c1a4bc5a622f49880f0b77cd00b2f55c

## How to test ##
- Start a call with microphone and camera
- Disable local audio and video
- Reload the page in the browser
- Start a call again

**Result with this pull request:**
Audio and video are still disabled.

**Result without this pull request:**
Audio and video are enabled.
