### PR TITLE
Fix disabling video when joining a call in a room with more than five participants

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -791,9 +791,9 @@
 			localVideo.hide();
 		},
 		disableVideo: function() {
-			this._mediaControlsView.disableVideo();
-			// Always hide the video, even if "disableVideo" returned "false".
-			this.hideVideo();
+			if (this._mediaControlsView.disableVideo()) {
+				this.hideVideo();
+			}
 		},
 		// Called from webrtc.js
 		disableScreensharingButton: function() {

--- a/js/app.js
+++ b/js/app.js
@@ -328,7 +328,6 @@
 					self.stopListening(self.activeRoom, 'change:displayName');
 					self.stopListening(self.activeRoom, 'change:participantFlags');
 
-					var participants;
 					if (OC.getCurrentUser().uid) {
 						roomChannel.trigger('active', token);
 
@@ -337,15 +336,6 @@
 								self.activeRoom = room;
 							}
 						});
-						participants = self.activeRoom.get('participants');
-					} else {
-						// The public page supports only a single room, so the
-						// active room is already the room for the given token.
-						participants = self.activeRoom.get('participants');
-					}
-					// Disable video when entering a room with more than 5 participants.
-					if (participants && Object.keys(participants).length > 5) {
-						self.disableVideo();
 					}
 
 					self._emptyContentView.setActiveRoom(self.activeRoom);
@@ -602,6 +592,15 @@
 				if (this.pendingNickChange) {
 					this.setGuestName(this.pendingNickChange);
 					delete this.pendingNickChange;
+				}
+			}.bind(this));
+
+			this.signaling.on('joinCall', function() {
+				// Disable video when joining a call in a room with more than 5
+				// participants.
+				var participants = this.activeRoom.get('participants');
+				if (participants && Object.keys(participants).length > 5) {
+					this.disableVideo();
 				}
 			}.bind(this));
 

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -237,9 +237,9 @@
 			localVideo.hide();
 		},
 		disableVideo: function() {
-			this._mediaControlsView.disableVideo();
-			// Always hide the video, even if "disableVideo" returned "false".
-			this.hideVideo();
+			if (this._mediaControlsView.disableVideo()) {
+				this.hideVideo();
+			}
 		},
 		// Called from webrtc.js
 		disableScreensharingButton: function() {

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -83,7 +83,6 @@
 				.then(function() {
 					self.stopListening(self.activeRoom, 'change:participantFlags');
 
-					var participants;
 					if (OC.getCurrentUser().uid) {
 						roomChannel.trigger('active', token);
 
@@ -92,11 +91,6 @@
 								self.activeRoom = room;
 							}
 						});
-						participants = self.activeRoom.get('participants');
-					}
-					// Disable video when entering a room with more than 5 participants.
-					if (participants && Object.keys(participants).length > 5) {
-						self.disableVideo();
 					}
 				});
 		},
@@ -126,6 +120,15 @@
 		onStart: function() {
 			this.signaling = OCA.Talk.Signaling.createConnection();
 			this.connection = new OCA.Talk.Connection(this);
+
+			this.signaling.on('joinCall', function() {
+				// Disable video when joining a call in a room with more than 5
+				// participants.
+				var participants = this.activeRoom.get('participants');
+				if (participants && Object.keys(participants).length > 5) {
+					this.disableVideo();
+				}
+			}.bind(this));
 
 			$(window).unload(function () {
 				this.connection.leaveCurrentRoom();


### PR DESCRIPTION
## How to test ##
- Create a room and add five or more participants to it
- Create another room with no participants, start a call and enable the video (to guarantee that the last call used had video enabled and thus the next call will have it enabled too, as the setting is remembered)
- Reload Talk UI
- Enter the room with five or more participants
- Start a call in the room with five or more participants

**Result with this pull request:**
Local video is disabled.

**Result without this pull request:**
Local video is enabled.
