### PR TITLE
[stable17] Request offer again when receiving peer fails

### DIFF
--- a/js/views/videoview.js
+++ b/js/views/videoview.js
@@ -130,8 +130,18 @@
 			this._rawParticipantName = rawParticipantName;
 			this._participantName = participantName;
 
+			// Restore icon if needed after "avatar()" resets it.
+			var restoreIconLoadingCallback = function() {
+				if (this._connectionStatus === ConnectionStatus.NEW ||
+						this._connectionStatus === ConnectionStatus.CHECKING ||
+						this._connectionStatus === ConnectionStatus.DISCONNECTED_LONG ||
+						this._connectionStatus === ConnectionStatus.FAILED) {
+					this.getUI('avatar').addClass('icon-loading');
+				}
+			}.bind(this);
+
 			if (userId && userId.length) {
-				this.getUI('avatar').avatar(userId, this.participantAvatarSize);
+				this.getUI('avatar').avatar(userId, this.participantAvatarSize, undefined, undefined, restoreIconLoadingCallback);
 			} else {
 				this.getUI('avatar').imageplaceholder('?', rawParticipantName, this.participantAvatarSize);
 				this.getUI('avatar').css('background-color', '#b9b9b9');

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -17,7 +17,7 @@ var spreedPeerConnectionTable = [];
 	var ownScreenPeer = null;
 	var hasLocalMedia = false;
 	var selfInCall = 0;  // OCA.SpreedMe.app.FLAG_DISCONNECTED, not available yet.
-	var delayedCreatePeer = [];
+	var delayedConnectionToPeer = [];
 
 	function updateParticipantsUI(currentUsersNo) {
 		'use strict';
@@ -209,7 +209,7 @@ var spreedPeerConnectionTable = [];
 					// offer in a reasonable time, the current peer calls the
 					// remote peer instead of waiting to be called to
 					// reestablish the connection.
-					delayedCreatePeer[sessionId] = setTimeout(function() {
+					delayedConnectionToPeer[sessionId] = setTimeout(function() {
 						createPeer();
 					}, 10000);
 				}
@@ -228,9 +228,9 @@ var spreedPeerConnectionTable = [];
 			OCA.SpreedMe.videos.remove(sessionId);
 			delete spreedMappingTable[sessionId];
 			delete guestNamesTable[sessionId];
-			if (delayedCreatePeer[sessionId]) {
-				clearTimeout(delayedCreatePeer[sessionId]);
-				delete delayedCreatePeer[sessionId];
+			if (delayedConnectionToPeer[sessionId]) {
+				clearTimeout(delayedConnectionToPeer[sessionId]);
+				delete delayedConnectionToPeer[sessionId];
 			}
 		});
 
@@ -348,9 +348,9 @@ var spreedPeerConnectionTable = [];
 				}
 			}
 
-			if (message.roomType === 'video' && delayedCreatePeer[message.from]) {
-				clearTimeout(delayedCreatePeer[message.from]);
-				delete delayedCreatePeer[message.from];
+			if (message.roomType === 'video' && delayedConnectionToPeer[message.from]) {
+				clearTimeout(delayedConnectionToPeer[message.from]);
+				delete delayedConnectionToPeer[message.from];
 			}
 
 			if (!selfInCall) {

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -196,6 +196,12 @@ var spreedPeerConnectionTable = [];
 				if (useMcu) {
 					// TODO(jojo): Already create peer object to avoid duplicate offers.
 					webrtc.connection.requestOffer(user, "video");
+
+					delayedConnectionToPeer[user.sessionId] = setInterval(function() {
+						console.log('No offer received for new peer, request offer again');
+
+						webrtc.connection.requestOffer(user, 'video');
+					}, 10000);
 				} else if (userHasStreams(selfInCall) && (!userHasStreams(user) || sessionId < currentSessionId)) {
 					// To avoid overloading the user joining a room (who previously called
 					// all the other participants), we decide who calls who by comparing
@@ -613,6 +619,16 @@ var spreedPeerConnectionTable = [];
 
 									videoView.setConnectionStatus(OCA.Talk.Views.VideoView.ConnectionStatus.FAILED_NO_RESTART);
 								}
+							} else {
+								console.log('Request offer again');
+
+								signaling.requestOffer(peer.id, 'video');
+
+								delayedConnectionToPeer[peer.id] = setInterval(function() {
+									console.log('No offer received, request offer again');
+
+									signaling.requestOffer(peer.id, 'video');
+								}, 10000);
 							}
 							break;
 						case 'closed':


### PR DESCRIPTION
Replaces #1881

When the MCU is used and the connection with another participant failed until now there was no reconnection. Now a new offer is periodically requested until the connection is established again.

Note that even if the previous offer arrives after a new one is requested everything still works as expected. The MCU closes the previous connection whenever it sends a new offer, so if a previous offer arrives and a connection is made it will be closed as soon as the new offer is sent and reconnected again when the new offer is handled. Although receiving the previous offer would have stopped the periodic request of offers even if the new one failed the peer will eventually change to the ICE failed state, which will start a new reconnection routine.

In a related change, when the MCU is not used if no offer is received from the other participant the participant with the smaller ID now also sends an offer periodically instead of just once.

However, in this case, there are still glare issues (crossed offers between peers, it can be seen by replacing the `break` with a `sleep(12)` in scenario 1 below), they are not fixed by this change (without MCU this change only addresses missing offers).

Finally, a missing spinner on user avatars during the initial connection was also fixed.

# How to test
## Scenario 1
- Randomly drop most offers by adding
```
if ($decodedMessage['type'] === 'offer' && rand(0, 100) < 90) {
    break;
}
```
before [adding messages in the SignalingController](https://github.com/nextcloud/spreed/blob/d4b7300828927111142f2552fcc9b46809758b10/lib/Controller/SignalingController.php#L134)
- Start a call with a user
- Join the call with another user or guest

### Result with this pull request

The participants are eventually connected despite several offers having failed.

### Result without this pull request

The participants are kept trying to connect with each other (unless either the first or the second offer succeeded; in that case leave the call and join again until the wrong behaviour is shown). Also, the avatar of the user does not show a spinner during the initial connection.



## Scenario 2
- Modify the code of the external signaling server to simulate a lot of failures (sorry for the formatting, I did not find a way to use lists and blocks of code)
  - In _mcu_janus.go_
    - After `log.Printf("Already connected as subscriber for %s, leaving and re-joining", p.streamType)` add `time.Sleep(5 * time.Second)` to cause an answer to be ignored when a new offer is closing the previous one.
  - In _hub.go_  
    - Add `"math/rand"` to the imports at the top
    - Replace `mc, err = session.GetOrCreateSubscriber(ctx, h.mcu, message.Recipient.SessionId, data.RoomType)` in _processMcuMessage_ with
`if rand.Intn(100) < 70 {
    err = nil
} else {
    mc, err = session.GetOrCreateSubscriber(ctx, h.mcu, message.Recipient.SessionId, data.RoomType)
}`
    to drop a lot of offers instead of sending them.
    - Before those lines, add
`if rand.Intn(100) < 90 {
    time.Sleep(10 * time.Second)
}`
to delay most of the offers longer than the timeout used in the WebUI to request new ones (unlike the other issues I do not recall seeing this in the real world, but worth checking it just in case).
    - Replace `ctx, cancel := context.WithTimeout(context.Background(), h.mcuTimeout)` with `ctx, cancel := context.WithTimeout(context.Background(), time.Duration(18) * time.Second)` to ensure that the delayed offer will be eventually sent (otherwise it would be cancelled due to the timeout); another option would have been to change the default timeout in the configuration.
- Setup the MCU
- Start a call with a user
- Join the call with another user or guest

### Result with this pull request

The participants are eventually connected despite several offers having failed or arrived out of order due to a delay, and even if a connection failed during the negotiation.

### Result without this pull request

The participants are kept trying to connect with each other (unless the first and the second offer succeeded without delay; in that case leave the call and join again until the wrong behaviour is shown). Also, the avatar of the user does not show a spinner during the initial connection.
