### PR TITLE
Fix hidding video causing audio to not be played

### DIFF
--- a/css/video.scss
+++ b/css/video.scss
@@ -319,6 +319,10 @@ video {
 	width: 32px;
 	height: 32px;
 	background-size: 22px;
+
+	&.hidden {
+		display: none;
+	}
 }
 
 .muteIndicator.audio-on,

--- a/js/views/videoview.js
+++ b/js/views/videoview.js
@@ -195,13 +195,13 @@
 
 			// Hide the video until it is explicitly marked as available and
 			// enabled.
-			this.getUI('video').hide();
+			this.getUI('video').addClass('hidden');
 		},
 
 		setVideoAvailable: function(videoAvailable) {
 			if (!videoAvailable) {
 				this.getUI('avatarContainer').show();
-				this.getUI('video').hide();
+				this.getUI('video').addClass('hidden');
 				this.getUI('hideRemoteVideoButton').hide();
 
 				return;
@@ -211,7 +211,7 @@
 
 			if (this._videoEnabled) {
 				this.getUI('avatarContainer').hide();
-				this.getUI('video').show();
+				this.getUI('video').removeClass('hidden');
 			}
 		},
 
@@ -220,7 +220,7 @@
 
 			if (!videoEnabled) {
 				this.getUI('avatarContainer').show();
-				this.getUI('video').hide();
+				this.getUI('video').addClass('hidden');
 				this.getUI('hideRemoteVideoButton')
 						.attr('data-original-title', t('spreed', 'Enable video'))
 						.removeClass('icon-video')
@@ -230,7 +230,7 @@
 			}
 
 			this.getUI('avatarContainer').hide();
-			this.getUI('video').show();
+			this.getUI('video').removeClass('hidden');
 			this.getUI('hideRemoteVideoButton')
 					.attr('data-original-title', t('spreed', 'Disable video'))
 					.removeClass('icon-video-off')

--- a/js/views/videoview.js
+++ b/js/views/videoview.js
@@ -84,7 +84,7 @@
 			this.getUI('avatar').css('opacity', '0.5');
 
 			this.getUI('hideRemoteVideoButton').attr('data-original-title', t('spreed', 'Disable video'));
-			this.getUI('hideRemoteVideoButton').hide();
+			this.getUI('hideRemoteVideoButton').addClass('hidden');
 
 			this.getUI('screenSharingIndicator').attr('data-original-title', t('spreed', 'Show screen'));
 		},
@@ -146,9 +146,9 @@
 			}
 
 			if (connectionStatus === ConnectionStatus.FAILED_NO_RESTART) {
-				this.getUI('muteIndicator').hide();
-				this.getUI('hideRemoteVideoButton').hide();
-				this.getUI('screenSharingIndicator').hide();
+				this.getUI('muteIndicator').addClass('hidden');
+				this.getUI('hideRemoteVideoButton').addClass('hidden');
+				this.getUI('screenSharingIndicator').addClass('hidden');
 				this.getUI('iceFailedIndicator').removeClass('not-failed');
 
 				return;
@@ -200,17 +200,17 @@
 
 		setVideoAvailable: function(videoAvailable) {
 			if (!videoAvailable) {
-				this.getUI('avatarContainer').show();
+				this.getUI('avatarContainer').removeClass('hidden');
 				this.getUI('video').addClass('hidden');
-				this.getUI('hideRemoteVideoButton').hide();
+				this.getUI('hideRemoteVideoButton').addClass('hidden');
 
 				return;
 			}
 
-			this.getUI('hideRemoteVideoButton').show();
+			this.getUI('hideRemoteVideoButton').removeClass('hidden');
 
 			if (this._videoEnabled) {
-				this.getUI('avatarContainer').hide();
+				this.getUI('avatarContainer').addClass('hidden');
 				this.getUI('video').removeClass('hidden');
 			}
 		},
@@ -219,7 +219,7 @@
 			this._videoEnabled = videoEnabled;
 
 			if (!videoEnabled) {
-				this.getUI('avatarContainer').show();
+				this.getUI('avatarContainer').removeClass('hidden');
 				this.getUI('video').addClass('hidden');
 				this.getUI('hideRemoteVideoButton')
 						.attr('data-original-title', t('spreed', 'Enable video'))
@@ -229,7 +229,7 @@
 				return;
 			}
 
-			this.getUI('avatarContainer').hide();
+			this.getUI('avatarContainer').addClass('hidden');
 			this.getUI('video').removeClass('hidden');
 			this.getUI('hideRemoteVideoButton')
 					.attr('data-original-title', t('spreed', 'Disable video'))


### PR DESCRIPTION
When a remote peer is added its remote stream is attached to a new video element (even if the remote peer is audio only). Immediately after [that the video element is hidden](https://github.com/nextcloud/spreed/blob/a3a711626ecc2b622228880d7fa2b784ebdf37bc/js/views/videoview.js#L198), and it is kept hidden until an unmute message for the video is received.

Sometimes ([mostly reproducible with Safari](https://github.com/nextcloud/spreed/pull/1524)) even if the remote audio was being received no audio was played if the video element was hidden; in those cases showing the video element (for example, by removing `display: none` from the video element with the developer tools of the browser) caused the audio to start playing (even if there was no video being received).

The issue only happened when using `jQuery.hide()`; it seems that its internal handling can somehow conflict with the audio playing in some cases. Therefore, now the element is hidden just by adding the `hidden` CSS class instead, which seems to cause the audio to be played without problems.
