### PR TITLE
Disable video by default when joining calls

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -627,13 +627,17 @@
 
 				delete this._reconnectCallToken;
 
-				// Disable video when joining a call in a room with more than 5
-				// participants.
-				var participants = this.activeRoom.get('participants');
-				if (participants && Object.keys(participants).length > 5) {
+				if (this.activeRoom.get('type') === this.ROOM_TYPE_ONE_TO_ONE) {
+					this._mediaControlsView.setAudioEnabled(true);
 					this.setVideoEnabled(false);
+
+					return;
 				}
 
+				this._mediaControlsView.setAudioEnabled(false);
+				this.setVideoEnabled(false);
+
+				var participants = this.activeRoom.get('participants');
 				var numberOfParticipantsAndGuests = (participants? Object.keys(participants).length: 0) +
 						this.activeRoom.get('numGuests');
 				if (this.signaling.isNoMcuWarningEnabled() && numberOfParticipantsAndGuests >= 5) {

--- a/js/app.js
+++ b/js/app.js
@@ -710,6 +710,16 @@
 				localMediaChannel.trigger('waitingForPermissions');
 			}
 
+			var participants = this.activeRoom.get('participants');
+			var numberOfParticipantsAndGuests = (participants? Object.keys(participants).length: 0) +
+					this.activeRoom.get('numGuests');
+			if (numberOfParticipantsAndGuests >= 5) {
+				this.signaling.setSendVideoIfAvailable(false);
+				this.setVideoEnabled(false);
+			} else {
+				this.signaling.setSendVideoIfAvailable(true);
+			}
+
 			OCA.SpreedMe.webrtc.startMedia(this.token);
 		},
 		startLocalMedia: function(configuration) {

--- a/js/connection.js
+++ b/js/connection.js
@@ -119,7 +119,7 @@
 					if (configuration.audio) {
 						flags |= OCA.SpreedMe.app.FLAG_WITH_AUDIO;
 					}
-					if (configuration.video) {
+					if (configuration.video && self.app.signaling.getSendVideoIfAvailable()) {
 						flags |= OCA.SpreedMe.app.FLAG_WITH_VIDEO;
 					}
 				}

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -192,6 +192,16 @@
 				localMediaChannel.trigger('waitingForPermissions');
 			}
 
+			var participants = this.activeRoom.get('participants');
+			var numberOfParticipantsAndGuests = (participants? Object.keys(participants).length: 0) +
+					this.activeRoom.get('numGuests');
+			if (numberOfParticipantsAndGuests >= 5) {
+				this.signaling.setSendVideoIfAvailable(false);
+				this.setVideoEnabled(false);
+			} else {
+				this.signaling.setSendVideoIfAvailable(true);
+			}
+
 			OCA.SpreedMe.webrtc.startMedia(this.token);
 		},
 		startLocalMedia: function(configuration) {

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -147,13 +147,17 @@
 
 				delete this._reconnectCallToken;
 
-				// Disable video when joining a call in a room with more than 5
-				// participants.
-				var participants = this.activeRoom.get('participants');
-				if (participants && Object.keys(participants).length > 5) {
+				if (this.activeRoom.get('type') === this.ROOM_TYPE_ONE_TO_ONE) {
+					this._mediaControlsView.setAudioEnabled(true);
 					this.setVideoEnabled(false);
+
+					return;
 				}
 
+				this._mediaControlsView.setAudioEnabled(false);
+				this.setVideoEnabled(false);
+
+				var participants = this.activeRoom.get('participants');
 				var numberOfParticipantsAndGuests = (participants? Object.keys(participants).length: 0) +
 						this.activeRoom.get('numGuests');
 				if (this.signaling.isNoMcuWarningEnabled() && numberOfParticipantsAndGuests >= 5) {

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -135,6 +135,10 @@
 		return this.sessionId;
 	};
 
+	OCA.Talk.Signaling.Base.prototype.getCurrentCallFlags = function() {
+		return this.currentCallFlags;
+	};
+
 	OCA.Talk.Signaling.Base.prototype.disconnect = function() {
 		this.sessionId = '';
 		this.currentCallToken = null;
@@ -524,9 +528,13 @@
 		}
 	};
 
-	OCA.Talk.Signaling.Internal.prototype.forceReconnect = function(newSession) {
+	OCA.Talk.Signaling.Internal.prototype.forceReconnect = function(newSession, flags) {
 		if (newSession) {
 			console.log('Forced reconnects with a new session are not supported in the internal signaling; same session as before will be used');
+		}
+
+		if (flags !== undefined) {
+			this.currentCallFlags = flags;
 		}
 
 		// FIXME Naive reconnection routine; as the same session is kept peers
@@ -846,7 +854,11 @@
 		OCA.Talk.Signaling.Base.prototype.disconnect.apply(this, arguments);
 	};
 
-	OCA.Talk.Signaling.Standalone.prototype.forceReconnect = function(newSession) {
+	OCA.Talk.Signaling.Standalone.prototype.forceReconnect = function(newSession, flags) {
+		if (flags !== undefined) {
+			this.currentCallFlags = flags;
+		}
+
 		if (!this.connected) {
 			if (!newSession) {
 				// Not connected, will do reconnect anyway.

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -76,6 +76,7 @@
 		this.pendingChatRequests = [];
 		this._lastChatMessagesFetch = null;
 		this.chatBatchSize = 100;
+		this._sendVideoIfAvailable = true;
 	}
 
 	OCA.Talk.Signaling.Base = Base;
@@ -297,6 +298,14 @@
 				}
 			}.bind(this)
 		});
+	};
+
+	OCA.Talk.Signaling.Base.prototype.getSendVideoIfAvailable = function() {
+		return this._sendVideoIfAvailable;
+	};
+
+	OCA.Talk.Signaling.Base.prototype.setSendVideoIfAvailable = function(sendVideoIfAvailable) {
+		this._sendVideoIfAvailable = sendVideoIfAvailable;
 	};
 
 	OCA.Talk.Signaling.Base.prototype._joinCallSuccess = function(/* token */) {

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -524,8 +524,15 @@
 		}
 	};
 
-	OCA.Talk.Signaling.Internal.prototype.forceReconnect = function(/* newSession */) {
-		console.error("Forced reconnects are not supported with the internal signaling.");
+	OCA.Talk.Signaling.Internal.prototype.forceReconnect = function(newSession) {
+		if (newSession) {
+			console.log('Forced reconnects with a new session are not supported in the internal signaling; same session as before will be used');
+		}
+
+		// FIXME Naive reconnection routine; as the same session is kept peers
+		// must be explicitly ended before the reconnection is forced.
+		this.leaveCall(this.currentCallToken, true);
+		this.joinCall(this.currentCallToken);
 	};
 
 	OCA.Talk.Signaling.Internal.prototype._sendMessageWithCallback = function(ev) {

--- a/js/simplewebrtc/bundled.js
+++ b/js/simplewebrtc/bundled.js
@@ -673,7 +673,9 @@ function Peer(options) {
     }
   } else {
     this.parent.localStreams.forEach(function (stream) {
-      self.pc.addStream(stream);
+      stream.getTracks().forEach(function (track) {
+        self.pc.addTrack(track, stream);
+      });
     });
   } // proxy events to parent
 

--- a/js/simplewebrtc/bundled.js
+++ b/js/simplewebrtc/bundled.js
@@ -629,6 +629,7 @@ function Peer(options) {
   this.sharemyscreen = options.sharemyscreen || false;
   this.browserPrefix = options.prefix;
   this.stream = options.stream;
+  this.sendVideoIfAvailable = options.sendVideoIfAvailable === undefined ? true : options.sendVideoIfAvailable;
   this.enableDataChannels = options.enableDataChannels === undefined ? this.parent.config.enableDataChannels : options.enableDataChannels;
   this.receiveMedia = options.receiveMedia || this.parent.config.receiveMedia;
   this.channels = {};
@@ -674,7 +675,9 @@ function Peer(options) {
   } else {
     this.parent.localStreams.forEach(function (stream) {
       stream.getTracks().forEach(function (track) {
-        self.pc.addTrack(track, stream);
+        if (track.kind !== 'video' || self.sendVideoIfAvailable) {
+          self.pc.addTrack(track, stream);
+        }
       });
     });
   } // proxy events to parent
@@ -1081,7 +1084,8 @@ function SimpleWebRTC(opts) {
           type: message.roomType,
           enableDataChannels: self.config.enableDataChannels && message.roomType !== 'screen',
           sharemyscreen: message.roomType === 'screen' && !message.broadcaster,
-          broadcaster: message.roomType === 'screen' && !message.broadcaster ? self.connection.getSessionid() : null
+          broadcaster: message.roomType === 'screen' && !message.broadcaster ? self.connection.getSessionid() : null,
+          sendVideoIfAvailable: self.connection.getSendVideoIfAvailable()
         });
         self.emit('createdPeer', peer);
       }

--- a/js/simplewebrtc/peer.js
+++ b/js/simplewebrtc/peer.js
@@ -68,7 +68,9 @@ function Peer(options) {
 		}
 	} else {
 		this.parent.localStreams.forEach(function (stream) {
-			self.pc.addStream(stream);
+			stream.getTracks().forEach(function (track) {
+				self.pc.addTrack(track, stream);
+			});
 		});
 	}
 

--- a/js/simplewebrtc/peer.js
+++ b/js/simplewebrtc/peer.js
@@ -25,6 +25,7 @@ function Peer(options) {
 	this.sharemyscreen = options.sharemyscreen || false;
 	this.browserPrefix = options.prefix;
 	this.stream = options.stream;
+	this.sendVideoIfAvailable = options.sendVideoIfAvailable === undefined ? true : options.sendVideoIfAvailable;
 	this.enableDataChannels = options.enableDataChannels === undefined ? this.parent.config.enableDataChannels : options.enableDataChannels;
 	this.receiveMedia = options.receiveMedia || this.parent.config.receiveMedia;
 	this.channels = {};
@@ -69,7 +70,9 @@ function Peer(options) {
 	} else {
 		this.parent.localStreams.forEach(function (stream) {
 			stream.getTracks().forEach(function (track) {
-				self.pc.addTrack(track, stream);
+				if (track.kind !== 'video' || self.sendVideoIfAvailable) {
+					self.pc.addTrack(track, stream);
+				}
 			});
 		});
 	}

--- a/js/simplewebrtc/simplewebrtc.js
+++ b/js/simplewebrtc/simplewebrtc.js
@@ -108,7 +108,8 @@ function SimpleWebRTC(opts) {
 					type: message.roomType,
 					enableDataChannels: self.config.enableDataChannels && message.roomType !== 'screen',
 					sharemyscreen: message.roomType === 'screen' && !message.broadcaster,
-					broadcaster: message.roomType === 'screen' && !message.broadcaster ? self.connection.getSessionid() : null
+					broadcaster: message.roomType === 'screen' && !message.broadcaster ? self.connection.getSessionid() : null,
+					sendVideoIfAvailable: self.connection.getSendVideoIfAvailable()
 				});
 				self.emit('createdPeer', peer);
 			}

--- a/js/views/mediacontrolsview.js
+++ b/js/views/mediacontrolsview.js
@@ -183,7 +183,7 @@
 			} else {
 				this._webrtc.pauseVideo();
 
-				this.getUI('videoButton').attr('data-original-title', t('spreed', 'Enable video (v)'))
+				this.getUI('videoButton').attr('data-original-title', this._getEnableVideoButtonTitle())
 					.addClass('local-video-disabled video-disabled icon-video-off')
 					.removeClass('icon-video');
 				this.getUI('audioButton').addClass('local-video-disabled');
@@ -193,6 +193,14 @@
 			this.videoEnabled = videoEnabled;
 
 			return true;
+		},
+
+		_getEnableVideoButtonTitle: function() {
+			if (!this._app.signaling || this._app.signaling.getSendVideoIfAvailable()) {
+				return t('spreed', 'Enable video (v)');
+			}
+
+			return t('spreed', 'Enable video (v) - Your connection will be briefly interrupted when enabling the video for the first time');
 		},
 
 		/**

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -130,7 +130,8 @@ var spreedPeerConnectionTable = [];
 			receiveMedia: {
 				offerToReceiveAudio: 0,
 				offerToReceiveVideo: 0
-			}
+			},
+			sendVideoIfAvailable: signaling.getSendVideoIfAvailable()
 		});
 		webrtc.emit('createdPeer', ownPeer);
 		ownPeer.start();
@@ -184,7 +185,8 @@ var spreedPeerConnectionTable = [];
 					receiveMedia: {
 						offerToReceiveAudio: 1,
 						offerToReceiveVideo: 1
-					}
+					},
+					sendVideoIfAvailable: signaling.getSendVideoIfAvailable()
 				});
 				webrtc.emit('createdPeer', peer);
 				peer.start();


### PR DESCRIPTION
Fixes #1798

Until now, when local video was available it was always sent to the other peers (directly, or indirectly through the MCU); even if the video was disabled a black stream was sent. Despite being more lightweight than the full video that black stream still needs to be processed by the clients, which could require lots of resources when several of those black streams are sent in a large group call.

The proper way to handle this would be not to send the video when it is disabled and only send it when it is available and enabled, triggering a renegotiation of the streams whenever the video is enabled or disabled. However, renegotiation is not supported yet in the WebUI nor in mobile apps, so for the time being now video, even if available, is disabled and not sent by default when joining a call in a room with 5 participants or more. If the video is not being sent but it is then enabled this will cause a reconnection to the other peers and from that point on the video will be sent, even if it is later disabled. If the call is left and then joined again the video will be not sent until explicitly enabled again.

Besides that, now audio and video are always disabled by default when joining a call, except for audio in one-to-one calls where it is enabled.

Issues:
- [X] `inCall` flags are not properly set after a reconnection - This is already the case in _master_ and it will be fixed in [a different pull request](https://github.com/nextcloud/spreed/pull/1824) that this one will be rebased on (plus [some changes in this pull request](https://github.com/nextcloud/spreed/pull/1818/commits/b909224016d29d0e63b7f59457cbe771196def90))
- Improve the naive reconnection without MCU, as it is somewhat flaky - The problem is caused by crossed offers between peers after the reconnection; the problem is not specific to this pull request (although this makes easier to trigger it) so it will be fixed in a different one
- [X] ~~Fix video being sent by default for guests, as guests do not have access to the list of participants and thus the check for the number of participants does not work~~ Actually guests do have access to the list of participants provided in the room object; the problem was a different one, see below
- [X] Fix video being sent by default if there are less than 5 registered users in the room but the total number of participants, including guests, is 5 or more than 5
- [X] Fix note about potential performance issues shown again after reconnecting when no MCU is used
- [X] Fix having to enable the video twice, because after reconnecting the video is disabled
- [X] Show tooltip on video button when clicking on it will cause a reconnection
- [X] Better testing of media changes while a reconnection is in progress, as that will probably wreak havoc - I made in some quick tests and surprisingly it seems to work fine; in any case, if something needs to be fixed it can be done in a follow up pull request
- UX during reconnections is not good (as the UI bounces between call and chat) - This is already the case in _master_ and it will be fixed in a different pull request (probably a follow-up and not needed as a base for this pull request)
