### PR TITLE
Replace deprecated OC.redirect() with the correct way to redirect

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -253,7 +253,7 @@ Signaling.Base.prototype.joinCall = function(token, flags) {
 				// Server maintenance, lobby kicked in, or room not found.
 				// We first redirect to the conversation again and that
 				// will then show the proper error message to the user.
-				OC.redirect(generateUrl('call/' + token))
+				window.location = generateUrl('call/' + token)
 			})
 	})
 }


### PR DESCRIPTION
Ref https://github.com/nextcloud/server/blob/b9bc2417e7a8dc81feb0abe20359bedaf864f790/core/src/OC/navigation.js#L22-L27