### PR TITLE
Executor /help bugfixe

### DIFF
--- a/lib/Chat/Command/Executor.php
+++ b/lib/Chat/Command/Executor.php
@@ -132,9 +132,9 @@ class Executor {
 						$tempHelp = substr($tempHelp, 0, strpos($tempHelp, "\n"));
 					}
 				}
-				$helps[] = $command->getCommand() .' -> ' . $tempHelp;
+				$helps[] = $tempHelp;
 			} else {
-				$helps[] = $command->getCommand() .' -> ' . $response;
+				$helps[] = $response;
 			}
 		}
 

--- a/lib/Chat/Command/Executor.php
+++ b/lib/Chat/Command/Executor.php
@@ -115,7 +115,7 @@ class Executor {
 			if ($command->getApp() !== '') {
 				$response = $this->execHelpSingleCommand($room, $message, $command->getApp() . ' ' . $command->getCommand());
 			} else {
-				if ($command->getCommand() === 'help') {
+				if ($command->getCommand() === 'help' || strpos($command->getScript(),'alias:') !== FALSE )  {
 					continue;
 				}
 				$response = $this->execHelpSingleCommand($room, $message, $command->getCommand());
@@ -132,9 +132,9 @@ class Executor {
 						$tempHelp = substr($tempHelp, 0, strpos($tempHelp, "\n"));
 					}
 				}
-				$helps[] = $tempHelp;
+				$helps[] = $command->getCommand() .' -> ' . $tempHelp;
 			} else {
-				$helps[] = $response;
+				$helps[] = $command->getCommand() .' -> ' . $response;
 			}
 		}
 

--- a/lib/Chat/Command/Executor.php
+++ b/lib/Chat/Command/Executor.php
@@ -115,7 +115,7 @@ class Executor {
 			if ($command->getApp() !== '') {
 				$response = $this->execHelpSingleCommand($room, $message, $command->getApp() . ' ' . $command->getCommand());
 			} else {
-				if ($command->getCommand() === 'help' || strpos($command->getScript(),'alias:') !== FALSE )  {
+				if ($command->getCommand() === 'help' || strpos($command->getScript(),'alias:') !== false) {
 					continue;
 				}
 				$response = $this->execHelpSingleCommand($room, $message, $command->getCommand());


### PR DESCRIPTION
There is a bug when showing /help with alias command, since I presume an alias is just another way to write the command. I decide to skip the alias: when showing help
I also added the command name in the output to show the user what comand to input.