### PR TITLE
Show a call summary when only guests joined

### DIFF
--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -114,8 +114,8 @@ class Listener {
 		$duration = $this->timeFactory->getTime() - $activeSince->getTimestamp();
 		$userIds = $room->getParticipantUserIds($activeSince);
 
-		if (empty($userIds) || (\count($userIds) === 1 && $room->getActiveGuests() === 0)) {
-			// Single user pinged or guests only => no activity
+		if ((\count($userIds) + $room->getActiveGuests()) === 1) {
+			// Single user pinged or guests only => no summary/activity
 			$room->resetActiveSince();
 			return false;
 		}
@@ -124,6 +124,21 @@ class Listener {
 
 		if (!$room->resetActiveSince()) {
 			// Race-condition, the room was already reset.
+			return false;
+		}
+
+		$actorId = $userIds[0] ?? 'guests-only';
+		$actorType = $actorId !== 'guests-only' ? 'users' : 'guests';
+		$this->chatManager->addSystemMessage($room, $actorType, $actorId, json_encode([
+			'message' => 'call_ended',
+			'parameters' => [
+				'users' => $userIds,
+				'guests' => $numGuests,
+				'duration' => $duration,
+			],
+		]), $this->timeFactory->getDateTime(), false);
+
+		if (empty($userIds)) {
 			return false;
 		}
 
@@ -144,15 +159,6 @@ class Listener {
 			$this->logger->logException($e, ['app' => 'spreed']);
 			return false;
 		}
-
-		$this->chatManager->addSystemMessage($room, 'users', $userIds[0], json_encode([
-			'message' => 'call_ended',
-			'parameters' => [
-				'users' => $userIds,
-				'guests' => $numGuests,
-				'duration' => $duration,
-			],
-		]), $this->timeFactory->getDateTime(), false);
 
 		foreach ($userIds as $userId) {
 			try {

--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -82,7 +82,7 @@ class Listener {
 		};
 		$dispatcher->addListener(Room::class . '::postRemoveBySession', $listener);
 		$dispatcher->addListener(Room::class . '::postRemoveUser', $listener);
-		$dispatcher->addListener(Room::class . '::postSessionLeaveCall', $listener);
+		$dispatcher->addListener(Room::class . '::postSessionLeaveCall', $listener, -100);
 
 		$listener = function(GenericEvent $event) {
 			/** @var Room $room */

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -360,6 +360,13 @@ class SystemMessage {
 		$displayedUsers = $numUsers;
 
 		switch ($numUsers) {
+			case 0:
+				$subject = $this->l->n(
+					'Call with %n guest (Duration {duration})',
+					'Call with %n guests (Duration {duration})',
+					$parameters['guests']
+				);
+				break;
 			case 1:
 				$subject = $this->l->t('Call with {user1} and {user2} (Duration {duration})');
 				$subject = str_replace('{user2}', $this->l->n('%n guest', '%n guests', $parameters['guests']), $subject);
@@ -401,8 +408,10 @@ class SystemMessage {
 		}
 
 		$params = [];
-		for ($i = 1; $i <= $displayedUsers; $i++) {
-			$params['user' . $i] = $this->getUser($parameters['users'][$i - 1]);
+		if ($displayedUsers > 0) {
+			for ($i = 1; $i <= $displayedUsers; $i++) {
+				$params['user' . $i] = $this->getUser($parameters['users'][$i - 1]);
+			}
 		}
 
 		$subject = str_replace('{duration}', $this->getDuration($parameters['duration']), $subject);

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -1053,7 +1053,7 @@ class Room {
 			->andWhere($query->expr()->nonEmptyString('user_id'));
 
 		if ($maxLastJoined instanceof \DateTimeInterface) {
-			$query->andWhere($query->expr()->gt('last_joined_call', $query->createNamedParameter($maxLastJoined, IQueryBuilder::PARAM_DATE)));
+			$query->andWhere($query->expr()->gte('last_joined_call', $query->createNamedParameter($maxLastJoined, IQueryBuilder::PARAM_DATE)));
 		}
 
 		$result = $query->execute();


### PR DESCRIPTION
Also found a way to show the call summary after the last leave message, since the behaviour does not require an active session anymore since #2012 

Fix #1166 