### PR TITLE
Fix duplicated call button when joining the same room again in Files app

### DIFF
--- a/js/filesplugin.js
+++ b/js/filesplugin.js
@@ -120,6 +120,11 @@
 		},
 
 		setActiveRoom: function(activeRoom) {
+			// Ignore reconnections to the same room.
+			if (this._activeRoom === activeRoom) {
+				return;
+			}
+
 			this.stopListening(this._activeRoom, 'change:participantFlags', this._updateCallContainer);
 			// Signaling uses its own event system, so Backbone methods can not
 			// be used.
@@ -444,6 +449,13 @@
 		},
 
 		setActiveRoom: function(activeRoom) {
+			// Ignore reconnections to the same room.
+			if (this._activeRoom === activeRoom) {
+				return;
+			}
+
+			this._activeRoom = activeRoom;
+
 			if (!activeRoom) {
 				if (this._callButton) {
 					this._callButton.$el.remove();


### PR DESCRIPTION
## How to test (scenario 1) ##
- Setup an MCU
- In the Files app, as user A share a file with user B
- Open the Chat tab for the file
- In the Chat tab, start a call as user A
- In the Chat tab, join the call as user B
- Trigger an ICE failure so there is a reconnection (for example, by running one of the browsers in another machine and unplugging and plugin again the cable)

**Result with this pull request:**
After the reconnection the UI is as expected.

**Result without this pull request:**
After the reconnection there is a duplicated call button