### PR TITLE
Remove bottom border for search result category captions

### DIFF
--- a/src/components/Caption.vue
+++ b/src/components/Caption.vue
@@ -47,7 +47,6 @@ export default {
 		box-shadow: none !important;
 		user-select: none;
 		pointer-events: none;
-		border-bottom: 1px solid var(--color-border-dark);
 		padding-left: 10px;
 
 		&:not(:first-child) {

--- a/src/components/LeftSidebar/ActionCaption/ActionCaption.vue
+++ b/src/components/LeftSidebar/ActionCaption/ActionCaption.vue
@@ -49,7 +49,6 @@ export default {
 		pointer-events: none;
 
 		margin-left: 10px;
-		border-bottom: 1px solid var(--color-border-dark);
 
 		&:not(:first-child) {
 			margin-top: 22px;


### PR DESCRIPTION
Before, the separators actually made it look like the headings belong to the elements _above_ them, which is of course not the case. Simple whitespace separation is enough here, so we can remove the borders. :)

Also looks much more like Nextcloud style, light and not so boxy. Please review @nextcloud/designers-talk 

![search results before](https://user-images.githubusercontent.com/925062/71611752-3cb56680-2bce-11ea-8a50-f3a78d561968.png) ![search results after](https://user-images.githubusercontent.com/925062/71611753-3d4dfd00-2bce-11ea-8f58-9cabf52ba24a.png)
