### PR TITLE
Add Emoji picker to message form

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -35,6 +35,18 @@
 				class="new-message-form">
 				<div
 					class="new-message-form__button">
+					<EmojiPicker @select="addEmoji">
+						<button
+							type="button"
+							class="new-message-form__icon new-message-form__button"
+							:aria-label="t('spreed', 'Add emoji')"
+							:aria-haspopup="true">
+							🙂
+						</button>
+					</EmojiPicker>
+				</div>
+				<div
+					class="new-message-form__button">
 					<Actions
 						default-icon="icon-clip-add-file"
 						class="new-message-form__button"
@@ -84,6 +96,7 @@ import { postNewMessage } from '../../services/messagesService'
 import Quote from '../Quote'
 import Actions from '@nextcloud/vue/dist/Components/Actions'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
+import EmojiPicker from '@nextcloud/vue/dist/Components/EmojiPicker'
 import SHA1 from 'crypto-js/sha1'
 import Hex from 'crypto-js/enc-hex'
 import { shareFile } from '../../services/filesSharingServices'
@@ -104,6 +117,7 @@ export default {
 		Quote,
 		Actions,
 		ActionButton,
+		EmojiPicker,
 	},
 	data: function() {
 		return {
@@ -300,6 +314,16 @@ export default {
 			// Uploads and shares the files
 			processFiles(files, this.token, uploadId)
 		},
+
+		/**
+		 * Add selected emoji to text input area
+		 *
+		 * @param {Emoji} emoji Emoji object
+		 */
+		addEmoji(emoji) {
+			this.text += emoji
+		},
+
 	},
 }
 </script>
@@ -336,6 +360,17 @@ export default {
 			background-color: transparent;
 			border: none;
 		}
+
+		// put a grey round background when popover is opened
+		// or hover-focused
+		&__icon:hover,
+		&__icon:focus,
+		&__icon:active {
+			opacity: $opacity_full;
+			// good looking on dark AND white bg
+			background-color: $icon-focus-bg;
+		}
+
 	}
 }
 </style>


### PR DESCRIPTION
This MR adds the new emoji picker from [nextcloud-vue](https://github.com/nextcloud/nextcloud-vue) to the new message form of the Talk text chat. This solves #1130 .

![image](https://user-images.githubusercontent.com/1677436/88466711-7386fd00-cecf-11ea-984b-4e5b0fd30ab8.png)

![image](https://user-images.githubusercontent.com/1677436/88466710-6964fe80-cecf-11ea-814e-b3fd3db16ca2.png)

![image](https://user-images.githubusercontent.com/1677436/88466719-8ef20800-cecf-11ea-9a5c-8f96f4ae9987.png)
