### PR TITLE
Relabel the sections to high-performance backend to avoid confusion

### DIFF
--- a/src/components/AdminSettings/HostedSignalingServer.vue
+++ b/src/components/AdminSettings/HostedSignalingServer.vue
@@ -23,7 +23,7 @@
 <template>
 	<div id="hosted_signaling_server" class="videocalls section">
 		<h2>
-			{{ t('spreed', 'Hosted signaling server') }}
+			{{ t('spreed', 'Hosted high-performance backend') }}
 		</h2>
 
 		<p class="settings-hint">

--- a/src/components/AdminSettings/SignalingServer.vue
+++ b/src/components/AdminSettings/SignalingServer.vue
@@ -28,7 +28,7 @@
 			placeholder="wss://signaling.example.org"
 			:value="server"
 			:disabled="loading"
-			:aria-label="t('spreed', 'Signaling server URL')"
+			:aria-label="t('spreed', 'High-performance backend URL')"
 			@input="updateServer">
 		<input :id="'verify' + index"
 			type="checkbox"

--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -23,7 +23,7 @@
 <template>
 	<div id="signaling_server" class="videocalls section">
 		<h2>
-			{{ t('spreed', 'Signaling servers') }}
+			{{ t('spreed', 'High-performance backend') }}
 			<span v-if="saved" class="icon icon-checkmark-color" :title="t('spreed', 'Saved')" />
 			<a v-else-if="!loading && showAddServerButton"
 				v-tooltip.auto="t('spreed', 'Add a new server')"


### PR DESCRIPTION
Fix #3526 