### PR TITLE
Ignore temporary message ids on get-last-known

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -274,8 +274,14 @@ export default {
 		 * @returns {string} The last known message id.
 		 */
 		getLastKnownMessageId() {
-			if (this.messagesList[this.messagesList.length - 1]) {
-				return this.messagesList[this.messagesList.length - 1].id.toString()
+			for (let i = 1; i < this.messagesList.length; i++) {
+				if (this.messagesList[this.messagesList.length - i]) {
+					const id = this.messagesList[this.messagesList.length - i].id.toString()
+					// Ignore temporary messages
+					if (!id.startsWith('temp-')) {
+						return id
+					}
+				}
 			}
 			return '0'
 		},

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -117,7 +117,7 @@ export default {
 		 */
 		createTemporaryMessageId() {
 			const date = new Date()
-			return date.getTime()
+			return 'temp-' + date.getTime()
 		},
 		/**
 		 * Sends the new message


### PR DESCRIPTION
Otherwise the last read message id will be set to a timestamp and you will never have unread messages again