### PR TITLE
[stable17] Do not immediately join the conversation in Files app

### DIFF
--- a/js/filesplugin.js
+++ b/js/filesplugin.js
@@ -326,8 +326,10 @@
 			this.$el.prepend('<div class="ui-not-ready-placeholder icon-loading"></div>');
 
 			OCA.Talk.FilesPlugin.isTalkSidebarSupportedForFile(fileInfo).then(function(supported) {
-				if (supported) {
-					this._setFileInfoWhenTalkSidebarIsSupportedForFile(fileInfo);
+				if (supported && this.model === fileInfo) {
+					this._setFileInfoWhenRoomIsJoinedInTalkSidebarForFile(fileInfo);
+				} else if (supported) {
+					this._setFileInfoWhenRoomIsNotJoinedInTalkSidebarForFile(fileInfo);
 				} else {
 					this._setFileInfoWhenTalkSidebarIsNotSupportedForFile();
 				}
@@ -342,7 +344,15 @@
 			this._renderFileNotSharedUi();
 		},
 
-		_setFileInfoWhenTalkSidebarIsSupportedForFile: function(fileInfo) {
+		_setFileInfoWhenRoomIsNotJoinedInTalkSidebarForFile: function(fileInfo) {
+			this.model = null;
+
+			this._roomForFileModel.leave();
+
+			this._renderRoomNotJoinedUi(fileInfo);
+		},
+
+		_setFileInfoWhenRoomIsJoinedInTalkSidebarForFile: function(fileInfo) {
 			if (this.model === fileInfo) {
 				this.$el.find('.ui-not-ready-placeholder').remove();
 
@@ -406,6 +416,7 @@
 			this._roomForFileModel.join(this.model.get('id'));
 
 			this.$el.find('.file-not-shared').remove();
+			this.$el.find('.room-not-joined').remove();
 
 			// If the details view is rendered again after the chat view has
 			// been appended to this tab the chat view would stop working due to
@@ -424,6 +435,23 @@
 			setTimeout(function() {
 				OCA.SpreedMe.app._chatView.reloadMessageList();
 			}, 0);
+		},
+
+		_renderRoomNotJoinedUi: function(fileInfo) {
+			this.$el.empty();
+
+			var $roomNotJoinedMessage = $(
+				'<div class="emptycontent room-not-joined">' +
+				'    <div class="icon icon-talk"></div>' +
+				'    <h2>' + t('spreed', 'Join the conversation') + '</h2>' +
+				'    <button class="primary">' + t('spreed', 'Join') + '</button>' +
+				'</div>');
+
+			$roomNotJoinedMessage.find('button').click(function() {
+				this._setFileInfoWhenRoomIsJoinedInTalkSidebarForFile(fileInfo);
+			}.bind(this));
+
+			this.$el.append($roomNotJoinedMessage);
 		},
 
 		_renderFileNotSharedUi: function() {

--- a/js/filesplugin.js
+++ b/js/filesplugin.js
@@ -443,8 +443,8 @@
 			var $roomNotJoinedMessage = $(
 				'<div class="emptycontent room-not-joined">' +
 				'    <div class="icon icon-talk"></div>' +
-				'    <h2>' + t('spreed', 'Join the conversation') + '</h2>' +
-				'    <button class="primary">' + t('spreed', 'Join') + '</button>' +
+				'    <h2>' + t('spreed', 'Discuss this file') + '</h2>' +
+				'    <button class="primary">' + t('spreed', 'Join conversation') + '</button>' +
 				'</div>');
 
 			$roomNotJoinedMessage.find('button').click(function() {
@@ -460,9 +460,9 @@
 			var $fileNotSharedMessage = $(
 				'<div class="emptycontent file-not-shared">' +
 				'    <div class="icon icon-talk"></div>' +
-				'    <h2>' + t('spreed', 'Start a conversation') + '</h2>' +
-				'    <p>' + t('spreed', 'Share this file with others to discuss') + '</p>' +
-				'    <button class="primary">' + t('spreed', 'Share') + '</button>' +
+				'    <h2>' + t('spreed', 'Discuss this file') + '</h2>' +
+				'    <p>' + t('spreed', 'Share this file with others to discuss it') + '</p>' +
+				'    <button class="primary">' + t('spreed', 'Share this file') + '</button>' +
 				'</div>');
 
 			$fileNotSharedMessage.find('button').click(function() {

--- a/js/publicshare.js
+++ b/js/publicshare.js
@@ -80,8 +80,8 @@
 			this._$roomNotJoinedMessage = $(
 				'<div class="emptycontent room-not-joined">' +
 				'    <div class="icon icon-talk"></div>' +
-				'    <h2>' + t('spreed', 'Join the conversation') + '</h2>' +
-				'    <button class="primary" disabled="disabled">' + t('spreed', 'Join') + '<span class="icon icon-loading-small hidden"/></button>' +
+				'    <h2>' + t('spreed', 'Discuss this file') + '</h2>' +
+				'    <button class="primary" disabled="disabled">' + t('spreed', 'Join conversation') + '<span class="icon icon-loading-small hidden"/></button>' +
 				'</div>');
 
 			this._$joinRoomButton = this._$roomNotJoinedMessage.find('button');


### PR DESCRIPTION
Related to #2347 
Fixes #1366 

Before as soon as the chat tab loaded if the file was shared the user automatically joined the conversation. Now the conversation must be explicitly joined by clicking a button in the chat tab. This prevents accidentally joining a room or even creating them when opening the details of a different file.

Note that in this current version the user always needs to explicitly click the _Join_ button to see the chat messages (except if she changed to a different tab and went back to the Chat tab). It would be better if the chat messages are automatically shown if the conversation is already created and the user has already joined, but for now always having to join should be good enough (and better than accidentally creating/joining the conversation).