### PR TITLE
Only load the newest 50 messages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+This is the documentation for Nextcloud Talk

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,3 @@
+site_name: Nextcloud Talk documentation
+theme: readthedocs
+


### PR DESCRIPTION
Please load only the newest 50 (or so) messages when entering a Chat in Nextcloud Talk. If you want to read older messages there should be a button "load older messages".
That way Talk would be alot faster when loading a chat.

cheers