### PR TITLE
Fix using signaling before its settings are fetched

### DIFF
--- a/src/services/callsService.js
+++ b/src/services/callsService.js
@@ -22,7 +22,7 @@
 
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
-import { joinCall as webRtcJoinCall, signaling } from '../utils/webrtc/index'
+import { joinCall as webRtcJoinCall, getSignaling } from '../utils/webrtc/index'
 
 /**
  * Join a call as participant
@@ -44,6 +44,8 @@ const joinCall = async function(token, flags) {
  */
 const leaveCall = async function(token) {
 	try {
+		const signaling = await getSignaling()
+
 		await signaling.leaveCurrentCall()
 	} catch (error) {
 		console.debug('Error while leaving call: ', error)

--- a/src/services/participantsService.js
+++ b/src/services/participantsService.js
@@ -22,7 +22,7 @@
 
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
-import { signaling } from '../utils/webrtc/index'
+import { getSignaling } from '../utils/webrtc/index'
 import { EventBus } from '../services/EventBus'
 
 /**
@@ -33,6 +33,8 @@ import { EventBus } from '../services/EventBus'
  */
 const joinConversation = async(token) => {
 	try {
+		const signaling = await getSignaling()
+
 		signaling.joinRoom(token).then(() => {
 			EventBus.$emit('joinedConversation')
 		})
@@ -52,6 +54,8 @@ const joinConversation = async(token) => {
  */
 const leaveConversation = async function(token) {
 	try {
+		const signaling = await getSignaling()
+
 		signaling.leaveRoom(token)
 		// FIXME Signaling should not handle leaving a conversation
 		// const response = await axios.delete(generateOcsUrl('apps/spreed/api/v1', 2) + `room/${token}/participants/active`)


### PR DESCRIPTION
The signaling object is created after the signaling settings are fetched. As the settings are fetched as soon as the application starts it was assumed that the signaling object was always available when it was going to be used, but that may not be the case if the request to fetch the settings take longer than expected.

Now the signaling object is guarded behind an async function that returns it if it is available or fetches the settings and then returns the object once available. Also, if a new signaling object is tried to be created while the settings are being fetched it will also wait until the first request succeeded and return the same object in all cases.

## How to test
- Add `sleep(5);` before [returning the signaling settings from the server](https://github.com/nextcloud/spreed/blob/81db771748c2a35c0d953d608c9996a3cdf02102/lib/Controller/SignalingController.php#L104)
- Open a conversation as a user
- Refresh the page so the same conversation is loaded again

### Result with this pull request
The chat messages are eventually loaded.

### Result without this pull request
The chat messages are never loaded. In the browser console there is an error about signaling being null.
