### PR TITLE
End search operation when selecting a conversation

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
@@ -24,7 +24,8 @@
 		<Conversation
 			v-for="item of conversationsList"
 			:key="item.id"
-			:item="item" />
+			:item="item"
+			@click.native="handleConversationClick" />
 		<template
 			v-if="!initialisedConversations">
 			<LoadingHint
@@ -135,6 +136,10 @@ export default {
 				console.debug('Error while fetching conversations: ', error)
 			}
 		},
+		// Emit the click event so the search text in the leftsidebar can be reset.
+		handleConversationClick() {
+			this.$emit('click-conversation')
+		}
 	},
 }
 </script>

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -32,7 +32,8 @@
 				:title="t('spreed', 'Conversations')" />
 			<li>
 				<ConversationsList
-					:search-text="searchText" />
+					:search-text="searchText"
+					@click-conversation="handleClickConversation" />
 			</li>
 			<template v-if="isSearching">
 				<template v-if="searchResultsUsers.length !== 0">
@@ -215,6 +216,10 @@ export default {
 		hasOneToOneConversationWith(userId) {
 			return !!this.conversationsList.find(conversation => conversation.type === CONVERSATION.TYPE.ONE_TO_ONE && conversation.name === userId)
 		},
+		// Reset the search text, therefore end the search operation.
+		handleClickConversation() {
+			this.searchText = ''
+		}
 	},
 }
 </script>


### PR DESCRIPTION
How to test: 

1) Initiate a search for a conversation;
2) click on an existing conversation;

Before this pr: 
The search filter is still applied and the conversations are still filtered;

After this pr: 
The search filter is cleared and the search operation is ended

Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>