### PR TITLE
Fix font-size of the chat input

### DIFF
--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -353,6 +353,11 @@ export default {
 }
 
 // Support for the placeholder text in the div contenteditable
+div[contenteditable] {
+	font-size: 14px;
+}
+
+// Support for the placeholder text in the div contenteditable
 [contenteditable]:empty:before{
 	content: attr(placeholder);
 	display: block;


### PR DESCRIPTION
@ma12-co @jancborchardt was it intentionally to keep 13 as a size on the input? Or an oversight?