### PR TITLE
Fix vertical position of confirm icon in authenticate page

### DIFF
--- a/css/authenticate.css
+++ b/css/authenticate.css
@@ -25,6 +25,10 @@ input[type="password"] + .icon-confirm {
 	position: absolute;
 	right: 15px;
 
+	/* Needed to honour the height set below for "input[type='submit']" by
+	 * overriding a rule set in the server. */
+	height: 45px;
+
 	border: none;
 	/* Needed to override an important rule set in the server. */
 	background-color: transparent !important;


### PR DESCRIPTION
Since nextcloud/server#14468 the server explicitly sets [the height of confirm icons inside password inputs](https://github.com/nextcloud/server/commit/250352012113432e000523170c1874f9afe0ef74#diff-5e3a8038f073563d61e06df777f2ddb4R257), which overrides [the height set in Talk for submit inputs in the authenticate page](https://github.com/nextcloud/spreed/blob/173e06508cbdb3a708010772aaa4a259d64fce25/css/authenticate.css#L43). Therefore, the height set by the server needs to be overriden to honour the height set in Talk (which matches [the height of the password input in the authenticate page](https://github.com/nextcloud/spreed/blob/173e06508cbdb3a708010772aaa4a259d64fce25/css/authenticate.css#L8)).

**Before**
![Talk-Authenticate-Confirm-Icon-Before](https://user-images.githubusercontent.com/26858233/57284586-c2b9f580-70b1-11e9-8351-90062e9ae351.png)

**After**
![Talk-Authenticate-Confirm-Icon-After](https://user-images.githubusercontent.com/26858233/57284597-c483b900-70b1-11e9-8480-f55718571117.png)
