### PR TITLE
Add lobby screen and lobby timer input

### DIFF
--- a/src/components/LobbyScreen.vue
+++ b/src/components/LobbyScreen.vue
@@ -1,0 +1,66 @@
+<!--
+  - @copyright Copyright (c) 2020, Daniel Calviño Sánchez <danxuliu@gmail.com>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<div class="lobby emptycontent">
+		<div class="icon icon-lobby" />
+		<h2>{{ currentConversationName }}</h2>
+		<p>{{ message }}</p>
+	</div>
+</template>
+
+<script>
+import moment from '@nextcloud/moment'
+
+export default {
+
+	name: 'LobbyScreen',
+
+	computed: {
+
+		token() {
+			return this.$store.getters.getToken()
+		},
+
+		currentConversation() {
+			return this.$store.getters.conversations[this.token]
+		},
+
+		currentConversationName() {
+			return this.currentConversation ? this.currentConversation.displayName : ''
+		},
+
+		message() {
+			let message = t('spreed', 'You are currently waiting in the lobby')
+
+			if (this.currentConversation.lobbyTimer) {
+				// PHP timestamp is second-based; JavaScript timestamp is
+				// millisecond based.
+				const startTime = moment.unix(this.currentConversation.lobbyTimer).format('LLL')
+				message = t('spreed', 'You are currently waiting in the lobby. This meeting is scheduled for {startTime}', { startTime: startTime })
+			}
+
+			return message
+		},
+
+	},
+
+}
+</script>

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -47,12 +47,17 @@ import MessagesGroup from './MessagesGroup/MessagesGroup'
 import { fetchMessages, lookForNewMessages } from '../../services/messagesService'
 import CancelableRequest from '../../utils/cancelableRequest'
 import Axios from '@nextcloud/axios'
+import isInLobby from '../../mixins/isInLobby'
 
 export default {
 	name: 'MessagesList',
 	components: {
 		MessagesGroup,
 	},
+
+	mixins: [
+		isInLobby,
+	],
 
 	props: {
 		/**
@@ -158,13 +163,18 @@ export default {
 
 			return true
 		},
+
+		conversation() {
+			return this.$store.getters.conversations[this.token]
+		},
 	},
 
 	watch: {
-		// Watchers for "token" and "isParticipant" need to be separated and can
-		// not be unified in a boolean computed property (as for example that
-		// would not change when the token changes but the current participant
-		// is a participant in the old and the new conversation).
+		// Watchers for "token", "isParticipant" and "isInLobby" need to be
+		// separated and can not be unified in a boolean computed property (as
+		// for example that would not change when the token changes but the
+		// current participant is a participant in the old and the new
+		// conversation).
 		token: {
 			immediate: true,
 			handler() {
@@ -173,6 +183,12 @@ export default {
 		},
 
 		isParticipant: {
+			immediate: true,
+			handler() {
+				this.handleStartGettingMessagesPreconditions()
+			},
+		},
+		isInLobby: {
 			immediate: true,
 			handler() {
 				this.handleStartGettingMessagesPreconditions()
@@ -290,7 +306,7 @@ export default {
 		},
 
 		handleStartGettingMessagesPreconditions() {
-			if (this.token && this.isParticipant) {
+			if (this.token && this.isParticipant && !this.isInLobby) {
 				this.startGettingMessages()
 			} else {
 				this.cancelLookForNewMessages()

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -167,23 +167,15 @@ export default {
 		// is a participant in the old and the new conversation).
 		token: {
 			immediate: true,
-			handler(token) {
-				if (token && this.isParticipant) {
-					this.startGettingMessages()
-				} else {
-					this.cancelLookForNewMessages()
-				}
+			handler() {
+				this.handleStartGettingMessagesPreconditions()
 			},
 		},
 
 		isParticipant: {
 			immediate: true,
-			handler(isParticipant) {
-				if (this.token && isParticipant) {
-					this.startGettingMessages()
-				} else {
-					this.cancelLookForNewMessages()
-				}
+			handler() {
+				this.handleStartGettingMessagesPreconditions()
 			},
 		},
 	},
@@ -295,6 +287,14 @@ export default {
 				return moment()
 			}
 			return moment.unix(message.timestamp)
+		},
+
+		handleStartGettingMessagesPreconditions() {
+			if (this.token && this.isParticipant) {
+				this.startGettingMessages()
+			} else {
+				this.cancelLookForNewMessages()
+			}
 		},
 
 		/**

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -1,4 +1,4 @@
-x<!--
+<!--
   - @copyright Copyright (c) 2019 Marco Ambrosini <marcoambrosini@pm.me>
   -
   - @author Marco Ambrosini <marcoambrosini@pm.me>

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -205,29 +205,6 @@ export default {
 			}
 		},
 
-		async toggleGuests() {
-			try {
-				await this.$store.dispatch('toggleGuests', {
-					token: this.token,
-					allowGuests: this.conversation.type !== CONVERSATION.TYPE.PUBLIC,
-				})
-			} catch (exeption) {
-				console.error(exeption)
-				OCP.Toast.error(t('spreed', 'An error occurred while toggling guests'))
-			}
-		},
-
-		async toggleLobby() {
-			try {
-				await this.$store.dispatch('toggleLobby', {
-					token: this.token,
-					enableLobby: this.conversation.lobbyState !== WEBINAR.LOBBY.NON_MODERATORS,
-				})
-			} catch (exeption) {
-				console.error(exeption)
-				OCP.Toast.error(t('spreed', 'An error occurred while toggling the lobby'))
-			}
-		},
 		async getParticipants() {
 			if (this.token === '') {
 				return

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -69,6 +69,7 @@ import { EventBus } from '../../../services/EventBus'
 import { CONVERSATION, WEBINAR } from '../../../constants'
 import { searchPossibleConversations } from '../../../services/conversationsService'
 import { fetchParticipants } from '../../../services/participantsService'
+import isInLobby from '../../../mixins/isInLobby'
 
 export default {
 	name: 'ParticipantsTab',
@@ -79,6 +80,10 @@ export default {
 		Hint,
 		ParticipantsList,
 	},
+
+	mixins: [
+		isInLobby,
+	],
 
 	props: {
 		displaySearchBox: {
@@ -206,7 +211,7 @@ export default {
 		},
 
 		async getParticipants() {
-			if (this.token === '') {
+			if (this.token === '' || this.isInLobby) {
 				return
 			}
 

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -102,6 +102,7 @@ import {
 	addToFavorites,
 	removeFromFavorites,
 } from '../../services/conversationsService'
+import isInLobby from '../../mixins/isInLobby'
 
 export default {
 	name: 'RightSidebar',
@@ -115,6 +116,10 @@ export default {
 		CollectionList,
 		ParticipantsTab,
 	},
+
+	mixins: [
+		isInLobby,
+	],
 
 	props: {
 		showChatInSidebar: {
@@ -135,7 +140,7 @@ export default {
 			return this.$store.getters.getSidebarStatus()
 		},
 		opened() {
-			return !!this.token && this.show
+			return !!this.token && !this.isInLobby && this.show
 		},
 		token() {
 			return this.$store.getters.getToken()

--- a/src/mixins/isInLobby.js
+++ b/src/mixins/isInLobby.js
@@ -1,0 +1,48 @@
+/**
+ *
+ * @copyright Copyright (c) 2020, Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { PARTICIPANT, WEBINAR } from '../constants'
+
+/**
+ * Mixin to check whether the current participant is waiting in the lobby or
+ * not.
+ *
+ * Components using this mixin require a "conversation" property (that can be
+ * null) with, at least, "participantType" and "lobbyState" properties.
+ */
+export default {
+
+	computed: {
+		isModerator() {
+			return this.conversation
+				&& (this.conversation.participantType === PARTICIPANT.TYPE.OWNER
+					|| this.conversation.participantType === PARTICIPANT.TYPE.MODERATOR
+					|| this.conversation.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR)
+		},
+
+		isInLobby() {
+			return this.conversation
+				&& this.conversation.lobbyState === WEBINAR.LOBBY.NON_MODERATORS
+				&& !this.isModerator
+		},
+	},
+
+}

--- a/src/services/conversationsService.js
+++ b/src/services/conversationsService.js
@@ -198,11 +198,13 @@ const makePrivate = async function(token) {
  * Change the lobby state
  * @param {string} token The token of the conversation to be modified
  * @param {int} newState The new lobby state to set
+ * @param {int} timestamp The UNIX timestamp (in seconds) to set, if any
  */
-const changeLobbyState = async function(token, newState) {
+const changeLobbyState = async function(token, newState, timestamp) {
 	try {
 		const response = await axios.put(generateOcsUrl('apps/spreed/api/v1', 2) + `room/${token}/webinar/lobby`, {
 			state: newState,
+			timer: timestamp,
 		})
 		return response
 	} catch (error) {

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -142,6 +142,19 @@ const actions = {
 
 		commit('addConversation', conversation)
 	},
+
+	async setLobbyTimer({ commit, getters }, { token, timestamp }) {
+		const conversation = Object.assign({}, getters.conversations[token])
+		if (!conversation) {
+			return
+		}
+
+		// The backend requires the state and timestamp to be set together.
+		await changeLobbyState(token, conversation.lobbyState, timestamp)
+		conversation.lobbyTimer = timestamp
+
+		commit('addConversation', conversation)
+	},
 }
 
 export default { state, mutations, getters, actions }

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -1,11 +1,14 @@
 <template>
 	<div class="mainView">
-		<TopBar :force-white-icons="showChatInSidebar" />
-
-		<ChatView v-if="!showChatInSidebar" :token="token" />
+		<LobbyScreen v-if="isInLobby" />
 		<template v-else>
-			<CallView
-				:token="token" />
+			<TopBar :force-white-icons="showChatInSidebar" />
+
+			<ChatView v-if="!showChatInSidebar" :token="token" />
+			<template v-else>
+				<CallView
+					:token="token" />
+			</template>
 		</template>
 	</div>
 </template>
@@ -13,16 +16,22 @@
 <script>
 import CallView from '../components/CallView/CallView'
 import ChatView from '../components/ChatView'
+import LobbyScreen from '../components/LobbyScreen'
 import TopBar from '../components/TopBar/TopBar'
 import { PARTICIPANT } from '../constants'
+import isInLobby from '../mixins/isInLobby'
 
 export default {
 	name: 'MainView',
 	components: {
 		CallView,
 		ChatView,
+		LobbyScreen,
 		TopBar,
 	},
+	mixins: [
+		isInLobby,
+	],
 	props: {
 		token: {
 			type: String,
@@ -40,6 +49,10 @@ export default {
 	*/
 
 	computed: {
+		conversation() {
+			return this.$store.getters.conversations[this.token]
+		},
+
 		participant() {
 			if (typeof this.token === 'undefined') {
 				return {


### PR DESCRIPTION
Requires #2666

Fixes #2582
Fixes #2583

This pull request adds the input to the moderation menu to set the lobby timer and shows the lobby screen when joining as a non moderator a conversation with the lobby active.

Note that this adds checks about being in the lobby to MessagesList and ParticipantsTab to prevent fetching data from the server. This is a temporary and quick fix that follows the current code, but this should be properly fixed later (views should not be concerned about the state of a conversation to try to fetch data from the server or not, this should be abstracted away and handled outside the views).

Known issues:
- When the lobby is enabled in the moderation menu the lobby timer picker is shown; this messes with the menu size and it is partially hidden. Once closed and opened again it has the proper position. I guess that the actions menu should somehow detect (or maybe be explicitly notified) that a new action has been shown to reposition itself, but I do not know if it should already work and I am doing something wrong or if it is not implemented yet :-) @nextcloud/vuejs 

- In the guest UI the sidebar is shown for a split second and then hidden if joining a conversation with the lobby enabled. The reason is that, by default, the regular UI is rendered and then, when it is detected that the lobby is active, the sidebar is hidden. Instead of starting with the full UI it would be better to start with just a loading spinner until the initial state can be set (that is, until the guest has joined the conversation and the conversation data has been received). Something for another pull request, though.
  - Something similar happens in the user UI; if opening the URL of a conversation with a lobby the error message _An error occured while fetching the participants_ is shown, as when the ParticipantsTab component is created the token is known but not that the conversation is in the lobby and thus that participants can not be fetched, so the request to fetch the participants is made anyway.

- When using the external signaling server the guest UI is not _immediately_ updated when enabling and disabling the lobby. This is a [known issue already present in Talk 7](https://github.com/nextcloud/spreed/issues/2146).

- There is a repeated error in the browser console about failing type check. This is [a bug in the ActionInput component](https://github.com/nextcloud/nextcloud-vue/issues/793).

- Pressing enter after clearing the DateTimePicker triggers an error `Cannot read property 'target' of null`. This seems to be a problem in the ActionInput component, as it happens too in the documentation examples.
