### PR TITLE
make rename button always visible

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -726,7 +726,13 @@ input[type="password"] {
 			display: flex;
 			align-items: center;
 			.edit-button {
-				display: none;
+				opacity: .3;
+
+				&:hover,
+				&:focus,
+				&:active {
+					opacity: 1;
+				}
 
 				.icon {
 					background-color: transparent;
@@ -734,9 +740,6 @@ input[type="password"] {
 					padding: 13px 22px;
 					margin: 0;
 				}
-			}
-			&:hover .edit-button {
-				display: block;
 			}
 		}
 		.input-wrapper {


### PR DESCRIPTION
rename buttons for guest participants and rooms should always be visible (at least with opacity) to make their very existence more obvious