### PR TITLE
Cancel getparticipants requests once changing conversation

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -92,7 +92,8 @@ import { loadState } from '@nextcloud/initial-state'
 import SHA1 from 'crypto-js/sha1'
 import Hex from 'crypto-js/enc-hex'
 import CancelableRequest from '../../../utils/cancelableRequest'
-import Axios from "@nextcloud/axios"
+import Axios from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
 
 export default {
 	name: 'ParticipantsTab',
@@ -287,7 +288,7 @@ export default {
 				this.contactsLoading = false
 			} catch (exception) {
 				console.error(exception)
-				OCP.Toast.error(t('spreed', 'An error occurred while performing the search'))
+				showError(t('spreed', 'An error occurred while performing the search'))
 			}
 		},
 
@@ -341,7 +342,7 @@ export default {
 			} catch (exception) {
 				if (!Axios.isCancel(exception)) {
 					console.error(exception)
-					OCP.Toast.error(t('spreed', 'An error occurred while fetching the participants'))
+					showError(t('spreed', 'An error occurred while fetching the participants'))
 				}
 			}
 		},

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -92,6 +92,7 @@ import { loadState } from '@nextcloud/initial-state'
 import SHA1 from 'crypto-js/sha1'
 import Hex from 'crypto-js/enc-hex'
 import CancelableRequest from '../../../utils/cancelableRequest'
+import Axios from "@nextcloud/axios"
 
 export default {
 	name: 'ParticipantsTab',
@@ -338,8 +339,10 @@ export default {
 				})
 				this.participantsInitialised = true
 			} catch (exception) {
-				console.error(exception)
-				OCP.Toast.error(t('spreed', 'An error occurred while fetching the participants'))
+				if (!Axios.isCancel(exception)) {
+					console.error(exception)
+					OCP.Toast.error(t('spreed', 'An error occurred while fetching the participants'))
+				}
 			}
 		},
 	},

--- a/src/services/participantsService.js
+++ b/src/services/participantsService.js
@@ -137,8 +137,8 @@ const demoteFromModerator = async(token, options) => {
 	return response
 }
 
-const fetchParticipants = async(token) => {
-	const response = await axios.get(generateOcsUrl('apps/spreed/api/v1/room', 2) + token + '/participants')
+const fetchParticipants = async(token, options) => {
+	const response = await axios.get(generateOcsUrl('apps/spreed/api/v1/room', 2) + token + '/participants', options)
 	return response
 }
 


### PR DESCRIPTION
Avoid duplicating getparticipants requests when quickly switching between conversations.

Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>