### PR TITLE
Persistent one-to-one rooms

### DIFF
--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -82,6 +82,9 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 * `notification-levels` - Users can select when they want to be notified in conversations
 * `invite-groups-and-mails` - Groups can be added to existing conversations via the add participant endpoint
 
+### 6.0
+* `locked-one-to-one-rooms` - One-to-one conversations are now locked to the users. Neither guests nor other participants can be added, so the options to do that should be hidden as well. Also a user can only leave a one-to-one room (not delete). It will be deleted when the other participant left too. If the other participant posts a new chat message or starts a call, the left-participant will be re-added.
+
 ## Room management
 
 ### Creating a new room

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -245,7 +245,7 @@
 		},
 
 		_canModerate: function() {
-			return this._canFullModerate() || this.model.get('participantType') === 6;
+			return this.model.get('type') !== 1 && (this._canFullModerate() || this.model.get('participantType') === 6);
 		},
 
 		_canFullModerate: function() {

--- a/js/views/participantview.js
+++ b/js/views/participantview.js
@@ -90,7 +90,7 @@
 		 * the room; otherwise the form is hidden.
 		 */
 		_updateAddParticipantFormVisibility: function() {
-			if (!this.room ||
+			if (!this.room || this.room.get('type') === 1 ||
 					(this.room.get('participantType') !== OCA.SpreedMe.app.OWNER &&
 					this.room.get('participantType') !== OCA.SpreedMe.app.MODERATOR)) {
 				this.ui.addParticipantForm.hide();

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -165,7 +165,7 @@
 				icon = 'icon icon-public';
 			}
 
-			var isDeletable = this.model.get('participantType') === 1 || this.model.get('participantType') === 2;
+			var isDeletable = this.model.get('type') !== 1 && (this.model.get('participantType') === 1 || this.model.get('participantType') === 2);
 			var isLeavable = !isDeletable || (this.model.get('type') !== 1 && Object.keys(this.model.get('participants')).length > 1);
 
 			return {

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -65,6 +65,7 @@ class Capabilities implements IPublicCapability {
 					'in-call-flags',
 					'notification-levels',
 					'invite-groups-and-mails',
+					'locked-one-to-one-rooms',
 				],
 			],
 		];

--- a/lib/Chat/AutoComplete/SearchPlugin.php
+++ b/lib/Chat/AutoComplete/SearchPlugin.php
@@ -66,8 +66,15 @@ class SearchPlugin implements ISearchPlugin {
 	 */
 	public function search($search, $limit, $offset, ISearchResult $searchResult) {
 
+		$userIds = $this->room->getParticipantUserIds();
+		if ($this->room->getType() === Room::ONE_TO_ONE_CALL
+			&& $this->room->getName() !== '') {
+			// Add potential leavers of one-to-one rooms again.
+			$userIds[] = $this->room->getName();
+		}
+
 		// FIXME Handle guests
-		$this->searchUsers($search, $this->room->getParticipantUserIds(), $searchResult);
+		$this->searchUsers($search, $userIds, $searchResult);
 
 		if ($this->room->getObjectType() === 'file') {
 			$usersWithFileAccess = $this->util->getUsersWithAccessFile($this->room->getObjectId());

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -97,6 +97,11 @@ class Listener {
 			$listener->sendSystemMessage($room, 'conversation_created');
 		});
 		$dispatcher->addListener(Room::class . '::postSetName', function(GenericEvent $event) {
+			if ($event->getArgument('oldName') === '' ||
+				  $event->getArgument('newName') === '') {
+				return;
+			}
+
 			/** @var Room $room */
 			$room = $event->getSubject();
 			/** @var self $listener */

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -146,6 +146,11 @@ class Listener {
 
 			/** @var Room $room */
 			$room = $event->getSubject();
+
+			if ($room->getType() === Room::ONE_TO_ONE_CALL) {
+				return;
+			}
+
 			/** @var self $listener */
 			$listener = \OC::$server->query(self::class);
 			foreach ($participants as $participant) {
@@ -159,6 +164,10 @@ class Listener {
 			$user = $event->getArgument('user');
 			/** @var Room $room */
 			$room = $event->getSubject();
+
+			if ($room->getType() === Room::ONE_TO_ONE_CALL) {
+				return;
+			}
 
 			/** @var self $listener */
 			$listener = \OC::$server->query(self::class);

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -141,6 +141,8 @@ class CallController extends OCSController {
 			}
 		}
 
+		$room->ensureOneToOneRoomIsFilled();
+
 		$sessionId = $participant->getSessionId();
 		if ($sessionId === '0') {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -200,6 +200,7 @@ class ChatController extends OCSController {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
+		$room->ensureOneToOneRoomIsFilled();
 		$creationDateTime = $this->timeFactory->getDateTime('now', new \DateTimeZone('UTC'));
 
 		try {

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -863,6 +863,7 @@ class RoomController extends OCSController {
 	protected function removeSelfFromRoomLogic(Room $room, Participant $participant): DataResponse {
 		if ($room->getType() !== Room::ONE_TO_ONE_CALL) {
 			if ($participant->hasModeratorPermissions(false)
+				&& $room->getNumberOfParticipants() > 1
 				&& $room->getNumberOfModerators() === 1) {
 				return new DataResponse([], Http::STATUS_BAD_REQUEST);
 			}

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -560,17 +560,18 @@ class RoomController extends OCSController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
+		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
 		$roomName = trim($roomName);
 
 		if ($roomName === '' || strlen($roomName) > 200) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
-		if (!$room->setName($roomName)) {
-			return new DataResponse([], Http::STATUS_METHOD_NOT_ALLOWED);
-		}
-
-		return new DataResponse([]);
+		$room->setName($roomName);
+		return new DataResponse();
 	}
 
 	/**
@@ -596,6 +597,10 @@ class RoomController extends OCSController {
 
 		if (!$participant->hasModeratorPermissions()) {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
+		}
+
+		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
 		$room->deleteRoom();
@@ -682,9 +687,12 @@ class RoomController extends OCSController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
+		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
 		$participants = $room->getParticipantUserIds();
 
-		$updateRoomType = $room->getType() === Room::ONE_TO_ONE_CALL ? Room::GROUP_CALL : false;
 		$participantsToAdd = [];
 		if ($source === 'users') {
 			$newUser = $this->userManager->get($newParticipant);
@@ -722,18 +730,16 @@ class RoomController extends OCSController {
 
 			\call_user_func_array([$room, 'addUsers'], $participantsToAdd);
 		} else if ($source === 'emails') {
+			$data = [];
+			if ($room->changeType(Room::PUBLIC_CALL)) {
+				$data = ['type' => $room->getType()];
+			}
+
 			$this->guestManager->inviteByEmail($room, $newParticipant);
-			$updateRoomType = $room->getType() !== Room::PUBLIC_CALL ? Room::PUBLIC_CALL : false;
+
+			return new DataResponse($data);
 		} else {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
-		}
-
-		if ($updateRoomType !== false) {
-			// In case a user is added to a one2one room, we change the call to a group room
-			// In case an email is added to a closed room, we change the call to a public room
-			$room->changeType($updateRoomType);
-
-			return new DataResponse(['type' => $room->getType()]);
 		}
 
 		return new DataResponse();
@@ -765,12 +771,13 @@ class RoomController extends OCSController {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
-		$data = [];
-		if ($room->getType() !== Room::PUBLIC_CALL) {
-			// In case a user is added to a one2one call, we change the call to a group call
-			// In case a guest is added to a non-public call, we change the call to a public call
-			$room->changeType(Room::PUBLIC_CALL);
+		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
 
+		$data = [];
+		// In case a guest is added to a non-public call, we change the call to a public call
+		if ($room->changeType(Room::PUBLIC_CALL)) {
 			$data = ['type' => $room->getType()];
 		}
 
@@ -811,8 +818,7 @@ class RoomController extends OCSController {
 		}
 
 		if ($room->getType() === Room::ONE_TO_ONE_CALL) {
-			$room->deleteRoom();
-			return new DataResponse([]);
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
 		try {
@@ -854,13 +860,14 @@ class RoomController extends OCSController {
 	}
 
 	protected function removeSelfFromRoomLogic(Room $room, Participant $participant): DataResponse {
-		if ($room->getType() === Room::ONE_TO_ONE_CALL || $room->getNumberOfParticipants() === 1) {
+		if ($room->getType() !== Room::ONE_TO_ONE_CALL) {
+			if ($participant->hasModeratorPermissions(false)
+				&& $room->getNumberOfModerators() === 1) {
+				return new DataResponse([], Http::STATUS_BAD_REQUEST);
+			}
+		} else if ($room->getNumberOfParticipants() === 1) {
 			$room->deleteRoom();
-			return new DataResponse([]);
-		}
-
-		if ($participant->hasModeratorPermissions(false) && $room->getNumberOfModerators() === 1) {
-			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+			return new DataResponse();
 		}
 
 		$currentUser = $this->userManager->get($participant->getUser());
@@ -870,7 +877,7 @@ class RoomController extends OCSController {
 
 		$room->removeUser($currentUser, Room::PARTICIPANT_LEFT);
 
-		return new DataResponse([]);
+		return new DataResponse();
 	}
 
 	/**
@@ -937,8 +944,8 @@ class RoomController extends OCSController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		if ($room->getType() !== Room::PUBLIC_CALL) {
-			$room->changeType(Room::PUBLIC_CALL);
+		if (!$room->changeType(Room::PUBLIC_CALL)) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
 		return new DataResponse();
@@ -964,8 +971,8 @@ class RoomController extends OCSController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		if ($room->getType() === Room::PUBLIC_CALL) {
-			$room->changeType(Room::GROUP_CALL);
+		if (!$room->changeType(Room::GROUP_CALL)) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
 		return new DataResponse();

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -363,6 +363,7 @@ class RoomController extends OCSController {
 		// If room exists: Reuse that one, otherwise create a new one.
 		try {
 			$room = $this->manager->getOne2OneRoom($this->userId, $targetUser->getUID());
+			$room->ensureOneToOneRoomIsFilled();
 			return new DataResponse(['token' => $room->getToken()], Http::STATUS_OK);
 		} catch (RoomNotFoundException $e) {
 			$room = $this->manager->createOne2OneRoom();

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -443,6 +443,25 @@ class Room {
 		return true;
 	}
 
+	public function ensureOneToOneRoomIsFilled(): void {
+		if ($this->getType() !== self::ONE_TO_ONE_CALL) {
+			return;
+		}
+
+		if ($this->getName() === '') {
+			return;
+		}
+
+		if ($this->manager->isValidParticipant($this->getName())) {
+			$this->addUsers([
+				'userId' => $this->getName(),
+				'participantType' => Participant::OWNER,
+			]);
+		}
+
+		$this->setName('');
+	}
+
 	/**
 	 * @param array[] ...$participants
 	 */

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -272,10 +272,6 @@ class Room {
 	public function setName(string $newName): bool {
 		$oldName = $this->getName();
 		if ($newName === $oldName) {
-			return true;
-		}
-
-		if ($this->getType() === self::ONE_TO_ONE_CALL) {
 			return false;
 		}
 
@@ -399,13 +395,16 @@ class Room {
 	}
 
 	/**
-	 * @param int $newType Currently it is only allowed to change to: self::GROUP_CALL, self::PUBLIC_CALL
+	 * @param int $newType Currently it is only allowed to change between `self::GROUP_CALL` and `self::PUBLIC_CALL`
 	 * @return bool True when the change was valid, false otherwise
 	 */
 	public function changeType(int $newType): bool {
-		$newType = (int) $newType;
 		if ($newType === $this->getType()) {
 			return true;
+		}
+
+		if ($this->getType() === self::ONE_TO_ONE_CALL) {
+			return false;
 		}
 
 		if (!in_array($newType, [self::GROUP_CALL, self::PUBLIC_CALL], true)) {
@@ -540,6 +539,10 @@ class Room {
 			'reason' => $reason,
 		]));
 
+		if ($this->getType() === self::ONE_TO_ONE_CALL) {
+			$this->setName($user->getUID());
+		}
+
 		$query = $this->db->getQueryBuilder();
 		$query->delete('talk_participants')
 			->where($query->expr()->eq('room_id', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)))
@@ -551,6 +554,7 @@ class Room {
 			'participant' => $participant,
 			'reason' => $reason,
 		]));
+
 	}
 
 	/**

--- a/tests/acceptance/features/conversation.feature
+++ b/tests/acceptance/features/conversation.feature
@@ -54,7 +54,7 @@ Feature: conversation
     And I see that the "Join a conversation or start a new one Say hi to your friends and colleagues!" empty content message is shown in the main view
     And I see that the sidebar is closed
 
-  Scenario: delete a one-to-one conversation
+  Scenario: leave a one-to-one conversation
     Given I act as John
     And I am logged in
     And I have opened the Talk app
@@ -70,14 +70,14 @@ Feature: conversation
     And I see that the chat is shown in the main view
     And I see that the sidebar is open
     When I act as John
-    And I delete the "admin" conversation
+    And I leave the "admin" conversation
     Then I see that the "admin" conversation is not shown in the list
     And I see that the "Join a conversation or start a new one Say hi to your friends and colleagues!" empty content message is shown in the main view
     And I see that the sidebar is closed
     And I act as Jane
-    And I see that the "user0" conversation is not shown in the list
-    And I see that the "This conversation has ended" empty content message is shown in the main view
-    And I see that the sidebar is closed
+    And I see that the "user0" conversation is shown in the list
+    And I see that the chat is shown in the main view
+    And I see that the sidebar is open
 
   Scenario: leave a conversation
     Given I act as John

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -188,13 +188,28 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	 * @param TableNode|null $formData
 	 */
 	public function userCreatesRoom($user, $identifier, TableNode $formData = null) {
+		$this->userCreatesRoomWith($user, $identifier, 201, $formData);
+	}
+
+	/**
+	 * @Then /^user "([^"]*)" creates room "([^"]*)" with (\d+)$/
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 * @param int $statusCode
+	 * @param TableNode|null $formData
+	 */
+	public function userCreatesRoomWith($user, $identifier, $statusCode, TableNode $formData = null) {
 		$this->setCurrentUser($user);
 		$this->sendRequest('POST', '/apps/spreed/api/v1/room', $formData);
-		$this->assertStatusCode($this->response, 201);
+		$this->assertStatusCode($this->response, $statusCode);
 
 		$response = $this->getDataFromResponse($this->response);
-		self::$identifierToToken[$identifier] = $response['token'];
-		self::$tokenToIdentifier[$response['token']] = $identifier;
+
+		if ($statusCode === 201) {
+			self::$identifierToToken[$identifier] = $response['token'];
+			self::$tokenToIdentifier[$response['token']] = $identifier;
+		}
 	}
 
 	/**

--- a/tests/integration/features/callapi/one-to-one.feature
+++ b/tests/integration/features/callapi/one-to-one.feature
@@ -104,3 +104,21 @@ Feature: callapi/one-to-one
     Then user "participant1" leaves room "room" with 200
     Then user "participant1" sees 0 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404
+
+  Scenario: Sending a message into a one-to-one chat re-adds the participants
+    Given user "participant1" creates room "room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" is participant of room "room"
+    And user "participant2" is participant of room "room"
+    When user "participant1" removes themselves from room "room" with 200
+    Then user "participant1" is not participant of room "room"
+    When user "participant2" joins room "room" with 200
+    Then user "participant1" is not participant of room "room"
+    Then user "participant1" sees 0 peers in call "room" with 404
+    And user "participant2" sees 0 peers in call "room" with 200
+    When user "participant2" joins call "room" with 200
+    Then user "participant1" is participant of room "room"
+    And user "participant1" sees 1 peers in call "room" with 200
+    And user "participant2" sees 1 peers in call "room" with 200
+

--- a/tests/integration/features/chat/one-to-one.feature
+++ b/tests/integration/features/chat/one-to-one.feature
@@ -53,3 +53,17 @@ Feature: chat/one-to-one
       | room            | actorType | actorId      | actorDisplayName         | message   | messageParameters |
       | one-to-one room | users     | participant2 | participant2-displayname | Message 2 | []                |
       | one-to-one room | users     | participant1 | participant1-displayname | Message 1 | []                |
+
+  Scenario: Sending a message into a one-to-one chat re-adds the participants
+    Given user "participant1" creates room "one-to-one room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" is participant of room "one-to-one room"
+    And user "participant2" is participant of room "one-to-one room"
+    When user "participant1" removes themselves from room "one-to-one room" with 200
+    Then user "participant1" is not participant of room "one-to-one room"
+    When user "participant2" sends message "Message" to room "one-to-one room" with 201
+    Then user "participant1" is participant of room "one-to-one room"
+    Then user "participant1" sees the following messages in room "one-to-one room" with 200
+      | room            | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | one-to-one room | users     | participant2 | participant2-displayname | Message   | []                |

--- a/tests/integration/features/conversation/one-to-one.feature
+++ b/tests/integration/features/conversation/one-to-one.feature
@@ -127,3 +127,58 @@ Feature: one-to-one
     And user "participant1" is participant of room "room11"
     And user "participant3" is not participant of room "room11"
     When user "participant1" demotes "participant3" in room "room11" with 404
+
+  Scenario: User1 invites user2 to a one2one room twice, it's the same room
+    Given user "participant1" creates room "room12"
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" is participant of room "room12"
+    And user "participant2" is participant of room "room12"
+    And user "participant1" is participant of the following rooms
+      | id     | type | participantType | participants |
+      | room12 | 1    | 1               | participant1-displayname, participant2-displayname |
+    And user "participant2" is participant of the following rooms
+      | id     | type | participantType | participants |
+      | room12 | 1    | 1               | participant1-displayname, participant2-displayname |
+    When user "participant1" creates room "room13" with 200
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" is participant of room "room12"
+    And user "participant2" is participant of room "room12"
+    And user "participant1" is participant of the following rooms
+      | id     | type | participantType | participants |
+      | room12 | 1    | 1               | participant1-displayname, participant2-displayname |
+    And user "participant2" is participant of the following rooms
+      | id     | type | participantType | participants |
+      | room12 | 1    | 1               | participant1-displayname, participant2-displayname |
+
+  Scenario: User1 invites user2 to a one2one room, leaves and does it again, it's the same room
+    Given user "participant1" creates room "room14"
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" is participant of room "room14"
+    And user "participant2" is participant of room "room14"
+    And user "participant1" is participant of the following rooms
+      | id     | type | participantType | participants |
+      | room14 | 1    | 1               | participant1-displayname, participant2-displayname |
+    And user "participant2" is participant of the following rooms
+      | id     | type | participantType | participants |
+      | room14 | 1    | 1               | participant1-displayname, participant2-displayname |
+    When user "participant1" removes themselves from room "room14" with 200
+    Then user "participant1" is not participant of room "room14"
+    And user "participant1" is participant of the following rooms
+    And user "participant2" is participant of room "room14"
+    And user "participant2" is participant of the following rooms
+      | id     | type | participantType | participants |
+      | room14 | 1    | 1               | participant2-displayname |
+    When user "participant1" creates room "room15" with 200
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" is participant of room "room14"
+    And user "participant2" is participant of room "room14"
+    And user "participant1" is participant of the following rooms
+      | id     | type | participantType | participants |
+      | room14 | 1    | 1               | participant1-displayname, participant2-displayname |
+    And user "participant2" is participant of the following rooms
+      | id     | type | participantType | participants |
+      | room14 | 1    | 1               | participant1-displayname, participant2-displayname |

--- a/tests/integration/features/conversation/one-to-one.feature
+++ b/tests/integration/features/conversation/one-to-one.feature
@@ -37,62 +37,64 @@ Feature: one-to-one
     And user "participant2" is participant of room "room2"
     When user "participant1" removes themselves from room "room2" with 200
     Then user "participant1" is not participant of room "room2"
-    And user "participant2" is not participant of room "room2"
+    And user "participant1" is participant of the following rooms
+    And user "participant2" is participant of room "room2"
+    And user "participant2" is participant of the following rooms
+      | id    | type | participantType | participants |
+      | room2 | 1    | 1               | participant2-displayname |
 
-  Scenario: User1 invites user2 to a one2one room and deletes it
+  Scenario: User1 invites user2 to a one2one room and tries to delete it
     Given user "participant1" creates room "room3"
       | roomType | 1 |
       | invite   | participant2 |
     Then user "participant1" is participant of room "room3"
     And user "participant2" is participant of room "room3"
-    When user "participant1" deletes room "room3" with 200
-    Then user "participant1" is not participant of room "room3"
-    And user "participant2" is not participant of room "room3"
+    When user "participant1" deletes room "room3" with 400
+    Then user "participant1" is participant of room "room3"
+    And user "participant2" is participant of room "room3"
 
-  Scenario: User1 invites user2 to a one2one room and removes user2
+  Scenario: User1 invites user2 to a one2one room and tries to remove user2
     Given user "participant1" creates room "room4"
       | roomType | 1 |
       | invite   | participant2 |
     Then user "participant1" is participant of room "room4"
     And user "participant2" is participant of room "room4"
-    When user "participant1" removes "participant2" from room "room4" with 200
-    Then user "participant1" is not participant of room "room4"
-    And user "participant2" is not participant of room "room4"
+    When user "participant1" removes "participant2" from room "room4" with 400
+    Then user "participant1" is participant of room "room4"
+    And user "participant2" is participant of room "room4"
 
-  Scenario: User1 invites user2 to a one2one room and renames it
+  Scenario: User1 invites user2 to a one2one room and tries to rename it
     Given user "participant1" creates room "room5"
       | roomType | 1 |
       | invite   | participant2 |
     And user "participant1" is participant of room "room5"
     And user "participant2" is participant of room "room5"
-    When user "participant1" renames room "room5" to "new name" with 405
+    When user "participant1" renames room "room5" to "new name" with 400
 
-  Scenario: User1 invites user2 to a one2one room and make it public
+  Scenario: User1 invites user2 to a one2one room and tries to make it public
     Given user "participant1" creates room "room6"
       | roomType | 1 |
       | invite   | participant2 |
     And user "participant1" is participant of room "room6"
     And user "participant2" is participant of room "room6"
-    When user "participant1" makes room "room6" public with 200
+    When user "participant1" makes room "room6" public with 400
     Then user "participant1" is participant of the following rooms
       | id    | type | participantType | participants |
-      | room6 | 3    | 1               | participant1-displayname, participant2-displayname |
+      | room6 | 1    | 1               | participant1-displayname, participant2-displayname |
 
-  Scenario: User1 invites user2 to a one2one room and invites user3
+  Scenario: User1 invites user2 to a one2one room and tries to invite user3
     Given user "participant1" creates room "room7"
       | roomType | 1 |
       | invite   | participant2 |
     And user "participant1" is participant of room "room7"
     And user "participant2" is participant of room "room7"
     And user "participant3" is not participant of room "room7"
-    When user "participant1" adds "participant3" to room "room7" with 200
+    When user "participant1" adds "participant3" to room "room7" with 400
     Then user "participant1" is participant of the following rooms
       | id    | type | participantType | participants |
-      | room7 | 2    | 1               | participant1-displayname, participant2-displayname, participant3-displayname |
-    And user "participant3" is participant of room "room7"
+      | room7 | 1    | 1               | participant1-displayname, participant2-displayname |
+    And user "participant3" is not participant of room "room7"
     Then user "participant3" is participant of the following rooms
-      | id    | type | participantType | participants |
-      | room7 | 2    | 3               | participant1-displayname, participant2-displayname, participant3-displayname |
 
   Scenario: User1 invites user2 to a one2one room and promote user2 to moderator
     Given user "participant1" creates room "room8"

--- a/tests/integration/features/conversation/remove-participant.feature
+++ b/tests/integration/features/conversation/remove-participant.feature
@@ -7,15 +7,6 @@ Feature: public
 #
 # Removing an owner
 #
-  Scenario: Owner removes owner
-    Given user "participant1" creates room "room"
-      | roomType | 1 |
-      | invite   | participant3 |
-    And user "participant1" makes room "room" public with 200
-    And user "participant3" is participant of room "room"
-    When user "participant1" removes "participant3" from room "room" with 403
-    Then user "participant3" is participant of room "room"
-
   Scenario: Owner removes self participant from empty public room
     Given user "participant1" creates room "room"
       | roomType | 3 |
@@ -46,36 +37,6 @@ Feature: public
     When user "participant1" removes "participant1" from room "room" with 200
     Then user "participant1" is not participant of room "room"
     And user "participant2" is participant of room "room"
-
-  Scenario: Moderator removes owner
-    Given user "participant1" creates room "room"
-      | roomType | 1 |
-      | invite   | participant3 |
-    And user "participant1" makes room "room" public with 200
-    And user "participant1" adds "participant2" to room "room" with 200
-    And user "participant1" promotes "participant2" in room "room" with 200
-    And user "participant3" is participant of room "room"
-    When user "participant2" removes "participant3" from room "room" with 403
-    Then user "participant3" is participant of room "room"
-
-  Scenario: User removes owner
-    Given user "participant1" creates room "room"
-      | roomType | 1 |
-      | invite   | participant3 |
-    And user "participant1" makes room "room" public with 200
-    And user "participant1" adds "participant2" to room "room" with 200
-    And user "participant3" is participant of room "room"
-    When user "participant2" removes "participant3" from room "room" with 403
-    Then user "participant3" is participant of room "room"
-
-  Scenario: Stranger removes owner
-    Given user "participant1" creates room "room"
-      | roomType | 1 |
-      | invite   | participant3 |
-    And user "participant1" makes room "room" public with 200
-    And user "participant3" is participant of room "room"
-    When user "participant2" removes "participant3" from room "room" with 404
-    Then user "participant3" is participant of room "room"
 
 #
 # Removing a moderator

--- a/tests/integration/features/sharing/hooks.feature
+++ b/tests/integration/features/sharing/hooks.feature
@@ -729,7 +729,10 @@ Feature: hooks
       | roomType | 1 |
       | invite   | participant2 |
     And user "participant1" shares "welcome.txt" with room "own one-to-one room" with OCS 100
-    When user "participant1" deletes room "own one-to-one room" with 200
+    When user "participant1" removes themselves from room "own one-to-one room" with 200
+    When user "participant2" removes themselves from room "own one-to-one room" with 200
+    And user "participant1" is not participant of room "own one-to-one room"
+    And user "participant2" is not participant of room "own one-to-one room"
     Then user "participant1" gets last share
     And the OCS status code should be "404"
     And user "participant2" gets last share

--- a/tests/integration/features/sharing/sharees.feature
+++ b/tests/integration/features/sharing/sharees.feature
@@ -22,9 +22,6 @@ Feature: sharees
     Then "exact rooms" sharees returned is empty
     And "rooms" sharees returned is empty
 
-  # One-to-one rooms do not have a name (and it can not be set) and are
-  # currently ignored by the sharees code (although supported by the sharing
-  # code).
   Scenario: search one-to-one room
     Given user "participant1" creates room "one-to-one room"
       | roomType | 1 |
@@ -32,8 +29,8 @@ Feature: sharees
     When user "participant1" gets sharees for
       | search | participant2 |
     Then "exact rooms" sharees returned is empty
-    And "rooms" sharees returned is empty
-
+    And "rooms" sharees returned are
+      | participant2-displayname | one-to-one room |
 
 
   Scenario: search own group room with no matches
@@ -256,7 +253,7 @@ Feature: sharees
       | roomType | 2 |
       | roomName | room |
     And user "participant1" renames room "group room not invited to" to "Group room not invited to" with 200
-    And user "participant2" creates room "unnamed own group room"
+    And user "participant2" creates room "case insensitive match"
       | roomType | 2 |
       | roomName | room |
     And user "participant2" creates room "own group room"
@@ -274,6 +271,7 @@ Feature: sharees
       | search | room |
     Then "exact rooms" sharees returned are
       | Room | group room invited to as member of a group |
+      | room | case insensitive match |
     And "rooms" sharees returned are
       | Group room | group room invited to |
       | Own group room | own group room |

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -77,6 +77,7 @@ class CapabilitiesTest extends TestCase {
 					'in-call-flags',
 					'notification-levels',
 					'invite-groups-and-mails',
+					'locked-one-to-one-rooms',
 				],
 			],
 		], $capabilities->getCapabilities());
@@ -117,6 +118,7 @@ class CapabilitiesTest extends TestCase {
 					'in-call-flags',
 					'notification-levels',
 					'invite-groups-and-mails',
+					'locked-one-to-one-rooms',
 				],
 			],
 		], $capabilities->getCapabilities());


### PR DESCRIPTION
- [x]  Based on #1585 

The idea is to make one-to-one rooms persistent:
* No more guests allowed
* You can not add people to it
* You can only leave it, not delete it

If the second user:
* leaves: the room is deleted
* posts a chat message: participant 1 is readded
* starts a call: participant 1 is readded

This prevents misunderstandings like #1528 and is also more in line with the behaviour of other messengers.