### PR TITLE
Improve reply feature's user experience

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -27,6 +27,7 @@ the main body of the message as well as a quote.
 <template>
 	<div
 		class="message"
+		:class="{'hover': showActions && !isSystemMessage}"
 		@mouseover="showActions=true"
 		@mouseleave="showActions=false">
 		<div v-if="isFirstMessage && showAuthor" class="message__author">
@@ -327,7 +328,7 @@ export default {
 @import '../../../../assets/variables';
 
 .message {
-	padding: 4px 0 4px 0;
+	padding: 12px 8px;
 	&__author {
 		color: var(--color-text-maxcontrast);
 	}
@@ -376,10 +377,15 @@ export default {
 			padding: 0 8px 0 8px;
 			&__actions.action-item {
 				position: absolute;
-				top: -12px;
-				right: 0;
+				bottom: -11px;
+				right: -4px;
 			}
 		}
 	}
+}
+
+.hover {
+	background-color: var(--color-background-hover);
+	border-radius: 8px;
 }
 </style>


### PR DESCRIPTION
- [x] Provide hover feedback for the message that is going to be the object of the reply;
- [x] Align the reply button with the bottom of the Message component (now it's aligned to the top and it can be very confusing at times);
- [ ] <del> Add on-click tooltip for quick reply by right-clicking from anywhere on the message. Since we now have only one action we could make the cursor a pointer over a replyable message and provide a tooltip with a reply button. This way the user doesn't have to reach over to the reply button on the right.</del>


![Peek 2020-03-29 19-57](https://user-images.githubusercontent.com/26852655/77856452-9d693500-71f7-11ea-83f3-f0d15ed4cefa.gif)


Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>