### PR TITLE
Use shared Browserslist config

### DIFF
--- a/js/simplewebrtc/bundled.js
+++ b/js/simplewebrtc/bundled.js
@@ -17,7 +17,7 @@ var getUserMedia = function getUserMedia(constraints, callback) {
 
   window.navigator.mediaDevices.getUserMedia(constraints).then(function (stream) {
     callback(null, stream);
-  })["catch"](function (error) {
+  }).catch(function (error) {
     callback(error, null);
   });
 }; // cache for constraints and callback
@@ -41,7 +41,7 @@ module.exports = function (mode, constraints, cb) {
       video: true
     }).then(function (stream) {
       callback(null, stream);
-    })["catch"](function (error) {
+    }).catch(function (error) {
       callback(error, null);
     });
   } else if (navigator.webkitGetUserMedia) {
@@ -327,7 +327,7 @@ LocalMedia.prototype.start = function (mediaConstraints, cb) {
     if (cb) {
       return cb(null, stream);
     }
-  })["catch"](function (err) {
+  }).catch(function (err) {
     // Fallback for users without a camera
     if (self.config.audioFallback && err.name === 'NotFoundError' && constraints.video !== false) {
       constraints.video = false;
@@ -705,10 +705,10 @@ Peer.prototype.offer = function (options) {
       }
 
       this.send('offer', offer);
-    }.bind(this))["catch"](function (error) {
+    }.bind(this)).catch(function (error) {
       console.warn("setLocalDescription for offer failed: ", error);
     }.bind(this));
-  }.bind(this))["catch"](function (error) {
+  }.bind(this)).catch(function (error) {
     console.warn("createOffer failed: ", error);
   }.bind(this));
 };
@@ -716,7 +716,7 @@ Peer.prototype.offer = function (options) {
 Peer.prototype.handleOffer = function (offer) {
   this.pc.setRemoteDescription(offer).then(function () {
     this.answer();
-  }.bind(this))["catch"](function (error) {
+  }.bind(this)).catch(function (error) {
     console.warn("setRemoteDescription for offer failed: ", error);
   }.bind(this));
 };
@@ -736,16 +736,16 @@ Peer.prototype.answer = function () {
       }
 
       this.send('answer', answer);
-    }.bind(this))["catch"](function (error) {
+    }.bind(this)).catch(function (error) {
       console.warn("setLocalDescription for answer failed: ", error);
     }.bind(this));
-  }.bind(this))["catch"](function (error) {
+  }.bind(this)).catch(function (error) {
     console.warn("createAnswer failed: ", error);
   }.bind(this));
 };
 
 Peer.prototype.handleAnswer = function (answer) {
-  this.pc.setRemoteDescription(answer)["catch"](function (error) {
+  this.pc.setRemoteDescription(answer).catch(function (error) {
     console.warn("setRemoteDescription for answer failed: ", error);
   }.bind(this));
 };
@@ -3698,11 +3698,11 @@ module.exports = function (window, edgeVersion) {
               });
               stream = streams[remoteMsid.stream];
             } else {
-              if (!streams["default"]) {
-                streams["default"] = new window.MediaStream();
+              if (!streams.default) {
+                streams.default = new window.MediaStream();
               }
 
-              stream = streams["default"];
+              stream = streams.default;
             }
 
             if (stream) {
@@ -3791,12 +3791,12 @@ module.exports = function (window, edgeVersion) {
             addTrackToStreamAndFireEvent(track, streams[remoteMsid.stream]);
             receiverList.push([track, rtpReceiver, streams[remoteMsid.stream]]);
           } else {
-            if (!streams["default"]) {
-              streams["default"] = new window.MediaStream();
+            if (!streams.default) {
+              streams.default = new window.MediaStream();
             }
 
-            addTrackToStreamAndFireEvent(track, streams["default"]);
-            receiverList.push([track, rtpReceiver, streams["default"]]);
+            addTrackToStreamAndFireEvent(track, streams.default);
+            receiverList.push([track, rtpReceiver, streams.default]);
           }
         } else {
           // FIXME: actually the receiver should be created later.
@@ -3950,7 +3950,7 @@ module.exports = function (window, edgeVersion) {
       newState = 'checking';
     } else if (states.disconnected > 0) {
       newState = 'disconnected';
-    } else if (states["new"] > 0) {
+    } else if (states.new > 0) {
       newState = 'new';
     } else if (states.connected > 0) {
       newState = 'connected';
@@ -3994,7 +3994,7 @@ module.exports = function (window, edgeVersion) {
       newState = 'connecting';
     } else if (states.disconnected > 0) {
       newState = 'disconnected';
-    } else if (states["new"] > 0) {
+    } else if (states.new > 0) {
       newState = 'new';
     } else if (states.connected > 0) {
       newState = 'connected';
@@ -5250,7 +5250,7 @@ var safariShim = _interopRequireWildcard(require("./safari/safari_shim"));
 
 var commonShim = _interopRequireWildcard(require("./common_shim"));
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
 
 /*
  *  Copyright (c) 2016 The WebRTC project authors. All Rights Reserved.
@@ -5421,7 +5421,7 @@ var _getusermedia = require("./getusermedia");
 
 var _getdisplaymedia = require("./getdisplaymedia");
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -6288,7 +6288,7 @@ exports.shimGetUserMedia = shimGetUserMedia;
 
 var utils = _interopRequireWildcard(require("../utils.js"));
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -6531,9 +6531,9 @@ var _sdp = _interopRequireDefault(require("sdp"));
 
 var utils = _interopRequireWildcard(require("./utils"));
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -6557,7 +6557,7 @@ function shimRTCIceCandidate(window) {
       // Augment the native candidate with the parsed fields.
       var nativeCandidate = new NativeRTCIceCandidate(args);
 
-      var parsedCandidate = _sdp["default"].parseCandidate(args.candidate);
+      var parsedCandidate = _sdp.default.parseCandidate(args.candidate);
 
       var augmentedCandidate = Object.assign(nativeCandidate, parsedCandidate); // Add a serializer that does not serialize the extra attributes.
 
@@ -6611,11 +6611,11 @@ function shimMaxMessageSize(window) {
       return false;
     }
 
-    var sections = _sdp["default"].splitSections(description.sdp);
+    var sections = _sdp.default.splitSections(description.sdp);
 
     sections.shift();
     return sections.some(function (mediaSection) {
-      var mLine = _sdp["default"].parseMLine(mediaSection);
+      var mLine = _sdp.default.parseMLine(mediaSection);
 
       return mLine && mLine.kind === 'application' && mLine.protocol.indexOf('SCTP') !== -1;
     });
@@ -6678,7 +6678,7 @@ function shimMaxMessageSize(window) {
       maxMessageSize = 65535;
     }
 
-    var match = _sdp["default"].matchPrefix(description.sdp, 'a=max-message-size:');
+    var match = _sdp.default.matchPrefix(description.sdp, 'a=max-message-size:');
 
     if (match.length > 0) {
       maxMessageSize = parseInt(match[0].substr(19), 10);
@@ -6898,9 +6898,9 @@ var _getusermedia = require("./getusermedia");
 
 var _getdisplaymedia = require("./getdisplaymedia");
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
 
 function shimPeerConnection(window) {
   var browserDetails = utils.detectBrowser(window);
@@ -6958,7 +6958,7 @@ function shimPeerConnection(window) {
     window.RTCDTMFSender = window.RTCDtmfSender;
   }
 
-  var RTCPeerConnectionShim = (0, _rtcpeerconnectionShim["default"])(window, browserDetails.version);
+  var RTCPeerConnectionShim = (0, _rtcpeerconnectionShim.default)(window, browserDetails.version);
 
   window.RTCPeerConnection = function (config) {
     if (config && config.iceServers) {
@@ -6998,7 +6998,7 @@ exports.filterIceServers = filterIceServers;
 
 var utils = _interopRequireWildcard(require("../utils"));
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
 
 // Edge does not like
 // 1) stun: filtered after 14393 unless ?transport=udp is present
@@ -7114,7 +7114,7 @@ function shimGetUserMedia(window) {
   var origGetUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
 
   navigator.mediaDevices.getUserMedia = function (c) {
-    return origGetUserMedia(c)["catch"](function (e) {
+    return origGetUserMedia(c).catch(function (e) {
       return Promise.reject(shimError_(e));
     });
   };
@@ -7160,7 +7160,7 @@ var _getusermedia = require("./getusermedia");
 
 var _getdisplaymedia = require("./getdisplaymedia");
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -7414,7 +7414,7 @@ exports.shimGetUserMedia = shimGetUserMedia;
 
 var utils = _interopRequireWildcard(require("../utils"));
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -7500,7 +7500,7 @@ exports.shimCreateOfferLegacy = shimCreateOfferLegacy;
 
 var utils = _interopRequireWildcard(require("../utils"));
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1086,6 +1086,12 @@
         "node-releases": "^1.1.23"
       }
     },
+    "browserslist-config-nextcloud": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/browserslist-config-nextcloud/-/browserslist-config-nextcloud-0.0.1.tgz",
+      "integrity": "sha512-BUpPPPfE42jL2puSqfnsoOMoz6g+jqznoaoZmig4Kx1ULApBmM6iH+/7V1yblQz2PsOp39HET1byAB3h3h+kew==",
+      "dev": true
+    },
     "buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "attachmediastream": "^2.1.0",
     "babelify": "^10.0.0",
     "browserify": "^16.2.3",
+    "browserslist-config-nextcloud": "0.0.1",
     "handlebars": "^4.1.2",
     "hark": "^1.2.3",
     "mockconsole": "0.0.1",
@@ -22,5 +23,8 @@
     "webrtc-adapter": "^7.2.4",
     "webrtcsupport": "^2.2.0",
     "wildemitter": "^1.2.1"
-  }
+  },
+  "browserslist": [
+    "extends browserslist-config-nextcloud"
+  ]
 }

--- a/vue/.babelrc.js
+++ b/vue/.babelrc.js
@@ -2,12 +2,7 @@ module.exports = {
 	plugins: ['@babel/plugin-syntax-dynamic-import'],
 	presets: [
 		[
-			'@babel/preset-env',
-			{
-				targets: {
-					browsers: ['last 2 versions', 'ie >= 11']
-				}
-			}
+			'@babel/preset-env'
 		]
 	]
 }

--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -2006,6 +2006,12 @@
         "node-releases": "^1.1.19"
       }
     },
+    "browserslist-config-nextcloud": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/browserslist-config-nextcloud/-/browserslist-config-nextcloud-0.0.1.tgz",
+      "integrity": "sha512-BUpPPPfE42jL2puSqfnsoOMoz6g+jqznoaoZmig4Kx1ULApBmM6iH+/7V1yblQz2PsOp39HET1byAB3h3h+kew==",
+      "dev": true
+    },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",

--- a/vue/package.json
+++ b/vue/package.json
@@ -23,8 +23,7 @@
     "vuex": "^3.1.1"
   },
   "browserslist": [
-    "last 2 versions",
-    "ie >= 11"
+    "extends browserslist-config-nextcloud"
   ],
   "devDependencies": {
     "@babel/core": "^7.4.5",
@@ -32,6 +31,7 @@
     "@babel/preset-env": "^7.4.5",
     "babel-eslint": "^10.0.2",
     "babel-loader": "^8.0.6",
+    "browserslist-config-nextcloud": "0.0.1",
     "css-loader": "^3.0.0",
     "eslint": "^5.16.0",
     "eslint-config-standard": "^12.0.0",


### PR DESCRIPTION
See nextcloud/server#15988

The target browsers used by Babel are now got from `browserslist-config-nextcloud`, which will automatically keep them in sync with the server.

This also makes possible to bundle SimpleWebRTC again in Talk when the _spreed_ directory is a child of the server directory of Nextcloud. This was failing since nextcloud/server#15988 was merged because Babel gets the target browsers from the Browserslist configuration, which in turn was read from _package.json_ in the server directory (as [Browserslist uses the `browserslist`key in the _package.json_ in current or parent directories](https://www.npmjs.com/package/browserslist#queries)). However, as `browserslist-config-nextcloud` was not a development dependency of Talk it was not available in _node_modules_, Babel could not find it and the bundling failed.
