### PR TITLE
Fix fullscreen having a black bar on top

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -434,6 +434,15 @@ export default {
 			color: #FFFFFF;
 		}
 	}
+
+	// Fix fullscreen black bar on top
+	&:fullscreen {
+		padding-top: 0;
+
+		::v-deep .app-sidebar {
+			height: 100vh;
+		}
+	}
 }
 
 .app-content {


### PR DESCRIPTION
The room freed by the header vanishing was not filled up:
![fullscreen black bar](https://user-images.githubusercontent.com/925062/81438785-a097ff00-916d-11ea-811e-e3e57adcc8f8.png)

Fixed:
![Fullscreen fixed](https://user-images.githubusercontent.com/925062/81438790-a1309580-916d-11ea-8e22-47f202037cac.png)
