### PR TITLE
Get rid of underscore, jQuery and the console.log statements

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -26,8 +26,6 @@
  *
  */
 
-/* eslint-disable no-console */
-
 import {
 	fetchSignalingSettings,
 	pullSignalingMessages,
@@ -195,7 +193,7 @@ Signaling.Base.prototype.joinRoom = function(token, password) {
 			password: password,
 		})
 			.then(function(result) {
-				console.log('Joined', result)
+				console.debug('Joined', result)
 				this.currentRoomToken = token
 				this._trigger('joinRoom', [token])
 				resolve()
@@ -343,7 +341,7 @@ Signaling.Internal.prototype.on = function(ev/*, handler */) {
 
 Signaling.Internal.prototype.forceReconnect = function(newSession, flags) {
 	if (newSession) {
-		console.log('Forced reconnects with a new session are not supported in the internal signaling; same session as before will be used')
+		console.warn('Forced reconnects with a new session are not supported in the internal signaling; same session as before will be used')
 	}
 
 	if (flags !== undefined) {
@@ -390,9 +388,9 @@ Signaling.Internal.prototype._doLeaveRoom = function(token) {
 
 Signaling.Internal.prototype.sendCallMessage = function(data) {
 	if (data.type === 'answer') {
-		console.log('ANSWER', data)
+		console.debug('ANSWER', data)
 	} else if (data.type === 'offer') {
-		console.log('OFFER', data)
+		console.debug('OFFER', data)
 	}
 	this.spreedArrayConnection.push({
 		ev: 'message',
@@ -434,7 +432,7 @@ Signaling.Internal.prototype._startPullingMessages = function() {
 					this._trigger('message', [message.data])
 					break
 				default:
-					console.log('Unknown Signaling Message')
+					console.error('Unknown Signaling Message', message)
 					break
 				}
 				this._trigger('onAfterReceiveMessage', [message])
@@ -480,7 +478,7 @@ Signaling.Internal.prototype.sendPendingMessages = function() {
 		this.spreedArrayConnection.splice(0, pendingMessagesLength)
 		this.isSendingMessages = false
 	}.bind(this)).catch(function(/* xhr, textStatus, errorThrown */) {
-		console.log('Sending pending signaling messages has failed.')
+		console.error('Sending pending signaling messages has failed.')
 		this.isSendingMessages = false
 	}.bind(this))
 }
@@ -524,7 +522,7 @@ Signaling.Standalone.prototype.reconnect = function() {
 	// Wiggle interval a little bit to prevent all clients from connecting
 	// simultaneously in case the server connection is interrupted.
 	const interval = this.reconnectIntervalMs - (this.reconnectIntervalMs / 2) + (this.reconnectIntervalMs * Math.random())
-	console.log('Reconnect in', interval)
+	console.info('Reconnect in', interval)
 	this.reconnected = true
 	this.reconnectTimer = window.setTimeout(function() {
 		this.reconnectTimer = null
@@ -541,7 +539,7 @@ Signaling.Standalone.prototype.reconnect = function() {
 }
 
 Signaling.Standalone.prototype.connect = function() {
-	console.log('Connecting to', this.url)
+	console.debug('Connecting to', this.url)
 	this.callbacks = {}
 	this.id = 1
 	this.pendingMessages = []
@@ -550,16 +548,16 @@ Signaling.Standalone.prototype.connect = function() {
 	this.socket = new WebSocket(this.url)
 	window.signalingSocket = this.socket
 	this.socket.onopen = function(event) {
-		console.log('Connected', event)
+		console.debug('Connected', event)
 		this.reconnectIntervalMs = this.initialReconnectIntervalMs
 		this.sendHello()
 	}.bind(this)
 	this.socket.onerror = function(event) {
-		console.log('Error', event)
+		console.error('Error', event)
 		this.reconnect()
 	}.bind(this)
 	this.socket.onclose = function(event) {
-		console.log('Close', event)
+		console.debug('Close', event)
 		this.reconnect()
 	}.bind(this)
 	this.socket.onmessage = function(event) {
@@ -567,7 +565,7 @@ Signaling.Standalone.prototype.connect = function() {
 		if (typeof (data) === 'string') {
 			data = JSON.parse(data)
 		}
-		console.log('Received', data)
+		console.debug('Received', data)
 		const id = data.id
 		if (id && this.callbacks.hasOwnProperty(id)) {
 			const cb = this.callbacks[id]
@@ -601,7 +599,7 @@ Signaling.Standalone.prototype.connect = function() {
 			break
 		default:
 			if (!id) {
-				console.log('Ignore unknown event', data)
+				console.error('Ignore unknown event', data)
 			}
 			break
 		}
@@ -703,14 +701,14 @@ Signaling.Standalone.prototype.doSend = function(msg, callback) {
 		this.callbacks[id] = callback
 		msg['id'] = '' + id
 	}
-	console.log('Sending', msg)
+	console.debug('Sending', msg)
 	this.socket.send(JSON.stringify(msg))
 }
 
 Signaling.Standalone.prototype.sendHello = function() {
 	let msg
 	if (this.resumeId) {
-		console.log('Trying to resume session', this.sessionId)
+		console.debug('Trying to resume session', this.sessionId)
 		msg = {
 			'type': 'hello',
 			'hello': {
@@ -740,7 +738,7 @@ Signaling.Standalone.prototype.sendHello = function() {
 }
 
 Signaling.Standalone.prototype.helloResponseReceived = function(data) {
-	console.log('Hello response received', data)
+	console.debug('Hello response received', data)
 	if (data.type !== 'hello') {
 		if (this.resumeId) {
 			// Resuming the session failed, reconnect as new session.
@@ -758,7 +756,7 @@ Signaling.Standalone.prototype.helloResponseReceived = function(data) {
 	const resumedSession = !!this.resumeId
 	this.connected = true
 	if (this._forceReconnect && resumedSession) {
-		console.log('Perform pending forced reconnect')
+		console.info('Perform pending forced reconnect')
 		this.forceReconnect(true)
 		return
 	}
@@ -813,7 +811,7 @@ Signaling.Standalone.prototype.joinRoom = function(token /*, password */) {
 		// If we would join without a connection to the signaling server here,
 		// the room would be re-joined again in the "helloResponseReceived"
 		// callback, leading to two entries for anonymous participants.
-		console.log('Not connected to signaling server yet, defer joining room', token)
+		console.info('Not connected to signaling server yet, defer joining room', token)
 		this.currentRoomToken = token
 		return this._pendingJoinRoomPromise
 	}
@@ -839,11 +837,11 @@ Signaling.Standalone.prototype.joinRoom = function(token /*, password */) {
 
 Signaling.Standalone.prototype._joinRoomSuccess = function(token, nextcloudSessionId) {
 	if (!this.sessionId) {
-		console.log('No hello response received yet, not joining room', token)
+		console.error('No hello response received yet, not joining room', token)
 		return
 	}
 
-	console.log('Join room', token)
+	console.debug('Join room', token)
 	this.doSend({
 		'type': 'room',
 		'room': {
@@ -860,7 +858,7 @@ Signaling.Standalone.prototype._joinRoomSuccess = function(token, nextcloudSessi
 
 Signaling.Standalone.prototype.joinCall = function(token, flags) {
 	if (this.signalingRoomJoined !== token) {
-		console.log('Not joined room yet, not joining call', token)
+		console.debug('Not joined room yet, not joining call', token)
 		this.pendingJoinCall = {
 			token: token,
 			flags: flags,
@@ -882,7 +880,7 @@ Signaling.Standalone.prototype._leaveCallSuccess = function(/* token */) {
 }
 
 Signaling.Standalone.prototype.joinResponseReceived = function(data, token) {
-	console.log('Joined', data, token)
+	console.debug('Joined', data, token)
 	this.signalingRoomJoined = token
 	if (this.pendingJoinCall && token === this.pendingJoinCall.token) {
 		this.joinCall(this.pendingJoinCall.token, this.pendingJoinCall.flags)
@@ -901,14 +899,14 @@ Signaling.Standalone.prototype.joinResponseReceived = function(data, token) {
 }
 
 Signaling.Standalone.prototype._doLeaveRoom = function(token) {
-	console.log('Leave room', token)
+	console.debug('Leave room', token)
 	this.doSend({
 		'type': 'room',
 		'room': {
 			'roomid': '',
 		},
 	}, function(data) {
-		console.log('Left', data)
+		console.debug('Left', data)
 		this.signalingRoomJoined = null
 		// Any users we previously had in the room also "left" for us.
 		const leftUsers = Object.keys(this.joinedUsers)
@@ -931,7 +929,7 @@ Signaling.Standalone.prototype.processEvent = function(data) {
 		this.processRoomParticipantsEvent(data)
 		break
 	default:
-		console.log('Unsupported event target', data)
+		console.error('Unsupported event target', data)
 		break
 	}
 }
@@ -944,7 +942,7 @@ Signaling.Standalone.prototype.processRoomEvent = function(data) {
 	case 'join':
 		joinedUsers = data.event.join || []
 		if (joinedUsers.length) {
-			console.log('Users joined', joinedUsers)
+			console.debug('Users joined', joinedUsers)
 			let leftUsers = {}
 			if (this.reconnected) {
 				this.reconnected = false
@@ -967,7 +965,7 @@ Signaling.Standalone.prototype.processRoomEvent = function(data) {
 	case 'leave':
 		leftSessionIds = data.event.leave || []
 		if (leftSessionIds.length) {
-			console.log('Users left', leftSessionIds)
+			console.debug('Users left', leftSessionIds)
 			for (i = 0; i < leftSessionIds.length; i++) {
 				delete this.joinedUsers[leftSessionIds[i]]
 			}
@@ -979,7 +977,7 @@ Signaling.Standalone.prototype.processRoomEvent = function(data) {
 		this.processRoomMessageEvent(data.event.message.data)
 		break
 	default:
-		console.log('Unknown room event', data)
+		console.error('Unknown room event', data)
 		break
 	}
 }
@@ -991,12 +989,12 @@ Signaling.Standalone.prototype.processRoomMessageEvent = function(data) {
 		EventBus.$emit('shouldRefreshChatMessages')
 		break
 	default:
-		console.log('Unknown room message event', data)
+		console.error('Unknown room message event', data)
 	}
 }
 
 Signaling.Standalone.prototype.processRoomListEvent = function(data) {
-	console.log('Room list event', data)
+	console.debug('Room list event', data)
 	EventBus.$emit('shouldRefreshConversations')
 }
 
@@ -1008,7 +1006,7 @@ Signaling.Standalone.prototype.processRoomParticipantsEvent = function(data) {
 		EventBus.$emit('shouldRefreshConversations')
 		break
 	default:
-		console.log('Unknown room participant event', data)
+		console.error('Unknown room participant event', data)
 		break
 	}
 }
@@ -1023,7 +1021,7 @@ Signaling.Standalone.prototype.requestOffer = function(sessionid, roomType) {
 		// Got a user object.
 		sessionid = sessionid.sessionId || sessionid.sessionid
 	}
-	console.log('Request offer from', sessionid)
+	console.debug('Request offer from', sessionid)
 	this.doSend({
 		'type': 'message',
 		'message': {
@@ -1052,7 +1050,7 @@ Signaling.Standalone.prototype.sendOffer = function(sessionid, roomType) {
 		// Got a user object.
 		sessionid = sessionid.sessionId || sessionid.sessionid
 	}
-	console.log('Send offer to', sessionid)
+	console.debug('Send offer to', sessionid)
 	this.doSend({
 		'type': 'message',
 		'message': {

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -26,7 +26,7 @@
  *
  */
 
-/* global $, _ */
+/* global $ */
 
 /* eslint-disable no-console */
 
@@ -446,7 +446,7 @@ Signaling.Internal.prototype._startPullingMessages = function() {
 	request(this.currentRoomToken)
 		.then(function(result) {
 			this.pullMessagesFails = 0
-			$.each(result.data.ocs.data, function(id, message) {
+			result.data.ocs.data.forEach(message => {
 				this._trigger('onBeforeReceiveMessage', [message])
 				switch (message.type) {
 				case 'usersInRoom':
@@ -464,7 +464,7 @@ Signaling.Internal.prototype._startPullingMessages = function() {
 					break
 				}
 				this._trigger('onAfterReceiveMessage', [message])
-			}.bind(this))
+			})
 			this._startPullingMessages()
 		}.bind(this))
 		.catch(function(jqXHR, textStatus/*, errorThrown */) {

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -26,8 +26,6 @@
  *
  */
 
-/* global $ */
-
 /* eslint-disable no-console */
 
 import {
@@ -212,30 +210,6 @@ Signaling.Base.prototype.joinRoom = function(token, password) {
 			}.bind(this))
 			.catch(function(result) {
 				reject(result)
-
-				if (result.status === 403) {
-					// This should not happen anymore since we ask for the password before
-					// even trying to join the call, but let's keep it for now.
-					OC.dialogs.prompt(
-						t('spreed', 'Please enter the password for this call'),
-						t('spreed', 'Password required'),
-						function(result, password) {
-							if (result && password !== '') {
-								this.joinRoom(token, password)
-							}
-						}.bind(this),
-						true,
-						t('spreed', 'Password'),
-						true
-					).then(function() {
-						const $dialog = $('.oc-dialog:visible')
-						$dialog.find('.ui-icon').remove()
-
-						const $buttons = $dialog.find('button')
-						$buttons.eq(0).text(t('core', 'Cancel'))
-						$buttons.eq(1).text(t('core', 'Submit'))
-					})
-				}
 			}.bind(this))
 	})
 }

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -208,7 +208,7 @@ Signaling.Base.prototype.joinRoom = function(token, password) {
 			}.bind(this))
 			.catch(function(result) {
 				reject(result)
-			}.bind(this))
+			})
 	})
 }
 

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -34,6 +34,7 @@ import CancelableRequest from './cancelableRequest'
 import { EventBus } from '../services/EventBus'
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
+import { showError } from '@nextcloud/dialogs'
 
 const Signaling = {
 	Base: {},
@@ -365,8 +366,7 @@ Signaling.Internal.prototype._sendMessageWithCallback = function(ev) {
 		}.bind(this))
 		.catch(function(err) {
 			console.error(err)
-			OC.Notification.show('Sending signaling message with callback has failed.', {
-				type: 'error',
+			showError(t('spreed', 'Sending signaling message has failed.'), {
 				timeout: 15,
 			})
 		})

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -98,11 +98,7 @@ Signaling.Base.prototype.on = function(ev, handler) {
 	case 'turnservers':
 		servers = this.settings[ev] || []
 		if (servers.length) {
-			// The caller expects the handler to be called when the data
-			// is available, so defer to simulate a delayed response.
-			// FIXME is defer needed? _.defer(function() {
 			handler(servers)
-			// FIXME is defer needed? })
 		}
 		break
 	}
@@ -941,7 +937,7 @@ Signaling.Standalone.prototype._doLeaveRoom = function(token) {
 		console.log('Left', data)
 		this.signalingRoomJoined = null
 		// Any users we previously had in the room also "left" for us.
-		const leftUsers = _.keys(this.joinedUsers)
+		const leftUsers = Object.keys(this.joinedUsers)
 		if (leftUsers.length) {
 			this._trigger('usersLeft', [leftUsers])
 		}
@@ -980,13 +976,13 @@ Signaling.Standalone.prototype.processRoomEvent = function(data) {
 				this.reconnected = false
 				// The browser reconnected, some of the previous sessions
 				// may now no longer exist.
-				leftUsers = _.extend({}, this.joinedUsers)
+				leftUsers = Object.assign({}, this.joinedUsers)
 			}
 			for (i = 0; i < joinedUsers.length; i++) {
 				this.joinedUsers[joinedUsers[i].sessionid] = true
 				delete leftUsers[joinedUsers[i].sessionid]
 			}
-			leftUsers = _.keys(leftUsers)
+			leftUsers = Object.keys(leftUsers)
 			if (leftUsers.length) {
 				this._trigger('usersLeft', [leftUsers])
 			}

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -776,7 +776,7 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 		}
 	})
 
-	webrtc.on('localMediaStarted', function(configuration) {
+	webrtc.on('localMediaStarted', function(/* configuration */) {
 		console.info('localMediaStarted')
 
 		clearLocalStreamRequestedTimeoutAndHideNotification()
@@ -867,7 +867,7 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 	})
 
 	// Local screen added.
-	webrtc.on('localScreenAdded', function(video) {
+	webrtc.on('localScreenAdded', function(/* video */) {
 		const currentSessionId = signaling.getSessionId()
 		for (const sessionId in usersInCallMapping) {
 			if (!usersInCallMapping.hasOwnProperty(sessionId)) {

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -667,7 +667,7 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 				checkPeerMedia(peer, video, 'video').then(function() {
 					clearInterval(peer.check_video_interval)
 					peer.check_video_interval = null
-				})
+				}).catch()
 			})
 		}, 1000)
 		peer.check_audio_interval = setInterval(function() {
@@ -675,7 +675,7 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 				checkPeerMedia(peer, audio, 'audio').then(function() {
 					clearInterval(peer.check_audio_interval)
 					peer.check_audio_interval = null
-				})
+				}).catch()
 			})
 		}, 1000)
 	}

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -29,6 +29,7 @@
 import SimpleWebRTC from './simplewebrtc/simplewebrtc'
 import { PARTICIPANT } from '../../constants.js'
 import store from '../../store/index.js'
+import { showError } from '@nextcloud/dialogs'
 
 let webrtc
 const spreedPeerConnectionTable = []
@@ -747,7 +748,7 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 		localStreamRequestedTimeout = null
 
 		if (localStreamRequestedTimeoutNotification) {
-			OC.Notification.hide(localStreamRequestedTimeoutNotification)
+			localStreamRequestedTimeoutNotification.hideToast()
 			localStreamRequestedTimeoutNotification = null
 		}
 	}
@@ -763,7 +764,9 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 		localStreamRequestedTimeout = setTimeout(function() {
 			// FIXME emit an event and handle it as needed instead of
 			// calling UI code from here.
-			localStreamRequestedTimeoutNotification = OC.Notification.show(t('spreed', 'This is taking longer than expected. Are the media permissions already granted (or rejected)? If yes please restart your browser, as audio and video are failing'), { type: 'error' })
+			localStreamRequestedTimeoutNotification = showError(t('spreed', 'This is taking longer than expected. Are the media permissions already granted (or rejected)? If yes please restart your browser, as audio and video are failing'), {
+				timeout: 10,
+			})
 		}, 10000)
 	})
 
@@ -807,8 +810,7 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 			console.error('Error while accessing microphone & camera: ', error.message || error.name)
 		}
 
-		OC.Notification.show(message, {
-			type: 'error',
+		showError(message, {
 			timeout: 15,
 		})
 	})

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -26,8 +26,6 @@
  *
  */
 
-/* global $ */
-
 /* eslint-disable no-console */
 
 import SimpleWebRTC from './simplewebrtc/simplewebrtc'
@@ -625,29 +623,29 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 	})
 
 	function checkPeerMedia(peer, track, mediaType) {
-		const defer = $.Deferred()
-		peer.pc.getStats(track).then(function(stats) {
-			let result = false
-			stats.forEach(function(statsReport) {
-				if (result || statsReport.mediaType !== mediaType || !statsReport.hasOwnProperty('bytesReceived')) {
-					return
-				}
+		return new Promise((resolve, reject) => {
+			peer.pc.getStats(track).then(function(stats) {
+				let result = false
+				stats.forEach(function(statsReport) {
+					if (result || statsReport.mediaType !== mediaType || !statsReport.hasOwnProperty('bytesReceived')) {
+						return
+					}
 
-				if (statsReport.bytesReceived > 0) {
-					webrtc.emit('unmute', {
-						id: peer.id,
-						name: mediaType,
-					})
-					result = true
+					if (statsReport.bytesReceived > 0) {
+						webrtc.emit('unmute', {
+							id: peer.id,
+							name: mediaType,
+						})
+						result = true
+					}
+				})
+				if (result) {
+					resolve()
+				} else {
+					reject(new Error())
 				}
 			})
-			if (result) {
-				defer.resolve()
-			} else {
-				defer.reject()
-			}
 		})
-		return defer
 	}
 
 	function stopPeerCheckMedia(peer) {


### PR DESCRIPTION
- [x] console.log in signaling
- [x] console.log in webrtc
- [x] $.* in signaling
- [x] $() in signaling
- [x] $.* in webrtc
- [x] _.* in signaling
- [x] Replace OC.Notifications with `@nextcloud/dialogs`

Fix #2562 