### PR TITLE
Fix redirect on "Talk to …" links

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -222,7 +222,7 @@ class PageController extends Controller {
 			}
 		} catch (RoomNotFoundException $e) {
 			return new RedirectResponse($this->url->linkToRoute('core.login.showLoginForm', [
-				'redirect_url' => $this->url->linkToRoute('spreed.Page.index', ['token' => $token]),
+				'redirect_url' => $this->url->linkToRoute('spreed.pagecontroller.showCall', ['token' => $token]),
 			]));
 		}
 
@@ -272,13 +272,13 @@ class PageController extends Controller {
 				if ($room->getType() !== Room::PUBLIC_CALL) {
 					throw new RoomNotFoundException();
 				}
-				return new RedirectResponse($this->url->linkToRoute('spreed.Page.index', ['token' => $token]));
+				return new RedirectResponse($this->url->linkToRoute('spreed.pagecontroller.showCall', ['token' => $token]));
 			} catch (RoomNotFoundException $e) {
 				return new RedirectResponse($this->url->linkToRoute('core.login.showLoginForm', [
-					'redirect_url' => $this->url->linkToRoute('spreed.Page.index', ['token' => $token]),
+					'redirect_url' => $this->url->linkToRoute('spreed.pagecontroller.showCall', ['token' => $token]),
 				]));
 			}
 		}
-		return new RedirectResponse($this->url->linkToRoute('spreed.Page.index', ['token' => $token]));
+		return new RedirectResponse($this->url->linkToRoute('spreed.pagecontroller.showCall', ['token' => $token]));
 	}
 }


### PR DESCRIPTION
Fix #2777

1. Open the contacts menu in the top
2. Click on the "Talk to …" option for a user

### Expected
Conversation opens

### Actually
You are redirected to `index.php/apps/spreed?token=…` which is not recognized by the router and therefor not opening the conversation