### PR TITLE
Fix joining call before joining room after forced reconnection with external signaling

### DIFF
--- a/js/signaling.js
+++ b/js/signaling.js
@@ -843,6 +843,7 @@
 			});
 		}
 		this.resumeId = null;
+		this.signalingRoomJoined = null;
 	};
 
 	OCA.Talk.Signaling.Standalone.prototype.disconnect = function() {

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -1057,10 +1057,13 @@
 		}.bind(this));
 	};
 
-	OCA.Talk.Signaling.Standalone.prototype.joinCall = function(token) {
+	OCA.Talk.Signaling.Standalone.prototype.joinCall = function(token, flags) {
 		if (this.signalingRoomJoined !== token) {
 			console.log("Not joined room yet, not joining call", token);
-			this.pendingJoinCall = token;
+			this.pendingJoinCall = {
+				token: token,
+				flags: flags
+			};
 			return;
 		}
 
@@ -1080,8 +1083,8 @@
 	OCA.Talk.Signaling.Standalone.prototype.joinResponseReceived = function(data, token) {
 		console.log("Joined", data, token);
 		this.signalingRoomJoined = token;
-		if (token === this.pendingJoinCall) {
-			this.joinCall(this.pendingJoinCall);
+		if (this.pendingJoinCall && token === this.pendingJoinCall.token) {
+			this.joinCall(this.pendingJoinCall.token, this.pendingJoinCall.flags);
 			this.pendingJoinCall = null;
 		}
 		if (this.roomCollection) {


### PR DESCRIPTION
The first commit is a follow up to 226d59a64403e8f9a399e6042e928316329ada11 to keep the call flags also after joining a pending call.

The second commit is the real fix to the issue (although it requires the first commit to properly keep the call flags).

When the external signaling server is used, [after successfully sending a `joinRoom` message to the Nextcloud server](https://github.com/nextcloud/spreed/blob/8d7a5e03513f9449da9b8062831ebfd8055b26ad/js/signaling.js#L236) a message [is sent too the external signaling server](https://github.com/nextcloud/spreed/blob/8d7a5e03513f9449da9b8062831ebfd8055b26ad/js/signaling.js#L1046); this registers the Nextcloud session in the signaling server, and is needed by the signaling server to be able to properly process further messages from that session.

Joining a call requires that the Nextcloud session is registered, so [`joinCall()` is queued until joining the room](https://github.com/nextcloud/spreed/blob/8d7a5e03513f9449da9b8062831ebfd8055b26ad/js/signaling.js#L1084) if called [before that](https://github.com/nextcloud/spreed/blob/8d7a5e03513f9449da9b8062831ebfd8055b26ad/js/signaling.js#L1062); whether the session is registered or not is tracked with `signalingRoomJoined`.

When a reconnection is forced the room is joined again and, if the participant was in a call, [the call is joined again](https://github.com/nextcloud/spreed/blob/8d7a5e03513f9449da9b8062831ebfd8055b26ad/js/signaling.js#L242). As the Nextcloud session changed the call should not be joined until the new session is registered again. However, as `signalingRoomJoined` was emptied only in `leaveRoom()` and this is not called in a forced reconnection [its value](https://github.com/nextcloud/spreed/blob/8d7a5e03513f9449da9b8062831ebfd8055b26ad/js/signaling.js#L1082) still matched the room token, so the call was immediately joined after a reconnection without properly waiting for the session to be registered. Due to this the external signaling server could received the message to join the call after or before the session was registered (depending on how fast the messages were sent and processed), and thus the call was properly joined or not depending on the case.

In the external signaling server the Nextcloud session is unregistered when the `bye` message is received, so for parallelism with that behaviour `signalingRoomJoined` is now emptied too when sending the `bye` message (instead of explicitly emptying it only for forced reconnections). @fancycode Please verify that this is the right place to do it.

## How to test
- Setup the MCU
- For easier and consistent testing, add a delay to [`this._joinRoomSuccess(token, result.ocs.data.sessionId);`](https://github.com/nextcloud/spreed/blob/8d7a5e03513f9449da9b8062831ebfd8055b26ad/js/signaling.js#L248) (just something like `setTimeout(function() { this._joinRoomSuccess... }.bind(this), 2000);`) so it is always executed after [`this.joinCall(token, this.currentCallFlags);`](https://github.com/nextcloud/spreed/blob/8d7a5e03513f9449da9b8062831ebfd8055b26ad/js/signaling.js#L243)
- Create a room and add four or more participants to it (so there are five or more participants including the owner)
- Start a call in the room
- With another user, join the call
- Enable video

### Results with this pull request
After some seconds the participant that enabled the video joins the call again and the other participant can see her

### Results without this pull request
The participant that enabled the video keeps waiting for the other participant to join the call again, and the other participant keeps waiting for the participant that enabled the video to join the call again
