### PR TITLE
Guest name option is missing in calls

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -118,7 +118,8 @@
 			icon="icon-contacts-dark">
 			<ParticipantsTab :display-search-box="displaySearchBox" />
 		</AppSidebarTab>
-		<AppSidebarTab v-if="getUserId"
+		<AppSidebarTab
+			v-if="getUserId"
 			id="projects"
 			:order="3"
 			:name="t('spreed', 'Projects')"
@@ -128,8 +129,14 @@
 				type="room"
 				:name="conversation.displayName" />
 		</AppSidebarTab>
-		<!-- Guest username setting form -->
-		<SetGuestUsername v-if="!getUserId" />
+		<AppSidebarTab
+			v-if="!getUserId"
+			id="settings"
+			:order="4"
+			:name="t('spreed', 'Settings')"
+			icon="icon-settings">
+			<SetGuestUsername />
+		</AppSidebarTab>
 	</AppSidebar>
 </template>
 


### PR DESCRIPTION

The content of AppSidebar only shows non-AppSidebarTab components
when there is no AppSidebarTab. So as soon as a guest joined the call
and the Chat was moved into a sidebar tab, the rename option was gone


> ### After
> ![Bildschirmfoto von 2020-03-26 18-30-18](https://user-images.githubusercontent.com/213943/77677902-a5736b80-6f90-11ea-9aef-2d56e416f39f.png)