### PR TITLE
Fix view for participants without streams

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -438,6 +438,19 @@ var spreedPeerConnectionTable = [];
 				var videoView = new OCA.Talk.Views.VideoView({
 					peerId: id
 				});
+
+				// When the MCU is used and the other participant has no streams
+				// or when no MCU is used and neither the local participant nor
+				// the other one has no streams there will be no Peer for that
+				// other participant, so the VideoView status will not be
+				// modified later and thus it needs to be fully set now.
+				if ((signaling.hasFeature('mcu') && user && !userHasStreams(user)) ||
+						(!signaling.hasFeature('mcu') && user && !userHasStreams(user) && !hasLocalMedia)) {
+					videoView.setConnectionStatus(OCA.Talk.Views.VideoView.ConnectionStatus.COMPLETED);
+					videoView.setAudioAvailable(false);
+					videoView.setVideoAvailable(false);
+				}
+
 				videoView.setParticipant(userId);
 				videoView.setScreenAvailable(!!spreedListofSharedScreens[id]);
 


### PR DESCRIPTION
When the MCU is used if a participant has no audio nor video streams no peer connection will be created by that participant to send the streams to the MCU, and no peer connections will be created by the rest of the participants to receive the streams of that participant from the MCU. As a VideoView is created for every participant when they join the call and later updated once the peer connection is established the VideoView for participants without streams was always kept in its initial state. Now the VideoView is explicitly set to a "connected without streams" state as soon as it is created for participants without streams.

Note, however, that this shows the avatar and the "audio not available" icon, but it does not show the participant name (except a generic "Guest" for guests), as the participant name is updated through the data channel of the peer connection, so when the participant has no streams the nick is never updated nor even set. As explained in #1825 it is currently not possible to get the nick from the participant list instead of the data channel, so for the time being no nick can be shown in the view.

All the issues described above happen also if no MCU is used and both the local participant and the remote one have no streams; if the local participant or the remote one has any stream then a peer connection is created between them, even if the other participant has no stream.

## How to test (scenario 1)
- Setup the MCU
- Start a public call with a user rejecting media permissions
- Join that public call with a guest rejecting media permissions

### Result with this pull request

A ? avatar, "Guest" and the "audio not available" icon are shown for the guest in the user screen, and the user avatar (without name) and the "audio not available" icon are shown for the user in the guest screen.

### Result without this pull request

A dimmed ? avatar with a spinning icon is shown for the guest in the user screen, and a dimmed user avatar is shown for the user in the guest screen.



## How to test (scenario 2)
- Do not use the MCU
- Start a public call with a user rejecting media permissions
- Join that public call with a guest rejecting media permissions

### Result with this pull request

A ? avatar, "Guest" and the "audio not available" icon are shown for the guest in the user screen, and the user avatar (without name) and the "audio not available" icon are shown for the user in the guest screen.

### Result without this pull request

A dimmed ? avatar with a spinning icon is shown for the guest in the user screen, and a dimmed user avatar is shown for the user in the guest screen.



## How to test (scenario 3a)
- Do not use the MCU
- Start a public call with a user granting media permissions
- Join the room of that public call with a guest and set a name
- Join that public call with the guest rejecting media permissions

### Result with and without this pull request (it worked before, so there should be no changes)

Once the connection between the user and the guest is made, the avatar of the guest, the name and the "audio not available" icon are shown for the guest in the user screen.



## How to test (scenario 3b)
- Do not use the MCU
- Start a public call with a guest granting media permissions
- Join that public call with a user rejecting media permissions

### Result with and without this pull request (it worked before, so there should be no changes)

Once the connection between the user and the guest is made, the avatar of the guest, the name and the "audio not available" icon are shown for the user in the guest screen.
