### PR TITLE
Remove unused template parameters

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -272,11 +272,7 @@ class PageController extends Controller {
 			$this->eventDispatcher->dispatchTyped(new LoadViewer());
 		}
 
-		$params = [
-			'token' => $token,
-			'signaling-settings' => $this->talkConfig->getSettings($this->userId),
-		];
-		$response = new TemplateResponse($this->appName, 'index', $params);
+		$response = new TemplateResponse($this->appName, 'index');
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedConnectDomain('*');
 		$csp->addAllowedMediaDomain('blob:');
@@ -328,11 +324,7 @@ class PageController extends Controller {
 			$this->serverConfig->getAppValue('spreed', 'prefer_h264', 'no') === 'yes'
 		);
 
-		$params = [
-			'token' => $token,
-			'signaling-settings' => $this->talkConfig->getSettings($this->userId),
-		];
-		$response = new PublicTemplateResponse($this->appName, 'index', $params);
+		$response = new PublicTemplateResponse($this->appName, 'index');
 		$response->setFooterVisible(false);
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedConnectDomain('*');


### PR DESCRIPTION
The template does not use those variables, so let's remove them for now:
https://github.com/nextcloud/spreed/blob/2f154e5b3fedcd5c3ccde84f9b692725063acf00/templates/index.php

If they are ever used again it will use initial state.