### PR TITLE
Move things that should not be there outside of signaling object

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -623,6 +623,13 @@
 				if (participants && Object.keys(participants).length > 5) {
 					this.setVideoEnabled(false);
 				}
+
+				var numberOfParticipantsAndGuests = (participants? Object.keys(participants).length: 0) +
+						this.activeRoom.get('numGuests');
+				if (this.signaling.isNoMcuWarningEnabled() && numberOfParticipantsAndGuests >= 5) {
+					var warning = t('spreed', 'Calls with more than 4 participants without an external signaling server can experience connectivity issues and cause high load on participating devices.');
+					OC.Notification.showTemporary(warning, { timeout: 30, type: 'warning' });
+				}
 			}.bind(this));
 
 			$(window).unload(function () {

--- a/js/connection.js
+++ b/js/connection.js
@@ -22,6 +22,10 @@
 		this.app.signaling.on('roomChanged', function() {
 			this.leaveCurrentRoom();
 		}.bind(this));
+
+		this.app.signaling.on('pullMessagesStoppedOnFail', function() {
+			this.leaveCurrentRoom();
+		}.bind(this));
 	}
 
 	OCA.Talk.Connection = Connection;

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -143,6 +143,13 @@
 				if (participants && Object.keys(participants).length > 5) {
 					this.setVideoEnabled(false);
 				}
+
+				var numberOfParticipantsAndGuests = (participants? Object.keys(participants).length: 0) +
+						this.activeRoom.get('numGuests');
+				if (this.signaling.isNoMcuWarningEnabled() && numberOfParticipantsAndGuests >= 5) {
+					var warning = t('spreed', 'Calls with more than 4 participants without an external signaling server can experience connectivity issues and cause high load on participating devices.');
+					OC.Notification.showTemporary(warning, { timeout: 30, type: 'warning' });
+				}
 			}.bind(this));
 
 			$(window).unload(function () {

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -639,6 +639,8 @@
 					// Request has been aborted. Ignore.
 				} else if (this.currentRoomToken) {
 					if (this.pullMessagesFails >= 3) {
+						console.log('Stop pulling messages after repeated failures');
+
 						this._trigger('pullMessagesStoppedOnFail');
 
 						return;

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -639,16 +639,8 @@
 					// Request has been aborted. Ignore.
 				} else if (this.currentRoomToken) {
 					if (this.pullMessagesFails >= 3) {
-						if (OCA.SpreedMe.webrtc) {
-							// Force leaving the call in WebRTC; leaving the
-							// room indirectly runs
-							// signaling.leaveCurrentCall(), but if the
-							// signaling fails to leave the call no event will
-							// be triggered and the call will not be left from
-							// WebRTC point of view.
-							OCA.SpreedMe.webrtc.leaveCall();
-						}
-						OCA.SpreedMe.app.connection.leaveCurrentRoom();
+						this._trigger('pullMessagesStoppedOnFail');
+
 						return;
 					}
 

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -125,6 +125,10 @@
 		}
 	};
 
+	OCA.Talk.Signaling.Base.prototype.isNoMcuWarningEnabled = function() {
+		return !this.settings.hideWarning;
+	};
+
 	OCA.Talk.Signaling.Base.prototype.getSessionid = function() {
 		return this.sessionId;
 	};
@@ -544,21 +548,6 @@
 	OCA.Talk.Signaling.Internal.prototype._joinRoomSuccess = function(token, sessionId) {
 		this.sessionId = sessionId;
 		this._startPullingMessages();
-	};
-
-	OCA.Talk.Signaling.Internal.prototype._joinCallSuccess = function() {
-		if (this.hideWarning) {
-			return;
-		}
-
-		var numParticipants = Object.keys(OCA.SpreedMe.app.activeRoom.get('participants')).length +
-			OCA.SpreedMe.app.activeRoom.get('numGuests');
-		if (numParticipants <= 4) {
-			return;
-		}
-
-		var warning = t('spreed', 'Calls with more than 4 participants without an external signaling server can experience connectivity issues and cause high load on participating devices.');
-		OC.Notification.showTemporary(warning, { timeout: 30, type: 'warning' });
 	};
 
 	OCA.Talk.Signaling.Internal.prototype._doLeaveRoom = function(token) {

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -378,6 +378,16 @@ var spreedPeerConnectionTable = [];
 		}
 		OCA.SpreedMe.webrtc = webrtc;
 
+		signaling.on('pullMessagesStoppedOnFail', function() {
+			// Force leaving the call in WebRTC; when pulling messages stops due
+			// to failures the room is left, and leaving the room indirectly
+			// runs signaling.leaveCurrentCall(), but if the signaling fails to
+			// leave the call (which is likely due to the messages failing to be
+			// received) no event will be triggered and the call will not be
+			// left from WebRTC point of view.
+			webrtc.leaveCall();
+		});
+
 		OCA.SpreedMe.webrtc.startMedia = function (token) {
 			webrtc.joinCall(token);
 		};


### PR DESCRIPTION
Follow up to #1059, #1631 and #1649

The signaling object should not directly modify the UI, and it should not directly perform the handling needed by other parts of the code when pulling messages stops due to repeated failures (an event should be triggered instead, and the interested objects should handle it as needed).

This pull request should not change the behaviour of the moved code; the no MCU warning should still be shown as before (that is, when enabled in the settings and joining a call with more than 4 participants with the internal signaling server), and when a room is deleted the UI should be updated for the users in the room and an ongoing call should be stopped.
