### PR TITLE
Fix cursor on selected tab header

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -601,6 +601,14 @@ input[type="password"] {
 }
 /* END: move padding fixes and icons-for-tabs capability into core */
 
+/* In Talk clicking on the selected tab header has no effect, so the pointer
+ * cursor should not be used. */
+.tabHeaders .tabHeader.selected,
+.tabHeaders .tabHeader.selected .icon,
+.tabHeaders .tabHeader.selected a {
+	cursor: default;
+}
+
 #app-sidebar.hidden {
 	display: none !important;
 }


### PR DESCRIPTION
The pointer cursor should be used on clickable elements, but clicking on a selected tab header has no effect, so now the default cursor is used instead.

This is Talk specific; for example in the _Files_ app clicking on some tab headers when they are selected does nothing while clicking on others when they are selected reloads the tab. Due to this the CSS was modified here [instead of in server](https://github.com/nextcloud/server/blob/15ae6338644d90a2a8d633892fd0b78acee97576/core/css/apps.scss#L824).

**Before, tab selected:**
![Cursor-Tab-Header-Selected-Before](https://user-images.githubusercontent.com/26858233/55623067-32cb1800-57a2-11e9-94f8-936ba9efcd31.png)

**Before, tab not selected:**
![Cursor-Tab-Header-Not-Selected-Before](https://user-images.githubusercontent.com/26858233/55623069-352d7200-57a2-11e9-9c49-4e2ed1912ef9.png)

**After, tab selected:**
![Cursor-Tab-Header-Selected-After](https://user-images.githubusercontent.com/26858233/55623072-38286280-57a2-11e9-91ef-6c4c1cd814bc.png)

**After, tab not selected (no changes):**
![Cursor-Tab-Header-Not-Selected-After](https://user-images.githubusercontent.com/26858233/55623077-39f22600-57a2-11e9-9544-7fb0196117bb.png)
