### PR TITLE
Fix ICE failed indicator icon not forced to white in call

### DIFF
--- a/css/video.scss
+++ b/css/video.scss
@@ -407,6 +407,9 @@ video {
 	&.icon-screen-off {
 		background-image: url(icon-color-path('screen-off', 'actions', 'fff', 1, true));
 	}
+	&.icon-error {
+		background-image: url(icon-color-path('error', 'actions', 'fff', 1, true));
+	}
 
 	/* ".force-icon-white-in-call" can be combined with ".icon-shadow" just like
 	 * ".icon-white". */


### PR DESCRIPTION
Before:
![Icon-Ice-Failed-Before](https://user-images.githubusercontent.com/26858233/55538798-86186a00-56bf-11e9-8e93-80c2da4a3e38.png)

After:
![Icon-Ice-Failed-After](https://user-images.githubusercontent.com/26858233/55538806-87e22d80-56bf-11e9-8036-eb0721d03c26.png)

## How to test: ##
- Force [`setConnectionStatus`](https://github.com/nextcloud/spreed/blob/e928527ff421cbe4e969d70b2986cec062695fe6/js/views/videoview.js#L127) to always set the failed status with `connectionStatus = ConnectionStatus.FAILED_NO_RESTART;` (or wait patiently for several ICE failures in a row... but this dirty hack is faster ;-) ).
- Start a call with one user
- Join the call with another user

### Result with this pull request: ###
The ICE failed indicator icon shown above the other peer name is white.

### Result without this pull request: ###
The ICE failed indicator icon shown above the other peer name is black.
