### PR TITLE
Move requests from CallInfoView to room model

### DIFF
--- a/js/models/room.js
+++ b/js/models/room.js
@@ -34,9 +34,7 @@
 	 * constructor options.
 	 *
 	 * Besides fetching the data from the server it supports renaming the room
-	 * by calling "save('name', nameToSet, options)"; in this case the options
-	 * must contain, at least, "patch: true" (it may contain other options like
-	 * a success callback too if needed).
+	 * by calling "save('name', nameToSet, options)".
 	 */
 	var Room = Backbone.Model.extend({
 		defaults: {
@@ -79,6 +77,31 @@
 			if (!attributes.name) {
 				return t('spreed', 'Room name can not be empty');
 			}
+		},
+		save: function(key, value, options) {
+			if (typeof key !== 'string') {
+				throw 'Room.save only supports single attributes';
+			}
+
+			var supportedKeys = [
+				'name',
+			];
+
+			if (supportedKeys.indexOf(key) === -1) {
+				throw 'Room.save does not support the "' + key + '" key';
+			}
+
+			if (options && options.patch !== undefined && !options.patch) {
+				throw 'Room.save does not support "options.patch = false"';
+			}
+
+			options = options || {};
+
+			// "patch: true" is needed to send only the changed attribute
+			// instead of a complete representation of the model.
+			options.patch = true;
+
+			return Backbone.Model.prototype.save.call(this, key, value, options);
 		},
 		sync: function(method, model, options) {
 			// When saving a model "Backbone.Model.save" calls "sync" with an

--- a/js/models/room.js
+++ b/js/models/room.js
@@ -34,9 +34,9 @@
 	 * constructor options.
 	 *
 	 * Besides fetching the data from the server it supports renaming the room
-	 * by calling "save('displayName', nameToSet, options)"; in this case the
-	 * options must contain, at least, "patch: true" (it may contain other
-	 * options like a success callback too if needed).
+	 * by calling "save('name', nameToSet, options)"; in this case the options
+	 * must contain, at least, "patch: true" (it may contain other options like
+	 * a success callback too if needed).
 	 */
 	var Room = Backbone.Model.extend({
 		defaults: {

--- a/js/models/room.js
+++ b/js/models/room.js
@@ -108,15 +108,16 @@
 			// "update" method, which by default sends a "PUT" request that
 			// contains all the attributes of the model. In order to send only
 			// the attributes to be saved "patch: true" must be set in the
-			// options. However, this causes a "PATCH" request instead of a
-			// "PUT" request to be sent, so the "method" must be changed from
-			// "patch" to "update", as the backend expects a "PUT" request.
-			// Moreover, the endpoint to rename a room expects the name to be
-			// provided in a "roomName" attribute instead of a "name"
-			// attribute, so that has to be changed too.
+			// options. However, this causes a "PATCH" request to be sent, so
+			// the "method" must be changed from "patch" to "create", "update"
+			// or "delete" if the backend expects a "POST", "PUT" or "DELETE"
+			// request instead.
+
 			if (method === 'patch' && options.attrs.name !== undefined) {
 				method = 'update';
 
+				// The endpoint to rename a room expects the name to be provided
+				// in a "roomName" attribute instead of a "name" attribute.
 				options.attrs.roomName = options.attrs.name;
 				delete options.attrs.name;
 			}

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -121,7 +121,6 @@
 				model: this.model,
 				modelAttribute: nameAttribute,
 				modelSaveOptions: {
-					patch: true,
 					success: function() {
 						// Renaming a room by setting "name" is not expected to
 						// change any other attribute in the server, but the

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -265,13 +265,10 @@
 		 */
 		confirmPassword: function(e) {
 			e.preventDefault();
+
 			var newPassword = this.ui.passwordInput.val().trim();
-			$.ajax({
-				url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('token') + '/password',
-				type: 'PUT',
-				data: {
-					password: newPassword
-				},
+
+			this.model.setPassword(newPassword, {
 				success: function() {
 					this.ui.passwordInput.val('');
 					OC.hideMenus();

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -120,14 +120,6 @@
 			this._nameEditableTextLabel = new OCA.SpreedMe.Views.EditableTextLabel({
 				model: this.model,
 				modelAttribute: nameAttribute,
-				modelSaveOptions: {
-					success: function() {
-						// Renaming a room by setting "name" is not expected to
-						// change any other attribute in the server, but the
-						// model is fetched again anyway to be on the safe side.
-						OCA.SpreedMe.app.signaling.syncRooms();
-					}.bind(this)
-				},
 
 				extraClassNames: 'room-name',
 				labelTagName: 'h2',
@@ -253,11 +245,7 @@
 		toggleLinkCheckbox: function() {
 			var isPublic = this.ui.linkCheckbox.attr('checked') === 'checked';
 
-			this.model.setPublic(isPublic, {
-				success: function() {
-					OCA.SpreedMe.app.signaling.syncRooms();
-				}
-			});
+			this.model.setPublic(isPublic);
 		},
 
 		/**
@@ -272,7 +260,6 @@
 				success: function() {
 					this.ui.passwordInput.val('');
 					OC.hideMenus();
-					OCA.SpreedMe.app.signaling.syncRooms();
 				}.bind(this),
 				error: function() {
 					OC.Notification.show(t('spreed', 'Error occurred while setting password'), {type: 'error'});

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -251,11 +251,9 @@
 		 * Share link
 		 */
 		toggleLinkCheckbox: function() {
-			var shareLink = this.ui.linkCheckbox.attr('checked') === 'checked';
+			var isPublic = this.ui.linkCheckbox.attr('checked') === 'checked';
 
-			$.ajax({
-				url: OC.linkToOCS('apps/spreed/api/v1/room', 2) + this.model.get('token') + '/public',
-				type: shareLink ? 'POST' : 'DELETE',
+			this.model.setPublic(isPublic, {
 				success: function() {
 					OCA.SpreedMe.app.signaling.syncRooms();
 				}

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -125,7 +125,7 @@
 						// Renaming a room by setting "name" is not expected to
 						// change any other attribute in the server, but the
 						// model is fetched again anyway to be on the safe side.
-						this.model.fetch();
+						OCA.SpreedMe.app.signaling.syncRooms();
 					}.bind(this)
 				},
 

--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -123,9 +123,9 @@
 				modelSaveOptions: {
 					patch: true,
 					success: function() {
-						// Renaming a room by setting "displayName" causes "name" to
-						// change too in the server, so the model has to be fetched
-						// again to get the changes.
+						// Renaming a room by setting "name" is not expected to
+						// change any other attribute in the server, but the
+						// model is fetched again anyway to be on the safe side.
 						this.model.fetch();
 					}.bind(this)
 				},


### PR DESCRIPTION
This pull request is a refactoring that has almost no behaviour changes, except for a minor difference: now when a room is renamed, if the internal signaling server is used all the rooms are fetched instead of only the renamed one, and if the external signaling server is used the rooms are fetched only once instead of twice.

It needs to be backported to _stable16_, as it serves as the base for further fixes.