### PR TITLE
Fix internal signaling status code detection

### DIFF
--- a/src/services/signalingService.js
+++ b/src/services/signalingService.js
@@ -33,8 +33,8 @@ const fetchSignalingSettings = async(token) => {
 	return axios.get(generateOcsUrl('apps/spreed/api/v1/signaling', 2) + 'settings')
 }
 
-const pullSignalingMessages = async(token) => {
-	return axios.get(generateOcsUrl('apps/spreed/api/v1/signaling', 2) + token)
+const pullSignalingMessages = async(token, options) => {
+	return axios.get(generateOcsUrl('apps/spreed/api/v1/signaling', 2) + token, options)
 }
 
 const getWelcomeMessage = async(serverId) => {

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -448,12 +448,10 @@ Signaling.Internal.prototype._startPullingMessages = function() {
 			})
 			this._startPullingMessages()
 		}.bind(this))
-		.catch(function(jqXHR, textStatus/*, errorThrown */) {
-			if (jqXHR.status === 0 && textStatus === 'abort') {
-				// Request has been aborted. Ignore.
-			} else if (token !== this.currentRoomToken) {
+		.catch(function(error) {
+			if (token !== this.currentRoomToken) {
 				// User navigated away in the meantime. Ignore
-			} else if (jqXHR.status === 404 || jqXHR.status === 403) {
+			} else if (error.response.status === 404 || error.response.status === 403) {
 				console.error('Stop pulling messages because room does not exist or is not accessible')
 				this._trigger('pullMessagesStoppedOnFail')
 			} else if (token) {

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -451,6 +451,8 @@ Signaling.Internal.prototype._startPullingMessages = function() {
 		.catch(function(error) {
 			if (token !== this.currentRoomToken) {
 				// User navigated away in the meantime. Ignore
+			} else if (axios.isCancel(error)) {
+				console.debug('Pulling messages request was cancelled')
 			} else if (error.response.status === 404 || error.response.status === 403) {
 				console.error('Stop pulling messages because room does not exist or is not accessible')
 				this._trigger('pullMessagesStoppedOnFail')


### PR DESCRIPTION
Split from #3338 for faster merging

When you navigated away, the signaling is currently not stopped, but does something else.
But because the 404 detection failed as well, we retried signaling 3 more times before stopping.