### PR TITLE
Better chat notification handling

### DIFF
--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -363,10 +363,6 @@ class ChatManager {
 	 *         timeout expired.
 	 */
 	public function waitForNewMessages(Room $chat, int $offset, int $limit, int $timeout, ?IUser $user, bool $includeLastKnown): array {
-		if ($user instanceof IUser) {
-			$this->notifier->markMentionNotificationsRead($chat, $user->getUID());
-		}
-
 		if ($this->cache instanceof NullCache
 			|| $this->cache instanceof ArrayCache) {
 			return $this->waitForNewMessagesWithDatabase($chat, $offset, $limit, $timeout, $includeLastKnown);

--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -334,7 +334,6 @@ class Notifier {
 	 * 1. The participant is not a guest
 	 * 2. The participant is not the writing user
 	 * 3. The participant was not mentioned already
-	 * 4. The participant must not be active in the room
 	 *
 	 * @param Participant $participant
 	 * @param IComment $comment
@@ -352,15 +351,6 @@ class Notifier {
 			return false;
 		}
 
-		if (\in_array($userId, $alreadyNotifiedUsers, true)) {
-			return false;
-		}
-
-		if ($participant->getSession() instanceof Session) {
-			// User is online
-			return false;
-		}
-
-		return true;
+		return !\in_array($userId, $alreadyNotifiedUsers, true);
 	}
 }

--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -219,31 +219,6 @@ class Notifier {
 	}
 
 	/**
-	 * Removes all the pending mention notifications for the room
-	 *
-	 * @param Room $chat
-	 * @param string $userId
-	 */
-	public function markMentionNotificationsRead(Room $chat, ?string $userId): void {
-		if ($userId === null || $userId === '') {
-			return;
-		}
-
-		$shouldFlush = $this->notificationManager->defer();
-		$notification = $this->notificationManager->createNotification();
-
-		$notification
-			->setApp('spreed')
-			->setObject('chat', $chat->getToken())
-			->setUser($userId);
-
-		$this->notificationManager->markProcessed($notification);
-		if ($shouldFlush) {
-			$this->notificationManager->flush();
-		}
-	}
-
-	/**
 	 * Returns the IDs of the users mentioned in the given comment.
 	 *
 	 * @param IComment $comment

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -283,6 +283,7 @@ class Notifier implements INotifier {
 			throw new \InvalidArgumentException('Unknown object type');
 		}
 
+
 		$subjectParameters = $notification->getSubjectParameters();
 
 		$richSubjectUser = null;
@@ -311,6 +312,12 @@ class Notifier implements INotifier {
 
 		$messageParameters = $notification->getMessageParameters();
 		if (!isset($messageParameters['commentId'])) {
+			throw new AlreadyProcessedException();
+		}
+
+		if (!$this->notificationManager->isPreparingPushNotification()
+			&& $participant->getAttendee()->getLastReadMessage() >= $messageParameters['commentId']) {
+			// Mark notification processed when the user read the message already
 			throw new AlreadyProcessedException();
 		}
 

--- a/tests/php/Chat/ChatManagerTest.php
+++ b/tests/php/Chat/ChatManagerTest.php
@@ -265,10 +265,6 @@ class ChatManagerTest extends TestCase {
 			->with('chat', 1234, $offset, 'asc', $limit)
 			->willReturn($expected);
 
-		$this->notifier->expects($this->once())
-			->method('markMentionNotificationsRead')
-			->with($chat, 'userId');
-
 		/** @var IUser|\PHPUnit_Framework_MockObject_MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
@@ -302,10 +298,6 @@ class ChatManagerTest extends TestCase {
 				[],
 				$expected
 			);
-
-		$this->notifier->expects($this->once())
-			->method('markMentionNotificationsRead')
-			->with($chat, 'userId');
 
 		/** @var IUser|\PHPUnit_Framework_MockObject_MockObject $user */
 		$user = $this->createMock(IUser::class);


### PR DESCRIPTION
- [x] Dont remove all chat notifications when pulling for new messages
- [x] Also notifier users which are active in the chat
- [x] Remove all chat notifications when joining a room
- [x] Mark chat notifications of read messages done

Fix #1575 
