### PR TITLE
Correctly trim user list on name generation

### DIFF
--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -776,8 +776,8 @@ class Manager {
 		}
 
 		$roomName = implode(', ', $displayNames);
-		if (strlen($roomName) > 128) {
-			$roomName = substr($roomName, 120) . '…';
+		if (mb_strlen($roomName) > 64) {
+			$roomName = mb_substr($roomName, 0, 60) . '…';
 		}
 		return $roomName;
 	}


### PR DESCRIPTION
### Steps
1. Have a conversation with many participants (or fake it by extending the string here: https://github.com/nextcloud/spreed/blob/c9bc798a4fb53dbfa174a861f32495fa1e8efa48/lib/Manager.php#L778 )
2. In the database clear the room name from oc_talk_rooms (to simulate old server)
3. Try to load the UI and check the room list

### Before
Loading circle for ever

### After
List is loaded