### PR TITLE
Fix mentions to all and guests not using user bubbles

### DIFF
--- a/css/icons.scss
+++ b/css/icons.scss
@@ -29,6 +29,12 @@
 		background-image: url('../img/changelog.svg');
 	}
 
+	// "forced-white" needs to be included in the class name as the UserBubble
+	// does not accept several classes.
+	.icon-group-forced-white {
+		background-image: url(icon-color-path('group', 'actions', 'fff', 1, true));
+	}
+
 	.forced-white {
 		&.icon-menu-people {
 			background-image: url(icon-color-path('menu-people', 'spreed', 'fff', 1));

--- a/css/icons.scss
+++ b/css/icons.scss
@@ -34,6 +34,9 @@
 	.icon-group-forced-white {
 		background-image: url(icon-color-path('group', 'actions', 'fff', 1, true));
 	}
+	.icon-user-forced-white {
+		background-image: url(icon-color-path('user', 'actions', 'fff', 1, true));
+	}
 
 	.forced-white {
 		&.icon-menu-people {

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -289,6 +289,8 @@ export default {
 				return Mention
 			} else if (messagePartType === 'call') {
 				return Mention
+			} else if (messagePartType === 'guest') {
+				return Mention
 			} else if (messagePartType === 'file') {
 				return FilePreview
 			}

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -287,6 +287,8 @@ export default {
 				return PlainText
 			} else if (messagePartType === 'user') {
 				return Mention
+			} else if (messagePartType === 'call') {
+				return Mention
 			} else if (messagePartType === 'file') {
 				return FilePreview
 			}

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
@@ -20,7 +20,11 @@
 -->
 
 <template>
-	<UserBubble
+	<UserBubble v-if="isMentionToAll"
+		:display-name="data.name"
+		:avatar-image="'icon-group-forced-white'"
+		:primary="true" />
+	<UserBubble v-else
 		:display-name="data.name"
 		:user="data.id"
 		:primary="isCurrentUser" />
@@ -50,6 +54,9 @@ export default {
 	},
 
 	computed: {
+		isMentionToAll() {
+			return this.data.type === 'call'
+		},
 		isCurrentUser() {
 			return this.$store.getters.getActorType() === 'users'
 				&& this.data.id === this.$store.getters.getUserId()

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
@@ -24,6 +24,10 @@
 		:display-name="data.name"
 		:avatar-image="'icon-group-forced-white'"
 		:primary="true" />
+	<UserBubble v-else-if="isMentionToGuest"
+		:display-name="data.name"
+		:avatar-image="'icon-user-forced-white'"
+		:primary="isCurrentGuest" />
 	<UserBubble v-else
 		:display-name="data.name"
 		:user="data.id"
@@ -56,6 +60,13 @@ export default {
 	computed: {
 		isMentionToAll() {
 			return this.data.type === 'call'
+		},
+		isMentionToGuest() {
+			return this.data.type === 'guest'
+		},
+		isCurrentGuest() {
+			return this.$store.getters.getActorType() === 'guests'
+				&& this.data.id === ('guest/' + this.$store.getters.getSessionHash())
 		},
 		isCurrentUser() {
 			return this.$store.getters.getActorType() === 'users'


### PR DESCRIPTION
There is an error in the console about `user` property being required. This is [a bug in the UserBubble component](https://github.com/nextcloud/nextcloud-vue/issues/796).

The avatar for guests uses the generic user icon instead of the _?_ character. Again this is a limitation of the UserBubble component, as [it is currently not possible to set a specific character for the avatar](https://github.com/nextcloud/nextcloud-vue/issues/797).
