### PR TITLE
Fix using "activeRoom" in the shortcut handler before joining a room

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -231,6 +231,12 @@
 				$('div[contenteditable=true]:focus').length === 0 &&
 				!event.ctrlKey) {
 
+				// Shortcuts are not available in the starting page (before
+				// joining a room).
+				if (!this.activeRoom) {
+					return;
+				}
+
 				// When not in a call, only the f-shortcut is visible and can be used
 				var flags = this.activeRoom.get('participantFlags') || 0;
 				var inCall = (flags & OCA.SpreedMe.app.FLAG_IN_CALL) !== 0;


### PR DESCRIPTION
Follow up to #1946 

Note that the fullscreen shortcut could be used in the starting page. However, that would hide the navigation bar and no room could then be joined, so it would not make much sense. Therefore, the shortcuts are totally disabled in the starting page instead of fixing calling "get('participantFlags')" on a null room.

## How to test
- Open the browser console
- Open Talk (without joining any room)
- Press a key

### Result with this pull request
No errors appear in the browser console.

### Result without this pull request
`this.activeRoom is null` is shown in the browser console.
