### PR TITLE
Don't mark the window/tab unread for own messages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -122,7 +122,19 @@ export default {
 
 			const lastMessage = {}
 			conversationList.forEach(conversation => {
-				lastMessage[conversation.token] = 0 + (conversation.lastMessage && conversation.lastMessage.id ? conversation.lastMessage.id : 0)
+				lastMessage[conversation.token] = 0
+				if (conversation.lastMessage) {
+					const currentActorIsAuthor = conversation.lastMessage.actorType === this.$store.getters.getActorType()
+						&& conversation.lastMessage.actorId === this.$store.getters.getActorId()
+					if (currentActorIsAuthor) {
+						// Set a special value when the actor is the author so we can skip it.
+						// Can't use 0 though because hidden commands result in 0
+						// and they would hide other previously posted new messages
+						lastMessage[conversation.token] = -1
+					} else {
+						lastMessage[conversation.token] = 0 + (conversation.lastMessage && conversation.lastMessage.id ? conversation.lastMessage.id : 0)
+					}
+				}
 			})
 			return lastMessage
 		},
@@ -135,8 +147,9 @@ export default {
 		atLeastOneLastMessageIdChanged() {
 			let modified = false
 			Object.keys(this.lastMessageMap).forEach(token => {
-				if (!this.savedLastMessageMap[token]
-					|| this.savedLastMessageMap[token] !== this.lastMessageMap[token]) {
+				if (!this.savedLastMessageMap[token] // Conversation is new
+					|| (this.savedLastMessageMap[token] !== this.lastMessageMap[token] // Last message changed
+						&& this.lastMessageMap[token] !== -1)) { // But is not from the current user
 					modified = true
 				}
 			})

--- a/src/App.vue
+++ b/src/App.vue
@@ -132,7 +132,10 @@ export default {
 						// and they would hide other previously posted new messages
 						lastMessage[conversation.token] = -1
 					} else {
-						lastMessage[conversation.token] = 0 + (conversation.lastMessage && conversation.lastMessage.id ? conversation.lastMessage.id : 0)
+						lastMessage[conversation.token] = Math.max(
+							conversation.lastMessage && conversation.lastMessage.id ? conversation.lastMessage.id : 0,
+							this.$store.getters.getLastKnownMessageId(conversation.token) ? this.$store.getters.getLastKnownMessageId(conversation.token) : 0,
+						)
 					}
 				}
 			})


### PR DESCRIPTION
Otherwise when you write a message and immediately navigate away,
the next refresh of the room list will always tell you that messages
have been posted.

### Steps

1. Create a conversation
2. Post a chat message and switch to another tab before the room list is refreshed

### Before

Tab is marked with `*` after the room list is refreshed

### After

Tab is not marked.

Fix #3256 