### PR TITLE
Handle the new reference id for snappier chat feeling

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -50,3 +50,4 @@ title: Capabilities
 * `config => conversations => can-create` - Whether the user can create public and group conversations, if not only one-to-one conversations are allowed
 * `force-mute` - "forceMute" signaling messages can be sent to mute other participants.
 * `conversation-v2` - The conversations API v2 is less load heavy and should be used by clients when available. Check the difference in the [Conversation API documentation](conversation.md).
+* `chat-reference-id` - an optional referenceId can be sent with a chat message to be able to identify it in parallel get requests to earlier fade out a temporary message

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -44,6 +44,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         `systemMessage` | string | empty for normal chat message or the type of the system message (untranslated)
         `messageType` | string | Currently known types are `comment`, `system` and `command`
         `isReplyable` | bool | True if the user can post a reply to this message (only available with `chat-replies` capability)
+        `referenceId` | string | A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability)
         `message` | string | Message string with placeholders (see [Rich Object String](https://github.com/nextcloud/server/issues/1706))
         `messageParameters` | array | Message parameters for `message` (see [Rich Object String](https://github.com/nextcloud/server/issues/1706))
 
@@ -58,6 +59,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
     `message` | string | The message the user wants to say
     `actorDisplayName` | string | Guest display name (ignored for logged in users)
     `replyTo` | int | The message ID this message is a reply to (only allowed for messages from the same conversation and when the message type is not `system` or `command`)
+    `referenceId` | string | A reference string to be able to identify the message again in a "get messages" request, should be a random sha256 (only available with `chat-reference-id` capability)
 
 * Response:
     - Header:

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -96,6 +96,7 @@ class Capabilities implements IPublicCapability {
 					'chat-replies',
 					'circles-support',
 					'force-mute',
+					'chat-reference-id',
 				],
 				'config' => [
 					'attachments' => $attachments,

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -145,11 +145,12 @@ class ChatManager {
 	 * @param string $actorType
 	 * @param string $actorId
 	 * @param string $message
-	 * @param IComment|null $replyTo
 	 * @param \DateTime $creationDateTime
+	 * @param IComment|null $replyTo
+	 * @param string $referenceId
 	 * @return IComment
 	 */
-	public function sendMessage(Room $chat, Participant $participant, string $actorType, string $actorId, string $message, \DateTime $creationDateTime, ?IComment $replyTo): IComment {
+	public function sendMessage(Room $chat, Participant $participant, string $actorType, string $actorId, string $message, \DateTime $creationDateTime, ?IComment $replyTo, string $referenceId): IComment {
 		$comment = $this->commentsManager->create($actorType, $actorId, 'chat', (string) $chat->getId());
 		$comment->setMessage($message, self::MAX_CHAT_LENGTH);
 		$comment->setCreationDateTime($creationDateTime);
@@ -159,6 +160,11 @@ class ChatManager {
 
 		if ($replyTo instanceof IComment) {
 			$comment->setParentId($replyTo->getId());
+		}
+
+		$referenceId = trim(substr($referenceId, 0, 40));
+		if ($referenceId !== '') {
+			$comment->setReferenceId($referenceId);
 		}
 
 		$event = new ChatParticipantEvent($chat, $comment, $participant);

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -121,12 +121,13 @@ class ChatController extends AEnvironmentAwareController {
 	 *
 	 * @param string $message the message to send
 	 * @param string $actorDisplayName for guests
+	 * @param string $referenceId for the message to be able to later identify it again
 	 * @param int $replyTo Parent id which this message is a reply to
 	 * @return DataResponse the status code is "201 Created" if successful, and
 	 *         "404 Not found" if the room or session for a guest user was not
 	 *         found".
 	 */
-	public function sendMessage(string $message, string $actorDisplayName = '', int $replyTo = 0): DataResponse {
+	public function sendMessage(string $message, string $actorDisplayName = '', string $referenceId = '', int $replyTo = 0): DataResponse {
 
 		if ($this->userId === null) {
 			$actorType = 'guests';
@@ -170,7 +171,7 @@ class ChatController extends AEnvironmentAwareController {
 		$creationDateTime = $this->timeFactory->getDateTime('now', new \DateTimeZone('UTC'));
 
 		try {
-			$comment = $this->chatManager->sendMessage($this->room, $this->participant, $actorType, $actorId, $message, $creationDateTime, $parent);
+			$comment = $this->chatManager->sendMessage($this->room, $this->participant, $actorType, $actorId, $message, $creationDateTime, $parent, $referenceId);
 		} catch (MessageTooLongException $e) {
 			return new DataResponse([], Http::STATUS_REQUEST_ENTITY_TOO_LARGE);
 		} catch (\Exception $e) {

--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -175,6 +175,7 @@ class Message {
 			'systemMessage' => $this->getMessageType() === 'system' ? $this->getMessageRaw() : '',
 			'messageType' => $this->getMessageType(),
 			'isReplyable' => $this->isReplyable(),
+			'referenceId' => (string) $this->getComment()->getReferenceId(),
 		];
 	}
 }

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -83,9 +83,10 @@ import { postNewMessage } from '../../services/messagesService'
 import Quote from '../Quote'
 import Actions from '@nextcloud/vue/dist/Components/Actions'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
+import SHA1 from 'crypto-js/sha1'
+import Hex from 'crypto-js/enc-hex'
 import { shareFile } from '../../services/filesSharingServices'
 import { processFiles } from '../../utils/fileUpload'
-
 import { CONVERSATION } from '../../constants'
 
 const picker = getFilePickerBuilder(t('spreed', 'File to share'))
@@ -190,8 +191,9 @@ export default {
 		 * @returns {Object}
 		 */
 		createTemporaryMessage() {
+			const tempId = this.createTemporaryMessageId()
 			const message = Object.assign({}, {
-				id: this.createTemporaryMessageId(),
+				id: tempId,
 				actorId: this.$store.getters.getActorId(),
 				actorType: this.$store.getters.getActorType(),
 				actorDisplayName: this.$store.getters.getDisplayName(),
@@ -202,6 +204,7 @@ export default {
 				messageParameters: {},
 				token: this.token,
 				isReplyable: false,
+				referenceId: Hex.stringify(SHA1(tempId)),
 			})
 
 			if (this.$store.getters.getActorType() === 'guests') {

--- a/src/services/messagesService.js
+++ b/src/services/messagesService.js
@@ -63,13 +63,14 @@ const lookForNewMessages = async({ token, lastKnownMessageId }, options) => {
 /**
  * Posts a new messageto the server.
  *
- * @param {object} param0 The message object that is destructured;
- * @param {string} token The conversation token;
- * @param {string} message The message object;
- * @param {Number} parent The id of the message to be replied to.
+ * @param {object} param0 The message object that is destructured
+ * @param {string} token The conversation token
+ * @param {string} message The message object
+ * @param {string} referenceId A reference id to identify the message later again
+ * @param {Number} parent The id of the message to be replied to
  */
-const postNewMessage = async function({ token, message, actorDisplayName, parent }) {
-	const response = await axios.post(generateOcsUrl('apps/spreed/api/v1/chat', 2) + token, { message, actorDisplayName, replyTo: parent })
+const postNewMessage = async function({ token, message, actorDisplayName, referenceId, parent }) {
+	const response = await axios.post(generateOcsUrl('apps/spreed/api/v1/chat', 2) + token, { message, actorDisplayName, referenceId, replyTo: parent })
 	return response
 }
 

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -68,6 +68,17 @@ const getters = {
 		return {}
 	},
 
+	getTemporaryReferences: (state) => (token, referenceId) => {
+		if (!state.messages[token]) {
+			return []
+		}
+
+		return Object.values(state.messages[token]).filter(message => {
+			return message.referenceId === referenceId
+				&& ('' + message.id).startsWith('temp-')
+		})
+	},
+
 	getFirstKnownMessageId: (state) => (token) => {
 		if (state.firstKnown[token]) {
 			return state.firstKnown[token]
@@ -153,6 +164,14 @@ const actions = {
 			context.commit('addMessage', message.parent)
 			message.parent = message.parent.id
 		}
+
+		if (message.referenceId) {
+			const tempMessages = context.getters.getTemporaryReferences(message.token, message.referenceId)
+			tempMessages.forEach(tempMessage => {
+				context.commit('deleteMessage', tempMessage)
+			})
+		}
+
 		context.commit('addMessage', message)
 	},
 

--- a/tests/integration/features/chat/reference-id.feature
+++ b/tests/integration/features/chat/reference-id.feature
@@ -1,0 +1,36 @@
+Feature: chat/reference-id
+  Background:
+    Given user "participant1" exists
+
+  Scenario: user can send a message with a reference id and see it afterwards
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" sends message "Message 1" with reference id "ref 1" to room "group room" with 201
+    When user "participant1" sends message "Message 2" with reference id "ref 2" to room "group room" with 201
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters | referenceId |
+      | group room | users     | participant1 | participant1-displayname | Message 2 | []                | ref 2       |
+      | group room | users     | participant1 | participant1-displayname | Message 1 | []                | ref 1       |
+
+  Scenario: user can send a message with the same reference id
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" sends message "Message 1" with reference id "ref 1" to room "group room" with 201
+    When user "participant1" sends message "Message 2" with reference id "ref 1" to room "group room" with 201
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters | referenceId |
+      | group room | users     | participant1 | participant1-displayname | Message 2 | []                | ref 1       |
+      | group room | users     | participant1 | participant1-displayname | Message 1 | []                | ref 1       |
+
+  Scenario: too long references dont break the api
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" sends message "Message 1" with reference id "1234567890123456789012345678901234567890" to room "group room" with 201
+    When user "participant1" sends message "Message 2" with reference id "too long ref is cut off 123456789012345678901234567890" to room "group room" with 201
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters | referenceId |
+      | group room | users     | participant1 | participant1-displayname | Message 2 | []                | too long ref is cut off 1234567890123456 |
+      | group room | users     | participant1 | participant1-displayname | Message 1 | []                | 1234567890123456789012345678901234567890 |

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -96,6 +96,7 @@ class CapabilitiesTest extends TestCase {
 					'chat-replies',
 					'circles-support',
 					'force-mute',
+					'chat-reference-id',
 				],
 				'config' => [
 					'attachments' => [
@@ -187,6 +188,7 @@ class CapabilitiesTest extends TestCase {
 					'chat-replies',
 					'circles-support',
 					'force-mute',
+					'chat-reference-id',
 				],
 				'config' => [
 					'attachments' => [


### PR DESCRIPTION
- [x] Requires https://github.com/nextcloud/server/pull/19890
- [x] Handle reference id in the backend (allowing to set it and expose it)
- [x] Handle reference id in the UI when sending a message
- [x] Expand integration and unit tests

### To test
Apply the following patch to simulate a lot of notifications being sent:
```diff
diff --git a/lib/Controller/ChatController.php b/lib/Controller/ChatController.php
index d0bf74ee..ef984dd5 100644
--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -191,6 +191,8 @@ class ChatController extends AEnvironmentAwareController {
                if ($parentMessage instanceof Message) {
                        $data['parent'] = $parentMessage->toArray();
                }
+
+               sleep(10);
                return new DataResponse($data, Http::STATUS_CREATED);
        }
 

```

### Before
![Peek 2020-03-11 13-28](https://user-images.githubusercontent.com/213943/76417160-a60ae000-639c-11ea-9376-c643d2203453.gif)

### After
![Peek 2020-03-11 13-30](https://user-images.githubusercontent.com/213943/76417161-a7d4a380-639c-11ea-81fe-a44de8470bfc.gif)
