### PR TITLE
Fix new messages not loaded if they arrive while the sidebar is hidden

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -543,6 +543,11 @@
 				}
 
 				this._chatView.restoreScrollPosition();
+
+				// When the chat is attached again the message list needs to be
+				// reloaded to add the messages that could have been received
+				// while detached.
+				this._chatView.reloadMessageList();
 			}.bind(this));
 			this._chatView.listenTo(this._sidebarView, 'close', function() {
 				if (this._sidebarView.getCurrentTabId() !== 'chat') {


### PR DESCRIPTION
## How to test
- Start a call in the main Talk UI
- Send enough messages to show a scroll bar in the message list
- Hide the sidebar
- Join the conversation with another user
- Send a new message
- Show the sidebar again

### Result with this pull request
The message list can be scrolled to the bottom and the new message is shown

### Result without this pull request
The message list is already at the bottom but the new message is not shown

Backport to stable16?