### PR TITLE
Fix chat jumping back when typing a new message

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -414,7 +414,7 @@
 			if (!this._chatViewInMainView) {
 				this._sidebarView.removeTab('chat');
 				this._chatView.$el.prependTo('#app-content-wrapper');
-				this._chatView.reloadMessageList();
+				this._chatView.handleSizeChanged();
 				this._chatView.setTooltipContainer($('#app'));
 				this._chatView.focusChatInput();
 				this._chatViewInMainView = true;
@@ -429,7 +429,7 @@
 				this._chatView.$el.detach();
 				this._sidebarView.addTab('chat', { label: t('spreed', 'Chat'), icon: 'icon-comment', priority: 100 }, this._chatView);
 				this._sidebarView.selectTab('chat');
-				this._chatView.reloadMessageList();
+				this._chatView.handleSizeChanged();
 				this._chatView.setTooltipContainer(this._chatView.$el);
 				this._chatViewInMainView = false;
 			}
@@ -575,43 +575,43 @@
 			}.bind(this));
 
 			// Opening or closing the sidebar changes the width of the main
-			// view, so if the chat view is in the main view it needs to be
-			// reloaded.
-			var reloadMessageListOnSidebarVisibilityChange = function() {
+			// view, so if the chat view is in the main view it needs to handle
+			// a size change.
+			var handleSizeChangedOnSidebarVisibilityChange = function() {
 				if (!this._chatViewInMainView) {
 					return;
 				}
 
-				this._chatView.reloadMessageList();
+				this._chatView.handleSizeChanged();
 			}.bind(this);
-			this._chatView.listenTo(this._sidebarView, 'opened', reloadMessageListOnSidebarVisibilityChange);
-			this._chatView.listenTo(this._sidebarView, 'closed', reloadMessageListOnSidebarVisibilityChange);
+			this._chatView.listenTo(this._sidebarView, 'opened', handleSizeChangedOnSidebarVisibilityChange);
+			this._chatView.listenTo(this._sidebarView, 'closed', handleSizeChangedOnSidebarVisibilityChange);
 
 			// Resizing the window can change the size of the chat view, both
 			// when it is in the main view and in the sidebar, so the chat view
-			// needs to be reloaded. The initial reload is not very heavy, so
-			// the handler is not debounced for a snappier feel and to reduce
-			// flickering.
+			// needs to handle a size change. The initial reload is not very
+			// heavy, so the window resize handler is not debounced for a
+			// snappier feel and to reduce flickering.
 			// However, resizing the window below certain width causes the
 			// navigation bar to be hidden; an explicit handling is needed in
 			// this case because the app navigation (or, more specifically, its
 			// Snap object) adds a transition to the app content, so the reload
 			// needs to be delayed to give the transition time to end and thus
 			// give the app content time to get its final size.
-			var reloadMessageListOnWindowResize = function() {
+			var handleSizeChangedOnWindowResize = function() {
 				var chatView = this._chatView;
 
 				if ($(window).width() >= 768 || !this._chatViewInMainView) {
-					chatView.reloadMessageList();
+					chatView.handleSizeChanged();
 
 					return;
 				}
 
 				setTimeout(function() {
-					chatView.reloadMessageList();
+					chatView.handleSizeChanged();
 				}, 300);
 			}.bind(this);
-			$(window).resize(reloadMessageListOnWindowResize);
+			$(window).resize(handleSizeChangedOnWindowResize);
 
 			this._messageCollection.listenTo(roomChannel, 'leaveCurrentRoom', function() {
 				this.stopReceivingMessages();

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -391,10 +391,25 @@
 		},
 
 		/**
-		 * Reloads the message list.
+		 * Reloads the message list and updates internal values based on the
+		 * size of the chat view.
 		 *
 		 * This needs to be called whenever the size of the chat view has
 		 * changed.
+		 */
+		handleSizeChanged: function() {
+			this.reloadMessageList();
+
+			if (this.$el && this.$el.find('.newCommentRow .message').length > 0) {
+				// Before the 3.0.0 release jQuery rounded the height to the nearest
+				// integer, but Firefox has subpixel accuracy, so the height
+				// returned by jQuery can not be used in the calculations.
+				this._newMessageFieldHeight = this.$el.find('.newCommentRow .message').get(0).getBoundingClientRect().height;
+			}
+		},
+
+		/**
+		 * Reloads the message list.
 		 *
 		 * When the message list is reloaded its size may have changed (for
 		 * example, if the chat view was detached from the main view and

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -888,6 +888,15 @@
 				$field.data('submitButtonEl', $submitButton);
 			}
 
+			// Pressing Arrow-up/down in an empty/unchanged input brings back the last sent messages
+			if (this.lastComments.length !== 0 && !$field.atwho('isSelecting')) {
+				if (ev.keyCode === 38 || ev.keyCode === 40) {
+					this._loopThroughLastComments(ev, $field);
+				} else {
+					this.currentLastComment = -1;
+				}
+			}
+
 			var newMessageFieldOldHeight = this._newMessageFieldHeight;
 			// Before the 3.0.0 release jQuery rounded the height to the nearest
 			// integer, but Firefox has subpixel accuracy, so the height
@@ -904,16 +913,6 @@
 			if (ev.keyCode === 13 && !ev.shiftKey && !$field.atwho('isSelecting')) {
 				$submitButton.click();
 				ev.preventDefault();
-			}
-
-			// Pressing Arrow-up/down in an empty/unchanged input brings back the last sent messages
-			if (this.lastComments.length !== 0 && !$field.atwho('isSelecting')) {
-
-				if (ev.keyCode === 38 || ev.keyCode === 40) {
-					this._loopThroughLastComments(ev, $field);
-				} else {
-					this.currentLastComment = -1;
-				}
 			}
 		},
 

--- a/js/views/chatview.js
+++ b/js/views/chatview.js
@@ -1033,6 +1033,14 @@
 			$form.find('.submitLoading').addClass('hidden');
 			$form.find('.message').text('').prop('contenteditable', true);
 
+			// Update the stored height of the new message field after cleaning
+			// it.
+			//
+			// Before the 3.0.0 release jQuery rounded the height to the nearest
+			// integer, but Firefox has subpixel accuracy, so the height
+			// returned by jQuery can not be used in the calculations.
+			this._newMessageFieldHeight = $form.find('.message').get(0).getBoundingClientRect().height;
+
 			$form.find('.message').focus();
 
 			// The new message does not need to be explicitly added to the list


### PR DESCRIPTION
Follow up to #1953 

## How to test
### Scenario 1
- Send a chat message of several lines

### Scenario 2
- Send several chat messages with different numbers of lines
- Loop through the previous messages with arrow up/down

### Scenario 3
- Make the browser window narrow and reload the conversation
- Type, without sending it, a message with several lines
- Widen the browser window as much as possible
- Type another character

### Scenario 4
- Start a call
- Type, without sending it, a message with several lines
- Leave the call
- Type another character

### Result with this pull request
The chat is kept at the same scroll position.

### Result without this pull request
The chat jumps back.
