### PR TITLE
🍱 Dashboard adaption for Nextcloud 20

### DIFF
--- a/css/icons.scss
+++ b/css/icons.scss
@@ -11,6 +11,7 @@
 
 .app-talk,
 .talk-modal,
+#talk-panel,
 #talk-sidebar,
 #call-container,
 .talkChatTab {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -35,6 +35,7 @@ use OCA\Talk\Collaboration\Collaborators\Listener as CollaboratorsListener;
 use OCA\Talk\Collaboration\Resources\ConversationProvider;
 use OCA\Talk\Collaboration\Resources\Listener as ResourceListener;
 use OCA\Talk\Config;
+use OCA\Talk\Dashboard\TalkPanel;
 use OCA\Talk\Events\ChatEvent;
 use OCA\Talk\Events\RoomEvent;
 use OCA\Talk\Files\Listener as FilesListener;
@@ -95,6 +96,8 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(\OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent::class, UnifiedSearchCSSLoader::class);
 
 		$context->registerSearchProvider(ConversationSearch::class);
+
+		$context->registerDashboardPanel(TalkPanel::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -35,7 +35,7 @@ use OCA\Talk\Collaboration\Collaborators\Listener as CollaboratorsListener;
 use OCA\Talk\Collaboration\Resources\ConversationProvider;
 use OCA\Talk\Collaboration\Resources\Listener as ResourceListener;
 use OCA\Talk\Config;
-use OCA\Talk\Dashboard\TalkPanel;
+use OCA\Talk\Dashboard\TalkWidget;
 use OCA\Talk\Events\ChatEvent;
 use OCA\Talk\Events\RoomEvent;
 use OCA\Talk\Files\Listener as FilesListener;
@@ -97,7 +97,7 @@ class Application extends App implements IBootstrap {
 
 		$context->registerSearchProvider(ConversationSearch::class);
 
-		$context->registerDashboardPanel(TalkPanel::class);
+		$context->registerDashboardWidget(TalkWidget::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Dashboard/TalkPanel.php
+++ b/lib/Dashboard/TalkPanel.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Dashboard;
+
+
+class TalkPanel implements \OCP\Dashboard\IPanel {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getId(): string {
+		return 'spreed';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getTitle(): string {
+		return 'Talk';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getOrder(): int {
+		return 10;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getIconClass(): string {
+		return 'icon-talk';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getUrl(): ?string {
+		return \OC::$server->getURLGenerator()->getAbsoluteURL('/apps/spreed');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function load(): void {
+		\OC_Util::addScript('spreed', 'dashboard');
+	}
+}

--- a/lib/Dashboard/TalkPanel.php
+++ b/lib/Dashboard/TalkPanel.php
@@ -23,8 +23,18 @@
 
 namespace OCA\Talk\Dashboard;
 
+use OCP\IL10N;
 
 class TalkPanel implements \OCP\Dashboard\IPanel {
+
+	/** @var IL10N */
+	private $l10n;
+
+	public function __construct(
+		IL10N $l10n
+	) {
+		$this->l10n = $l10n;
+	}
 
 	/**
 	 * @inheritDoc
@@ -37,7 +47,7 @@ class TalkPanel implements \OCP\Dashboard\IPanel {
 	 * @inheritDoc
 	 */
 	public function getTitle(): string {
-		return 'Talk';
+		return $this->l10n->t('Talk mentions');
 	}
 
 	/**

--- a/lib/Dashboard/TalkPanel.php
+++ b/lib/Dashboard/TalkPanel.php
@@ -24,6 +24,7 @@
 namespace OCA\Talk\Dashboard;
 
 use OCP\IL10N;
+use OCP\Util;
 
 class TalkPanel implements \OCP\Dashboard\IPanel {
 
@@ -75,6 +76,6 @@ class TalkPanel implements \OCP\Dashboard\IPanel {
 	 * @inheritDoc
 	 */
 	public function load(): void {
-		\OC_Util::addScript('spreed', 'dashboard');
+		Util::addScript('spreed', 'dashboard');
 	}
 }

--- a/lib/Dashboard/TalkWidget.php
+++ b/lib/Dashboard/TalkWidget.php
@@ -56,7 +56,7 @@ class TalkWidget implements IWidget {
 	 * @inheritDoc
 	 */
 	public function getTitle(): string {
-		return $this->l10n->t('Conversations');
+		return $this->l10n->t('Talk mentions');
 	}
 
 	/**

--- a/lib/Dashboard/TalkWidget.php
+++ b/lib/Dashboard/TalkWidget.php
@@ -26,7 +26,7 @@ namespace OCA\Talk\Dashboard;
 use OCP\IL10N;
 use OCP\Util;
 
-class TalkPanel implements \OCP\Dashboard\IPanel {
+class TalkWidget implements \OCP\Dashboard\IWidget {
 
 	/** @var IL10N */
 	private $l10n;

--- a/lib/Dashboard/TalkWidget.php
+++ b/lib/Dashboard/TalkWidget.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
  *
@@ -23,17 +25,23 @@
 
 namespace OCA\Talk\Dashboard;
 
+use OCP\Dashboard\IWidget;
 use OCP\IL10N;
+use OCP\IURLGenerator;
 use OCP\Util;
 
-class TalkWidget implements \OCP\Dashboard\IWidget {
+class TalkWidget implements IWidget {
 
+	/** @var IURLGenerator */
+	private $url;
 	/** @var IL10N */
 	private $l10n;
 
 	public function __construct(
+		IURLGenerator $url,
 		IL10N $l10n
 	) {
+		$this->url = $url;
 		$this->l10n = $l10n;
 	}
 
@@ -48,7 +56,7 @@ class TalkWidget implements \OCP\Dashboard\IWidget {
 	 * @inheritDoc
 	 */
 	public function getTitle(): string {
-		return $this->l10n->t('Talk mentions');
+		return $this->l10n->t('Conversations');
 	}
 
 	/**
@@ -69,7 +77,7 @@ class TalkWidget implements \OCP\Dashboard\IWidget {
 	 * @inheritDoc
 	 */
 	public function getUrl(): ?string {
-		return \OC::$server->getURLGenerator()->getAbsoluteURL('/apps/spreed');
+		return $this->url->linkToRouteAbsolute('spreed.Page.index');
 	}
 
 	/**

--- a/lib/Dashboard/TalkWidget.php
+++ b/lib/Dashboard/TalkWidget.php
@@ -84,6 +84,7 @@ class TalkWidget implements IWidget {
 	 * @inheritDoc
 	 */
 	public function load(): void {
+		Util::addStyle('spreed', 'icons');
 		Util::addScript('spreed', 'dashboard');
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3618,9 +3618,9 @@
 			}
 		},
 		"@nextcloud/vue-dashboard": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue-dashboard/-/vue-dashboard-0.1.0.tgz",
-			"integrity": "sha512-ESaeGVcD9IOxo4c23nYdT6vm1dMBG/bY9um3eZh+SouRizipW9mfEE+AhGaP7QiQko/XpztJ53jVUZx7FP3ORA==",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue-dashboard/-/vue-dashboard-0.1.3.tgz",
+			"integrity": "sha512-7b02zkarX7b18IRQmZEW1NM+dvtcUih2M0+CZyuQfcvfyMQudOz+BdA/oD1p7PmdBds1IR8OvY1+CnpmgAzfQg==",
 			"requires": {
 				"@nextcloud/vue": "^2.3.0",
 				"core-js": "^3.6.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3617,6 +3617,16 @@
 				"vue2-datepicker": "^3.4.1"
 			}
 		},
+		"@nextcloud/vue-dashboard": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue-dashboard/-/vue-dashboard-0.1.0.tgz",
+			"integrity": "sha512-ESaeGVcD9IOxo4c23nYdT6vm1dMBG/bY9um3eZh+SouRizipW9mfEE+AhGaP7QiQko/XpztJ53jVUZx7FP3ORA==",
+			"requires": {
+				"@nextcloud/vue": "^2.3.0",
+				"core-js": "^3.6.4",
+				"vue": "^2.6.11"
+			}
+		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"@nextcloud/moment": "^1.1.1",
 		"@nextcloud/router": "^1.1.0",
 		"@nextcloud/vue": "^2.3.0",
-		"@nextcloud/vue-dashboard": "^0.1.0",
+		"@nextcloud/vue-dashboard": "^0.1.3",
 		"attachmediastream": "^2.1.0",
 		"crypto-js": "^4.0.0",
 		"debounce": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"@nextcloud/moment": "^1.1.1",
 		"@nextcloud/router": "^1.1.0",
 		"@nextcloud/vue": "^2.3.0",
+		"@nextcloud/vue-dashboard": "^0.1.0",
 		"attachmediastream": "^2.1.0",
 		"crypto-js": "^4.0.0",
 		"debounce": "^1.2.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -79,7 +79,7 @@ export default {
 		isInCall,
 	],
 
-	data: function() {
+	data() {
 		return {
 			savedLastMessageMap: {},
 			defaultPageTitle: false,

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -1,0 +1,54 @@
+/*
+ * @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import Vue from 'vue'
+import { generateFilePath } from '@nextcloud/router'
+import { getRequestToken } from '@nextcloud/auth'
+import { translate, translatePlural } from '@nextcloud/l10n'
+import Dashboard from './views/Dashboard'
+
+// CSP config for webpack dynamic chunk loading
+// eslint-disable-next-line
+__webpack_nonce__ = btoa(getRequestToken())
+
+// Correct the root of the app for chunk loading
+// OC.linkTo matches the apps folders
+// OC.generateUrl ensure the index.php (or not)
+// We do not want the index.php since we're loading files
+// eslint-disable-next-line
+__webpack_public_path__ = generateFilePath('spreed', '', 'js/')
+
+Vue.prototype.t = translate
+Vue.prototype.n = translatePlural
+Vue.prototype.OC = OC
+Vue.prototype.OCA = OCA
+
+document.addEventListener('DOMContentLoaded', function() {
+
+	OCA.Dashboard.register('spreed', (el) => {
+		const View = Vue.extend(Dashboard)
+		new View({
+			propsData: {},
+		}).$mount(el)
+	})
+
+})

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -1,0 +1,115 @@
+<!--
+  - @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
+  -
+  - @author Julius Härtl <jus@bitgrid.net>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<ul v-if="roomOptions.length > 0">
+		<li v-for="conversation in roomOptions" :key="conversation.token">
+			<a :href="callLink(conversation)" class="conversation">
+				<ConversationIcon
+					:item="conversation"
+					:hide-favorite="false"
+					:hide-call="false" />
+				<div class="conversation__details">
+					<h3>{{ conversation.displayName }}</h3>
+					<p class="message">{{ conversation.lastMessage.message }}</p>
+				</div>
+				<button v-if="conversation.hasCall" class="primary success">{{ t('spreed', 'Join call') }}</button>
+			</a>
+		</li>
+	</ul>
+	<div v-else>
+		<EmptyContent icon="icon-talk">
+			{{ t('spreed', 'Join a conversation or start a new one') }}
+			<template #desc>
+				<p>{{ t('spreed', 'Say hi to your friends and colleagues!') }}</p>
+				<button>{{ t('spreed', 'Start a conversation') }}</button>
+			</template>
+		</EmptyContent>
+	</div>
+</template>
+
+<script>
+import ConversationIcon from './../components/ConversationIcon'
+import EmptyContent from '@nextcloud/vue/dist/Components/EmptyContent'
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+
+export default {
+	name: 'Dashboard',
+	components: { ConversationIcon, EmptyContent },
+	data() {
+		return {
+			roomOptions: [],
+		}
+	},
+	computed: {
+		callLink() {
+			return (conversation) => {
+				return '/index.php/call/' + conversation.token
+			}
+		},
+	},
+	beforeMount() {
+		this.fetchRooms()
+		setInterval(() => this.fetchRooms(), 5000)
+	},
+	methods: {
+		fetchRooms() {
+			axios.get(generateOcsUrl('/apps/spreed/api/v1', 2) + 'room').then((response) => {
+				const rooms = response.data.ocs.data.slice(0, 6)
+				rooms.sort((a, b) => b.lastActivity - a.lastActivity)
+				this.roomOptions = rooms
+			})
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+	li a {
+		display: flex;
+		align-items: flex-start;
+		padding: 5px;
+
+		&:hover {
+			background-color: var(--color-background-hover);
+			border-radius: var(--border-radius);
+		}
+	}
+
+	.conversation__details {
+		padding: 3px;
+		overflow: hidden;
+	}
+
+	h3 {
+		font-size: 100%;
+		margin: 0;
+	}
+
+	.message {
+		width: 100%;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+</style>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -90,7 +90,8 @@ export default {
 		align-items: flex-start;
 		padding: 8px;
 
-		&:hover {
+		&:hover,
+		&:focus {
 			background-color: var(--color-background-hover);
 			border-radius: var(--border-radius-large);
 		}

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -32,7 +32,7 @@
 					<h3>{{ conversation.displayName }}</h3>
 					<p class="message">{{ conversation.lastMessage.message }}</p>
 				</div>
-				<button v-if="conversation.hasCall" class="primary success">{{ t('spreed', 'Join call') }}</button>
+				<button v-if="conversation.hasCall" class="primary success icon-video-white" :title="t('spreed', 'Join call')" />
 			</a>
 		</li>
 	</ul>
@@ -75,7 +75,7 @@ export default {
 	methods: {
 		fetchRooms() {
 			axios.get(generateOcsUrl('/apps/spreed/api/v1', 2) + 'room').then((response) => {
-				const rooms = response.data.ocs.data.slice(0, 6)
+				const rooms = response.data.ocs.data.slice(0, 7)
 				rooms.sort((a, b) => b.lastActivity - a.lastActivity)
 				this.roomOptions = rooms
 			})
@@ -85,31 +85,56 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-	li a {
+	li .conversation {
 		display: flex;
 		align-items: flex-start;
-		padding: 5px;
+		padding: 8px;
 
 		&:hover {
 			background-color: var(--color-background-hover);
-			border-radius: var(--border-radius);
+			border-radius: var(--border-radius-large);
 		}
-	}
 
-	.conversation__details {
-		padding: 3px;
-		overflow: hidden;
-	}
+		.conversation-icon {
+			position: relative;
 
-	h3 {
-		font-size: 100%;
-		margin: 0;
-	}
+			// Do not show favorite or call icons
+			// Favorite not needed as only important calls are shown
+			// Call icon not needed as "Join call" button is there
+			::v-deep .overlap-icon {
+				display: none;
+				top: 3px;
+				left: 32px;
+			}
+		}
 
-	.message {
-		width: 100%;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
+		.conversation__details {
+			padding-left: 8px;
+			max-height: 44px;
+			flex-grow: 1;
+			overflow: hidden;
+
+			h3,
+			.message {
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+
+			h3 {
+				font-size: 100%;
+				margin: 0;
+			}
+
+			.message {
+				width: 100%;
+				color: var(--color-text-maxcontrast);
+			}
+		}
+
+		button.primary {
+			padding: 21px;
+			margin: 0;
+		}
 	}
 </style>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -39,10 +39,12 @@
 		</template>
 		<template v-slot:empty-content>
 			<EmptyContent icon="icon-talk">
-				{{ t('spreed', 'Join a conversation or start a new one') }}
+				{{ t('spreed', 'Say hi to your friends and colleagues!') }}
 				<template #desc>
-					<p>{{ t('spreed', 'Say hi to your friends and colleagues!') }}</p>
-					<button>{{ t('spreed', 'Start a conversation') }}</button>
+					<button
+						@click="clickStartNew">
+						{{ t('spreed', 'Start a conversation') }}
+					</button>
 				</template>
 			</EmptyContent>
 		</template>
@@ -130,6 +132,9 @@ export default {
 				this.loading = false
 			})
 		},
+		clickStartNew() {
+			window.location = generateUrl('/apps/spreed')
+		},
 	},
 }
 </script>
@@ -141,5 +146,6 @@ export default {
 
 	.empty-content {
 		text-align: center;
+		margin-top: 5vh;
 	}
 </style>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -48,6 +48,7 @@
 </template>
 
 <script>
+import { DashboardWidget, DashboardWidgetItem } from '@nextcloud/vue-dashboard'
 import ConversationIcon from './../components/ConversationIcon'
 import EmptyContent from '@nextcloud/vue/dist/Components/EmptyContent'
 import axios from '@nextcloud/axios'
@@ -66,7 +67,7 @@ const propertySort = (properties) => (a, b) => properties.map(obj => {
 
 export default {
 	name: 'Dashboard',
-	components: { ConversationIcon, EmptyContent },
+	components: { DashboardWidget, DashboardWidgetItem, ConversationIcon, EmptyContent },
 	data() {
 		return {
 			roomOptions: [],

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -33,7 +33,7 @@
 					<ConversationIcon
 						:item="item"
 						:hide-favorite="true"
-						:hide-call="true" />
+						:hide-call="false" />
 				</template>
 			</DashboardWidgetItem>
 		</template>
@@ -135,6 +135,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+	::v-deep .item-list__entry {
+		position: relative;
+	}
+
 	.empty-content {
 		text-align: center;
 	}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -13,6 +13,7 @@ module.exports = {
 		'talk-public-share-auth-sidebar': path.join(__dirname, 'src', 'mainPublicShareAuthSidebar.js'),
 		'talk-public-share-sidebar': path.join(__dirname, 'src', 'mainPublicShareSidebar.js'),
 		'flow': path.join(__dirname, 'src', 'flow.js'),
+		'dashboard': path.join(__dirname, 'src', 'dashboard.js'),
 	},
 	output: {
 		path: path.resolve(__dirname, './js'),


### PR DESCRIPTION
For https://github.com/nextcloud/server/pull/21346

This implements a basic dashboard panel for Talk that lists the recent conversations. 

- [x] Create conversation button in empty content view is non-functional
- [ ] ~~Figure out if we can join a call directly by clicking on the start call button~~
- [x] Show a loading placeholders
- [x] Properly style conversation list to match the talk sidebar

![image](https://user-images.githubusercontent.com/3404133/87131888-5dedc280-c295-11ea-95dd-1af0300c88bd.png)

cc @nickvergessen @jancborchardt @ma12-co 