### PR TITLE
Show warning when browser silently fails to get user media

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -986,8 +986,45 @@ var spreedPeerConnectionTable = [];
 			forceReconnect(signaling);
 		});
 
+		var localStreamRequestedTimeout = null;
+		var localStreamRequestedTimeoutNotification = null;
+
+		var clearLocalStreamRequestedTimeoutAndHideNotification = function() {
+			clearTimeout(localStreamRequestedTimeout);
+			localStreamRequestedTimeout = null;
+
+			if (localStreamRequestedTimeoutNotification) {
+				OC.Notification.hide(localStreamRequestedTimeoutNotification);
+				localStreamRequestedTimeoutNotification = null;
+			}
+		};
+
+		// In some cases the browser may enter in a faulty state in which
+		// "getUserMedia" does not return neither successfully nor with an
+		// error. It is not possible to detect this except by guessing when some
+		// time passes and the user has not granted nor rejected the media
+		// permissions.
+		OCA.SpreedMe.webrtc.on('localStreamRequested', function () {
+			clearLocalStreamRequestedTimeoutAndHideNotification();
+
+			localStreamRequestedTimeout = setTimeout(function() {
+				// FIXME emit an event and handle it as needed instead of
+				// calling UI code from here.
+				localStreamRequestedTimeoutNotification = OC.Notification.show(t('spreed', 'This is taking longer than expected. Are the media permissions already granted (or rejected)? If yes please restart your browser, as audio and video are failing'), { type: 'error' });
+			}, 10000);
+		});
+
+		signaling.on('leaveRoom', function(token) {
+			if (signaling.currentRoomToken === token) {
+				clearLocalStreamRequestedTimeoutAndHideNotification();
+			}
+		});
+
 		OCA.SpreedMe.webrtc.on('localMediaStarted', function (configuration) {
 			console.log('localMediaStarted');
+
+			clearLocalStreamRequestedTimeoutAndHideNotification();
+
 			app.startLocalMedia(configuration);
 			hasLocalMedia = true;
 			var signaling = OCA.SpreedMe.app.signaling;
@@ -998,6 +1035,9 @@ var spreedPeerConnectionTable = [];
 
 		OCA.SpreedMe.webrtc.on('localMediaError', function(error) {
 			console.log('Access to microphone & camera failed', error);
+
+			clearLocalStreamRequestedTimeoutAndHideNotification();
+
 			hasLocalMedia = false;
 			var message;
 			if ((error.name === "NotSupportedError" &&


### PR DESCRIPTION
In some cases the browser may enter in a faulty state in which [`getUserMedia`](https://github.com/nextcloud/spreed/blob/1145eaeb091f863fc3b96f6088151be891e27062/js/simplewebrtc/localmedia.js#L74) does not return neither successfully nor with an error. It is not possible to detect this except by guessing when some time passes and the user has not granted nor rejected the media permissions, so now a warning is shown to the user when that happens.

However, not having granted nor rejected the media permissions after some time does not guarantee that there is a problem; it could simply be that the user has not done it yet. Therefore, the warning is hidden if the media permissions are finally granted or rejected, or when joining the call has been interrupted (for example, due to changing to a different room).

How to test? Well, it is tricky :-P I do not know how to trigger the faulty state in the browser; sometimes happens, I have not seen any pattern. However I was "lucky" enough to have it while testing this and it works as expected ;-)

The other thing to test is that the message does not appear if the media permissions are granted or rejected, that it is hidden if the media permissions are granted or rejected after the message is shown, and that it is hidden (or not even shown if done fast enough) if changing to a different room while waiting for the media permissions to be granted or rejected.
