### PR TITLE
Adjust the logic for delete/leave buttons

### DIFF
--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -342,6 +342,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 * Response:
     - Header:
         + `200 OK`
+        + `400 Bad Request` When the participant is a moderator/owner and there are no other moderators/owners left.
         + `403 Forbidden` When the current user is not a moderator/owner
         + `403 Forbidden` When the participant to remove is an owner
         + `404 Not Found` When the room could not be found for the participant
@@ -373,6 +374,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 * Response:
     - Header:
         + `200 OK`
+        + `400 Bad Request` When the participant is a moderator/owner and there are no other moderators/owners left.
         + `404 Not Found` When the room could not be found for the participant
 
 ### Join a room (available for call and chat)
@@ -420,11 +422,11 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 * Response:
     - Header:
         + `200 OK`
+        + `400 Bad Request` When the participant to promote is not a normal user (type `3`)
         + `403 Forbidden` When the current user is not a moderator/owner
         + `403 Forbidden` When the participant to remove is an owner
         + `404 Not Found` When the room could not be found for the participant
         + `404 Not Found` When the participant to remove could not be found
-        + `412 Precondition Failed` When the participant to promote is not a normal user (type `3`)
 
 ### Demote a moderator to a user
 
@@ -439,10 +441,10 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 * Response:
     - Header:
         + `200 OK`
+        + `400 Bad Request` When the participant to demote is not a moderator (type `2`)
         + `403 Forbidden` When the current user is not a moderator/owner
         + `404 Not Found` When the room could not be found for the participant
         + `404 Not Found` When the participant to demote could not be found
-        + `412 Precondition Failed` When the participant to demote is not a moderator (type `2`)
 
 
 ## Call management

--- a/js/models/room.js
+++ b/js/models/room.js
@@ -110,12 +110,29 @@
 
 			OCA.SpreedMe.app.connection.leaveCurrentRoom();
 		},
-		removeSelf: function() {
-			this.destroy({
-				url: this.url() + '/participants/self'
+		removeSelf: function(options) {
+			var self = this;
+
+			// Removing self can fail, so wait for the server response to remove
+			// the model from its collection and to leave the room.
+			var success = options? options.success: undefined;
+			options = _.extend({}, options, {
+				url: this.url() + '/participants/self',
+				wait: true,
+				success: function() {
+					self.leave();
+
+					if (success) {
+						success.apply(this, arguments);
+					}
+				}
 			});
+
+			return Backbone.Model.prototype.destroy.call(this, options);
 		},
 		destroy: function(options) {
+			// Destroying a room is not expected to fail, so leave the room
+			// without waiting for the server response for a snappier UI.
 			this.leave();
 
 			return Backbone.Model.prototype.destroy.call(this, options);

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -237,7 +237,20 @@
 		removeRoom: function() {
 			this.$el.slideUp();
 
-			this.model.removeSelf();
+			this.model.removeSelf({
+				error: function(model, response) {
+					if (response.status === 400) {
+						OC.Notification.showTemporary(t('spreed', 'You need to promote a new moderator before you can leave the conversation.'));
+
+						// Close the menu, as nothing changed and thus the item
+						// will not be rendered again.
+						this.menuShown = false;
+						this.toggleMenuClass();
+
+						this.$el.slideDown();
+					}
+				}.bind(this)
+			});
 		},
 		deleteRoom: function() {
 			if (this.model.get('participantType') !== 1 &&

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -88,7 +88,7 @@
 									'</button>'+
 								'</li>'+
 								'<li><div class="separator"></div></li>'+
-								'{{#if isRemovable}}'+
+								'{{#if isLeavable}}'+
 								'<li>'+
 									'<button class="remove-room-button">'+
 										'<span class="{{#if isDeletable}}icon-close{{else}}icon-delete{{/if}}"></span>'+
@@ -165,17 +165,17 @@
 				icon = 'icon icon-public';
 			}
 
-			// If a room is a one2one room it can not be removed from the list, only be deleted for both participants.
-			var isRemovable = this.model.get('type') !== 1;
+			var isDeletable = this.model.get('participantType') === 1 || this.model.get('participantType') === 2;
+			var isLeavable = !isDeletable || (this.model.get('type') !== 1 && Object.keys(this.model.get('participants')).length > 1);
+
 			return {
 				icon: icon,
 				canFavorite: this.model.get('participantType') !== 5,
 				notifyAlways: this.model.get('notificationLevel') === OCA.SpreedMe.app.NOTIFY_ALWAYS,
 				notifyMention: this.model.get('notificationLevel') === OCA.SpreedMe.app.NOTIFY_MENTION,
 				notifyNever: this.model.get('notificationLevel') === OCA.SpreedMe.app.NOTIFY_NEVER,
-				isRemovable: isRemovable,
-				isDeletable: !isRemovable || ((this.model.get('participantType') === 1 || this.model.get('participantType') === 2) &&
-					(Object.keys(this.model.get('participants')).length > 1 || this.model.get('numGuests') > 0)),
+				isLeavable: isLeavable,
+				isDeletable: isDeletable,
 				numUnreadMessages: this.model.get('unreadMessages') > 99 ? '99+' : this.model.get('unreadMessages')
 			};
 		},

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -17,6 +17,7 @@ default:
         - FilesAppContext
         - FilesAppSharingContext
         - LoginPageContext
+        - NotificationContext
         - PublicShareContext
 
         # Talk app contexts

--- a/tests/acceptance/features/conversation.feature
+++ b/tests/acceptance/features/conversation.feature
@@ -44,12 +44,12 @@ Feature: conversation
     And I see that the "admin" conversation is not active
     And I see that the number of participants shown in the list is "1"
 
-  Scenario: leave a conversation
+  Scenario: delete a conversation
     Given I am logged in
     And I have opened the Talk app
     And I create a group conversation named "Group"
     And I see that the "Group" conversation is active
-    When I leave the "Group" conversation
+    When I delete the "Group" conversation
     Then I see that the "Group" conversation is not shown in the list
     And I see that the "Join a conversation or start a new one Say hi to your friends and colleagues!" empty content message is shown in the main view
     And I see that the sidebar is closed
@@ -79,12 +79,36 @@ Feature: conversation
     And I see that the "This conversation has ended" empty content message is shown in the main view
     And I see that the sidebar is closed
 
-  Scenario: create a new conversation after leaving the active one
+  Scenario: leave a conversation
+    Given I act as John
+    And I am logged in
+    And I have opened the Talk app
+    And I create a group conversation named "Group"
+    And I add "admin" to the participants
+    And I see that the number of participants shown in the list is "2"
+    And I act as Jane
+    And I am logged in as the admin
+    And I have opened the Talk app
+    And I open the "Group" conversation
+    And I see that the "Group" conversation is active
+    And I see that the chat is shown in the main view
+    And I see that the sidebar is open
+    When I leave the "Group" conversation
+    Then I see that the "Group" conversation is not shown in the list
+    And I see that the "Join a conversation or start a new one Say hi to your friends and colleagues!" empty content message is shown in the main view
+    And I see that the sidebar is closed
+    And I act as John
+    And I see that the number of participants shown in the list is "1"
+    And I see that the "Group" conversation is active
+    And I see that the chat is shown in the main view
+    And I see that the sidebar is open
+
+  Scenario: create a new conversation after deleting the active one
     Given I am logged in
     And I have opened the Talk app
     And I create a group conversation named "Group"
     And I see that the "Group" conversation is active
-    And I leave the "Group" conversation
+    And I delete the "Group" conversation
     And I see that the "Group" conversation is not shown in the list
     And I see that the "Join a conversation or start a new one Say hi to your friends and colleagues!" empty content message is shown in the main view
     And I see that the sidebar is closed
@@ -95,7 +119,7 @@ Feature: conversation
     And I see that the number of participants shown in the list is "1"
     And I see that "user0" is shown in the list of participants as a moderator
 
-  Scenario: change to another conversation after leaving the active one
+  Scenario: change to another conversation after deleting the active one
     Given I am logged in
     And I have opened the Talk app
     And I create a one-to-one conversation with "admin"
@@ -105,7 +129,7 @@ Feature: conversation
     And I see that the "admin" conversation is not active
     And I see that the "Group" conversation is active
     And I see that the number of participants shown in the list is "1"
-    And I leave the "Group" conversation
+    And I delete the "Group" conversation
     And I see that the "Group conversation is not shown in the list
     And I see that the "Join a conversation or start a new one Say hi to your friends and colleagues!" empty content message is shown in the main view
     And I see that the sidebar is closed

--- a/tests/acceptance/features/conversation.feature
+++ b/tests/acceptance/features/conversation.feature
@@ -103,6 +103,19 @@ Feature: conversation
     And I see that the chat is shown in the main view
     And I see that the sidebar is open
 
+  Scenario: leave a conversation when there are no other moderators in the room
+    Given I am logged in
+    And I have opened the Talk app
+    And I create a group conversation named "Group"
+    And I add "admin" to the participants
+    And I see that the number of participants shown in the list is "2"
+    When I leave the "Group" conversation
+    Then I see that the "You need to promote a new moderator before you can leave the conversation." notification is shown
+    And I see that the number of participants shown in the list is "2"
+    And I see that the "Group" conversation is active
+    And I see that the chat is shown in the main view
+    And I see that the sidebar is open
+
   Scenario: create a new conversation after deleting the active one
     Given I am logged in
     And I have opened the Talk app

--- a/tests/integration/features/conversation/delete-room.feature
+++ b/tests/integration/features/conversation/delete-room.feature
@@ -54,13 +54,3 @@ Feature: public
     When user "participant2" deletes room "room" with 404
     Then user "participant1" is participant of room "room"
     And user "participant2" is not participant of room "room"
-
-  Scenario: User1 creates a public room and deletes themself
-    Given user "participant1" creates room "room"
-      | roomType | 3 |
-      | roomName | room |
-    And user "participant1" is participant of room "room"
-    And user "participant2" is not participant of room "room"
-    And user "participant3" is not participant of room "room"
-    When user "participant1" removes "participant1" from room "room" with 403
-    Then user "participant1" is participant of room "room"

--- a/tests/integration/features/conversation/one-to-one.feature
+++ b/tests/integration/features/conversation/one-to-one.feature
@@ -100,7 +100,7 @@ Feature: one-to-one
       | invite   | participant2 |
     And user "participant1" is participant of room "room8"
     And user "participant2" is participant of room "room8"
-    When user "participant1" promotes "participant2" in room "room8" with 412
+    When user "participant1" promotes "participant2" in room "room8" with 400
 
   Scenario: User1 invites user2 to a one2one room and demote user2 to moderator
     Given user "participant1" creates room "room9"
@@ -108,7 +108,7 @@ Feature: one-to-one
       | invite   | participant2 |
     And user "participant1" is participant of room "room9"
     And user "participant2" is participant of room "room9"
-    When user "participant1" demotes "participant2" in room "room9" with 412
+    When user "participant1" demotes "participant2" in room "room9" with 400
 
   Scenario: User1 invites user2 to a one2one room and promote non-invited user
     Given user "participant1" creates room "room10"

--- a/tests/integration/features/conversation/remove-participant.feature
+++ b/tests/integration/features/conversation/remove-participant.feature
@@ -16,6 +16,37 @@ Feature: public
     When user "participant1" removes "participant3" from room "room" with 403
     Then user "participant3" is participant of room "room"
 
+  Scenario: Owner removes self participant from empty public room
+    Given user "participant1" creates room "room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" is participant of room "room"
+    When user "participant1" removes "participant1" from room "room" with 200
+    Then user "participant1" is not participant of room "room"
+
+  Scenario: Owner removes self participant from public room when there are other users in the room
+    Given user "participant1" creates room "room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "room" with 200
+    And user "participant1" is participant of room "room"
+    And user "participant2" is participant of room "room"
+    When user "participant1" removes "participant1" from room "room" with 400
+    Then user "participant1" is participant of room "room"
+    And user "participant2" is participant of room "room"
+
+  Scenario: Owner removes self participant from public room when there are other moderators in the room
+    Given user "participant1" creates room "room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "room" with 200
+    And user "participant1" promotes "participant2" in room "room" with 200
+    And user "participant1" is participant of room "room"
+    And user "participant2" is participant of room "room"
+    When user "participant1" removes "participant1" from room "room" with 200
+    Then user "participant1" is not participant of room "room"
+    And user "participant2" is participant of room "room"
+
   Scenario: Moderator removes owner
     Given user "participant1" creates room "room"
       | roomType | 1 |
@@ -70,6 +101,49 @@ Feature: public
     And user "participant3" is participant of room "room"
     When user "participant2" removes "participant3" from room "room" with 200
     Then user "participant3" is not participant of room "room"
+
+  Scenario: Moderator removes self participant from empty public room
+    Given user "participant1" creates room "room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "room" with 200
+    And user "participant1" promotes "participant2" in room "room" with 200
+    And user "participant1" removes "participant1" from room "room" with 200
+    And user "participant1" is not participant of room "room"
+    And user "participant2" is participant of room "room"
+    When user "participant2" removes "participant2" from room "room" with 200
+    Then user "participant2" is not participant of room "room"
+
+  Scenario: Moderator removes self participant from public room when there are other users in the room
+    Given user "participant1" creates room "room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "room" with 200
+    And user "participant1" promotes "participant2" in room "room" with 200
+    And user "participant1" removes "participant1" from room "room" with 200
+    And user "participant1" is not participant of room "room"
+    And user "participant2" adds "participant3" to room "room" with 200
+    And user "participant2" is participant of room "room"
+    And user "participant3" is participant of room "room"
+    When user "participant2" removes "participant2" from room "room" with 400
+    Then user "participant2" is participant of room "room"
+    And user "participant3" is participant of room "room"
+
+  Scenario: Moderator removes self participant from public room when there are other moderators in the room
+    Given user "participant1" creates room "room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "room" with 200
+    And user "participant1" promotes "participant2" in room "room" with 200
+    And user "participant1" removes "participant1" from room "room" with 200
+    And user "participant1" is not participant of room "room"
+    And user "participant2" adds "participant3" to room "room" with 200
+    And user "participant2" promotes "participant3" in room "room" with 200
+    And user "participant2" is participant of room "room"
+    And user "participant3" is participant of room "room"
+    When user "participant2" removes "participant2" from room "room" with 200
+    Then user "participant2" is not participant of room "room"
+    And user "participant3" is participant of room "room"
 
   Scenario: User removes moderator
     Given user "participant1" creates room "room"


### PR DESCRIPTION
> * Delete - is only available to logged in moderators and owners
> * Leave - is always shown, when Delete is not shown, or
        when there are other other users and it's not one-to-one

- [x] Adjust buttons displayed
- [x] Prevent the last moderator/owner from leaving

Fix #1435 