### PR TITLE
Update Talk action to Nextcloud blue

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -24,7 +24,7 @@ import FlowPostToConversation from './views/FlowPostToConversation'
 
 window.OCA.WorkflowEngine.registerOperator({
 	id: 'OCA\\Talk\\Flow\\Operation',
-	color: 'tomato',
+	color: '#0082c9',
 	operation: '',
 	options: FlowPostToConversation,
 })


### PR DESCRIPTION
As discussed @juliushaertl 

Not tested just quickly changed. Nextcloud Talk should of course have the Nextcloud color (not themed), not a random "tomato" color. ;)