### PR TITLE
👤🏷️ Guest mentions 

### DIFF
--- a/js/filesplugin.js
+++ b/js/filesplugin.js
@@ -641,6 +641,7 @@
 				OCA.SpreedMe.app.signaling.syncRooms().then(function() {
 					roomsChannel.trigger('joinedRoom', OCA.SpreedMe.app.activeRoom);
 
+					OCA.SpreedMe.app._chatView.setRoom(OCA.SpreedMe.app.activeRoom);
 					OCA.SpreedMe.app._messageCollection.setRoomToken(OCA.SpreedMe.app.activeRoom.get('token'));
 					OCA.SpreedMe.app._messageCollection.receiveMessages();
 				});

--- a/js/models/room.js
+++ b/js/models/room.js
@@ -1,4 +1,4 @@
-/* global Backbone, OCA */
+/* global Backbone, Hashes, OCA */
 
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
@@ -20,7 +20,7 @@
  *
  */
 
-(function(OCA, Backbone) {
+(function(OCA, Backbone, Hashes) {
 	'use strict';
 
 	OCA.SpreedMe = OCA.SpreedMe || {};
@@ -64,6 +64,11 @@
 			guestList: '',
 			lastMessage: [],
 			active: false
+		},
+		initialize: function() {
+			this.listenTo(this, 'change:sessionId', function() {
+				this.set('hashedSessionId', new Hashes.SHA1().hex(this.attributes.sessionId));
+			});
 		},
 		url: function() {
 			return OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.get('token');
@@ -141,4 +146,4 @@
 
 	OCA.SpreedMe.Models.Room = Room;
 
-})(OCA, Backbone);
+})(OCA, Backbone, Hashes);

--- a/js/publicshareauth.js
+++ b/js/publicshareauth.js
@@ -147,6 +147,7 @@
 
 					setPageTitle(OCA.SpreedMe.app.activeRoom.get('displayName'));
 
+					OCA.SpreedMe.app._chatView.setRoom(OCA.SpreedMe.app.activeRoom);
 					OCA.SpreedMe.app._messageCollection.setRoomToken(OCA.SpreedMe.app.activeRoom.get('token'));
 					OCA.SpreedMe.app._messageCollection.receiveMessages();
 

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -99,8 +99,13 @@
 						var $avatar = $li.find('.avatar');
 						if ($avatar.data('user-id') === 'all') {
 							$avatar.addClass('avatar icon icon-contacts');
-						} else {
+						} else if ($avatar.data('user-id') && $avatar.data('user-id').indexOf('guest/') !== 0) {
 							$avatar.avatar($avatar.data('user-id'), 32);
+						} else {
+							var displayName = $avatar.data('user-display-name');
+							var customName = displayName !== t('spreed', 'Guest') ? displayName : '';
+							$avatar.imageplaceholder(customName ? customName.substr(0, 1) : '?', customName, 32);
+							$avatar.css('background-color', '#b9b9b9');
 						}
 						return $li;
 					},
@@ -243,7 +248,9 @@
 			if (OC.getCurrentUser().uid) {
 				this.$el.find('.avatar').avatar(OC.getCurrentUser().uid, 32, undefined, false, undefined, OC.getCurrentUser().displayName);
 			} else {
-				this.$el.find('.avatar').imageplaceholder('?', this.getOption('guestNameModel').get('nick'), 128);
+				var displayName = this.getOption('guestNameModel').get('nick');
+				var customName = displayName !== t('spreed', 'Guest') ? displayName : '';
+				this.$el.find('.avatar').imageplaceholder(customName ? customName.substr(0, 1) : '?', customName, 128);
 				this.$el.find('.avatar').css('background-color', '#b9b9b9');
 				this.showChildView('guestName', this._guestNameEditableTextLabel, { replaceElement: true, allowMissingEl: true } );
 			}
@@ -613,7 +620,9 @@
 						$element.avatar($element.data('user-id'), size, undefined, false, undefined, $element.data('user-display-name'));
 					}
 				} else {
-					$element.imageplaceholder('?', $element.data('user-display-name'), size);
+					var displayName = $element.data('user-display-name');
+					var customName = displayName !== t('spreed', 'Guest') ? displayName : '';
+					$element.imageplaceholder(customName ? customName.substr(0, 1) : '?', customName, size);
 					$element.css('background-color', '#b9b9b9');
 				}
 			};

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -606,14 +606,14 @@
 			$el.find('.has-tooltip').tooltip({container: this._tooltipContainer});
 
 			var setAvatar = function($element, size) {
-				if ($element.data('user-id')) {
+				if ($element.data('user-id') && $element.data('user-id').substr(0, 6) !== 'guest/') {
 					if ($element.data('user-id') === 'all') {
 						$element.addClass('avatar icon icon-contacts');
 					} else {
 						$element.avatar($element.data('user-id'), size, undefined, false, undefined, $element.data('user-display-name'));
 					}
 				} else {
-					$element.imageplaceholder('?', $element.data('displayname'), size);
+					$element.imageplaceholder('?', $element.data('user-display-name'), size);
 					$element.css('background-color', '#b9b9b9');
 				}
 			};
@@ -806,7 +806,7 @@
 				var $this = $(this),
 					$inserted = $this.parent(),
 					userId = $this.find('.avatar').data('user-id');
-				if (userId.indexOf(' ') !== -1) {
+				if (userId.indexOf(' ') !== -1 || userId.indexOf('guest/') === 0) {
 					$inserted.html('@"' + userId + '"');
 				} else {
 					$inserted.html('@' + userId);

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -438,7 +438,10 @@
 			formattedMessage = this._plainToRich(formattedMessage);
 			formattedMessage = formattedMessage.replace(/\n/g, '<br/>');
 			formattedMessage = OCA.SpreedMe.Views.RichObjectStringParser.parseMessage(
-				formattedMessage, commentModel.get('messageParameters'));
+				formattedMessage, commentModel.get('messageParameters'), {
+					userId: OC.getCurrentUser().uid,
+					sessionHash: this.model.get('hashedSessionId'),
+				});
 
 			var data = _.extend({}, commentModel.attributes, {
 				actorDisplayName: actorDisplayName,

--- a/js/views/participantlistview.js
+++ b/js/views/participantlistview.js
@@ -120,12 +120,13 @@
 				var model = this.model;
 				this.$el.find('.avatar').each(function() {
 					var $element = $(this);
+					var firstChar = $element.data('displayName') ? $element.data('displayName').substr(0, 1) : '?';
 
 					if (model.get('participantType') === OCA.SpreedMe.app.GUEST_MODERATOR) {
-						$element.imageplaceholder('M', model.get('displayName'), 32);
+						$element.imageplaceholder(firstChar, model.get('displayName'), 32);
 						$element.css('background-color', '#b9b9b9');
 					} else if (model.get('participantType') === OCA.SpreedMe.app.GUEST) {
-						$element.imageplaceholder('?', model.get('displayName'), 32);
+						$element.imageplaceholder(firstChar, model.get('displayName'), 32);
 						$element.css('background-color', '#b9b9b9');
 					} else {
 						$element.avatar(model.get('userId'), 32, undefined, false, undefined, model.get('displayName'));

--- a/js/views/richobjectstringparser.js
+++ b/js/views/richobjectstringparser.js
@@ -1,4 +1,4 @@
-/* global OC, OCA */
+/* global OCA */
 
 /**
  * @copyright (c) 2016 Joas Schilling <coding@schilljs.com>
@@ -9,16 +9,17 @@
  * later. See the COPYING file.
  */
 
-(function(OC, OCA) {
+(function(OCA) {
 
 	OCA.SpreedMe.Views.RichObjectStringParser = {
 
 		/**
 		 * @param {string} subject
 		 * @param {Object} parameters
+		 * @param {Object} context
 		 * @returns {string}
 		 */
-		parseMessage: function(subject, parameters) {
+		parseMessage: function(subject, parameters, context) {
 			var self = this,
 				regex = /\{([a-z0-9-]+)\}/gi,
 				matches = subject.match(regex);
@@ -31,7 +32,7 @@
 					return;
 				}
 
-				var parsed = self.parseParameter(parameters[parameter]);
+				var parsed = self.parseParameter(parameters[parameter], context);
 				subject = subject.replace('{' + parameter + '}', parsed);
 			});
 
@@ -44,8 +45,11 @@
 		 * @param {string} parameter.id
 		 * @param {string} parameter.name
 		 * @param {string} parameter.link
+		 * @param {Object} context
+		 * @param {string} context.userId
+		 * @param {string} context.sessionHash
 		 */
-		parseParameter: function(parameter) {
+		parseParameter: function(parameter, context) {
 			switch (parameter.type) {
 				case 'user':
 					if (!this.userLocalTemplate) {
@@ -54,8 +58,18 @@
 					if (!parameter.name) {
 						parameter.name = parameter.id;
 					}
-					if (OC.getCurrentUser().uid === parameter.id) {
+					if (context.userId === parameter.id) {
 						parameter.isCurrentUser = true;
+					}
+					return this.userLocalTemplate(parameter);
+				case 'guest':
+					if (!this.userLocalTemplate) {
+						this.userLocalTemplate = OCA.Talk.Views.Templates['richobjectstringparser_userlocal'];
+					}
+
+					parameter.isGuest = true;
+					if (!context.userId && context.sessionHash) {
+						parameter.isCurrentUser = 'guest/' + context.sessionHash === parameter.id;
 					}
 					return this.userLocalTemplate(parameter);
 
@@ -89,4 +103,4 @@
 
 	};
 
-})(OC, OCA);
+})(OCA);

--- a/js/views/templates.js
+++ b/js/views/templates.js
@@ -356,14 +356,26 @@ templates['richobjectstringparser_unknownlink'] = template({"compiler":[7,">= 4.
 },"useData":true});
 templates['richobjectstringparser_userlocal'] = template({"1":function(container,depth0,helpers,partials,data) {
     return "currentUser";
+},"3":function(container,depth0,helpers,partials,data) {
+    var helper;
+
+  return "data-guest-session=\""
+    + container.escapeExpression(((helper = (helper = helpers.id || (depth0 != null ? depth0.id : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"id","hash":{},"data":data}) : helper)))
+    + "\"";
+},"5":function(container,depth0,helpers,partials,data) {
+    var helper;
+
+  return "data-user-id=\""
+    + container.escapeExpression(((helper = (helper = helpers.id || (depth0 != null ? depth0.id : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"id","hash":{},"data":data}) : helper)))
+    + "\"";
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "<span class=\"atwho-inserted\" contenteditable=\"false\"><span class=\"mention-user avatar-name-wrapper "
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isCurrentUser : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "\"><span class=\"avatar\" data-user-id=\""
-    + alias4(((helper = (helper = helpers.id || (depth0 != null ? depth0.id : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"id","hash":{},"data":data}) : helper)))
-    + "\" data-user-display-name=\""
+    + "\"><span class=\"avatar\" "
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isGuest : depth0),{"name":"if","hash":{},"fn":container.program(3, data, 0),"inverse":container.program(5, data, 0),"data":data})) != null ? stack1 : "")
+    + " data-user-display-name=\""
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + "\"></span><strong>"
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))

--- a/js/views/templates/richobjectstringparser_userlocal.handlebars
+++ b/js/views/templates/richobjectstringparser_userlocal.handlebars
@@ -3,4 +3,4 @@
     after the mention, and thus causing the mention to "touch" the following
     text; "~" from Handlebars can not be used because it is not recursive, it
     only applies to a single level }}
-<span class="atwho-inserted" contenteditable="false"><span class="mention-user avatar-name-wrapper {{#if isCurrentUser}}currentUser{{/if}}"><span class="avatar" data-user-id="{{id}}" data-user-display-name="{{name}}"></span><strong>{{name}}</strong></span></span>
+<span class="atwho-inserted" contenteditable="false"><span class="mention-user avatar-name-wrapper {{#if isCurrentUser}}currentUser{{/if}}"><span class="avatar" {{#if isGuest}}data-guest-session="{{id}}"{{else}}data-user-id="{{id}}"{{/if}} data-user-display-name="{{name}}"></span><strong>{{name}}</strong></span></span>

--- a/lib/GuestManager.php
+++ b/lib/GuestManager.php
@@ -128,7 +128,7 @@ class GuestManager {
 		$row = $result->fetch();
 		$result->closeCursor();
 
-		if (isset($row['display_name'])) {
+		if (isset($row['display_name']) && $row['display_name'] !== '') {
 			return $row['display_name'];
 		}
 
@@ -150,6 +150,10 @@ class GuestManager {
 		$map = [];
 
 		while ($row = $result->fetch()) {
+			if ($row['display_name'] === '') {
+				continue;
+			}
+
 			$map[$row['session_hash']] = $row['display_name'];
 		}
 		$result->closeCursor();

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -51,6 +51,8 @@ class Manager {
 	private $userManager;
 	/** @var CommentsManager */
 	private $commentsManager;
+	/** @var TalkSession */
+	private $talkSession;
 	/** @var EventDispatcherInterface */
 	private $dispatcher;
 	/** @var ITimeFactory */
@@ -65,6 +67,7 @@ class Manager {
 								ISecureRandom $secureRandom,
 								IUserManager $userManager,
 								CommentsManager $commentsManager,
+								TalkSession $talkSession,
 								EventDispatcherInterface $dispatcher,
 								ITimeFactory $timeFactory,
 								IHasher $hasher,
@@ -74,6 +77,7 @@ class Manager {
 		$this->secureRandom = $secureRandom;
 		$this->userManager = $userManager;
 		$this->commentsManager = $commentsManager;
+		$this->talkSession = $talkSession;
 		$this->dispatcher = $dispatcher;
 		$this->timeFactory = $timeFactory;
 		$this->hasher = $hasher;
@@ -702,7 +706,12 @@ class Manager {
 		}
 
 		try {
-			$room->getParticipant($userId);
+			if ($userId === '') {
+				$sessionId = $this->talkSession->getSessionForRoom($room->getToken());
+				$room->getParticipantBySession($sessionId);
+			} else {
+				$room->getParticipant($userId);
+			}
 		} catch (ParticipantNotFoundException $e) {
 			// Do not leak the name of rooms the user is not a part of
 			return $this->l->t('Private conversation');

--- a/tests/acceptance/features/app-files.feature
+++ b/tests/acceptance/features/app-files.feature
@@ -99,15 +99,21 @@ Feature: app-files
     And I open the details view for "welcome (2).txt"
     And I open the Chat tab in the details view of the Files app
     When I act as John
-    And I send a new chat message with the text "Hello"
+    And I send a new chat message with the text "Hello @user0"
     And I act as Jane
-    And I see that the message 1 was sent by "admin" with the text "Hello"
-    And I send a new chat message with the text "Hi!"
-    Then I see that the message 1 was sent by "admin" with the text "Hello"
-    And I see that the message 2 was sent by "user0" with the text "Hi!"
+    And I see that the message 1 was sent by "admin" with the text "Hello user0"
+    And I type a new chat message with the text "Hi @"
+    And I choose the candidate mention for "admin"
+    And I send the current chat message
+    Then I see that the message 1 was sent by "admin" with the text "Hello user0"
+    And I see that the message 1 contains a formatted mention of "user0" as current user
+    And I see that the message 2 was sent by "user0" with the text "Hi admin"
+    And I see that the message 2 contains a formatted mention of "admin"
     And I act as John
-    And I see that the message 1 was sent by "admin" with the text "Hello"
-    And I see that the message 2 was sent by "user0" with the text "Hi!"
+    And I see that the message 1 was sent by "admin" with the text "Hello user0"
+    And I see that the message 1 contains a formatted mention of "user0"
+    And I see that the message 2 was sent by "user0" with the text "Hi admin"
+    And I see that the message 2 contains a formatted mention of "admin" as current user
 
 #  Scenario: chat in a reshared file
 #    Given I act as John

--- a/tests/acceptance/features/bootstrap/ChatContext.php
+++ b/tests/acceptance/features/bootstrap/ChatContext.php
@@ -177,6 +177,15 @@ class ChatContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function formattedMentionInChatMessageOfAllParticipantsOf($chatAncestor, $number, $roomName) {
+		return Locator::forThe()->xpath("span/span[contains(concat(' ', normalize-space(@class), ' '), ' mention-call ') and contains(concat(' ', normalize-space(@class), ' '), ' currentUser ') and normalize-space() = '$roomName']")->
+				descendantOf(self::textOfChatMessage($chatAncestor, $number))->
+				describedAs("Formatted mention of all participants of $roomName in chat message $number in the list of received messages");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function formattedLinkInChatMessageTo($chatAncestor, $number, $url) {
 		return Locator::forThe()->xpath("a[normalize-space(@href) = '$url']")->
 				descendantOf(self::textOfChatMessage($chatAncestor, $number))->
@@ -403,6 +412,13 @@ class ChatContext implements Context, ActorAwareInterface {
 	 */
 	public function iSeeThatTheMessageContainsAFormattedMentionOfAsCurrentUser($number, $user) {
 		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::formattedMentionInChatMessageOfAsCurrentUser($this->chatAncestor, $number, $user), 10));
+	}
+
+	/**
+	 * @Then I see that the message :number contains a formatted mention of all participants of :roomName
+	 */
+	public function iSeeThatTheMessageContainsAFormattedMentionOfAllParticipantsOf($number, $roomName) {
+		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::formattedMentionInChatMessageOfAllParticipantsOf($this->chatAncestor, $number, $roomName), 10));
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/ChatContext.php
+++ b/tests/acceptance/features/bootstrap/ChatContext.php
@@ -154,7 +154,10 @@ class ChatContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function formattedMentionInChatMessageOf($chatAncestor, $number, $user) {
-		return Locator::forThe()->xpath("span/span[contains(concat(' ', normalize-space(@class), ' '), ' mention-user ') and normalize-space() = '$user']")->
+		// User mentions have an image avatar, but guest mentions have a plain
+		// text avatar, so the avatar needs to be excluded when matching the
+		// name.
+		return Locator::forThe()->xpath("span/span[contains(concat(' ', normalize-space(@class), ' '), ' mention-user ')]//*[normalize-space() = '$user']/ancestor::span")->
 				descendantOf(self::textOfChatMessage($chatAncestor, $number))->
 				describedAs("Formatted mention of $user in chat message $number in the list of received messages");
 	}
@@ -163,7 +166,10 @@ class ChatContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function formattedMentionInChatMessageOfAsCurrentUser($chatAncestor, $number, $user) {
-		return Locator::forThe()->xpath("span/span[contains(concat(' ', normalize-space(@class), ' '), ' mention-user ') and contains(concat(' ', normalize-space(@class), ' '), ' currentUser ') and normalize-space() = '$user']")->
+		// User mentions have an image avatar, but guest mentions have a plain
+		// text avatar, so the avatar needs to be excluded when matching the
+		// name.
+		return Locator::forThe()->xpath("span/span[contains(concat(' ', normalize-space(@class), ' '), ' mention-user ') and contains(concat(' ', normalize-space(@class), ' '), ' currentUser ')]//*[normalize-space() = '$user']/ancestor::span")->
 				descendantOf(self::textOfChatMessage($chatAncestor, $number))->
 				describedAs("Formatted mention of $user as current user in chat message $number in the list of received messages");
 	}
@@ -184,6 +190,33 @@ class ChatContext implements Context, ActorAwareInterface {
 		return Locator::forThe()->css(".filePreviewContainer")->
 				descendantOf(self::textOfChatMessage($chatAncestor, $number))->
 				describedAs("Formatted file preview in chat message $number in the list of received messages");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function guestNameEditableTextLabel($chatAncestor) {
+		return Locator::forThe()->css(".guest-name.editable-text-label")->
+				descendantOf(self::chatView($chatAncestor))->
+				describedAs("Guest name editable text label");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function guestNameEditButton($chatAncestor) {
+		return Locator::forThe()->css(".edit-button")->
+				descendantOf(self::guestNameEditableTextLabel($chatAncestor))->
+				describedAs("Guest name edit button");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function guestNameInput($chatAncestor) {
+		return Locator::forThe()->css(".username")->
+				descendantOf(self::guestNameEditableTextLabel($chatAncestor))->
+				describedAs("Guest name input");
 	}
 
 	/**
@@ -244,9 +277,20 @@ class ChatContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function mentionAutocompleteCandidateFor($name) {
-		return Locator::forThe()->xpath("//li[contains(concat(' ', normalize-space(@class), ' '), ' chat-view-mention-autocomplete ') and normalize-space() = '$name']")->
+		// User mentions have an image avatar, but guest mentions have a plain
+		// text avatar, so the avatar needs to be excluded when matching the
+		// name.
+		return Locator::forThe()->xpath("//li[contains(concat(' ', normalize-space(@class), ' '), ' chat-view-mention-autocomplete ')]//*[normalize-space() = '$name']/ancestor::li")->
 				descendantOf(self::mentionAutocompleteContainer())->
 				describedAs("Mention autocomplete candidate for $name");
+	}
+
+	/**
+	 * @When I set my guest name to :name
+	 */
+	public function iSetMyGuestNameTo($name) {
+		$this->actor->find(self::guestNameEditButton($this->chatAncestor), 10)->click();
+		$this->actor->find(self::guestNameInput($this->chatAncestor), 2)->setValue($name . "\r");
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/ChatContext.php
+++ b/tests/acceptance/features/bootstrap/ChatContext.php
@@ -207,6 +207,15 @@ class ChatContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function newChatMessageSendIcon($chatAncestor) {
+		return Locator::forThe()->css(".icon-confirm")->
+				descendantOf(self::newChatMessageForm($chatAncestor))->
+				describedAs("New chat message send icon");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function newChatMessageWorkingIcon($chatAncestor) {
 		return Locator::forThe()->css(".submitLoading")->
 				descendantOf(self::newChatMessageForm($chatAncestor))->
@@ -220,6 +229,54 @@ class ChatContext implements Context, ActorAwareInterface {
 		return Locator::forThe()->css(".share")->
 				descendantOf(self::newChatMessageForm($chatAncestor))->
 				describedAs("Share button");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function mentionAutocompleteContainer() {
+		// The container is added directly in the body, not in the chat view.
+		return Locator::forThe()->css(".atwho-container")->
+				describedAs("Mention autocomplete container");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function mentionAutocompleteCandidateFor($name) {
+		return Locator::forThe()->xpath("//li[contains(concat(' ', normalize-space(@class), ' '), ' chat-view-mention-autocomplete ') and normalize-space() = '$name']")->
+				descendantOf(self::mentionAutocompleteContainer())->
+				describedAs("Mention autocomplete candidate for $name");
+	}
+
+	/**
+	 * @When I type a new chat message with the text :message
+	 */
+	public function iTypeANewChatMessageWithTheText($message) {
+		// Instead of waiting for the input to be enabled before sending a new
+		// message it is easier to wait for the working icon to not be shown.
+		if (!WaitFor::elementToBeEventuallyNotShown(
+				$this->actor,
+				self::newChatMessageWorkingIcon($this->chatAncestor),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("The working icon for the new message was still being shown after $timeout seconds");
+		}
+
+		$this->actor->find(self::newChatMessageInput($this->chatAncestor), 10)->setValue($message);
+	}
+
+	/**
+	 * @When I choose the candidate mention for :name
+	 */
+	public function iChooseTheCandidateMentionFor($name) {
+		$this->actor->find(self::mentionAutocompleteCandidateFor($name), 10)->click();
+	}
+
+	/**
+	 * @When I send the current chat message
+	 */
+	public function iSendTheCurrentChatMessage() {
+		$this->actor->find(self::newChatMessageSendIcon($this->chatAncestor), 10)->click();
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/ChatContext.php
+++ b/tests/acceptance/features/bootstrap/ChatContext.php
@@ -162,6 +162,15 @@ class ChatContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function formattedMentionInChatMessageOfAsCurrentUser($chatAncestor, $number, $user) {
+		return Locator::forThe()->xpath("span/span[contains(concat(' ', normalize-space(@class), ' '), ' mention-user ') and contains(concat(' ', normalize-space(@class), ' '), ' currentUser ') and normalize-space() = '$user']")->
+				descendantOf(self::textOfChatMessage($chatAncestor, $number))->
+				describedAs("Formatted mention of $user as current user in chat message $number in the list of received messages");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function formattedLinkInChatMessageTo($chatAncestor, $number, $url) {
 		return Locator::forThe()->xpath("a[normalize-space(@href) = '$url']")->
 				descendantOf(self::textOfChatMessage($chatAncestor, $number))->
@@ -286,6 +295,13 @@ class ChatContext implements Context, ActorAwareInterface {
 	 */
 	public function iSeeThatTheMessageContainsAFormattedMentionOf($number, $user) {
 		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::formattedMentionInChatMessageOf($this->chatAncestor, $number, $user), 10));
+	}
+
+	/**
+	 * @Then I see that the message :number contains a formatted mention of :user as current user
+	 */
+	public function iSeeThatTheMessageContainsAFormattedMentionOfAsCurrentUser($number, $user) {
+		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::formattedMentionInChatMessageOfAsCurrentUser($this->chatAncestor, $number, $user), 10));
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/ChatContext.php
+++ b/tests/acceptance/features/bootstrap/ChatContext.php
@@ -278,7 +278,9 @@ class ChatContext implements Context, ActorAwareInterface {
 	 */
 	public static function mentionAutocompleteContainer() {
 		// The container is added directly in the body, not in the chat view.
-		return Locator::forThe()->css(".atwho-container")->
+		// Moreover, there could be several atwho containers, so it needs to be
+		// got based on the elements that it contains.
+		return Locator::forThe()->xpath("//li[contains(concat(' ', normalize-space(@class), ' '), ' chat-view-mention-autocomplete ')]/ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' atwho-container ')]")->
 				describedAs("Mention autocomplete container");
 	}
 

--- a/tests/acceptance/features/bootstrap/ParticipantListContext.php
+++ b/tests/acceptance/features/bootstrap/ParticipantListContext.php
@@ -115,4 +115,18 @@ class ParticipantListContext implements Context, ActorAwareInterface {
 		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::moderatorIndicatorFor($participantName), 10));
 	}
 
+	/**
+	 * @Then I see that :participantName is shown in the list of participants as a normal participant
+	 */
+	public function iSeeThatIsShownInTheListOfParticipantsAsANormalParticipant($participantName) {
+		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::itemInParticipantsListFor($participantName), 10));
+
+		if (!WaitFor::elementToBeEventuallyNotShown(
+				$this->actor,
+				self::moderatorIndicatorFor($participantName),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("Participant $participantName is still marked as a moderator after $timeout seconds but it should be a normal participant instead");
+		}
+	}
+
 }

--- a/tests/acceptance/features/chat.feature
+++ b/tests/acceptance/features/chat.feature
@@ -168,6 +168,30 @@ Feature: chat
     And I see that the message 1 was sent by "user0" with the text "Hello admin"
     And I see that the message 1 contains a formatted mention of "admin" as current user
 
+  Scenario: mention a guest from the candidate mentions
+    Given I act as John
+    And I am logged in
+    And I have opened the Talk app
+    And I create a public conversation named "Public"
+    And I see that the chat is shown in the main view
+    And I write down the public conversation link
+    And I act as Jane
+    And I visit the public conversation link I wrote down
+    And I see that the current page is the public conversation link I wrote down
+    And I see that the chat is shown in the main view
+    And I set my guest name to "Rob"
+    When I act as John
+    And I see that "Rob" is shown in the list of participants as a normal participant
+    And I type a new chat message with the text "Hello @"
+    And I choose the candidate mention for "Rob"
+    And I send the current chat message
+    # The generated avatar is plain text, so it appears in the message itself
+    Then I see that the message 1 was sent by "user0" with the text "Hello RRob"
+    And I see that the message 1 contains a formatted mention of "Rob"
+    And I act as Jane
+    And I see that the message 1 was sent by "user0" with the text "Hello RRob"
+    And I see that the message 1 contains a formatted mention of "Rob" as current user
+
   Scenario: mention another user and a URL
     Given I am logged in
     And I have opened the Talk app

--- a/tests/acceptance/features/chat.feature
+++ b/tests/acceptance/features/chat.feature
@@ -192,6 +192,27 @@ Feature: chat
     And I see that the message 1 was sent by "user0" with the text "Hello RRob"
     And I see that the message 1 contains a formatted mention of "Rob" as current user
 
+  Scenario: mention all users in a public room from the candidate mentions
+    Given I act as John
+    And I am logged in
+    And I have opened the Talk app
+    And I create a public conversation named "Public"
+    And I see that the chat is shown in the main view
+    And I write down the public conversation link
+    And I act as Jane
+    And I visit the public conversation link I wrote down
+    And I see that the current page is the public conversation link I wrote down
+    And I see that the chat is shown in the main view
+    When I act as John
+    And I type a new chat message with the text "Hello @"
+    And I choose the candidate mention for "Public"
+    And I send the current chat message
+    Then I see that the message 1 was sent by "user0" with the text "Hello Public"
+    And I see that the message 1 contains a formatted mention of all participants of "Public"
+    And I act as Jane
+    And I see that the message 1 was sent by "user0" with the text "Hello Public"
+    And I see that the message 1 contains a formatted mention of all participants of "Public"
+
   Scenario: mention another user and a URL
     Given I am logged in
     And I have opened the Talk app

--- a/tests/acceptance/features/chat.feature
+++ b/tests/acceptance/features/chat.feature
@@ -129,13 +129,23 @@ Feature: chat
     And I see that the message 6 was sent by "admin" with the text "Fine too!"
 
   Scenario: mention another user
-    Given I am logged in
+    Given I act as John
+    And I am logged in
     And I have opened the Talk app
-    And I create a group conversation named "Group"
+    And I create a one-to-one conversation with "admin"
     And I see that the chat is shown in the main view
-    When I send a new chat message with the text "Hello @admin"
+    And I act as Jane
+    And I am logged in as the admin
+    And I have opened the Talk app
+    And I open the "user0" conversation
+    And I see that the chat is shown in the main view
+    When I act as John
+    And I send a new chat message with the text "Hello @admin"
     Then I see that the message 1 was sent by "user0" with the text "Hello admin"
     And I see that the message 1 contains a formatted mention of "admin"
+    And I act as Jane
+    And I see that the message 1 was sent by "user0" with the text "Hello admin"
+    And I see that the message 1 contains a formatted mention of "admin" as current user
 
   Scenario: mention another user and a URL
     Given I am logged in

--- a/tests/acceptance/features/chat.feature
+++ b/tests/acceptance/features/chat.feature
@@ -147,6 +147,27 @@ Feature: chat
     And I see that the message 1 was sent by "user0" with the text "Hello admin"
     And I see that the message 1 contains a formatted mention of "admin" as current user
 
+  Scenario: mention another user from the candidate mentions
+    Given I act as John
+    And I am logged in
+    And I have opened the Talk app
+    And I create a one-to-one conversation with "admin"
+    And I see that the chat is shown in the main view
+    And I act as Jane
+    And I am logged in as the admin
+    And I have opened the Talk app
+    And I open the "user0" conversation
+    And I see that the chat is shown in the main view
+    When I act as John
+    And I type a new chat message with the text "Hello @"
+    And I choose the candidate mention for "admin"
+    And I send the current chat message
+    Then I see that the message 1 was sent by "user0" with the text "Hello admin"
+    And I see that the message 1 contains a formatted mention of "admin"
+    And I act as Jane
+    And I see that the message 1 was sent by "user0" with the text "Hello admin"
+    And I see that the message 1 contains a formatted mention of "admin" as current user
+
   Scenario: mention another user and a URL
     Given I am logged in
     And I have opened the Talk app

--- a/tests/acceptance/features/chat.feature
+++ b/tests/acceptance/features/chat.feature
@@ -192,6 +192,57 @@ Feature: chat
     And I see that the message 1 was sent by "user0" with the text "Hello RRob"
     And I see that the message 1 contains a formatted mention of "Rob" as current user
 
+  Scenario: mention a guest that has not set her name yet from the candidate mentions
+    Given I act as John
+    And I am logged in
+    And I have opened the Talk app
+    And I create a public conversation named "Public"
+    And I see that the chat is shown in the main view
+    And I write down the public conversation link
+    And I act as Jane
+    And I visit the public conversation link I wrote down
+    And I see that the current page is the public conversation link I wrote down
+    And I see that the chat is shown in the main view
+    When I act as John
+    And I see that "Guest" is shown in the list of participants as a normal participant
+    And I type a new chat message with the text "Hello @"
+    And I choose the candidate mention for "Guest"
+    And I send the current chat message
+    # The generated avatar is plain text, so it appears in the message itself
+    Then I see that the message 1 was sent by "user0" with the text "Hello ?Guest"
+    And I see that the message 1 contains a formatted mention of "Guest"
+    And I act as Jane
+    And I see that the message 1 was sent by "user0" with the text "Hello ?Guest"
+    And I see that the message 1 contains a formatted mention of "Guest" as current user
+
+  Scenario: mention a guest that has cleared her name from the candidate mentions
+    Given I act as John
+    And I am logged in
+    And I have opened the Talk app
+    And I create a public conversation named "Public"
+    And I see that the chat is shown in the main view
+    And I write down the public conversation link
+    And I act as Jane
+    And I visit the public conversation link I wrote down
+    And I see that the current page is the public conversation link I wrote down
+    And I see that the chat is shown in the main view
+    And I set my guest name to "Rob"
+    And I act as John
+    And I see that "Rob" is shown in the list of participants as a normal participant
+    And I act as Jane
+    And I set my guest name to ""
+    When I act as John
+    And I see that "Guest" is shown in the list of participants as a normal participant
+    And I type a new chat message with the text "Hello @"
+    And I choose the candidate mention for "Guest"
+    And I send the current chat message
+    # The generated avatar is plain text, so it appears in the message itself
+    Then I see that the message 1 was sent by "user0" with the text "Hello ?Guest"
+    And I see that the message 1 contains a formatted mention of "Guest"
+    And I act as Jane
+    And I see that the message 1 was sent by "user0" with the text "Hello ?Guest"
+    And I see that the message 1 contains a formatted mention of "Guest" as current user
+
   Scenario: mention all users in a public room from the candidate mentions
     Given I act as John
     And I am logged in

--- a/tests/acceptance/features/public-share-auth.feature
+++ b/tests/acceptance/features/public-share-auth.feature
@@ -39,17 +39,24 @@ Feature: public share auth
     And I visit the shared link I wrote down
     And I see that the current page is the Authenticate page for the shared link I wrote down
     When I request the password
-    And I send a new chat message with the text "Hello"
-    And I see that the message 1 was sent by "Guest" with the text "Hello"
+    And I send a new chat message with the text "Hello @user0"
+    And I see that the message 1 was sent by "Guest" with the text "Hello user0"
     And I act as John
     And I have opened the Talk app
     And I open the "Password request: welcome.txt" conversation
-    And I send a new chat message with the text "Hi!"
-    Then I see that the message 1 was sent by "Guest" with the text "Hello"
-    And I see that the message 2 was sent by "user0" with the text "Hi!"
+    And I type a new chat message with the text "Hi @"
+    And I choose the candidate mention for "Guest"
+    And I send the current chat message
+    Then I see that the message 1 was sent by "Guest" with the text "Hello user0"
+    And I see that the message 1 contains a formatted mention of "user0" as current user
+    # The generated avatar is plain text, so it appears in the message itself
+    And I see that the message 2 was sent by "user0" with the text "Hi ?Guest"
+    And I see that the message 2 contains a formatted mention of "Guest"
     And I act as Jane
-    And I see that the message 1 was sent by "Guest" with the text "Hello"
-    And I see that the message 2 was sent by "user0" with the text "Hi!"
+    And I see that the message 1 was sent by "Guest" with the text "Hello user0"
+    And I see that the message 1 contains a formatted mention of "user0"
+    And I see that the message 2 was sent by "user0" with the text "Hi ?Guest"
+    And I see that the message 2 contains a formatted mention of "Guest" as current user
 
   Scenario: access a link share with a password protected by Talk after a chat
     Given I act as John

--- a/tests/integration/features/chat/mentions.feature
+++ b/tests/integration/features/chat/mentions.feature
@@ -132,16 +132,25 @@ Feature: chat/mentions
       | all          | room                     | calls  |
       | participant2 | participant2-displayname | users  |
       | participant3 | participant3-displayname | users  |
+      | GUEST_ID     | Guest                    | guests |
     And user "participant2" gets the following candidate mentions in room "public room" for "" with 200
       | id           | label                    | source |
       | all          | room                     | calls  |
       | participant1 | participant1-displayname | users  |
       | participant3 | participant3-displayname | users  |
+      | GUEST_ID     | Guest                    | guests |
     And user "participant3" gets the following candidate mentions in room "public room" for "" with 200
       | id           | label                    | source |
       | all          | room                     | calls  |
       | participant1 | participant1-displayname | users  |
       | participant2 | participant2-displayname | users  |
+      | GUEST_ID     | Guest                    | guests |
+    And user "guest" gets the following candidate mentions in room "public room" for "" with 200
+      | id           | label                    | source |
+      | all          | room                     | calls  |
+      | participant1 | participant1-displayname | users  |
+      | participant2 | participant2-displayname | users  |
+      | participant3 | participant3-displayname | users  |
 
   Scenario: get matched mentions in a public room
     When user "participant1" creates room "public room"
@@ -162,6 +171,62 @@ Feature: chat/mentions
       | id           | label                    | source |
       | participant1 | participant1-displayname | users  |
       | participant2 | participant2-displayname | users  |
+    And user "guest" gets the following candidate mentions in room "public room" for "part" with 200
+      | id           | label                    | source |
+      | participant1 | participant1-displayname | users  |
+      | participant2 | participant2-displayname | users  |
+      | participant3 | participant3-displayname | users  |
+
+  Scenario: get matched guest mentions in a public room
+    When user "participant1" creates room "public room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "participant3" joins room "public room" with 200
+    And user "guest1" joins room "public room" with 200
+    And user "guest2" joins room "public room" with 200
+    Then user "participant1" gets the following candidate mentions in room "public room" for "uest" with 200
+      | id           | label                    | source |
+      | GUEST_ID     | Guest                    | guests |
+      | GUEST_ID     | Guest                    | guests |
+    And user "participant2" gets the following candidate mentions in room "public room" for "uest" with 200
+      | id           | label                    | source |
+      | GUEST_ID     | Guest                    | guests |
+      | GUEST_ID     | Guest                    | guests |
+    And user "participant3" gets the following candidate mentions in room "public room" for "uest" with 200
+      | id           | label                    | source |
+      | GUEST_ID     | Guest                    | guests |
+      | GUEST_ID     | Guest                    | guests |
+    And user "guest1" gets the following candidate mentions in room "public room" for "uest" with 200
+      | id           | label                    | source |
+      | GUEST_ID     | Guest                    | guests |
+    And user "guest2" gets the following candidate mentions in room "public room" for "uest" with 200
+      | id           | label                    | source |
+      | GUEST_ID     | Guest                    | guests |
+
+  Scenario: get matched named guest mentions in a public room
+    When user "participant1" creates room "public room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "public room" with 200
+    And user "participant3" joins room "public room" with 200
+    And user "guest1" joins room "public room" with 200
+    And guest "guest1" sets name to "FooBar" in room "public room" with 200
+    And user "guest2" joins room "public room" with 200
+    Then user "participant1" gets the following candidate mentions in room "public room" for "oob" with 200
+      | id           | label                    | source |
+      | GUEST_ID     | FooBar                   | guests |
+    And user "participant2" gets the following candidate mentions in room "public room" for "oob" with 200
+      | id           | label                    | source |
+      | GUEST_ID     | FooBar                   | guests |
+    And user "participant3" gets the following candidate mentions in room "public room" for "oob" with 200
+      | id           | label                    | source |
+      | GUEST_ID     | FooBar                   | guests |
+    And user "guest1" gets the following candidate mentions in room "public room" for "oob" with 200
+      | id           | label                    | source |
+    And user "guest2" gets the following candidate mentions in room "public room" for "oob" with 200
+      | id           | label                    | source |
+      | GUEST_ID     | FooBar                   | guests |
 
   Scenario: get unmatched mentions in a public room
     When user "participant1" creates room "public room"
@@ -173,6 +238,7 @@ Feature: chat/mentions
     Then user "participant1" gets the following candidate mentions in room "public room" for "unknown" with 200
     And user "participant2" gets the following candidate mentions in room "public room" for "unknown" with 200
     And user "participant3" gets the following candidate mentions in room "public room" for "unknown" with 200
+    And user "guest" gets the following candidate mentions in room "public room" for "unknown" with 200
 
   Scenario: get mentions in a public room with a participant not in the room
     When user "participant1" creates room "public room"

--- a/tests/php/Controller/SignalingControllerTest.php
+++ b/tests/php/Controller/SignalingControllerTest.php
@@ -700,6 +700,7 @@ class SignalingControllerTest extends \Test\TestCase {
 			$this->secureRandom,
 			$this->createMock(IUserManager::class),
 			$this->createMock(CommentsManager::class),
+			$this->createMock(TalkSession::class),
 			$dispatcher,
 			$this->timeFactory,
 			$this->createMock(IHasher::class),

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -29,6 +29,7 @@ use OCA\Spreed\Manager;
 use OCA\Spreed\Participant;
 use OCA\Spreed\Room;
 use OCA\Spreed\Signaling\BackendNotifier;
+use OCA\Spreed\TalkSession;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Http\Client\IClientService;
 use OCP\IGroupManager;
@@ -129,6 +130,7 @@ class BackendNotifierTest extends \Test\TestCase {
 			$this->secureRandom,
 			$this->createMock(IUserManager::class),
 			$this->createMock(CommentsManager::class),
+			$this->createMock(TalkSession::class),
 			$dispatcher,
 			$this->timeFactory,
 			$this->createMock(IHasher::class),


### PR DESCRIPTION
- [x] Requires https://github.com/nextcloud/server/pull/16331

### Notes
* `@"guest/<sha1(webrtc session id)>"` is used to mention a guest
* After reloading the chat, the mentions are not for "you" anymore. This is because we don't reuse the session id, so you get a new one (see #1793 )

### Todo
- [x] ~~Get guest mentions from comments~~ =>  https://github.com/nextcloud/server/pull/16331
- [x] Parse mentions and create the rich object parameters
- [x] Render the guest mentions in the chat view
- [x] Make sure the autocomplete uses the guest avatar
- [x] ~~Think about browser notifications~~ => https://github.com/nextcloud/spreed/issues/1975