### PR TITLE
Feature/3949/allow editing before upload

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,6 +32,7 @@
 		<RightSidebar
 			:show-chat-in-sidebar="isInCall" />
 		<PreventUnload :when="warnLeaving" />
+		<UploadEditor />
 	</Content>
 </template>
 
@@ -61,6 +62,7 @@ import duplicateSessionHandler from './mixins/duplicateSessionHandler'
 import isInCall from './mixins/isInCall'
 import talkHashCheck from './mixins/talkHashCheck'
 import { generateUrl } from '@nextcloud/router'
+import UploadEditor from './components/UploadEditor'
 
 export default {
 	name: 'App',
@@ -70,6 +72,7 @@ export default {
 		LeftSidebar,
 		PreventUnload,
 		RightSidebar,
+		UploadEditor,
 	},
 
 	mixins: [

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -23,8 +23,8 @@
 
 <template>
 	<file-preview v-bind="filePreview"
-		class="container"
-		:class="{ 'is-viewer-available': isViewerAvailable, 'upload-editor': isUploadEditor }"
+		class="file-preview"
+		:class="{ 'file-preview--viewer-available': isViewerAvailable, 'file-preview--upload-editor': isUploadEditor }"
 		@click="showPreview">
 		<img v-if="!isLoading && !failed"
 			:class="previewSizeClass"
@@ -37,6 +37,10 @@
 		<span v-if="isLoading"
 			class="preview loading" />
 		<strong>{{ name }}</strong>
+		<button v-if="isUploadEditor"
+			class="remove-file primary">
+			<Close class="remove-file__icon" @click="$emit('remove-file', id)" />
+		</button>
 		<ProgressBar v-if="isTemporaryUpload && !isUploadEditor" :value="uploadProgress" />
 	</file-preview>
 </template>
@@ -44,12 +48,14 @@
 <script>
 import { generateUrl, imagePath } from '@nextcloud/router'
 import ProgressBar from '@nextcloud/vue/dist/Components/ProgressBar'
+import Close from 'vue-material-design-icons/Close'
 
 export default {
 	name: 'FilePreview',
 
 	components: {
 		ProgressBar,
+		Close,
 	},
 
 	props: {
@@ -227,8 +233,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '../../../../../assets/variables.scss';
 
-.container {
+.file-preview {
+	position: relative;
 	width: 100%;
 	/* The file preview can not be a block; otherwise it would fill the whole
 	width of the container and the loading icon would not be centered on the
@@ -243,6 +251,9 @@ export default {
 		/* Trick to keep the same position while adding a padding to show
 			* the background. */
 		box-sizing: content-box !important;
+		.remove-file {
+			visibility: visible;
+		}
 	}
 
 	.preview {
@@ -264,17 +275,34 @@ export default {
 		white-space: nowrap;
 	}
 
-	&:not(.is-viewer-available) {
+	&:not(.file-preview--viewer-available) {
 		strong:after {
 			content: ' ↗';
 		}
 	}
+	&--upload-editor {
+		max-width: 160px;
+		max-height: 160px;
+		margin: 10px;
+		.preview {
+			margin: auto;
+		}
+	}
 }
 
-.upload-editor {
-	max-width: 160px;
-	max-height: 160px;
-	margin: 10px;
+.remove-file {
+	visibility: hidden;
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	box-shadow: 0 0 4px var(--color-box-shadow);
+	width: $clickable-area;
+	height: $clickable-area;
+	padding: 0;
+	margin: 0;
+	&__icon {
+		color: var(--color-primary-text);
+	}
 }
 
 </style>

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -26,7 +26,7 @@
 		class="file-preview"
 		:class="{ 'file-preview--viewer-available': isViewerAvailable, 'file-preview--upload-editor': isUploadEditor }"
 		@click="showPreview">
-		<img v-if="!isLoading && !failed"
+		<img v-if="(!isLoading && !failed) || hasTemporaryImageUrl"
 			:class="previewSizeClass"
 			alt=""
 			:src="previewUrl">
@@ -108,6 +108,11 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		// The link to the file for displaying it in the preview
+		localUrl: {
+			type: String,
+			default: '',
+		},
 	},
 	data() {
 		return {
@@ -143,6 +148,10 @@ export default {
 			return 'preview'
 		},
 		previewUrl() {
+			if (this.hasTemporaryImageUrl) {
+				return this.localUrl
+			}
+
 			if (this.previewAvailable !== 'yes' || this.$store.getters.getUserId() === null) {
 				return OC.MimeType.getIconUrl(this.mimetype)
 			}
@@ -185,6 +194,9 @@ export default {
 				}
 			}
 			return 0
+		},
+		hasTemporaryImageUrl() {
+			return this.mimetype.startsWith('image/') && this.localUrl
 		},
 	},
 	mounted() {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -23,11 +23,14 @@
 
 <template>
 	<file-preview v-bind="filePreview"
+		:tabindex="wrapperTabIndex"
 		class="file-preview"
 		:class="{ 'file-preview--viewer-available': isViewerAvailable, 'file-preview--upload-editor': isUploadEditor }"
-		@click="showPreview">
+		@click="handleClick"
+		@keydown.enter="handleClick">
 		<img v-if="(!isLoading && !failed) || hasTemporaryImageUrl"
 			:class="previewSizeClass"
+			class="file-preview__image"
 			alt=""
 			:src="previewUrl">
 		<img v-if="!isLoading && failed"
@@ -38,6 +41,8 @@
 			class="preview loading" />
 		<strong>{{ name }}</strong>
 		<button v-if="isUploadEditor"
+			tabindex="1"
+			:aria-label="removeAriaLabel"
 			class="remove-file primary">
 			<Close class="remove-file__icon" @click="$emit('remove-file', id)" />
 		</button>
@@ -198,6 +203,14 @@ export default {
 		hasTemporaryImageUrl() {
 			return this.mimetype.startsWith('image/') && this.localUrl
 		},
+
+		wrapperTabIndex() {
+			return this.isUploadEditor ? '0' : ''
+		},
+
+		removeAriaLabel() {
+			return t('spreed', 'Remove' + this.name)
+		},
 	},
 	mounted() {
 		const img = new Image()
@@ -211,7 +224,12 @@ export default {
 		img.src = this.previewUrl
 	},
 	methods: {
-		showPreview(event) {
+		handleClick(event) {
+			if (this.isUploadEditor) {
+				this.$emit('remove-file', this.id)
+				return
+			}
+
 			if (!this.isViewerAvailable) {
 				// Regular event handling by opening the link.
 				return
@@ -266,6 +284,10 @@ export default {
 		.remove-file {
 			visibility: visible;
 		}
+	}
+
+	&__image {
+		object-fit: cover;
 	}
 
 	.preview {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -285,6 +285,8 @@ export default {
 		display: block;
 		overflow: hidden;
 		white-space: nowrap;
+		text-overflow: ellipsis;
+		margin-top: 4px;
 	}
 
 	&:not(.file-preview--viewer-available) {
@@ -296,6 +298,7 @@ export default {
 		max-width: 160px;
 		max-height: 160px;
 		margin: 10px;
+		padding: 12px;
 		.preview {
 			margin: auto;
 		}

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -1,7 +1,9 @@
 <!--
   - @copyright Copyright (c) 2019 Joas Schilling <coding@schilljs.com>
+  - @copyright Copyright (c) 2020 Marco Ambrosini <marcoambrosini@pm.me>
   -
   - @author Joas Schilling <coding@schilljs.com>
+  - @author Marco Ambrosini <marcoambrosini@pm.me>
   -
   - @license GNU AGPL version 3 or any later version
   -
@@ -20,11 +22,9 @@
 -->
 
 <template>
-	<a :href="link"
+	<file-preview v-bind="filePreview"
 		class="container"
-		:class="{ 'is-viewer-available': isViewerAvailable }"
-		target="_blank"
-		rel="noopener noreferrer"
+		:class="{ 'is-viewer-available': isViewerAvailable, 'upload-editor': isUploadEditor }"
 		@click="showPreview">
 		<img v-if="!isLoading && !failed"
 			:class="previewSizeClass"
@@ -37,8 +37,8 @@
 		<span v-if="isLoading"
 			class="preview loading" />
 		<strong>{{ name }}</strong>
-		<ProgressBar v-if="isTemporaryUpload" :value="uploadProgress" />
-	</a>
+		<ProgressBar v-if="isTemporaryUpload && !isUploadEditor" :value="uploadProgress" />
+	</file-preview>
 </template>
 
 <script>
@@ -97,6 +97,11 @@ export default {
 			type: String,
 			default: '',
 		},
+		// True if this component is used in the upload editor
+		isUploadEditor: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	data() {
 		return {
@@ -105,6 +110,23 @@ export default {
 		}
 	},
 	computed: {
+		// This is used to decide which outer element type to use
+		// a or div
+		filePreview() {
+			if (this.isUploadEditor || this.isTemporaryUpload) {
+				return {
+					is: 'div',
+					tag: 'div',
+				}
+			}
+			return {
+				is: 'a',
+				tag: 'a',
+				href: this.link,
+				target: '_blank',
+				rel: 'noopener noreferrer',
+			}
+		},
 		defaultIconUrl() {
 			return imagePath('core', 'filetypes/file')
 		},
@@ -213,20 +235,14 @@ export default {
 	image. */
 	display: inline-block;
 
-	/* Show a hover colour around the preview when navigating with the
-	 * keyboard through the file links (or hovering them with the mouse). */
-	&:hover,
-	&:focus,
-	&:active {
-		.preview {
-			background-color: var(--color-background-hover);
+	border-radius: 16px;
 
-			/* Trick to keep the same position while adding a padding to show
-			 * the background. */
-			box-sizing: content-box !important;
-			padding: 10px;
-			margin: -10px;
-		}
+	&:hover,
+	&:focus {
+		background-color: var(--color-background-hover);
+		/* Trick to keep the same position while adding a padding to show
+			* the background. */
+		box-sizing: content-box !important;
 	}
 
 	.preview {
@@ -244,6 +260,8 @@ export default {
 		/* As the file preview is an inline block the name is set as a block to
 		force it to be on its own line below the preview. */
 		display: block;
+		overflow: hidden;
+		white-space: nowrap;
 	}
 
 	&:not(.is-viewer-available) {
@@ -251,6 +269,12 @@ export default {
 			content: ' ↗';
 		}
 	}
+}
+
+.upload-editor {
+	max-width: 160px;
+	max-height: 160px;
+	margin: 10px;
 }
 
 </style>

--- a/src/components/UploadEditor.vue
+++ b/src/components/UploadEditor.vue
@@ -1,0 +1,122 @@
+<!--
+  - @copyright Copyright (c) 2020 Marco Ambrosini <marcoambrosini@pm.me>
+  -
+  - @author Marco Ambrosini <marcoambrosini@pm.me>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+	<Modal v-if="showModal"
+		@close="handleDismiss">
+		<div class="upload-editor">
+			<div class="upload-editor__previews">
+				<template v-for="file in files">
+					<FilePreview
+						:key="file.temporaryMessage.id"
+						v-bind="file.temporaryMessage.messageParameters.file"
+						:is-upload-editor="true" />
+				</template>
+			</div>
+			<div class="upload-editor__actions">
+				<button @click="handleDismiss">
+					Dismiss
+				</button>
+				<button class="primary" @click="handleUpload">
+					Upload
+				</button>
+			</div>
+		</div>
+	</Modal>
+</template>
+
+<script>
+
+import Modal from '@nextcloud/vue/dist/Components/Modal'
+import FilePreview from './MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue'
+
+export default {
+	name: 'UploadEditor',
+
+	components: {
+		Modal,
+		FilePreview,
+	},
+
+	data() {
+		return {
+			modalDismissed: false,
+		}
+	},
+
+	computed: {
+		currentUploadId() {
+			return this.$store.getters.currentUploadId
+		},
+
+		files() {
+			if (this.currentUploadId) {
+				return this.$store.getters.getShareableFiles(this.currentUploadId)
+			}
+			return []
+		},
+
+		showUploadEditor() {
+			return this.$store.getters.showUploadEditor
+		},
+
+		showModal() {
+			return this.showUploadEditor && !this.modalDismissed
+		},
+	},
+
+	watch: {
+		currentUploadId() {
+			this.modalDismissed = false
+		},
+	},
+
+	methods: {
+		handleDismiss() {
+			this.modalDismissed = true
+		},
+
+		handleUpload() {
+			this.$store.dispatch('uploadFiles', this.currentUploadId)
+			this.modalDismissed = true
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+
+.upload-editor {
+	height: 100%;
+	&__previews {
+		display: flex;
+		flex-wrap: wrap;
+		overflow: auto;
+	}
+	&__actions {
+		display: flex;
+		justify-content: space-between;
+		margin-bottom: 16px;
+		margin-top: 16px;
+	}
+}
+
+</style>

--- a/src/components/UploadEditor.vue
+++ b/src/components/UploadEditor.vue
@@ -30,17 +30,21 @@
 			class="hidden-visually"
 			@change="handleFileInput">
 		<div class="upload-editor">
-			<div class="upload-editor__previews">
+			<transition-group
+				class="upload-editor__previews"
+				name="fade"
+				tag="div">
 				<template v-for="file in files">
 					<FilePreview
 						:key="file.temporaryMessage.id"
 						v-bind="file.temporaryMessage.messageParameters.file"
-						:is-upload-editor="true" />
+						:is-upload-editor="true"
+						@remove-file="handleRemoveFileFromSelection" />
 				</template>
-				<button class="upload-editor__add-more primary" @click="clickImportInput">
+				<button :key="'addMore'" class="upload-editor__add-more primary" @click="clickImportInput">
 					<Plus :size="48" class="upload-editor__plus-icon" />
 				</button>
-			</div>
+			</transition-group>
 			<div class="upload-editor__actions">
 				<button @click="handleDismiss">
 					Dismiss
@@ -126,6 +130,10 @@ export default {
 		handleFileInput(event) {
 			const files = Object.values(event.target.files)
 			processFiles(files, this.token, this.currentUploadId)
+		},
+
+		handleRemoveFileFromSelection(id) {
+			this.$store.dispatch('removeFileFromSelection', id)
 		},
 	},
 }

--- a/src/components/UploadEditor.vue
+++ b/src/components/UploadEditor.vue
@@ -21,6 +21,7 @@
 
 <template>
 	<Modal v-if="showModal"
+		class="upload-editor"
 		@close="handleDismiss">
 		<!--native file picker, hidden -->
 		<input id="file-upload"
@@ -29,30 +30,30 @@
 			type="file"
 			class="hidden-visually"
 			@change="handleFileInput">
-		<div class="upload-editor">
-			<transition-group
-				class="upload-editor__previews"
-				name="fade"
-				tag="div">
-				<template v-for="file in files">
-					<FilePreview
-						:key="file.temporaryMessage.id"
-						v-bind="file.temporaryMessage.messageParameters.file"
-						:is-upload-editor="true"
-						@remove-file="handleRemoveFileFromSelection" />
-				</template>
-				<button :key="'addMore'" class="upload-editor__add-more primary" @click="clickImportInput">
+		<transition-group
+			class="upload-editor__previews"
+			name="fade"
+			tag="div">
+			<template v-for="file in files">
+				<FilePreview
+					:key="file.temporaryMessage.id"
+					v-bind="file.temporaryMessage.messageParameters.file"
+					:is-upload-editor="true"
+					@remove-file="handleRemoveFileFromSelection" />
+			</template>
+			<div :key="'addMore'" class="add-more">
+				<button class="add-more__button primary" @click="clickImportInput">
 					<Plus :size="48" class="upload-editor__plus-icon" />
 				</button>
-			</transition-group>
-			<div class="upload-editor__actions">
-				<button @click="handleDismiss">
-					Dismiss
-				</button>
-				<button class="primary" @click="handleUpload">
-					Upload
-				</button>
 			</div>
+		</transition-group>
+		<div class="upload-editor__actions">
+			<button @click="handleDismiss">
+				Dismiss
+			</button>
+			<button class="primary" @click="handleUpload">
+				Upload
+			</button>
 		</div>
 	</Modal>
 </template>
@@ -152,14 +153,20 @@ export default {
 	&__actions {
 		display: flex;
 		justify-content: space-between;
-		margin-bottom: 16px;
 		margin-top: 16px;
 	}
-	&__add-more {
-		width: 100px;
-		height: 100px;
+}
+
+.add-more {
+	width: 180px;
+	height: 180px;
+	display: flex;
+	margin: 10px;
+	&__button {
+		width: 80px;
+		height: 80px;
 		border: none;
-		border-radius: var(--border-radius-large);
+		border-radius: var(--border-radius-pill);
 		position: relative;
 		z-index: 2;
 		box-shadow: 0 0 4px var(--color-box-shadow);

--- a/src/components/UploadEditor.vue
+++ b/src/components/UploadEditor.vue
@@ -69,7 +69,7 @@ export default {
 
 		files() {
 			if (this.currentUploadId) {
-				return this.$store.getters.getShareableFiles(this.currentUploadId)
+				return this.$store.getters.getInitialisedUploads(this.currentUploadId)
 			}
 			return []
 		},

--- a/src/components/UploadEditor.vue
+++ b/src/components/UploadEditor.vue
@@ -42,7 +42,9 @@
 					@remove-file="handleRemoveFileFromSelection" />
 			</template>
 			<div :key="'addMore'" class="add-more">
-				<button class="add-more__button primary" @click="clickImportInput">
+				<button :aria-label="addMoreAriaLabel"
+					class="add-more__button primary"
+					@click="clickImportInput">
 					<Plus :size="48" class="upload-editor__plus-icon" />
 				</button>
 			</div>
@@ -102,6 +104,10 @@ export default {
 
 		showModal() {
 			return this.showUploadEditor && !this.modalDismissed
+		},
+
+		addMoreAriaLabel() {
+			return t('spreed', 'Add more files')
 		},
 	},
 

--- a/src/components/UploadEditor.vue
+++ b/src/components/UploadEditor.vue
@@ -144,16 +144,21 @@ export default {
 @import '../assets/variables.scss';
 
 .upload-editor {
-	height: 100%;
 	&__previews {
-		display: flex;
-		flex-wrap: wrap;
+		overflow-x: hidden !important;
+		display: grid;
+		position: relative;
 		overflow: auto;
+		grid-template-columns: repeat(4, auto);
 	}
 	&__actions {
 		display: flex;
 		justify-content: space-between;
 		margin-top: 16px;
+		margin-bottom: 4px;
+		button {
+			margin: 0 4px 0 4px;
+		}
 	}
 }
 
@@ -171,7 +176,7 @@ export default {
 		z-index: 2;
 		box-shadow: 0 0 4px var(--color-box-shadow);
 		padding: 0;
-		margin: 0;
+		margin: auto;
 		&__plus {
 			color: var(--color-primary-text);
 			z-index: 3;
@@ -179,4 +184,10 @@ export default {
 	}
 }
 
+::v-deep .modal-container {
+	display: flex !important;
+	flex-direction: column;
+	padding: 12px !important;
+	min-width: 400px;
+}
 </style>

--- a/src/components/UploadEditor.vue
+++ b/src/components/UploadEditor.vue
@@ -22,6 +22,13 @@
 <template>
 	<Modal v-if="showModal"
 		@close="handleDismiss">
+		<!--native file picker, hidden -->
+		<input id="file-upload"
+			ref="fileUploadInput"
+			multiple
+			type="file"
+			class="hidden-visually"
+			@change="handleFileInput">
 		<div class="upload-editor">
 			<div class="upload-editor__previews">
 				<template v-for="file in files">
@@ -30,6 +37,9 @@
 						v-bind="file.temporaryMessage.messageParameters.file"
 						:is-upload-editor="true" />
 				</template>
+				<button class="upload-editor__add-more primary" @click="clickImportInput">
+					<Plus :size="48" class="upload-editor__plus-icon" />
+				</button>
 			</div>
 			<div class="upload-editor__actions">
 				<button @click="handleDismiss">
@@ -47,6 +57,8 @@
 
 import Modal from '@nextcloud/vue/dist/Components/Modal'
 import FilePreview from './MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue'
+import Plus from 'vue-material-design-icons/Plus'
+import { processFiles } from '../utils/fileUpload'
 
 export default {
 	name: 'UploadEditor',
@@ -54,6 +66,7 @@ export default {
 	components: {
 		Modal,
 		FilePreview,
+		Plus,
 	},
 
 	data() {
@@ -63,6 +76,10 @@ export default {
 	},
 
 	computed: {
+		token() {
+			return this.$store.getters.getToken()
+		},
+
 		currentUploadId() {
 			return this.$store.getters.currentUploadId
 		},
@@ -98,11 +115,24 @@ export default {
 			this.$store.dispatch('uploadFiles', this.currentUploadId)
 			this.modalDismissed = true
 		},
+		/**
+		 * Clicks the hidden file input when clicking the correspondent ActionButton,
+		 * thus opening the file-picker
+		 */
+		clickImportInput() {
+			this.$refs.fileUploadInput.click()
+		},
+
+		handleFileInput(event) {
+			const files = Object.values(event.target.files)
+			processFiles(files, this.token, this.currentUploadId)
+		},
 	},
 }
 </script>
 
 <style lang="scss" scoped>
+@import '../assets/variables.scss';
 
 .upload-editor {
 	height: 100%;
@@ -116,6 +146,21 @@ export default {
 		justify-content: space-between;
 		margin-bottom: 16px;
 		margin-top: 16px;
+	}
+	&__add-more {
+		width: 100px;
+		height: 100px;
+		border: none;
+		border-radius: var(--border-radius-large);
+		position: relative;
+		z-index: 2;
+		box-shadow: 0 0 4px var(--color-box-shadow);
+		padding: 0;
+		margin: 0;
+		&__plus {
+			color: var(--color-primary-text);
+			z-index: 3;
+		}
 	}
 }
 

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -33,6 +33,7 @@ const state = {
 	uploads: {
 	},
 	currentUploadId: undefined,
+	showUploadEditor: false,
 }
 
 const getters = {
@@ -68,6 +69,10 @@ const getters = {
 
 	currentUploadId: (state) => {
 		return state.currentUploadId
+	},
+
+	showUploadEditor: (state) => {
+		return state.showUploadEditor
 	},
 }
 
@@ -140,6 +145,11 @@ const mutations = {
 	// Sets the id of the current upload operation
 	setCurrentUploadId(state, currentUploadId) {
 		state.currentUploadId = currentUploadId
+	},
+
+	// Shows hides the upload editor
+	showUploadEditor(state, show) {
+		state.showUploadEditor = show
 	},
 }
 

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -172,6 +172,15 @@ const mutations = {
 	showUploadEditor(state, show) {
 		state.showUploadEditor = show
 	},
+
+	removeFileFromSelection(state, fileId) {
+		const uploadId = state.currentUploadId
+		for (const key in state.uploads[uploadId].files) {
+			if (state.uploads[uploadId].files[key].temporaryMessage.id === fileId) {
+				Vue.delete(state.uploads[uploadId].files, key)
+			}
+		}
+	},
 }
 
 const actions = {
@@ -272,6 +281,10 @@ const actions = {
 	 */
 	markFileAsShared(context, { uploadId, index }) {
 		context.commit('markFileAsShared', { uploadId, index })
+	},
+
+	removeFileFromSelection({ commit }, fileId) {
+		commit('removeFileFromSelection', fileId)
 	},
 
 }

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -32,6 +32,7 @@ const state = {
 	attachmentFolder: loadState('talk', 'attachment_folder'),
 	uploads: {
 	},
+	currentUploadId: undefined,
 }
 
 const getters = {
@@ -63,6 +64,10 @@ const getters = {
 		} else {
 			return 0
 		}
+	},
+
+	currentUploadId: (state) => {
+		return state.currentUploadId
 	},
 }
 
@@ -131,6 +136,11 @@ const mutations = {
 		console.debug('uploadId: ' + uploadId + ' index: ' + index)
 		Vue.set(state.uploads[uploadId].files[index], 'temporaryMessage', temporaryMessage)
 	},
+
+	// Sets the id of the current upload operation
+	setCurrentUploadId(state, currentUploadId) {
+		state.currentUploadId = currentUploadId
+	},
 }
 
 const actions = {
@@ -147,6 +157,8 @@ const actions = {
 
 		// Add temporary messages
 		for (const index in state.uploads[uploadId].files) {
+			// Set last upload id
+			commit('setCurrentUploadId', { uploadId })
 			// Mark file as uploading to prevent a second function call to start a
 			// second upload for the same file
 			commit('markFileAsUploading', { uploadId, index })

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -200,8 +200,10 @@ const actions = {
 			commit('markFileAsInitialised', { uploadId, index })
 			// currentFile to be uploaded
 			const currentFile = state.uploads[uploadId].files[index].file
+			// Get localurl for previews
+			const localUrl = URL.createObjectURL(currentFile)
 			// Create temporary message for the file and add it to the message list
-			const temporaryMessage = createTemporaryMessage('{file}', token, uploadId, index, currentFile)
+			const temporaryMessage = createTemporaryMessage('{file}', token, uploadId, index, currentFile, localUrl)
 			// Add the temporary messages to the store
 			commit('setTemporaryMessageForFile', { uploadId, index, temporaryMessage })
 		}

--- a/src/utils/fileUpload.js
+++ b/src/utils/fileUpload.js
@@ -29,7 +29,6 @@
   * @returns {string} The unique path
   */
 
-import { shareFile } from '../services/filesSharingServices'
 import store from '../store/index'
 
 const findUniquePath = async function(client, userRoot, path) {
@@ -70,22 +69,7 @@ const findUniquePath = async function(client, userRoot, path) {
 const processFiles = async function(files, token, uploadId) {
 	// Process these files in the store
 	await store.dispatch('initialiseUpload', { uploadId, token, files })
-	// Get the files that have successfully been uploaded from the store
-	const shareableFiles = store.getters.getShareableFiles(uploadId)
 
-	// Share each of those files in the conversation
-	for (const index in shareableFiles) {
-		const path = shareableFiles[index].sharePath
-		try {
-			const temporaryMessage = shareableFiles[index].temporaryMessage
-
-			store.dispatch('markFileAsSharing', { uploadId, index })
-			await shareFile(path, token, temporaryMessage.referenceId)
-			store.dispatch('markFileAsShared', { uploadId, index })
-		} catch (exception) {
-			console.debug('An error happened when triying to share your file: ', exception)
-		}
-	}
 }
 
 export {

--- a/src/utils/fileUpload.js
+++ b/src/utils/fileUpload.js
@@ -69,7 +69,7 @@ const findUniquePath = async function(client, userRoot, path) {
  */
 const processFiles = async function(files, token, uploadId) {
 	// Process these files in the store
-	await store.dispatch('uploadFiles', { uploadId, token, files })
+	await store.dispatch('initialiseUpload', { uploadId, token, files })
 	// Get the files that have successfully been uploaded from the store
 	const shareableFiles = store.getters.getShareableFiles(uploadId)
 

--- a/src/utils/temporaryMessage.js
+++ b/src/utils/temporaryMessage.js
@@ -24,7 +24,7 @@ import store from '../store/index'
 import SHA1 from 'crypto-js/sha1'
 import Hex from 'crypto-js/enc-hex'
 
-const createTemporaryMessage = (text, token, uploadId, index, file) => {
+const createTemporaryMessage = (text, token, uploadId, index, file, localUrl) => {
 	const messageToBeReplied = store.getters.getMessageToBeReplied(token)
 	const date = new Date()
 	let tempId = 'temp-' + date.getTime()
@@ -39,6 +39,7 @@ const createTemporaryMessage = (text, token, uploadId, index, file) => {
 			'name': file.name,
 			index,
 			uploadId,
+			localUrl,
 		}
 	}
 	const message = Object.assign({}, {

--- a/src/utils/temporaryMessage.js
+++ b/src/utils/temporaryMessage.js
@@ -30,16 +30,17 @@ const createTemporaryMessage = (text, token, uploadId, index, file, localUrl) =>
 	let tempId = 'temp-' + date.getTime()
 	const messageParameters = {}
 	if (file) {
-		tempId += '-' + uploadId + '-' + index
+		tempId += '-' + uploadId + '-' + Math.random()
 		messageParameters.file = {
 			'type': 'file',
 			'file': file,
 			'mimetype': file.type,
 			'id': tempId,
 			'name': file.name,
-			index,
+			// index, will be the id from now on
 			uploadId,
 			localUrl,
+			index,
 		}
 	}
 	const message = Object.assign({}, {


### PR DESCRIPTION
Follow-up:
- [ ] Prevent duplicate uploads
- [ ]  Upload indicator should be overlaid on image, and just vanish when it’s uploaded
- [ ]  Re-drop files on modal