### PR TITLE
Fix trying to create Peer for participant without streams

### DIFF
--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -241,6 +241,8 @@ function usersChanged(signaling, newUsers, disconnectedSessionIds) {
 					console.debug('No offer nor answer received, sending offer again')
 					createPeer()
 				}, 10000)
+			} else {
+				console.debug('User has no streams, not sending another offer')
 			}
 		}
 

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -207,7 +207,7 @@ function usersChanged(signaling, newUsers, disconnectedSessionIds) {
 		}
 
 		if (!webrtc.webrtc.getPeers(sessionId, 'video').length) {
-			if (useMcu) {
+			if (useMcu && userHasStreams(user)) {
 				// TODO(jojo): Already create peer object to avoid duplicate offers.
 				signaling.requestOffer(user, 'video')
 
@@ -216,13 +216,13 @@ function usersChanged(signaling, newUsers, disconnectedSessionIds) {
 
 					signaling.requestOffer(user, 'video')
 				}, 10000)
-			} else if (userHasStreams(selfInCall) && (!userHasStreams(user) || sessionId < currentSessionId)) {
+			} else if (!useMcu && userHasStreams(selfInCall) && (!userHasStreams(user) || sessionId < currentSessionId)) {
 				// To avoid overloading the user joining a room (who previously called
 				// all the other participants), we decide who calls who by comparing
 				// the session ids of the users: "larger" ids call "smaller" ones.
 				console.debug('Starting call with', user)
 				createPeer()
-			} else if (userHasStreams(selfInCall) && userHasStreams(user) && sessionId > currentSessionId) {
+			} else if (!useMcu && userHasStreams(selfInCall) && userHasStreams(user) && sessionId > currentSessionId) {
 				// If the remote peer is not aware that it was disconnected
 				// from the current peer the remote peer will not send a new
 				// offer; thus, if the current peer does not receive a new


### PR DESCRIPTION
When the MCU is used, if a participant does not send audio nor video streams the self Peer to connect to the MCU is not created. Due to this requesting an offer from that participant never succeeds, and thus a Peer to get the streams will never be created.

## How to test
- Setup the MCU
- Start a call with a user
- Join the call with a guest and reject the media permissions

### Result with this pull request
No offers are requested from the guest.

### Result without this pull request
In the browser console of the user _No offer received for new peer, request offer again_ appears again and again (every 10 seconds).
