### PR TITLE
Do not load Talk sidebar in public share page of folder shares

### DIFF
--- a/lib/PublicShare/TemplateLoader.php
+++ b/lib/PublicShare/TemplateLoader.php
@@ -24,8 +24,11 @@ declare(strict_types=1);
 
 namespace OCA\Talk\PublicShare;
 
+use OCP\Files\FileInfo;
+use OCP\Share\IShare;
 use OCP\Util;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Helper class to extend the "publicshare" template from the server.
@@ -37,8 +40,10 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class TemplateLoader {
 
 	public static function register(EventDispatcherInterface $dispatcher): void {
-		$dispatcher->addListener('OCA\Files_Sharing::loadAdditionalScripts', static function() {
-			self::loadTalkSidebarUi();
+		$dispatcher->addListener('OCA\Files_Sharing::loadAdditionalScripts', static function(GenericEvent $event) {
+			/** @var IShare $share */
+			$share = $event->getArgument('share');
+			self::loadTalkSidebarUi($share);
 		});
 	}
 
@@ -47,11 +52,17 @@ class TemplateLoader {
 	 *
 	 * This method should be called when loading additional scripts for the
 	 * public share page of the server.
+	 *
+	 * @param IShare $share
 	 */
-	public static function loadTalkSidebarUi(): void {
+	public static function loadTalkSidebarUi(IShare $share): void {
 		$config = \OC::$server->getConfig();
 		if ($config->getAppValue('spreed', 'conversations_files', '1') !== '1' ||
 			$config->getAppValue('spreed', 'conversations_files_public_shares', '1') !== '1') {
+			return;
+		}
+
+		if ($share->getNodeType() !== FileInfo::TYPE_FILE) {
 			return;
 		}
 


### PR DESCRIPTION
Requires nextcloud/server#17575

The Talk sidebar is only shown for file shares, so there is no need to load it for folder shares. Moreover, this also prevents some of the hacks used to show the Talk sidebar to mess with the layout used for folders.
