### PR TITLE
[stable17] Fix local media not stopped when leaving a call

### DIFF
--- a/js/simplewebrtc/bundled.js
+++ b/js/simplewebrtc/bundled.js
@@ -283,6 +283,29 @@ function LocalMedia(opts) {
 }
 
 util.inherits(LocalMedia, WildEmitter);
+/**
+ * Clones a MediaStream that will be ended when the original MediaStream is
+ * ended.
+ */
+
+var cloneLinkedStream = function cloneLinkedStream(stream) {
+  var linkedStream = new MediaStream();
+  stream.getTracks().forEach(function (track) {
+    var linkedTrack = track.clone();
+    linkedStream.addTrack(linkedTrack); // Keep a reference of all the linked clones of a track to be able to
+    // stop them when the track is stopped.
+
+    if (!track.linkedTracks) {
+      track.linkedTracks = [];
+    }
+
+    track.linkedTracks.push(linkedTrack);
+    track.addEventListener('ended', function () {
+      linkedTrack.stop();
+    });
+  });
+  return linkedStream;
+};
 
 LocalMedia.prototype.start = function (mediaConstraints, cb) {
   var self = this;
@@ -312,7 +335,7 @@ LocalMedia.prototype.start = function (mediaConstraints, cb) {
     // even when the stream sent is muted.
 
 
-    var audioMonitorStream = stream.clone();
+    var audioMonitorStream = cloneLinkedStream(stream);
 
     if (constraints.audio && self.config.detectSpeakingEvents) {
       self._setupAudioMonitor(audioMonitorStream, self.config.harkOptions);
@@ -363,7 +386,17 @@ LocalMedia.prototype.stopStream = function (stream) {
 
     if (idx > -1) {
       stream.getTracks().forEach(function (track) {
-        track.stop();
+        track.stop(); // Linked tracks must be explicitly stopped, as stopping a track
+        // does not trigger the "ended" event, and due to a bug in
+        // Firefox it is not possible to explicitly dispatch the event
+        // either (nor any other event with a different name):
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1473457
+
+        if (track.linkedTracks) {
+          track.linkedTracks.forEach(function (linkedTrack) {
+            linkedTrack.stop();
+          });
+        }
       });
 
       this._removeStream(stream);
@@ -371,7 +404,17 @@ LocalMedia.prototype.stopStream = function (stream) {
   } else {
     this.localStreams.forEach(function (stream) {
       stream.getTracks().forEach(function (track) {
-        track.stop();
+        track.stop(); // Linked tracks must be explicitly stopped, as stopping a track
+        // does not trigger the "ended" event, and due to a bug in
+        // Firefox it is not possible to explicitly dispatch the event
+        // either (nor any other event with a different name):
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1473457
+
+        if (track.linkedTracks) {
+          track.linkedTracks.forEach(function (linkedTrack) {
+            linkedTrack.stop();
+          });
+        }
       });
 
       self._removeStream(stream);


### PR DESCRIPTION
Fixes a regression introduced in #2016

The local stream used to capture the microphone is cloned to be used by the audio monitor. When the call is left the original stream was stopped, but the cloned one not, so the microphone was still being captured. Now the cloned stream is a linked clone, so when the original stream is stopped the clone is stopped too.

# How to test
- Start a call
- Leave the call

## Result with this pull request

The indicator of active media capture is no longer shown by the browser.

## Result without this pull request

The indicator of active media capture is still shown by the browser.
