### PR TITLE
Replace OC.Util.formatDate with the actual moment function

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -84,6 +84,7 @@ import Quote from '../../../Quote'
 import { EventBus } from '../../../../services/EventBus'
 import emojiRegex from 'emoji-regex'
 import { PARTICIPANT } from '../../../../constants'
+import moment from '@nextcloud/moment'
 
 export default {
 	name: 'Message',
@@ -217,7 +218,7 @@ export default {
 		},
 
 		messageTime() {
-			return OC.Util.formatDate(this.timestamp * 1000, 'LT')
+			return moment(this.timestamp * 1000).format('LT')
 		},
 		quote() {
 			return this.parent && this.$store.getters.message(this.token, this.parent)


### PR DESCRIPTION
See:
https://github.com/nextcloud/server/blob/eaf4724acc3b4720239d789f6028526945b8bba0/core/src/OC/util.js#L119-L123

`@nextcloud/moment` is already included in our package anyway

Less log spam with chat messages