### PR TITLE
Fix flickering spinner on avatars during calls with the MCU

### DIFF
--- a/js/views/videoview.js
+++ b/js/views/videoview.js
@@ -102,17 +102,35 @@
 		},
 
 		setParticipant: function(userId, participantName) {
+			// Needed for guest avatars, as if no name is given the avatar
+			// should show "?" instead of the first letter of the "Guest"
+			// placeholder.
+			var rawParticipantName = participantName;
+
+			// "Guest" placeholder is not shown until the initial connection for
+			// consistency with regular users.
+			if (!(userId && userId.length) && this._connectionStatus !== ConnectionStatus.NEW) {
+				participantName = participantName || t('spreed', 'Guest');
+			}
+
+			if (this.hasOwnProperty('_userId') && this.hasOwnProperty('_rawParticipantName') && this.hasOwnProperty('_participantName') &&
+					userId === this._userId && rawParticipantName === this._rawParticipantName && participantName === this._participantName) {
+				// Do not set again the avatar if it has already been set to
+				// workaround the MCU setting the participant again and again
+				// and thus causing a loading icon to be shown on the avatar
+				// again and again.
+				return;
+			}
+
+			this._userId = userId;
+			this._rawParticipantName = rawParticipantName;
+			this._participantName = participantName;
+
 			if (userId && userId.length) {
 				this.getUI('avatar').avatar(userId, 128);
 			} else {
-				this.getUI('avatar').imageplaceholder('?', participantName, 128);
+				this.getUI('avatar').imageplaceholder('?', rawParticipantName, 128);
 				this.getUI('avatar').css('background-color', '#b9b9b9');
-
-				// "Guest" placeholder is not shown until the initial connection
-				// for consistency with regular users.
-				if (this._connectionStatus !== ConnectionStatus.NEW) {
-					participantName = participantName || t('spreed', 'Guest');
-				}
 			}
 
 			this.getUI('nameIndicator').text(participantName);


### PR DESCRIPTION
Fixes #1511

This is actually a workaround; the proper fix would be [to get the participant names from the list of participants instead of from the data channel](https://github.com/nextcloud/spreed/issues/991), but unfortunately [guests do not have access to the participants end point](https://github.com/nextcloud/spreed/blob/1b9f73987379ecfc2b80cb6855773cfbf1c53b20/lib/Controller/RoomController.php#L565-L567) (why is this? Could it be changed to get a proper fix in the future?) and the list of participants provided in [the room information does not contain the nicks of the guests](https://github.com/nextcloud/spreed/blob/1b9f73987379ecfc2b80cb6855773cfbf1c53b20/lib/Controller/RoomController.php#L255-L256) (only [how many of them are active](https://github.com/nextcloud/spreed/blob/1b9f73987379ecfc2b80cb6855773cfbf1c53b20/lib/Controller/RoomController.php#L251)), so that approach is not currently possible.

The second proper fix would be to add a model that keeps track of the nick and trigger and event only when it has actually changed. However that would require much more changes than I am comfortable with so close to 6.0.1.

So, for the time being, the state is tracked in the view itself, which now only updates the avatar and name when needed instead of every time that `setParticipant` is called.

## How to test

- Setup the MCU
- Join a call with other registered users (as the issue is not visible for guests)

### Result with this pull request ###

The avatars of the users do not flicker.

If a guest changes her name her avatar and name will be updated for the rest of participants; if a registered user changes her name or avatar during a call it will not be shown for the rest of participants, but this is the case too in _master_, it is not related to this pull request (and it should not happen very often anyway).

### Result without this pull request ###

The avatars of the users flicker.

