### PR TITLE
Dedicated connection warning icon

### DIFF
--- a/css/icons.scss
+++ b/css/icons.scss
@@ -81,9 +81,6 @@
 		&.icon-screen-off {
 			background-image: url(icon-color-path('screen-off', 'actions', 'fff', 1, true));
 		}
-		&.icon-error {
-			background-image: url(icon-color-path('error', 'actions', 'fff', 1, true));
-		}
 	}
 
 	.icon-favorite {

--- a/css/icons.scss
+++ b/css/icons.scss
@@ -81,6 +81,9 @@
 		&.icon-screen-off {
 			background-image: url(icon-color-path('screen-off', 'actions', 'fff', 1, true));
 		}
+		&.icon-error {
+			background-image: url(icon-color-path('error', 'actions', 'fff', 1, true));
+		}
 	}
 
 	.icon-favorite {

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -80,14 +80,33 @@
 				</li>
 			</ul>
 		</div>
+		<div class="network-connection-state">
+			<Popover
+				v-if="qualityWarningTooltip"
+				:boundaries-element="boundaryElement"
+				:aria-label="qualityWarningAriaLabel"
+				trigger="hover"
+				:open="qualityWarningTooltip.show">
+				<NetworkStrength2Alert
+					slot="trigger"
+					fill-color="#e9322d"
+					title=""
+					:size="24" />
+				<template>
+					<span>{{ qualityWarningTooltip.content }}</span>
+				</template>
+			</Popover>
+		</div>
 	</div>
 </template>
 
 <script>
 import escapeHtml from 'escape-html'
 import { showMessage } from '@nextcloud/dialogs'
+import Popover from '@nextcloud/vue/dist/Components/Popover'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 import SpeakingWhileMutedWarner from '../../../utils/webrtc/SpeakingWhileMutedWarner'
+import NetworkStrength2Alert from 'vue-material-design-icons/NetworkStrength2Alert'
 
 export default {
 
@@ -95,6 +114,11 @@ export default {
 
 	directives: {
 		tooltip: Tooltip,
+	},
+
+	components: {
+		NetworkStrength2Alert,
+		Popover,
 	},
 
 	props: {
@@ -110,6 +134,14 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		qualityWarningAriaLabel: {
+			type: String,
+			default: '',
+		},
+		qualityWarningTooltip: {
+			type: Object,
+			default: null,
+		},
 	},
 
 	data() {
@@ -118,6 +150,7 @@ export default {
 			speakingWhileMutedNotification: null,
 			screenSharingMenuOpen: false,
 			splitScreenSharingMenu: false,
+			boundaryElement: document.querySelector('.main-view'),
 		}
 	},
 
@@ -481,5 +514,14 @@ export default {
 
 #muteWrapper .icon-audio-off + .volume-indicator {
 	background: linear-gradient(0deg, gray, white 36px);
+}
+
+.network-connection-state {
+	position: absolute;
+	bottom: 0;
+	right: 16px;
+	width: 32px;
+	height: 32px;
+	filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
 }
 </style>

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -86,12 +86,15 @@
 				:boundaries-element="boundaryElement"
 				:aria-label="qualityWarningAriaLabel"
 				trigger="hover"
-				:open="qualityWarningTooltip.show">
+				:auto-hide="false"
+				:open="showQualityWarningTooltip">
 				<NetworkStrength2Alert
 					slot="trigger"
 					fill-color="#e9322d"
 					title=""
-					:size="24" />
+					:size="24"
+					@mouseover="mouseover = true"
+					@mouseleave="mouseover = false" />
 				<div class="hint">
 					<span>{{ qualityWarningTooltip.content }}</span>
 					<div class="hint__actions">
@@ -100,6 +103,11 @@
 							class="primary"
 							@click="executeQualityWarningTooltipAction">
 							{{ qualityWarningTooltip.actionLabel }}
+						</button>
+						<button
+							v-if="!isQualityWarningTooltipDismissed"
+							@click="isQualityWarningTooltipDismissed = true">
+							{{ t('spreed', 'Dismiss') }}
 						</button>
 					</div>
 				</div>
@@ -159,6 +167,8 @@ export default {
 			screenSharingMenuOpen: false,
 			splitScreenSharingMenu: false,
 			boundaryElement: document.querySelector('.main-view'),
+			isQualityWarningTooltipDismissed: false,
+			mouseover: false,
 		}
 	},
 
@@ -286,6 +296,10 @@ export default {
 			}
 
 			return (this.model.attributes.localScreen || this.splitScreenSharingMenu) ? t('spreed', 'Screensharing options') : t('spreed', 'Enable screensharing')
+		},
+
+		showQualityWarningTooltip() {
+			return this.qualityWarningTooltip && (!this.isQualityWarningTooltipDismissed || this.mouseover)
 		},
 
 	},
@@ -430,8 +444,10 @@ export default {
 			}
 			if (this.qualityWarningTooltip.action === 'disableScreenShare') {
 				this.model.stopSharingScreen()
+				this.isQualityWarningTooltipDismissed = true
 			} else if (this.qualityWarningTooltip.action === 'disableVideo') {
 				this.model.disableVideo()
+				this.isQualityWarningTooltipDismissed = true
 			}
 		},
 	},

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -110,18 +110,6 @@ export default {
 			type: Boolean,
 			default: false,
 		},
-		qualityWarningAudioTooltip: {
-			type: Object,
-			default: null,
-		},
-		qualityWarningVideoTooltip: {
-			type: Object,
-			default: null,
-		},
-		qualityWarningScreenTooltip: {
-			type: Object,
-			default: null,
-		},
 	},
 
 	data() {
@@ -150,10 +138,6 @@ export default {
 					content: t('spreed', 'No audio'),
 					show: false,
 				}
-			}
-
-			if (this.qualityWarningAudioTooltip) {
-				return this.qualityWarningAudioTooltip
 			}
 
 			if (this.speakingWhileMutedNotification) {
@@ -212,10 +196,6 @@ export default {
 				return t('spreed', 'No camera')
 			}
 
-			if (this.qualityWarningVideoTooltip) {
-				return this.qualityWarningVideoTooltip
-			}
-
 			if (this.model.attributes.videoEnabled) {
 				return t('spreed', 'Disable video (v)')
 			}
@@ -254,10 +234,6 @@ export default {
 		screenSharingButtonTooltip() {
 			if (this.screenSharingMenuOpen) {
 				return null
-			}
-
-			if (this.qualityWarningScreenTooltip) {
-				return this.qualityWarningScreenTooltip
 			}
 
 			return (this.model.attributes.localScreen || this.splitScreenSharingMenu) ? t('spreed', 'Screensharing options') : t('spreed', 'Enable screensharing')

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -92,9 +92,17 @@
 					fill-color="#e9322d"
 					title=""
 					:size="24" />
-				<template>
+				<div class="hint">
 					<span>{{ qualityWarningTooltip.content }}</span>
-				</template>
+					<div class="hint__actions">
+						<button
+							v-if="qualityWarningTooltip.action"
+							class="primary"
+							@click="executeQualityWarningTooltipAction">
+							{{ qualityWarningTooltip.actionLabel }}
+						</button>
+					</div>
+				</div>
 			</Popover>
 		</div>
 	</div>
@@ -416,6 +424,16 @@ export default {
 				}
 			})
 		},
+		executeQualityWarningTooltipAction() {
+			if (this.qualityWarningTooltip.action === '') {
+				return
+			}
+			if (this.qualityWarningTooltip.action === 'disableScreenShare') {
+				this.model.stopSharingScreen()
+			} else if (this.qualityWarningTooltip.action === 'disableVideo') {
+				this.model.disableVideo()
+			}
+		},
 	},
 }
 </script>
@@ -523,5 +541,16 @@ export default {
 	width: 32px;
 	height: 32px;
 	filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
+}
+
+.hint {
+	padding: 4px;
+	text-align: left;
+	&__actions{
+		display: flex;
+		flex-direction: row-reverse;
+		justify-content: space-between;
+		padding-top:4px;
+	}
 }
 </style>

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -108,7 +108,6 @@ export default {
 		return {
 			callAnalyzer: callAnalyzer,
 			qualityWarningInGracePeriodTimeout: null,
-			qualityWarningWasRecentlyShownTimeout: null,
 		}
 	},
 
@@ -207,14 +206,6 @@ export default {
 			return label
 		},
 
-		// The quality warning tooltip is automatically shown only if the
-		// quality warning has not been shown in the last minute. Otherwise the
-		// tooltip is hidden even if the warning is shown, although the tooltip
-		// can be shown anyway by hovering on the warning.
-		showQualityWarningTooltip() {
-			return !this.qualityWarningWasRecentlyShownTimeout
-		},
-
 		qualityWarningTooltip() {
 			if (!this.showQualityWarning) {
 				return null
@@ -250,8 +241,6 @@ export default {
 				tooltip.actionLabel = ''
 				tooltip.action = ''
 			}
-
-			tooltip.show = this.showQualityWarningTooltip
 
 			return tooltip
 		},
@@ -301,20 +290,6 @@ export default {
 			this.qualityWarningInGracePeriodTimeout = window.setTimeout(() => {
 				this.qualityWarningInGracePeriodTimeout = null
 			}, 10000)
-		},
-
-		showQualityWarning: function(showQualityWarning) {
-			if (showQualityWarning) {
-				return
-			}
-
-			if (this.qualityWarningWasRecentlyShownTimeout) {
-				window.clearTimeout(this.qualityWarningWasRecentlyShownTimeout)
-			}
-
-			this.qualityWarningWasRecentlyShownTimeout = window.setTimeout(() => {
-				this.qualityWarningWasRecentlyShownTimeout = null
-			}, 60000)
 		},
 
 	},

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -21,8 +21,7 @@
 <template>
 	<div id="localVideoContainer"
 		class="videoContainer videoView"
-		:class="videoContainerClass"
-		:aria-label="videoContainerAriaLabel">
+		:class="videoContainerClass">
 		<transition name="fade">
 			<span v-show="showQualityWarning"
 				v-tooltip="qualityWarningTooltip"
@@ -128,16 +127,7 @@ export default {
 				'speaking': this.localMediaModel.attributes.speaking,
 				'video-container-grid': this.isGrid,
 				'video-container-stripe': this.isStripe,
-				'bad-connection-quality': this.showQualityWarning,
 			}
-		},
-
-		videoContainerAriaLabel() {
-			if (!this.showQualityWarning) {
-				return null
-			}
-
-			return this.qualityWarningAriaLabel
 		},
 
 		userId() {
@@ -407,13 +397,6 @@ export default {
 
 .avatar-container {
 	margin: auto;
-}
-
-.bad-connection-quality {
-	.video,
-	.avatar-container {
-		opacity: 0.5
-	}
 }
 
 .qualityWarning {

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -220,27 +220,40 @@ export default {
 				return null
 			}
 
-			let message = ''
+			const tooltip = {}
 			if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you. To improve the situation try to disable your video while doing a screenshare.')
+				tooltip.content = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you. To improve the situation try to disable your video while doing a screenshare.')
+				tooltip.actionLabel = t('spreed', 'Disable video')
+				tooltip.action = 'disableVideo'
 			} else if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.localScreen) {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see your screen.')
+				tooltip.content = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see your screen.')
+				tooltip.actionLabel = ''
+				tooltip.action = ''
 			} else if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.videoEnabled) {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you.')
+				tooltip.content = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you.')
+				tooltip.actionLabel = ''
+				tooltip.action = ''
 			} else if (this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video while doing a screenshare.')
+				tooltip.content = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video while doing a screenshare.')
+				tooltip.actionLabel = t('spreed', 'Disable video')
+				tooltip.action = 'disableVideo'
 			} else if (this.localMediaModel.attributes.localScreen) {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see your screen. To improve the situation try to disable your screenshare.')
+				tooltip.content = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see your screen. To improve the situation try to disable your screenshare.')
+				tooltip.actionLabel = t('spreed', 'Disable screenshare')
+				tooltip.action = 'disableScreenShare'
 			} else if (this.localMediaModel.attributes.videoEnabled) {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video.')
+				tooltip.content = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video.')
+				tooltip.actionLabel = t('spreed', 'Disable video')
+				tooltip.action = 'disableVideo'
 			} else {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand you.')
+				tooltip.content = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand you.')
+				tooltip.actionLabel = ''
+				tooltip.action = ''
 			}
 
-			return {
-				content: message,
-				show: this.showQualityWarningTooltip,
-			}
+			tooltip.show = this.showQualityWarningTooltip
+
+			return tooltip
 		},
 	},
 

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -234,28 +234,18 @@ export default {
 		},
 
 		qualityWarningTooltip() {
-			if (this.qualityWarningAudioTooltip) {
-				return this.qualityWarningAudioTooltip
-			}
-
-			if (this.qualityWarningVideoTooltip) {
-				return this.qualityWarningVideoTooltip
-			}
-
-			if (this.qualityWarningScreenTooltip) {
-				return this.qualityWarningScreenTooltip
-			}
-
-			return null
-		},
-
-		qualityWarningAudioTooltip() {
-			if (!this.showQualityWarning || !this.localMediaModel.attributes.audioEnabled) {
-				return null
+			if (!this.showQualityWarning) {
+				return false
 			}
 
 			let message = ''
-			if (this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
+			if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
+				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you. To improve the situation try to disable your video while doing a screenshare.')
+			} else if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.localScreen) {
+				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see your screen.')
+			} else if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.videoEnabled) {
+				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you.')
+			} else if (this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
 				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video while doing a screenshare.')
 			} else if (this.localMediaModel.attributes.localScreen) {
 				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see your screen. To improve the situation try to disable your screenshare.')
@@ -267,35 +257,6 @@ export default {
 
 			return {
 				content: message,
-				show: this.showQualityWarningTooltip,
-			}
-		},
-
-		qualityWarningVideoTooltip() {
-			if (!this.showQualityWarning || this.localMediaModel.attributes.audioEnabled || !this.localMediaModel.attributes.videoEnabled) {
-				return null
-			}
-
-			let message = ''
-			if (this.localMediaModel.attributes.localScreen) {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you. To improve the situation try to disable your video while doing a screenshare.')
-			} else {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you.')
-			}
-
-			return {
-				content: message,
-				show: this.showQualityWarningTooltip,
-			}
-		},
-
-		qualityWarningScreenTooltip() {
-			if (!this.showQualityWarning || this.localMediaModel.attributes.audioEnabled || this.localMediaModel.attributes.videoEnabled || !this.localMediaModel.attributes.localScreen) {
-				return null
-			}
-
-			return {
-				content: t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see your screen.'),
 				show: this.showQualityWarningTooltip,
 			}
 		},

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -23,6 +23,12 @@
 		class="videoContainer videoView"
 		:class="videoContainerClass"
 		:aria-label="videoContainerAriaLabel">
+		<transition name="fade">
+			<span v-show="showQualityWarning"
+				v-tooltip="qualityWarningTooltip"
+				:aria-label="qualityWarningAriaLabel"
+				class="qualityWarning forced-white icon icon-error" />
+		</transition>
 		<video v-show="localMediaModel.attributes.videoEnabled"
 			id="localVideo"
 			ref="video"
@@ -51,9 +57,6 @@
 				:model="localMediaModel"
 				:local-call-participant-model="localCallParticipantModel"
 				:screen-sharing-button-hidden="isSidebar"
-				:quality-warning-audio-tooltip="qualityWarningAudioTooltip"
-				:quality-warning-video-tooltip="qualityWarningVideoTooltip"
-				:quality-warning-screen-tooltip="qualityWarningScreenTooltip"
 				@switchScreenToId="$emit('switchScreenToId', $event)" />
 		</transition>
 	</div>
@@ -74,6 +77,10 @@ import { CONNECTION_QUALITY } from '../../../utils/webrtc/analyzers/PeerConnecti
 export default {
 
 	name: 'LocalVideo',
+
+	directives: {
+		tooltip: Tooltip,
+	},
 
 	components: {
 		Avatar,
@@ -219,12 +226,27 @@ export default {
 		},
 
 		// The quality warning tooltip is automatically shown only if the
-		// quality warning (dimmed video) has not been shown in the last minute.
-		// Otherwise the tooltip is hidden even if the warning is shown,
-		// although the tooltip can be shown anyway by hovering on the media
-		// button.
+		// quality warning has not been shown in the last minute. Otherwise the
+		// tooltip is hidden even if the warning is shown, although the tooltip
+		// can be shown anyway by hovering on the warning.
 		showQualityWarningTooltip() {
 			return !this.qualityWarningWasRecentlyShownTimeout
+		},
+
+		qualityWarningTooltip() {
+			if (this.qualityWarningAudioTooltip) {
+				return this.qualityWarningAudioTooltip
+			}
+
+			if (this.qualityWarningVideoTooltip) {
+				return this.qualityWarningVideoTooltip
+			}
+
+			if (this.qualityWarningScreenTooltip) {
+				return this.qualityWarningScreenTooltip
+			}
+
+			return null
 		},
 
 		qualityWarningAudioTooltip() {
@@ -431,6 +453,18 @@ export default {
 	.avatar-container {
 		opacity: 0.5
 	}
+}
+
+.qualityWarning {
+	position: absolute;
+	right: 0;
+
+	width: 44px;
+	height: 44px;
+	background-size: 24px;
+
+	/* Needed to show in front of the avatar container. */
+	z-index: 10;
 }
 
 </style>

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -228,27 +228,34 @@ export default {
 		},
 
 		qualityWarningAudioTooltip() {
-			if (!this.showQualityWarning || !this.localMediaModel.attributes.audioEnabled || this.localMediaModel.attributes.videoEnabled || this.localMediaModel.attributes.localScreen) {
+			if (!this.showQualityWarning || !this.localMediaModel.attributes.audioEnabled) {
 				return null
 			}
 
+			let message = ''
+			if (this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
+				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video while doing a screenshare.')
+			} else if (this.localMediaModel.attributes.localScreen) {
+				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see your screen. To improve the situation try to disable your screenshare.')
+			} else if (this.localMediaModel.attributes.videoEnabled) {
+				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video.')
+			} else {
+				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand you.')
+			}
+
 			return {
-				content: t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand you.'),
+				content: message,
 				show: this.showQualityWarningTooltip,
 			}
 		},
 
 		qualityWarningVideoTooltip() {
-			if (!this.showQualityWarning || !this.localMediaModel.attributes.videoEnabled) {
+			if (!this.showQualityWarning || this.localMediaModel.attributes.audioEnabled || !this.localMediaModel.attributes.videoEnabled) {
 				return null
 			}
 
 			let message = ''
-			if (this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.localScreen) {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video while doing a screenshare.')
-			} else if (this.localMediaModel.attributes.audioEnabled) {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video.')
-			} else if (this.localMediaModel.attributes.localScreen) {
+			if (this.localMediaModel.attributes.localScreen) {
 				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you. To improve the situation try to disable your video while doing a screenshare.')
 			} else {
 				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you.')
@@ -261,19 +268,12 @@ export default {
 		},
 
 		qualityWarningScreenTooltip() {
-			if (!this.showQualityWarning || !this.localMediaModel.attributes.localScreen || this.localMediaModel.attributes.videoEnabled) {
+			if (!this.showQualityWarning || this.localMediaModel.attributes.audioEnabled || this.localMediaModel.attributes.videoEnabled || !this.localMediaModel.attributes.localScreen) {
 				return null
 			}
 
-			let message = ''
-			if (this.localMediaModel.attributes.audioEnabled) {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see your screen. To improve the situation try to disable your screenshare.')
-			} else {
-				message = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see your screen.')
-			}
-
 			return {
-				content: message,
+				content: t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see your screen.'),
 				show: this.showQualityWarningTooltip,
 			}
 		},

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -22,12 +22,6 @@
 	<div id="localVideoContainer"
 		class="videoContainer videoView"
 		:class="videoContainerClass">
-		<transition name="fade">
-			<span v-show="showQualityWarning"
-				v-tooltip="qualityWarningTooltip"
-				:aria-label="qualityWarningAriaLabel"
-				class="qualityWarning forced-white icon icon-error" />
-		</transition>
 		<video v-show="localMediaModel.attributes.videoEnabled"
 			id="localVideo"
 			ref="video"
@@ -56,6 +50,8 @@
 				:model="localMediaModel"
 				:local-call-participant-model="localCallParticipantModel"
 				:screen-sharing-button-hidden="isSidebar"
+				:quality-warning-aria-label="qualityWarningAriaLabel"
+				:quality-warning-tooltip="qualityWarningTooltip"
 				@switchScreenToId="$emit('switchScreenToId', $event)" />
 		</transition>
 	</div>
@@ -76,10 +72,6 @@ import { CONNECTION_QUALITY } from '../../../utils/webrtc/analyzers/PeerConnecti
 export default {
 
 	name: 'LocalVideo',
-
-	directives: {
-		tooltip: Tooltip,
-	},
 
 	components: {
 		Avatar,
@@ -225,7 +217,7 @@ export default {
 
 		qualityWarningTooltip() {
 			if (!this.showQualityWarning) {
-				return false
+				return null
 			}
 
 			let message = ''
@@ -397,18 +389,6 @@ export default {
 
 .avatar-container {
 	margin: auto;
-}
-
-.qualityWarning {
-	position: absolute;
-	right: 0;
-
-	width: 44px;
-	height: 44px;
-	background-size: 24px;
-
-	/* Needed to show in front of the avatar container. */
-	z-index: 10;
 }
 
 </style>


### PR DESCRIPTION
- [x] Red https://materialdesignicons.com/icon/network-strength-2-alert
- [x] Pin to the right in the controls section
- [x] Show tooltip on this icon
- [x] Add button to disable video/screenshare if applicable

![Bildschirmfoto von 2020-07-15 16-45-14](https://user-images.githubusercontent.com/213943/87559486-a4d72000-c6ba-11ea-93ee-ea0230ee04fc.png)

Use:
```diff
diff --git a/src/components/CallView/shared/LocalVideo.vue b/src/components/CallView/shared/LocalVideo.vue
index 317b113d0..cfacbb433 100644
--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -176,18 +175,21 @@ export default {
                },
 
                senderConnectionQualityAudioIsBad() {
+                       return true
                        return callAnalyzer
                                && (callAnalyzer.attributes.senderConnectionQualityAudio === CONNECTION_QUALITY.VERY_BAD
                                 || callAnalyzer.attributes.senderConnectionQualityAudio === CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
                },
 
                senderConnectionQualityVideoIsBad() {
+                       return true
                        return callAnalyzer
                                && (callAnalyzer.attributes.senderConnectionQualityVideo === CONNECTION_QUALITY.VERY_BAD
                                 || callAnalyzer.attributes.senderConnectionQualityVideo === CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
                },
 
                senderConnectionQualityScreenIsBad() {
+                       return true
                        return callAnalyzer
                                && (callAnalyzer.attributes.senderConnectionQualityScreen === CONNECTION_QUALITY.VERY_BAD
                                 || callAnalyzer.attributes.senderConnectionQualityScreen === CONNECTION_QUALITY.NO_TRANSMITTED_DATA)

```
to simulate
