### PR TITLE
Fix file attributes passed to viewer

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -150,14 +150,6 @@ export default {
 			event.stopPropagation()
 			event.preventDefault()
 
-			if (this.isMimeTypeOfTextApp(this.mimetype)) {
-				// The Text app fails to load when not all fileinfo data is given.
-				// So we have to query the folder to get all the necessary details.
-				OCA.Viewer.open({
-					path: this.internalAbsolutePath,
-				})
-				return
-			}
 			OCA.Viewer.open({
 				// Viewer expects an internal absolute path starting with "/".
 				path: this.internalAbsolutePath,
@@ -171,36 +163,6 @@ export default {
 					},
 				],
 			})
-		},
-
-		isMimeTypeOfTextApp(mimetype) {
-			// keep in sync with https://github.com/nextcloud/text/blob/master/src/helpers/mime.js
-			return [
-				'text/markdown',
-
-				'text/plain',
-				'application/cmd',
-				'application/x-empty',
-				'application/x-msdos-program',
-				'application/epub+zip',
-				'application/javascript',
-				'application/json',
-				'application/x-perl',
-				'application/x-php',
-				'application/x-tex',
-				'application/xml',
-				'application/yaml',
-				'text/css',
-				'text/csv',
-				'text/html',
-				'text/x-c',
-				'text/x-c++src',
-				'text/x-h',
-				'text/x-java-source',
-				'text/x-ldif',
-				'text/x-python',
-				'text/x-shellscript',
-			].indexOf(mimetype) !== -1
 		},
 	},
 }

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -163,8 +163,11 @@ export default {
 				path: this.internalAbsolutePath,
 				list: [
 					{
+						fileid: parseInt(this.id, 10),
 						filename: this.internalAbsolutePath,
 						basename: this.name,
+						mime: this.mimetype,
+						hasPreview: this.previewAvailable === 'yes',
 					},
 				],
 			})


### PR DESCRIPTION
Follow up to #3370 and #3409

When an explicit file list is given the Viewer uses the attributes included in it, but only the `filename` and the `basename` were provided. Now [all the known file attributes](https://github.com/nextcloud/server/blob/787c2a17e3874a02388bd7bf493f4263b43b93c1/lib/public/RichObjectStrings/Definitions.php#L245-L280) which are also used by the Viewer are provided.

This makes possible to get rid of [the hack to open the Text files](https://github.com/nextcloud/spreed/pull/3409), as the missing [attributes needed by Text](https://github.com/nextcloud/text/blob/1061537667fc37e4a0c0500920cc680fe4af92af/src/components/ViewerComponent.vue#L37-L58) were `fileid` and `mime` (technically when a single file is given in the file list [the mime type is set by the Viewer itself](https://github.com/nextcloud/viewer/blob/015809170a0104f57e5704a956e1e6012cfd90b5/src/views/Viewer.vue#L385) so it was not really needed in this case, but it was included anyway for consistency).

Note, however, that the missing attributes issue is still not really fixed. Other plugins may expect attributes that are not part of the `RichObjectStrings` definition (for example, [the Viewer plugin for Images expects an `etag` property](https://github.com/nextcloud/viewer/blob/ea0dab02cfb7ff5892d08f683aeab430306b2951/src/components/Images.vue#L54-L58)), and those need to be fetched from the server (that is the reason why just a single path instead of a file list was provided to the Viewer when it was introduced in Talk, as when no file list is provided the Viewer takes care of fetching the file info). Anyway, something for a follow up pull request.
