### PR TITLE
Fix removing users when an old session id expires in the signaling server.

### DIFF
--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -422,7 +422,7 @@ class SignalingController extends OCSController {
 			$room->ping($userId, $sessionId, $this->timeFactory->getTime());
 		} else if ($action === 'leave') {
 			if (!empty($userId)) {
-				$room->leaveRoom($userId);
+				$room->leaveRoom($userId, $sessionId);
 			} else if ($participant instanceof Participant) {
 				$room->removeParticipantBySession($participant, Room::PARTICIPANT_LEFT);
 			}

--- a/tests/php/Controller/SignalingControllerTest.php
+++ b/tests/php/Controller/SignalingControllerTest.php
@@ -34,6 +34,7 @@ use OCA\Spreed\Signaling\Messages;
 use OCA\Spreed\TalkSession;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IDBConnection;
+use OCP\IL10N;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Security\IHasher;
@@ -695,10 +696,12 @@ class SignalingControllerTest extends \Test\TestCase {
 			$dbConnection,
 			\OC::$server->getConfig(),
 			$this->secureRandom,
+			$this->createMock(IUserManager::class),
 			$this->createMock(CommentsManager::class),
 			$dispatcher,
 			$this->timeFactory,
-			$this->createMock(IHasher::class)
+			$this->createMock(IHasher::class),
+			$this->createMock(IL10N::class)
 		);
 		$this->recreateSignalingController();
 


### PR DESCRIPTION
It could happen that an old session id expired while a user already re-joined a room with a new session id. Once the old session id expired, the user got removed from the room.

Original report by @danxuliu against the standalone signaling server:

-----

## How to test:

- Log in as a user in Nextcloud
- Open the Talk app
- Enter a room
- Reload the page in the web browser
- Wait around 10 seconds

## Expected result:
The user is shown as active in the list of participants.

## Actual result:
The user is shown as not active in the list of participants. When the user changes from active to inactive the signaling server logs show Closing expired session; although this is followed by Removed session and the ID of the expired session it seems that something else changes and causes the user to be no longer active in the room.

-----

My feedback

A similar issue happens if you join the same room with different browsers but the same user and are using the PHP signaling backend:

- Join room with user in browser A
- Join room with user in browser B
- Navigate away in browser A
- After a couple of seconds, browser B shows the user as no longer in the room and also navigates away - from the room (to /apps/spreed) after some more seconds.

I think the root cause is that for logged in users only one session id is stored in the database.
With that, I can reproduce your issue in Firefox, but not in Chrome. When reloading, Chrome sends a Bye message to the signaling server which immediately invalidates the session and removes the user from the room.

Firefox doesn't send the Bye request from the unload handler, so the session times our after a few seconds (the reload generates a new session). Once the old session times out, the leave event is sent to Talk (including the user id and the session id). Talk removes the user from the participants table and the user is shown as no longer in the meeting / will leave the call.

Imho the solution would be to modify Talk to check in the leave event handling https://github.com/nextcloud/spreed/blob/1a4f96436a88e6f0a6b4fe4a599721ca1f166f0b/lib/Controller/SignalingController.php#L424
if the user to remove is still with the session to remove in the database or if he has a new session id (in which case nothing should be removed).

However the real fix would be to support multiple session ids per user to also handle the case I described above. This could for example happen if you connect to a room on your desktop and the mobile app.