### PR TITLE
[stable17] Enable join button by default in public share pages

### DIFF
--- a/js/publicshare.js
+++ b/js/publicshare.js
@@ -37,11 +37,9 @@
 			if ($(window).width() > 1111) {
 				// Delay showing the Talk sidebar, as if it is shown too soon
 				// after the page loads (even if it has loaded) there will be no
-				// transition and the join button will not be enabled.
+				// transition.
 				setTimeout(function() {
-					this.showTalkSidebar().then(function() {
-						this._$joinRoomButton.prop('disabled', false);
-					}.bind(this));
+					this.showTalkSidebar();
 				}.bind(this), 1000);
 			}
 		},
@@ -81,7 +79,7 @@
 				'<div class="emptycontent room-not-joined">' +
 				'    <div class="icon icon-talk"></div>' +
 				'    <h2>' + t('spreed', 'Discuss this file') + '</h2>' +
-				'    <button class="primary" disabled="disabled">' + t('spreed', 'Join conversation') + '<span class="icon icon-loading-small hidden"/></button>' +
+				'    <button class="primary">' + t('spreed', 'Join conversation') + '<span class="icon icon-loading-small hidden"/></button>' +
 				'</div>');
 
 			this._$joinRoomButton = this._$roomNotJoinedMessage.find('button');


### PR DESCRIPTION
Follow up to #2347 

The join button was initially disabled in public share pages and enabled once the Talk sidebar was fully shown. As the Talk sidebar is shown using a transition showing the Talk sidebar had to be delayed after the page load, as in some cases the transition was ignored and the sidebar was immediately shown. When that happened, as there was no transition, the join button was never enabled.

However, despite using a delay of one second in some cases (apparently if the system load is high) the transition did not happen either. Instead of increasing the delay even more, which does not guarantee anything, now the join button is enabled since the beginning.
