### PR TITLE
Start with the call service

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -167,8 +167,12 @@ export default {
 		})
 
 		if (getCurrentUser()) {
+			console.debug('Setting current user')
 			this.$store.dispatch('setCurrentUser', getCurrentUser())
+		} else {
+			console.debug('Can not set current user because it\'s a guest')
 		}
+
 		if (this.getUserId === null) {
 			this.fetchSingleConversation(this.token)
 			window.setInterval(() => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -135,12 +135,15 @@ export default {
 		 */
 		EventBus.$once('conversationsReceived', () => {
 			if (this.$route.name === 'conversation') {
-				const CURRENT_CONVERSATION_NAME = this.getConversationName(this.token)
-				this.setPageTitle(CURRENT_CONVERSATION_NAME)
+				// Adjust the page title once the conversation list is loaded
+				this.setPageTitle(this.getConversationName(this.token), false)
+
+				// Automatically join the conversation as well
+				joinConversation(this.token)
 			}
 
 			if (!getCurrentUser()) {
-				joinConversation(this.token)
+				// Set the current actor/participant for guests
 				const conversation = this.$store.getters.conversations[this.token]
 				this.$store.dispatch('setCurrentParticipant', conversation)
 			}

--- a/src/services/callsService.js
+++ b/src/services/callsService.js
@@ -1,0 +1,72 @@
+/**
+ * @copyright Copyright (c) 2019 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+
+/**
+ * Join a call as participant
+ * @param {string} token The token of the call to be joined.
+ * @param {int} flags The available PARTICIPANT.CALL_FLAG for this participants
+ */
+const joinCall = async function(token, flags) {
+	try {
+		const response = await axios.post(generateOcsUrl('apps/spreed/api/v1', 2) + `call/${token}`, {
+			flags,
+		})
+		return response
+	} catch (error) {
+		console.debug('Error while joining call: ', error)
+	}
+}
+
+/**
+ * Leave a call as participant
+ * @param {string} token The token of the call to be left
+ */
+const leaveCall = async function(token) {
+	try {
+		const response = await axios.delete(generateOcsUrl('apps/spreed/api/v1', 2) + `call/${token}`)
+		return response
+	} catch (error) {
+		console.debug('Error while leaving call: ', error)
+	}
+}
+
+/**
+ * Fetches all peers for a call
+ * @param {string} token The token of the call to be fetched.
+ */
+const fetchPeers = async function(token) {
+	try {
+		const response = await axios.get(generateOcsUrl('apps/spreed/api/v1', 2) + `call/${token}`)
+		return response
+	} catch (error) {
+		console.debug('Error while fetching the peers: ', error)
+	}
+}
+
+export {
+	joinCall,
+	leaveCall,
+	fetchPeers,
+}

--- a/src/store/actorStore.js
+++ b/src/store/actorStore.js
@@ -58,6 +58,16 @@ const getters = {
 	getDisplayName: (state) => () => {
 		return state.displayName
 	},
+	getParticipantIdentifier: (state) => () => {
+		if (state.actorType === 'guests') {
+			return {
+				sessionId: state.sessionId,
+			}
+		}
+		return {
+			participant: state.userId,
+		}
+	},
 }
 
 const mutations = {

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -21,6 +21,7 @@
  */
 import Vue from 'vue'
 import { makePublic, makePrivate, changeLobbyState } from '../services/conversationsService'
+import { getCurrentUser } from '@nextcloud/auth'
 import { CONVERSATION, WEBINAR } from '../constants'
 
 const getDefaultState = () => {
@@ -76,6 +77,19 @@ const actions = {
 	 */
 	addConversation(context, conversation) {
 		context.commit('addConversation', conversation)
+
+		const currentUser = getCurrentUser()
+		context.dispatch('addParticipantOnce', {
+			token: conversation.token,
+			participant: {
+				inCall: conversation.participantFlags,
+				lastPing: conversation.lastPing,
+				sessionId: conversation.sessionId,
+				participantType: conversation.participantType,
+				userId: currentUser ? currentUser.uid : '',
+				displayName: currentUser && currentUser.displayName ? currentUser.displayName : '',
+			},
+		})
 	},
 
 	/**


### PR DESCRIPTION
- [x] Current participant info is only available when you visited the participants tab:
  - This does not work for guests at all
  - The information for the current user should be taken from the conversation endpoint to populate the current user at least
- [x] The Conversation info is not updated instantly but just on the next 30s pull, so the current user can trigger multiple joins
- [ ] The audio/video flag need to be set based on a store (last used settings + start without video in big calls) - Maybe in a follow up