### PR TITLE
Fix fullscreen having a black bar on bottom of sidebar, ref #3484

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -486,7 +486,7 @@ export default {
 		padding-top: 0;
 
 		::v-deep .app-sidebar {
-			height: 100vh;
+			height: 100vh !important;
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/spreed/pull/3484, where the sidebar height rule was overwritten by other changes. cc @nickvergessen @ma12-co as discussed. :)