### PR TITLE
Design fixes of top right controls

### DIFF
--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -38,14 +38,13 @@
 				{{ layoutHintText }}
 				<div class="hint__actions">
 					<button
-						class="error"
 						@click="showLayoutHint=false, hintDismissed=true">
 						{{ t('spreed', 'Dismiss') }}
 					</button>
 					<button
 						class="primary"
 						@click="changeView">
-						{{ t('spreed', 'Use promoted-view') }}
+						{{ t('spreed', 'Use promoted view') }}
 					</button>
 				</div>
 			</div>
@@ -228,9 +227,9 @@ export default {
 
 		changeViewText() {
 			if (this.isGrid) {
-				return t('spreed', 'Switch to promoted view')
+				return t('spreed', 'Promoted view')
 			} else {
-				return t('spreed', 'Switch to grid view')
+				return t('spreed', 'Grid view')
 			}
 		},
 		changeViewIconClass() {
@@ -242,7 +241,7 @@ export default {
 		},
 
 		layoutHintText() {
-			return t('Spreed', `The videos in this call don't fit in your window: consider maximising it or switching to 'promoted view' for a better experience`)
+			return t('Spreed', `The amount of videos don't fit in the window. Maximize or switch to 'promoted view' for a better experience.`)
 		},
 		isFileConversation() {
 			return this.conversation.objectType === 'file' && this.conversation.objectId

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -21,6 +21,7 @@
 
 <template>
 	<div class="top-bar">
+		<CallButton class="top-bar__button" />
 		<!-- Call layout switcher -->
 		<Popover v-if="isInCall"
 			class="top-bar__button"
@@ -53,6 +54,7 @@
 		<Actions
 			v-shortkey="['f']"
 			class="top-bar__button"
+			menuAlign="right"
 			@shortkey.native="toggleFullscreen">
 			<ActionButton
 				:icon="iconFullscreen"
@@ -131,7 +133,6 @@
 				</ActionInput>
 			</template>
 		</Actions>
-		<CallButton class="top-bar__button" />
 		<Actions v-if="showOpenSidebarButton"
 			class="top-bar__button"
 			close-after-click="true">


### PR DESCRIPTION
- Wording and design detail fixes
- Fix order of top right controls so the primary button isn’t just inbetween icons.

Before | After
---- | ----
![top controls before collapsed](https://user-images.githubusercontent.com/925062/81440921-1fdb0200-9171-11ea-8a0e-6bafd06c1640.png) | ![controls fixed collapsed](https://user-images.githubusercontent.com/925062/81440924-20739880-9171-11ea-95f5-4a744970ed81.png)
![top controls before](https://user-images.githubusercontent.com/925062/81440923-20739880-9171-11ea-94b7-613c9e157c19.png) | ![Controls fixed](https://user-images.githubusercontent.com/925062/81440925-210c2f00-9171-11ea-8035-4dd7b520abc4.png)
