### PR TITLE
Preserve whitespace when posting code

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/PlainText.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/PlainText.vue
@@ -37,7 +37,7 @@ export default {
 
 	computed: {
 		text() {
-			return this.clickableLinks(escapeHtml(this.data.text)).replace(/\n/g, '<br>')
+			return this.clickableLinks(escapeHtml(this.data.text))
 		},
 	},
 
@@ -68,5 +68,9 @@ export default {
 <style lang="scss" scoped>
 ::v-deep .external:after {
 	content: " ↗";
+}
+
+span {
+	white-space:pre-wrap;
 }
 </style>


### PR DESCRIPTION
Post code, e.g.:
```
export default {
	name: 'PlainText',
	props: {
		data: {
			type: Object,
			required: true,
		},
	},

	computed: {
		text() {
			return this.clickableLinks(escapeHtml(this.data.text))
		},
	},
```

Before | After
---|---
![Bildschirmfoto von 2020-01-15 22-39-54](https://user-images.githubusercontent.com/213943/72473953-1b689300-37e8-11ea-9a1a-16f0be742611.png) | ![Bildschirmfoto von 2020-01-15 22-39-36](https://user-images.githubusercontent.com/213943/72473974-26232800-37e8-11ea-8c0d-2b885d54c71d.png)
