### PR TITLE
Fix unsharing screen of other peers when one screen was unshared

### DIFF
--- a/src/utils/webrtc/simplewebrtc/webrtc.js
+++ b/src/utils/webrtc/simplewebrtc/webrtc.js
@@ -88,7 +88,7 @@ function WebRTC(opts) {
 	})
 	this.on('unshareScreen', function(message) {
 		// End peers we were receiving the screensharing stream from.
-		const peers = self.getPeers(message.from, 'screen')
+		const peers = self.getPeers(message.id, 'screen')
 		peers.forEach(function(peer) {
 			if (!peer.sharemyscreen) {
 				peer.end()


### PR DESCRIPTION
When the `unshareScreen` signaling message is received [an internal `unshareScreen` with the id of the peer that sent the message is emitted](https://github.com/nextcloud/spreed/blob/848f55bdff583c0f30c8babbb129cd70e31fe859/src/utils/webrtc/simplewebrtc/peer.js#L251). However, when the internal `unshareScreen` was handled the id of the other peer was expected to be in the `from` property instead of the `id` property. As the `id` property was undefined [this caused that all the screen peers were processed](https://github.com/nextcloud/spreed/blob/3f56ae160638ef37e1040b1f16e544ddddca559a/src/utils/webrtc/simplewebrtc/webrtc.js#L132-L136) and ended instead of only the one that sent the message.
