### PR TITLE
Fix sharing own screen when other peer is sharing the screen

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -76,8 +76,7 @@ var spreedPeerConnectionTable = [];
 			return;
 		}
 
-		var screenPeers = webrtc.webrtc.getPeers(sessionId, 'screen');
-		if (useMcu && !screenPeers.length) {
+		if (useMcu) {
 			// TODO(jojo): Already create peer object to avoid duplicate offers.
 			// TODO(jojo): We should use "requestOffer" as with regular
 			// audio/video peers. Not possible right now as there is no way
@@ -85,6 +84,7 @@ var spreedPeerConnectionTable = [];
 			// from the MCU should be requested.
 			webrtc.connection.sendOffer(sessionId, "screen");
 		} else if (!useMcu) {
+			var screenPeers = webrtc.webrtc.getPeers(sessionId, 'screen');
 			var screenPeerSharedTo = screenPeers.find(function(screenPeer) {
 				return screenPeer.sharemyscreen === true;
 			});

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -338,6 +338,13 @@ var spreedPeerConnectionTable = [];
 				clearTimeout(delayedCreatePeer[message.from]);
 				delete delayedCreatePeer[message.from];
 			}
+
+			// MCU screen offers do not include the "broadcaster" property,
+			// which is expected by SimpleWebRTC in screen offers from a remote
+			// peer, so it needs to be explicitly added.
+			if (signaling.hasFeature("mcu") && message.roomType === 'screen') {
+				message.broadcaster = message.from;
+			}
 		});
 
 		webrtc = new SimpleWebRTC({

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -76,15 +76,19 @@ var spreedPeerConnectionTable = [];
 			return;
 		}
 
-		if (!webrtc.webrtc.getPeers(sessionId, 'screen').length) {
-			if (useMcu) {
-				// TODO(jojo): Already create peer object to avoid duplicate offers.
-				// TODO(jojo): We should use "requestOffer" as with regular
-				// audio/video peers. Not possible right now as there is no way
-				// for clients to know that screensharing is active and an offer
-				// from the MCU should be requested.
-				webrtc.connection.sendOffer(sessionId, "screen");
-			} else {
+		var screenPeers = webrtc.webrtc.getPeers(sessionId, 'screen');
+		if (useMcu && !screenPeers.length) {
+			// TODO(jojo): Already create peer object to avoid duplicate offers.
+			// TODO(jojo): We should use "requestOffer" as with regular
+			// audio/video peers. Not possible right now as there is no way
+			// for clients to know that screensharing is active and an offer
+			// from the MCU should be requested.
+			webrtc.connection.sendOffer(sessionId, "screen");
+		} else if (!useMcu) {
+			var screenPeerSharedTo = screenPeers.find(function(screenPeer) {
+				return screenPeer.sharemyscreen === true;
+			});
+			if (!screenPeerSharedTo) {
 				var peer = webrtc.webrtc.createPeer({
 					id: sessionId,
 					type: 'screen',

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -318,6 +318,10 @@ var spreedPeerConnectionTable = [];
 
 			var peers = OCA.SpreedMe.webrtc.webrtc.peers;
 			var stalePeer = peers.find(function(peer) {
+				if (peer.sharemyscreen) {
+					return false;
+				}
+
 				return peer.id === message.from && peer.type === message.roomType && peer.sid !== message.sid;
 			});
 


### PR DESCRIPTION
This pull request fixes a regression introduced when the [support for the MCU was added](https://github.com/nextcloud/spreed/commit/1060fb8c) (Talk 4.0).

I have fixed the issue when there is no MCU, but it seems that it is also present when a MCU is used (at least, based on a test I made in our company instance it is present in latest release, so I guess it is present in master too).

@fancycode @Ivansss Could you fix this when a MCU is being used too? I am not confident enough to mess with the MCU related code without having a local MCU to test against it ;-) Thanks a lot :-)

One thing to keep in mind: when a MCU is used the `Peer` object that represents the screen received from the remote peer has `sharemyscreen` set to `true`, just like the `Peer` object that represents the local screen sent to the remote peer. Therefore, it is not possible to differentiate between screen peers (which is how I fixed it when no MCU is used).

This seems to happen because the screen offer received when the MCU is used does not contain the `broadcaster` property, which [is used by SimpleWebRTC to set the `sharemyscreen` property](https://github.com/nextcloud/spreed/blob/05905d1972ae35e011ff41c17a914d28bf551140/js/simplewebrtc.js#L18045); ~~I guess that it would be a matter of adding it to [the `sendOffer` data](https://github.com/nextcloud/spreed/blob/e6486263887240b70db4e68e35edd8f4d94d1468/js/signaling.js#L1263), but I do not really know.~~ No, that does not work; see comments below.

## How to test: ##
- Start call with user A
- Join call with user B
- Share screen with user A
- Share screen with user B

**Result with this pull request:**
Both users can see both screens (by clicking on the screen icon in their video/avatar).

**Result without this pull request:**
User A can not see the screen of user B; user B can see both screens.
