### PR TITLE
Prevent resharing of the same file

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -285,7 +285,18 @@ export default {
 			for (const index in shareableFiles) {
 				// The pat of the file to share to the conversation
 				const path = this.$store.getters.getAttachmentFolder() + '/' + shareableFiles[index].name
-				shareFile(path, token)
+				try {
+					// Mark current file as sharing
+					this.$store.dispatch('markFileAsSharing', { token, index })
+				} catch {
+					continue
+				}
+				try {
+					await shareFile(path, token)
+					this.$store.dispatch('markFileAsShared', { token, index })
+				} catch (exception) {
+					console.debug('An error happened when triying to share your file: ', exception)
+				}
 			}
 		},
 	},

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -169,6 +169,7 @@ const actions = {
 	 * Mark a file as shared
 	 * @param {object} context default store context;
 	 * @param {object} param1 conversation token and original file index
+	 * @throws {Error} when the item is already being shared by another async call
 	 */
 	markFileAsSharing({ commit, state }, { token, index }) {
 		if (state.files[token][index].status !== 'successUpload') {

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -39,15 +39,17 @@ const getters = {
 	// Returns all the files that have been successfully uploaded
 	getShareableFiles: (state) => (token) => {
 		if (state.files[token]) {
-			const shareableFiles = []
+			const shareableFiles = {}
 			for (const index in state.files[token]) {
 				const currentFile = state.files[token][index]
 				if (currentFile.status === 'successUpload') {
-					shareableFiles.push(currentFile.file)
+					shareableFiles[index] = (currentFile.file)
 				}
 			}
 			return shareableFiles
-		} return undefined
+		} else {
+			return {}
+		}
 	},
 
 	getAttachmentFolder: (state) => () => {
@@ -82,6 +84,16 @@ const mutations = {
 	// Marks a given file as uploading
 	markFileAsUploading(state, { token, index }) {
 		state.files[token][index].status = 'uploading'
+	},
+
+	// Marks a given file as sharing
+	markFileAsSharing(state, { token, index }) {
+		state.files[token][index].status = 'sharing'
+	},
+
+	// Marks a given file as shared
+	markFileAsShared(state, { token, index }) {
+		state.files[token][index].status = 'shared'
 	},
 
 	/**
@@ -152,6 +164,28 @@ const actions = {
 	setAttachmentFolder(context, attachmentFolder) {
 		context.commit('setAttachmentFolder', attachmentFolder)
 	},
+
+	/**
+	 * Mark a file as shared
+	 * @param {object} context default store context;
+	 * @param {object} param1 conversation token and original file index
+	 */
+	markFileAsSharing({ commit, state }, { token, index }) {
+		if (state.files[token][index].status !== 'successUpload') {
+			throw new Error('Item is already being shared')
+		}
+		commit('markFileAsSharing', { token, index })
+	},
+
+	/**
+	 * Mark a file as shared
+	 * @param {object} context default store context;
+	 * @param {object} param1 conversation token and original file index
+	 */
+	markFileAsShared(context, { token, index }) {
+		context.commit('markFileAsShared', { token, index })
+	},
+
 }
 
 export default { state, mutations, getters, actions }


### PR DESCRIPTION
### How to test

1) Create a conversation with no previously shared files 
2) Upload a file;
3) Upload a second file;

### before this pr: 
When sharing the second file, the first file is re-shared before the second.

### after this pr: 
When sharing the second file, only the second file is shared.



Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>