### PR TITLE
Fix stopping local media when leaving a call

### DIFF
--- a/js/signaling.js
+++ b/js/signaling.js
@@ -332,7 +332,7 @@
 			method: 'DELETE',
 			async: false,
 			success: function () {
-				this._trigger('leaveCall', [token]);
+				this._trigger('leaveCall', [token, keepToken]);
 				this._leaveCallSuccess(token);
 				// We left the current call.
 				if (!keepToken && token === this.currentCallToken) {

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -633,6 +633,15 @@
 					// Request has been aborted. Ignore.
 				} else if (this.currentRoomToken) {
 					if (this.pullMessagesFails >= 3) {
+						if (OCA.SpreedMe.webrtc) {
+							// Force leaving the call in WebRTC; leaving the
+							// room indirectly runs
+							// signaling.leaveCurrentCall(), but if the
+							// signaling fails to leave the call no event will
+							// be triggered and the call will not be left from
+							// WebRTC point of view.
+							OCA.SpreedMe.webrtc.leaveCall();
+						}
 						OCA.SpreedMe.app.connection.leaveCurrentRoom();
 						return;
 					}

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -307,7 +307,15 @@ var spreedPeerConnectionTable = [];
 			});
 			usersInCallChanged(signaling, usersInCallMapping);
 		});
-		signaling.on('leaveCall', function () {
+		signaling.on('leaveCall', function (token, reconnect) {
+			// When the MCU is used and there is a connection error the call is
+			// left and then joined again to perform the reconnection. In those
+			// cases the call should be kept active from the point of view of
+			// WebRTC.
+			if (reconnect) {
+				return;
+			}
+
 			webrtc.leaveCall();
 		});
 


### PR DESCRIPTION
(The test steps may not be accurate, so sorry :-P; I am writing them from memory, but I have no time to check them if I want to get the train :-P )

## How to test (scenario 1) ##
- Setup an MCU
- Start a call as user A
- Join the call as user B
- Trigger an ICE failure so there is a reconnection (for example, by running one of the browsers in another machine and unplugging and plugin again the cable)

**Result with this pull request:**
One of the users left the call and joined again to make the reconnection; both users can see and hear each other.

**Result without this pull request:**
One of the users left the call and joined again to make the reconnection; the user who joined again can see and hear the other user, but the user who was kept in the call can not see nor hear the user who reconnected.

## How to test (scenario 2) ##
- Do not use an MCU (this happens with the internal signaling server)
- Create a public conversation as user A and add user B
- Start a call in the conversation as user B
- Join the call as a guest
- Delete the conversation as user A

**Result with this pull request:**
The UI is updated for user B and guest to show that the conversation has ended; they can no longer hear each other.

**Result without this pull request:**
User B and guest can still hear each other, despite the UI saying that the conversation has ended.
