### PR TITLE
Add drop shadow again on icons in the topbar too

### DIFF
--- a/css/icons.scss
+++ b/css/icons.scss
@@ -46,11 +46,14 @@
 	&.in-call {
 		.app-navigation-toggle,
 		.action-item__menutoggle {
-			color: #fff;
+			color: #ffffff;
+			filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
 		}
 	}
 
 	.forced-white {
+		filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
+
 		&.icon-menu-people {
 			background-image: url(icon-color-path('menu-people', 'spreed', 'fff', 1));
 		}

--- a/src/App.vue
+++ b/src/App.vue
@@ -423,8 +423,32 @@ export default {
 .content {
 	height: 100%;
 
+	::v-deep .app-content:hover {
+		.action-item--single {
+			background-color: rgba(0, 0, 0, .1) !important;
+
+			&:hover {
+				background-color: rgba(0, 0, 0, .2) !important;
+			}
+		}
+	}
+
+	::v-deep .app-navigation-toggle {
+		top: 10px;
+		right: -10px;
+		border-radius: var(--border-radius-pill);
+	}
+
 	&.in-call {
-		::v-deep #app-navigation-toggle:before {
+		&:hover ::v-deep .app-navigation-toggle {
+			background-color: rgba(0, 0, 0, .1) !important;
+
+			&:hover {
+				background-color: rgba(0, 0, 0, .2) !important;
+			}
+		}
+
+		::v-deep .app-navigation-toggle:before {
 			/* Force white handle when inside a call */
 			color: #FFFFFF;
 		}

--- a/src/components/CallView/shared/Video.vue
+++ b/src/components/CallView/shared/Video.vue
@@ -450,6 +450,7 @@ export default {
 		color: white;
 		position: relative;
 		font-size: 20px;
+		filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
 		&--promoted {
 			font-weight: bold;
 		}


### PR DESCRIPTION
### Before
![Bildschirmfoto von 2020-05-14 13-34-54](https://user-images.githubusercontent.com/213943/81929961-2b528100-95e8-11ea-83ee-069bfd90afd1.png)

### After
![Bildschirmfoto von 2020-05-14 13-34-12](https://user-images.githubusercontent.com/213943/81929959-2ab9ea80-95e8-11ea-83a9-b6509253022b.png)

It's at least a bit better, but the `…` is very small so the shadow is also small
