### PR TITLE
Fix setters failing in EditableTextLabel before first render

### DIFF
--- a/js/views/editabletextlabel.js
+++ b/js/views/editabletextlabel.js
@@ -114,6 +114,10 @@
 			this.mergeOptions(options, ['model', 'modelAttribute', 'modelSaveOptions', 'labelPlaceholder']);
 
 			this._editionEnabled = true;
+
+			// Needed to use "getUI" before the view is first rendered (even if
+			// no elements would exist at that point).
+			this.bindUIElements();
 		},
 
 		setModelAttribute: function(modelAttribute) {


### PR DESCRIPTION
Fixes #1977

The setter methods in EditableTextLabel (indirectly) update its HTML elements using `getUI()`. Those setters may be used before the label is first rendered (for example, to set up some default values in the initialization of a parent view), so `bindUIElements()` needs to be called to prevent `getUI()` from failing due to `this._ui` not being defined yet in those cases (note that no UI elements will be actually bound, as before the first render they have not been created yet, but that is not a problem due to the way in which the elements are updated from the setters).

_But, wait... what does all that have to do with #1977?_ A little context first.
- with almost every browser, `t('X', 'Y') === t('X', 'Y')` is true
- with Chromium >= 73 with experimental web platform features enabled, `t('X', 'Y') === t('X', 'Y')` is false

The reason is that [the `translate` function uses `DOMPurify.sanitize`](https://github.com/nextcloud/server/blob/master/core/src/OC/l10n.js#L87), and [since DOMPurify 1.0.9 the Trusted Types API is used if available](https://github.com/cure53/DOMPurify/pull/310/commits/bd599cac5d643fc7604fd458c7ecfbb6f6c66113) (which it is since Chromium 73 if the experimental features are enabled), so `DOMPurify.sanitize` returns a `TrustedHtml` object instead of a string. [In most cases this should make no difference](https://github.com/cure53/DOMPurify/blob/master/README.md#what-about-dompurify-and-trusted-types), but in the case of strict comparisons you check for object identity, so no implicit conversion to string is done, and as a different object is returned each time that `DOMPurify.sanitize` is called the comparison fails.

Enough context. Now let me show you why this caused the issue ;-)

When a `CallInfoView` is initialized it creates an `EditableTextLabel` with [_Conversation name_ as the default label placeholder](https://github.com/nextcloud/spreed/blob/741be231262ffa58087cbe24f9b117f6479ec2e8/js/views/callinfoview.js#L137). Then, [the label is set up as needed based on the type of the room and the current user](https://github.com/nextcloud/spreed/blob/741be231262ffa58087cbe24f9b117f6479ec2e8/js/views/callinfoview.js#L146); when the room is a group or public room [the label placeholder is set again to _Conversation name_](https://github.com/nextcloud/spreed/blob/741be231262ffa58087cbe24f9b117f6479ec2e8/js/views/callinfoview.js#L247). If the same placeholder as before is set [the `EditableTextLabel` is not supposed to be updated](https://github.com/nextcloud/spreed/blob/3f84baf2605347cc31555302949bb80dfd66d800/js/views/editabletextlabel.js#L137), but as we have seen, `t('X', 'Y') === t('X', 'Y')` is false when the Trusted Types API is available, so [`setLabelPlaceholder()` updates the text of the label](https://github.com/nextcloud/spreed/blob/3f84baf2605347cc31555302949bb80dfd66d800/js/views/editabletextlabel.js#L143). Finally, when [`getUI()` is called](https://github.com/nextcloud/spreed/blob/3f84baf2605347cc31555302949bb80dfd66d800/js/views/editabletextlabel.js#L171) the `EditableTextLabel` was not rendered yet (remember that we come from the `CallInfoView` initialization) nor its UI elements were bound yet, so `this._ui` is not defined and _Uncaught TypeError: Cannot read property 'label' of undefined_ is thrown.

_Wait a minute... but when the room is a one-to-one room [a different placeholder is set too](https://github.com/nextcloud/spreed/blob/741be231262ffa58087cbe24f9b117f6479ec2e8/js/views/callinfoview.js#L241), yet everything works as expected. What is going on?_

Ah, a keen reader. The difference here is that the `EditableTextLabel` in this case is not... editable :-) By default [`EditableTextLabel`s are editable](https://github.com/nextcloud/spreed/blob/3f84baf2605347cc31555302949bb80dfd66d800/js/views/editabletextlabel.js#L116) (makes sense, I guess :-P ), and [when they are set as not editable the view is rendered again (or for the first time!)](https://github.com/nextcloud/spreed/blob/3f84baf2605347cc31555302949bb80dfd66d800/js/views/editabletextlabel.js#L163). When the `EditableTextLabel` is set up as needed based on the type of the room and the current user [it is first set as not editable](https://github.com/nextcloud/spreed/blob/741be231262ffa58087cbe24f9b117f6479ec2e8/js/views/callinfoview.js#L229) and, then, the placeholder is set. So in this case the view was already rendered when the placeholder was set so `this._ui` was defined and everything worked nicely. Setting the `EditableTextLabel` as editable also renders the view again, but [only if it was not editable before](https://github.com/nextcloud/spreed/blob/3f84baf2605347cc31555302949bb80dfd66d800/js/views/editabletextlabel.js#L146-L154), and thus as by default they are editable the label was not rendered [when the user was the owner or a moderator of the room](https://github.com/nextcloud/spreed/blob/741be231262ffa58087cbe24f9b117f6479ec2e8/js/views/callinfoview.js#L227).

Tricky, right? ;-)

## How to test

- Start Chromium >= 73 with `{chromium-executable} --enable-experimental-web-platform-features` or start it normally, visit `chrome://flags/#enable-experimental-web-platform-features` and enable them
- Open a group conversation as its owner

### Result with this pull request

The conversation name is shown in the right sidebar.

### Result without this pull request

The conversation name is not shown in the right sidebar. _Uncaught TypeError: Cannot read property 'label' of undefined_ is shown in the browser console.
