### PR TITLE
Use nextcloudci Docker image for node

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,13 +5,14 @@ steps:
   - name: check-simplewebrtc-bundle
     image: nextcloudci/node:node-7
     commands:
-      - make npm-init
+      - npm ci
       - ./check-simplewebrtc-bundle.sh
   - name: check-vuejs-builds
     image: nextcloudci/node:node-7
     commands:
-      - make npm-init
-      - ./check-vuejs-builds.sh
+      - npm ci
+      - cd vue/ && npm ci
+      - cd .. && ./check-vuejs-builds.sh
   - name: check-handlebars-templates
     image: nextcloudci/node:node-7
     commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,17 +3,17 @@ name: check-builds
 
 steps:
   - name: check-simplewebrtc-bundle
-    image: node:lts
+    image: nextcloudci/node:node-7
     commands:
       - make npm-init
       - ./check-simplewebrtc-bundle.sh
   - name: check-vuejs-builds
-    image: node:lts
+    image: nextcloudci/node:node-7
     commands:
       - make npm-init
       - ./check-vuejs-builds.sh
   - name: check-handlebars-templates
-    image: node:lts
+    image: nextcloudci/node:node-7
     commands:
       - npm install -g handlebars
       - ./check-handlebars-templates.sh


### PR DESCRIPTION
The NPM major version was recently bumped in the _node:lts_ Docker image, so CI started to fail due to unclean JavaScript builds. The server seems to require the previous version due to incompatible dependencies, so for consistency the JavaScript files are still built and checked with the previous version instead of updating them to the new one.

Besides that  NPM dependencies in CI are now installed using `npm ci` instead of `npm install`. According to [its documentation](https://docs.npmjs.com/cli/ci) "_npm ci will never write to package.json or any of the package-locks_", so this should solve [the issue of `option: true` sometimes being wrongly removed from the _package-lock.json_ in CI builds](https://github.com/nextcloud/spreed/pull/2065#issuecomment-518183575).