### PR TITLE
Fix autocompletion issues

### DIFF
--- a/css/At.scss
+++ b/css/At.scss
@@ -129,4 +129,14 @@
 		width: 32px;
 		height: 32px;
 	}
+
+	.atwho-view {
+		background: var(--color-main-background);
+		color: var(--color-main-text);
+	}
+
+	.atwho-cur {
+		background: var(--color-primary);
+		color: var(--color-primary-text);
+	}
 }

--- a/css/At.scss
+++ b/css/At.scss
@@ -61,8 +61,8 @@
 		}
 	}
 	.atwho-cur {
-	// background: #44a8f2;
-	background: #5BB8FF;
+		// background: #44a8f2;
+		background: #5BB8FF;
 		color: white;
 	}
 
@@ -130,14 +130,23 @@
 		height: 32px;
 	}
 
+	// Override all colors with our theming and dark mode
 	.atwho-view {
 		background: var(--color-main-background);
 		color: var(--color-main-text);
-	}
+		box-shadow: 0 0 5px var(--color-box-shadow);
 
-	.atwho-cur {
-		background: var(--color-primary);
-		color: var(--color-primary-text);
+		&::-webkit-scrollbar-track {
+			background-color: var(--color-background-dark);
+		}
+		&::-webkit-scrollbar-thumb {
+			background-color: var(--color-background-darker);
+		}
+
+		.atwho-cur {
+			background: var(--color-primary);
+			color: var(--color-primary-text);
+		}
 	}
 }
 

--- a/css/At.scss
+++ b/css/At.scss
@@ -140,3 +140,11 @@
 		color: var(--color-primary-text);
 	}
 }
+
+// Override conflicting rules from the comments tab.
+.talk.candidate-mentions {
+	.atwho-view {
+		top: unset;
+		display: unset;
+	}
+}

--- a/css/At.scss
+++ b/css/At.scss
@@ -1,0 +1,132 @@
+// Copied from vue-at (https://github.com/fritx/vue-at/blob/d16d5eefdae8987c0bffe2d9c3867b7da12c808f/src/At.scss)
+// and wrapped to affect only the panel for candidate mentions.
+
+.talk.candidate-mentions {
+
+	// atwho.css https://github.com/ichord/At.js
+	.atwho-view {
+		// position:absolute;
+		// top: 0;
+		// left: 0;
+		// display: none;
+		// margin-top: 18px;
+		// background: white;
+		color: black;
+		// border: 1px solid #DDD;
+		border-radius: 3px;
+		box-shadow: 0 0 5px rgba(0,0,0,0.1);
+		min-width: 120px;
+		z-index: 11110 !important;
+	}
+	.atwho-ul {
+		/* width: 100px; */
+		list-style:none;
+		// padding:0;
+		// margin:auto;
+		// max-height: 200px;
+		// overflow-y: auto;
+	}
+	.atwho-li {
+		display: block;
+		// padding: 5px 10px;
+		// border-bottom: 1px solid #DDD;
+		// cursor: pointer;
+		/* border-top: 1px solid #C8C8C8; */
+	}
+
+	////// added 1
+	.atwho-view {
+		// font-size: 14px;
+		// min-width: 140px;
+		// max-width: 180px;
+		border-radius: 6px;
+		// overflow: hidden;
+		box-shadow: 0 0 10px 0 rgba(101, 111, 122, .5);
+	}
+	.atwho-ul {
+		max-height: 135px;
+		padding: 0;
+		margin: 0;
+	}
+	.atwho-li {
+		box-sizing: border-box;
+		height: 27px;
+		padding: 0 12px;
+		white-space: nowrap;
+		display: flex;
+		align-items: center;
+		span {
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+	}
+	.atwho-cur {
+	// background: #44a8f2;
+	background: #5BB8FF;
+		color: white;
+	}
+
+	////// added 2
+	.atwho-wrap {
+		position: relative;
+	}
+	&.atwho-panel {
+		position: absolute;
+	}
+	.atwho-inner {
+		position: relative;
+	}
+	.atwho-view {
+		position: absolute;
+		bottom: 0;
+		left: -0.8em; // 抵消左边距
+		cursor: default;
+		background-color: rgba(255,255,255,.94);
+		min-width: 140px;
+		max-width: 180px;
+		max-height: 200px;
+		overflow-y: auto;
+		&::-webkit-scrollbar {
+			width: 11px;
+			height: 11px;
+		}
+		&::-webkit-scrollbar-track {
+			// background-color: rgba(127, 127, 127, .1);
+			background-color: #F5F5F5;
+		}
+		&::-webkit-scrollbar-thumb {
+			min-height: 36px;
+			border: 2px solid transparent;
+			border-top: 3px solid transparent;
+			border-bottom: 3px solid transparent;
+			background-clip: padding-box;
+			border-radius: 7px;
+			// background-color: rgba(0, 0, 0, 0.2);
+			background-color: #C4C4C4;
+		}
+	}
+}
+
+.talk.candidate-mentions {
+	// Override "max-width: 180px", as that makes the autocompletion panel too
+	// narrow.
+	.atwho-view {
+		max-width: unset;
+	}
+
+	// Override autocompletion panel items height, as they are too short
+	// for the avatars and also need some padding.
+	.atwho-li {
+		height: unset;
+		padding-top: 6px;
+		padding-bottom: 6px;
+	}
+
+	// Although the height of its wrapper is 32px the height of the icon
+	// is the default 16px. This is a temporary fix until it is fixed
+	// in the avatar component.
+	.atwho-li .icon-group-forced-white {
+		width: 32px;
+		height: 32px;
+	}
+}

--- a/css/icons.scss
+++ b/css/icons.scss
@@ -70,7 +70,7 @@
 
 // The atwho panel is a direct child of the body, so it is not affected by
 // .app-Talk rules above.
-.atwho-panel {
+.talk.candidate-mentions.atwho-panel {
 	// "forced-white" needs to be included in the class name as the Avatar does
 	// not accept several classes.
 	.icon-group-forced-white {

--- a/css/icons.scss
+++ b/css/icons.scss
@@ -76,14 +76,4 @@
 	.icon-group-forced-white {
 		background-image: url(icon-color-path('group', 'actions', 'fff', 1, true));
 	}
-
-	.atwho-view {
-		background: var(--color-main-background);
-		color: var(--color-main-text);
-	}
-
-	.atwho-cur {
-		background: var(--color-primary);
-		color: var(--color-primary-text);
-	}
 }

--- a/css/merged-files.scss
+++ b/css/merged-files.scss
@@ -1,1 +1,2 @@
+@import 'At.scss';
 @import 'icons.scss';

--- a/css/merged.scss
+++ b/css/merged.scss
@@ -1,1 +1,2 @@
+@import 'At.scss';
 @import 'icons.scss';

--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -73,6 +73,33 @@ import { searchPossibleMentions } from '../../../services/mentionsService'
 import Avatar from '@nextcloud/vue/dist/Components/Avatar'
 import Mention from '../../MessagesList/MessagesGroup/Message/MessagePart/Mention'
 
+/**
+ * Removes the default atwho style sheet added by the vue-at component.
+ *
+ * The rules in that style sheet are too broad and affect other elements
+ * besides those from the vue-at panel.
+ */
+function removeDefaultAtWhoStyleSheet() {
+	const styleElements = document.querySelectorAll('style')
+	for (let i = 0; i < styleElements.length; i++) {
+		const sheet = styleElements[i].sheet
+
+		if (sheet.cssRules.length !== 15) {
+			continue
+		}
+
+		for (const cssRule of sheet.cssRules) {
+			if (cssRule.cssText === '.atwho-view { color: rgb(0, 0, 0); border-radius: 3px; box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 5px; min-width: 120px; z-index: 11110 !important; }') {
+				styleElements[i].remove()
+
+				return
+			}
+		}
+	}
+}
+
+removeDefaultAtWhoStyleSheet()
+
 export default {
 	name: 'AdvancedInput',
 	components: {
@@ -146,7 +173,7 @@ export default {
 		 */
 		EventBus.$on('routeChange', this.focusInput)
 
-		this.addCustomAtWhoStyleSheet()
+		this.atWhoPanelExtraClasses = 'talk candidate-mentions'
 	},
 	beforeDestroy() {
 		EventBus.$off('routeChange', this.focusInput)
@@ -259,53 +286,6 @@ export default {
 				name: candidate.label,
 				type: type,
 			}
-		},
-
-		/**
-		 * Adds a special style sheet to customize atwho elements.
-		 *
-		 * The <style> section has no effect on the atwho elements, as the atwho
-		 * panel is reparented to the body, and the rules added there are rooted
-		 * on the AdvancedInput.
-		 */
-		addCustomAtWhoStyleSheet() {
-			for (let i = 0; i < document.styleSheets.length; i++) {
-				const sheet = document.styleSheets[i]
-				// None of the default properties of a style sheet can be used
-				// as an ID. Adding a "data-id" attribute would work in Firefox,
-				// but not in Chromium, as it does not provide a "dataset"
-				// property in styleSheet objects. Therefore it is necessary to
-				// check the rules themselves, but as the order is undefined a
-				// matching rule needs to be looked for in all of them.
-				if (sheet.cssRules.length !== 3) {
-					continue
-				}
-
-				for (const cssRule of sheet.cssRules) {
-					if (cssRule.cssText === '.atwho-view { max-width: unset; }') {
-						return
-					}
-				}
-			}
-
-			const style = document.createElement('style')
-
-			document.head.appendChild(style)
-
-			// "insertRule" calls below need to be kept in sync with the
-			// condition above.
-
-			// Override "max-width: 180px", as that makes the autocompletion
-			// panel too narrow.
-			style.sheet.insertRule('.atwho-view { max-width: unset; }', 0)
-			// Override autocompletion panel items height, as they are too short
-			// for the avatars and also need some padding.
-			style.sheet.insertRule('.atwho-li { height: unset; padding-top: 6px; padding-bottom: 6px; }', 0)
-
-			// Although the height of its wrapper is 32px the height of the icon
-			// is the default 16px. This is a temporary fix until it is fixed
-			// in the avatar component.
-			style.sheet.insertRule('.atwho-li .icon-group-forced-white { width: 32px; height: 32px; }', 0)
 		},
 	},
 }

--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -271,15 +271,29 @@ export default {
 		addCustomAtWhoStyleSheet() {
 			for (let i = 0; i < document.styleSheets.length; i++) {
 				const sheet = document.styleSheets[i]
-				if (sheet.title === 'at-who-custom') {
-					return
+				// None of the default properties of a style sheet can be used
+				// as an ID. Adding a "data-id" attribute would work in Firefox,
+				// but not in Chromium, as it does not provide a "dataset"
+				// property in styleSheet objects. Therefore it is necessary to
+				// check the rules themselves, but as the order is undefined a
+				// matching rule needs to be looked for in all of them.
+				if (sheet.cssRules.length !== 3) {
+					continue
+				}
+
+				for (const cssRule of sheet.cssRules) {
+					if (cssRule.cssText === '.atwho-view { max-width: unset; }') {
+						return
+					}
 				}
 			}
 
 			const style = document.createElement('style')
-			style.setAttribute('title', 'at-who-custom')
 
 			document.head.appendChild(style)
+
+			// "insertRule" calls below need to be kept in sync with the
+			// condition above.
 
 			// Override "max-width: 180px", as that makes the autocompletion
 			// panel too narrow.

--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -281,9 +281,9 @@ export default {
 
 			document.head.appendChild(style)
 
-			// Override "width: 180px", as that makes the autocompletion panel
-			// too narrow.
-			style.sheet.insertRule('.atwho-view { width: unset; }', 0)
+			// Override "max-width: 180px", as that makes the autocompletion
+			// panel too narrow.
+			style.sheet.insertRule('.atwho-view { max-width: unset; }', 0)
 			// Override autocompletion panel items height, as they are too short
 			// for the avatars and also need some padding.
 			style.sheet.insertRule('.atwho-li { height: unset; padding-top: 6px; padding-bottom: 6px; }', 0)

--- a/src/mixins/vueAtReparenter.js
+++ b/src/mixins/vueAtReparenter.js
@@ -42,6 +42,10 @@ export default {
 			 * The selector for the HTML element to reparent the vue-at panel to.
 			 */
 			atWhoPanelParentSelector: 'body',
+			/**
+			 * Extra CSS classes to be set in the vue-at panel.
+			 */
+			atWhoPanelExtraClasses: '',
 			at: null,
 			atWhoPanelElement: null,
 			originalWrapElement: null,
@@ -63,6 +67,16 @@ export default {
 			}
 
 			return this.at.atwho
+		},
+
+		/**
+		 * Returns a list of CSS clases from the space separated string
+		 * "atWhoPanelExtraClasses".
+		 *
+		 * @returns {Array} the list of CSS classes
+		 */
+		atWhoPanelExtraClassesList() {
+			return this.atWhoPanelExtraClasses.split(' ').filter(cssClass => cssClass !== '')
 		},
 	},
 
@@ -92,6 +106,10 @@ export default {
 				// proper parent until that happens
 				Vue.nextTick(function() {
 					this.atWhoPanelElement = this.at.$refs.wrap.querySelector('.atwho-panel')
+
+					if (this.atWhoPanelExtraClassesList.length > 0) {
+						this.atWhoPanelElement.classList.add(...this.atWhoPanelExtraClassesList)
+					}
 
 					this.originalWrapElement = this.at.$refs.wrap
 					this.at.$refs.wrap = window.document.querySelector(this.atWhoPanelParentSelector)

--- a/src/mixins/vueAtReparenter.js
+++ b/src/mixins/vueAtReparenter.js
@@ -39,8 +39,8 @@ export default {
 	data: function() {
 		return {
 			/**
-			* The selector for the HTML element to reparent the vue-at panel to.
-			*/
+			 * The selector for the HTML element to reparent the vue-at panel to.
+			 */
 			atWhoPanelParentSelector: 'body',
 			at: null,
 			atWhoPanelElement: null,


### PR DESCRIPTION
Follow up to #2691 

This pull request mainly fixes the autocompletion in the chat tab of the Files app. Basically it removes the default vue-at style sheet and replaces it with a custom one that only affects Talk candidate mentions, as the selectors used in the default one were too broad and affected too the autocompletion in the comments tab.

In a similar way the selectors used in the comments tab are too broad too and affect Talk candidate mentions, so some of these rules had to be overriden for that element.

Although I tried to dynamically change the vue-at style sheet it did not fully work (most rules were fine, but for some reason the text was not properly aligned, may be related to the order of the rules that is not the same in the original CSS file and in the JavaScript objects), so for the time being a full SCSS file was added.

There are still a couple of issues:
- When typing a mention in the chat tab the panel jumps. This does not happen in the regular UI, and it is caused by setting the position after reparenting the element (which ironically is needed to prevent the jumping in the regular UI). I still need to investigate this, but this should not be a blocker for this pull request.
- If the candidate mentions are open in the chat tab when changing to a different file they will not be hidden. Not sure how to fix that yet, although it could be done anyway in another pull request too.

## How to test
- Open the Files app
- Open the chat tab of a shared file (if you are sharing it for the first time reload, as there is currently a bug in the server that causes the placeholder in the chat tab to not be updated)
- In the message in put type _@_ and the first letter of a user that the file is shared with

### Result with this pull request
The candidate mentions are shown.

### Result without this pull request
The candidate mentions are not shown.
