### PR TITLE
Add tags to sharing integration tests to split them in Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -554,7 +554,7 @@ trigger:
 
 ---
 kind: pipeline
-name: int-sqlite-sharing
+name: int-sqlite-sharing-set-1
 
 steps:
   - name: integration-sharing
@@ -572,7 +572,109 @@ steps:
 
       # Run integration tests
       - cd tests/integration/
-      - bash run.sh features/sharing
+      - bash run.sh --tags set-1 features/sharing
+
+services:
+  - name: cache
+    image: redis
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+    - pull_request
+    - push
+
+---
+kind: pipeline
+name: int-sqlite-sharing-set-2
+
+steps:
+  - name: integration-sharing
+    image: nextcloudci/php7.1:php7.1-16
+    environment:
+      APP_NAME: spreed
+      CORE_BRANCH: master
+      DATABASEHOST: sqlite
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
+      - cd ../server
+      - ./occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
+
+      # Run integration tests
+      - cd tests/integration/
+      - bash run.sh --tags set-2 features/sharing
+
+services:
+  - name: cache
+    image: redis
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+    - pull_request
+    - push
+
+---
+kind: pipeline
+name: int-sqlite-sharing-set-3
+
+steps:
+  - name: integration-sharing
+    image: nextcloudci/php7.1:php7.1-16
+    environment:
+      APP_NAME: spreed
+      CORE_BRANCH: master
+      DATABASEHOST: sqlite
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
+      - cd ../server
+      - ./occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
+
+      # Run integration tests
+      - cd tests/integration/
+      - bash run.sh --tags set-3 features/sharing
+
+services:
+  - name: cache
+    image: redis
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+    - pull_request
+    - push
+
+---
+kind: pipeline
+name: int-sqlite-sharing-set-4
+
+steps:
+  - name: integration-sharing
+    image: nextcloudci/php7.1:php7.1-16
+    environment:
+      APP_NAME: spreed
+      CORE_BRANCH: master
+      DATABASEHOST: sqlite
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
+      - cd ../server
+      - ./occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
+
+      # Run integration tests
+      - cd tests/integration/
+      - bash run.sh --tags set-4 features/sharing
 
 services:
   - name: cache
@@ -720,7 +822,7 @@ trigger:
 
 ---
 kind: pipeline
-name: int-mysql-sharing
+name: int-mysql-sharing-set-1
 
 steps:
   - name: integration-sharing
@@ -738,7 +840,139 @@ steps:
 
       # Run integration tests
       - cd tests/integration/
-      - bash run.sh features/sharing
+      - bash run.sh --tags set-1 features/sharing
+
+services:
+  - name: cache
+    image: redis
+  - name: mysql
+    image: mysql:5.7.22
+    environment:
+      MYSQL_ROOT_PASSWORD: owncloud
+      MYSQL_USER: oc_autotest
+      MYSQL_PASSWORD: owncloud
+      MYSQL_DATABASE: oc_autotest
+    command: [ "--innodb_large_prefix=true", "--innodb_file_format=barracuda", "--innodb_file_per_table=true" ]
+    tmpfs:
+      - /var/lib/mysql
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+#    - pull_request
+    - push
+
+---
+kind: pipeline
+name: int-mysql-sharing-set-2
+
+steps:
+  - name: integration-sharing
+    image: nextcloudci/php7.1:php7.1-16
+    environment:
+      APP_NAME: spreed
+      CORE_BRANCH: master
+      DATABASEHOST: mysql
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
+      - cd ../server
+      - ./occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
+
+      # Run integration tests
+      - cd tests/integration/
+      - bash run.sh --tags set-2 features/sharing
+
+services:
+  - name: cache
+    image: redis
+  - name: mysql
+    image: mysql:5.7.22
+    environment:
+      MYSQL_ROOT_PASSWORD: owncloud
+      MYSQL_USER: oc_autotest
+      MYSQL_PASSWORD: owncloud
+      MYSQL_DATABASE: oc_autotest
+    command: [ "--innodb_large_prefix=true", "--innodb_file_format=barracuda", "--innodb_file_per_table=true" ]
+    tmpfs:
+      - /var/lib/mysql
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+#    - pull_request
+    - push
+
+---
+kind: pipeline
+name: int-mysql-sharing-set-3
+
+steps:
+  - name: integration-sharing
+    image: nextcloudci/php7.1:php7.1-16
+    environment:
+      APP_NAME: spreed
+      CORE_BRANCH: master
+      DATABASEHOST: mysql
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
+      - cd ../server
+      - ./occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
+
+      # Run integration tests
+      - cd tests/integration/
+      - bash run.sh --tags set-3 features/sharing
+
+services:
+  - name: cache
+    image: redis
+  - name: mysql
+    image: mysql:5.7.22
+    environment:
+      MYSQL_ROOT_PASSWORD: owncloud
+      MYSQL_USER: oc_autotest
+      MYSQL_PASSWORD: owncloud
+      MYSQL_DATABASE: oc_autotest
+    command: [ "--innodb_large_prefix=true", "--innodb_file_format=barracuda", "--innodb_file_per_table=true" ]
+    tmpfs:
+      - /var/lib/mysql
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+#    - pull_request
+    - push
+
+---
+kind: pipeline
+name: int-mysql-sharing-set-4
+
+steps:
+  - name: integration-sharing
+    image: nextcloudci/php7.1:php7.1-16
+    environment:
+      APP_NAME: spreed
+      CORE_BRANCH: master
+      DATABASEHOST: mysql
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
+      - cd ../server
+      - ./occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
+
+      # Run integration tests
+      - cd tests/integration/
+      - bash run.sh --tags set-4 features/sharing
 
 services:
   - name: cache
@@ -890,7 +1124,7 @@ trigger:
 
 ---
 kind: pipeline
-name: int-pgsql-sharing
+name: int-pgsql-sharing-set-1
 
 steps:
   - name: integration-sharing
@@ -908,7 +1142,133 @@ steps:
 
       # Run integration tests
       - cd tests/integration/
-      - bash run.sh features/sharing
+      - bash run.sh --tags set-1 features/sharing
+
+services:
+  - name: cache
+    image: redis
+  - name: pgsql
+    image: postgres:10
+    environment:
+      POSTGRES_USER: oc_autotest
+      POSTGRES_DB: oc_autotest_dummy
+      POSTGRES_PASSWORD:
+    tmpfs:
+      - /var/lib/postgresql/data
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+#    - pull_request
+    - push
+
+---
+kind: pipeline
+name: int-pgsql-sharing-set-2
+
+steps:
+  - name: integration-sharing
+    image: nextcloudci/php7.1:php7.1-16
+    environment:
+      APP_NAME: spreed
+      CORE_BRANCH: master
+      DATABASEHOST: pgsql
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
+      - cd ../server
+      - ./occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
+
+      # Run integration tests
+      - cd tests/integration/
+      - bash run.sh --tags set-2 features/sharing
+
+services:
+  - name: cache
+    image: redis
+  - name: pgsql
+    image: postgres:10
+    environment:
+      POSTGRES_USER: oc_autotest
+      POSTGRES_DB: oc_autotest_dummy
+      POSTGRES_PASSWORD:
+    tmpfs:
+      - /var/lib/postgresql/data
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+#    - pull_request
+    - push
+
+---
+kind: pipeline
+name: int-pgsql-sharing-set-3
+
+steps:
+  - name: integration-sharing
+    image: nextcloudci/php7.1:php7.1-16
+    environment:
+      APP_NAME: spreed
+      CORE_BRANCH: master
+      DATABASEHOST: pgsql
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
+      - cd ../server
+      - ./occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
+
+      # Run integration tests
+      - cd tests/integration/
+      - bash run.sh --tags set-3 features/sharing
+
+services:
+  - name: cache
+    image: redis
+  - name: pgsql
+    image: postgres:10
+    environment:
+      POSTGRES_USER: oc_autotest
+      POSTGRES_DB: oc_autotest_dummy
+      POSTGRES_PASSWORD:
+    tmpfs:
+      - /var/lib/postgresql/data
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+#    - pull_request
+    - push
+
+---
+kind: pipeline
+name: int-pgsql-sharing-set-4
+
+steps:
+  - name: integration-sharing
+    image: nextcloudci/php7.1:php7.1-16
+    environment:
+      APP_NAME: spreed
+      CORE_BRANCH: master
+      DATABASEHOST: pgsql
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
+      - cd ../server
+      - ./occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
+
+      # Run integration tests
+      - cd tests/integration/
+      - bash run.sh --tags set-4 features/sharing
 
 services:
   - name: cache

--- a/tests/integration/features/sharing/create.feature
+++ b/tests/integration/features/sharing/create.feature
@@ -1,3 +1,4 @@
+@set-1
 Feature: create
 
   Background:

--- a/tests/integration/features/sharing/delete.feature
+++ b/tests/integration/features/sharing/delete.feature
@@ -1,3 +1,4 @@
+@set-1
 Feature: delete
 
   Background:

--- a/tests/integration/features/sharing/get.feature
+++ b/tests/integration/features/sharing/get.feature
@@ -1,3 +1,4 @@
+@set-2
 Feature: get
 
   Background:

--- a/tests/integration/features/sharing/hooks.feature
+++ b/tests/integration/features/sharing/hooks.feature
@@ -1,3 +1,4 @@
+@set-3
 Feature: hooks
 
   Background:

--- a/tests/integration/features/sharing/move.feature
+++ b/tests/integration/features/sharing/move.feature
@@ -1,3 +1,4 @@
+@set-3
 Feature: move
 
   Background:

--- a/tests/integration/features/sharing/restore.feature
+++ b/tests/integration/features/sharing/restore.feature
@@ -1,3 +1,4 @@
+@set-3
 Feature: delete
 
   Background:

--- a/tests/integration/features/sharing/sharees.feature
+++ b/tests/integration/features/sharing/sharees.feature
@@ -1,3 +1,4 @@
+@set-4
 Feature: sharees
   Background:
     Given user "participant1" exists

--- a/tests/integration/features/sharing/transfer-ownership.feature
+++ b/tests/integration/features/sharing/transfer-ownership.feature
@@ -1,3 +1,4 @@
+@set-4
 Feature: transfer-ownership
 
   Background:

--- a/tests/integration/features/sharing/update.feature
+++ b/tests/integration/features/sharing/update.feature
@@ -1,3 +1,4 @@
+@set-4
 Feature: update
 
   Background:

--- a/tests/integration/run-docker.sh
+++ b/tests/integration/run-docker.sh
@@ -251,6 +251,15 @@ if [ "$1" = "--database-image" ]; then
 	shift 2
 fi
 
+# "-- tags XXX" option can be provided to limit the tests run to those with the
+# given Behat tags.
+TAGS=""
+if [ "$1" = "--tags" ]; then
+	TAGS="--tags $2"
+
+	shift 2
+fi
+
 # If no parameter is provided to this script all the integration tests are run.
 SCENARIO_TO_RUN=$1
 
@@ -261,4 +270,4 @@ prepareDocker
 
 echo "Running tests"
 # --tty is needed to get colourful output.
-docker exec --tty $NEXTCLOUD_LOCAL_CONTAINER bash -c "cd nextcloud/apps/spreed/tests/integration && ./run.sh $SCENARIO_TO_RUN"
+docker exec --tty $NEXTCLOUD_LOCAL_CONTAINER bash -c "cd nextcloud/apps/spreed/tests/integration && ./run.sh $TAGS $SCENARIO_TO_RUN"

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -15,8 +15,17 @@ ${ROOT_DIR}/occ app:enable spreed
 ${ROOT_DIR}/occ app:enable spreedcheats
 ${ROOT_DIR}/occ app:list | grep spreed
 
+# "-- tags XXX" option can be provided to limit the tests run to those with the
+# given Behat tags.
+TAGS=""
+if [ "$1" = "--tags" ]; then
+	TAGS="--tags $2"
+
+	shift 2
+fi
+
 export TEST_SERVER_URL="http://localhost:8080/"
-${APP_INTEGRATION_DIR}/vendor/bin/behat -f junit -f pretty $1 $2
+${APP_INTEGRATION_DIR}/vendor/bin/behat -f junit -f pretty $TAGS $1 $2
 RESULT=$?
 
 kill $PHPPID


### PR DESCRIPTION
As the sharing integration tests take very long to run they usually time out in Drone, so they need to be split and run in smaller sets. To do this the feature files were tagged as `set-1`, `set-2`... and the Drone
pipeline that run all the sharing integration tests was split in several pipelines, each one running only one of the sets.
