### PR TITLE
Small fixes on the ConversationIcon design

### DIFF
--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -25,7 +25,7 @@
 			class="avatar icon"
 			:class="iconClass" />
 		<Avatar v-else
-			:size="40"
+			:size="44"
 			:user="item.name"
 			:display-name="item.displayName"
 			class="conversation-icon__avatar" />
@@ -94,11 +94,6 @@ export default {
 	width: 44px;
 	height: 44px;
 
-	&__avatar {
-		// we request 40px avatars, but
-		// conversation icons are 44px
-		margin: 2px;
-	}
 	.icon:not(.icon-favorite) {
 		width: 44px;
 		height: 44px;

--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -27,7 +27,8 @@
 		<Avatar v-else
 			:size="40"
 			:user="item.name"
-			:display-name="item.displayName" />
+			:display-name="item.displayName"
+			class="conversation-icon__avatar" />
 		<div v-if="showFavorite"
 			class="favorite-mark">
 			<span class="icon icon-favorite" />
@@ -90,41 +91,42 @@ export default {
 
 <style lang="scss" scoped>
 .conversation-icon {
-	width: 40px;
-	height: 40px;
-}
-
-.icon:not(.icon-favorite) {
-	width: 44px;
-	height: 44px;
-	line-height: 44px;
-	font-size: 24px;
-	background-color: var(--color-background-darker);
-
-	&.icon-changelog {
-		background-size: 44px;
+	&__avatar {
+		// we request 40px avatars, but
+		// conversation icons are 44px
+		margin: 2px;
 	}
-	&.icon-public,
-	&.icon-contacts,
-	&.icon-password,
-	&.icon-file,
-	&.icon-mail {
-		background-size: 20px;
+	.icon:not(.icon-favorite) {
+		width: 44px;
+		height: 44px;
+		line-height: 44px;
+		font-size: 24px;
+		background-color: var(--color-background-darker);
+
+		&.icon-changelog {
+			background-size: 44px;
+		}
+		&.icon-public,
+		&.icon-contacts,
+		&.icon-password,
+		&.icon-file,
+		&.icon-mail {
+			background-size: 20px;
+		}
+
 	}
 
-}
+	.favorite-mark {
+		position: absolute;
+		top: 8px;
+		left: calc(44px - 8px);
+		line-height: 100%;
 
-.favorite-mark {
-	position: absolute;
-	top: 8px;
-	left: calc(44px - 8px);
-	line-height: 100%;
-
-	.icon-favorite {
-		display: inline-block;
-		vertical-align: middle;
-		background-image: var(--icon-star-dark-FC0);
-		background-size: 20px;
+		.icon-favorite {
+			display: inline-block;
+			vertical-align: middle;
+			background-image: var(--icon-star-dark-FC0);
+		}
 	}
 }
 

--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -91,6 +91,9 @@ export default {
 
 <style lang="scss" scoped>
 .conversation-icon {
+	width: 44px;
+	height: 44px;
+
 	&__avatar {
 		// we request 40px avatars, but
 		// conversation icons are 44px

--- a/src/components/LeftSidebar/ConversationsList/AppContentListItem/AppContentListItem.vue
+++ b/src/components/LeftSidebar/ConversationsList/AppContentListItem/AppContentListItem.vue
@@ -150,7 +150,7 @@ export default {
 	cursor: pointer;
 	&__content {
 		width: 240px;
-		margin-left: 6px;
+		margin-left: 8px;
 		&__line-one {
 			display: flex;
 			justify-content: space-between;


### PR DESCRIPTION
- Fix alignment and proper sizing of the elements
- Reduced star size for better antialiasing

| Before | After |
|:---------:|:------:|
|![Kazam_screenshot_00001](https://user-images.githubusercontent.com/14975046/71823553-c5814600-3097-11ea-87f7-9bb5b7bac1a8.png)|![Kazam_screenshot_00000](https://user-images.githubusercontent.com/14975046/71823551-c5814600-3097-11ea-949b-38f2660a22f7.png)|