### PR TITLE
Die gracefully when user joins again in another tab/device

### DIFF
--- a/docs/participant.md
+++ b/docs/participant.md
@@ -109,18 +109,28 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
     field | type | Description
     ------|------|------------
     `password` | string | Optional: Password is only required for users which are of type `4` or `5` and only when the conversation has `hasPassword` set to true.
+    `force` | bool | If set to `false` and the user has an active session already a `409 Conflict` will be returned (Default: true - to keep the old behaviour)
 
 * Response:
     - Status code:
         + `200 OK`
         + `403 Forbidden` When the password is required and didn't match
         + `404 Not Found` When the conversation could not be found for the participant
+        + `409 Conflict` When the user already has an active session in the conversation. The suggested behaviour is to ask the user whether they want to kill the old session and force join unless the last ping is older than 60 seconds or older than 40 seconds when the conflicting session is not marked as in a call.
 
-    - Data:
+    - Data in case of `200 OK`:
 
         field | type | Description
         ------|------|------------
         `sessionId` | string | 512 character long string
+
+    - Data in case of `409 Conflict`:
+
+        field | type | Description
+        ------|------|------------
+        `sessionId` | string | 512 character long string
+        `inCall` | int | Flags whether the conflicting session is in a potential call
+        `lastPing` | int | Timestamp of the last ping of the conflicting session
 
 ## Leave a conversation (not available for call and chat anymore)
 

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1154,14 +1154,26 @@ class RoomController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
-		if ($force === false && $this->userId !== null) {
-			try {
-				$participant = $room->getParticipant($this->userId);
-				if ($participant->getSessionId() !== '0') {
-					return new DataResponse([], Http::STATUS_CONFLICT);
+		if ($force === false) {
+			if ($this->userId !== null) {
+				try {
+					$participant = $room->getParticipant($this->userId);
+					if ($participant->getSessionId() !== '0') {
+						return new DataResponse([], Http::STATUS_CONFLICT);
+					}
+				} catch (ParticipantNotFoundException $e) {
+					// All fine, carry on
 				}
-			} catch (ParticipantNotFoundException $e) {
-				// All fine, carry on
+			} else {
+				$session = $this->session->getSessionForRoom($token);
+				try {
+					$participant = $room->getParticipantBySession($session);
+					if ($participant->getSessionId() !== '0') {
+						return new DataResponse([], Http::STATUS_CONFLICT);
+					}
+				} catch (ParticipantNotFoundException $e) {
+					// All fine, carry on
+				}
 			}
 		}
 

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1159,7 +1159,11 @@ class RoomController extends AEnvironmentAwareController {
 				try {
 					$participant = $room->getParticipant($this->userId);
 					if ($participant->getSessionId() !== '0') {
-						return new DataResponse([], Http::STATUS_CONFLICT);
+						return new DataResponse([
+							'sessionId' => $participant->getSessionId(),
+							'inCall' => $participant->getInCallFlags(),
+							'lastPing' => $participant->getLastPing(),
+						], Http::STATUS_CONFLICT);
 					}
 				} catch (ParticipantNotFoundException $e) {
 					// All fine, carry on
@@ -1169,7 +1173,11 @@ class RoomController extends AEnvironmentAwareController {
 				try {
 					$participant = $room->getParticipantBySession($session);
 					if ($participant->getSessionId() !== '0') {
-						return new DataResponse([], Http::STATUS_CONFLICT);
+						return new DataResponse([
+							'sessionId' => $participant->getSessionId(),
+							'inCall' => $participant->getInCallFlags(),
+							'lastPing' => $participant->getLastPing(),
+						], Http::STATUS_CONFLICT);
 					}
 				} catch (ParticipantNotFoundException $e) {
 					// All fine, carry on

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1154,34 +1154,34 @@ class RoomController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
-		if ($force === false) {
-			if ($this->userId !== null) {
-				try {
-					$participant = $room->getParticipant($this->userId);
-					if ($participant->getSessionId() !== '0') {
-						return new DataResponse([
-							'sessionId' => $participant->getSessionId(),
-							'inCall' => $participant->getInCallFlags(),
-							'lastPing' => $participant->getLastPing(),
-						], Http::STATUS_CONFLICT);
-					}
-				} catch (ParticipantNotFoundException $e) {
-					// All fine, carry on
-				}
+		$previousSession = null;
+		if ($this->userId !== null) {
+			try {
+				$previousSession = $room->getParticipant($this->userId);
+			} catch (ParticipantNotFoundException $e) {
+			}
+		} else {
+			$session = $this->session->getSessionForRoom($token);
+			try {
+				$previousSession = $room->getParticipantBySession($session);
+			} catch (ParticipantNotFoundException $e) {
+			}
+		}
+
+		if ($previousSession instanceof Participant && $previousSession->getSessionId() !== '0') {
+			// Previous session was active
+			if ($force === false) {
+				return new DataResponse([
+					'sessionId' => $previousSession->getSessionId(),
+					'inCall' => $previousSession->getInCallFlags(),
+					'lastPing' => $previousSession->getLastPing(),
+				], Http::STATUS_CONFLICT);
+			}
+
+			if ($this->userId === null) {
+				$room->removeParticipantBySession($previousSession, Room::PARTICIPANT_LEFT);
 			} else {
-				$session = $this->session->getSessionForRoom($token);
-				try {
-					$participant = $room->getParticipantBySession($session);
-					if ($participant->getSessionId() !== '0') {
-						return new DataResponse([
-							'sessionId' => $participant->getSessionId(),
-							'inCall' => $participant->getInCallFlags(),
-							'lastPing' => $participant->getLastPing(),
-						], Http::STATUS_CONFLICT);
-					}
-				} catch (ParticipantNotFoundException $e) {
-					// All fine, carry on
-				}
+				$room->leaveRoomAsParticipant($previousSession);
 			}
 		}
 
@@ -1226,7 +1226,7 @@ class RoomController extends AEnvironmentAwareController {
 				$room->removeParticipantBySession($participant, Room::PARTICIPANT_LEFT);
 			} else {
 				$participant = $room->getParticipant($this->userId);
-				$room->leaveRoom($participant->getUser());
+				$room->leaveRoomAsParticipant($participant);
 			}
 		} catch (RoomNotFoundException $e) {
 		} catch (ParticipantNotFoundException $e) {

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1144,13 +1144,25 @@ class RoomController extends AEnvironmentAwareController {
 	 *
 	 * @param string $token
 	 * @param string $password
+	 * @param bool $force
 	 * @return DataResponse
 	 */
-	public function joinRoom(string $token, string $password = ''): DataResponse {
+	public function joinRoom(string $token, string $password = '', bool $force = true): DataResponse {
 		try {
 			$room = $this->manager->getRoomForParticipantByToken($token, $this->userId);
 		} catch (RoomNotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		if ($force === false && $this->userId !== null) {
+			try {
+				$participant = $room->getParticipant($this->userId);
+				if ($participant->getSessionId() !== '0') {
+					return new DataResponse([], Http::STATUS_CONFLICT);
+				}
+			} catch (ParticipantNotFoundException $e) {
+				// All fine, carry on
+			}
 		}
 
 		$user = $this->userManager->get($this->userId);

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -313,7 +313,17 @@ class SignalingController extends OCSController {
 			$data[] = ['type' => 'usersInRoom', 'data' => $this->getUsersInRoom($room, $pingTimestamp)];
 		} catch (RoomNotFoundException $e) {
 			$data[] = ['type' => 'usersInRoom', 'data' => []];
-			return new DataResponse($data, Http::STATUS_NOT_FOUND);
+
+			// Was the session killed or the complete conversation?
+			try {
+				$this->manager->getRoomForParticipantByToken($token, $this->userId);
+
+				// Session was killed, make the UI redirect to an error
+				return new DataResponse($data, Http::STATUS_CONFLICT);
+			} catch (RoomNotFoundException $e) {
+				// Complete conversation was killed, bye!
+				return new DataResponse($data, Http::STATUS_NOT_FOUND);
+			}
 		}
 
 		return new DataResponse($data);

--- a/src/services/SessionStorage.js
+++ b/src/services/SessionStorage.js
@@ -1,0 +1,30 @@
+/**
+ * @copyright Copyright (c) 2020 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { getBuilder } from '@nextcloud/browser-storage'
+
+/**
+ * Note: This uses the browsers sessionStorage not the browserStorage.
+ * As per https://stackoverflow.com/q/20325763 this is NOT shared between tabs.
+ * For us this is the solution we were looking for, as it allows us to
+ * identify if a user reloaded a conversation in the same tab,
+ * or entered it in another tab.
+ */
+export default getBuilder('talk').clearOnLogout().build()

--- a/src/services/participantsService.js
+++ b/src/services/participantsService.js
@@ -27,6 +27,7 @@ import {
 	signalingLeaveConversation,
 } from '../utils/webrtc/index'
 import { EventBus } from './EventBus'
+import SessionStorage from './SessionStorage'
 
 /**
  * Joins the current user to a conversation specified with
@@ -35,10 +36,16 @@ import { EventBus } from './EventBus'
  * @param {string} token The conversation token;
  */
 const joinConversation = async(token) => {
+	const isReloading = SessionStorage.getItem('joined_conversation') === token
+
 	try {
-		const response = await axios.post(generateOcsUrl('apps/spreed/api/v2', 2) + `room/${token}/participants/active`)
+		const response = await axios.post(generateOcsUrl('apps/spreed/api/v2', 2) + `room/${token}/participants/active`, {
+			force: isReloading,
+		})
+
 		// FIXME Signaling should not be synchronous
 		await signalingJoinConversation(token, response.data.ocs.data.sessionId)
+		SessionStorage.setItem('joined_conversation', token)
 		EventBus.$emit('joinedConversation')
 		return response
 	} catch (error) {

--- a/src/services/participantsService.js
+++ b/src/services/participantsService.js
@@ -32,6 +32,7 @@ import {
 } from '../utils/webrtc/index'
 import { EventBus } from './EventBus'
 import SessionStorage from './SessionStorage'
+import {PARTICIPANT} from "../constants";
 
 /**
  * Joins the current user to a conversation specified with
@@ -40,11 +41,12 @@ import SessionStorage from './SessionStorage'
  * @param {string} token The conversation token;
  */
 const joinConversation = async(token) => {
-	const isReloading = SessionStorage.getItem('joined_conversation') === token
+	// When the token is in the last joined conversation, the user is reloading or force joining
+	const forceJoin = SessionStorage.getItem('joined_conversation') === token
 
 	try {
 		const response = await axios.post(generateOcsUrl('apps/spreed/api/v2', 2) + `room/${token}/participants/active`, {
-			force: isReloading,
+			force: forceJoin,
 		})
 
 		// FIXME Signaling should not be synchronous
@@ -54,7 +56,18 @@ const joinConversation = async(token) => {
 		return response
 	} catch (error) {
 		if (error.response.status === 409) {
-			await confirmForceJoinConversation(token)
+			const responseData = error.response.data.ocs.data
+			let maxLastPingAge = new Date().getTime() / 1000 - 40
+			if (responseData.inCall !== PARTICIPANT.CALL_FLAG.DISCONNECTED) {
+				// When the user is/was in a call, we accept 20 seconds more delay
+				maxLastPingAge -= 20
+			}
+			if (maxLastPingAge > responseData.lastPing) {
+				console.debug('Force joining automatically because the old session didn\'t ping for 40 seconds')
+				await forceJoinConversation(token)
+			} else {
+				await confirmForceJoinConversation(token)
+			}
 		} else {
 			console.debug(error)
 			showError(t('spreed', 'Failed to join the conversation. Try to reload the page.'))
@@ -78,11 +91,15 @@ const confirmForceJoinConversation = async(token) => {
 				window.location = generateUrl('/apps/spreed')
 			} else {
 				// Confirm
-				SessionStorage.setItem('joined_conversation', token)
-				joinConversation(token)
+				forceJoinConversation(token)
 			}
 		}
 	)
+}
+
+const forceJoinConversation = async(token) => {
+	SessionStorage.setItem('joined_conversation', token)
+	await joinConversation(token)
 }
 
 /**

--- a/src/services/participantsService.js
+++ b/src/services/participantsService.js
@@ -32,7 +32,7 @@ import {
 } from '../utils/webrtc/index'
 import { EventBus } from './EventBus'
 import SessionStorage from './SessionStorage'
-import {PARTICIPANT} from "../constants";
+import { PARTICIPANT } from '../constants'
 
 /**
  * Joins the current user to a conversation specified with

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -296,6 +296,7 @@ function Internal(settings) {
 	this.hideWarning = settings.hideWarning
 	this.spreedArrayConnection = []
 
+	this.pullMessageErrorToast = null
 	this.pullMessagesFails = 0
 	this.pullMessagesRequest = null
 
@@ -409,6 +410,11 @@ Signaling.Internal.prototype._startPullingMessages = function() {
 	request(token)
 		.then(function(result) {
 			this.pullMessagesFails = 0
+			if (this.pullMessageErrorToast) {
+				this.pullMessageErrorToast.hideToast()
+				this.pullMessageErrorToast = null
+			}
+
 			result.data.ocs.data.forEach(message => {
 				this._trigger('onBeforeReceiveMessage', [message])
 				switch (message.type) {
@@ -436,6 +442,7 @@ Signaling.Internal.prototype._startPullingMessages = function() {
 			} else if (axios.isCancel(error)) {
 				console.debug('Pulling messages request was cancelled')
 			} else if (error.response && error.response.status === 409) {
+				// Participant joined a second time and this session was killed
 				console.error('Session was killed but the conversation still exists')
 				this._trigger('pullMessagesStoppedOnFail')
 
@@ -460,22 +467,32 @@ Signaling.Internal.prototype._startPullingMessages = function() {
 					}
 				)
 			} else if (error.response && (error.response.status === 404 || error.response.status === 403)) {
-				console.error('Stop pulling messages because room does not exist or is not accessible')
-				this._trigger('pullMessagesStoppedOnFail')
+				// Conversation was deleted or the user was removed
+				console.error('Conversation was not found anymore')
+				OC.redirect(generateUrl('/apps/spreed/not-found'))
 			} else if (token) {
-				if (this.pullMessagesFails >= 3) {
-					console.error('Stop pulling messages after repeated failures')
+				if (this.pullMessagesFails === 1) {
+					this.pullMessageErrorToast = showError(t('spreed', 'Lost connection to signaling server. Trying to reconnect.'), {
+						timeout: -1,
+					})
+				}
+				if (this.pullMessagesFails === 30) {
+					if (this.pullMessageErrorToast) {
+						this.pullMessageErrorToast.hideToast()
+					}
 
-					this._trigger('pullMessagesStoppedOnFail')
-
+					// Giving up after 5 minutes
+					this.pullMessageErrorToast = showError(t('spreed', 'Lost connection to signaling server. Try to reload the page manually.'), {
+						timeout: -1,
+					})
 					return
 				}
 
 				this.pullMessagesFails++
-				// Retry to pull messages after 5 seconds
+				// Retry to pull messages after 10 seconds
 				window.setTimeout(function() {
 					this._startPullingMessages()
-				}.bind(this), 5000)
+				}.bind(this), 10000)
 			}
 		}.bind(this))
 }


### PR DESCRIPTION
### Steps
1. In Tab 1 open a conversation as User A and join the call
2. In Window 2 open the same conversation as User B and join the call
3. In Tab 2 or Device 2 open the conversation as User 1 and leave it again
4. :boom: 

- [ ] Based on #3591
- [x] `addParticipantOnce` used a wrong check to see if a user already exists.
- [x] Internal signaling stops the signaling query and is just silent from there on in the old tab
- [ ] External signaling is in limbo state and people joining later will get a different set of participants compared to users that were online all the time