### PR TITLE
Fix shares done via talk

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -269,6 +269,16 @@ class SystemMessage {
 				$userFolder = $this->rootFolder->getUserFolder($participant->getUser());
 				if ($userFolder instanceof Node) {
 					$userNodes = $userFolder->getById($node->getId());
+
+					if (empty($userNodes)) {
+						// FIXME This should be much more sensible, e.g.
+						// 1. Only be executed on "Waiting for new messages"
+						// 2. Once per request
+						\OC_Util::tearDownFS();
+						\OC_Util::setupFS($participant->getUser());
+						$userNodes = $userFolder->getById($node->getId());
+					}
+
 					if (empty($userNodes)) {
 						throw new NotFoundException('File was not found');
 					}


### PR DESCRIPTION
Fix #2733

> ### Re-setup the filesystem in case a share message failed
> 
> This happens when your request is already waiting for new chat messages.
> The filesystem is already set up, so the share will not be discovered
> unless the mount points are initialised freshly
