### PR TITLE
Fix copying to clipboard

### DIFF
--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -298,7 +298,11 @@
 		 * Clipboard
 		 */
 		initClipboard: function() {
-			var clipboard = new Clipboard('.clipboard-button');
+			if (this.ui.clipboardButton.length === 0) {
+				return;
+			}
+
+			var clipboard = new Clipboard(this.ui.clipboardButton[0]);
 			clipboard.on('success', function(e) {
 				var $input = $(e.trigger);
 				$input.tooltip('hide')

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -298,12 +298,17 @@
 		 * Clipboard
 		 */
 		initClipboard: function() {
+			if (this._clipboard) {
+				this._clipboard.destroy();
+				delete this._clipboard;
+			}
+
 			if (this.ui.clipboardButton.length === 0) {
 				return;
 			}
 
-			var clipboard = new Clipboard(this.ui.clipboardButton[0]);
-			clipboard.on('success', function(e) {
+			this._clipboard = new Clipboard(this.ui.clipboardButton[0]);
+			this._clipboard.on('success', function(e) {
 				var $input = $(e.trigger);
 				$input.tooltip('hide')
 					.attr('data-original-title', t('core', 'Link copied!'))
@@ -316,7 +321,7 @@
 						.tooltip('fixTitle');
 				}, 3000);
 			});
-			clipboard.on('error', function (e) {
+			this._clipboard.on('error', function (e) {
 				var $input = $(e.trigger);
 				var actionMsg = '';
 				if (/iPhone|iPad/i.test(navigator.userAgent)) {

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -271,12 +271,17 @@
 		 * Clipboard
 		 */
 		initClipboard: function() {
+			if (this._clipboard) {
+				this._clipboard.destroy();
+				delete this._clipboard;
+			}
+
 			if (this.ui.clipboardButton.length === 0) {
 				return;
 			}
 
-			var clipboard = new Clipboard(this.ui.clipboardButton[0]);
-			clipboard.on('success', function(e) {
+			this._clipboard = new Clipboard(this.ui.clipboardButton[0]);
+			this._clipboard.on('success', function(e) {
 				var $input = $(e.trigger);
 				$input.tooltip('hide')
 					.attr('data-original-title', t('core', 'Link copied!'))
@@ -289,7 +294,7 @@
 						.tooltip('fixTitle');
 				}, 3000);
 			});
-			clipboard.on('error', function (e) {
+			this._clipboard.on('error', function (e) {
 				var $input = $(e.trigger);
 				var actionMsg = '';
 				if (/iPhone|iPad/i.test(navigator.userAgent)) {

--- a/js/views/roomlistview.js
+++ b/js/views/roomlistview.js
@@ -271,7 +271,11 @@
 		 * Clipboard
 		 */
 		initClipboard: function() {
-			var clipboard = new Clipboard('.clipboard-button');
+			if (this.ui.clipboardButton.length === 0) {
+				return;
+			}
+
+			var clipboard = new Clipboard(this.ui.clipboardButton[0]);
 			clipboard.on('success', function(e) {
 				var $input = $(e.trigger);
 				$input.tooltip('hide')


### PR DESCRIPTION
This fixes a repeated copy of a link when clicking on the copy link button (mostly noticeable as a slow down in older Firefox versions, although the underlying issue happens in every browser).

When the Clipboard object is created it attaches event listeners to the given element or to all the elements that match the given DOM selector. As all the clipboard buttons in the Talk UI (except the one in the empty content view) have the `clipboard-button` CSS class all the Clipboard objects listened to clicks on all the buttons, so clicking on a single button triggered as many copies as buttons and thus Clipboard objects were in the page. Now the Clipboard objects attach listeners only to their corresponding clipboard button.

Besides that, the previous Clipboard object is now explicitly destroyed when replaced with a new one to ensure proper lifecycle management.

This probably happens in _stable15_ too (I have not checked), but it is probably not worth a backport (but if you think it should be backported feel free to call the backport bot ;-) ).