### PR TITLE
Fix remote video visible behind avatar before being explicitly shown

### DIFF
--- a/js/views/videoview.js
+++ b/js/views/videoview.js
@@ -192,6 +192,10 @@
 			}
 
 			this.bindUIElements();
+
+			// Hide the video until it is explicitly marked as available and
+			// enabled.
+			this.getUI('video').hide();
 		},
 
 		setVideoAvailable: function(videoAvailable) {


### PR DESCRIPTION
This pull request fixes the video shown behind the avatar (or the avatar shown in front of the video, as you prefer) for a few moments after establishing a connection with a video peer in a call.

It happened because both the avatar and the video element were visible after establishing a connection and before receiving through the data channel whether the video was available or not (which shows and hides the avatar and video as needed).
