### PR TITLE
Remove conversation names and tokens from reshares when you are not a participant

### DIFF
--- a/lib/Share/Helper/ShareAPIController.php
+++ b/lib/Share/Helper/ShareAPIController.php
@@ -85,6 +85,14 @@ class ShareAPIController {
 		}
 
 		$result['share_with_displayname'] = $room->getDisplayName($this->userId);
+		try {
+			$room->getParticipant($this->userId);
+		} catch (ParticipantNotFoundException $e) {
+			// Removing the conversation token from the leaked data if not a participant.
+			// Adding some unique but reproducable part to the share_with here
+			// so the avatars for conversations are distinguishable
+			$result['share_with'] = 'private_conversation_' . substr(sha1($room->getName() . $room->getId()), 0, 6);
+		}
 		if ($room->getType() === Room::PUBLIC_CALL) {
 			$result['token'] = $share->getToken();
 		}

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -64,7 +64,7 @@ class SharingContext implements Context {
 	 */
 	public function userCreatesFolder($user, $destination) {
 		$this->currentUser = $user;
-	
+
 		$url = "/$user/$destination/";
 
 		$this->sendingToDav('MKCOL', $url);
@@ -81,7 +81,7 @@ class SharingContext implements Context {
 	 */
 	public function userMovesFileTo(string $user, string $source, string $destination) {
 		$this->currentUser = $user;
-	
+
 		$url = "/$user/$source";
 
 		$headers = [];
@@ -111,7 +111,7 @@ class SharingContext implements Context {
 	 */
 	public function userDeletesFile($user, $file) {
 		$this->currentUser = $user;
-	
+
 		$url = "/$user/$file";
 
 		$this->sendingToDav('DELETE', $url);
@@ -587,7 +587,11 @@ class SharingContext implements Context {
 		if (array_key_exists('share_type', $expectedFields) &&
 				$expectedFields['share_type'] == 10 /* Share::SHARE_TYPE_ROOM */ &&
 				array_key_exists('share_with', $expectedFields)) {
-			$expectedFields['share_with'] = FeatureContext::getTokenForIdentifier($expectedFields['share_with']);
+			if ($expectedFields['share_with'] === 'private_conversation') {
+				$expectedFields['share_with'] = 'REGEXP /^private_conversation_[0-9a-f]{6}$/';
+			} else {
+				$expectedFields['share_with'] = FeatureContext::getTokenForIdentifier($expectedFields['share_with']);
+			}
 		}
 
 		foreach ($expectedFields as $field => $value) {

--- a/tests/integration/features/sharing/create.feature
+++ b/tests/integration/features/sharing/create.feature
@@ -396,8 +396,8 @@ Feature: create
       | mimetype               | text/plain |
       | storage_id             | home::participant2 |
       | file_target            | /welcome (2).txt |
-      | share_with             | group room |
-      | share_with_displayname | Group room |
+      | share_with             | private_conversation |
+      | share_with_displayname | Private conversation |
     And user "participant3" gets last share
     And share is returned with
       | uid_owner              | participant1 |

--- a/tests/integration/features/sharing/get.feature
+++ b/tests/integration/features/sharing/get.feature
@@ -614,6 +614,151 @@ Feature: get
       | share_with             | private_conversation |
       | share_with_displayname | Private conversation |
 
+  Scenario: get all shares and reshares of a file reshared to a group room not invited to
+    Given user "participant2" creates room "group room not invited to"
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant2" renames room "group room not invited to" to "Group room not invited to" with 200
+    And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with room "group room not invited to" with OCS 100
+    When user "participant1" gets all shares and reshares for "/welcome.txt"
+    Then the list of returned shares has 2 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant2 |
+      | share_with_displayname | participant2-displayname |
+      | share_type             | 0 |
+    And share 1 is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | private_conversation |
+      | share_with_displayname | Private conversation |
+
+  Scenario: get all shares and reshares of a file reshared to a public room not invited to
+    Given user "participant2" creates room "public room not invited to"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant2" renames room "public room not invited to" to "Public room not invited to" with 200
+    And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with room "public room not invited to" with OCS 100
+    When user "participant1" gets all shares and reshares for "/welcome.txt"
+    Then the list of returned shares has 2 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant2 |
+      | share_with_displayname | participant2-displayname |
+      | share_type             | 0 |
+    And share 1 is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | private_conversation |
+      | share_with_displayname | Private conversation |
+      | token                  | A_TOKEN |
+
+  Scenario: get all shares and reshares of a file reshared to a public room invited to
+    Given user "participant2" creates room "public room invited to"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant2" renames room "public room invited to" to "Public room invited to" with 200
+    And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with room "public room invited to" with OCS 100
+    And user "participant2" adds "participant1" to room "public room invited to" with 200
+    When user "participant1" gets all shares and reshares for "/welcome.txt"
+    Then the list of returned shares has 2 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant2 |
+      | share_with_displayname | participant2-displayname |
+      | share_type             | 0 |
+    And share 1 is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room invited to |
+      | share_with_displayname | Public room invited to |
+      | token                  | A_TOKEN |
+
+  Scenario: get all shares and reshares of a file reshared to a public room self-joined to
+    Given user "participant2" creates room "public room self-joined to"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant2" renames room "public room self-joined to" to "Public room self-joined to" with 200
+    And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" shares "welcome (2).txt" with room "public room self-joined to" with OCS 100
+    And user "participant1" joins room "public room self-joined to" with 200
+    When user "participant1" gets all shares and reshares for "/welcome.txt"
+    Then the list of returned shares has 2 shares
+    And share 0 is returned with
+      | uid_owner              | participant1 |
+      | displayname_owner      | participant1-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | participant2 |
+      | share_with_displayname | participant2-displayname |
+      | share_type             | 0 |
+    And share 1 is returned with
+      | uid_owner              | participant2 |
+      | displayname_owner      | participant2-displayname |
+      | uid_file_owner         | participant1 |
+      | displayname_file_owner | participant1-displayname |
+      | path                   | /welcome.txt |
+      | item_type              | file |
+      | mimetype               | text/plain |
+      | storage_id             | home::participant1 |
+      | file_target            | /welcome (2).txt |
+      | share_with             | public room self-joined to |
+      | share_with_displayname | Public room self-joined to |
+      | token                  | A_TOKEN |
+
   Scenario: get all shares and reshares of a deleted file
     Given user "participant1" creates room "own group room"
       | roomType | 2 |

--- a/tests/integration/features/sharing/get.feature
+++ b/tests/integration/features/sharing/get.feature
@@ -330,8 +330,8 @@ Feature: get
       | mimetype               | text/plain |
       | storage_id             | home::participant1 |
       | file_target            | /welcome (2).txt |
-      | share_with             | one-to-one room not invited to |
-      | share_with_displayname | Private conversation|
+      | share_with             | private_conversation |
+      | share_with_displayname | Private conversation |
 
   Scenario: get all shares and reshares of a user who reshared a file to an owned one-to-one room
     Given user "participant2" creates room "one-to-one room not invited to"
@@ -364,7 +364,7 @@ Feature: get
       | mimetype               | text/plain |
       | storage_id             | home::participant1 |
       | file_target            | /welcome (2).txt |
-      | share_with             | one-to-one room not invited to |
+      | share_with             | private_conversation |
       | share_with_displayname | Private conversation |
 
   Scenario: get all shares and reshares of a user who reshared a file to a one-to-one room
@@ -398,7 +398,7 @@ Feature: get
       | mimetype               | text/plain |
       | storage_id             | home::participant1 |
       | file_target            | /welcome (2).txt |
-      | share_with             | one-to-one room not invited to |
+      | share_with             | private_conversation |
       | share_with_displayname | Private conversation |
 
   Scenario: get all shares of a file
@@ -543,7 +543,7 @@ Feature: get
       | mimetype               | text/plain |
       | storage_id             | home::participant1 |
       | file_target            | /welcome (2).txt |
-      | share_with             | one-to-one room not invited to |
+      | share_with             | private_conversation |
       | share_with_displayname | Private conversation |
 
   Scenario: get all shares and reshares of a file reshared to a one-to-one room by its owner
@@ -577,7 +577,7 @@ Feature: get
       | mimetype               | text/plain |
       | storage_id             | home::participant1 |
       | file_target            | /welcome (2).txt |
-      | share_with             | one-to-one room not invited to |
+      | share_with             | private_conversation |
       | share_with_displayname | Private conversation |
 
   Scenario: get all shares and reshares of a file reshared to a one-to-one room by its second participant
@@ -611,7 +611,7 @@ Feature: get
       | mimetype               | text/plain |
       | storage_id             | home::participant1 |
       | file_target            | /welcome (2).txt |
-      | share_with             | one-to-one room not invited to |
+      | share_with             | private_conversation |
       | share_with_displayname | Private conversation |
 
   Scenario: get all shares and reshares of a deleted file
@@ -729,7 +729,7 @@ Feature: get
       | mimetype               | httpd/unix-directory |
       | storage_id             | home::participant1 |
       | file_target            | /subfolder |
-      | share_with             | one-to-one room not invited to |
+      | share_with             | private_conversation |
       | share_with_displayname | Private conversation |
       | permissions            | 31 |
 

--- a/tests/integration/features/sharing/transfer-ownership.feature
+++ b/tests/integration/features/sharing/transfer-ownership.feature
@@ -128,8 +128,8 @@ Feature: transfer-ownership
       | mimetype               | text/plain |
       | storage_id             | home::participant2 |
       | file_target            | /welcome.txt |
-      | share_with             | group room |
-      | share_with_displayname | Group room |
+      | share_with             | private_conversation |
+      | share_with_displayname | Private conversation |
     And user "participant3" gets last share
     And share is returned with
       | uid_owner              | participant2 |


### PR DESCRIPTION
Signed-off-by: Joas Schilling <coding@schilljs.com>