### PR TITLE
Send media streams in calls only by moderators

### DIFF
--- a/src/PublicShareAuthSidebar.vue
+++ b/src/PublicShareAuthSidebar.vue
@@ -37,7 +37,6 @@
 import { getCurrentUser } from '@nextcloud/auth'
 import CallView from './components/CallView/CallView'
 import ChatView from './components/ChatView'
-import { PARTICIPANT } from './constants'
 import { EventBus } from './services/EventBus'
 import { fetchConversation } from './services/conversationsService'
 import {
@@ -148,7 +147,6 @@ export default {
 			await this.$store.dispatch('joinCall', {
 				token: this.token,
 				participantIdentifier: this.$store.getters.getParticipantIdentifier(),
-				flags: PARTICIPANT.CALL_FLAG.IN_CALL,
 			})
 		},
 

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -40,6 +40,7 @@
 					@switchScreenToId="_switchScreenToId" />
 			</template>
 			<LocalVideo ref="localVideo"
+				:token="token"
 				:local-media-model="localMediaModel"
 				:local-call-participant-model="localCallParticipantModel"
 				:use-constrained-layout="useConstrainedLayout"

--- a/src/components/CallView/LocalMediaControls.vue
+++ b/src/components/CallView/LocalMediaControls.vue
@@ -465,7 +465,7 @@ export default {
 
 .nameIndicator button.audio-disabled:not(.no-audio-available),
 .nameIndicator button.video-disabled:not(.no-video-available),
-.nameIndicator button.screensharing-disabled {
+.nameIndicator button.screensharing-disabled:not(.no-screensharing-available) {
 	&:hover,
 	&:focus {
 		opacity: 1;

--- a/src/components/CallView/LocalVideo.vue
+++ b/src/components/CallView/LocalVideo.vue
@@ -35,6 +35,7 @@
 			</div>
 		</div>
 		<LocalMediaControls ref="localMediaControls"
+			:token="token"
 			:model="localMediaModel"
 			:local-call-participant-model="localCallParticipantModel"
 			:screen-sharing-button-hidden="useConstrainedLayout"
@@ -60,6 +61,10 @@ export default {
 	},
 
 	props: {
+		token: {
+			type: String,
+			required: true,
+		},
 		localMediaModel: {
 			type: Object,
 			required: true,

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -143,12 +143,25 @@ export default {
 			return [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR].indexOf(participantType) !== -1
 		},
 
+		isSendingMediaAllowed() {
+			return this.conversation.participantType === PARTICIPANT.TYPE.OWNER
+				|| this.conversation.participantType === PARTICIPANT.TYPE.MODERATOR
+				|| this.conversation.objectType === 'share:password'
+				|| this.conversation.objectType === 'file'
+		},
+
 		async joinCall() {
+			let flags = PARTICIPANT.CALL_FLAG.IN_CALL
+			if (this.isSendingMediaAllowed()) {
+				flags |= PARTICIPANT.CALL_FLAG.WITH_AUDIO | PARTICIPANT.CALL_FLAG.WITH_VIDEO
+			}
+
 			console.info('Joining call')
 			this.loading = true
 			await this.$store.dispatch('joinCall', {
 				token: this.token,
 				participantIdentifier: this.$store.getters.getParticipantIdentifier(),
+				flags: flags,
 			})
 			this.loading = false
 		},

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -149,7 +149,6 @@ export default {
 			await this.$store.dispatch('joinCall', {
 				token: this.token,
 				participantIdentifier: this.$store.getters.getParticipantIdentifier(),
-				flags: PARTICIPANT.CALL_FLAG.IN_CALL, // FIXME add audio+video as per setting
 			})
 			this.loading = false
 		},

--- a/src/services/callsService.js
+++ b/src/services/callsService.js
@@ -26,13 +26,21 @@ import { joinCall as webRtcJoinCall, getSignaling } from '../utils/webrtc/index'
 
 /**
  * Join a call as participant
+ *
+ * The flags constrain the media to send when joining the call. If no flags are
+ * provided both audio and video are available. Otherwise only the specified
+ * media will be allowed to be sent.
+ *
+ * Note that the flags are constraints, but not requeriments. Only the specified
+ * media is allowed to be sent, but it is not guaranteed to be sent. For
+ * example, if WITH_VIDEO is provided but the device does not have a camera.
+ *
  * @param {string} token The token of the call to be joined.
  * @param {int} flags The available PARTICIPANT.CALL_FLAG for this participants
  */
 const joinCall = async function(token, flags) {
 	try {
-		// FIXME flags is ignored?
-		await webRtcJoinCall(token)
+		await webRtcJoinCall(token, flags)
 	} catch (error) {
 		console.debug('Error while joining call: ', error)
 	}

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -102,6 +102,27 @@ const actions = {
 		if (!currentUser.uid) {
 			currentUser = getCurrentUser()
 		}
+
+		if (!currentUser || !currentUser.uid) {
+			// Guests can not fetch the full participant list, but at least the
+			// participants store can be populated with the user ID, session ID,
+			// participant type and call status of the users from the
+			// conversation data.
+			context.dispatch('purgeParticipantsStore', conversation.token)
+
+			for (const participantId in conversation.participants) {
+				context.dispatch('addParticipant', {
+					token: conversation.token,
+					participant: {
+						inCall: conversation.participants[participantId].call,
+						sessionId: conversation.participants[participantId].sessionId,
+						participantType: conversation.participants[participantId].type,
+						userId: participantId,
+					},
+				})
+			}
+		}
+
 		context.dispatch('addParticipantOnce', {
 			token: conversation.token,
 			participant: {

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -105,7 +105,7 @@ function setupWebRtc() {
 	})
 }
 
-async function joinCall(token) {
+async function joinCall(token, flags) {
 	await connectSignaling()
 
 	setupWebRtc()
@@ -115,7 +115,7 @@ async function joinCall(token) {
 	return new Promise((resolve, reject) => {
 		startedCall = resolve
 
-		webRtc.startMedia(token)
+		webRtc.startMedia(token, flags)
 	})
 }
 

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -87,6 +87,8 @@ LocalMedia.prototype.start = function(mediaConstraints, cb) {
 	const constraints = mediaConstraints || this.config.media
 
 	if (!constraints.audio && !constraints.video) {
+		self.emit('localStream', constraints, null)
+
 		if (cb) {
 			return cb(null, null)
 		}

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -86,6 +86,14 @@ LocalMedia.prototype.start = function(mediaConstraints, cb) {
 	const self = this
 	const constraints = mediaConstraints || this.config.media
 
+	if (!constraints.audio && !constraints.video) {
+		if (cb) {
+			return cb(null, null)
+		}
+
+		return
+	}
+
 	if (!navigator || !navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
 		const error = new Error('MediaStreamError')
 		error.name = 'NotSupportedError'

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -344,9 +344,9 @@ SimpleWebRTC.prototype.setVolumeForAll = function(volume) {
 	})
 }
 
-SimpleWebRTC.prototype.joinCall = function(name) {
+SimpleWebRTC.prototype.joinCall = function(name, mediaConstraints) {
 	if (this.config.autoRequestMedia) {
-		this.startLocalVideo()
+		this.startLocalVideo(mediaConstraints)
 	}
 	this.roomName = name
 	this.emit('joinedRoom', name)
@@ -360,13 +360,13 @@ SimpleWebRTC.prototype.getEl = function(idOrEl) {
 	}
 }
 
-SimpleWebRTC.prototype.startLocalVideo = function() {
+SimpleWebRTC.prototype.startLocalVideo = function(mediaConstraints) {
 	const self = this
-	this.webrtc.start(this.config.media, function(err, stream) {
+	this.webrtc.start(mediaConstraints, function(err, stream) {
 		if (err) {
 			self.emit('localMediaError', err)
 		} else {
-			self.emit('localMediaStarted', self.config.media)
+			self.emit('localMediaStarted', mediaConstraints)
 
 			const localVideoContainer = self.getLocalVideoContainer()
 			if (localVideoContainer) {

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -424,8 +424,15 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 		webrtc.leaveCall()
 	})
 
-	webrtc.startMedia = function(token) {
-		webrtc.joinCall(token)
+	webrtc.startMedia = function(token, flags) {
+		// If no flags are provided try to enable both audio and video.
+		// Otherwise, try to enable only that allowed by the flags.
+		const mediaConstraints = {
+			audio: !flags || !!(flags & PARTICIPANT.CALL_FLAG.WITH_AUDIO),
+			video: !flags || !!(flags & PARTICIPANT.CALL_FLAG.WITH_VIDEO),
+		}
+
+		webrtc.joinCall(token, mediaConstraints)
 	}
 
 	const sendDataChannelToAll = function(channel, message, payload) {


### PR DESCRIPTION
Fixes #3203

This still needs more work, as currently it applies to all conversations. It should be configurable somehow, and also handled by mobile applications.
