### PR TITLE
Fix peer creation for participants no longer in the call

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -228,6 +228,10 @@ var spreedPeerConnectionTable = [];
 			OCA.SpreedMe.videos.remove(sessionId);
 			delete spreedMappingTable[sessionId];
 			delete guestNamesTable[sessionId];
+			if (delayedCreatePeer[sessionId]) {
+				clearTimeout(delayedCreatePeer[sessionId]);
+				delete delayedCreatePeer[sessionId];
+			}
 		});
 
 		previousUsersInRoom = previousUsersInRoom.diff(disconnectedSessionIds);

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -349,6 +349,12 @@ var spreedPeerConnectionTable = [];
 				delete delayedCreatePeer[message.from];
 			}
 
+			if (!selfInCall) {
+				console.log('Offer received when not in the call, ignore');
+
+				message.type = 'offer-to-ignore';
+			}
+
 			// MCU screen offers do not include the "broadcaster" property,
 			// which is expected by SimpleWebRTC in screen offers from a remote
 			// peer, so it needs to be explicitly added.


### PR DESCRIPTION
This pull request fixes an issue with the internal signaling server, although it serves as a basis for a later fix with the external signaling server.

It prevents Peer objects from being created after the current participant left a call (as WebRTC still listens to the signaling events, so offers are still handled in the normal way; the proper fix would be to disconnect WebRTC from the signaling, but that requires deeper changes), and it also cancels the delayed peer creation if the other participant left the call (as in that case it makes no sense to still create a peer for that participant if no offer was received from him).

@Ivansss Note that I did not include in this pull request the fix to ignore a received offer if that offer comes from a participant not in the call; I am a little worried that it could also happen that when a participant joins the call the offer can be received before the participants update, so the participant would not be in the call from the point of view of the receiver and thus no peer would be created. Anyway, getting an offer from a participant that left the call is rather uncommon, so I think that for now we can keep it as is until we figure how to handle both scenarios.

## How to test

- Test with older versions of Firefox (for example, 52) or Chromium (for example, 62), as newer versions would reconnect instead of showing the bug (it may happen in other scenarios as well, but this is the "easiest" way to test)
- Insert the following lines [before users are appended to the list in `SignalingController::getUsersInRoom`](https://github.com/nextcloud/spreed/blob/6e1e78ec05bf4bce192fbe373a6c6606534bb6d4/lib/Controller/SignalingController.php#L237):
```
	$sessionId = $this->session->getSessionForRoom($room->getToken());
	if ($participant->getSessionId() > $sessionId && !rand(0, 3)) {
		continue;
	}
```

This will make that, sometimes, the participant that received the WebRTC offer from another participant disconnects from that participant.

- Insert `console.log('DELAYING PEER CREATION')` [before queuing the peer creation](https://github.com/nextcloud/spreed/blob/4bb188e884238b50e1b1c76b8c630e59feb48272/js/webrtc.js#L212)
- Start a call with user A
- Open the browser console
- Join the same call with user B
- Open the browser console
- Wait until `DELAYING PEER CREATION` is shown in one of the browser consoles
- Leave the call in the other browser (before 10 seconds have passed since the message was shown)

### Result with this pull request

No Peer object for the other participant is created neither in the browser of the participant that left the call (which can be checked through `OCA.SpreedMe.webrtc.webrtc.peers`) nor in the browser of the participant still in the call.

### Result without this pull request

A Peer object for the participant that is still in the call is created in the browser of the participant that left the call; a peer object (and its VideoView) for the participant that left the call is created in the browser of the participant that is still in the call.
