### PR TITLE
Disable tooltip and menu in the participant component

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -30,7 +30,9 @@
 		<div class="participant-row__avatar-wrapper">
 			<Avatar
 				:user="computedId"
-				:display-name="computedName" />
+				:display-name="computedName"
+				:disableMenu="true"
+				:disableTooltip="true" />
 		</div>
 
 		<span class="participant-row__user-name">{{ computedName }}</span>


### PR DESCRIPTION
 fix #2575

No need for a menu or tooltip in the `Participant` component's avatar.

Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>