### PR TITLE
[stable17] Fix "MessageTooLongException" when mentioning someone in a long comment

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace OCA\Spreed\Notification;
 
 
+use OCA\Spreed\Chat\CommentsManager;
 use OCA\Spreed\Chat\MessageParser;
 use OCA\Spreed\Config;
 use OCA\Spreed\Exceptions\ParticipantNotFoundException;
@@ -31,7 +32,6 @@ use OCA\Spreed\GuestManager;
 use OCA\Spreed\Manager;
 use OCA\Spreed\Participant;
 use OCA\Spreed\Room;
-use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -66,7 +66,7 @@ class Notifier implements INotifier {
 	protected $manager;
 	/** @var INotificationManager */
 	protected $notificationManager;
-	/** @var ICommentsManager */
+	/** @var CommentsManager */
 	protected $commentManager;
 	/** @var MessageParser */
 	protected $messageParser;
@@ -81,7 +81,7 @@ class Notifier implements INotifier {
 								IShareManager $shareManager,
 								Manager $manager,
 								INotificationManager $notificationManager,
-								ICommentsManager $commentManager,
+								CommentsManager $commentManager,
 								MessageParser $messageParser,
 								Definitions $definitions) {
 		$this->lFactory = $lFactory;

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -21,6 +21,7 @@
 
 namespace OCA\Spreed\Tests\php\Notifications;
 
+use OCA\Spreed\Chat\CommentsManager;
 use OCA\Spreed\Chat\MessageParser;
 use OCA\Spreed\Config;
 use OCA\Spreed\Exceptions\ParticipantNotFoundException;
@@ -32,7 +33,6 @@ use OCA\Spreed\Notification\Notifier;
 use OCA\Spreed\Participant;
 use OCA\Spreed\Room;
 use OCP\Comments\IComment;
-use OCP\Comments\ICommentsManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
@@ -63,7 +63,7 @@ class NotifierTest extends \Test\TestCase {
 	protected $manager;
 	/** @var INotificationManager|MockObject */
 	protected $notificationManager;
-	/** @var ICommentsManager|MockObject */
+	/** @var CommentsManager|MockObject */
 	protected $commentsManager;
 	/** @var MessageParser|MockObject */
 	protected $messageParser;
@@ -83,7 +83,7 @@ class NotifierTest extends \Test\TestCase {
 		$this->shareManager = $this->createMock(IShareManager::class);
 		$this->manager = $this->createMock(Manager::class);
 		$this->notificationManager = $this->createMock(INotificationManager::class);
-		$this->commentsManager = $this->createMock(ICommentsManager::class);
+		$this->commentsManager = $this->createMock(CommentsManager::class);
 		$this->messageParser = $this->createMock(MessageParser::class);
 		$this->definitions = $this->createMock(Definitions::class);
 


### PR DESCRIPTION
Backport #2265 