### PR TITLE
Fix duplicated candidate mentions in file rooms

### DIFF
--- a/lib/Chat/AutoComplete/SearchPlugin.php
+++ b/lib/Chat/AutoComplete/SearchPlugin.php
@@ -65,6 +65,14 @@ class SearchPlugin implements ISearchPlugin {
 	 * @since 13.0.0
 	 */
 	public function search($search, $limit, $offset, ISearchResult $searchResult) {
+		if ($this->room->getObjectType() === 'file') {
+			$usersWithFileAccess = $this->util->getUsersWithAccessFile($this->room->getObjectId());
+			if (!empty($usersWithFileAccess)) {
+				$this->searchUsers($search, $usersWithFileAccess, $searchResult);
+			}
+
+			return false;
+		}
 
 		$userIds = $this->room->getParticipantUserIds();
 		if ($this->room->getType() === Room::ONE_TO_ONE_CALL
@@ -75,13 +83,6 @@ class SearchPlugin implements ISearchPlugin {
 
 		// FIXME Handle guests
 		$this->searchUsers($search, $userIds, $searchResult);
-
-		if ($this->room->getObjectType() === 'file') {
-			$usersWithFileAccess = $this->util->getUsersWithAccessFile($this->room->getObjectId());
-			if (!empty($usersWithFileAccess)) {
-				$this->searchUsers($search, $usersWithFileAccess, $searchResult);
-			}
-		}
 
 		return false;
 	}

--- a/tests/integration/features/chat/mentions.feature
+++ b/tests/integration/features/chat/mentions.feature
@@ -183,3 +183,69 @@ Feature: chat/mentions
     And user "guest" joins room "public room" with 200
     Then user "participant4" gets the following candidate mentions in room "public room" for "" with 404
     And user "guest2" gets the following candidate mentions in room "public room" for "" with 404
+
+
+
+  Scenario: get mentions in a file room with no other joined participant
+    Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    When user "participant1" gets the room for path "welcome.txt" with 200
+    And user "participant1" is participant of room "file welcome.txt room"
+    And user "participant2" is not participant of room "file welcome.txt room"
+    Then user "participant1" gets the following candidate mentions in room "file welcome.txt room" for "" with 200
+      | id           | label                    | source |
+      | all          | welcome.txt              | calls  |
+      | participant2 | participant2-displayname | users  |
+    And user "participant2" gets the following candidate mentions in room "file welcome.txt room" for "" with 404
+
+  Scenario: get mentions in a file room
+    Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    When user "participant1" gets the room for path "welcome.txt" with 200
+    And user "participant2" gets the room for path "welcome (2).txt" with 200
+    And user "participant1" is participant of room "file welcome (2).txt room"
+    And user "participant2" is participant of room "file welcome (2).txt room"
+    Then user "participant1" gets the following candidate mentions in room "file welcome (2).txt room" for "" with 200
+      | id           | label                    | source |
+      | all          | welcome.txt              | calls  |
+      | participant2 | participant2-displayname | users  |
+    And user "participant2" gets the following candidate mentions in room "file welcome (2).txt room" for "" with 200
+      | id           | label                    | source |
+      | all          | welcome.txt              | calls  |
+      | participant1 | participant1-displayname | users  |
+
+  Scenario: get matched mentions in a file room
+    Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    When user "participant1" gets the room for path "welcome.txt" with 200
+    And user "participant2" gets the room for path "welcome (2).txt" with 200
+    And user "participant1" is participant of room "file welcome (2).txt room"
+    And user "participant2" is participant of room "file welcome (2).txt room"
+    Then user "participant1" gets the following candidate mentions in room "file welcome (2).txt room" for "part" with 200
+      | id           | label                    | source |
+      | participant2 | participant2-displayname | users  |
+    And user "participant2" gets the following candidate mentions in room "file welcome (2).txt room" for "part" with 200
+      | id           | label                    | source |
+      | participant1 | participant1-displayname | users  |
+
+  Scenario: get unmatched mentions in a file room
+    Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    When user "participant1" gets the room for path "welcome.txt" with 200
+    And user "participant2" gets the room for path "welcome (2).txt" with 200
+    And user "participant1" is participant of room "file welcome (2).txt room"
+    And user "participant2" is participant of room "file welcome (2).txt room"
+    Then user "participant1" gets the following candidate mentions in room "file welcome (2).txt room" for "unknown" with 200
+    And user "participant2" gets the following candidate mentions in room "file welcome (2).txt room" for "unknown" with 200
+
+  Scenario: get mentions in a file room with a participant without access to the file
+    Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    When user "participant1" gets the room for path "welcome.txt" with 200
+    And user "participant2" gets the room for path "welcome (2).txt" with 200
+    And user "participant1" is participant of room "file welcome (2).txt room"
+    And user "participant2" is participant of room "file welcome (2).txt room"
+    Then user "participant3" gets the following candidate mentions in room "file welcome (2).txt room" for "" with 404
+
+  Scenario: mention a participant with access to the file but not joined in a file room
+    Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant1" gets the room for path "welcome.txt" with 200
+    And user "participant1" is participant of room "file welcome.txt room"
+    And user "participant2" is not participant of room "file welcome.txt room"
+    When user "participant1" sends message "hi @participant2" to room "file welcome.txt room" with 201
+    Then user "participant2" is participant of room "file welcome.txt room"


### PR DESCRIPTION
Requires #1676 and #1677 ~~(I will rebase on master the last two commits of this pull request once those two pull requests are merged)~~.

In regular rooms only the current participants are candidates in mentions, but in file rooms the candidates are all the users with access to the file, even if they are not currently participants of the room. However, as the users with access to the file are a superset of the current participants those participants were returned twice. Therefore, now candidates for mentions in file rooms are got only from the users with access to the file instead of in addition to the current participants.

## How to test: ##

- In the Files app, share a file with another user
- Open the Chat tab for that file
- As the other user, open the Chat tab for the file (so the user joins the room for the file)
- As the original user, type _@_ in the Chat tab to show the candidate mentions

### Result with this pull request: ###
The other user appears once in the candidate mentions

### Result without this pull request: ###
The other user appears twice in the candidate mentions
