### PR TITLE
Notify the users to reload when an update happened in the background

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -122,6 +122,15 @@ class RoomController extends AEnvironmentAwareController {
 		$this->talkConfig = $talkConfig;
 	}
 
+	protected function getTalkHashHeader(): array {
+		return [
+			'X-Nextcloud-Talk-Hash' => sha1(
+				$this->config->getSystemValueString('version') . '#' .
+				$this->config->getAppValue('spreed', 'installed_version', '') . '#' .
+				$this->config->getAppValue('theming', 'cachebuster', '1')
+		)];
+	}
+
 	/**
 	 * Get all currently existent rooms which the user has joined
 	 *
@@ -144,7 +153,7 @@ class RoomController extends AEnvironmentAwareController {
 			}
 		}
 
-		return new DataResponse($return);
+		return new DataResponse($return, Http::STATUS_OK, $this->getTalkHashHeader());
 	}
 
 	/**
@@ -167,7 +176,7 @@ class RoomController extends AEnvironmentAwareController {
 				}
 			}
 
-			return new DataResponse($this->formatRoom($room, $participant));
+			return new DataResponse($this->formatRoom($room, $participant), Http::STATUS_OK, $this->getTalkHashHeader());
 		} catch (RoomNotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}

--- a/src/services/conversationsService.js
+++ b/src/services/conversationsService.js
@@ -23,12 +23,16 @@
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 import { CONVERSATION, SHARE } from '../constants'
+import { showError } from '@nextcloud/dialogs'
+
+let talkCacheBusterHash = null
 
 /**
  * Fetches the conversations from the server.
  */
 const fetchConversations = async function() {
 	const response = await axios.get(generateOcsUrl('apps/spreed/api/v2', 2) + 'room')
+	checkTalkVersionHash(response)
 	return response
 }
 
@@ -38,7 +42,23 @@ const fetchConversations = async function() {
  */
 const fetchConversation = async function(token) {
 	const response = await axios.get(generateOcsUrl('apps/spreed/api/v2', 2) + `room/${token}`)
+	checkTalkVersionHash(response)
 	return response
+}
+
+const checkTalkVersionHash = function(response) {
+	const newTalkCacheBusterHash = response.headers['x-nextcloud-talk-hash']
+	if (talkCacheBusterHash === null) {
+		console.debug('Setting initial Talk Hash: ', newTalkCacheBusterHash)
+		talkCacheBusterHash = newTalkCacheBusterHash
+	} else if (talkCacheBusterHash !== newTalkCacheBusterHash) {
+		console.debug('Updating Talk Hash: ', newTalkCacheBusterHash)
+		talkCacheBusterHash = newTalkCacheBusterHash
+
+		showError(t('spreed', 'Nextcloud Talk was updated, please reload the page'), {
+			timeout: -1,
+		})
+	}
 }
 
 /**

--- a/src/services/conversationsService.js
+++ b/src/services/conversationsService.js
@@ -26,14 +26,29 @@ import { CONVERSATION, SHARE } from '../constants'
 import { showError } from '@nextcloud/dialogs'
 
 let talkCacheBusterHash = null
+let maintenanceWarning = null
 
 /**
  * Fetches the conversations from the server.
  */
 const fetchConversations = async function() {
-	const response = await axios.get(generateOcsUrl('apps/spreed/api/v2', 2) + 'room')
-	checkTalkVersionHash(response)
-	return response
+	try {
+		const response = await axios.get(generateOcsUrl('apps/spreed/api/v2', 2) + 'room')
+		checkTalkVersionHash(response)
+
+		if (maintenanceWarning) {
+			maintenanceWarning.hideToast()
+			maintenanceWarning = null
+		}
+		return response
+	} catch (error) {
+		if (error.response.status === 503 && !maintenanceWarning) {
+			maintenanceWarning = showError(t('spreed', 'Nextcloud is in maintenance mode, please reload the page'), {
+				timeout: -1,
+			})
+		}
+		throw error
+	}
 }
 
 /**
@@ -41,9 +56,23 @@ const fetchConversations = async function() {
  * @param {string} token The token of the conversation to be fetched.
  */
 const fetchConversation = async function(token) {
-	const response = await axios.get(generateOcsUrl('apps/spreed/api/v2', 2) + `room/${token}`)
-	checkTalkVersionHash(response)
-	return response
+	try {
+		const response = await axios.get(generateOcsUrl('apps/spreed/api/v2', 2) + `room/${token}`)
+		checkTalkVersionHash(response)
+
+		if (maintenanceWarning) {
+			maintenanceWarning.hideToast()
+			maintenanceWarning = null
+		}
+		return response
+	} catch (error) {
+		if (error.response.status === 503 && !maintenanceWarning) {
+			maintenanceWarning = showError(t('spreed', 'Nextcloud is in maintenance mode, please reload the page'), {
+				timeout: -1,
+			})
+		}
+		throw error
+	}
 }
 
 const checkTalkVersionHash = function(response) {


### PR DESCRIPTION
### Steps

1. In Tab 1 open Talk
2. Modify the info.xml of Talk to send Nextcloud into maintenance mode
3. Now see a "showError" `Nextcloud is in maintenance mode, please reload the page` (**don't** do that)
4. Change version back
5. In Tab 1 message disappears on next room list refresh
6. Change version again
7. In Tab 2 run the update
8. In Tab 1 see a "showError" `Nextcloud Talk was updated, please reload the page` popping up

Should help with users that have the tab open for a long time.