### PR TITLE
Make activities link to the conversation

### DIFF
--- a/lib/Activity/Provider/Base.php
+++ b/lib/Activity/Provider/Base.php
@@ -126,6 +126,7 @@ abstract class Base implements IProvider {
 			'type' => 'call',
 			'id' => $room->getId(),
 			'name' => $room->getDisplayName($userId),
+			'link' => $this->url->linkToRouteAbsolute('spreed.Page.showCall', ['token' => $room->getToken()]),
 			'call-type' => $stringType,
 		];
 	}

--- a/tests/php/Activity/Provider/BaseTest.php
+++ b/tests/php/Activity/Provider/BaseTest.php
@@ -236,12 +236,21 @@ class BaseTest extends TestCase {
 			->method('getDisplayName')
 			->with('user')
 			->willReturn($expectedName);
+		$room->expects($this->once())
+			->method('getToken')
+			->willReturn('token');
+
+		$this->url->expects($this->once())
+			->method('linkToRouteAbsolute')
+			->with('spreed.Page.showCall', ['token' => 'token'])
+			->willReturn('url');
 
 		$this->assertEquals([
 			'type' => 'call',
 			'id' => $id,
 			'name' => $expectedName,
 			'call-type' => $expectedType,
+			'link' => 'url',
 		], self::invokePrivate($provider, 'getRoom', [$room, 'user']));
 	}
 


### PR DESCRIPTION
Fix #3523 

Before | After
---|---
![Bildschirmfoto von 2020-05-13 16-11-16](https://user-images.githubusercontent.com/213943/81823322-8165ec80-9534-11ea-8d19-677e4024c1b9.png) | ![Bildschirmfoto von 2020-05-13 16-11-13](https://user-images.githubusercontent.com/213943/81823328-82971980-9534-11ea-8e2f-24191c4f2994.png)

In case we decide to backport this to stable18, the route needs to be changed.
