### PR TITLE
Fix status not kept after forced reconnections

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -617,6 +617,16 @@
 			}.bind(this));
 
 			this.signaling.on('joinCall', function() {
+				// Do not perform the initial adjustments when joining a call
+				// again due to a forced reconnection.
+				if (this._reconnectCallToken === this.activeRoom.get('token')) {
+					delete this._reconnectCallToken;
+
+					return;
+				}
+
+				delete this._reconnectCallToken;
+
 				// Disable video when joining a call in a room with more than 5
 				// participants.
 				var participants = this.activeRoom.get('participants');
@@ -629,6 +639,12 @@
 				if (this.signaling.isNoMcuWarningEnabled() && numberOfParticipantsAndGuests >= 5) {
 					var warning = t('spreed', 'Calls with more than 4 participants without an external signaling server can experience connectivity issues and cause high load on participating devices.');
 					OC.Notification.showTemporary(warning, { timeout: 30, type: 'warning' });
+				}
+			}.bind(this));
+
+			this.signaling.on('leaveCall', function (token, reconnect) {
+				if (reconnect) {
+					this._reconnectCallToken = token;
 				}
 			}.bind(this));
 

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -137,6 +137,16 @@
 			}.bind(this));
 
 			this.signaling.on('joinCall', function() {
+				// Do not perform the initial adjustments when joining a call
+				// again due to a forced reconnection.
+				if (this._reconnectCallToken === this.activeRoom.get('token')) {
+					delete this._reconnectCallToken;
+
+					return;
+				}
+
+				delete this._reconnectCallToken;
+
 				// Disable video when joining a call in a room with more than 5
 				// participants.
 				var participants = this.activeRoom.get('participants');
@@ -149,6 +159,12 @@
 				if (this.signaling.isNoMcuWarningEnabled() && numberOfParticipantsAndGuests >= 5) {
 					var warning = t('spreed', 'Calls with more than 4 participants without an external signaling server can experience connectivity issues and cause high load on participating devices.');
 					OC.Notification.showTemporary(warning, { timeout: 30, type: 'warning' });
+				}
+			}.bind(this));
+
+			this.signaling.on('leaveCall', function (token, reconnect) {
+				if (reconnect) {
+					this._reconnectCallToken = token;
 				}
 			}.bind(this));
 

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -70,6 +70,7 @@
 		this.sessionId = '';
 		this.currentRoomToken = null;
 		this.currentCallToken = null;
+		this.currentCallFlags = null;
 		this.handlers = {};
 		this.features = {};
 		this.pendingChatRequests = [];
@@ -136,6 +137,7 @@
 	OCA.Talk.Signaling.Base.prototype.disconnect = function() {
 		this.sessionId = '';
 		this.currentCallToken = null;
+		this.currentCallFlags = null;
 	};
 
 	OCA.Talk.Signaling.Base.prototype.hasFeature = function(feature) {
@@ -173,6 +175,7 @@
 		if (this.currentCallToken) {
 			this.leaveCall(this.currentCallToken);
 			this.currentCallToken = null;
+			this.currentCallFlags = null;
 		}
 	};
 
@@ -232,9 +235,10 @@
 				this._runPendingChatRequests();
 				if (this.currentCallToken === token) {
 					// We were in this call before, join again.
-					this.joinCall(token);
+					this.joinCall(token, this.currentCallFlags);
 				} else {
 					this.currentCallToken = null;
+					this.currentCallFlags = null;
 				}
 				this._joinRoomSuccess(token, result.ocs.data.sessionId);
 			}.bind(this),
@@ -311,6 +315,7 @@
 			},
 			success: function () {
 				this.currentCallToken = token;
+				this.currentCallFlags = flags;
 				this._trigger('joinCall', [token]);
 				this._joinCallSuccess(token);
 			}.bind(this),
@@ -341,6 +346,7 @@
 				// We left the current call.
 				if (!keepToken && token === this.currentCallToken) {
 					this.currentCallToken = null;
+					this.currentCallFlags = null;
 				}
 			}.bind(this)
 		});


### PR DESCRIPTION
## How to test (scenario 1)
- Setup the MCU
- Create a group or public conversation and add more than 5 users
- Start a call with one user
- Join the call with another user (or guest)
- Enable the video
- Trigger a forced reconnection (for example, by disconnecting the Internet cable in one of the machines, although there are currently some bugs and instead of a forced reconnection you may get no reconnection at all...)

### Result with this pull request ###
The video is enabled after the reconnection.

### Result without this pull request ###
The video is disabled again after the reconnection.

## How to test (scenario 2)
- Setup the MCU
- Add `console.log(usersInCallMapping);` to the handler of `usersChanged` event [after the mapping is updated](https://github.com/nextcloud/spreed/blob/d55617ca22595f9771d5f28684b00f4e25a0e703/js/webrtc.js#L300)
- Open your browser console
- Create a conversation
- Start a call with one user; only allow microphone, but not camera (or unplug the camera)
- Join the call with another user (or guest); only allow microphone, but not camera (or unplug the camera)
- Trigger a forced reconnection (for example, by disconnecting the Internet cable in one of the machines, although there are currently some bugs and instead of a forced reconnection you may get no reconnection at all...)

### Result with this pull request ###
In the browser console the flags in the `usersInCallMapping` of the reconnected user is 3 (which means that audio but not video is available in the call).

### Result without this pull request ###
In the browser console the flags in the `usersInCallMapping` of the reconnected user is 7 ([the default value used when no flags are provided](https://github.com/nextcloud/spreed/blob/c739c36c8be87a69d500a819be7423e3c5b692fa/lib/Controller/CallController.php#L92), which means that audio and video are available in the call).