### PR TITLE
Don't break LessThan3 in last message

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -194,6 +194,7 @@ export default {
 					lastMessage: this.simpleLastChatMessage,
 				}, undefined, {
 					escape: false,
+					sanitize: false,
 				})
 			}
 
@@ -207,6 +208,7 @@ export default {
 				lastMessage: this.simpleLastChatMessage,
 			}, undefined, {
 				escape: false,
+				sanitize: false,
 			})
 		},
 


### PR DESCRIPTION
The real fix for #2815 

Before | After
---|---
![Bildschirmfoto von 2020-05-28 13-07-19](https://user-images.githubusercontent.com/213943/83134419-9fab1b00-a0e4-11ea-80f0-4eba58ac0260.png) | ![Bildschirmfoto von 2020-05-28 13-07-00](https://user-images.githubusercontent.com/213943/83134411-9d48c100-a0e4-11ea-90d4-b6e5a7e15539.png)

Requires master of Nextcloud to be https://github.com/nextcloud/server/pull/20976 or later