### PR TITLE
Add user to file room when joining it instead of when getting its token

### DIFF
--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -104,12 +104,6 @@ class FilesController extends OCSController {
 			$room = $this->manager->createPublicRoom($name, 'file', $fileId);
 		}
 
-		try {
-			$room->getParticipant($this->currentUser);
-		} catch (ParticipantNotFoundException $e) {
-			$room->addUsers(['userId' => $this->currentUser]);
-		}
-
 		return new DataResponse([
 			'token' => $room->getToken()
 		]);

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -40,6 +40,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	/** @var array[] */
 	protected static $sessionIdToUser;
 	/** @var array[] */
+	protected static $userToSessionId;
+	/** @var array[] */
 	protected static $messages;
 
 	/** @var string */
@@ -82,6 +84,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		self::$identifierToToken = [];
 		self::$tokenToIdentifier = [];
 		self::$sessionIdToUser = [];
+		self::$userToSessionId = [];
 		self::$messages = [];
 
 		$this->createdUsers = [];
@@ -165,6 +168,12 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	 * @param string $identifier
 	 */
 	public function userIsParticipantOfRoom($user, $isParticipant, $identifier) {
+		if (substr($user, 0, strlen('guest')) === 'guest') {
+			$this->guestIsParticipantOfRoom($user, $isParticipant, $identifier);
+
+			return;
+		}
+
 		$this->setCurrentUser($user);
 		$this->sendRequest('GET', '/apps/spreed/api/v1/room');
 		$this->assertStatusCode($this->response, 200);
@@ -189,6 +198,37 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		}
 
 		PHPUnit_Framework_Assert::assertEquals($isParticipant, false, 'Room ' . $identifier . ' not found in user´s room list');
+	}
+
+	/**
+	 * @param string $guest
+	 * @param string $isParticipant
+	 * @param string $identifier
+	 */
+	private function guestIsParticipantOfRoom($guest, $isParticipant, $identifier) {
+		$this->setCurrentUser($guest);
+		$this->sendRequest('GET', '/apps/spreed/api/v1/room/' . self::$identifierToToken[$identifier]);
+
+		$response = $this->getDataFromResponse($this->response);
+
+		$isParticipant = $isParticipant === 'is';
+
+		if ($isParticipant) {
+			$this->assertStatusCode($this->response, 200);
+			PHPUnit_Framework_Assert::assertEquals(self::$userToSessionId[$guest], sha1($response['sessionId']));
+
+			return;
+		}
+
+		if ($this->response->getStatusCode() === 200) {
+			// Public rooms can always be got, but if the guest is not a
+			// participant the sessionId will be 0.
+			PHPUnit_Framework_Assert::assertEquals(0, $response['sessionId']);
+
+			return;
+		}
+
+		$this->assertStatusCode($this->response, 404);
 	}
 
 	/**
@@ -345,6 +385,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			// database, though, so the ID stored in the database and returned
 			// in chat messages is a hashed version instead.
 			self::$sessionIdToUser[sha1($response['sessionId'])] = $user;
+			self::$userToSessionId[$user] = sha1($response['sessionId']);
 		}
 	}
 
@@ -532,6 +573,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			// database, though, so the ID stored in the database and returned
 			// in chat messages is a hashed version instead.
 			self::$sessionIdToUser[sha1($response['sessionId'])] = $user;
+			self::$userToSessionId[$user] = sha1($response['sessionId']);
 		}
 	}
 

--- a/tests/integration/features/chat/mentions.feature
+++ b/tests/integration/features/chat/mentions.feature
@@ -189,6 +189,7 @@ Feature: chat/mentions
   Scenario: get mentions in a file room with no other joined participant
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
     When user "participant1" gets the room for path "welcome.txt" with 200
+    And user "participant1" joins room "file welcome.txt room" with 200
     And user "participant1" is participant of room "file welcome.txt room"
     And user "participant2" is not participant of room "file welcome.txt room"
     Then user "participant1" gets the following candidate mentions in room "file welcome.txt room" for "" with 200
@@ -199,8 +200,9 @@ Feature: chat/mentions
 
   Scenario: get mentions in a file room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
-    When user "participant1" gets the room for path "welcome.txt" with 200
-    And user "participant2" gets the room for path "welcome (2).txt" with 200
+    When user "participant2" gets the room for path "welcome (2).txt" with 200
+    And user "participant1" joins room "file welcome (2).txt room" with 200
+    And user "participant2" joins room "file welcome (2).txt room" with 200
     And user "participant1" is participant of room "file welcome (2).txt room"
     And user "participant2" is participant of room "file welcome (2).txt room"
     Then user "participant1" gets the following candidate mentions in room "file welcome (2).txt room" for "" with 200
@@ -214,8 +216,9 @@ Feature: chat/mentions
 
   Scenario: get matched mentions in a file room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
-    When user "participant1" gets the room for path "welcome.txt" with 200
-    And user "participant2" gets the room for path "welcome (2).txt" with 200
+    When user "participant2" gets the room for path "welcome (2).txt" with 200
+    And user "participant1" joins room "file welcome (2).txt room" with 200
+    And user "participant2" joins room "file welcome (2).txt room" with 200
     And user "participant1" is participant of room "file welcome (2).txt room"
     And user "participant2" is participant of room "file welcome (2).txt room"
     Then user "participant1" gets the following candidate mentions in room "file welcome (2).txt room" for "part" with 200
@@ -227,8 +230,9 @@ Feature: chat/mentions
 
   Scenario: get unmatched mentions in a file room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
-    When user "participant1" gets the room for path "welcome.txt" with 200
-    And user "participant2" gets the room for path "welcome (2).txt" with 200
+    When user "participant2" gets the room for path "welcome (2).txt" with 200
+    And user "participant1" joins room "file welcome (2).txt room" with 200
+    And user "participant2" joins room "file welcome (2).txt room" with 200
     And user "participant1" is participant of room "file welcome (2).txt room"
     And user "participant2" is participant of room "file welcome (2).txt room"
     Then user "participant1" gets the following candidate mentions in room "file welcome (2).txt room" for "unknown" with 200
@@ -236,8 +240,9 @@ Feature: chat/mentions
 
   Scenario: get mentions in a file room with a participant without access to the file
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
-    When user "participant1" gets the room for path "welcome.txt" with 200
-    And user "participant2" gets the room for path "welcome (2).txt" with 200
+    When user "participant2" gets the room for path "welcome (2).txt" with 200
+    And user "participant1" joins room "file welcome (2).txt room" with 200
+    And user "participant2" joins room "file welcome (2).txt room" with 200
     And user "participant1" is participant of room "file welcome (2).txt room"
     And user "participant2" is participant of room "file welcome (2).txt room"
     Then user "participant3" gets the following candidate mentions in room "file welcome (2).txt room" for "" with 404
@@ -245,6 +250,7 @@ Feature: chat/mentions
   Scenario: mention a participant with access to the file but not joined in a file room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
     And user "participant1" gets the room for path "welcome.txt" with 200
+    And user "participant1" joins room "file welcome.txt room" with 200
     And user "participant1" is participant of room "file welcome.txt room"
     And user "participant2" is not participant of room "file welcome.txt room"
     When user "participant1" sends message "hi @participant2" to room "file welcome.txt room" with 201

--- a/tests/integration/features/conversation/files.feature
+++ b/tests/integration/features/conversation/files.feature
@@ -19,8 +19,8 @@ Feature: conversation/files
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
     When user "participant1" gets the room for path "welcome.txt" with 200
     And user "participant2" gets the room for path "welcome (2).txt" with 200
-    Then user "participant1" is participant of room "file welcome (2).txt room"
-    And user "participant2" is participant of room "file welcome (2).txt room"
+    Then user "participant1" is not participant of room "file welcome (2).txt room"
+    And user "participant2" is not participant of room "file welcome (2).txt room"
 
   Scenario: get room for folder shared with user
     Given user "participant1" creates folder "/test"
@@ -34,8 +34,8 @@ Feature: conversation/files
     And user "participant1" shares "test" with user "participant2" with OCS 100
     When user "participant1" gets the room for path "test/renamed.txt" with 200
     And user "participant2" gets the room for path "test/renamed.txt" with 200
-    Then user "participant1" is participant of room "file test/renamed.txt room"
-    And user "participant2" is participant of room "file test/renamed.txt room"
+    Then user "participant1" is not participant of room "file test/renamed.txt room"
+    And user "participant2" is not participant of room "file test/renamed.txt room"
 
   Scenario: get room for file in folder reshared with user
     Given user "participant1" creates folder "/test"
@@ -45,9 +45,9 @@ Feature: conversation/files
     When user "participant1" gets the room for path "test/renamed.txt" with 200
     And user "participant2" gets the room for path "test/renamed.txt" with 200
     And user "participant3" gets the room for path "test/renamed.txt" with 200
-    Then user "participant1" is participant of room "file test/renamed.txt room"
-    And user "participant2" is participant of room "file test/renamed.txt room"
-    And user "participant3" is participant of room "file test/renamed.txt room"
+    Then user "participant1" is not participant of room "file test/renamed.txt room"
+    And user "participant2" is not participant of room "file test/renamed.txt room"
+    And user "participant3" is not participant of room "file test/renamed.txt room"
 
   Scenario: get room for file no longer shared
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
@@ -60,8 +60,8 @@ Feature: conversation/files
     Given user "participant1" shares "welcome.txt" with group "group1" with OCS 100
     When user "participant1" gets the room for path "welcome.txt" with 200
     And user "participant2" gets the room for path "welcome (2).txt" with 200
-    Then user "participant1" is participant of room "file welcome (2).txt room"
-    And user "participant2" is participant of room "file welcome (2).txt room"
+    Then user "participant1" is not participant of room "file welcome (2).txt room"
+    And user "participant2" is not participant of room "file welcome (2).txt room"
 
   Scenario: get room for file shared with user and group
     Given user "participant1" shares "welcome.txt" with group "group1" with OCS 100
@@ -69,9 +69,9 @@ Feature: conversation/files
     When user "participant1" gets the room for path "welcome.txt" with 200
     And user "participant2" gets the room for path "welcome (2).txt" with 200
     And user "participant3" gets the room for path "welcome (2).txt" with 200
-    Then user "participant1" is participant of room "file welcome (2).txt room"
-    And user "participant2" is participant of room "file welcome (2).txt room"
-    And user "participant3" is participant of room "file welcome (2).txt room"
+    Then user "participant1" is not participant of room "file welcome (2).txt room"
+    And user "participant2" is not participant of room "file welcome (2).txt room"
+    And user "participant3" is not participant of room "file welcome (2).txt room"
 
 
 
@@ -84,8 +84,8 @@ Feature: conversation/files
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
     When user "participant1" gets the room for path "welcome.txt" with 200
     And user "participant2" gets the room for path "welcome (2).txt" with 200
-    Then user "participant1" is participant of room "file welcome (2).txt room"
-    And user "participant2" is participant of room "file welcome (2).txt room"
+    Then user "participant1" is not participant of room "file welcome (2).txt room"
+    And user "participant2" is not participant of room "file welcome (2).txt room"
 
 
 
@@ -178,6 +178,28 @@ Feature: conversation/files
 
 
 
+  Scenario: owner of a shared file is not removed from its room after leaving it
+    Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    # Note that the room token is got by a different user than the one that
+    # joins the room
+    And user "participant2" gets the room for path "welcome (2).txt" with 200
+    And user "participant1" joins room "file welcome (2).txt room" with 200
+    And user "participant1" is participant of room "file welcome (2).txt room"
+    When user "participant1" leaves room "file welcome (2).txt room" with 200
+    Then user "participant1" is participant of room "file welcome (2).txt room"
+
+  Scenario: user with access to a file is not removed from its room after leaving it
+    Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    # Note that the room token is got by a different user than the one that
+    # joins the room
+    And user "participant1" gets the room for path "welcome.txt" with 200
+    And user "participant2" joins room "file welcome.txt room" with 200
+    And user "participant2" is participant of room "file welcome.txt room"
+    When user "participant2" leaves room "file welcome.txt room" with 200
+    Then user "participant2" is participant of room "file welcome.txt room"
+
+
+
   Scenario: owner of a shared file can join its room again after removing self from it
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
     # Note that the room token is got by a different user than the one that
@@ -210,6 +232,8 @@ Feature: conversation/files
   Scenario: owner is not participant of room for file no longer shared
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
     And user "participant1" gets the room for path "welcome.txt" with 200
+    And user "participant1" joins room "file welcome.txt room" with 200
+    And user "participant1" leaves room "file welcome.txt room" with 200
     And user "participant1" is participant of room "file welcome.txt room"
     When user "participant1" deletes last share
     Then user "participant1" is participant of room "file welcome.txt room"
@@ -219,6 +243,8 @@ Feature: conversation/files
   Scenario: user is not participant of room for file no longer with access to it
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
     And user "participant2" gets the room for path "welcome (2).txt" with 200
+    And user "participant2" joins room "file welcome (2).txt room" with 200
+    And user "participant2" leaves room "file welcome (2).txt room" with 200
     And user "participant2" is participant of room "file welcome (2).txt room"
     When user "participant1" deletes last share
     Then user "participant2" is participant of room "file welcome (2).txt room"

--- a/tests/integration/features/conversation/files.feature
+++ b/tests/integration/features/conversation/files.feature
@@ -145,22 +145,26 @@ Feature: conversation/files
 
 
 
-  Scenario: owner of a shared file can join its room again after leaving it
+  Scenario: owner of a shared file can join its room again after removing self from it
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    # Note that the room token is got by a different user than the one that
+    # joins the room
     And user "participant2" gets the room for path "welcome (2).txt" with 200
     And user "participant1" joins room "file welcome (2).txt room" with 200
     And user "participant1" is participant of room "file welcome (2).txt room"
-    When user "participant1" leaves room "file welcome (2).txt room" with 200
+    When user "participant1" removes themselves from room "file welcome (2).txt room" with 200
     And user "participant1" is not participant of room "file welcome (2).txt room"
     And user "participant1" joins room "file welcome (2).txt room" with 200
     Then user "participant1" is participant of room "file welcome (2).txt room"
 
-  Scenario: user with access to a file can join its room again after leaving it
+  Scenario: user with access to a file can join its room again after removing self from it
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    # Note that the room token is got by a different user than the one that
+    # joins the room
     And user "participant1" gets the room for path "welcome.txt" with 200
     And user "participant2" joins room "file welcome.txt room" with 200
     And user "participant2" is participant of room "file welcome.txt room"
-    When user "participant2" leaves room "file welcome.txt room" with 200
+    When user "participant2" removes themselves from room "file welcome.txt room" with 200
     And user "participant2" is not participant of room "file welcome.txt room"
     And user "participant2" joins room "file welcome.txt room" with 200
     Then user "participant2" is participant of room "file welcome.txt room"

--- a/tests/integration/features/conversation/files.feature
+++ b/tests/integration/features/conversation/files.feature
@@ -117,6 +117,15 @@ Feature: conversation/files
     When user "participant2" joins room "file test/renamed.txt room" with 200
     Then user "participant2" is participant of room "file test/renamed.txt room"
 
+  Scenario: user with access to a file in a reshared folder can join its room
+    Given user "participant1" creates folder "/test"
+    And user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
+    And user "participant1" shares "test" with user "participant2" with OCS 100
+    And user "participant2" shares "test" with user "participant3" with OCS 100
+    And user "participant3" gets the room for path "test/renamed.txt" with 200
+    When user "participant3" joins room "file test/renamed.txt room" with 200
+    Then user "participant3" is participant of room "file test/renamed.txt room"
+
   Scenario: owner of a no longer shared file can not join its room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
     And user "participant2" gets the room for path "welcome (2).txt" with 200
@@ -142,6 +151,30 @@ Feature: conversation/files
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
     And user "participant1" gets the room for path "welcome.txt" with 200
     When user "guest" joins room "file welcome.txt room" with 404
+
+
+
+  Scenario: join room for file shared with group
+    Given user "participant1" shares "welcome.txt" with group "group1" with OCS 100
+    And user "participant1" gets the room for path "welcome.txt" with 200
+    And user "participant2" gets the room for path "welcome (2).txt" with 200
+    When user "participant1" joins room "file welcome.txt room" with 200
+    And user "participant2" joins room "file welcome.txt room" with 200
+    Then user "participant1" is participant of room "file welcome (2).txt room"
+    And user "participant2" is participant of room "file welcome (2).txt room"
+
+  Scenario: join room for file shared with user and group
+    Given user "participant1" shares "welcome.txt" with group "group1" with OCS 100
+    And user "participant1" shares "welcome.txt" with user "participant3" with OCS 100
+    And user "participant1" gets the room for path "welcome.txt" with 200
+    And user "participant2" gets the room for path "welcome (2).txt" with 200
+    And user "participant3" gets the room for path "welcome (2).txt" with 200
+    When user "participant1" joins room "file welcome.txt room" with 200
+    And user "participant2" joins room "file welcome.txt room" with 200
+    And user "participant3" joins room "file welcome.txt room" with 200
+    Then user "participant1" is participant of room "file welcome (2).txt room"
+    And user "participant2" is participant of room "file welcome (2).txt room"
+    And user "participant3" is participant of room "file welcome (2).txt room"
 
 
 

--- a/tests/integration/features/conversation/join-leave.feature
+++ b/tests/integration/features/conversation/join-leave.feature
@@ -1,0 +1,92 @@
+Feature: conversation/join-leave
+
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    Given user "participant3" exists
+
+  Scenario: join a one-to-one room
+    Given user "participant1" creates room "room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    When user "participant1" joins room "room" with 200
+    And user "participant2" joins room "room" with 200
+    And user "participant3" joins room "room" with 404
+    And user "guest" joins room "room" with 404
+    Then user "participant1" is participant of room "room"
+    And user "participant2" is participant of room "room"
+    And user "participant3" is not participant of room "room"
+    And user "guest" is not participant of room "room"
+
+  Scenario: leave a one-to-one room
+    Given user "participant1" creates room "room"
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" joins room "room" with 200
+    And user "participant2" joins room "room" with 200
+    When user "participant1" leaves room "room" with 200
+    And user "participant2" leaves room "room" with 200
+    Then user "participant1" is participant of room "room"
+    And user "participant2" is participant of room "room"
+
+
+
+  Scenario: join a group room
+    Given user "participant1" creates room "room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "room" with 200
+    When user "participant1" joins room "room" with 200
+    And user "participant2" joins room "room" with 200
+    And user "participant3" joins room "room" with 404
+    And user "guest" joins room "room" with 404
+    Then user "participant1" is participant of room "room"
+    And user "participant2" is participant of room "room"
+    And user "participant3" is not participant of room "room"
+    And user "guest" is not participant of room "room"
+
+  Scenario: leave a group room
+    Given user "participant1" creates room "room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "room" with 200
+    And user "participant1" joins room "room" with 200
+    And user "participant2" joins room "room" with 200
+    When user "participant1" leaves room "room" with 200
+    And user "participant2" leaves room "room" with 200
+    Then user "participant1" is participant of room "room"
+    And user "participant2" is participant of room "room"
+
+
+
+  Scenario: join a public room
+    Given user "participant1" creates room "room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "room" with 200
+    When user "participant1" joins room "room" with 200
+    And user "participant2" joins room "room" with 200
+    And user "participant3" joins room "room" with 200
+    And user "guest" joins room "room" with 200
+    Then user "participant1" is participant of room "room"
+    And user "participant2" is participant of room "room"
+    And user "participant3" is participant of room "room"
+    And user "guest" is participant of room "room"
+
+  Scenario: leave a public room
+    Given user "participant1" creates room "room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds "participant2" to room "room" with 200
+    And user "participant1" joins room "room" with 200
+    And user "participant2" joins room "room" with 200
+    And user "participant3" joins room "room" with 200
+    And user "guest" joins room "room" with 200
+    When user "participant1" leaves room "room" with 200
+    And user "participant2" leaves room "room" with 200
+    And user "participant3" leaves room "room" with 200
+    And user "guest" leaves room "room" with 200
+    Then user "participant1" is participant of room "room"
+    And user "participant2" is participant of room "room"
+    And user "participant3" is not participant of room "room"
+    And user "guest" is not participant of room "room"


### PR DESCRIPTION
Follow up to #1344 

This fixes the code so it behaves as stated in the documentation.

In practice currently this should make no difference, as in the Files app the user joins the room immediately after getting its token; however, this makes possible to get the token without joining the room, which will be needed in the future [to improve the UX of the Files app](https://github.com/nextcloud/spreed/issues/1366).

Besides the fix itself the integration tests were adjusted and extended.
