### PR TITLE
Remove empty space when the "Add" button is not shown in the sidebar

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -1013,8 +1013,9 @@ input[type="password"] {
 	right: 15px;
 }
 
-#app-sidebar #chatView .newCommentForm {
-	/* Make room to show the "Add" button when chat is shown in the sidebar. */
+#app-sidebar #chatView .newCommentForm.with-add-button {
+	/* Make room to show the "Add" button if needed when chat is shown in the
+	 * sidebar. */
 	margin-right: 44px;
 }
 


### PR DESCRIPTION
Follow up to #1697 

This can be tested by opening a conversation as a guest.

**Before:**
![Guest-Sidebar-No-Add-Button-Before](https://user-images.githubusercontent.com/26858233/55871315-b44bed00-5b8a-11e9-8d21-cbaff5daff9d.png)

**After:**
![Guest-Sidebar-No-Add-Button-After](https://user-images.githubusercontent.com/26858233/55871320-b746dd80-5b8a-11e9-8694-93fe27f3724d.png)
