### PR TITLE
Add shortcut to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ version+=master
 
 all: dev-setup build-js-production
 
+d: dev-setup watch-js
+
 dev-setup: clean-dev npm-init
 
 dependabot: dev-setup npm-update build-js-production


### PR DESCRIPTION
`make d` 
d as 'develop'

Quick shortcut to build and watch for changes. Handy when switching branches 

Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>