### PR TITLE
Replace "overflow: scroll;" with "overflow: auto;"

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -204,7 +204,7 @@ export default {
 		&__input {
 			flex-grow: 1;
 			max-height: $message-form-max-height;
-			overflow-y: scroll;
+			overflow-y: auto;
 			overflow-x: hidden;
 			max-width: $message-max-width;
 		}

--- a/src/components/RightSidebar/Participants/ParticipantsList/ParticipantsList.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/ParticipantsList.vue
@@ -182,7 +182,7 @@ export default {
 
 <style lang="scss" scoped>
 .scrollable {
-	overflow-y: scroll;
+	overflow-y: auto;
 	overflow-x: hidden;
 }
 

--- a/src/views/RoomSelector.vue
+++ b/src/views/RoomSelector.vue
@@ -63,7 +63,7 @@
 		padding: 20px;
 	}
 	#room-list {
-		overflow-y: scroll;
+		overflow-y: auto;
 		flex: 0 1 auto;
 	}
 	li {


### PR DESCRIPTION
`overflow: scroll;` always* shows the scroll bars, even if they are not needed; if the scroll bars should be shown only when needed `overflow: auto;` should be used instead.

*In newer browsers `overflow: scroll;` behaves like `overflow: auto;`, so this change makes no difference in those cases, but older browsers respect the [expected behaviour](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Values).
