### PR TITLE
Fix chat view in right sidebar

### DIFF
--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -1,0 +1,59 @@
+<!--
+  - @copyright Copyright (c) 2019, Daniel Calviño Sánchez (danxuliu@gmail.com)
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<div class="chatView">
+		<MessagesList :token="token" />
+		<NewMessageForm />
+	</div>
+</template>
+
+<script>
+import MessagesList from './MessagesList/MessagesList'
+import NewMessageForm from './NewMessageForm/NewMessageForm'
+
+export default {
+
+	name: 'ChatView',
+
+	components: {
+		MessagesList,
+		NewMessageForm,
+	},
+
+	props: {
+		token: {
+			type: String,
+			required: true,
+		},
+	},
+
+}
+</script>
+
+<style lang="scss" scoped>
+.chatView {
+	height: 100%;
+
+	display: flex;
+	flex-direction: column;
+	flex-grow: 1;
+}
+</style>

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -190,6 +190,11 @@ export default {
 	}
 }
 
+.app-sidebar-tabs__content #tab-chat {
+	/* Remove padding to maximize the space for the chat view. */
+	padding: 0;
+}
+
 /** TODO: fix these in the nextcloud-vue library **/
 
 ::v-deep .app-sidebar-header__menu {

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -49,10 +49,7 @@
 			:order="1"
 			:name="t('spreed', 'Chat')"
 			icon="icon-comment">
-			<template v-if="showChatInSidebar">
-				<MessagesList :token="token" />
-				<NewMessageForm />
-			</template>
+			<ChatView v-if="showChatInSidebar" :token="token" />
 			<template v-else>
 				This should be hidden, but the visibility of the tab can not change at the moment:
 				https://github.com/nextcloud/nextcloud-vue/issues/747
@@ -81,8 +78,7 @@ import ActionCheckbox from '@nextcloud/vue/dist/Components/ActionCheckbox'
 import ActionText from '@nextcloud/vue/dist/Components/ActionText'
 import AppSidebar from '@nextcloud/vue/dist/Components/AppSidebar'
 import AppSidebarTab from '@nextcloud/vue/dist/Components/AppSidebarTab'
-import MessagesList from '../MessagesList/MessagesList'
-import NewMessageForm from '../NewMessageForm/NewMessageForm'
+import ChatView from '../ChatView'
 import { CollectionList } from 'nextcloud-vue-collections'
 import { CONVERSATION, WEBINAR } from '../../constants'
 import ParticipantsTab from './Participants/ParticipantsTab'
@@ -94,9 +90,8 @@ export default {
 		ActionText,
 		AppSidebar,
 		AppSidebarTab,
+		ChatView,
 		CollectionList,
-		MessagesList,
-		NewMessageForm,
 		ParticipantsTab,
 	},
 

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -177,7 +177,18 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
+
+/* Force scroll bars in tabs content instead of in whole sidebar. */
+::v-deep .app-sidebar-tabs__content {
+	overflow: hidden;
+
+	section {
+		height: 100%;
+
+		overflow-y: auto;
+	}
+}
 
 /** TODO: fix these in the nextcloud-vue library **/
 

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -2,10 +2,7 @@
 	<div class="mainView">
 		<TopBar :force-white-icons="showChatInSidebar" />
 
-		<template v-if="!showChatInSidebar">
-			<MessagesList :token="token" />
-			<NewMessageForm />
-		</template>
+		<ChatView v-if="!showChatInSidebar" :token="token" />
 		<template v-else>
 			<CallView
 				:token="token" />
@@ -15,8 +12,7 @@
 
 <script>
 import CallView from '../components/CallView/CallView'
-import MessagesList from '../components/MessagesList/MessagesList'
-import NewMessageForm from '../components/NewMessageForm/NewMessageForm'
+import ChatView from '../components/ChatView'
 import TopBar from '../components/TopBar/TopBar'
 import { PARTICIPANT } from '../constants'
 
@@ -24,8 +20,7 @@ export default {
 	name: 'MainView',
 	components: {
 		CallView,
-		MessagesList,
-		NewMessageForm,
+		ChatView,
 		TopBar,
 	},
 	props: {

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="chatview">
+	<div class="mainView">
 		<TopBar :force-white-icons="showChatInSidebar" />
 
 		<template v-if="!showChatInSidebar">
@@ -92,7 +92,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.chatview {
+.mainView {
 	height: 100%;
 	display: flex;
 	flex-grow: 1;


### PR DESCRIPTION
When a call was started and the chat view was moved to the right sidebar the chat view did not fill the available space.

Besides that, for consistency with how the scroll bar behave in the chat view (it is shown for the message list only instead of for the whole sidebar, as otherwise it would be cumbersome to use) now all the tab contents show their own scroll bar if needed (instead of using a scroll bar for the whole sidebar).
