### PR TITLE
Fix misplaced chat view in public share auth page

### DIFF
--- a/css/publicshareauth.scss
+++ b/css/publicshareauth.scss
@@ -216,6 +216,10 @@ input#request-password-button:disabled ~ .icon {
 	margin-top: 0;
 }
 
+#talk-sidebar #chatView .newCommentForm.with-add-button {
+	/* Make room to show the "Add" button if needed. */
+	margin-right: 44px;
+}
 
 /* Unset conflicting rules from guest.css for the sidebar */
 #talk-sidebar {

--- a/js/views/templates.js
+++ b/js/views/templates.js
@@ -55,12 +55,14 @@ templates['chatview_add_comment'] = template({"1":function(container,depth0,help
 },"3":function(container,depth0,helpers,partials,data) {
     return "		<div class=\"guest-name\"></div>\n";
 },"5":function(container,depth0,helpers,partials,data) {
-    return "false";
+    return " with-add-button";
 },"7":function(container,depth0,helpers,partials,data) {
-    return "true";
+    return "false";
 },"9":function(container,depth0,helpers,partials,data) {
-    return "disabled=\"\"";
+    return "true";
 },"11":function(container,depth0,helpers,partials,data) {
+    return "disabled=\"\"";
+},"13":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "		<button class=\"share icon-add has-tooltip\" title=\""
@@ -73,18 +75,20 @@ templates['chatview_add_comment'] = template({"1":function(container,depth0,help
     + alias4(((helper = (helper = helpers.actorId || (depth0 != null ? depth0.actorId : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"actorId","hash":{},"data":data}) : helper)))
     + "\"></div>\n"
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.actorId : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.program(3, data, 0),"data":data})) != null ? stack1 : "")
-    + "	</div>\n	<form class=\"newCommentForm\">\n		<div contentEditable=\""
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isReadOnly : depth0),{"name":"if","hash":{},"fn":container.program(5, data, 0),"inverse":container.program(7, data, 0),"data":data})) != null ? stack1 : "")
+    + "	</div>\n	<form class=\"newCommentForm"
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.canShare : depth0),{"name":"if","hash":{},"fn":container.program(5, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "\">\n		<div contentEditable=\""
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isReadOnly : depth0),{"name":"if","hash":{},"fn":container.program(7, data, 0),"inverse":container.program(9, data, 0),"data":data})) != null ? stack1 : "")
     + "\" class=\"message\" data-placeholder=\""
     + alias4(((helper = (helper = helpers.newMessagePlaceholder || (depth0 != null ? depth0.newMessagePlaceholder : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"newMessagePlaceholder","hash":{},"data":data}) : helper)))
     + "\">"
     + alias4(((helper = (helper = helpers.message || (depth0 != null ? depth0.message : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"message","hash":{},"data":data}) : helper)))
     + "</div>\n		<input class=\"submit icon-confirm has-tooltip\" type=\"submit\" "
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isReadOnly : depth0),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isReadOnly : depth0),{"name":"if","hash":{},"fn":container.program(11, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + " value=\"\" title=\""
     + alias4(((helper = (helper = helpers.submitText || (depth0 != null ? depth0.submitText : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"submitText","hash":{},"data":data}) : helper)))
     + "\"/>\n		<div class=\"submitLoading icon-loading-small hidden\"></div>\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.canShare : depth0),{"name":"if","hash":{},"fn":container.program(11, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.canShare : depth0),{"name":"if","hash":{},"fn":container.program(13, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "	</form>\n</div>\n";
 },"useData":true});
 templates['chatview_comment'] = template({"1":function(container,depth0,helpers,partials,data) {

--- a/js/views/templates.js
+++ b/js/views/templates.js
@@ -73,7 +73,7 @@ templates['chatview_add_comment'] = template({"1":function(container,depth0,help
     + alias4(((helper = (helper = helpers.actorId || (depth0 != null ? depth0.actorId : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"actorId","hash":{},"data":data}) : helper)))
     + "\"></div>\n"
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.actorId : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.program(3, data, 0),"data":data})) != null ? stack1 : "")
-    + "	</div>\n	<form class=\"newCommentForm\">\n	<div contentEditable=\""
+    + "	</div>\n	<form class=\"newCommentForm\">\n		<div contentEditable=\""
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isReadOnly : depth0),{"name":"if","hash":{},"fn":container.program(5, data, 0),"inverse":container.program(7, data, 0),"data":data})) != null ? stack1 : "")
     + "\" class=\"message\" data-placeholder=\""
     + alias4(((helper = (helper = helpers.newMessagePlaceholder || (depth0 != null ? depth0.newMessagePlaceholder : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"newMessagePlaceholder","hash":{},"data":data}) : helper)))

--- a/js/views/templates/chatview_add_comment.handlebars
+++ b/js/views/templates/chatview_add_comment.handlebars
@@ -7,7 +7,7 @@
 		<div class="guest-name"></div>
 		{{/if}}
 	</div>
-	<form class="newCommentForm">
+	<form class="newCommentForm{{#if canShare}} with-add-button{{/if}}">
 		<div contentEditable="{{#if isReadOnly}}false{{else}}true{{/if}}" class="message" data-placeholder="{{newMessagePlaceholder}}">{{message}}</div>
 		<input class="submit icon-confirm has-tooltip" type="submit" {{#if isReadOnly}}disabled=""{{/if}} value="" title="{{submitText}}"/>
 		<div class="submitLoading icon-loading-small hidden"></div>

--- a/js/views/templates/chatview_add_comment.handlebars
+++ b/js/views/templates/chatview_add_comment.handlebars
@@ -8,7 +8,7 @@
 		{{/if}}
 	</div>
 	<form class="newCommentForm">
-	<div contentEditable="{{#if isReadOnly}}false{{else}}true{{/if}}" class="message" data-placeholder="{{newMessagePlaceholder}}">{{message}}</div>
+		<div contentEditable="{{#if isReadOnly}}false{{else}}true{{/if}}" class="message" data-placeholder="{{newMessagePlaceholder}}">{{message}}</div>
 		<input class="submit icon-confirm has-tooltip" type="submit" {{#if isReadOnly}}disabled=""{{/if}} value="" title="{{submitText}}"/>
 		<div class="submitLoading icon-loading-small hidden"></div>
 		{{#if canShare}}


### PR DESCRIPTION
Fixes #1541 

This only happens when requesting a password by Talk with a logged in user; guests are fine.

**Before, user:**
![PublicShareAuth-User-Before](https://user-images.githubusercontent.com/26858233/55824976-4ad5cb00-5b05-11e9-8bcf-e7a02bd51890.png)

**Before, guest:**
![PublicShareAuth-Guest-Before](https://user-images.githubusercontent.com/26858233/55824980-4d382500-5b05-11e9-9b2e-b6c84bebe39c.png)

**After, user:**
![PublicShareAuth-User-After](https://user-images.githubusercontent.com/26858233/55824990-52956f80-5b05-11e9-91ea-a0e7e7fd6e41.png)

**After, guest (no changes):**
![PublicShareAuth-Guest-After](https://user-images.githubusercontent.com/26858233/55824985-50331580-5b05-11e9-9496-9db96c9dbfd7.png)
