### PR TITLE
Dont allow to move mountpoints into mountpoints

### DIFF
--- a/tests/integration/features/sharing/move.feature
+++ b/tests/integration/features/sharing/move.feature
@@ -50,8 +50,6 @@ Feature: move
       | share_with             | group room |
       | share_with_displayname | Group room |
 
-
-
 #  # When an own share is moved into a received shared folder the ownership of
 #  # the share is handed over to the folder owner.
 #  Scenario: move share to received shared folder from a user in the room
@@ -210,8 +208,6 @@ Feature: move
 #    Then the OCS status code should be "404"
 #    And the HTTP status code should be "200"
 
-
-
   Scenario: move received share to another folder
     Given user "participant1" creates room "group room"
       | roomType | 2 |
@@ -272,95 +268,3 @@ Feature: move
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     When user "participant3" moves file "/welcome (2).txt" to "/test/renamed.txt"
     Then the HTTP status code should be "403"
-
-  # Received shares can be moved into other received shares, though. However,
-  # they are moved back to the default share folder.
-  Scenario: move received share to received shared folder from a user in the room
-    Given user "participant1" creates room "group room"
-      | roomType | 2 |
-      | roomName | room |
-    And user "participant1" renames room "group room" to "Group room" with 200
-    And user "participant1" adds "participant2" to room "group room" with 200
-    And user "participant1" adds "participant3" to room "group room" with 200
-    And user "participant3" creates folder "/test"
-    And user "participant3" shares "/test" with user "participant2" with OCS 100
-    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
-    When user "participant2" moves file "/welcome (2).txt" to "/test/renamed.txt"
-    Then user "participant1" gets last share
-    And share is returned with
-      | uid_owner              | participant1 |
-      | displayname_owner      | participant1-displayname |
-      | path                   | /welcome.txt |
-      | item_type              | file |
-      | mimetype               | text/plain |
-      | storage_id             | home::participant1 |
-      | file_target            | /welcome.txt |
-      | share_with             | group room |
-      | share_with_displayname | Group room |
-    And user "participant2" gets last share
-    And share is returned with
-      | uid_owner              | participant1 |
-      | displayname_owner      | participant1-displayname |
-      | path                   | /renamed.txt |
-      | item_type              | file |
-      | mimetype               | text/plain |
-      | storage_id             | shared::/renamed.txt |
-      | file_target            | /renamed.txt |
-      | share_with             | group room |
-      | share_with_displayname | Group room |
-    And user "participant3" gets last share
-    And share is returned with
-      | uid_owner              | participant1 |
-      | displayname_owner      | participant1-displayname |
-      | path                   | /welcome (2).txt |
-      | item_type              | file |
-      | mimetype               | text/plain |
-      | storage_id             | shared::/welcome (2).txt |
-      | file_target            | /welcome (2).txt |
-      | share_with             | group room |
-      | share_with_displayname | Group room |
-
-  Scenario: move received share to received shared folder from a user not in the room
-    Given user "participant1" creates room "group room"
-      | roomType | 2 |
-      | roomName | room |
-    And user "participant1" renames room "group room" to "Group room" with 200
-    And user "participant1" adds "participant2" to room "group room" with 200
-    And user "participant1" adds "participant3" to room "group room" with 200
-    And user "participant4" creates folder "/test"
-    And user "participant4" shares "/test" with user "participant2" with OCS 100
-    And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
-    When user "participant2" moves file "/welcome (2).txt" to "/test/renamed.txt"
-    Then user "participant1" gets last share
-    And share is returned with
-      | uid_owner              | participant1 |
-      | displayname_owner      | participant1-displayname |
-      | path                   | /welcome.txt |
-      | item_type              | file |
-      | mimetype               | text/plain |
-      | storage_id             | home::participant1 |
-      | file_target            | /welcome.txt |
-      | share_with             | group room |
-      | share_with_displayname | Group room |
-    And user "participant2" gets last share
-    And share is returned with
-      | uid_owner              | participant1 |
-      | displayname_owner      | participant1-displayname |
-      | path                   | /renamed.txt |
-      | item_type              | file |
-      | mimetype               | text/plain |
-      | storage_id             | shared::/renamed.txt |
-      | file_target            | /renamed.txt |
-      | share_with             | group room |
-      | share_with_displayname | Group room |
-    And user "participant3" gets last share
-    And share is returned with
-      | uid_owner              | participant1 |
-      | displayname_owner      | participant1-displayname |
-      | path                   | /welcome (2).txt |
-      | item_type              | file |
-      | mimetype               | text/plain |
-      | storage_id             | shared::/welcome (2).txt |
-      | file_target            | /welcome (2).txt |
-      | share_with             | group room |
-      | share_with_displayname | Group room |


### PR DESCRIPTION
This was fixed in https://github.com/nextcloud/server/pull/14691 but should actually have never worked.