### PR TITLE
Delay message sending when socket is null

### DIFF
--- a/js/signaling.js
+++ b/js/signaling.js
@@ -866,9 +866,9 @@
 	};
 
 	OCA.Talk.Signaling.Standalone.prototype.doSend = function(msg, callback) {
-		if (!this.connected && msg.type !== "hello") {
-			// Defer sending any messages until the hello rsponse has been
-			// received.
+		if (!this.connected && msg.type !== "hello" || this.socket === null) {
+			// Defer sending any messages until the hello response has been
+			// received and when the socket is open
 			this.pendingMessages.push([msg, callback]);
 			return;
 		}


### PR DESCRIPTION
We had 648 log entries for this in sentry since dec 2018:
> ### TypeError
> this.socket is null