### PR TITLE
Fix double scrollbar

### DIFF
--- a/src/components/ConversationsOptionsList.vue
+++ b/src/components/ConversationsOptionsList.vue
@@ -83,8 +83,8 @@ export default {
 	text-overflow: ellipsis;
 }
 
+// Override vue overflow rules for <ul> elements within app-navigation
 .contacts-list {
-	overflow: visible;
-	display: block;
+	overflow: visible !important;
 }
 </style>

--- a/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
@@ -160,7 +160,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+// Override vue overflow rules for <ul> elements within app-navigation
 .conversations {
-	overflow: visible;
+	overflow: visible !important;
 }
 </style>

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -299,4 +299,12 @@ export default {
 	border-bottom: 1px solid var(--color-border-dark);
 }
 
+// Override vue overflow rules for <ul> elements within app-navigation
+.left-sidebar__list {
+	height: 100% !important;
+	width: 100% !important;
+	overflow-y: auto !important;
+	overflow-x: hidden !important;
+}
+
 </style>


### PR DESCRIPTION
Talk is the only app that have multiple uls within the app-navigation. 
```
ul (Main navigation list)
    li (Conversations caption)
    ul (Conversations list)
        li (Conversation)
        li (Conversation)

...and so forth
```
This patch overrides the `.app-navigation ul` rules coming from the vue library, that are targeted to all `ul` in the navigation, making them all scrollable and sometimes causing double scrollbars to be displayed

Fix #3539
Fix #3556

Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>