### PR TITLE
Show sidebar when Viewer is opened

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -150,6 +150,12 @@ export default {
 			event.stopPropagation()
 			event.preventDefault()
 
+			// The Viewer expects a file to be set in the sidebar if the sidebar
+			// is open.
+			if (this.$store.getters.getSidebarStatus) {
+				OCA.Files.Sidebar.state.file = this.internalAbsolutePath
+			}
+
 			OCA.Viewer.open({
 				// Viewer expects an internal absolute path starting with "/".
 				path: this.internalAbsolutePath,

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -23,6 +23,7 @@
 <template>
 	<AppSidebar
 		v-show="opened"
+		id="app-sidebar"
 		:title="title"
 		:starred="isFavorited"
 		:title-editable="canModerate && isRenamingConversation"
@@ -239,6 +240,12 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+
+/* Override style set in server for "#app-sidebar" to match the style set in
+ * nextcloud-vue for ".app-sidebar". */
+#app-sidebar {
+	display: flex;
+}
 
 /* Force scroll bars in tabs content instead of in whole sidebar. */
 ::v-deep .app-sidebar-tabs__content {


### PR DESCRIPTION
The Viewer expects that, if the app has a sidebar, an `OCA.Files.Sidebar` object exists. This object should contain a `state.file` property with the name of the file currently shown (or an empty string if the sidebar is closed), and `open` and `close` functions to be called by the Viewer when opening and closing the sidebar is triggered by the Viewer.

The sidebar adjusts its width to the width of the sidebar once the opening ends. The sidebar comes from nextcloud/vue, and its opening is animated with a transition, so `OCA.Files.Sidebar.open` needs to wait until the transition ends to be resolved.

Besides the `OCA.Files.Sidebar` object [the Viewer also expects that the sidebar element in the DOM has an `app-sidebar` id](https://github.com/nextcloud/viewer/blob/015809170a0104f57e5704a956e1e6012cfd90b5/src/views/Viewer.vue#L653-L676). In nextcloud/vue >= 2.0.0 [the id of the sidebar was changed to `app-sidebar-vue`](https://github.com/nextcloud/nextcloud-vue/pull/1026), so it needs to be overridden to be found by the Viewer.

This pull request just makes possible to show and hide the sidebar when the Viewer is open. Changing the sidebar contents to also show the chat or the call view (depending on the state of the conversation) is still pending.
