### PR TITLE
Assume video is off if the received video bytes are very low

### DIFF
--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -652,6 +652,12 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 					}
 
 					if (statsReport.bytesReceived > 0) {
+						if (mediaType === 'video' && statsReport.bytesReceived < 2000) {
+							// A video with less than 2000 bytes is an empty single frame of the MCU
+							// console.debug('Participant is registered with with video but didn\'t send a lot of data, so we assume the video is disabled for now.')
+							result = true
+							return
+						}
 						webrtc.emit('unmute', {
 							id: peer.id,
 							name: mediaType,


### PR DESCRIPTION
Ref https://github.com/nextcloud/spreed/issues/1583

So this is now triggered all the time by the video-quality checking I guess.
Also it caused "black" blocks for people with disabled videos on the grid view when someone joins.