### PR TITLE
Bugfix/noid/fix chatview layout glitches

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -327,7 +327,6 @@ export default {
 
 .message {
 	padding: 4px 0 4px 0;
-	flex-direction: column;
 	&__author {
 		color: var(--color-text-maxcontrast);
 	}

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -337,7 +337,8 @@ export default {
 		&__text {
 			flex: 1 1 auto;
 			color: var(--color-text-light);
-			overflow-wrap: break-word;
+			white-space: pre-wrap;
+			word-break: break-word;
 			max-width: $message-max-width;
 			.single-emoji {
 				font-size: 250%;

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
@@ -20,18 +20,20 @@
 -->
 
 <template>
-	<UserBubble v-if="isMentionToAll"
-		:display-name="data.name"
-		:avatar-image="'icon-group-forced-white'"
-		:primary="true" />
-	<UserBubble v-else-if="isMentionToGuest"
-		:display-name="data.name"
-		:avatar-image="'icon-user-forced-white'"
-		:primary="isCurrentGuest" />
-	<UserBubble v-else
-		:display-name="data.name"
-		:user="data.id"
-		:primary="isCurrentUser" />
+	<div class="mention">
+		<UserBubble v-if="isMentionToAll"
+			:display-name="data.name"
+			:avatar-image="'icon-group-forced-white'"
+			:primary="true" />
+		<UserBubble v-else-if="isMentionToGuest"
+			:display-name="data.name"
+			:avatar-image="'icon-user-forced-white'"
+			:primary="isCurrentGuest" />
+		<UserBubble v-else
+			:display-name="data.name"
+			:user="data.id"
+			:primary="isCurrentUser" />
+	</div>
 </template>
 
 <script>
@@ -75,3 +77,10 @@ export default {
 	},
 }
 </script>
+
+:<style lang="scss" scoped>
+.mention {
+	display: contents;
+	white-space: nowrap;
+}
+</style>

--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -348,6 +348,8 @@ export default {
 	width: 100%;
 	border:none;
 	margin: 0;
+	word-break: break-word;
+	white-space: pre-wrap;
 }
 
 // Support for the placeholder text in the div contenteditable

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -31,7 +31,7 @@ components.
 				<h6>{{ getDisplayName }}</h6>
 			</div>
 			<div class="quote__main__text">
-				<p>{{ shortenQuotedMessage }}</p>
+				<p>{{ simpleQuotedMessage }}</p>
 			</div>
 		</div>
 		<div v-if="isNewMessageFormQuote" class="quote__main__right">
@@ -145,49 +145,6 @@ export default {
 			return subtitle
 		},
 
-		shortenQuotedMessage() {
-			let cutAtChar = 200
-
-			// We allow a maximum of 2 line breaks
-			const firstNewline = this.simpleQuotedMessage.indexOf('\n')
-			if (firstNewline !== -1) {
-				const secondNewline = this.simpleQuotedMessage.indexOf('\n', firstNewline + 1)
-				if (secondNewline !== -1) {
-					cutAtChar = Math.min(cutAtChar, secondNewline)
-				}
-			}
-
-			let cuttingAfterWord = true
-			if (cutAtChar <= this.simpleQuotedMessage.length) {
-				// When we cut the string, we look for the next space.
-				const nextSpace = this.simpleQuotedMessage.indexOf(' ', cutAtChar)
-				if (nextSpace !== -1 && nextSpace < cutAtChar + 15) {
-					// If it is in a reasonable distance, we finish the word and cut after it
-					cutAtChar = nextSpace
-				} else {
-					// If not, we look if there is a space reasonable before the cut position
-					const previousSpace = this.simpleQuotedMessage.lastIndexOf(' ', cutAtChar)
-					if (previousSpace !== -1 && previousSpace > cutAtChar - 15) {
-						cutAtChar = previousSpace
-					} else {
-						// We didn't find any space in near distance, so we cut
-						// just where we are and add the … at the position,
-						// since we cut in the middle of the word.
-						cuttingAfterWord = false
-					}
-				}
-			} else {
-				return this.simpleQuotedMessage
-			}
-
-			let message = this.simpleQuotedMessage.substr(0, cutAtChar)
-			if (cuttingAfterWord) {
-				message += ' …'
-			} else {
-				message += '…'
-			}
-			return message
-		},
 	},
 	methods: {
 		/**
@@ -225,6 +182,10 @@ export default {
 			& p {
 				text-overflow: ellipsis;
 				overflow: hidden;
+				// Allow 2 lines max and ellipsize the overflow;
+				display: -webkit-box;
+				-webkit-line-clamp: 2;
+				-webkit-box-orient: vertical;
 			}
 		}
 	}

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -31,7 +31,7 @@ components.
 				<h6>{{ getDisplayName }}</h6>
 			</div>
 			<div class="quote__main__text">
-				<p>{{ simpleQuotedMessage }}</p>
+				<p>{{ shortenedQuoteMessage }}</p>
 			</div>
 		</div>
 		<div v-if="isNewMessageFormQuote" class="quote__main__right">
@@ -143,6 +143,16 @@ export default {
 			})
 
 			return subtitle
+		},
+		// Shorten the message to 250 characters and append three dots to the end of the
+		// string. This is needed because on very wide screens, if the 250 characters
+		// fit, the css rules won't ellipsize the text-overflow.
+		shortenedQuoteMessage() {
+			if (this.simpleQuotedMessage.length >= 250) {
+				return this.simpleQuotedMessage.substring(0, 250) + '…'
+			} else {
+				return this.simpleQuotedMessage
+			}
 		},
 
 	},

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -207,11 +207,10 @@ export default {
 
 .quote {
 	border-left: 4px solid var(--color-primary);
-	margin: 10px 0 10px 0;
-	padding: 0 0 0 10px;
+	margin: 4px 0 4px 8px;
+	padding-left: 8px;
 	display: flex;
 	max-width: $messages-list-max-width - $message-utils-width;
-	margin: 0;
 	&__main {
 		display: flex;
 		flex-direction: column;
@@ -221,8 +220,9 @@ export default {
 		}
 		&__text {
 			color: var(--color-text-light);
+			white-space: pre-wrap;
+			word-break: break-word;
 			& p {
-				max-width: 662px;
 				text-overflow: ellipsis;
 				overflow: hidden;
 			}


### PR DESCRIPTION

### Layout

How to test:
1) Reduce the width of the screen to 600px or so;
2) Write a long word in the new message form so that the word is take more than 1 line long;

Before this pr: 
* The newmessageform layout breaks (gets wider)
* When posting the message, the messageslist layout brakes as well in the same way;

After this pr: 
* The words are correctly broken down


### Quote: 
Now the quote component limits the amount of rows in the quote via CSS

How to test:

1) Open a conversation with long quotes (more than 2 lines);
2) Resize the window (make it narrower);


Before this pr: 
* The amount of text displayed doesn't change and the quote row number increase.

After this pr: 
* The amount of text displayed is less and the row number is the same (2)
