### PR TITLE
Fix sharing integration tests and loading shares

### DIFF
--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -280,6 +280,7 @@ class RoomShareProvider implements IShareProvider {
 			->setShareType((int)$data['share_type'])
 			->setPermissions((int)$data['permissions'])
 			->setTarget($data['file_target'])
+			->setStatus((int)$data['accepted'])
 			->setToken($data['token']);
 
 		$shareTime = $this->timeFactory->getDateTime();

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -281,6 +281,22 @@ class SharingContext implements Context {
 	}
 
 	/**
+	 * @When user :user accepts last share
+	 *
+	 * @param string $user
+	 */
+	public function userAcceptsLastShare(string $user) {
+		$this->currentUser = $user;
+
+		$url = '/apps/files_sharing/api/v1/shares/pending/' . $this->getLastShareId();
+
+		$this->sendingTo('POST', $url);
+
+		$this->theHTTPStatusCodeShouldBe(200);
+		$this->theOCSStatusCodeShouldBe(100);
+	}
+
+	/**
 	 * @When user :user gets all shares
 	 *
 	 * @param string $user

--- a/tests/integration/features/chat/mentions.feature
+++ b/tests/integration/features/chat/mentions.feature
@@ -254,6 +254,7 @@ Feature: chat/mentions
 
   Scenario: get mentions in a file room with no other joined participant
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     When user "participant1" gets the room for path "welcome.txt" with 200
     And user "participant1" joins room "file welcome.txt room" with 200
     And user "participant1" is participant of room "file welcome.txt room"
@@ -266,6 +267,7 @@ Feature: chat/mentions
 
   Scenario: get mentions in a file room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     When user "participant2" gets the room for path "welcome (2).txt" with 200
     And user "participant1" joins room "file welcome (2).txt room" with 200
     And user "participant2" joins room "file welcome (2).txt room" with 200
@@ -282,6 +284,7 @@ Feature: chat/mentions
 
   Scenario: get matched mentions in a file room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     When user "participant2" gets the room for path "welcome (2).txt" with 200
     And user "participant1" joins room "file welcome (2).txt room" with 200
     And user "participant2" joins room "file welcome (2).txt room" with 200
@@ -296,6 +299,7 @@ Feature: chat/mentions
 
   Scenario: get unmatched mentions in a file room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     When user "participant2" gets the room for path "welcome (2).txt" with 200
     And user "participant1" joins room "file welcome (2).txt room" with 200
     And user "participant2" joins room "file welcome (2).txt room" with 200
@@ -306,6 +310,7 @@ Feature: chat/mentions
 
   Scenario: get mentions in a file room with a participant without access to the file
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     When user "participant2" gets the room for path "welcome (2).txt" with 200
     And user "participant1" joins room "file welcome (2).txt room" with 200
     And user "participant2" joins room "file welcome (2).txt room" with 200
@@ -315,6 +320,7 @@ Feature: chat/mentions
 
   Scenario: mention a participant with access to the file but not joined in a file room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" gets the room for path "welcome.txt" with 200
     And user "participant1" joins room "file welcome.txt room" with 200
     And user "participant1" is participant of room "file welcome.txt room"
@@ -326,6 +332,7 @@ Feature: chat/mentions
 
   Scenario: get mentions in a room for a file shared by link with no other joined participant
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" by link with OCS 100
     When user "participant1" gets the room for last share with 200
     And user "participant1" joins room "file last share room" with 200
@@ -341,7 +348,9 @@ Feature: chat/mentions
 
   Scenario: get mentions in a room for a file shared by link
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" with user "participant4" with OCS 100
+    And user "participant4" accepts last share
     And user "participant1" shares "welcome.txt" by link with OCS 100
     When user "participant1" gets the room for last share with 200
     And user "participant1" joins room "file last share room" with 200
@@ -393,7 +402,9 @@ Feature: chat/mentions
 
   Scenario: get matched mentions in a room for a file shared by link
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" with user "participant4" with OCS 100
+    And user "participant4" accepts last share
     And user "participant1" shares "welcome.txt" by link with OCS 100
     When user "participant2" gets the room for last share with 200
     And user "participant1" joins room "file last share room" with 200
@@ -438,7 +449,9 @@ Feature: chat/mentions
 
   Scenario: get unmatched mentions in a room for a file shared by link
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" with user "participant4" with OCS 100
+    And user "participant4" accepts last share
     And user "participant1" shares "welcome.txt" by link with OCS 100
     When user "participant2" gets the room for last share with 200
     And user "participant1" joins room "file last share room" with 200
@@ -464,6 +477,7 @@ Feature: chat/mentions
 
   Scenario: get mentions in a room for a file shared by link with a participant without access to the file and not joined
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" by link with OCS 100
     When user "participant2" gets the room for last share with 200
     And user "participant1" joins room "file last share room" with 200
@@ -475,6 +489,7 @@ Feature: chat/mentions
 
   Scenario: mention a participant with access to the file but not joined in a room for a file shared by link
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" by link with OCS 100
     And user "participant1" gets the room for last share with 200
     And user "participant1" joins room "file last share room" with 200
@@ -485,6 +500,7 @@ Feature: chat/mentions
 
   Scenario: mention a participant with access to the file but not joined by self-joined user and guest in a room for a file shared by link
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" by link with OCS 100
     # Users without access to a file shared by link need to log in (so further
     # requests keep the same session) and get the room (so the share token is
@@ -503,6 +519,7 @@ Feature: chat/mentions
 
   Scenario: mention a participant without access to the file but joined in a room for a file shared by link
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" by link with OCS 100
     And user "participant1" gets the room for last share with 200
     And user "participant1" joins room "file last share room" with 200

--- a/tests/integration/features/chat/system-messages.feature
+++ b/tests/integration/features/chat/system-messages.feature
@@ -104,6 +104,7 @@ Feature: System messages
 
   Scenario: Joining room for file
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" gets the room for path "welcome.txt" with 200
     When user "participant1" joins room "file welcome.txt room" with 200
     And user "participant2" joins room "file welcome.txt room" with 200

--- a/tests/integration/features/conversation/files.feature
+++ b/tests/integration/features/conversation/files.feature
@@ -17,6 +17,7 @@ Feature: conversation/files
 
   Scenario: get room for file shared with user
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     When user "participant1" gets the room for path "welcome.txt" with 200
     And user "participant2" gets the room for path "welcome (2).txt" with 200
     Then user "participant1" is not participant of room "file welcome (2).txt room"
@@ -25,6 +26,7 @@ Feature: conversation/files
   Scenario: get room for folder shared with user
     Given user "participant1" creates folder "/test"
     And user "participant1" shares "test" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     When user "participant1" gets the room for path "test" with 404
     And user "participant2" gets the room for path "test" with 404
 
@@ -32,6 +34,7 @@ Feature: conversation/files
     Given user "participant1" creates folder "/test"
     And user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
     And user "participant1" shares "test" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     When user "participant1" gets the room for path "test/renamed.txt" with 200
     And user "participant2" gets the room for path "test/renamed.txt" with 200
     Then user "participant1" is not participant of room "file test/renamed.txt room"
@@ -41,7 +44,9 @@ Feature: conversation/files
     Given user "participant1" creates folder "/test"
     And user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
     And user "participant1" shares "test" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" shares "test" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     When user "participant1" gets the room for path "test/renamed.txt" with 200
     And user "participant2" gets the room for path "test/renamed.txt" with 200
     And user "participant3" gets the room for path "test/renamed.txt" with 200
@@ -51,6 +56,7 @@ Feature: conversation/files
 
   Scenario: get room for file no longer shared
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" deletes last share
     When user "participant1" gets the room for path "welcome.txt" with 404
 
@@ -58,6 +64,7 @@ Feature: conversation/files
 
   Scenario: get room for file shared with group
     Given user "participant1" shares "welcome.txt" with group "group1" with OCS 100
+    And user "participant2" accepts last share
     When user "participant1" gets the room for path "welcome.txt" with 200
     And user "participant2" gets the room for path "welcome (2).txt" with 200
     Then user "participant1" is not participant of room "file welcome (2).txt room"
@@ -65,7 +72,9 @@ Feature: conversation/files
 
   Scenario: get room for file shared with user and group
     Given user "participant1" shares "welcome.txt" with group "group1" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     When user "participant1" gets the room for path "welcome.txt" with 200
     And user "participant2" gets the room for path "welcome (2).txt" with 200
     And user "participant3" gets the room for path "welcome (2).txt" with 200
@@ -77,6 +86,7 @@ Feature: conversation/files
 
   Scenario: get room for link share
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" by link with OCS 100
     When user "participant1" gets the room for last share with 200
     And user "participant2" gets the room for last share with 200
@@ -89,6 +99,7 @@ Feature: conversation/files
 
   Scenario: get room for link share protected by password
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" by link with OCS 100
       | password | 123456 |
     When user "participant1" gets the room for last share with 404
@@ -105,6 +116,7 @@ Feature: conversation/files
 
   Scenario: get room for link no longer shared
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" by link with OCS 100
     And user "participant1" deletes last share
     When user "participant1" gets the room for last share with 404
@@ -139,6 +151,7 @@ Feature: conversation/files
     And user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
     And user "participant1" shares "test" by link with OCS 100
     And user "participant1" shares "test" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     When user "participant1" gets the room for path "test/renamed.txt" with 200
     And user "participant2" gets the room for path "test/renamed.txt" with 200
     Then user "participant1" is not participant of room "file test/renamed.txt room"
@@ -147,6 +160,7 @@ Feature: conversation/files
   Scenario: get room for file shared with user and by link
     Given user "participant1" shares "welcome.txt" by link with OCS 100
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     When user "participant1" gets the room for path "welcome.txt" with 200
     And user "participant2" gets the room for path "welcome (2).txt" with 200
     Then user "participant1" is not participant of room "file welcome (2).txt room"
@@ -154,6 +168,7 @@ Feature: conversation/files
 
   Scenario: get room for last link share also shared with user
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" by link with OCS 100
     When user "participant1" gets the room for last share with 200
     And user "participant2" gets the room for last share with 200
@@ -164,12 +179,14 @@ Feature: conversation/files
 
   Scenario: owner of a shared file can join its room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" gets the room for path "welcome (2).txt" with 200
     When user "participant1" joins room "file welcome (2).txt room" with 200
     Then user "participant1" is participant of room "file welcome (2).txt room"
 
   Scenario: user with access to a file can join its room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" gets the room for path "welcome.txt" with 200
     When user "participant2" joins room "file welcome.txt room" with 200
     Then user "participant2" is participant of room "file welcome.txt room"
@@ -178,6 +195,7 @@ Feature: conversation/files
     Given user "participant1" creates folder "/test"
     And user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
     And user "participant1" shares "test" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" gets the room for path "test/renamed.txt" with 200
     When user "participant1" joins room "file test/renamed.txt room" with 200
     Then user "participant1" is participant of room "file test/renamed.txt room"
@@ -186,6 +204,7 @@ Feature: conversation/files
     Given user "participant1" creates folder "/test"
     And user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
     And user "participant1" shares "test" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" gets the room for path "test/renamed.txt" with 200
     When user "participant2" joins room "file test/renamed.txt room" with 200
     Then user "participant2" is participant of room "file test/renamed.txt room"
@@ -194,13 +213,16 @@ Feature: conversation/files
     Given user "participant1" creates folder "/test"
     And user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
     And user "participant1" shares "test" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" shares "test" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     And user "participant3" gets the room for path "test/renamed.txt" with 200
     When user "participant3" joins room "file test/renamed.txt room" with 200
     Then user "participant3" is participant of room "file test/renamed.txt room"
 
   Scenario: owner of a no longer shared file can not join its room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" gets the room for path "welcome (2).txt" with 200
     And user "participant1" deletes last share
     When user "participant1" joins room "file welcome (2).txt room" with 404
@@ -208,7 +230,9 @@ Feature: conversation/files
 
   Scenario: user no longer with access to a file can not join its room
     Given user "participant1" shares "welcome.txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" gets the room for path "welcome.txt" with 200
     And user "participant1" deletes last share
     When user "participant2" joins room "file welcome.txt room" with 404
@@ -216,12 +240,14 @@ Feature: conversation/files
 
   Scenario: user without access to a file can not join its room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" gets the room for path "welcome.txt" with 200
     When user "participant3" joins room "file welcome.txt room" with 404
     Then user "participant3" is not participant of room "file welcome.txt room"
 
   Scenario: guest can not join a file room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" gets the room for path "welcome.txt" with 200
     When user "guest" joins room "file welcome.txt room" with 404
 
@@ -229,6 +255,7 @@ Feature: conversation/files
 
   Scenario: join room for file shared with group
     Given user "participant1" shares "welcome.txt" with group "group1" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" gets the room for path "welcome.txt" with 200
     And user "participant2" gets the room for path "welcome (2).txt" with 200
     When user "participant1" joins room "file welcome.txt room" with 200
@@ -238,7 +265,9 @@ Feature: conversation/files
 
   Scenario: join room for file shared with user and group
     Given user "participant1" shares "welcome.txt" with group "group1" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     And user "participant1" gets the room for path "welcome.txt" with 200
     And user "participant2" gets the room for path "welcome (2).txt" with 200
     And user "participant3" gets the room for path "welcome (2).txt" with 200
@@ -259,6 +288,7 @@ Feature: conversation/files
 
   Scenario: user with access to a file shared by link can join its room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" by link with OCS 100
     And user "participant2" gets the room for last share with 200
     When user "participant2" joins room "file last share room" with 200
@@ -284,6 +314,7 @@ Feature: conversation/files
 
   Scenario: owner of a shared file is not removed from its room after leaving it
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     # Note that the room token is got by a different user than the one that
     # joins the room
     And user "participant2" gets the room for path "welcome (2).txt" with 200
@@ -294,6 +325,7 @@ Feature: conversation/files
 
   Scenario: user with access to a file is not removed from its room after leaving it
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     # Note that the room token is got by a different user than the one that
     # joins the room
     And user "participant1" gets the room for path "welcome.txt" with 200
@@ -314,6 +346,7 @@ Feature: conversation/files
 
   Scenario: user with access to a file shared by link is not removed from its room after leaving it
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" by link with OCS 100
     And user "participant2" gets the room for last share with 200
     And user "participant2" joins room "file last share room" with 200
@@ -345,6 +378,7 @@ Feature: conversation/files
 
   Scenario: owner of a shared file can join its room again after removing self from it
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     # Note that the room token is got by a different user than the one that
     # joins the room
     And user "participant2" gets the room for path "welcome (2).txt" with 200
@@ -357,6 +391,7 @@ Feature: conversation/files
 
   Scenario: user with access to a file can join its room again after removing self from it
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     # Note that the room token is got by a different user than the one that
     # joins the room
     And user "participant1" gets the room for path "welcome.txt" with 200
@@ -381,6 +416,7 @@ Feature: conversation/files
 
   Scenario: user with access to a file shared by link can join its room again after removing self from it
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" by link with OCS 100
     And user "participant2" gets the room for last share with 200
     And user "participant2" joins room "file last share room" with 200
@@ -413,6 +449,7 @@ Feature: conversation/files
 
   Scenario: owner is not participant of room for file no longer shared
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" gets the room for path "welcome.txt" with 200
     And user "participant1" joins room "file welcome.txt room" with 200
     And user "participant1" leaves room "file welcome.txt room" with 200
@@ -424,6 +461,7 @@ Feature: conversation/files
 
   Scenario: user is not participant of room for file no longer with access to it
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" gets the room for path "welcome (2).txt" with 200
     And user "participant2" joins room "file welcome (2).txt room" with 200
     And user "participant2" leaves room "file welcome (2).txt room" with 200
@@ -448,6 +486,7 @@ Feature: conversation/files
 
   Scenario: user is participant of room for file no longer shared by link but with access to it
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" by link with OCS 100
     And user "participant2" gets the room for last share with 200
     And user "participant2" joins room "file last share room" with 200

--- a/tests/integration/features/conversation/lobby.feature
+++ b/tests/integration/features/conversation/lobby.feature
@@ -55,6 +55,7 @@ Feature: conversation/lobby
 
   Scenario: set lobby state in file room
     Given user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" gets the room for path "welcome.txt" with 200
     And user "participant2" gets the room for path "welcome (2).txt" with 200
     And user "participant1" joins room "file welcome.txt room" with 200

--- a/tests/integration/features/sharing/create.feature
+++ b/tests/integration/features/sharing/create.feature
@@ -325,6 +325,7 @@ Feature: create
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
     And user "participant2" shares "welcome.txt" with user "participant1" with OCS 100
+    And user "participant1" accepts last share
     When user "participant1" shares "welcome (2).txt" with room "group room"
     Then share is returned with
       | uid_owner              | participant1 |
@@ -372,6 +373,7 @@ Feature: create
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
     And user "participant2" shares "welcome.txt" with user "participant1" with OCS 100
+    And user "participant1" accepts last share
     When user "participant1" shares "welcome (2).txt" with room "group room"
     Then share is returned with
       | uid_owner              | participant1 |
@@ -424,6 +426,7 @@ Feature: create
       | permissions            | 1 |
       | share_type             | 0 |
       | mail_send              | 1 |
+    And user "participant1" accepts last share
     When user "participant1" shares "welcome (2).txt" with room "group room"
     Then the OCS status code should be "404"
     And the HTTP status code should be "200"
@@ -767,6 +770,7 @@ Feature: create
     And user "participant1" renames room "group room" to "Group room" with 200
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     When user "participant1" shares "welcome.txt" with room "group room"
     Then share is returned with
       | uid_owner              | participant1 |

--- a/tests/integration/features/sharing/delete.feature
+++ b/tests/integration/features/sharing/delete.feature
@@ -221,6 +221,7 @@ Feature: delete
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     When user "participant1" deletes last share
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -243,6 +244,7 @@ Feature: delete
       | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     When user "participant1" deletes last share
     Then the OCS status code should be "100"
@@ -309,6 +311,7 @@ Feature: delete
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     When user "participant2" deletes last share
     Then the OCS status code should be "100"

--- a/tests/integration/features/sharing/get.feature
+++ b/tests/integration/features/sharing/get.feature
@@ -187,6 +187,7 @@ Feature: get
     And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
     And user "participant1" shares "test" with room "own one-to-one room" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     And user "participant3" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
     And user "participant1" creates folder "/deleted"
     And user "participant1" shares "deleted" with room "group room invited to" with OCS 100
@@ -258,10 +259,12 @@ Feature: get
     And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
     And user "participant1" shares "test" with room "own one-to-one room" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     And user "participant3" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
     And user "participant1" creates folder "/deleted"
     And user "participant1" shares "deleted" with room "group room invited to" with OCS 100
     And user "participant2" shares "deleted" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     And user "participant1" deletes file "deleted"
     When user "participant1" gets all shares and reshares
     Then the list of returned shares has 6 shares
@@ -338,6 +341,7 @@ Feature: get
       | roomType | 1 |
       | invite   | participant3 |
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
     When user "participant1" gets all shares and reshares
     Then the list of returned shares has 2 shares
@@ -372,6 +376,7 @@ Feature: get
       | roomType | 1 |
       | invite   | participant3 |
     And user "participant1" shares "welcome.txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     And user "participant3" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
     When user "participant1" gets all shares and reshares
     Then the list of returned shares has 2 shares
@@ -423,6 +428,7 @@ Feature: get
     And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
     And user "participant1" shares "test" with room "own one-to-one room" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     And user "participant3" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
     When user "participant1" gets all shares for "/welcome.txt"
     Then the list of returned shares has 2 shares
@@ -469,6 +475,7 @@ Feature: get
     And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
     And user "participant1" shares "test" with room "own one-to-one room" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     And user "participant3" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
     And user "participant1" deletes file "welcome.txt"
     When user "participant1" gets all shares for "/welcome.txt"
@@ -497,6 +504,7 @@ Feature: get
     And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
     And user "participant1" shares "test" with room "own one-to-one room" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     And user "participant3" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
     When user "participant1" gets all shares and reshares for "/welcome.txt"
     Then the list of returned shares has 4 shares
@@ -551,6 +559,7 @@ Feature: get
       | roomType | 1 |
       | invite   | participant3 |
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
     When user "participant1" gets all shares and reshares for "/welcome.txt"
     Then the list of returned shares has 2 shares
@@ -585,6 +594,7 @@ Feature: get
       | roomType | 1 |
       | invite   | participant3 |
     And user "participant1" shares "welcome.txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     And user "participant3" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
     When user "participant1" gets all shares and reshares for "/welcome.txt"
     Then the list of returned shares has 2 shares
@@ -620,6 +630,7 @@ Feature: get
       | roomName | room |
     And user "participant2" renames room "group room not invited to" to "Group room not invited to" with 200
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" shares "welcome (2).txt" with room "group room not invited to" with OCS 100
     When user "participant1" gets all shares and reshares for "/welcome.txt"
     Then the list of returned shares has 2 shares
@@ -655,6 +666,7 @@ Feature: get
       | roomName | room |
     And user "participant2" renames room "public room not invited to" to "Public room not invited to" with 200
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" shares "welcome (2).txt" with room "public room not invited to" with OCS 100
     When user "participant1" gets all shares and reshares for "/welcome.txt"
     Then the list of returned shares has 2 shares
@@ -691,6 +703,7 @@ Feature: get
       | roomName | room |
     And user "participant2" renames room "public room invited to" to "Public room invited to" with 200
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" shares "welcome (2).txt" with room "public room invited to" with OCS 100
     And user "participant2" adds "participant1" to room "public room invited to" with 200
     When user "participant1" gets all shares and reshares for "/welcome.txt"
@@ -728,6 +741,7 @@ Feature: get
       | roomName | room |
     And user "participant2" renames room "public room self-joined to" to "Public room self-joined to" with 200
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" shares "welcome (2).txt" with room "public room self-joined to" with OCS 100
     And user "participant1" joins room "public room self-joined to" with 200
     When user "participant1" gets all shares and reshares for "/welcome.txt"
@@ -781,6 +795,7 @@ Feature: get
     And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
     And user "participant1" shares "test" with room "own one-to-one room" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     And user "participant3" shares "welcome (2).txt" with room "one-to-one room not invited to" with OCS 100
     And user "participant1" deletes file "welcome.txt"
     When user "participant1" gets all shares and reshares for "/welcome.txt"
@@ -814,6 +829,7 @@ Feature: get
     And user "participant1" shares "test2" with room "own one-to-one room" with OCS 100
     And user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
     And user "participant2" shares "subfolder" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     And user "participant3" shares "subfolder" with room "one-to-one room not invited to" with OCS 100
     # Only direct children are taken into account
     When user "participant1" gets all shares for "/test" and its subfiles
@@ -905,6 +921,7 @@ Feature: get
     And user "participant1" shares "test2" with room "own one-to-one room" with OCS 100
     And user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
     And user "participant2" shares "subfolder" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     And user "participant3" shares "subfolder" with room "one-to-one room not invited to" with OCS 100
     And user "participant1" deletes file "test"
     When user "participant1" gets all shares for "/test" and its subfiles
@@ -1145,6 +1162,7 @@ Feature: get
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     When user "participant1" gets the share-type DAV property for "/welcome.txt"
     Then the response contains a share-types DAV property with
       | 10 |
@@ -1158,6 +1176,7 @@ Feature: get
       | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" shares "welcome (2).txt" with room "group room" with OCS 100
     When user "participant1" gets the share-type DAV property for "/welcome.txt"
     Then the response contains a share-types DAV property with
@@ -1173,6 +1192,7 @@ Feature: get
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     When user "participant2" gets the share-type DAV property for "/welcome (2).txt"
     Then the response contains a share-types DAV property with
       | 0 |
@@ -1186,6 +1206,7 @@ Feature: get
       | roomName | room |
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" shares "welcome (2).txt" with room "group room" with OCS 100
     When user "participant2" gets the share-type DAV property for "/welcome (2).txt"
     Then the response contains a share-types DAV property with
@@ -1199,6 +1220,7 @@ Feature: get
       | roomName | room |
     And user "participant1" creates folder "/test"
     And user "participant1" shares "/test" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" shares "/test" with room "group room" with OCS 100
     When user "participant1" gets the share-type DAV property for "/test"
     Then the response contains a share-types DAV property with
@@ -1211,6 +1233,7 @@ Feature: get
     And user "participant1" creates folder "/test"
     And user "participant1" moves file "/welcome.txt" to "/test/renamed.txt" with 201
     And user "participant1" shares "/test/renamed.txt" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" shares "renamed.txt" with room "group room" with OCS 100
     When user "participant1" gets the share-type DAV property for "/test"
     Then the response contains a share-types DAV property with
@@ -1224,6 +1247,7 @@ Feature: get
     And user "participant1" creates folder "/test"
     And user "participant1" creates folder "/test/subfolder"
     And user "participant1" shares "/test/subfolder" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant2" shares "subfolder" with room "group room" with OCS 100
     When user "participant1" gets the share-type DAV property for "/test"
     Then the response contains a share-types DAV property with
@@ -1308,6 +1332,7 @@ Feature: get
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant1" shares "test/subfolder" with room "group room" with OCS 100
     And user "participant1" shares "test/subfolder" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     When user "participant1" gets recent files
     Then the response contains a share-types file property for "/welcome.txt" with
       | 10 |

--- a/tests/integration/features/sharing/hooks.feature
+++ b/tests/integration/features/sharing/hooks.feature
@@ -188,6 +188,7 @@ Feature: hooks
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant2" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant1" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     When user "participant1" removes "participant2" from room "group room" with 200
     Then user "participant1" gets last share
     And the OCS status code should be "404"
@@ -408,6 +409,7 @@ Feature: hooks
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     When user "participant1" removes "participant2" from room "group room" with 200
     Then user "participant1" gets last share
     And share is returned with
@@ -492,6 +494,7 @@ Feature: hooks
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant2" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant1" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     And user "participant1" removes "participant2" from room "group room" with 200
     When user "participant1" adds "participant2" to room "group room" with 200
     Then user "participant1" gets last share
@@ -677,6 +680,7 @@ Feature: hooks
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     And user "participant1" removes "participant2" from room "group room" with 200
     When user "participant1" adds "participant2" to room "group room" with 200
     Then user "participant1" gets last share
@@ -785,6 +789,7 @@ Feature: hooks
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     When user "participant1" deletes room "group room" with 200
     Then user "participant1" gets all shares
     And the list of returned shares has 0 shares
@@ -816,6 +821,7 @@ Feature: hooks
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant2" moves file "welcome (2).txt" to "renamed.txt"
     And user "participant2" shares "renamed.txt" with user "participant3" with OCS 100
+    And user "participant3" accepts last share
     When user "participant1" deletes room "group room" with 200
     Then user "participant1" gets all shares
     And the list of returned shares has 0 shares
@@ -990,6 +996,7 @@ Feature: hooks
     And user "participant1" adds "participant3" to room "group room invited to" with 200
     And user "participant1" shares "welcome.txt" with room "group room invited to" with OCS 100
     And user "participant2" shares "welcome (2).txt" with user "participant4" with OCS 100
+    And user "participant4" accepts last share
     When user "participant2" is deleted
     Then user "participant1" gets last share
     And share is returned with

--- a/tests/integration/features/sharing/move.feature
+++ b/tests/integration/features/sharing/move.feature
@@ -265,6 +265,7 @@ Feature: move
     And user "participant1" adds "participant3" to room "group room" with 200
     And user "participant3" creates folder "/test"
     And user "participant3" shares "/test" with user "participant2" with OCS 100
+    And user "participant2" accepts last share
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     When user "participant3" moves file "/welcome (2).txt" to "/test/renamed.txt"
     Then the HTTP status code should be "403"

--- a/tests/integration/features/sharing/transfer-ownership.feature
+++ b/tests/integration/features/sharing/transfer-ownership.feature
@@ -56,6 +56,7 @@ Feature: transfer-ownership
     And user "participant1" adds "participant2" to room "group room" with 200
     And user "participant1" adds "participant3" to room "group room" with 200
     And user "participant3" shares "welcome.txt" with user "participant1" with OCS 100
+    And user "participant1" accepts last share
     And user "participant1" shares "welcome (2).txt" with room "group room" with OCS 100
     When transfering ownership from "participant1" to "participant2"
     Then user "participant1" gets last share


### PR DESCRIPTION
* User and group shares are not accepted before assuming they work
* The accept state was not set on the object after loading a share from the database