### PR TITLE
[stable15] Fix removal of stale peers when a screen is shared

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -313,11 +313,16 @@ var spreedPeerConnectionTable = [];
 
 			var peers = OCA.SpreedMe.webrtc.webrtc.peers;
 			var stalePeer = peers.find(function(peer) {
-				return peer.id === message.from && peer.sid !== message.sid;
+				return peer.id === message.from && peer.type === message.roomType && peer.sid !== message.sid;
 			});
 
 			if (stalePeer) {
-				usersChanged(signaling, [], [stalePeer.id]);
+				stalePeer.end();
+
+				if (message.roomType === 'video') {
+					OCA.SpreedMe.speakers.remove(stalePeer.id, true);
+					OCA.SpreedMe.videos.remove(stalePeer.id);
+				}
 			}
 
 			if (delayedCreatePeer[message.from]) {

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -325,7 +325,7 @@ var spreedPeerConnectionTable = [];
 				}
 			}
 
-			if (delayedCreatePeer[message.from]) {
+			if (message.roomType === 'video' && delayedCreatePeer[message.from]) {
 				clearTimeout(delayedCreatePeer[message.from]);
 				delete delayedCreatePeer[message.from];
 			}

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -442,7 +442,8 @@ var spreedPeerConnectionTable = [];
 				};
 
 				var screenSharingIndicator = document.createElement('button');
-				screenSharingIndicator.className = 'screensharingIndicator force-icon-white-in-call icon-shadow icon-screen screen-off';
+				var screenOnOffClass = spreedListofSharedScreens[id]? 'screen-on': 'screen-off';
+				screenSharingIndicator.className = 'screensharingIndicator force-icon-white-in-call icon-shadow icon-screen ' + screenOnOffClass;
 				screenSharingIndicator.setAttribute('data-original-title', t('spreed', 'Show screen'));
 
 				var iceFailedIndicator = document.createElement('button');


### PR DESCRIPTION
Replaces #1739 (as the branch name matched a protected pattern and thus it could not be force pushed to fix an eslint issue).

Backport of #1569

The automatic backport had failed because #1554 was never merged; unfortunately this slipped and currently screen sharing is broken (or, at least, flaky) in _stable15_.
