### PR TITLE
Handle error when joining room in the external signaling server

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -927,7 +927,7 @@ Signaling.Standalone.prototype._joinRoomSuccess = function(token, nextcloudSessi
 			'sessionid': nextcloudSessionId,
 		},
 	}, function(data) {
-		this.joinResponseReceived(data, token)
+		this.joinResponseReceived(data, token, nextcloudSessionId)
 	}.bind(this))
 }
 
@@ -958,8 +958,16 @@ Signaling.Standalone.prototype.joinCall = function(token, flags) {
 	return Signaling.Base.prototype.joinCall.apply(this, arguments)
 }
 
-Signaling.Standalone.prototype.joinResponseReceived = function(data, token) {
+Signaling.Standalone.prototype.joinResponseReceived = function(data, token, nextcloudSessionId) {
 	console.debug('Joined', data, token)
+
+	if (data.type === 'error') {
+		// Keep trying until the room is joined in the signaling server too.
+		this._joinRoomSuccess(token, nextcloudSessionId)
+
+		return
+	}
+
 	this.signalingRoomJoined = token
 	if (this.pendingJoinCall && token === this.pendingJoinCall.token) {
 		const pendingJoinCallResolve = this.pendingJoinCall.resolve

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -973,16 +973,6 @@ Signaling.Standalone.prototype.joinResponseReceived = function(data, token) {
 
 		this.pendingJoinCall = null
 	}
-	if (this.roomCollection) {
-		// The list of rooms is not fetched from the server. Update ping
-		// of joined room so it gets sorted to the top.
-		this.roomCollection.forEach(function(room) {
-			if (room.get('token') === token) {
-				room.set('lastPing', (new Date()).getTime() / 1000)
-			}
-		})
-		this.roomCollection.sort()
-	}
 }
 
 Signaling.Standalone.prototype._doLeaveRoom = function(token) {


### PR DESCRIPTION
:warning: :warning: :warning: **Work in progress** :warning: :warning: :warning: 

## How to test (scenario 1)

- Make joining the call from the externel signaling server fail sometimes by adding `if (rand(0, 9) < 7) { sleep(11); }` before [the ping in `SignalingController`](https://github.com/nextcloud/spreed/blob/84d42604e60aa1c31ecf698dcc069f36c494148a/lib/Controller/SignalingController.php#L525) (11 or [whatever value you have set as the timeout in the external signaling server](https://github.com/strukturag/nextcloud-spreed-signaling/blob/5dcfeda1e9edd7076b71e052e67ea086c0a7460f/server.conf.in#L61) + 1)
- Open the browser console
- As user A, join a conversation (repeat as needed until the message `Join room XXX` is shown followed by `Joined`, which means that joining in the external signaling server did not wait and succeeded)
- Start a call
- In a private window, open the browser console
- As user B, join the same conversation (repeat as needed until the message `Join room XXX` is shown but it is not followed by `Joined`, which means that joining in the external signaling server is taking longer)
- Join the call

### Result with this pull request

`Joined` is eventually shown with an error, but joining is automatically retried until it succeeds. The call view is not shown until the conversation is joined, and when that happens it connects to user A.

### Result without this pull request

`Joined` is eventually shown with an error. The call view is immediately shown, but it never connects to user A.


## How to test (scenario 2) - WIP

- Make joining the call from the externel signaling server take longer sometimes by adding `if (rand(0, 9) < 3) { sleep(8); }` before [the ping in `SignalingController`](https://github.com/nextcloud/spreed/blob/84d42604e60aa1c31ecf698dcc069f36c494148a/lib/Controller/SignalingController.php#L525) (8 or [whatever value you have set as the timeout in the external signaling server](https://github.com/strukturag/nextcloud-spreed-signaling/blob/5dcfeda1e9edd7076b71e052e67ea086c0a7460f/server.conf.in#L61) - 2)
- Open the browser console
- Join a conversation (repeat as needed until the message `Join room XXX` is shown but it is not followed by `Joined`, which means that joining in the external signaling server is taking longer)
- Change to a different conversation (repeat as needed until the message `Join room XXX` is shown followed by `Joined`, which means that joining in the external signaling server did not wait and succeeded)

### Result with this pull request

`Joined` is eventually shown for the previous conversation, but the latest conversation is automatically joined again. If a call is started it will connect to the other user.

### Result without this pull request

`Joined` is eventually shown for the previous conversation. If a call is started it will never connect to the other user.
