### PR TITLE
Make sure the secondary view has an id

### DIFF
--- a/src/views/FilesSidebarCallView.js
+++ b/src/views/FilesSidebarCallView.js
@@ -36,6 +36,7 @@ export default class FilesSidebarCallView {
 		this.callViewInstance = OCA.Talk.newCallView()
 
 		this.$el = document.createElement('div')
+		this.id = 'FilesSidebarCallView'
 
 		this.callViewInstance.$mount(this.$el)
 		this.$el = this.callViewInstance.$el


### PR DESCRIPTION
The secondary view registration requires its views to have an id property set https://github.com/nextcloud/server/blob/b476659ac888618fdb01c1316db073237c9222d3/apps/files/src/services/Sidebar.js#L69

To reproduce enable the talk app and try to access the system tags in the files sidebar.

Related fix for system tags https://github.com/nextcloud/server/pull/19511