### PR TITLE
Fix participant type detection

### DIFF
--- a/src/components/Sidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/Sidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -103,7 +103,7 @@ export default {
 			return this.participant.label
 		},
 		participantType() {
-			return this.participant.type
+			return this.participant.participantType
 		},
 		sessionId() {
 			return this.participant.sessionId


### PR DESCRIPTION
1. Create a conversation
2. Look at the participant list and search for `(moderator)` next to your name

Regression from https://github.com/nextcloud/spreed/commit/e7453a8102716a96a9a790a278fcfd53fd2ec235#diff-bc1cb9aced147cca84ef194eba1170f6R105 where participantType was read from the wrong property