### PR TITLE
add to Flow category

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -34,6 +34,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	<category>multimedia</category>
 	<category>social</category>
+	<category>workflow</category>
 
 	<website>https://github.com/nextcloud/spreed</website>
 	<bugs>https://github.com/nextcloud/spreed/issues</bugs>


### PR DESCRIPTION
since #2487  is merged, Talk should also be enlisted in the new [Flow category](https://apps.nextcloud.com/categories/workflow) on the appstore.