### PR TITLE
l10n: Changed spelling of "user name" to "username" 

### DIFF
--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -118,7 +118,7 @@ export default {
 			}
 
 			if (displayName === '') {
-				return t('spreed', '[Unknown user name]')
+				return t('spreed', '[Unknown username]')
 			}
 
 			return displayName

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -117,7 +117,7 @@ export default {
 			}
 
 			if (displayName === '') {
-				return t('spreed', '[Unknown user name]')
+				return t('spreed', '[Unknown username]')
 			}
 
 			return displayName

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -116,7 +116,7 @@ export default {
 				}
 
 				if (displayName === '') {
-					return t('spreed', '[Unknown user name]')
+					return t('spreed', '[Unknown username]')
 				}
 
 				return displayName


### PR DESCRIPTION
Using "username" like on > 200 strings over the whole Nextcloud project.

Signed-off-by: rakekniven mark.ziegler@rakekniven.de