### PR TITLE
Get rid of "hark" data channel

### DIFF
--- a/src/utils/webrtc/simplewebrtc/webrtc.js
+++ b/src/utils/webrtc/simplewebrtc/webrtc.js
@@ -58,34 +58,6 @@ function WebRTC(opts) {
 	// call localMedia constructor
 	localMedia.call(this, this.config)
 
-	this.on('speaking', function() {
-		if (!self.hardMuted) {
-			// FIXME: should use sendDirectlyToAll, but currently has different semantics wrt payload
-			self.peers.forEach(function(peer) {
-				if (peer.enableDataChannels) {
-					const dc = peer.getDataChannel('hark')
-					if (dc.readyState !== 'open') {
-						return
-					}
-					dc.send(JSON.stringify({ type: 'speaking' }))
-				}
-			})
-		}
-	})
-	this.on('stoppedSpeaking', function() {
-		if (!self.hardMuted) {
-			// FIXME: should use sendDirectlyToAll, but currently has different semantics wrt payload
-			self.peers.forEach(function(peer) {
-				if (peer.enableDataChannels) {
-					const dc = peer.getDataChannel('hark')
-					if (dc.readyState !== 'open') {
-						return
-					}
-					dc.send(JSON.stringify({ type: 'stoppedSpeaking' }))
-				}
-			})
-		}
-	})
 	this.on('unshareScreen', function(message) {
 		// End peers we were receiving the screensharing stream from.
 		const peers = self.getPeers(message.id, 'screen')

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -895,8 +895,6 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 			} else {
 				console.debug('Unknown message type %s from %s datachannel', data.type, label, data)
 			}
-		} else if (label === 'hark') {
-			// Ignore messages from hark datachannel
 		} else {
 			console.debug('Unknown message from %s datachannel', label, data)
 		}


### PR DESCRIPTION
The Web UI sends `speaking` and `stoppedSpeaking` messages through the `status` and `hark` data channels, but the messages are simply ignored when received in the `hark` data channel. The Android and iOS apps do not even use the `hark` data channel, neither for sending nor for listening, so it can be fully removed.

Moreover, with latest Janus versions the peers receive all data channel messages in the `JanusDataChannel` data channel, no matter on which data channel they were originally sent. As the `speaking` and `stoppedSpeaking` messages are sent through the `status` data channel sending them too through the `hark` data channel caused the messages to be handled twice.