### PR TITLE
Fix guest collisions

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsList/ParticipantsList.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/ParticipantsList.vue
@@ -26,7 +26,7 @@
 			:class="{'scrollable': scrollable }">
 			<Participant
 				v-for="participant in participants"
-				:key="participant.userId"
+				:key="participant.userId + participant.sessionId"
 				:participant="participant"
 				@clickParticipant="handleClickParticipant" />
 			<!-- 'search for more' empty content to display at the end of the


### PR DESCRIPTION
Duplicate keys detected: ''. This may cause an update error.

### Steps

1. Create a public conversation
2. Join as 2 guests
3. As one of them set a name
4. As the creator of the conversation check the participants tab for the updated name :heavy_multiplication_x: 
5. Check your browsers console:
```
 [Vue warn]: Duplicate keys detected: ''. This may cause an update error.

found in

---> <ParticipantsList> at src/components/RightSidebar/Participants/ParticipantsList/ParticipantsList.vue
       <CurrentParticipants> at src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
         <ParticipantsTab> at src/components/RightSidebar/Participants/ParticipantsTab.vue
           <AppSidebarTab>
             <AppSidebar>
               <RightSidebar> at src/components/RightSidebar/RightSidebar.vue
                 <Content>
                   <App> at src/App.vue
                     <Root>
```

