### PR TITLE
Warn user on high load

### DIFF
--- a/css/icons.scss
+++ b/css/icons.scss
@@ -81,9 +81,6 @@
 		&.icon-screen-off {
 			background-image: url(icon-color-path('screen-off', 'actions', 'fff', 1, true));
 		}
-		&.icon-error {
-			background-image: url(icon-color-path('error', 'actions', 'fff', 1, true));
-		}
 	}
 
 	.icon-favorite {

--- a/css/icons.scss
+++ b/css/icons.scss
@@ -81,6 +81,9 @@
 		&.icon-screen-off {
 			background-image: url(icon-color-path('screen-off', 'actions', 'fff', 1, true));
 		}
+		&.icon-error {
+			background-image: url(icon-color-path('error', 'actions', 'fff', 1, true));
+		}
 	}
 
 	.icon-favorite {

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -110,6 +110,18 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		qualityWarningAudioTooltip: {
+			type: Object,
+			default: null,
+		},
+		qualityWarningVideoTooltip: {
+			type: Object,
+			default: null,
+		},
+		qualityWarningScreenTooltip: {
+			type: Object,
+			default: null,
+		},
 	},
 
 	data() {
@@ -138,6 +150,10 @@ export default {
 					content: t('spreed', 'No audio'),
 					show: false,
 				}
+			}
+
+			if (this.qualityWarningAudioTooltip) {
+				return this.qualityWarningAudioTooltip
 			}
 
 			if (this.speakingWhileMutedNotification) {
@@ -196,6 +212,10 @@ export default {
 				return t('spreed', 'No camera')
 			}
 
+			if (this.qualityWarningVideoTooltip) {
+				return this.qualityWarningVideoTooltip
+			}
+
 			if (this.model.attributes.videoEnabled) {
 				return t('spreed', 'Disable video (v)')
 			}
@@ -234,6 +254,10 @@ export default {
 		screenSharingButtonTooltip() {
 			if (this.screenSharingMenuOpen) {
 				return null
+			}
+
+			if (this.qualityWarningScreenTooltip) {
+				return this.qualityWarningScreenTooltip
 			}
 
 			return (this.model.attributes.localScreen || this.splitScreenSharingMenu) ? t('spreed', 'Screensharing options') : t('spreed', 'Enable screensharing')

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -156,7 +156,13 @@ export default {
 		},
 
 		showQualityWarning() {
-			return this.senderConnectionQualityAudioIsBad || this.qualityWarningInGracePeriodTimeout
+			return this.senderConnectionQualityIsBad || this.qualityWarningInGracePeriodTimeout
+		},
+
+		senderConnectionQualityIsBad() {
+			return this.senderConnectionQualityAudioIsBad
+				|| this.senderConnectionQualityVideoIsBad
+				|| this.senderConnectionQualityScreenIsBad
 		},
 
 		senderConnectionQualityAudioIsBad() {
@@ -165,8 +171,37 @@ export default {
 				 || callAnalyzer.attributes.senderConnectionQualityAudio === CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
 		},
 
+		senderConnectionQualityVideoIsBad() {
+			return callAnalyzer
+				&& (callAnalyzer.attributes.senderConnectionQualityVideo === CONNECTION_QUALITY.VERY_BAD
+				 || callAnalyzer.attributes.senderConnectionQualityVideo === CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
+		},
+
+		senderConnectionQualityScreenIsBad() {
+			return callAnalyzer
+				&& (callAnalyzer.attributes.senderConnectionQualityScreen === CONNECTION_QUALITY.VERY_BAD
+				 || callAnalyzer.attributes.senderConnectionQualityScreen === CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
+		},
+
 		qualityWarningAriaLabel() {
-			return t('spreed', 'Bad sent audio quality')
+			let label = ''
+			if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
+				label = t('spreed', 'Bad sent video and screen quality.')
+			} else if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.localScreen) {
+				label = t('spreed', 'Bad sent screen quality.')
+			} else if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.videoEnabled) {
+				label = t('spreed', 'Bad sent video quality.')
+			} else if (this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
+				label = t('spreed', 'Bad sent audio, video and screen quality.')
+			} else if (this.localMediaModel.attributes.localScreen) {
+				label = t('spreed', 'Bad sent audio and screen quality.')
+			} else if (this.localMediaModel.attributes.videoEnabled) {
+				label = t('spreed', 'Bad sent audio and video quality.')
+			} else {
+				label = t('spreed', 'Bad sent audio quality.')
+			}
+
+			return label
 		},
 
 		// The quality warning tooltip is automatically shown only if the
@@ -183,7 +218,13 @@ export default {
 			}
 
 			let message = ''
-			if (this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
+			if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
+				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you. To improve the situation try to disable your video while doing a screenshare.')
+			} else if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.localScreen) {
+				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see your screen.')
+			} else if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.videoEnabled) {
+				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you.')
+			} else if (this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
 				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video while doing a screenshare.')
 			} else if (this.localMediaModel.attributes.localScreen) {
 				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see your screen. To improve the situation try to disable your screenshare.')
@@ -220,8 +261,8 @@ export default {
 			this._setLocalStream(localStream)
 		},
 
-		senderConnectionQualityAudioIsBad: function(senderConnectionQualityAudioIsBad) {
-			if (!senderConnectionQualityAudioIsBad) {
+		senderConnectionQualityIsBad: function(senderConnectionQualityIsBad) {
+			if (!senderConnectionQualityIsBad) {
 				return
 			}
 

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -21,7 +21,7 @@
 <template>
 	<div id="localVideoContainer"
 		class="videoContainer videoView"
-		:class="{ speaking: localMediaModel.attributes.speaking, 'video-container-grid': isGrid, 'video-container-stripe': isStripe }">
+		:class="videoContainerClass">
 		<transition name="fade">
 			<span v-show="showQualityWarning"
 				v-tooltip="qualityWarningTooltip"
@@ -122,6 +122,14 @@ export default {
 	},
 
 	computed: {
+
+		videoContainerClass() {
+			return {
+				'speaking': this.localMediaModel.attributes.speaking,
+				'video-container-grid': this.isGrid,
+				'video-container-stripe': this.isStripe,
+			}
+		},
 
 		userId() {
 			return this.$store.getters.getUserId()

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -117,6 +117,7 @@ export default {
 		return {
 			callAnalyzer: callAnalyzer,
 			qualityWarningInGracePeriodTimeout: null,
+			qualityWarningWasRecentlyShownTimeout: null,
 		}
 	},
 
@@ -168,6 +169,14 @@ export default {
 			return t('spreed', 'Bad sent audio quality')
 		},
 
+		// The quality warning tooltip is automatically shown only if the
+		// quality warning has not been shown in the last minute. Otherwise the
+		// tooltip is hidden even if the warning is shown, although the tooltip
+		// can be shown anyway by hovering on the warning.
+		showQualityWarningTooltip() {
+			return !this.qualityWarningWasRecentlyShownTimeout
+		},
+
 		qualityWarningTooltip() {
 			if (!this.showQualityWarning) {
 				return false
@@ -186,7 +195,7 @@ export default {
 
 			return {
 				content: message,
-				show: true,
+				show: this.showQualityWarningTooltip,
 			}
 		},
 	},
@@ -223,6 +232,20 @@ export default {
 			this.qualityWarningInGracePeriodTimeout = window.setTimeout(() => {
 				this.qualityWarningInGracePeriodTimeout = null
 			}, 3000)
+		},
+
+		showQualityWarning: function(showQualityWarning) {
+			if (showQualityWarning) {
+				return
+			}
+
+			if (this.qualityWarningWasRecentlyShownTimeout) {
+				window.clearTimeout(this.qualityWarningWasRecentlyShownTimeout)
+			}
+
+			this.qualityWarningWasRecentlyShownTimeout = window.setTimeout(() => {
+				this.qualityWarningWasRecentlyShownTimeout = null
+			}, 60000)
 		},
 
 	},

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -231,18 +231,28 @@ export default {
 		},
 
 		qualityWarningTooltip() {
-			if (!this.showQualityWarning) {
-				return false
+			if (this.qualityWarningAudioTooltip) {
+				return this.qualityWarningAudioTooltip
+			}
+
+			if (this.qualityWarningVideoTooltip) {
+				return this.qualityWarningVideoTooltip
+			}
+
+			if (this.qualityWarningScreenTooltip) {
+				return this.qualityWarningScreenTooltip
+			}
+
+			return null
+		},
+
+		qualityWarningAudioTooltip() {
+			if (!this.showQualityWarning || !this.localMediaModel.attributes.audioEnabled) {
+				return null
 			}
 
 			let message = ''
-			if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you. To improve the situation try to disable your video while doing a screenshare.')
-			} else if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.localScreen) {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see your screen.')
-			} else if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.videoEnabled) {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you.')
-			} else if (this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
+			if (this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
 				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video while doing a screenshare.')
 			} else if (this.localMediaModel.attributes.localScreen) {
 				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see your screen. To improve the situation try to disable your screenshare.')
@@ -254,6 +264,35 @@ export default {
 
 			return {
 				content: message,
+				show: this.showQualityWarningTooltip,
+			}
+		},
+
+		qualityWarningVideoTooltip() {
+			if (!this.showQualityWarning || this.localMediaModel.attributes.audioEnabled || !this.localMediaModel.attributes.videoEnabled) {
+				return null
+			}
+
+			let message = ''
+			if (this.localMediaModel.attributes.localScreen) {
+				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you. To improve the situation try to disable your video while doing a screenshare.')
+			} else {
+				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you.')
+			}
+
+			return {
+				content: message,
+				show: this.showQualityWarningTooltip,
+			}
+		},
+
+		qualityWarningScreenTooltip() {
+			if (!this.showQualityWarning || this.localMediaModel.attributes.audioEnabled || this.localMediaModel.attributes.videoEnabled || !this.localMediaModel.attributes.localScreen) {
+				return null
+			}
+
+			return {
+				content: t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see your screen.'),
 				show: this.showQualityWarningTooltip,
 			}
 		},

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -116,6 +116,7 @@ export default {
 	data() {
 		return {
 			callAnalyzer: callAnalyzer,
+			qualityWarningInGracePeriodTimeout: null,
 		}
 	},
 
@@ -154,6 +155,10 @@ export default {
 		},
 
 		showQualityWarning() {
+			return this.senderConnectionQualityAudioIsBad || this.qualityWarningInGracePeriodTimeout
+		},
+
+		senderConnectionQualityAudioIsBad() {
 			return callAnalyzer
 				&& (callAnalyzer.attributes.senderConnectionQualityAudio === CONNECTION_QUALITY.VERY_BAD
 				 || callAnalyzer.attributes.senderConnectionQualityAudio === CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
@@ -204,6 +209,20 @@ export default {
 
 		'localMediaModel.attributes.localStream': function(localStream) {
 			this._setLocalStream(localStream)
+		},
+
+		senderConnectionQualityAudioIsBad: function(senderConnectionQualityAudioIsBad) {
+			if (!senderConnectionQualityAudioIsBad) {
+				return
+			}
+
+			if (this.qualityWarningInGracePeriodTimeout) {
+				window.clearTimeout(this.qualityWarningInGracePeriodTimeout)
+			}
+
+			this.qualityWarningInGracePeriodTimeout = window.setTimeout(() => {
+				this.qualityWarningInGracePeriodTimeout = null
+			}, 3000)
 		},
 
 	},

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -306,7 +306,7 @@ export default {
 
 			this.qualityWarningInGracePeriodTimeout = window.setTimeout(() => {
 				this.qualityWarningInGracePeriodTimeout = null
-			}, 3000)
+			}, 10000)
 		},
 
 		showQualityWarning: function(showQualityWarning) {

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -23,12 +23,6 @@
 		class="videoContainer videoView"
 		:class="videoContainerClass"
 		:aria-label="videoContainerAriaLabel">
-		<transition name="fade">
-			<span v-show="showQualityWarning"
-				v-tooltip="qualityWarningTooltip"
-				:aria-label="qualityWarningAriaLabel"
-				class="qualityWarning forced-white icon icon-error" />
-		</transition>
 		<video v-show="localMediaModel.attributes.videoEnabled"
 			id="localVideo"
 			ref="video"
@@ -57,6 +51,9 @@
 				:model="localMediaModel"
 				:local-call-participant-model="localCallParticipantModel"
 				:screen-sharing-button-hidden="isSidebar"
+				:quality-warning-audio-tooltip="qualityWarningAudioTooltip"
+				:quality-warning-video-tooltip="qualityWarningVideoTooltip"
+				:quality-warning-screen-tooltip="qualityWarningScreenTooltip"
 				@switchScreenToId="$emit('switchScreenToId', $event)" />
 		</transition>
 	</div>
@@ -69,7 +66,6 @@ import LocalMediaControls from './LocalMediaControls'
 import Hex from 'crypto-js/enc-hex'
 import SHA1 from 'crypto-js/sha1'
 import { showInfo } from '@nextcloud/dialogs'
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 import video from '../../../mixins/video.js'
 import VideoBackground from './VideoBackground'
 import { callAnalyzer } from '../../../utils/webrtc/index'
@@ -78,10 +74,6 @@ import { CONNECTION_QUALITY } from '../../../utils/webrtc/analyzers/PeerConnecti
 export default {
 
 	name: 'LocalVideo',
-
-	directives: {
-		tooltip: Tooltip,
-	},
 
 	components: {
 		Avatar,
@@ -223,27 +215,12 @@ export default {
 		},
 
 		// The quality warning tooltip is automatically shown only if the
-		// quality warning has not been shown in the last minute. Otherwise the
-		// tooltip is hidden even if the warning is shown, although the tooltip
-		// can be shown anyway by hovering on the warning.
+		// quality warning (dimmed video) has not been shown in the last minute.
+		// Otherwise the tooltip is hidden even if the warning is shown,
+		// although the tooltip can be shown anyway by hovering on the media
+		// button.
 		showQualityWarningTooltip() {
 			return !this.qualityWarningWasRecentlyShownTimeout
-		},
-
-		qualityWarningTooltip() {
-			if (this.qualityWarningAudioTooltip) {
-				return this.qualityWarningAudioTooltip
-			}
-
-			if (this.qualityWarningVideoTooltip) {
-				return this.qualityWarningVideoTooltip
-			}
-
-			if (this.qualityWarningScreenTooltip) {
-				return this.qualityWarningScreenTooltip
-			}
-
-			return null
 		},
 
 		qualityWarningAudioTooltip() {
@@ -438,18 +415,6 @@ export default {
 	.avatar-container {
 		opacity: 0.5
 	}
-}
-
-.qualityWarning {
-	position: absolute;
-	right: 0;
-
-	width: 44px;
-	height: 44px;
-	background-size: 24px;
-
-	/* Needed to show in front of the avatar container. */
-	z-index: 10;
 }
 
 </style>

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -21,7 +21,8 @@
 <template>
 	<div id="localVideoContainer"
 		class="videoContainer videoView"
-		:class="videoContainerClass">
+		:class="videoContainerClass"
+		:aria-label="videoContainerAriaLabel">
 		<transition name="fade">
 			<span v-show="showQualityWarning"
 				v-tooltip="qualityWarningTooltip"
@@ -128,7 +129,16 @@ export default {
 				'speaking': this.localMediaModel.attributes.speaking,
 				'video-container-grid': this.isGrid,
 				'video-container-stripe': this.isStripe,
+				'bad-connection-quality': this.showQualityWarning,
 			}
+		},
+
+		videoContainerAriaLabel() {
+			if (!this.showQualityWarning) {
+				return null
+			}
+
+			return this.qualityWarningAriaLabel
 		},
 
 		userId() {
@@ -382,6 +392,13 @@ export default {
 
 .avatar-container {
 	margin: auto;
+}
+
+.bad-connection-quality {
+	.video,
+	.avatar-container {
+		opacity: 0.5
+	}
 }
 
 .qualityWarning {

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -224,34 +224,27 @@ export default {
 		},
 
 		qualityWarningAudioTooltip() {
-			if (!this.showQualityWarning || !this.localMediaModel.attributes.audioEnabled) {
+			if (!this.showQualityWarning || !this.localMediaModel.attributes.audioEnabled || this.localMediaModel.attributes.videoEnabled || this.localMediaModel.attributes.localScreen) {
 				return null
 			}
 
-			let message = ''
-			if (this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video while doing a screenshare.')
-			} else if (this.localMediaModel.attributes.localScreen) {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see your screen. To improve the situation try to disable your screenshare.')
-			} else if (this.localMediaModel.attributes.videoEnabled) {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video.')
-			} else {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand you.')
-			}
-
 			return {
-				content: message,
+				content: t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand you.'),
 				show: this.showQualityWarningTooltip,
 			}
 		},
 
 		qualityWarningVideoTooltip() {
-			if (!this.showQualityWarning || this.localMediaModel.attributes.audioEnabled || !this.localMediaModel.attributes.videoEnabled) {
+			if (!this.showQualityWarning || !this.localMediaModel.attributes.videoEnabled) {
 				return null
 			}
 
 			let message = ''
-			if (this.localMediaModel.attributes.localScreen) {
+			if (this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.localScreen) {
+				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video while doing a screenshare.')
+			} else if (this.localMediaModel.attributes.audioEnabled) {
+				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video.')
+			} else if (this.localMediaModel.attributes.localScreen) {
 				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you. To improve the situation try to disable your video while doing a screenshare.')
 			} else {
 				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you.')
@@ -264,12 +257,19 @@ export default {
 		},
 
 		qualityWarningScreenTooltip() {
-			if (!this.showQualityWarning || this.localMediaModel.attributes.audioEnabled || this.localMediaModel.attributes.videoEnabled || !this.localMediaModel.attributes.localScreen) {
+			if (!this.showQualityWarning || !this.localMediaModel.attributes.localScreen || this.localMediaModel.attributes.videoEnabled) {
 				return null
 			}
 
+			let message = ''
+			if (this.localMediaModel.attributes.audioEnabled) {
+				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see your screen. To improve the situation try to disable your screenshare.')
+			} else {
+				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see your screen.')
+			}
+
 			return {
-				content: t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see your screen.'),
+				content: message,
 				show: this.showQualityWarningTooltip,
 			}
 		},

--- a/src/utils/webrtc/analyzers/AverageStatValue.js
+++ b/src/utils/webrtc/analyzers/AverageStatValue.js
@@ -1,0 +1,135 @@
+/**
+ *
+ * @copyright Copyright (c) 2020, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+const STAT_VALUE_TYPE = {
+	CUMULATIVE: 0,
+	RELATIVE: 1,
+}
+
+/**
+ * Helper to calculate the average of the last N instances of an RTCStatsReport
+ * value.
+ *
+ * The average is a weighted average in which the latest elements have a higher
+ * weight. Specifically, the first item has a weight of 1, the last item has a
+ * weight of 3, and all the intermediate items have a weight that increases
+ * linearly from 1 to 3. The weights can be set when the AverageStatValue is
+ * created by specifying the weight of the last item.
+ *
+ * The number of items to keep track of must be set when the AverageStatValue is
+ * created. Once N items have been added adding a new one will discard the
+ * oldest value. "hasEnoughData()" can be used to check if at least N items have
+ * been added already and the average is reliable.
+ *
+ * An RTCStatsReport value can be cumulative since the creation of the
+ * RTCPeerConnection (like a sent packet count), or it can be an independent
+ * value at a certain point of time (like the round trip time). To be able to
+ * calculate the average the AverageStatValue converts cumulative values to
+ * relative ones. When the AverageStatValue is created it must be set whether
+ * the values that will be added are cumulative or not.
+ *
+ * The conversion from cumulative to relative is done automatically. Note,
+ * however, that the first value added to a cumulative AverageStatValue after
+ * creating or resetting it will be treated as 0 in the average calculation,
+ * as it will be the base from which the rest of relative values are calculated.
+ *
+ * Besides the weighted average it is possible to "peek" the last value, either
+ * the raw value that was added or the relative one after the conversion (which,
+ * for non cumulative values, will be the raw value too).
+ *
+ * @param {int} count the number of instances to take into account.
+ * @param {STAT_VALUE_TYPE} type whether the value is cumulative or relative.
+ * @param {int} lastValueWeight the value to calculate the weights of all the
+ *        items, from the first (weight 1) to the last one.
+ */
+function AverageStatValue(count, type = STAT_VALUE_TYPE.CUMULATIVE, lastValueWeight = 3) {
+	this._count = count
+	this._type = type
+	this._extraWeightForEachElement = (lastValueWeight - 1) / (count - 1)
+
+	this._rawValues = []
+	this._relativeValues = []
+}
+AverageStatValue.prototype = {
+
+	reset: function() {
+		this._rawValues = []
+		this._relativeValues = []
+	},
+
+	add: function(value) {
+		if (this._rawValues.length === this._count) {
+			this._rawValues.shift()
+			this._relativeValues.shift()
+		}
+
+		let relativeValue = value
+		if (this._type === STAT_VALUE_TYPE.CUMULATIVE) {
+			// The first added value will be meaningless as it will be 0 and
+			// used as the base for the rest of values.
+			const lastRawValue = this._rawValues.length ? this._rawValues[this._rawValues.length - 1] : value
+			relativeValue = value - lastRawValue
+		}
+
+		this._rawValues.push(value)
+		this._relativeValues.push(relativeValue)
+	},
+
+	getLastRawValue: function() {
+		if (this._rawValues.length < 1) {
+			return NaN
+		}
+
+		return this._rawValues[this._rawValues.length - 1]
+	},
+
+	getLastRelativeValue: function() {
+		if (this._relativeValues.length < 1) {
+			return NaN
+		}
+
+		return this._relativeValues[this._relativeValues.length - 1]
+	},
+
+	hasEnoughData: function() {
+		return this._rawValues.length === this._count
+	},
+
+	getWeightedAverage: function() {
+		let weightedValues = 0
+		let weightsSum = 0
+
+		for (let i = 0; i < this._relativeValues.length; i++) {
+			const weight = 1 + (i * this._extraWeightForEachElement)
+
+			weightedValues += this._relativeValues[i] * weight
+			weightsSum += weight
+		}
+
+		return weightedValues / weightsSum
+	},
+
+}
+
+export {
+	STAT_VALUE_TYPE,
+	AverageStatValue,
+}

--- a/src/utils/webrtc/analyzers/CallAnalyzer.js
+++ b/src/utils/webrtc/analyzers/CallAnalyzer.js
@@ -1,0 +1,145 @@
+/**
+ *
+ * @copyright Copyright (c) 2020, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import {
+	ParticipantAnalyzer,
+} from './ParticipantAnalyzer'
+
+/**
+ * Analyzer for the quality of the connections of a call.
+ *
+ * After a CallAnalyzer is created the analysis will be automatically started.
+ *
+ * When the quality of the connections change different events will be triggered
+ * depending on the case:
+ * - 'change:senderConnectionQualityAudio'
+ * - 'change:senderConnectionQualityVideo'
+ * - 'change:senderConnectionQualityScreen'
+ *
+ * The reported values are based on CONNECTION_QUALITY values of
+ * PeerConnectionAnalyzer.
+ *
+ * Besides the event themselves, the quality can be known too using
+ * "get(valueName)" or even directly from the "attributes" object.
+ *
+ * Once the CallAnalyzer is no longer needed "destroy()" must be called to stop
+ * the analysis.
+ *
+ * @param {LocalMediaModel} localMediaModel the model for the local media.
+ * @param {LocalCallParticipantModel} localCallParticipantModel the model for
+ *        the local participant; null if an MCU is not used.
+ * @param {CallParticipantCollection} callParticipantCollection the collection
+ *        for the remote participants.
+ */
+export default function CallAnalyzer(localMediaModel, localCallParticipantModel, callParticipantCollection) {
+	this.attributes = {
+		senderConnectionQualityAudio: null,
+		senderConnectionQualityVideo: null,
+		senderConnectionQualityScreen: null,
+	}
+
+	this._handlers = []
+
+	this._localMediaModel = localMediaModel
+	this._localCallParticipantModel = localCallParticipantModel
+	this._callParticipantCollection = callParticipantCollection
+
+	this._handleSenderConnectionQualityAudioChangeBound = this._handleSenderConnectionQualityAudioChange.bind(this)
+	this._handleSenderConnectionQualityVideoChangeBound = this._handleSenderConnectionQualityVideoChange.bind(this)
+	this._handleSenderConnectionQualityScreenChangeBound = this._handleSenderConnectionQualityScreenChange.bind(this)
+
+	if (localCallParticipantModel) {
+		this._localParticipantAnalyzer = new ParticipantAnalyzer()
+		this._localParticipantAnalyzer.setSenderParticipant(localMediaModel, localCallParticipantModel)
+
+		this._localParticipantAnalyzer.on('change:senderConnectionQualityAudio', this._handleSenderConnectionQualityAudioChangeBound)
+		this._localParticipantAnalyzer.on('change:senderConnectionQualityVideo', this._handleSenderConnectionQualityVideoChangeBound)
+		this._localParticipantAnalyzer.on('change:senderConnectionQualityScreen', this._handleSenderConnectionQualityScreenChangeBound)
+	}
+}
+CallAnalyzer.prototype = {
+
+	get: function(key) {
+		return this.attributes[key]
+	},
+
+	set: function(key, value) {
+		this.attributes[key] = value
+
+		this._trigger('change:' + key, [value])
+	},
+
+	on: function(event, handler) {
+		if (!this._handlers.hasOwnProperty(event)) {
+			this._handlers[event] = [handler]
+		} else {
+			this._handlers[event].push(handler)
+		}
+	},
+
+	off: function(event, handler) {
+		const handlers = this._handlers[event]
+		if (!handlers) {
+			return
+		}
+
+		const index = handlers.indexOf(handler)
+		if (index !== -1) {
+			handlers.splice(index, 1)
+		}
+	},
+
+	_trigger: function(event, args) {
+		let handlers = this._handlers[event]
+		if (!handlers) {
+			return
+		}
+
+		args.unshift(this)
+
+		handlers = handlers.slice(0)
+		for (let i = 0; i < handlers.length; i++) {
+			const handler = handlers[i]
+			handler.apply(handler, args)
+		}
+	},
+
+	destroy: function() {
+		if (this._localParticipantAnalyzer) {
+			this._localParticipantAnalyzer.off('change:senderConnectionQualityAudio', this._handleSenderConnectionQualityAudioChangeBound)
+
+			this._localParticipantAnalyzer.destroy()
+		}
+	},
+
+	_handleSenderConnectionQualityAudioChange: function(participantAnalyzer, senderConnectionQualityAudio) {
+		this.set('senderConnectionQualityAudio', senderConnectionQualityAudio)
+	},
+
+	_handleSenderConnectionQualityVideoChange: function(participantAnalyzer, senderConnectionQualityVideo) {
+		this.set('senderConnectionQualityVideo', senderConnectionQualityVideo)
+	},
+
+	_handleSenderConnectionQualityScreenChange: function(participantAnalyzer, senderConnectionQualityScreen) {
+		this.set('senderConnectionQualityScreen', senderConnectionQualityScreen)
+	},
+
+}

--- a/src/utils/webrtc/analyzers/ParticipantAnalyzer.js
+++ b/src/utils/webrtc/analyzers/ParticipantAnalyzer.js
@@ -1,0 +1,343 @@
+/**
+ *
+ * @copyright Copyright (c) 2020, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import {
+	PEER_DIRECTION,
+	PeerConnectionAnalyzer,
+} from './PeerConnectionAnalyzer'
+
+/**
+ * Analyzer for the quality of the connections of a Participant.
+ *
+ * After a ParticipantAnalyzer is created the participant to analyze must be set
+ * using any of the "setXXXParticipant" methods; "setSenderReceiverParticipant"
+ * is meant to be used when there is no HPB, while "setSenderParticipant" and
+ * "setReceiverParticipant" are meant to be used when there is an HPB for the
+ * local and remote participants respectively.
+ *
+ * When the quality of the connections change different events will be triggered
+ * depending on the case:
+ * - 'change:senderConnectionQualityAudio'
+ * - 'change:senderConnectionQualityVideo'
+ * - 'change:senderConnectionQualityScreen'
+ * - 'change:receiverConnectionQualityAudio'
+ * - 'change:receiverConnectionQualityVideo'
+ * - 'change:receiverConnectionQualityScreen'
+ *
+ * The reported values are based on CONNECTION_QUALITY values of
+ * PeerConnectionAnalyzer.
+ *
+ * Note that the connections will be analyzed only when the corresponding media
+ * is enabled so, for example, if a sender participant has muted but still has
+ * the video enabled only the video quality will be analyzed until the audio is
+ * unmuted again. This is done not only because the connection quality of media
+ * is less relevant when the media is disabled, but also because the connection
+ * stats provided by the browser and used for the analysis are less reliable in
+ * that case.
+ *
+ * Once the ParticipantAnalyzer is no longer needed "destroy()" must be called
+ * to stop the analysis.
+ */
+function ParticipantAnalyzer() {
+	this._handlers = []
+
+	this._localMediaModel = null
+	this._localCallParticipantModel = null
+	this._callParticipantModel = null
+
+	this._peer = null
+	this._screenPeer = null
+
+	this._senderPeerConnectionAnalyzer = null
+	this._receiverPeerConnectionAnalyzer = null
+	this._senderScreenPeerConnectionAnalyzer = null
+	this._receiverScreenPeerConnectionAnalyzer = null
+
+	this._handlePeerChangeBound = this._handlePeerChange.bind(this)
+	this._handleScreenPeerChangeBound = this._handleScreenPeerChange.bind(this)
+	this._handleSenderAudioEnabledChangeBound = this._handleSenderAudioEnabledChange.bind(this)
+	this._handleSenderVideoEnabledChangeBound = this._handleSenderVideoEnabledChange.bind(this)
+	this._handleReceiverAudioAvailableChangeBound = this._handleReceiverAudioAvailableChange.bind(this)
+	this._handleReceiverVideoAvailableChangeBound = this._handleReceiverVideoAvailableChange.bind(this)
+	this._handleConnectionQualityAudioChangeBound = this._handleConnectionQualityAudioChange.bind(this)
+	this._handleConnectionQualityVideoChangeBound = this._handleConnectionQualityVideoChange.bind(this)
+	this._handleConnectionQualityScreenChangeBound = this._handleConnectionQualityScreenChange.bind(this)
+}
+ParticipantAnalyzer.prototype = {
+
+	on: function(event, handler) {
+		if (!this._handlers.hasOwnProperty(event)) {
+			this._handlers[event] = [handler]
+		} else {
+			this._handlers[event].push(handler)
+		}
+	},
+
+	off: function(event, handler) {
+		const handlers = this._handlers[event]
+		if (!handlers) {
+			return
+		}
+
+		const index = handlers.indexOf(handler)
+		if (index !== -1) {
+			handlers.splice(index, 1)
+		}
+	},
+
+	_trigger: function(event, args) {
+		let handlers = this._handlers[event]
+		if (!handlers) {
+			return
+		}
+
+		args.unshift(this)
+
+		handlers = handlers.slice(0)
+		for (let i = 0; i < handlers.length; i++) {
+			const handler = handlers[i]
+			handler.apply(handler, args)
+		}
+	},
+
+	destroy: function() {
+		if (this._localCallParticipantModel) {
+			this._localCallParticipantModel.off('change:peer', this._handlePeerChangeBound)
+		}
+
+		if (this._callParticipantModel) {
+			this._callParticipantModel.off('change:peer', this._handlePeerChangeBound)
+		}
+
+		this._stopListeningToAudioVideoChanges()
+		this._stopListeningToScreenChanges()
+
+		this._localMediaModel = null
+		this._localCallParticipantModel = null
+		this._callParticipantModel = null
+
+		this._peer = null
+		this._screenPeer = null
+
+		this._senderPeerConnectionAnalyzer = null
+		this._receiverPeerConnectionAnalyzer = null
+		this._senderScreenPeerConnectionAnalyzer = null
+		this._receiverScreenPeerConnectionAnalyzer = null
+	},
+
+	setSenderParticipant: function(localMediaModel, localCallParticipantModel) {
+		this.destroy()
+
+		this._localMediaModel = localMediaModel
+		this._localCallParticipantModel = localCallParticipantModel
+
+		if (this._localCallParticipantModel) {
+			this._senderPeerConnectionAnalyzer = new PeerConnectionAnalyzer()
+			this._senderScreenPeerConnectionAnalyzer = new PeerConnectionAnalyzer()
+
+			this._localCallParticipantModel.on('change:peer', this._handlePeerChangeBound)
+			this._handlePeerChange(this._localCallParticipantModel, this._localCallParticipantModel.get('peer'))
+
+			this._localCallParticipantModel.on('change:screenPeer', this._handleScreenPeerChangeBound)
+			this._handleScreenPeerChange(this._localCallParticipantModel, this._localCallParticipantModel.get('screenPeer'))
+		}
+	},
+
+	setReceiverParticipant: function(callParticipantModel) {
+		this.destroy()
+
+		this._callParticipantModel = callParticipantModel
+
+		if (this._callParticipantModel) {
+			this._receiverPeerConnectionAnalyzer = new PeerConnectionAnalyzer()
+			this._receiverScreenPeerConnectionAnalyzer = new PeerConnectionAnalyzer()
+
+			this._callParticipantModel.on('change:peer', this._handlePeerChangeBound)
+			this._handlePeerChange(this._callParticipantModel, this._callParticipantModel.get('peer'))
+
+			this._callParticipantModel.on('change:screenPeer', this._handleScreenPeerChangeBound)
+			this._handleScreenPeerChange(this._callParticipantModel, this._callParticipantModel.get('screenPeer'))
+		}
+	},
+
+	setSenderReceiverParticipant: function(localMediaModel, callParticipantModel) {
+		this.destroy()
+
+		this._localMediaModel = localMediaModel
+		this._callParticipantModel = callParticipantModel
+
+		if (this._callParticipantModel) {
+			this._senderPeerConnectionAnalyzer = new PeerConnectionAnalyzer()
+			this._receiverPeerConnectionAnalyzer = new PeerConnectionAnalyzer()
+			this._senderScreenPeerConnectionAnalyzer = new PeerConnectionAnalyzer()
+			this._receiverScreenPeerConnectionAnalyzer = new PeerConnectionAnalyzer()
+
+			this._callParticipantModel.on('change:peer', this._handlePeerChangeBound)
+			this._handlePeerChange(this._callParticipantModel, this._callParticipantModel.get('peer'))
+
+			this._callParticipantModel.on('change:screenPeer', this._handleScreenPeerChangeBound)
+			this._handleScreenPeerChange(this._callParticipantModel, this._callParticipantModel.get('screenPeer'))
+		}
+	},
+
+	_handlePeerChange: function(model, peer) {
+		this._peer = peer
+
+		if (peer) {
+			this._startListeningToAudioVideoChanges()
+		} else {
+			this._stopListeningToAudioVideoChanges()
+		}
+	},
+
+	_handleScreenPeerChange: function(model, screenPeer) {
+		this._screenPeer = screenPeer
+
+		if (screenPeer) {
+			this._startListeningToScreenChanges()
+		} else {
+			this._stopListeningToScreenChanges()
+		}
+	},
+
+	_startListeningToAudioVideoChanges: function() {
+		if (this._localMediaModel) {
+			this._senderPeerConnectionAnalyzer.setPeerConnection(this._peer.pc, PEER_DIRECTION.SENDER)
+
+			this._senderPeerConnectionAnalyzer.on('change:connectionQualityAudio', this._handleConnectionQualityAudioChangeBound)
+			this._senderPeerConnectionAnalyzer.on('change:connectionQualityVideo', this._handleConnectionQualityVideoChangeBound)
+
+			this._localMediaModel.on('change:audioEnabled', this._handleSenderAudioEnabledChangeBound)
+			this._localMediaModel.on('change:videoEnabled', this._handleSenderVideoEnabledChangeBound)
+
+			this._handleSenderAudioEnabledChange(this._localMediaModel, this._localMediaModel.get('audioEnabled'))
+			this._handleSenderVideoEnabledChange(this._localMediaModel, this._localMediaModel.get('videoEnabled'))
+		}
+
+		if (this._callParticipantModel) {
+			this._receiverPeerConnectionAnalyzer.setPeerConnection(this._peer.pc, PEER_DIRECTION.RECEIVER)
+
+			this._receiverPeerConnectionAnalyzer.on('change:connectionQualityAudio', this._handleConnectionQualityAudioChangeBound)
+			this._receiverPeerConnectionAnalyzer.on('change:connectionQualityVideo', this._handleConnectionQualityVideoChangeBound)
+
+			this._callParticipantModel.on('change:audioAvailable', this._handleReceiverAudioAvailableChangeBound)
+			this._callParticipantModel.on('change:videoAvailable', this._handleReceiverVideoAvailableChangeBound)
+
+			this._handleReceiverAudioAvailableChange(this._localMediaModel, this._callParticipantModel.get('audioAvailable'))
+			this._handleReceiverVideoAvailableChange(this._localMediaModel, this._callParticipantModel.get('videoAvailable'))
+		}
+	},
+
+	_startListeningToScreenChanges: function() {
+		if (this._localMediaModel) {
+			this._senderScreenPeerConnectionAnalyzer.setPeerConnection(this._screenPeer.pc, PEER_DIRECTION.SENDER)
+
+			this._senderScreenPeerConnectionAnalyzer.on('change:connectionQualityVideo', this._handleConnectionQualityScreenChangeBound)
+		}
+
+		if (this._callParticipantModel) {
+			this._receiverScreenPeerConnectionAnalyzer.setPeerConnection(this._screenPeer.pc, PEER_DIRECTION.RECEIVER)
+
+			this._receiverScreenPeerConnectionAnalyzer.on('change:connectionQualityVideo', this._handleConnectionQualityScreenChangeBound)
+		}
+	},
+
+	_stopListeningToAudioVideoChanges: function() {
+		if (this._localMediaModel) {
+			this._senderPeerConnectionAnalyzer.setPeerConnection(null)
+
+			this._senderPeerConnectionAnalyzer.off('change:connectionQualityAudio', this._handleConnectionQualityAudioChangeBound)
+			this._senderPeerConnectionAnalyzer.off('change:connectionQualityVideo', this._handleConnectionQualityVideoChangeBound)
+
+			this._localMediaModel.off('change:audioEnabled', this._handleSenderAudioEnabledChangeBound)
+			this._localMediaModel.off('change:videoEnabled', this._handleSenderVideoEnabledChangeBound)
+		}
+
+		if (this._callParticipantModel) {
+			this._receiverPeerConnectionAnalyzer.setPeerConnection(null)
+
+			this._receiverPeerConnectionAnalyzer.off('change:connectionQualityAudio', this._handleConnectionQualityAudioChangeBound)
+			this._receiverPeerConnectionAnalyzer.off('change:connectionQualityVideo', this._handleConnectionQualityVideoChangeBound)
+
+			this._callParticipantModel.off('change:audioAvailable', this._handleReceiverAudioAvailableChangeBound)
+			this._callParticipantModel.off('change:videoAvailable', this._handleReceiverVideoAvailableChangeBound)
+		}
+	},
+
+	_stopListeningToScreenChanges: function() {
+		if (this._localMediaModel) {
+			this._senderScreenPeerConnectionAnalyzer.setPeerConnection(null)
+
+			this._senderPeerConnectionAnalyzer.off('change:connectionQualityVideo', this._handleConnectionQualityScreenChangeBound)
+		}
+
+		if (this._callParticipantModel) {
+			this._receiverScreenPeerConnectionAnalyzer.setPeerConnection(null)
+
+			this._receiverPeerConnectionAnalyzer.off('change:connectionQualityVideo', this._handleConnectionQualityScreenChangeBound)
+		}
+	},
+
+	_handleConnectionQualityAudioChange: function(peerConnectionAnalyzer, connectionQualityAudio) {
+		if (peerConnectionAnalyzer === this._senderPeerConnectionAnalyzer) {
+			this._trigger('change:senderConnectionQualityAudio', [connectionQualityAudio])
+		} else if (peerConnectionAnalyzer === this._receiverPeerConnectionAnalyzer) {
+			this._trigger('change:receiverConnectionQualityAudio', [connectionQualityAudio])
+		}
+	},
+
+	_handleConnectionQualityVideoChange: function(peerConnectionAnalyzer, connectionQualityVideo) {
+		if (peerConnectionAnalyzer === this._senderPeerConnectionAnalyzer) {
+			this._trigger('change:senderConnectionQualityVideo', [connectionQualityVideo])
+		} else if (peerConnectionAnalyzer === this._receiverPeerConnectionAnalyzer) {
+			this._trigger('change:receiverConnectionQualityVideo', [connectionQualityVideo])
+		}
+	},
+
+	_handleConnectionQualityScreenChange: function(peerConnectionAnalyzer, connectionQualityScreen) {
+		if (peerConnectionAnalyzer === this._senderScreenPeerConnectionAnalyzer) {
+			this._trigger('change:senderConnectionQualityScreen', [connectionQualityScreen])
+		} else if (peerConnectionAnalyzer === this._receiverScreenPeerConnectionAnalyzer) {
+			this._trigger('change:receiverConnectionQualityScreen', [connectionQualityScreen])
+		}
+	},
+
+	_handleSenderAudioEnabledChange: function(localMediaModel, audioEnabled) {
+		this._senderPeerConnectionAnalyzer.setAnalysisEnabledAudio(audioEnabled)
+	},
+
+	_handleSenderVideoEnabledChange: function(localMediaModel, videoEnabled) {
+		this._senderPeerConnectionAnalyzer.setAnalysisEnabledVideo(videoEnabled)
+	},
+
+	_handleReceiverAudioAvailableChange: function(callParticipantModel, audioAvailable) {
+		this._receiverPeerConnectionAnalyzer.setAnalysisEnabledAudio(audioAvailable)
+	},
+
+	_handleReceiverVideoAvailableChange: function(callParticipantModel, videoAvailable) {
+		this._receiverPeerConnectionAnalyzer.setAnalysisEnabledVideo(videoAvailable)
+	},
+
+}
+
+export {
+	ParticipantAnalyzer,
+}

--- a/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
+++ b/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
@@ -1,0 +1,432 @@
+/**
+ *
+ * @copyright Copyright (c) 2020, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import {
+	STAT_VALUE_TYPE,
+	AverageStatValue,
+} from './AverageStatValue'
+
+const CONNECTION_QUALITY = {
+	UNKNOWN: 0,
+	GOOD: 1,
+	MEDIUM: 2,
+	BAD: 3,
+	VERY_BAD: 4,
+	NO_TRANSMITTED_DATA: 5,
+}
+
+const PEER_DIRECTION = {
+	SENDER: 0,
+	RECEIVER: 1,
+}
+
+/**
+ * Analyzer for the quality of the connection of an RTCPeerConnection.
+ *
+ * After creation "setPeerConnection(RTCPeerConnection)" must be called to set
+ * the RTCPeerConnection to analyze. The analysis will start and stop
+ * automatically based on the connection state, except when closed. Suprisingly,
+ * "iceConnectionStateChange" is not called when the ICE connection state
+ * changes to closed, so the change can not be detected from the
+ * PeerConnectionAnalyzer. This change can be detected from the signaling,
+ * though, and thus must be handled by the user of this class by calling
+ * "setPeerConnection(null)" to stop the analysis. Similarly,
+ * "setPeerConnection(null)" must be called too if the RTCPeerConnection is
+ * active but the analyzer is no longer needed.
+ *
+ * The reported connection quality is mainly based on the packets lost ratio,
+ * but also in other stats, like the amount of transmitted packets. UNKNOWN is
+ * used when the analysis is started or stopped (including when it is done
+ * automatically due to changes in the ICE connection status). In general even
+ * if the quality of the connection is bad WebRTC is able to keep audio and
+ * video at acceptable quality levels; only when the reported connection quality
+ * is very bad or no data is transmitted at all the audio and video quality may
+ * not be enough.
+ */
+function PeerConnectionAnalyzer() {
+	this._packets = {
+		'audio': new AverageStatValue(5, STAT_VALUE_TYPE.CUMULATIVE),
+		'video': new AverageStatValue(5, STAT_VALUE_TYPE.CUMULATIVE),
+	}
+	this._packetsLost = {
+		'audio': new AverageStatValue(5, STAT_VALUE_TYPE.CUMULATIVE),
+		'video': new AverageStatValue(5, STAT_VALUE_TYPE.CUMULATIVE),
+	}
+	this._packetsLostRatio = {
+		'audio': new AverageStatValue(5, STAT_VALUE_TYPE.RELATIVE),
+		'video': new AverageStatValue(5, STAT_VALUE_TYPE.RELATIVE),
+	}
+	this._packetsPerSecond = {
+		'audio': new AverageStatValue(5, STAT_VALUE_TYPE.RELATIVE),
+		'video': new AverageStatValue(5, STAT_VALUE_TYPE.RELATIVE),
+	}
+	// Only the last relative value is used, but as it is a cumulative value the
+	// previous one is needed as a base to calculate the last one.
+	this._timestamps = {
+		'audio': new AverageStatValue(2, STAT_VALUE_TYPE.CUMULATIVE),
+		'video': new AverageStatValue(2, STAT_VALUE_TYPE.CUMULATIVE),
+	}
+
+	this._peerConnection = null
+	this._peerDirection = null
+
+	this._getStatsInterval = null
+
+	this._handleIceConnectionStateChangedBound = this._handleIceConnectionStateChanged.bind(this)
+	this._processStatsBound = this._processStats.bind(this)
+
+	this._connectionQualityAudio = CONNECTION_QUALITY.UNKNOWN
+	this._connectionQualityVideo = CONNECTION_QUALITY.UNKNOWN
+}
+PeerConnectionAnalyzer.prototype = {
+
+	getConnectionQualityAudio: function() {
+		return this._connectionQualityAudio
+	},
+
+	getConnectionQualityVideo: function() {
+		return this._connectionQualityVideo
+	},
+
+	_setConnectionQualityAudio: function(connectionQualityAudio) {
+		this._connectionQualityAudio = connectionQualityAudio
+	},
+
+	_setConnectionQualityVideo: function(connectionQualityVideo) {
+		this._connectionQualityVideo = connectionQualityVideo
+	},
+
+	setPeerConnection: function(peerConnection, peerDirection = null) {
+		if (this._peerConnection) {
+			this._peerConnection.removeEventListener('iceconnectionstatechange', this._handleIceConnectionStateChangedBound)
+			this._stopGetStatsInterval()
+		}
+
+		this._peerConnection = peerConnection
+		this._peerDirection = peerDirection
+
+		if (this._peerConnection) {
+			this._peerConnection.addEventListener('iceconnectionstatechange', this._handleIceConnectionStateChangedBound)
+			this._handleIceConnectionStateChangedBound()
+		}
+	},
+
+	_handleIceConnectionStateChanged: function() {
+		// Note that even if the ICE connection state is "disconnected" the
+		// connection is actually active, media is still transmitted, and the
+		// stats are properly updated.
+		if (!this._peerConnection || (this._peerConnection.iceConnectionState !== 'connected' && this._peerConnection.iceConnectionState !== 'completed' && this._peerConnection.iceConnectionState !== 'disconnected')) {
+			this._setConnectionQualityAudio(CONNECTION_QUALITY.UNKNOWN)
+			this._setConnectionQualityVideo(CONNECTION_QUALITY.UNKNOWN)
+
+			this._stopGetStatsInterval()
+
+			return
+		}
+
+		if (this._getStatsInterval) {
+			// Already active, nothing to do.
+			return
+		}
+
+		this._getStatsInterval = window.setInterval(() => {
+			this._peerConnection.getStats().then(this._processStatsBound)
+		}, 1000)
+	},
+
+	_stopGetStatsInterval: function() {
+		window.clearInterval(this._getStatsInterval)
+		this._getStatsInterval = null
+	},
+
+	_processStats: function(stats) {
+		if (!this._peerConnection || (this._peerConnection.iceConnectionState !== 'connected' && this._peerConnection.iceConnectionState !== 'completed' && this._peerConnection.iceConnectionState !== 'disconnected')) {
+			return
+		}
+
+		if (this._peerDirection === PEER_DIRECTION.SENDER) {
+			this._processSenderStats(stats)
+		} else if (this._peerDirection === PEER_DIRECTION.RECEIVER) {
+			this._processReceiverStats(stats)
+		}
+
+		this._setConnectionQualityAudio(this._calculateConnectionQualityAudio())
+		this._setConnectionQualityVideo(this._calculateConnectionQualityVideo())
+	},
+
+	_processSenderStats: function(stats) {
+		// Packets are calculated as "packetsReceived + packetsLost" or as
+		// "packetsSent" depending on the browser (see below).
+		const packets = {
+			'audio': -1,
+			'video': -1,
+		}
+
+		// Packets stats for a sender are checked from the point of view of the
+		// receiver.
+		const packetsReceived = {
+			'audio': -1,
+			'video': -1,
+		}
+
+		const packetsLost = {
+			'audio': -1,
+			'video': -1,
+		}
+
+		// If "packetsReceived" is not available (like in Chromium) use
+		// "packetsSent" instead; it may be measured at a different time from
+		// the received statistics, so checking "packetsLost" against it may not
+		// be fully accurate, but it should be close enough.
+		const packetsSent = {
+			'audio': -1,
+			'video': -1,
+		}
+
+		// Timestamp is set to "timestampReceived" or "timestampSent" depending
+		// on how "packets" were calculated.
+		const timestamp = {
+			'audio': -1,
+			'video': -1,
+		}
+
+		const timestampReceived = {
+			'audio': -1,
+			'video': -1,
+		}
+
+		const timestampSent = {
+			'audio': -1,
+			'video': -1,
+		}
+
+		for (const stat of stats.values()) {
+			if (stat.type === 'outbound-rtp') {
+				if ('packetsSent' in stat && 'kind' in stat) {
+					packetsSent[stat.kind] = stat.packetsSent
+
+					if ('timestamp' in stat && 'kind' in stat) {
+						timestampSent[stat.kind] = stat.timestamp
+					}
+				}
+			} else if (stat.type === 'remote-inbound-rtp') {
+				if ('packetsReceived' in stat && 'kind' in stat) {
+					packetsReceived[stat.kind] = stat.packetsReceived
+
+					if ('timestamp' in stat && 'kind' in stat) {
+						timestampReceived[stat.kind] = stat.timestamp
+					}
+				}
+				if ('packetsLost' in stat && 'kind' in stat) {
+					packetsLost[stat.kind] = stat.packetsLost
+				}
+			}
+		}
+
+		for (const kind of ['audio', 'video']) {
+			if (packetsReceived[kind] >= 0 && packetsLost[kind] >= 0) {
+				packets[kind] = packetsReceived[kind] + packetsLost[kind]
+				timestamp[kind] = timestampReceived[kind]
+			} else if (packetsSent[kind] >= 0) {
+				packets[kind] = packetsSent[kind]
+				timestamp[kind] = timestampSent[kind]
+			}
+
+			// In some (strange) cases a newer stat may report a lower value
+			// than a previous one (it seems to happen if the connection delay
+			// is high; probably the browser assumes that a packet was lost but
+			// later receives the acknowledgment). If that happens just keep the
+			// previous value to prevent distorting the analysis with negative
+			// ratios of lost packets.
+			if (packetsLost[kind] >= 0 && packetsLost[kind] < this._packetsLost[kind].getLastRawValue()) {
+				packetsLost[kind] = this._packetsLost[kind].getLastRawValue()
+			}
+
+			if (packets[kind] >= 0) {
+				this._packets[kind].add(packets[kind])
+			}
+			if (packetsLost[kind] >= 0) {
+				this._packetsLost[kind].add(packetsLost[kind])
+			}
+			if (packets[kind] >= 0 && packetsLost[kind] >= 0) {
+				// The packet stats are cumulative values, so the isolated
+				// values are got from the helper object.
+				// If there were no transmitted packets in the last stats the
+				// ratio is higher than 1 both to signal that and to force the
+				// quality towards a very bad quality faster, but not
+				// immediately.
+				let packetsLostRatio = 1.5
+				if (this._packets[kind].getLastRelativeValue() > 0) {
+					packetsLostRatio = this._packetsLost[kind].getLastRelativeValue() / this._packets[kind].getLastRelativeValue()
+				}
+				this._packetsLostRatio[kind].add(packetsLostRatio)
+			}
+			if (timestamp[kind] >= 0) {
+				this._timestamps[kind].add(timestamp[kind])
+			}
+			if (packets[kind] >= 0 && timestamp[kind] >= 0) {
+				const elapsedSeconds = this._timestamps[kind].getLastRelativeValue() / 1000
+				// The packet stats are cumulative values, so the isolated
+				// values are got from the helper object.
+				const packetsPerSecond = this._packets[kind].getLastRelativeValue() / elapsedSeconds
+				this._packetsPerSecond[kind].add(packetsPerSecond)
+			}
+		}
+	},
+
+	_processReceiverStats: function(stats) {
+		// Packets are calculated as "packetsReceived + packetsLost".
+		const packets = {
+			'audio': -1,
+			'video': -1,
+		}
+
+		const packetsReceived = {
+			'audio': -1,
+			'video': -1,
+		}
+
+		const packetsLost = {
+			'audio': -1,
+			'video': -1,
+		}
+
+		const timestamp = {
+			'audio': -1,
+			'video': -1,
+		}
+
+		for (const stat of stats.values()) {
+			if (stat.type === 'inbound-rtp') {
+				if ('packetsReceived' in stat && 'kind' in stat) {
+					packetsReceived[stat.kind] = stat.packetsReceived
+				}
+				if ('packetsLost' in stat && 'kind' in stat) {
+					packetsLost[stat.kind] = stat.packetsLost
+				}
+				if ('timestamp' in stat && 'kind' in stat) {
+					timestamp[stat.kind] = stat.timestamp
+				}
+			}
+		}
+
+		for (const kind of ['audio', 'video']) {
+			if (packetsReceived[kind] >= 0 && packetsLost[kind] >= 0) {
+				packets[kind] = packetsReceived[kind] + packetsLost[kind]
+			}
+
+			// In some (strange) cases a newer stat may report a lower value
+			// than a previous one (it seems to happen if the connection delay
+			// is high; probably the browser assumes that a packet was lost but
+			// later receives the acknowledgment). If that happens just keep the
+			// previous value to prevent distorting the analysis with negative
+			// ratios of lost packets.
+			if (packetsLost[kind] >= 0 && packetsLost[kind] < this._packetsLost[kind].getLastRawValue()) {
+				packetsLost[kind] = this._packetsLost[kind].getLastRawValue()
+			}
+
+			if (packets[kind] >= 0) {
+				this._packets[kind].add(packets[kind])
+			}
+			if (packetsLost[kind] >= 0) {
+				this._packetsLost[kind].add(packetsLost[kind])
+			}
+			if (packets[kind] >= 0 && packetsLost[kind] >= 0) {
+				// The packet stats are cumulative values, so the isolated
+				// values are got from the helper object.
+				// If there were no transmitted packets in the last stats the
+				// ratio is higher than 1 both to signal that and to force the
+				// quality towards a very bad quality faster, but not
+				// immediately.
+				let packetsLostRatio = 1.5
+				if (this._packets[kind].getLastRelativeValue() > 0) {
+					packetsLostRatio = this._packetsLost[kind].getLastRelativeValue() / this._packets[kind].getLastRelativeValue()
+				}
+				this._packetsLostRatio[kind].add(packetsLostRatio)
+			}
+			if (timestamp[kind] >= 0) {
+				this._timestamps[kind].add(timestamp[kind])
+			}
+			if (packets[kind] >= 0 && timestamp[kind] >= 0) {
+				const elapsedSeconds = this._timestamps[kind].getLastRelativeValue() / 1000
+				// The packet stats are cumulative values, so the isolated
+				// values are got from the helper object.
+				const packetsPerSecond = this._packets[kind].getLastRelativeValue() / elapsedSeconds
+				this._packetsPerSecond[kind].add(packetsPerSecond)
+			}
+		}
+	},
+
+	_calculateConnectionQualityAudio: function() {
+		return this._calculateConnectionQuality(this._packetsLostRatio['audio'], this._packetsPerSecond['audio'])
+	},
+
+	_calculateConnectionQualityVideo: function() {
+		return this._calculateConnectionQuality(this._packetsLostRatio['video'], this._packetsPerSecond['video'])
+	},
+
+	_calculateConnectionQuality: function(packetsLostRatio, packetsPerSecond) {
+		if (!packetsLostRatio.hasEnoughData() || !packetsPerSecond.hasEnoughData()) {
+			return CONNECTION_QUALITY.UNKNOWN
+		}
+
+		const packetsLostRatioWeightedAverage = packetsLostRatio.getWeightedAverage()
+		if (packetsLostRatioWeightedAverage >= 1) {
+			return CONNECTION_QUALITY.NO_TRANSMITTED_DATA
+		}
+
+		// In some cases there may be packets being transmitted without any lost
+		// packet, but if the number of packets is too low the connection is
+		// most likely in bad shape anyway.
+		// Note that in the case of video the number of transmitted packets
+		// depend on the resolution, frame rate and changes between frames, but
+		// even for a small (320x420) static video around 20 packets are
+		// transmitted on a good connection. If a high quality video is tried to
+		// be sent on a bad network the browser will automatically reduce its
+		// quality to keep a smooth video, albeit on a lower resolution. Thus
+		// with a threshold of 10 packets issues can be detected too for videos,
+		// although only once they can not be further downscaled.
+		if (packetsPerSecond.getWeightedAverage() < 10) {
+			return CONNECTION_QUALITY.VERY_BAD
+		}
+
+		if (packetsLostRatioWeightedAverage > 0.3) {
+			return CONNECTION_QUALITY.VERY_BAD
+		}
+
+		if (packetsLostRatioWeightedAverage > 0.2) {
+			return CONNECTION_QUALITY.BAD
+		}
+
+		if (packetsLostRatioWeightedAverage > 0.1) {
+			return CONNECTION_QUALITY.MEDIUM
+		}
+
+		return CONNECTION_QUALITY.GOOD
+	},
+
+}
+
+export {
+	CONNECTION_QUALITY,
+	PEER_DIRECTION,
+	PeerConnectionAnalyzer,
+}

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -123,7 +123,7 @@ function setupWebRtc() {
 
 	const _signaling = signaling
 
-	webRtc = initWebRtc(_signaling, callParticipantCollection)
+	webRtc = initWebRtc(_signaling, callParticipantCollection, localCallParticipantModel)
 	localCallParticipantModel.setWebRtc(webRtc)
 	localMediaModel.setWebRtc(webRtc)
 

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -23,6 +23,7 @@ import Axios from '@nextcloud/axios'
 import CancelableRequest from '../cancelableRequest'
 import Signaling from '../signaling'
 import initWebRtc from './webrtc'
+import CallAnalyzer from './analyzers/CallAnalyzer'
 import CallParticipantCollection from './models/CallParticipantCollection'
 import LocalCallParticipantModel from './models/LocalCallParticipantModel'
 import LocalMediaModel from './models/LocalMediaModel'
@@ -34,6 +35,7 @@ let webRtc = null
 const callParticipantCollection = new CallParticipantCollection()
 const localCallParticipantModel = new LocalCallParticipantModel()
 const localMediaModel = new LocalMediaModel()
+let callAnalyzer = null
 let sentVideoQualityThrottler = null
 
 let cancelFetchSignalingSettings = null
@@ -163,6 +165,12 @@ async function signalingJoinCall(token) {
 
 		sentVideoQualityThrottler = new SentVideoQualityThrottler(localMediaModel, callParticipantCollection)
 
+		if (signaling.hasFeature('mcu')) {
+			callAnalyzer = new CallAnalyzer(localMediaModel, localCallParticipantModel, callParticipantCollection)
+		} else {
+			callAnalyzer = new CallAnalyzer(localMediaModel, null, callParticipantCollection)
+		}
+
 		return new Promise((resolve, reject) => {
 			startedCall = resolve
 			failedToStartCall = reject
@@ -181,6 +189,9 @@ async function signalingJoinCall(token) {
 async function signalingLeaveCall(token) {
 	sentVideoQualityThrottler.destroy()
 	sentVideoQualityThrottler = null
+
+	callAnalyzer.destroy()
+	callAnalyzer = null
 
 	if (tokensInSignaling[token]) {
 		await signaling.leaveCall(token)
@@ -213,6 +224,8 @@ export {
 	callParticipantCollection,
 	localCallParticipantModel,
 	localMediaModel,
+
+	callAnalyzer,
 
 	signalingJoinConversation,
 	signalingJoinCall,

--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -305,7 +305,7 @@ CallParticipantModel.prototype = {
 	},
 
 	setScreenPeer: function(screenPeer) {
-		if (this.get('peerId') !== screenPeer.id) {
+		if (screenPeer && this.get('peerId') !== screenPeer.id) {
 			console.warn('Mismatch between stored peer ID and ID of given screen peer: ', this.get('peerId'), screenPeer.id)
 		}
 

--- a/src/utils/webrtc/models/LocalCallParticipantModel.js
+++ b/src/utils/webrtc/models/LocalCallParticipantModel.js
@@ -25,6 +25,8 @@ export default function LocalCallParticipantModel() {
 
 	this.attributes = {
 		peerId: null,
+		peer: null,
+		screenPeer: null,
 		guestName: null,
 	}
 
@@ -36,8 +38,14 @@ export default function LocalCallParticipantModel() {
 
 LocalCallParticipantModel.prototype = {
 
+	get: function(key) {
+		return this.attributes[key]
+	},
+
 	set: function(key, value) {
 		this.attributes[key] = value
+
+		this._trigger('change:' + key, [value])
 	},
 
 	on: function(event, handler) {
@@ -92,6 +100,22 @@ LocalCallParticipantModel.prototype = {
 
 		this._webRtc.on('forcedMute', this._handleForcedMuteBound)
 		this._unwatchDisplayNameChange = store.watch(state => state.actorStore.displayName, this.setGuestName.bind(this))
+	},
+
+	setPeer: function(peer) {
+		if (peer && this.get('peerId') !== peer.id) {
+			console.warn('Mismatch between stored peer ID and ID of given peer: ', this.get('peerId'), peer.id)
+		}
+
+		this.set('peer', peer)
+	},
+
+	setScreenPeer: function(screenPeer) {
+		if (screenPeer && this.get('peerId') !== screenPeer.id) {
+			console.warn('Mismatch between stored peer ID and ID of given screen peer: ', this.get('peerId'), screenPeer.id)
+		}
+
+		this.set('screenPeer', screenPeer)
 	},
 
 	setGuestName: function(guestName) {

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -41,6 +41,7 @@ let ownScreenPeer = null
 let selfInCall = PARTICIPANT.CALL_FLAG.DISCONNECTED
 const delayedConnectionToPeer = []
 let callParticipantCollection = null
+let localCallParticipantModel = null
 let showedTURNWarning = false
 
 function arrayDiff(a, b) {
@@ -72,6 +73,8 @@ function createScreensharingPeer(signaling, sessionId) {
 		})
 		webrtc.emit('createdPeer', ownScreenPeer)
 		ownScreenPeer.start()
+
+		localCallParticipantModel.setScreenPeer(ownScreenPeer)
 	}
 
 	if (sessionId === currentSessionId) {
@@ -134,6 +137,8 @@ function checkStartPublishOwnPeer(signaling) {
 	})
 	webrtc.emit('createdPeer', ownPeer)
 	ownPeer.start()
+
+	localCallParticipantModel.setPeer(ownPeer)
 }
 
 function userHasStreams(user) {
@@ -308,8 +313,9 @@ function usersInCallChanged(signaling, users) {
 	}
 }
 
-export default function initWebRTC(signaling, _callParticipantCollection) {
+export default function initWebRTC(signaling, _callParticipantCollection, _localCallParticipantModel) {
 	callParticipantCollection = _callParticipantCollection
+	localCallParticipantModel = _localCallParticipantModel
 
 	signaling.on('usersLeft', function(users) {
 		users.forEach(function(user) {
@@ -733,6 +739,8 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 			webrtc.removePeers(ownPeer.id)
 			ownPeer.end()
 			ownPeer = null
+
+			localCallParticipantModel.setPeer(ownPeer)
 		}
 
 		usersChanged(signaling, [], previousUsersInRoom)
@@ -931,6 +939,8 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 		if (ownScreenPeer) {
 			ownScreenPeer = null
 
+			localCallParticipantModel.setScreenPeer(ownScreenPeer)
+
 			signaling.sendRoomMessage({
 				roomType: 'screen',
 				type: 'unshareScreen',
@@ -943,11 +953,15 @@ export default function initWebRTC(signaling, _callParticipantCollection) {
 			webrtc.removePeers(ownPeer.id)
 			ownPeer.end()
 			ownPeer = null
+
+			localCallParticipantModel.setPeer(ownPeer)
 		}
 
 		if (ownScreenPeer) {
 			ownScreenPeer.end()
 			ownScreenPeer = null
+
+			localCallParticipantModel.setScreenPeer(ownScreenPeer)
 		}
 
 		selfInCall = PARTICIPANT.CALL_FLAG.DISCONNECTED


### PR DESCRIPTION
This shows a warning icon and a tooltip when the HPB is used and the connection quality of the sent audio is very bad (enough to most likely cause robo voice, or no voice at all). Similarly the quality of the video and/or the screen are also checked and a warning is shown if it is likely that the video is not smooth.

The analyzer checks the RTC stats, so it explicitly checks the network load, but it implicitly checks the system load too, as in that case there will be also packet losses and higher round trip times.

Please refer to the code documentation for details.

Pending:
- [X] Rebase and fix up
- [X] Clean TODOs
- [X] Add code documentation
- [X] A different way to warn the user? Maybe dimming the local container for the avatar and the video?
- [X] Prevent the warning to be shown and hidden repeteadly when the connection oscillates between bad and very bad - The tooltip is no longer repeteadly shown and hidden, and the warning icon is not immediately hidden again if it was just shown. It would be better if the analyzer could detect a repeated oscillation between two quality levels and only report one of them (yet being able to report the other one if the conditions change), but I think that the current approach is good enough (as it should not be a very common scenario anyway).
- [X] ~~Try to be smart when the connection quality is bad and automatically reduce the video quality or disable it? If done, definitely in a follow up pull request.~~  - After some more thought I would not do this. If the connection quality is bad the browser will automatically reduce the video quality and increase it again once possible, and disabling the video could be too intrusive; if the user is notified that disabling the video could improve the situation and she does not disable it we should not decide for the user.

Follow up pull request:
- Warn the user too when the connection quality of the received audio is bad, and when the sent audio is bad and the HPB is not used. The problem is that the browser generates the RTP stats in bursts (it may not report any lost packet in 5 seconds and then all of a sudden report all the previous lost packets, so even if the stats are smoothed the analysis is not reliable). I have an idea to handle that, but it will be probably done in a follow up pull request.
