### PR TITLE
Fix setting again the same lobby state in the UI

### DIFF
--- a/js/views/callinfoview.js
+++ b/js/views/callinfoview.js
@@ -318,6 +318,10 @@
 		},
 
 		setLobbyStateAllParticipants: function() {
+			if (this.model.get('lobbyState') === OCA.SpreedMe.app.LOBBY_NONE) {
+				return;
+			}
+
 			this.ui.allParticipantsRadio.prop('disabled', true);
 			this.ui.allParticipantsLabel.addClass('icon-loading-small');
 
@@ -338,6 +342,10 @@
 		},
 
 		setLobbyStateModeratorsOnly: function() {
+			if (this.model.get('lobbyState') === OCA.SpreedMe.app.LOBBY_NON_MODERATORS) {
+				return;
+			}
+
 			this.ui.moderatorsOnlyRadio.prop('disabled', true);
 			this.ui.moderatorsOnlyLabel.addClass('icon-loading-small');
 


### PR DESCRIPTION
Bug from #1926 

Sending a request to the server to set the same lobby state is valid, but unneeded. Moreover, the `CallInfoView` is rendered again only when the lobby state changes, so if the same state is set again a loading spinner will be shown instead of the radio button until something else changes in the room.

## How to test (Scenario 1)
- Create a conversation
- Enable for all participants

### Result with this pull request
No request to set the lobby state is sent, and the radio button for _All participants_ is not modified.

### Result without this pull request
A request to set the lobby state is sent, and the radio button for _All participants_ becomes a loading spinner.

## How to test (Scenario 2)
- Create a conversation
- Enable for moderators only
- Enable again for moderators only

### Result with this pull request
The request to set the lobby state is not sent again, and the radio button for _Moderators only_ is not modified.

### Result without this pull request
Another request to set the lobby state is sent, and the radio button for _Moderators only_ becomes a loading spinner.
