### PR TITLE
Don't access the store recursively again

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -190,7 +190,7 @@ export default {
 
 	watch: {
 		conversation() {
-			this.conversationName = this.$store.getters.conversation(this.token).displayName
+			this.conversationName = this.conversation.displayName
 		},
 	},
 


### PR DESCRIPTION
Before this error appeared when no conversation was selected

> Error in callback for watcher "conversation": "TypeError: this.$store.getters.conversation(...) is undefined"

Or sould we add an argument to the watcher and use the value from there?