### PR TITLE
↩️ Reply to messages

### DIFF
--- a/docs/chat.md
+++ b/docs/chat.md
@@ -54,6 +54,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
     ------|------|------------
     `message` | string | The message the user wants to say
     `actorDisplayName` | string | Guest display name (ignored for logged in users)
+    `replyTo` | int | The message ID this message is a reply to (only allowed for messages from the same conversation and when the message type is not `system` or `command`)
 
 * Response:
     - Header:

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -40,6 +40,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         `actorDisplayName` | string | Display name of the message author
         `timestamp` | int | Timestamp in seconds and UTC time zone
         `systemMessage` | string | empty for normal chat message or the type of the system message (untranslated)
+        `messageType` | string | Currently known types are `comment`, `system` and `command`
         `message` | string | Message string with placeholders (see [Rich Object String](https://github.com/nextcloud/server/issues/1706))
         `messageParameters` | array | Message parameters for `message` (see [Rich Object String](https://github.com/nextcloud/server/issues/1706))
 

--- a/js/models/chatmessage.js
+++ b/js/models/chatmessage.js
@@ -49,7 +49,8 @@
 			actorDisplayName: '',
 			timestamp: 0,
 			message: '',
-			messageParameters: []
+			messageParameters: [],
+			replyTo: 0
 		},
 
 		url: function() {

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -138,16 +138,21 @@ class ChatManager {
 	 * @param string $actorType
 	 * @param string $actorId
 	 * @param string $message
+	 * @param IComment|null $replyTo
 	 * @param \DateTime $creationDateTime
 	 * @return IComment
 	 */
-	public function sendMessage(Room $chat, Participant $participant, string $actorType, string $actorId, string $message, \DateTime $creationDateTime): IComment {
+	public function sendMessage(Room $chat, Participant $participant, string $actorType, string $actorId, string $message, \DateTime $creationDateTime, ?IComment $replyTo): IComment {
 		$comment = $this->commentsManager->create($actorType, $actorId, 'chat', (string) $chat->getId());
 		$comment->setMessage($message, self::MAX_CHAT_LENGTH);
 		$comment->setCreationDateTime($creationDateTime);
 		// A verb ('comment', 'like'...) must be provided to be able to save a
 		// comment
 		$comment->setVerb('comment');
+
+		if ($replyTo instanceof IComment) {
+			$comment->setParentId($replyTo->getId());
+		}
 
 		$this->dispatcher->dispatch(self::class . '::preSendMessage', new GenericEvent($chat, [
 			'comment' => $comment,
@@ -175,6 +180,22 @@ class ChatManager {
 				'participant' => $participant,
 			]));
 		} catch (NotFoundException $e) {
+		}
+
+		return $comment;
+	}
+
+	/**
+	 * @param Room $chat
+	 * @param string $parentId
+	 * @return IComment
+	 * @throws NotFoundException
+	 */
+	public function getParentComment(Room $chat, string $parentId): IComment {
+		$comment = $this->commentsManager->get($parentId);
+
+		if ($comment->getObjectType() !== 'chat' || $comment->getObjectId() !== (string) $chat->getId()) {
+			throw new NotFoundException('Parent not found in the right context');
 		}
 
 		return $comment;

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -235,8 +235,7 @@ class SystemMessage {
 			throw new \OutOfBoundsException('Unknown subject');
 		}
 
-		$comment->setMessage($message, ChatManager::MAX_CHAT_LENGTH);
-		$chatMessage->setMessage($parsedMessage, $parsedParameters);
+		$chatMessage->setMessage($parsedMessage, $parsedParameters, $message);
 	}
 
 	/**

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -157,6 +157,12 @@ class ChatController extends AEnvironmentAwareController {
 				// Someone is trying to reply cross-rooms or to a non-existing message
 				return new DataResponse([], Http::STATUS_BAD_REQUEST);
 			}
+
+			$parentMessage = $this->messageParser->createMessage($this->room, $this->participant, $parent, $this->l);
+			$this->messageParser->parseMessage($parentMessage);
+			if ($parentMessage->getMessageType() === 'system' || $parentMessage->getMessageType() === 'command') {
+				return new DataResponse([], Http::STATUS_BAD_REQUEST);
+			}
 		}
 
 		$this->room->ensureOneToOneRoomIsFilled();

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -349,6 +349,7 @@ class ChatController extends AEnvironmentAwareController {
 			'message' => $message->getMessage(),
 			'messageParameters' => $message->getMessageParameters(),
 			'systemMessage' => $message->getMessageType() === 'system' ? $message->getMessageRaw() : '',
+			'messageType' => $message->getMessageType(),
 		];
 	}
 

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -348,7 +348,7 @@ class ChatController extends AEnvironmentAwareController {
 			'timestamp' => $message->getComment()->getCreationDateTime()->getTimestamp(),
 			'message' => $message->getMessage(),
 			'messageParameters' => $message->getMessageParameters(),
-			'systemMessage' => $message->getMessageType() === 'system' ? $message->getComment()->getMessage() : '',
+			'systemMessage' => $message->getMessageType() === 'system' ? $message->getMessageRaw() : '',
 		];
 	}
 

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -328,6 +328,7 @@ class RoomController extends AEnvironmentAwareController {
 			'message' => $message->getMessage(),
 			'messageParameters' => $message->getMessageParameters(),
 			'systemMessage' => $message->getMessageType() === 'system' ? $message->getMessageRaw() : '',
+			'messageType' => $message->getMessageType(),
 		];
 	}
 

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -327,7 +327,7 @@ class RoomController extends AEnvironmentAwareController {
 			'timestamp' => $lastMessage->getCreationDateTime()->getTimestamp(),
 			'message' => $message->getMessage(),
 			'messageParameters' => $message->getMessageParameters(),
-			'systemMessage' => $message->getMessageType() === 'system' ? $lastMessage->getMessage() : '',
+			'systemMessage' => $message->getMessageType() === 'system' ? $message->getMessageRaw() : '',
 		];
 	}
 

--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -52,6 +52,9 @@ class Message {
 	/** @var string */
 	protected $message = '';
 
+	/** @var string */
+	protected $rawMessage = '';
+
 	/** @var array */
 	protected $parameters = [];
 
@@ -106,9 +109,10 @@ class Message {
 		return $this->visible;
 	}
 
-	public function setMessage(string $message, array $parameters): void {
+	public function setMessage(string $message, array $parameters, string $rawMessage = ''): void {
 		$this->message = $message;
 		$this->parameters = $parameters;
+		$this->rawMessage = $rawMessage;
 	}
 
 	public function getMessage(): string {
@@ -117,6 +121,10 @@ class Message {
 
 	public function getMessageParameters(): array {
 		return $this->parameters;
+	}
+
+	public function getMessageRaw(): string {
+		return $this->rawMessage;
 	}
 
 	public function setMessageType(string $type): void {

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -165,7 +165,7 @@ class Notifier implements INotifier {
 			}
 			return $this->parseCall($notification, $room, $l);
 		}
-		if ($subject === 'mention' || $subject === 'chat') {
+		if ($subject === 'reply' || $subject === 'mention' || $subject === 'chat') {
 			return $this->parseChatMessage($notification, $room, $participant, $l);
 		}
 
@@ -251,25 +251,31 @@ class Notifier implements INotifier {
 		if ($notification->getSubject() === 'chat') {
 			if ($room->getType() === Room::ONE_TO_ONE_CALL) {
 				$subject = $l->t('{user} sent you a private message');
+			} else if ($richSubjectUser) {
+				$subject = $l->t('{user} sent a message in conversation {call}');
+			} else if (!$isGuest) {
+				$subject = $l->t('A deleted user sent a message in conversation {call}');
 			} else {
-				if ($richSubjectUser) {
-					$subject = $l->t('{user} sent a message in conversation {call}');
-				} else if (!$isGuest) {
-					$subject = $l->t('A deleted user sent a message in conversation {call}');
-				} else {
-					$subject = $l->t('A guest sent a message in conversation {call}');
-				}
+				$subject = $l->t('A guest sent a message in conversation {call}');
+			}
+		} else if ($notification->getSubject() === 'reply') {
+			if ($room->getType() === Room::ONE_TO_ONE_CALL) {
+				$subject = $l->t('{user} replied to your private message');
+			} else if ($richSubjectUser) {
+				$subject = $l->t('{user} replied to your message in conversation {call}');
+			} else if (!$isGuest) {
+				$subject = $l->t('A deleted user replied to your message in conversation {call}');
+			} else {
+				$subject = $l->t('A guest replied to your message in conversation {call}');
 			}
 		} else if ($room->getType() === Room::ONE_TO_ONE_CALL) {
 			$subject = $l->t('{user} mentioned you in a private conversation');
+		} else if ($richSubjectUser) {
+			$subject = $l->t('{user} mentioned you in conversation {call}');
+		} else if (!$isGuest) {
+			$subject = $l->t('A deleted user mentioned you in conversation {call}');
 		} else {
-			if ($richSubjectUser) {
-				$subject = $l->t('{user} mentioned you in conversation {call}');
-			} else if (!$isGuest) {
-				$subject = $l->t('A deleted user mentioned you in conversation {call}');
-			} else {
-				$subject = $l->t('A guest mentioned you in conversation {call}');
-			}
+			$subject = $l->t('A guest mentioned you in conversation {call}');
 		}
 		$notification = $this->addActionButton($notification, $l->t('View chat'), false);
 

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -639,6 +639,13 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			}
 		}, $actual);
 
+		foreach ($messages as $message) {
+			// Include the received messages in the list of messages used for
+			// replies; this is needed to get special messages not explicitly
+			// sent like those for shared files.
+			self::$messages[$message['message']] = $message['id'];
+		}
+
 		if ($formData === null) {
 			PHPUnit_Framework_Assert::assertEmpty($messages);
 			return;
@@ -646,6 +653,11 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$includeParents = in_array('parentMessage', $formData->getRow(0), true);
 
 		PHPUnit_Framework_Assert::assertCount(count($formData->getHash()), $messages, 'Message count does not match');
+		for ($i = 0; $i < count($formData->getHash()); $i++) {
+			if ($formData->getHash()[$i]['messageParameters'] === '"IGNORE"') {
+				$messages[$i]['messageParameters'] = 'IGNORE';
+			}
+		}
 		PHPUnit_Framework_Assert::assertEquals($formData->getHash(), array_map(function($message) use($includeParents) {
 			$data = [
 				'room' => self::$tokenToIdentifier[$message['token']],

--- a/tests/integration/features/chat/reply.feature
+++ b/tests/integration/features/chat/reply.feature
@@ -62,21 +62,20 @@ Feature: chat/reply
 
 
 
-  Scenario: user can reply to private commands
+  Scenario: user can not reply to commands
     Given user "participant1" creates room "group room"
       | roomType | 2 |
       | invite   | attendees1 |
     And user "participant1" sends message "/help" to room "group room" with 201
     # In the tests the reference for the message to reply to is got from the
     # messages originally sent, not from how they are returned by the server.
-    When user "participant1" sends reply "Message X-1" on message "/help" to room "group room" with 201
+    When user "participant1" sends reply "Message X-1" on message "/help" to room "group room" with 400
     Then user "participant1" sees the following messages in room "group room" with 200
-      | room       | actorType | actorId      | actorDisplayName         | message                                    | messageParameters | parentMessage                              |
-      | group room | users     | participant1 | participant1-displayname | Message X-1                                | []                | There are currently no commands available. |
-      | group room | bots      | talk         | talk-bot                 | There are currently no commands available. | []                |                                            |
+      | room       | actorType | actorId | actorDisplayName | message                                    | messageParameters | parentMessage |
+      | group room | bots      | talk    | talk-bot         | There are currently no commands available. | []                |               |
     And user "participant2" sees the following messages in room "group room" with 200
 
-  Scenario: user can reply to system messages
+  Scenario: user can not reply to system messages
     Given user "participant1" creates room "group room"
       | roomType | 2 |
       | invite   | attendees1 |
@@ -86,13 +85,9 @@ Feature: chat/reply
       | room       | actorType | actorId      | actorDisplayName         | systemMessage        |
       | group room | users     | participant1 | participant1-displayname | user_added           |
       | group room | users     | participant1 | participant1-displayname | conversation_created |
-    When user "participant1" sends reply "Message X-1" on message "conversation_created" to room "group room" with 201
+    When user "participant1" sends reply "Message X-1" on message "conversation_created" to room "group room" with 400
     Then user "participant1" sees the following messages in room "group room" with 200
-      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage                |
-      | group room | users     | participant1 | participant1-displayname | Message X-1 | []                | You created the conversation |
     And user "participant2" sees the following messages in room "group room" with 200
-      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage                    |
-      | group room | users     | participant1 | participant1-displayname | Message X-1 | []                | {actor} created the conversation |
 
 
 

--- a/tests/integration/features/chat/reply.feature
+++ b/tests/integration/features/chat/reply.feature
@@ -62,6 +62,34 @@ Feature: chat/reply
 
 
 
+  Scenario: user can reply to shared file messages
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | invite   | attendees1 |
+    And user "participant1" shares "welcome.txt" with room "group room"
+    # The messages need to be got so the file message is added to the list of
+    # known messages to reply to.
+    # The file message parameters are not relevant for this test and are quite
+    # large, so they are simply ignored.
+    And user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | {file}  | "IGNORE"          |               |
+    And user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | {file}  | "IGNORE"          |               |
+    When user "participant1" sends reply "Message X-1" on message "{file}" to room "group room" with 201
+    And user "participant2" sends reply "Message X-2" on message "{file}" to room "group room" with 201
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant2 | participant2-displayname | Message X-2 | []                | {file}        |
+      | group room | users     | participant1 | participant1-displayname | Message X-1 | []                | {file}        |
+      | group room | users     | participant1 | participant1-displayname | {file}      | "IGNORE"          |               |
+    And user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant2 | participant2-displayname | Message X-2 | []                | {file}        |
+      | group room | users     | participant1 | participant1-displayname | Message X-1 | []                | {file}        |
+      | group room | users     | participant1 | participant1-displayname | {file}      | "IGNORE"          |               |
+
   Scenario: user can not reply to commands
     Given user "participant1" creates room "group room"
       | roomType | 2 |

--- a/tests/php/Chat/NotifierTest.php
+++ b/tests/php/Chat/NotifierTest.php
@@ -174,7 +174,35 @@ class NotifierTest extends \Test\TestCase {
 			->method('notify')
 			->with($notification);
 
-		$this->notifier->notifyMentionedUsers($room, $comment);
+		$this->notifier->notifyMentionedUsers($room, $comment, []);
+	}
+
+	public function testNotNotifyMentionedUserIfReplyToAuthor() {
+		$comment = $this->newComment(108, 'users', 'testUser', new \DateTime('@' . 1000000016), 'Mention @anotherUser');
+
+		$room = $this->createMock(Room::class);
+		$room->expects($this->any())
+			->method('getToken')
+			->willReturn('Token123');
+
+		$notification = $this->newNotification($room, $comment);
+
+		$this->notificationManager->expects($this->once())
+			->method('createNotification')
+			->willReturn($notification);
+
+		$notification->expects($this->never())
+			->method('setUser');
+
+		$notification->expects($this->once())
+			->method('setMessage')
+			->with('comment')
+			->willReturnSelf();
+
+		$this->notificationManager->expects($this->never())
+			->method('notify');
+
+		$this->notifier->notifyMentionedUsers($room, $comment, ['anotherUser']);
 	}
 
 	public function testNotifyMentionedUsersByGuest() {
@@ -217,7 +245,7 @@ class NotifierTest extends \Test\TestCase {
 			->method('notify')
 			->with($notification);
 
-		$this->notifier->notifyMentionedUsers($room, $comment);
+		$this->notifier->notifyMentionedUsers($room, $comment, []);
 	}
 
 	public function testNotifyMentionedUsersWithLongMessageStartMention() {
@@ -261,7 +289,7 @@ class NotifierTest extends \Test\TestCase {
 			->method('notify')
 			->with($notification);
 
-		$this->notifier->notifyMentionedUsers($room, $comment);
+		$this->notifier->notifyMentionedUsers($room, $comment, []);
 	}
 
 	public function testNotifyMentionedUsersWithLongMessageMiddleMention() {
@@ -305,7 +333,7 @@ class NotifierTest extends \Test\TestCase {
 			->method('notify')
 			->with($notification);
 
-		$this->notifier->notifyMentionedUsers($room, $comment);
+		$this->notifier->notifyMentionedUsers($room, $comment, []);
 	}
 
 	public function testNotifyMentionedUsersWithLongMessageEndMention() {
@@ -349,7 +377,7 @@ class NotifierTest extends \Test\TestCase {
 			->method('notify')
 			->with($notification);
 
-		$this->notifier->notifyMentionedUsers($room, $comment);
+		$this->notifier->notifyMentionedUsers($room, $comment, []);
 	}
 
 	public function testNotifyMentionedUsersToSelf() {
@@ -369,7 +397,7 @@ class NotifierTest extends \Test\TestCase {
 		$this->notificationManager->expects($this->never())
 			->method('notify');
 
-		$this->notifier->notifyMentionedUsers($room, $comment);
+		$this->notifier->notifyMentionedUsers($room, $comment, []);
 	}
 
 	public function testNotifyMentionedUsersToUnknownUser() {
@@ -390,7 +418,7 @@ class NotifierTest extends \Test\TestCase {
 		$this->notificationManager->expects($this->never())
 			->method('notify');
 
-		$this->notifier->notifyMentionedUsers($room, $comment);
+		$this->notifier->notifyMentionedUsers($room, $comment, []);
 	}
 
 	public function testNotifyMentionedUsersToUserNotInvitedToChat() {
@@ -421,7 +449,7 @@ class NotifierTest extends \Test\TestCase {
 		$this->notificationManager->expects($this->never())
 			->method('notify');
 
-		$this->notifier->notifyMentionedUsers($room, $comment);
+		$this->notifier->notifyMentionedUsers($room, $comment, []);
 	}
 
 	public function testNotifyMentionedUsersNoMentions() {
@@ -438,7 +466,7 @@ class NotifierTest extends \Test\TestCase {
 		$this->notificationManager->expects($this->never())
 			->method('notify');
 
-		$this->notifier->notifyMentionedUsers($room, $comment);
+		$this->notifier->notifyMentionedUsers($room, $comment, []);
 	}
 
 	public function testNotifyMentionedUsersSeveralMentions() {
@@ -487,7 +515,7 @@ class NotifierTest extends \Test\TestCase {
 				[ $notification ]
 			);
 
-		$this->notifier->notifyMentionedUsers($room, $comment);
+		$this->notifier->notifyMentionedUsers($room, $comment, []);
 	}
 
 	public function testRemovePendingNotificationsForRoom() {

--- a/tests/php/Chat/Parser/SystemMessageTest.php
+++ b/tests/php/Chat/Parser/SystemMessageTest.php
@@ -368,17 +368,13 @@ class SystemMessageTest extends TestCase {
 				->method('getFileFromShare');
 		}
 
-		$comment->expects($this->once())
-			->method('setMessage')
-			->with($message);
-
 		/** @var Room|MockObject $room */
 		$room = $this->createMock(Room::class);
 		$chatMessage = new Message($room, $participant, $comment, $this->l);
 		$chatMessage->setMessage(json_encode([
 			'message' => $message,
 			'parameters' => $parameters,
-		]), []);
+		]), [], $message);
 
 		$parser->parseMessage($chatMessage);
 

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -436,6 +436,12 @@ class ChatControllerTest extends TestCase {
 				$chatMessage->expects($this->once())
 					->method('getVisibility')
 					->willReturn(true);
+				$chatMessage->expects($this->atLeastOnce())
+					->method('getComment')
+					->willReturn($comment);
+				$chatMessage->expects($this->once())
+					->method('getRoom')
+					->willReturn($room);
 
 				$i--;
 				return $chatMessage;
@@ -508,6 +514,12 @@ class ChatControllerTest extends TestCase {
 				$chatMessage->expects($this->once())
 					->method('getVisibility')
 					->willReturn(true);
+				$chatMessage->expects($this->atLeastOnce())
+					->method('getComment')
+					->willReturn($comment);
+				$chatMessage->expects($this->once())
+					->method('getRoom')
+					->willReturn($room);
 
 				$i--;
 				return $chatMessage;
@@ -583,6 +595,12 @@ class ChatControllerTest extends TestCase {
 				$chatMessage->expects($this->once())
 					->method('getVisibility')
 					->willReturn(true);
+				$chatMessage->expects($this->atLeastOnce())
+					->method('getComment')
+					->willReturn($comment);
+				$chatMessage->expects($this->once())
+					->method('getRoom')
+					->willReturn($room);
 
 				$i--;
 				return $chatMessage;
@@ -666,6 +684,12 @@ class ChatControllerTest extends TestCase {
 				$chatMessage->expects($this->once())
 					->method('getVisibility')
 					->willReturn(true);
+				$chatMessage->expects($this->atLeastOnce())
+					->method('getComment')
+					->willReturn($comment);
+				$chatMessage->expects($this->once())
+					->method('getRoom')
+					->willReturn($room);
 
 				$i++;
 				return $chatMessage;

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -220,6 +220,206 @@ class ChatControllerTest extends TestCase {
 		$this->assertEquals($expected, $response);
 	}
 
+	public function testSendReplyByUser() {
+		$participant = $this->createMock(Participant::class);
+		$this->room->expects($this->exactly(2))
+			->method('getToken')
+			->willReturn('testToken');
+
+		$date = new \DateTime();
+		$this->timeFactory->expects($this->once())
+			->method('getDateTime')
+			->willReturn($date);
+
+		/** @var IComment|MockObject $comment */
+		$parent = $this->newComment(23, 'user', $this->userId . '2', $date, 'testMessage original');
+
+		/** @var IComment|MockObject $comment */
+		$comment = $this->newComment(42, 'user', $this->userId, $date, 'testMessage');
+		$this->chatManager->expects($this->once())
+			->method('sendMessage')
+			->with($this->room,
+				$participant,
+				'users',
+				$this->userId,
+				'testMessage',
+				$this->newMessageDateTimeConstraint,
+				$parent
+			)
+			->willReturn($comment);
+		$this->chatManager->expects($this->once())
+			->method('getParentComment')
+			->with($this->room, 23)
+			->willReturn($parent);
+
+		$parentMessage = $this->createMock(Message::class);
+		$parentMessage->expects($this->once())
+			->method('getActorType')
+			->willReturn('user');
+		$parentMessage->expects($this->once())
+			->method('getActorId')
+			->willReturn($this->userId . '2');
+		$parentMessage->expects($this->once())
+			->method('getActorDisplayName')
+			->willReturn('displayName2');
+		$parentMessage->expects($this->once())
+			->method('getMessage')
+			->willReturn('parsedMessage2');
+		$parentMessage->expects($this->once())
+			->method('getMessageParameters')
+			->willReturn(['arg' => 'uments2']);
+		$parentMessage->expects($this->exactly(3))
+			->method('getMessageType')
+			->willReturn('comment');
+		$parentMessage->expects($this->exactly(2))
+			->method('getComment')
+			->willReturn($parent);
+		$parentMessage->expects($this->once())
+			->method('getRoom')
+			->willReturn($this->room);
+
+		$chatMessage = $this->createMock(Message::class);
+		$chatMessage->expects($this->once())
+			->method('getActorType')
+			->willReturn('user');
+		$chatMessage->expects($this->once())
+			->method('getActorId')
+			->willReturn($this->userId);
+		$chatMessage->expects($this->once())
+			->method('getActorDisplayName')
+			->willReturn('displayName');
+		$chatMessage->expects($this->once())
+			->method('getMessage')
+			->willReturn('parsedMessage');
+		$chatMessage->expects($this->once())
+			->method('getMessageParameters')
+			->willReturn(['arg' => 'uments']);
+		$chatMessage->expects($this->once())
+			->method('getMessageType')
+			->willReturn('comment');
+		$chatMessage->expects($this->once())
+			->method('getVisibility')
+			->willReturn(true);
+		$chatMessage->expects($this->exactly(2))
+			->method('getComment')
+			->willReturn($comment);
+		$chatMessage->expects($this->once())
+			->method('getRoom')
+			->willReturn($this->room);
+
+		$this->messageParser->expects($this->exactly(2))
+			->method('createMessage')
+			->withConsecutive(
+				[$this->room, $participant, $parent, $this->l],
+				[$this->room, $participant, $comment, $this->l]
+			)
+			->willReturnOnConsecutiveCalls($parentMessage, $chatMessage);
+
+		$this->messageParser->expects($this->exactly(2))
+			->method('parseMessage')
+			->withConsecutive([$parentMessage], [$chatMessage]);
+
+		$this->controller->setRoom($this->room);
+		$this->controller->setParticipant($participant);
+		$response = $this->controller->sendMessage('testMessage', '', 23);
+		$expected = new DataResponse([
+			'id' => 42,
+			'token' => 'testToken',
+			'actorType' => 'user',
+			'actorId' => $this->userId,
+			'actorDisplayName' => 'displayName',
+			'timestamp' => $date->getTimestamp(),
+			'message' => 'parsedMessage',
+			'messageParameters' => ['arg' => 'uments'],
+			'systemMessage' => '',
+			'parent' => [
+				'id' => 23,
+				'token' => 'testToken',
+				'actorType' => 'user',
+				'actorId' => $this->userId . '2',
+				'actorDisplayName' => 'displayName2',
+				'timestamp' => $date->getTimestamp(),
+				'message' => 'parsedMessage2',
+				'messageParameters' => ['arg' => 'uments2'],
+				'systemMessage' => '',
+			]
+		], Http::STATUS_CREATED);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testSendReplyByUserToCommand() {
+		$participant = $this->createMock(Participant::class);
+
+		$date = new \DateTime();
+		/** @var IComment|MockObject $comment */
+		$parent = $this->newComment(23, 'user', $this->userId . '2', $date, 'testMessage original');
+
+		$this->chatManager->expects($this->never())
+			->method('sendMessage');
+		$this->chatManager->expects($this->once())
+			->method('getParentComment')
+			->with($this->room, 23)
+			->willReturn($parent);
+
+		$parentMessage = $this->createMock(Message::class);
+		$parentMessage->expects($this->exactly(2))
+			->method('getMessageType')
+			->willReturn('command');
+
+		$this->messageParser->expects($this->once())
+			->method('createMessage')
+			->with($this->room, $participant, $parent, $this->l)
+			->willReturn($parentMessage);
+
+		$this->messageParser->expects($this->once())
+			->method('parseMessage')
+			->with($parentMessage);
+
+		$this->controller->setRoom($this->room);
+		$this->controller->setParticipant($participant);
+		$response = $this->controller->sendMessage('testMessage', '', 23);
+		$expected = new DataResponse([], Http::STATUS_BAD_REQUEST);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testSendReplyByUserToSystemMessage() {
+		$participant = $this->createMock(Participant::class);
+
+		$date = new \DateTime();
+		/** @var IComment|MockObject $comment */
+		$parent = $this->newComment(23, 'user', $this->userId . '2', $date, 'testMessage original');
+
+		$this->chatManager->expects($this->never())
+			->method('sendMessage');
+		$this->chatManager->expects($this->once())
+			->method('getParentComment')
+			->with($this->room, 23)
+			->willReturn($parent);
+
+		$parentMessage = $this->createMock(Message::class);
+		$parentMessage->expects($this->once())
+			->method('getMessageType')
+			->willReturn('system');
+
+		$this->messageParser->expects($this->once())
+			->method('createMessage')
+			->with($this->room, $participant, $parent, $this->l)
+			->willReturn($parentMessage);
+
+		$this->messageParser->expects($this->once())
+			->method('parseMessage')
+			->with($parentMessage);
+
+		$this->controller->setRoom($this->room);
+		$this->controller->setParticipant($participant);
+		$response = $this->controller->sendMessage('testMessage', '', 23);
+		$expected = new DataResponse([], Http::STATUS_BAD_REQUEST);
+
+		$this->assertEquals($expected, $response);
+	}
+
 	public function testSendMessageByUserNotJoinedButInRoom() {
 		$participant = $this->createMock(Participant::class);
 		$this->room->expects($this->once())

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -180,7 +180,7 @@ class ChatControllerTest extends TestCase {
 		$chatMessage->expects($this->once())
 			->method('getMessageParameters')
 			->willReturn(['arg' => 'uments']);
-		$chatMessage->expects($this->once())
+		$chatMessage->expects($this->exactly(2))
 			->method('getMessageType')
 			->willReturn('comment');
 		$chatMessage->expects($this->once())
@@ -215,6 +215,7 @@ class ChatControllerTest extends TestCase {
 			'message' => 'parsedMessage',
 			'messageParameters' => ['arg' => 'uments'],
 			'systemMessage' => '',
+			'messageType' => 'comment',
 		], Http::STATUS_CREATED);
 
 		$this->assertEquals($expected, $response);
@@ -268,7 +269,7 @@ class ChatControllerTest extends TestCase {
 		$parentMessage->expects($this->once())
 			->method('getMessageParameters')
 			->willReturn(['arg' => 'uments2']);
-		$parentMessage->expects($this->exactly(3))
+		$parentMessage->expects($this->exactly(4))
 			->method('getMessageType')
 			->willReturn('comment');
 		$parentMessage->expects($this->exactly(2))
@@ -294,7 +295,7 @@ class ChatControllerTest extends TestCase {
 		$chatMessage->expects($this->once())
 			->method('getMessageParameters')
 			->willReturn(['arg' => 'uments']);
-		$chatMessage->expects($this->once())
+		$chatMessage->expects($this->exactly(2))
 			->method('getMessageType')
 			->willReturn('comment');
 		$chatMessage->expects($this->once())
@@ -332,6 +333,7 @@ class ChatControllerTest extends TestCase {
 			'message' => 'parsedMessage',
 			'messageParameters' => ['arg' => 'uments'],
 			'systemMessage' => '',
+			'messageType' => 'comment',
 			'parent' => [
 				'id' => 23,
 				'token' => 'testToken',
@@ -342,6 +344,7 @@ class ChatControllerTest extends TestCase {
 				'message' => 'parsedMessage2',
 				'messageParameters' => ['arg' => 'uments2'],
 				'systemMessage' => '',
+				'messageType' => 'comment',
 			]
 		], Http::STATUS_CREATED);
 
@@ -459,7 +462,7 @@ class ChatControllerTest extends TestCase {
 		$chatMessage->expects($this->once())
 			->method('getMessageParameters')
 			->willReturn(['arg' => 'uments2']);
-		$chatMessage->expects($this->once())
+		$chatMessage->expects($this->exactly(2))
 			->method('getMessageType')
 			->willReturn('comment');
 		$chatMessage->expects($this->once())
@@ -494,6 +497,7 @@ class ChatControllerTest extends TestCase {
 			'message' => 'parsedMessage2',
 			'messageParameters' => ['arg' => 'uments2'],
 			'systemMessage' => '',
+			'messageType' => 'comment',
 		], Http::STATUS_CREATED);
 
 		$this->assertEquals($expected, $response);
@@ -546,7 +550,7 @@ class ChatControllerTest extends TestCase {
 		$chatMessage->expects($this->once())
 			->method('getMessageParameters')
 			->willReturn(['arg' => 'uments3']);
-		$chatMessage->expects($this->once())
+		$chatMessage->expects($this->exactly(2))
 			->method('getMessageType')
 			->willReturn('comment');
 		$chatMessage->expects($this->once())
@@ -581,6 +585,7 @@ class ChatControllerTest extends TestCase {
 			'message' => 'parsedMessage3',
 			'messageParameters' => ['arg' => 'uments3'],
 			'systemMessage' => '',
+			'messageType' => 'comment',
 		], Http::STATUS_CREATED);
 
 		$this->assertEquals($expected, $response);
@@ -630,7 +635,7 @@ class ChatControllerTest extends TestCase {
 				$chatMessage->expects($this->once())
 					->method('getMessageParameters')
 					->willReturn(['testMessageParameters' . $i]);
-				$chatMessage->expects($this->once())
+				$chatMessage->expects($this->exactly(2))
 					->method('getMessageType')
 					->willReturn('comment');
 				$chatMessage->expects($this->once())
@@ -654,10 +659,10 @@ class ChatControllerTest extends TestCase {
 		$this->controller->setParticipant($participant);
 		$response = $this->controller->receiveMessages(0, $limit, $offset);
 		$expected = new DataResponse([
-			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User4', 'timestamp'=>1000000016, 'message'=>'testMessage4', 'messageParameters'=>['testMessageParameters4'], 'systemMessage' => ''],
-			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>'User3', 'timestamp'=>1000000015, 'message'=>'testMessage3', 'messageParameters'=>['testMessageParameters3'], 'systemMessage' => ''],
-			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>'User2', 'timestamp'=>1000000008, 'message'=>'testMessage2', 'messageParameters'=>['testMessageParameters2'], 'systemMessage' => ''],
-			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User1', 'timestamp'=>1000000004, 'message'=>'testMessage1', 'messageParameters'=>['testMessageParameters1'], 'systemMessage' => '']
+			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User4', 'timestamp'=>1000000016, 'message'=>'testMessage4', 'messageParameters'=>['testMessageParameters4'], 'systemMessage' => '', 'messageType' => 'comment'],
+			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>'User3', 'timestamp'=>1000000015, 'message'=>'testMessage3', 'messageParameters'=>['testMessageParameters3'], 'systemMessage' => '', 'messageType' => 'comment'],
+			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>'User2', 'timestamp'=>1000000008, 'message'=>'testMessage2', 'messageParameters'=>['testMessageParameters2'], 'systemMessage' => '', 'messageType' => 'comment'],
+			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User1', 'timestamp'=>1000000004, 'message'=>'testMessage1', 'messageParameters'=>['testMessageParameters1'], 'systemMessage' => '', 'messageType' => 'comment']
 		], Http::STATUS_OK);
 		$expected->addHeader('X-Chat-Last-Given', 108);
 
@@ -708,7 +713,7 @@ class ChatControllerTest extends TestCase {
 				$chatMessage->expects($this->once())
 					->method('getMessageParameters')
 					->willReturn(['testMessageParameters' . $i]);
-				$chatMessage->expects($this->once())
+				$chatMessage->expects($this->exactly(2))
 					->method('getMessageType')
 					->willReturn('comment');
 				$chatMessage->expects($this->once())
@@ -732,10 +737,10 @@ class ChatControllerTest extends TestCase {
 		$this->controller->setParticipant($participant);
 		$response = $this->controller->receiveMessages(0, $limit, $offset);
 		$expected = new DataResponse([
-			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User4', 'timestamp'=>1000000016, 'message'=>'testMessage4', 'messageParameters'=>['testMessageParameters4'], 'systemMessage' => ''],
-			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>'User3', 'timestamp'=>1000000015, 'message'=>'testMessage3', 'messageParameters'=>['testMessageParameters3'], 'systemMessage' => ''],
-			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>'User2', 'timestamp'=>1000000008, 'message'=>'testMessage2', 'messageParameters'=>['testMessageParameters2'], 'systemMessage' => ''],
-			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User1', 'timestamp'=>1000000004, 'message'=>'testMessage1', 'messageParameters'=>['testMessageParameters1'], 'systemMessage' => '']
+			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User4', 'timestamp'=>1000000016, 'message'=>'testMessage4', 'messageParameters'=>['testMessageParameters4'], 'systemMessage' => '', 'messageType' => 'comment'],
+			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>'User3', 'timestamp'=>1000000015, 'message'=>'testMessage3', 'messageParameters'=>['testMessageParameters3'], 'systemMessage' => '', 'messageType' => 'comment'],
+			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>'User2', 'timestamp'=>1000000008, 'message'=>'testMessage2', 'messageParameters'=>['testMessageParameters2'], 'systemMessage' => '', 'messageType' => 'comment'],
+			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User1', 'timestamp'=>1000000004, 'message'=>'testMessage1', 'messageParameters'=>['testMessageParameters1'], 'systemMessage' => '', 'messageType' => 'comment']
 		], Http::STATUS_OK);
 		$expected->addHeader('X-Chat-Last-Given', 108);
 
@@ -789,7 +794,7 @@ class ChatControllerTest extends TestCase {
 				$chatMessage->expects($this->once())
 					->method('getMessageParameters')
 					->willReturn(['testMessageParameters' . $i]);
-				$chatMessage->expects($this->once())
+				$chatMessage->expects($this->exactly(2))
 					->method('getMessageType')
 					->willReturn('comment');
 				$chatMessage->expects($this->once())
@@ -813,10 +818,10 @@ class ChatControllerTest extends TestCase {
 		$this->controller->setParticipant($participant);
 		$response = $this->controller->receiveMessages(0, $limit, $offset);
 		$expected = new DataResponse([
-			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User4', 'timestamp'=>1000000016, 'message'=>'testMessage4', 'messageParameters'=>['testMessageParameters4'], 'systemMessage' => ''],
-			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>'User3', 'timestamp'=>1000000015, 'message'=>'testMessage3', 'messageParameters'=>['testMessageParameters3'], 'systemMessage' => ''],
-			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>'User2', 'timestamp'=>1000000008, 'message'=>'testMessage2', 'messageParameters'=>['testMessageParameters2'], 'systemMessage' => ''],
-			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User1', 'timestamp'=>1000000004, 'message'=>'testMessage1', 'messageParameters'=>['testMessageParameters1'], 'systemMessage' => '']
+			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User4', 'timestamp'=>1000000016, 'message'=>'testMessage4', 'messageParameters'=>['testMessageParameters4'], 'systemMessage' => '', 'messageType' => 'comment'],
+			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>'User3', 'timestamp'=>1000000015, 'message'=>'testMessage3', 'messageParameters'=>['testMessageParameters3'], 'systemMessage' => '', 'messageType' => 'comment'],
+			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>'User2', 'timestamp'=>1000000008, 'message'=>'testMessage2', 'messageParameters'=>['testMessageParameters2'], 'systemMessage' => '', 'messageType' => 'comment'],
+			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User1', 'timestamp'=>1000000004, 'message'=>'testMessage1', 'messageParameters'=>['testMessageParameters1'], 'systemMessage' => '', 'messageType' => 'comment']
 		], Http::STATUS_OK);
 		$expected->addHeader('X-Chat-Last-Given', 108);
 
@@ -878,7 +883,7 @@ class ChatControllerTest extends TestCase {
 				$chatMessage->expects($this->once())
 					->method('getMessageParameters')
 					->willReturn(['testMessageParameters' . $i]);
-				$chatMessage->expects($this->once())
+				$chatMessage->expects($this->exactly(2))
 					->method('getMessageType')
 					->willReturn('comment');
 				$chatMessage->expects($this->once())
@@ -902,10 +907,10 @@ class ChatControllerTest extends TestCase {
 		$this->controller->setParticipant($participant);
 		$response = $this->controller->receiveMessages(1, $limit, $offset, $timeout);
 		$expected = new DataResponse([
-			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User1', 'timestamp'=>1000000004, 'message'=>'testMessage1', 'messageParameters'=>['testMessageParameters1'], 'systemMessage' => ''],
-			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>'User2', 'timestamp'=>1000000008, 'message'=>'testMessage2', 'messageParameters'=>['testMessageParameters2'], 'systemMessage' => ''],
-			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>'User3', 'timestamp'=>1000000015, 'message'=>'testMessage3', 'messageParameters'=>['testMessageParameters3'], 'systemMessage' => ''],
-			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User4', 'timestamp'=>1000000016, 'message'=>'testMessage4', 'messageParameters'=>['testMessageParameters4'], 'systemMessage' => ''],
+			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User1', 'timestamp'=>1000000004, 'message'=>'testMessage1', 'messageParameters'=>['testMessageParameters1'], 'systemMessage' => '', 'messageType' => 'comment'],
+			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>'User2', 'timestamp'=>1000000008, 'message'=>'testMessage2', 'messageParameters'=>['testMessageParameters2'], 'systemMessage' => '', 'messageType' => 'comment'],
+			['id'=>110, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUnknownUser', 'actorDisplayName'=>'User3', 'timestamp'=>1000000015, 'message'=>'testMessage3', 'messageParameters'=>['testMessageParameters3'], 'systemMessage' => '', 'messageType' => 'comment'],
+			['id'=>111, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User4', 'timestamp'=>1000000016, 'message'=>'testMessage4', 'messageParameters'=>['testMessageParameters4'], 'systemMessage' => '', 'messageType' => 'comment'],
 		], Http::STATUS_OK);
 		$expected->addHeader('X-Chat-Last-Given', 111);
 

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -136,6 +136,7 @@ class ChatControllerTest extends TestCase {
 		$comment->method('getActorId')->willReturn($actorId);
 		$comment->method('getCreationDateTime')->willReturn($creationDateTime);
 		$comment->method('getMessage')->willReturn($message);
+		$comment->method('getParentId')->willReturn('0');
 
 		return $comment;
 	}
@@ -185,6 +186,12 @@ class ChatControllerTest extends TestCase {
 		$chatMessage->expects($this->once())
 			->method('getVisibility')
 			->willReturn(true);
+		$chatMessage->expects($this->exactly(2))
+			->method('getComment')
+			->willReturn($comment);
+		$chatMessage->expects($this->once())
+			->method('getRoom')
+			->willReturn($this->room);
 
 		$this->messageParser->expects($this->once())
 			->method('createMessage')
@@ -258,6 +265,12 @@ class ChatControllerTest extends TestCase {
 		$chatMessage->expects($this->once())
 			->method('getVisibility')
 			->willReturn(true);
+		$chatMessage->expects($this->exactly(2))
+			->method('getComment')
+			->willReturn($comment);
+		$chatMessage->expects($this->once())
+			->method('getRoom')
+			->willReturn($this->room);
 
 		$this->messageParser->expects($this->once())
 			->method('createMessage')
@@ -339,6 +352,12 @@ class ChatControllerTest extends TestCase {
 		$chatMessage->expects($this->once())
 			->method('getVisibility')
 			->willReturn(true);
+		$chatMessage->expects($this->exactly(2))
+			->method('getComment')
+			->willReturn($comment);
+		$chatMessage->expects($this->once())
+			->method('getRoom')
+			->willReturn($this->room);
 
 		$this->messageParser->expects($this->once())
 			->method('createMessage')

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -686,7 +686,7 @@ class NotifierTest extends \Test\TestCase {
 		$notification->expects($this->once())
 			->method('getApp')
 			->willReturn('spreed');
-		$notification->expects($this->exactly(2))
+		$notification->expects($this->atLeast(2))
 			->method('getSubject')
 			->willReturn($isMention ? 'mention'  : 'chat');
 		$notification->expects($this->once())


### PR DESCRIPTION
- [x] API changes
- [x] Return the original message as parent, so it can be rendered easily
- [ ] Add UI to reply to a message
- [ ] Adjust UI to render the parent message

PR might be delayed if the UI is not ready for 17.

For the UI maybe @jenniferpiperek and @jancborchardt have some comments? :)
From my PoV:
* There should be a reply button (or hidden in a … menu) on each message (future stuff may come too, like delete, etc), on mobile apps swiping to left (telegram) or right (whatsapp, viber) should be a shortcut to additional long press
* When starting to reply, a hint or the message itself is displayed on the new comment form, so you see what you are replying to (check the chat apps from above)
* The parent message is put as a one-liner in the top of the original message (trimmed), in a perfect world (maybe in Vue.JS) clicking the parent would jump to that message (like in any chat app)

---

To reply on this PR apply the following patch (219 being the comment id you want to reply to)
```diff
diff --git a/js/views/chatview.js b/js/views/chatview.js
index 16788817..0c0916d3 100644
--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -842,7 +842,8 @@
                        message = this._commentBodyHTML2Plain($commentField);
                        var data = {
                                token: this.collection.token,
-                               message: message
+                               message: message,
+                               replyTo: 219
                        };
 
                        if (!OC.getCurrentUser().uid) {
```

Fix #1136 