### PR TITLE
Ignore node modules when running integration tests in Docker

### DIFF
--- a/tests/integration/run-docker.sh
+++ b/tests/integration/run-docker.sh
@@ -151,7 +151,15 @@ function prepareDocker() {
 	# "docker cp" does not take them into account (the extracted files are set
 	# to root).
 	echo "Copying local Git working directory of Nextcloud to the container"
-	tar --create --file="$NEXTCLOUD_LOCAL_TAR" --exclude=".git" --exclude="./build" --exclude="./config/config.php" --exclude="./data" --exclude="./data-autotest" --exclude="./tests" --directory=../../../../ .
+	tar --create --file="$NEXTCLOUD_LOCAL_TAR" \
+		--exclude=".git" \
+		--exclude="./build" \
+		--exclude="./config/config.php" \
+		--exclude="./data" \
+		--exclude="./data-autotest" \
+		--exclude="./tests" \
+		--directory=../../../../ \
+		.
 
 	docker exec $NEXTCLOUD_LOCAL_CONTAINER mkdir /nextcloud
 	docker cp - $NEXTCLOUD_LOCAL_CONTAINER:/nextcloud/ < "$NEXTCLOUD_LOCAL_TAR"

--- a/tests/integration/run-docker.sh
+++ b/tests/integration/run-docker.sh
@@ -158,6 +158,7 @@ function prepareDocker() {
 		--exclude="./data" \
 		--exclude="./data-autotest" \
 		--exclude="./tests" \
+		--exclude="node_modules" \
 		--directory=../../../../ \
 		.
 


### PR DESCRIPTION
Copy of nextcloud/server#14737
