### PR TITLE
Do not add left padding to system messages

### DIFF
--- a/css/chatview.scss
+++ b/css/chatview.scss
@@ -217,9 +217,12 @@ body:not(#body-public) #chatView .comment .authorRow:not(.currentUser):not(.gues
 }
 
 #chatView .comments li .message {
-	padding-left: 40px;
 	display: inline-block;
 	width: calc(100% - 80px);
+}
+
+#chatView .comments li:not(.systemMessage) .message {
+	padding-left: 40px;
 }
 
 #chatView .comment .action {

--- a/css/chatview.scss
+++ b/css/chatview.scss
@@ -216,7 +216,7 @@ body:not(#body-public) #chatView .comment .authorRow:not(.currentUser):not(.gues
 	display: none;
 }
 
-#chatView .comments:not(.systemMessage) li .message {
+#chatView .comments li .message {
 	padding-left: 40px;
 	display: inline-block;
 	width: calc(100% - 80px);


### PR DESCRIPTION
Follow up to #1807 

The first commit fixes the CSS selector introduced in #1807, as the `not` CSS pseudo-class always matched (because `.systemMessage` is set on `.comment` elements but not on `.comments` elements) and thus was not needed.

The second commit removes the left padding from system messages, as based on the changes from #1807 (specifically, [a54b5b68](https://github.com/nextcloud/spreed/pull/1807/commits/a54b5b688c23ffdeb65b41f585c4c13a5d21dc13#diff-08b9df88f30d00395d664617e4f322c4R219)) one of the _intents_ of the change seemed to be that, although the CSS selector was not properly set. I can not assure it as it was not documented nor mentioned anywhere, though, it is just an assumption.

**Before:**
![System-Messages-Padding-Before](https://user-images.githubusercontent.com/26858233/59290142-2cf92380-8c78-11e9-8c9e-909f198cb796.png)

**After:**
![System-Messages-Padding-After](https://user-images.githubusercontent.com/26858233/59290149-2f5b7d80-8c78-11e9-8295-e8cc38bd7a78.png)
