### PR TITLE
Fix "MessageTooLongException" when mentioning someone in a long comment

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Notification;
 
 
+use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Chat\MessageParser;
 use OCA\Talk\Config;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
@@ -31,7 +32,6 @@ use OCA\Talk\GuestManager;
 use OCA\Talk\Manager;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
-use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -44,7 +44,6 @@ use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 use OCP\RichObjectStrings\Definitions;
-use OCP\Share;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager as IShareManager;
 use OCP\Share\IShare;
@@ -67,7 +66,7 @@ class Notifier implements INotifier {
 	protected $manager;
 	/** @var INotificationManager */
 	protected $notificationManager;
-	/** @var ICommentsManager */
+	/** @var CommentsManager */
 	protected $commentManager;
 	/** @var MessageParser */
 	protected $messageParser;
@@ -82,7 +81,7 @@ class Notifier implements INotifier {
 								IShareManager $shareManager,
 								Manager $manager,
 								INotificationManager $notificationManager,
-								ICommentsManager $commentManager,
+								CommentsManager $commentManager,
 								MessageParser $messageParser,
 								Definitions $definitions) {
 		$this->lFactory = $lFactory;

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -21,6 +21,7 @@
 
 namespace OCA\Talk\Tests\php\Notifications;
 
+use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Chat\MessageParser;
 use OCA\Talk\Config;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
@@ -32,7 +33,6 @@ use OCA\Talk\Notification\Notifier;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCP\Comments\IComment;
-use OCP\Comments\ICommentsManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
@@ -63,7 +63,7 @@ class NotifierTest extends \Test\TestCase {
 	protected $manager;
 	/** @var INotificationManager|MockObject */
 	protected $notificationManager;
-	/** @var ICommentsManager|MockObject */
+	/** @var CommentsManager|MockObject */
 	protected $commentsManager;
 	/** @var MessageParser|MockObject */
 	protected $messageParser;
@@ -83,7 +83,7 @@ class NotifierTest extends \Test\TestCase {
 		$this->shareManager = $this->createMock(IShareManager::class);
 		$this->manager = $this->createMock(Manager::class);
 		$this->notificationManager = $this->createMock(INotificationManager::class);
-		$this->commentsManager = $this->createMock(ICommentsManager::class);
+		$this->commentsManager = $this->createMock(CommentsManager::class);
 		$this->messageParser = $this->createMock(MessageParser::class);
 		$this->definitions = $this->createMock(Definitions::class);
 


### PR DESCRIPTION
### Steps
1. Write a message longer than 1000  chars in a one-to-one conversation

or 

1. Mention someone in a chat message that is longer than 1000 chars

### Expected
Works fine

### Actually
Notification parsing does boom:
https://sentry.io/organizations/nextcloud-gmbh/issues/1173980740/?project=1500477
> OCP\Comments\MessageTooLongException
> Comment message must not exceed 1000 characters


### Why this weird patch works
The `OCA\Talk\Chat\CommentsManager` is overwriting the maximum length in the `getCommentFromData()` method.