### PR TITLE
Feature/noid/improve ui

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -311,6 +311,12 @@ export default {
 	mounted() {
 		// see browserCheck mixin
 		this.checkBrowser()
+		// Check sidebar status in previous sessions
+		if (localStorage.getItem('sidebarOpen') === 'false') {
+			this.$store.dispatch('hideSidebar')
+		} else if (localStorage.getItem('sidebarOpen') === 'true') {
+			this.$store.dispatch('showSidebar')
+		}
 	},
 
 	methods: {

--- a/src/components/CallView/GridView/GridView.vue
+++ b/src/components/CallView/GridView/GridView.vue
@@ -320,7 +320,7 @@ export default {
 		},
 
 		sidebarStatus() {
-			return this.$store.getters.getSidebarStatus()
+			return this.$store.getters.getSidebarStatus
 		},
 		// Current aspect ratio of each video component
 		videoContainerAspectRatio() {

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -110,12 +110,14 @@ export default {
 			contactsLoading: false,
 			// The conversation name (while editing)
 			conversationName: '',
+			// Sidebar status before starting editing operation
+			sidebarOpenBeforeEditingName: '',
 		}
 	},
 
 	computed: {
 		show() {
-			return this.$store.getters.getSidebarStatus()
+			return this.$store.getters.getSidebarStatus
 		},
 		opened() {
 			return !!this.token && !this.isInLobby && this.show
@@ -201,12 +203,6 @@ export default {
 			}
 
 			this.conversation.isFavorite = !this.conversation.isFavorite
-		},
-
-		handleRenameConversation() {
-			// Copy the current conversation's title into the renaming title
-			this.conversationName = this.title
-			this.$store.dispatch('isRenamingConversation', true)
 		},
 
 		/**

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -22,7 +22,7 @@
 
 <template>
 	<AppSidebar
-		v-if="opened"
+		v-show="opened"
 		:title="title"
 		:starred="isFavorited"
 		:title-editable="canModerate && isRenamingConversation"
@@ -188,10 +188,16 @@ export default {
 		},
 	},
 
+	watch: {
+		conversation() {
+			this.conversationName = this.$store.getters.conversation(this.token).displayName
+		},
+	},
+
 	methods: {
 		handleClose() {
-			this.$store.dispatch('hideSidebar')
 			this.dismissEditing()
+			this.$store.dispatch('hideSidebar')
 			localStorage.setItem('sidebarOpen', 'false')
 		},
 

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -109,8 +109,6 @@ export default {
 		return {
 			contactsLoading: false,
 			lobbyTimerLoading: false,
-			// Changes the conversation title into an input field for renaming
-			isRenamingConversation: false,
 			// The conversation name (while editing)
 			conversationName: '',
 		}
@@ -214,6 +212,9 @@ export default {
 				return this.conversation.displayName
 			}
 		},
+		isRenamingConversation() {
+			return this.$store.getters.isRenamingConversation
+		},
 	},
 
 	methods: {
@@ -234,7 +235,7 @@ export default {
 		handleRenameConversation() {
 			// Copy the current conversation's title into the renaming title
 			this.conversationName = this.title
-			this.isRenamingConversation = true
+			this.$store.dispatch('isRenamingConversation', true)
 		},
 
 		/**
@@ -250,7 +251,7 @@ export default {
 			const name = event.target[0].value.trim()
 			try {
 				await setConversationName(this.token, name)
-				this.isRenamingConversation = false
+				this.$store.dispatch('isRenamingConversation', false)
 			} catch (exception) {
 				console.debug(exception)
 			}

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -31,78 +31,6 @@
 		@submit-title="handleSubmitTitle"
 		@dismiss-editing="isRenamingConversation = false"
 		@close="handleClose">
-		<template v-if="isFileConversation || (conversationHasSettings && showModerationMenu)"
-			v-slot:secondary-actions>
-			<ActionLink
-				v-if="isFileConversation"
-				icon="icon-text"
-				:href="linkToFile">
-				{{ t('spreed', 'Go to file') }}
-			</ActionLink>
-			<ActionButton
-				v-if="canModerate"
-				:close-after-click="true"
-				icon="icon-rename"
-				@click="handleRenameConversation">
-				{{ t('spreed', 'Rename conversation') }}
-			</ActionButton>
-			<ActionText
-				v-if="canFullModerate"
-				icon="icon-shared"
-				:title="t('spreed', 'Guests')" />
-			<ActionCheckbox
-				v-if="canFullModerate"
-				:checked="isSharedPublicly"
-				@change="toggleGuests">
-				{{ t('spreed', 'Share link') }}
-			</ActionCheckbox>
-			<ActionButton
-				v-if="canFullModerate"
-				icon="icon-clippy"
-				:close-after-click="true"
-				@click="handleCopyLink">
-				{{ t('spreed', 'Copy link') }}
-			</ActionButton>
-			<!-- password -->
-			<ActionCheckbox
-				v-if="canFullModerate && isSharedPublicly"
-				class="share-link-password-checkbox"
-				:checked="isPasswordProtected"
-				@check="handlePasswordEnable"
-				@uncheck="handlePasswordDisable">
-				{{ t('spreed', 'Password protection') }}
-			</ActionCheckbox>
-			<ActionInput
-				v-show="isEditingPassword"
-				class="share-link-password"
-				icon="icon-password"
-				type="password"
-				:value.sync="password"
-				autocomplete="new-password"
-				@submit="handleSetNewPassword">
-				{{ t('spreed', 'Enter a password') }}
-			</ActionInput>
-			<ActionText
-				v-if="canFullModerate"
-				icon="icon-lobby"
-				:title="t('spreed', 'Webinar')" />
-			<ActionCheckbox
-				v-if="canFullModerate"
-				:checked="hasLobbyEnabled"
-				@change="toggleLobby">
-				{{ t('spreed', 'Enable lobby') }}
-			</ActionCheckbox>
-			<ActionInput
-				v-if="canFullModerate && hasLobbyEnabled"
-				icon="icon-calendar-dark"
-				type="datetime-local"
-				v-bind="dateTimePickerAttrs"
-				:value="lobbyTimer"
-				:disabled="lobbyTimerLoading"
-				@change="setLobbyTimer">
-				{{ t('spreed', 'Start time (optional)') }}
-			</ActionInput>
-		</template>
 		<AppSidebarTab
 			v-if="showChatInSidebar"
 			id="chat"
@@ -141,11 +69,6 @@
 </template>
 
 <script>
-import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
-import ActionCheckbox from '@nextcloud/vue/dist/Components/ActionCheckbox'
-import ActionInput from '@nextcloud/vue/dist/Components/ActionInput'
-import ActionLink from '@nextcloud/vue/dist/Components/ActionLink'
-import ActionText from '@nextcloud/vue/dist/Components/ActionText'
 import AppSidebar from '@nextcloud/vue/dist/Components/AppSidebar'
 import AppSidebarTab from '@nextcloud/vue/dist/Components/AppSidebarTab'
 import ChatView from '../ChatView'
@@ -155,21 +78,14 @@ import ParticipantsTab from './Participants/ParticipantsTab'
 import {
 	addToFavorites,
 	removeFromFavorites,
-	setConversationPassword,
 	setConversationName,
 } from '../../services/conversationsService'
 import isInLobby from '../../mixins/isInLobby'
-import { generateUrl } from '@nextcloud/router'
 import SetGuestUsername from '../SetGuestUsername'
 
 export default {
 	name: 'RightSidebar',
 	components: {
-		ActionButton,
-		ActionCheckbox,
-		ActionInput,
-		ActionText,
-		ActionLink,
 		AppSidebar,
 		AppSidebarTab,
 		ChatView,
@@ -193,10 +109,6 @@ export default {
 		return {
 			contactsLoading: false,
 			lobbyTimerLoading: false,
-			// The conversation's password
-			password: '',
-			// Switch for the password-editing operation
-			isEditingPassword: false,
 			// Changes the conversation title into an input field for renaming
 			isRenamingConversation: false,
 			// The conversation name (while editing)
@@ -239,17 +151,6 @@ export default {
 			}
 
 			return this.conversation.isFavorite
-		},
-
-		conversationHasSettings() {
-			return this.conversation.type === CONVERSATION.TYPE.GROUP
-				|| this.conversation.type === CONVERSATION.TYPE.PUBLIC
-		},
-		isSharedPublicly() {
-			return this.conversation.type === CONVERSATION.TYPE.PUBLIC
-		},
-		hasLobbyEnabled() {
-			return this.conversation.lobbyState === WEBINAR.LOBBY.NON_MODERATORS
 		},
 
 		lobbyTimer() {
@@ -302,30 +203,6 @@ export default {
 			return this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE && (this.canFullModerate || this.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR)
 		},
 
-		showModerationMenu() {
-			return this.canModerate && (this.canFullModerate || this.isSharedPublicly)
-		},
-		isPasswordProtected() {
-			return this.conversation.hasPassword
-		},
-		linkToConversation() {
-			if (this.token !== '') {
-				return window.location.protocol + '//' + window.location.host + generateUrl('/call/' + this.token)
-			} else {
-				return ''
-			}
-		},
-
-		isFileConversation() {
-			return this.conversation.objectType === 'file' && this.conversation.objectId
-		},
-		linkToFile() {
-			if (this.isFileConversation) {
-				return window.location.protocol + '//' + window.location.host + generateUrl('/f/' + this.conversation.objectId)
-			} else {
-				return ''
-			}
-		},
 		/**
 		 * The conversation title value passed into the AppSidebar component.
 		 * @returns {string} The conversation's title.
@@ -354,55 +231,6 @@ export default {
 			this.conversation.isFavorite = !this.conversation.isFavorite
 		},
 
-		async toggleGuests() {
-			await this.$store.dispatch('toggleGuests', {
-				token: this.token,
-				allowGuests: this.conversation.type !== CONVERSATION.TYPE.PUBLIC,
-			})
-		},
-
-		async toggleLobby() {
-			await this.$store.dispatch('toggleLobby', {
-				token: this.token,
-				enableLobby: this.conversation.lobbyState !== WEBINAR.LOBBY.NON_MODERATORS,
-			})
-		},
-
-		async setLobbyTimer(date) {
-			this.lobbyTimerLoading = true
-
-			let timestamp = 0
-			if (date) {
-				// PHP timestamp is second-based; JavaScript timestamp is
-				// millisecond based.
-				timestamp = date.getTime() / 1000
-			}
-
-			await this.$store.dispatch('setLobbyTimer', {
-				token: this.token,
-				timestamp: timestamp,
-			})
-
-			this.lobbyTimerLoading = false
-		},
-		async handlePasswordDisable() {
-			// disable the password protection for the current conversation
-			if (this.conversation.hasPassword) {
-				await setConversationPassword(this.token, '')
-			}
-			this.password = ''
-			this.isEditingPassword = false
-		},
-		async handlePasswordEnable() {
-			this.isEditingPassword = true
-		},
-
-		async handleSetNewPassword() {
-			await setConversationPassword(this.token, this.password)
-			this.password = ''
-			this.isEditingPassword = false
-		},
-
 		handleRenameConversation() {
 			// Copy the current conversation's title into the renaming title
 			this.conversationName = this.title
@@ -427,14 +255,7 @@ export default {
 				console.debug(exception)
 			}
 		},
-		async handleCopyLink() {
-			try {
-				await this.$copyText(this.linkToConversation)
-				OCP.Toast.success(t('spreed', 'Conversation link copied to clipboard.'))
-			} catch (error) {
-				OCP.Toast.error(t('spreed', 'The link could not be copied.'))
-			}
-		},
+
 	},
 }
 </script>

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -108,7 +108,6 @@ export default {
 	data() {
 		return {
 			contactsLoading: false,
-			lobbyTimerLoading: false,
 			// The conversation name (while editing)
 			conversationName: '',
 		}
@@ -149,36 +148,6 @@ export default {
 			}
 
 			return this.conversation.isFavorite
-		},
-
-		lobbyTimer() {
-			// A timestamp of 0 means that there is no lobby, but it would be
-			// interpreted as the Unix epoch by the DateTimePicker.
-			if (this.conversation.lobbyTimer === 0) {
-				return undefined
-			}
-
-			// PHP timestamp is second-based; JavaScript timestamp is
-			// millisecond based.
-			return this.conversation.lobbyTimer * 1000
-		},
-
-		dateTimePickerAttrs() {
-			return {
-				format: 'YYYY-MM-DD HH:mm',
-				firstDayOfWeek: window.firstDay + 1, // Provided by server
-				lang: {
-					days: window.dayNamesShort, // Provided by server
-					months: window.monthNamesShort, // Provided by server
-				},
-				// Do not update the value until the confirm button has been
-				// pressed. Otherwise it would not be possible to set a lobby
-				// for today, because as soon as the day is selected the lobby
-				// timer would be set, but as no time was set at that point the
-				// lobby timer would be set to today at 00:00, which would
-				// disable the lobby due to being in the past.
-				confirm: true,
-			}
 		},
 
 		displaySearchBox() {

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -190,6 +190,7 @@ export default {
 		handleClose() {
 			this.$store.dispatch('hideSidebar')
 			this.dismissEditing()
+			localStorage.setItem('sidebarOpen', 'false')
 		},
 
 		async onFavoriteChange() {

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -29,7 +29,7 @@
 		@update:starred="onFavoriteChange"
 		@update:title="handleUpdateTitle"
 		@submit-title="handleSubmitTitle"
-		@dismiss-editing="isRenamingConversation = false"
+		@dismiss-editing="dismissEditing"
 		@close="handleClose">
 		<AppSidebarTab
 			v-if="showChatInSidebar"
@@ -220,6 +220,7 @@ export default {
 	methods: {
 		handleClose() {
 			this.$store.dispatch('hideSidebar')
+			this.dismissEditing()
 		},
 
 		async onFavoriteChange() {
@@ -251,10 +252,14 @@ export default {
 			const name = event.target[0].value.trim()
 			try {
 				await setConversationName(this.token, name)
-				this.$store.dispatch('isRenamingConversation', false)
+				this.dismissEditing()
 			} catch (exception) {
 				console.debug(exception)
 			}
+		},
+
+		dismissEditing() {
+			this.$store.dispatch('isRenamingConversation', false)
 		},
 
 	},

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -190,6 +190,7 @@ export default {
 			password: '',
 			// Switch for the password-editing operation
 			isEditingPassword: false,
+			lobbyTimerLoading: false,
 		}
 	},
 
@@ -303,6 +304,36 @@ export default {
 		isPasswordProtected() {
 			return this.conversation.hasPassword
 		},
+		lobbyTimer() {
+			// A timestamp of 0 means that there is no lobby, but it would be
+			// interpreted as the Unix epoch by the DateTimePicker.
+			if (this.conversation.lobbyTimer === 0) {
+				return undefined
+			}
+
+			// PHP timestamp is second-based; JavaScript timestamp is
+			// millisecond based.
+			return this.conversation.lobbyTimer * 1000
+		},
+
+		dateTimePickerAttrs() {
+			return {
+				format: 'YYYY-MM-DD HH:mm',
+				firstDayOfWeek: window.firstDay + 1, // Provided by server
+				lang: {
+					days: window.dayNamesShort, // Provided by server
+					months: window.monthNamesShort, // Provided by server
+				},
+				// Do not update the value until the confirm button has been
+				// pressed. Otherwise it would not be possible to set a lobby
+				// for today, because as soon as the day is selected the lobby
+				// timer would be set, but as no time was set at that point the
+				// lobby timer would be set to today at 00:00, which would
+				// disable the lobby due to being in the past.
+				confirm: true,
+			}
+		},
+
 	},
 
 	mounted() {

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -21,7 +21,6 @@
 
 <template>
 	<div class="top-bar">
-		<CallButton />
 		<!-- Call layout switcher -->
 		<Popover v-if="isInCall"
 			class="top-bar__button"
@@ -361,6 +360,7 @@ export default {
 	methods: {
 		openSidebar() {
 			this.$store.dispatch('showSidebar')
+			localStorage.setItem('sidebarOpen', 'true')
 		},
 
 		fullScreenChanged() {

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -85,7 +85,7 @@
 				{{ t('spreed', 'Share link') }}
 			</ActionCheckbox>
 			<ActionButton
-				v-if="canFullModerate && isSharedPublicly"
+				v-if="canFullModerate"
 				icon="icon-clippy"
 				:close-after-click="true"
 				@click="handleCopyLink">

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -220,7 +220,7 @@ export default {
 		},
 
 		showOpenSidebarButton() {
-			return !this.$store.getters.getSidebarStatus()
+			return !this.$store.getters.getSidebarStatus
 		},
 
 		changeViewText() {
@@ -467,8 +467,8 @@ export default {
 			}
 		},
 		handleRenameConversation() {
-			this.$store.dispatch('showSidebar')
 			this.$store.dispatch('isRenamingConversation', true)
+			this.$store.dispatch('showSidebar')
 		},
 	},
 }

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -22,7 +22,6 @@
 <template>
 	<div class="top-bar">
 		<CallButton />
-		</Actions>
 		<!-- Call layout switcher -->
 		<Popover v-if="isInCall"
 			class="top-bar__button"
@@ -69,10 +68,8 @@
 				@click="handleRenameConversation">
 				{{ t('spreed', 'Rename conversation') }}
 			</ActionButton>
-			<ActionText
-				v-if="canFullModerate"
-				icon="icon-shared"
-				:title="t('spreed', 'Guests')" />
+			<ActionSeparator
+				v-if="canFullModerate" />
 			<ActionCheckbox
 				v-if="canFullModerate"
 				:checked="isSharedPublicly"
@@ -105,10 +102,8 @@
 				@submit="handleSetNewPassword">
 				{{ t('spreed', 'Enter a password') }}
 			</ActionInput>
-			<ActionText
-				v-if="canFullModerate"
-				icon="icon-lobby"
-				:title="t('spreed', 'Webinar')" />
+			<ActionSeparator
+				v-if="canFullModerate" />
 			<ActionCheckbox
 				v-if="canFullModerate"
 				:checked="hasLobbyEnabled"
@@ -125,6 +120,7 @@
 				@change="setLobbyTimer">
 				{{ t('spreed', 'Start time (optional)') }}
 			</ActionInput>
+			<ActionSeparator />
 			<ActionButton
 				v-shortkey="['f']"
 				:icon="iconFullscreen"
@@ -134,6 +130,7 @@
 				{{ labelFullscreen }}
 			</ActionButton>
 		</Actions>
+		<CallButton class="top-bar__button" />
 		<Actions v-if="showOpenSidebarButton"
 			class="top-bar__button"
 			close-after-click="true">
@@ -153,7 +150,7 @@ import { EventBus } from '../../services/EventBus'
 import ActionCheckbox from '@nextcloud/vue/dist/Components/ActionCheckbox'
 import ActionInput from '@nextcloud/vue/dist/Components/ActionInput'
 import ActionLink from '@nextcloud/vue/dist/Components/ActionLink'
-import ActionText from '@nextcloud/vue/dist/Components/ActionText'
+import ActionSeparator from '@nextcloud/vue/dist/Components/ActionSeparator'
 import { CONVERSATION, WEBINAR, PARTICIPANT } from '../../constants'
 import {
 	setConversationPassword,
@@ -168,10 +165,10 @@ export default {
 		Actions,
 		ActionCheckbox,
 		ActionInput,
-		ActionText,
 		ActionLink,
 		CallButton,
 		Popover,
+		ActionSeparator,
 	},
 
 	props: {
@@ -460,6 +457,7 @@ export default {
 	justify-content: flex-end;
 	padding: 0 6px;
 	&__button {
+		margin: 0 2px;
 		align-self: center;
 	}
 

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -21,7 +21,6 @@
 
 <template>
 	<div class="top-bar">
-		<CallButton class="top-bar__button" />
 		<!-- Call layout switcher -->
 		<Popover v-if="isInCall"
 			class="top-bar__button"
@@ -55,6 +54,15 @@
 		<Actions
 			v-if="isFileConversation || (conversationHasSettings && showModerationMenu)"
 			class="top-bar__button">
+			<ActionButton
+				v-shortkey="['f']"
+				:icon="iconFullscreen"
+				:aria-label="t('spreed', 'Toggle fullscreen')"
+				@shortkey.native="toggleFullscreen"
+				@click="toggleFullscreen">
+				{{ labelFullscreen }}
+			</ActionButton>
+			<ActionSeparator />
 			<ActionLink
 				v-if="isFileConversation"
 				icon="icon-text"
@@ -120,16 +128,8 @@
 				@change="setLobbyTimer">
 				{{ t('spreed', 'Start time (optional)') }}
 			</ActionInput>
-			<ActionSeparator />
-			<ActionButton
-				v-shortkey="['f']"
-				:icon="iconFullscreen"
-				:aria-label="t('spreed', 'Toggle fullscreen')"
-				@shortkey.native="toggleFullscreen"
-				@click="toggleFullscreen">
-				{{ labelFullscreen }}
-			</ActionButton>
 		</Actions>
+		<CallButton class="top-bar__button" />
 		<Actions v-if="showOpenSidebarButton"
 			class="top-bar__button"
 			close-after-click="true">

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -22,15 +22,6 @@
 <template>
 	<div class="top-bar">
 		<CallButton />
-		<Actions class="top-bar__button">
-			<ActionButton
-				v-shortkey="['f']"
-				:icon="iconFullscreen"
-				:aria-label="t('spreed', 'Toggle fullscreen')"
-				@shortkey.native="toggleFullscreen"
-				@click="toggleFullscreen">
-				{{ labelFullscreen }}
-			</ActionButton>
 		</Actions>
 		<!-- Call layout switcher -->
 		<Popover v-if="isInCall"
@@ -134,6 +125,14 @@
 				@change="setLobbyTimer">
 				{{ t('spreed', 'Start time (optional)') }}
 			</ActionInput>
+			<ActionButton
+				v-shortkey="['f']"
+				:icon="iconFullscreen"
+				:aria-label="t('spreed', 'Toggle fullscreen')"
+				@shortkey.native="toggleFullscreen"
+				@click="toggleFullscreen">
+				{{ labelFullscreen }}
+			</ActionButton>
 		</Actions>
 		<Actions v-if="showOpenSidebarButton"
 			class="top-bar__button"

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -21,6 +21,7 @@
 
 <template>
 	<div class="top-bar">
+		<CallButton class="top-bar__button" />
 		<!-- Call layout switcher -->
 		<Popover v-if="isInCall"
 			class="top-bar__button"
@@ -76,7 +77,7 @@
 				{{ t('spreed', 'Share link') }}
 			</ActionCheckbox>
 			<ActionButton
-				v-if="canFullModerate"
+				v-if="canFullModerate && isSharedPublicly"
 				icon="icon-clippy"
 				:close-after-click="true"
 				@click="handleCopyLink">
@@ -129,7 +130,6 @@
 				{{ labelFullscreen }}
 			</ActionButton>
 		</Actions>
-		<CallButton class="top-bar__button" />
 		<Actions v-if="showOpenSidebarButton"
 			class="top-bar__button"
 			close-after-click="true">

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -441,6 +441,7 @@ export default {
 		},
 		handleRenameConversation() {
 			this.$store.dispatch('showSidebar')
+			this.$store.dispatch('isRenamingConversation', true)
 		},
 	},
 }

--- a/src/store/sidebarStore.js
+++ b/src/store/sidebarStore.js
@@ -23,10 +23,12 @@
 const state = {
 	show: true,
 	isRenamingConversation: false,
+	sidebarOpenBeforeEditing: null,
+
 }
 
 const getters = {
-	getSidebarStatus: (state) => () => {
+	getSidebarStatus: (state) => {
 		return state.show
 	},
 	isRenamingConversation: (state) => {
@@ -58,9 +60,13 @@ const mutations = {
 	 */
 	isRenamingConversation(state, boolean) {
 		if (boolean) {
+			// Record sidebar status before starting editing process
+			state.sidebarOpenBeforeEditing = state.show
 			state.isRenamingConversation = true
-		} else if (!boolean) {
+		} else {
 			state.isRenamingConversation = false
+			// Go back to the previous sidebar state
+			state.show = state.sidebarOpenBeforeEditing
 		}
 	},
 }
@@ -89,9 +95,7 @@ const actions = {
 	 * @param {boolean} boolean the state of the renaming action;
 	 */
 	isRenamingConversation(context, boolean) {
-		if (boolean) {
-			context.commit('isRenamingConversation', boolean)
-		}
+		context.commit('isRenamingConversation', boolean)
 	},
 }
 

--- a/src/store/sidebarStore.js
+++ b/src/store/sidebarStore.js
@@ -29,7 +29,7 @@ const getters = {
 	getSidebarStatus: (state) => () => {
 		return state.show
 	},
-	isRenamingConversation: (state) => () => {
+	isRenamingConversation: (state) => {
 		return state.isRenamingConversation
 	},
 }

--- a/src/store/sidebarStore.js
+++ b/src/store/sidebarStore.js
@@ -21,7 +21,7 @@
  */
 
 const state = {
-	show: false,
+	show: true,
 	isRenamingConversation: false,
 }
 

--- a/src/store/sidebarStore.js
+++ b/src/store/sidebarStore.js
@@ -22,11 +22,15 @@
 
 const state = {
 	show: false,
+	isRenamingConversation: false,
 }
 
 const getters = {
 	getSidebarStatus: (state) => () => {
 		return state.show
+	},
+	isRenamingConversation: (state) => () => {
+		return state.isRenamingConversation
 	},
 }
 
@@ -47,6 +51,18 @@ const mutations = {
 	hideSidebar(state) {
 		state.show = false
 	},
+	/**
+	 * Renaming state of the conversation
+	 * @param {object} state current store state;
+	 * @param {boolean} boolean the state of the renaming action;
+	 */
+	isRenamingConversation(state, boolean) {
+		if (boolean) {
+			state.isRenamingConversation = true
+		} else if (!boolean) {
+			state.isRenamingConversation = false
+		}
+	},
 }
 
 const actions = {
@@ -66,6 +82,16 @@ const actions = {
 	 */
 	hideSidebar(context) {
 		context.commit('hideSidebar')
+	},
+	/**
+	 * Renaming state of the conversation
+	 * @param {object} context default store context;
+	 * @param {boolean} boolean the state of the renaming action;
+	 */
+	isRenamingConversation(context, boolean) {
+		if (boolean) {
+			context.commit('isRenamingConversation', boolean)
+		}
 	},
 }
 

--- a/src/store/sidebarStore.js
+++ b/src/store/sidebarStore.js
@@ -21,7 +21,7 @@
  */
 
 const state = {
-	show: true,
+	show: false,
 }
 
 const getters = {


### PR DESCRIPTION
Improve the UI/UX by taking the moderation menu out of the sidebar and set the sidebar to be closed by default. 
* The only action that is 'sidebar-dependent' was renaming, for this we open the sidebar and focus the rename input;
* Moved the fullscreen button in the actions too;
* Removed captions, added separators instead;
* I'm tempted to move the sidebar toggle in the actions too and call it 'participants', but that'd be accurate only if we'd get rid of the projects tab;
cc @nextcloud/designers

![Peek 2020-04-25 19-06](https://user-images.githubusercontent.com/26852655/80285889-5142df00-8728-11ea-8878-3d9f9e4ad534.gif)

Fix #1002
Fix #3356