### PR TITLE
Ignore "forceMute" message if already muted

### DIFF
--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -50,6 +50,9 @@ function LocalMedia(opts) {
 	this._log = this.logger.log.bind(this.logger, 'LocalMedia:')
 	this._logerror = this.logger.error.bind(this.logger, 'LocalMedia:')
 
+	this._audioEnabled = true
+	this._videoEnabled = true
+
 	this.localStreams = []
 	this._audioMonitorStreams = []
 	this.localScreens = []
@@ -156,6 +159,11 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 		self._audioMonitorStreams.push(audioMonitorStream)
 
 		stream.getTracks().forEach(function(track) {
+			if ((track.kind === 'audio' && !self._audioEnabled)
+				|| (track.kind === 'video' && !self._videoEnabled)) {
+				track.enabled = false
+			}
+
 			track.addEventListener('ended', function() {
 				if (isAllTracksEnded(stream)) {
 					self._removeStream(stream)
@@ -290,6 +298,10 @@ LocalMedia.prototype._handleAudioInputIdChanged = function(mediaDevicesManager, 
 				this._setupAudioMonitor(audioMonitorStream, this.config.harkOptions)
 			}
 
+			if (!this._audioEnabled) {
+				clonedTrack.enabled = false
+			}
+
 			clonedTrack.addEventListener('ended', () => {
 				if (isAllTracksEnded(stream)) {
 					this._removeStream(stream)
@@ -405,6 +417,10 @@ LocalMedia.prototype._handleVideoInputIdChanged = function(mediaDevicesManager, 
 			}
 
 			stream.addTrack(clonedTrack)
+
+			if (!this._videoEnabled) {
+				clonedTrack.enabled = false
+			}
 
 			clonedTrack.addEventListener('ended', () => {
 				if (isAllTracksEnded(stream)) {

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -530,11 +530,11 @@ LocalMedia.prototype.unmute = function() {
 
 // Video controls
 LocalMedia.prototype.pauseVideo = function() {
-	this._videoEnabled(false)
+	this._setVideoEnabled(false)
 	this.emit('videoOff')
 }
 LocalMedia.prototype.resumeVideo = function() {
-	this._videoEnabled(true)
+	this._setVideoEnabled(true)
 	this.emit('videoOn')
 }
 
@@ -558,7 +558,9 @@ LocalMedia.prototype._setAudioEnabled = function(bool) {
 		})
 	})
 }
-LocalMedia.prototype._videoEnabled = function(bool) {
+LocalMedia.prototype._setVideoEnabled = function(bool) {
+	this._videoEnabled = bool
+
 	this.localStreams.forEach(function(stream) {
 		stream.getVideoTracks().forEach(function(track) {
 			track.enabled = !!bool

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -111,8 +111,10 @@ function SimpleWebRTC(opts) {
 		} else if (message.type === 'control') {
 			if (message.payload.action === 'forceMute') {
 				if (message.payload.peerId === self.connection.getSessionId()) {
-					self.mute()
-					self.emit('forcedMute')
+					if (self.webrtc.isAudioEnabled()) {
+						self.mute()
+						self.emit('forcedMute')
+					}
 				} else {
 					self.emit('mute', { id: message.payload.peerId })
 				}


### PR DESCRIPTION
Follow up to #4052 

Before the UI only allowed to send the `forceMute` message to participants that were not muted. Now that moderators can mute all the other participants at once the message may be received by participants that are already muted, so it needs to be ignored in that case. Otherwise the user would see a _You have been muted by a moderator_ notification even if already muted.

Pending:
- [X] Ensure that `isAudioEnabled` works as expected