### PR TITLE
Fix getting messages in MessagesList

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -310,6 +310,11 @@ export default {
 			await this.getOldMessages()
 			// Once the history is received, startslooking for new messages.
 			this.$nextTick(() => {
+				if (this._isBeingDestroyed || this._isDestroyed) {
+					console.debug('Prevent getting new messages on a destroyed MessagesList')
+					return
+				}
+
 				this.getNewMessages()
 			})
 		},


### PR DESCRIPTION
Requires #2637 and #2665
Fixes a regression introduced in 3730748849

The MessagesList component only started getting the messages after a conversation was joined. Due to this the messages were not updated after joining a call, as the original MessageList component was removed from the main view and a new component was added to the sidebar, but as the conversation was not changed the new MessagesList component did not fetch new messages and only showed those that were already in the store.

Now getting the messages is done based on the conversation token and whether the current participant is a participant of the conversation or not. Both checks are needed and independent; when "token" changes that signals a change in the current conversation, and when "isParticipant" changes that signals that the current participant is now a participant or not any longer of the conversation.

Note that getting the messages can not be done on 'routeChange' events, as the token might not have been updated yet when the event is handled, which would cause the messages for the new conversation to be got with the token of the previous conversation (and with that all sort of problems).

Finally, when scrolling to bottom it is necessary to check that there is any message in the conversation. Otherwise "beforeUpdate" could be triggered by some property change before the first batch of messages is received, which would clear the "initiated" flag and thus no scrolling would happen once the messages are finally got.

## How to test
- Join a conversation
- Start a call

### Result with this pull request
The _You have started the call_ message is shown in the chat view in the sidebar.

### Result without this pull request
The _You have started the call_ message is not shown in the chat view in the sidebar.
