### PR TITLE
Make joining the call synchronous

### DIFF
--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -96,6 +96,7 @@ async function connectSignaling(token) {
 
 let pendingJoinCallToken = null
 let startedCall = null
+let failedToStartCall = null
 
 function startCall(signaling, configuration) {
 	let flags = PARTICIPANT.CALL_FLAG.IN_CALL
@@ -108,9 +109,11 @@ function startCall(signaling, configuration) {
 		}
 	}
 
-	signaling.joinCall(pendingJoinCallToken, flags)
-
-	startedCall()
+	signaling.joinCall(pendingJoinCallToken, flags).then(() => {
+		startedCall()
+	}).catch(error => {
+		failedToStartCall(error)
+	})
 }
 
 function setupWebRtc() {
@@ -162,6 +165,7 @@ async function signalingJoinCall(token) {
 
 		return new Promise((resolve, reject) => {
 			startedCall = resolve
+			failedToStartCall = reject
 
 			webRtc.startMedia(token)
 		})


### PR DESCRIPTION
Replaces #3584

This ensures that the call status in the store will match the call status in the server. Although in other cases updating the local status before the server acknowledges it makes it feel snappier in the case of the call status it feels strange, as the call view would be shown empty without any hint that joining the call is still in progress.

Note that there is still an issue if the user tries to join the call before even getting the signaling settings (as in that case [`signalingJoinCall` just returns](https://github.com/nextcloud/spreed/blob/9570c3a9e492203363e46f31dfc8a33fac136993/src/utils/webrtc/index.js#L155) and `joinCall` continues as if the operation finished), but that is something for another pull request. In any case, when that happens, once the user joins the room the call status is updated and the call view is hidden again.

## How to test

- Start a call
- Apply the patch described in the first step of #3583 to slow joining the call in the server
- In another tab/window/browser, join the conversation
- Open the network console of the browser; once you see a GET request to `room` count 23 seconds, then join the call

### Result with this pull request

The call view is not shown until the call has been joined in the server (but the _Join call_ button will show a loading spinner showing that joining the call is in progress).

### Result without this pull request

The call view is shown, but without other participants. Then the chat view is shown again. And then the call view is shown with the other participant.
