### PR TITLE
Fix sidebar and fullscreen in IE11

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -389,10 +389,20 @@ input[type="password"] {
 	margin-left: 0;
 }
 #content:-ms-fullscreen #app-content {
-	margin-left: 0;
+	margin-left: 0 !important;
 }
 #content:fullscreen #app-content {
 	margin-left: 0;
+}
+
+#content:-ms-fullscreen #app-sidebar {
+	/* The sidebar height is unset in Talk to override the "100vh-50px" set in
+	 * server and force it to get the full height in fullscreen mode. However,
+	 * IE11 does not support "unset", so the height needs to be explicitly set
+	 * to 100%. */
+	height: 100%;
+	/* Remove the space added when IE is used to not overlap with the header. */
+	top: 0;
 }
 
 /* Set the background of the content to the same colour as the app content and

--- a/css/style.scss
+++ b/css/style.scss
@@ -518,6 +518,12 @@ input[type="password"] {
 	top: 0;
 }
 
+/* The server sets the position of the sidebar as fixed when IE is used, so it
+ * needs to be pulled down to not overlap with the header. */
+.ie #app-sidebar {
+	top: $header-height;
+}
+
 @include icon-black-white('menu-people', 'spreed', 1);
 @include icon-black-white('no-password', 'spreed', 1);
 @include icon-black-white('share-window', 'spreed', 1);


### PR DESCRIPTION
This pull request fixes some structure issues in Internet Explorer 11 (the sidebar appearing behind the header and the chat view not stretching to fill the area of the navigation bar in fullscreen); the CSS changes should not affect any other browser except Internet Explorer.
