### PR TITLE
Make sure pinging session ids only uses indexes

### DIFF
--- a/lib/Room.php
+++ b/lib/Room.php
@@ -1319,8 +1319,7 @@ class Room {
 		$query = $this->db->getQueryBuilder();
 		$query->update('talk_participants')
 			->set('last_ping', $query->createNamedParameter($timestamp, IQueryBuilder::PARAM_INT))
-			->where($query->expr()->eq('room_id', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)))
-			->andWhere($query->expr()->in('session_id', $query->createNamedParameter($sessionIds, IQueryBuilder::PARAM_STR_ARRAY)));
+			->where($query->expr()->in('session_id', $query->createNamedParameter($sessionIds, IQueryBuilder::PARAM_STR_ARRAY)));
 
 		$query->execute();
 	}


### PR DESCRIPTION
Since sessions are unique globally (apart from '0' which is filtered out before)
we can update the ping only based on the index instead of
index + additional where check

See https://github.com/nextcloud/spreed/pull/3285#issuecomment-639433523 for analysis