### PR TITLE
Force "Plan B" semantics with the MCU.

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -351,6 +351,11 @@ var spreedPeerConnectionTable = [];
 			enableDataChannels: true,
 			nick: OC.getCurrentUser().displayName
 		});
+		if (signaling.hasFeature('mcu')) {
+			// Force "Plan-B" semantics if the MCU is used, which doesn't support
+			// "Unified Plan" with SimpleWebRTC yet.
+			webrtc.webrtc.config.peerConnectionConfig.sdpSemantics = 'plan-b';
+		}
 		OCA.SpreedMe.webrtc = webrtc;
 
 		OCA.SpreedMe.webrtc.startMedia = function (token) {


### PR DESCRIPTION
See https://webrtc.org/web-apis/chrome/unified-plan/ for details.

"Unified Plan" is starting to be the default with Chrome 72 but is not supported completely by the MCU with SimpleWebRTC yet.
