### PR TITLE
Get password from session if not given when joining room

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -160,8 +160,6 @@ class PageController extends Controller {
 				$token = '';
 			}
 
-			$this->talkSession->removePasswordForRoom($token);
-
 			if ($room instanceof Room && $room->hasPassword()) {
 				// If the user joined themselves or is not found, they need the password.
 				try {
@@ -172,12 +170,14 @@ class PageController extends Controller {
 				}
 
 				if ($requirePassword) {
+					$password = $password !== '' ? $password : (string) $this->talkSession->getPasswordForRoom($token);
 
 					$passwordVerification = $room->verifyPassword($password);
 
 					if ($passwordVerification['result']) {
-						$this->talkSession->setPasswordForRoom($token, $token);
+						$this->talkSession->setPasswordForRoom($token, $password);
 					} else {
+						$this->talkSession->removePasswordForRoom($token);
 						if ($passwordVerification['url'] === '') {
 							return new TemplateResponse($this->appName, 'authenticate', [
 								'wrongpw' => $password !== '',
@@ -226,13 +226,14 @@ class PageController extends Controller {
 			]));
 		}
 
-		$this->talkSession->removePasswordForRoom($token);
 		if ($room->hasPassword()) {
-			$passwordVerification = $room->verifyPassword($password);
+			$password = $password !== '' ? $password : (string) $this->talkSession->getPasswordForRoom($token);
 
+			$passwordVerification = $room->verifyPassword($password);
 			if ($passwordVerification['result']) {
-				$this->talkSession->setPasswordForRoom($token, $token);
+				$this->talkSession->setPasswordForRoom($token, $password);
 			} else {
+				$this->talkSession->removePasswordForRoom($token);
 				if ($passwordVerification['url'] === '') {
 					return new TemplateResponse($this->appName, 'authenticate', [
 						'wrongpw' => $password !== '',

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -879,10 +879,11 @@ class RoomController extends AEnvironmentAwareController {
 
 		$user = $this->userManager->get($this->userId);
 		try {
+			$result = $room->verifyPassword((string) $this->session->getPasswordForRoom($token));
 			if ($user instanceof IUser) {
-				$newSessionId = $room->joinRoom($user, $password, $this->session->getPasswordForRoom($token) === $room->getToken());
+				$newSessionId = $room->joinRoom($user, $password, $result['result']);
 			} else {
-				$newSessionId = $room->joinRoomGuest($password, $this->session->getPasswordForRoom($token) === $room->getToken());
+				$newSessionId = $room->joinRoomGuest($password, $result['result']);
 			}
 		} catch (InvalidPasswordException $e) {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);

--- a/tests/acceptance/features/conversation-public.feature
+++ b/tests/acceptance/features/conversation-public.feature
@@ -33,6 +33,8 @@ Feature: conversation
     And I see that the current page is the Authenticate page for the public conversation link I wrote down
     And I authenticate with password "abcdef" in public conversation
     Then I see that the current page is the public conversation link I wrote down
+    And I see that the chat is shown in the main view
+    And I see that the sidebar is open
 
   Scenario: join a public conversation protected by password with an invalid password
     Given I act as John
@@ -43,6 +45,40 @@ Feature: conversation
     And I see that the conversation is password protected
     And I write down the public conversation link
     When I act as Jane
+    And I visit the public conversation link I wrote down
+    And I see that the current page is the Authenticate page for the public conversation link I wrote down
+    And I authenticate with password "fedcba" in public conversation
+    Then I see that the current page is the Wrong password page for the public conversation link I wrote down
+
+  Scenario: join a public conversation protected by password with a valid password as a user
+    Given I act as John
+    And I am logged in
+    And I have opened the Talk app
+    And I create a public conversation named "Public"
+    And I protect the conversation with the password "abcdef"
+    And I see that the conversation is password protected
+    And I write down the public conversation link
+    When I act as Jane
+    And I am logged in as the admin
+    And I visit the public conversation link I wrote down
+    And I see that the current page is the Authenticate page for the public conversation link I wrote down
+    And I authenticate with password "abcdef" in public conversation
+    Then I see that the current page is the public conversation link I wrote down
+    And I see that the "Public" conversation is active
+    And I see that the chat is shown in the main view
+    And I see that the sidebar is open
+    And I see that the number of participants shown in the list is "2"
+
+  Scenario: join a public conversation protected by password with an invalid password as a user
+    Given I act as John
+    And I am logged in
+    And I have opened the Talk app
+    And I create a public conversation named "Public"
+    And I protect the conversation with the password "abcdef"
+    And I see that the conversation is password protected
+    And I write down the public conversation link
+    When I act as Jane
+    And I am logged in as the admin
     And I visit the public conversation link I wrote down
     And I see that the current page is the Authenticate page for the public conversation link I wrote down
     And I authenticate with password "fedcba" in public conversation

--- a/tests/acceptance/features/conversation-public.feature
+++ b/tests/acceptance/features/conversation-public.feature
@@ -50,6 +50,25 @@ Feature: conversation
     And I authenticate with password "fedcba" in public conversation
     Then I see that the current page is the Wrong password page for the public conversation link I wrote down
 
+  Scenario: join again a public conversation protected by password
+    Given I act as John
+    And I am logged in
+    And I have opened the Talk app
+    And I create a public conversation named "Public"
+    And I protect the conversation with the password "abcdef"
+    And I see that the conversation is password protected
+    And I write down the public conversation link
+    And I act as Jane
+    And I visit the public conversation link I wrote down
+    And I see that the current page is the Authenticate page for the public conversation link I wrote down
+    And I authenticate with password "abcdef" in public conversation
+    And I see that the current page is the public conversation link I wrote down
+    And I see that the chat is shown in the main view
+    And I see that the sidebar is open
+    When I visit the Home page
+    And I visit the public conversation link I wrote down
+    Then I see that the current page is the Authenticate page for the public conversation link I wrote down
+
   Scenario: join a public conversation protected by password with a valid password as a user
     Given I act as John
     And I am logged in
@@ -83,3 +102,25 @@ Feature: conversation
     And I see that the current page is the Authenticate page for the public conversation link I wrote down
     And I authenticate with password "fedcba" in public conversation
     Then I see that the current page is the Wrong password page for the public conversation link I wrote down
+
+  Scenario: join again a public conversation protected by password as a user
+    Given I act as John
+    And I am logged in
+    And I have opened the Talk app
+    And I create a public conversation named "Public"
+    And I protect the conversation with the password "abcdef"
+    And I see that the conversation is password protected
+    And I write down the public conversation link
+    And I act as Jane
+    And I am logged in as the admin
+    And I visit the public conversation link I wrote down
+    And I see that the current page is the Authenticate page for the public conversation link I wrote down
+    And I authenticate with password "abcdef" in public conversation
+    And I see that the current page is the public conversation link I wrote down
+    And I see that the "Public" conversation is active
+    And I see that the chat is shown in the main view
+    And I see that the sidebar is open
+    And I see that the number of participants shown in the list is "2"
+    When I visit the Home page
+    And I visit the public conversation link I wrote down
+    Then I see that the current page is the Authenticate page for the public conversation link I wrote down


### PR DESCRIPTION
This pull request was extracted from [the lobby pull request](https://github.com/nextcloud/spreed/pull/1926), as the change is not needed for the current lobby UI but it should be kept anyway.

As mentioned in [the lobby pull request](https://github.com/nextcloud/spreed/pull/1926#issuecomment-525259604):

> The commit itself introduced a regression when joining a password protected conversation as a logged in user (I have added an acceptance test that shows it); I fixed it for logged in users following the change you made for guests... but please check it :-)

Besides that I have added some acceptance tests that check that it is possible to join a password protected room again without having to enter again the password. @nickvergessen I am not sure if that is the expected behaviour (as [it is not exactly what you described](https://github.com/nextcloud/spreed/pull/1926#issuecomment-525287425) and it requires an additional change from what you originally did to not remove the password after joining the room), so please check that too; if that is not the expected behaviour the last fixup commit (the one that keeps the password after joining the room) needs to be dropped and the last acceptance tests adjusted to show that it is needed to authenticate again.
