### PR TITLE
Fix talk:room:* command completion for participant options

### DIFF
--- a/lib/Command/Room/TRoomCommand.php
+++ b/lib/Command/Room/TRoomCommand.php
@@ -369,8 +369,13 @@ trait TRoomCommand {
 			return [];
 		}
 
-		return array_map(function (Participant $participant) {
-			return $participant->getUser();
-		}, $room->searchParticipants($context->getCurrentWord()));
+		$users = [];
+		foreach ($room->searchParticipants($context->getCurrentWord()) as $participant) {
+			if (!$participant->isGuest()) {
+				$users[] = $participant->getUser();
+			}
+		}
+
+		return $users;
 	}
 }


### PR DESCRIPTION
We can't deal with guest participants in CLI commands (we rely on user ids) and `array_map()` currently returns a empty string for guest participants that is stripped later anyway. This fix makes this behaviour just more explicit.

I don't think that we should support guest participants in CLI commands in general anyway, can't think of a reasonable use case. What do you guys think?

Guess we should backport this to stable19, too.