### PR TITLE
Change video quality based on the number of participants

### DIFF
--- a/src/utils/webrtc/SentVideoQualityThrottler.js
+++ b/src/utils/webrtc/SentVideoQualityThrottler.js
@@ -1,0 +1,270 @@
+/**
+ *
+ * @copyright Copyright (c) 2020, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Helper to adjust the quality of the sent video based on the current call
+ * state.
+ *
+ * The properties of the local video (like resolution or frame rate) can be
+ * changed on the fly during a call with immediate effect, without having to
+ * reconnect to the call. This class uses that feature to dynamically reduce or
+ * increase the video quality depending on the call state. Basically the goal is
+ * to reduce the CPU usage when there are too many participants in a call.
+ *
+ * @param {LocalMediaModel} localMediaModel the model for the local media.
+ * @param {CallParticipantCollection} callParticipantCollection the collection
+ *        that contains the models for the rest of the participants in the call.
+ */
+export default function SentVideoQualityThrottler(localMediaModel, callParticipantCollection) {
+	this._localMediaModel = localMediaModel
+	this._callParticipantCollection = callParticipantCollection
+
+	// By default the constraints used when getting the video try to get the
+	// highest quality
+	this._currentQuality = this.QUALITY.HIGH
+
+	this._availableVideosThreshold = {}
+	this._availableVideosThreshold[this.QUALITY.THUMBNAIL] = 15
+	this._availableVideosThreshold[this.QUALITY.VERY_LOW] = 10
+	this._availableVideosThreshold[this.QUALITY.LOW] = 7
+	this._availableVideosThreshold[this.QUALITY.MEDIUM] = 4
+	// QUALITY.HIGH otherwise
+
+	this._availableAudiosThreshold = {}
+	this._availableAudiosThreshold[this.QUALITY.THUMBNAIL] = 40
+	this._availableAudiosThreshold[this.QUALITY.VERY_LOW] = 30
+	this._availableAudiosThreshold[this.QUALITY.LOW] = 20
+	this._availableAudiosThreshold[this.QUALITY.MEDIUM] = 10
+	// QUALITY.HIGH otherwise
+
+	this._handleLocalVideoAvailableChangeBound = this._handleLocalVideoAvailableChange.bind(this)
+	this._handleAddParticipantBound = this._handleAddParticipant.bind(this)
+	this._handleRemoveParticipantBound = this._handleRemoveParticipant.bind(this)
+	this._adjustVideoQualityIfNeededBound = this._adjustVideoQualityIfNeeded.bind(this)
+
+	this._localMediaModel.on('change:videoAvailable', this._handleLocalVideoAvailableChangeBound)
+
+	if (this._localMediaModel.get('videoAvailable')) {
+		this._startListeningToChanges()
+	}
+}
+SentVideoQualityThrottler.prototype = {
+
+	QUALITY: {
+		THUMBNAIL: 0,
+		VERY_LOW: 1,
+		LOW: 2,
+		MEDIUM: 3,
+		HIGH: 4,
+	},
+
+	destroy: function() {
+		this._localMediaModel.off('change:videoAvailable', this._handleLocalVideoAvailableChangeBound)
+
+		this._stopListeningToChanges()
+	},
+
+	_handleLocalVideoAvailableChange: function(localMediaModel, videoAvailable) {
+		if (videoAvailable) {
+			this._startListeningToChanges()
+		} else {
+			this._stopListeningToChanges()
+		}
+	},
+
+	_startListeningToChanges: function() {
+		this._localMediaModel.on('change:videoEnabled', this._adjustVideoQualityIfNeededBound)
+		this._localMediaModel.on('change:audioEnabled', this._adjustVideoQualityIfNeededBound)
+
+		this._callParticipantCollection.on('add', this._handleAddParticipantBound)
+		this._callParticipantCollection.on('remove', this._handleRemoveParticipantBound)
+
+		this._callParticipantCollection.callParticipantModels.forEach(callParticipantModel => {
+			callParticipantModel.on('change:videoAvailable', this._adjustVideoQualityIfNeededBound)
+			callParticipantModel.on('change:audioAvailable', this._adjustVideoQualityIfNeededBound)
+		})
+
+		this._adjustVideoQualityIfNeeded()
+	},
+
+	_stopListeningToChanges: function() {
+		this._localMediaModel.off('change:videoEnabled', this._adjustVideoQualityIfNeededBound)
+		this._localMediaModel.off('change:audioEnabled', this._adjustVideoQualityIfNeededBound)
+
+		this._callParticipantCollection.off('add', this._handleAddParticipantBound)
+		this._callParticipantCollection.off('remove', this._handleRemoveParticipantBound)
+
+		this._callParticipantCollection.callParticipantModels.forEach(callParticipantModel => {
+			callParticipantModel.off('change:videoAvailable', this._adjustVideoQualityIfNeededBound)
+			callParticipantModel.off('change:audioAvailable', this._adjustVideoQualityIfNeededBound)
+		})
+	},
+
+	_handleAddParticipant: function(callParticipantCollection, callParticipantModel) {
+		callParticipantModel.on('change:videoAvailable', this._adjustVideoQualityIfNeededBound)
+		callParticipantModel.on('change:audioAvailable', this._adjustVideoQualityIfNeededBound)
+
+		this._adjustVideoQualityIfNeeded()
+	},
+
+	_handleRemoveParticipant: function(callParticipantCollection, callParticipantModel) {
+		callParticipantModel.off('change:videoAvailable', this._adjustVideoQualityIfNeededBound)
+		callParticipantModel.off('change:audioAvailable', this._adjustVideoQualityIfNeededBound)
+
+		this._adjustVideoQualityIfNeeded()
+	},
+
+	_adjustVideoQualityIfNeeded: function() {
+		if (!this._localMediaModel.get('videoAvailable') || !this._localMediaModel.get('videoEnabled')) {
+			return
+		}
+
+		const quality = this._getQualityForState()
+		if (quality === this._currentQuality) {
+			return
+		}
+
+		this._applyConstraints(quality)
+	},
+
+	_getQualityForState: function() {
+		if (this._localMediaModel.get('audioEnabled')) {
+			return this.QUALITY.HIGH
+		}
+
+		let availableVideosCount = 0
+		let availableAudiosCount = 0
+		this._callParticipantCollection.callParticipantModels.forEach(callParticipantModel => {
+			if (callParticipantModel.get('videoAvailable')) {
+				availableVideosCount++
+			}
+			if (callParticipantModel.get('audioAvailable')) {
+				availableAudiosCount++
+			}
+		})
+
+		for (let i = this.QUALITY.THUMBNAIL; i < this.QUALITY.HIGH; i++) {
+			if (availableVideosCount >= this._availableVideosThreshold[i]
+				|| availableAudiosCount >= this._availableAudiosThreshold[i]) {
+				return i
+			}
+		}
+
+		return this.QUALITY.HIGH
+	},
+
+	_applyConstraints: function(quality) {
+		const localStream = this._localMediaModel.get('localStream')
+		if (!localStream) {
+			console.warn('No local stream to adjust its video quality found')
+			return
+		}
+
+		const localVideoTracks = localStream.getVideoTracks()
+		if (localVideoTracks.length === 0) {
+			console.warn('No local video track to adjust its quality found')
+			return
+		}
+
+		if (localVideoTracks.length > 1) {
+			console.warn('More than one local video track to adjust its quality found: ' + localVideoTracks.length)
+			return
+		}
+
+		const constraints = this._getConstraintsForQuality(quality)
+
+		localVideoTracks[0].applyConstraints(constraints).then(() => {
+			console.debug('Changed quality to ' + quality)
+			this._currentQuality = quality
+		}).catch(error => {
+			console.warn('Failed to set quality ' + quality, error)
+		})
+	},
+
+	_getConstraintsForQuality: function(quality) {
+		if (quality === this.QUALITY.HIGH) {
+			return {
+				video: true,
+				// The frame rate needs to be explicitly set; otherwise the
+				// browser may keep the previous stream when changing to a laxer
+				// constraint.
+				frameRate: {
+					max: 30,
+				},
+			}
+		}
+
+		if (quality === this.QUALITY.MEDIUM) {
+			return {
+				width: {
+					max: 640,
+				},
+				height: {
+					max: 480,
+				},
+				frameRate: {
+					max: 24,
+				},
+			}
+		}
+
+		if (quality === this.QUALITY.LOW) {
+			return {
+				width: {
+					max: 480,
+				},
+				height: {
+					max: 320,
+				},
+				frameRate: {
+					max: 15,
+				},
+			}
+		}
+
+		if (quality === this.QUALITY.VERY_LOW) {
+			return {
+				width: {
+					max: 320,
+				},
+				height: {
+					max: 240,
+				},
+				frameRate: {
+					max: 8,
+				},
+			}
+		}
+
+		return {
+			width: {
+				max: 320,
+			},
+			height: {
+				max: 240,
+			},
+			frameRate: {
+				max: 1,
+			},
+		}
+	},
+
+}

--- a/src/utils/webrtc/SentVideoQualityThrottler.js
+++ b/src/utils/webrtc/SentVideoQualityThrottler.js
@@ -48,17 +48,17 @@ export default function SentVideoQualityThrottler(localMediaModel, callParticipa
 	this._speakingOrInGracePeriodAfterSpeaking = false
 
 	this._availableVideosThreshold = {}
-	this._availableVideosThreshold[this.QUALITY.THUMBNAIL] = 15
-	this._availableVideosThreshold[this.QUALITY.VERY_LOW] = 10
-	this._availableVideosThreshold[this.QUALITY.LOW] = 7
-	this._availableVideosThreshold[this.QUALITY.MEDIUM] = 4
+	this._availableVideosThreshold[QUALITY.THUMBNAIL] = 15
+	this._availableVideosThreshold[QUALITY.VERY_LOW] = 10
+	this._availableVideosThreshold[QUALITY.LOW] = 7
+	this._availableVideosThreshold[QUALITY.MEDIUM] = 4
 	// QUALITY.HIGH otherwise
 
 	this._availableAudiosThreshold = {}
-	this._availableAudiosThreshold[this.QUALITY.THUMBNAIL] = 40
-	this._availableAudiosThreshold[this.QUALITY.VERY_LOW] = 30
-	this._availableAudiosThreshold[this.QUALITY.LOW] = 20
-	this._availableAudiosThreshold[this.QUALITY.MEDIUM] = 10
+	this._availableAudiosThreshold[QUALITY.THUMBNAIL] = 40
+	this._availableAudiosThreshold[QUALITY.VERY_LOW] = 30
+	this._availableAudiosThreshold[QUALITY.LOW] = 20
+	this._availableAudiosThreshold[QUALITY.MEDIUM] = 10
 	// QUALITY.HIGH otherwise
 
 	this._handleLocalVideoAvailableChangeBound = this._handleLocalVideoAvailableChange.bind(this)
@@ -75,8 +75,6 @@ export default function SentVideoQualityThrottler(localMediaModel, callParticipa
 	}
 }
 SentVideoQualityThrottler.prototype = {
-
-	QUALITY: QUALITY,
 
 	destroy: function() {
 		this._localMediaModel.off('change:videoAvailable', this._handleLocalVideoAvailableChangeBound)
@@ -182,7 +180,7 @@ SentVideoQualityThrottler.prototype = {
 
 	_getQualityForState: function() {
 		if (this._speakingOrInGracePeriodAfterSpeaking) {
-			return this.QUALITY.HIGH
+			return QUALITY.HIGH
 		}
 
 		let availableVideosCount = 0
@@ -196,14 +194,14 @@ SentVideoQualityThrottler.prototype = {
 			}
 		})
 
-		for (let i = this.QUALITY.THUMBNAIL; i < this.QUALITY.HIGH; i++) {
+		for (let i = QUALITY.THUMBNAIL; i < QUALITY.HIGH; i++) {
 			if (availableVideosCount >= this._availableVideosThreshold[i]
 				|| availableAudiosCount >= this._availableAudiosThreshold[i]) {
 				return i
 			}
 		}
 
-		return this.QUALITY.HIGH
+		return QUALITY.HIGH
 	},
 
 }

--- a/src/utils/webrtc/VideoConstrainer.js
+++ b/src/utils/webrtc/VideoConstrainer.js
@@ -1,0 +1,159 @@
+/**
+ *
+ * @copyright Copyright (c) 2020, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+const QUALITY = {
+	THUMBNAIL: 0,
+	VERY_LOW: 1,
+	LOW: 2,
+	MEDIUM: 3,
+	HIGH: 4,
+}
+
+/**
+ * Helper to adjust the quality of a video stream.
+ *
+ * Despite having a common API, different browsers handle media constraints in
+ * different ways. For example, if a video is constrained to a low maximum
+ * resolution but then the constraint is relaxed with a higher maximum
+ * resolution some browsers will increase the resolution, but others will just
+ * stays with the previous resolution, as it still matches the constraints. In
+ * other cases, setting a low frame rate may fail, but it may work if given a
+ * little more room. This class tries to abstract all those details and provide
+ * a simple interface to set the constraints based on some general quality
+ * description.
+ *
+ * @param {LocalMediaModel} localMediaModel the model for the local media.
+ */
+function VideoConstrainer(localMediaModel) {
+	this._localMediaModel = localMediaModel
+
+	// By default the constraints used when getting the video try to get the
+	// highest quality
+	this._currentQuality = QUALITY.HIGH
+}
+VideoConstrainer.prototype = {
+
+	applyConstraints: function(quality) {
+		if (quality === this._currentQuality) {
+			return
+		}
+
+		const localStream = this._localMediaModel.get('localStream')
+		if (!localStream) {
+			console.warn('No local stream to adjust its video quality found')
+			return
+		}
+
+		const localVideoTracks = localStream.getVideoTracks()
+		if (localVideoTracks.length === 0) {
+			console.warn('No local video track to adjust its quality found')
+			return
+		}
+
+		if (localVideoTracks.length > 1) {
+			console.warn('More than one local video track to adjust its quality found: ' + localVideoTracks.length)
+			return
+		}
+
+		const constraints = this._getConstraintsForQuality(quality)
+
+		localVideoTracks[0].applyConstraints(constraints).then(() => {
+			console.debug('Changed quality to ' + quality)
+			this._currentQuality = quality
+		}).catch(error => {
+			console.warn('Failed to set quality ' + quality, error)
+		})
+	},
+
+	_getConstraintsForQuality: function(quality) {
+		if (quality === QUALITY.HIGH) {
+			return {
+				video: true,
+				// The frame rate needs to be explicitly set; otherwise the
+				// browser may keep the previous stream when changing to a laxer
+				// constraint.
+				frameRate: {
+					max: 30,
+				},
+			}
+		}
+
+		if (quality === QUALITY.MEDIUM) {
+			return {
+				width: {
+					max: 640,
+				},
+				height: {
+					max: 480,
+				},
+				frameRate: {
+					max: 24,
+				},
+			}
+		}
+
+		if (quality === QUALITY.LOW) {
+			return {
+				width: {
+					max: 480,
+				},
+				height: {
+					max: 320,
+				},
+				frameRate: {
+					max: 15,
+				},
+			}
+		}
+
+		if (quality === QUALITY.VERY_LOW) {
+			return {
+				width: {
+					max: 320,
+				},
+				height: {
+					max: 240,
+				},
+				frameRate: {
+					max: 8,
+				},
+			}
+		}
+
+		return {
+			width: {
+				max: 320,
+			},
+			height: {
+				max: 240,
+			},
+			frameRate: {
+				max: 1,
+			},
+		}
+	},
+
+}
+
+export {
+	QUALITY,
+	VideoConstrainer,
+}

--- a/src/utils/webrtc/VideoConstrainer.js
+++ b/src/utils/webrtc/VideoConstrainer.js
@@ -51,7 +51,7 @@ function VideoConstrainer(localMediaModel) {
 }
 VideoConstrainer.prototype = {
 
-	applyConstraints: function(quality) {
+	applyConstraints: async function(quality) {
 		if (quality === this._currentQuality) {
 			return
 		}
@@ -75,12 +75,14 @@ VideoConstrainer.prototype = {
 
 		const constraints = this._getConstraintsForQuality(quality)
 
-		localVideoTracks[0].applyConstraints(constraints).then(() => {
+		try {
+			await localVideoTracks[0].applyConstraints(constraints)
 			console.debug('Changed quality to ' + quality)
 			this._currentQuality = quality
-		}).catch(error => {
+		} catch (error) {
 			console.warn('Failed to set quality ' + quality, error)
-		})
+			throw error
+		}
 	},
 
 	_getConstraintsForQuality: function(quality) {

--- a/src/utils/webrtc/VideoConstrainer.js
+++ b/src/utils/webrtc/VideoConstrainer.js
@@ -98,6 +98,8 @@ VideoConstrainer.prototype = {
 			await this._applyRoughResolutionConstraints(localVideoTrack, resolutionConstraints)
 
 			const frameRateConstraints = {
+				width: constraints.width,
+				height: constraints.height,
 				frameRate: constraints.frameRate,
 			}
 

--- a/src/utils/webrtc/VideoConstrainer.js
+++ b/src/utils/webrtc/VideoConstrainer.js
@@ -88,12 +88,18 @@ VideoConstrainer.prototype = {
 	_getConstraintsForQuality: function(quality) {
 		if (quality === QUALITY.HIGH) {
 			return {
-				video: true,
-				// The frame rate needs to be explicitly set; otherwise the
-				// browser may keep the previous stream when changing to a laxer
-				// constraint.
+				width: {
+					ideal: 720,
+					min: 640,
+				},
+				height: {
+					ideal: 540,
+					min: 480,
+				},
 				frameRate: {
 					max: 30,
+					ideal: 30,
+					min: 20,
 				},
 			}
 		}
@@ -102,12 +108,18 @@ VideoConstrainer.prototype = {
 			return {
 				width: {
 					max: 640,
+					ideal: 560,
+					min: 480,
 				},
 				height: {
 					max: 480,
+					ideal: 420,
+					min: 320,
 				},
 				frameRate: {
 					max: 24,
+					ideal: 24,
+					min: 15,
 				},
 			}
 		}
@@ -116,12 +128,18 @@ VideoConstrainer.prototype = {
 			return {
 				width: {
 					max: 480,
+					ideal: 360,
+					min: 320,
 				},
 				height: {
 					max: 320,
+					ideal: 270,
+					min: 240,
 				},
 				frameRate: {
 					max: 15,
+					ideal: 15,
+					min: 8,
 				},
 			}
 		}

--- a/src/utils/webrtc/VideoConstrainer.js
+++ b/src/utils/webrtc/VideoConstrainer.js
@@ -121,7 +121,7 @@ VideoConstrainer.prototype = {
 		} catch (error) {
 			console.warn('Failed to set resolution', constraints, error)
 
-			if (!this._increaseMaxResolution(constraints)) {
+			if (!this._increaseMaxResolution(constraints) && !this._decreaseMinResolution(constraints)) {
 				console.warn('Resolution range can not be further increased')
 				throw error
 			}
@@ -138,7 +138,7 @@ VideoConstrainer.prototype = {
 		} catch (error) {
 			console.warn('Failed to set frame rate', constraints, error)
 
-			if (!this._increaseMaxFrameRate(constraints)) {
+			if (!this._increaseMaxFrameRate(constraints) && !this._decreaseMinFrameRate(constraints)) {
 				console.warn('Frame rate range can not be further increased')
 				throw error
 			}
@@ -251,6 +251,24 @@ VideoConstrainer.prototype = {
 		return changed
 	},
 
+	_decreaseMinResolution: function(constraints) {
+		let changed = false
+
+		if (constraints.width && constraints.width.min) {
+			const previousWidthMin = constraints.width.min
+			constraints.width.min = Math.min(Math.round(constraints.width.min / 1.5), 64)
+			changed = previousWidthMin !== constraints.width.min
+		}
+
+		if (constraints.height && constraints.height.min) {
+			const previousHeightMin = constraints.height.min
+			constraints.height.min = Math.min(Math.round(constraints.height.min / 1.5), 64)
+			changed = previousHeightMin !== constraints.height.min
+		}
+
+		return changed
+	},
+
 	_increaseMaxFrameRate: function(constraints) {
 		let changed = false
 
@@ -258,6 +276,18 @@ VideoConstrainer.prototype = {
 			const previousFrameRateMax = constraints.frameRate.max
 			constraints.frameRate.max = Math.min(Math.round(constraints.frameRate.max * 1.5), 60)
 			changed = previousFrameRateMax !== constraints.frameRate.max
+		}
+
+		return changed
+	},
+
+	_decreaseMinFrameRate: function(constraints) {
+		let changed = false
+
+		if (constraints.frameRate && constraints.frameRate.min) {
+			const previousFrameRateMin = constraints.frameRate.max
+			constraints.frameRate.min = Math.min(Math.round(constraints.frameRate.min / 1.5), 1)
+			changed = previousFrameRateMin !== constraints.frameRate.min
 		}
 
 		return changed

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -24,6 +24,7 @@ import initWebRtc from './webrtc'
 import CallParticipantCollection from './models/CallParticipantCollection'
 import LocalCallParticipantModel from './models/LocalCallParticipantModel'
 import LocalMediaModel from './models/LocalMediaModel'
+import SentVideoQualityThrottler from './SentVideoQualityThrottler'
 import { PARTICIPANT } from '../../constants'
 import { EventBus } from '../../services/EventBus'
 
@@ -32,6 +33,7 @@ let webRtc = null
 const callParticipantCollection = new CallParticipantCollection()
 const localCallParticipantModel = new LocalCallParticipantModel()
 const localMediaModel = new LocalMediaModel()
+let sentVideoQualityThrottler = null
 
 let pendingConnectSignaling = null
 
@@ -125,6 +127,8 @@ async function signalingJoinCall(token) {
 
 	currentToken = token
 
+	sentVideoQualityThrottler = new SentVideoQualityThrottler(localMediaModel, callParticipantCollection)
+
 	return new Promise((resolve, reject) => {
 		startedCall = resolve
 
@@ -139,6 +143,9 @@ async function signalingJoinCall(token) {
  * @returns {Promise<void>}
  */
 async function signalingLeaveCall(token) {
+	sentVideoQualityThrottler.destroy()
+	sentVideoQualityThrottler = null
+
 	await getSignaling()
 	await signaling.leaveCall(token)
 }

--- a/src/utils/webrtc/models/CallParticipantCollection.js
+++ b/src/utils/webrtc/models/CallParticipantCollection.js
@@ -25,13 +25,47 @@ export default function CallParticipantCollection() {
 
 	this.callParticipantModels = []
 
+	this._handlers = []
+
 }
 
 CallParticipantCollection.prototype = {
 
+	on: function(event, handler) {
+		if (!this._handlers.hasOwnProperty(event)) {
+			this._handlers[event] = [handler]
+		} else {
+			this._handlers[event].push(handler)
+		}
+	},
+
+	off: function(event, handler) {
+		const index = this._handlers[event].indexOf(handler)
+		if (index !== -1) {
+			this._handlers[event].splice(index, 1)
+		}
+	},
+
+	_trigger: function(event, args) {
+		let handlers = this._handlers[event]
+		if (!handlers) {
+			return
+		}
+
+		args.unshift(this)
+
+		handlers = handlers.slice(0)
+		for (let i = 0; i < handlers.length; i++) {
+			const handler = handlers[i]
+			handler.apply(handler, args)
+		}
+	},
+
 	add: function(options) {
 		const callParticipantModel = new CallParticipantModel(options)
 		this.callParticipantModels.push(callParticipantModel)
+
+		this._trigger('add', [callParticipantModel])
 
 		return callParticipantModel
 	},
@@ -47,7 +81,11 @@ CallParticipantCollection.prototype = {
 			return callParticipantModel.attributes.peerId === peerId
 		})
 		if (index !== -1) {
+			const callParticipantModel = this.callParticipantModels[index]
+
 			this.callParticipantModels.splice(index, 1)
+
+			this._trigger('remove', [callParticipantModel])
 		}
 	},
 

--- a/src/utils/webrtc/models/CallParticipantCollection.js
+++ b/src/utils/webrtc/models/CallParticipantCollection.js
@@ -40,9 +40,14 @@ CallParticipantCollection.prototype = {
 	},
 
 	off: function(event, handler) {
-		const index = this._handlers[event].indexOf(handler)
+		const handlers = this._handlers[event]
+		if (!handlers) {
+			return
+		}
+
+		const index = handlers.indexOf(handler)
 		if (index !== -1) {
-			this._handlers[event].splice(index, 1)
+			handlers.splice(index, 1)
 		}
 	},
 

--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -96,9 +96,14 @@ CallParticipantModel.prototype = {
 	},
 
 	off: function(event, handler) {
-		const index = this._handlers[event].indexOf(handler)
+		const handlers = this._handlers[event]
+		if (!handlers) {
+			return
+		}
+
+		const index = handlers.indexOf(handler)
 		if (index !== -1) {
-			this._handlers[event].splice(index, 1)
+			handlers.splice(index, 1)
 		}
 	},
 

--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -52,6 +52,8 @@ export default function CallParticipantModel(options) {
 		screen: null,
 	}
 
+	this._handlers = []
+
 	this.set('peerId', options.peerId)
 
 	this._webRtc = options.webRtc
@@ -81,6 +83,42 @@ CallParticipantModel.prototype = {
 
 	set: function(key, value) {
 		this.attributes[key] = value
+
+		this._trigger('change:' + key, [value])
+	},
+
+	on: function(event, handler) {
+		if (!this._handlers.hasOwnProperty(event)) {
+			this._handlers[event] = [handler]
+		} else {
+			this._handlers[event].push(handler)
+		}
+	},
+
+	off: function(event, handler) {
+		const index = this._handlers[event].indexOf(handler)
+		if (index !== -1) {
+			this._handlers[event].splice(index, 1)
+		}
+	},
+
+	_trigger: function(event, args) {
+		let handlers = this._handlers[event]
+		if (!handlers) {
+			return
+		}
+
+		if (!args) {
+			args = []
+		}
+
+		args.unshift(this)
+
+		handlers = handlers.slice(0)
+		for (let i = 0; i < handlers.length; i++) {
+			const handler = handlers[i]
+			handler.apply(handler, args)
+		}
 	},
 
 	_handlePeerStreamAdded: function(peer) {

--- a/src/utils/webrtc/models/LocalCallParticipantModel.js
+++ b/src/utils/webrtc/models/LocalCallParticipantModel.js
@@ -47,9 +47,14 @@ LocalCallParticipantModel.prototype = {
 	},
 
 	off: function(event, handler) {
-		const index = this._handlers[event].indexOf(handler)
+		const handlers = this._handlers[event]
+		if (!handlers) {
+			return
+		}
+
+		const index = handlers.indexOf(handler)
 		if (index !== -1) {
-			this._handlers[event].splice(index, 1)
+			handlers.splice(index, 1)
 		}
 	},
 

--- a/src/utils/webrtc/models/LocalMediaModel.js
+++ b/src/utils/webrtc/models/LocalMediaModel.js
@@ -77,9 +77,14 @@ LocalMediaModel.prototype = {
 	},
 
 	off: function(event, handler) {
-		const index = this._handlers[event].indexOf(handler)
+		const handlers = this._handlers[event]
+		if (!handlers) {
+			return
+		}
+
+		const index = handlers.indexOf(handler)
 		if (index !== -1) {
-			this._handlers[event].splice(index, 1)
+			handlers.splice(index, 1)
 		}
 	},
 

--- a/src/utils/webrtc/models/LocalMediaModel.js
+++ b/src/utils/webrtc/models/LocalMediaModel.js
@@ -76,6 +76,13 @@ LocalMediaModel.prototype = {
 		}
 	},
 
+	off: function(event, handler) {
+		const index = this._handlers[event].indexOf(handler)
+		if (index !== -1) {
+			this._handlers[event].splice(index, 1)
+		}
+	},
+
 	_trigger: function(event, args) {
 		let handlers = this._handlers[event]
 		if (!handlers) {


### PR DESCRIPTION
Requires #3418

Video conference, by its very nature, requires a lot of resources in the clients, and not only in the server. In fact, when there are a lot of participants in a call, usually the CPU of the client becomes the bottleneck, as it struggles to decode all the incoming videos as well as encoding the one being sent.

In order to (try to) reduce the overall resources needed, but specially the load on the CPU of the clients, now the quality of the sent video is automatically adjusted based on the number of participants with audio and video in a call. The video quality of someone actively speaking (not just with audio enabled) is always kept at a high quality, but for the rest of the participants the quality is reduced; how much depends on the number of participants with audio and/or video enabled in the call.

There is a threshold for each quality. When the number of participants (besides the self participant) with audio or video in the call is above or equal the threshold that quality is used. In case of clash between the thresholds the most restrictive one wins. The default thresholds are basically guesses; whether a different value would be more suitable is something that is still to be seen :-)

Both the audio and video thresholds refer to enabled audio and video. That is, if a participant has audio or video available but has muted himself and disabled the video then it will not be taken into account in the thresholds (but if you hide the video of someone else only for you that participant will still be taken into account).

It would be good to count too participants that can send audio or video (even if they are not doing it that at the moment), as in a 40-50 participants call, even if everyone is muted, it is very likely that just the connections cause a high load.

Currently screensharing does not affect the video quality (if there are 20 screen shares enabled but only one video the video quality would be high), and the screen sharing quality is not affected either by the thresholds.

Finally, when you are the one speaking, the promoted participant, which would be the previous speaker, would be shown in large but with a low quality. I do not think that keeping track of the promoted participants in order to keep the high quality would be worth it; for me having the video of someone else not speaking shown in large when you are speaking is strange anyway, so if the video is also in low quality... well, so be it :-)

Pending issues:
- [X] ~~`audioAvailable` changes do not trigger a change in video quality (missing event handler)~~
- [X] ~~The thresholds are not properly defined~~
- [ ] Possible bug when changing from quality _level - 1_ to quality _level_; the `max` property of _level - 1_ is the same as the `min` property of _level_, so in some browsers the quality might not go up due to the old quality still matching the new constraints
  - I have not been able to reproduce again the "Video quality does not go up due to old quality still matching the new constraints", so I can not test whether there is a bug or not from the overlapping values :shrug: 

Possible improvements (probably future):
- [ ] Count participants that can send audio or video too
- [ ] Take screen shares into account for video quality, and change screen sharing quality based on the number of participants
- [ ] Calls without HPB require more resources in the clients, so maybe use lower thresholds when there is no HPB
