### PR TITLE
[stable17] Fix moderation menu width when date picker is not shown

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -1127,6 +1127,26 @@ body:not(#body-public) .participantWithList > li > span:not(.currentUser):not(.g
 			}
 		}
 
+		.menuitem-details {
+			/* Base the details width on the widest element, which is the date
+			 * picker, to prevent the text from being too narrow when the date
+			 * picker is not shown.
+			 *
+			 * The width is calculated from the date picker width (210px) plus
+			 * the width of the margins, padding and between the datepicker and
+			 * the borders of the menu (107px).
+			 */
+			width: 317px;
+
+			@media (max-width: 1315px) {
+				max-width: 317px;
+				/* Used when viewport is between 1111px and 1315px. */
+				width: calc(27vw - 38px);
+				/* Used when viewport is < 1111px. */
+				min-width: 262px;
+			}
+		}
+
 		.menuitem.lobby-timer-option {
 			/**
 			 * Force full opacity in the menu item so the pop up is shown with

--- a/css/style.scss
+++ b/css/style.scss
@@ -1145,6 +1145,8 @@ body:not(#body-public) .participantWithList > li > span:not(.currentUser):not(.g
 				/* Used when viewport is < 1111px. */
 				min-width: 262px;
 			}
+
+			padding-right: 14px;
 		}
 
 		.menuitem.lobby-timer-option {


### PR DESCRIPTION
**Before (wide screen):**
![Moderation-Menu-Wide-Screen-Lobby-Disabled-Before](https://user-images.githubusercontent.com/26858233/68938503-cfc14b00-079e-11ea-91ed-d82f09d7bfe8.png)

**After (wide screen):**
![Moderation-Menu-Wide-Screen-Lobby-Disabled-After](https://user-images.githubusercontent.com/26858233/68938507-d2bc3b80-079e-11ea-8f0d-36557fbbf4a7.png)
![Moderation-Menu-Wide-Screen-Lobby-Enabled-After](https://user-images.githubusercontent.com/26858233/68938514-d485ff00-079e-11ea-9810-9473ad1503f0.png)

**Before (narrow screen):**
![Moderation-Menu-Narrow-Screen-Lobby-Disabled-Before](https://user-images.githubusercontent.com/26858233/68938554-e4054800-079e-11ea-92e3-eff1600c1691.png)

**After (narrow screen):**
![Moderation-Menu-Narrow-Screen-Lobby-Disabled-After](https://user-images.githubusercontent.com/26858233/68938562-e667a200-079e-11ea-9453-4e7e424092d4.png)
![Moderation-Menu-Narrow-Screen-Lobby-Enabled-After](https://user-images.githubusercontent.com/26858233/68938567-e798cf00-079e-11ea-8450-289f2597e21c.png)

**Padding before:**
![Moderation-Menu-Details-Padding-Before](https://user-images.githubusercontent.com/26858233/68938578-ef587380-079e-11ea-95ed-056fdc759287.png)

**Padding after:**
![Moderation-Menu-Details-Padding-After](https://user-images.githubusercontent.com/26858233/68938583-f089a080-079e-11ea-8497-718fd1e35de3.png)
