### PR TITLE
Make possible to show and hide the Talk sidebar in public share pages

### DIFF
--- a/css/publicshare.scss
+++ b/css/publicshare.scss
@@ -58,7 +58,9 @@
 
 
 
-@include icon-black-white('menu-people', 'spreed', 1);
+.icon-menu-people {
+	@include icon-color('menu-people', 'spreed', $color-primary-text, 1);
+}
 
 #talk-sidebar-trigger {
 	width: 44px;

--- a/css/publicshare.scss
+++ b/css/publicshare.scss
@@ -72,8 +72,8 @@
 	overflow-y: auto;
 	z-index: 500;
 
-	transition: 300ms width ease-in-out,
-				300ms min-width ease-in-out;
+	transition: var(--animation-quick) width ease-in-out,
+				var(--animation-quick) min-width ease-in-out;
 }
 
 #talk-sidebar.disappear {

--- a/css/publicshare.scss
+++ b/css/publicshare.scss
@@ -58,6 +58,26 @@
 
 
 
+@include icon-black-white('menu-people', 'spreed', 1);
+
+#talk-sidebar-trigger {
+	width: 44px;
+	height: 44px;
+
+	background-color: transparent;
+	border-color: transparent;
+
+	opacity: 0.6;
+
+	&:hover,
+	&:focus,
+	&:active {
+		opacity: 1;
+	}
+}
+
+
+
 /* Properties based on the app-sidebar */
 #talk-sidebar {
 	position: relative;

--- a/js/publicshare.js
+++ b/js/publicshare.js
@@ -32,17 +32,31 @@
 
 			this.setupSignalingEventHandlers();
 
-			// Delay showing the Talk sidebar, as if it is shown too soon after
-			// the page loads (even if it has loaded) there will be no
-			// transition and the join button will not be enabled.
-			setTimeout(function() {
-				this.showTalkSidebar().then(function() {
-					this._$joinRoomButton.prop('disabled', false);
-				}.bind(this));
-			}.bind(this), 1000);
+			// Open the sidebar by default based on the window width
+			// using the same threshold as in the main Talk UI.
+			if ($(window).width() > 1111) {
+				// Delay showing the Talk sidebar, as if it is shown too soon
+				// after the page loads (even if it has loaded) there will be no
+				// transition and the join button will not be enabled.
+				setTimeout(function() {
+					this.showTalkSidebar().then(function() {
+						this._$joinRoomButton.prop('disabled', false);
+					}.bind(this));
+				}.bind(this), 1000);
+			}
 		},
 
 		setupLayoutForTalkSidebar: function() {
+			this._talkSidebarTrigger = $('<button id="talk-sidebar-trigger" class="icon-menu-people icon-white"></button>');
+			this._talkSidebarTrigger.click(function() {
+				if ($('#talk-sidebar').hasClass('disappear')) {
+					this.showAndUpdateTalkSidebar();
+				} else {
+					this.hideTalkSidebar();
+				}
+			}.bind(this));
+			$('.header-right').append(this._talkSidebarTrigger);
+
 			$('#app-content').append($('footer'));
 
 			this._$callContainerWrapper = $('<div id="call-container-wrapper" class="hidden"></div>');
@@ -228,6 +242,19 @@
 
 		leaveRoom: function() {
 			this.hideTalkSidebarTimeout = setTimeout(this.hideTalkSidebar, 5000);
+		},
+
+		/**
+		 * Shows the Talk sidebar and updates its contents.
+		 */
+		showAndUpdateTalkSidebar: function() {
+			this.showTalkSidebar().then(function() {
+				this._$joinRoomButton.prop('disabled', false);
+
+				// Once the sidebar is shown its size has changed, so
+				// the chat view needs to handle a size change.
+				OCA.SpreedMe.app._chatView.handleSizeChanged();
+			}.bind(this));
 		},
 
 		/**

--- a/js/publicshare.js
+++ b/js/publicshare.js
@@ -47,7 +47,7 @@
 		},
 
 		setupLayoutForTalkSidebar: function() {
-			this._talkSidebarTrigger = $('<button id="talk-sidebar-trigger" class="icon-menu-people icon-white"></button>');
+			this._talkSidebarTrigger = $('<button id="talk-sidebar-trigger" class="icon-menu-people"></button>');
 			this._talkSidebarTrigger.click(function() {
 				if ($('#talk-sidebar').hasClass('disappear')) {
 					this.showAndUpdateTalkSidebar();

--- a/js/publicshare.js
+++ b/js/publicshare.js
@@ -258,14 +258,16 @@
 
 				$('#talk-sidebar').get(0).addEventListener('transitionend', resolveOnceSidebarIsOpen);
 			} else {
+				var animationQuickValue = getComputedStyle(document.documentElement).getPropertyValue('--animation-quick');
+
 				// The browser does not support the "ontransitionend" event, so
 				// just wait a few milliseconds more than the duration of the
-				// transition (300ms).
+				// transition.
 				setTimeout(function() {
 					console.log('ontransitionend is not supported; the sidebar should have been fully shown by now');
 
 					deferred.resolve();
-				}, 500);
+				}, Number.parseInt(animationQuickValue) + 200);
 			}
 
 			$('#talk-sidebar').removeClass('disappear');


### PR DESCRIPTION
Fixes #2313 

As discussed with @jancborchardt now an icon is shown in the header of the public share page that makes possible to show and hide the Talk sidebar.

For 18 it would be nice to add an API that apps with an UI embedded in the public share page, like Text, can use to better integrate the button. But for the time being this is good enough ;-)

![talk-sidebar-in-public-share-page-toggle](https://user-images.githubusercontent.com/26858233/68313269-927cff00-00b4-11ea-9e36-c1518ef74f20.png)

@jospoortvliet FYI