### PR TITLE
Fix guests joining a call

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -856,7 +856,9 @@ Signaling.Standalone.prototype.joinRoom = function(token /*, password */) {
 		// callback, leading to two entries for anonymous participants.
 		console.log('Not connected to signaling server yet, defer joining room', token)
 		this.currentRoomToken = token
-		return
+		return new Promise((resolve, reject) => {
+			// FIXME ?
+		})
 	}
 
 	return Signaling.Base.prototype.joinRoom.apply(this, arguments)


### PR DESCRIPTION
Guests dont load the participants tab, so they failed on
finding themselves in the participant list to update the call flags.
Now they add themselves on loading the conversation.

Fix #2555 