### PR TITLE
Set the correct placeholder avatar

### DIFF
--- a/src/components/CallView/Video.vue
+++ b/src/components/CallView/Video.vue
@@ -31,6 +31,7 @@
 				:disable-menu="true"
 				:disable-tooltip="true"
 				:user="model.attributes.userId"
+				:display-name="model.attributes.name"
 				:class="avatarClass" />
 			<Avatar v-else
 				:size="avatarSize"


### PR DESCRIPTION
Before the connection is established the avatar still shows the `a` for me.
After a connection is established it correctly shows `H`for the displayname now.

Any idea where the first wrong avatar is loaded @danxuliu ?