### PR TITLE
Stop the chat from going crazy when it is mounted a second time in th…

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -152,6 +152,10 @@ export default {
 		})
 	},
 
+	beforeDestroy() {
+		this.cancelLookForNewMessages()
+	},
+
 	beforeUpdate() {
 		/**
 		 * If the component is not initiated, scroll to the bottom of the message list.


### PR DESCRIPTION
…e sidebar

1. Open a conversation
2. Write something in the chat
3. Press "Start call" so the chat is moved to the sidebar
4. 2 long polling requests will now go crazy and kill your browser

I think there should be more changes?
`this.isInitiated` should be determinated by the storage, not the view. currently each time the chat is toggled between main view and sidebar, a lookIntoFuture=0 (get history) request is done. This is not necessary. We loaded the history already. We should just start long polling again, or do I get this wrong @ma12-co 