### PR TITLE
Do not reuse media constraints between independent media requests

### DIFF
--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -65,7 +65,7 @@ import Avatar from '@nextcloud/vue/dist/Components/Avatar'
 import LocalMediaControls from './LocalMediaControls'
 import Hex from 'crypto-js/enc-hex'
 import SHA1 from 'crypto-js/sha1'
-import { showInfo } from '@nextcloud/dialogs'
+import { showInfo, showError } from '@nextcloud/dialogs'
 import video from '../../../mixins/video.js'
 import VideoBackground from './VideoBackground'
 import { callAnalyzer } from '../../../utils/webrtc/index'
@@ -163,6 +163,10 @@ export default {
 
 		avatarSizeClass() {
 			return 'avatar-' + this.avatarSize + 'px'
+		},
+
+		localStreamVideoError() {
+			return this.localMediaModel.attributes.localStream && this.localMediaModel.attributes.localStreamRequestVideoError
 		},
 
 		showQualityWarning() {
@@ -293,6 +297,18 @@ export default {
 
 		'localMediaModel.attributes.localStream': function(localStream) {
 			this._setLocalStream(localStream)
+		},
+
+		localStreamVideoError: {
+			immediate: true,
+
+			handler: function(localStreamVideoError) {
+				if (localStreamVideoError) {
+					showError(t('spreed', 'Error while accessing camera'), {
+						timeout: 0,
+					})
+				}
+			},
 		},
 
 		senderConnectionQualityIsBad: function(senderConnectionQualityIsBad) {

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -350,11 +350,15 @@ SimpleWebRTC.prototype.getEl = function(idOrEl) {
 
 SimpleWebRTC.prototype.startLocalVideo = function() {
 	const self = this
-	this.webrtc.start(this.config.media, function(err, stream) {
+	const constraints = {
+		audio: true,
+		video: true,
+	}
+	this.webrtc.start(constraints, function(err, stream) {
 		if (err) {
 			self.emit('localMediaError', err)
 		} else {
-			self.emit('localMediaStarted', self.config.media)
+			self.emit('localMediaStarted', constraints)
 
 			const localVideoContainer = self.getLocalVideoContainer()
 			if (localVideoContainer) {

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -82,12 +82,6 @@ function SimpleWebRTC(opts) {
 		connection = this.connection = this.config.connection
 	}
 
-	connection.on('connect', function() {
-		self.emit('connectionReady', connection.getSessionId())
-		self.sessionReady = true
-		self.testReadiness()
-	})
-
 	connection.on('message', function(message) {
 		const peers = self.webrtc.getPeers(message.from, message.roomType)
 		let peer
@@ -162,11 +156,6 @@ function SimpleWebRTC(opts) {
 	if (config.debug) {
 		this.on('*', this.logger.log.bind(this.logger, 'SimpleWebRTC event:'))
 	}
-
-	// check for readiness
-	this.webrtc.on('localStream', function() {
-		self.testReadiness()
-	})
 
 	this.webrtc.on('message', function(payload) {
 		self.connection.emit('message', payload)
@@ -433,17 +422,6 @@ SimpleWebRTC.prototype.stopScreenShare = function() {
 			peer.end()
 		}
 	})
-}
-
-SimpleWebRTC.prototype.testReadiness = function() {
-	const self = this
-	if (this.sessionReady) {
-		if (!this.config.media.video && !this.config.media.audio) {
-			self.emit('readyToCall', self.connection.getSessionId())
-		} else if (this.webrtc.localStreams.length > 0) {
-			self.emit('readyToCall', self.connection.getSessionId())
-		}
-	}
 }
 
 SimpleWebRTC.prototype.createRoom = function(name, cb) {


### PR DESCRIPTION
When getting the user media for the first time both audio and video are requested. If video is not available then the user media is got again requesting only audio. However, as the media constraints were reused in any following user media request as soon as video failed once it was never requested again. Therefore if a camera was plugged in later it was ignored until Talk was restarted.

Now getting the user media always tries first with both audio and video and then fallbacks to trying only with audio, even if video was not available in a previous request.

Besides that, now an error message is shown to the user if the video could not be got (except if the reason is that there is no camera).

## How to test (scenario 1)
- Start a call without a camera
- Leave the call
- Plug in the camera (and wait a little so the browser finds it)
- Start a call again

### Result with this pull request
The camera is available in the call.

### Result without this pull request
The camera is not available in the call.

## How to test (scenario 2)
- Start a call with a camera that can not be used

### Result with this pull request
The camera is not available in the call, but an error is shown to the user.

### Result without this pull request
The camera is not available in the call and no error is shown to the user.
