### PR TITLE
Stop Firefox Addon "Grammar and Spell Checker" from breaking the chat

### DIFF
--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -62,6 +62,7 @@
 			:contenteditable="activeInput"
 			:placeHolder="placeholderText"
 			class="new-message-form__advancedinput"
+			data-lt-active="false"
 			@keydown.enter="handleKeydown"
 			@paste="onPaste" />
 	</At>


### PR DESCRIPTION
Fix #2847 