### PR TITLE
Only update read marker when receiving new messages.

### DIFF
--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -330,7 +330,7 @@ class ChatController extends AEnvironmentAwareController {
 		$newLastKnown = end($comments);
 		if ($newLastKnown instanceof IComment) {
 			$response->addHeader('X-Chat-Last-Given', $newLastKnown->getId());
-			if ($setReadMarker === 1) {
+			if ($setReadMarker === 1 && $lookIntoFuture) {
 				$this->participant->setLastReadMessage((int) $newLastKnown->getId());
 			}
 		}


### PR DESCRIPTION
**Before:**
Read marker was updated even when receiving chat history, so the read marker was wrongly updated with the last messageId from the chat history.

**Now:**
Read marker is only updated when receiving new messages (lookIntoFuture).
Also the read marker is updated before receiving the first (lookIntoFuture) response with `lastKnownMessageId`.

Regression from https://github.com/nextcloud/spreed/pull/1214