### PR TITLE
Make build system compatible with /compile bot

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   },
   "author": "",
   "license": "AGPL-3.0",
+  "scripts": {
+    "build": "make npm-init build-js-production bundle-simplewebrtc"
+  },
   "devDependencies": {
     "@babel/core": "^7.5.0",
     "@babel/preset-env": "^7.5.0",


### PR DESCRIPTION
The /compile bot first installs the NPM packages with [`npm init`](https://github.com/skjnldsv/npmbuildbot/blob/68cb24ddcd90e6a1d14940dd37f82b7452a3330b/lib/compile.js#L5) and then performs the build with [`npm run build`](https://github.com/skjnldsv/npmbuildbot/blob/68cb24ddcd90e6a1d14940dd37f82b7452a3330b/lib/compile.js#L20), which executes the command defined in `scripts->build` in _package.json_.

Currently `npm init` does not install all the NPM packages needed by Talk; it is necessary to run it [both in the root folder and in the _/vue_ folder](https://github.com/nextcloud/spreed/blob/de78f1040bf9538870679dd2f18b6be29a851a18/Makefile#L37). Due to this `make npm-init` needs to be run from the build script to install all the needed packages before performing the actual build.

**Edit:** I added a commit that updated _webrtc-adapter_ in _package.json_ and _nextcloud-vue-collections_ in _/vue/package.json_ and invoked the bot with `/compile fixup /`; a new fixup commit was created with the expected contents (now I have removed both the commits and the call to the /compile bot). Also worth noting that [the new checks](https://github.com/nextcloud/spreed/pull/1983) worked as expected when [the files were missing](https://drone.nextcloud.com/nextcloud/spreed/2627/1/2) and [once they were added by compile bot](https://drone.nextcloud.com/nextcloud/spreed/2628/1/2).