### PR TITLE
Bugfix/noid/combine empty sources

### DIFF
--- a/src/components/Hint.vue
+++ b/src/components/Hint.vue
@@ -47,5 +47,6 @@ export default {
 		box-shadow: none !important;
 		user-select: none;
 		pointer-events: none;
+		padding-left: 10px;
 	}
 </style>

--- a/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
@@ -26,7 +26,7 @@
 			:key="item.id"
 			:item="item" />
 		<Hint v-if="searchText && !conversationsList.length"
-			:hint="t('spreed', 'No search results')" />
+			:hint="t('spreed', 'No matches')" />
 	</ul>
 </template>
 

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -35,28 +35,33 @@
 					:search-text="searchText" />
 			</li>
 			<template v-if="isSearching">
-				<Caption
-					:title="t('spreed', 'Contacts')" />
-				<li v-if="searchResultsUsers.length !== 0">
-					<ContactsList :contacts="searchResultsUsers" />
-				</li>
-				<Hint v-else-if="contactsLoading" :hint="t('spreed', 'Loading')" />
-				<Hint v-else :hint="t('spreed', 'No search results')" />
+				<template v-if="searchResultsUsers.length !== 0">
+					<Caption
+						:title="t('spreed', 'Contacts')" />
+					<li v-if="searchResultsUsers.length !== 0">
+						<ContactsList :contacts="searchResultsUsers" />
+					</li>
+				</template>
 
-				<Caption
-					:title="t('spreed', 'Groups')" />
-				<li v-if="searchResultsGroups.length !== 0">
-					<GroupsList :groups="searchResultsGroups" />
-				</li>
-				<Hint v-else-if="contactsLoading" :hint="t('spreed', 'Loading')" />
-				<Hint v-else :hint="t('spreed', 'No search results')" />
+				<template v-if="searchResultsGroups.length !== 0">
+					<Caption
+						:title="t('spreed', 'Groups')" />
+					<li v-if="searchResultsGroups.length !== 0">
+						<GroupsList :groups="searchResultsGroups" />
+					</li>
+				</template>
 
-				<Caption
-					:title="t('spreed', 'Circles')" />
-				<li v-if="searchResultsCircles.length !== 0">
-					<CirclesList :circles="searchResultsCircles" />
-				</li>
-				<Hint v-else-if="contactsLoading" :hint="t('spreed', 'Loading')" />
+				<template v-if="searchResultsCircles.length !== 0">
+					<Caption
+						:title="t('spreed', 'Circles')" />
+					<li v-if="searchResultsCircles.length !== 0">
+						<CirclesList :circles="searchResultsCircles" />
+					</li>
+				</template>
+
+				<Caption v-if="sourcesWithoutResults"
+					:title="sourcesWithoutResultsList" />
+				<Hint v-if="contactsLoading" :hint="t('spreed', 'Loading')" />
 				<Hint v-else :hint="t('spreed', 'No search results')" />
 			</template>
 		</ul>
@@ -102,6 +107,7 @@ export default {
 			searchResultsGroups: [],
 			searchResultsCircles: [],
 			contactsLoading: false,
+			isCirclesEnabled: true, // FIXME
 		}
 	},
 
@@ -111,6 +117,43 @@ export default {
 		},
 		isSearching() {
 			return this.searchText !== ''
+		},
+
+		sourcesWithoutResults() {
+			return !this.searchResultsUsers.length
+				|| !this.searchResultsGroups.length
+				|| (this.isCirclesEnabled && !this.searchResultsCircles.length)
+		},
+
+		sourcesWithoutResultsList() {
+			if (!this.searchResultsUsers.length) {
+				if (!this.searchResultsGroups.length) {
+					if (this.isCirclesEnabled && !this.searchResultsCircles.length) {
+						return t('spreed', 'Contacts, groups and circles')
+					} else {
+						return t('spreed', 'Contacts and groups')
+					}
+				} else {
+					if (this.isCirclesEnabled && !this.searchResultsCircles.length) {
+						return t('spreed', 'Contacts and circles')
+					} else {
+						return t('spreed', 'Contacts')
+					}
+				}
+			} else {
+				if (!this.searchResultsGroups.length) {
+					if (this.isCirclesEnabled && !this.searchResultsCircles.length) {
+						return t('spreed', 'Groups and circles')
+					} else {
+						return t('spreed', 'Groups')
+					}
+				} else if (!this.searchResultsGroups.length) {
+					if (this.isCirclesEnabled && !this.searchResultsCircles.length) {
+						return t('spreed', 'Circles')
+					}
+				}
+			}
+			return t('spreed', 'Other sources')
 		},
 	},
 


### PR DESCRIPTION
Before | After with some matches | After with no matches
---|---|---
![Bildschirmfoto von 2020-01-08 12-10-27](https://user-images.githubusercontent.com/213943/71990802-555bf700-3234-11ea-8ec2-89e13659bef4.png) | ![Bildschirmfoto von 2020-01-08 16-30-01](https://user-images.githubusercontent.com/213943/71990804-555bf700-3234-11ea-9375-2774d25e833e.png) | ![Bildschirmfoto von 2020-01-08 16-29-29](https://user-images.githubusercontent.com/213943/71990803-555bf700-3234-11ea-83bf-40b6627077e0.png)


cc @nextcloud/designers-talk 
Should we use "Other sources" instead of listing them?
The problem is the number of sources is getting bigger and bigger, currently we have:
* Contacts (local users)
* Groups
* Emails
* Circles

We could also use "Other sources" or something like that. But then it's not clear which values are checked.

Pre-requirement for #2677 

Fix #2574 