### PR TITLE
Fix microphone not available when camera can not be accessed

### DIFF
--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -132,8 +132,9 @@ LocalMedia.prototype.start = function(mediaConstraints, cb) {
 			return cb(null, stream)
 		}
 	}).catch(function(err) {
-		// Fallback for users without a camera
-		if (self.config.audioFallback && err.name === 'NotFoundError' && constraints.video !== false) {
+		// Fallback for users without a camera or with a camera that can not be
+		// accessed.
+		if (self.config.audioFallback && (err.name === 'NotFoundError' || err.name === 'NotReadableError') && constraints.video !== false) {
 			constraints.video = false
 			self.start(constraints, cb)
 			return


### PR DESCRIPTION
`getUserMedia` is first called for both audio and video and then, if the camera was not found, it was called again only for audio. In some cases (for example, in Windows if the camera device is being used by another application, or if permissions for the camera are not granted at a system level) it could happen that a camera device is found but it can not be accessed by the browser. If that happened `getUserMedia` was not called again only for audio and the microphone was also seen as not available, even if the problem was only with the camera.

This would still need more love regarding the [error shown to the user](https://github.com/nextcloud/spreed/blob/a611336813570773d1b7292de7f3787d9652e366/src/utils/webrtc/webrtc.js#L812) if the device is found but can not be accessed, but for that some additional changes would be needed when calling `getUserMedia` and that is probably going to be modified anyway when adding the source selection, so for now this is good enough.