### PR TITLE
Fix guest names in call view

### DIFF
--- a/src/components/CallView/shared/Screen.vue
+++ b/src/components/CallView/shared/Screen.vue
@@ -29,6 +29,8 @@
 
 <script>
 import attachMediaStream from 'attachmediastream'
+import SHA1 from 'crypto-js/sha1'
+import Hex from 'crypto-js/enc-hex'
 
 export default {
 
@@ -64,11 +66,31 @@ export default {
 				return t('spreed', 'Your screen')
 			}
 
-			if (this.callParticipantModel.attributes.name) {
-				return t('spreed', "{participantName}'s screen", { participantName: this.callParticipantModel.attributes.name })
+			if (this.remoteParticipantName) {
+				return t('spreed', "{participantName}'s screen", { participantName: this.remoteParticipantName })
 			}
 
-			return t('spreed', "Guest's screen")
+			return null
+		},
+
+		remoteSessionHash() {
+			return Hex.stringify(SHA1(this.callParticipantModel.attributes.peerId))
+		},
+
+		remoteParticipantName() {
+			let remoteParticipantName = this.callParticipantModel.attributes.name
+
+			// The name is undefined and not shown until a connection is made
+			// for registered users, so do not fall back to the guest name in
+			// the store either until the connection was made.
+			if (!this.callParticipantModel.attributes.userId && !remoteParticipantName && remoteParticipantName !== undefined) {
+				remoteParticipantName = this.$store.getters.getGuestName(
+					this.$store.getters.getToken(),
+					this.remoteSessionHash,
+				)
+			}
+
+			return remoteParticipantName
 		},
 
 	},

--- a/src/components/CallView/shared/Video.vue
+++ b/src/components/CallView/shared/Video.vue
@@ -183,7 +183,7 @@ export default {
 		},
 
 		firstLetterOfGuestName() {
-			const customName = this.participantName !== t('spreed', 'Guest') ? this.participantName : '?'
+			const customName = this.participantName && this.participantName !== t('spreed', 'Guest') ? this.participantName : '?'
 			return customName.charAt(0)
 		},
 
@@ -194,7 +194,10 @@ export default {
 		participantName() {
 			let participantName = this.model.attributes.name
 
-			if (!this.model.attributes.userId) {
+			// The name is undefined and not shown until a connection is made
+			// for registered users, so do not fall back to the guest name in
+			// the store either until the connection was made.
+			if (!this.model.attributes.userId && !participantName && participantName !== undefined) {
 				participantName = this.$store.getters.getGuestName(
 					this.$store.getters.getToken(),
 					this.sessionHash,

--- a/src/utils/webrtc/models/LocalCallParticipantModel.js
+++ b/src/utils/webrtc/models/LocalCallParticipantModel.js
@@ -19,6 +19,8 @@
  *
  */
 
+import store from '../../../store/index.js'
+
 export default function LocalCallParticipantModel() {
 
 	this.attributes = {
@@ -80,6 +82,7 @@ LocalCallParticipantModel.prototype = {
 	setWebRtc: function(webRtc) {
 		if (this._webRtc) {
 			this._webRtc.off('forcedMute', this._handleForcedMuteBound)
+			this._unwatchDisplayNameChange()
 		}
 
 		this._webRtc = webRtc
@@ -88,6 +91,7 @@ LocalCallParticipantModel.prototype = {
 		this.set('guestName', null)
 
 		this._webRtc.on('forcedMute', this._handleForcedMuteBound)
+		this._unwatchDisplayNameChange = store.watch(state => state.actorStore.displayName, this.setGuestName.bind(this))
 	},
 
 	setGuestName: function(guestName) {

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -465,7 +465,7 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 		peer.nickInterval = setInterval(function() {
 			let payload
 			if (signaling.settings.userId === null) {
-				payload = localStorage.getItem('nick')
+				payload = store.getters.getDisplayName()
 			} else {
 				payload = {
 					'name': store.getters.getDisplayName(),
@@ -490,7 +490,7 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 			webrtc.emit('audioOn')
 		}
 		if (signaling.settings.userId === null) {
-			const currentGuestNick = localStorage.getItem('nick')
+			const currentGuestNick = store.getters.getDisplayName()
 			sendDataChannelToAll('status', 'nickChanged', currentGuestNick)
 		}
 


### PR DESCRIPTION
Fixes #3387

Guest names still do not work when the guest has no audio nor video available (as in that case there is no data channel to send the name); that will have to wait until it is possible to link the external signaling server session ID and the Nextcloud session ID.
