### PR TITLE
Fix video marked as available due to screen sharing

### DIFF
--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -717,6 +717,10 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 			return
 		}
 
+		if (peer.type === 'screen') {
+			return
+		}
+
 		startPeerCheckMedia(peer, peer.stream)
 	})
 


### PR DESCRIPTION
When the external signaling server is used the incoming audio and video stream is checked to know if there is actually audio and video being received. However, that check was performed also for the screen peer. As the audio/video peer and the screen peer of the same participant have the same id [that caused the video to be marked as available](https://github.com/nextcloud/spreed/blob/0dd47e5dcbac8fc540665e40213a6b5bc6dabbbb/src/utils/webrtc/webrtc.js#L661-L664) even if the other participant was not sending any video. Now the check is performed only on the audio/video peer.
