### PR TITLE
Fix speaker promotion with newer Janus versions

### DIFF
--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -216,7 +216,7 @@ CallParticipantModel.prototype = {
 			return
 		}
 
-		if (label !== 'status') {
+		if (label !== 'status' && label !== 'JanusDataChannel') {
 			return
 		}
 


### PR DESCRIPTION
Fixes (in the WebUI, but changes in the mobile apps are needed) #3937

When Janus is used even if it is possible to open several data channels with different labels and send data on them all the messages are received in the first data channel opened.

Although currently several data channels are opened in Talk in practice only the "status" data channel is used (and messages received in data channels with a different label are ignored). This is also the first data channel opened when Janus is used, so until now everything happened to work (with Janus 0.4.3).

However, with newer Janus versions the data channel messages are received instead on a data channel opened by Janus, which is named "JanusDataChannel". It is not possible to change that behaviour on Janus except by patching it, so for broader compatibility the messages received in "JanusDataChannel" are treated like messages received in the "status" data channel ([this was partially done already](https://github.com/nextcloud/spreed/commit/62f6205fafe88800a3338bb273d58599e75427dd); this commit finishes the change).
