### PR TITLE
Reload page on changing conversation and disable start/join call when Talk hash is dirty

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -56,6 +56,7 @@ import {
 } from './utils/webrtc/index'
 import { emit } from '@nextcloud/event-bus'
 import browserCheck from './mixins/browserCheck'
+import talkHashCheck from './mixins/talkHashCheck'
 
 export default {
 	name: 'App',
@@ -67,7 +68,10 @@ export default {
 		RightSidebar,
 	},
 
-	mixins: [browserCheck],
+	mixins: [
+		browserCheck,
+		talkHashCheck,
+	],
 
 	data: function() {
 		return {

--- a/src/App.vue
+++ b/src/App.vue
@@ -57,6 +57,7 @@ import {
 import { emit } from '@nextcloud/event-bus'
 import browserCheck from './mixins/browserCheck'
 import talkHashCheck from './mixins/talkHashCheck'
+import { generateUrl } from '@nextcloud/router'
 
 export default {
 	name: 'App',
@@ -255,6 +256,13 @@ export default {
 		})
 
 		const beforeRouteChangeListener = (to, from, next) => {
+
+			if (this.isNextcloudTalkHashDirty) {
+				// Nextcloud Talk configuration changed, reload the page when changing configuration
+				window.location = generateUrl('call/' + to.params.token)
+				return
+			}
+
 			/**
 			 * This runs whenever the new route is a conversation.
 			 */

--- a/src/FilesSidebarCallViewApp.vue
+++ b/src/FilesSidebarCallViewApp.vue
@@ -35,6 +35,7 @@ import { PARTICIPANT } from './constants'
 import CallView from './components/CallView/CallView'
 import PreventUnload from 'vue-prevent-unload'
 import browserCheck from './mixins/browserCheck'
+import talkHashCheck from './mixins/talkHashCheck'
 
 export default {
 
@@ -45,7 +46,10 @@ export default {
 		PreventUnload,
 	},
 
-	mixins: [browserCheck],
+	mixins: [
+		browserCheck,
+		talkHashCheck,
+	],
 
 	data() {
 		return {

--- a/src/PublicShareAuthSidebar.vue
+++ b/src/PublicShareAuthSidebar.vue
@@ -49,6 +49,7 @@ import {
 } from './services/participantsService'
 import { signalingKill } from './utils/webrtc/index'
 import browserCheck from './mixins/browserCheck'
+import talkHashCheck from './mixins/talkHashCheck'
 
 export default {
 
@@ -59,7 +60,10 @@ export default {
 		ChatView,
 	},
 
-	mixins: [browserCheck],
+	mixins: [
+		browserCheck,
+		talkHashCheck,
+	],
 
 	data() {
 		return {

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -59,6 +59,7 @@ import {
 } from './services/participantsService'
 import { signalingKill } from './utils/webrtc/index'
 import browserCheck from './mixins/browserCheck'
+import talkHashCheck from './mixins/talkHashCheck'
 
 export default {
 
@@ -71,7 +72,10 @@ export default {
 		PreventUnload,
 	},
 
-	mixins: [browserCheck],
+	mixins: [
+		browserCheck,
+		talkHashCheck,
+	],
 
 	props: {
 		shareToken: {

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -73,6 +73,9 @@ export default {
 		token() {
 			return this.$store.getters.getToken()
 		},
+		isNextcloudTalkHashDirty() {
+			return this.$store.getters.isNextcloudTalkHashDirty
+		},
 
 		conversation() {
 			if (this.$store.getters.conversation(this.token)) {
@@ -110,6 +113,7 @@ export default {
 			return (!this.conversation.canStartCall
 					&& !this.conversation.hasCall)
 				|| this.isBlockedByLobby
+				|| this.isNextcloudTalkHashDirty
 		},
 
 		leaveCallLabel() {
@@ -133,6 +137,10 @@ export default {
 		},
 
 		startCallToolTip() {
+			if (this.isNextcloudTalkHashDirty) {
+				return t('spreed', 'Nextcloud Talk was updated, you need to reload the page before you can start or join a call')
+			}
+
 			if (this.callButtonTooltipText) {
 				return this.callButtonTooltipText
 			}

--- a/src/mixins/talkHashCheck.js
+++ b/src/mixins/talkHashCheck.js
@@ -1,0 +1,60 @@
+/**
+ * @copyright Copyright (c) 2019 Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @author Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { showError } from '@nextcloud/dialogs'
+
+const talkHashCheck = {
+	data() {
+		return {
+			reloadWarningShown: false,
+		}
+	},
+
+	computed: {
+		isNextcloudTalkHashDirty() {
+			return this.$store.getters.isNextcloudTalkHashDirty
+		},
+	},
+
+	watch: {
+		isNextcloudTalkHashDirty(isDirty) {
+			if (isDirty) {
+				this.showReloadWarning()
+			}
+		},
+	},
+
+	methods: {
+		showReloadWarning() {
+			if (this.reloadWarningShown) {
+				return
+			}
+
+			this.reloadWarningShown = true
+			showError(t('spreed', 'Nextcloud Talk was updated, please reload the page'), {
+				timeout: 0,
+			})
+		},
+	},
+}
+
+export default talkHashCheck

--- a/src/services/conversationsService.js
+++ b/src/services/conversationsService.js
@@ -24,10 +24,9 @@ import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 import { CONVERSATION, SHARE } from '../constants'
 import { showError } from '@nextcloud/dialogs'
+import store from '../store/index'
 
-let talkCacheBusterHash = null
 let maintenanceWarning = null
-let updateWarning = null
 
 /**
  * Fetches the conversations from the server.
@@ -82,21 +81,11 @@ const fetchConversation = async function(token) {
 
 const checkTalkVersionHash = function(response) {
 	const newTalkCacheBusterHash = response.headers['x-nextcloud-talk-hash']
-	if (!newTalkCacheBusterHash || updateWarning) {
+	if (!newTalkCacheBusterHash) {
 		return
 	}
 
-	if (talkCacheBusterHash === null) {
-		console.debug('Setting initial Talk Hash: ', newTalkCacheBusterHash)
-		talkCacheBusterHash = newTalkCacheBusterHash
-	} else if (talkCacheBusterHash !== newTalkCacheBusterHash) {
-		console.debug('Updating Talk Hash: ', newTalkCacheBusterHash)
-		talkCacheBusterHash = newTalkCacheBusterHash
-
-		updateWarning = showError(t('spreed', 'Nextcloud Talk was updated, please reload the page'), {
-			timeout: 0,
-		})
-	}
+	store.dispatch('setNextcloudTalkHash', newTalkCacheBusterHash)
 }
 
 /**

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -34,6 +34,7 @@ import windowVisibilityStore from './windowVisibilityStore'
 import fileUploadStore from './fileUploadStore'
 import newGroupConversationStore from './newGroupConversationStore'
 import callViewStore from './callViewStore'
+import talkHashStore from './talkHashStore'
 
 Vue.use(Vuex)
 
@@ -53,6 +54,7 @@ export default new Store({
 		fileUploadStore,
 		newGroupConversationStore,
 		callViewStore,
+		talkHashStore,
 	},
 
 	mutations,

--- a/src/store/talkHashStore.js
+++ b/src/store/talkHashStore.js
@@ -1,0 +1,73 @@
+/**
+ * @copyright Copyright (c) 2019 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+const state = {
+	initialNextcloudTalkHash: '',
+	isNextcloudTalkHashDirty: false,
+}
+
+const getters = {
+	isNextcloudTalkHashDirty: (state) => {
+		return state.isNextcloudTalkHashDirty
+	},
+}
+
+const mutations = {
+	/**
+	 * Set the initial NextcloudTalkHash
+	 *
+	 * @param {object} state current store state
+	 * @param {string} hash Sha1 over some config information
+	 */
+	setInitialNextcloudTalkHash(state, hash) {
+		state.initialNextcloudTalkHash = hash
+	},
+
+	/**
+	 * Mark the NextcloudTalkHash as dirty
+	 *
+	 * @param {object} state current store state
+	 */
+	markNextcloudTalkHashDirty(state) {
+		state.isNextcloudTalkHashDirty = true
+	},
+}
+
+const actions = {
+	/**
+	 * Set the actor from the current user
+	 *
+	 * @param {object} context default store context;
+	 * @param {string} hash Sha1 over some config information
+	 */
+	setNextcloudTalkHash(context, hash) {
+		if (!context.state.initialNextcloudTalkHash) {
+			console.debug('X-Nextcloud-Talk-Hash initialised: ', hash)
+			context.commit('setInitialNextcloudTalkHash', hash)
+		} else if (context.state.initialNextcloudTalkHash !== hash && !state.isNextcloudTalkHashDirty) {
+			console.debug('X-Nextcloud-Talk-Hash marked dirty: ', hash)
+			context.commit('markNextcloudTalkHashDirty')
+		}
+	},
+}
+
+export default { state, mutations, getters, actions }


### PR DESCRIPTION
### Steps
1. Load a conversation
2. Modify a config or place `context.commit('setInitialNextcloudTalkHash', hash + hash)` in
https://github.com/nextcloud/spreed/blob/fcd7960c18709fa516cc1757395cf8ff26a72fd7/src/store/talkHashStore.js#L65 before step 1
3. After the next room (list) refresh you should see `X-Nextcloud-Talk-Hash marked dirty:  RANDOM_SHA1` in the console
4. "Start call" button is now disabled
5. Clicking on another conversation will make a page reload

Fix #3672 