### PR TITLE
Make possible to select input media devices before calls

### DIFF
--- a/src/components/MediaDevicesPreview.vue
+++ b/src/components/MediaDevicesPreview.vue
@@ -1,0 +1,407 @@
+<!--
+  - @copyright Copyright (c) 2020, Daniel Calviño Sánchez (danxuliu@gmail.com)
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<div class="mediaDevicesPreview">
+		<MediaDevicesSelector kind="audioinput"
+			:devices="devices"
+			:device-id="audioInputId"
+			:enabled="enabled"
+			@update:deviceId="audioInputId = $event" />
+		<div class="preview preview-audio">
+			<div v-if="!audioPreviewAvailable"
+				class="preview-not-available">
+				<div v-if="audioStreamError"
+					class="icon icon-error" />
+				<div v-else-if="!audioInputId"
+					class="icon icon-audio-off" />
+				<div v-else-if="!enabled"
+					class="icon icon-audio" />
+				<div v-else-if="!audioStream"
+					class="icon icon-loading" />
+			</div>
+			<!-- v-show has to be used instead of v-if/else to ensure that the
+				 reference is always valid once mounted. -->
+			<div v-show="audioPreviewAvailable"
+				class="volume-indicator-wrapper">
+				<div class="icon icon-audio" />
+				<span ref="volumeIndicator"
+					class="volume-indicator"
+					:style="{ 'height': currentVolumeIndicatorHeight + 'px' }" />
+			</div>
+		</div>
+		<MediaDevicesSelector kind="videoinput"
+			:devices="devices"
+			:device-id="videoInputId"
+			:enabled="enabled"
+			@update:deviceId="videoInputId = $event" />
+		<div class="preview preview-video">
+			<div v-if="!videoPreviewAvailable"
+				class="preview-not-available">
+				<div v-if="videoStreamError"
+					class="icon icon-error" />
+				<div v-else-if="!videoInputId"
+					class="icon icon-video-off" />
+				<div v-else-if="!enabled"
+					class="icon icon-video" />
+				<div v-else-if="!videoStream"
+					class="icon icon-loading" />
+			</div>
+			<!-- v-show has to be used instead of v-if/else to ensure that the
+				 reference is always valid once mounted. -->
+			<video v-show="videoPreviewAvailable"
+				ref="video"
+				tabindex="-1" />
+		</div>
+	</div>
+</template>
+
+<script>
+import attachMediaStream from 'attachmediastream'
+import hark from 'hark'
+import { mediaDevicesManager } from '../utils/webrtc/index'
+import MediaDevicesSelector from './MediaDevicesSelector'
+
+export default {
+
+	name: 'MediaDevicesPreview',
+
+	components: {
+		MediaDevicesSelector,
+	},
+
+	props: {
+		enabled: {
+			type: Boolean,
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			mounted: false,
+			mediaDevicesManager: mediaDevicesManager,
+			audioStream: null,
+			audioStreamError: false,
+			videoStream: null,
+			videoStreamError: false,
+			hark: null,
+			currentVolume: -100,
+			volumeThreshold: -100,
+		}
+	},
+
+	computed: {
+		devices() {
+			return mediaDevicesManager.attributes.devices
+		},
+
+		audioInputId: {
+			get() {
+				return mediaDevicesManager.attributes.audioInputId
+			},
+			set(value) {
+				mediaDevicesManager.attributes.audioInputId = value
+			},
+		},
+
+		videoInputId: {
+			get() {
+				return mediaDevicesManager.attributes.videoInputId
+			},
+			set(value) {
+				mediaDevicesManager.attributes.videoInputId = value
+			},
+		},
+
+		audioPreviewAvailable() {
+			return this.audioInputId && this.audioStream
+		},
+
+		videoPreviewAvailable() {
+			return this.videoInputId && this.videoStream
+		},
+
+		currentVolumeIndicatorHeight() {
+			// refs can not be accessed on the initial render, only after the
+			// component has been mounted.
+			if (!this.mounted) {
+				return 0
+			}
+
+			// WebRTC volume goes from -100 (silence) to 0 (loudest sound in the
+			// system); for the volume indicator only sounds above the threshold
+			// are taken into account.
+			let currentVolumeProportion = 0
+			if (this.currentVolume > this.volumeThreshold) {
+				currentVolumeProportion = (this.volumeThreshold - this.currentVolume) / this.volumeThreshold
+			}
+
+			const volumeIndicatorStyle = window.getComputedStyle ? getComputedStyle(this.$refs.volumeIndicator, null) : this.$refs.volumeIndicator.currentStyle
+
+			const maximumVolumeIndicatorHeight = this.$refs.volumeIndicator.parentElement.clientHeight - (parseInt(volumeIndicatorStyle.bottom, 10) * 2)
+
+			return maximumVolumeIndicatorHeight * currentVolumeProportion
+		},
+
+	},
+
+	watch: {
+		enabled(enabled) {
+			if (this.enabled) {
+				this.mediaDevicesManager.enableDeviceEvents()
+				this.updateAudioStream()
+				this.updateVideoStream()
+			} else {
+				this.mediaDevicesManager.disableDeviceEvents()
+				this.stopAudioStream()
+				this.stopVideoStream()
+			}
+		},
+
+		audioInputId(audioInputId) {
+			if (!this.enabled) {
+				return
+			}
+
+			this.updateAudioStream()
+		},
+
+		videoInputId(videoInputId) {
+			if (!this.enabled) {
+				return
+			}
+
+			this.updateVideoStream()
+		},
+	},
+
+	mounted() {
+		this.mounted = true
+
+		if (!this.mediaDevicesManager.isSupported()) {
+			// DOMException constructor is not supported in Internet Explorer,
+			// so a plain object is used instead.
+			this.audioStreamError = {
+				message: 'MediaDevicesManager is not supported',
+				name: 'NotSupportedError',
+			}
+			this.videoStreamError = {
+				message: 'MediaDevicesManager is not supported',
+				name: 'NotSupportedError',
+			}
+		}
+	},
+
+	destroyed() {
+		this.stopAudioStream()
+		this.stopVideoStream()
+
+		if (this.enabled) {
+			this.mediaDevicesManager.disableDeviceEvents()
+		}
+	},
+
+	methods: {
+
+		updateAudioStream() {
+			if (!this.mediaDevicesManager.isSupported()) {
+				return
+			}
+
+			// When the audio input device changes the previous stream must be
+			// stopped before a new one is requested, as for example currently
+			// Firefox does not support having two different audio input devices
+			// active at the same time:
+			// https://bugzilla.mozilla.org/show_bug.cgi?id=1468700
+			this.stopAudioStream()
+
+			this.audioStreamError = false
+
+			if (!this.audioInputId) {
+				return
+			}
+
+			this.mediaDevicesManager.getUserMedia({ audio: true })
+				.then(stream => {
+					this.setAudioStream(stream)
+				})
+				.catch(error => {
+					console.error('Error getting audio stream: ' + error.name + ': ' + error.message)
+					this.audioStreamError = true
+					this.setAudioStream(null)
+				})
+		},
+
+		updateVideoStream() {
+			if (!this.mediaDevicesManager.isSupported()) {
+				return
+			}
+
+			// Video stream is stopped too to avoid potential issues similar to
+			// the audio ones (see "updateAudioStream").
+			this.stopVideoStream()
+
+			this.videoStreamError = false
+
+			if (!this.videoInputId) {
+				return
+			}
+
+			this.mediaDevicesManager.getUserMedia({ video: true })
+				.then(stream => {
+					this.setVideoStream(stream)
+				})
+				.catch(error => {
+					console.error('Error getting video stream: ' + error.name + ': ' + error.message)
+					this.videoStreamError = true
+					this.setVideoStream(null)
+				})
+		},
+
+		setAudioStream(audioStream) {
+			this.audioStream = audioStream
+
+			if (!audioStream) {
+				return
+			}
+
+			this.hark = hark(this.audioStream)
+			this.hark.on('volume_change', (volume, volumeThreshold) => {
+				this.currentVolume = volume
+				this.volumeThreshold = volumeThreshold
+			})
+		},
+
+		setVideoStream(videoStream) {
+			this.videoStream = videoStream
+
+			if (!this.$refs.video) {
+				return
+			}
+
+			if (!videoStream) {
+				return
+			}
+
+			const options = {
+				autoplay: true,
+				mirror: true,
+				muted: true,
+			}
+			attachMediaStream(videoStream, this.$refs.video, options)
+		},
+
+		stopAudioStream() {
+			if (!this.audioStream) {
+				return
+			}
+
+			this.audioStream.getTracks().forEach(function(track) {
+				track.stop()
+			})
+
+			this.audioStream = null
+
+			if (this.hark) {
+				this.hark.stop()
+				this.hark.off('volume_change')
+				this.hark = null
+			}
+		},
+
+		stopVideoStream() {
+			if (!this.videoStream) {
+				return
+			}
+
+			this.videoStream.getTracks().forEach(function(track) {
+				track.stop()
+			})
+
+			this.videoStream = null
+
+			if (this.$refs.video) {
+				this.$refs.video.srcObject = null
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.preview {
+	display: flex;
+	justify-content: center;
+
+	.icon {
+		background-size: 64px;
+		width: 64px;
+		height: 64px;
+		opacity: 0.4;
+	}
+}
+
+.preview-audio {
+	.preview-not-available .icon {
+		margin-top: 16px;
+		margin-bottom: 16px;
+	}
+
+	.volume-indicator-wrapper {
+		/* Make the wrapper the positioning context of the volume indicator. */
+		position: relative;
+
+		margin-top: 16px;
+		margin-bottom: 16px;
+	}
+
+	.volume-indicator {
+		position: absolute;
+
+		width: 6px;
+		right: 0;
+
+		/* The button height is 64px; the volume indicator button is 56px at
+		 * maximum, but its value will be changed based on the current volume;
+		 * the height change will reveal more or less of the gradient, which has
+		 * absolute dimensions and thus does not change when the height
+		 * changes. */
+		height: 56px;
+		bottom: 4px;
+
+		background: linear-gradient(0deg, green, yellow, red 54px);
+
+		opacity: 0.7;
+	}
+}
+
+.preview-video {
+	.preview-not-available .icon {
+		margin-top: 64px;
+		margin-bottom: 64px;
+	}
+
+	video {
+		display: block;
+		max-height: 192px;
+	}
+}
+</style>

--- a/src/components/MediaDevicesPreview.vue
+++ b/src/components/MediaDevicesPreview.vue
@@ -331,7 +331,7 @@ export default {
 
 			this.audioStreamError = null
 
-			if (!this.audioInputId) {
+			if (this.audioInputId === null || this.audioInputId === undefined) {
 				return
 			}
 
@@ -377,7 +377,7 @@ export default {
 
 			this.videoStreamError = null
 
-			if (!this.videoInputId) {
+			if (this.videoInputId === null || this.videoInputId === undefined) {
 				return
 			}
 

--- a/src/components/MediaDevicesPreview.vue
+++ b/src/components/MediaDevicesPreview.vue
@@ -139,6 +139,32 @@ export default {
 			},
 		},
 
+		audioStreamInputId() {
+			if (!this.audioStream) {
+				return null
+			}
+
+			const audioTracks = this.audioStream.getAudioTracks()
+			if (audioTracks.length < 1) {
+				return null
+			}
+
+			return audioTracks[0].getSettings().deviceId
+		},
+
+		videoStreamInputId() {
+			if (!this.videoStream) {
+				return null
+			}
+
+			const videoTracks = this.videoStream.getVideoTracks()
+			if (videoTracks.length < 1) {
+				return null
+			}
+
+			return videoTracks[0].getSettings().deviceId
+		},
+
 		audioPreviewAvailable() {
 			return this.audioInputId && this.audioStream
 		},
@@ -286,6 +312,10 @@ export default {
 				return
 			}
 
+			if (this.audioStreamInputId && this.audioStreamInputId === this.audioInputId) {
+				return
+			}
+
 			if (this.pendingGetUserMediaAudioCount) {
 				this.pendingGetUserMediaAudioCount++
 
@@ -328,6 +358,10 @@ export default {
 
 		updateVideoStream() {
 			if (!this.mediaDevicesManager.isSupported()) {
+				return
+			}
+
+			if (this.videoStreamInputId && this.videoStreamInputId === this.videoInputId) {
 				return
 			}
 

--- a/src/components/MediaDevicesSelector.vue
+++ b/src/components/MediaDevicesSelector.vue
@@ -1,0 +1,166 @@
+<!--
+  - @copyright Copyright (c) 2020, Daniel Calviño Sánchez (danxuliu@gmail.com)
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<div class="media-devices-selector">
+		<label :for="deviceSelectorId">{{ deviceSelectorLabel }}</label>
+		<Multiselect :id="deviceSelectorId"
+			v-model="deviceSelectedOption"
+			:options="deviceOptions"
+			track-by="id"
+			label="label"
+			:allow-empty="false"
+			:placeholder="deviceSelectorPlaceholder"
+			:disabled="!enabled || !deviceOptionsAvailable" />
+	</div>
+</template>
+
+<script>
+import Multiselect from '@nextcloud/vue/dist/Components/Multiselect'
+
+export default {
+
+	name: 'MediaDevicesSelector',
+
+	components: {
+		Multiselect,
+	},
+
+	props: {
+		kind: {
+			validator(value) {
+				return ['audioinput', 'videoinput'].indexOf(value) !== -1
+			},
+			required: true,
+		},
+		devices: {
+			type: Array,
+			required: true,
+		},
+		deviceId: {
+			type: String,
+			default: undefined,
+		},
+		enabled: {
+			type: Boolean,
+			default: true,
+		},
+	},
+
+	data() {
+		return {
+			deviceSelectedOption: null,
+		}
+	},
+
+	computed: {
+		deviceSelectorId() {
+			return 'device-selector-' + this.kind
+		},
+
+		deviceSelectorLabel() {
+			if (this.kind === 'audioinput') {
+				return t('spreed', 'Microphone:')
+			}
+
+			if (this.kind === 'videoinput') {
+				return t('spreed', 'Camera:')
+			}
+
+			return null
+		},
+
+		deviceOptionsAvailable() {
+			return this.deviceOptions.length > 0
+		},
+
+		deviceSelectorPlaceholder() {
+			if (this.kind === 'audioinput') {
+				return this.audioInputSelectorPlaceholder
+			}
+
+			if (this.kind === 'videoinput') {
+				return this.videoInputSelectorPlaceholder
+			}
+
+			return null
+		},
+
+		audioInputSelectorPlaceholder() {
+			if (!this.deviceOptionsAvailable) {
+				return t('spreed', 'No microphone available')
+			}
+
+			return t('spreed', 'Select microphone')
+		},
+
+		videoInputSelectorPlaceholder() {
+			if (!this.deviceOptionsAvailable) {
+				return t('spreed', 'No camera available')
+			}
+
+			return t('spreed', 'Select camera')
+		},
+
+		deviceOptions() {
+			return this.devices.filter(device => device.kind === this.kind).map(device => {
+				return {
+					id: device.deviceId,
+					label: device.label ? device.label : device.fallbackLabel,
+				}
+			})
+		},
+
+		deviceSelectedOptionFromDeviceId() {
+			return this.deviceOptions.find(option => option.id === this.deviceId)
+		},
+	},
+
+	watch: {
+		deviceSelectedOptionFromDeviceId(deviceSelectedOptionFromDeviceId) {
+			this.deviceSelectedOption = deviceSelectedOptionFromDeviceId
+		},
+
+		deviceSelectedOption(deviceSelectedOption) {
+			if (deviceSelectedOption && deviceSelectedOption.id === null) {
+				this.$emit('update:deviceId', null)
+				return
+			}
+			this.$emit('update:deviceId', deviceSelectedOption ? deviceSelectedOption.id : undefined)
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.media-devices-selector {
+	display: flex;
+	align-items: center;
+
+	margin-top: 5px;
+	margin-bottom: 5px;
+
+	.multiselect {
+		flex-grow: 1;
+
+		margin-left: 5px;
+	}
+}
+</style>

--- a/src/components/MediaDevicesSelector.vue
+++ b/src/components/MediaDevicesSelector.vue
@@ -88,7 +88,7 @@ export default {
 		},
 
 		deviceOptionsAvailable() {
-			return this.deviceOptions.length > 0
+			return this.deviceOptions.length > 1
 		},
 
 		deviceSelectorPlaceholder() {
@@ -120,12 +120,19 @@ export default {
 		},
 
 		deviceOptions() {
-			return this.devices.filter(device => device.kind === this.kind).map(device => {
+			const options = this.devices.filter(device => device.kind === this.kind).map(device => {
 				return {
 					id: device.deviceId,
 					label: device.label ? device.label : device.fallbackLabel,
 				}
 			})
+
+			options.push({
+				id: null,
+				label: t('spreed', 'None'),
+			})
+
+			return options
 		},
 
 		deviceSelectedOptionFromDeviceId() {

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -27,6 +27,7 @@
 		:title="title"
 		:starred="isFavorited"
 		:title-editable="canModerate && isRenamingConversation"
+		@update:active="handleUpdateActive"
 		@update:starred="onFavoriteChange"
 		@update:title="handleUpdateTitle"
 		@submit-title="handleSubmitTitle"
@@ -66,6 +67,13 @@
 			icon="icon-settings">
 			<SetGuestUsername />
 		</AppSidebarTab>
+		<AppSidebarTab
+			id="preview"
+			:order="5"
+			:name="t('spreed', 'Preview')"
+			icon="icon-video">
+			<MediaDevicesPreview :enabled="!showChatInSidebar && activeTab === 'preview'" />
+		</AppSidebarTab>
 	</AppSidebar>
 </template>
 
@@ -73,6 +81,7 @@
 import AppSidebar from '@nextcloud/vue/dist/Components/AppSidebar'
 import AppSidebarTab from '@nextcloud/vue/dist/Components/AppSidebarTab'
 import ChatView from '../ChatView'
+import MediaDevicesPreview from '../MediaDevicesPreview'
 import { CollectionList } from 'nextcloud-vue-collections'
 import BrowserStorage from '../../services/BrowserStorage'
 import { CONVERSATION, WEBINAR, PARTICIPANT } from '../../constants'
@@ -92,6 +101,7 @@ export default {
 		AppSidebarTab,
 		ChatView,
 		CollectionList,
+		MediaDevicesPreview,
 		ParticipantsTab,
 		SetGuestUsername,
 	},
@@ -109,6 +119,7 @@ export default {
 
 	data() {
 		return {
+			activeTab: null,
 			contactsLoading: false,
 			// The conversation name (while editing)
 			conversationName: '',
@@ -213,6 +224,10 @@ export default {
 			}
 
 			this.conversation.isFavorite = !this.conversation.isFavorite
+		},
+
+		handleUpdateActive(active) {
+			this.activeTab = active
 		},
 
 		/**

--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -22,14 +22,44 @@
 /**
  * Wrapper for MediaDevices to simplify its use.
  *
+ * The MediaDevicesManager keeps an updated list of devices that can be accessed
+ * from "attributes.devices". Clients of this class must call
+ * "enableDeviceEvents()" to start keeping track of the devices, and
+ * "disableDeviceEvents()" once it is no longer needed. Eventually there must be
+ * one call to "disableDeviceEvents()" for each call to "enableDeviceEvents()",
+ * but several clients can be active at the same time.
+ *
+ * Each element of "attributes.devices" is an object with the following fields:
+ * - deviceId: the unique identifier for the device
+ * - groupId: two or more devices have the same groupId if they belong to the
+ *   same physical device
+ * - kind: either "audioinput", "videoinput" or "audiooutput"
+ * - label: a human readable identifier for the device
+ *
+ * Note that the list may not contain some kind of devices due to browser
+ * limitations (for example, currently Firefox does not list "audiooutput"
+ * devices).
+ *
+ * The label may not be available if persistent media permissions have not been
+ * granted and a MediaStream has not been active.
+ *
  * "attributes.audioInputId" and "attributes.videoInputId" define the devices
  * that will be used when calling "getUserMedia(constraints)".
+ *
+ * The selected devices will be automatically cleared if they are no longer
+ * available.
  */
 export default function MediaDevicesManager() {
 	this.attributes = {
+		devices: [],
+
 		audioInputId: undefined,
 		videoInputId: undefined,
 	}
+
+	this._enabledCount = 0
+
+	this._updateDevicesBound = this._updateDevices.bind(this)
 }
 MediaDevicesManager.prototype = {
 
@@ -46,6 +76,90 @@ MediaDevicesManager.prototype = {
 	 */
 	isSupported: function() {
 		return navigator && navigator.mediaDevices && navigator.mediaDevices.getUserMedia && navigator.mediaDevices.enumerateDevices
+	},
+
+	enableDeviceEvents: function() {
+		if (!this.isSupported()) {
+			return
+		}
+
+		this._enabledCount++
+
+		this._updateDevices()
+
+		navigator.mediaDevices.addEventListener('devicechange', this._updateDevicesBound)
+	},
+
+	disableDeviceEvents: function() {
+		if (!this.isSupported()) {
+			return
+		}
+
+		this._enabledCount--
+
+		if (!this._enabledCount) {
+			navigator.mediaDevices.removeEventListener('devicechange', this._updateDevicesBound)
+		}
+	},
+
+	_updateDevices: function() {
+		navigator.mediaDevices.enumerateDevices().then(devices => {
+			const removedDevices = this.attributes.devices.filter(oldDevice => !devices.find(device => oldDevice.deviceId === device.deviceId && oldDevice.kind === device.kind))
+			const updatedDevices = devices.filter(device => this.attributes.devices.find(oldDevice => device.deviceId === oldDevice.deviceId && device.kind === oldDevice.kind))
+			const addedDevices = devices.filter(device => !this.attributes.devices.find(oldDevice => device.deviceId === oldDevice.deviceId && device.kind === oldDevice.kind))
+
+			removedDevices.forEach(removedDevice => {
+				this._removeDevice(removedDevice)
+			})
+			updatedDevices.forEach(updatedDevice => {
+				this._updateDevice(updatedDevice)
+			})
+			addedDevices.forEach(addedDevice => {
+				this._addDevice(addedDevice)
+			})
+		}).catch(function(error) {
+			console.error('Could not update known media devices: ' + error.name + ': ' + error.message)
+		})
+	},
+
+	_removeDevice: function(removedDevice) {
+		if (removedDevice.kind === 'audioinput' && this.attributes.audioInputId === removedDevice.deviceId) {
+			this.attributes.audioInputId = undefined
+		} else if (removedDevice.kind === 'videoinput' && this.attributes.videoInputId === removedDevice.deviceId) {
+			this.attributes.videoInputId = undefined
+		}
+
+		const removedDeviceIndex = this.attributes.devices.findIndex(oldDevice => oldDevice.deviceId === removedDevice.deviceId && oldDevice.kind === removedDevice.kind)
+		if (removedDeviceIndex >= 0) {
+			this.attributes.devices.splice(removedDeviceIndex, 1)
+		}
+	},
+
+	_updateDevice: function(updatedDevice) {
+		const oldDevice = this.attributes.devices.find(oldDevice => oldDevice.deviceId === updatedDevice.deviceId && oldDevice.kind === updatedDevice.kind)
+
+		// Only update the label if it has a value, as it may have been
+		// removed if there is currently no active stream.
+		if (updatedDevice.label) {
+			oldDevice.label = updatedDevice.label
+		}
+
+		// These should not have changed, but just in case
+		oldDevice.groupId = updatedDevice.groupId
+		oldDevice.kind = updatedDevice.kind
+	},
+
+	_addDevice: function(addedDevice) {
+		// Copy the device to add, as its properties are read only and
+		// thus they can not be updated later.
+		addedDevice = {
+			deviceId: addedDevice.deviceId,
+			groupId: addedDevice.groupId,
+			kind: addedDevice.kind,
+			label: addedDevice.label,
+		}
+
+		this.attributes.devices.push(addedDevice)
 	},
 
 	/**
@@ -82,6 +196,20 @@ MediaDevicesManager.prototype = {
 			constraints.video.deviceId = this.attributes.videoInputId
 		}
 
-		return navigator.mediaDevices.getUserMedia(constraints)
+		return navigator.mediaDevices.getUserMedia(constraints).then(stream => {
+			// The list of devices is always updated when a stream is started as
+			// that is the only time at which the full device information is
+			// guaranteed to be available.
+			this._updateDevices()
+
+			return stream
+		}).catch(error => {
+			// The list of devices is also updated in case of failure, as even
+			// if getting the stream failed the permissions may have been
+			// permanently granted.
+			this._updateDevices()
+
+			throw error
+		})
 	},
 }

--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -49,7 +49,9 @@
  * that will be used when calling "getUserMedia(constraints)".
  *
  * The selected devices will be automatically cleared if they are no longer
- * available.
+ * available. When no device of certain kind is selected and there are other
+ * devices of that kind the selected device will fall back to the first one
+ * found, or to the one with the "default" id (if any).
  */
 export default function MediaDevicesManager() {
 	this.attributes = {
@@ -62,6 +64,9 @@ export default function MediaDevicesManager() {
 	this._enabledCount = 0
 
 	this._knownDevices = {}
+
+	this._fallbackAudioInputId = undefined
+	this._fallbackVideoInputId = undefined
 
 	this._updateDevicesBound = this._updateDevices.bind(this)
 }
@@ -127,15 +132,27 @@ MediaDevicesManager.prototype = {
 	},
 
 	_removeDevice: function(removedDevice) {
-		if (removedDevice.kind === 'audioinput' && this.attributes.audioInputId === removedDevice.deviceId) {
-			this.attributes.audioInputId = undefined
-		} else if (removedDevice.kind === 'videoinput' && this.attributes.videoInputId === removedDevice.deviceId) {
-			this.attributes.videoInputId = undefined
-		}
-
 		const removedDeviceIndex = this.attributes.devices.findIndex(oldDevice => oldDevice.deviceId === removedDevice.deviceId && oldDevice.kind === removedDevice.kind)
 		if (removedDeviceIndex >= 0) {
 			this.attributes.devices.splice(removedDeviceIndex, 1)
+		}
+
+		if (removedDevice.kind === 'audioinput') {
+			if (this._fallbackAudioInputId === removedDevice.deviceId) {
+				const firstAudioInputDevice = this.attributes.devices.find(device => device.kind === 'audioinput')
+				this._fallbackAudioInputId = firstAudioInputDevice ? firstAudioInputDevice.deviceId : undefined
+			}
+			if (this.attributes.audioInputId === removedDevice.deviceId) {
+				this.attributes.audioInputId = this._fallbackAudioInputId
+			}
+		} else if (removedDevice.kind === 'videoinput') {
+			if (this._fallbackVideoInputId === removedDevice.deviceId) {
+				const firstVideoInputDevice = this.attributes.devices.find(device => device.kind === 'videoinput')
+				this._fallbackVideoInputId = firstVideoInputDevice ? firstVideoInputDevice.deviceId : undefined
+			}
+			if (this.attributes.videoInputId === removedDevice.deviceId) {
+				this.attributes.videoInputId = this._fallbackVideoInputId
+			}
 		}
 	},
 
@@ -185,6 +202,24 @@ MediaDevicesManager.prototype = {
 
 		// Always refresh the known device with the latest values.
 		this._knownDevices[addedDevice.kind + '-' + addedDevice.deviceId] = addedDevice
+
+		// Set first available device as fallback, and override any
+		// fallback previously set if the default device is added.
+		if (addedDevice.kind === 'audioinput') {
+			if (!this._fallbackAudioInputId || addedDevice.deviceId === 'default') {
+				this._fallbackAudioInputId = addedDevice.deviceId
+			}
+			if (this.attributes.audioInputId === undefined) {
+				this.attributes.audioInputId = this._fallbackAudioInputId
+			}
+		} else if (addedDevice.kind === 'videoinput') {
+			if (!this._fallbackVideoInputId || addedDevice.deviceId === 'default') {
+				this._fallbackVideoInputId = addedDevice.deviceId
+			}
+			if (this.attributes.videoInputId === undefined) {
+				this.attributes.videoInputId = this._fallbackVideoInputId
+			}
+		}
 
 		this.attributes.devices.push(addedDevice)
 	},

--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -41,9 +41,13 @@
  * limitations (for example, currently Firefox does not list "audiooutput"
  * devices).
  *
- * The label may not be available if persistent media permissions have not been
- * granted and a MediaStream has not been active. In those cases the fallback
- * label can be used instead.
+ * In some browsers if persistent media permissions have not been granted and a
+ * MediaStream is not active the list may contain at most one device of each
+ * kind, and all of them with empty attributes except for the kind.
+ *
+ * In other browsers just the label may not be available if persistent media
+ * permissions have not been granted and a MediaStream has not been active. In
+ * those cases the fallback label can be used instead.
  *
  * "attributes.audioInputId" and "attributes.videoInputId" define the devices
  * that will be used when calling "getUserMedia(constraints)".
@@ -191,14 +195,14 @@ MediaDevicesManager.prototype = {
 		} else {
 			// Generate a fallback label to be used when the actual label is
 			// not available.
-			if (addedDevice.deviceId === 'default') {
+			if (addedDevice.deviceId === 'default' || addedDevice.deviceId === '') {
 				addedDevice.fallbackLabel = t('spreed', 'Default')
 			} else if (addedDevice.kind === 'audioinput') {
-				addedDevice.fallbackLabel = t('spreed', 'Microphone {number}', { number: Object.values(this._knownDevices).filter(device => device.kind === 'audioinput').length + 1 })
+				addedDevice.fallbackLabel = t('spreed', 'Microphone {number}', { number: Object.values(this._knownDevices).filter(device => device.kind === 'audioinput' && device.deviceId !== '').length + 1 })
 			} else if (addedDevice.kind === 'videoinput') {
-				addedDevice.fallbackLabel = t('spreed', 'Camera {number}', { number: Object.values(this._knownDevices).filter(device => device.kind === 'videoinput').length + 1 })
+				addedDevice.fallbackLabel = t('spreed', 'Camera {number}', { number: Object.values(this._knownDevices).filter(device => device.kind === 'videoinput' && device.deviceId !== '').length + 1 })
 			} else if (addedDevice.kind === 'audiooutput') {
-				addedDevice.fallbackLabel = t('spreed', 'Speaker {number}', { number: Object.values(this._knownDevices).filter(device => device.kind === 'audioutput').length + 1 })
+				addedDevice.fallbackLabel = t('spreed', 'Speaker {number}', { number: Object.values(this._knownDevices).filter(device => device.kind === 'audioutput' && device.deviceId !== '').length + 1 })
 			}
 		}
 

--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -1,0 +1,87 @@
+/**
+ *
+ * @copyright Copyright (c) 2020, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Wrapper for MediaDevices to simplify its use.
+ *
+ * "attributes.audioInputId" and "attributes.videoInputId" define the devices
+ * that will be used when calling "getUserMedia(constraints)".
+ */
+export default function MediaDevicesManager() {
+	this.attributes = {
+		audioInputId: undefined,
+		videoInputId: undefined,
+	}
+}
+MediaDevicesManager.prototype = {
+
+	/**
+	 * Returns whether getting user media and enumerating media devices is
+	 * supported or not.
+	 *
+	 * Note that even if false is returned the MediaDevices interface could be
+	 * technically supported by the browser but not available due to the page
+	 * being loaded in an insecure context.
+	 *
+	 * @returns {boolean} true if MediaDevices interface is supported, false
+	 *          otherwise.
+	 */
+	isSupported: function() {
+		return navigator && navigator.mediaDevices && navigator.mediaDevices.getUserMedia && navigator.mediaDevices.enumerateDevices
+	},
+
+	/**
+	 * Wrapper for MediaDevices.getUserMedia to use the selected audio and video
+	 * input devices.
+	 *
+	 * The selected audio and video input devices are used only if the
+	 * constraints do not specify a device already. Otherwise the devices in the
+	 * constraints are respected.
+	 *
+	 * @param {MediaStreamConstraints} constraints the constraints specifying
+	 *        the media to request
+	 * @returns {Promise} resolved with a MediaStream object when successful, or
+	 *          rejected with a DOMException in case of error
+	 */
+	getUserMedia: function(constraints) {
+		if (!this.isSupported()) {
+			return new Promise((resolve, reject) => {
+				reject(new DOMException('MediaDevicesManager is not supported', 'NotSupportedError'))
+			})
+		}
+
+		if (constraints.audio && !constraints.audio.deviceId && this.attributes.audioInputId) {
+			if (!(constraints.audio instanceof Object)) {
+				constraints.audio = {}
+			}
+			constraints.audio.deviceId = this.attributes.audioInputId
+		}
+
+		if (constraints.video && !constraints.video.deviceId && this.attributes.videoInputId) {
+			if (!(constraints.video instanceof Object)) {
+				constraints.video = {}
+			}
+			constraints.video.deviceId = this.attributes.videoInputId
+		}
+
+		return navigator.mediaDevices.getUserMedia(constraints)
+	},
+}

--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -51,7 +51,9 @@
  * The selected devices will be automatically cleared if they are no longer
  * available. When no device of certain kind is selected and there are other
  * devices of that kind the selected device will fall back to the first one
- * found, or to the one with the "default" id (if any).
+ * found, or to the one with the "default" id (if any). It is possible to
+ * explicitly disable devices of certain kind by setting xxxInputId to "null"
+ * (in that case the fallback devices will not be taken into account).
  */
 export default function MediaDevicesManager() {
 	this.attributes = {
@@ -244,18 +246,26 @@ MediaDevicesManager.prototype = {
 			})
 		}
 
-		if (constraints.audio && !constraints.audio.deviceId && this.attributes.audioInputId) {
-			if (!(constraints.audio instanceof Object)) {
-				constraints.audio = {}
+		if (constraints.audio && !constraints.audio.deviceId) {
+			if (this.attributes.audioInputId) {
+				if (!(constraints.audio instanceof Object)) {
+					constraints.audio = {}
+				}
+				constraints.audio.deviceId = this.attributes.audioInputId
+			} else if (this.attributes.audioInputId === null) {
+				constraints.audio = false
 			}
-			constraints.audio.deviceId = this.attributes.audioInputId
 		}
 
-		if (constraints.video && !constraints.video.deviceId && this.attributes.videoInputId) {
-			if (!(constraints.video instanceof Object)) {
-				constraints.video = {}
+		if (constraints.video && !constraints.video.deviceId) {
+			if (this.attributes.videoInputId) {
+				if (!(constraints.video instanceof Object)) {
+					constraints.video = {}
+				}
+				constraints.video.deviceId = this.attributes.videoInputId
+			} else if (this.attributes.videoInputId === null) {
+				constraints.video = false
 			}
-			constraints.video.deviceId = this.attributes.videoInputId
 		}
 
 		return navigator.mediaDevices.getUserMedia(constraints).then(stream => {

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -27,6 +27,7 @@ import CallAnalyzer from './analyzers/CallAnalyzer'
 import CallParticipantCollection from './models/CallParticipantCollection'
 import LocalCallParticipantModel from './models/LocalCallParticipantModel'
 import LocalMediaModel from './models/LocalMediaModel'
+import MediaDevicesManager from './MediaDevicesManager'
 import SentVideoQualityThrottler from './SentVideoQualityThrottler'
 import { PARTICIPANT } from '../../constants'
 import { fetchSignalingSettings } from '../../services/signalingService'
@@ -35,6 +36,7 @@ let webRtc = null
 const callParticipantCollection = new CallParticipantCollection()
 const localCallParticipantModel = new LocalCallParticipantModel()
 const localMediaModel = new LocalMediaModel()
+const mediaDevicesManager = new MediaDevicesManager()
 let callAnalyzer = null
 let sentVideoQualityThrottler = null
 
@@ -224,6 +226,8 @@ export {
 	callParticipantCollection,
 	localCallParticipantModel,
 	localMediaModel,
+
+	mediaDevicesManager,
 
 	callAnalyzer,
 

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -5,6 +5,9 @@ const hark = require('hark')
 const getScreenMedia = require('./getscreenmedia')
 const WildEmitter = require('wildemitter')
 const mockconsole = require('mockconsole')
+// Only mediaDevicesManager is used, but it can not be assigned here due to not
+// being initialized yet.
+const webrtcIndex = require('../index.js')
 
 function isAllTracksEnded(stream) {
 	let isAllTracksEnded = true
@@ -43,7 +46,7 @@ function LocalMedia(opts) {
 	this._audioMonitorStreams = []
 	this.localScreens = []
 
-	if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+	if (!webrtcIndex.mediaDevicesManager.isSupported()) {
 		this._logerror('Your browser does not support local media capture.')
 	}
 
@@ -86,7 +89,7 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 	const self = this
 	const constraints = mediaConstraints || this.config.media
 
-	if (!navigator || !navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+	if (!webrtcIndex.mediaDevicesManager.isSupported()) {
 		const error = new Error('MediaStreamError')
 		error.name = 'NotSupportedError'
 
@@ -99,7 +102,7 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 
 	this.emit('localStreamRequested', constraints, context)
 
-	navigator.mediaDevices.getUserMedia(constraints).then(function(stream) {
+	webrtcIndex.mediaDevicesManager.getUserMedia(constraints).then(function(stream) {
 		// Although the promise should be resolved only if all the constraints
 		// are met Edge resolves it if both audio and video are requested but
 		// only audio is available.


### PR DESCRIPTION
Requires #3912
Fixes #358

This pull request adds a new _Preview_ tab to the right sidebar to select the audio and video devices to be used when a call is started, and also to be able to check whether the devices are properly working (or whether your lack of pants is visible or not before starting the call).

The `MediaDevices` Web API [provides device labels only if a stream is active or if permanent media permissions have been granted](https://developer.mozilla.org/en-US/docs/Web/API/MediaDeviceInfo/label). Due to this a fallback label is generated to be used when the actual device label is unknown. This fallback label is persistent for the whole session, so if a device is connected, disconnected and connected again later after other devices have also been connected the same fallback label as before will be used.

Nevertheless, the fallback label should be rarely visible; the device labels are updated whenever a stream is started, which is anytime that a different device preview starts, so in most cases the actual device label will be shown to the user.

Currently the audio and video input devices can be selected only when not in a call. The `Preview` tab is not usable during calls, so it would be better to remove it. However I tried using `v-if="!showChatInSidebar"` and the sidebar tabs behaved weirdly (they were out of order when the preview tab was shown again). As (eventually) it will be possible to change the devices during calls too for now the preview tab is shown but with its contents disabled during calls.

**Caveats:**

- Detecting device changes only works if media permissions have been granted (either permanently or because there is an active stream). In most cases it should not be a problem, but if the user does not grant permanent media permissions, disables microphone and camera and then connects a new device the device will not be shown in the device list, which could be confusing for the user (although fortunately it should not be a common scenario).
Currently this could be solved in Firefox by polling the devices when permissions are not granted, but that would be a short term solution. Due to a change in the MediaDevices spec ([already partially implemented in Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1019176)) eventually it will not be possible to enumerate devices either when permissions are not granted, only to know if there is a microphone or camera connected, but nothing else. Due to this I do not think that adding the polling is worth it.

- The sources can be overriden by the system and it does not seem possible to detect that from the web app. For example, if the user selects an audio device but then changes the source used by the browser with PulseAudio (through `pavucontrol`) Talk will still show the original device as being the one used. If the user does the change explicitly it should not be a big problem, although it could be if some other element in the system does it and then the user does not understand why the device that is selected is not the one being used. Alas there does not seem to be anything that can be done here.

- Chromium does not properly set PulseAudio virtual audio sources (and it does not offer PulseAudio monitors as sources either). For example, if the _module-echo-cancel_ is loaded (`pactl load-module module-echo-cancel`) a virtual device on top of each normal input device will be created. If the virtual device is selected in Chromium, however, the normal device will be actually used instead of the virtual one (as can be seen by checking the recording device being used in `pavucontrol`). Unfortunately it does not seem possible to detect this; if the user selects a virtual device... it would not work as expected, and virtual devices can not be filtered out either :-(

- When switching several times between audio devices in Firefox a _NotReadableError_ with message _Concurrent mic process limit_ is sometimes thrown. When that happens Firefox will get stuck to the last selected microphone and it will not be possible to change it. Moreover, it will not be possible to change it even from `pavucontrol`. Reloading the page seems to be the only way to solve this. In this pull request streams are explicitly stopped before a new one is started, so this looks like a lower level issue; maybe under the hood stopping the stream does not immediately stops it and in some cases it clashes with the new requested stream, but I have no idea.

- If permissions have been rejected the user must explicitly remove the denied permissions before previews work again. It does not seem to be possible to trigger the permissions dialog once they have been rejected (the Permissions API has a [_request_](https://developer.mozilla.org/en-US/docs/Web/API/Permissions) method, but it is not implemented in any browser yet).

Pending:
- [X] If the preview tab is never opened before a call and then it is opened during a call "No microphone/camera" will be shown, even if those devices are actually being used in the call - If an error happened when getting the media for the call this will not be reflected in the preview tab, but this can be addressed when making possible to change the devices during a call
- [X] Selecting the same option again removes it, ~~not sure if a bug or expected behaviour when using the Multiselect component~~ - It is a configurable property in the https://vue-multiselect.js.org component used by Multiselect
- [X] If an error happened when getting the preview provide also a text with the error instead of just an icon
- [ ] Improve toasts when media could not be got (as both audio and video could have been explicitly disabled but an error would be shown nevertheless)
- [X] Update devices when getting user media if some device label is not known yet
- [X] ~~Get a single stream for both audio and video instead of separate ones for previews?~~ - Separate media permission requests for each type feels better (to me, at least :-P )
- [ ] Move `MediaDevicesPreview` to the `Settings` tab? In that case the preview should not be immediately visible and a button should be added to enable and disable the preview. Otherwise guests will always be asked for media permissions just by opening the conversation. Besides that I prefer to have a `Preview` tab with a video icon as it seems more intuitive about what it does. On the other hand, once changing the devices also during calls is implemented the name `Preview` is less appropriate... So I do not know :shrug: Other alternatives are also welcome, of course :-)
- [ ] Selecting the media devices is currently possible in the main Talk UI. When Talk is shown in the sidebar a _Preview_ tab would be too much (specially in the Files app). What could be done in those cases? For the Files app and the public share page maybe adding a settings button next to the _Start/Join call_ button that shows a dialog could be an option. In the video verification, on the other hand, when _Request password_ is clicked the user immediately starts the call. Maybe in that case it would make sense to first show a screen to select the audio and video devices (and allow the user to check how the video looks even if there is only one camera) and when that dialog is accepted then start the call? All this could be done in follow up pull requests, though.

Follow up pull requests:
- Make possible to select the audio output device
- Make possible to change the devices also during calls
- Persist the selected device ID between sessions?
