### PR TITLE
Fix parameter passed to OC.Notification

### DIFF
--- a/js/views/mediacontrolsview.js
+++ b/js/views/mediacontrolsview.js
@@ -1,4 +1,4 @@
-/* global Marionette, $ */
+/* global Marionette */
 
 /**
  *
@@ -21,7 +21,7 @@
  *
  */
 
-(function(OC, OCA, Marionette, $) {
+(function(OC, OCA, Marionette) {
 
 	'use strict';
 
@@ -350,4 +350,4 @@
 
 	OCA.SpreedMe.Views.MediaControlsView = MediaControlsView;
 
-})(OC, OCA, Marionette, $);
+})(OC, OCA, Marionette);

--- a/js/views/mediacontrolsview.js
+++ b/js/views/mediacontrolsview.js
@@ -320,7 +320,7 @@
 
 						if (extensionURL) {
 							var text = t('spreed', 'Screensharing extension is required to share your screen.');
-							var element = $('<a>').attr('href', extensionURL).attr('target','_blank').text(text);
+							var element = '<a href="' + extensionURL + '" target="_blank">' + escapeHTML(text) + '</a>';
 
 							OC.Notification.showTemporary(element, {isHTML: true});
 						} else {


### PR DESCRIPTION
Requires nextcloud/server#16369

[`OC.Notification.showTemporary` expects a string as its first parameter](https://github.com/nextcloud/server/blob/2d0337332d64065c5bf36dfb775c48976c0f730d/core/src/OC/notification.js#L139) (even if it contains HTML markup), but a jQuery object was passed instead; until now this just happened to work due to the internal implementation of that method, but this no longer works since [the switch to Toastify in Nextcloud 17](https://github.com/nextcloud/server/pull/15124).

## How to test

- Use Chromium < 72 without the screensharing extension
- Start a call
- Share the screen

### Result with this pull request

The notification shows _Screensharing extension is required to share your screen._; clicking on it opens the extension page.

### Result without this pull request

The notification shows _[Object object]_.
