### PR TITLE
Conversations in Unified Search

### DIFF
--- a/css/unified-search.scss
+++ b/css/unified-search.scss
@@ -1,0 +1,23 @@
+.unified-search {
+	.conversation-icon {
+		background-color: var(--color-background-darker);
+		background-size: 22px !important;
+
+		// We always want to use the white icons, this is why we don't use var(--color-white) here.
+		&.icon-public {
+			background-image: url(icon-color-path('public', 'actions', 'fff', 1, true));
+		}
+		&.icon-contacts {
+			background-image: url(icon-color-path('contacts', 'places', 'fff', 1, true));
+		}
+		&.icon-password {
+			background-image: url(icon-color-path('password', 'actions', 'fff', 1, true));
+		}
+		&.icon-file {
+			background-image: url(icon-color-path('text', 'filetypes', 'fff', 1, true));
+		}
+		&.icon-mail {
+			background-image: url(icon-color-path('mail', 'actions', 'fff', 1, true));
+		}
+	}
+}

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -53,6 +53,8 @@ use OCA\Talk\PublicShare\TemplateLoader as PublicShareTemplateLoader;
 use OCA\Talk\PublicShareAuth\Listener as PublicShareAuthListener;
 use OCA\Talk\PublicShareAuth\TemplateLoader as PublicShareAuthTemplateLoader;
 use OCA\Talk\Room;
+use OCA\Talk\Search\ConversationSearch;
+use OCA\Talk\Search\UnifiedSearchCSSLoader;
 use OCA\Talk\Settings\Personal;
 use OCA\Talk\Share\Listener as ShareListener;
 use OCA\Talk\Share\RoomShareProvider;
@@ -90,6 +92,9 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(BeforeUserLoggedOutEvent::class, BeforeUserLoggedOutListener::class);
 		$context->registerEventListener(BeforeTemplateRenderedEvent::class, PublicShareTemplateLoader::class);
 		$context->registerEventListener(BeforeTemplateRenderedEvent::class, PublicShareAuthTemplateLoader::class);
+		$context->registerEventListener(\OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent::class, UnifiedSearchCSSLoader::class);
+
+		$context->registerSearchProvider(ConversationSearch::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Search/ConversationSearch.php
+++ b/lib/Search/ConversationSearch.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Search;
+
+use OCA\Talk\Manager;
+use OCA\Talk\Room;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\Search\IProvider;
+use OCP\Search\ISearchQuery;
+use OCP\Search\SearchResult;
+
+class ConversationSearch implements IProvider {
+
+	/** @var Manager */
+	protected $manager;
+	/** @var IURLGenerator */
+	protected $url;
+	/** @var IL10N */
+	protected $l;
+
+	public function __construct(
+		Manager $manager,
+		IURLGenerator $url,
+		IL10N $l
+	) {
+		$this->manager = $manager;
+		$this->url = $url;
+		$this->l = $l;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getId(): string {
+		return 'talk_conversations';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getName(): string {
+		return $this->l->t('Conversations');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function search(IUser $user, ISearchQuery $query): SearchResult {
+		$rooms = $this->manager->getRoomsForParticipant($user->getUID());
+
+		$result = [];
+		foreach ($rooms as $room) {
+			if (
+				$room->getType() === Room::CHANGELOG_CONVERSATION || (
+					stripos($room->getName(), $query->getTerm()) === false &&
+					stripos($room->getDisplayName($user->getUID()), $query->getTerm()) === false
+				)
+			) {
+				continue;
+			}
+
+			$icon = '';
+			$iconClass = '';
+			if ($room->getType() === Room::ONE_TO_ONE_CALL) {
+				$users = $room->getParticipantUserIds();
+				foreach ($users as $participantId) {
+					if ($participantId !== $user->getUID()) {
+						$icon = $this->url->linkToRouteAbsolute('core.avatar.getAvatar', [
+							'userId' => $participantId,
+							'size' => 128,
+						]);
+					}
+				}
+			} elseif ($room->getObjectType() === 'file') {
+				$iconClass = 'conversation-icon icon-file';
+			} elseif ($room->getObjectType() === 'share:password') {
+				$iconClass = 'conversation-icon icon-password';
+			} elseif ($room->getObjectType() === 'emails') {
+				$iconClass = 'conversation-icon icon-mail';
+			} elseif ($room->getType() === Room::PUBLIC_CALL) {
+				$iconClass = 'conversation-icon icon-public';
+			} else {
+				$iconClass = 'conversation-icon icon-contacts';
+			}
+
+			$result[] = new ConversationSearchResult(
+				$icon,
+				$room->getDisplayName($user->getUID()),
+				'',
+				$this->url->linkToRouteAbsolute('spreed.Page.showCall', ['token' => $room->getToken()]),
+				$iconClass,
+				true
+			);
+		}
+
+		return SearchResult::complete(
+			$this->l->t('Conversations'),
+			$result
+		);
+	}
+}

--- a/lib/Search/ConversationSearchResult.php
+++ b/lib/Search/ConversationSearchResult.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Search;
+
+use OCP\Search\ASearchResultEntry;
+
+class ConversationSearchResult extends ASearchResultEntry {
+}

--- a/lib/Search/UnifiedSearchCSSLoader.php
+++ b/lib/Search/UnifiedSearchCSSLoader.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Search;
+
+use OCA\Talk\AppInfo\Application;
+use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Util;
+
+class UnifiedSearchCSSLoader implements IEventListener {
+	public function handle(Event $event): void {
+		if (!$event instanceof BeforeTemplateRenderedEvent) {
+			return;
+		}
+
+		if ($event->isLoggedIn()) {
+			Util::addStyle(Application::APP_ID, 'unified-search');
+		}
+	}
+}


### PR DESCRIPTION
- [x] Requires https://github.com/nextcloud/server/pull/21971

Bright | Dark
---|---
![Bildschirmfoto von 2020-08-03 15-40-15](https://user-images.githubusercontent.com/213943/89189070-c16ec580-d59f-11ea-80a5-bd8256f0c28e.png) | ![Bildschirmfoto von 2020-08-03 15-40-26](https://user-images.githubusercontent.com/213943/89189058-bf0c6b80-d59f-11ea-9529-2af648bcef0f.png)

Fix #3493 

- [x] Icons are not white
- [x] Avatars of one-to-one conversations are not rounded
- [ ] ~~Last message as subline? Or participants?~~ => None for now due to performance

