### PR TITLE
Fix condition to ignore stats in "checkMediaPeer"

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -851,7 +851,7 @@ var spreedPeerConnectionTable = [];
 			peer.pc.getStats(track).then(function(stats) {
 				var result = false;
 				stats.forEach(function(statsReport) {
-					if (!result && statsReport.mediaType !== mediaType || !statsReport.hasOwnProperty('bytesReceived')) {
+					if (result || statsReport.mediaType !== mediaType || !statsReport.hasOwnProperty('bytesReceived')) {
 						return;
 					}
 


### PR DESCRIPTION
This fixes a regression introduced in 31cc6de8e8a78440e585c5d4d3aed117a54ee110

Once a result was found all the following stats that had `bytesReceived` were checked, even if their media type did not match. However, note that, while incorrect, this did not cause any practical issue, as the first time that the peer was unmuted the proper stat was checked, and the following incorrect checks just unmuted again an already unmuted peer.

Note that #1583 is NOT fixed by this. Even if joining a call using the MCU with audio and video disabled sometimes works as expected (that is, remote peers see audio and video disabled for the peer that has joined) it is just luck; simply [the audio/video on/off information sent when the connection is completed](https://github.com/nextcloud/spreed/blob/45a66bffcfd13061ded7c21a45fb313114b5dece/js/webrtc.js#L493-L503) arrived after `checkMediaPeer` already unmuted the audio and/or the video.
