### PR TITLE
Page title does not update immediately

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -375,11 +375,11 @@ export default {
 		 * @returns {string} The conversation's name
 		 */
 		getConversationName(token) {
-			if (!this.$store.getters.conversation(this.token)) {
+			if (!this.$store.getters.conversation(token)) {
 				return ''
 			}
 
-			return this.$store.getters.conversation(this.token).displayName
+			return this.$store.getters.conversation(token).displayName
 		},
 
 		async fetchSingleConversation(token) {


### PR DESCRIPTION
Regression from f981a352288429e670c106459ea8717661882cbd

### Steps

1. Create 2 conversations A and B
2. Open conversation A and check the page title
3. Open conversation B and check the page title
4. Open another tab or window
5. Bring back the conversation B tab and check the page title