### PR TITLE
Fix missing element for Chromium screensharing extension

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -52,6 +52,7 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Notification\IManager as INotificationManager;
+use OCP\Util;
 
 class PageController extends Controller {
 	/** @var string|null */
@@ -233,6 +234,9 @@ class PageController extends Controller {
 			}
 		}
 
+		// Needed to enable the screensharing extension in Chromium < 72.
+		Util::addHeader('meta', ['id' => "app", 'class' => 'nc-enable-screensharing-extension']);
+
 		$this->initialStateService->provideInitialState(
 			'talk', 'prefer_h264',
 			$this->serverConfig->getAppValue('spreed', 'prefer_h264', 'no') === 'yes'
@@ -310,6 +314,9 @@ class PageController extends Controller {
 				return new RedirectResponse($passwordVerification['url']);
 			}
 		}
+
+		// Needed to enable the screensharing extension in Chromium < 72.
+		Util::addHeader('meta', ['id' => "app", 'class' => 'nc-enable-screensharing-extension']);
 
 		$this->initialStateService->provideInitialState(
 			'talk', 'prefer_h264',

--- a/lib/Files/TemplateLoader.php
+++ b/lib/Files/TemplateLoader.php
@@ -58,6 +58,9 @@ class TemplateLoader implements IEventListener {
 		Util::addStyle(Application::APP_ID, 'merged-files');
 		Util::addScript(Application::APP_ID, 'talk-files-sidebar');
 		Util::addScript(Application::APP_ID, 'talk-files-sidebar-loader');
+
+		// Needed to enable the screensharing extension in Chromium < 72.
+		Util::addHeader('meta', ['id' => "app", 'class' => 'nc-enable-screensharing-extension']);
 	}
 
 }

--- a/lib/PublicShare/TemplateLoader.php
+++ b/lib/PublicShare/TemplateLoader.php
@@ -68,6 +68,9 @@ class TemplateLoader {
 
 		Util::addStyle('spreed', 'merged-public-share');
 		Util::addScript('spreed', 'talk-public-share-sidebar');
+
+		// Needed to enable the screensharing extension in Chromium < 72.
+		Util::addHeader('meta', ['id' => "app", 'class' => 'nc-enable-screensharing-extension']);
 	}
 
 }

--- a/lib/PublicShareAuth/TemplateLoader.php
+++ b/lib/PublicShareAuth/TemplateLoader.php
@@ -65,6 +65,9 @@ class TemplateLoader {
 
 		Util::addStyle('spreed', 'merged-share-auth');
 		Util::addScript('spreed', 'talk-public-share-auth-sidebar');
+
+		// Needed to enable the screensharing extension in Chromium < 72.
+		Util::addHeader('meta', ['id' => "app", 'class' => 'nc-enable-screensharing-extension']);
 	}
 
 }


### PR DESCRIPTION
This fixes a regression introduced in Talk 8 (although it happened too in the Talk sidebar in previous versions, but in those cases it was a bug).

In Chromium < 72 an extension is needed to share the screen. Once installed, [the extension enables itself only in those pages that contain an element with id `app` and class `nc-enable-screensharing-extension`](https://github.com/nextcloud/spreed-screensharing-chrome-extension/blob/8322906269d649550c0d673cc1d1708a6b642186/extension/detector.js#L29-L33) when [the document is loaded](https://github.com/nextcloud/spreed-screensharing-chrome-extension/blob/513880aabfd3a4a94f7e1b69f38937844d08e949/extension/manifest.json#L27).

As the element can not be added after the document has loaded and the screen sharing should work also when Talk is enabled in other apps a (hacky and very likely not compliant) `meta` element is added in the `header` element to be found by the extension whenever Talk is used.

Adding `id` and `class` attributes to a `meta` element (as well as `data-chromeExtensionData` by the extension itself) is quite hacky. I would rather modify the extension to keep the current check but also look for a `meta` element with name `nc-enable-screensharing-extension` and set its `property` attribute with the same value as the current `data-chromeExtensionData`, but I do not know how easy or hard it is to publish a new version of the extension, nor whether the browser would automatically get the update.

## How to test
- Install the [screen sharing extension](https://chrome.google.com/webstore/detail/screensharing-for-nextclo/kepnpjhambipllfmgmbapncekcmabkol) in Chromium < 72
- Open the browser again
- Start a call
- Share the screen

### Result with this pull request

The screen is shared.

### Result without this pull request

The message _Screensharing extension is required to share your screen_ is shown.
