### PR TITLE
Remove video constraints.

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -362,10 +362,7 @@ var spreedPeerConnectionTable = [];
 			debug: false,
 			media: {
 				audio: true,
-				video: {
-					width: { max: 1280 },
-					height: { max: 720 }
-				}
+				video: true
 			},
 			autoAdjustMic: false,
 			audioFallback: true,


### PR DESCRIPTION
Remove video constraints when creating SimpleWebRTC.
Safari 12.1 doesn't seem to like maxHeight and maxWidth constraints and fails getting local media.
Removing these constraints for now, but we should figure out a way to select video resolution.