### PR TITLE
Do not remove other event handlers when setting the active room

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -376,9 +376,7 @@
 					self._emptyContentView.setActiveRoom(self.activeRoom);
 
 					self.setPageTitle(self.activeRoom.get('displayName'));
-					self.listenTo(self.activeRoom, 'change:displayName', function(model, value) {
-						self.setPageTitle(value);
-					});
+					self.listenTo(self.activeRoom, 'change:displayName', self._updatePageTitleOnDisplayNameChange);
 
 					self.updateContentsLayout();
 					self.listenTo(self.activeRoom, 'change:participantFlags', self.updateContentsLayout);
@@ -389,6 +387,9 @@
 
 					self.updateSidebarWithActiveRoom();
 				});
+		},
+		_updatePageTitleOnDisplayNameChange: function(model, value) {
+			this.setPageTitle(value);
 		},
 		updateContentsLayout: function() {
 			if (!this.activeRoom) {

--- a/js/app.js
+++ b/js/app.js
@@ -358,10 +358,12 @@
 			var self = this;
 			this.signaling.syncRooms()
 				.then(function() {
-					self.stopListening(self.activeRoom, 'change:displayName');
-					self.stopListening(self.activeRoom, 'change:participantType');
-					self.stopListening(self.activeRoom, 'change:participantFlags');
-					self.stopListening(self.activeRoom, 'change:lobbyState');
+					self.stopListening(self.activeRoom, 'change:displayName', self._updatePageTitleOnDisplayNameChange);
+					self.stopListening(self.activeRoom, 'change:participantFlags', self.updateContentsLayout);
+					self.stopListening(self.activeRoom, 'change:participantType', self.updateContentsLayout);
+					self.stopListening(self.activeRoom, 'change:participantType', self._updateSidebar);
+					self.stopListening(self.activeRoom, 'change:lobbyState', self.updateContentsLayout);
+					self.stopListening(self.activeRoom, 'change:lobbyState', self._updateSidebar);
 
 					if (OC.getCurrentUser().uid) {
 						roomChannel.trigger('active', token);


### PR DESCRIPTION
Fixes a regression introduced in #1926 (specifically, 0ab60ec44651f56c251d2206a4a6e6e89f534bc7)

## How to test
- Create a public conversation
- Join the conversation as a guest
- As a moderator, promote the guest to moderator

### Result with this pull request
The participant list is shown for the guest.

### Result without this pull request
The participant list is not shown for the guest (although the moderation menu is).
