### PR TITLE
Fix eslint warnings

### DIFF
--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -47,7 +47,6 @@
 			&nbsp;
 			<span>{{ scope.item.label }}</span>
 			<em v-if="isNotAvailable(scope.item)">&nbsp;{{ getStatus(scope.item) }}</em>
-
 		</template>
 		<template v-slot:embeddedItem="scope">
 			<!-- The root element itself is ignored, only its contents are taken

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -31,7 +31,9 @@
 			<EmptyContent v-if="item.empty"
 				class="half-screen"
 				icon="icon-checkmark">
-				<template #desc>{{ t('spreed', 'No unread mentions') }}</template>
+				<template #desc>
+					{{ t('spreed', 'No unread mentions') }}
+				</template>
 			</EmptyContent>
 			<DashboardWidgetItem v-else :item="getWidgetItem(item)">
 				<template v-slot:avatar>


### PR DESCRIPTION
```
/spreed/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
  49:80  warning  Expected 1 line break before closing tag (`</template>`), but 2 line breaks found  vue/multiline-html-element-content-newline

✖ 1 problem (0 errors, 1 warning)

/spreed/src/views/Dashboard.vue
  34:21  warning  Expected 1 line break after opening tag (`<template>`), but no line breaks found    vue/singleline-html-element-content-newline
  34:60  warning  Expected 1 line break before closing tag (`</template>`), but no line breaks found  vue/singleline-html-element-content-newline

✖ 2 problems (0 errors, 2 warnings)
```