### PR TITLE
Fix signaling messages with no payload and with unserialized attributes

### DIFF
--- a/js/signaling.js
+++ b/js/signaling.js
@@ -573,18 +573,9 @@
 		} else if(data.type === 'offer') {
 			console.log("OFFER", data);
 		}
-
-		// The RTCSessionDescription removes custom payload attributes in it's toJSON
-		// method. The one value we set is the nick, so we need to toJSON and toObject
-		// the description and add the nick to the payload again.
-		// {@see https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription/toJSON}
-		var tempString =  JSON.stringify(data);
-		var tempData = JSON.parse(tempString);
-		tempData.payload.nick = data.payload.nick;
-
 		this.spreedArrayConnection.push({
 			ev: "message",
-			fn: JSON.stringify(tempData),
+			fn: JSON.stringify(data),
 			sessionId: this.sessionId
 		});
 	};

--- a/js/simplewebrtc/bundled.js
+++ b/js/simplewebrtc/bundled.js
@@ -689,7 +689,14 @@ Peer.prototype.offer = function (options) {
   this.pc.createOffer(options).then(function (offer) {
     this.pc.setLocalDescription(offer).then(function () {
       if (this.parent.config.nick) {
-        offer.nick = this.parent.config.nick;
+        // The offer is a RTCSessionDescription that only serializes
+        // its own attributes to JSON, so if extra attributes are needed
+        // a regular object has to be sent instead.
+        offer = {
+          type: offer.type,
+          sdp: offer.sdp,
+          nick: this.parent.config.nick
+        };
       }
 
       this.send('offer', offer);
@@ -713,7 +720,14 @@ Peer.prototype.answer = function () {
   this.pc.createAnswer().then(function (answer) {
     this.pc.setLocalDescription(answer).then(function () {
       if (this.parent.config.nick) {
-        answer.nick = this.parent.config.nick;
+        // The answer is a RTCSessionDescription that only serializes
+        // its own attributes to JSON, so if extra attributes are needed
+        // a regular object has to be sent instead.
+        answer = {
+          type: answer.type,
+          sdp: answer.sdp,
+          nick: this.parent.config.nick
+        };
       }
 
       this.send('answer', answer);

--- a/js/simplewebrtc/peer.js
+++ b/js/simplewebrtc/peer.js
@@ -84,7 +84,14 @@ Peer.prototype.offer = function(options) {
 	this.pc.createOffer(options).then(function(offer) {
 		this.pc.setLocalDescription(offer).then(function() {
 			if (this.parent.config.nick) {
-				offer.nick = this.parent.config.nick;
+				// The offer is a RTCSessionDescription that only serializes
+				// its own attributes to JSON, so if extra attributes are needed
+				// a regular object has to be sent instead.
+				offer = {
+					type: offer.type,
+					sdp: offer.sdp,
+					nick: this.parent.config.nick,
+				};
 			}
 			this.send('offer', offer);
 		}.bind(this)).catch(function(error) {
@@ -107,7 +114,14 @@ Peer.prototype.answer = function() {
 	this.pc.createAnswer().then(function(answer) {
 		this.pc.setLocalDescription(answer).then(function() {
 			if (this.parent.config.nick) {
-				answer.nick = this.parent.config.nick;
+				// The answer is a RTCSessionDescription that only serializes
+				// its own attributes to JSON, so if extra attributes are needed
+				// a regular object has to be sent instead.
+				answer = {
+					type: answer.type,
+					sdp: answer.sdp,
+					nick: this.parent.config.nick,
+				};
 			}
 			this.send('answer', answer);
 		}.bind(this)).catch(function(error) {


### PR DESCRIPTION
This pull request fixes a regression introduced in c02c8c08, as well as the regression introduced in 9f1212ab that it fixed.

Not all the call messages contain a payload, so when a message without payload was tried to be sent an error happened. Instead of checking that and keep the special handling in the signaling object now `sendCallMessage` assumes again that the given payload is serializable as is, so the special cases are handled by the (indirect) callers of `sendCallMessage`.

## How to test (regression introduced in 9f1212ab) ##
- Start a call with user A
- Join the call with user B

### Result with this pull request ###
The user names are shown for the peers in the call screen.

### Result before c02c8c08 ###
The user names are not shown for the peers in the call screen.

## How to test (regression introduced in c02c8c08) ##
- Start a call with user A
- Join the call with user B
- Share the screen with any user
- Stop sharing the screen*

* It could be tested too by causing an ICE failure and a reconnection, but stopping the screen sharing is way easier.

### Result with this pull request ###
The UI is updated for both users to reflect that the screen sharing has stopped.

### Result without this pull request ###
The UI is not updated for both users to reflect that the screen sharing has stopped.
