### PR TITLE
Use the preview information for better fallback icons

### DIFF
--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -575,13 +575,18 @@
 			var previewSize = Math.ceil(128 * window.devicePixelRatio);
 
 			var defaultIconUrl = OC.imagePath('core', 'filetypes/file');
-			var previewUrl = OC.generateUrl(
-				'/core/preview?fileId={fileId}&x={width}&y={height}&forceIcon=true',
-				{
-					fileId: $filePreview.data('file-id'),
-					width: previewSize,
-					height: previewSize
-				});
+			var previewUrl = defaultIconUrl;
+			if ($filePreview.data('preview-available') === 'yes') {
+				previewUrl = OC.generateUrl(
+					'/core/preview?fileId={fileId}&x={width}&y={height}',
+					{
+						fileId: $filePreview.data('file-id'),
+						width: previewSize,
+						height: previewSize
+					});
+			} else {
+				previewUrl = OC.MimeType.getIconUrl($filePreview.data('mimetype'));
+			}
 
 			// If the default file icon can not be loaded either there is
 			// nothing else that can be done, just remove the loading icon

--- a/js/views/templates.js
+++ b/js/views/templates.js
@@ -149,6 +149,10 @@ templates['richobjectstringparser_filepreview'] = template({"compiler":[7,">= 4.
     + alias4(((helper = (helper = helpers.link || (depth0 != null ? depth0.link : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"link","hash":{},"data":data}) : helper)))
     + "\" class=\"filePreviewContainer\" target=\"_blank\" rel=\"noopener noreferrer\">\n	<span class=\"filePreview\" data-file-id=\""
     + alias4(((helper = (helper = helpers.id || (depth0 != null ? depth0.id : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"id","hash":{},"data":data}) : helper)))
+    + "\" data-mimetype=\""
+    + alias4(((helper = (helper = helpers.mimetype || (depth0 != null ? depth0.mimetype : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"mimetype","hash":{},"data":data}) : helper)))
+    + "\" data-preview-available=\""
+    + alias4(((helper = (helper = helpers["preview-available"] || (depth0 != null ? depth0["preview-available"] : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"preview-available","hash":{},"data":data}) : helper)))
     + "\"></span>\n	<strong>"
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + "</strong>\n</a>\n";

--- a/js/views/templates/richobjectstringparser_filepreview.handlebars
+++ b/js/views/templates/richobjectstringparser_filepreview.handlebars
@@ -1,4 +1,4 @@
 <a href="{{link}}" class="filePreviewContainer" target="_blank" rel="noopener noreferrer">
-	<span class="filePreview" data-file-id="{{id}}"></span>
+	<span class="filePreview" data-file-id="{{id}}" data-mimetype="{{mimetype}}" data-preview-available="{{preview-available}}"></span>
 	<strong>{{name}}</strong>
 </a>

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -33,10 +33,10 @@ use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IL10N;
+use OCP\IPreview as IPreviewManager;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
-use OCP\IUserSession;
 
 class SystemMessage {
 
@@ -44,6 +44,8 @@ class SystemMessage {
 	protected $userManager;
 	/** @var GuestManager */
 	protected $guestManager;
+	/** @var IPreviewManager */
+	protected $previewManager;
 	/** @var RoomShareProvider */
 	protected $shareProvider;
 	/** @var IRootFolder */
@@ -60,11 +62,13 @@ class SystemMessage {
 
 	public function __construct(IUserManager $userManager,
 								GuestManager $guestManager,
+								IPreviewManager $previewManager,
 								RoomShareProvider $shareProvider,
 								IRootFolder $rootFolder,
 								IURLGenerator $url) {
 		$this->userManager = $userManager;
 		$this->guestManager = $guestManager;
+		$this->previewManager = $previewManager;
 		$this->shareProvider = $shareProvider;
 		$this->rootFolder = $rootFolder;
 		$this->url = $url;
@@ -274,6 +278,8 @@ class SystemMessage {
 			'name' => $name,
 			'path' => $path,
 			'link' => $url,
+			'mimetype' => $node->getMimeType(),
+			'preview-available' => $this->previewManager->isAvailable($node) ? 'yes' : 'no',
 		];
 	}
 


### PR DESCRIPTION
Left after, right before (size change is unrelated, I zoomed on screenshots to match more icons on a screen)
- [x] Depends on https://github.com/nextcloud/server/pull/14589

> ![bildschirmfoto von 2019-03-07 20-31-10](https://user-images.githubusercontent.com/213943/53984021-c31d2b00-4118-11e9-8ab2-96a3c76dfdc8.png)

