### PR TITLE
Fix audio not played before video is received in Chromium

### DIFF
--- a/js/views/videoview.js
+++ b/js/views/videoview.js
@@ -54,6 +54,7 @@
 		template: OCA.Talk.Views.Templates['videoview'],
 
 		ui: {
+			'audio': 'audio',
 			'video': 'video',
 			'avatarContainer': '.avatar-container',
 			'avatar': '.avatar',
@@ -175,6 +176,24 @@
 
 				return;
 			}
+		},
+
+		/**
+		 * Sets the element with the audio stream.
+		 *
+		 * @param HTMLVideoElement|null audioElement the element to set, or null
+		 *        to remove the current one.
+		 */
+		setAudioElement: function(audioElement) {
+			this.getUI('audio').remove();
+
+			if (audioElement) {
+				this.$el.prepend(audioElement);
+			}
+
+			this.bindUIElements();
+
+			this.getUI('audio').addClass('hidden');
 		},
 
 		setAudioAvailable: function(audioAvailable) {

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -1125,7 +1125,7 @@ var spreedPeerConnectionTable = [];
 			}
 		});
 
-		OCA.SpreedMe.webrtc.on('videoAdded', function(video, peer) {
+		OCA.SpreedMe.webrtc.on('videoAdded', function(video, audio, peer) {
 			console.log('VIDEO ADDED', peer);
 			if (peer.type === 'screen') {
 				OCA.SpreedMe.webrtc.emit('screenAdded', video, peer);
@@ -1145,6 +1145,7 @@ var spreedPeerConnectionTable = [];
 				videoView.setParticipant(userId, participantName);
 
 				videoView.setVideoElement(video);
+				videoView.setAudioElement(audio);
 			}
 
 			var otherSpeakerPromoted = false;


### PR DESCRIPTION
Chromium does not play the audio in a video element before the video is available. Due to this, when the remote peer had audio and video available if both were disabled (for example, when the remote peer has just joined the call) and then the audio was enabled the audio from the remote peer was not heard in Chromium until the video was also enabled. Instead of using a video element for both the audio and the video now an audio element was added to play the audio tracks of the remote stream.

The change is applied to all browsers, though, as using an audio element for the audio tracks makes sense in all of them (even if until now they worked fine except for Chromium).

## How to test
- Create a new public conversation
- Start a call as the owner in that conversation from a machine with audio and video (or use the fake streams of Firefox, but with a recent Firefox version*)
- Join the call with a guest using Chromium
- Enable the audio as the owner

*It seems that old Firefox versions did not even send a black stream until the video was enabled for the first time, so there was no video track and the audio was played without problems in Chromium.

### Result with this pull request
The audio from the owner is heard in Chromium.

### Result without this pull request
The audio from the owner is not heard in Chromium; if the owner enables the video then the audio is also heard.
