### PR TITLE
Update VideoView on ICE disconnected/failed with MCU

### DIFF
--- a/css/video.scss
+++ b/css/video.scss
@@ -60,6 +60,13 @@ video {
 	filter: none;
 }
 
+#videos .videoContainer.not-connected {
+	video,
+	.avatar {
+		opacity: 0.5;
+	}
+}
+
 #videos .videoContainer:not(.promoted) video {
 	max-height: 200px;
 	max-width: 100%;
@@ -70,10 +77,6 @@ video {
 
 #videos .videoContainer .avatar {
 	box-shadow: 0 0 15px $color-box-shadow;
-}
-
-#videos .videoContainer .avatar.not-connected {
-	opacity: 0.5;
 }
 
 .participants-1 #videos .videoContainer video,

--- a/css/video.scss
+++ b/css/video.scss
@@ -72,6 +72,10 @@ video {
 	box-shadow: 0 0 15px $color-box-shadow;
 }
 
+#videos .videoContainer .avatar.not-connected {
+	opacity: 0.5;
+}
+
 .participants-1 #videos .videoContainer video,
 .participants-2 #videos .videoContainer video {
 	padding: 0;

--- a/js/views/videoview.js
+++ b/js/views/videoview.js
@@ -81,7 +81,7 @@
 			this.render();
 
 			this.getUI('avatar').addClass('icon-loading');
-			this.getUI('avatar').css('opacity', '0.5');
+			this.getUI('avatar').addClass('not-connected');
 
 			this.getUI('hideRemoteVideoButton').attr('data-original-title', t('spreed', 'Disable video'));
 			this.getUI('hideRemoteVideoButton').addClass('hidden');
@@ -146,6 +146,7 @@
 			this._connectionStatus = connectionStatus;
 
 			this.getUI('avatar').removeClass('icon-loading');
+			this.getUI('avatar').addClass('not-connected');
 			this.getUI('iceFailedIndicator').addClass('not-failed');
 
 			if (connectionStatus === ConnectionStatus.CHECKING ||
@@ -158,7 +159,7 @@
 
 			if (connectionStatus === ConnectionStatus.CONNECTED ||
 					connectionStatus === ConnectionStatus.COMPLETED) {
-				this.getUI('avatar').css('opacity', '1');
+				this.getUI('avatar').removeClass('not-connected');
 
 				return;
 			}

--- a/js/views/videoview.js
+++ b/js/views/videoview.js
@@ -80,8 +80,9 @@
 
 			this.render();
 
+			this.$el.addClass('not-connected');
+
 			this.getUI('avatar').addClass('icon-loading');
-			this.getUI('avatar').addClass('not-connected');
 
 			this.getUI('hideRemoteVideoButton').attr('data-original-title', t('spreed', 'Disable video'));
 			this.getUI('hideRemoteVideoButton').addClass('hidden');
@@ -145,8 +146,9 @@
 		setConnectionStatus: function(connectionStatus) {
 			this._connectionStatus = connectionStatus;
 
+			this.$el.addClass('not-connected');
+
 			this.getUI('avatar').removeClass('icon-loading');
-			this.getUI('avatar').addClass('not-connected');
 			this.getUI('iceFailedIndicator').addClass('not-failed');
 
 			if (connectionStatus === ConnectionStatus.CHECKING ||
@@ -159,7 +161,7 @@
 
 			if (connectionStatus === ConnectionStatus.CONNECTED ||
 					connectionStatus === ConnectionStatus.COMPLETED) {
-				this.getUI('avatar').removeClass('not-connected');
+				this.$el.removeClass('not-connected');
 
 				return;
 			}

--- a/js/views/videoview.js
+++ b/js/views/videoview.js
@@ -148,7 +148,6 @@
 
 			this.$el.addClass('not-connected');
 
-			this.getUI('avatar').removeClass('icon-loading');
 			this.getUI('iceFailedIndicator').addClass('not-failed');
 
 			if (connectionStatus === ConnectionStatus.CHECKING ||
@@ -158,6 +157,8 @@
 
 				return;
 			}
+
+			this.getUI('avatar').removeClass('icon-loading');
 
 			if (connectionStatus === ConnectionStatus.CONNECTED ||
 					connectionStatus === ConnectionStatus.COMPLETED) {

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -539,37 +539,40 @@ var spreedPeerConnectionTable = [];
 						case 'disconnected':
 							console.log('Disconnected.');
 
-							if (!signaling.hasFeature("mcu")) {
-								// ICE failures will be handled in "iceFailed"
-								// below for MCU installations.
-								videoView.setConnectionStatus(OCA.Talk.Views.VideoView.ConnectionStatus.DISCONNECTED);
+							videoView.setConnectionStatus(OCA.Talk.Views.VideoView.ConnectionStatus.DISCONNECTED);
 
-								setTimeout(function() {
+							setTimeout(function() {
+								if (peer.pc.iceConnectionState !== 'disconnected') {
+									return;
+								}
+
+								videoView.setConnectionStatus(OCA.Talk.Views.VideoView.ConnectionStatus.DISCONNECTED_LONG);
+
+								if (!signaling.hasFeature("mcu")) {
+									// ICE failures will be handled in "iceFailed"
+									// below for MCU installations.
+
 									// If the peer is still disconnected after 5 seconds we try ICE restart.
-									if(peer.pc.iceConnectionState === 'disconnected') {
-										videoView.setConnectionStatus(OCA.Talk.Views.VideoView.ConnectionStatus.DISCONNECTED_LONG);
-
-										if (spreedPeerConnectionTable[peer.id] < 5) {
-											if (peer.pc.localDescription.type === 'offer' &&
-												peer.pc.signalingState === 'stable') {
-												spreedPeerConnectionTable[peer.id] ++;
-												console.log('ICE restart.');
-												peer.icerestart();
-											}
+									if (spreedPeerConnectionTable[peer.id] < 5) {
+										if (peer.pc.localDescription.type === 'offer' &&
+											peer.pc.signalingState === 'stable') {
+											spreedPeerConnectionTable[peer.id] ++;
+											console.log('ICE restart.');
+											peer.icerestart();
 										}
 									}
-								}, 5000);
-							}
+								}
+							}, 5000);
 							break;
 						case 'failed':
 							console.log('Connection failed.');
+
+							videoView.setConnectionStatus(OCA.Talk.Views.VideoView.ConnectionStatus.FAILED);
 
 							if (!signaling.hasFeature("mcu")) {
 								// ICE failures will be handled in "iceFailed"
 								// below for MCU installations.
 								if (spreedPeerConnectionTable[peer.id] < 5) {
-									videoView.setConnectionStatus(OCA.Talk.Views.VideoView.ConnectionStatus.FAILED);
-
 									if (peer.pc.localDescription.type === 'offer' &&
 										peer.pc.signalingState === 'stable') {
 										spreedPeerConnectionTable[peer.id] ++;


### PR DESCRIPTION
When the ICE connection state changed to disconnected or failed the VideoView was not updated when the MCU was used. However, when the MCU is not used the VideoView is updated to let the user know that there is a problem in the connection with the other peer. Thus, now the code was adjusted to update the VideoView regardless of whether the MCU is used or not.

Besides that, now the opacity of the avatar and the video is reduced when the peer is disconnected; this should give a faster feedback that there are issues in the connection than just showing the loading icon on long disconnections or failures.

Unfortunately, the loading icon can not be shown on the video, so when the video is enabled its appearance is the same whether there is an ICE disconnected, a long disconnection or an ICE failed; for now this is good enough. A possible enhancement for the future would be to switch from the video to the avatar on long disconnections or failures. But future ;-)
