### PR TITLE
💬 Status adaption for Nextcloud 20

### DIFF
--- a/css/At.scss
+++ b/css/At.scss
@@ -150,8 +150,8 @@
 		}
 
 		.atwho-cur {
-			background: var(--color-primary);
-			color: var(--color-primary-text);
+			background: var(--color-primary-light);
+			color: var(--color-main-text);
 		}
 	}
 }

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -116,6 +116,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
     ------|------|------------
     `search` | string | Search term for name suggestions (should at least be 1 character)
     `limit` | int | Number of suggestions to receive (20 by default)
+    `includeStatus` | bool | Whether the user status information also needs to be loaded
 
 * Response:
     - Status code:
@@ -132,6 +133,9 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         `id` | string | The user id which should be sent as `@<id>` in the message (user ids that contain spaces as well as guest ids need to be wrapped in double-quotes when sending in a message: `@"space user"` and `@"guest/random-string"`)
         `label` | string | The displayname of the user
         `source` | string | The type of the user, currently only `users`, `guests` or `calls` (for mentioning the whole conversation
+        `status` | string | Optional: Only available with `includeStatus=true` and for users with a set status
+        `statusIcon` | string | Optional: Only available with `includeStatus=true` and for users with a set status
+        `statusMessage` | string | Optional: Only available with `includeStatus=true` and for users with a set status
         
 ## System messages
 

--- a/docs/participant.md
+++ b/docs/participant.md
@@ -6,6 +6,11 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 
 * Method: `GET`
 * Endpoint: `/room/{token}/participants`
+* Data:
+
+    field | type | Description
+    ------|------|------------
+    `includeStatus` | bool | Whether the user status information also needs to be loaded
 
 * Response:
     - Status code:
@@ -24,6 +29,9 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         `participantType` | int | Permissions level of the participant
         `lastPing` | int | Timestamp of the last ping of the user (should be used for sorting)
         `sessionId` | string | `'0'` if not connected, otherwise a 512 character long string
+        `status` | string | Optional: Only available with `includeStatus=true` and for users with a set status
+        `statusIcon` | string | Optional: Only available with `includeStatus=true` and for users with a set status
+        `statusMessage` | string | Optional: Only available with `includeStatus=true` and for users with a set status
 
 ## Add a participant to a conversation
 

--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -46,6 +46,8 @@
 				:disable-menu="true" />
 			&nbsp;
 			<span>{{ scope.item.label }}</span>
+			<em v-if="isNotAvailable(scope.item)">&nbsp;{{ getStatus(scope.item) }}</em>
+
 		</template>
 		<template v-slot:embeddedItem="scope">
 			<!-- The root element itself is ignored, only its contents are taken
@@ -76,6 +78,7 @@
 
 <script>
 import At from 'vue-at'
+import UserStatus from '../../../mixins/userStatus'
 import VueAtReparenter from '../../../mixins/vueAtReparenter'
 import { EventBus } from '../../../services/EventBus'
 import { searchPossibleMentions } from '../../../services/mentionsService'
@@ -153,6 +156,7 @@ export default {
 	},
 	mixins: [
 		VueAtReparenter,
+		UserStatus,
 	],
 	props: {
 		/**
@@ -349,6 +353,14 @@ export default {
 			}
 
 			return 'user'
+		},
+
+		getStatus(candidate) {
+			const status = this.getStatusMessage(candidate)
+			if (status) {
+				return '(' + status + ')'
+			}
+			return ''
 		},
 	},
 }

--- a/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
+++ b/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
@@ -29,6 +29,7 @@
 
 import ParticipantsList from '../ParticipantsList/ParticipantsList'
 import { PARTICIPANT } from '../../../../constants'
+import UserStatus from '../../../../mixins/userStatus'
 
 export default {
 	name: 'CurrentParticipants',
@@ -36,6 +37,10 @@ export default {
 	components: {
 		ParticipantsList,
 	},
+
+	mixins: [
+		UserStatus,
+	],
 
 	props: {
 		searchText: {
@@ -76,6 +81,7 @@ export default {
 		 * Sort two participants by:
 		 * - type (moderators before normal participants)
 		 * - online status
+		 * - user status (away + dnd at the end)
 		 * - display name
 		 *
 		 * @param {object} participant1 First participant
@@ -103,6 +109,12 @@ export default {
 				}
 			} else if (participant2.sessionId === '0') {
 				return -1
+			}
+
+			const participant1Away = this.isNotAvailable(participant1)
+			const participant2Away = this.isNotAvailable(participant2)
+			if (participant1Away !== participant2Away) {
+				return participant1Away ? 1 : -1
 			}
 
 			return participant1.displayName.localeCompare(participant2.displayName)

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -33,11 +33,18 @@
 			:name="computedName"
 			:source="participant.source"
 			:offline="isOffline" />
-		<span class="participant-row__user-name">{{ computedName }}</span>
-		<span v-if="showModeratorLabel" class="participant-row__moderator-indicator">({{ t('spreed', 'moderator') }})</span>
-		<span v-if="isGuest" class="participant-row__guest-indicator">({{ t('spreed', 'guest') }})</span>
-		<span v-if="callIconClass" class="icon callstate-icon" :class="callIconClass" />
-		<span v-if="isNotAvailable(participant)" class="participant-row__status">{{ getStatusMessage(participant) }}</span>
+		<div>
+			<div class="participant-row__user-descriptor">
+				<span class="participant-row__user-name">{{ computedName }}</span>
+				<span v-if="showModeratorLabel" class="participant-row__moderator-indicator">({{ t('spreed', 'moderator') }})</span>
+				<span v-if="isGuest" class="participant-row__guest-indicator">({{ t('spreed', 'guest') }})</span>
+				<span v-if="callIconClass" class="icon callstate-icon" :class="callIconClass" />
+			</div>
+			<div v-if="isNotAvailable(participant)"
+				class="participant-row__status">
+				<span>{{ getStatusMessage(participant) }}</span>
+			</div>
+		</div>
 		<Actions
 			v-if="canModerate && !isSearched"
 			:aria-label="t('spreed', 'Participant settings')"
@@ -300,8 +307,8 @@ export default {
 		padding-left: 5px;
 	}
 	&__status {
+		padding-left: 6px;
 		color: var(--color-text-maxcontrast);
-		/* TODO bring this to a new line */
 	}
 	&__icon {
 		width: 32px;

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -37,6 +37,7 @@
 		<span v-if="showModeratorLabel" class="participant-row__moderator-indicator">({{ t('spreed', 'moderator') }})</span>
 		<span v-if="isGuest" class="participant-row__guest-indicator">({{ t('spreed', 'guest') }})</span>
 		<span v-if="callIconClass" class="icon callstate-icon" :class="callIconClass" />
+		<span v-if="isNotAvailable(participant)" class="participant-row__status">{{ getStatusMessage(participant) }}</span>
 		<Actions
 			v-if="canModerate && !isSearched"
 			:aria-label="t('spreed', 'Participant settings')"
@@ -66,6 +67,7 @@
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import Actions from '@nextcloud/vue/dist/Components/Actions'
 import { CONVERSATION, PARTICIPANT } from '../../../../../constants'
+import UserStatus from '../../../../../mixins/userStatus'
 import isEqual from 'lodash/isEqual'
 import AvatarWrapper from '../../../../AvatarWrapper/AvatarWrapper'
 
@@ -77,6 +79,10 @@ export default {
 		ActionButton,
 		AvatarWrapper,
 	},
+
+	mixins: [
+		UserStatus,
+	],
 
 	props: {
 		participant: {
@@ -292,6 +298,10 @@ export default {
 		color: var(--color-text-maxcontrast);
 		font-weight: 300;
 		padding-left: 5px;
+	}
+	&__status {
+		color: var(--color-text-maxcontrast);
+		/* TODO bring this to a new line */
 	}
 	&__icon {
 		width: 32px;

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -33,7 +33,7 @@
 			:name="computedName"
 			:source="participant.source"
 			:offline="isOffline" />
-		<div>
+		<div class="participant-row__user-wrapper">
 			<div class="participant-row__user-descriptor">
 				<span class="participant-row__user-name">{{ computedName }}</span>
 				<span v-if="showModeratorLabel" class="participant-row__moderator-indicator">({{ t('spreed', 'moderator') }})</span>
@@ -290,11 +290,13 @@ export default {
 	height: 44px;
 	cursor: pointer;
 	padding: 0 5px;
-	margin: 5px 0;
+	margin: 8px 0;
 	border-radius: 22px;
 
+	&__user-wrapper {
+		padding-left: 8px;
+	}
 	&__user-name {
-		margin-left: 6px;
 		display: inline-block;
 		vertical-align: middle;
 		line-height: normal;
@@ -307,8 +309,8 @@ export default {
 		padding-left: 5px;
 	}
 	&__status {
-		padding-left: 6px;
 		color: var(--color-text-maxcontrast);
+		line-height: 1.3em;
 	}
 	&__icon {
 		width: 32px;

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -336,7 +336,7 @@ export default {
 
 .offline {
 
-	& > span {
+	.participant-row__user-descriptor > span {
 		color: var(--color-text-maxcontrast);
 	}
 }

--- a/src/mixins/userStatus.js
+++ b/src/mixins/userStatus.js
@@ -1,0 +1,56 @@
+/**
+ * @copyright Copyright (c) 2020 Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @author Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+const userStatus = {
+	methods: {
+		getStatusMessage(userData) {
+			if (!this.isNotAvailable(userData)) {
+				return ''
+			}
+
+			let status = ''
+			if (userData.statusIcon) {
+				status = userData.statusIcon + ' '
+			}
+
+			if (userData.statusMessage) {
+				status += userData.statusMessage
+			} else if (userData.status === 'dnd') {
+				status += t('spreed', 'Do not disturb')
+			} else {
+				status += t('spreed', 'Away')
+			}
+
+			return status
+		},
+
+		isNotAvailable(userData) {
+			if (!userData.status) {
+				return false
+			}
+
+			return userData.status === 'away' || userData.status === 'dnd'
+		},
+	},
+}
+
+export default userStatus

--- a/src/services/mentionsService.js
+++ b/src/services/mentionsService.js
@@ -33,6 +33,7 @@ const searchPossibleMentions = async function(token, searchText) {
 		const response = await axios.get(generateOcsUrl('apps/spreed/api/v1/chat', 2) + `${token}/mentions`, {
 			params: {
 				search: searchText,
+				includeStatus: 1,
 			},
 		})
 		return response

--- a/src/services/participantsService.js
+++ b/src/services/participantsService.js
@@ -223,6 +223,9 @@ const demoteFromModerator = async(token, options) => {
 }
 
 const fetchParticipants = async(token, options) => {
+	options = options || {}
+	options.params = options.params || {}
+	options.params.includeStatus = true
 	const response = await axios.get(generateOcsUrl('apps/spreed/api/v2/room', 2) + token + '/participants', options)
 	return response
 }

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -42,6 +42,7 @@ use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\UserStatus\IManager as IUserStatusManager;
 use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
@@ -62,6 +63,8 @@ class ChatControllerTest extends TestCase {
 	protected $messageParser;
 	/** @var IManager|MockObject */
 	protected $autoCompleteManager;
+	/** @var IUserStatusManager|MockObject */
+	protected $statusManager;
 	/** @var SearchPlugin|MockObject */
 	protected $searchPlugin;
 	/** @var ISearchResult|MockObject */
@@ -90,6 +93,7 @@ class ChatControllerTest extends TestCase {
 		$this->guestManager = $this->createMock(GuestManager::class);
 		$this->messageParser = $this->createMock(MessageParser::class);
 		$this->autoCompleteManager = $this->createMock(IManager::class);
+		$this->statusManager = $this->createMock(IUserStatusManager::class);
 		$this->searchPlugin = $this->createMock(SearchPlugin::class);
 		$this->searchResult = $this->createMock(ISearchResult::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
@@ -118,6 +122,7 @@ class ChatControllerTest extends TestCase {
 			$this->guestManager,
 			$this->messageParser,
 			$this->autoCompleteManager,
+			$this->statusManager,
 			$this->searchPlugin,
 			$this->searchResult,
 			$this->timeFactory,

--- a/tests/php/Controller/RoomControllerTest.php
+++ b/tests/php/Controller/RoomControllerTest.php
@@ -43,6 +43,7 @@ use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserManager;
+use OCP\UserStatus\IManager as IUserStatusManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -58,6 +59,8 @@ class RoomControllerTest extends TestCase {
 	protected $userManager;
 	/** @var IGroupManager|MockObject */
 	protected $groupManager;
+	/** @var IUserStatusManager|MockObject */
+	protected $statusManager;
 	/** @var Manager|MockObject */
 	protected $manager;
 	/** @var RoomService|MockObject */
@@ -91,6 +94,7 @@ class RoomControllerTest extends TestCase {
 		$this->manager = $this->createMock(Manager::class);
 		$this->roomService = $this->createMock(RoomService::class);
 		$this->guestManager = $this->createMock(GuestManager::class);
+		$this->statusManager = $this->createMock(IUserStatusManager::class);
 		$this->chatManager = $this->createMock(ChatManager::class);
 		$this->dispatcher = $this->createMock(IEventDispatcher::class);
 		$this->messageParser = $this->createMock(MessageParser::class);
@@ -117,6 +121,7 @@ class RoomControllerTest extends TestCase {
 			$this->manager,
 			$this->roomService,
 			$this->guestManager,
+			$this->statusManager,
 			$this->chatManager,
 			$this->dispatcher,
 			$this->messageParser,


### PR DESCRIPTION
- [x] Add away/dnd state on mentions
- [x] Add away/dnd state on the participant list
- [ ] Show status icon as overlay on avatars? => Follow up after nextcloud-vue support

### Mentions

* Status shown when away or dnd

### Participant list

* Status shown when away or dnd
* People with status sorted to the end of their section (moderator, online, user status)

> ![Bildschirmfoto von 2020-08-05 17-10-03](https://user-images.githubusercontent.com/213943/89430016-9373b780-d73e-11ea-8f9d-457b05917d35.png)

