### PR TITLE
Fix WebRTC not supported handling

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -677,7 +677,7 @@
 				this._mediaControlsView.setSharedScreens(OCA.SpreedMe.sharedScreens);
 			}
 
-			if (!OCA.SpreedMe.webrtc.capabilities.support) {
+			if (!OCA.SpreedMe.webrtc.capabilities.supportRTCPeerConnection) {
 				localMediaChannel.trigger('webRtcNotSupported');
 			} else {
 				localMediaChannel.trigger('waitingForPermissions');
@@ -705,7 +705,7 @@
 			this._localVideoView.$el.removeClass('hidden');
 			this.initAudioVideoSettings(configuration);
 
-			if (OCA.SpreedMe.webrtc.capabilities.support) {
+			if (OCA.SpreedMe.webrtc.capabilities.supportRTCPeerConnection) {
 				localMediaChannel.trigger('startWithoutLocalMedia');
 			}
 		},

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -159,7 +159,7 @@
 				this._mediaControlsView.setWebRtc(OCA.SpreedMe.webrtc);
 			}
 
-			if (!OCA.SpreedMe.webrtc.capabilities.support) {
+			if (!OCA.SpreedMe.webrtc.capabilities.supportRTCPeerConnection) {
 				localMediaChannel.trigger('webRtcNotSupported');
 			} else {
 				localMediaChannel.trigger('waitingForPermissions');
@@ -185,7 +185,7 @@
 
 			this.initAudioVideoSettings(configuration);
 
-			if (OCA.SpreedMe.webrtc.capabilities.support) {
+			if (OCA.SpreedMe.webrtc.capabilities.supportRTCPeerConnection) {
 				localMediaChannel.trigger('startWithoutLocalMedia');
 			}
 		},

--- a/js/simplewebrtc/bundled.js
+++ b/js/simplewebrtc/bundled.js
@@ -4,6 +4,17 @@
 /* global module, chrome */
 // getScreenMedia helper by @HenrikJoreteg
 var getUserMedia = function getUserMedia(constraints, callback) {
+  if (!window.navigator || !window.navigator.mediaDevices || !window.navigator.mediaDevices.getUserMedia) {
+    var error = new Error('MediaStreamError');
+    error.name = 'NotSupportedError';
+
+    if (callback) {
+      callback(error, null);
+    }
+
+    return;
+  }
+
   window.navigator.mediaDevices.getUserMedia(constraints).then(function (stream) {
     callback(null, stream);
   }).catch(function (error) {
@@ -276,6 +287,18 @@ util.inherits(LocalMedia, WildEmitter);
 LocalMedia.prototype.start = function (mediaConstraints, cb) {
   var self = this;
   var constraints = mediaConstraints || this.config.media;
+
+  if (!navigator || !navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+    var error = new Error('MediaStreamError');
+    error.name = 'NotSupportedError';
+
+    if (cb) {
+      return cb(error, null);
+    }
+
+    return;
+  }
+
   this.emit('localStreamRequested', constraints);
   navigator.mediaDevices.getUserMedia(constraints).then(function (stream) {
     // Although the promise should be resolved only if all the constraints

--- a/js/simplewebrtc/getscreenmedia.js
+++ b/js/simplewebrtc/getscreenmedia.js
@@ -2,6 +2,17 @@
 
 // getScreenMedia helper by @HenrikJoreteg
 var getUserMedia = function(constraints, callback) {
+	if (!window.navigator || !window.navigator.mediaDevices || !window.navigator.mediaDevices.getUserMedia) {
+		var error = new Error('MediaStreamError');
+		error.name = 'NotSupportedError';
+
+		if (callback) {
+			callback(error, null);
+		}
+
+		return;
+	}
+
 	window.navigator.mediaDevices.getUserMedia(constraints).then(function(stream) {
 		callback(null, stream);
 	}).catch(function(error) {

--- a/js/simplewebrtc/localmedia.js
+++ b/js/simplewebrtc/localmedia.js
@@ -58,6 +58,17 @@ LocalMedia.prototype.start = function (mediaConstraints, cb) {
 	var self = this;
 	var constraints = mediaConstraints || this.config.media;
 
+	if (!navigator || !navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+		var error = new Error('MediaStreamError');
+		error.name = 'NotSupportedError';
+
+		if (cb) {
+			return cb(error, null);
+		}
+
+		return;
+	}
+
 	this.emit('localStreamRequested', constraints);
 
 	navigator.mediaDevices.getUserMedia(constraints).then(function (stream) {

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -965,13 +965,14 @@ var spreedPeerConnectionTable = [];
 			console.log('Access to microphone & camera failed', error);
 			hasLocalMedia = false;
 			var message;
-			if (error.name === "NotAllowedError") {
-				if (error.message && error.message.indexOf("Only secure origins") !== -1) {
-					message = t('spreed', 'Access to microphone & camera is only possible with HTTPS');
-					message += ': ' + t('spreed', 'Please move your setup to HTTPS');
-				} else {
-					message = t('spreed', 'Access to microphone & camera was denied');
-				}
+			if ((error.name === "NotSupportedError" &&
+					OCA.SpreedMe.webrtc.capabilities.supportRTCPeerConnection) ||
+				(error.name === "NotAllowedError" &&
+					error.message && error.message.indexOf("Only secure origins") !== -1)) {
+				message = t('spreed', 'Access to microphone & camera is only possible with HTTPS');
+				message += ': ' + t('spreed', 'Please move your setup to HTTPS');
+			} else if (error.name === "NotAllowedError") {
+				message = t('spreed', 'Access to microphone & camera was denied');
 			} else if(!OCA.SpreedMe.webrtc.capabilities.support) {
 				console.log('WebRTC not supported');
 


### PR DESCRIPTION
The first commit fixes a regression introduced in #1524. In [LocalMedia v3 it is no longer checked if `getUserMedia` is available before using it](https://github.com/otalk/localmedia/commit/4e2b762f2657f56e00b2ad310f27b983869518a8#diff-e77e08357daa2faadc3f58fce7b6b452L51) (it was done [internally by getUserMedia](https://github.com/otalk/getUserMedia/blob/7ce6444ca9d6cd2c7b67497a14c5dbafef4c3383/getusermedia.js#L20)), so an explicit check was added and an error is thrown if not (just like it was done before).

Note that if there is an ongoing call Internet Explorer 11 still tries to join the call and is shown to other participants, even if WebRTC is not supported; the commit only ensures that the proper message is shown. Fixing this to prevent Internet Explorer to join would require deeper work, so for now it is still kept like that.

The second commit fixes the handling when WebRTC is supported by the browser but [`getDisplayMedia` is not available due to being called in an unsecure context](https://w3c.github.io/mediacapture-main/#local-content). In that case the _Access to microphone & camera is only possible with HTTPS_ message is now shown instead of the _WebRTC is not supported in your browser_ message (and the user joins the call as a viewer, just like if access to microphone and camera was not granted by the user).

Note that the bug fixed by the second commit is probably present also in Talk 5 (I have not verified that), but it is not a big problem, so a backport is probably not worth.

All this can be tested by starting a call with Internet Explorer 11 (which does not support WebRTC) or with latest development version of Edge through HTTP (as it supports WebRTC but does not define `getUserMedia` in HTTP; probably latest development version of Chromium does the same, although I have not checked).
