### PR TITLE
Start to move added files to appdata

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -28,7 +28,21 @@ return [
 			'url' => '/',
 			'verb' => 'GET',
 		],
+
+		/**
+		 * Previews
+		 */
+		[
+			'name' => 'Preview#getPreviewByFileId',
+			'url' => '/attachment/{token}/{fileId}',
+			'verb' => 'GET',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
 	],
+
 	'ocs' => [
 		/**
 		 * Signaling

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -157,7 +157,7 @@ return [
 		 * Files
 		 */
 		[
-			'name' => 'Files#copyFileToRoom',
+			'name' => 'Attachment#copyFileToAttachment',
 			'url' => '/api/{apiVersion}/chat/{token}/file',
 			'verb' => 'POST',
 			'requirements' => [

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -140,6 +140,19 @@ return [
 		],
 
 		/**
+		 * Files
+		 */
+		[
+			'name' => 'Files#copyFileToRoom',
+			'url' => '/api/{apiVersion}/chat/{token}/file',
+			'verb' => 'POST',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
+
+		/**
 		 * Room
 		 */
 		[

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -165,6 +165,15 @@ return [
 				'token' => '^[a-z0-9]{4,30}$',
 			],
 		],
+		[
+			'name' => 'Attachment#copyAttachmentToFile',
+			'url' => '/api/{apiVersion}/chat/{token}/attachment/{id}',
+			'verb' => 'POST',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
 
 		/**
 		 * Room

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -1090,18 +1090,27 @@
 			var $shareButton = $form.find('.share');
 			var $shareLoadingIcon = $form.find('.shareLoading');
 
-			OC.dialogs.filepicker(t('spreed', 'File to share'), function(targetPath) {
+			OC.dialogs.filepicker(t('spreed', 'File to share'), function(targetPath, clickType) {
 				$shareButton.addClass('hidden');
 				$shareLoadingIcon.removeClass('hidden');
 
+				var url = OC.linkToOCS('apps/files_sharing/api/v1', 2) + 'shares';
+				var data = {
+					shareType: OC.Share.SHARE_TYPE_ROOM,
+					path: targetPath,
+					shareWith: self.collection.token
+				};
+				if (clickType === 'attach') {
+					url = OC.linkToOCS('apps/spreed/api/v1/chat', 2) + self.collection.token + '/file';
+					data = {
+						path: targetPath
+					};
+				}
 				$.ajax({
 					type: 'POST',
-					// url: OC.linkToOCS('apps/files_sharing/api/v1', 2) + 'shares',
-					url: OC.linkToOCS('apps/spreed/api/v1/chat', 2) + self.collection.token + '/file',
+					url: url,
 					dataType: 'json',
-					data: {
-						path: targetPath
-					}
+					data: data
 				}).always(function() {
 					$shareLoadingIcon.addClass('hidden');
 					$shareButton.removeClass('hidden');
@@ -1118,7 +1127,20 @@
 
 					OC.Notification.showTemporary(message);
 				});
-			}, false, ['*', 'httpd/unix-directory'], true, OC.dialogs.FILEPICKER_TYPE_CHOOSE);
+			}, false, ['*', 'httpd/unix-directory'], true, OC.dialogs.FILEPICKER_TYPE_CUSTOM, '', {
+				buttons: [
+					{
+						text: t('spreed', 'Share'),
+						type: 'share',
+						defaultButton: false
+					},
+					{
+						text: t('spreed', 'Attach'),
+						type: 'attach',
+						defaultButton: true
+					}
+				]
+			});
 		},
 
 	});

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -1084,12 +1084,11 @@
 
 				$.ajax({
 					type: 'POST',
-					url: OC.linkToOCS('apps/files_sharing/api/v1', 2) + 'shares',
+					// url: OC.linkToOCS('apps/files_sharing/api/v1', 2) + 'shares',
+					url: OC.linkToOCS('apps/spreed/api/v1/chat', 2) + self.collection.token + '/file',
 					dataType: 'json',
 					data: {
-						shareType: OC.Share.SHARE_TYPE_ROOM,
-						path: targetPath,
-						shareWith: self.collection.token
+						path: targetPath
 					}
 				}).always(function() {
 					$shareLoadingIcon.addClass('hidden');

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -848,13 +848,25 @@
 			var defaultIconUrl = OC.imagePath('core', 'filetypes/file');
 			var previewUrl = defaultIconUrl;
 			if ($filePreview.data('preview-available') === 'yes') {
-				previewUrl = OC.generateUrl(
-					'/core/preview?fileId={fileId}&x={width}&y={height}',
-					{
-						fileId: $filePreview.data('file-id'),
-						width: previewSize,
-						height: previewSize
-					});
+				if ($filePreview.data('type') === 'talk-attachment') {
+					previewSize *= 2;
+					previewUrl = OC.generateUrl(
+						'/apps/spreed/attachment/{conversation}/{fileId}?x={width}&y={height}',
+						{
+							conversation: this.model.get('token'),
+							fileId: $filePreview.data('file-id'),
+							width: previewSize,
+							height: previewSize
+						});
+				} else {
+					previewUrl = OC.generateUrl(
+						'/core/preview?fileId={fileId}&x={width}&y={height}',
+						{
+							fileId: $filePreview.data('file-id'),
+							width: previewSize,
+							height: previewSize
+						});
+				}
 			} else {
 				previewUrl = OC.MimeType.getIconUrl($filePreview.data('mimetype'));
 			}

--- a/js/views/richobjectstringparser.js
+++ b/js/views/richobjectstringparser.js
@@ -80,6 +80,17 @@
 
 					return this.callTemplate(parameter);
 
+				case 'talk-attachment':
+					parameter.link = 'https://nextcloud18.local/';
+					if (parameter['preview-available'] === 'yes' && (
+						parameter.mimetype.indexOf('image/') === 0 ||
+						parameter.mimetype.indexOf('video/') === 0)) {
+						if (!this.mediaTemplate) {
+							this.mediaTemplate = OCA.Talk.Views.Templates['richobjectstringparser_talkattachment_media'];
+						}
+						return this.mediaTemplate(parameter);
+					}
+
 				case 'file':
 					if (!this.filePreviewTemplate) {
 						this.filePreviewTemplate = OCA.Talk.Views.Templates['richobjectstringparser_filepreview'];

--- a/js/views/templates.js
+++ b/js/views/templates.js
@@ -377,6 +377,8 @@ templates['richobjectstringparser_filepreview'] = template({"compiler":[8,">= 4.
     + alias5(((helper = (helper = helpers.link || (depth0 != null ? depth0.link : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"link","hash":{},"data":data}) : helper)))
     + "\" class=\"filePreviewContainer\" target=\"_blank\" rel=\"noopener noreferrer\">\n	<span class=\"filePreview\" data-file-id=\""
     + alias5(((helper = (helper = helpers.id || (depth0 != null ? depth0.id : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"id","hash":{},"data":data}) : helper)))
+    + "\" data-type=\""
+    + alias5(((helper = (helper = helpers.type || (depth0 != null ? depth0.type : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"type","hash":{},"data":data}) : helper)))
     + "\" data-mimetype=\""
     + alias5(((helper = (helper = helpers.mimetype || (depth0 != null ? depth0.mimetype : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"mimetype","hash":{},"data":data}) : helper)))
     + "\" data-preview-available=\""
@@ -384,6 +386,21 @@ templates['richobjectstringparser_filepreview'] = template({"compiler":[8,">= 4.
     + "\"></span>\n	<strong>"
     + alias5(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"name","hash":{},"data":data}) : helper)))
     + "</strong>\n</a>\n";
+},"useData":true});
+templates['richobjectstringparser_talkattachment_media'] = template({"compiler":[8,">= 4.3.0"],"main":function(container,depth0,helpers,partials,data) {
+    var helper, alias1=container.propertyIsEnumerable, alias2=depth0 != null ? depth0 : (container.nullContext || {}), alias3=container.hooks.helperMissing, alias4="function", alias5=container.escapeExpression;
+
+  return "<a href=\""
+    + alias5(((helper = (helper = helpers.link || (depth0 != null ? depth0.link : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"link","hash":{},"data":data}) : helper)))
+    + "\" class=\"filePreviewContainer\" target=\"_blank\" rel=\"noopener noreferrer\">\n	<span class=\"filePreview\" data-file-id=\""
+    + alias5(((helper = (helper = helpers.id || (depth0 != null ? depth0.id : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"id","hash":{},"data":data}) : helper)))
+    + "\" data-type=\""
+    + alias5(((helper = (helper = helpers.type || (depth0 != null ? depth0.type : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"type","hash":{},"data":data}) : helper)))
+    + "\" data-mimetype=\""
+    + alias5(((helper = (helper = helpers.mimetype || (depth0 != null ? depth0.mimetype : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"mimetype","hash":{},"data":data}) : helper)))
+    + "\" data-preview-available=\""
+    + alias5(((helper = (helper = helpers["preview-available"] || (depth0 != null ? depth0["preview-available"] : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"preview-available","hash":{},"data":data}) : helper)))
+    + "\"></span>\n</a>\n";
 },"useData":true});
 templates['richobjectstringparser_unknown'] = template({"compiler":[8,">= 4.3.0"],"main":function(container,depth0,helpers,partials,data) {
     var helper, alias1=container.propertyIsEnumerable;

--- a/js/views/templates/richobjectstringparser_talkattachment_media.handlebars
+++ b/js/views/templates/richobjectstringparser_talkattachment_media.handlebars
@@ -1,4 +1,3 @@
 <a href="{{link}}" class="filePreviewContainer" target="_blank" rel="noopener noreferrer">
 	<span class="filePreview" data-file-id="{{id}}" data-type="{{type}}" data-mimetype="{{mimetype}}" data-preview-available="{{preview-available}}"></span>
-	<strong>{{name}}</strong>
 </a>

--- a/lib/Controller/AEnvironmentAwareOCSController.php
+++ b/lib/Controller/AEnvironmentAwareOCSController.php
@@ -28,9 +28,9 @@ namespace OCA\Talk\Controller;
 
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
-use OCP\AppFramework\Controller;
+use OCP\AppFramework\OCSController;
 
-abstract class AEnvironmentAwareController extends Controller implements IEnvironmentAwareController {
+abstract class AEnvironmentAwareOCSController extends OCSController implements IEnvironmentAwareController {
 
 	/** @var Room */
 	protected $room;

--- a/lib/Controller/AttachmentController.php
+++ b/lib/Controller/AttachmentController.php
@@ -35,7 +35,7 @@ use OCP\Files\NotFoundException;
 use OCP\IConfig;
 use OCP\IRequest;
 
-class FilesController extends AEnvironmentAwareOCSController {
+class AttachmentController extends AEnvironmentAwareOCSController {
 
 	/** @var ChatManager */
 	protected $chatManager;
@@ -70,7 +70,7 @@ class FilesController extends AEnvironmentAwareOCSController {
 	 * @param string $path
 	 * @return DataResponse
 	 */
-	public function copyFileToRoom(string $path): DataResponse {
+	public function copyFileToAttachment(string $path): DataResponse {
 		$participant = $this->getParticipant();
 		$room = $this->getRoom();
 

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -32,7 +32,7 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IRequest;
 
-class CallController extends AEnvironmentAwareController {
+class CallController extends AEnvironmentAwareOCSController {
 
 	/** @var ITimeFactory */
 	private $timeFactory;

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -43,7 +43,7 @@ use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserManager;
 
-class ChatController extends AEnvironmentAwareController {
+class ChatController extends AEnvironmentAwareOCSController {
 
 	/** @var string */
 	private $userId;

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -35,7 +35,7 @@ use OCP\Files\NotFoundException;
 use OCP\IConfig;
 use OCP\IRequest;
 
-class FilesController extends AEnvironmentAwareController {
+class FilesController extends AEnvironmentAwareOCSController {
 
 	/** @var ChatManager */
 	protected $chatManager;

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -1,0 +1,141 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Controller;
+
+use OCA\Talk\Chat\ChatManager;
+use OCA\Talk\Participant;
+use OCA\Talk\Room;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\File;
+use OCP\Files\NotFoundException;
+use OCP\IConfig;
+use OCP\IRequest;
+
+class FilesController extends AEnvironmentAwareController {
+
+	/** @var ChatManager */
+	protected $chatManager;
+	/** @var IRootFolder */
+	protected $rootFolder;
+	/** @var ITimeFactory */
+	protected $timeFactory;
+	/** @var IConfig */
+	protected $config;
+
+	public function __construct(
+			string $appName,
+			IRequest $request,
+			ChatManager $chatManager,
+			IRootFolder $rootFolder,
+			ITimeFactory $timeFactory,
+			IConfig $config
+	) {
+		parent::__construct($appName, $request);
+		$this->chatManager = $chatManager;
+		$this->rootFolder = $rootFolder;
+		$this->timeFactory = $timeFactory;
+		$this->config = $config;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @RequireParticipant
+	 * @RequireReadWriteConversation
+	 * @RequireModeratorOrNoLobby
+	 *
+	 * @param string $path
+	 * @return DataResponse
+	 */
+	public function copyFileToRoom(string $path): DataResponse {
+		$participant = $this->getParticipant();
+		$room = $this->getRoom();
+
+		if (!$room instanceof Room) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if (!$participant instanceof Participant || $participant->isGuest()) {
+			return new DataResponse([], Http::STATUS_FORBIDDEN);
+		}
+
+		$userFolder = $this->rootFolder->getUserFolder($participant->getUser());
+		try {
+			/** @var File $node */
+			$node = $userFolder->get($path);
+		} catch (NotFoundException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if (!$node instanceof File) {
+			return new DataResponse([], Http::STATUS_METHOD_NOT_ALLOWED);
+		}
+
+		$folder = $this->getConversationFolder($room);
+
+		$newFileName = $this->timeFactory->getTime() . '-' . $node->getName();
+		try {
+			$folder->get($newFileName);
+			return new DataResponse([], Http::STATUS_CONFLICT);
+		} catch (NotFoundException $e) {
+			$file = $folder->newFile($newFileName);
+		}
+
+		$resource = $node->fopen('r');
+		$file->putContent($resource);
+		fclose($resource);
+
+		$message = ['message' => 'attachment', 'parameters' => ['fileId' => $file->getId()]];
+
+		$this->chatManager->addSystemMessage(
+			$room, 'users', $participant->getUser(),
+			json_encode($message), $this->timeFactory->getDateTime(), true
+		);
+
+		return new DataResponse([], Http::STATUS_CREATED);
+	}
+
+	protected function getConversationFolder(Room $room): Folder {
+		$instanceId = $this->config->getSystemValueString('instanceid');
+		$appDataFolderName = 'appdata_' . $instanceId . '/talk'; // FIXME appId
+
+		try {
+			/** @var Folder $appDataFolder */
+			$appDataFolder = $this->rootFolder->get($appDataFolderName);
+		} catch (NotFoundException $e) {
+			/** @var Folder $appDataFolder */
+			$appDataFolder = $this->rootFolder->newFolder($appDataFolderName);
+		}
+
+		try {
+			$folder = $appDataFolder->get($room->getToken());
+		} catch (NotFoundException $e) {
+			$folder = $appDataFolder->newFolder($room->getToken());
+		}
+
+		return $folder;
+	}
+}

--- a/lib/Controller/IEnvironmentAwareController.php
+++ b/lib/Controller/IEnvironmentAwareController.php
@@ -1,10 +1,8 @@
 <?php
 declare(strict_types=1);
 /**
- * @copyright Copyright (c) 2016 Lukas Reschke <lukas@statuscode.ch>
- * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ * @copyright Copyright (c) 2019 Joas Schilling <coding@schilljs.com>
  *
- * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Joas Schilling <coding@schilljs.com>
  *
  * @license GNU AGPL version 3 or any later version
@@ -30,27 +28,14 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCP\AppFramework\Controller;
 
-abstract class AEnvironmentAwareController extends Controller implements IEnvironmentAwareController {
+interface IEnvironmentAwareController  {
 
-	/** @var Room */
-	protected $room;
-	/** @var Participant */
-	protected $participant;
+	public function setRoom(Room $room): void;
 
-	public function setRoom(Room $room): void {
-		$this->room = $room;
-	}
+	public function getRoom(): ?Room;
 
-	public function getRoom(): ?Room {
-		return $this->room;
-	}
+	public function setParticipant(Participant $participant): void;
 
-	public function setParticipant(Participant $participant): void {
-		$this->participant = $participant;
-	}
-
-	public function getParticipant(): ?Participant {
-		return $this->participant;
-	}
+	public function getParticipant(): ?Participant;
 
 }

--- a/lib/Controller/PreviewController.php
+++ b/lib/Controller/PreviewController.php
@@ -1,0 +1,167 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Controller;
+
+use OCA\Talk\Chat\ChatManager;
+use OCA\Talk\Participant;
+use OCA\Talk\Room;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\FileDisplayResponse;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\File;
+use OCP\Files\Node;
+use OCP\Files\NotFoundException;
+use OCP\IConfig;
+use OCP\IPreview;
+use OCP\IRequest;
+
+class PreviewController extends AEnvironmentAwareController {
+
+	/** @var ChatManager */
+	protected $chatManager;
+	/** @var IRootFolder */
+	protected $rootFolder;
+	/** @var ITimeFactory */
+	protected $timeFactory;
+	/** @var IConfig */
+	protected $config;
+	/** @var IPreview */
+	protected $preview;
+
+	public function __construct(
+			string $appName,
+			IRequest $request,
+			ChatManager $chatManager,
+			IRootFolder $rootFolder,
+			ITimeFactory $timeFactory,
+			IPreview $preview,
+			IConfig $config
+	) {
+		parent::__construct($appName, $request);
+		$this->chatManager = $chatManager;
+		$this->rootFolder = $rootFolder;
+		$this->timeFactory = $timeFactory;
+		$this->preview = $preview;
+		$this->config = $config;
+	}
+
+	protected function getConversationFolder(Room $room): Folder {
+		$instanceId = $this->config->getSystemValueString('instanceid');
+		$appDataFolderName = 'appdata_' . $instanceId . '/talk'; // FIXME appId
+
+		try {
+			/** @var Folder $appDataFolder */
+			$appDataFolder = $this->rootFolder->get($appDataFolderName);
+		} catch (NotFoundException $e) {
+			/** @var Folder $appDataFolder */
+			$appDataFolder = $this->rootFolder->newFolder($appDataFolderName);
+		}
+
+		try {
+			$folder = $appDataFolder->get($room->getToken());
+		} catch (NotFoundException $e) {
+			$folder = $appDataFolder->newFolder($room->getToken());
+		}
+
+		return $folder;
+	}
+
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 * @RequireParticipant
+	 * @RequireModeratorOrNoLobby
+	 *
+	 * @param int $fileId
+	 * @param int $x
+	 * @param int $y
+	 * @param bool $a
+	 * @param bool $forceIcon
+	 * @param string $mode
+	 *
+	 * @return DataResponse|FileDisplayResponse
+	 */
+	public function getPreviewByFileId(
+		int $fileId = -1,
+		int $x = 32,
+		int $y = 32,
+		bool $a = false,
+		bool $forceIcon = true,
+		string $mode = 'fill') {
+
+		if ($fileId === -1 || $x === 0 || $y === 0) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
+		$conversationFolder = $this->getConversationFolder($this->getRoom());
+		$nodes = $conversationFolder->getById($fileId);
+		if (empty($nodes)) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		$node = array_pop($nodes);
+
+		return $this->fetchPreview($node, $x, $y, $a, $forceIcon, $mode);
+	}
+
+	/**
+	 * @param Node $node
+	 * @param int $x
+	 * @param int $y
+	 * @param bool $a
+	 * @param bool $forceIcon
+	 * @param string $mode
+	 * @return DataResponse|FileDisplayResponse
+	 */
+	private function fetchPreview(
+		Node $node,
+		int $x,
+		int $y,
+		bool $a,
+		bool $forceIcon ,
+		string $mode) : Http\Response {
+
+		if (!($node instanceof File) || (!$forceIcon && !$this->preview->isAvailable($node))) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+		if (!$node->isReadable()) {
+			return new DataResponse([], Http::STATUS_FORBIDDEN);
+		}
+
+		try {
+			$f = $this->preview->getPreview($node, $x, $y, !$a, $mode);
+			$response = new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
+//			$response->cacheFor(3600 * 24);
+			return $response;
+		} catch (NotFoundException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		} catch (\InvalidArgumentException $e) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
+	}
+}

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -51,7 +51,7 @@ use OCP\IGroupManager;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
-class RoomController extends AEnvironmentAwareController {
+class RoomController extends AEnvironmentAwareOCSController {
 	/** @var string|null */
 	private $userId;
 	/** @var TalkSession */

--- a/lib/Controller/WebinaryController.php
+++ b/lib/Controller/WebinaryController.php
@@ -29,7 +29,7 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IRequest;
 
-class WebinaryController extends AEnvironmentAwareController {
+class WebinaryController extends AEnvironmentAwareOCSController {
 
 	/** @var ITimeFactory */
 	protected $timeFactory;


### PR DESCRIPTION
Ref #1811

- [x] Requires `talk-attachment` rich object type: https://github.com/nextcloud/server/pull/17181/
- [x] Requires `getById` to work inside folders outside of the users root: https://github.com/nextcloud/server/pull/17175
- [x] API to attach a file to a conversation
- [x] API to save an attachment to your files
- [ ] 2 options on the file picker to "share" and "attach" https://github.com/nextcloud/server/pull/17260
- [x] Previews for attachments

### Follow up?
- [ ] `...` menu on the attachments to allow storing to own files
- [ ] Improved message structure for items without thumbnails
- [ ] Viewer apps for "shares" and "attachments"
- [ ] Media tab in the sidebar
- [ ] Discuss quota/pruge options
- [ ] Upload including junking