### PR TITLE
Fix screensharing offer sent to peers not in the call

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -1162,6 +1162,8 @@ var spreedPeerConnectionTable = [];
 			for (var sessionId in usersInCallMapping) {
 				if (!usersInCallMapping.hasOwnProperty(sessionId)) {
 					continue;
+				} else if (!usersInCallMapping[sessionId].inCall) {
+					continue;
 				} else if (sessionId === currentSessionId) {
 					// Running with MCU, no need to create screensharing
 					// subscriber for client itself.


### PR DESCRIPTION
Fixes #1736 

Regression introduced in bff77f9f3fbe74ebd629cd9810dcdffdcc09e30b

Despite its name, `usersInCallMapping` includes all the users in the room, not only those currently in the call. Therefore, when iterating through it, it should be checked whether a user is in the call or not to prevent sending the screensharing offer to peers not in the call.

Note that it is still possible (although highly unlikely) that if a user shares the screen at the same time that another user lefts the call the user that left the call receives the screensharing offer (as the first user would not be aware yet that the second user left the call, so the offer would be sent). This would turn the chat background black for the second user as described in #1736, as once a user lefts a call the signaling events are still listened to and handled (WebRTC is never torn down once set up).

Besides not sending the offer to users not in the call it would be necessary that users not in the call ignore the signaling events (that is, tear down WebRTC when leaving a call). However, that would require deeper changes and they would not be automatically _backportable_, so that is something for later.
