### PR TITLE
Pass base URL of Nextcloud to signaling server in backend requests.

### DIFF
--- a/docs/standalone-signaling-api-v1.md
+++ b/docs/standalone-signaling-api-v1.md
@@ -99,6 +99,8 @@ must contain two additional HTTP headers:
 - `Spreed-Signaling-Checksum`: SHA256-HMAC of the random string and the request
   body, calculated with a shared secret. The shared secret is configured on
   both sides, so the checksum can be verified.
+- `Spreed-Signaling-Backend`: Base URL of the Nextcloud server performing the
+  request.
 
 ### Example
 

--- a/lib/Signaling/BackendNotifier.php
+++ b/lib/Signaling/BackendNotifier.php
@@ -30,6 +30,7 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCP\Http\Client\IClientService;
 use OCP\ILogger;
+use OCP\IUrlGenerator;
 use OCP\Security\ISecureRandom;
 
 class BackendNotifier {
@@ -43,17 +44,21 @@ class BackendNotifier {
 	private $secureRandom;
 	/** @var Manager */
 	private $signalingManager;
+	/** @var IUrlGenerator */
+	private $urlGenerator;
 
 	public function __construct(Config $config,
 								ILogger $logger,
 								IClientService $clientService,
 								ISecureRandom $secureRandom,
-								Manager $signalingManager) {
+								Manager $signalingManager,
+								IURLGenerator $urlGenerator) {
 		$this->config = $config;
 		$this->logger = $logger;
 		$this->clientService = $clientService;
 		$this->secureRandom = $secureRandom;
 		$this->signalingManager = $signalingManager;
+		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**
@@ -113,6 +118,7 @@ class BackendNotifier {
 		$hash = hash_hmac('sha256', $random . $body, $this->config->getSignalingSecret());
 		$headers['Spreed-Signaling-Random'] = $random;
 		$headers['Spreed-Signaling-Checksum'] = $hash;
+		$headers['Spreed-Signaling-Backend'] = $this->urlGenerator->getBaseUrl();
 
 		$params = [
 			'headers' => $headers,

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -38,6 +38,7 @@ use OCP\Http\Client\IClientService;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\ILogger;
+use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Security\IHasher;
@@ -76,6 +77,8 @@ class BackendNotifierTest extends \Test\TestCase {
 	private $timeFactory;
 	/** @var \OCA\Talk\Signaling\Manager|MockObject */
 	private $signalingManager;
+	/** @var IURLGenerator|MockObject */
+	private $urlGenerator;
 	/** @var CustomBackendNotifier */
 	private $controller;
 
@@ -102,6 +105,7 @@ class BackendNotifierTest extends \Test\TestCase {
 		$this->userId = 'testUser';
 		$this->secureRandom = \OC::$server->getSecureRandom();
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$groupManager = $this->createMock(IGroupManager::class);
 		$config = \OC::$server->getConfig();
 		$this->signalingSecret = 'the-signaling-secret';
@@ -154,7 +158,8 @@ class BackendNotifierTest extends \Test\TestCase {
 			$this->createMock(ILogger::class),
 			$this->createMock(IClientService::class),
 			$this->secureRandom,
-			$this->signalingManager
+			$this->signalingManager,
+			$this->urlGenerator
 		);
 	}
 


### PR DESCRIPTION
With https://github.com/strukturag/nextcloud-spreed-signaling/pull/28 the signaling server supports multiple backends, i.e. you can run a single signaling server for multiple Nextcloud instances. When a backend request reaches the signaling server, it must know from which Nextcloud instance it was sent - this PR adds the necessary header to the request.

Please also backport this to all supported versions of Talk.