### PR TITLE
Ignore generated and minified JS files during l10n sync

### DIFF
--- a/.l10nignore
+++ b/.l10nignore
@@ -1,0 +1,3 @@
+js/admin/allowed-groups.js
+js/admin/commands.js
+js/admin/sha1.js


### PR DESCRIPTION
Caused the sync to not run.