### PR TITLE
Check the signaling server connection and show the version in the adm…

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -47,6 +47,15 @@ return [
 			],
 		],
 		[
+			'name' => 'Signaling#getWelcomeMessage',
+			'url' => '/api/{apiVersion}/signaling/welcome/{serverId}',
+			'verb' => 'GET',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'serverId' => '^\d+$',
+			],
+		],
+		[
 			'name' => 'Signaling#backend',
 			'url' => '/api/{apiVersion}/signaling/backend',
 			'verb' => 'POST',

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -150,6 +150,8 @@ class SignalingController extends OCSController {
 			}
 
 			return new DataResponse($data);
+		} catch (\GuzzleHttp\Exception\ConnectException $e) {
+			return new DataResponse(['error' => 'CAN_NOT_CONNECT'], Http::STATUS_INTERNAL_SERVER_ERROR);
 		} catch (\Exception $e) {
 			return new DataResponse(['error' => $e->getCode()], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -141,12 +141,8 @@ class SignalingController extends OCSController {
 			$body = $response->getBody();
 
 			$data = json_decode($body, true);
-			if (!is_array($data)) {
+			if (!is_array($data) || !isset($data['version'])) {
 				return new DataResponse(['error' => 'JSON_INVALID'], Http::STATUS_INTERNAL_SERVER_ERROR);
-			}
-
-			if (!isset($data['version'])) {
-				return new DataResponse(['error' => 'VERSION_TOO_OLD'], Http::STATUS_INTERNAL_SERVER_ERROR);
 			}
 
 			return new DataResponse($data);

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -38,6 +38,7 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Http\Client\IClientService;
 use OCP\IDBConnection;
 use OCP\IRequest;
 use OCP\IUser;
@@ -66,6 +67,8 @@ class SignalingController extends OCSController {
 	private $dispatcher;
 	/** @var ITimeFactory */
 	private $timeFactory;
+	/** @var IClientService */
+	private $clientService;
 	/** @var string|null */
 	private $userId;
 
@@ -79,6 +82,7 @@ class SignalingController extends OCSController {
 								IUserManager $userManager,
 								IEventDispatcher $dispatcher,
 								ITimeFactory $timeFactory,
+								IClientService $clientService,
 								?string $UserId) {
 		parent::__construct($appName, $request);
 		$this->config = $config;
@@ -89,6 +93,7 @@ class SignalingController extends OCSController {
 		$this->userManager = $userManager;
 		$this->dispatcher = $dispatcher;
 		$this->timeFactory = $timeFactory;
+		$this->clientService = $clientService;
 		$this->userId = $UserId;
 	}
 
@@ -102,6 +107,52 @@ class SignalingController extends OCSController {
 	 */
 	public function getSettings(): DataResponse {
 		return new DataResponse($this->config->getSettings($this->userId));
+	}
+
+	/**
+	 * Only available for logged in users because guests can not use the apps
+	 * right now.
+	 *
+	 * @param int $serverId
+	 * @return DataResponse
+	 */
+	public function getWelcomeMessage(int $serverId): DataResponse {
+		$signalingServers = $this->config->getSignalingServers();
+		if (empty($signalingServers) || !isset($signalingServers[$serverId])) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		$url = rtrim($signalingServers[$serverId]['server'], '/');
+
+		if (strpos($url, 'wss://') === 0) {
+			$url = 'https://' . substr($url, 6);
+		}
+
+		if (strpos($url, 'ws://') === 0) {
+			$url = 'http://' . substr($url, 5);
+		}
+
+		$client = $this->clientService->newClient();
+		try {
+			$response = $client->get($url . '/api/v1/welcome', [
+				'verify' => (bool) $signalingServers[$serverId]['verify'],
+			]);
+
+			$body = $response->getBody();
+
+			$data = json_decode($body, true);
+			if (!is_array($data)) {
+				return new DataResponse(['error' => 'JSON_INVALID'], Http::STATUS_INTERNAL_SERVER_ERROR);
+			}
+
+			if (!isset($data['version'])) {
+				return new DataResponse(['error' => 'VERSION_TOO_OLD'], Http::STATUS_INTERNAL_SERVER_ERROR);
+			}
+
+			return new DataResponse($data);
+		} catch (\Exception $e) {
+			return new DataResponse(['error' => $e->getCode()], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
 	}
 
 	/**

--- a/src/components/AdminSettings/SignalingServer.vue
+++ b/src/components/AdminSettings/SignalingServer.vue
@@ -85,6 +85,7 @@ export default {
 			checked: false,
 			customError: '',
 			versionFound: '',
+			canNotConnect: false,
 			responseNotValidJson: false,
 			versionNotSupported: false,
 		}
@@ -94,6 +95,9 @@ export default {
 		connectionState() {
 			if (!this.checked) {
 				return t('spreed', 'Status: Checking connection')
+			}
+			if (this.canNotConnect) {
+				return t('spreed', 'Error: Can not connect to server')
 			}
 			if (this.responseNotValidJson) {
 				return t('spreed', 'Error: Server did not respond with proper JSON')
@@ -140,6 +144,7 @@ export default {
 
 			this.customError = ''
 			this.versionFound = ''
+			this.canNotConnect = false
 			this.responseNotValidJson = false
 			this.versionNotSupported = false
 
@@ -150,7 +155,9 @@ export default {
 			} catch (exception) {
 				this.checked = true
 				this.customError = t('spreed', 'Error: Unknown error occurred')
-				if (exception.response.data.ocs.data.error === 'JSON_INVALID') {
+				if (exception.response.data.ocs.data.error === 'CAN_NOT_CONNECT') {
+					this.canNotConnect = true
+				} else if (exception.response.data.ocs.data.error === 'JSON_INVALID') {
 					this.responseNotValidJson = true
 				} else if (exception.response.data.ocs.data.error === 'VERSION_TOO_OLD') {
 					this.versionNotSupported = true

--- a/src/components/AdminSettings/SignalingServer.vue
+++ b/src/components/AdminSettings/SignalingServer.vue
@@ -87,7 +87,6 @@ export default {
 			versionFound: '',
 			canNotConnect: false,
 			responseNotValidJson: false,
-			versionNotSupported: false,
 		}
 	},
 
@@ -101,9 +100,6 @@ export default {
 			}
 			if (this.responseNotValidJson) {
 				return t('spreed', 'Error: Server did not respond with proper JSON')
-			}
-			if (this.versionNotSupported) {
-				return t('spreed', 'Error: Server version is too old')
 			}
 			if (this.customError) {
 				return this.customError
@@ -159,8 +155,6 @@ export default {
 					this.canNotConnect = true
 				} else if (exception.response.data.ocs.data.error === 'JSON_INVALID') {
 					this.responseNotValidJson = true
-				} else if (exception.response.data.ocs.data.error === 'VERSION_TOO_OLD') {
-					this.versionNotSupported = true
 				} else if (exception.response.data.ocs.data.error) {
 					this.customError = t('spreed', 'Error: Server responded with: {error}', exception.response.data.ocs.data)
 				}

--- a/src/components/AdminSettings/SignalingServer.vue
+++ b/src/components/AdminSettings/SignalingServer.vue
@@ -83,10 +83,8 @@ export default {
 	data() {
 		return {
 			checked: false,
-			customError: '',
+			errorMessage: '',
 			versionFound: '',
-			canNotConnect: false,
-			responseNotValidJson: false,
 		}
 	},
 
@@ -95,14 +93,8 @@ export default {
 			if (!this.checked) {
 				return t('spreed', 'Status: Checking connection')
 			}
-			if (this.canNotConnect) {
-				return t('spreed', 'Error: Can not connect to server')
-			}
-			if (this.responseNotValidJson) {
-				return t('spreed', 'Error: Server did not respond with proper JSON')
-			}
-			if (this.customError) {
-				return this.customError
+			if (this.errorMessage) {
+				return this.errorMessage
 			}
 			return t('spreed', 'OK: Running version: {version}', {
 				version: this.versionFound,
@@ -138,11 +130,8 @@ export default {
 		async checkServerVersion() {
 			this.checked = false
 
-			this.customError = ''
+			this.errorMessage = ''
 			this.versionFound = ''
-			this.canNotConnect = false
-			this.responseNotValidJson = false
-			this.versionNotSupported = false
 
 			try {
 				const response = await getWelcomeMessage(this.index)
@@ -150,15 +139,15 @@ export default {
 				this.versionFound = response.data.ocs.data.version
 			} catch (exception) {
 				this.checked = true
-				this.customError = t('spreed', 'Error: Unknown error occurred')
 				if (exception.response.data.ocs.data.error === 'CAN_NOT_CONNECT') {
-					this.canNotConnect = true
+					this.errorMessage = t('spreed', 'Error: Can not connect to server')
 				} else if (exception.response.data.ocs.data.error === 'JSON_INVALID') {
-					this.responseNotValidJson = true
+					this.errorMessage = t('spreed', 'Error: Server did not respond with proper JSON')
 				} else if (exception.response.data.ocs.data.error) {
-					this.customError = t('spreed', 'Error: Server responded with: {error}', exception.response.data.ocs.data)
+					this.errorMessage = t('spreed', 'Error: Server responded with: {error}', exception.response.data.ocs.data)
+				} else {
+					this.errorMessage = t('spreed', 'Error: Unknown error occurred')
 				}
-				console.debug(exception.response.data.ocs.data.error)
 			}
 		},
 	},

--- a/src/components/AdminSettings/SignalingServer.vue
+++ b/src/components/AdminSettings/SignalingServer.vue
@@ -28,7 +28,7 @@
 			placeholder="wss://signaling.example.org"
 			:value="server"
 			:disabled="loading"
-			:aria-label="t('spreed', 'TURN server URL')"
+			:aria-label="t('spreed', 'Signaling server URL')"
 			@input="updateServer">
 		<input :id="'verify' + index"
 			type="checkbox"
@@ -42,11 +42,14 @@
 			v-tooltip.auto="t('spreed', 'Delete this server')"
 			class="icon icon-delete"
 			@click="removeServer" />
+
+		<span v-if="server">{{ connectionState }}</span>
 	</div>
 </template>
 
 <script>
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
+import { getWelcomeMessage } from '../../services/signalingService'
 
 export default {
 	name: 'SignalingServer',
@@ -77,6 +80,50 @@ export default {
 		},
 	},
 
+	data() {
+		return {
+			checked: false,
+			customError: '',
+			versionFound: '',
+			responseNotValidJson: false,
+			versionNotSupported: false,
+		}
+	},
+
+	computed: {
+		connectionState() {
+			if (!this.checked) {
+				return t('spreed', 'Status: Checking connection')
+			}
+			if (this.responseNotValidJson) {
+				return t('spreed', 'Error: Server did not respond with proper JSON')
+			}
+			if (this.versionNotSupported) {
+				return t('spreed', 'Error: Server version is too old')
+			}
+			if (this.customError) {
+				return this.customError
+			}
+			return t('spreed', 'OK: Running version: {version}', {
+				version: this.versionFound,
+			})
+		},
+	},
+
+	watch: {
+		loading(isLoading) {
+			if (!isLoading) {
+				this.checkServerVersion()
+			}
+		},
+	},
+
+	mounted() {
+		if (this.server) {
+			this.checkServerVersion()
+		}
+	},
+
 	methods: {
 		removeServer() {
 			this.$emit('removeServer', this.index)
@@ -86,6 +133,32 @@ export default {
 		},
 		updateVerify(event) {
 			this.$emit('update:verify', event.target.checked)
+		},
+
+		async checkServerVersion() {
+			this.checked = false
+
+			this.customError = ''
+			this.versionFound = ''
+			this.responseNotValidJson = false
+			this.versionNotSupported = false
+
+			try {
+				const response = await getWelcomeMessage(this.index)
+				this.checked = true
+				this.versionFound = response.data.ocs.data.version
+			} catch (exception) {
+				this.checked = true
+				this.customError = t('spreed', 'Error: Unknown error occurred')
+				if (exception.response.data.ocs.data.error === 'JSON_INVALID') {
+					this.responseNotValidJson = true
+				} else if (exception.response.data.ocs.data.error === 'VERSION_TOO_OLD') {
+					this.versionNotSupported = true
+				} else if (exception.response.data.ocs.data.error) {
+					this.customError = t('spreed', 'Error: Server responded with: {error}', exception.response.data.ocs.data)
+				}
+				console.debug(exception.response.data.ocs.data.error)
+			}
 		},
 	},
 }

--- a/src/services/signalingService.js
+++ b/src/services/signalingService.js
@@ -37,7 +37,12 @@ const pullSignalingMessages = async(token) => {
 	return axios.get(generateOcsUrl('apps/spreed/api/v1/signaling', 2) + token)
 }
 
+const getWelcomeMessage = async(serverId) => {
+	return axios.get(generateOcsUrl('apps/spreed/api/v1/signaling', 2) + 'welcome/' + serverId)
+}
+
 export {
 	fetchSignalingSettings,
 	pullSignalingMessages,
+	getWelcomeMessage,
 }


### PR DESCRIPTION

![Bildschirmfoto von 2020-04-06 17-05-59](https://user-images.githubusercontent.com/213943/78574624-885d5900-782a-11ea-9cb6-0181956b440b.png)

![Bildschirmfoto von 2020-04-06 17-06-45](https://user-images.githubusercontent.com/213943/78574625-898e8600-782a-11ea-8479-fe795bda0d9c.png)

I prefixed the messages with `OK: ` and `Error: ` after the screenshots.

For now this is okay I guess, in the future we could have icons displayed additionally, but for the current cases this is enough.