### PR TITLE
Fix pending forced reconnection after WebSocket reconnection

### DIFF
--- a/js/signaling.js
+++ b/js/signaling.js
@@ -867,6 +867,8 @@
 			}
 
 			this._forceReconnect = true;
+			this.resumeId = null;
+			this.signalingRoomJoined = null;
 			return;
 		}
 


### PR DESCRIPTION
When the WebSocket is disconnected from the external signaling server [it is automatically reconnected to it](https://github.com/nextcloud/spreed/blob/71f66fe9b1e86fb244f9c7809bdf27c4c68e3d17/js/signaling.js#L783-L790); if [a forced reconnection was queued while the WebSocket was disconnected](https://github.com/nextcloud/spreed/blob/71f66fe9b1e86fb244f9c7809bdf27c4c68e3d17/js/signaling.js#L863-L871) it was supposed to be performed [as soon as it was reconnected](https://github.com/nextcloud/spreed/blob/71f66fe9b1e86fb244f9c7809bdf27c4c68e3d17/js/signaling.js#L985-L989). However, `_forceReconnect` tracks whether there is a pending forced reconnection, and as it was set to false when `Signaling.Standalone.connect()` was called the queued forced reconnection never happened after a WebSocket reconnection (which caused the previous session to be resumed instead of a new one being created).

`_forceReconnect` is only used to force the reconnection with a new session after receiving the hello response from the server, and it is set to false when the forced reconnection is properly done, so it can be safely removed from `connect()`.

## How to test
- Setup the external signaling server
- For easier testing, add `console.log('ICE FAILED ON PUBLISHER');` or something like that to [the `iceFailed` handler](https://github.com/nextcloud/spreed/blob/fde6bd2208c753b797fbfad0eda02b06ff6ae6d8/js/webrtc.js#L996).
- Start a call in a room with user A
- Join the call with user B from a browser in a different machine than the server
- Open the browser console
- Unplug the cable
- Wait until the WebSocket has been disconnected and the `ICE FAILED ON PUBLISHER` has been printed (as that will trigger a forced reconnection while the WebSocket is disconnected).
- Plug the cable again

### Result with this pull request
User B is reconnected with a new session; user A is in the call from user B's point of view, and user B is in the call from user A's point of view.

### Result without this pull request
User B is reconnected with the same session as before; user A is not in the call from user B's point of view, and user B may or may not be in the call from user A's point of view, but in any case user B will not be heard nor seen.
