### PR TITLE
Add documentation about testing the TURN server

### DIFF
--- a/docs/TURN.md
+++ b/docs/TURN.md
@@ -100,6 +100,18 @@ simple-log
 
 - The TURN server on `<yourChosenPortNumber>` needs to be accessible for all Talk participants, so you need to open it to the web and if your TURN server is running **behind a NAT**, forward it to the related machine. Also make sure to set the [`--external-ip` option](https://github.com/coturn/coturn/wiki/turnserver#options) when your TURN server is in a private network.
 
+#### 6. Testing the TURN server
+
+When the TURN server is set in the Talk settings a basic test against the TURN server is performed. You can perform a deeper test by forcing your browser to send the media of a call only through the TURN server:
+
+- Join a call
+- Open your browser console
+- Type `OCA.Talk.SimpleWebRTC.webrtc.config.peerConnectionConfig.iceTransportPolicy = 'relay'` in the console and press Enter
+- Leave the call
+- Join the call again
+
+Now, in that browser, the media sent to and received from other participants in the call should go through the TURN server. If the call works then the TURN server should work.
+
 ### What else
 Nextcloud Talk´s WebRTC handling is still mostly based on the one from the [Spreed.ME](https://www.spreed.me/) WebRTC solution. For this reason, all guides about how to configure coTURN for it, applies to Nextcloud Talk too.
 


### PR DESCRIPTION
In order to know if a TURN server is working it is useful to actually test the data transfer through the TURN server instead of just checking if it generates relay candidates.

[When an RTCPeerConnection is created](https://github.com/nextcloud/spreed/blob/848f55bdff583c0f30c8babbb129cd70e31fe859/src/utils/webrtc/simplewebrtc/peer.js#L36) an RTCConfiguration can be provided to configure it. One of the values it accepts is [`iceTransportPolicy`](https://developer.mozilla.org/en-US/docs/Web/API/RTCConfiguration#RTCIceTransportPolicy_enum), which can be either set to `all` to gather all types of candidates or to `relay` to only gather relay candidates.

Note that the types of candidates used during a call can not be limited by just sending specific candidate types to the other peer during the ICE negotiation. Although in some cases it works in others it does not. I have not been able to find why, though. (Provided I did not mess something) I guess that even if the browser does not send a candidate to the other peer the browser still considers it and establishes a connection if possible using that candidate, but I do not really know.

In any case, the connection can be limited to relay candidates using `iceTransportPolicy` and it does not need any change in the code of Talk.
