### PR TITLE
User participants are identified by userId in the participant store, …

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -224,7 +224,7 @@ export default {
 				}
 			} else {
 				data = {
-					participant: this.computedId,
+					userId: this.computedId,
 				}
 			}
 			return data

--- a/src/store/actorStore.js
+++ b/src/store/actorStore.js
@@ -65,7 +65,7 @@ const getters = {
 			}
 		}
 		return {
-			participant: state.userId,
+			userId: state.userId,
 		}
 	},
 }

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -62,8 +62,8 @@ const getters = {
 
 		let index
 
-		if (participantIdentifier.hasOwnProperty('participant')) {
-			index = state.participants[token].findIndex(participant => participant.userId === participantIdentifier.participant)
+		if (participantIdentifier.hasOwnProperty('userId')) {
+			index = state.participants[token].findIndex(participant => participant.userId === participantIdentifier.userId)
 		} else {
 			index = state.participants[token].findIndex(participant => participant.sessionId === participantIdentifier.sessionId)
 		}
@@ -144,7 +144,15 @@ const actions = {
 			return
 		}
 
-		await promoteToModerator(token, participantIdentifier)
+		if (participantIdentifier.userId) {
+			// Moderation endpoint requires "participant" instead of "userId"
+			await promoteToModerator(token, {
+				participant: participantIdentifier.userId,
+			})
+		} else {
+			// Guests are identified by sessionId in both cases
+			await promoteToModerator(token, participantIdentifier)
+		}
 
 		const participant = getters.getParticipant(token, index)
 		const updatedData = {
@@ -158,7 +166,15 @@ const actions = {
 			return
 		}
 
-		await demoteFromModerator(token, participantIdentifier)
+		if (participantIdentifier.userId) {
+			// Moderation endpoint requires "participant" instead of "userId"
+			await demoteFromModerator(token, {
+				participant: participantIdentifier.userId,
+			})
+		} else {
+			// Guests are identified by sessionId in both cases
+			await demoteFromModerator(token, participantIdentifier)
+		}
 
 		const participant = getters.getParticipant(token, index)
 		const updatedData = {


### PR DESCRIPTION
…not by participant

Split from https://github.com/nextcloud/spreed/pull/3338 for faster merging

Not sure where `participant` comes from. I guess a copy paste fail.
userId is used in the rooms getParticipant:
https://github.com/nextcloud/spreed/blob/445756dea3356a3f2d39ad00ad581ebb4c86bda2/lib/Controller/RoomController.php#L851
And the calls getPeers:
https://github.com/nextcloud/spreed/blob/06a045ed1e82facb477caedd918200cdd4c34ea9/lib/Controller/CallController.php#L66

The old Room API also had no `participant` key:
https://github.com/nextcloud/spreed/blob/445756dea3356a3f2d39ad00ad581ebb4c86bda2/lib/Controller/RoomController.php#L338

This should explain and solve some of the "duplicate avatar" issues like #2913 