### PR TITLE
Dispatch an event to signal interest in defering the notifications

### DIFF
--- a/lib/Notification/Listener.php
+++ b/lib/Notification/Listener.php
@@ -29,7 +29,6 @@ use OCA\Talk\Events\RoomEvent;
 use OCA\Talk\Room;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\Event;
-use OCP\EventDispatcher\GenericEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Notification\IApp;
 use OCP\Notification\IManager;


### PR DESCRIPTION
Backportable hack for the biggest issue of https://github.com/nextcloud/spreed/pull/3743

This can be backported easily and when the notifications app is running https://github.com/nextcloud/notifications/pull/651 it will help making everything faster