### PR TITLE
Reset the signaling server settings after unit tests

### DIFF
--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -137,6 +137,8 @@ class BackendNotifierTest extends \Test\TestCase {
 	}
 
 	public function tearDown() {
+		$config = \OC::$server->getConfig();
+		$config->deleteAppValue('spreed', 'signaling_servers');
 		$this->app->getContainer()->registerService(BackendNotifier::class, function() {
 			return $this->originalBackendNotifier;
 		});


### PR DESCRIPTION
To allow using the server again afterwards
