### PR TITLE
Fix duplicated event listeners in ParticipantAnalyzer

### DIFF
--- a/src/utils/webrtc/analyzers/ParticipantAnalyzer.js
+++ b/src/utils/webrtc/analyzers/ParticipantAnalyzer.js
@@ -199,22 +199,26 @@ ParticipantAnalyzer.prototype = {
 	},
 
 	_handlePeerChange: function(model, peer) {
+		if (this._peer) {
+			this._stopListeningToAudioVideoChanges()
+		}
+
 		this._peer = peer
 
 		if (peer) {
 			this._startListeningToAudioVideoChanges()
-		} else {
-			this._stopListeningToAudioVideoChanges()
 		}
 	},
 
 	_handleScreenPeerChange: function(model, screenPeer) {
+		if (this._screenPeer) {
+			this._stopListeningToScreenChanges()
+		}
+
 		this._screenPeer = screenPeer
 
 		if (screenPeer) {
 			this._startListeningToScreenChanges()
-		} else {
-			this._stopListeningToScreenChanges()
 		}
 	},
 


### PR DESCRIPTION
Follow up to #3839 

The event listeners where not properly stopped when a Peer was set, so if the same Peer was set twice the listeners were duplicated, which in turn could lead to errors due to only one of them being removed.

## How to test
- Setup the HPB
- Start call
- Leave call
- Start call
- Leave call
- Start call

### Result with this pull request
The call is started.

### Result without this pull request
The call is not started. Browser console shows an error about calling `setAnalysisEnabledAudio` on a null object.
