### PR TITLE
Fix flow notifications

### DIFF
--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -310,7 +310,7 @@ class Notifier {
 	 * @return bool
 	 */
 	private function shouldUserBeNotified($userId, IComment $comment): bool {
-		if ($userId === $comment->getActorId()) {
+		if ($comment->getActorType() === 'users' && $userId === $comment->getActorId()) {
 			// Do not notify the user if they mentioned themselves
 			return false;
 		}


### PR DESCRIPTION
Steps

* Create a public share
* Create a flow to post to a channel on uploads
* Upload as a guest on the public share (with https://github.com/nextcloud/server/pull/19186 applied)
* Wait for the notification on your user

> ![https://i.imgflip.com/1c1uej.jpg](https://i.imgflip.com/1c1uej.jpg)

Fix #2861 
