### PR TITLE
Fix getting messages in MessagesList in Talk sidebar

### DIFF
--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -320,10 +320,6 @@ export default {
 }
 
 .chatView {
-	/* The chat view shares its parent with the call button, so the default
-	 * "height: 100%" needs to be unset. */
-	height: unset;
-
 	overflow: hidden;
 }
 </style>

--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -50,6 +50,7 @@
 <script>
 
 import { getFileConversation } from './services/filesIntegrationServices'
+import { fetchConversation } from './services/conversationsService'
 import { joinConversation, leaveConversation } from './services/participantsService'
 import CancelableRequest from './utils/cancelableRequest'
 import { getCurrentUser } from '@nextcloud/auth'
@@ -126,7 +127,15 @@ export default {
 		async joinConversation() {
 			await this.getFileConversation()
 
-			joinConversation(this.token)
+			await joinConversation(this.token)
+
+			// The current participant (which is automatically set when fetching
+			// the current conversation) is needed for the MessagesList to start
+			// getting the messages. No need to wait for it, but fetching the
+			// conversation needs to be done once the user has joined the
+			// conversation (otherwise only limited data would be received if
+			// the user was not a participant of the conversation yet).
+			this.fetchCurrentConversation()
 		},
 
 		leaveConversation() {
@@ -159,6 +168,15 @@ export default {
 					console.debug(exception)
 				}
 			}
+		},
+
+		async fetchCurrentConversation() {
+			if (!this.token) {
+				return
+			}
+
+			const response = await fetchConversation(this.token)
+			this.$store.dispatch('addConversation', response.data.ocs.data)
 		},
 
 		/**

--- a/src/mainChatTab.js
+++ b/src/mainChatTab.js
@@ -36,6 +36,7 @@ import { getRequestToken } from '@nextcloud/auth'
 // Directives
 import contenteditableDirective from 'vue-contenteditable-directive'
 import { translate, translatePlural } from '@nextcloud/l10n'
+import vuescroll from 'vue-scroll'
 
 // CSP config for webpack dynamic chunk loading
 // eslint-disable-next-line
@@ -55,6 +56,7 @@ Vue.prototype.OCA = OCA
 
 Vue.use(contenteditableDirective)
 Vue.use(Vuex)
+Vue.use(vuescroll, { debounce: 600 })
 
 const newTab = () => new Vue({
 	store,

--- a/src/services/participantsService.js
+++ b/src/services/participantsService.js
@@ -35,9 +35,9 @@ const joinConversation = async(token) => {
 	try {
 		const signaling = await getSignaling()
 
-		signaling.joinRoom(token).then(() => {
-			EventBus.$emit('joinedConversation')
-		})
+		await signaling.joinRoom(token)
+
+		EventBus.$emit('joinedConversation')
 
 		// FIXME Signaling should not handle joining a conversation
 		// const response = await axios.post(generateOcsUrl('apps/spreed/api/v1', 2) + `room/${token}/participants/active`)
@@ -56,7 +56,8 @@ const leaveConversation = async function(token) {
 	try {
 		const signaling = await getSignaling()
 
-		signaling.leaveRoom(token)
+		await signaling.leaveRoom(token)
+
 		// FIXME Signaling should not handle leaving a conversation
 		// const response = await axios.delete(generateOcsUrl('apps/spreed/api/v1', 2) + `room/${token}/participants/active`)
 		// return response


### PR DESCRIPTION
Follow up to #2666 and #2692

## How to test
- Open the Files app
- Open the chat tab of a shared file (if you are sharing it for the first time reload, as there is currently a bug in the server that causes the placeholder in the chat tab to not be updated)
- Join the conversation

### Result with this pull request
The messages are shown.

### Result without this pull request
The message list is empty.
