### PR TITLE
Fix missing notifications to signaling backend for some room events

### DIFF
--- a/lib/Signaling/Listener.php
+++ b/lib/Signaling/Listener.php
@@ -130,6 +130,39 @@ class Listener {
 			$room = $event->getSubject();
 			$notifier->roomModified($room);
 		});
+		$dispatcher->addListener(Room::class . '::postSetPassword', function(GenericEvent $event) {
+			if (self::isUsingInternalSignaling()) {
+				return;
+			}
+
+			/** @var BackendNotifier $notifier */
+			$notifier = \OC::$server->query(BackendNotifier::class);
+
+			$room = $event->getSubject();
+			$notifier->roomModified($room);
+		});
+		$dispatcher->addListener(Room::class . '::postChangeType', function(GenericEvent $event) {
+			if (self::isUsingInternalSignaling()) {
+				return;
+			}
+
+			/** @var BackendNotifier $notifier */
+			$notifier = \OC::$server->query(BackendNotifier::class);
+
+			$room = $event->getSubject();
+			$notifier->roomModified($room);
+		});
+		$dispatcher->addListener(Room::class . '::postSetReadOnly', function(GenericEvent $event) {
+			if (self::isUsingInternalSignaling()) {
+				return;
+			}
+
+			/** @var BackendNotifier $notifier */
+			$notifier = \OC::$server->query(BackendNotifier::class);
+
+			$room = $event->getSubject();
+			$notifier->roomModified($room);
+		});
 		$dispatcher->addListener(Room::class . '::postSetParticipantType', function(GenericEvent $event) {
 			if (self::isUsingInternalSignaling()) {
 				return;

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -255,6 +255,69 @@ class BackendNotifierTest extends \Test\TestCase {
 		], $bodies);
 	}
 
+	public function testRoomPasswordChanged() {
+		$room = $this->manager->createPublicRoom();
+		$room->setPassword('password');
+
+		$requests = $this->controller->getRequests();
+		$bodies = array_map(function($request) use ($room) {
+			return json_decode($this->validateBackendRequest($this->baseUrl . '/api/v1/room/' . $room->getToken(), $request), true);
+		}, $requests);
+		$this->assertContains([
+			'type' => 'update',
+			'update' => [
+				'userids' => [
+				],
+				'properties' => [
+					'name' => $room->getDisplayName(''),
+					'type' => $room->getType(),
+				],
+			],
+		], $bodies);
+	}
+
+	public function testRoomTypeChanged() {
+		$room = $this->manager->createPublicRoom();
+		$room->changeType(Room::GROUP_CALL);
+
+		$requests = $this->controller->getRequests();
+		$bodies = array_map(function($request) use ($room) {
+			return json_decode($this->validateBackendRequest($this->baseUrl . '/api/v1/room/' . $room->getToken(), $request), true);
+		}, $requests);
+		$this->assertContains([
+			'type' => 'update',
+			'update' => [
+				'userids' => [
+				],
+				'properties' => [
+					'name' => $room->getDisplayName(''),
+					'type' => $room->getType(),
+				],
+			],
+		], $bodies);
+	}
+
+	public function testRoomReadOnlyChanged() {
+		$room = $this->manager->createPublicRoom();
+		$room->setReadOnly(Room::READ_ONLY);
+
+		$requests = $this->controller->getRequests();
+		$bodies = array_map(function($request) use ($room) {
+			return json_decode($this->validateBackendRequest($this->baseUrl . '/api/v1/room/' . $room->getToken(), $request), true);
+		}, $requests);
+		$this->assertContains([
+			'type' => 'update',
+			'update' => [
+				'userids' => [
+				],
+				'properties' => [
+					'name' => $room->getDisplayName(''),
+					'type' => $room->getType(),
+				],
+			],
+		], $bodies);
+	}
+
 	public function testRoomDelete() {
 		$room = $this->manager->createPublicRoom();
 		$room->addUsers([


### PR DESCRIPTION
The signaling backend was not notified when the password, type or read only state of the room was modified so, in turn, the signaling backend did not notify the clients about those changes.

This could be seen in the WebUI when the external signaling server was used, as in that case [calling `syncRooms` does nothing until the signaling server notifies the clients](https://github.com/nextcloud/spreed/blob/9d427613335109ce360071d7d4d55c85d9cc6350/js/signaling.js#L1220), so there is no fetch, the attributes are not updated and thus the UI is not updated either.

## How to test: ##
- Setup the external signaling server
- Create a group room
- Make the room public

### Result with this pull request: ###
The UI is updated to reflect that the room is now public.

### Result without this pull request: ###
The UI is not updated to reflect that the room is now public (there are no buttons to copy the link or set the password). Note that the UI will be eventually updated due to [the recurring forced synchronization](https://github.com/nextcloud/spreed/blob/9d427613335109ce360071d7d4d55c85d9cc6350/js/signaling.js#L743-L745), but not due to making the room public.
