### PR TITLE
Fix duplicated participants in store when using guest page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -306,19 +306,7 @@ export default {
 			 */
 			const response = await fetchConversation(token)
 			// this.$store.dispatch('purgeConversationsStore')
-			const conversationData = response.data.ocs.data
-			this.$store.dispatch('addConversation', conversationData)
-			this.$store.dispatch('addParticipant', {
-				token,
-				participant: {
-					userId: getCurrentUser() ? getCurrentUser().uid : '', // TODO Does this work for public shares while being logged in, etc?
-					displayName: getCurrentUser() ? getCurrentUser().displayName : '', // TODO guest name from localstore?
-					inCall: conversationData.participantFlags,
-					lastPing: conversationData.lastPing,
-					sessionId: conversationData.sessionId,
-					participantType: conversationData.participantType,
-				},
-			})
+			this.$store.dispatch('addConversation', response.data.ocs.data)
 
 			/**
 			 * Emits a global event that is used in App.vue to update the page title once the

--- a/src/App.vue
+++ b/src/App.vue
@@ -151,6 +151,12 @@ export default {
 	},
 
 	beforeMount() {
+		if (!getCurrentUser()) {
+			EventBus.$once('joinedConversation', () => {
+				this.fixmeDelayedSetupOfGuestUsers()
+			})
+		}
+
 		if (this.$route.name === 'conversation') {
 			// Update current token in the token store
 			this.$store.dispatch('updateToken', this.$route.params.token)
@@ -173,14 +179,6 @@ export default {
 		 */
 		EventBus.$once('conversationsReceived', () => {
 			if (this.$route.name === 'conversation') {
-				if (!getCurrentUser()) {
-					EventBus.$once('joinedConversation', () => {
-						// FIXME Refresh the data now that the user joined the conversation
-						// The join request returns this data already, but it's lost in the signaling code
-						this.fetchSingleConversation(this.token)
-					})
-				}
-
 				// Adjust the page title once the conversation list is loaded
 				this.setPageTitle(this.getConversationName(this.token), false)
 			}
@@ -228,17 +226,14 @@ export default {
 		} else {
 			console.debug('Can not set current user because it\'s a guest')
 		}
-
-		if (this.getUserId === null) {
-			EventBus.$on('signalingConnectionEstablished', () => {
-				this.fixmeDelayedSetupOfGuestUsers()
-			})
-		}
 	},
 
 	methods: {
 		fixmeDelayedSetupOfGuestUsers() {
+			// FIXME Refresh the data now that the user joined the conversation
+			// The join request returns this data already, but it's lost in the signaling code
 			this.fetchSingleConversation(this.token)
+
 			window.setInterval(() => {
 				this.fetchSingleConversation(this.token)
 			}, 30000)

--- a/src/App.vue
+++ b/src/App.vue
@@ -154,6 +154,8 @@ export default {
 		if (this.$route.name === 'conversation') {
 			// Update current token in the token store
 			this.$store.dispatch('updateToken', this.$route.params.token)
+			// Automatically join the conversation as well
+			joinConversation(this.$route.params.token)
 		}
 
 		// FIXME Signaling should be done on conversation level, as the signaling information depends on it.
@@ -181,10 +183,6 @@ export default {
 
 				// Adjust the page title once the conversation list is loaded
 				this.setPageTitle(this.getConversationName(this.token), false)
-				// Update current token in the token store
-				this.$store.dispatch('updateToken', this.token)
-				// Automatically join the conversation as well
-				joinConversation(this.token)
 			}
 
 			if (!getCurrentUser()) {

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -86,8 +86,8 @@ const actions = {
 				lastPing: conversation.lastPing,
 				sessionId: conversation.sessionId,
 				participantType: conversation.participantType,
-				userId: currentUser ? currentUser.uid : '',
-				displayName: currentUser && currentUser.displayName ? currentUser.displayName : '',
+				userId: currentUser ? currentUser.uid : '', // TODO Does this work for public shares while being logged in, etc?
+				displayName: currentUser && currentUser.displayName ? currentUser.displayName : '', // TODO guest name from localstore?
 			},
 		})
 	},

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -132,7 +132,7 @@ const actions = {
 	 * @param {string} token the conversation to add the participant;
 	 * @param {object} participant the participant;
 	 */
-	addParticipantOnce({ commit }, { token, participant }) {
+	addParticipantOnce({ commit, getters }, { token, participant }) {
 		const index = getters.getParticipantIndex(token, participant)
 		if (index === -1) {
 			commit('addParticipant', { token, participant })


### PR DESCRIPTION
This pull request fixes adding the same participant again and again to the store when using the guest page. It also fixes adding again the participant with the previous session as well as the participant with the new session both associated to the current guest when reloading the guest page.

Besides that it cleans up the initialization code of guest pages, as the conversations should be fetched only after the guest has joined the conversation, and not the other way round.
