### PR TITLE
Fix leak of components due to EventBus event handlers

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
@@ -70,20 +70,22 @@ export default {
 			this.fetchConversations()
 		}, 30000)
 
-		EventBus.$on('routeChange', ({ from, to }) => {
+		EventBus.$on('routeChange', this.onRouteChange)
+		EventBus.$on('shouldRefreshConversations', this.fetchConversations)
+	},
+	beforeDestroy() {
+		EventBus.$off('routeChange', this.onRouteChange)
+		EventBus.$off('shouldRefreshConversations', this.fetchConversations)
+	},
+	methods: {
+		onRouteChange({ from, to }) {
 			if (from.name === 'conversation') {
 				leaveConversation(from.params.token)
 			}
 			if (to.name === 'conversation') {
 				joinConversation(to.params.token)
 			}
-		})
-
-		EventBus.$on('shouldRefreshConversations', () => {
-			this.fetchConversations()
-		})
-	},
-	methods: {
+		},
 		sortConversations(conversation1, conversation2) {
 			if (conversation1.isFavorite !== conversation2.isFavorite) {
 				return conversation1.isFavorite ? -1 : 1

--- a/src/components/LeftSidebar/SearchBox/SearchBox.vue
+++ b/src/components/LeftSidebar/SearchBox/SearchBox.vue
@@ -73,9 +73,10 @@ export default {
 		/**
 		 * Listen to routeChange global events and focus on the
 		 */
-		EventBus.$on('routeChange', () => {
-			this.focusInput()
-		})
+		EventBus.$on('routeChange', this.focusInput)
+	},
+	beforeDestroy() {
+		EventBus.$off('routeChange', this.focusInput)
 	},
 	methods: {
 		// Focus the input field of the current componnent.

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -146,12 +146,12 @@ export default {
 		 * Add a listener for when we joined a conversation
 		 * Until then guests can not grab any messages
 		 */
-		EventBus.$on('joinedConversation', () => {
-			this.onRouteChange()
-		})
+		EventBus.$on('joinedConversation', this.onRouteChange)
 	},
 
 	beforeDestroy() {
+		EventBus.$off('joinedConversation', this.onRouteChange)
+
 		this.cancelLookForNewMessages()
 	},
 

--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -75,9 +75,10 @@ export default {
 		/**
 		 * Listen to routeChange global events and focus on the
 		 */
-		EventBus.$on('routeChange', () => {
-			this.focusInput()
-		})
+		EventBus.$on('routeChange', this.focusInput)
+	},
+	beforeDestroy() {
+		EventBus.$off('routeChange', this.focusInput)
 	},
 	methods: {
 		/**

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -153,25 +153,31 @@ export default {
 
 	beforeMount() {
 		this.getParticipants()
-		/**
-		 * If the route changes, the search filter is reset and we get participants again
-		 */
-		EventBus.$on('routeChange', () => {
-			this.searchText = ''
-			this.$nextTick(() => {
-				this.getParticipants()
-			})
-		})
+
+		EventBus.$on('routeChange', this.onRouteChange)
 
 		// FIXME this works only temporary until signaling is fixed to be only on the calls
 		// Then we have to search for another solution. Maybe the room list which we update
 		// periodically gets a hash of all online sessions?
-		EventBus.$on('Signaling::participantListChanged', () => {
-			this.getParticipants()
-		})
+		EventBus.$on('Signaling::participantListChanged', this.getParticipants)
+	},
+
+	beforeDestroy() {
+		EventBus.$off('routeChange', this.onRouteChange)
+		EventBus.$off('Signaling::participantListChanged', this.getParticipants)
 	},
 
 	methods: {
+		/**
+		 * If the route changes, the search filter is reset and we get participants again
+		 */
+		onRouteChange() {
+			this.searchText = ''
+			this.$nextTick(() => {
+				this.getParticipants()
+			})
+		},
+
 		handleClose() {
 			this.$store.dispatch('hideSidebar')
 		},


### PR DESCRIPTION
Several EventBus event handlers were registered in the components, but never unregistered. Due to this even when the components were destroyed the handlers were still active, so the references to the components prevented them to be garbage collected.

Moreover, as the handlers were still active they were still called when their associated event was triggered, which could cause for example an infinite loop of requests to get new messages (as the store was disconnected and thus the MessagesList component [never got an updated last known message ID, so it requested again and again new messages](https://github.com/nextcloud/spreed/blob/5368f4a98a95d3193c59a03513668cdcee7acbca/src/components/MessagesList/MessagesList.vue#L313)).

## How to test
- Open the Network tab of the browser development tools
- Join a conversation
- Start a call
- Leave the call
- Join another conversation

### Result with this pull request
Nothing unusual in the Network tab of the browser development tools.

### Result without this pull request
The Network tab of the browser development tools is flooded with requests to get new messages.
