### PR TITLE
[stable17] Fix shared screens in Talk sidebar

### DIFF
--- a/css/files.scss
+++ b/css/files.scss
@@ -98,8 +98,10 @@
 }
 
 /* Screensharing in Talk sidebar */
-.talkCallInfoView #call-container-wrapper #screens {
-	display: none;
+.talkCallInfoView #call-container-wrapper #call-container.screensharing #screens {
+	/* The row with the participants is shorter in the Talk sidebar to make room
+	 * for the promoted video and the shared screens. */
+	height: calc(100% - 100px);
 }
 
 

--- a/css/files.scss
+++ b/css/files.scss
@@ -104,6 +104,15 @@
 	height: calc(100% - 100px);
 }
 
+.talkCallInfoView #call-container-wrapper #call-container.screensharing .videoContainer {
+	max-height: 100px;
+
+	/* Avatars slightly overflow the container; although they overlap the shared
+	 * screen it is not too bad and it is better than compressing even further
+	 * the shared screen. */
+	overflow: visible;
+}
+
 
 
 

--- a/css/publicshare.scss
+++ b/css/publicshare.scss
@@ -209,8 +209,10 @@
 }
 
 /* Screensharing in Talk sidebar */
-#talk-sidebar #call-container-wrapper #screens {
-	display: none;
+#talk-sidebar #call-container-wrapper #call-container.screensharing #screens {
+	/* The row with the participants is shorter in the Talk sidebar to make room
+	 * for the promoted video and the shared screens. */
+	height: calc(100% - 100px);
 }
 
 

--- a/css/publicshare.scss
+++ b/css/publicshare.scss
@@ -215,6 +215,15 @@
 	height: calc(100% - 100px);
 }
 
+#talk-sidebar #call-container-wrapper #call-container.screensharing .videoContainer {
+	max-height: 100px;
+
+	/* Avatars slightly overflow the container; although they overlap the shared
+	 * screen it is not too bad and it is better than compressing even further
+	 * the shared screen. */
+	overflow: visible;
+}
+
 
 
 #talk-sidebar #videos .videoContainer:not(.promoted) video {

--- a/css/publicshareauth.scss
+++ b/css/publicshareauth.scss
@@ -144,28 +144,6 @@ input#request-password-button:disabled ~ .icon {
 	box-sizing: border-box;
 }
 
-/* Screensharing in Talk sidebar */
-#talk-sidebar #call-container.screensharing #videos .videoContainer video {
-	max-height: 200px;
-	background-color: transparent;
-	box-shadow: 0;
-}
-
-#talk-sidebar #call-container.screensharing #screens {
-	position: absolute;
-	width: 100%;
-	height: calc(100% - 200px);
-	top: 0;
-	background-color: transparent;
-}
-
-#talk-sidebar #call-container.screensharing .screenContainer {
-	position: relative;
-	width: 100%;
-	height: 100%;
-	overflow: hidden;
-}
-
 /**
  * Cascade parent element height to the chat view in the sidebar to limit the
  * vertical scroll bar only to the list of messages. Otherwise, the vertical

--- a/css/video.scss
+++ b/css/video.scss
@@ -15,7 +15,8 @@
 }
 
 .videoContainer,
-#app-content.screensharing .videoContainer {
+#app-content.screensharing .videoContainer,
+#call-container.screensharing .videoContainer {
 	position: relative;
 	width: 100%;
 	padding: 0 2%;
@@ -31,11 +32,13 @@
 }
 
 .videoContainer.hidden,
-#app-content.screensharing .videoContainer.hidden {
+#app-content.screensharing .videoContainer.hidden,
+#call-container.screensharing .videoContainer.hidden {
 	display: none;
 }
 
-#app-content.screensharing .videoContainer {
+#app-content.screensharing .videoContainer,
+#call-container.screensharing .videoContainer {
 	max-height: 200px;
 }
 

--- a/css/video.scss
+++ b/css/video.scss
@@ -214,7 +214,6 @@ video {
 	width: 100%;
 	height: calc(100% - 200px);
 	top: 0;
-	overflow-y: scroll;
 	background-color: transparent;
 }
 

--- a/css/video.scss
+++ b/css/video.scss
@@ -48,7 +48,8 @@ video {
 	vertical-align: top; /* fix white line below video */
 }
 
-#app-content.screensharing .videoContainer video {
+#app-content.screensharing .videoContainer video,
+#call-container.screensharing .videoContainer video {
 	max-height: 200px;
 	background-color: transparent;
 	box-shadow: none;
@@ -209,7 +210,8 @@ video {
 
 
 
-#app-content.screensharing #screens {
+#app-content.screensharing #screens,
+#call-container.screensharing #screens {
 	position: absolute;
 	width: 100%;
 	height: calc(100% - 200px);
@@ -217,7 +219,8 @@ video {
 	background-color: transparent;
 }
 
-#app-content.screensharing .screenContainer {
+#app-content.screensharing .screenContainer,
+#call-container.screensharing .screenContainer {
 	position: relative;
 	width: 100%;
 	height: 100%;

--- a/js/embedded.js
+++ b/js/embedded.js
@@ -155,6 +155,7 @@
 			if (!OCA.SpreedMe.webrtc) {
 				OCA.SpreedMe.initWebRTC(this);
 				this._mediaControlsView.setWebRtc(OCA.SpreedMe.webrtc);
+				this._mediaControlsView.setSharedScreens(OCA.SpreedMe.sharedScreens);
 				this._speakingWhileMutedWarner.setWebRtc(OCA.SpreedMe.webrtc);
 			}
 

--- a/js/publicshare.js
+++ b/js/publicshare.js
@@ -73,6 +73,7 @@
 			});
 
 			OCA.SpreedMe.app._localVideoView.render();
+			OCA.SpreedMe.app._mediaControlsView.hideScreensharingButton();
 			$('#videos').append(OCA.SpreedMe.app._localVideoView.$el);
 
 			this._$roomNotJoinedMessage = $(


### PR DESCRIPTION
This pull request fixes several issues with screen sharing in the Talk sidebar:
- Fixes screens shared by others not shown in the Talk sidebar in Files app and public share pages
- Fixes videos overlapping the shared screens in the Talk sidebar
- For consistency with Files app, removes the _Share screen_ button in public share pages (as due to a bug in the local video container width it was visible only when other screens were already shared, so for the time being the button is now always hidden)
- Fixes changing between the screen shared by the current participant and the screen shared by the other participant in the public share authentication page
- Removes an unneeded empty scroll bar in all share screens (also in the main Talk UI)

# How to test
## Scenario 1
- Share a file by link
- Protect the link with a password
- Protect the password by Talk
- In a private window or other browser, open the link
- Request the password
- Share the screen
- In the original window, open the password request in Talk and join the call
- Enable the video
- Share the screen too
- In the other window, show the share screen menu and click "Show your screen"

### Result with this pull request

The other participant is shown to the left, and his video is below the shared screen, not overlapping with it. Changing between shared screens works.

### Result without this pull request

The other participant is shown in the middle, and his video overlaps the shared screen. Despite clicking "Show your screen" the local screen is not shown once the remote screen was shown.



## Scenario 2
- Share a file by link, open the _Chat_ tab and join the conversation
- Open Talk
- Start a call in the conversation for the shared file
- Enable the video
- Share the screen
- In a private window or other browser, open the link and join the call

### Result with this pull request

The other participant is shown to the left, and both the video and the shared screen are visible (the video is shown below the shared screen).

### Result without this pull request

The other participant is shown in the middle, and the video is visible, but not the shared screen.




## Scenario 3
- Share a file with another user
- In a private window or other browser, log in as the other user
- Open the details view for the shared file, open the _Chat_ tab and join the conversation
- Open Talk
- Start a call in the conversation for the shared file
- Enable the video
- Share the screen
- In the original window, open the _Chat_ tab and join the call

### Result with this pull request

The other participant is shown to the left, and both the video and the shared screen are visible (the video is shown below the shared screen). The "Share screen" button is not visible.

### Result without this pull request

The other participant is shown in the middle, and the video is visible, but not the shared screen. The "Share screen" button is also visible.
