### PR TITLE
Reconnect on all ICE failures when using the MCU

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -421,6 +421,56 @@ var spreedPeerConnectionTable = [];
 			OCA.SpreedMe.webrtc.sendDirectlyToAll(channel, message, payload);
 		};
 
+		var forceReconnect = function(signaling, flags) {
+			if (ownPeer) {
+				OCA.SpreedMe.webrtc.removePeers(ownPeer.id);
+				OCA.SpreedMe.speakers.remove(ownPeer.id, true);
+				OCA.SpreedMe.videos.remove(ownPeer.id);
+				delete spreedMappingTable[ownPeer.id];
+				ownPeer.end();
+				ownPeer = null;
+			}
+
+			usersChanged(signaling, [], previousUsersInRoom);
+			usersInCallMapping = {};
+			previousUsersInRoom = [];
+
+			// Reconnects with a new session id will trigger "usersChanged"
+			// with the users in the room and that will re-establish the
+			// peerconnection streams.
+			// If flags are undefined the current call flags are used.
+			signaling.forceReconnect(true, flags);
+		};
+
+		OCA.SpreedMe.webrtc.webrtc.on('videoOn', function () {
+			var signaling = OCA.SpreedMe.app.signaling;
+			if (signaling.getSendVideoIfAvailable()) {
+				return;
+			}
+
+			// When enabling the local video if the video is not being sent a
+			// reconnection is forced to start sending it.
+			signaling.setSendVideoIfAvailable(true);
+
+			var flags = signaling.getCurrentCallFlags();
+			flags |= OCA.SpreedMe.app.FLAG_WITH_VIDEO;
+
+			forceReconnect(signaling, flags);
+		});
+
+		OCA.SpreedMe.webrtc.webrtc.on('iceFailed', function (/* peer */) {
+			var signaling = OCA.SpreedMe.app.signaling;
+			if (!signaling.hasFeature("mcu")) {
+				// ICE restarts will be handled by "iceConnectionStateChange"
+				// above.
+				return;
+			}
+
+			// For now assume the connection to the MCU is interrupted on ICE
+			// failures and force a reconnection of all streams.
+			forceReconnect(signaling);
+		});
+
 		OCA.SpreedMe.videos = {
 			videoViews: [],
 			add: function(id) {
@@ -947,56 +997,6 @@ var spreedPeerConnectionTable = [];
 
 		OCA.SpreedMe.webrtc.on('localScreenStopped', function() {
 			app.disableScreensharingButton();
-		});
-
-		var forceReconnect = function(signaling, flags) {
-			if (ownPeer) {
-				OCA.SpreedMe.webrtc.removePeers(ownPeer.id);
-				OCA.SpreedMe.speakers.remove(ownPeer.id, true);
-				OCA.SpreedMe.videos.remove(ownPeer.id);
-				delete spreedMappingTable[ownPeer.id];
-				ownPeer.end();
-				ownPeer = null;
-			}
-
-			usersChanged(signaling, [], previousUsersInRoom);
-			usersInCallMapping = {};
-			previousUsersInRoom = [];
-
-			// Reconnects with a new session id will trigger "usersChanged"
-			// with the users in the room and that will re-establish the
-			// peerconnection streams.
-			// If flags are undefined the current call flags are used.
-			signaling.forceReconnect(true, flags);
-		};
-
-		OCA.SpreedMe.webrtc.webrtc.on('videoOn', function () {
-			var signaling = OCA.SpreedMe.app.signaling;
-			if (signaling.getSendVideoIfAvailable()) {
-				return;
-			}
-
-			// When enabling the local video if the video is not being sent a
-			// reconnection is forced to start sending it.
-			signaling.setSendVideoIfAvailable(true);
-
-			var flags = signaling.getCurrentCallFlags();
-			flags |= OCA.SpreedMe.app.FLAG_WITH_VIDEO;
-
-			forceReconnect(signaling, flags);
-		});
-
-		OCA.SpreedMe.webrtc.webrtc.on('iceFailed', function (/* peer */) {
-			var signaling = OCA.SpreedMe.app.signaling;
-			if (!signaling.hasFeature("mcu")) {
-				// ICE restarts will be handled by "iceConnectionStateChange"
-				// above.
-				return;
-			}
-
-			// For now assume the connection to the MCU is interrupted on ICE
-			// failures and force a reconnection of all streams.
-			forceReconnect(signaling);
 		});
 
 		var localStreamRequestedTimeout = null;


### PR DESCRIPTION
Until now, when using the MCU, reconnections only happened when [the connection failed for the peer that sent the offer](https://github.com/nextcloud/spreed/blob/9c0bbf7a4d657991fe6cc018c3d31f28de2b40a8/js/simplewebrtc/peer.js#L53-L54), that is, for [the own peer object that sends the media to the MCU](https://github.com/nextcloud/spreed/blob/9c0bbf7a4d657991fe6cc018c3d31f28de2b40a8/js/webrtc.js#L109); if the connection failed on any of the other peers ([those that receive the media from the MCU](https://github.com/nextcloud/spreed/blob/9c0bbf7a4d657991fe6cc018c3d31f28de2b40a8/js/webrtc.js#L198)) there was no reconnection.

In some cases it could happen that one of the connections to the MCU to receive the media from another participant failed while the other connections to receive the media as well as the connection to send it were kept connected. In that case the participant would still be in the call, but she would not be able to hear or see the other participant. To prevent this now reconnections are forced on any ICE failures when using the MCU.

Note that this does not lead to any glare issues (two peers sending an offer to each other), as when the MCU is used peers only send their own offer to the MCU and receive offers for the rest of the peers from the MCU.

All of the above applies only when the MCU is used; when the MCU is not used the unconditional reconnection can not be applied (due to the glare issues), so [reconnections when the MCU is not used still need to be fixed](https://github.com/nextcloud/spreed/blob/9c0bbf7a4d657991fe6cc018c3d31f28de2b40a8/js/webrtc.js#L560-L561).