### PR TITLE
Fix search box to add participants shown to regular participants

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -308,8 +308,9 @@ export default {
 		},
 
 		displaySearchBox() {
-			return this.conversation.type === CONVERSATION.TYPE.GROUP
-				|| this.conversation.type === CONVERSATION.TYPE.PUBLIC
+			return this.canFullModerate
+				&& (this.conversation.type === CONVERSATION.TYPE.GROUP
+					|| this.conversation.type === CONVERSATION.TYPE.PUBLIC)
 		},
 		isSearching() {
 			return this.searchText !== ''


### PR DESCRIPTION
Only logged in moderators can add participants to a conversation, so the search box should be shown only to them.