### PR TITLE
Leave conversation when navigating away

### DIFF
--- a/src/FilesSidebarCallViewApp.vue
+++ b/src/FilesSidebarCallViewApp.vue
@@ -19,15 +19,19 @@
   -->
 
 <template>
-	<CallView v-if="isInFile"
-		v-show="isInCall"
-		:token="token"
-		:use-constrained-layout="true" />
+	<div v-if="isInFile">
+		<CallView
+			v-show="isInCall"
+			:token="token"
+			:use-constrained-layout="true" />
+		<PreventUnload :when="isInCall" />
+	</div>
 </template>
 
 <script>
 import { PARTICIPANT } from './constants'
 import CallView from './components/CallView/CallView'
+import PreventUnload from 'vue-prevent-unload'
 
 export default {
 
@@ -35,6 +39,7 @@ export default {
 
 	components: {
 		CallView,
+		PreventUnload,
 	},
 
 	data() {

--- a/src/services/participantsService.js
+++ b/src/services/participantsService.js
@@ -67,6 +67,15 @@ const leaveConversation = async function(token) {
 }
 
 /**
+ * Leaves the conversation specified with the token.
+ *
+ * @param {string} token The conversation token;
+ */
+const leaveConversationSync = function(token) {
+	axios.delete(generateOcsUrl('apps/spreed/api/v1/room', 2) + token + '/participants/active')
+}
+
+/**
  * Add a participant to a conversation.
  * @param {token} token the conversation token.
  * @param {string} newParticipant the id of the new participant
@@ -136,6 +145,7 @@ const fetchParticipants = async(token) => {
 export {
 	joinConversation,
 	leaveConversation,
+	leaveConversationSync,
 	addParticipant,
 	removeCurrentUserFromConversation,
 	removeUserFromConversation,

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -65,6 +65,10 @@ async function getSignaling() {
 	return signaling
 }
 
+function getSignalingSync() {
+	return signaling
+}
+
 let currentToken = null
 let startedCall = null
 
@@ -121,5 +125,6 @@ export {
 	localMediaModel,
 	connectSignaling,
 	getSignaling,
+	getSignalingSync,
 	joinCall,
 }


### PR DESCRIPTION
* Enter a chat
* Click on another app in the top menu
* Check with another participant whether you are still active in the conversation (or look at the database directly)

Fix #2621 