### PR TITLE
Prevent unwanted clickables for file names and others

### DIFF
--- a/css/chatview.scss
+++ b/css/chatview.scss
@@ -369,3 +369,7 @@ body:not(#body-public) #chatView .comment:not(.newCommentRow) .message .mention-
 	 * force it to be on its own line below the preview. */
 	display: block;
 }
+
+#chatView .comment .message .external:after {
+	content: " ↗";
+}

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -452,12 +452,19 @@
 		},
 
 		_plainToRich: function(message) {
-			var urlRegex = /(\s|^)(https?:\/\/)?((?:[-A-Z0-9+_]+\.)+[-A-Z]+(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*)(\s|$)/ig;
+			/**
+			 * In Talk we only parse URLs with a protocol to avoid undesired
+			 * clickables like composer.json. Therefor the method and regex were
+			 * copied from OCP.Comments and adjusted accordingly.
+			 */
+			// var urlRegex = /(\s|^)(https?:\/\/)?((?:[-A-Z0-9+_]+\.)+[-A-Z]+(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*)(\s|$)/ig;
+			var urlRegex = /(\s|^)(https?:\/\/)((?:[-A-Z0-9+_]+\.)+[-A-Z]+(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*)(\s|$)/ig;
 			return message.replace(urlRegex, function (_, leadingSpace, protocol, url, trailingSpace) {
 				var linkText = url;
-				if (!protocol) {
-					protocol = 'https://';
-				} else if (protocol === 'http://') {
+				// if (!protocol) {
+				// 	protocol = 'https://';
+				// } else
+				if (protocol === 'http://') {
 					linkText = protocol + url;
 				}
 

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -460,6 +460,10 @@
 			// var urlRegex = /(\s|^)(https?:\/\/)?((?:[-A-Z0-9+_]+\.)+[-A-Z]+(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*)(\s|$)/ig;
 			var urlRegex = /(\s|^)(https?:\/\/)((?:[-A-Z0-9+_]+\.)+[-A-Z]+(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*)(\s|$)/ig;
 			return message.replace(urlRegex, function (_, leadingSpace, protocol, url, trailingSpace) {
+				if (url.substr(-1) === ')' && url.indexOf('(') === -1) {
+					url = url.substr(0, url.length - 1);
+					trailingSpace = ')' + trailingSpace;
+				}
 				var linkText = url;
 				// if (!protocol) {
 				// 	protocol = 'https://';

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -435,7 +435,7 @@
 			}
 
 			var formattedMessage = escapeHTML(commentModel.get('message'));
-			formattedMessage = OCP.Comments.plainToRich(formattedMessage);
+			formattedMessage = this._plainToRich(formattedMessage);
 			formattedMessage = formattedMessage.replace(/\n/g, '<br/>');
 			formattedMessage = OCA.SpreedMe.Views.RichObjectStringParser.parseMessage(
 				formattedMessage, commentModel.get('messageParameters'));
@@ -449,6 +449,20 @@
 				formattedMessage: formattedMessage
 			});
 			return data;
+		},
+
+		_plainToRich: function(message) {
+			var urlRegex = /(\s|^)(https?:\/\/)?((?:[-A-Z0-9+_]+\.)+[-A-Z]+(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*)(\s|$)/ig;
+			return message.replace(urlRegex, function (_, leadingSpace, protocol, url, trailingSpace) {
+				var linkText = url;
+				if (!protocol) {
+					protocol = 'https://';
+				} else if (protocol === 'http://') {
+					linkText = protocol + url;
+				}
+
+				return leadingSpace + '<a class="external" target="_blank" rel="noopener noreferrer" href="' + protocol + url + '">' + linkText + '</a>' + trailingSpace;
+			});
 		},
 
 		_onAddModelStart: function() {


### PR DESCRIPTION
In Talk we only parse URLs with a protocol to avoid undesired clickables like composer.json
Therefor the method and regex were copied from OCP.Comments and adjusted accordingly.

* `composer.json` => not clickable :heavy_check_mark: 
* `https://nextcloud.com/` => clickable as `nextcloud.com/` :heavy_check_mark: 
* `http://nextcloud.com/` => clickable as `http://nextcloud.com/`:heavy_check_mark: 
* `(see http://nextcloud.com/)` => clickable as `http://nextcloud.com/` :heavy_check_mark: 
* `https://en.wikipedia.org/wiki/Android_(OS)` => clickable as `https://en.wikipedia.org/wiki/Android_(OS)` :heavy_check_mark: 

cc @blizzz up to you, if we copy the behaviour back to the comments API.
