### PR TITLE
Fix MediaDevicesSelector not updated when mounted

### DIFF
--- a/src/components/MediaDevicesSelector.vue
+++ b/src/components/MediaDevicesSelector.vue
@@ -143,10 +143,18 @@ export default {
 	},
 
 	watch: {
-		deviceSelectedOptionFromDeviceId(deviceSelectedOptionFromDeviceId) {
-			this.deviceSelectedOption = deviceSelectedOptionFromDeviceId
+		// The watcher needs to be set as "immediate" to ensure that
+		// "deviceSelectedOption" will be set when mounted.
+		deviceSelectedOptionFromDeviceId: {
+			handler(deviceSelectedOptionFromDeviceId) {
+				this.deviceSelectedOption = deviceSelectedOptionFromDeviceId
+			},
+			immediate: true,
 		},
 
+		// The watcher should not be set as "immediate" to prevent
+		// "update:deviceId" from being emitted when mounted with the same value
+		// initially passed to the component.
 		deviceSelectedOption(deviceSelectedOption) {
 			if (deviceSelectedOption && deviceSelectedOption.id === null) {
 				this.$emit('update:deviceId', null)


### PR DESCRIPTION
Follow up to #4032 

The watcher that updated the selected option based on the `deviceId` passed to the component was not executed when the component was mounted, so it was undefined until something else modified that device ID.

This was not noticeable when the MediaDevicesPreview was shown in the sidebar, as in that case it was mounted once when the UI was loaded and never destroyed, but once moved to the SettingsDialog the component is created and destroyed whenever the dialog is open or closed.

## How to test
- Open the settings dialog
- Close the settings dialog
- Open the settings dialog

### Result with this pull request
The same devices that were selected before closing the dialog will be selected once it is opened again.

### Result without this pull request
There will be no devices selected.
