### PR TITLE
Also scroll on inactive tabs

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -161,15 +161,15 @@ export default {
 		},
 
 		/**
-		 * In order for the state of the component to be sticky, the browser window must be
-		 * active and the div .scroller must be scrolled to the bottom.
+		 * In order for the state of the component to be sticky,
+		 * the div .scroller must be scrolled to the bottom.
 		 * When isSticky is true, as new messages are appended to the list, the div .scroller
 		 * automatically scrolls down to the last message, if it's false, new messages are
 		 * appended but the scrolling position is not altered.
 		 * @returns {boolean}
 		 */
 		isSticky() {
-			return this.isScrolledToBottom && this.$store.getters.windowIsVisible()
+			return this.isScrolledToBottom
 		},
 
 		/**


### PR DESCRIPTION
It's more what people expect than having to see that the window
is scrollable and not at the bottom. We might revert this, when the
"Unread messages" marker was implemented, but I don't think we should

Signed-off-by: Joas Schilling <coding@schilljs.com>