### PR TITLE
Feature/noid/show unsupported browser warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20821,6 +20821,14 @@
 			"resolved": "https://registry.npmjs.org/vue-at/-/vue-at-2.5.0-beta.2.tgz",
 			"integrity": "sha512-WXjngEaNyNWFU9unUUdK5kGolCHgG3jmlUIgeRnKlHpskbgGjIE/HGTOWnMfLEqjYJl9DTzt/SKPWDoFVaND/A=="
 		},
+		"vue-browser-detect-plugin": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/vue-browser-detect-plugin/-/vue-browser-detect-plugin-0.1.8.tgz",
+			"integrity": "sha512-b3GADgUfEe3MsIAshRTP7eDx4p8YyYqunQwkey4bOIqCJ7/ufeFu/7EIm8TqNjVsaipwbc0mX/ad8cmhYobiWw==",
+			"requires": {
+				"vue": "^2.5.17"
+			}
+		},
 		"vue-clipboard2": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/vue-clipboard2/-/vue-clipboard2-0.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"util": "^0.12.2",
 		"vue": "^2.6.11",
 		"vue-at": "^2.5.0-beta.2",
+		"vue-browser-detect-plugin": "^0.1.8",
 		"vue-clipboard2": "^0.3.1",
 		"vue-fragment": "^1.5.1",
 		"vue-observe-visibility": "^0.4.6",

--- a/src/App.vue
+++ b/src/App.vue
@@ -290,6 +290,11 @@ export default {
 		}
 	},
 
+	mounted() {
+		// see browserCheck mixin
+		this.checkBrowser()
+	},
+
 	methods: {
 		fixmeDelayedSetupOfGuestUsers() {
 			// FIXME Refresh the data now that the user joined the conversation

--- a/src/App.vue
+++ b/src/App.vue
@@ -50,6 +50,7 @@ import {
 	connectSignaling,
 	getSignalingSync,
 } from './utils/webrtc/index'
+import browserCheck from './mixins/browserCheck'
 
 export default {
 	name: 'App',
@@ -60,6 +61,9 @@ export default {
 		PreventUnload,
 		RightSidebar,
 	},
+
+	mixins: [browserCheck],
+
 	data: function() {
 		return {
 			savedLastMessageMap: {},

--- a/src/FilesSidebarCallViewApp.vue
+++ b/src/FilesSidebarCallViewApp.vue
@@ -1,6 +1,8 @@
 <!--
   - @copyright Copyright (c) 2019, Daniel Calviño Sánchez <danxuliu@gmail.com>
   -
+  - @author Marco Ambrosini <marcoambrosini@pm.me>
+  -
   - @license GNU AGPL version 3 or any later version
   -
   - This program is free software: you can redistribute it and/or modify
@@ -32,6 +34,7 @@
 import { PARTICIPANT } from './constants'
 import CallView from './components/CallView/CallView'
 import PreventUnload from 'vue-prevent-unload'
+import browserCheck from './mixins/browserCheck'
 
 export default {
 
@@ -41,6 +44,8 @@ export default {
 		CallView,
 		PreventUnload,
 	},
+
+	mixins: [browserCheck],
 
 	data() {
 		return {
@@ -146,6 +151,11 @@ export default {
 
 			this.restoreSidebarHeaderContents()
 		},
+	},
+
+	mounted() {
+		// see browserCheck mixin
+		this.checkBrowser()
 	},
 
 	methods: {

--- a/src/PublicShareAuthSidebar.vue
+++ b/src/PublicShareAuthSidebar.vue
@@ -1,6 +1,8 @@
 <!--
   - @copyright Copyright (c) 2020, Daniel Calviño Sánchez <danxuliu@gmail.com>
   -
+  - @author Marco Ambrosini <marcoambrosini@pm.me>
+  -
   - @license GNU AGPL version 3 or any later version
   -
   - This program is free software: you can redistribute it and/or modify
@@ -48,6 +50,8 @@ import {
 	getSignaling,
 	getSignalingSync,
 } from './utils/webrtc/index'
+import browserCheck from './mixins/browserCheck'
+
 export default {
 
 	name: 'PublicShareAuthSidebar',
@@ -56,6 +60,8 @@ export default {
 		CallView,
 		ChatView,
 	},
+
+	mixins: [browserCheck],
 
 	data() {
 		return {
@@ -105,6 +111,11 @@ export default {
 				leaveConversationSync(this.token)
 			}
 		})
+	},
+
+	mounted() {
+		// see browserCheck mixin
+		this.checkBrowser()
 	},
 
 	methods: {

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -1,6 +1,8 @@
 <!--
   - @copyright Copyright (c) 2020, Daniel Calviño Sánchez <danxuliu@gmail.com>
   -
+  - @author Marco Ambrosini <marcoambrosini@pm.me>
+  -
   - @license GNU AGPL version 3 or any later version
   -
   - This program is free software: you can redistribute it and/or modify
@@ -56,6 +58,7 @@ import {
 	getSignaling,
 	getSignalingSync,
 } from './utils/webrtc/index'
+import browserCheck from './mixins/browserCheck'
 
 export default {
 
@@ -67,6 +70,8 @@ export default {
 		ChatView,
 		PreventUnload,
 	},
+
+	mixins: [browserCheck],
 
 	props: {
 		shareToken: {
@@ -124,6 +129,11 @@ export default {
 				leaveConversationSync(this.token)
 			}
 		})
+	},
+
+	mounted() {
+		// see browserCheck mixin
+		this.checkBrowser()
 	},
 
 	methods: {

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -21,7 +21,14 @@
 
 <template>
 	<button v-if="showStartCallButton"
-		:disabled="startCallButtonDisabled || loading"
+		v-tooltip="{
+			placement: 'auto',
+			trigger: 'hover',
+			content: callButtonTooltipText,
+			autoHide: false,
+			html: true
+		}"
+		:disabled="startCallButtonDisabled || loading || blockCalls"
 		class="top-bar__button primary"
 		@click="joinCall">
 		<span
@@ -42,9 +49,17 @@
 
 <script>
 import { CONVERSATION, PARTICIPANT, WEBINAR } from '../../constants'
+import browserCheck from '../../mixins/browserCheck'
+import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 
 export default {
 	name: 'CallButton',
+
+	directives: {
+		Tooltip,
+	},
+
+	mixins: [browserCheck],
 
 	data() {
 		return {

--- a/src/main.js
+++ b/src/main.js
@@ -37,11 +37,15 @@ import router from './router/router'
 import { generateFilePath } from '@nextcloud/router'
 import { getRequestToken } from '@nextcloud/auth'
 
+// Plugins
+import browserDetect from 'vue-browser-detect-plugin'
+
 // Directives
 import VueClipboard from 'vue-clipboard2'
 import { translate, translatePlural } from '@nextcloud/l10n'
 import VueObserveVisibility from 'vue-observe-visibility'
 import VueShortKey from 'vue-shortkey'
+Vue.use(browserDetect)
 
 // CSP config for webpack dynamic chunk loading
 // eslint-disable-next-line
@@ -58,6 +62,7 @@ Vue.prototype.t = translate
 Vue.prototype.n = translatePlural
 Vue.prototype.OC = OC
 Vue.prototype.OCA = OCA
+Vue.use(browserDetect)
 
 Vue.use(Vuex)
 Vue.use(VueRouter)

--- a/src/mainFilesSidebar.js
+++ b/src/mainFilesSidebar.js
@@ -30,6 +30,9 @@ import FilesSidebarTabApp from './FilesSidebarTabApp'
 import Vuex from 'vuex'
 import store from './store'
 
+// Plugins
+import browserDetect from 'vue-browser-detect-plugin'
+
 // Utils
 import { generateFilePath } from '@nextcloud/router'
 import { getRequestToken } from '@nextcloud/auth'
@@ -56,6 +59,7 @@ Vue.prototype.OCA = OCA
 
 Vue.use(Vuex)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
+Vue.use(browserDetect)
 
 const newCallView = () => new Vue({
 	store,

--- a/src/mainPublicShareAuthSidebar.js
+++ b/src/mainPublicShareAuthSidebar.js
@@ -30,6 +30,9 @@ import store from './store'
 import { generateFilePath } from '@nextcloud/router'
 import { getRequestToken } from '@nextcloud/auth'
 
+// Plugins
+import browserDetect from 'vue-browser-detect-plugin'
+
 // Directives
 import { translate, translatePlural } from '@nextcloud/l10n'
 import VueShortKey from 'vue-shortkey'
@@ -52,6 +55,7 @@ Vue.prototype.OCA = OCA
 
 Vue.use(Vuex)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
+Vue.use(browserDetect)
 
 /**
  * Wraps all the body contents in its own container.

--- a/src/mainPublicShareSidebar.js
+++ b/src/mainPublicShareSidebar.js
@@ -29,6 +29,9 @@ import store from './store'
 import { generateFilePath } from '@nextcloud/router'
 import { getRequestToken } from '@nextcloud/auth'
 
+// plugins
+import browserDetect from 'vue-browser-detect-plugin'
+
 // Directives
 import { translate, translatePlural } from '@nextcloud/l10n'
 import VueShortKey from 'vue-shortkey'
@@ -51,6 +54,7 @@ Vue.prototype.OCA = OCA
 
 Vue.use(Vuex)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
+Vue.use(browserDetect)
 
 function adjustLayout() {
 	document.querySelector('#app-content').append(document.querySelector('footer'))

--- a/src/mixins/browserCheck.js
+++ b/src/mixins/browserCheck.js
@@ -24,18 +24,37 @@ import { showError } from '@nextcloud/dialogs'
 
 const browserCheck = {
 	mounted() {
-		if (this.$browserDetect.isFirefox) {
+		if (!this.isFullySupported) {
 			showError(
-				t('spreed', `The browser you're using is not supported. Please use the latest version of {firefox}, {edge}, {chrome} or {safari}.`)
-					.replace('{firefox}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://www.mozilla.org/en-US/firefox/new/">Mozilla Firefox</a>')
-					.replace('{edge}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://www.microsoft.com/en-us/edge">Microsoft Edge</a>')
-					.replace('{chrome}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://www.google.com/chrome/?brand=CHBD&gclid=EAIaIQobChMIkY_v0ZDU6AIVhYXVCh0sfA7XEAAYASAAEgIKfPD_BwE&gclsrc=aw.ds">Google Chrome</a>')
-					.replace('{safari}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://support.apple.com/downloads/safari">Apple Safari</a>'),
+				this.unsupportedWarning,
 				{
-					timeout: 30,
+					timeout: 3600,
 					isHTML: true,
 				})
 		}
+	},
+	computed: {
+		isFullySupported() {
+			return (this.$browserDetect.isFirefox && this.$browserDetect.meta.version >= 52)
+			|| (this.$browserDetect.isChrome && this.$browserDetect.meta.version >= 49)
+		},
+		blockCalls() {
+			return (this.$browserDetect.isFirefox && this.$browserDetect.meta.version < 52)
+			|| (this.$browserDetect.isChrome && this.$browserDetect.meta.version < 49)
+		},
+		unsupportedWarning() {
+			return t('spreed', "The browser you're using is not fully supported by talk. Please use the latest version of {firefox}, {edge}, {chrome} or {safari}.").replace('{firefox}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://www.mozilla.org/en-US/firefox/new/">Mozilla Firefox</a>').replace('{edge}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://www.microsoft.com/en-us/edge">Microsoft Edge</a>').replace('{chrome}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://www.google.com/chrome/?brand=CHBD&gclid=EAIaIQobChMIkY_v0ZDU6AIVhYXVCh0sfA7XEAAYASAAEgIKfPD_BwE&gclsrc=aw.ds">Google Chrome</a>').replace('{safari}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://support.apple.com/downloads/safari">Apple Safari</a>')
+		},
+		callButtonTooltipText() {
+			if (this.blockCalls) {
+				return this.unsupportedWarning
+			} else {
+				// Passind a falsy value into the content of the tooltip
+				// is the only way to disable it conditionally.
+				return false
+			}
+		},
+
 	},
 }
 

--- a/src/mixins/browserCheck.js
+++ b/src/mixins/browserCheck.js
@@ -23,15 +23,17 @@
 import { showError } from '@nextcloud/dialogs'
 
 const browserCheck = {
-	mounted() {
-		if (!this.isFullySupported) {
-			showError(
-				this.unsupportedWarning,
-				{
-					timeout: 3600,
-					isHTML: true,
-				})
-		}
+	methods: {
+		checkBrowser() {
+			if (!this.isFullySupported) {
+				showError(
+					this.unsupportedWarning,
+					{
+						timeout: 3600,
+						isHTML: true,
+					})
+			}
+		},
 	},
 	computed: {
 		isFullySupported() {

--- a/src/mixins/browserCheck.js
+++ b/src/mixins/browserCheck.js
@@ -29,8 +29,7 @@ const browserCheck = {
 				showError(
 					this.unsupportedWarning,
 					{
-						timeout: 3600,
-						isHTML: true,
+						timeout: 0,
 					})
 			}
 		},
@@ -44,10 +43,11 @@ const browserCheck = {
 		blockCalls() {
 			return (this.$browserDetect.isFirefox && this.$browserDetect.meta.version < 52)
 			|| (this.$browserDetect.isChrome && this.$browserDetect.meta.version < 49)
+			|| this.$browserDetect.isIE
 		},
 		// Used both in the toast and in the callbutton tooltip
 		unsupportedWarning() {
-			return t('spreed', "The browser you're using is not fully supported by talk. Please use the latest version of {firefox}, {edge}, {chrome} or {safari}.").replace('{firefox}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://www.mozilla.org/en-US/firefox/new/">Mozilla Firefox</a>').replace('{edge}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://www.microsoft.com/en-us/edge">Microsoft Edge</a>').replace('{chrome}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://www.google.com/chrome/?brand=CHBD&gclid=EAIaIQobChMIkY_v0ZDU6AIVhYXVCh0sfA7XEAAYASAAEgIKfPD_BwE&gclsrc=aw.ds">Google Chrome</a>').replace('{safari}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://support.apple.com/downloads/safari">Apple Safari</a>')
+			return t('spreed', "The browser you're using is not fully supported by talk. Please use the latest version of Mozilla Firefox, Microsoft Edge, Google Chrome or Apple Safari.")
 		},
 		// Used in CallButton.vue
 		callButtonTooltipText() {

--- a/src/mixins/browserCheck.js
+++ b/src/mixins/browserCheck.js
@@ -1,0 +1,42 @@
+/**
+ * @copyright Copyright (c) 2019 Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @author Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { showError } from '@nextcloud/dialogs'
+
+const browserCheck = {
+	mounted() {
+		if (this.$browserDetect.isFirefox) {
+			showError(
+				t('spreed', `The browser you're using is not supported. Please use the latest version of {firefox}, {edge}, {chrome} or {safari}.`)
+					.replace('{firefox}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://www.mozilla.org/en-US/firefox/new/">Mozilla Firefox</a>')
+					.replace('{edge}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://www.microsoft.com/en-us/edge">Microsoft Edge</a>')
+					.replace('{chrome}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://www.google.com/chrome/?brand=CHBD&gclid=EAIaIQobChMIkY_v0ZDU6AIVhYXVCh0sfA7XEAAYASAAEgIKfPD_BwE&gclsrc=aw.ds">Google Chrome</a>')
+					.replace('{safari}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://support.apple.com/downloads/safari">Apple Safari</a>'),
+				{
+					timeout: 30,
+					isHTML: true,
+				})
+		}
+	},
+}
+
+export default browserCheck

--- a/src/mixins/browserCheck.js
+++ b/src/mixins/browserCheck.js
@@ -40,13 +40,16 @@ const browserCheck = {
 			return (this.$browserDetect.isFirefox && this.$browserDetect.meta.version >= 52)
 			|| (this.$browserDetect.isChrome && this.$browserDetect.meta.version >= 49)
 		},
+		// Disable the call button and show the tooltip
 		blockCalls() {
 			return (this.$browserDetect.isFirefox && this.$browserDetect.meta.version < 52)
 			|| (this.$browserDetect.isChrome && this.$browserDetect.meta.version < 49)
 		},
+		// Used both in the toast and in the callbutton tooltip
 		unsupportedWarning() {
 			return t('spreed', "The browser you're using is not fully supported by talk. Please use the latest version of {firefox}, {edge}, {chrome} or {safari}.").replace('{firefox}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://www.mozilla.org/en-US/firefox/new/">Mozilla Firefox</a>').replace('{edge}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://www.microsoft.com/en-us/edge">Microsoft Edge</a>').replace('{chrome}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://www.google.com/chrome/?brand=CHBD&gclid=EAIaIQobChMIkY_v0ZDU6AIVhYXVCh0sfA7XEAAYASAAEgIKfPD_BwE&gclsrc=aw.ds">Google Chrome</a>').replace('{safari}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://support.apple.com/downloads/safari">Apple Safari</a>')
 		},
+		// Used in CallButton.vue
 		callButtonTooltipText() {
 			if (this.blockCalls) {
 				return this.unsupportedWarning

--- a/src/mixins/browserCheck.js
+++ b/src/mixins/browserCheck.js
@@ -47,7 +47,7 @@ const browserCheck = {
 		},
 		// Used both in the toast and in the callbutton tooltip
 		unsupportedWarning() {
-			return t('spreed', "The browser you're using is not fully supported by talk. Please use the latest version of Mozilla Firefox, Microsoft Edge, Google Chrome or Apple Safari.")
+			return t('spreed', "The browser you're using is not fully supported by Nextcloud Talk. Please use the latest version of Mozilla Firefox, Microsoft Edge, Google Chrome or Apple Safari.")
 		},
 		// Used in CallButton.vue
 		callButtonTooltipText() {


### PR DESCRIPTION
How to test: 

1) Open an unsupported browser https://github.com/nextcloud/spreed#supported-browsers;
2) See a toast error;
3) See disabled call button with tooltip;

![Screenshot from 2020-04-07 14-03-52](https://user-images.githubusercontent.com/26852655/78667124-b1d4be00-78d8-11ea-8570-d2b31ee96496.png)

![Screenshot from 2020-04-07 14-04-34](https://user-images.githubusercontent.com/26852655/78667128-b305eb00-78d8-11ea-8a46-b1c5a0153340.png)

