### PR TITLE
Support symfony command lines with --help

### DIFF
--- a/lib/Chat/Command/Executor.php
+++ b/lib/Chat/Command/Executor.php
@@ -120,7 +120,16 @@ class Executor {
 
 			$response = trim($response);
 			if (strpos($response, "\n")) {
-				$helps[] = substr($response, 0, strpos($response, "\n"));
+				$tempHelp = substr($response, 0, strpos($response, "\n"));
+				if ($tempHelp === 'Description:') {
+					$hasHelpSection = strpos($response, "\nHelp:\n");
+					if ($hasHelpSection !== false) {
+						// Symfony console command with --help detected
+						$tempHelp = substr($response, $hasHelpSection + 7);
+						$tempHelp = substr($tempHelp, 0, strpos($tempHelp, "\n"));
+					}
+				}
+				$helps[] = $tempHelp;
 			} else {
 				$helps[] = $response;
 			}
@@ -139,7 +148,17 @@ class Executor {
 			$input = explode(' ', $arguments, 2);
 			if (count($input) === 1) {
 				$command = $this->commandService->find('', $arguments);
-				return $this->execShell($room, $message, $command, '--help');
+				$response = $this->execShell($room, $message, $command, '--help');
+
+				if (strpos($response, 'Description:') === 0) {
+					$hasHelpSection = strpos($response, "\nHelp:\n");
+					if ($hasHelpSection !== false) {
+						// Symfony console command with --help detected
+						$response = substr($response, $hasHelpSection + 7);
+					}
+				}
+
+				return $response;
 			}
 
 			[$app, $cmd] = $input;


### PR DESCRIPTION
Required for commands which use `occ` themselves ( https://github.com/nickv-nextcloud/talk_simple_poll/issues/5 ), so the help is correctly detected in the `--help` output of symfony commands:

```
Description:
  Simple polls for Nextcloud Talk

Usage:
  talk:poll <token> <userId> <payload>

Arguments:
  token                 
  userId                
  payload               

Options:
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
      --no-warnings     Skip global warnings, show command output only
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  /poll - Simple polls for Nextcloud Talk
  			
  Start a poll by sending a message with /poll and your question in the first line
  and each possible answer in a follow up line, e.g.:
      /poll When should we leave?
      1pm
      2pm
      3pm
      4pm
  
  To close a running poll send a message with:
      /poll close

```