### PR TITLE
Don't break when showing the login mask to users

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -293,8 +293,12 @@ class PageController extends Controller {
 				throw new RoomNotFoundException();
 			}
 		} catch (RoomNotFoundException $e) {
+			$redirectUrl = $this->url->linkToRoute('spreed.Page.index');
+			if ($token) {
+				$redirectUrl = $this->url->linkToRoute('spreed.pagecontroller.showCall', ['token' => $token]);
+			}
 			return new RedirectResponse($this->url->linkToRoute('core.login.showLoginForm', [
-				'redirect_url' => $this->url->linkToRoute('spreed.pagecontroller.showCall', ['token' => $token]),
+				'redirect_url' => $redirectUrl,
 			]));
 		}
 


### PR DESCRIPTION
### Steps
1. As a guest open `/index.php/apps/spreed/`
2. Be greeted by:
```

    Remote Address: 127.0.0.1
    Request ID: r3N4WLXqWiYKNzADk5mj
    Type: Symfony\Component\Routing\Exception\InvalidParameterException
    Code: 0
    Message: Parameter "token" for route "spreed.pagecontroller.showCall" must match "[^/]++" ("" given) to generate a corresponding URL.
    File: /home/nickv/Nextcloud/19/server/3rdparty/symfony/routing/Generator/UrlGenerator.php
    Line: 193

```