### PR TITLE
Don't show a "left call" message when a user was not in the call and …

### DIFF
--- a/lib/Listener.php
+++ b/lib/Listener.php
@@ -106,7 +106,10 @@ class Listener {
 		$sessionIds = $this->talkSession->getAllActiveSessions();
 		foreach ($sessionIds as $sessionId) {
 			$room = $this->manager->getRoomForSession($user->getUID(), $sessionId);
-			$room->changeInCall($sessionId, Participant::FLAG_DISCONNECTED);
+			$participant = $room->getParticipant($user->getUID());
+			if ($participant->getInCallFlags() !== Participant::FLAG_DISCONNECTED) {
+				$room->changeInCall($sessionId, Participant::FLAG_DISCONNECTED);
+			}
 			$room->leaveRoom($user->getUID(), $sessionId);
 		}
 	}


### PR DESCRIPTION
…logs out

### Steps
1. Create a new room
2. Join the chat
3. Logout
4. Login again
5. Join the chat again

### Expected
Nothing changed

### Actual
A chat message "You left the call"

Fix #2233 