### PR TITLE
Fix participant actions not updated on current participant type changes

### DIFF
--- a/js/views/participantlistview.js
+++ b/js/views/participantlistview.js
@@ -99,6 +99,8 @@
 				},
 			},
 			initialize: function() {
+				this.room = this.model.collection.room;
+
 				this.listenTo(uiChannel, 'document:click', function(event) {
 					var target = $(event.target);
 					if (!target.closest('.popovermenu').is(this.ui.menu) && !target.is(this.ui.menuButton)) {
@@ -113,11 +115,11 @@
 					isModerator = false;
 				if (OC.getCurrentUser().uid) {
 					isSelf = this.model.get('userId') === OC.getCurrentUser().uid;
-					isModerator = OCA.SpreedMe.app.activeRoom.get('participantType') === OCA.SpreedMe.app.OWNER ||
-						OCA.SpreedMe.app.activeRoom.get('participantType') === OCA.SpreedMe.app.MODERATOR;
+					isModerator = this.room.get('participantType') === OCA.SpreedMe.app.OWNER ||
+						this.room.get('participantType') === OCA.SpreedMe.app.MODERATOR;
 				} else {
-					isSelf = this.model.get('sessionId') === OCA.SpreedMe.app.activeRoom.get('sessionId');
-					isModerator = OCA.SpreedMe.app.activeRoom.get('participantType') === OCA.SpreedMe.app.GUEST_MODERATOR;
+					isSelf = this.model.get('sessionId') === this.room.get('sessionId');
+					isModerator = this.room.get('participantType') === OCA.SpreedMe.app.GUEST_MODERATOR;
 				}
 
 				var canModerate = this.model.get('participantType') !== OCA.SpreedMe.app.OWNER &&       // can not moderate owners
@@ -221,7 +223,7 @@
 
 				$.ajax({
 					type: 'POST',
-					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + OCA.SpreedMe.app.activeRoom.get('token') + '/moderators',
+					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.room.get('token') + '/moderators',
 					data: data,
 					success: function() {
 						if (self.model.get('userId')) {
@@ -267,7 +269,7 @@
 
 				$.ajax({
 					type: 'DELETE',
-					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + OCA.SpreedMe.app.activeRoom.get('token') + '/moderators',
+					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.room.get('token') + '/moderators',
 					data:data,
 					success: function() {
 						if (self.model.get('userId')) {
@@ -309,7 +311,7 @@
 
 				$.ajax({
 					type: 'DELETE',
-					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + OCA.SpreedMe.app.activeRoom.get('token') + endpoint,
+					url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.room.get('token') + endpoint,
 					data: {
 						participant: participantId
 					},

--- a/js/views/participantlistview.js
+++ b/js/views/participantlistview.js
@@ -101,6 +101,13 @@
 			initialize: function() {
 				this.room = this.model.collection.room;
 
+				// When the type of the current participant changes the
+				// available actions on the participant shown by this item view
+				// change too, so the view should be rendered again.
+				this.listenTo(this.room, 'change:participantType', function() {
+					this.render();
+				});
+
 				this.listenTo(uiChannel, 'document:click', function(event) {
 					var target = $(event.target);
 					if (!target.closest('.popovermenu').is(this.ui.menu) && !target.is(this.ui.menuButton)) {


### PR DESCRIPTION
## How to test ##
- As user A, create a group room and add user B and user C to it
- In a different browser, join the room with user B
- As user A, promote user B to moderator

### Result with this pull request ###
The UI is updated for user B, and user B can now moderate user C.

### Result without this pull request ###
The UI is partially updated for user B, but user B needs to reload the page to be able to moderate user C.
