### PR TITLE
Fix volume indicator shown when audio is not available

### DIFF
--- a/js/views/mediacontrolsview.js
+++ b/js/views/mediacontrolsview.js
@@ -153,10 +153,14 @@
 		setAudioAvailable: function(audioAvailable) {
 			if (audioAvailable) {
 				this.getUI('audioButton').removeClass('no-audio-available');
+
+				this.getUI('volumeIndicator').removeClass('hidden');
 			} else {
 				this.getUI('audioButton').removeClass('audio-disabled icon-audio')
 					.addClass('no-audio-available icon-audio-off')
 					.attr('data-original-title', t('spreed', 'No audio'));
+
+				this.getUI('volumeIndicator').addClass('hidden');
 			}
 
 			this._audioAvailable = audioAvailable;


### PR DESCRIPTION
Bug from #2021

## How to test
- Start a call
- Do not grant access to the microphone

### Results with this pull request ###
The volume indicator is not shown

### Results without this pull request ###
The volume indicator is shown
