### PR TITLE
Add volume indicator for the local audio

### DIFF
--- a/css/video.scss
+++ b/css/video.scss
@@ -446,3 +446,30 @@ video {
 		opacity: 1;
 	}
 }
+
+
+
+#muteWrapper {
+	display: inline-block;
+
+	/* Make the wrapper the positioning context of the volume indicator. */
+	position: relative;
+}
+
+#muteWrapper .volume-indicator {
+	position: absolute;
+
+	width: 3px;
+	right: 0px;
+
+	/* The button height is 44px; the volume indicator button is 36px at
+	 * maximum, but its value will be changed based on the current volume; the
+	 * height change will reveal more or less of the gradient, which has
+	 * absolute dimensions and thus does not change when the height changes. */
+	height: 36px;
+	bottom: 4px;
+
+	background: linear-gradient(0deg, green, yellow, red 36px);
+
+	opacity: 0.7;
+}

--- a/js/views/templates.js
+++ b/js/views/templates.js
@@ -243,9 +243,9 @@ templates['localvideoview'] = template({"compiler":[7,">= 4.0.0"],"main":functio
 templates['mediacontrolsview'] = template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
-  return "<button id=\"mute\" class=\"icon-audio force-icon-white-in-call icon-shadow\" data-placement=\"top\" data-toggle=\"tooltip\" data-original-title=\""
+  return "<div id=\"muteWrapper\">\n	<button id=\"mute\" class=\"icon-audio force-icon-white-in-call icon-shadow\" data-placement=\"top\" data-toggle=\"tooltip\" data-original-title=\""
     + alias4(((helper = (helper = helpers.muteAudioButtonTitle || (depth0 != null ? depth0.muteAudioButtonTitle : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"muteAudioButtonTitle","hash":{},"data":data}) : helper)))
-    + "\"></button>\n<button id=\"hideVideo\" class=\"icon-video force-icon-white-in-call icon-shadow\" data-placement=\"top\" data-toggle=\"tooltip\" data-original-title=\""
+    + "\"></button>\n	<span class=\"volume-indicator\"></span>\n</div>\n<button id=\"hideVideo\" class=\"icon-video force-icon-white-in-call icon-shadow\" data-placement=\"top\" data-toggle=\"tooltip\" data-original-title=\""
     + alias4(((helper = (helper = helpers.hideVideoButtonTitle || (depth0 != null ? depth0.hideVideoButtonTitle : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"hideVideoButtonTitle","hash":{},"data":data}) : helper)))
     + "\"></button>\n<button id=\"screensharing-button\" class=\"app-navigation-entry-utils-menu-button icon-screen-off force-icon-white-in-call icon-shadow screensharing-disabled\" data-placement=\"top\" data-toggle=\"tooltip\" data-original-title=\""
     + alias4(((helper = (helper = helpers.screensharingButtonTitle || (depth0 != null ? depth0.screensharingButtonTitle : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"screensharingButtonTitle","hash":{},"data":data}) : helper)))

--- a/js/views/templates/mediacontrolsview.handlebars
+++ b/js/views/templates/mediacontrolsview.handlebars
@@ -1,4 +1,7 @@
-<button id="mute" class="icon-audio force-icon-white-in-call icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="{{muteAudioButtonTitle}}"></button>
+<div id="muteWrapper">
+	<button id="mute" class="icon-audio force-icon-white-in-call icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="{{muteAudioButtonTitle}}"></button>
+	<span class="volume-indicator"></span>
+</div>
 <button id="hideVideo" class="icon-video force-icon-white-in-call icon-shadow" data-placement="top" data-toggle="tooltip" data-original-title="{{hideVideoButtonTitle}}"></button>
 <button id="screensharing-button" class="app-navigation-entry-utils-menu-button icon-screen-off force-icon-white-in-call icon-shadow screensharing-disabled" data-placement="top" data-toggle="tooltip" data-original-title="{{screensharingButtonTitle}}"></button>
 <div id="screensharing-menu" class="app-navigation-entry-menu">


### PR DESCRIPTION
The volume is shown as a vertical bar next to the audio icon that grows and shrinks (with a fixed bottom position) depending on the volume level. The bar is coloured with a gradient from green to yellow to red for better clarity of the current volume.

The previous way of indicating speech (a pulse animation in the audio icon) has not been modified; this is an additional visualization (only for the local audio) to provide a more noticeable feedback to the user.

![Volume-Bar-Black-0](https://user-images.githubusercontent.com/26858233/61551046-6b8eb480-aa54-11e9-8a62-de6142176e05.png)
![Volume-Bar-Black-33](https://user-images.githubusercontent.com/26858233/61551052-6df10e80-aa54-11e9-9029-674b016c9a9d.png)
![Volume-Bar-Black-66](https://user-images.githubusercontent.com/26858233/61551058-6fbad200-aa54-11e9-96af-1b51f1208ef7.png)
![Volume-Bar-Black-100](https://user-images.githubusercontent.com/26858233/61551060-70ebff00-aa54-11e9-9adf-88bae0539022.png)

I am not sure if adding a transition to the height with something like `transition: 'height 0.5s ease';` to `#muteWrapper .volume-indicator` makes it look nicer or not.

I am not sure either if the volume bar should be always shown with the same opacity or if it should be slightly dimmed when the local audio is not enabled (currently when the local audio is not enabled the volume bar is not visible, but it will work as if the audio was not disabled once https://github.com/nextcloud/spreed/pull/2016 and this pull request are merged).
