### PR TITLE
Allow longer chat messages

### DIFF
--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -583,7 +583,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         + `201 Created`
         + `400 Bad Request` In case of any other error
         + `404 Not Found` When the conversation could not be found for the participant
-        + `413 Payload Too Large` When the message was longer than the allowed limit of 1000 characters
+        + `413 Payload Too Large` When the message was longer than the allowed limit of 32000 characters (or 1000 until Nextcloud 16.0.1, check the `spreed => config => chat => max-length` capability for the limit)
 
     - Data:
         The full message array of the new message, as defined in [Receive chat messages of a conversation](#receive-chat-messages-of-a-conversation)

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -45,6 +45,8 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class ChatManager {
 
+	public const MAX_CHAT_LENGTH = 32000;
+
 	/** @var CommentsManager|ICommentsManager */
 	private $commentsManager;
 	/** @var EventDispatcherInterface */
@@ -77,7 +79,7 @@ class ChatManager {
 	 */
 	public function addSystemMessage(Room $chat, string $actorType, string $actorId, string $message, \DateTime $creationDateTime, bool $sendNotifications): IComment {
 		$comment = $this->commentsManager->create($actorType, $actorId, 'chat', (string) $chat->getId());
-		$comment->setMessage($message);
+		$comment->setMessage($message, self::MAX_CHAT_LENGTH);
 		$comment->setCreationDateTime($creationDateTime);
 		$comment->setVerb('system');
 		try {
@@ -108,7 +110,8 @@ class ChatManager {
 	 */
 	public function addChangelogMessage(Room $chat, string $message): IComment {
 		$comment = $this->commentsManager->create('guests', 'changelog', 'chat', (string) $chat->getId());
-		$comment->setMessage($message);
+
+		$comment->setMessage($message, self::MAX_CHAT_LENGTH);
 		$comment->setCreationDateTime($this->timeFactory->getDateTime());
 		$comment->setVerb('comment'); // Has to be comment, so it counts as unread message
 
@@ -140,7 +143,7 @@ class ChatManager {
 	 */
 	public function sendMessage(Room $chat, Participant $participant, string $actorType, string $actorId, string $message, \DateTime $creationDateTime): IComment {
 		$comment = $this->commentsManager->create($actorType, $actorId, 'chat', (string) $chat->getId());
-		$comment->setMessage($message);
+		$comment->setMessage($message, self::MAX_CHAT_LENGTH);
 		$comment->setCreationDateTime($creationDateTime);
 		// A verb ('comment', 'like'...) must be provided to be able to save a
 		// comment

--- a/lib/Chat/Command/Executor.php
+++ b/lib/Chat/Command/Executor.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace OCA\Spreed\Chat\Command;
 
 
+use OCA\Spreed\Chat\ChatManager;
 use OCA\Spreed\Model\Command;
 use OCA\Spreed\Room;
 use OCA\Spreed\Service\CommandService;
@@ -76,7 +77,7 @@ class Executor {
 				'user' => $user,
 				'visibility' => $command->getResponse(),
 				'output' => $e->getMessage(),
-			]));
+			]), ChatManager::MAX_CHAT_LENGTH);
 			$message->setActor('bots', $command->getName());
 			$message->setVerb('command');
 			return;
@@ -95,7 +96,7 @@ class Executor {
 			'user' => $user,
 			'visibility' => $command->getResponse(),
 			'output' => $output,
-		]));
+		]), ChatManager::MAX_CHAT_LENGTH);
 		$message->setActor('bots', $command->getName());
 		$message->setVerb('command');
 	}

--- a/lib/Chat/CommentsManager.php
+++ b/lib/Chat/CommentsManager.php
@@ -52,7 +52,11 @@ class CommentsManager extends Manager {
 	 * @return IComment
 	 */
 	public function getCommentFromData(array $data): IComment {
-		return new Comment($this->normalizeDatabaseData($data));
+		$message = $data['message'];
+		unset($data['message']);
+		$comment = new Comment($this->normalizeDatabaseData($data));
+		$comment->setMessage($message, ChatManager::MAX_CHAT_LENGTH);
+		return $comment;
 	}
 
 	/**

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace OCA\Spreed\Chat\Parser;
 
 
+use OCA\Spreed\Chat\ChatManager;
 use OCA\Spreed\Exceptions\ParticipantNotFoundException;
 use OCA\Spreed\GuestManager;
 use OCA\Spreed\Model\Message;
@@ -234,7 +235,7 @@ class SystemMessage {
 			throw new \OutOfBoundsException('Unknown subject');
 		}
 
-		$comment->setMessage($message);
+		$comment->setMessage($message, ChatManager::MAX_CHAT_LENGTH);
 		$chatMessage->setMessage($parsedMessage, $parsedParameters);
 	}
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -146,7 +146,7 @@ class Notifier implements INotifier {
 			}
 			return $this->parseCall($notification, $room, $l);
 		}
-		if ($subject === 'mention' ||  $subject === 'chat') {
+		if ($subject === 'mention' || $subject === 'chat') {
 			return $this->parseChatMessage($notification, $room, $participant, $l);
 		}
 


### PR DESCRIPTION
Requires https://github.com/nextcloud/server/pull/16088

New max length in Talk is 32.000 chars, @Ivansss @mario are you checking the size, do we need to expose it with a capability?

Fix #1906 