### PR TITLE
Don't overwrite the conversation name while renaming

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -192,7 +192,9 @@ export default {
 
 	watch: {
 		conversation() {
-			this.conversationName = this.conversation.displayName
+			if (!this.isRenamingConversation) {
+				this.conversationName = this.conversation.displayName
+			}
 		},
 	},
 


### PR DESCRIPTION
Apply the following patch to make the problem occur more often:
```diff
diff --git a/src/components/LeftSidebar/ConversationsList/ConversationsList.vue b/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
index 6ca3a596..d95ef7d3 100644
--- a/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
@@ -88,7 +88,7 @@ export default {
                        if (!this.isFetchingConversations) {
                                this.fetchConversations()
                        }
-               }, 30000)
+               }, 3000)
 
                EventBus.$on('routeChange', this.onRouteChange)
                EventBus.$on('shouldRefreshConversations', this.debounceFetchConversations)

```

Then try to rename a conversation and take longer than 3 seconds with the open input and modified text => :boom:  => Your changes are overwritten by the refreshal of the conversation list.

Regression from https://github.com/nextcloud/spreed/pull/3389/commits/1d46c421a51ace2edba574db328249c88e8c9d25 aka https://github.com/nextcloud/spreed/pull/3389