### PR TITLE
Final release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,29 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 5.99.10 – 2019-04-02
+## 6.0.0 – 2019-04-DD
 ### Added
-- Administrators can now define commands which can be used in the chat. See [commands.md](https://github.com/nextcloud/spreed/blob/master/docs/commands.md) for more information
+- Administrators can now define commands which can be used in the chat. See [commands.md](https://github.com/nextcloud/spreed/blob/master/docs/commands.md) for more information. You can install some sample commands via the console.
   [#1453](https://github.com/nextcloud/spreed/pull/1453)
+  [#1662](https://github.com/nextcloud/spreed/pull/1662)
+- There is now a "Talk updates" conversation which will help the user to discover some features
+  [#1616](https://github.com/nextcloud/spreed/pull/1616)
+  [#1662](https://github.com/nextcloud/spreed/pull/1662)
 - `@all` mentions all participants in the conversation
   [#1531](https://github.com/nextcloud/spreed/pull/1531)
 - Allow to get the last sent message again with `arrow-up`
   [#1520](https://github.com/nextcloud/spreed/pull/1520)
+- Conversations can be added to the new Nextcloud 16 projects
+  [#1611](https://github.com/nextcloud/spreed/pull/1611)
+  [#1663](https://github.com/nextcloud/spreed/pull/1663)
 - Conversations associated to files now have a link to the file
   [#1387](https://github.com/nextcloud/spreed/pull/1387)
 - The Talk app can now be restricted to a group of users in the Talk administration settings
   [#1585](https://github.com/nextcloud/spreed/pull/1585)
 - Show a warning when a call has many participants and no external signaling server is used
   [#1649](https://github.com/nextcloud/spreed/pull/1649)
+- Added an easy-to-find option to copy the link of a conversation
+  [#1670](https://github.com/nextcloud/spreed/pull/1670)
 
 ### Changed
 - One-to-one conversations are now persistent and can not be turned into group conversations by accident. Also when one of the participants leaves the conversation, the conversation is not automatically deleted anymore.
@@ -40,6 +49,8 @@ All notable changes to this project will be documented in this file.
   [#1426](https://github.com/nextcloud/spreed/pull/1426)
   [#1496](https://github.com/nextcloud/spreed/pull/1496)
   [#1502](https://github.com/nextcloud/spreed/pull/1502)
+- Fixed an issue when a link was posted into the chat at the end of a line
+  [#1666](https://github.com/nextcloud/spreed/pull/1666)
 
 ## 5.0.2 – 2019-01-30
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 6.0.0 – 2019-04-DD
+## 6.0.0-RC1 – 2019-04-11
 ### Added
 - Administrators can now define commands which can be used in the chat. See [commands.md](https://github.com/nextcloud/spreed/blob/master/docs/commands.md) for more information. You can install some sample commands via the console.
   [#1453](https://github.com/nextcloud/spreed/pull/1453)
@@ -51,6 +51,34 @@ All notable changes to this project will be documented in this file.
   [#1502](https://github.com/nextcloud/spreed/pull/1502)
 - Fixed an issue when a link was posted into the chat at the end of a line
   [#1666](https://github.com/nextcloud/spreed/pull/1666)
+
+## 5.0.3 – 2019-04-11
+### Changed
+- Remove some conversation informations for non-participants
+  [#1518](https://github.com/nextcloud/spreed/pull/1518)
+
+### Fixed
+- Fix duplicated call summary message when multiple people leave at the same time
+  [#1599](https://github.com/nextcloud/spreed/pull/1599)
+- Allow multiline text insertion in chrome-based browsers
+  [#1579](https://github.com/nextcloud/spreed/pull/1579)
+- Fix multiple race-conditions that could interrupt connections, end calls or prevent connections between single participants
+  [#1523](https://github.com/nextcloud/spreed/pull/1523)
+  [#1542](https://github.com/nextcloud/spreed/pull/1542)
+  [#1543](https://github.com/nextcloud/spreed/pull/1543)
+- Enable "Plan B" for chrome/chromium for better MCU support
+  [#1613](https://github.com/nextcloud/spreed/pull/1613)
+- Delay signaling messages when the socket is not yet opened
+  [#1551](https://github.com/nextcloud/spreed/pull/1551)
+- Correctly readd the default STUN server on empty values
+  [#1501](https://github.com/nextcloud/spreed/pull/1501)
+
+## 4.0.4 – 2019-04-11
+### Fixed
+- Enable "Plan B" for chrome/chromium for better MCU support
+  [#1614](https://github.com/nextcloud/spreed/pull/1614)
+- Delay signaling messages when the socket is not yet opened
+  [#1552](https://github.com/nextcloud/spreed/pull/1552)
 
 ## 5.0.2 – 2019-01-30
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 ## Why is this so awesome?
 
-* 💬 **Chat integration!** Nextcloud Talk comes with some simple text chat since Nextcloud 13. More features are planned for future versions.
+* 💬 **Chat integration!** Nextcloud Talk comes with a simple text chat. Allowing you to share files from your Nextcloud and mentioning other participants.
 * 👥 **Private, group, public and password protected calls!** Just invite somebody, a whole group or send a public link to invite to a call.
 * 💻 **Screen sharing!** Share your screen with participants of your call. You just need to use Firefox version 52 (or newer), latest Edge or Chrome 49 (or newer) with this [Chrome extension](https://chrome.google.com/webstore/detail/screensharing-for-nextclo/kepnpjhambipllfmgmbapncekcmabkol).
-* 🚀 **Integration with other Nextcloud apps!** Currently Contacts and users – more to come.
+* 🚀 **Integration with other Nextcloud apps** like Files, Contacts and Deck. More to come.
 * 🙈 **We’re not reinventing the wheel!** Based on the great [simpleWebRTC](https://simplewebrtc.com/) library.
 
 And in the works for the [coming versions](https://github.com/nextcloud/spreed/milestones/):

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 * 💬 **Chat integration!** Nextcloud Talk comes with some simple text chat since Nextcloud 13. More features are planned for future versions.
 * 👥 **Private, group, public and password protected calls!** Just invite somebody, a whole group or send a public link to invite to a call.
-* 💻 **Screen sharing!** Share your screen with participants of your call. You just need to use Firefox version 52 (or newer) or Chrome with this [Chrome extension](https://chrome.google.com/webstore/detail/screensharing-for-nextclo/kepnpjhambipllfmgmbapncekcmabkol).
+* 💻 **Screen sharing!** Share your screen with participants of your call. You just need to use Firefox version 52 (or newer), latest Edge or Chrome 49 (or newer) with this [Chrome extension](https://chrome.google.com/webstore/detail/screensharing-for-nextclo/kepnpjhambipllfmgmbapncekcmabkol).
 * 🚀 **Integration with other Nextcloud apps!** Currently Contacts and users – more to come.
 * 🙈 **We’re not reinventing the wheel!** Based on the great [simpleWebRTC](https://simplewebrtc.com/) library.
 
@@ -19,9 +19,12 @@ If you have suggestions or problems, please [open an issue](https://github.com/n
 
 ### Supported Browsers
 
-Firefox | Chrome/Chromium | Edge | Safari | Opera
----|---|---|---|---
-✔️ 52 or later | ✔️ 49 or later | ⏳ [Planned](https://github.com/nextcloud/spreed/issues/687) | ⏳ [Planned](https://github.com/nextcloud/spreed/issues/687) | ❌ Not planned yet
+| Browser | Compatible |
+|---|---|
+| Firefox | ✔️ 52 or later |
+| Chrome/Chromium | ✔️ 49 or later |
+| Edge | ⚠️ latest versions <br> 🎤 Speakers are not promoted <br> 🏷 Name changes while a call is on-going are not reflected |
+| Safari | ⚠️ 12 or later <br> ❌ No screensharing support <br> 🖥 Viewing screens of others works |
 
 
 ## Installing for Production

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>5.99.10</version>
+	<version>6.0.0</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -3,21 +3,20 @@
 	  xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
 	<id>spreed</id>
 	<name>Talk</name>
-	<summary><![CDATA[Video & audio-conferencing using WebRTC]]></summary>
-	<description><![CDATA[Video & audio-conferencing using WebRTC
+	<summary><![CDATA[Chat, video & audio-conferencing using WebRTC]]></summary>
+	<description><![CDATA[Chat, video & audio-conferencing using WebRTC
 
-* 💬 **Chat integration!** Nextcloud Talk comes with some simple text chat since Nextcloud 13. More features are planned for future versions.
+* 💬 **Chat integration!** Nextcloud Talk comes with a simple text chat. Allowing you to share files from your Nextcloud and mentioning other participants.
 * 👥 **Private, group, public and password protected calls!** Just invite somebody, a whole group or send a public link to invite to a call.
-* 💻 **Screen sharing!** Share your screen with participants of your call.
-* 🚀 **Integration with other Nextcloud apps!** Currently Contacts and users – more to come.
-* 🙈 **We’re not reinventing the wheel!** Based on the great [simpleWebRTC](https://simplewebrtc.com/) library.
+* 💻 **Screen sharing!** Share your screen with participants of your call. You just need to use Firefox version 52 (or newer), latest Edge or Chrome 49 (or newer) with this [Chrome extension](https://chrome.google.com/webstore/detail/screensharing-for-nextclo/kepnpjhambipllfmgmbapncekcmabkol).
+* 🚀 **Integration with other Nextcloud apps** like Files, Contacts and Deck. More to come.
 
 And in the works for the [coming versions](https://github.com/nextcloud/spreed/milestones/):
 * ✋ [Federated calls](https://github.com/nextcloud/spreed/issues/21), to call people on other Nextclouds
 
 	]]></description>
 
-	<version>6.0.0</version>
+	<version>6.0.0-RC.1</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -496,7 +496,7 @@
 				return false;
 			}
 
-			return model1.get('actorType') !== 'bots' &&
+			return (model1.get('actorType') !== 'bots' || model1.get('actorId') === 'changelog') &&
 				(model1.get('systemMessage').length === 0) === (model2.get('systemMessage').length === 0) &&
 				model1.get('actorId') === model2.get('actorId') &&
 				model1.get('actorType') === model2.get('actorType');

--- a/lib/Chat/Changelog/Manager.php
+++ b/lib/Chat/Changelog/Manager.php
@@ -85,6 +85,7 @@ class Manager {
 				. 'In this conversation you will be informed about new features available in Nextcloud Talk.'
 			),
 			$this->l->t('New in Talk 6'),
+			$this->l->t('* Microsoft Edge and Safari can now be used to participate in audio and video calls'),
 			$this->l->t('* One-to-one conversations are now persistent and can not be turned into group conversations by accident anymore. Also when one of the participants leaves the conversation, the conversation is not automatically deleted anymore. Only if both participants leave, the conversation is deleted from the server'),
 			$this->l->t('* You can now notify all participants by posting "@all" into the chat'),
 			$this->l->t('* With the "arrow-up" key you can repost your last message'),

--- a/lib/Chat/Changelog/Manager.php
+++ b/lib/Chat/Changelog/Manager.php
@@ -69,7 +69,7 @@ class Manager {
 		$hasReceivedLog = $this->getChangelogForUser($userId);
 
 		foreach ($logs as $key => $changelog) {
-			if ($key < $hasReceivedLog) {
+			if ($key < $hasReceivedLog || $changelog === '') {
 				continue;
 			}
 			$this->chatManager->addChangelogMessage($room, $changelog);
@@ -80,7 +80,16 @@ class Manager {
 
 	public function getChangelogs(): array {
 		return [
-			$this->l->t("Welcome to Nextcloud Talk!\nIn this conversation you will be informed about new features available in Nextcloud Talk."),
+			$this->l->t(
+				"Welcome to Nextcloud Talk!\n"
+				. 'In this conversation you will be informed about new features available in Nextcloud Talk.'
+			),
+			$this->l->t('New in Talk 6'),
+			$this->l->t('* One-to-one conversations are now persistent and can not be turned into group conversations by accident anymore. Also when one of the participants leaves the conversation, the conversation is not automatically deleted anymore. Only if both participants leave, the conversation is deleted from the server'),
+			$this->l->t('* You can now notify all participants by posting "@all" into the chat'),
+			$this->l->t('* With the "arrow-up" key you can repost your last message'),
+			$this->l->t('* Talk can now have commands, send "/help" as a chat message to see if your administrator configured some'),
+			$this->l->t('* With projects you can create quick links between conversations, files and other items'),
 		];
 	}
 }

--- a/lib/Command/Command/Add.php
+++ b/lib/Command/Command/Add.php
@@ -109,5 +109,9 @@ class Add extends Base {
 		$output->writeln('<info>Command added</info>');
 		$output->writeln('');
 		$this->renderCommands(Base::OUTPUT_FORMAT_PLAIN, $output, [$command]);
+
+		$output->writeln('');
+		$output->writeln("<comment>If you think your command makes sense for other users as well, feel free to share it in the following github issue:\n https://github.com/nextcloud/spreed/issues/1566</comment>");
+
 	}
 }


### PR DESCRIPTION
- [x] Adjust version
- [x] Add user changelog to Changelog Conversation
- [x] Projects: https://github.com/nextcloud/spreed/pull/1663
- [x] Sample commands: https://github.com/nextcloud/spreed/pull/1662

---

## 6.0.0 – 2019-04-DD
### Added
- Administrators can now define commands which can be used in the chat. See [commands.md](https://github.com/nextcloud/spreed/blob/master/docs/commands.md) for more information. You can install some sample commands via the console.  [#1453](https://github.com/nextcloud/spreed/pull/1453)  [#1662](https://github.com/nextcloud/spreed/pull/1662)
- There is now a "Talk updates" conversation which will help the user to discover some features  [#1616](https://github.com/nextcloud/spreed/pull/1616)  [#1662](https://github.com/nextcloud/spreed/pull/1662)
- `@all` mentions all participants in the conversation  [#1531](https://github.com/nextcloud/spreed/pull/1531)
- Allow to get the last sent message again with `arrow-up`  [#1520](https://github.com/nextcloud/spreed/pull/1520)
- Conversations can be added to the new Nextcloud 16 projects  [#1611](https://github.com/nextcloud/spreed/pull/1611)  [#1663](https://github.com/nextcloud/spreed/pull/1663)
- Conversations associated to files now have a link to the file  [#1387](https://github.com/nextcloud/spreed/pull/1387)
- The Talk app can now be restricted to a group of users in the Talk administration settings  [#1585](https://github.com/nextcloud/spreed/pull/1585)
- Show a warning when a call has many participants and no external signaling server is used  [#1649](https://github.com/nextcloud/spreed/pull/1649)
- Added an easy-to-find option to copy the link of a conversation  [#1670](https://github.com/nextcloud/spreed/pull/1670)

### Changed
- One-to-one conversations are now persistent and can not be turned into group conversations by accident. Also when one of the participants leaves the conversation, the conversation is not automatically deleted anymore.  [#1591](https://github.com/nextcloud/spreed/pull/1591)  [#1588](https://github.com/nextcloud/spreed/pull/1588)
- Conversations must have a name now  [#1567](https://github.com/nextcloud/spreed/pull/1567)

### Fixed
- Fix multiple race-conditions that could interrupt connections, end calls or prevent connections between single participants  [#1522](https://github.com/nextcloud/spreed/pull/1522)  [#1533](https://github.com/nextcloud/spreed/pull/1533)  [#1534](https://github.com/nextcloud/spreed/pull/1534)  [#1549](https://github.com/nextcloud/spreed/pull/1549)
- Use better icons when a file without preview or a folder is shared into the chat  [#1601](https://github.com/nextcloud/spreed/pull/1601)
- Prevent issues when two participants share their screens  [#1571](https://github.com/nextcloud/spreed/pull/1571)
- Correctly remember last media state when reloading in a call  [#1548](https://github.com/nextcloud/spreed/pull/1548)  [#5174](https://github.com/nextcloud/spreed/pull/1574)
- Do not show conversation names and other details if the user is not a participant  [#1426](https://github.com/nextcloud/spreed/pull/1426)  [#1496](https://github.com/nextcloud/spreed/pull/1496)  [#1502](https://github.com/nextcloud/spreed/pull/1502)
- Fixed an issue when a link was posted into the chat at the end of a line  [#1666](https://github.com/nextcloud/spreed/pull/1666)
