### PR TITLE
Only react to shortcuts which can be used and make sense

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -231,6 +231,13 @@
 				$('div[contenteditable=true]:focus').length === 0 &&
 				!event.ctrlKey) {
 
+				// When not in a call, only the f-shortcut is visible and can be used
+				var flags = this.activeRoom.get('participantFlags') || 0;
+				var inCall = (flags & OCA.SpreedMe.app.FLAG_IN_CALL) !== 0;
+				if (!inCall && key !== 70) {
+					return;
+				}
+
 				// Actual shortcut handling
 				switch (key) {
 					case 86: // 'v'


### PR DESCRIPTION
It makes no sense to listen to any other shortcuts apart from **F** because they don't change anything in the chat