### PR TITLE
[stable16] Bump 6.0.2 version also in "package.json" and "package-lock.json" files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spreed",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spreed",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "",
   "main": " ",
   "repository": {

--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spreed",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vue/package.json
+++ b/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spreed",
   "description": "",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "author": "Joas Schilling <coding@schilljs.com>",
   "license": "agpl",
   "private": true,


### PR DESCRIPTION
Follow up to #1890 
