### PR TITLE
Get room properties for the signaling server from separate function.

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -195,3 +195,9 @@ Explanations:
 * Event class: `OCA\Talk\Events\SignalingEvent`
 * Event name: `OCA\Talk\Controller\SignalingController::EVENT_BACKEND_SIGNALING_ROOMS`
 * Since: 8.0.0
+
+### Get conversation properties for signaling
+
+* Event class: `OCA\Talk\Events\SignalingRoomPropertiesEvent`
+* Event name: `OCA\Talk\Room::EVENT_BEFORE_SIGNALING_PROPERTIES`
+* Since: 8.0.5

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -102,7 +102,6 @@ class CallController extends AEnvironmentAwareController {
 	/**
 	 * @PublicPage
 	 * @RequireParticipant
-	 * @RequireModeratorOrNoLobby
 	 *
 	 * @return DataResponse
 	 */

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -436,10 +436,7 @@ class SignalingController extends OCSController {
 			'room' => [
 				'version' => '1.0',
 				'roomid' => $room->getToken(),
-				'properties' => [
-					'name' => $room->getDisplayName((string) $userId),
-					'type' => $room->getType(),
-				],
+				'properties' => $room->getPropertiesForSignaling((string) $userId),
 			],
 		];
 		if ($event->getSession()) {

--- a/lib/Events/SignalingRoomPropertiesEvent.php
+++ b/lib/Events/SignalingRoomPropertiesEvent.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Events;
+
+
+use OCA\Talk\Room;
+
+class SignalingRoomPropertiesEvent extends RoomEvent {
+
+	/** @var string|null */
+	protected $userId;
+	/** @var array */
+	protected $properties;
+
+	public function __construct(Room $room, ?string $userId, array $properties) {
+		parent::__construct($room);
+		$this->userId = $userId;
+		$this->properties = $properties;
+	}
+
+	public function getUserId(): ?string {
+		return $this->userId;
+	}
+
+	public function getProperties(): array {
+		return $this->properties;
+	}
+
+	public function setProperty(string $property, $data): void {
+		$this->properties[$property] = $data;
+	}
+
+	public function unsetProperty(string $property): void {
+		unset($this->properties[$property]);
+	}
+}

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -36,6 +36,7 @@ use OCA\Talk\Events\ParticipantEvent;
 use OCA\Talk\Events\RemoveParticipantEvent;
 use OCA\Talk\Events\RemoveUserEvent;
 use OCA\Talk\Events\RoomEvent;
+use OCA\Talk\Events\SignalingRoomPropertiesEvent;
 use OCA\Talk\Events\VerifyRoomPasswordEvent;
 use OCA\Talk\Exceptions\InvalidPasswordException;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
@@ -100,6 +101,7 @@ class Room {
 	public const EVENT_AFTER_SESSION_JOIN_CALL = self::class . '::postSessionJoinCall';
 	public const EVENT_BEFORE_SESSION_LEAVE_CALL = self::class . '::preSessionLeaveCall';
 	public const EVENT_AFTER_SESSION_LEAVE_CALL = self::class . '::postSessionLeaveCall';
+	public const EVENT_BEFORE_SIGNALING_PROPERTIES = self::class . '::beforeSignalingProperties';
 
 	/** @var Manager */
 	private $manager;
@@ -276,6 +278,23 @@ class Room {
 	public function setParticipant(?string $userId, Participant $participant): void {
 		$this->currentUser = $userId;
 		$this->participant = $participant;
+	}
+
+	/**
+	 * Return the room properties to send to the signaling server.
+	 *
+	 * @param string $userId
+	 * @return array
+	 */
+	public function getPropertiesForSignaling(string $userId): array {
+		$properties = [
+			'name' => $this->getDisplayName($userId),
+			'type' => $this->getType(),
+		];
+
+		$event = new SignalingRoomPropertiesEvent($this, $userId, $properties);
+		$this->dispatcher->dispatch(self::EVENT_BEFORE_SIGNALING_PROPERTIES, $event);
+		return $event->getProperties();
 	}
 
 	/**

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -290,6 +290,10 @@ class Room {
 		$properties = [
 			'name' => $this->getDisplayName($userId),
 			'type' => $this->getType(),
+			'lobby-state' => $this->getLobbyState(),
+			'lobby-timer' => $this->getLobbyTimer(),
+			'read-only' => $this->getReadOnly(),
+			'active-since' => $this->getActiveSince(),
 		];
 
 		$event = new SignalingRoomPropertiesEvent($this, $userId, $properties);

--- a/lib/Signaling/BackendNotifier.php
+++ b/lib/Signaling/BackendNotifier.php
@@ -131,10 +131,7 @@ class BackendNotifier {
 				// TODO(fancycode): We should try to get rid of 'alluserids' and
 				// find a better way to notify existing users to update the room.
 				'alluserids' => $room->getParticipantUserIds(),
-				'properties' => [
-					'name' => $room->getDisplayName(''),
-					'type' => $room->getType(),
-				],
+				'properties' => $room->getPropertiesForSignaling(''),
 			],
 		]);
 	}
@@ -155,10 +152,7 @@ class BackendNotifier {
 				// TODO(fancycode): We should try to get rid of 'alluserids' and
 				// find a better way to notify existing users to update the room.
 				'alluserids' => $room->getParticipantUserIds(),
-				'properties' => [
-					'name' => $room->getDisplayName(''),
-					'type' => $room->getType(),
-				],
+				'properties' => $room->getPropertiesForSignaling(''),
 			],
 		]);
 	}
@@ -179,10 +173,7 @@ class BackendNotifier {
 				// TODO(fancycode): We should try to get rid of 'alluserids' and
 				// find a better way to notify existing users to update the room.
 				'alluserids' => $room->getParticipantUserIds(),
-				'properties' => [
-					'name' => $room->getDisplayName(''),
-					'type' => $room->getType(),
-				],
+				'properties' => $room->getPropertiesForSignaling(''),
 			],
 		]);
 	}
@@ -199,10 +190,7 @@ class BackendNotifier {
 			'type' => 'update',
 			'update' => [
 				'userids' => $room->getParticipantUserIds(),
-				'properties' => [
-					'name' => $room->getDisplayName(''),
-					'type' => $room->getType(),
-				],
+				'properties' => $room->getPropertiesForSignaling(''),
 			],
 		]);
 	}

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -48,6 +48,18 @@ export default {
 	},
 	*/
 
+	watch: {
+		isInLobby: function(isInLobby) {
+			// User is now blocked by the lobby
+			if (isInLobby && this.participant.inCall !== PARTICIPANT.CALL_FLAG.DISCONNECTED) {
+				this.$store.dispatch('leaveCall', {
+					token: this.token,
+					participantIdentifier: this.$store.getters.getParticipantIdentifier(),
+				})
+			}
+		},
+	},
+
 	computed: {
 		conversation() {
 			return this.$store.getters.conversations[this.token]

--- a/tests/php/Controller/SignalingControllerTest.php
+++ b/tests/php/Controller/SignalingControllerTest.php
@@ -367,10 +367,6 @@ class SignalingControllerTest extends \Test\TestCase {
 
 		$participant = $this->createMock(Participant::class);
 		$room->expects($this->once())
-			->method('getDisplayName')
-			->with($this->userId)
-			->willReturn($roomName);
-		$room->expects($this->once())
 			->method('getParticipant')
 			->with($this->userId)
 			->willReturn($participant);
@@ -378,8 +374,12 @@ class SignalingControllerTest extends \Test\TestCase {
 			->method('getToken')
 			->willReturn($roomToken);
 		$room->expects($this->once())
-			->method('getType')
-			->willReturn(Room::ONE_TO_ONE_CALL);
+			->method('getPropertiesForSignaling')
+			->with($this->userId)
+			->willReturn([
+				'name' => $roomName,
+				'type' => Room::ONE_TO_ONE_CALL,
+			]);
 
 		$result = $this->performBackendRequest([
 			'type' => 'room',
@@ -414,10 +414,6 @@ class SignalingControllerTest extends \Test\TestCase {
 
 		$participant = $this->createMock(Participant::class);
 		$room->expects($this->once())
-			->method('getDisplayName')
-			->with('')
-			->willReturn($roomName);
-		$room->expects($this->once())
 			->method('getParticipantBySession')
 			->with($sessionId)
 			->willReturn($participant);
@@ -425,8 +421,12 @@ class SignalingControllerTest extends \Test\TestCase {
 			->method('getToken')
 			->willReturn($roomToken);
 		$room->expects($this->once())
-			->method('getType')
-			->willReturn(Room::PUBLIC_CALL);
+			->method('getPropertiesForSignaling')
+			->with('')
+			->willReturn([
+				'name' => $roomName,
+				'type' => Room::PUBLIC_CALL,
+			]);
 
 		$result = $this->performBackendRequest([
 			'type' => 'room',
@@ -461,10 +461,6 @@ class SignalingControllerTest extends \Test\TestCase {
 
 		$participant = $this->createMock(Participant::class);
 		$room->expects($this->once())
-			->method('getDisplayName')
-			->with($this->userId)
-			->willReturn($roomName);
-		$room->expects($this->once())
 			->method('getParticipant')
 			->with($this->userId)
 			->willThrowException(new ParticipantNotFoundException());
@@ -476,8 +472,12 @@ class SignalingControllerTest extends \Test\TestCase {
 			->method('getToken')
 			->willReturn($roomToken);
 		$room->expects($this->once())
-			->method('getType')
-			->willReturn(Room::PUBLIC_CALL);
+			->method('getPropertiesForSignaling')
+			->with($this->userId)
+			->willReturn([
+				'name' => $roomName,
+				'type' => Room::PUBLIC_CALL,
+			]);
 
 		$result = $this->performBackendRequest([
 			'type' => 'room',
@@ -550,10 +550,6 @@ class SignalingControllerTest extends \Test\TestCase {
 
 		$participant = $this->createMock(Participant::class);
 		$room->expects($this->once())
-			->method('getDisplayName')
-			->with($this->userId)
-			->willReturn($roomName);
-		$room->expects($this->once())
 			->method('getParticipant')
 			->with($this->userId)
 			->willReturn($participant);
@@ -561,8 +557,12 @@ class SignalingControllerTest extends \Test\TestCase {
 			->method('getToken')
 			->willReturn($roomToken);
 		$room->expects($this->once())
-			->method('getType')
-			->willReturn(Room::ONE_TO_ONE_CALL);
+			->method('getPropertiesForSignaling')
+			->with($this->userId)
+			->willReturn([
+				'name' => $roomName,
+				'type' => Room::ONE_TO_ONE_CALL,
+			]);
 
 		$result = $this->performBackendRequest([
 			'type' => 'room',

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -204,6 +204,10 @@ class BackendNotifierTest extends \Test\TestCase {
 				'properties' => [
 					'name' => $room->getDisplayName(''),
 					'type' => $room->getType(),
+					'lobby-state' => Webinary::LOBBY_NONE,
+					'lobby-timer' => null,
+					'read-only' => Room::READ_WRITE,
+					'active-since' => null,
 				],
 			],
 		], $bodies);
@@ -237,6 +241,10 @@ class BackendNotifierTest extends \Test\TestCase {
 				'properties' => [
 					'name' => $room->getDisplayName(''),
 					'type' => $room->getType(),
+					'lobby-state' => Webinary::LOBBY_NONE,
+					'lobby-timer' => null,
+					'read-only' => Room::READ_WRITE,
+					'active-since' => null,
 				],
 			],
 		], $bodies);
@@ -258,6 +266,10 @@ class BackendNotifierTest extends \Test\TestCase {
 				'properties' => [
 					'name' => $room->getDisplayName(''),
 					'type' => $room->getType(),
+					'lobby-state' => Webinary::LOBBY_NONE,
+					'lobby-timer' => null,
+					'read-only' => Room::READ_WRITE,
+					'active-since' => null,
 				],
 			],
 		], $bodies);
@@ -279,6 +291,10 @@ class BackendNotifierTest extends \Test\TestCase {
 				'properties' => [
 					'name' => $room->getDisplayName(''),
 					'type' => $room->getType(),
+					'lobby-state' => Webinary::LOBBY_NONE,
+					'lobby-timer' => null,
+					'read-only' => Room::READ_WRITE,
+					'active-since' => null,
 				],
 			],
 		], $bodies);
@@ -300,6 +316,10 @@ class BackendNotifierTest extends \Test\TestCase {
 				'properties' => [
 					'name' => $room->getDisplayName(''),
 					'type' => $room->getType(),
+					'lobby-state' => Webinary::LOBBY_NONE,
+					'lobby-timer' => null,
+					'read-only' => Room::READ_WRITE,
+					'active-since' => null,
 				],
 			],
 		], $bodies);
@@ -321,6 +341,10 @@ class BackendNotifierTest extends \Test\TestCase {
 				'properties' => [
 					'name' => $room->getDisplayName(''),
 					'type' => $room->getType(),
+					'lobby-state' => Webinary::LOBBY_NONE,
+					'lobby-timer' => null,
+					'read-only' => Room::READ_ONLY,
+					'active-since' => null,
 				],
 			],
 		], $bodies);
@@ -342,6 +366,10 @@ class BackendNotifierTest extends \Test\TestCase {
 				'properties' => [
 					'name' => $room->getDisplayName(''),
 					'type' => $room->getType(),
+					'lobby-state' => Webinary::LOBBY_NON_MODERATORS,
+					'lobby-timer' => null,
+					'read-only' => Room::READ_WRITE,
+					'active-since' => null,
 				],
 			],
 		], $bodies);
@@ -495,6 +523,7 @@ class BackendNotifierTest extends \Test\TestCase {
 		$bodies = array_map(function($request) use ($room) {
 			return json_decode($this->validateBackendRequest($this->baseUrl . '/api/v1/room/' . $room->getToken(), $request), true);
 		}, $requests);
+
 		$this->assertContains([
 			'type' => 'update',
 			'update' => [
@@ -503,6 +532,10 @@ class BackendNotifierTest extends \Test\TestCase {
 				'properties' => [
 					'name' => $room->getDisplayName(''),
 					'type' => $room->getType(),
+					'lobby-state' => Webinary::LOBBY_NONE,
+					'lobby-timer' => null,
+					'read-only' => Room::READ_WRITE,
+					'active-since' => null,
 					'foo' => 'bar',
 					'room' => $room->getToken(),
 				],

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -25,6 +25,7 @@ namespace OCA\Talk\Tests\php\Signaling;
 use OCA\Talk\AppInfo\Application;
 use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Config;
+use OCA\Talk\Events\SignalingRoomPropertiesEvent;
 use OCA\Talk\Manager;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
@@ -42,6 +43,7 @@ use OCP\IUserManager;
 use OCP\Security\IHasher;
 use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 class CustomBackendNotifier extends BackendNotifier {
 
@@ -92,6 +94,8 @@ class BackendNotifierTest extends \Test\TestCase {
 	protected $app;
 	/** @var BackendNotifier */
 	protected $originalBackendNotifier;
+	/** @var IEventDispatcher */
+	private $dispatcher;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -125,7 +129,7 @@ class BackendNotifierTest extends \Test\TestCase {
 		});
 
 		$dbConnection = \OC::$server->getDatabaseConnection();
-		$dispatcher = \OC::$server->query(IEventDispatcher::class);
+		$this->dispatcher = \OC::$server->query(IEventDispatcher::class);
 		$this->manager = new Manager(
 			$dbConnection,
 			$config,
@@ -133,7 +137,7 @@ class BackendNotifierTest extends \Test\TestCase {
 			$this->createMock(IUserManager::class),
 			$this->createMock(CommentsManager::class),
 			$this->createMock(TalkSession::class),
-			$dispatcher,
+			$this->dispatcher,
 			$this->timeFactory,
 			$this->createMock(IHasher::class),
 			$this->createMock(IL10N::class)
@@ -469,6 +473,38 @@ class BackendNotifierTest extends \Test\TestCase {
 						'sessionId' => $guestSession,
 						'participantType' => Participant::GUEST,
 					],
+				],
+			],
+		], $bodies);
+	}
+
+	public function testRoomPropertiesEvent(): void {
+		$listener = static function(SignalingRoomPropertiesEvent $event) {
+			$room = $event->getRoom();
+			$event->setProperty('foo', 'bar');
+			$event->setProperty('room', $room->getToken());
+		};
+
+		$this->dispatcher->addListener(Room::EVENT_BEFORE_SIGNALING_PROPERTIES, $listener);
+
+		$room = $this->manager->createPublicRoom();
+		$this->controller->clearRequests();
+		$room->setName('Test room');
+
+		$requests = $this->controller->getRequests();
+		$bodies = array_map(function($request) use ($room) {
+			return json_decode($this->validateBackendRequest($this->baseUrl . '/api/v1/room/' . $room->getToken(), $request), true);
+		}, $requests);
+		$this->assertContains([
+			'type' => 'update',
+			'update' => [
+				'userids' => [
+				],
+				'properties' => [
+					'name' => $room->getDisplayName(''),
+					'type' => $room->getType(),
+					'foo' => 'bar',
+					'room' => $room->getToken(),
 				],
 			],
 		], $bodies);


### PR DESCRIPTION
This makes it easier to extend the properties in the future (@danxuliu might need this for #2146).

Also dispatch an event so other apps can extend the properties to return.