### PR TITLE
[stable18] If available create a cacheentry

### DIFF
--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Share;
 
+use OC\Files\Cache\Cache;
 use OCA\Talk\Events\ParticipantEvent;
 use OCA\Talk\Events\RemoveUserEvent;
 use OCA\Talk\Events\RoomEvent;
@@ -305,6 +306,14 @@ class RoomShareProvider implements IShareProvider {
 		$share->setNodeType($data['item_type']);
 
 		$share->setProviderId($this->identifier());
+
+		if (isset($data['f_permissions'])) {
+			$entryData = $data;
+			$entryData['permissions'] = $entryData['f_permissions'];
+			$entryData['parent'] = $entryData['f_parent'];
+			$share->setNodeCacheEntry(Cache::cacheEntryFromData($entryData,
+				\OC::$server->getMimeTypeLoader()));
+		}
 
 		return $share;
 	}


### PR DESCRIPTION
Backport of #3622 

This seems to work (before it entered [the `else`, now it enters the `if`](https://github.com/nextcloud/server/blob/v18.0.6/apps/files_sharing/lib/SharedMount.php#L240-L243)), and [the equivalent code in the `DefaultShareProvider.php` is there since Nextcloud 11](https://github.com/nextcloud/server/blob/14a561ddad8bbd6ae1d524a49c70a7926c06310f/lib/private/Share20/DefaultShareProvider.php#L851-L857).

But I do not really know if this could lead to any issue in Nextcloud 18, so a review from the masters is more than welcome :-)
