### PR TITLE
Prefer standard API for screen sharing

### DIFF
--- a/js/simplewebrtc/bundled.js
+++ b/js/simplewebrtc/bundled.js
@@ -25,7 +25,15 @@ module.exports = function (mode, constraints, cb) {
     return callback(error);
   }
 
-  if (navigator.webkitGetUserMedia) {
+  if (navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia) {
+    navigator.mediaDevices.getDisplayMedia({
+      video: true
+    }).then(function (stream) {
+      callback(null, stream);
+    }).catch(function (error) {
+      callback(error, null);
+    });
+  } else if (navigator.webkitGetUserMedia) {
     var chromever = parseInt(window.navigator.userAgent.match(/Chrome\/(\d+)\./)[1], 10);
     var maxver = 33; // Chrome 71 dropped support for "window.chrome.webstore;".
 
@@ -162,14 +170,6 @@ module.exports = function (mode, constraints, cb) {
       error.name = 'FF52_REQUIRED';
       return callback(error);
     }
-  } else if (navigator.mediaDevices && navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) {
-    navigator.mediaDevices.getDisplayMedia({
-      video: true
-    }).then(function (stream) {
-      callback(null, stream);
-    }).catch(function (error) {
-      callback(error, null);
-    });
   }
 };
 

--- a/js/simplewebrtc/bundled.js
+++ b/js/simplewebrtc/bundled.js
@@ -998,8 +998,14 @@ function SimpleWebRTC(opts) {
     if (options.hasOwnProperty(item)) {
       this.config[item] = options[item];
     }
-  } // attach detected support for convenience
+  } // Override screensharing support detection to fit the custom
+  // "getScreenMedia" module.
+  // Note that this is a coarse check; calling "getScreenMedia" may fail even
+  // if "supportScreenSharing" is true.
 
+
+  var screenSharingSupported = window.navigator.mediaDevices && window.navigator.mediaDevices.getDisplayMedia || window.navigator.webkitGetUserMedia || window.navigator.userAgent.match('Firefox');
+  webrtcSupport.supportScreenSharing = window.location.protocol === 'https:' && screenSharingSupported; // attach detected support for convenience
 
   this.capabilities = webrtcSupport; // call WildEmitter constructor
 

--- a/js/simplewebrtc/getscreenmedia.js
+++ b/js/simplewebrtc/getscreenmedia.js
@@ -23,7 +23,13 @@ module.exports = function (mode, constraints, cb) {
 		return callback(error);
 	}
 
-	if (navigator.webkitGetUserMedia) {
+	if (navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia) {
+		navigator.mediaDevices.getDisplayMedia({video: true}).then(function(stream) {
+			callback(null, stream);
+		}).catch(function(error) {
+			callback(error, null);
+		});
+	} else if (navigator.webkitGetUserMedia) {
 		var chromever = parseInt(window.navigator.userAgent.match(/Chrome\/(\d+)\./)[1], 10);
 		var maxver = 33;
 		// Chrome 71 dropped support for "window.chrome.webstore;".
@@ -143,12 +149,6 @@ module.exports = function (mode, constraints, cb) {
 			error.name = 'FF52_REQUIRED';
 			return callback(error);
 		}
-	} else if (navigator.mediaDevices && navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) {
-		navigator.mediaDevices.getDisplayMedia({video: true}).then(function(stream) {
-			callback(null, stream);
-		}).catch(function(error) {
-			callback(error, null);
-		});
 	}
 };
 

--- a/js/simplewebrtc/simplewebrtc.js
+++ b/js/simplewebrtc/simplewebrtc.js
@@ -60,6 +60,16 @@ function SimpleWebRTC(opts) {
 		}
 	}
 
+	// Override screensharing support detection to fit the custom
+	// "getScreenMedia" module.
+	// Note that this is a coarse check; calling "getScreenMedia" may fail even
+	// if "supportScreenSharing" is true.
+	var screenSharingSupported =
+			(window.navigator.mediaDevices && window.navigator.mediaDevices.getDisplayMedia) ||
+			(window.navigator.webkitGetUserMedia) ||
+			(window.navigator.userAgent.match('Firefox'));
+	webrtcSupport.supportScreenSharing = window.location.protocol === 'https:' && screenSharingSupported;
+
 	// attach detected support for convenience
 	this.capabilities = webrtcSupport;
 

--- a/js/views/mediacontrolsview.js
+++ b/js/views/mediacontrolsview.js
@@ -223,8 +223,11 @@
 				return;
 			}
 
+			// The standard "getDisplayMedia" does not support pre-filtering the
+			// type of display sources, so the unified menu is used in that case
+			// too.
 			var splitShare = false;
-			if (window.navigator.userAgent.match('Firefox')) {
+			if (window.navigator.userAgent.match('Firefox') && !window.navigator.mediaDevices.getDisplayMedia) {
 				var ffver = parseInt(window.navigator.userAgent.match(/Firefox\/(.*)/)[1], 10);
 				splitShare = (ffver >= 52);
 			}


### PR DESCRIPTION
The standard `getDisplayMedia` is now used whenever available, although the old behaviour is kept for backwards compatibility.

Note that `getDisplayMedia` spec [forbids limiting the display sources to be chosen by the user](https://w3c.github.io/mediacapture-screen-share/#mediadevices-additions), so the split menu to choose between window and screen is no longer shown in Firefox >= 66 (and, even if the old API was used, it would be useless, as for consistency with the spec [the old `getUserMedia` constraints no longer work](https://bugzilla.mozilla.org/show_bug.cgi?id=1474376)).

This can be tested by sharing the screen in Firefox >= 66, Chromium >= 72 and Edge >= 18 (and also older versions of Firefox and Chromium to check that they still behave as expected).

@Ivansss Could you please test again with latest Safari and HTTPS? Our test the other day may have failed due to using an unsecure context, as theoretically [latest Safari development version should support `getDisplayMedia`](https://bugs.webkit.org/show_bug.cgi?id=186294#c12) (although maybe a flag needs to be enabled or something like that).
