### PR TITLE
Do not allow JavaScript "eval"

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -187,7 +187,6 @@ class PageController extends Controller {
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedConnectDomain('*');
 		$csp->addAllowedMediaDomain('blob:');
-		$csp->allowEvalScript();
 		$response->setContentSecurityPolicy($csp);
 		return $response;
 	}
@@ -234,7 +233,6 @@ class PageController extends Controller {
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedConnectDomain('*');
 		$csp->addAllowedMediaDomain('blob:');
-		$csp->allowEvalScript(true);
 		$response->setContentSecurityPolicy($csp);
 		return $response;
 	}


### PR DESCRIPTION
Requires #1706 (I will rebase once it is merged).

Talk no longer uses JavaScript "eval", so the Content Security Policy [can now be configured to prevent its use](https://github.com/nextcloud/spreed/pull/1253).
