### PR TITLE
Warn the user if speaking while muted

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -618,6 +618,8 @@
 
 			this._mediaControlsView = this._localVideoView._mediaControlsView;
 
+			this._speakingWhileMutedWarner = new OCA.Talk.Views.SpeakingWhileMutedWarner();
+
 			$(document).on('click', this.onDocumentClick);
 			OC.Util.History.addOnPopStateHandler(_.bind(this._onPopState, this));
 		},
@@ -726,6 +728,7 @@
 				OCA.SpreedMe.initWebRTC(this);
 				this._mediaControlsView.setWebRtc(OCA.SpreedMe.webrtc);
 				this._mediaControlsView.setSharedScreens(OCA.SpreedMe.sharedScreens);
+				this._speakingWhileMutedWarner.setWebRtc(OCA.SpreedMe.webrtc);
 			}
 
 			if (!OCA.SpreedMe.webrtc.capabilities.supportRTCPeerConnection) {

--- a/js/app.js
+++ b/js/app.js
@@ -618,7 +618,7 @@
 
 			this._mediaControlsView = this._localVideoView._mediaControlsView;
 
-			this._speakingWhileMutedWarner = new OCA.Talk.Views.SpeakingWhileMutedWarner();
+			this._speakingWhileMutedWarner = new OCA.Talk.Views.SpeakingWhileMutedWarner(this._mediaControlsView);
 
 			$(document).on('click', this.onDocumentClick);
 			OC.Util.History.addOnPopStateHandler(_.bind(this._onPopState, this));

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -88,6 +88,8 @@
 			});
 
 			this._mediaControlsView = this._localVideoView._mediaControlsView;
+
+			this._speakingWhileMutedWarner = new OCA.Talk.Views.SpeakingWhileMutedWarner();
 		},
 		onStart: function() {
 			this.signaling = OCA.Talk.Signaling.createConnection();
@@ -153,6 +155,7 @@
 			if (!OCA.SpreedMe.webrtc) {
 				OCA.SpreedMe.initWebRTC(this);
 				this._mediaControlsView.setWebRtc(OCA.SpreedMe.webrtc);
+				this._speakingWhileMutedWarner.setWebRtc(OCA.SpreedMe.webrtc);
 			}
 
 			if (!OCA.SpreedMe.webrtc.capabilities.supportRTCPeerConnection) {

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -89,7 +89,7 @@
 
 			this._mediaControlsView = this._localVideoView._mediaControlsView;
 
-			this._speakingWhileMutedWarner = new OCA.Talk.Views.SpeakingWhileMutedWarner();
+			this._speakingWhileMutedWarner = new OCA.Talk.Views.SpeakingWhileMutedWarner(this._mediaControlsView);
 		},
 		onStart: function() {
 			this.signaling = OCA.Talk.Signaling.createConnection();

--- a/js/merged-files.json
+++ b/js/merged-files.json
@@ -18,6 +18,7 @@
   "views/mediacontrolsview.js",
   "views/richobjectstringparser.js",
   "views/screenview.js",
+  "views/speakingwhilemutedwarner.js",
   "views/templates.js",
   "views/videoview.js",
   "views/virtuallist.js",

--- a/js/merged-guest.json
+++ b/js/merged-guest.json
@@ -24,6 +24,7 @@
   "views/richobjectstringparser.js",
   "views/screenview.js",
   "views/sidebarview.js",
+  "views/speakingwhilemutedwarner.js",
   "views/tabview.js",
   "views/templates.js",
   "views/videoview.js",

--- a/js/merged-share-auth.json
+++ b/js/merged-share-auth.json
@@ -19,6 +19,7 @@
   "views/mediacontrolsview.js",
   "views/richobjectstringparser.js",
   "views/screenview.js",
+  "views/speakingwhilemutedwarner.js",
   "views/templates.js",
   "views/videoview.js",
   "views/virtuallist.js",

--- a/js/merged.json
+++ b/js/merged.json
@@ -27,6 +27,7 @@
   "views/roomlistview.js",
   "views/screenview.js",
   "views/sidebarview.js",
+  "views/speakingwhilemutedwarner.js",
   "views/tabview.js",
   "views/templates.js",
   "views/videoview.js",

--- a/js/simplewebrtc/bundled.js
+++ b/js/simplewebrtc/bundled.js
@@ -434,13 +434,13 @@ LocalMedia.prototype.stopScreenShare = function (stream) {
 
 
 LocalMedia.prototype.mute = function () {
-  this._audioEnabled(false);
+  this._setAudioEnabled(false);
 
   this.emit('audioOff');
 };
 
 LocalMedia.prototype.unmute = function () {
-  this._audioEnabled(true);
+  this._setAudioEnabled(true);
 
   this.emit('audioOn');
 }; // Video controls
@@ -470,7 +470,8 @@ LocalMedia.prototype.resume = function () {
 }; // Internal methods for enabling/disabling audio/video
 
 
-LocalMedia.prototype._audioEnabled = function (bool) {
+LocalMedia.prototype._setAudioEnabled = function (bool) {
+  this._audioEnabled = bool;
   this.localStreams.forEach(function (stream) {
     stream.getAudioTracks().forEach(function (track) {
       track.enabled = !!bool;

--- a/js/simplewebrtc/localmedia.js
+++ b/js/simplewebrtc/localmedia.js
@@ -40,6 +40,7 @@ function LocalMedia(opts) {
 	this._logerror = this.logger.error.bind(this.logger, 'LocalMedia:');
 
 	this.localStreams = [];
+	this._audioMonitorStreams = [];
 	this.localScreens = [];
 
 	if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
@@ -47,7 +48,6 @@ function LocalMedia(opts) {
 	}
 
 	this._audioMonitors = [];
-	this.on('localStreamStopped', this._stopAudioMonitor.bind(this));
 	this.on('localScreenStopped', this._stopAudioMonitor.bind(this));
 }
 
@@ -81,10 +81,14 @@ LocalMedia.prototype.start = function (mediaConstraints, cb) {
 			return;
 		}
 
+		// The audio monitor stream is never disabled to be able to analyze it
+		// even when the stream sent is muted.
+		var audioMonitorStream = stream.clone();
 		if (constraints.audio && self.config.detectSpeakingEvents) {
-			self._setupAudioMonitor(stream, self.config.harkOptions);
+			self._setupAudioMonitor(audioMonitorStream, self.config.harkOptions);
 		}
 		self.localStreams.push(stream);
+		self._audioMonitorStreams.push(audioMonitorStream);
 
 		stream.getTracks().forEach(function (track) {
 			track.addEventListener('ended', function () {
@@ -292,6 +296,8 @@ LocalMedia.prototype._removeStream = function (stream) {
 	var idx = this.localStreams.indexOf(stream);
 	if (idx > -1) {
 		this.localStreams.splice(idx, 1);
+		this._stopAudioMonitor(this._audioMonitorStreams[idx]);
+		this._audioMonitorStreams.splice(idx, 1);
 		this.emit('localStreamStopped', stream);
 	} else {
 		idx = this.localScreens.indexOf(stream);
@@ -309,7 +315,13 @@ LocalMedia.prototype._setupAudioMonitor = function (stream, harkOptions) {
 	var timeout;
 
 	audio.on('speaking', function () {
-		self.emit('speaking');
+		self._speaking = true;
+
+		if (self._audioEnabled) {
+			self.emit('speaking');
+		} else {
+			self.emit('speakingWhileMuted');
+		}
 	});
 
 	audio.on('stopped_speaking', function () {
@@ -318,9 +330,30 @@ LocalMedia.prototype._setupAudioMonitor = function (stream, harkOptions) {
 		}
 
 		timeout = setTimeout(function () {
-			self.emit('stoppedSpeaking');
+			self._speaking = false;
+
+			if (self._audioEnabled) {
+				self.emit('stoppedSpeaking');
+			} else {
+				self.emit('stoppedSpeakingWhileMuted');
+			}
 		}, 1000);
 	});
+
+	self.on('audioOn', function() {
+		if (self._speaking) {
+			self.emit('stoppedSpeakingWhileMuted');
+			self.emit('speaking');
+		}
+	});
+
+	self.on('audioOff', function() {
+		if (self._speaking) {
+			self.emit('stoppedSpeaking');
+			self.emit('speakingWhileMuted');
+		}
+	});
+
 	audio.on('volume_change', function (volume, threshold) {
 		self.emit('volumeChange', volume, threshold);
 	});

--- a/js/simplewebrtc/localmedia.js
+++ b/js/simplewebrtc/localmedia.js
@@ -195,12 +195,12 @@ LocalMedia.prototype.stopScreenShare = function (stream) {
 
 // Audio controls
 LocalMedia.prototype.mute = function () {
-	this._audioEnabled(false);
+	this._setAudioEnabled(false);
 	this.emit('audioOff');
 };
 
 LocalMedia.prototype.unmute = function () {
-	this._audioEnabled(true);
+	this._setAudioEnabled(true);
 	this.emit('audioOn');
 };
 
@@ -225,7 +225,9 @@ LocalMedia.prototype.resume = function () {
 };
 
 // Internal methods for enabling/disabling audio/video
-LocalMedia.prototype._audioEnabled = function (bool) {
+LocalMedia.prototype._setAudioEnabled = function (bool) {
+	this._audioEnabled = bool;
+
 	this.localStreams.forEach(function (stream) {
 		stream.getAudioTracks().forEach(function (track) {
 			track.enabled = !!bool;

--- a/js/views/mediacontrolsview.js
+++ b/js/views/mediacontrolsview.js
@@ -162,6 +162,20 @@
 			this._audioAvailable = audioAvailable;
 		},
 
+		setSpeakingWhileMutedNotification: function(message) {
+			if (!message) {
+				this.getUI('audioButton').tooltip('dispose');
+
+				return;
+			}
+
+			this.getUI('audioButton').tooltip('hide')
+					.attr('data-original-title', message)
+					.tooltip('_fixTitle')
+					.tooltip({placement: 'bottom', trigger: 'manual'})
+					.tooltip('show');
+		},
+
 		_handleVolumeChange: function(currentVolume, threshold) {
 			// WebRTC volume goes from -100 (silence) to 0 (loudest sound in the
 			// system); for the volume indicator only sounds above the threshold

--- a/js/views/speakingwhilemutedwarner.js
+++ b/js/views/speakingwhilemutedwarner.js
@@ -49,7 +49,8 @@
 	 * to the user even if the browser window is not in the foreground (provided
 	 * the user granted the permissions to receive notifications from the site).
 	 */
-	function SpeakingWhileMutedWarner() {
+	function SpeakingWhileMutedWarner(view) {
+		this._view = view;
 		this._handleSpeakingWhileMutedBound = this._handleSpeakingWhileMuted.bind(this);
 		this._handleStoppedSpeakingWhileMutedBound = this._handleStoppedSpeakingWhileMuted.bind(this);
 	}
@@ -107,7 +108,8 @@
 				return;
 			}
 
-			this._notification = OC.Notification.show(message);
+			this._view.setSpeakingWhileMutedNotification(message);
+			this._notification = true;
 		},
 
 		_showBrowserNotification: function(message) {
@@ -157,9 +159,9 @@
 			this._pendingBrowserNotification = false;
 
 			if (this._notification) {
-				OC.Notification.hide(this._notification);
+				this._view.setSpeakingWhileMutedNotification(null);
 
-				this._notification = null;
+				this._notification = false;
 			}
 
 			if (this._browserNotification) {

--- a/js/views/speakingwhilemutedwarner.js
+++ b/js/views/speakingwhilemutedwarner.js
@@ -1,0 +1,103 @@
+/* global OC, OCA */
+
+/**
+ *
+ * @copyright Copyright (c) 2019, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+(function(OC, OCA) {
+
+	'use strict';
+
+	OCA.Talk = OCA.Talk || {};
+	OCA.Talk.Views = OCA.Talk.Views || {};
+
+	/**
+	 * Helper to warn the user if she is talking while muted.
+	 *
+	 * The WebRTC helper emits events when it detects that the user is speaking
+	 * while muted; this helper shows a warning to the user based on those
+	 * events.
+	 *
+	 * The warning is not immediately shown, though; the WebRTC helper flags
+	 * even short sounds as "speaking" (provided they are strong enough), so to
+	 * prevent unnecesary warnings the user has to speak for a few seconds for
+	 * the warning to be shown. On the other hand, the warning is hidden as soon
+	 * as the WebRTC helper detects that the speaking has stopped; in this case
+	 * there is no delay, as the helper itself has a delay before emitting the
+	 * event.
+	 */
+	function SpeakingWhileMutedWarner() {
+		this._handleSpeakingWhileMutedBound = this._handleSpeakingWhileMuted.bind(this);
+		this._handleStoppedSpeakingWhileMutedBound = this._handleStoppedSpeakingWhileMuted.bind(this);
+	}
+	SpeakingWhileMutedWarner.prototype = {
+
+		setWebRtc: function(webrtc) {
+			if (this._webrtc && this._webrtc.webrtc) {
+				this._webrtc.webrtc.off('speakingWhileMuted', this._handleSpeakingWhileMutedBound);
+				this._webrtc.webrtc.off('stoppedSpeakingWhileMuted', this._handleStoppedSpeakingWhileMutedBound);
+			}
+
+			this._webrtc = webrtc;
+
+			this._webrtc.webrtc.on('speakingWhileMuted', this._handleSpeakingWhileMutedBound);
+			this._webrtc.webrtc.on('stoppedSpeakingWhileMuted', this._handleStoppedSpeakingWhileMutedBound);
+		},
+
+		_handleSpeakingWhileMuted: function() {
+			this._startedSpeakingTimeout = setTimeout(function() {
+				delete this._startedSpeakingTimeout;
+
+				this._showWarning();
+			}.bind(this), 3000);
+		},
+
+		_handleStoppedSpeakingWhileMuted: function() {
+			if (this._startedSpeakingTimeout) {
+				clearTimeout(this._startedSpeakingTimeout);
+				delete this._startedSpeakingTimeout;
+			}
+
+			this._hideWarning();
+		},
+
+		_showWarning: function() {
+			if (this._notification) {
+				return;
+			}
+
+			this._notification = OC.Notification.show(t('spreed', 'You seem to be talking while muted, please unmute yourself for others to hear you'));
+		},
+
+		_hideWarning: function() {
+			if (!this._notification) {
+				return;
+			}
+
+			OC.Notification.hide(this._notification);
+
+			this._notification = null;
+		},
+
+	};
+
+	OCA.Talk.Views.SpeakingWhileMutedWarner = SpeakingWhileMutedWarner;
+
+})(OC, OCA);


### PR DESCRIPTION
Fixes #285

If the user is speaking while muted now an `OC.Notification` is shown (the notification is not immediate, though; it only appears after three seconds of "speech" (not actual speech, but just sounds above some volume threshold)); in the future it could be more integrated with the local video view if needed, but for now I would say that the `OC.Notification` is good enough.

However, if the browser is hidden the `OC.Notification` (or one integrated in the local video view) is not useful, as the user would not be able to see it. In those cases a browser notification is used instead, as it is visible even if the browser is hidden (provided the user grants access to notifications from the site; if not the OC.Notification is shown as a fallback, even if in most cases it will not be seen by the user, but there is nothing else that can be done in that case).

Unfortunately, currently there are some issues:
- The `OC.Notification` in Nextcloud 17 is only shown for 7 seconds, instead of being there until the user stops speaking or unmutes; [this is a regression in the server and it will be fixed there](https://github.com/nextcloud/server/pull/16573).
- [Chromium limits `setTimeout` to 1000 milliseconds in background tabs](https://codereview.chromium.org/6577021); due to this [the audio analyzer is called with less frequency than in foreground tabs](https://github.com/otalk/hark/blob/f3fa6e4ae44bc024f4a08e8faa91f0fe02fa55d1/hark.js#L104-L138) and the speaking detection is much less reliable (it needs a lot more time to detect that the user is speaking). In order to solve this it will be probably needed to use WebWorkers, so I would defer this fix for later.
- If the browser is behind another window but not minimized the [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) still flags the window as visible, so in that case the `OC.Notification` is shown instead of the browser notification. I have not found a reliable way to check that scenario; the closest would be to check if the document has focus, but then if the browser window is in the foreground and the user has clicked the browser UI the document would not have focus and a browser notification would be shown, which would be unexpected too. I guess that we can defer this too until some solution is found.

Besides those issues there are also some pending enhancements:
- Do not show the notification if there is no other participant in the conversation. I would defer this for a later pull request once some other changes are made in the WebRTC code.
- Do not show the notification again if the notification was dismissed by the user before (but show it anyway if the user has unmuted and then muted again). I am not sure about this one, though; on one hand the notification may be a little annoying if there is more background noise than usual, but on the other hand the user may dismiss it at the beginning of a long conversation and when her speaking time comes she may have forgotten about it.

Finally, the current volume threshold is the one that was being used until now. It may need some tweaking (probably to make it higher), but I am not sure. Needs testing in different environments ;-)
