### PR TITLE
Always try to use microphone if camera failed

### DIFF
--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -134,7 +134,7 @@ LocalMedia.prototype.start = function(mediaConstraints, cb) {
 	}).catch(function(err) {
 		// Fallback for users without a camera or with a camera that can not be
 		// accessed.
-		if (self.config.audioFallback && (err.name === 'NotFoundError' || err.name === 'NotReadableError') && constraints.video !== false) {
+		if (self.config.audioFallback && constraints.video !== false) {
 			constraints.video = false
 			self.start(constraints, cb)
 			return


### PR DESCRIPTION
When getting the local media it is first tried to get both microphone and camera and, if that fails, then it is tried to get only the microphone.

However, this was done only when certain errors happened while trying to get both the microphone and the camera. Now, [no matter the error](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#Exceptions), it is tried too to get only the microphone; if the media is still unavailable it will fail again, but this should help with some further scenarios not covered yet in the previously handled errors in which camera is not available but microphone is.

Found while testing #3730 with Firefox 77 with microphone but no camera, as in that case a `NNotAllowedError` was triggered when _resistFingerprinting_ was enabled (if it was not enabled then `NotFoundError`was triggered, which was already handled).

Fix #154