### PR TITLE
Release v6.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 6.0.3 – 2019-07-22
+### Changed
+- Chat messages can now be longer than 1.000 characters
+  [#1901](https://github.com/nextcloud/spreed/pull/1901)
+- Users matching the autocomplete at the beginning of their name are now sorted to the top
+  [#1968](https://github.com/nextcloud/spreed/pull/1968)
+- Only strings starting with http:// or https:// are now made clickable as links
+  [#1965](https://github.com/nextcloud/spreed/pull/1965)
+
+### Fixed
+- Fix layout issues of the chat on the share authentication page
+  [#1901](https://github.com/nextcloud/spreed/pull/1901)
+- Fix issues with calls when a user logs out while being in a call
+  [#1947](https://github.com/nextcloud/spreed/pull/1947)
+- Fix a problem when joining a public conversation as a non-invited logged-in user
+  [#1914](https://github.com/nextcloud/spreed/pull/1914)
+- Fix missing tooltip with full date on timestamp for the first message of a user in a grouped block
+  [#1914](https://github.com/nextcloud/spreed/pull/1914)
+- Commands based on the Symfony Command component can now provide a useful help message
+  [#1901](https://github.com/nextcloud/spreed/pull/1901)
+
 ## 6.0.2 – 2019-06-06
 ### Fixed
 - Fix message list not reloaded after switching tabs in the sidebar

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>6.0.2</version>
+	<version>6.0.3</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spreed",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spreed",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "",
   "main": " ",
   "repository": {

--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spreed",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vue/package.json
+++ b/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spreed",
   "description": "",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "author": "Joas Schilling <coding@schilljs.com>",
   "license": "agpl",
   "private": true,


### PR DESCRIPTION
### Todo
- [x] https://github.com/nextcloud/spreed/pull/2006
- [x] https://github.com/nextcloud/spreed/pull/2033
- [x] https://github.com/nextcloud/spreed/pull/2034

## 6.0.3 – 2019-07-19
### Changed
- Chat messages can now be longer than 1.000 characters  [#1901](https://github.com/nextcloud/spreed/pull/1901)
- Users matching the autocomplete at the beginning of their name are now sorted to the top  [#1968](https://github.com/nextcloud/spreed/pull/1968)
- Only strings starting with http:// or https:// are now made clickable as links  [#1965](https://github.com/nextcloud/spreed/pull/1965)

### Fixed
- Fix layout issues of the chat on the share authentication page  [#1901](https://github.com/nextcloud/spreed/pull/1901)
- Fix issues with calls when a user logs out while being in a call  [#1947](https://github.com/nextcloud/spreed/pull/1947)
- Fix a problem when joining a public conversation as a non-invited logged-in user  [#1914](https://github.com/nextcloud/spreed/pull/1914)
- Fix missing tooltip with full date on timestamp for the first message of a user in a grouped  lock  [#1914](https://github.com/nextcloud/spreed/pull/1914)
- Commands based on the Symfony Command component can now provide a useful help message  [#1901](https://github.com/nextcloud/spreed/pull/1901)

