### PR TITLE
Fix stopping screensharing from the browser

### DIFF
--- a/js/simplewebrtc/bundled.js
+++ b/js/simplewebrtc/bundled.js
@@ -1154,9 +1154,7 @@ function SimpleWebRTC(opts) {
   this.webrtc.on('localScreenStopped', function ()
   /*stream*/
   {
-    if (self.getLocalScreen()) {
-      self.stopScreenShare();
-    }
+    self.stopScreenShare();
     /*
     self.connection.emit('unshareScreen');
     self.webrtc.peers.forEach(function (peer) {
@@ -1165,7 +1163,6 @@ function SimpleWebRTC(opts) {
     	}
     });
     */
-
   });
   this.webrtc.on('channelMessage', function (peer, label, data) {
     if (data.type === 'volume') {

--- a/js/simplewebrtc/simplewebrtc.js
+++ b/js/simplewebrtc/simplewebrtc.js
@@ -213,9 +213,7 @@ function SimpleWebRTC(opts) {
 		// this is done by the application code in "webrtc.js".
 	});
 	this.webrtc.on('localScreenStopped', function (/*stream*/) {
-		if (self.getLocalScreen()) {
-			self.stopScreenShare();
-		}
+		self.stopScreenShare();
 		/*
 		self.connection.emit('unshareScreen');
 		self.webrtc.peers.forEach(function (peer) {


### PR DESCRIPTION
Requires #1738 

This pull request fixes a regression introduced in #1524.

In the old LocalMedia module bundled in the official SimpleWebRTC 2.2.3 [the local screen was not removed before `localScreenStopped` was emitted](https://github.com/nextcloud/spreed/blob/9b082ea8894f54ebd58e0408009ab3f4a5b9b720/js/simplewebrtc.js#L7618-L7624). However, in the current LocalMedia module [it is](https://github.com/nextcloud/spreed/blob/master/js/simplewebrtc/localmedia.js#L286-L287), so `SimpleWebRTC.stopScreenShare` was never called when the screensharing was stopped from the browser (instead of from the Talk UI itself), and thus the Talk UI was not updated neither locally nor for the remote peers.

### How to test ###
- Start a call
- Join a call with another user
- Share the screen
- Stop sharing the screen with the browser UI (for example, revoking the access to the screen from the address bar in Firefox)

## Result with this pull request ##
The UI is updated and the screen is no longer shared.

## Result without this pull request ##
The screen sharing UI is still shown, although no longer updated, neither locally nor for the remote peers.
