### PR TITLE
Avoid jump when avatar gets sticky

### DIFF
--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -181,7 +181,7 @@ export default {
 	flex-direction: column;
 	&__avatar {
 		position: sticky;
-		top: 44px;
+		top: 0;
 		height: 52px;
 		width: 52px;
 		padding: 18px 10px 10px 10px;


### PR DESCRIPTION
The sticky avatar currently jumps a bit since it already has enough spacing though the margin that is applied. Therefore setting the top to 0px makes sure that it is not jumping around when scrolling but just staying attached to the top.

Really neat design detail btw. :heart: 