### PR TITLE
Fix removal of stale peers when a screen is shared

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -326,7 +326,7 @@ var spreedPeerConnectionTable = [];
 				}
 			}
 
-			if (delayedCreatePeer[message.from]) {
+			if (message.roomType === 'video' && delayedCreatePeer[message.from]) {
 				clearTimeout(delayedCreatePeer[message.from]);
 				delete delayedCreatePeer[message.from];
 			}

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -402,6 +402,7 @@ var spreedPeerConnectionTable = [];
 					peerId: id
 				});
 				videoView.setParticipant(userId);
+				videoView.setScreenAvailable(!!spreedListofSharedScreens[id]);
 
 				OCA.SpreedMe.videos.videoViews[id] = videoView;
 

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -314,11 +314,16 @@ var spreedPeerConnectionTable = [];
 
 			var peers = OCA.SpreedMe.webrtc.webrtc.peers;
 			var stalePeer = peers.find(function(peer) {
-				return peer.id === message.from && peer.sid !== message.sid;
+				return peer.id === message.from && peer.type === message.roomType && peer.sid !== message.sid;
 			});
 
 			if (stalePeer) {
-				usersChanged(signaling, [], [stalePeer.id]);
+				stalePeer.end();
+
+				if (message.roomType === 'video') {
+					OCA.SpreedMe.speakers.remove(stalePeer.id, true);
+					OCA.SpreedMe.videos.remove(stalePeer.id);
+				}
 			}
 
 			if (delayedCreatePeer[message.from]) {


### PR DESCRIPTION
Fixes #1559
Follow up to #1533

When a screen is shared a new offer is sent, just like when a video (or audio only) connection starts; any offer coming from the same peer has the same id, even if the type of the offer is different and separate Peer objects are created for each offer. Due to this now a peer is stale only if both the id and type of the new offer matches an existing peer; otherwise when the screen offer was received the video peer was seen as stale and removed.

Besides fixing #1559 the first commit also addresses the issues from #1533 but for shared screens instead of videos. However, there is still a pending issue: if the signaling returns a wrong user list to the user A causing it to disconnect from user B while user B is sharing the screen, when user A reconnects only video will be received, but not the screen. However, this should be a pretty uncommon scenario, and even if it happens stopping the screen sharing and starting it again makes it work again, so I will dig into it in the future (I will open an issue to not forget about it).

The second commit fixes the screen icon in the VideoView when there is a reconnection caused by a wrong user list returned by the signaling (like the issues in #1533). The third commit is just a "formal" fix; theoretically it could be a problem if user A shares the screen while user B is waiting for a delayed reconnection (pretty uncommon scenario too), but I have not actually tested it (nor found it "in the wild").

Note that the second commit can not be automatically backported to _stable15_ due to depending on #1513.

Finally, two users sharing their screens do not work, but it is not a recent issue; it has been broken since [the MCU support was added](https://github.com/nextcloud/spreed/commit/1060fb8c), so please share only a single screen at a time when testing this ;-)
