### PR TITLE
Fix messages not loaded when commands are used with the MCU

### DIFF
--- a/js/signaling.js
+++ b/js/signaling.js
@@ -432,9 +432,10 @@
 
 		this._waitTimeUntilRetry = 1;
 
-		// Fetch more messages if PHP backend or a whole batch has been received
-		// (more messages might be available in this case).
-		if (this.receiveMessagesAgain || (messages && messages.length === this.chatBatchSize)) {
+		// Fetch more messages if PHP backend, or if the returned status is not
+		// "304 Not modified" (as in that case there could be more messages that
+		// need to be fetched).
+		if (this.receiveMessagesAgain || xhr.status !== 304) {
 			this._receiveChatMessages();
 		}
 

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -200,6 +200,15 @@ class ChatController extends AEnvironmentAwareController {
 	 *   If messages have been returned (status=200) the new $lastKnownMessageId
 	 *   for the follow up query is available as `X-Chat-Last-Given` header.
 	 *
+	 * The limit specifies the maximum number of messages that will be returned,
+	 * although the actual number of returned messages could be lower if some
+	 * messages are not visible to the participant. Note that if none of the
+	 * messages are visible to the participant the returned number of messages
+	 * will be 0, yet the status will still be 200. Also note that
+	 * `X-Chat-Last-Given` may reference a message not visible and thus not
+	 * returned, but it should be used nevertheless as the $lastKnownMessageId
+	 * for the follow up query.
+	 *
 	 * @param int $lookIntoFuture Polling for new messages (1) or getting the history of the chat (0)
 	 * @param int $limit Number of chat messages to receive (100 by default, 200 at most)
 	 * @param int $lastKnownMessageId The last known message (serves as offset)

--- a/tests/integration/features/chat/commands.feature
+++ b/tests/integration/features/chat/commands.feature
@@ -1,0 +1,33 @@
+Feature: chat/commands
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+
+  Scenario: user can see own help command and others can not
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    When user "participant1" sends message "/help" to room "group room" with 201
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId | actorDisplayName | message                                    | messageParameters |
+      | group room | bots      | talk    | talk-bot         | There are currently no commands available. | []                |
+    And user "participant2" sees the following messages in room "group room" with 200
+
+  Scenario: user can see own help command along with regular messages and others can not
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "group room" with 200
+    When user "participant1" sends message "Message 1" to room "group room" with 201
+    And user "participant1" sends message "/help" to room "group room" with 201
+    And user "participant1" sends message "Message 2" to room "group room" with 201
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message                                    | messageParameters |
+      | group room | users     | participant1 | participant1-displayname | Message 2                                  | []                |
+      | group room | bots      | talk         | talk-bot                 | There are currently no commands available. | []                |
+      | group room | users     | participant1 | participant1-displayname | Message 1                                  | []                |
+    And user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | group room | users     | participant1 | participant1-displayname | Message 2 | []                |
+      | group room | users     | participant1 | participant1-displayname | Message 1 | []                |


### PR DESCRIPTION
Fixes #1797, which is a regression introduced in #1453 

When fetching chat messages `ChatController` may not return as many messages as requested. In the past this meant that there were no more messages in the room, but since the introduction of commands [some messages may not be returned because they should not be visible to the participant fetching them](https://github.com/nextcloud/spreed/blob/f1667ac2f77cc56d8e5e69eac0e4f28fd2c5187e/lib/Controller/ChatController.php#L238-L240). Thus, now the number of returned messages does not mean anything regarding whether there are still more messages in the room or not, but this can be known by looking for a `304 Not modified` response (which is only sent when there are no more messages in the room).

When no MUC is used the chat messages are polled again and again, so the behaviour change explained above made no difference. However, when the MCU is used [the messages are fetched until there are no more messages in the room](https://github.com/nextcloud/spreed/blob/0c3a58b4f510c3bf7632295b5bb6652e6ab016e2/js/signaling.js#L1237-L1238) and, then, they are only fetched [when a new message is sent](https://github.com/nextcloud/spreed/blob/0c3a58b4f510c3bf7632295b5bb6652e6ab016e2/js/signaling.js#L1160-L1161). Checking whether there are more messages in the room or not was based on the number of returned messages, so the fetch of messages until there were no more messages in the room wrongly stopped when fetching a batch of messages that included one not visible for the current participant.

Mobile apps were not affected even if the MCU was used because they always poll for messages again and again.

Besides the fix itself I have documented the new `ChatController` behaviour explicitly and through some basic integration tests (although more would be needed to check the 304 status and so on, but for now it is good enough).

## How to test ##
-Setup the MCU
-Create a public conversation and write 100 messages or more
-Call the help command with /help
-Write another bunch of messages
-In the WebUI open the conversation with a different participant

### Result with this pull request ###
All the messages are loaded.

### Result without this pull request ###
Last messages are not loaded.
