### PR TITLE
Store the guest name in browser storage

### DIFF
--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -120,7 +120,7 @@ export default {
 			return this.$store.getters.getGuestName(
 				this.$store.getters.getToken(),
 				this.sessionHash,
-			) || localStorage.getItem('nick') || t('spreed', 'Guest')
+			)
 		},
 
 		avatarSize() {


### PR DESCRIPTION
### Step
1. As a guest join a conversation
2. Set a guest user name
3. Do a page refresh (e.g. because being prompted by the "Talk was updated" notice)
4. Check that your name is still set