### PR TITLE
Fix participants added to the wrong token

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -228,11 +228,14 @@ export default {
 			}
 
 			try {
-				const participants = await fetchParticipants(this.token)
-				this.$store.dispatch('purgeParticipantsStore', this.token)
+				// The token must be stored in a local variable to ensure that
+				// the same token is used after waiting.
+				const token = this.token
+				const participants = await fetchParticipants(token)
+				this.$store.dispatch('purgeParticipantsStore', token)
 				participants.data.ocs.data.forEach(participant => {
 					this.$store.dispatch('addParticipant', {
-						token: this.token,
+						token: token,
 						participant,
 					})
 				})


### PR DESCRIPTION
When getting the participants the token must be stored in a local variable. Otherwise the token could be updated while waiting to fetch the participants, so using the property would cause the fetched participants to be added to the new token instead of to the original one.

Even if the participants are then fetched again and the store content is fixed, due to the reactivity system of Vue setting the participants associated to the wrong token, even if briefly, can lead to surprising and hard to debug behaviours.

Note that I have not checked the rest of the code for similar problems, so this could be lurking around somewhere else.

## How to test
- Add `sleep(5);` to the beginning of [`RoomController::getParticipants()`](https://github.com/nextcloud/spreed/blob/f565bdb3e3df70fd4793b6ca82ca00dc5b4543d2/lib/Controller/RoomController.php#L647)
- Add `if (token !== this.token) { console.log('Token mismatch!', token, this.token)` after [fetching the participants](https://github.com/nextcloud/spreed/blob/4e905595226c08933c130ff76d5c53569d524656/src/components/RightSidebar/Participants/ParticipantsTab.vue#L235)
- Open Talk UI as a user
- Open the browser console
- Join a conversation
- Quickly change to a different conversation

_Token mismatch!_ followed by the tokens of both conversations will be eventually printed in the browser console.
