### PR TITLE
Make  room names non-optional

### DIFF
--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -174,7 +174,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 * Response:
     - Header:
         + `200 OK`
-        + `400 Bad Request` When the name is too long
+        + `400 Bad Request` When the name is too long or empty
         + `403 Forbidden` When the current user is not a moderator/owner
         + `404 Not Found` When the room could not be found for the participant
         + `405 Method Not Allowed` When the room is a one to one room

--- a/js/app.js
+++ b/js/app.js
@@ -136,7 +136,7 @@
 							});
 							results.push({
 								id: "create-public-room",
-								displayName: t('spreed', '{name} (public)', { name: shortenedName }),
+								displayName: shortenedName,
 								type: "createPublicRoom"
 							});
 						}
@@ -152,7 +152,7 @@
 				},
 				formatResult: function (element) {
 					if (element.type === "createPublicRoom") {
-						return '<span><div class="avatar icon icon-public"></div>' + escapeHTML(element.displayName) + '</span>';
+						return '<span><div class="avatar icon icon-public"></div>' + t('spreed', '{name} (public)', { name: element.displayName }) + '</span>';
 					}
 
 					if (element.type === "createGroupRoom" || element.type === 'group') {

--- a/js/app.js
+++ b/js/app.js
@@ -111,16 +111,11 @@
 							});
 						});
 
-						//Add custom entry to create a new empty group or public room
+						// Add custom entry to create a new empty group or public room
 						if (OCA.SpreedMe.app._searchTerm === '') {
 							results.unshift({
-								id: "create-public-room",
-								displayName: t('spreed', 'New public conversation'),
-								type: "createPublicRoom"
-							});
-							results.unshift({
 								id: "create-group-room",
-								displayName: t('spreed', 'New group conversation'),
+								displayName: t('spreed', 'Enter name for a new conversation'),
 								type: "createGroupRoom"
 							});
 						} else {
@@ -175,10 +170,14 @@
 						this.connection.createGroupVideoCall(e.val, '');
 						break;
 					case 'createPublicRoom':
-						this.connection.createPublicVideoCall(OCA.SpreedMe.app._searchTerm);
+						if (OCA.SpreedMe.app._searchTerm !== '') {
+							this.connection.createPublicVideoCall(OCA.SpreedMe.app._searchTerm);
+						}
 						break;
 					case 'createGroupRoom':
-						this.connection.createGroupVideoCall('', OCA.SpreedMe.app._searchTerm);
+						if (OCA.SpreedMe.app._searchTerm !== '') {
+							this.connection.createGroupVideoCall('', OCA.SpreedMe.app._searchTerm);
+						}
 						break;
 					default:
 						console.log('Unknown type', e.object.type);

--- a/js/models/participantcollection.js
+++ b/js/models/participantcollection.js
@@ -44,7 +44,7 @@
 		 */
 		setRoom: function(room) {
 			this.stopListening(this.room, 'change:participants');
-			this.stopListening(this.room, 'change:guestList');
+			this.stopListening(this.room, 'change:numGuests');
 
 			this.room = room;
 			this.url = OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.room.get('token') + '/participants';
@@ -54,7 +54,7 @@
 			this.listenTo(this.room, 'change:participants', function() {
 				this.fetch();
 			});
-			this.listenTo(this.room, 'change:guestList', function() {
+			this.listenTo(this.room, 'change:numGuests', function() {
 				this.fetch();
 			});
 		},

--- a/js/models/room.js
+++ b/js/models/room.js
@@ -75,6 +75,11 @@
 			// attributes hash to be set on the model.
 			return (result.ocs === undefined)? result : result.ocs.data;
 		},
+		validate: function(attributes, options) {
+			if (!attributes.name) {
+				return t('spreed', 'Room name can not be empty');
+			}
+		},
 		sync: function(method, model, options) {
 			// When saving a model "Backbone.Model.save" calls "sync" with an
 			// "update" method, which by default sends a "PUT" request that

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -612,7 +612,7 @@
 					switch(message.type) {
 						case "usersInRoom":
 							this._trigger('usersInRoom', [message.data]);
-							this._trigger("participantListChanged");
+							this._trigger('participantListChanged');
 							break;
 						case "message":
 							if (typeof(message.data) === 'string') {
@@ -1107,7 +1107,7 @@
 						this._trigger("usersLeft", [leftUsers]);
 					}
 					this._trigger("usersJoined", [joinedUsers]);
-					this._trigger("participantListChanged");
+					this._trigger('participantListChanged');
 				}
 				break;
 			case "leave":
@@ -1118,7 +1118,7 @@
 						delete this.joinedUsers[leftSessionIds[i]];
 					}
 					this._trigger("usersLeft", [leftSessionIds]);
-					this._trigger("participantListChanged");
+					this._trigger('participantListChanged');
 				}
 				break;
 			case "message":
@@ -1184,7 +1184,7 @@
 		switch (data.event.type) {
 			case "update":
 				this._trigger("usersChanged", [data.event.update.users || []]);
-				this._trigger("participantListChanged");
+				this._trigger('participantListChanged');
 				this.internalSyncRooms();
 				break;
 			default:

--- a/js/views/editabletextlabel.js
+++ b/js/views/editabletextlabel.js
@@ -219,6 +219,9 @@
 					this.modelSaveOptions.success.apply(this, arguments);
 				}
 			}, this);
+			options.error = _.bind(function() {
+				this.hideInput();
+			}, this);
 
 			this.model.save(this.modelAttribute, newText, options);
 		},

--- a/js/views/editabletextlabel.js
+++ b/js/views/editabletextlabel.js
@@ -211,8 +211,17 @@
 				return;
 			}
 
+			// TODO This should show the error message instead of just hiding
+			// the input without changes.
+			var hideInputOnValidationError = function(/*model, error*/) {
+				this.hideInput();
+			}.bind(this);
+			this.model.listenToOnce(this.model, 'invalid', hideInputOnValidationError);
+
 			var options = _.clone(this.modelSaveOptions || {});
 			options.success = _.bind(function() {
+				this.model.stopListening(this.model, 'invalid', hideInputOnValidationError);
+
 				this.hideInput();
 
 				if (this.modelSaveOptions && _.isFunction(this.modelSaveOptions.success)) {
@@ -220,6 +229,8 @@
 				}
 			}, this);
 			options.error = _.bind(function() {
+				this.model.stopListening(this.model, 'invalid', hideInputOnValidationError);
+
 				this.hideInput();
 			}, this);
 

--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -125,7 +125,7 @@ class Listener {
 			$event->setApp('spreed')
 				->setType('spreed')
 				->setAuthor('')
-				->setObject('room', $room->getId(), $room->getName())
+				->setObject('room', $room->getId())
 				->setTimestamp($this->timeFactory->getTime())
 				->setSubject('call', [
 					'room' => $room->getId(),
@@ -180,12 +180,11 @@ class Listener {
 			$event->setApp('spreed')
 				->setType('spreed')
 				->setAuthor($actorId)
-				->setObject('room', $room->getId(), $room->getName())
+				->setObject('room', $room->getId())
 				->setTimestamp($this->timeFactory->getTime())
 				->setSubject('invitation', [
 					'user' => $actor->getUID(),
 					'room' => $room->getId(),
-					'name' => $room->getName(),
 				]);
 		} catch (\InvalidArgumentException $e) {
 			$this->logger->logException($e, ['app' => 'spreed']);
@@ -199,7 +198,15 @@ class Listener {
 			}
 
 			try {
-				$event->setAffectedUser($participant['userId']);
+				$roomName = $room->getDisplayName($participant['userId']);
+				$event
+					->setObject('room', $room->getId(), $roomName)
+					->setSubject('invitation', [
+						'user' => $actor->getUID(),
+						'room' => $room->getId(),
+						'name' => $roomName,
+					])
+					->setAffectedUser($participant['userId']);
 				$this->activityManager->publish($event);
 			} catch (\InvalidArgumentException $e) {
 				$this->logger->logException($e, ['app' => 'spreed']);

--- a/lib/Activity/Provider/Base.php
+++ b/lib/Activity/Provider/Base.php
@@ -101,7 +101,7 @@ abstract class Base implements IProvider {
 			->setRichSubject($subject, $parameters);
 	}
 
-	protected function getRoom(IL10N $l, Room $room): array {
+	protected function getRoom(Room $room, string $userId): array {
 		switch ($room->getType()) {
 			case Room::ONE_TO_ONE_CALL:
 				$stringType = 'one2one';
@@ -118,7 +118,7 @@ abstract class Base implements IProvider {
 		return [
 			'type' => 'call',
 			'id' => $room->getId(),
-			'name' => $room->getName() ?: $l->t('a conversation'),
+			'name' => $room->getDisplayName($userId),
 			'call-type' => $stringType,
 		];
 	}

--- a/lib/Activity/Provider/Invitation.php
+++ b/lib/Activity/Provider/Invitation.php
@@ -45,7 +45,7 @@ class Invitation extends Base {
 			$roomParameter = $this->getFormerRoom($l, (int) $parameters['room']);
 			try {
 				$room = $this->manager->getRoomById((int) $parameters['room']);
-				$roomParameter = $this->getRoom($l, $room);
+				$roomParameter = $this->getRoom($room, $event->getAffectedUser());
 			} catch (RoomNotFoundException $e) {
 			}
 

--- a/lib/Chat/Parser/UserMention.php
+++ b/lib/Chat/Parser/UserMention.php
@@ -103,7 +103,7 @@ class UserMention {
 				$messageParameters[$mentionParameterId] = [
 					'type' => $mention['type'],
 					'id' => $chatMessage->getRoom()->getToken(),
-					'name' => $chatMessage->getRoom()->getName() ?: $this->l->t('Conversation'),
+					'name' => $chatMessage->getRoom()->getDisplayName($chatMessage->getParticipant()->getUser()),
 					'call-type' => $this->getRoomType($chatMessage->getRoom()),
 				];
 			} else {

--- a/lib/Collaboration/Collaborators/RoomPlugin.php
+++ b/lib/Collaboration/Collaborators/RoomPlugin.php
@@ -53,14 +53,16 @@ class RoomPlugin implements ISearchPlugin {
 			return false;
 		}
 
+		$userId = $this->userSession->getUser()->getUID();
+
 		$result = ['wide' => [], 'exact' => []];
 
-		$rooms = $this->manager->getRoomsForParticipant($this->userSession->getUser()->getUID());
+		$rooms = $this->manager->getRoomsForParticipant($userId);
 		foreach ($rooms as $room) {
 			if (stripos($room->getName(), $search) !== false) {
-				$item = $this->roomToSearchResultItem($room);
+				$item = $this->roomToSearchResultItem($room, $userId);
 
-				if (strtolower($room->getName()) === strtolower($search)) {
+				if (strtolower($item['label']) === strtolower($search)) {
 					$result['exact'][] = $item;
 				} else {
 					$result['wide'][] = $item;
@@ -74,14 +76,10 @@ class RoomPlugin implements ISearchPlugin {
 		return false;
 	}
 
-	/**
-	 * @param Room $room
-	 * @return array
-	 */
-	private function roomToSearchResultItem(Room $room): array {
+	private function roomToSearchResultItem(Room $room, string $userId): array {
 		return
 		[
-			'label' => $room->getName(),
+			'label' => $room->getDisplayName($userId),
 			'value' => [
 				'shareType' => Share::SHARE_TYPE_ROOM,
 				'shareWith' => $room->getToken()

--- a/lib/Collaboration/Collaborators/RoomPlugin.php
+++ b/lib/Collaboration/Collaborators/RoomPlugin.php
@@ -59,7 +59,7 @@ class RoomPlugin implements ISearchPlugin {
 
 		$rooms = $this->manager->getRoomsForParticipant($userId);
 		foreach ($rooms as $room) {
-			if (stripos($room->getName(), $search) !== false) {
+			if (stripos($room->getDisplayName($userId), $search) !== false) {
 				$item = $this->roomToSearchResultItem($room, $userId);
 
 				if (strtolower($item['label']) === strtolower($search)) {

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -336,7 +336,7 @@ class ChatController extends OCSController {
 		try {
 			/** @var Room $room */
 			/** @var Participant $participant */
-			[$room, ] = $this->getRoomAndParticipant($token);
+			[$room, $participant] = $this->getRoomAndParticipant($token);
 		} catch (RoomNotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
@@ -364,7 +364,7 @@ class ChatController extends OCSController {
 		if ($search === '' || strpos('all', $search) !== false) {
 			array_unshift($results, [
 				'id' => 'all',
-				'label' => $room->getName() ?: $this->l->t('Conversation'),
+				'label' => $room->getDisplayName($participant->getUser()),
 				'source' => 'calls',
 			]);
 		}

--- a/lib/Controller/PublicShareAuthController.php
+++ b/lib/Controller/PublicShareAuthController.php
@@ -31,6 +31,7 @@ use OCP\AppFramework\OCSController;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\IUserSession;
 use OCP\Share;
 use OCP\Share\IManager as IShareManager;
 use OCP\Share\Exceptions\ShareNotFound;
@@ -41,6 +42,8 @@ class PublicShareAuthController extends OCSController {
 	private $userManager;
 	/** @var IShareManager */
 	private $shareManager;
+	/** @var IUserSession */
+	private $userSession;
 	/** @var Manager */
 	private $manager;
 
@@ -49,11 +52,13 @@ class PublicShareAuthController extends OCSController {
 			IRequest $request,
 			IUserManager $userManager,
 			IShareManager $shareManager,
+			IUserSession $userSession,
 			Manager $manager
 	) {
 		parent::__construct($appName, $request);
 		$this->userManager = $userManager;
 		$this->shareManager = $shareManager;
+		$this->userSession = $userSession;
 		$this->manager = $manager;
 	}
 
@@ -106,10 +111,13 @@ class PublicShareAuthController extends OCSController {
 			'participantType' => Participant::OWNER,
 		]);
 
+		$user = $this->userSession->getUser();
+		$userId = $user instanceof IUser ? $user->getUID() : '';
+
 		return new DataResponse([
 			'token' => $room->getToken(),
 			'name' => $room->getName(),
-			'displayName' => $room->getName(),
+			'displayName' => $room->getDisplayName($userId),
 		], Http::STATUS_CREATED);
 	}
 }

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -197,7 +197,7 @@ class RoomController extends OCSController {
 
 		$roomData = array_merge($roomData, [
 			'name' => $room->getName(),
-			'displayName' => $room->getName(),
+			'displayName' => $room->getDisplayName($currentParticipant->getUser()),
 			'objectType' => $room->getObjectType(),
 			'objectId' => $room->getObjectId(),
 			'participantType' => $currentParticipant->getParticipantType(),
@@ -217,11 +217,6 @@ class RoomController extends OCSController {
 			} else {
 				$roomData['notificationLevel'] = $room->getType() === Room::ONE_TO_ONE_CALL ? Participant::NOTIFY_ALWAYS : Participant::NOTIFY_MENTION;
 			}
-		}
-
-		if ($room->getObjectType() === 'share:password') {
-			// FIXME use an event
-			$roomData['displayName'] = $this->l10n->t('Password request: %s', [$room->getName()]);
 		}
 
 		$currentUser = $this->userManager->get($currentParticipant->getUser());
@@ -284,76 +279,6 @@ class RoomController extends OCSController {
 			'numGuests' => $numActiveGuests,
 			'lastMessage' => $lastMessage,
 		]);
-
-		if (!$currentParticipant->isGuest()) {
-			unset($participantList[$currentParticipant->getUser()]);
-			$numOtherParticipants = \count($participantList);
-			$numGuestParticipants = $numActiveGuests;
-		} else {
-			$numOtherParticipants = \count($participantList);
-			$numGuestParticipants = $numActiveGuests - 1;
-		}
-
-		$guestString = '';
-		switch ($room->getType()) {
-			case Room::ONE_TO_ONE_CALL:
-				// As name of the room use the name of the other person participating
-				if ($numOtherParticipants === 1) {
-					// Only one other participant
-					reset($participantList);
-					$roomData['name'] = key($participantList);
-					$roomData['displayName'] = $participantList[$roomData['name']]['name'];
-				} else {
-					// Invalid user count, there must be exactly 2 users in each one2one room
-					$this->logger->warning('one2one room found with invalid participant count. Leaving room for everyone', [
-						'app' => 'spreed',
-					]);
-					$room->deleteRoom();
-				}
-				break;
-
-			/** @noinspection PhpMissingBreakStatementInspection */
-			case Room::PUBLIC_CALL:
-				if ($numGuestParticipants) {
-					if ($currentParticipant->isGuest()) {
-						$guestString = $this->l10n->n('%n other guest', '%n other guests', $numGuestParticipants);
-					} else {
-						$guestString = $this->l10n->n('%n guest', '%n guests', $numGuestParticipants);
-					}
-				}
-
-			// no break;
-
-			case Room::GROUP_CALL:
-				if ($room->getName() === '') {
-					// As name of the room use the names of the other participants
-					$participantList = array_map(function($participant) {
-						return $participant['name'];
-					}, $participantList);
-					if ($currentParticipant->isGuest()) {
-						$participantList[] = $this->l10n->t('You');
-					} else if ($numOtherParticipants === 0) {
-						$participantList = [$this->l10n->t('You')];
-					}
-
-					if ($guestString !== '') {
-						$participantList[] = $guestString;
-					}
-
-					$roomData['displayName'] = implode($this->l10n->t(', '), $participantList);
-				}
-				break;
-
-			default:
-				// Invalid room type
-				$this->logger->warning('Invalid room type found. Leaving room for everyone', [
-					'app' => 'spreed',
-				]);
-				$room->deleteRoom();
-				throw new RoomNotFoundException('The room type is unknown');
-		}
-
-		$roomData['guestList'] = $guestString;
 
 		return $roomData;
 	}
@@ -450,7 +375,7 @@ class RoomController extends OCSController {
 			return new DataResponse([
 				'token' => $room->getToken(),
 				'name' => $room->getName(),
-				'displayName' => $targetUser->getDisplayName(),
+				'displayName' => $room->getDisplayName($currentUser->getUID()),
 			], Http::STATUS_CREATED);
 		}
 	}
@@ -500,7 +425,7 @@ class RoomController extends OCSController {
 		return new DataResponse([
 			'token' => $room->getToken(),
 			'name' => $room->getName(),
-			'displayName' => $room->getName(),
+			'displayName' => $room->getDisplayName($currentUser->getUID()),
 		], Http::STATUS_CREATED);
 	}
 
@@ -512,6 +437,11 @@ class RoomController extends OCSController {
 	 * @return DataResponse
 	 */
 	protected function createEmptyRoom(string $roomName, bool $public = true): DataResponse {
+		$roomName = trim($roomName);
+		if ($roomName === '') {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
 		$currentUser = $this->userManager->get($this->userId);
 
 		if (!$currentUser instanceof IUser) {
@@ -532,7 +462,7 @@ class RoomController extends OCSController {
 		return new DataResponse([
 			'token' => $room->getToken(),
 			'name' => $room->getName(),
-			'displayName' => $room->getName(),
+			'displayName' => $room->getDisplayName($currentUser->getUID()),
 		], Http::STATUS_CREATED);
 	}
 
@@ -628,7 +558,9 @@ class RoomController extends OCSController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		if (strlen($roomName) > 200) {
+		$roomName = trim($roomName);
+
+		if ($roomName === '' || strlen($roomName) > 200) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -59,8 +59,6 @@ class RoomController extends OCSController {
 	private $userManager;
 	/** @var IGroupManager */
 	private $groupManager;
-	/** @var ILogger */
-	private $logger;
 	/** @var Manager */
 	private $manager;
 	/** @var GuestManager */
@@ -80,7 +78,6 @@ class RoomController extends OCSController {
 								TalkSession $session,
 								IUserManager $userManager,
 								IGroupManager $groupManager,
-								ILogger $logger,
 								Manager $manager,
 								GuestManager $guestManager,
 								ChatManager $chatManager,
@@ -92,7 +89,6 @@ class RoomController extends OCSController {
 		$this->userId = $UserId;
 		$this->userManager = $userManager;
 		$this->groupManager = $groupManager;
-		$this->logger = $logger;
 		$this->manager = $manager;
 		$this->guestManager = $guestManager;
 		$this->chatManager = $chatManager;
@@ -253,6 +249,12 @@ class RoomController extends OCSController {
 						'call' => $participant->getInCallFlags(),
 						'sessionId' => $participant->getSessionId(),
 					];
+
+					if ($room->getType() === Room::ONE_TO_ONE_CALL &&
+						  $user->getUID() !== $currentParticipant->getUser()) {
+						// FIXME This should not be done, but currently all the clients use it to get the avatar of the user …
+						$roomData['name'] = $user->getUID();
+					}
 				}
 
 				if ($participant->getSessionId() !== '0' && $participant->getLastPing() <= $this->timeFactory->getTime() - 100) {

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -441,7 +441,7 @@ class SignalingController extends OCSController {
 				'version' => '1.0',
 				'roomid' => $room->getToken(),
 				'properties' => [
-					'name' => $room->getName(),
+					'name' => $room->getDisplayName((string) $userId),
 					'type' => $room->getType(),
 				],
 			],

--- a/lib/GuestManager.php
+++ b/lib/GuestManager.php
@@ -171,7 +171,7 @@ class GuestManager {
 
 		$template = $this->mailer->createEMailTemplate('Talk.InviteByEmail', [
 			'invitee' => $invitee,
-			'roomName' => $room->getName(),
+			'roomName' => $room->getDisplayName(''),
 			'roomLink' => $link,
 		]);
 
@@ -191,17 +191,10 @@ class GuestManager {
 			$subject
 		);
 
-		if ($room->getName()) {
-			$template->addBodyButton(
-				$this->l->t('Join »%s«', [$room->getName()]),
-				$link
-			);
-		} else {
-			$template->addBodyButton(
-				$this->l->t('Join now'),
-				$link
-			);
-		}
+		$template->addBodyButton(
+			$this->l->t('Join »%s«', [$room->getDisplayName('')]),
+			$link
+		);
 
 		$template->addFooter();
 

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -138,6 +138,10 @@ class Room {
 		return $this->name;
 	}
 
+	public function getDisplayName(string $userId): string {
+		return $this->manager->resolveRoomDisplayName($this, $userId);
+	}
+
 	public function getActiveGuests(): int {
 		return $this->activeGuests;
 	}
@@ -271,8 +275,6 @@ class Room {
 		if ($this->getType() === self::ONE_TO_ONE_CALL) {
 			return false;
 		}
-
-		$oldName = $this->getName();
 
 		$this->dispatcher->dispatch(self::class . '::preSetName', new GenericEvent($this, [
 			'newName' => $newName,

--- a/lib/Share/Helper/DeletedShareAPIController.php
+++ b/lib/Share/Helper/DeletedShareAPIController.php
@@ -41,20 +41,14 @@ class DeletedShareAPIController {
 
 	/** @var string */
 	private $userId;
-
-	/** @var IUserManager */
-	private $userManager;
-
 	/** @var Manager */
 	private $manager;
 
 	public function __construct(
 			string $UserId,
-			IUserManager $userManager,
 			Manager $manager
 	) {
 		$this->userId = $UserId;
-		$this->userManager = $userManager;
 		$this->manager = $manager;
 	}
 
@@ -76,22 +70,7 @@ class DeletedShareAPIController {
 			return $result;
 		}
 
-		// The display name of one-to-one rooms is set to the display name of
-		// the other participant.
-		$roomName = $room->getName();
-		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
-			$userIds = $room->getParticipantUserIds();
-			foreach ($userIds as $userId) {
-				if ($this->userId !== $userId) {
-					$user = $this->userManager->get($userId);
-					if ($user instanceof IUser) {
-						$roomName = $user->getDisplayName();
-					}
-				}
-			}
-		}
-
-		$result['share_with_displayname'] = $roomName;
+		$result['share_with_displayname'] = $room->getDisplayName($this->userId);
 
 		return $result;
 	}

--- a/lib/Share/Helper/ShareAPIController.php
+++ b/lib/Share/Helper/ShareAPIController.php
@@ -84,32 +84,7 @@ class ShareAPIController {
 			return $result;
 		}
 
-		$roomName = $room->getName();
-		try {
-			$room->getParticipant($this->userId);
-
-			if ($room->getType() === Room::ONE_TO_ONE_CALL) {
-				$userIds = $room->getParticipantUserIds();
-				foreach ($userIds as $userId) {
-					if ($this->userId === $userId) {
-						continue;
-					}
-
-					$user = $this->userManager->get($userId);
-					if ($user instanceof IUser) {
-						$roomName = $user->getDisplayName();
-						break;
-					}
-				}
-			} else if ($roomName === '') {
-				$roomName = $this->l->t('Unnamed conversation');
-			}
-		} catch (ParticipantNotFoundException $e) {
-			// Do not leak the name of rooms the user is not a part of
-			$roomName = $this->l->t('Private conversation');
-		}
-
-		$result['share_with_displayname'] = $roomName;
+		$result['share_with_displayname'] = $room->getDisplayName($this->userId);
 		if ($room->getType() === Room::PUBLIC_CALL) {
 			$result['token'] = $share->getToken();
 		}

--- a/lib/Signaling/BackendNotifier.php
+++ b/lib/Signaling/BackendNotifier.php
@@ -132,7 +132,7 @@ class BackendNotifier {
 				// find a better way to notify existing users to update the room.
 				'alluserids' => $room->getParticipantUserIds(),
 				'properties' => [
-					'name' => $room->getName(),
+					'name' => $room->getDisplayName(''),
 					'type' => $room->getType(),
 				],
 			],
@@ -156,7 +156,7 @@ class BackendNotifier {
 				// find a better way to notify existing users to update the room.
 				'alluserids' => $room->getParticipantUserIds(),
 				'properties' => [
-					'name' => $room->getName(),
+					'name' => $room->getDisplayName(''),
 					'type' => $room->getType(),
 				],
 			],
@@ -180,7 +180,7 @@ class BackendNotifier {
 				// find a better way to notify existing users to update the room.
 				'alluserids' => $room->getParticipantUserIds(),
 				'properties' => [
-					'name' => $room->getName(),
+					'name' => $room->getDisplayName(''),
 					'type' => $room->getType(),
 				],
 			],
@@ -200,7 +200,7 @@ class BackendNotifier {
 			'update' => [
 				'userids' => $room->getParticipantUserIds(),
 				'properties' => [
-					'name' => $room->getName(),
+					'name' => $room->getDisplayName(''),
 					'type' => $room->getType(),
 				],
 			],

--- a/tests/acceptance/features/bootstrap/TalkAppContext.php
+++ b/tests/acceptance/features/bootstrap/TalkAppContext.php
@@ -80,6 +80,15 @@ class TalkAppContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function searchInputInSelect2Dropdown() {
+		return Locator::forThe()->css(".select2-search .select2-input")->
+				descendantOf(self::select2Dropdown())->
+				describedAs("Search input in select2 dropdown in Talk app");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function itemInSelect2DropdownFor($text) {
 		return Locator::forThe()->xpath("//*[contains(concat(' ', normalize-space(@class), ' '), ' select2-result-label ')]//span/text()[normalize-space() = '$text']/ancestor::li")->
 				descendantOf(self::select2Dropdown())->

--- a/tests/acceptance/features/chat.feature
+++ b/tests/acceptance/features/chat.feature
@@ -3,7 +3,7 @@ Feature: chat
   Scenario: send a message
     Given I am logged in
     And I have opened the Talk app
-    And I create a group conversation
+    And I create a group conversation named "Group"
     And I see that the chat is shown in the main view
     When I send a new chat message with the text "Hello"
     Then I see that the message 1 was sent by "user0" with the text "Hello"
@@ -11,7 +11,7 @@ Feature: chat
   Scenario: send several messages
     Given I am logged in
     And I have opened the Talk app
-    And I create a group conversation
+    And I create a group conversation named "Group"
     And I see that the chat is shown in the main view
     When I send a new chat message with the text "Hello"
     And I send a new chat message with the text "World"
@@ -131,7 +131,7 @@ Feature: chat
   Scenario: mention another user
     Given I am logged in
     And I have opened the Talk app
-    And I create a group conversation
+    And I create a group conversation named "Group"
     And I see that the chat is shown in the main view
     When I send a new chat message with the text "Hello @admin"
     Then I see that the message 1 was sent by "user0" with the text "Hello admin"
@@ -140,7 +140,7 @@ Feature: chat
   Scenario: mention another user and a URL
     Given I am logged in
     And I have opened the Talk app
-    And I create a group conversation
+    And I create a group conversation named "Group"
     And I see that the chat is shown in the main view
     When I send a new chat message with the text "Hello @admin, check http://www.nextcloud.com"
     # As the message contains child HTML elements (due to the contacts menu for

--- a/tests/acceptance/features/conversation.feature
+++ b/tests/acceptance/features/conversation.feature
@@ -3,8 +3,8 @@ Feature: conversation
   Scenario: create a group conversation
     Given I am logged in
     And I have opened the Talk app
-    When I create a group conversation
-    Then I see that the "You" conversation is active
+    When I create a group conversation named "Group"
+    Then I see that the "Group" conversation is active
     And I see that the chat is shown in the main view
     And I see that the sidebar is open
     And I see that the number of participants shown in the list is "1"
@@ -24,33 +24,33 @@ Feature: conversation
   Scenario: rename a conversation
     Given I am logged in
     And I have opened the Talk app
-    And I create a group conversation
-    And I see that the "You" conversation is active
+    And I create a group conversation named "Group"
+    And I see that the "Group" conversation is active
     When I rename the conversation to "Test conversation"
     Then I see that the "Test conversation" conversation is active
 
   Scenario: change between conversations
     Given I am logged in
     And I have opened the Talk app
-    And I create a group conversation
-    And I see that the "You" conversation is active
+    And I create a group conversation named "Group"
+    And I see that the "Group" conversation is active
     And I see that the number of participants shown in the list is "1"
     And I create a one-to-one conversation with "admin"
-    And I see that the "You" conversation is not active
+    And I see that the "Group" conversation is not active
     And I see that the "admin" conversation is active
     And I see that the number of participants shown in the list is "2"
-    When I open the "You" conversation
-    Then I see that the "You" conversation is active
+    When I open the "Group" conversation
+    Then I see that the "Group" conversation is active
     And I see that the "admin" conversation is not active
     And I see that the number of participants shown in the list is "1"
 
   Scenario: leave a conversation
     Given I am logged in
     And I have opened the Talk app
-    And I create a group conversation
-    And I see that the "You" conversation is active
-    When I leave the "You" conversation
-    Then I see that the "You" conversation is not shown in the list
+    And I create a group conversation named "Group"
+    And I see that the "Group" conversation is active
+    When I leave the "Group" conversation
+    Then I see that the "Group" conversation is not shown in the list
     And I see that the "Join a conversation or start a new one Say hi to your friends and colleagues!" empty content message is shown in the main view
     And I see that the sidebar is closed
 
@@ -82,14 +82,14 @@ Feature: conversation
   Scenario: create a new conversation after leaving the active one
     Given I am logged in
     And I have opened the Talk app
-    And I create a group conversation
-    And I see that the "You" conversation is active
-    And I leave the "You" conversation
-    And I see that the "You" conversation is not shown in the list
+    And I create a group conversation named "Group"
+    And I see that the "Group" conversation is active
+    And I leave the "Group" conversation
+    And I see that the "Group" conversation is not shown in the list
     And I see that the "Join a conversation or start a new one Say hi to your friends and colleagues!" empty content message is shown in the main view
     And I see that the sidebar is closed
-    When I create a group conversation
-    Then I see that the "You" conversation is active
+    When I create a group conversation named "Group"
+    Then I see that the "Group" conversation is active
     And I see that the chat is shown in the main view
     And I see that the sidebar is open
     And I see that the number of participants shown in the list is "1"
@@ -101,12 +101,12 @@ Feature: conversation
     And I create a one-to-one conversation with "admin"
     And I see that the "admin" conversation is active
     And I see that the number of participants shown in the list is "2"
-    And I create a group conversation
+    And I create a group conversation named "Group"
     And I see that the "admin" conversation is not active
-    And I see that the "You" conversation is active
+    And I see that the "Group" conversation is active
     And I see that the number of participants shown in the list is "1"
-    And I leave the "You" conversation
-    And I see that the "You" conversation is not shown in the list
+    And I leave the "Group" conversation
+    And I see that the "Group conversation is not shown in the list
     And I see that the "Join a conversation or start a new one Say hi to your friends and colleagues!" empty content message is shown in the main view
     And I see that the sidebar is closed
     When I open the "admin" conversation

--- a/tests/acceptance/features/room-shares.feature
+++ b/tests/acceptance/features/room-shares.feature
@@ -30,17 +30,17 @@ Feature: room-shares
     Given I act as John
     And I am logged in
     And I have opened the Talk app
-    And I create a group conversation
+    And I create a group conversation named "Group conversation"
     And I add "admin" to the participants
     And I add "user1" to the participants
     And I act as Jane
     And I am logged in as the admin
     And I have opened the Talk app
-    And I open the "user0, user1" conversation
+    And I open the "Group conversation" conversation
     And I act as Jim
     And I am logged in as "user1"
     And I have opened the Talk app
-    And I open the "user0, admin" conversation
+    And I open the "Group conversation" conversation
     When I act as John
     And I start the share operation
     And I select "welcome.txt" in the file picker
@@ -56,7 +56,7 @@ Feature: room-shares
     And I see that the details view is open
     And I open the "Sharing" tab in the details view
     And I see that the "Sharing" tab in the details view is eventually loaded
-    And I see that the file is shared with me in the conversation "Unnamed conversation" by "user0"
+    And I see that the file is shared with me in the conversation "Group conversation" by "user0"
     And I act as Jim
     And I see that the message 1 was sent by "user0" with the text "welcome (2).txt"
     And I see that the message 1 contains a formatted file preview
@@ -66,16 +66,13 @@ Feature: room-shares
     And I see that the details view is open
     And I open the "Sharing" tab in the details view
     And I see that the "Sharing" tab in the details view is eventually loaded
-    And I see that the file is shared with me in the conversation "Unnamed conversation" by "user0"
+    And I see that the file is shared with me in the conversation "Group conversation" by "user0"
 
   Scenario: share a file to a group room from the Sharing tab in the Files app
     Given I act as John
     And I am logged in
     And I have opened the Talk app
-    And I create a group conversation
-    # Currently files can be shared with a room from the Files app only if the
-    # room has a name explicitly set.
-    And I rename the conversation to "Group conversation"
+    And I create a group conversation named "Group conversation"
     And I add "admin" to the participants
     And I act as Jane
     And I am logged in as the admin

--- a/tests/integration/features/callapi/password.feature
+++ b/tests/integration/features/callapi/password.feature
@@ -12,6 +12,7 @@ Feature: callapi/public
   Scenario: User1 invites user2 to a public room and they can do everything
     When user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" sets password "foobar" for room "room" with 200
     And user "participant1" adds "participant2" to room "room" with 200
     Then user "participant1" is participant of room "room"
@@ -40,6 +41,7 @@ Feature: callapi/public
   Scenario: User1 invites user2 to a public room and user3 can not join without password
     When user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" sets password "foobar" for room "room" with 200
     And user "participant1" adds "participant2" to room "room" with 200
     Then user "participant1" is participant of room "room"
@@ -73,6 +75,7 @@ Feature: callapi/public
   Scenario: User1 invites user2 to a public room and user3 can join with password
     When user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" sets password "foobar" for room "room" with 200
     And user "participant1" adds "participant2" to room "room" with 200
     Then user "participant1" is participant of room "room"
@@ -107,6 +110,7 @@ Feature: callapi/public
   Scenario: User1 invites user2 to a public room and guest can not join without password
     When user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" sets password "foobar" for room "room" with 200
     And user "participant1" adds "participant2" to room "room" with 200
     Then user "participant1" is participant of room "room"
@@ -133,6 +137,7 @@ Feature: callapi/public
   Scenario: User1 invites user2 to a public room and guest can join with password
     When user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" sets password "foobar" for room "room" with 200
     And user "participant1" adds "participant2" to room "room" with 200
     Then user "participant1" is participant of room "room"

--- a/tests/integration/features/callapi/public.feature
+++ b/tests/integration/features/callapi/public.feature
@@ -12,6 +12,7 @@ Feature: callapi/public
   Scenario: User1 invites user2 to a public room and they can do everything
     When user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     Then user "participant1" is participant of room "room"
     And user "participant2" is participant of room "room"
@@ -45,6 +46,7 @@ Feature: callapi/public
   Scenario: User1 invites user2 to a public room and user3 can do everything
     When user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     Then user "participant1" is participant of room "room"
     Then user "participant3" is not participant of room "room"
@@ -77,6 +79,7 @@ Feature: callapi/public
   Scenario: User1 invites user2 to a public room and guest can do everything
     When user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     Then user "participant1" is participant of room "room"
     And user "guest" sees 0 peers in call "room" with 404

--- a/tests/integration/features/chat/password.feature
+++ b/tests/integration/features/chat/password.feature
@@ -7,6 +7,7 @@ Feature: chat/password
   Scenario: owner can send and receive chat messages to and from public password protected room
     Given user "participant1" creates room "public password protected room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" sets password "foobar" for room "public password protected room" with 200
     When user "participant1" sends message "Message 1" to room "public password protected room" with 201
     Then user "participant1" sees the following messages in room "public password protected room" with 200
@@ -16,6 +17,7 @@ Feature: chat/password
   Scenario: invited user can send and receive chat messages to and from public password protected room
     Given user "participant1" creates room "public password protected room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" sets password "foobar" for room "public password protected room" with 200
     And user "participant1" adds "participant2" to room "public password protected room" with 200
     When user "participant2" sends message "Message 1" to room "public password protected room" with 201
@@ -26,6 +28,7 @@ Feature: chat/password
   Scenario: not invited but joined with password user can send and receive chat messages to and from public password protected room
     Given user "participant1" creates room "public password protected room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" sets password "foobar" for room "public password protected room" with 200
     And user "participant3" joins room "public password protected room" with 200
       | password | foobar |
@@ -37,6 +40,7 @@ Feature: chat/password
   Scenario: not invited user can not send nor receive chat messages to and from public password protected room
     Given user "participant1" creates room "public password protected room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" sets password "foobar" for room "public password protected room" with 200
     When user "participant3" sends message "Message 1" to room "public password protected room" with 404
     And user "participant1" sends message "Message 2" to room "public password protected room" with 201
@@ -45,6 +49,7 @@ Feature: chat/password
   Scenario: joined with password guest can send and receive chat messages to and from public password protected room
     Given user "participant1" creates room "public password protected room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" sets password "foobar" for room "public password protected room" with 200
     And user "guest" joins room "public password protected room" with 200
       | password | foobar |
@@ -56,6 +61,7 @@ Feature: chat/password
   Scenario: not joined guest can not send nor receive chat messages to and from public password protected room
     Given user "participant1" creates room "public password protected room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" sets password "foobar" for room "public password protected room" with 200
     When user "guest" sends message "Message 1" to room "public password protected room" with 404
     And user "participant1" sends message "Message 2" to room "public password protected room" with 201
@@ -64,6 +70,7 @@ Feature: chat/password
   Scenario: everyone in a public password protected room can receive messages from everyone in that room
     Given user "participant1" creates room "public password protected room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" sets password "foobar" for room "public password protected room" with 200
     And user "participant1" adds "participant2" to room "public password protected room" with 200
     And user "participant3" joins room "public password protected room" with 200

--- a/tests/integration/features/chat/public.feature
+++ b/tests/integration/features/chat/public.feature
@@ -7,6 +7,7 @@ Feature: chat/public
   Scenario: owner can send and receive chat messages to and from public room
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     When user "participant1" sends message "Message 1" to room "public room" with 201
     Then user "participant1" sees the following messages in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
@@ -15,6 +16,7 @@ Feature: chat/public
   Scenario: invited user can send and receive chat messages to and from public room
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "public room" with 200
     When user "participant2" sends message "Message 1" to room "public room" with 201
     Then user "participant2" sees the following messages in room "public room" with 200
@@ -24,6 +26,7 @@ Feature: chat/public
   Scenario: not invited but joined user can send and receive chat messages to and from public room
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant3" joins room "public room" with 200
     When user "participant3" sends message "Message 1" to room "public room" with 201
     Then user "participant3" sees the following messages in room "public room" with 200
@@ -33,6 +36,7 @@ Feature: chat/public
   Scenario: not invited user can not send nor receive chat messages to and from public room
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     When user "participant3" sends message "Message 1" to room "public room" with 404
     And user "participant1" sends message "Message 2" to room "public room" with 201
     Then user "participant3" sees the following messages in room "public room" with 404
@@ -40,6 +44,7 @@ Feature: chat/public
   Scenario: joined guest can send and receive chat messages to and from public room
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     And user "guest" joins room "public room" with 200
     When user "guest" sends message "Message 1" to room "public room" with 201
     Then user "guest" sees the following messages in room "public room" with 200
@@ -49,6 +54,7 @@ Feature: chat/public
   Scenario: not joined guest can not send nor receive chat messages to and from public room
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     When user "guest" sends message "Message 1" to room "public room" with 404
     And user "participant1" sends message "Message 2" to room "public room" with 201
     Then user "guest" sees the following messages in room "public room" with 404
@@ -56,6 +62,7 @@ Feature: chat/public
   Scenario: everyone in a public room can receive messages from everyone in that room
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "public room" with 200
     And user "guest" joins room "public room" with 200
     When user "participant1" sends message "Message 1" to room "public room" with 201

--- a/tests/integration/features/chat/rich-messages.feature
+++ b/tests/integration/features/chat/rich-messages.feature
@@ -7,6 +7,7 @@ Feature: chat/public
   Scenario: message without enrichable references has empty parameters
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     When user "participant1" sends message "Message without enrichable references" to room "public room" with 201
     Then user "participant1" sees the following messages in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message                               | messageParameters |
@@ -15,6 +16,7 @@ Feature: chat/public
   Scenario: message with mention to valid user has mention parameter
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     When user "participant1" sends message "Mention to @participant2" to room "public room" with 201
     Then user "participant1" sees the following messages in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message                    | messageParameters |
@@ -23,6 +25,7 @@ Feature: chat/public
   Scenario: message with mention to invalid user has mention parameter
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     When user "participant1" sends message "Mention to @unknownUser" to room "public room" with 201
     Then user "participant1" sees the following messages in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message                    | messageParameters |
@@ -31,6 +34,7 @@ Feature: chat/public
   Scenario: message with duplicated mention has single mention parameter
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     When user "participant1" sends message "Mention to @participant2 and @participant2 again" to room "public room" with 201
     Then user "participant1" sees the following messages in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message                                              | messageParameters |
@@ -39,6 +43,7 @@ Feature: chat/public
   Scenario: message with mentions to several users has mention parameters
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     When user "participant1" sends message "Mention to @participant2, @unknownUser, @participant2 again and @participant3" to room "public room" with 201
     Then user "participant1" sees the following messages in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message                                                                                | messageParameters |

--- a/tests/integration/features/chat/system-messages.feature
+++ b/tests/integration/features/chat/system-messages.feature
@@ -10,6 +10,7 @@ Feature: System messages
   Scenario: Creating an empty room
     When user "participant1" creates room "room"
       | roomType | 2 |
+      | roomName | room |
     Then user "participant1" sees the following system messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | systemMessage |
       | room | users     | participant1 | participant1-displayname | conversation_created |
@@ -17,6 +18,7 @@ Feature: System messages
   Scenario: Rename a room
     Given user "participant1" creates room "room"
       | roomType | 2 |
+      | roomName | room |
     When user "participant1" renames room "room" to "system test" with 200
     Then user "participant1" sees the following system messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | systemMessage |
@@ -26,6 +28,7 @@ Feature: System messages
   Scenario: Toggle guests
     Given user "participant1" creates room "room"
       | roomType | 2 |
+      | roomName | room |
     When user "participant1" makes room "room" public with 200
     Then user "participant1" sees the following system messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | systemMessage |
@@ -41,6 +44,7 @@ Feature: System messages
   Scenario: Toggle password
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     When user "participant1" sets password "123456" for room "room" with 200
     Then user "participant1" sees the following system messages in room "room" with 200
       | room       | actorType | actorId      | actorDisplayName         | systemMessage |
@@ -75,6 +79,7 @@ Feature: System messages
   Scenario: Participant escalation
     Given user "participant1" creates room "room"
       | roomType | 2 |
+      | roomName | room |
     Then user "participant1" sees the following system messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | systemMessage |
       | room | users     | participant1 | participant1-displayname | conversation_created |

--- a/tests/integration/features/conversation/add-participant.feature
+++ b/tests/integration/features/conversation/add-participant.feature
@@ -7,6 +7,7 @@ Feature: public
   Scenario: Owner invites a user
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
@@ -19,6 +20,7 @@ Feature: public
   Scenario: User invites a user
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
@@ -39,6 +41,7 @@ Feature: public
   Scenario: Moderator invites a user
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     When user "participant1" promotes "participant2" in room "room" with 200
     And user "participant1" is participant of the following rooms
@@ -62,6 +65,7 @@ Feature: public
   Scenario: Stranger invites a user
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant3" adds "participant2" to room "room" with 404
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |

--- a/tests/integration/features/conversation/delete-room.feature
+++ b/tests/integration/features/conversation/delete-room.feature
@@ -7,6 +7,7 @@ Feature: public
   Scenario: Owner deletes
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
       | room | 3    | 1               | participant1-displayname |
@@ -18,6 +19,7 @@ Feature: public
   Scenario: Moderator deletes
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant1" promotes "participant2" in room "room" with 200
     And user "participant2" is participant of the following rooms
@@ -32,6 +34,7 @@ Feature: public
   Scenario: User deletes
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant2" is participant of the following rooms
       | id   | type | participantType | participants |
@@ -45,6 +48,7 @@ Feature: public
   Scenario: Stranger deletes
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" is participant of room "room"
     And user "participant2" is not participant of room "room"
     When user "participant2" deletes room "room" with 404
@@ -54,6 +58,7 @@ Feature: public
   Scenario: User1 creates a public room and deletes themself
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" is participant of room "room"
     And user "participant2" is not participant of room "room"
     And user "participant3" is not participant of room "room"

--- a/tests/integration/features/conversation/promotion-demotion.feature
+++ b/tests/integration/features/conversation/promotion-demotion.feature
@@ -7,6 +7,7 @@ Feature: public
   Scenario: Owner promotes/demotes moderator
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant2" is participant of the following rooms
       | id   | type | participantType | participants |
@@ -23,6 +24,7 @@ Feature: public
   Scenario: Moderator promotes/demotes moderator
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant1" adds "participant3" to room "room" with 200
     And user "participant3" is participant of the following rooms
@@ -41,6 +43,7 @@ Feature: public
   Scenario: User promotes/demotes moderator
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant1" adds "participant3" to room "room" with 200
     And user "participant3" is participant of the following rooms
@@ -62,6 +65,7 @@ Feature: public
   Scenario: Stranger promotes/demotes moderator
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant3" to room "room" with 200
     And user "participant3" is participant of the following rooms
       | id   | type | participantType | participants |

--- a/tests/integration/features/conversation/public-private.feature
+++ b/tests/integration/features/conversation/public-private.feature
@@ -7,6 +7,7 @@ Feature: public
   Scenario: Owner makes room private/public
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
       | room | 3    | 1               | participant1-displayname |
@@ -22,6 +23,7 @@ Feature: public
   Scenario: Moderator makes room private/public
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
       | room | 3    | 1               | participant1-displayname |
@@ -39,6 +41,7 @@ Feature: public
   Scenario: User makes room private/public
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
       | room | 3    | 1               | participant1-displayname |
@@ -59,6 +62,7 @@ Feature: public
   Scenario: Stranger makes room private/public
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
       | room | 3    | 1               | participant1-displayname |

--- a/tests/integration/features/conversation/remove-participant.feature
+++ b/tests/integration/features/conversation/remove-participant.feature
@@ -52,6 +52,7 @@ Feature: public
   Scenario: Owner removes moderator
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant3" to room "room" with 200
     And user "participant1" promotes "participant3" in room "room" with 200
     And user "participant3" is participant of room "room"
@@ -61,6 +62,7 @@ Feature: public
   Scenario: Moderator removes moderator
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant1" promotes "participant2" in room "room" with 200
     And user "participant1" adds "participant3" to room "room" with 200
@@ -72,6 +74,7 @@ Feature: public
   Scenario: User removes moderator
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant1" adds "participant3" to room "room" with 200
     And user "participant1" promotes "participant3" in room "room" with 200
@@ -82,6 +85,7 @@ Feature: public
   Scenario: Stranger removes moderator
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant3" to room "room" with 200
     And user "participant1" promotes "participant3" in room "room" with 200
     And user "participant3" is participant of room "room"
@@ -94,6 +98,7 @@ Feature: public
   Scenario: Owner removes user
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant3" to room "room" with 200
     And user "participant3" is participant of room "room"
     When user "participant1" removes "participant3" from room "room" with 200
@@ -102,6 +107,7 @@ Feature: public
   Scenario: Moderator removes user
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant1" promotes "participant2" in room "room" with 200
     And user "participant1" adds "participant3" to room "room" with 200
@@ -112,6 +118,7 @@ Feature: public
   Scenario: User removes user
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant1" adds "participant3" to room "room" with 200
     And user "participant3" is participant of room "room"
@@ -121,6 +128,7 @@ Feature: public
   Scenario: Stranger removes user
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant3" to room "room" with 200
     And user "participant3" is participant of room "room"
     When user "participant2" removes "participant3" from room "room" with 404
@@ -132,6 +140,7 @@ Feature: public
   Scenario: Owner removes stranger
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant3" is not participant of room "room"
     When user "participant1" removes "participant3" from room "room" with 404
     Then user "participant3" is not participant of room "room"
@@ -139,6 +148,7 @@ Feature: public
   Scenario: Moderator removes stranger
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     When user "participant1" promotes "participant2" in room "room" with 200
     And user "participant3" is not participant of room "room"
@@ -148,6 +158,7 @@ Feature: public
   Scenario: User removes stranger
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant3" is not participant of room "room"
     When user "participant2" removes "participant3" from room "room" with 403
@@ -156,6 +167,7 @@ Feature: public
   Scenario: Stranger removes stranger
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant3" is not participant of room "room"
     When user "participant2" removes "participant3" from room "room" with 404
     And user "participant3" is not participant of room "room"

--- a/tests/integration/features/conversation/remove-self.feature
+++ b/tests/integration/features/conversation/remove-self.feature
@@ -7,6 +7,7 @@ Feature: public
   Scenario: Owner removes the room from their room list
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     Then user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
       | room | 3    | 1               | participant1-displayname |
@@ -18,6 +19,7 @@ Feature: public
   Scenario: Moderator removes the room from their room list
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant1" promotes "participant2" in room "room" with 200
     And user "participant2" is participant of the following rooms
@@ -32,6 +34,7 @@ Feature: public
   Scenario: User removes the room from their room list
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant2" is participant of the following rooms
       | id   | type | participantType | participants |
@@ -45,6 +48,7 @@ Feature: public
   Scenario: Stranger removes the room from their room list
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" is participant of room "room"
     And user "participant2" is not participant of room "room"
     When user "participant2" removes themselves from room "room" with 404

--- a/tests/integration/features/conversation/rename-room.feature
+++ b/tests/integration/features/conversation/rename-room.feature
@@ -7,6 +7,7 @@ Feature: public
   Scenario: Owner renames
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" is participant of room "room"
     When user "participant1" renames room "room" to "new name" with 200
     Then user "participant1" is participant of room "room"
@@ -14,6 +15,7 @@ Feature: public
   Scenario: Moderator renames
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" is participant of room "room"
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant2" is participant of room "room"
@@ -23,6 +25,7 @@ Feature: public
   Scenario: User renames
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" is participant of room "room"
     And user "participant1" adds "participant2" to room "room" with 200
     And user "participant2" is participant of room "room"
@@ -31,6 +34,7 @@ Feature: public
   Scenario: Stranger renames
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" is participant of room "room"
     And user "participant2" is not participant of room "room"
     When user "participant2" renames room "room" to "new name" with 404

--- a/tests/integration/features/conversation/set-password.feature
+++ b/tests/integration/features/conversation/set-password.feature
@@ -7,6 +7,7 @@ Feature: public
   Scenario: Owner sets a room password
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
       | room | 3    | 1               | participant1-displayname |
@@ -21,6 +22,7 @@ Feature: public
   Scenario: Moderator sets a room password
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
       | room | 3    | 1               | participant1-displayname |
@@ -37,6 +39,7 @@ Feature: public
   Scenario: User sets a room password
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
       | room | 3    | 1               | participant1-displayname |
@@ -55,6 +58,7 @@ Feature: public
   Scenario: Stranger sets a room password
     Given user "participant1" creates room "room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" is participant of the following rooms
       | id   | type | participantType | participants |
       | room | 3    | 1               | participant1-displayname |

--- a/tests/integration/features/sharing/create.feature
+++ b/tests/integration/features/sharing/create.feature
@@ -76,6 +76,7 @@ Feature: create
   Scenario: create share with an owned group room
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Own group room" with 200
     And user "participant1" adds "participant2" to room "own group room" with 200
     When user "participant1" shares "welcome.txt" with room "own group room"
@@ -104,6 +105,7 @@ Feature: create
   Scenario: create share with a group room invited to
     Given user "participant2" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant2" adds "participant1" to room "group room invited to" with 200
     When user "participant1" shares "welcome.txt" with room "group room invited to"
@@ -143,6 +145,7 @@ Feature: create
   Scenario: create share with a group room no longer invited to
     Given user "participant2" creates room "group room no longer invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" adds "participant1" to room "group room no longer invited to" with 200
     And user "participant2" removes "participant1" from room "group room no longer invited to" with 200
     When user "participant1" shares "welcome.txt" with room "group room no longer invited to"
@@ -156,6 +159,7 @@ Feature: create
   Scenario: create share with an owned public room
     Given user "participant1" creates room "own public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" renames room "own public room" to "Own public room" with 200
     And user "participant1" adds "participant2" to room "own public room" with 200
     And user "participant3" joins room "own public room" with 200
@@ -199,6 +203,7 @@ Feature: create
   Scenario: create share with a public room invited to
     Given user "participant2" creates room "public room invited to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant2" renames room "public room invited to" to "Public room invited to" with 200
     And user "participant2" adds "participant1" to room "public room invited to" with 200
     And user "participant3" joins room "public room invited to" with 200
@@ -242,6 +247,7 @@ Feature: create
   Scenario: create share with a public room self joined to
     Given user "participant2" creates room "public room self joined to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant2" renames room "public room self joined to" to "Public room self joined to" with 200
     And user "participant1" joins room "public room self joined to" with 200
     And user "participant3" joins room "public room self joined to" with 200
@@ -296,6 +302,7 @@ Feature: create
   Scenario: create share with a public room no longer joined to
     Given user "participant2" creates room "public room no longer joined to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" joins room "public room no longer joined to" with 200
     And user "participant1" leaves room "public room no longer joined to" with 200
     When user "participant1" shares "welcome.txt" with room "public room no longer joined to"
@@ -311,6 +318,7 @@ Feature: create
   Scenario: create share with a room of a received share whose owner is in the room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
@@ -358,6 +366,7 @@ Feature: create
   Scenario: create share with a room of a received share whose owner is not in the room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
     And user "participant2" shares "welcome.txt" with user "participant1" with OCS 100
@@ -404,6 +413,7 @@ Feature: create
   Scenario: create share with a room of a received share without reshare permissions
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
     And user "participant2" shares "welcome.txt" with user "participant1"
@@ -437,6 +447,7 @@ Feature: create
   Scenario: create share with an expiration date
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     When user "participant1" shares "welcome.txt" with room "group room"
@@ -468,6 +479,7 @@ Feature: create
   Scenario: create share with an invalid expiration date
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     When user "participant1" shares "welcome.txt" with room "group room"
       | expireDate | invalid date |
@@ -481,6 +493,7 @@ Feature: create
   Scenario: create share with specific permissions
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     When user "participant1" shares "welcome.txt" with room "group room"
@@ -514,11 +527,13 @@ Feature: create
   Scenario: create share again with another room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant1" creates room "another group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "another group room" to "Another group room" with 200
     And user "participant1" adds "participant3" to room "another group room" with 200
     When user "participant1" shares "welcome.txt" with room "another group room"
@@ -582,6 +597,7 @@ Feature: create
   Scenario: create share again with same room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -616,6 +632,7 @@ Feature: create
   Scenario: create share again with same room by a sharee
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -654,11 +671,13 @@ Feature: create
   Scenario: create share with a room that includes a user who already received that share through another room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant1" creates room "another group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "another group room" to "Another group room" with 200
     And user "participant1" adds "participant2" to room "another group room" with 200
     When user "participant1" shares "welcome.txt" with room "another group room"
@@ -698,6 +717,7 @@ Feature: create
   Scenario: create share with a user who already received that share through a room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -741,6 +761,7 @@ Feature: create
   Scenario: create share with a room including a user who already received that share directly
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100

--- a/tests/integration/features/sharing/delete.feature
+++ b/tests/integration/features/sharing/delete.feature
@@ -34,6 +34,7 @@ Feature: delete
   Scenario: delete share with an owned group room
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "own group room" with 200
     And user "participant1" shares "welcome.txt" with room "own group room" with OCS 100
     When user "participant1" deletes last share
@@ -47,6 +48,7 @@ Feature: delete
   Scenario: delete share with a group room invited to
     Given user "participant2" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" adds "participant1" to room "group room invited to" with 200
     And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
     When user "participant1" deletes last share
@@ -60,6 +62,7 @@ Feature: delete
   Scenario: delete share with an owned public room
     Given user "participant1" creates room "own public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "own public room" with 200
     And user "participant3" joins room "own public room" with 200
     And user "participant1" shares "welcome.txt" with room "own public room" with OCS 100
@@ -76,6 +79,7 @@ Feature: delete
   Scenario: delete share with a public room invited to
     Given user "participant2" creates room "public room invited to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant2" adds "participant1" to room "public room invited to" with 200
     And user "participant3" joins room "public room invited to" with 200
     And user "participant1" shares "welcome.txt" with room "public room invited to" with OCS 100
@@ -92,6 +96,7 @@ Feature: delete
   Scenario: delete share with a public room self joined to
     Given user "participant2" creates room "public room self joined to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" joins room "public room self joined to" with 200
     And user "participant3" joins room "public room self joined to" with 200
     And user "participant1" shares "welcome.txt" with room "public room self joined to" with OCS 100
@@ -141,6 +146,7 @@ Feature: delete
   Scenario: delete (unknown) share with a group room not invited to
     Given user "participant2" creates room "group room not invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "group room not invited to" to "Group room not invited to" with 200
     And user "participant2" adds "participant3" to room "group room not invited to" with 200
     And user "participant2" shares "welcome.txt" with room "group room not invited to" with OCS 100
@@ -173,6 +179,7 @@ Feature: delete
   Scenario: delete (unknown) share with a public room not joined to
     Given user "participant2" creates room "public room not joined to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant2" renames room "public room not joined to" to "Public room not joined to" with 200
     And user "participant2" adds "participant3" to room "public room not joined to" with 200
     And user "participant2" shares "welcome.txt" with room "public room not joined to" with OCS 100
@@ -209,6 +216,7 @@ Feature: delete
   Scenario: delete share with a user who also received that share through a room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -232,6 +240,7 @@ Feature: delete
   Scenario: delete share with a room including a user who also received that share directly
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -257,6 +266,7 @@ Feature: delete
   Scenario: delete received share
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
@@ -294,6 +304,7 @@ Feature: delete
   Scenario: delete share received directly and through a room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200

--- a/tests/integration/features/sharing/get.feature
+++ b/tests/integration/features/sharing/get.feature
@@ -11,6 +11,7 @@ Feature: get
   Scenario: get a share
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     When user "participant1" gets last share
@@ -28,6 +29,7 @@ Feature: get
   Scenario: get a received share
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -48,6 +50,7 @@ Feature: get
   Scenario: get a share using a user not invited to the room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     When user "participant2" gets last share
@@ -59,6 +62,7 @@ Feature: get
   Scenario: get a share after changing the room name
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -91,6 +95,7 @@ Feature: get
   Scenario: get an expired share
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room"
@@ -116,6 +121,7 @@ Feature: get
   Scenario: get an expired share moved by the sharee
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -145,6 +151,7 @@ Feature: get
   Scenario: get a share after deleting its file
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -161,9 +168,11 @@ Feature: get
   Scenario: get all shares of a user
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Own group room" with 200
     And user "participant2" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant2" adds "participant1" to room "group room invited to" with 200
     And user "participant1" creates room "own one-to-one room"
@@ -230,9 +239,11 @@ Feature: get
   Scenario: get all shares and reshares of a user
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Own group room" with 200
     And user "participant2" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant2" adds "participant1" to room "group room invited to" with 200
     And user "participant1" creates room "own one-to-one room"
@@ -393,9 +404,11 @@ Feature: get
   Scenario: get all shares of a file
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Own group room" with 200
     And user "participant2" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant2" adds "participant1" to room "group room invited to" with 200
     And user "participant1" creates room "own one-to-one room"
@@ -437,9 +450,11 @@ Feature: get
   Scenario: get all shares of a deleted file
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Own group room" with 200
     And user "participant2" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant2" adds "participant1" to room "group room invited to" with 200
     And user "participant1" creates room "own one-to-one room"
@@ -463,9 +478,11 @@ Feature: get
   Scenario: get all shares and reshares of a file
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Own group room" with 200
     And user "participant2" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant2" adds "participant1" to room "group room invited to" with 200
     And user "participant1" creates room "own one-to-one room"
@@ -600,9 +617,11 @@ Feature: get
   Scenario: get all shares and reshares of a deleted file
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Own group room" with 200
     And user "participant2" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant2" adds "participant1" to room "group room invited to" with 200
     And user "participant1" creates room "own one-to-one room"
@@ -626,9 +645,11 @@ Feature: get
   Scenario: get all shares of a folder
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Own group room" with 200
     And user "participant2" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant2" adds "participant1" to room "group room invited to" with 200
     And user "participant1" creates room "own one-to-one room"
@@ -687,9 +708,11 @@ Feature: get
   Scenario: get all shares of a deleted folder
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Own group room" with 200
     And user "participant2" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant2" adds "participant1" to room "group room invited to" with 200
     And user "participant1" creates room "own one-to-one room"
@@ -720,10 +743,12 @@ Feature: get
   Scenario: get all received shares of a user
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Own group room" with 200
     And user "participant1" adds "participant2" to room "own group room" with 200
     And user "participant2" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant2" adds "participant1" to room "group room invited to" with 200
     And user "participant2" adds "participant3" to room "group room invited to" with 200
@@ -786,10 +811,12 @@ Feature: get
   Scenario: get all received shares of a file
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Own group room" with 200
     And user "participant1" adds "participant2" to room "own group room" with 200
     And user "participant2" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant2" adds "participant1" to room "group room invited to" with 200
     And user "participant2" adds "participant3" to room "group room invited to" with 200
@@ -827,10 +854,12 @@ Feature: get
   Scenario: get all received shares of a deleted file
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Own group room" with 200
     And user "participant1" adds "participant2" to room "own group room" with 200
     And user "participant2" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant2" adds "participant1" to room "group room invited to" with 200
     And user "participant2" adds "participant3" to room "group room invited to" with 200
@@ -852,6 +881,7 @@ Feature: get
   Scenario: get deleted shares when deleting an own share
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant1" deletes last share
@@ -863,6 +893,7 @@ Feature: get
   Scenario: get deleted shares when deleting a received share
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
@@ -891,6 +922,7 @@ Feature: get
   Scenario: get deleted shares when deleting the file of an own share
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant1" deletes file "welcome.txt"
@@ -904,6 +936,7 @@ Feature: get
   Scenario: get DAV properties for a share
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     When user "participant1" gets the share-type DAV property for "/welcome.txt"
     Then the response contains a share-types DAV property with
@@ -912,6 +945,7 @@ Feature: get
   Scenario: get DAV properties for a folder with a share
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" creates folder "/test"
     And user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
     And user "participant1" shares "/test/renamed.txt" with room "group room" with OCS 100
@@ -922,6 +956,7 @@ Feature: get
   Scenario: get DAV properties for a received share
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     When user "participant2" gets the share-type DAV property for "/welcome (2).txt"
@@ -930,8 +965,10 @@ Feature: get
   Scenario: get DAV properties for a room share reshared with a user
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" creates room "another group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
@@ -942,8 +979,10 @@ Feature: get
   Scenario: get DAV properties for a user share reshared with a room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" creates room "another group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
     And user "participant2" shares "welcome (2).txt" with room "group room" with OCS 100
@@ -954,8 +993,10 @@ Feature: get
   Scenario: get DAV properties for a room share reshared with a user as the resharer
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" creates room "another group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
@@ -966,8 +1007,10 @@ Feature: get
   Scenario: get DAV properties for a user share reshared with a room as the resharer
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" creates room "another group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
     And user "participant2" shares "welcome (2).txt" with room "group room" with OCS 100
@@ -980,6 +1023,7 @@ Feature: get
   Scenario: get DAV properties for a reshared folder
     Given user "participant2" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" creates folder "/test"
     And user "participant1" shares "/test" with user "participant2" with OCS 100
     And user "participant2" shares "/test" with room "group room" with OCS 100
@@ -990,6 +1034,7 @@ Feature: get
   Scenario: get DAV properties for a folder with a reshare
     Given user "participant2" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" creates folder "/test"
     And user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
     And user "participant1" shares "/test/renamed.txt" with user "participant2" with OCS 100
@@ -1002,6 +1047,7 @@ Feature: get
   Scenario: get DAV properties for a folder with a reshared folder
     Given user "participant2" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" creates folder "/test"
     And user "participant1" creates folder "/test/subfolder"
     And user "participant1" shares "/test/subfolder" with user "participant2" with OCS 100
@@ -1016,6 +1062,7 @@ Feature: get
   Scenario: get files after sharing a file
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     When user "participant1" gets the DAV properties for "/"
@@ -1033,6 +1080,7 @@ Feature: get
   Scenario: get files after deleting a share
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant1" deletes last share
@@ -1048,6 +1096,7 @@ Feature: get
   Scenario: get files after deleting a received share
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant2" deletes last share
@@ -1063,6 +1112,7 @@ Feature: get
   Scenario: get files after deleting the file of a share
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant1" deletes file "welcome.txt"
@@ -1079,6 +1129,7 @@ Feature: get
   Scenario: get recent files including a share
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" creates folder "/test"
     And user "participant1" creates folder "/test/subfolder"
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100

--- a/tests/integration/features/sharing/hooks.feature
+++ b/tests/integration/features/sharing/hooks.feature
@@ -11,6 +11,7 @@ Feature: hooks
   Scenario: invite user to group room after a file was shared
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     When user "participant1" adds "participant2" to room "group room" with 200
@@ -29,6 +30,7 @@ Feature: hooks
   Scenario: join public room after a file was shared
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" renames room "public room" to "Public room" with 200
     And user "participant1" shares "welcome.txt" with room "public room" with OCS 100
     And user "participant2" joins room "public room" with 200
@@ -50,6 +52,7 @@ Feature: hooks
   Scenario: remove sharer from group room after sharing a file
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant2" shares "welcome.txt" with room "group room" with OCS 100
     When user "participant1" removes "participant2" from room "group room" with 200
@@ -61,6 +64,7 @@ Feature: hooks
   Scenario: remove herself from group room after sharing a file
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant2" shares "welcome.txt" with room "group room" with OCS 100
     When user "participant2" removes themselves from room "group room" with 200
@@ -72,6 +76,7 @@ Feature: hooks
   Scenario: leave group room after sharing a file
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant2" shares "welcome.txt" with room "group room" with OCS 100
@@ -102,6 +107,7 @@ Feature: hooks
   Scenario: leave public room invited to after sharing a file
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" renames room "public room" to "Public room" with 200
     And user "participant1" adds "participant2" to room "public room" with 200
     And user "participant2" shares "welcome.txt" with room "public room" with OCS 100
@@ -134,6 +140,7 @@ Feature: hooks
   Scenario: leave public room self joined to after sharing a file
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant2" joins room "public room" with 200
     And user "participant2" shares "welcome.txt" with room "public room" with OCS 100
     When user "participant2" leaves room "public room" with 200
@@ -145,6 +152,7 @@ Feature: hooks
   Scenario: remove sharer from group room with other shares after sharing a file
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" creates folder "test"
@@ -176,6 +184,7 @@ Feature: hooks
   Scenario: remove sharer from group room after sharing a file and a receiver reshared it
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant2" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant1" shares "welcome (2).txt" with user "participant3" with OCS 100
@@ -220,6 +229,7 @@ Feature: hooks
   Scenario: remove sharee from group room after a file was shared
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -241,6 +251,7 @@ Feature: hooks
   Scenario: remove sharee from group room after a file was shared and the sharee moved it
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -263,6 +274,7 @@ Feature: hooks
   Scenario: remove herself from group room after a file was shared
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -284,6 +296,7 @@ Feature: hooks
   Scenario: remove herself from group room after a file was shared and the sharee moved it
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -306,6 +319,7 @@ Feature: hooks
   Scenario: leave public room self joined to after a file was shared
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" renames room "public room" to "Public room" with 200
     And user "participant2" joins room "public room" with 200
     And user "participant1" shares "welcome.txt" with room "public room" with OCS 100
@@ -328,6 +342,7 @@ Feature: hooks
   Scenario: leave public room self joined to after a file was shared and the sharee moved it
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" renames room "public room" to "Public room" with 200
     And user "participant2" joins room "public room" with 200
     And user "participant1" shares "welcome.txt" with room "public room" with OCS 100
@@ -351,6 +366,7 @@ Feature: hooks
   Scenario: remove sharee from group room with other sharees after a file was shared and the sharees moved it
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
@@ -388,6 +404,7 @@ Feature: hooks
   Scenario: remove sharee from group room after a file was shared and the sharee reshared it
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
@@ -430,6 +447,7 @@ Feature: hooks
   Scenario: add sharer again to group room after sharing a file and the sharer was removed from the room
     Given user "participant2" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" adds "participant1" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant2" removes "participant1" from room "group room" with 200
@@ -442,6 +460,7 @@ Feature: hooks
   Scenario: add sharer again to group room after sharing a file and the sharer removed herself from the room
     Given user "participant2" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" adds "participant1" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant1" removes themselves from room "group room" with 200
@@ -454,6 +473,7 @@ Feature: hooks
   Scenario: join public room again after sharing a file and the sharer left the room
     Given user "participant2" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" joins room "public room" with 200
     And user "participant1" shares "welcome.txt" with room "public room" with OCS 100
     And user "participant1" leaves room "public room" with 200
@@ -468,6 +488,7 @@ Feature: hooks
   Scenario: add sharer again to group room after sharing a file and a receiver reshared it and the sharer was removed from the room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant2" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant1" shares "welcome (2).txt" with user "participant3" with OCS 100
@@ -513,6 +534,7 @@ Feature: hooks
   Scenario: add sharee again to group room after a file was shared and the sharee was removed from the room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -534,6 +556,7 @@ Feature: hooks
   Scenario: add sharee again to group room after a file was shared and moved by the sharee and the sharee was removed from the room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -556,6 +579,7 @@ Feature: hooks
   Scenario: add sharee again to group room after a file was shared and the sharee removed herself from the room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -577,6 +601,7 @@ Feature: hooks
   Scenario: add sharee again to group room after a file was shared and moved by the sharee and the sharee removed herself from the room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -599,6 +624,7 @@ Feature: hooks
   Scenario: join sharee again to public room after a file was shared and the sharee left the room
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" renames room "public room" to "Public room" with 200
     And user "participant2" joins room "public room" with 200
     And user "participant1" shares "welcome.txt" with room "public room" with OCS 100
@@ -621,6 +647,7 @@ Feature: hooks
   Scenario: join sharee again to public room after a file was shared and moved by the sharee and the sharee left the room
     Given user "participant1" creates room "public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" renames room "public room" to "Public room" with 200
     And user "participant2" joins room "public room" with 200
     And user "participant1" shares "welcome.txt" with room "public room" with OCS 100
@@ -646,6 +673,7 @@ Feature: hooks
   Scenario: add sharee again to group room after a file was shared and the sharee reshared it and the sharee was removed from the room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
@@ -710,6 +738,7 @@ Feature: hooks
   Scenario: delete group room after sharing a file
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "own group room" with 200
     And user "participant1" shares "welcome.txt" with room "own group room" with OCS 100
     When user "participant1" deletes room "own group room" with 200
@@ -721,6 +750,7 @@ Feature: hooks
   Scenario: delete public room after sharing a file
     Given user "participant1" creates room "own public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "own public room" with 200
     And user "participant3" joins room "own public room" with 200
     And user "participant1" shares "welcome.txt" with room "own public room" with OCS 100
@@ -735,6 +765,7 @@ Feature: hooks
   Scenario: delete room after a file was shared and the sharee moved it
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant2" moves file "welcome (2).txt" to "renamed.txt"
@@ -747,6 +778,7 @@ Feature: hooks
   Scenario: delete room after a file was shared and the sharee reshared it
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
@@ -776,6 +808,7 @@ Feature: hooks
   Scenario: delete room after a file was shared and the sharee moved and reshared it
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant2" moves file "welcome (2).txt" to "renamed.txt"
@@ -806,12 +839,15 @@ Feature: hooks
   Scenario: delete room after sharing a file with several rooms
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" creates room "another group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "another group room" to "Another group room" with 200
     And user "participant1" creates room "yet another group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "yet another group room" to "Yet another group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant2" to room "another group room" with 200
@@ -870,6 +906,7 @@ Feature: hooks
   Scenario: delete user after sharing a file
     Given user "participant1" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" adds "participant2" to room "group room invited to" with 200
     And user "participant2" shares "welcome.txt" with room "group room invited to" with OCS 100
     When user "participant2" is deleted
@@ -879,6 +916,7 @@ Feature: hooks
   Scenario: delete user after receiving a shared a file
     Given user "participant1" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant1" adds "participant2" to room "group room invited to" with 200
     And user "participant1" adds "participant3" to room "group room invited to" with 200
@@ -910,6 +948,7 @@ Feature: hooks
   Scenario: delete user after receiving and moving a shared a file
     Given user "participant1" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant1" adds "participant2" to room "group room invited to" with 200
     And user "participant1" adds "participant3" to room "group room invited to" with 200
@@ -942,6 +981,7 @@ Feature: hooks
   Scenario: delete user after resharing a file
     Given user "participant1" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant1" adds "participant2" to room "group room invited to" with 200
     And user "participant1" adds "participant3" to room "group room invited to" with 200

--- a/tests/integration/features/sharing/move.feature
+++ b/tests/integration/features/sharing/move.feature
@@ -9,6 +9,7 @@ Feature: move
   Scenario: move share to another folder
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
@@ -56,6 +57,7 @@ Feature: move
   Scenario: move share to received shared folder from a user in the room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
@@ -106,6 +108,7 @@ Feature: move
   Scenario: move share to received shared folder from a user not in the room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
@@ -156,6 +159,7 @@ Feature: move
   Scenario: move share to received shared folder which is also a received shared folder
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant3" creates folder "/test"
@@ -211,6 +215,7 @@ Feature: move
   Scenario: move received share to another folder
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
@@ -258,6 +263,7 @@ Feature: move
   Scenario: move received share to shared folder
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
@@ -272,6 +278,7 @@ Feature: move
   Scenario: move received share to received shared folder from a user in the room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
@@ -316,6 +323,7 @@ Feature: move
   Scenario: move received share to received shared folder from a user not in the room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200

--- a/tests/integration/features/sharing/restore.feature
+++ b/tests/integration/features/sharing/restore.feature
@@ -8,6 +8,7 @@ Feature: delete
   Scenario: restore deleted share
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
@@ -55,6 +56,7 @@ Feature: delete
   Scenario: restore share deleted after moving it
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
@@ -103,6 +105,7 @@ Feature: delete
   Scenario: restore deleted share after owner updated it
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200

--- a/tests/integration/features/sharing/sharees.feature
+++ b/tests/integration/features/sharing/sharees.feature
@@ -9,8 +9,10 @@ Feature: sharees
   Scenario: search empty name
     Given user "participant1" creates room "unnamed own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Group room" with 200
     And user "participant1" creates room "own one-to-one room"
       | roomType | 1 |
@@ -37,6 +39,7 @@ Feature: sharees
   Scenario: search own group room with no matches
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Group room" with 200
     When user "participant1" gets sharees for
       | search | unmatched search term |
@@ -46,6 +49,7 @@ Feature: sharees
   Scenario: search own group room with single match
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Group room" with 200
     When user "participant1" gets sharees for
       | search | room |
@@ -56,6 +60,7 @@ Feature: sharees
   Scenario: search own group room with single exact match
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Group room" with 200
     When user "participant1" gets sharees for
       | search | group room |
@@ -66,9 +71,11 @@ Feature: sharees
   Scenario: search own group room with several matches
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Group room" with 200
     And user "participant1" creates room "another own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "another own group room" to "Another group room" with 200
     When user "participant1" gets sharees for
       | search | group room |
@@ -82,9 +89,11 @@ Feature: sharees
   Scenario: search group room not invited to
     Given user "participant1" creates room "group room not invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room not invited to" to "Group room" with 200
     And user "participant2" creates room "another group room not invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "another group room not invited to" to "Another group room" with 200
     When user "participant3" gets sharees for
       | search | group room |
@@ -94,6 +103,7 @@ Feature: sharees
   Scenario: search group room invited to with single match
     Given user "participant1" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room invited to" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room invited to" with 200
     When user "participant2" gets sharees for
@@ -105,6 +115,7 @@ Feature: sharees
   Scenario: search group room invited to with single exact match
     Given user "participant1" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room invited to" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room invited to" with 200
     When user "participant2" gets sharees for
@@ -116,10 +127,12 @@ Feature: sharees
   Scenario: search group room invited to with several matches
     Given user "participant1" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room invited to" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room invited to" with 200
     And user "participant1" creates room "another group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "another group room invited to" to "Another group room" with 200
     And user "participant1" adds "participant2" to room "another group room invited to" with 200
     When user "participant2" gets sharees for
@@ -174,9 +187,11 @@ Feature: sharees
   Scenario: search public room not joined to
     Given user "participant1" creates room "public room not joined to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" renames room "public room not joined to" to "Public room" with 200
     And user "participant2" creates room "another public room not joined to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant2" renames room "another public room not joined to" to "Another public room" with 200
     When user "participant3" gets sharees for
       | search | public room |
@@ -186,6 +201,7 @@ Feature: sharees
   Scenario: search public room self joined to with single match
     Given user "participant1" creates room "public room self joined to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" renames room "public room self joined to" to "Public room" with 200
     And user "participant2" joins room "public room self joined to" with 200
     When user "participant2" gets sharees for
@@ -197,6 +213,7 @@ Feature: sharees
   Scenario: search public room self joined to with single exact match
     Given user "participant1" creates room "public room self joined to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" renames room "public room self joined to" to "Public room" with 200
     And user "participant2" joins room "public room self joined to" with 200
     When user "participant2" gets sharees for
@@ -208,10 +225,12 @@ Feature: sharees
   Scenario: search public room self joined to with several matches
     Given user "participant1" creates room "public room self joined to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" renames room "public room self joined to" to "Public room" with 200
     And user "participant2" joins room "public room self joined to" with 200
     And user "participant1" creates room "another public room self joined to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" renames room "another public room self joined to" to "Another public room" with 200
     And user "participant2" joins room "another public room self joined to" with 200
     When user "participant2" gets sharees for
@@ -230,21 +249,26 @@ Feature: sharees
     And user "participant1" renames room "group room invited to as member of a group" to "Room" with 200
     And user "participant1" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room invited to" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room invited to" with 200
     And user "participant1" creates room "group room not invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room not invited to" to "Group room not invited to" with 200
     And user "participant2" creates room "unnamed own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "own group room" to "Own group room" with 200
     And user "participant1" creates room "one-to-one room invited to"
       | roomType | 1 |
       | invite   | participant2 |
     And user "participant2" creates room "own public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant2" renames room "own public room" to "Own public room" with 200
     When user "participant2" gets sharees for
       | search | room |

--- a/tests/integration/features/sharing/transfer-ownership.feature
+++ b/tests/integration/features/sharing/transfer-ownership.feature
@@ -8,6 +8,7 @@ Feature: transfer-ownership
   Scenario: transfer ownership of a file shared with a room to a user in the room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
@@ -50,6 +51,7 @@ Feature: transfer-ownership
   Scenario: transfer ownership of a file reshared with a room to a user in the room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
@@ -101,6 +103,7 @@ Feature: transfer-ownership
   Scenario: transfer ownership of a file shared with a room to a user not in the room
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100

--- a/tests/integration/features/sharing/update.feature
+++ b/tests/integration/features/sharing/update.feature
@@ -102,6 +102,7 @@ Feature: update
   Scenario: update share with an owned group room
     Given user "participant1" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "own group room" to "Own group room" with 200
     And user "participant1" adds "participant2" to room "own group room" with 200
     And user "participant1" shares "welcome.txt" with room "own group room" with OCS 100
@@ -150,6 +151,7 @@ Feature: update
   Scenario: update share with a group room invited to
     Given user "participant2" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant2" adds "participant1" to room "group room invited to" with 200
     And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
@@ -198,6 +200,7 @@ Feature: update
   Scenario: update share with an owned public room
     Given user "participant1" creates room "own public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" renames room "own public room" to "Own public room" with 200
     And user "participant1" adds "participant2" to room "own public room" with 200
     And user "participant3" joins room "own public room" with 200
@@ -264,6 +267,7 @@ Feature: update
   Scenario: update share with a public room invited to
     Given user "participant2" creates room "public room invited to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant2" renames room "public room invited to" to "Public room invited to" with 200
     And user "participant2" adds "participant1" to room "public room invited to" with 200
     And user "participant3" joins room "public room invited to" with 200
@@ -330,6 +334,7 @@ Feature: update
   Scenario: update share with a public room self joined to
     Given user "participant2" creates room "public room self joined to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant2" renames room "public room self joined to" to "Public room self joined to" with 200
     And user "participant1" joins room "public room self joined to" with 200
     And user "participant3" joins room "public room self joined to" with 200
@@ -431,6 +436,7 @@ Feature: update
   Scenario: update (unknown) share with a group room not invited to
     Given user "participant2" creates room "group room not invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "group room not invited to" to "Group room not invited to" with 200
     And user "participant2" adds "participant3" to room "group room not invited to" with 200
     And user "participant2" shares "welcome.txt" with room "group room not invited to" with OCS 100
@@ -465,6 +471,7 @@ Feature: update
   Scenario: update (unknown) share with a public room not joined to
     Given user "participant2" creates room "public room not joined to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant2" renames room "public room not joined to" to "Public room not joined to" with 200
     And user "participant2" adds "participant3" to room "public room not joined to" with 200
     And user "participant2" shares "welcome.txt" with room "public room not joined to" with OCS 100
@@ -569,6 +576,7 @@ Feature: update
   Scenario: update received share with an owned group room
     Given user "participant2" creates room "own group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant2" renames room "own group room" to "Own group room" with 200
     And user "participant2" adds "participant1" to room "own group room" with 200
     And user "participant1" shares "welcome.txt" with room "own group room" with OCS 100
@@ -603,6 +611,7 @@ Feature: update
   Scenario: update received share with a group room invited to
     Given user "participant1" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant1" adds "participant2" to room "group room invited to" with 200
     And user "participant1" adds "participant3" to room "group room invited to" with 200
@@ -649,6 +658,7 @@ Feature: update
   Scenario: update received share with a group room no longer invited to
     Given user "participant1" creates room "group room no longer invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room no longer invited to" to "Group room no longer invited to" with 200
     And user "participant1" adds "participant2" to room "group room no longer invited to" with 200
     And user "participant1" adds "participant3" to room "group room no longer invited to" with 200
@@ -688,6 +698,7 @@ Feature: update
   Scenario: update received share with an owned public room
     Given user "participant2" creates room "own public room"
       | roomType | 3 |
+      | roomName | room |
     And user "participant2" renames room "own public room" to "Own public room" with 200
     And user "participant2" adds "participant1" to room "own public room" with 200
     And user "participant3" joins room "own public room" with 200
@@ -737,6 +748,7 @@ Feature: update
   Scenario: update received share with a public room invited to
     Given user "participant1" creates room "public room invited to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" renames room "public room invited to" to "Public room invited to" with 200
     And user "participant1" adds "participant2" to room "public room invited to" with 200
     And user "participant3" joins room "public room invited to" with 200
@@ -786,6 +798,7 @@ Feature: update
   Scenario: update received share with a public room self joined to
     Given user "participant1" creates room "public room self joined to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" renames room "public room self joined to" to "Public room self joined to" with 200
     And user "participant2" joins room "public room self joined to" with 200
     And user "participant3" joins room "public room self joined to" with 200
@@ -835,6 +848,7 @@ Feature: update
   Scenario: update received share with a public room no longer joined to
     Given user "participant1" creates room "public room no longer joined to"
       | roomType | 3 |
+      | roomName | room |
     And user "participant1" renames room "public room no longer joined to" to "Public room no longer joined to" with 200
     And user "participant2" joins room "public room no longer joined to" with 200
     And user "participant3" joins room "public room no longer joined to" with 200
@@ -878,6 +892,7 @@ Feature: update
   Scenario: update received share after moving it
     Given user "participant1" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant1" adds "participant2" to room "group room invited to" with 200
     And user "participant1" adds "participant3" to room "group room invited to" with 200
@@ -926,6 +941,7 @@ Feature: update
   Scenario: update received share with a room no longer invited to after moving it
     Given user "participant1" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant1" adds "participant2" to room "group room invited to" with 200
     And user "participant1" adds "participant3" to room "group room invited to" with 200
@@ -969,6 +985,7 @@ Feature: update
   Scenario: update received share with increased permissions
     Given user "participant1" creates room "group room invited to"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room invited to" to "Group room invited to" with 200
     And user "participant1" adds "participant2" to room "group room invited to" with 200
     And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
@@ -1008,6 +1025,7 @@ Feature: update
   Scenario: update share after sharee deleted it
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
@@ -1046,6 +1064,7 @@ Feature: update
   Scenario: update received share after deleting it
     Given user "participant1" creates room "group room"
       | roomType | 2 |
+      | roomName | room |
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100

--- a/tests/php/Activity/Provider/BaseTest.php
+++ b/tests/php/Activity/Provider/BaseTest.php
@@ -196,22 +196,16 @@ class BaseTest extends TestCase {
 			->method('getId')
 			->willReturn($id);
 		$room->expects($this->once())
-			->method('getName')
-			->willReturn($name);
-
-		$l = $this->createMock(IL10N::class);
-		$l->expects($this->any())
-			->method('t')
-			->willReturnCallback(function($text, $parameters = []) {
-				return vsprintf($text, $parameters);
-			});
+			->method('getDisplayName')
+			->with('user')
+			->willReturn($expectedName);
 
 		$this->assertEquals([
 			'type' => 'call',
 			'id' => $id,
 			'name' => $expectedName,
 			'call-type' => $expectedType,
-		], self::invokePrivate($provider, 'getRoom', [$l, $room]));
+		], self::invokePrivate($provider, 'getRoom', [$room, 'user']));
 	}
 
 	public function dataGetUser() {

--- a/tests/php/Activity/Provider/InvitationTest.php
+++ b/tests/php/Activity/Provider/InvitationTest.php
@@ -152,10 +152,13 @@ class InvitationTest extends TestCase {
 				->method('getRoomById')
 				->with($params['room'])
 				->willReturn($room);
+			$event->expects($this->once())
+				->method('getAffectedUser')
+				->willReturn('user');
 
 			$provider->expects($this->once())
 				->method('getRoom')
-				->with($l, $room)
+				->with($room, 'user')
 				->willReturn(['call-data']);
 		} else {
 			$this->manager->expects($this->once())

--- a/tests/php/Collaboration/Collaborators/RoomPluginTest.php
+++ b/tests/php/Collaboration/Collaborators/RoomPluginTest.php
@@ -81,7 +81,7 @@ class RoomPluginTest extends \Test\TestCase {
 			->willReturn($token);
 
 		$room->expects($this->any())
-			->method('getName')
+			->method('getDisplayName')
 			->willReturn($name);
 
 		return $room;

--- a/tests/php/Controller/RoomControllerTest.php
+++ b/tests/php/Controller/RoomControllerTest.php
@@ -38,7 +38,6 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IGroupManager;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -53,8 +52,6 @@ class RoomControllerTest extends \Test\TestCase {
 	protected $userManager;
 	/** @var IGroupManager|MockObject */
 	protected $groupManager;
-	/** @var ILogger|MockObject */
-	protected $logger;
 	/** @var Manager|MockObject */
 	protected $manager;
 	/** @var ChatManager|MockObject */
@@ -76,7 +73,6 @@ class RoomControllerTest extends \Test\TestCase {
 		$this->talkSession = $this->createMock(TalkSession::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
-		$this->logger = $this->createMock(ILogger::class);
 		$this->manager = $this->createMock(Manager::class);
 		$this->guestManager = $this->createMock(GuestManager::class);
 		$this->chatManager = $this->createMock(ChatManager::class);
@@ -93,7 +89,6 @@ class RoomControllerTest extends \Test\TestCase {
 			$this->talkSession,
 			$this->userManager,
 			$this->groupManager,
-			$this->logger,
 			$this->manager,
 			$this->guestManager,
 			$this->chatManager,

--- a/tests/php/Controller/SignalingControllerTest.php
+++ b/tests/php/Controller/SignalingControllerTest.php
@@ -358,7 +358,8 @@ class SignalingControllerTest extends \Test\TestCase {
 
 		$participant = $this->createMock(Participant::class);
 		$room->expects($this->once())
-			->method('getName')
+			->method('getDisplayName')
+			->with($this->userId)
 			->willReturn($roomName);
 		$room->expects($this->once())
 			->method('getParticipant')
@@ -404,7 +405,8 @@ class SignalingControllerTest extends \Test\TestCase {
 
 		$participant = $this->createMock(Participant::class);
 		$room->expects($this->once())
-			->method('getName')
+			->method('getDisplayName')
+			->with('')
 			->willReturn($roomName);
 		$room->expects($this->once())
 			->method('getParticipantBySession')
@@ -450,7 +452,8 @@ class SignalingControllerTest extends \Test\TestCase {
 
 		$participant = $this->createMock(Participant::class);
 		$room->expects($this->once())
-			->method('getName')
+			->method('getDisplayName')
+			->with($this->userId)
 			->willReturn($roomName);
 		$room->expects($this->once())
 			->method('getParticipant')
@@ -538,7 +541,8 @@ class SignalingControllerTest extends \Test\TestCase {
 
 		$participant = $this->createMock(Participant::class);
 		$room->expects($this->once())
-			->method('getName')
+			->method('getDisplayName')
+			->with($this->userId)
 			->willReturn($roomName);
 		$room->expects($this->once())
 			->method('getParticipant')

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -185,7 +185,7 @@ class BackendNotifierTest extends \Test\TestCase {
 					$this->userId,
 				],
 				'properties' => [
-					'name' => $room->getName(),
+					'name' => $room->getDisplayName(''),
 					'type' => $room->getType(),
 				],
 			],
@@ -218,7 +218,7 @@ class BackendNotifierTest extends \Test\TestCase {
 				'alluserids' => [
 				],
 				'properties' => [
-					'name' => $room->getName(),
+					'name' => $room->getDisplayName(''),
 					'type' => $room->getType(),
 				],
 			],
@@ -239,7 +239,7 @@ class BackendNotifierTest extends \Test\TestCase {
 				'userids' => [
 				],
 				'properties' => [
-					'name' => $room->getName(),
+					'name' => $room->getDisplayName(''),
 					'type' => $room->getType(),
 				],
 			],

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -30,8 +30,10 @@ use OCA\Spreed\Participant;
 use OCA\Spreed\Signaling\BackendNotifier;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Http\Client\IClientService;
+use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\Security\IHasher;
 use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -122,10 +124,12 @@ class BackendNotifierTest extends \Test\TestCase {
 			$dbConnection,
 			$config,
 			$this->secureRandom,
+			$this->createMock(IUserManager::class),
 			$this->createMock(CommentsManager::class),
 			$dispatcher,
 			$this->timeFactory,
-			$this->createMock(IHasher::class)
+			$this->createMock(IHasher::class),
+			$this->createMock(IL10N::class)
 		);
 	}
 


### PR DESCRIPTION
- [x] Based on #1531 
- [x] Check external signaling
- [x] Check the participant list refreshes correctly when a guest renames themselves
- [x] Handle empty name when selecting an option (currently silently fails)

Should work fine with Internal signaling already.
