### PR TITLE
Fix message list not reloaded after being shown again

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -510,6 +510,11 @@
 				}
 
 				this._chatView.restoreScrollPosition();
+
+				// When the chat is attached again the message list needs to be
+				// reloaded to add the messages that could have been received
+				// while detached.
+				this._chatView.reloadMessageList();
 			}.bind(this));
 
 			// Opening or closing the sidebar changes the width of the main


### PR DESCRIPTION
Let me quote myself from [the documentation of _virtuallist.js_](https://github.com/nextcloud/spreed/blob/7277141a1ee34477655549af2904855e001343b6/js/views/virtuallist.js#L80-L82):
>  Adding new elements is still possible while the virtual list is hidden, but note that "reload()" must be explicitly called once the container is visible again for the added elements to be loaded.

During a call the chat is moved to a tab in the sidebar, and when a different tab is selected the previous one is detached (and, thus, hidden). Despite having written that documentation above I forgot to reload the message list when the chat tab is selected again :facepalm:

## How to test
- Open a conversation with user A
- Start a call
- If the chat does not have a scroll bar already write enough messages to make a scroll bar appear
- Open the participants tab
- Open the same conversation with user B
- Write something in the chat
- Open the chat tab again with user A

### Result with this pull request
Scrolling down shows the new messages (it is not autoscrolled because that is done only when the messages are added while the chat is visible, and it is not worth to add an exception to autoscroll in this case because it will be removed anyway when #1164 is implemented ;-) ).

### Result without this pull request
It is not possible to scroll down to see the new messages; writing new messages does not update the chat either (because [the new messages are not after the last loaded ones](https://github.com/nextcloud/spreed/blob/7277141a1ee34477655549af2904855e001343b6/js/views/virtuallist.js#L312-L314)).
