### PR TITLE
[stable15] Fix sharing own screen when other peer is sharing the screen

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -76,8 +76,7 @@ var spreedPeerConnectionTable = [];
 			return;
 		}
 
-		var screenPeers = webrtc.webrtc.getPeers(sessionId, 'screen');
-		if (useMcu && !screenPeers.length) {
+		if (useMcu) {
 			// TODO(jojo): Already create peer object to avoid duplicate offers.
 			// TODO(jojo): We should use "requestOffer" as with regular
 			// audio/video peers. Not possible right now as there is no way
@@ -85,6 +84,7 @@ var spreedPeerConnectionTable = [];
 			// from the MCU should be requested.
 			webrtc.connection.sendOffer(sessionId, "screen");
 		} else if (!useMcu) {
+			var screenPeers = webrtc.webrtc.getPeers(sessionId, 'screen');
 			var screenPeerSharedTo = screenPeers.find(function(screenPeer) {
 				return screenPeer.sharemyscreen === true;
 			});

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -337,6 +337,13 @@ var spreedPeerConnectionTable = [];
 				clearTimeout(delayedCreatePeer[message.from]);
 				delete delayedCreatePeer[message.from];
 			}
+
+			// MCU screen offers do not include the "broadcaster" property,
+			// which is expected by SimpleWebRTC in screen offers from a remote
+			// peer, so it needs to be explicitly added.
+			if (signaling.hasFeature("mcu") && message.roomType === 'screen') {
+				message.broadcaster = message.from;
+			}
 		});
 
 		webrtc = new SimpleWebRTC({

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -76,15 +76,19 @@ var spreedPeerConnectionTable = [];
 			return;
 		}
 
-		if (!webrtc.webrtc.getPeers(sessionId, 'screen').length) {
-			if (useMcu) {
-				// TODO(jojo): Already create peer object to avoid duplicate offers.
-				// TODO(jojo): We should use "requestOffer" as with regular
-				// audio/video peers. Not possible right now as there is no way
-				// for clients to know that screensharing is active and an offer
-				// from the MCU should be requested.
-				webrtc.connection.sendOffer(sessionId, "screen");
-			} else {
+		var screenPeers = webrtc.webrtc.getPeers(sessionId, 'screen');
+		if (useMcu && !screenPeers.length) {
+			// TODO(jojo): Already create peer object to avoid duplicate offers.
+			// TODO(jojo): We should use "requestOffer" as with regular
+			// audio/video peers. Not possible right now as there is no way
+			// for clients to know that screensharing is active and an offer
+			// from the MCU should be requested.
+			webrtc.connection.sendOffer(sessionId, "screen");
+		} else if (!useMcu) {
+			var screenPeerSharedTo = screenPeers.find(function(screenPeer) {
+				return screenPeer.sharemyscreen === true;
+			});
+			if (!screenPeerSharedTo) {
 				var peer = webrtc.webrtc.createPeer({
 					id: sessionId,
 					type: 'screen',

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -317,6 +317,10 @@ var spreedPeerConnectionTable = [];
 
 			var peers = OCA.SpreedMe.webrtc.webrtc.peers;
 			var stalePeer = peers.find(function(peer) {
+				if (peer.sharemyscreen) {
+					return false;
+				}
+
 				return peer.id === message.from && peer.type === message.roomType && peer.sid !== message.sid;
 			});
 


### PR DESCRIPTION
Replaces #1740 (as the branch name matched a protected pattern and thus it could not be force pushed to rebase).

Backport of #1571
