### PR TITLE
Add again CSS rules for scrolling and padding in right sidebar

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -198,6 +198,21 @@ export default {
 
 <style lang="scss" scoped>
 
+/* Force scroll bars in tabs content instead of in whole sidebar. */
+::v-deep .app-sidebar-tabs__content {
+	overflow: hidden;
+
+	section {
+		height: 100%;
+
+		overflow-y: auto;
+	}
+}
+.app-sidebar-tabs__content #tab-chat {
+	/* Remove padding to maximize the space for the chat view. */
+	padding: 0;
+}
+
 /** TODO: fix these in the nextcloud-vue library **/
 
 ::v-deep .app-sidebar-header {


### PR DESCRIPTION
The CSS rules added in cbad9718ce and 1dc4b61b25 (both from #2608) were mistakenly* removed in 7620c3c279, so they are added again for proper scrolling and padding of the chat view in the right sidebar.

*@ma12-co I assume that it was a mistake made during the rebase, as those rules seem unrelated to the fix of the sidebar title, and as removing them causes the whole right sidebar to be scrolled when the chat is scrolled.
