### PR TITLE
Add an error message when no bytes were received in all states of a peer connection

### DIFF
--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -662,7 +662,7 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 				if (result) {
 					resolve()
 				} else {
-					reject(new Error())
+					reject(new Error('No bytes received'))
 				}
 			})
 		})


### PR DESCRIPTION
Signed-off-by: Joas Schilling <coding@schilljs.com>