### PR TITLE
Don't show a warning to use the same browser

### DIFF
--- a/src/mixins/browserCheck.js
+++ b/src/mixins/browserCheck.js
@@ -38,14 +38,17 @@ const browserCheck = {
 		isFullySupported() {
 			return (this.$browserDetect.isFirefox && this.$browserDetect.meta.version >= 52)
 			|| (this.$browserDetect.isChrome && this.$browserDetect.meta.version >= 49)
+			|| (this.$browserDetect.isSafari && this.$browserDetect.meta.version >= 12)
+			|| this.$browserDetect.isEdge
 		},
 		// Disable the call button and show the tooltip
 		blockCalls() {
 			return (this.$browserDetect.isFirefox && this.$browserDetect.meta.version < 52)
 			|| (this.$browserDetect.isChrome && this.$browserDetect.meta.version < 49)
+			|| (this.$browserDetect.isSafari && this.$browserDetect.meta.version < 12)
 			|| this.$browserDetect.isIE
 		},
-		// Used both in the toast and in the callbutton tooltip
+		// Used both in the toast and in the call button tooltip
 		unsupportedWarning() {
 			return t('spreed', "The browser you're using is not fully supported by Nextcloud Talk. Please use the latest version of Mozilla Firefox, Microsoft Edge, Google Chrome or Apple Safari.")
 		},
@@ -54,7 +57,7 @@ const browserCheck = {
 			if (this.blockCalls) {
 				return this.unsupportedWarning
 			} else {
-				// Passind a falsy value into the content of the tooltip
+				// Passing a falsy value into the content of the tooltip
 				// is the only way to disable it conditionally.
 				return false
 			}


### PR DESCRIPTION
### Scenarios

1. Be on Edge: See a warning to use "…, Microsoft Edge, …" instead
1. Be on Safari: See a warning to use "…, Safari" instead
1. Be on Safari 5 (last windows version) or <12 (not WebKit based): Call button is enabled but clicking it says "WebRTC is not supported by your browser"