### PR TITLE
Add support for opening files through viewer

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -32,6 +32,7 @@ use OCA\Talk\Manager;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\TalkSession;
+use OCA\Viewer\Event\LoadViewer;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -40,6 +41,7 @@ use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\Template\PublicTemplateResponse;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotPermittedException;
 use OCP\IInitialStateService;
@@ -53,6 +55,8 @@ use OCP\Notification\IManager as INotificationManager;
 class PageController extends Controller {
 	/** @var string|null */
 	private $userId;
+	/** @var IEventDispatcher */
+	private $eventDispatcher;
 	/** @var RoomController */
 	private $api;
 	/** @var TalkSession */
@@ -78,6 +82,7 @@ class PageController extends Controller {
 
 	public function __construct(string $appName,
 								IRequest $request,
+								IEventDispatcher $eventDispatcher,
 								RoomController $api,
 								TalkSession $session,
 								IUserSession $userSession,
@@ -91,6 +96,7 @@ class PageController extends Controller {
 								IRootFolder $rootFolder,
 								Config $config) {
 		parent::__construct($appName, $request);
+		$this->eventDispatcher = $eventDispatcher;
 		$this->api = $api;
 		$this->talkSession = $session;
 		$this->userSession = $userSession;
@@ -241,6 +247,10 @@ class PageController extends Controller {
 				} catch (NotPermittedException $e) {
 				}
 			}
+		}
+
+		if (class_exists(LoadViewer::class)) {
+			$this->eventDispatcher->dispatchTyped(new LoadViewer());
 		}
 
 		$params = [

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -23,7 +23,8 @@
 	<a :href="link"
 		class="container"
 		target="_blank"
-		rel="noopener noreferrer">
+		rel="noopener noreferrer"
+		@click="showPreview">
 		<img v-if="!isLoading && !failed"
 			class="preview"
 			alt=""
@@ -53,6 +54,10 @@ export default {
 			required: true,
 		},
 		name: {
+			type: String,
+			required: true,
+		},
+		path: {
 			type: String,
 			required: true,
 		},
@@ -91,6 +96,27 @@ export default {
 				height: previewSize,
 			})
 		},
+		isViewerAvailable() {
+			if (!OCA.Viewer) {
+				return false
+			}
+
+			const availableHandlers = OCA.Viewer.availableHandlers
+			for (let i = 0; i < availableHandlers.length; i++) {
+				if (availableHandlers[i].mimes.includes(this.mimetype)) {
+					return true
+				}
+			}
+
+			return false
+		},
+		internalAbsolutePath() {
+			if (this.path.startsWith('/')) {
+				return this.path
+			}
+
+			return '/' + this.path
+		},
 	},
 	mounted() {
 		const img = new Image()
@@ -102,6 +128,22 @@ export default {
 			this.isLoading = false
 		}
 		img.src = this.previewUrl
+	},
+	methods: {
+		showPreview(event) {
+			if (!this.isViewerAvailable) {
+				// Regular event handling by opening the link.
+				return
+			}
+
+			event.stopPropagation()
+			event.preventDefault()
+
+			OCA.Viewer.open({
+				// Viewer expects an internal absolute path starting with "/".
+				path: this.internalAbsolutePath,
+			})
+		},
 	},
 }
 </script>

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -22,6 +22,7 @@
 <template>
 	<a :href="link"
 		class="container"
+		:class="{ 'is-viewer-available': isViewerAvailable }"
 		target="_blank"
 		rel="noopener noreferrer"
 		@click="showPreview">
@@ -182,6 +183,12 @@ export default {
 		/* As the file preview is an inline block the name is set as a block to
 		force it to be on its own line below the preview. */
 		display: block;
+	}
+
+	&:not(.is-viewer-available) {
+		strong:after {
+			content: " ↗";
+		}
 	}
 }
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -156,6 +156,22 @@ export default {
 	image. */
 	display: inline-block;
 
+	/* Show a hover colour around the preview when navigating with the
+	 * keyboard through the file links (or hovering them with the mouse). */
+	&:hover,
+	&:focus,
+	&:active {
+		.preview {
+			background-color: var(--color-background-hover);
+
+			/* Trick to keep the same position while adding a padding to show
+			 * the background. */
+			box-sizing: content-box !important;
+			padding: 10px;
+			margin: -10px;
+		}
+	}
+
 	.preview {
 		display: block;
 		width: 128px;


### PR DESCRIPTION
Fix #2002

At this time the Viewer can open only internal files, which are available only for registered users. Therefore the Viewer is not loaded for guests.

Also, for the time being, due to a limitation in the Viewer API, when a file is opened the Viewer allows the user to iterate through all the files in the directory of that file instead of through all the files in the conversation, as it would have been expected.

Both issues will be solved in future releases of the viewer, so when that happens how the viewer is used will be updated in Talk.
