### PR TITLE
Ignore drag and drop events if files are not involved

### DIFF
--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -21,7 +21,7 @@
 <template>
 	<div
 		class="chatView"
-		@dragover.prevent="isDraggingOver = true"
+		@dragover.prevent="handleDragOver"
 		@dragleave.prevent="isDraggingOver = false"
 		@drop.prevent="handleDropFiles">
 		<transition name="slide" mode="out-in">
@@ -100,7 +100,17 @@ export default {
 
 	methods: {
 
+		handleDragOver(event) {
+			if (event.dataTransfer.types.includes('Files')) {
+				this.isDraggingOver = true
+			}
+		},
+
 		handleDropFiles(event) {
+			if (!this.isDraggingOver) {
+				return
+			}
+
 			// Restore non dragover state
 			this.isDraggingOver = false
 			// Stop the executin if the user is a guest


### PR DESCRIPTION
If a drag and drop events does not involve files the drop hint should not be shown, and the drop event does not need to be handled either. The drag event may not contain yet the files in its `dataTransfer.files` property, but [at least one of the types included in its `dataTransfer.types` property will be _Files_](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/types#Return_value).

## How to test
- Join a conversation
- Select some text in the sidebar (like a participant name)
- Drag and drop the name on the chat

### Result with this pull request
Nothing happens.

### Result without this pull request
The drop hint is shown, and once the text is dropped an error is shown in the browser console.

Fixes #3431 