### PR TITLE
Fix guest avatar when not connected in a call

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -418,7 +418,8 @@ export default {
 
 #videos .videoContainer.not-connected ::v-deep {
 	video,
-	.avatardiv {
+	.avatardiv,
+	.avatar.guest {
 		opacity: 0.5;
 	}
 }

--- a/src/components/CallView/Video.vue
+++ b/src/components/CallView/Video.vue
@@ -33,7 +33,7 @@
 				:display-name="model.attributes.name"
 				:class="avatarClass" />
 			<div v-else
-				:class="avatarSizeClass"
+				:class="guestAvatarClass"
 				class="avatar guest">
 				{{ firstLetterOfGuestName }}
 			</div>
@@ -125,15 +125,18 @@ export default {
 			return (this.useConstrainedLayout && !this.sharedData.promoted) ? 64 : 128
 		},
 
-		avatarSizeClass() {
-			return 'avatar-' + this.avatarSize + 'px'
-		},
-
 		avatarClass() {
 			return {
 				'icon-loading': this.model.attributes.connectionState !== ConnectionState.CONNECTED && this.model.attributes.connectionState !== ConnectionState.COMPLETED && this.model.attributes.connectionState !== ConnectionState.FAILED_NO_RESTART,
 			}
 		},
+
+		guestAvatarClass() {
+			return Object.assign(this.avatarClass, {
+				['avatar-' + this.avatarSize + 'px']: true,
+			})
+		},
+
 		firstLetterOfGuestName() {
 			const customName = this.participantName !== t('spreed', 'Guest') ? this.participantName : '?'
 			return customName.charAt(0)


### PR DESCRIPTION
This fixes a regression introduced in #2734

## How to test
- Start a call with a logged in user
- Join the call with a guest

### Result with this pull request

In the browser of the logged in user the avatar for the guest is translucent and shows a loading icon until the connection is established.

### Result without this pull request

In the browser of the logged in user the avatar for the guest always has full opacity and no loading icon, so there is no way to differentiate when the user is connecting or already connected.
