### PR TITLE
Fix Talk sidebar in public share pages without header actions

### DIFF
--- a/src/mainPublicShareSidebar.js
+++ b/src/mainPublicShareSidebar.js
@@ -86,6 +86,15 @@ function addTalkSidebarTrigger() {
 	talkSidebarTriggerElement.addEventListener('click', () => {
 		sidebarState.isOpen = !sidebarState.isOpen
 	})
+
+	// The ".header-right" element may not exist in the public share page if
+	// there are no header actions.
+	if (!document.querySelector('.header-right')) {
+		const headerRightElement = document.createElement('div')
+		headerRightElement.setAttribute('class', 'header-right')
+		document.querySelector('#header').append(headerRightElement)
+	}
+
 	document.querySelector('.header-right').append(talkSidebarTriggerElement)
 }
 


### PR DESCRIPTION
The `.header-right` element [may not exist in the public share page if there are no header actions](https://github.com/nextcloud/server/blob/74d40233f5d20429483de113dbf1242ca6669c0a/core/templates/layout.public.php#L58), for example, [if the downloads of the share are hidden](https://github.com/nextcloud/server/blob/cb057829f72c70e819f456edfadbb29d72dba832/apps/files_sharing/lib/Controller/ShareController.php#L506). In that case the `.header-right` element needs to be explicitly added.

## How to test
- Open the Files app
- Create a new public link share
- Hide downloads in the share
- Open the link in a private window

### Result with this pull request
The Talk sidebar is shown in the public share page.

### Result without this pull request
The Talk sidebar is not shown in the public share page.
