### PR TITLE
Bump default Docker image used in helper script to run integration tests

### DIFF
--- a/tests/integration/run-docker.sh
+++ b/tests/integration/run-docker.sh
@@ -215,7 +215,7 @@ cd "$(dirname $0)"
 
 # "--image XXX" option can be provided to set the Docker image to use to run
 # the integration tests (one of the "nextcloudci/phpX.Y:phpX.Y-Z" images).
-NEXTCLOUD_LOCAL_IMAGE="nextcloudci/php7.1:php7.1-15"
+NEXTCLOUD_LOCAL_IMAGE="nextcloudci/php7.3:php7.3-5"
 if [ "$1" = "--image" ]; then
 	NEXTCLOUD_LOCAL_IMAGE=$2
 


### PR DESCRIPTION
Support for PHP 7.1 was dropped in server.
