### PR TITLE
[stable17] Do not immediately join the conversation in public share pages

### DIFF
--- a/css/publicshare.scss
+++ b/css/publicshare.scss
@@ -91,6 +91,33 @@
 	justify-content: center;
 }
 
+#talk-sidebar .emptycontent.room-not-joined {
+	/* Override "margin-top: 30vh" set in server, as the message is already
+	 * centered in the Talk sidebar. */
+	margin-top: unset;
+
+	button {
+		padding-left: 24px;
+		padding-right: 24px;
+
+		.icon-loading-small {
+			/* Prevent the text from being moved when the icon is shown. */
+			position: absolute;
+
+			margin-left: 5px;
+			margin-top: 1px;
+
+			/* Unset the size set by the server for icons in empty content */
+			width: unset;
+			height: unset;
+
+			&.hidden {
+				display: none;
+			}
+		}
+	}
+}
+
 #talk-sidebar #emptycontent {
 	position: relative;
 

--- a/js/publicshare.js
+++ b/js/publicshare.js
@@ -32,7 +32,14 @@
 
 			this.setupSignalingEventHandlers();
 
-			this.enableTalkSidebar();
+			// Delay showing the Talk sidebar, as if it is shown too soon after
+			// the page loads (even if it has loaded) there will be no
+			// transition and the join button will not be enabled.
+			setTimeout(function() {
+				this.showTalkSidebar().then(function() {
+					this._$joinRoomButton.prop('disabled', false);
+				}.bind(this));
+			}.bind(this), 1000);
 		},
 
 		setupLayoutForTalkSidebar: function() {
@@ -70,7 +77,7 @@
 				this._$joinRoomButton.prop('disabled', true);
 				this._$joinRoomButton.find('.icon-loading-small').removeClass('hidden');
 
-				OCA.SpreedMe.app.signaling.joinRoom(OCA.SpreedMe.app.token);
+				this.enableTalkSidebar();
 			}.bind(this));
 
 			$('#talk-sidebar').append(this._$roomNotJoinedMessage);
@@ -190,10 +197,7 @@
 			OCA.SpreedMe.app.signaling.setRoom(OCA.SpreedMe.app.activeRoom);
 
 			OCA.SpreedMe.app.token = token;
-
-			this.showTalkSidebar().then(function() {
-				this._$joinRoomButton.prop('disabled', false);
-			}.bind(this));
+			OCA.SpreedMe.app.signaling.joinRoom(token);
 		},
 
 		_updateCallContainer: function() {

--- a/tests/acceptance/features/bootstrap/TalkPublicShareContext.php
+++ b/tests/acceptance/features/bootstrap/TalkPublicShareContext.php
@@ -34,12 +34,28 @@ class TalkPublicShareContext extends PublicShareContext {
 	}
 
 	/**
+	 * @return Locator
+	 */
+	public static function joinTheConversationButton() {
+		return Locator::forThe()->css(".room-not-joined button")->
+				descendantOf(self::talkSidebar())->
+				describedAs("Join the conversation button in the Talk sidebar in the public share page");
+	}
+
+	/**
 	 * @override I see that the current page is the shared link I wrote down
 	 */
 	public function iSeeThatTheCurrentPageIsTheSharedLinkIWroteDown() {
 		parent::iSeeThatTheCurrentPageIsTheSharedLinkIWroteDown();
 
 		$this->setChatAncestorForActor(self::talkSidebar(), $this->actor);
+	}
+
+	/**
+	 * @When I join the conversation in the Talk sidebar in the public share page
+	 */
+	public function iJoinTheConversationInTheTalkSidebarInThePublicSharePage() {
+		$this->actor->find(self::joinTheConversationButton(), 10)->click();
 	}
 
 	/**

--- a/tests/acceptance/features/public-share.feature
+++ b/tests/acceptance/features/public-share.feature
@@ -48,6 +48,7 @@ Feature: public share
     And I visit the shared link I wrote down
     And I see that the current page is the shared link I wrote down
     And I see that the Talk sidebar is shown in the public share page
+    And I join the conversation in the Talk sidebar in the public share page
     And I see that the current participant is the user "user0"
     # Visit the Home page so the header shows again the list of apps
     When I visit the Home page
@@ -69,6 +70,7 @@ Feature: public share
     And I visit the shared link I wrote down
     And I see that the current page is the shared link I wrote down
     And I see that the Talk sidebar is shown in the public share page
+    And I join the conversation in the Talk sidebar in the public share page
     And I see that the current participant is the user "admin"
     # Log in with the same user from a different window to check Talk while the
     # original window is in the public share page
@@ -99,6 +101,7 @@ Feature: public share
     And I visit the shared link I wrote down
     And I see that the current page is the shared link I wrote down
     And I see that the Talk sidebar is shown in the public share page
+    And I join the conversation in the Talk sidebar in the public share page
     When I type a new chat message with the text "Hello @"
     And I choose the candidate mention for "user0"
     And I send the current chat message
@@ -117,6 +120,7 @@ Feature: public share
     And I visit the shared link I wrote down
     And I see that the current page is the shared link I wrote down
     And I see that the Talk sidebar is shown in the public share page
+    And I join the conversation in the Talk sidebar in the public share page
     When I send a new chat message with the text "Hello @user0"
     Then I see that the message 1 was sent by "admin" with the text "Hello user0"
     And I see that the message 1 contains a formatted mention of "user0"
@@ -137,11 +141,13 @@ Feature: public share
     And I visit the shared link I wrote down
     And I see that the current page is the shared link I wrote down
     And I see that the Talk sidebar is shown in the public share page
+    And I join the conversation in the Talk sidebar in the public share page
     And I act as Jim
     And I am logged in as the admin
     And I visit the shared link I wrote down
     And I see that the current page is the shared link I wrote down
     And I see that the Talk sidebar is shown in the public share page
+    And I join the conversation in the Talk sidebar in the public share page
     When I act as Jane
     And I type a new chat message with the text "Hello @"
     And I choose the candidate mention for "admin"
@@ -170,11 +176,13 @@ Feature: public share
     And I visit the shared link I wrote down
     And I see that the current page is the shared link I wrote down
     And I see that the Talk sidebar is shown in the public share page
+    And I join the conversation in the Talk sidebar in the public share page
     And I set my guest name to "Cat"
     And I act as Jim
     And I visit the shared link I wrote down
     And I see that the current page is the shared link I wrote down
     And I see that the Talk sidebar is shown in the public share page
+    And I join the conversation in the Talk sidebar in the public share page
     When I type a new chat message with the text "Hello @"
     And I choose the candidate mention for "Cat"
     And I send the current chat message
@@ -195,6 +203,7 @@ Feature: public share
     And I visit the shared link I wrote down
     And I see that the current page is the shared link I wrote down
     And I see that the Talk sidebar is shown in the public share page
+    And I join the conversation in the Talk sidebar in the public share page
     When I type a new chat message with the text "Hello @"
     And I choose the candidate mention for "welcome.txt"
     And I send the current chat message


### PR DESCRIPTION
Before as soon as the public share page loaded the user or guest automatically joined the conversation. Now the conversation must be explicitly joined by clicking a button in the Talk sidebar.

However, the current approach still has a problem: if the conversation was not created yet as soon as the public share page is loaded the conversation is created, even if the user does not join it. When the conversation is created a system message is shown, so this could still be used for "stalking" (knowing when the recipient of a link share opened it for the first time).

This could be fixed by:
- Not adding the "XXX created the conversation" system message for file rooms (which I am not sure if it is very useful/needed in that case anyway).
- Splitting getting the token for a file room and creating the file room. Currently, when the room token is got and the room does not exist yet the room is automatically created. To fix the issue the UI should first try to get the room token and, if it does not exist yet, explicitly create it once the user wants to join the room.

  This would involve changes to _PublicShareController_, which was merged with _FilesIntegrationController_ for Talk 8, so it would be better to backport #2189 and #2245 to _stable17_ to avoid working twice when porting this to master.

@nickvergessen Thoughts? I would go with the first option, simply not adding the conversation created system message for file rooms.

Fix #2382