### PR TITLE
Sort participants by display name

### DIFF
--- a/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
+++ b/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
@@ -105,7 +105,7 @@ export default {
 				return -1
 			}
 
-			return participant2.displayName - participant1.displayName
+			return participant1.displayName.localeCompare(participant2.displayName)
 		},
 	},
 }


### PR DESCRIPTION
This PR fixes sorting of talk participants in a conversation by display name.

### Before

![image](https://user-images.githubusercontent.com/1677436/83943381-d62b1900-a7fb-11ea-8ebe-793fb81fd4ae.png)


### After

![image](https://user-images.githubusercontent.com/1677436/83943339-72085500-a7fb-11ea-94f8-2d53fba911b1.png)
