### PR TITLE
Bugfix/stop message history pending requests when changing conversation

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -79,7 +79,7 @@ export default {
 			 * which allows to cancel the previous long polling request for new
 			 * messages before making another one.
 			 */
-			cancelRequest: null,
+			cancelLookForNewMessges: null,
 		}
 	},
 
@@ -194,14 +194,14 @@ export default {
 			 * of this method, we call the `cancelRequest` function to clear it and reset
 			 * the cancelRequest to null in the component's data.
 			 */
-			if (typeof this.cancelRequest === 'function') {
-				this.cancelRequest('canceled')
-				this.cancelRequest = null
+			if (typeof this.cancelLookForNewMessges === 'function') {
+				this.cancelLookForNewMessges('canceled')
+				this.cancelLookForNewMessges = null
 			}
 			// Get a new request function and cancel function pair
-			const { lookForNewMessages, cancel } = cancelableLookForNewMessages()
+			const { lookForNewMessages, cancelLookForNewMessges } = cancelableLookForNewMessages()
 			// store the cancel function in the data
-			this.cancelRequest = cancel
+			this.cancelLookForNewMessges = cancelLookForNewMessges
 			const lastKnownMessageId = this.getLastKnownMessageId()
 			const messages = await lookForNewMessages(this.token, lastKnownMessageId)
 			if (messages !== undefined) {

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -80,6 +80,11 @@ export default {
 			 * messages before making another one.
 			 */
 			cancelLookForNewMessages: null,
+			/**
+			 * Stores the cancel function returned by `cancelableFetchMessages`,
+			 * which allows to cancel the previous request for old messages
+			 * when quickly switching to a new conversation.
+			 */
 			cancelFetchMessages: null,
 		}
 	},
@@ -179,7 +184,9 @@ export default {
 		 */
 		onRouteChange() {
 			this.isInitiated = false
+			// Gets the history of the conversation
 			this.getOldMessages()
+			// Listens for new messages
 			this.getNewMessages()
 		},
 		async getOldMessages() {
@@ -224,7 +231,7 @@ export default {
 			}
 			// Get a new request function and cancel function pair
 			const { lookForNewMessages, cancelLookForNewMessages } = cancelableLookForNewMessages()
-			// store the cancel function in the data
+			// Assign the new cancel function to our data value
 			this.cancelLookForNewMessages = cancelLookForNewMessages
 			const lastKnownMessageId = this.getLastKnownMessageId()
 			const messages = await lookForNewMessages(this.token, lastKnownMessageId)

--- a/src/services/messagesService.js
+++ b/src/services/messagesService.js
@@ -31,7 +31,7 @@ const cancelableFetchMessages = function() {
 	 * to the cancel function;
 	 * cancel= function that allows to delete the api call;
 	 */
-	const { token: cancelToken, cancel } = CANCEL_TOKEN.source()
+	const { token: cancelToken, cancel: cancelFetchMessages } = CANCEL_TOKEN.source()
 	/**
 	 * Fetches messages that belong to a particular conversation
 	 * specified with its token.
@@ -50,7 +50,7 @@ const cancelableFetchMessages = function() {
 	}
 	return {
 		fetchMessages,
-		cancel,
+		cancelFetchMessages,
 	}
 }
 
@@ -69,7 +69,7 @@ const cancelableLookForNewMessages = function() {
 	 * to the cancel function;
 	 * cancel= function that allows to delete the api call;
 	 */
-	const { token: cancelToken, cancel } = CANCEL_TOKEN.source()
+	const { token: cancelToken, cancel: cancelLookForNewMessages } = CANCEL_TOKEN.source()
 	/**
 	 * Fetches newly created messages that belong to a particular conversation
 	 * specified with its token.
@@ -92,7 +92,7 @@ const cancelableLookForNewMessages = function() {
 	}
 	return {
 		lookForNewMessages,
-		cancel,
+		cancelLookForNewMessages,
 	}
 }
 


### PR DESCRIPTION
Same as we did for long polling requests for new messages, but this time done for history requests, so that if the user quickly switches conversations, the previous pending request gets canceled.

@danxuliu hope u can notice my effort here in the commits history xD