### PR TITLE
Fix peers not connecting when talk is embedded in other pages

### DIFF
--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -87,6 +87,16 @@ function Peer(options) {
 
 util.inherits(Peer, WildEmitter)
 
+function shouldPreferH264() {
+	try {
+		return initialState.loadState('talk', 'prefer_h264')
+	} catch (exception) {
+		// If the state can not be loaded an exception is thrown
+		console.warn('Could not find initial state for H.264 preference')
+		return false
+	}
+}
+
 function preferH264VideoCodecIfAvailable(sessionDescription) {
 	const sdpInfo = sdpTransform.parse(sessionDescription.sdp)
 
@@ -142,7 +152,7 @@ function preferH264VideoCodecIfAvailable(sessionDescription) {
 
 Peer.prototype.offer = function(options) {
 	this.pc.createOffer(options).then(function(offer) {
-		if (initialState.loadState('talk', 'prefer_h264')) {
+		if (shouldPreferH264()) {
 			console.debug('Preferring hardware codec H.264 as per global configuration')
 			offer = preferH264VideoCodecIfAvailable(offer)
 		}
@@ -176,7 +186,7 @@ Peer.prototype.handleOffer = function(offer) {
 
 Peer.prototype.answer = function() {
 	this.pc.createAnswer().then(function(answer) {
-		if (initialState.loadState('talk', 'prefer_h264')) {
+		if (shouldPreferH264()) {
 			console.debug('Preferring hardware codec H.264 as per global configuration')
 			answer = preferH264VideoCodecIfAvailable(answer)
 		}

--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -87,11 +87,11 @@ function Peer(options) {
 
 util.inherits(Peer, WildEmitter)
 
-function preferH264VideoCodecIfAvailable(offer) {
-	const sdpInfo = sdpTransform.parse(offer.sdp)
+function preferH264VideoCodecIfAvailable(sessionDescription) {
+	const sdpInfo = sdpTransform.parse(sessionDescription.sdp)
 
 	if (!sdpInfo || !sdpInfo.media) {
-		return offer
+		return sessionDescription
 	}
 
 	// Find video media
@@ -103,7 +103,7 @@ function preferH264VideoCodecIfAvailable(offer) {
 	})
 
 	if (videoIndex === -1 || !sdpInfo.media[videoIndex].rtp) {
-		return offer
+		return sessionDescription
 	}
 
 	// Find all H264 codec videos
@@ -116,7 +116,7 @@ function preferH264VideoCodecIfAvailable(offer) {
 
 	if (!h264Rtps.length) {
 		// No H264 codecs found
-		return offer
+		return sessionDescription
 	}
 
 	// Sort the H264 codecs to the front in the payload (which defines the preferred order)
@@ -134,10 +134,10 @@ function preferH264VideoCodecIfAvailable(offer) {
 	// Write new payload order into video media payload
 	sdpInfo.media[videoIndex].payloads = payloads.join(' ')
 
-	// Write back the sdpInfo into the offer
-	offer.sdp = sdpTransform.write(sdpInfo)
+	// Write back the sdpInfo into the session description
+	sessionDescription.sdp = sdpTransform.write(sdpInfo)
 
-	return offer
+	return sessionDescription
 }
 
 Peer.prototype.offer = function(options) {


### PR DESCRIPTION
This fixes a regression introduced in #3153 

If the state can not be loaded (for example, if the server did not set the value, which happens when Talk is used in other apps) `loadState` throws an exception. This caused the creation of the offer to fail and thus prevented the peers to connect.

This pull request just ensures that the connection will go on if the value can not be found. @nickvergessen Feel free to set the initial state in the server also when Talk is used in other apps.

Steps below refer to the Files app, but it happens too in video verification and the Talk sidebar in public share pages.

## How to test
- Share a file with a user
- Join the conversation in the Files app
- Start a call
- With the other user, join the call in the Files app

### Result with this pull request
Both users connect with each other.

### Result without this pull request
Both users kept trying to connect to each other endlessly. Console shows `createOffer failed:  Error: "Could not find initial state prefer_h264 of talk"`.
