### PR TITLE
Fix room synchronization after failure

### DIFF
--- a/js/signaling.js
+++ b/js/signaling.js
@@ -1217,14 +1217,16 @@
 			return this._pendingSyncRooms;
 		}
 
-		var defer = $.Deferred();
-		this._pendingSyncRooms = OCA.Talk.Signaling.Base.prototype.syncRooms.apply(this, arguments);
-		this._pendingSyncRooms.then(function(rooms) {
+		this._pendingSyncRooms = $.Deferred();
+		OCA.Talk.Signaling.Base.prototype.syncRooms.apply(this, arguments).then(function(rooms) {
+			// Remove _pendingSyncRooms before resolving it to make possible to
+			// sync again from handlers if needed.
+			var pendingSyncRooms = this._pendingSyncRooms;
 			this._pendingSyncRooms = null;
 			this.rooms = rooms;
-			defer.resolve(rooms);
+			pendingSyncRooms.resolve(rooms);
 		}.bind(this));
-		return defer;
+		return this._pendingSyncRooms;
 	};
 
 	OCA.Talk.Signaling.Standalone.prototype.processRoomListEvent = function(data) {

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -207,14 +207,14 @@
 		var defer = $.Deferred();
 		if (this.roomCollection && OC.getCurrentUser().uid) {
 			this.roomCollection.fetch({
-				success: function(data) {
-					defer.resolve(data);
+				success: function(roomCollection) {
+					defer.resolve(roomCollection);
 				}
 			});
 		} else if (this.room) {
 			this.room.fetch({
-				success: function(data) {
-					defer.resolve(data);
+				success: function(room) {
+					defer.resolve(room);
 				}
 			});
 		} else {

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -209,12 +209,18 @@
 			this.roomCollection.fetch({
 				success: function(roomCollection) {
 					defer.resolve(roomCollection);
+				},
+				error: function(roomCollection, response) {
+					defer.reject(roomCollection, response);
 				}
 			});
 		} else if (this.room) {
 			this.room.fetch({
 				success: function(room) {
 					defer.resolve(room);
+				},
+				error: function(room, response) {
+					defer.reject(room, response);
 				}
 			});
 		} else {
@@ -1225,6 +1231,10 @@
 			this._pendingSyncRooms = null;
 			this.rooms = rooms;
 			pendingSyncRooms.resolve(rooms);
+		}.bind(this)).fail(function() {
+			var pendingSyncRooms = this._pendingSyncRooms;
+			this._pendingSyncRooms = null;
+			pendingSyncRooms.reject();
 		}.bind(this));
 		return this._pendingSyncRooms;
 	};

--- a/js/signaling.js
+++ b/js/signaling.js
@@ -1199,9 +1199,9 @@
 	};
 
 	OCA.Talk.Signaling.Standalone.prototype.syncRooms = function() {
-		if (this.pending_sync) {
+		if (this._pendingSyncRooms) {
 			// A sync request is already in progress, don't start another one.
-			return this.pending_sync;
+			return this._pendingSyncRooms;
 		}
 
 		// Never manually sync rooms, will be done based on notifications
@@ -1212,15 +1212,15 @@
 	};
 
 	OCA.Talk.Signaling.Standalone.prototype.internalSyncRooms = function() {
-		if (this.pending_sync) {
+		if (this._pendingSyncRooms) {
 			// A sync request is already in progress, don't start another one.
-			return this.pending_sync;
+			return this._pendingSyncRooms;
 		}
 
 		var defer = $.Deferred();
-		this.pending_sync = OCA.Talk.Signaling.Base.prototype.syncRooms.apply(this, arguments);
-		this.pending_sync.then(function(rooms) {
-			this.pending_sync = null;
+		this._pendingSyncRooms = OCA.Talk.Signaling.Base.prototype.syncRooms.apply(this, arguments);
+		this._pendingSyncRooms.then(function(rooms) {
+			this._pendingSyncRooms = null;
 			this.rooms = rooms;
 			defer.resolve(rooms);
 		}.bind(this));


### PR DESCRIPTION
`syncRooms` returns a deferred object, but if the request failed the deferred object was not rejected; due to this `internalSyncRooms` only handled successful synchronizations, but if a synchronization failed the `_pendingSyncRooms` property was never cleared, and thus further calls to "internalSyncRooms" did nothing (as it assumed that the previous synchronization was still being performed even if it failed already). This silently broke the UI, causing issues like no updates in the room list, not being able to change to another room or apparently taking forever to leave a call.

Besides properly rejecting the deferred object in `syncRooms` when the request fails this pull request adds automatic retry of room synchronization similar to the one used when pulling chat messages or connecting the socket; `internalSyncRooms` still never fails, but the synchronization is now retried again and again until it succeeds (with some waiting time between retries). This waiting time is ignored when the socket is reconnected, though; in that case the rooms are immediately synchronized again, as it is very likely that if the room synchronization failed a successful socket reconnection hints that the network is available again (and if it fails again, no problem, it will keep retrying).

## How to test
- Setup the external signaling server
- For easier and quicker testing, reduce the timeout from 30000 to 5000 in [the periodic call to `internalSyncRooms()`](https://github.com/nextcloud/spreed/blob/71f66fe9b1e86fb244f9c7809bdf27c4c68e3d17/js/signaling.js#L737) and add `console.log('SYNC REQUEST ALREADY IN PROGRESS');` or something like that to [`internalSyncRooms`](https://github.com/nextcloud/spreed/blob/71f66fe9b1e86fb244f9c7809bdf27c4c68e3d17/js/signaling.js#L1216)
- Create two conversations
- Join one of the conversations (with a browser in a different machine than the server)
- Open the browser console
- Unplug the Internet cable
- Wait until `SYNC REQUEST ALREADY IN PROGRESS` has been printed
- Plug the cable again
- Join the other conversation

### Result with this pull request
The other conversation is joined and shown in the UI.

### Result without this pull request
The current conversation is left, but the UI is not updated with the other conversation (the _This conversation has ended_ message is shown instead).
