### PR TITLE
Read only conversations

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>5.99.2</version>
+	<version>5.99.3</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -146,7 +146,7 @@ return [
 			'requirements' => ['apiVersion' => 'v1'],
 		],
 		[
-			'name' => 'Room#getRoom',
+			'name' => 'Room#getSingleRoom',
 			'url' => '/api/{apiVersion}/room/{token}',
 			'verb' => 'GET',
 			'requirements' => [

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -191,6 +191,15 @@ return [
 			],
 		],
 		[
+			'name' => 'Room#setReadOnly',
+			'url' => '/api/{apiVersion}/room/{token}/read-only',
+			'verb' => 'PUT',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
+		[
 			'name' => 'Room#setPassword',
 			'url' => '/api/{apiVersion}/room/{token}/password',
 			'verb' => 'PUT',

--- a/css/chatview.scss
+++ b/css/chatview.scss
@@ -68,10 +68,10 @@
 	border: none;
 	opacity: .3;
 }
-#chatView .newCommentForm .submit:hover,
-#chatView .newCommentForm .submit:focus,
-#chatView .newCommentForm .share:hover,
-#chatView .newCommentForm .share:focus {
+#chatView .newCommentForm .submit:hover:not(:disabled),
+#chatView .newCommentForm .submit:focus:not(:disabled),
+#chatView .newCommentForm .share:hover:not(:disabled),
+#chatView .newCommentForm .share:focus:not(:disabled) {
 	opacity: 1;
 }
 

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -8,6 +8,8 @@
   * [Get user´s rooms](#get-user-s-rooms)
   * [Get single room (also for guests)](#get-single-room-also-for-guests)
   * [Rename a room](#rename-a-room)
+  * [Set read-only for a room](#set-read-only-for-a-room)
+  * [Set password for a room](#set-password-for-a-room)
   * [Delete a room](#delete-a-room)
   * [Allow guests in a room (public room)](#allow-guests-in-a-room-public-room)
   * [Disallow guests in a room (group room)](#disallow-guests-in-a-room-group-room)
@@ -187,6 +189,23 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         + `403 Forbidden` When the current user is not a moderator/owner
         + `404 Not Found` When the room could not be found for the participant
         + `405 Method Not Allowed` When the room is a one to one room
+
+### Set read-only for a room
+
+* Method: `PUT`
+* Endpoint: `/room/{token}/read-only`
+* Data:
+
+    field | type | Description
+    ------|------|------------
+    `state` | int | New state for the room
+
+* Response:
+    - Header:
+        + `200 OK`
+        + `400 Bad Request` When the room type does not support read-only (only group and public room atm)
+        + `403 Forbidden` When the current user is not a moderator/owner or the room is not a public room
+        + `404 Not Found` When the room could not be found for the participant
 
 ### Set password for a room
 

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -45,6 +45,10 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 * `2` group
 * `3` public
 
+### Read-only states
+* `0` read-write
+* `1` read-only
+
 ### Participant types
 * `1` owner
 * `2` moderator
@@ -84,6 +88,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 
 ### 6.0
 * `locked-one-to-one-rooms` - One-to-one conversations are now locked to the users. Neither guests nor other participants can be added, so the options to do that should be hidden as well. Also a user can only leave a one-to-one room (not delete). It will be deleted when the other participant left too. If the other participant posts a new chat message or starts a call, the left-participant will be re-added.
+* `read-only-rooms` - Rooms can be in `read-only` mode which means people can not do calls or write chat messages.
 
 ## Room management
 
@@ -137,6 +142,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         `participantType` | int | Permissions level of the current user
         `participantInCall` | bool | Flag if the current user is in the call (deprecated, use `participantFlags` instead)
         `participantFlags` | int | Flags of the current user (only available with `in-call-flags` capability)
+        `readOnly` | int | Read-only state for the current user (only available with `read-only-rooms` capability)
         `count` | int | Number of active users
         `numGuests` | int | Number of active guests
         `lastPing` | int | Timestamp of the last ping of the current user (should be used for sorting)

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -31,6 +31,8 @@
 - [Chat](#chat)
   * [Receive chat messages of a room](#receive-chat-messages-of-a-room)
   * [Sending a new chat message](#sending-a-new-chat-message)
+  * [Get mention autocomplete suggestions](#get-mention-autocomplete-suggestions)
+  * [System messages](#system-messages)
 - [Guests](#guests)
   * [Set display name](#set-display-name)
 - [Signaling](#signaling)
@@ -622,6 +624,8 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 * `moderator_demoted` - {actor} demoted {user} from moderator
 * `guest_moderator_promoted` - {actor} promoted {user} to moderator
 * `guest_moderator_demoted` - {actor} demoted {user} from moderator
+* `read_only_off` - {actor} unlocked the conversation
+* `read_only` - {actor} locked the conversation
         
 ## Guests
 

--- a/js/app.js
+++ b/js/app.js
@@ -402,6 +402,7 @@
 			});
 			this._sidebarView.setCallInfoView(callInfoView);
 
+			this._chatView.setRoom(this.activeRoom);
 			this._messageCollection.setRoomToken(this.activeRoom.get('token'));
 			this._messageCollection.receiveMessages();
 		},
@@ -437,6 +438,7 @@
 			this._messageCollection = new OCA.SpreedMe.Models.ChatMessageCollection(null, {token: null});
 			this._chatView = new OCA.SpreedMe.Views.ChatView({
 				collection: this._messageCollection,
+				model: this.activeRoom,
 				id: 'chatView',
 				guestNameModel: this._localStorageModel
 			});

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -89,6 +89,7 @@
 						self._rooms.forEach(function(room) {
 							if (room.get('token') === token) {
 								self.activeRoom = room;
+								self._chatView.setRoom(room);
 							}
 						});
 					}
@@ -106,6 +107,7 @@
 			this._messageCollection = new OCA.SpreedMe.Models.ChatMessageCollection(null, {token: null});
 			this._chatView = new OCA.SpreedMe.Views.ChatView({
 				collection: this._messageCollection,
+				model: this.activeRoom,
 				id: 'chatView',
 				guestNameModel: this._localStorageModel
 			});

--- a/js/views/callbutton.js
+++ b/js/views/callbutton.js
@@ -45,11 +45,13 @@
 
 		templateContext: function() {
 			return {
+				isReadOnly: this.model.get('readOnly') === 1,
 				isInCall: (this.model.get('participantFlags') & OCA.SpreedMe.app.FLAG_IN_CALL) !== 0,
 				hasCall: this.model.get('hasCall'),
 				leaveCallText: t('spreed', 'Leave call'),
 				joinCallText: t('spreed', 'Join call'),
 				startCallText: t('spreed', 'Start call'),
+				readOnlyText: t('spreed', 'Calls are disabled in this conversation.'),
 			};
 		},
 
@@ -69,6 +71,9 @@
 				this.render();
 			},
 			'change:participantFlags': function() {
+				this.render();
+			},
+			'change:readOnly': function() {
 				this.render();
 			},
 		},

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -52,6 +52,12 @@
 			'paste div.message': '_onPaste'
 		},
 
+		modelEvents: {
+			'change:readOnly': function() {
+				this.render();
+			}
+		},
+
 		initialize: function() {
 			this.listenTo(this.collection, 'reset', this.render);
 			this.listenTo(this.collection, 'add:start', this._onAddModelStart);
@@ -71,6 +77,10 @@
 			});
 
 			_.bindAll(this, '_onAutoComplete');
+		},
+
+		setRoom: function(model) {
+			this.model = model;
 		},
 
 		_initAutoComplete: function($target) {
@@ -182,12 +192,22 @@
 				this._addCommentTemplate = OCA.Talk.Views.Templates['chatview_add_comment'];
 			}
 
+			var isReadOnly = this.model.get('readOnly') === 1;
+			var newMessagePlaceholder = t('spreed', 'New message …');
+			var submitText = t('spreed', 'Send');
+			if (isReadOnly) {
+				newMessagePlaceholder = t('spreed', 'You can not send messages, because the conversation is locked.');
+				submitText = t('spreed', 'The conversation is locked.');
+			}
+
 			return this._addCommentTemplate(_.extend({
 				actorId: OC.getCurrentUser().uid,
 				actorDisplayName: OC.getCurrentUser().displayName,
-				newMessagePlaceholder: t('spreed', 'New message …'),
-				submitText: t('spreed', 'Send'),
-				shareText: t('spreed', 'Share')
+				newMessagePlaceholder: newMessagePlaceholder,
+				submitText: submitText,
+				shareText: t('spreed', 'Share'),
+				isReadOnly: isReadOnly,
+				canShare: !isReadOnly && OC.getCurrentUser().uid,
 			}, params));
 		},
 

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -192,7 +192,7 @@
 				this._addCommentTemplate = OCA.Talk.Views.Templates['chatview_add_comment'];
 			}
 
-			var isReadOnly = this.model.get('readOnly') === 1;
+			var isReadOnly = this.model && this.model.get('readOnly') === 1;
 			var newMessagePlaceholder = t('spreed', 'New message …');
 			var submitText = t('spreed', 'Send');
 			if (isReadOnly) {

--- a/js/views/templates.js
+++ b/js/views/templates.js
@@ -3,23 +3,35 @@
 templates['callbutton'] = template({"1":function(container,depth0,helpers,partials,data) {
     var helper;
 
-  return "<button class=\"leave-call primary\">"
+  return "	<button class=\"leave-call primary\">"
     + container.escapeExpression(((helper = (helper = helpers.leaveCallText || (depth0 != null ? depth0.leaveCallText : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"leaveCallText","hash":{},"data":data}) : helper)))
     + "<span class=\"icon icon-loading-small hidden\"></span></button>\n";
 },"3":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.hasCall : depth0),{"name":"if","hash":{},"fn":container.program(4, data, 0),"inverse":container.program(6, data, 0),"data":data})) != null ? stack1 : "");
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.isReadOnly : depth0),{"name":"if","hash":{},"fn":container.program(4, data, 0),"inverse":container.program(6, data, 0),"data":data})) != null ? stack1 : "");
 },"4":function(container,depth0,helpers,partials,data) {
+    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
+
+  return "		<button class=\"join-call primary has-tooltip\" title=\""
+    + alias4(((helper = (helper = helpers.readOnlyText || (depth0 != null ? depth0.readOnlyText : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"readOnlyText","hash":{},"data":data}) : helper)))
+    + "\" disabled=\"\">"
+    + alias4(((helper = (helper = helpers.startCallText || (depth0 != null ? depth0.startCallText : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"startCallText","hash":{},"data":data}) : helper)))
+    + "</button>\n";
+},"6":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.hasCall : depth0),{"name":"if","hash":{},"fn":container.program(7, data, 0),"inverse":container.program(9, data, 0),"data":data})) != null ? stack1 : "");
+},"7":function(container,depth0,helpers,partials,data) {
     var helper;
 
-  return "<button class=\"join-call call-ongoing primary\">"
+  return "			<button class=\"join-call call-ongoing primary\">"
     + container.escapeExpression(((helper = (helper = helpers.joinCallText || (depth0 != null ? depth0.joinCallText : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"joinCallText","hash":{},"data":data}) : helper)))
     + "<span class=\"icon icon-loading-small hidden\"></span></button>\n";
-},"6":function(container,depth0,helpers,partials,data) {
+},"9":function(container,depth0,helpers,partials,data) {
     var helper;
 
-  return "<button class=\"join-call primary\">"
+  return "			<button class=\"join-call primary\">"
     + container.escapeExpression(((helper = (helper = helpers.startCallText || (depth0 != null ? depth0.startCallText : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"startCallText","hash":{},"data":data}) : helper)))
     + "<span class=\"icon icon-loading-small hidden\"></span></button>\n";
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
@@ -43,6 +55,12 @@ templates['chatview_add_comment'] = template({"1":function(container,depth0,help
 },"3":function(container,depth0,helpers,partials,data) {
     return "		<div class=\"guest-name\"></div>\n";
 },"5":function(container,depth0,helpers,partials,data) {
+    return "false";
+},"7":function(container,depth0,helpers,partials,data) {
+    return "true";
+},"9":function(container,depth0,helpers,partials,data) {
+    return "disabled=\"\"";
+},"11":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "		<button class=\"share icon-add has-tooltip\" title=\""
@@ -55,14 +73,18 @@ templates['chatview_add_comment'] = template({"1":function(container,depth0,help
     + alias4(((helper = (helper = helpers.actorId || (depth0 != null ? depth0.actorId : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"actorId","hash":{},"data":data}) : helper)))
     + "\"></div>\n"
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.actorId : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.program(3, data, 0),"data":data})) != null ? stack1 : "")
-    + "	</div>\n	<form class=\"newCommentForm\">\n		<div contentEditable=\"true\" class=\"message\" data-placeholder=\""
+    + "	</div>\n	<form class=\"newCommentForm\">\n	<div contentEditable=\""
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isReadOnly : depth0),{"name":"if","hash":{},"fn":container.program(5, data, 0),"inverse":container.program(7, data, 0),"data":data})) != null ? stack1 : "")
+    + "\" class=\"message\" data-placeholder=\""
     + alias4(((helper = (helper = helpers.newMessagePlaceholder || (depth0 != null ? depth0.newMessagePlaceholder : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"newMessagePlaceholder","hash":{},"data":data}) : helper)))
     + "\">"
     + alias4(((helper = (helper = helpers.message || (depth0 != null ? depth0.message : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"message","hash":{},"data":data}) : helper)))
-    + "</div>\n		<input class=\"submit icon-confirm has-tooltip\" type=\"submit\" value=\"\" title=\""
+    + "</div>\n		<input class=\"submit icon-confirm has-tooltip\" type=\"submit\" "
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isReadOnly : depth0),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + " value=\"\" title=\""
     + alias4(((helper = (helper = helpers.submitText || (depth0 != null ? depth0.submitText : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"submitText","hash":{},"data":data}) : helper)))
     + "\"/>\n		<div class=\"submitLoading icon-loading-small hidden\"></div>\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.actorId : depth0),{"name":"if","hash":{},"fn":container.program(5, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.canShare : depth0),{"name":"if","hash":{},"fn":container.program(11, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "	</form>\n</div>\n";
 },"useData":true});
 templates['chatview_comment'] = template({"1":function(container,depth0,helpers,partials,data) {

--- a/js/views/templates/callbutton.handlebars
+++ b/js/views/templates/callbutton.handlebars
@@ -1,9 +1,13 @@
 {{#if isInCall}}
-<button class="leave-call primary">{{leaveCallText}}<span class="icon icon-loading-small hidden"></span></button>
+	<button class="leave-call primary">{{leaveCallText}}<span class="icon icon-loading-small hidden"></span></button>
 {{else}}
-	{{#if hasCall}}
-<button class="join-call call-ongoing primary">{{joinCallText}}<span class="icon icon-loading-small hidden"></span></button>
+	{{#if isReadOnly}}
+		<button class="join-call primary has-tooltip" title="{{readOnlyText}}" disabled="">{{startCallText}}</button>
 	{{else}}
-<button class="join-call primary">{{startCallText}}<span class="icon icon-loading-small hidden"></span></button>
+		{{#if hasCall}}
+			<button class="join-call call-ongoing primary">{{joinCallText}}<span class="icon icon-loading-small hidden"></span></button>
+		{{else}}
+			<button class="join-call primary">{{startCallText}}<span class="icon icon-loading-small hidden"></span></button>
+		{{/if}}
 	{{/if}}
 {{/if}}

--- a/js/views/templates/chatview_add_comment.handlebars
+++ b/js/views/templates/chatview_add_comment.handlebars
@@ -8,10 +8,10 @@
 		{{/if}}
 	</div>
 	<form class="newCommentForm">
-		<div contentEditable="true" class="message" data-placeholder="{{newMessagePlaceholder}}">{{message}}</div>
-		<input class="submit icon-confirm has-tooltip" type="submit" value="" title="{{submitText}}"/>
+	<div contentEditable="{{#if isReadOnly}}false{{else}}true{{/if}}" class="message" data-placeholder="{{newMessagePlaceholder}}">{{message}}</div>
+		<input class="submit icon-confirm has-tooltip" type="submit" {{#if isReadOnly}}disabled=""{{/if}} value="" title="{{submitText}}"/>
 		<div class="submitLoading icon-loading-small hidden"></div>
-		{{#if actorId}}
+		{{#if canShare}}
 		<button class="share icon-add has-tooltip" title="{{shareText}}"></button>
 		<div class="shareLoading icon-loading-small hidden"></div>
 		{{/if}}

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -66,6 +66,7 @@ class Capabilities implements IPublicCapability {
 					'notification-levels',
 					'invite-groups-and-mails',
 					'locked-one-to-one-rooms',
+					'read-only-rooms',
 				],
 			],
 		];

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -27,6 +27,7 @@ use OCA\Spreed\Exceptions\ParticipantNotFoundException;
 use OCA\Spreed\GuestManager;
 use OCA\Spreed\Model\Message;
 use OCA\Spreed\Participant;
+use OCA\Spreed\Room;
 use OCA\Spreed\Share\RoomShareProvider;
 use OCP\Comments\IComment;
 use OCP\Files\IRootFolder;
@@ -126,6 +127,16 @@ class SystemMessage {
 			}
 		} else if ($message === 'call_ended') {
 			[$parsedMessage, $parsedParameters] = $this->parseCall($parameters);
+		} else if ($message === 'read_only_off') {
+			$parsedMessage = $this->l->t('{actor} unlocked the conversation');
+			if ($currentUserIsActor) {
+				$parsedMessage = $this->l->t('You unlocked the conversation');
+			}
+		} else if ($message === 'read_only') {
+			$parsedMessage = $this->l->t('{actor} locked the conversation');
+			if ($currentUserIsActor) {
+				$parsedMessage = $this->l->t('You locked the conversation');
+			}
 		} else if ($message === 'guests_allowed') {
 			$parsedMessage = $this->l->t('{actor} allowed guests');
 			if ($currentUserIsActor) {

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -138,6 +138,21 @@ class Listener {
 				$listener->sendSystemMessage($room, 'guests_disallowed', $event->getArguments());
 			}
 		});
+		$dispatcher->addListener(Room::class . '::postSetReadOnly', function(GenericEvent $event) {
+			$arguments = $event->getArguments();
+
+			/** @var Room $room */
+			$room = $event->getSubject();
+
+			/** @var self $listener */
+			$listener = \OC::$server->query(self::class);
+
+			if ($arguments['newType'] === Room::READ_ONLY) {
+				$listener->sendSystemMessage($room, 'read_only', $event->getArguments());
+			} else if ($arguments['newType'] === Room::READ_WRITE) {
+				$listener->sendSystemMessage($room, 'read_only_off', $event->getArguments());
+			}
+		});
 
 		$dispatcher->addListener(Room::class . '::postAddUsers', function(GenericEvent $event) {
 			$participants = $event->getArgument('users');

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -147,9 +147,9 @@ class Listener {
 			/** @var self $listener */
 			$listener = \OC::$server->query(self::class);
 
-			if ($arguments['newType'] === Room::READ_ONLY) {
+			if ($arguments['newState'] === Room::READ_ONLY) {
 				$listener->sendSystemMessage($room, 'read_only', $event->getArguments());
-			} else if ($arguments['newType'] === Room::READ_WRITE) {
+			} else if ($arguments['newState'] === Room::READ_WRITE) {
 				$listener->sendSystemMessage($room, 'read_only_off', $event->getArguments());
 			}
 		});

--- a/lib/Collaboration/Collaborators/RoomPlugin.php
+++ b/lib/Collaboration/Collaborators/RoomPlugin.php
@@ -59,6 +59,11 @@ class RoomPlugin implements ISearchPlugin {
 
 		$rooms = $this->manager->getRoomsForParticipant($userId);
 		foreach ($rooms as $room) {
+			if ($room->getReadOnly() === Room::READ_ONLY) {
+				// Can not add new shares to read-only rooms
+				continue;
+			}
+
 			if (stripos($room->getDisplayName($userId), $search) !== false) {
 				$item = $this->roomToSearchResultItem($room, $userId);
 

--- a/lib/Controller/AEnvironmentAwareController.php
+++ b/lib/Controller/AEnvironmentAwareController.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2016 Lukas Reschke <lukas@statuscode.ch>
+ * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Lukas Reschke <lukas@statuscode.ch>
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Controller;
+
+use OCA\Spreed\Participant;
+use OCA\Spreed\Room;
+use OCP\AppFramework\OCSController;
+
+abstract class AEnvironmentAwareController extends OCSController {
+
+	/** @var Room */
+	protected $room;
+	/** @var Participant */
+	protected $participant;
+
+	public function setRoom(Room $room): void {
+		$this->room = $room;
+	}
+
+	public function getRoom(): ?Room {
+		return $this->room;
+	}
+
+	public function setParticipant(Participant $participant): void {
+		$this->participant = $participant;
+	}
+
+	public function getParticipant(): ?Participant {
+		return $this->participant;
+	}
+
+}

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -28,12 +28,10 @@ use OCA\Spreed\Chat\AutoComplete\Sorter;
 use OCA\Spreed\Chat\ChatManager;
 use OCA\Spreed\Chat\MessageParser;
 use OCA\Spreed\GuestManager;
-use OCA\Spreed\Participant;
 use OCA\Spreed\Room;
 use OCA\Spreed\TalkSession;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
-use OCP\AppFramework\OCSController;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Collaboration\AutoComplete\IManager;
 use OCP\Collaboration\Collaborators\ISearchResult;
@@ -43,7 +41,7 @@ use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserManager;
 
-class ChatController extends OCSController {
+class ChatController extends AEnvironmentAwareController {
 
 	/** @var string */
 	private $userId;
@@ -80,11 +78,6 @@ class ChatController extends OCSController {
 	/** @var ITimeFactory */
 	protected $timeFactory;
 
-	/** @var Room */
-	private $room;
-	/** @var Participant */
-	private $participant;
-
 	public function __construct(string $appName,
 								?string $UserId,
 								IRequest $request,
@@ -113,17 +106,10 @@ class ChatController extends OCSController {
 		$this->l = $l;
 	}
 
-	public function setRoom(Room $room): void {
-		$this->room = $room;
-	}
-
-	public function setParticipant(Participant $participant): void {
-		$this->participant = $participant;
-	}
-
 	/**
 	 * @PublicPage
 	 * @RequireParticipant
+	 * @RequireReadWriteConversation
 	 *
 	 * Sends a new chat message to the given room.
 	 *
@@ -280,6 +266,7 @@ class ChatController extends OCSController {
 	/**
 	 * @PublicPage
 	 * @RequireParticipant
+	 * @RequireReadWriteConversation
 	 *
 	 * @param string $search
 	 * @param int $limit

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -39,18 +39,16 @@ use OCA\Spreed\Room;
 use OCA\Spreed\TalkSession;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
-use OCP\AppFramework\OCSController;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\IComment;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IGroup;
 use OCP\IGroupManager;
 
-class RoomController extends OCSController {
+class RoomController extends AEnvironmentAwareController {
 	/** @var string|null */
 	private $userId;
 	/** @var TalkSession */
@@ -71,11 +69,6 @@ class RoomController extends OCSController {
 	private $timeFactory;
 	/** @var IL10N */
 	private $l10n;
-
-	/** @var Room */
-	private $room;
-	/** @var Participant */
-	private $participant;
 
 	public function __construct(string $appName,
 								?string $UserId,
@@ -100,14 +93,6 @@ class RoomController extends OCSController {
 		$this->messageParser = $messageParser;
 		$this->timeFactory = $timeFactory;
 		$this->l10n = $l10n;
-	}
-
-	public function setRoom(Room $room): void {
-		$this->room = $room;
-	}
-
-	public function setParticipant(Participant $participant): void {
-		$this->participant = $participant;
 	}
 
 	/**
@@ -138,7 +123,7 @@ class RoomController extends OCSController {
 	 * @param string $token
 	 * @return DataResponse
 	 */
-	public function getRoom(string $token): DataResponse {
+	public function getSingleRoom(string $token): DataResponse {
 		try {
 			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId, true);
 
@@ -177,6 +162,7 @@ class RoomController extends OCSController {
 			// Deprecated, use participantFlags instead.
 			'participantInCall' => false,
 			'participantFlags' => Participant::FLAG_DISCONNECTED,
+			'readOnly' => Room::READ_WRITE,
 			'count' => 0,
 			'hasPassword' => $room->hasPassword(),
 			'hasCall' => false,
@@ -213,6 +199,7 @@ class RoomController extends OCSController {
 			// Deprecated, use participantFlags instead.
 			'participantInCall' => ($currentParticipant->getInCallFlags() & Participant::FLAG_IN_CALL) !== 0,
 			'participantFlags' => $currentParticipant->getInCallFlags(),
+			'readOnly' => $room->getReadOnly(),
 			'count' => $room->getNumberOfParticipants(false, $this->timeFactory->getTime() - 30),
 			'hasCall' => $room->getActiveSince() instanceof \DateTimeInterface,
 			'lastActivity' => $lastActivity,

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -810,6 +810,21 @@ class RoomController extends AEnvironmentAwareController {
 	}
 
 	/**
+	 * @NoAdminRequired
+	 * @RequireModeratorParticipant
+	 *
+	 * @param int $state
+	 * @return DataResponse
+	 */
+	public function setReadOnly(int $state): DataResponse {
+		if (!$this->room->setReadOnly($state)) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
+		return new DataResponse();
+	}
+
+	/**
 	 * @PublicPage
 	 * @RequireModeratorParticipant
 	 *

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -119,7 +119,7 @@ class Manager {
 			]));
 		}
 
-		return new Room($this, $this->db, $this->secureRandom, $this->dispatcher, $this->timeFactory, $this->hasher, (int) $row['id'], (int) $row['type'], $row['token'], $row['name'], $row['password'], (int) $row['active_guests'], $activeSince, $lastActivity, $lastMessage, (string) $row['object_type'], (string) $row['object_id']);
+		return new Room($this, $this->db, $this->secureRandom, $this->dispatcher, $this->timeFactory, $this->hasher, (int) $row['id'], (int) $row['type'], (int) $row['read_only'], $row['token'], $row['name'], $row['password'], (int) $row['active_guests'], $activeSince, $lastActivity, $lastMessage, (string) $row['object_type'], (string) $row['object_id']);
 	}
 
 	/**

--- a/lib/Middleware/Exceptions/ReadOnlyException.php
+++ b/lib/Middleware/Exceptions/ReadOnlyException.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Middleware\Exceptions;
+
+use OCP\AppFramework\Http;
+
+class ReadOnlyException extends \Exception {
+	public function __construct() {
+		parent::__construct('The conversation is read-only', Http::STATUS_FORBIDDEN);
+	}
+}

--- a/lib/Migration/Version5099Date20190319134820.php
+++ b/lib/Migration/Version5099Date20190319134820.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Spreed\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\Type;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version5099Date20190319134820 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('talk_rooms')) {
+			$table = $schema->getTable('talk_rooms');
+
+			if (!$table->hasColumn('read_only')) {
+				$table->addColumn('read_only', Type::INTEGER, [
+					'notnull' => true,
+					'length' => 6,
+					'default' => 0,
+				]);
+			}
+		}
+
+		return $schema;
+	}
+
+}

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -45,6 +45,9 @@ class Room {
 	public const GROUP_CALL = 2;
 	public const PUBLIC_CALL = 3;
 
+	public const READ_WRITE = 0;
+	public const READ_ONLY = 1;
+
 	public const PARTICIPANT_REMOVED = 'remove';
 	public const PARTICIPANT_LEFT = 'leave';
 
@@ -65,6 +68,8 @@ class Room {
 	private $id;
 	/** @var int */
 	private $type;
+	/** @var int */
+	private $readOnly;
 	/** @var string */
 	private $token;
 	/** @var string */
@@ -97,6 +102,7 @@ class Room {
 								IHasher $hasher,
 								int $id,
 								int $type,
+								int $readOnly,
 								string $token,
 								string $name,
 								string $password,
@@ -114,6 +120,7 @@ class Room {
 		$this->hasher = $hasher;
 		$this->id = $id;
 		$this->type = $type;
+		$this->readOnly = $readOnly;
 		$this->token = $token;
 		$this->name = $name;
 		$this->password = $password;
@@ -131,6 +138,10 @@ class Room {
 
 	public function getType(): int {
 		return $this->type;
+	}
+
+	public function getReadOnly(): int {
+		return $this->readOnly;
 	}
 
 	public function getToken(): string {

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -152,6 +152,10 @@ class RoomShareProvider implements IShareProvider {
 			throw new GenericShareException('Room not found', $this->l->t('Conversation not found'), 404);
 		}
 
+		if ($room->getReadOnly() === Room::READ_ONLY) {
+			throw new GenericShareException('Room not found', $this->l->t('Conversation not found'), 404);
+		}
+
 		try {
 			$room->getParticipant($share->getSharedBy());
 		} catch (ParticipantNotFoundException $e) {

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -360,6 +360,23 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" (locks|unlocks) room "([^"]*)" with (\d+)$/
+	 *
+	 * @param string $user
+	 * @param string $newState
+	 * @param string $identifier
+	 * @param string $statusCode
+	 */
+	public function userChangesReadOnlyStateOfTheRoom($user, $newState, $identifier, $statusCode) {
+		$this->setCurrentUser($user);
+		$this->sendRequest(
+			'PUT', '/apps/spreed/api/v1/room/' . self::$identifierToToken[$identifier] . '/read-only',
+			new TableNode([['state', $newState === 'unlocks' ? 0 : 1]])
+		);
+		$this->assertStatusCode($this->response, $statusCode);
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" adds "([^"]*)" to room "([^"]*)" with (\d+)$/
 	 *
 	 * @param string $user

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -502,11 +502,14 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->sendRequest('GET', '/apps/spreed/api/v1/chat/' . self::$identifierToToken[$identifier] . '?lookIntoFuture=0');
 		$this->assertStatusCode($this->response, $statusCode);
 
-		$messages = $this->getDataFromResponse($this->response);
-		$messages = array_filter($messages, function(array $message) {
+		$actual = $this->getDataFromResponse($this->response);
+		$messages = [];
+		array_map(function(array $message) use (&$messages) {
 			// Filter out system messages
-			return $message['systemMessage'] === '';
-		});
+			if ($message['systemMessage'] === '') {
+				$messages[] = $message;
+			}
+		}, $actual);
 
 		if ($formData === null) {
 			PHPUnit_Framework_Assert::assertEmpty($messages);

--- a/tests/integration/features/callapi/group-read-only.feature
+++ b/tests/integration/features/callapi/group-read-only.feature
@@ -1,0 +1,28 @@
+Feature: callapi/group-read-only
+  Background:
+    Given user "participant1" exists
+    And user "participant2" exists
+    And user "participant3" exists
+    And group "attendees1" exists
+    And user "participant2" is member of group "attendees1"
+
+  Scenario: User1 invites group attendees1 to a group room and they cant join the call in a locked conversation
+    When user "participant1" creates room "room"
+      | roomType | 2 |
+      | invite   | attendees1 |
+    Then user "participant1" is participant of room "room"
+    And user "participant2" is participant of room "room"
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant2" sees 0 peers in call "room" with 200
+    When user "participant1" locks room "room" with 200
+    And user "participant1" joins room "room" with 200
+    And user "participant1" joins call "room" with 403
+    And user "participant2" joins room "room" with 200
+    And user "participant2" joins call "room" with 403
+    Then user "participant1" sees 0 peers in call "room" with 403
+    And user "participant2" sees 0 peers in call "room" with 403
+    When user "participant1" unlocks room "room" with 200
+    And user "participant1" joins call "room" with 200
+    And user "participant2" joins call "room" with 200
+    Then user "participant1" sees 2 peers in call "room" with 200
+    And user "participant2" sees 2 peers in call "room" with 200

--- a/tests/integration/features/callapi/password.feature
+++ b/tests/integration/features/callapi/password.feature
@@ -127,7 +127,7 @@ Feature: callapi/public
     And user "guest" joins call "room" with 404
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404
-    Then user "guest" leaves call "room" with 200
+    Then user "guest" leaves call "room" with 404
     Then user "participant1" sees 1 peers in call "room" with 200
     And user "guest" sees 0 peers in call "room" with 404
     Then user "participant1" leaves call "room" with 200

--- a/tests/integration/features/callapi/public-read-only.feature
+++ b/tests/integration/features/callapi/public-read-only.feature
@@ -1,0 +1,69 @@
+Feature: callapi/public-read-only
+  Background:
+    Given user "participant1" exists
+    And user "participant2" exists
+    And user "participant3" exists
+
+  Scenario: User1 invites user2 to a public room and they cant join the call in a locked conversation
+    When user "participant1" creates room "room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "room" with 200
+    Then user "participant1" is participant of room "room"
+    And user "participant2" is participant of room "room"
+    Then user "participant1" sees 0 peers in call "room" with 200
+    And user "participant2" sees 0 peers in call "room" with 200
+    When user "participant1" locks room "room" with 200
+    And user "participant1" joins room "room" with 200
+    And user "participant1" joins call "room" with 403
+    And user "participant2" joins room "room" with 200
+    And user "participant2" joins call "room" with 403
+    Then user "participant1" sees 0 peers in call "room" with 403
+    And user "participant2" sees 0 peers in call "room" with 403
+    When user "participant1" unlocks room "room" with 200
+    And user "participant1" joins call "room" with 200
+    And user "participant2" joins call "room" with 200
+    Then user "participant1" sees 2 peers in call "room" with 200
+    And user "participant2" sees 2 peers in call "room" with 200
+
+  Scenario: User1 invites user2 to a public room and user3 cant join the call in a locked conversation
+    When user "participant1" creates room "room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "room" with 200
+    Then user "participant1" is participant of room "room"
+    Then user "participant3" is not participant of room "room"
+    When user "participant1" locks room "room" with 200
+    And user "participant1" joins room "room" with 200
+    And user "participant1" joins call "room" with 403
+    And user "participant3" joins room "room" with 200
+    And user "participant3" joins call "room" with 403
+    Then user "participant1" sees 0 peers in call "room" with 403
+    And user "participant3" sees 0 peers in call "room" with 403
+    When user "participant1" unlocks room "room" with 200
+    And user "participant1" joins call "room" with 200
+    And user "participant3" joins call "room" with 200
+    Then user "participant1" sees 2 peers in call "room" with 200
+    And user "participant3" sees 2 peers in call "room" with 200
+
+  Scenario: User1 invites user2 to a public room and guest cant join the call in a locked conversation
+    When user "participant1" creates room "room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "room" with 200
+    Then user "participant1" is participant of room "room"
+    When user "participant1" locks room "room" with 200
+    And user "guest" sees 0 peers in call "room" with 404
+    Then user "participant1" joins room "room" with 200
+    Then user "participant1" joins call "room" with 403
+    Then user "guest" joins room "room" with 200
+    And user "guest" joins call "room" with 403
+    Then user "participant1" sees 0 peers in call "room" with 403
+    And user "guest" sees 0 peers in call "room" with 403
+    When user "participant1" unlocks room "room" with 200
+    And user "participant1" sees 0 peers in call "room" with 200
+    And user "guest" sees 0 peers in call "room" with 200
+    Then user "participant1" joins call "room" with 200
+    And user "guest" joins call "room" with 200
+    Then user "participant1" sees 2 peers in call "room" with 200
+    And user "guest" sees 2 peers in call "room" with 200

--- a/tests/integration/features/chat/group-read-only.feature
+++ b/tests/integration/features/chat/group-read-only.feature
@@ -1,0 +1,47 @@
+Feature: chat/group-read-only
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+    And group "attendees1" exists
+    And user "participant2" is member of group "attendees1"
+
+  Scenario: owner can send and receive chat messages to and from group room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | invite   | attendees1 |
+    When user "participant1" sends message "Message 1" to room "group room" with 201
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | group room | users     | participant1 | participant1-displayname | Message 1 | []                |
+    When user "participant1" locks room "group room" with 200
+    When user "participant1" sends message "Message 2" to room "group room" with 403
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | group room | users     | participant1 | participant1-displayname | Message 1 | []                |
+    When user "participant1" unlocks room "group room" with 200
+    When user "participant1" sends message "Message 3" to room "group room" with 201
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | group room | users     | participant1 | participant1-displayname | Message 3 | []                |
+      | group room | users     | participant1 | participant1-displayname | Message 1 | []                |
+
+  Scenario: invited user can send and receive chat messages to and from group room
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | invite   | attendees1 |
+    When user "participant2" sends message "Message 1" to room "group room" with 201
+    Then user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | group room | users     | participant2 | participant2-displayname | Message 1 | []                |
+    When user "participant1" locks room "group room" with 200
+    When user "participant2" sends message "Message 2" to room "group room" with 403
+    Then user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | group room | users     | participant2 | participant2-displayname | Message 1 | []                |
+    When user "participant1" unlocks room "group room" with 200
+    When user "participant2" sends message "Message 3" to room "group room" with 201
+    Then user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | group room | users     | participant2 | participant2-displayname | Message 3 | []                |
+      | group room | users     | participant2 | participant2-displayname | Message 1 | []                |

--- a/tests/integration/features/chat/public-read-only.feature
+++ b/tests/integration/features/chat/public-read-only.feature
@@ -1,0 +1,69 @@
+Feature: chat/public-read-only
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+    And group "attendees1" exists
+    And user "participant2" is member of group "attendees1"
+
+  Scenario: owner can send and receive chat messages to and from group room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+      | roomName | room |
+    When user "participant1" sends message "Message 1" to room "public room" with 201
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | Message 1 | []                |
+    When user "participant1" locks room "public room" with 200
+    When user "participant1" sends message "Message 2" to room "public room" with 403
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | Message 1 | []                |
+    When user "participant1" unlocks room "public room" with 200
+    When user "participant1" sends message "Message 3" to room "public room" with 201
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | Message 3 | []                |
+      | public room | users     | participant1 | participant1-displayname | Message 1 | []                |
+
+  Scenario: invited user can send and receive chat messages to and from group room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    When user "participant2" sends message "Message 1" to room "public room" with 201
+    Then user "participant2" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | users     | participant2 | participant2-displayname | Message 1 | []                |
+    When user "participant1" locks room "public room" with 200
+    When user "participant2" sends message "Message 2" to room "public room" with 403
+    Then user "participant2" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | users     | participant2 | participant2-displayname | Message 1 | []                |
+    When user "participant1" unlocks room "public room" with 200
+    When user "participant2" sends message "Message 3" to room "public room" with 201
+    Then user "participant2" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | users     | participant2 | participant2-displayname | Message 3 | []                |
+      | public room | users     | participant2 | participant2-displayname | Message 1 | []                |
+
+  Scenario: not invited but joined user can send and receive chat messages to and from public room
+    Given user "participant1" creates room "public room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant3" joins room "public room" with 200
+    When user "participant3" sends message "Message 1" to room "public room" with 201
+    Then user "participant3" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | users     | participant3 | participant3-displayname | Message 1 | []                |
+    When user "participant1" locks room "public room" with 200
+    When user "participant3" sends message "Message 2" to room "public room" with 403
+    Then user "participant3" sees the following messages in room "public room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | users     | participant3 | participant3-displayname | Message 1 | []                |
+    When user "participant1" unlocks room "public room" with 200
+    When user "participant3" sends message "Message 3" to room "public room" with 201
+    Then user "participant3" sees the following messages in room "public room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | public room | users     | participant3 | participant3-displayname | Message 3 | []                |
+      | public room | users     | participant3 | participant3-displayname | Message 1 | []                |

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -78,6 +78,7 @@ class CapabilitiesTest extends TestCase {
 					'notification-levels',
 					'invite-groups-and-mails',
 					'locked-one-to-one-rooms',
+					'read-only-rooms',
 				],
 			],
 		], $capabilities->getCapabilities());
@@ -119,6 +120,7 @@ class CapabilitiesTest extends TestCase {
 					'notification-levels',
 					'invite-groups-and-mails',
 					'locked-one-to-one-rooms',
+					'read-only-rooms',
 				],
 			],
 		], $capabilities->getCapabilities());

--- a/tests/php/PasswordVerificationTest.php
+++ b/tests/php/PasswordVerificationTest.php
@@ -55,6 +55,7 @@ class PasswordVerificationTest extends TestCase {
 			$hasher,
 			1,
 			Room::PUBLIC_CALL,
+			Room::READ_WRITE,
 			'foobar',
 			'Test',
 			'passy',


### PR DESCRIPTION
The UI does currently not reflect the state, nor allow to change it, but it is a pre-requirement for #1616 

- [x] Add capability
- [x] Allow to set read-only state as moderator
- [x] Remove/disable chat input on read-only
- [x] Do not allow sending messages, starting call, … on the API
- [x] Remove/disable call button
- [x] Add system message
- [x] Do not allow to share files into read-only conversations
- [x] Raise an issue about the missing UI option: https://github.com/nextcloud/spreed/issues/1647

Fix #383