### PR TITLE
Prevent "No bytes received" to be logged by default

### DIFF
--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -687,7 +687,8 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 				checkPeerMedia(peer, video, 'video').then(function() {
 					clearInterval(peer.check_video_interval)
 					peer.check_video_interval = null
-				}).catch()
+				}).catch(() => {
+				})
 			})
 		}, 1000)
 		peer.check_audio_interval = setInterval(function() {
@@ -695,7 +696,8 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 				checkPeerMedia(peer, audio, 'audio').then(function() {
 					clearInterval(peer.check_audio_interval)
 					peer.check_audio_interval = null
-				}).catch()
+				}).catch(() => {
+				})
 			})
 		}, 1000)
 	}


### PR DESCRIPTION
As the catch did not have any function the caught error was logged by default by the browser. However, when a connection is established with the HPB it is perfectly normal that no bytes are received at first, so there is no point in logging that. There are some corner cases in which a connection may be established but no bytes are ever received, but in that case it can be detected by other means and the messages just flood the log providing no value and making more difficult to debug the issue. Due to all that now the "No bytes received" messages are no longer shown in the logs.
