### PR TITLE
[stable17] Fix position and size of avatars

### DIFF
--- a/css/files.scss
+++ b/css/files.scss
@@ -118,6 +118,22 @@
 .talkCallInfoView #videos .videoContainer:not(.promoted) .avatar img {
 	width: 64px !important;
 	height: 64px !important;
+	line-height: 64px !important;
+	/* imageplaceholder() sets font-size to "height * 0.55" */
+	font-size: 35.2px !important;
+}
+
+/* Text avatars need to be forced to 128px when promoted, as imageplaceholder()
+ * overrides the given size with the actual height of the element it was called
+ * on, so the text avatar may have a hardcoded height of 64px. Note that this
+ * does not apply to regular image avatars, as in that case they are always
+ * requested with a size of 128px. */
+.talkCallInfoView #videos .videoContainer.promoted .avatar {
+	width: 128px !important;
+	height: 128px !important;
+	line-height: 128px !important;
+	/* imageplaceholder() sets font-size to "height * 0.55" */
+	font-size: 70.4px !important;
 }
 
 

--- a/css/publicshare.scss
+++ b/css/publicshare.scss
@@ -178,6 +178,22 @@
 #talk-sidebar #videos .videoContainer:not(.promoted) .avatar img {
 	width: 64px !important;
 	height: 64px !important;
+	line-height: 64px !important;
+	/* imageplaceholder() sets font-size to "height * 0.55" */
+	font-size: 35.2px !important;
+}
+
+/* Text avatars need to be forced to 128px when promoted, as imageplaceholder()
+ * overrides the given size with the actual height of the element it was called
+ * on, so the text avatar may have a hardcoded height of 64px. Note that this
+ * does not apply to regular image avatars, as in that case they are always
+ * requested with a size of 128px. */
+#talk-sidebar #videos .videoContainer.promoted .avatar {
+	width: 128px !important;
+	height: 128px !important;
+	line-height: 128px !important;
+	/* imageplaceholder() sets font-size to "height * 0.55" */
+	font-size: 70.4px !important;
 }
 
 #talk-sidebar .participants-1 .videoView,

--- a/css/video.scss
+++ b/css/video.scss
@@ -85,11 +85,11 @@ video {
 }
 
 .videoContainer .avatar-container {
-	display: flex;
-	margin-bottom: 50px;
-}
-.videoContainer .avatar-container.hidden {
-	display: none;
+	position: absolute;
+	text-align: center;
+	bottom: 44px;
+	left: 0;
+	width: 100%;
 }
 .videoContainer .avatar-container .avatar {
 	display: inline-block;

--- a/css/video.scss
+++ b/css/video.scss
@@ -86,13 +86,13 @@ video {
 
 .videoContainer .avatar-container {
 	position: absolute;
-	text-align: center;
 	bottom: 44px;
 	left: 0;
 	width: 100%;
 }
 .videoContainer .avatar-container .avatar {
-	display: inline-block;
+	margin-left: auto;
+	margin-right: auto;
 }
 .videoContainer.promoted .avatar-container {
 	top: 30%;

--- a/js/publicshare.js
+++ b/js/publicshare.js
@@ -28,9 +28,6 @@
 		init: function() {
 			this._boundHideCallUi = this._hideCallUi.bind(this);
 
-			// Match the size set in the CSS.
-			OCA.Talk.Views.VideoView.prototype.participantAvatarSize = 64;
-
 			this.setupLayoutForTalkSidebar();
 
 			this.setupSignalingEventHandlers();


### PR DESCRIPTION
This fixes the regressions introduced in 6b04fb7 (promoted avatar was not shown above the other avatars, avatars in a large call were not stacked on each other so they overflowed the window), fixes the issue that 6b04fb7 was meant to fix, and also fixes an issue with guest avatars in the Files app.



## How to reproduce (scenario 1)
- Start a call
- Join the call with another two users

### Result with this pull request:
The promoted avatar is above the other avatars

### Result without this pull request:
The promoted avatar is at the same height as the other avatars



## How to reproduce (scenario 2)
- Join a call with several participants (five or more)
- Resize the window so it is narrow (or add several other participants)

### Result with this pull request:
The avatars are stacked and the local participant is visible (the local media buttons may be partially hidden, though; that will be fixed in another pull request)

### Result without this pull request:
Some avatars are fully visible (not stacked), but not every avatar is visible (some of them are out of the screen, including the local participant)



## How to reproduce (scenario 3)
- As a user, open the Files app and share a file by link; copy the link
- Open the Chat tab and join the call rejecting media permissions
- As a guest, open the link (that is, the public share page) and start a call rejecting media permissions
- As another guest, open the link and join the call rejecting media permissions

### Result with this pull request:
In the public share page, the avatars are at the same height

### Result without this pull request:
In the public share page, the avatars for guests are at a higher height than the avatar for the user



## How to reproduce (scenario 4)
- As a user, open the Files app and share a file by link; copy the link
- As a guest, open the link (that is, the public share page) and start a call
- As the user, open the Chat tab and join the call in the Files app
- As another guest, open the link and join the call
- Enable the microphone in the second guest

### Result with this pull request:
In the Files app, the avatar for the second guest is large and the avatar for the first guest is small

### Result without this pull request:
In the Files app, the avatar for the second guest is small and the avatar for the first guest is small, although the letter in the first guest is large
