### PR TITLE
Add empty referenceId when sending a message though flow

### DIFF
--- a/lib/Flow/Operation.php
+++ b/lib/Flow/Operation.php
@@ -141,7 +141,8 @@ class Operation implements IOperation {
 					$participant->getUser(),
 					$this->prepareMention($mode, $participant) . $message,
 					new \DateTime(),
-					null
+					null,
+					''
 				);
 			} catch (UnexpectedValueException $e) {
 				continue;


### PR DESCRIPTION
Fixes sending messages though flow operations that have caused an error otherwise due to the new sendMessage parameter.