### PR TITLE
Fix invalid index on public call pages

### DIFF
--- a/templates/index.php
+++ b/templates/index.php
@@ -5,6 +5,6 @@
 script('spreed', 'talk');
 
 style('spreed', 'merged');
-if ($_['user_uid'] !== '') {
+if (($_['user_uid'] ?? '') !== '') {
 	\OC::$server->getEventDispatcher()->dispatch('\OCP\Collaboration\Resources::loadAdditionalScripts');
 }


### PR DESCRIPTION
The `TemplateLayout` class only sets `user_uid` if the template is
rendered for a user, error and guest, but not for public pages. Hence
there should be a fallback for when the array index doesn't exist.

Issue discovered by Sentry.