### PR TITLE
Added a warning to use the absolute path to a custom command script.

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -57,6 +57,7 @@ It should return a useful description, the first line is also displayed in a lis
     ```
     ./occ talk:command:add calculator calculator "/path/to/calc.sh \"{ARGUMENTS_DOUBLEQUOTE_ESCAPED}\" {ROOM} {USER}" 1 3
     ```
+    Make sure to use the absolute path to your script.
     
 * User input by user `my user id` in the chat of room `index.php/call/4tf349j`:
     


### PR DESCRIPTION
I was trying to add a custom command to my NextCloud Talk instance. Adding the command was not a problem, however, I could not get output of the command. 

I was using a relative path to my script, instead of an absolute path. 

I've added a warning to the docs on how to add a new command.