### PR TITLE
Add chat tab to sidebar in Files app

### DIFF
--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -24,6 +24,17 @@
 			<div class="icon icon-talk" />
 			<h2>Conversations are not available for folders</h2>
 		</div>
+		<div v-else-if="isTalkSidebarSupportedForFile === undefined" class="emptycontent ui-not-ready-placeholder">
+			<div class="icon icon-loading" />
+		</div>
+		<div v-else-if="!isTalkSidebarSupportedForFile" class="emptycontent file-not-shared">
+			<div class="icon icon-talk" />
+			<h2>{{ t('spreed', 'Discuss this file') }}</h2>
+			<p>{{ t('spreed', 'Share this file with others to discuss it') }}</p>
+			<button class="primary" @click="openSharingTab">
+				{{ t('spreed', 'Share this file') }}
+			</button>
+		</div>
 		<p v-else>
 			Talk tab coming soon
 		</p>
@@ -48,6 +59,7 @@ export default {
 			 * Stores the cancel function returned by `cancelableLookForNewMessages`,
 			 */
 			cancelGetFileConversation: () => {},
+			isTalkSidebarSupportedForFile: undefined,
 		}
 	},
 
@@ -60,6 +72,15 @@ export default {
 		},
 		token() {
 			return this.$store.getters.getToken()
+		},
+	},
+
+	watch: {
+		fileInfo: {
+			immediate: true,
+			handler(fileInfo) {
+				this.setTalkSidebarSupportedForFile(fileInfo)
+			},
 		},
 	},
 
@@ -82,6 +103,90 @@ export default {
 					console.debug(exception)
 				}
 			}
+		},
+
+		/**
+		 * Sets whether the Talk sidebar is supported for the file or not.
+		 *
+		 * In some cases it is not possible to know if the Talk sidebar is
+		 * supported for the file or not just from the data in the FileInfo (for
+		 * example, for files in a folder shared by the current user). Due to
+		 * that this function is asynchronous; isTalkSidebarSupportedForFile
+		 * will be set as soon as possible (in some cases, immediately) with
+		 * either true or false, depending on whether the Talk sidebar is
+		 * supported for the file or not.
+		 *
+		 * The Talk sidebar is supported for a file if the file is shared with
+		 * the current user or by the current user to another user (as a user,
+		 * group...), or if the file is a descendant of a folder that meets
+		 * those conditions.
+		 *
+		 * @param {OCA.Files.FileInfo} fileInfo the FileInfo to check
+		 */
+		async setTalkSidebarSupportedForFile(fileInfo) {
+			this.isTalkSidebarSupportedForFile = undefined
+
+			if (!fileInfo) {
+				this.isTalkSidebarSupportedForFile = false
+
+				return
+			}
+
+			if (fileInfo.get('type') === 'dir') {
+				this.isTalkSidebarSupportedForFile = false
+
+				return
+			}
+
+			if (fileInfo.get('shareOwnerId')) {
+				// Shared with me
+				// TODO How to check that it is not a remote share? At least for
+				// local shares "shareTypes" is not defined when shared with me.
+				this.isTalkSidebarSupportedForFile = true
+
+				return
+			}
+
+			if (!fileInfo.get('shareTypes')) {
+				// When it is not possible to know whether the Talk sidebar is
+				// supported for a file or not only from the data in the
+				// FileInfo it is necessary to query the server.
+				// FIXME If the file is shared this will create the conversation
+				// if it does not exist yet.
+				this.isTalkSidebarSupportedForFile = (await getFileConversation({ fileId: fileInfo.id })) || false
+
+				return
+			}
+
+			const shareTypes = fileInfo.get('shareTypes').filter(function(shareType) {
+				// Ensure that shareType is an integer (as in the past shareType
+				// could be an integer or a string depending on whether the
+				// Sharing tab was opened or not).
+				shareType = parseInt(shareType)
+				return shareType === OC.Share.SHARE_TYPE_USER
+						|| shareType === OC.Share.SHARE_TYPE_GROUP
+						|| shareType === OC.Share.SHARE_TYPE_CIRCLE
+						|| shareType === OC.Share.SHARE_TYPE_ROOM
+						|| shareType === OC.Share.SHARE_TYPE_LINK
+						|| shareType === OC.Share.SHARE_TYPE_EMAIL
+			})
+
+			if (shareTypes.length === 0) {
+				// When it is not possible to know whether the Talk sidebar is
+				// supported for a file or not only from the data in the
+				// FileInfo it is necessary to query the server.
+				// FIXME If the file is shared this will create the conversation
+				// if it does not exist yet.
+				this.isTalkSidebarSupportedForFile = (await getFileConversation({ fileId: fileInfo.id })) || false
+
+				return
+			}
+
+			this.isTalkSidebarSupportedForFile = true
+		},
+
+		openSharingTab() {
+			OCA.Files.Sidebar.setActiveTab('sharing')
 		},
 	},
 }

--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -42,7 +42,12 @@
 				{{ t('spreed', 'Join conversation') }}
 			</button>
 		</div>
-		<ChatView v-else :token="token" />
+		<template v-else>
+			<button class="call-button primary" :disabled="true">
+				Calls will return soon
+			</button>
+			<ChatView :token="token" />
+		</template>
 	</div>
 </template>
 
@@ -285,5 +290,26 @@ export default {
 <style scoped>
 .talkChatTab {
 	height: 100%;
+
+	display: flex;
+	flex-grow: 1;
+	flex-direction: column;
+}
+
+.call-button {
+	/* Center button horizontally. */
+	margin-left: auto;
+	margin-right: auto;
+
+	margin-top: 10px;
+	margin-bottom: 10px;
+}
+
+.chatView {
+	/* The chat view shares its parent with the call button, so the default
+	* "height: 100%" needs to be unset. */
+	height: unset;
+
+	overflow: hidden;
 }
 </style>

--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -19,7 +19,15 @@
   - along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-	<p>Talk tab coming soon</p>
+	<div class="talkChatTab">
+		<div v-if="fileInfo && fileInfo.isDirectory()" class="emptycontent">
+			<div class="icon icon-talk" />
+			<h2>Conversations are not available for folders</h2>
+		</div>
+		<p v-else>
+			Talk tab coming soon
+		</p>
+	</div>
 </template>
 
 <script>

--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -84,7 +84,7 @@ export default {
 		 * Focuses the contenteditable div input
 		 */
 		focusInput() {
-			if (this.$route.name === 'conversation') {
+			if (this.$route && this.$route.name === 'conversation') {
 				const contentEditable = this.$refs.contentEditable
 				// This is a hack but it's the only way I've found to focus a contenteditable div
 				setTimeout(function() {

--- a/src/services/filesIntegrationServices.js
+++ b/src/services/filesIntegrationServices.js
@@ -1,0 +1,44 @@
+/**
+ * @copyright Copyright (c) 2019 Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @author Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+
+/**
+ * Gets the conversation token for a given file id
+ *
+ * @param {Object} .fileId the id of the file
+ * @param {Object} options unused
+ * @returns {String} the conversation token
+ */
+const getFileConversation = async function({ fileId }, options) {
+	try {
+		const response = await axios.get(generateOcsUrl('apps/spreed/api/v1', 2) + `file/${fileId}`)
+		return response
+	} catch (error) {
+		console.debug('Error while getting the token: ', error)
+	}
+}
+
+export {
+	getFileConversation,
+}

--- a/src/store/tokenStore.js
+++ b/src/store/tokenStore.js
@@ -22,11 +22,15 @@
 
 const state = {
 	token: '',
+	fileIdForToken: null,
 }
 
 const getters = {
 	getToken: (state) => () => {
 		return state.token
+	},
+	getFileIdForToken: (state) => () => {
+		return state.fileIdForToken
 	},
 }
 
@@ -40,6 +44,18 @@ const mutations = {
 	updateToken(state, newToken) {
 		state.token = newToken
 	},
+
+	/**
+	 * Updates the file ID for the current token
+	 *
+	 * @param {object} state current store state
+	 * @param {string} newToken The token of the active conversation
+	 * @param {int} newFileId The file ID of the active conversation
+	 */
+	updateTokenAndFileIdForToken(state, { newToken, newFileId }) {
+		state.token = newToken
+		state.fileIdForToken = newFileId
+	},
 }
 
 const actions = {
@@ -52,6 +68,17 @@ const actions = {
 	 */
 	updateToken(context, newToken) {
 		context.commit('updateToken', newToken)
+	},
+
+	/**
+	 * Updates the file ID for the current token
+	 *
+	 * @param {object} context default store context
+	 * @param {string} newToken The token of the active conversation
+	 * @param {int} newFileId The file ID of the active conversation
+	 */
+	updateTokenAndFileIdForToken(context, { newToken, newFileId }) {
+		context.commit('updateTokenAndFileIdForToken', { newToken, newFileId })
 	},
 }
 

--- a/src/views/FilesSidebarTab.vue
+++ b/src/views/FilesSidebarTab.vue
@@ -96,3 +96,12 @@ export default {
 	},
 }
 </script>
+
+<style scoped>
+#tab-chat {
+	height: 100%;
+
+	/* Remove padding to maximize the space for the chat view. */
+	padding: 0;
+}
+</style>

--- a/src/views/FilesSidebarTab.vue
+++ b/src/views/FilesSidebarTab.vue
@@ -79,13 +79,12 @@ export default {
 	},
 	mounted() {
 		try {
+			OCA.Talk.fileInfo = this.fileInfo
 			this.tab = OCA.Talk.newTab()
 			this.tab.$mount('#talk-tab-mount')
-			OCA.Talk.fileInfo = this.fileInfo
 		} catch (error) {
 			console.error('Unable to mount Chat tab', error)
 		}
-		console.info(this.fileInfo)
 	},
 	beforeDestroy() {
 		try {


### PR DESCRIPTION
Known issues:
- If the chat tab is opened again after a file is shared the button will still be "_Share this file_" instead of "_Join conversation_". It seems that the FileInfo is not properly updated in the server when a file is shared (or unshared). This needs to be further investigated, but it seems to be an issue in the server and not in Talk.
- The chat tab is shown for folders with a "_Conversations are not available for folders_" message (not localized). The tab will not be shown once #2605 is merged, but as it requires a change in server which was not ready for beta 3 that temporary warning is shown for now (to be able to release a Talk version that can be used with beta 3 of server).
- Chat input is not focused after the chat view is shown.
- This only adds the chat tab; calls in the sidebar will be added back in a different pull request.
