### PR TITLE
Fix scrolling issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11900,11 +11900,6 @@
 			"integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
 			"dev": true
 		},
-		"vue-virtual-scroll-list": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/vue-virtual-scroll-list/-/vue-virtual-scroll-list-1.4.4.tgz",
-			"integrity": "sha512-wU7FDpd9Xy4f62pf8SBg/ak21jMI/pdx4s4JPah+z/zuhmeAafQgp8BjtZvvt+b0BZOsOS1FJuCfUH7azTkivQ=="
-		},
 		"vue-visible": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/vue-visible/-/vue-visible-1.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7939,14 +7939,30 @@
 				"timers-browserify": "^2.0.4",
 				"tty-browserify": "0.0.0",
 				"url": "^0.11.0",
+				"util": "^0.11.0",
 				"vm-browserify": "^1.0.1"
 			},
 			"dependencies": {
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+					"dev": true
+				},
 				"punycode": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 					"dev": true
+				},
+				"util": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+					"integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+					"dev": true,
+					"requires": {
+						"inherits": "2.0.3"
+					}
 				}
 			}
 		},
@@ -11852,6 +11868,11 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.3.tgz",
 			"integrity": "sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ=="
+		},
+		"vue-scroll": {
+			"version": "2.1.13",
+			"resolved": "https://registry.npmjs.org/vue-scroll/-/vue-scroll-2.1.13.tgz",
+			"integrity": "sha512-GQnDA1UcFSdmL2Gjo/3+0jlOwvRvSpdzl+q+vOtQsAjb+uQDo8UG1RKxyoQ1lkJCz5uM8OSqb/6+L3LBqInk2w=="
 		},
 		"vue-style-loader": {
 			"version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"vue-observe-visibility": "^0.4.6",
 		"vue-prevent-unload": "^0.2.3",
 		"vue-router": "^3.1.3",
+		"vue-scroll": "^2.1.13",
 		"vue-virtual-scroll-list": "^1.4.4",
 		"vuex": "^3.1.2",
 		"webrtc-adapter": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
 		"vue-prevent-unload": "^0.2.3",
 		"vue-router": "^3.1.3",
 		"vue-scroll": "^2.1.13",
-		"vue-virtual-scroll-list": "^1.4.4",
 		"vuex": "^3.1.2",
 		"webrtc-adapter": "^7.3.0",
 		"webrtcsupport": "^2.2.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -59,11 +59,13 @@ export default {
 			savedLastMessageMap: {},
 			defaultPageTitle: false,
 			loading: false,
-			windowIsVisible: true,
 		}
 	},
 
 	computed: {
+		windowIsVisible() {
+			return this.$store.getters.windowIsVisible
+		},
 		conversations() {
 			return this.$store.getters.conversations
 		},
@@ -240,7 +242,7 @@ export default {
 		},
 
 		changeWindowVisibility() {
-			this.windowIsVisible = !document.hidden
+			this.$store.dispatch('setWindowVisibility', !document.hidden)
 			if (this.windowIsVisible) {
 				// Remove the potential "*" marker for unread chat messages
 				this.setPageTitle(this.getConversationName(this.token), false)

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -22,8 +22,6 @@
 
 This component is a wrapper for the list of messages. It's main purpose it to
 get the messagesList array and loop through the list to generate the messages.
-In order not to render each and every messages that is in the store, we use
-the Vue virtual scroll list component, whose docs you can find [here.](https://github.com/tangbc/vue-virtual-scroll-list)
 
 </docs>
 

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -368,5 +368,6 @@ export default {
 <style lang="scss" scoped>
 .scroller {
 	flex: 1 0;
+	overflow-y: auto;
 }
 </style>

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -30,9 +30,7 @@ the Vue virtual scroll list component, whose docs you can find [here.](https://g
 <template>
 	<!-- size and remain refer to the amount and initial height of the items that
 	are outside of the viewport -->
-	<virtual-list :size="40"
-		:remain="8"
-		:variable="true"
+	<div
 		class="scroller">
 		<MessagesGroup
 			v-for="item of messagesGroupedByAuthor"
@@ -41,12 +39,11 @@ the Vue virtual scroll list component, whose docs you can find [here.](https://g
 			v-bind="item"
 			:messages="item"
 			@deleteMessage="handleDeleteMessage" />
-	</virtual-list>
+	</div>
 </template>
 
 <script>
 import moment from '@nextcloud/moment'
-import virtualList from 'vue-virtual-scroll-list'
 import MessagesGroup from './MessagesGroup/MessagesGroup'
 import { fetchMessages, lookForNewMessages } from '../../services/messagesService'
 import { EventBus } from '../../services/EventBus'
@@ -57,7 +54,6 @@ export default {
 	name: 'MessagesList',
 	components: {
 		MessagesGroup,
-		virtualList,
 	},
 
 	props: {

--- a/src/main.js
+++ b/src/main.js
@@ -42,6 +42,7 @@ import contenteditableDirective from 'vue-contenteditable-directive'
 import VueClipboard from 'vue-clipboard2'
 import { translate, translatePlural } from '@nextcloud/l10n'
 import VueObserveVisibility from 'vue-observe-visibility'
+import vuescroll from 'vue-scroll'
 
 // CSP config for webpack dynamic chunk loading
 // eslint-disable-next-line
@@ -64,6 +65,7 @@ Vue.use(Vuex)
 Vue.use(VueRouter)
 Vue.use(VueClipboard)
 Vue.use(VueObserveVisibility)
+Vue.use(vuescroll, { debounce: 600 })
 
 export default new Vue({
 	el: '#content',

--- a/src/store/windowVisibilityStore.js
+++ b/src/store/windowVisibilityStore.js
@@ -20,34 +20,39 @@
  *
  */
 
-import Vue from 'vue'
-import Vuex, { Store } from 'vuex'
-import actorStore from './actorStore'
-import conversationsStore from './conversationsStore'
-import messagesStore from './messagesStore'
-import participantsStore from './participantsStore'
-import quoteReplyStore from './quoteReplyStore'
-import sidebarStore from './sidebarStore'
-import tokenStore from './tokenStore'
-import windowVisibilityStore from './windowVisibilityStore'
+const state = {
+	visible: true,
+}
 
-Vue.use(Vuex)
+const getters = {
+	windowIsVisible: (state) => () => {
+		return state.visible
+	},
+}
 
-const mutations = {}
+const mutations = {
+	/**
+	 * Sets the current visibility state
+	 *
+	 * @param {object} state current store state;
+	 * @param {boolean} value the value;
+	 */
+	setVisibility(state, value) {
+		state.visible = value
+	},
+}
 
-export default new Store({
-	modules: {
-		actorStore,
-		conversationsStore,
-		messagesStore,
-		participantsStore,
-		quoteReplyStore,
-		sidebarStore,
-		tokenStore,
-		windowVisibilityStore,
+const actions = {
+	/**
+	 * Sets the current visibility state
+	 *
+	 * @param {object} context the context object;
+	 * @param {boolean} value the value;
+	 */
+	setWindowVisibility(context, value) {
+		context.commit('setVisibility', value)
 	},
 
-	mutations,
+}
 
-	strict: process.env.NODE_ENV !== 'production',
-})
+export default { state, mutations, getters, actions }


### PR DESCRIPTION
Fixes #2636
Fixes #2681

The issues are fixed  by removing the virtual scroller

plus auto-scrolls the message list to the bottom when receiving new messages `&&`:
* the list was already scrolled to the bottom before receiving the new messages;
* the browser window is active.