### PR TITLE
Bugfix/noid/last participant leaving

### DIFF
--- a/src/components/CallView/GridView/GridView.vue
+++ b/src/components/CallView/GridView/GridView.vue
@@ -33,7 +33,7 @@
 				:style="gridStyle"
 				@mousemove="handleMovement"
 				@keydown="handleMovement">
-				<template v-if="!devMode">
+				<template v-if="!devMode && (!isStripe || showStripe)">
 					<EmptyCallView v-if="videos.length === 0 &&!isStripe" class="video" :is-grid="true" />
 					<template v-for="callParticipantModel in displayedVideos">
 						<Video
@@ -65,7 +65,7 @@
 						@switchScreenToId="1" />
 				</template>
 				<!-- Grid developer mode -->
-				<template v-else>
+				<template v-if="devMode">
 					<div
 						v-for="video in displayedVideos"
 						:key="video"
@@ -250,17 +250,19 @@ export default {
 			}
 		},
 
-		// Number of video components (includes localvideo if not in dev mode)
+		// Number of video components (includes localvideo and emptycontent)
 		videosCount() {
-			if (this.devMode || this.isStripe) {
+			// No need to include localvideo or emptycontent here
+			if (this.isStripe || this.devMode) {
 				return this.videos.length
 			} else {
 				// Count the emptycontent as a grid element
 				if (this.videos.length === 0) {
 					return 2
+				} else {
+					// Add the local video to the count
+					return this.videos.length + 1
 				}
-				// Add the local video to the count
-				return this.videos.length + 1
 			}
 		},
 
@@ -342,6 +344,9 @@ export default {
 			} else {
 				return 'height: 100%'
 			}
+		},
+		showStripe() {
+			return !(this.isStripe && this.videosCount === 0)
 		},
 	},
 

--- a/src/components/CallView/GridView/GridView.vue
+++ b/src/components/CallView/GridView/GridView.vue
@@ -22,7 +22,7 @@
 <template>
 	<div class="wrapper" :style="wrapperStyle">
 		<div :class="{'pagination-wrapper': isStripe, 'wrapper': !isStripe}">
-			<button v-if="hasPreviousPage && gridWidth > 0 && isStripe && showVideoOverlay"
+			<button v-if="hasPreviousPage && showNavigation"
 				class="grid-navigation grid-navigation__previous"
 				@click="handleClickPrevious">
 				<ChevronLeft :size="24" />
@@ -76,7 +76,7 @@
 					</h1>
 				</template>
 			</div>
-			<button v-if="hasNextPage && gridWidth > 0 && isStripe && showVideoOverlay"
+			<button v-if="hasNextPage && showNavigation"
 				class="grid-navigation grid-navigation__next"
 				@click="handleClickNext">
 				<ChevronRight :size="24" />
@@ -345,8 +345,13 @@ export default {
 				return 'height: 100%'
 			}
 		},
+		// Hides the stripe when there are no more videos
 		showStripe() {
 			return !(this.isStripe && this.videosCount === 0)
+		},
+		// Determines when to show the stripe navigation buttons
+		showNavigation() {
+			return this.gridWidth > 0 && this.isStripe && this.videosCount > 0 && this.showVideoOverlay
 		},
 	},
 


### PR DESCRIPTION
How to test

* create a 1to1 call;
* leave the call with one of the 2 participants;
* check the call view of the participant that is still in the call;

Before this pr: 
* The video component of the participant who left is still shown;

After this pr:
* The stripe disappears in promoted view if there are no videos to show; 

based on #3497