### PR TITLE
Improve chat loading

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -180,12 +180,12 @@ export default {
 		 *          otherwise.
 		 */
 		isParticipant() {
-			const participantIndex = this.$store.getters.getParticipantIndex(this.token, this.$store.getters.getParticipantIdentifier())
-			if (participantIndex === -1) {
+			if (!this.conversation) {
 				return false
 			}
 
-			return true
+			const participantIndex = this.$store.getters.getParticipantIndex(this.token, this.$store.getters.getParticipantIdentifier())
+			return participantIndex !== -1
 		},
 
 		conversation() {

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -191,28 +191,14 @@ export default {
 		conversation() {
 			return this.$store.getters.conversations[this.token]
 		},
+
+		chatIdentifier() {
+			return this.token + ':' + this.isParticipant + ':' + this.isInLobby
+		},
 	},
 
 	watch: {
-		// Watchers for "token", "isParticipant" and "isInLobby" need to be
-		// separated and can not be unified in a boolean computed property (as
-		// for example that would not change when the token changes but the
-		// current participant is a participant in the old and the new
-		// conversation).
-		token: {
-			immediate: true,
-			handler() {
-				this.handleStartGettingMessagesPreconditions()
-			},
-		},
-
-		isParticipant: {
-			immediate: true,
-			handler() {
-				this.handleStartGettingMessagesPreconditions()
-			},
-		},
-		isInLobby: {
+		chatIdentifier: {
 			immediate: true,
 			handler() {
 				this.handleStartGettingMessagesPreconditions()

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -318,8 +318,11 @@ export default {
 						token: this.token,
 						id: this.conversation.lastReadMessage,
 					})
+
+					this.getMessages(true)
+				} else {
+					this.getMessages(false)
 				}
-				this.getMessages()
 			} else {
 				this.cancelLookForNewMessages()
 			}
@@ -328,10 +331,14 @@ export default {
 		/**
 		 * Fetches the messages of a conversation given the conversation token. Triggers
 		 * a long-polling request for new messages.
+		 * @param {boolean} loadOldMessages In case it is the first visit of this conversation, we need to load the history
 		 */
-		async getMessages() {
-			// Gets the history of the conversation.
-			await this.getOldMessages(true)
+		async getMessages(loadOldMessages) {
+			if (loadOldMessages) {
+				// Gets the history of the conversation.
+				await this.getOldMessages(true)
+			}
+
 			// Once the history is loaded, scroll to bottom
 			this.scrollToBottom()
 			// Once the history is received, startslooking for new messages.

--- a/src/services/messagesService.js
+++ b/src/services/messagesService.js
@@ -44,7 +44,7 @@ const fetchMessages = async function({ token, lastKnownMessageId, includeLastKno
  * @param {int} lastKnownMessageId The id of the last message in the store.
  */
 const lookForNewMessages = async({ token, lastKnownMessageId }, options) => {
-	const response = await axios.get(generateOcsUrl('apps/spreed/api/v1/chat', 2) + token + '?lookIntoFuture=1' + '&includeLastKnown=0' + `&lastKnownMessageId=${lastKnownMessageId}`, options)
+	const response = await axios.get(generateOcsUrl('apps/spreed/api/v1/chat', 2) + token + '?lookIntoFuture=1' + `&lastKnownMessageId=${lastKnownMessageId}` + '&includeLastKnown=0', options)
 	return response
 }
 

--- a/src/services/messagesService.js
+++ b/src/services/messagesService.js
@@ -31,7 +31,13 @@ import { generateOcsUrl } from '@nextcloud/router'
  * @param {object} options options
  */
 const fetchMessages = async function({ token, lastKnownMessageId, includeLastKnown }, options) {
-	const response = await axios.get(generateOcsUrl('apps/spreed/api/v1/chat', 2) + token + '?lookIntoFuture=0' + `&lastKnownMessageId=${lastKnownMessageId || ''}` + `&includeLastKnown=${includeLastKnown || 0}`, options)
+	const response = await axios.get(generateOcsUrl('apps/spreed/api/v1/chat', 2) + token, Object.assign(options, {
+		params: {
+			lookIntoFuture: 0,
+			lastKnownMessageId,
+			includeLastKnown: includeLastKnown || 0,
+		},
+	}))
 	return response
 }
 
@@ -44,7 +50,13 @@ const fetchMessages = async function({ token, lastKnownMessageId, includeLastKno
  * @param {int} lastKnownMessageId The id of the last message in the store.
  */
 const lookForNewMessages = async({ token, lastKnownMessageId }, options) => {
-	const response = await axios.get(generateOcsUrl('apps/spreed/api/v1/chat', 2) + token + '?lookIntoFuture=1' + `&lastKnownMessageId=${lastKnownMessageId}` + '&includeLastKnown=0', options)
+	const response = await axios.get(generateOcsUrl('apps/spreed/api/v1/chat', 2) + token, Object.assign(options, {
+		params: {
+			lookIntoFuture: 1,
+			lastKnownMessageId,
+			includeLastKnown: 0,
+		},
+	}))
 	return response
 }
 

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -24,6 +24,10 @@ import Vue from 'vue'
 const state = {
 	messages: {
 	},
+	firstKnown: {
+	},
+	lastKnown: {
+	},
 }
 
 const getters = {
@@ -63,6 +67,20 @@ const getters = {
 		}
 		return {}
 	},
+
+	getFirstKnownMessageId: (state) => (token) => {
+		if (state.firstKnown[token]) {
+			return state.firstKnown[token]
+		}
+		return null
+	},
+
+	getLastKnownMessageId: (state) => (token) => {
+		if (state.lastKnown[token]) {
+			return state.lastKnown[token]
+		}
+		return null
+	},
 }
 
 const mutations = {
@@ -99,6 +117,24 @@ const mutations = {
 	addTemporaryMessage(state, message) {
 		Vue.set(state.messages[message.token], message.id, message)
 	},
+
+	/**
+	 * @param {object} state current store state;
+	 * @param {string} token Token of the conversation
+	 * @param {string} id Id of the first known chat message
+	 */
+	setFirstKnownMessageId(state, { token, id }) {
+		Vue.set(state.firstKnown, token, id)
+	},
+
+	/**
+	 * @param {object} state current store state;
+	 * @param {string} token Token of the conversation
+	 * @param {string} id Id of the last known chat message
+	 */
+	setLastKnownMessageId(state, { token, id }) {
+		Vue.set(state.lastKnown, token, id)
+	},
 }
 
 const actions = {
@@ -133,13 +169,31 @@ const actions = {
 	/**
 	 * Add a temporary message generated in the client to
 	 * the store, these messages are deleted once the full
-	 * message object is recived from the server.
+	 * message object is received from the server.
 	 *
 	 * @param {object} context default store context;
 	 * @param {object} message the temporary message;
 	 */
 	addTemporaryMessage(context, message) {
 		context.commit('addTemporaryMessage', message)
+	},
+
+	/**
+	 * @param {object} context default store context;
+	 * @param {string} token Token of the conversation
+	 * @param {string} id Id of the first known chat message
+	 */
+	setFirstKnownMessageId(context, { token, id }) {
+		context.commit('setFirstKnownMessageId', { token, id })
+	},
+
+	/**
+	 * @param {object} context default store context;
+	 * @param {string} token Token of the conversation
+	 * @param {string} id Id of the last known chat message
+	 */
+	setLastKnownMessageId(context, { token, id }) {
+		context.commit('setLastKnownMessageId', { token, id })
 	},
 }
 


### PR DESCRIPTION
Fixed errors:
* Chat was initialised twice, the later request would cancel the first one and therefor slowing the loading down a lot
* Chat headers were ignored. So in case someone used 200 commands in a row, the chat would load infinitly for all other users