### PR TITLE
Make possible to select input media devices during calls

### DIFF
--- a/src/components/MediaDevicesPreview.vue
+++ b/src/components/MediaDevicesPreview.vue
@@ -126,7 +126,7 @@ export default {
 				return mediaDevicesManager.attributes.audioInputId
 			},
 			set(value) {
-				mediaDevicesManager.attributes.audioInputId = value
+				mediaDevicesManager.set('audioInputId', value)
 			},
 		},
 
@@ -135,7 +135,7 @@ export default {
 				return mediaDevicesManager.attributes.videoInputId
 			},
 			set(value) {
-				mediaDevicesManager.attributes.videoInputId = value
+				mediaDevicesManager.set('videoInputId', value)
 			},
 		},
 

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -19,6 +19,7 @@
  *
  */
 
+import './shims/MediaStreamTrack'
 import Axios from '@nextcloud/axios'
 import CancelableRequest from '../cancelableRequest'
 import Signaling from '../signaling'

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -19,6 +19,7 @@
  *
  */
 
+import './shims/MediaStream'
 import './shims/MediaStreamTrack'
 import Axios from '@nextcloud/axios'
 import CancelableRequest from '../cancelableRequest'

--- a/src/utils/webrtc/shims/MediaStream.js
+++ b/src/utils/webrtc/shims/MediaStream.js
@@ -20,6 +20,40 @@
  */
 
 if (window.MediaStream) {
+	const originalMediaStreamAddTrack = window.MediaStream.prototype.addTrack
+	window.MediaStream.prototype.addTrack = function(track) {
+		let addTrackEventDispatched = false
+		const testAddTrackEvent = () => {
+			addTrackEventDispatched = true
+		}
+		this.addEventListener('addtrack', testAddTrackEvent)
+
+		originalMediaStreamAddTrack.apply(this, arguments)
+
+		this.removeEventListener('addtrack', testAddTrackEvent)
+
+		if (!addTrackEventDispatched) {
+			this.dispatchEvent(new MediaStreamTrackEvent('addtrack', { track: track }))
+		}
+	}
+
+	const originalMediaStreamRemoveTrack = window.MediaStream.prototype.removeTrack
+	window.MediaStream.prototype.removeTrack = function(track) {
+		let removeTrackEventDispatched = false
+		const testRemoveTrackEvent = () => {
+			removeTrackEventDispatched = true
+		}
+		this.addEventListener('removetrack', testRemoveTrackEvent)
+
+		originalMediaStreamRemoveTrack.apply(this, arguments)
+
+		this.removeEventListener('removetrack', testRemoveTrackEvent)
+
+		if (!removeTrackEventDispatched) {
+			this.dispatchEvent(new MediaStreamTrackEvent('removetrack', { track: track }))
+		}
+	}
+
 	// Event implementations do not support advanced parameters like "options"
 	// or "useCapture".
 	const originalMediaStreamDispatchEvent = window.MediaStream.prototype.dispatchEvent

--- a/src/utils/webrtc/shims/MediaStream.js
+++ b/src/utils/webrtc/shims/MediaStream.js
@@ -1,0 +1,79 @@
+/**
+ *
+ * @copyright Copyright (c) 2020, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+if (window.MediaStream) {
+	// Event implementations do not support advanced parameters like "options"
+	// or "useCapture".
+	const originalMediaStreamDispatchEvent = window.MediaStream.prototype.dispatchEvent
+	const originalMediaStreamAddEventListener = window.MediaStream.prototype.addEventListener
+	const originalMediaStreamRemoveEventListener = window.MediaStream.prototype.removeEventListener
+
+	window.MediaStream.prototype.dispatchEvent = function(event) {
+		if (this._listeners && this._listeners[event.type]) {
+			this._listeners[event.type].forEach(listener => {
+				listener.apply(this, [event])
+			})
+		}
+
+		return originalMediaStreamDispatchEvent.apply(this, arguments)
+	}
+
+	let isMediaStreamDispatchEventSupported
+
+	window.MediaStream.prototype.addEventListener = function(type, listener) {
+		if (isMediaStreamDispatchEventSupported === undefined) {
+			isMediaStreamDispatchEventSupported = false
+			const testDispatchEventSupportHandler = () => {
+				isMediaStreamDispatchEventSupported = true
+			}
+			originalMediaStreamAddEventListener.apply(this, ['test-dispatch-event-support', testDispatchEventSupportHandler])
+			originalMediaStreamDispatchEvent.apply(this, [new Event('test-dispatch-event-support')])
+			originalMediaStreamRemoveEventListener(this, ['test-dispatch-event-support', testDispatchEventSupportHandler])
+
+			console.debug('Is MediaStream.dispatchEvent() supported?: ', isMediaStreamDispatchEventSupported)
+		}
+
+		if (!isMediaStreamDispatchEventSupported) {
+			if (!this._listeners) {
+				this._listeners = []
+			}
+
+			if (!this._listeners.hasOwnProperty(type)) {
+				this._listeners[type] = [listener]
+			} else if (!this._listeners[type].includes(listener)) {
+				this._listeners[type].push(listener)
+			}
+		}
+
+		return originalMediaStreamAddEventListener.apply(this, arguments)
+	}
+
+	window.MediaStream.prototype.removeEventListener = function(type, listener) {
+		if (this._listeners && this._listeners[type]) {
+			const index = this._listeners[type].indexOf(listener)
+			if (index >= 0) {
+				this._listeners[type].splice(index, 1)
+			}
+		}
+
+		return originalMediaStreamRemoveEventListener.apply(this, arguments)
+	}
+}

--- a/src/utils/webrtc/shims/MediaStreamTrack.js
+++ b/src/utils/webrtc/shims/MediaStreamTrack.js
@@ -20,6 +20,15 @@
  */
 
 if (window.MediaStreamTrack) {
+	const originalMediaStreamTrackClone = window.MediaStreamTrack.prototype.clone
+	window.MediaStreamTrack.prototype.clone = function() {
+		const newTrack = originalMediaStreamTrackClone.apply(this, arguments)
+
+		this.dispatchEvent(new CustomEvent('cloned', { detail: newTrack }))
+
+		return newTrack
+	}
+
 	const originalMediaStreamTrackStop = window.MediaStreamTrack.prototype.stop
 	window.MediaStreamTrack.prototype.stop = function() {
 		const wasAlreadyEnded = this.readyState === 'ended'

--- a/src/utils/webrtc/shims/MediaStreamTrack.js
+++ b/src/utils/webrtc/shims/MediaStreamTrack.js
@@ -20,6 +20,17 @@
  */
 
 if (window.MediaStreamTrack) {
+	const originalMediaStreamTrackStop = window.MediaStreamTrack.prototype.stop
+	window.MediaStreamTrack.prototype.stop = function() {
+		const wasAlreadyEnded = this.readyState === 'ended'
+
+		originalMediaStreamTrackStop.apply(this, arguments)
+
+		if (!wasAlreadyEnded) {
+			this.dispatchEvent(new Event('ended'))
+		}
+	}
+
 	// Event implementations do not support advanced parameters like "options"
 	// or "useCapture".
 	const originalMediaStreamTrackDispatchEvent = window.MediaStreamTrack.prototype.dispatchEvent

--- a/src/utils/webrtc/shims/MediaStreamTrack.js
+++ b/src/utils/webrtc/shims/MediaStreamTrack.js
@@ -1,0 +1,79 @@
+/**
+ *
+ * @copyright Copyright (c) 2020, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+if (window.MediaStreamTrack) {
+	// Event implementations do not support advanced parameters like "options"
+	// or "useCapture".
+	const originalMediaStreamTrackDispatchEvent = window.MediaStreamTrack.prototype.dispatchEvent
+	const originalMediaStreamTrackAddEventListener = window.MediaStreamTrack.prototype.addEventListener
+	const originalMediaStreamTrackRemoveEventListener = window.MediaStreamTrack.prototype.removeEventListener
+
+	window.MediaStreamTrack.prototype.dispatchEvent = function(event) {
+		if (this._listeners && this._listeners[event.type]) {
+			this._listeners[event.type].forEach(listener => {
+				listener.apply(this, [event])
+			})
+		}
+
+		return originalMediaStreamTrackDispatchEvent.apply(this, arguments)
+	}
+
+	let isMediaStreamTrackDispatchEventSupported
+
+	window.MediaStreamTrack.prototype.addEventListener = function(type, listener) {
+		if (isMediaStreamTrackDispatchEventSupported === undefined) {
+			isMediaStreamTrackDispatchEventSupported = false
+			const testDispatchEventSupportHandler = () => {
+				isMediaStreamTrackDispatchEventSupported = true
+			}
+			originalMediaStreamTrackAddEventListener.apply(this, ['test-dispatch-event-support', testDispatchEventSupportHandler])
+			originalMediaStreamTrackDispatchEvent.apply(this, [new Event('test-dispatch-event-support')])
+			originalMediaStreamTrackRemoveEventListener(this, ['test-dispatch-event-support', testDispatchEventSupportHandler])
+
+			console.debug('Is MediaStreamTrack.dispatchEvent() supported?: ', isMediaStreamTrackDispatchEventSupported)
+		}
+
+		if (!isMediaStreamTrackDispatchEventSupported) {
+			if (!this._listeners) {
+				this._listeners = []
+			}
+
+			if (!this._listeners.hasOwnProperty(type)) {
+				this._listeners[type] = [listener]
+			} else if (!this._listeners[type].includes(listener)) {
+				this._listeners[type].push(listener)
+			}
+		}
+
+		return originalMediaStreamTrackAddEventListener.apply(this, arguments)
+	}
+
+	window.MediaStreamTrack.prototype.removeEventListener = function(type, listener) {
+		if (this._listeners && this._listeners[type]) {
+			const index = this._listeners[type].indexOf(listener)
+			if (index >= 0) {
+				this._listeners[type].splice(index, 1)
+			}
+		}
+
+		return originalMediaStreamTrackRemoveEventListener.apply(this, arguments)
+	}
+}

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -60,6 +60,9 @@ function LocalMedia(opts) {
 
 	this._audioMonitors = []
 	this.on('localScreenStopped', this._stopAudioMonitor.bind(this))
+
+	this._handleAudioInputIdChangedBound = this._handleAudioInputIdChanged.bind(this)
+	this._handleVideoInputIdChangedBound = this._handleVideoInputIdChanged.bind(this)
 }
 
 util.inherits(LocalMedia, WildEmitter)
@@ -162,6 +165,9 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 
 		self.emit('localStream', constraints, stream)
 
+		webrtcIndex.mediaDevicesManager.on('change:audioInputId', self._handleAudioInputIdChangedBound)
+		webrtcIndex.mediaDevicesManager.on('change:videoInputId', self._handleVideoInputIdChangedBound)
+
 		if (cb) {
 			return cb(null, stream)
 		}
@@ -183,9 +189,215 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 	})
 }
 
+LocalMedia.prototype._handleAudioInputIdChanged = function(mediaDevicesManager, audioInputId) {
+	const localStreamsChanged = []
+	const localTracksReplaced = []
+
+	if (this.localStreams.length === 0 && audioInputId) {
+		// Force the creation of a new stream to add a new audio track to it.
+		localTracksReplaced.push({ track: null, stream: null })
+	}
+
+	this.localStreams.forEach(stream => {
+		if (stream.getAudioTracks().length === 0) {
+			localStreamsChanged.push(stream)
+
+			localTracksReplaced.push({ track: null, stream })
+		}
+
+		stream.getAudioTracks().forEach(track => {
+			const settings = track.getSettings()
+			if (track.kind === 'audio' && settings && settings.deviceId !== audioInputId) {
+				track.stop()
+
+				stream.removeTrack(track)
+
+				if (!localStreamsChanged.includes(stream)) {
+					localStreamsChanged.push(stream)
+				}
+
+				localTracksReplaced.push({ track, stream })
+			}
+		})
+	})
+
+	if (audioInputId === null) {
+		localStreamsChanged.forEach(stream => {
+			this.emit('localStreamChanged', stream)
+		})
+
+		localTracksReplaced.forEach(trackStreamPair => {
+			this.emit('localTrackReplaced', null, trackStreamPair.track, trackStreamPair.stream)
+		})
+
+		return
+	}
+
+	if (localTracksReplaced.length === 0) {
+		return
+	}
+
+	webrtcIndex.mediaDevicesManager.getUserMedia({ audio: true }).then(stream => {
+		// According to the specification "getUserMedia({ audio: true })" will
+		// return a single audio track.
+		const track = stream.getTracks()[0]
+		if (stream.getTracks().length > 1) {
+			console.error('More than a single audio track returned by getUserMedia, only the first one will be used')
+		}
+
+		localTracksReplaced.forEach(trackStreamPair => {
+			const clonedTrack = track.clone()
+
+			let stream = trackStreamPair.stream
+			let streamIndex = this.localStreams.indexOf(stream)
+			if (streamIndex < 0) {
+				stream = new MediaStream()
+				this.localStreams.push(stream)
+				streamIndex = this.localStreams.length - 1
+			}
+
+			stream.addTrack(clonedTrack)
+
+			// The audio monitor stream is never disabled to be able to analyze
+			// it even when the stream sent is muted.
+			let audioMonitorStream
+			if (streamIndex > this._audioMonitorStreams.length - 1) {
+				audioMonitorStream = cloneLinkedStream(stream)
+				this._audioMonitorStreams.push(audioMonitorStream)
+			} else {
+				audioMonitorStream = this._audioMonitorStreams[streamIndex]
+			}
+
+			if (this.config.detectSpeakingEvents) {
+				this._setupAudioMonitor(audioMonitorStream, this.config.harkOptions)
+			}
+
+			clonedTrack.addEventListener('ended', () => {
+				if (isAllTracksEnded(stream)) {
+					this._removeStream(stream)
+				}
+			})
+
+			this.emit('localStreamChanged', stream)
+			this.emit('localTrackReplaced', clonedTrack, trackStreamPair.track, trackStreamPair.stream)
+		})
+
+		// After the clones were added to the local streams the original track
+		// is no longer needed.
+		track.stop()
+	}).catch(() => {
+		localStreamsChanged.forEach(stream => {
+			this.emit('localStreamChanged', stream)
+		})
+
+		localTracksReplaced.forEach(trackStreamPair => {
+			this.emit('localTrackReplaced', null, trackStreamPair.track, trackStreamPair.stream)
+		})
+	})
+}
+
+LocalMedia.prototype._handleVideoInputIdChanged = function(mediaDevicesManager, videoInputId) {
+	const localStreamsChanged = []
+	const localTracksReplaced = []
+
+	if (this.localStreams.length === 0 && videoInputId) {
+		// Force the creation of a new stream to add a new video track to it.
+		localTracksReplaced.push({ track: null, stream: null })
+	}
+
+	this.localStreams.forEach(stream => {
+		if (stream.getVideoTracks().length === 0) {
+			localStreamsChanged.push(stream)
+
+			localTracksReplaced.push({ track: null, stream })
+		}
+
+		stream.getVideoTracks().forEach(track => {
+			const settings = track.getSettings()
+			if (track.kind === 'video' && settings && settings.deviceId !== videoInputId) {
+				track.stop()
+
+				stream.removeTrack(track)
+
+				if (!localStreamsChanged.includes(stream)) {
+					localStreamsChanged.push(stream)
+				}
+
+				localTracksReplaced.push({ track, stream })
+			}
+		})
+	})
+
+	if (videoInputId === null) {
+		localStreamsChanged.forEach(stream => {
+			this.emit('localStreamChanged', stream)
+		})
+
+		localTracksReplaced.forEach(trackStreamPair => {
+			this.emit('localTrackReplaced', null, trackStreamPair.track, trackStreamPair.stream)
+		})
+
+		return
+	}
+
+	if (localTracksReplaced.length === 0) {
+		return
+	}
+
+	webrtcIndex.mediaDevicesManager.getUserMedia({ video: true }).then(stream => {
+		// According to the specification "getUserMedia({ video: true })" will
+		// return a single video track.
+		const track = stream.getTracks()[0]
+		if (stream.getTracks().length > 1) {
+			console.error('More than a single video track returned by getUserMedia, only the first one will be used')
+		}
+
+		localTracksReplaced.forEach(trackStreamPair => {
+			const clonedTrack = track.clone()
+
+			let stream = trackStreamPair.stream
+			if (!this.localStreams.includes(stream)) {
+				stream = new MediaStream()
+				this.localStreams.push(stream)
+
+				const audioMonitorStream = cloneLinkedStream(stream)
+				this._audioMonitorStreams.push(audioMonitorStream)
+			}
+
+			stream.addTrack(clonedTrack)
+
+			clonedTrack.addEventListener('ended', () => {
+				if (isAllTracksEnded(stream)) {
+					this._removeStream(stream)
+				}
+			})
+
+			this.emit('localStreamChanged', stream)
+			this.emit('localTrackReplaced', clonedTrack, trackStreamPair.track, trackStreamPair.stream)
+		})
+
+		// After the clones were added to the local streams the original track
+		// is no longer needed.
+		track.stop()
+	}).catch(() => {
+		localStreamsChanged.forEach(stream => {
+			this.emit('localStreamChanged', stream)
+		})
+
+		localTracksReplaced.forEach(trackStreamPair => {
+			this.emit('localTrackReplaced', null, trackStreamPair.track, trackStreamPair.stream)
+		})
+	})
+}
+
 LocalMedia.prototype.stop = function(stream) {
 	this.stopStream(stream)
 	this.stopScreenShare(stream)
+
+	if (!this.localStreams.length) {
+		webrtcIndex.mediaDevicesManager.off('change:audioInputId', this._handleAudioInputIdChangedBound)
+		webrtcIndex.mediaDevicesManager.off('change:videoInputId', this._handleVideoInputIdChangedBound)
+	}
 }
 
 LocalMedia.prototype.stopStream = function(stream) {

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -70,13 +70,6 @@ const cloneLinkedStream = function(stream) {
 		const linkedTrack = track.clone()
 		linkedStream.addTrack(linkedTrack)
 
-		// Keep a reference of all the linked clones of a track to be able to
-		// stop them when the track is stopped.
-		if (!track.linkedTracks) {
-			track.linkedTracks = []
-		}
-		track.linkedTracks.push(linkedTrack)
-
 		track.addEventListener('ended', function() {
 			linkedTrack.stop()
 		})
@@ -159,44 +152,18 @@ LocalMedia.prototype.stop = function(stream) {
 }
 
 LocalMedia.prototype.stopStream = function(stream) {
-	const self = this
-
 	if (stream) {
 		const idx = this.localStreams.indexOf(stream)
 		if (idx > -1) {
 			stream.getTracks().forEach(function(track) {
 				track.stop()
-
-				// Linked tracks must be explicitly stopped, as stopping a track
-				// does not trigger the "ended" event, and due to a bug in
-				// Firefox it is not possible to explicitly dispatch the event
-				// either (nor any other event with a different name):
-				// https://bugzilla.mozilla.org/show_bug.cgi?id=1473457
-				if (track.linkedTracks) {
-					track.linkedTracks.forEach(function(linkedTrack) {
-						linkedTrack.stop()
-					})
-				}
 			})
-			this._removeStream(stream)
 		}
 	} else {
 		this.localStreams.forEach(function(stream) {
 			stream.getTracks().forEach(function(track) {
 				track.stop()
-
-				// Linked tracks must be explicitly stopped, as stopping a track
-				// does not trigger the "ended" event, and due to a bug in
-				// Firefox it is not possible to explicitly dispatch the event
-				// either (nor any other event with a different name):
-				// https://bugzilla.mozilla.org/show_bug.cgi?id=1473457
-				if (track.linkedTracks) {
-					track.linkedTracks.forEach(function(linkedTrack) {
-						linkedTrack.stop()
-					})
-				}
 			})
-			self._removeStream(stream)
 		})
 	}
 }

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -74,6 +74,13 @@ util.inherits(LocalMedia, WildEmitter)
 const cloneLinkedTrack = function(track) {
 	const linkedTrack = track.clone()
 
+	// Keep a reference of all the linked clones of a track to be able to
+	// remove them when the source track is removed.
+	if (!track.linkedTracks) {
+		track.linkedTracks = []
+	}
+	track.linkedTracks.push(linkedTrack)
+
 	track.addEventListener('ended', function() {
 		linkedTrack.stop()
 	})
@@ -93,6 +100,16 @@ const cloneLinkedStream = function(stream) {
 
 	stream.getTracks().forEach(function(track) {
 		linkedStream.addTrack(cloneLinkedTrack(track))
+	})
+
+	stream.addEventListener('addtrack', function(event) {
+		linkedStream.addTrack(cloneLinkedTrack(event.track))
+	})
+
+	stream.addEventListener('removetrack', function(event) {
+		event.track.linkedTracks.forEach(linkedTrack => {
+			linkedStream.removeTrack(linkedTrack)
+		})
 	})
 
 	return linkedStream

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -57,6 +57,23 @@ function LocalMedia(opts) {
 util.inherits(LocalMedia, WildEmitter)
 
 /**
+ * Clones a MediaStreamTrack that will be ended when the original
+ * MediaStreamTrack is ended.
+ *
+ * @param {MediaStreamTrack} track the track to clone
+ * @returns {MediaStreamTrack} the linked track
+ */
+const cloneLinkedTrack = function(track) {
+	const linkedTrack = track.clone()
+
+	track.addEventListener('ended', function() {
+		linkedTrack.stop()
+	})
+
+	return linkedTrack
+}
+
+/**
  * Clones a MediaStream that will be ended when the original MediaStream is
  * ended.
  *
@@ -67,12 +84,7 @@ const cloneLinkedStream = function(stream) {
 	const linkedStream = new MediaStream()
 
 	stream.getTracks().forEach(function(track) {
-		const linkedTrack = track.clone()
-		linkedStream.addTrack(linkedTrack)
-
-		track.addEventListener('ended', function() {
-			linkedTrack.stop()
-		})
+		linkedStream.addTrack(cloneLinkedTrack(track))
 	})
 
 	return linkedStream

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -630,6 +630,17 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 		signaling.forceReconnect(true, flags)
 	}
 
+	function setHandlerForNegotiationNeeded(peer) {
+		peer.pc.addEventListener('negotiationneeded', function() {
+			// Negotiation needed will be first triggered before the connection
+			// is established, but forcing a reconnection should be done only
+			// once the connection was established.
+			if (peer.pc.iceConnectionState !== 'new' && peer.pc.iceConnectionState !== 'checking') {
+				forceReconnect(signaling)
+			}
+		})
+	}
+
 	webrtc.on('createdPeer', function(peer) {
 		console.debug('Peer created', peer)
 
@@ -659,6 +670,8 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 			} else {
 				setHandlerForIceConnectionStateChange(peer)
 			}
+
+			setHandlerForNegotiationNeeded(peer)
 
 			// Make sure required data channels exist for all peers. This
 			// is required for peers that get created by SimpleWebRTC from

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -610,6 +610,26 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 		})
 	}
 
+	const forceReconnect = function(signaling, flags) {
+		if (ownPeer) {
+			webrtc.removePeers(ownPeer.id)
+			ownPeer.end()
+			ownPeer = null
+
+			localCallParticipantModel.setPeer(ownPeer)
+		}
+
+		usersChanged(signaling, [], previousUsersInRoom)
+		usersInCallMapping = {}
+		previousUsersInRoom = []
+
+		// Reconnects with a new session id will trigger "usersChanged"
+		// with the users in the room and that will re-establish the
+		// peerconnection streams.
+		// If flags are undefined the current call flags are used.
+		signaling.forceReconnect(true, flags)
+	}
+
 	webrtc.on('createdPeer', function(peer) {
 		console.debug('Peer created', peer)
 
@@ -733,26 +753,6 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 	webrtc.on('peerStreamRemoved', function(peer) {
 		stopPeerCheckMedia(peer)
 	})
-
-	const forceReconnect = function(signaling, flags) {
-		if (ownPeer) {
-			webrtc.removePeers(ownPeer.id)
-			ownPeer.end()
-			ownPeer = null
-
-			localCallParticipantModel.setPeer(ownPeer)
-		}
-
-		usersChanged(signaling, [], previousUsersInRoom)
-		usersInCallMapping = {}
-		previousUsersInRoom = []
-
-		// Reconnects with a new session id will trigger "usersChanged"
-		// with the users in the room and that will re-establish the
-		// peerconnection streams.
-		// If flags are undefined the current call flags are used.
-		signaling.forceReconnect(true, flags)
-	}
 
 	webrtc.webrtc.on('videoOn', function() {
 		if (signaling.getSendVideoIfAvailable()) {


### PR DESCRIPTION
Requires #4028 

Follow up to #3913
Fixes #358

When an input device is changed during a call the old audio or video track is stopped, a new one is requested, and then the old track is replaced by the new one in the RTCPeerConnection. (Surprisingly) In most cases just replacing the track causes the new track to be used (and if the new track is null then the sent media is simply stopped), nothing else is needed. If the new track is not compatible with the old one (for example, if the video uses a different orientation) a renegotiation is needed. Proper renegotiation is not currently supported by the web UI nor the mobile applications, so in this case a reconnection is forced.

Renegotiation is also needed if the call is started without audio or video and then an audio or video input device is selected. In this case there will be no previous track to replace, and adding a new track needs a renegotiation.

The devices are changed during calls in the _Preview_ tab, just like done before calls. The tab is expected to be moved to a settings dialog, but that will be done in [another pull request](https://github.com/nextcloud/spreed/pull/4032).

The main trouble when changing devices during a call is that Firefox does not support more than a single device of each kind (audio or video) active at the same time. Therefore, when switching to another device all the active tracks of that kind must be stopped before requesting another track from a different device (otherwise a track from the currently active device will be returned, instead of a track from the requested device). Moreover, when an audio and video track are requested at the same time (like done when a call is started) in order to then request an audio or video track from a different device all the audio and video tracks must be stopped first (and not just the tracks from the kind being requested).

Adding some more fun, [`MediaStreamTrack.stop()` does not fire an `ended` event](https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-stop) (if the track is stopped [for any other reason then it does](https://w3c.github.io/mediacapture-main/#life-cycle-and-media-flow)), and even if it did [adding a listener to `MediaStreamTrack` or `MediaStream` does not work in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1473457) (although it does in Chromium).

Pending:
- [X] Fix forcing a reconnection for guests when the HPB is used, which is needed to handle renegotiation (needed for example if the call is started with a device disabled and then the device is enabled, or if changing to a device with different properties, like a camera in a different orientation) - Fixed in #4028
- [X] Fix checking the kind of a sender with a null track - Still needs to be handled in browsers without support for transceivers, but even in that case trying to replace a track of the wrong kind should not break anything, just fail.
- [X] Fix streams kept open when leaving a call while the preview was being shown - This is caused by the active tab not being always updated; it needs to be fixed in the Vue components, but it will not be an issue anymore after moving the preview to the settings dialog

To be addressed if needed in follow up pull requests:
- Handle changing the device in Firefox - Currently it works if audio or video are requested, but not if both audio and video are requested at the same time (like done when starting a call). Due to this, after starting a call currently you must disable both audio and video, and then you will be able to change the audio and video devices as expected (even if you then enable both audio and video, as they will be requested independently one of each other).
- Fix forcing a reconnection when the HPB is not used
- Renegotiation using a forced reconnection should also work while establishing a connection, and not only once the connection is fully established.
- Ensure that the video quality throttler, the connection quality warning and the speaking while muted warning still work as expected when tracks are changed
- Prevent changing devices during calls in browsers that do not support it
- Show a notification to the user when reconnecting due to a device change
- Use different icons when audio and video is disabled, when no device is available, and when no device is selected? Show the device preview if clicking on enable audio or video if no device is selected?
- Reuse active tracks when showing the preview? When a fake stream is requested it always starts from its initial colour, so the preview and the video in the call do not match. Could something similar happen with real cameras (one of the streams shown with "lag" respect to the other)?
