### PR TITLE
Fix message dates in public share authentication page

### DIFF
--- a/css/publicshareauth.scss
+++ b/css/publicshareauth.scss
@@ -216,6 +216,12 @@ input#request-password-button:disabled ~ .icon {
 	margin-top: 0;
 }
 
+#talk-sidebar #chatView .comments .message {
+	/* The messages are left padded, but they also use "width: calc(100%...", so
+	 * the padding should be included in the full width of the element. */
+	box-sizing: border-box;
+}
+
 #talk-sidebar #chatView .newCommentForm.with-add-button {
 	/* Make room to show the "Add" button if needed. */
 	margin-right: 44px;


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/nextcloud/spreed/pull/1807

The chat messages are expected to have the full width of its content row, except for some space used for the date. However, as [chat messages are left padded](https://github.com/nextcloud/spreed/blob/a54b5b688c23ffdeb65b41f585c4c13a5d21dc13/css/chatview.scss#L220) that padding must be included too in the width; otherwise there could be no room for the date.

This is only a problem in the public share authentication page, as [apps use by default `box-sizing: border-box` in all its elements](https://github.com/nextcloud/server/blob/3c30d293fa1d52ff51581091e3d39a30ac7474d3/core/css/apps.scss#L74-L76).

**Before:**
![PublicShareAuth-Message-Dates-Before](https://user-images.githubusercontent.com/26858233/59289885-79902f00-8c77-11e9-8eac-fba4a4469f7e.png)

**After:**
![PublicShareAuth-Message-Dates-After](https://user-images.githubusercontent.com/26858233/59289900-801ea680-8c77-11e9-8f2f-b65c205fda7c.png)
