### PR TITLE
Adjust transfer ownership integration tests to changes in server

### DIFF
--- a/tests/integration/features/sharing/transfer-ownership.feature
+++ b/tests/integration/features/sharing/transfer-ownership.feature
@@ -29,7 +29,7 @@ Feature: transfer-ownership
     And share is returned with
       | uid_owner              | participant2 |
       | displayname_owner      | participant2-displayname |
-      | path                   | REGEXP /\/transferred from participant1 on .*\/welcome.txt/ |
+      | path                   | REGEXP /\/transferred from participant1-displayname on .*\/welcome.txt/ |
       | item_type              | file |
       | mimetype               | text/plain |
       | storage_id             | home::participant2 |
@@ -124,7 +124,7 @@ Feature: transfer-ownership
     And share is returned with
       | uid_owner              | participant2 |
       | displayname_owner      | participant2-displayname |
-      | path                   | REGEXP /\/transferred from participant1 on .*\/welcome.txt/ |
+      | path                   | REGEXP /\/transferred from participant1-displayname on .*\/welcome.txt/ |
       | item_type              | file |
       | mimetype               | text/plain |
       | storage_id             | home::participant2 |


### PR DESCRIPTION
When transferring ownership of a share [now](https://github.com/nextcloud/server/pull/20360) the name includes the display name of the original owner instead of his ID.
