### PR TITLE
Add a combined settings tab

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -49,27 +49,21 @@
 			<ParticipantsTab :display-search-box="displaySearchBox" />
 		</AppSidebarTab>
 		<AppSidebarTab
-			v-if="getUserId"
-			id="projects"
+			id="settings-tab"
 			:order="3"
-			:name="t('spreed', 'Projects')"
-			icon="icon-projects">
-			<CollectionList v-if="conversation.token"
+			:name="t('spreed', 'Settings')"
+			icon="icon-settings">
+			<SetGuestUsername
+				v-if="!getUserId" />
+			<CollectionList
+				v-if="getUserId && conversation.token"
 				:id="conversation.token"
 				type="room"
 				:name="conversation.displayName" />
 		</AppSidebarTab>
 		<AppSidebarTab
-			v-if="!getUserId"
-			id="settings"
-			:order="4"
-			:name="t('spreed', 'Settings')"
-			icon="icon-settings">
-			<SetGuestUsername />
-		</AppSidebarTab>
-		<AppSidebarTab
 			id="preview"
-			:order="5"
+			:order="4"
 			:name="t('spreed', 'Preview')"
 			icon="icon-video">
 			<MediaDevicesPreview :enabled="!showChatInSidebar && activeTab === 'preview'" />


### PR DESCRIPTION
Combine projects and settings into settings for the upcoming bridge settings from #4010 

Also had to change the id from `settings` to `settings-tab` as there was server css kicking in

`id="settings"` | `id="settings-tab"`
---|---
![Bildschirmfoto von 2020-08-20 10-40-11](https://user-images.githubusercontent.com/213943/90747949-d6eb2b80-e2d1-11ea-8e2f-0f34d5141893.png) | ![Bildschirmfoto von 2020-08-20 10-40-04](https://user-images.githubusercontent.com/213943/90747956-d783c200-e2d1-11ea-8cde-a4486b64a7bf.png)

