### PR TITLE
Adjust room name input to default height for inputs from server

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -805,10 +805,6 @@ input[type="password"] {
 		.input-wrapper {
 			position: relative;
 
-			/* Pull up the wrapper slightly to prevent elements below it from
-			 * moving when it is shown. */
-			margin-top: -2px;
-
 			.username {
 				width: 100%;
 				margin: 4px 0 4px 0 !important;
@@ -826,7 +822,7 @@ input[type="password"] {
 				padding-right: 44px;
 
 				& + .icon-confirm {
-					top: 1px;
+					top: 4px;
 					right: 0;
 				}
 			}


### PR DESCRIPTION
The default height for input elements, as well as the confirm icons inside them, [has been changed in server to 34px for Nextcloud 16](https://github.com/nextcloud/server/commit/250352012113432e000523170c1874f9afe0ef74); this pull request adjusts the room name input to that new height.

**Before:**
![Room-Name-Input-Height-Before](https://user-images.githubusercontent.com/26858233/55969976-053d0d80-5c7f-11e9-8db6-f5c0735dd582.png)

**After:** (hard to see, but now the elements below it are not moved when the input field is shown)
![Room-Name-Input-Height-After](https://user-images.githubusercontent.com/26858233/55969989-079f6780-5c7f-11e9-9b8e-3b6a685ac3b0.png)
