### PR TITLE
Also bail out when the path is actually null

### DIFF
--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -830,7 +830,7 @@ class RoomShareProvider implements IShareProvider {
 
 	private function isAccessibleResult(array $data): bool {
 		// exclude shares leading to deleted file entries
-		if ($data['fileid'] === null) {
+		if ($data['fileid'] === null || $data['path'] === null) {
 			return false;
 		}
 


### PR DESCRIPTION
Apparently this can happen when a external mount was shared
that is later not available anymore

Ref https://help.nextcloud.com/t/nextcloud-talk-kills-nextcloud-after-update-to-v18-0-3/75257