### PR TITLE
Fix broken scss file breaking the icon-reply

### DIFF
--- a/css/icons.scss
+++ b/css/icons.scss
@@ -28,7 +28,7 @@
 	.icon-changelog {
 		background-image: url('../img/changelog.svg');
 	}
-	
+
 	.forced-white {
 		&.icon-menu-people {
 			background-image: url(icon-color-path('menu-people', 'spreed', 'fff', 1));
@@ -52,8 +52,9 @@
 			background-image: url(icon-color-path('screen-off', 'actions', 'fff', 1, true));
 		}
 	}
+
+	.icon-favorite {
+		/* Show favorite icon in yellow instead of default black. */
+		@include icon-color('star-dark', 'actions', 'FC0', 1, true);
+	}
 }
-
-
-/* Show favorite icon in yellow instead of default black. */
-@include icon-color('star-dark', 'actions', 'FC0', 1, true);


### PR DESCRIPTION
Setting the background like it was done basically added plain text to the scss breaking everything until the first `}` so the reply icon class did not work.

Fix #2567 