### PR TITLE
Move underscore template to precompiled Handlebars template

### DIFF
--- a/js/views/collectionsview.js
+++ b/js/views/collectionsview.js
@@ -29,7 +29,12 @@
 
 	OCA.SpreedMe.Views.CollectionsView = Marionette.View.extend({
 
-		template: '<div id="collectionsView"></div>',
+		template: function(context) {
+			// OCA.Talk.Views.Templates may not have been initialized when this
+			// view is initialized, so the template can not be directly
+			// assigned.
+			return OCA.Talk.Views.Templates['collectionsview'](context);
+		},
 
 		initialize: function(options) {
 			this.room = options.room;

--- a/js/views/templates.js
+++ b/js/views/templates.js
@@ -190,6 +190,9 @@ templates['chatview_comment'] = template({"1":function(container,depth0,helpers,
     + ((stack1 = ((helper = (helper = helpers.formattedMessage || (depth0 != null ? depth0.formattedMessage : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"formattedMessage","hash":{},"data":data}) : helper))) != null ? stack1 : "")
     + "</div>\n</li>\n";
 },"useData":true});
+templates['collectionsview'] = template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
+    return "<div id=\"collectionsView\"></div>\n";
+},"useData":true});
 templates['editabletextlabel'] = template({"1":function(container,depth0,helpers,partials,data) {
     var stack1;
 

--- a/js/views/templates/collectionsview.handlebars
+++ b/js/views/templates/collectionsview.handlebars
@@ -1,0 +1,1 @@
+<div id="collectionsView"></div>


### PR DESCRIPTION
Follow up to #1707 

The underscore template must be precompiled now that JavaScript "eval" is not allowed by the Content Security Policy; otherwise the main Talk UI (where the CollectionsView is used) fails to load properly (the _New conversation_ dropdown is not shown).
