### PR TITLE
Fix links style in Talk sidebar in public share auth page

### DIFF
--- a/css/publicshareauth.scss
+++ b/css/publicshareauth.scss
@@ -254,6 +254,13 @@ input#request-password-button:disabled ~ .icon {
 	padding-right: 34px;
 }
 
+/* Restore rules from style.scss (core) overriden by guest.css for the
+ * sidebar */
+#body-login #talk-sidebar a {
+	color: var(--color-main-text);
+	font-weight: inherit;
+}
+
 /* Unset conflicting rules from publicshareauth.css (core) for the sidebar */
 #talk-sidebar input[type="submit"],
 #talk-sidebar input.icon-confirm[type="submit"] {


### PR DESCRIPTION
**Before:**
![PublicShareAuth-Link-Before](https://user-images.githubusercontent.com/26858233/55824797-e0bd2600-5b04-11e9-8fff-dc10feb06171.png)

**After:**
![PublicShareAuth-Link-After](https://user-images.githubusercontent.com/26858233/55824798-e1ee5300-5b04-11e9-9b37-05d0b7555c47.png)
