### PR TITLE
Correctly initialise blur in chrome/chromium

### DIFF
--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -21,7 +21,9 @@
 
 <template>
 	<div class="video-backgroundbackground">
-		<div class="darken">
+		<div
+			ref="darkener"
+			class="darken">
 			<ResizeObserver
 				v-if="gridBlur === ''"
 				class="observer"
@@ -101,6 +103,16 @@ export default {
 			}
 		} catch (exception) {
 			console.debug(exception)
+		}
+	},
+
+	async mounted() {
+		if (!this.gridBlur) {
+			// Initialise blur
+			this.setBlur({
+				width: this.$refs['darkener'].clientWidth,
+				height: this.$refs['darkener'].clientHeight,
+			})
 		}
 	},
 


### PR DESCRIPTION
Before bluring of local avatars is missing in Chrome/Chromium after toggling between grid view and promoted view.