### PR TITLE
Fix "isReplyable" not set for temporary messages

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -107,6 +107,7 @@ export default {
 				message: this.text,
 				messageParameters: {},
 				token: this.token,
+				isReplyable: false,
 			})
 			/**
 			 * If the current message is a quote-reply messag, add the parent key to the

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -94,8 +94,6 @@ export default {
 		 * @returns {Object}
 		 */
 		createTemporaryMessage() {
-			console.error(this.text)
-
 			const message = Object.assign({}, {
 				id: this.createTemporaryMessageId(),
 				actorId: this.$store.getters.getActorId(),


### PR DESCRIPTION
## How to test
- Open a conversation
- Open the browser console
- Send a new message

### Result with this pull request
No errors are shown.

### Result without this pull request
`Missing required prop: "isReplyable"` error is shown.
