### PR TITLE
Make sure the avatar/video are not transparently overlaying in one-to…

### DIFF
--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -411,9 +411,14 @@ export default {
 }
 
 .bad-connection-quality {
+	/* This adds black bars around the video depending on the resolution,
+	 * but it's still better than having your half-transparent avatar
+	 * shine an underlying video/avatar through it. */
+	background-color: #000000;
+
 	.video,
 	.avatar-container {
-		opacity: 0.5
+		opacity: 0.3
 	}
 }
 


### PR DESCRIPTION
…-one calls

This adds black bars around the video depending on the resolution,
but it's still better than having your half-transparent avatar
shine an underlying video/avatar through it.


As per #3905 

x | Good connection | Bad connection (before) | Bad connection (after)
---|---|---|---
Avatar | ![Bildschirmfoto von 2020-07-15 13-00-39](https://user-images.githubusercontent.com/213943/87537766-75fd8180-c69b-11ea-915a-b8c76b96e79b.png) | ![Bildschirmfoto von 2020-07-15 13-07-53](https://user-images.githubusercontent.com/213943/87538446-806c4b00-c69c-11ea-8359-6eb3ec0bb53f.png) | ![Bildschirmfoto von 2020-07-15 13-00-10](https://user-images.githubusercontent.com/213943/87537761-74cc5480-c69b-11ea-988c-18f5792c234b.png)
Video | ![Bildschirmfoto von 2020-07-15 13-00-50](https://user-images.githubusercontent.com/213943/87537774-7a299f00-c69b-11ea-91a1-cc682aca25e0.png) | ![Bildschirmfoto von 2020-07-15 13-09-08](https://user-images.githubusercontent.com/213943/87538459-86fac280-c69c-11ea-97d7-f0a6ebf70fed.png) | ![Bildschirmfoto von 2020-07-15 13-01-10](https://user-images.githubusercontent.com/213943/87537780-7bf36280-c69b-11ea-90a9-3d95f554d9ff.png)


