### PR TITLE
Make sure matterbridge binary is executable

### DIFF
--- a/lib/Controller/MatterbridgeSettingsController.php
+++ b/lib/Controller/MatterbridgeSettingsController.php
@@ -27,6 +27,7 @@ namespace OCA\Talk\Controller;
 
 use OCA\Talk\MatterbridgeManager;
 use OCA\Talk\Exceptions\ImpossibleToKillException;
+use OCA\Talk\Exceptions\WrongPermissionsException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
@@ -49,10 +50,16 @@ class MatterbridgeSettingsController extends OCSController {
 	 * @return DataResponse
 	 */
 	public function getMatterbridgeVersion(): DataResponse {
-		$version = $this->bridgeManager->getCurrentVersionFromBinary();
-		if ($version === null) {
+		try {
+			$version = $this->bridgeManager->getCurrentVersionFromBinary();
+			if ($version === null) {
+				return new DataResponse([
+					'error' => 'binary',
+				], Http::STATUS_BAD_REQUEST);
+			}
+		} catch (WrongPermissionsException $e) {
 			return new DataResponse([
-				'error' => 'binary',
+				'error' => 'binary_permissions',
 			], Http::STATUS_BAD_REQUEST);
 		}
 

--- a/lib/Exceptions/WrongPermissionsException.php
+++ b/lib/Exceptions/WrongPermissionsException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Talk\Exceptions;
+
+class WrongPermissionsException extends \Exception {
+}

--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -40,6 +40,7 @@ use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Psr\Log\LoggerInterface;
 
 use OCA\Talk\Exceptions\ImpossibleToKillException;
+use OCA\Talk\Exceptions\WrongPermissionsException;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
 
 class MatterbridgeManager {
@@ -640,6 +641,33 @@ class MatterbridgeManager {
 		$binaryPath = $this->config->getAppValue('spreed', 'matterbridge_binary');
 		if (!file_exists($binaryPath)) {
 			return null;
+		}
+
+		// is www user the file owner?
+		$user = posix_getpwuid(posix_getuid());
+		$fileOwner = posix_getpwuid(fileowner($binaryPath));
+		$userIsOwner = $user['name'] === $fileOwner['name'];
+
+		// get file group and user groups
+		$fileGid = filegroup($binaryPath);
+		$myGids = posix_getgroups();
+
+		// check permissions
+		$perms = fileperms($binaryPath);
+		$uExec = (($perms & 0x0040) && !($perms & 0x0800));
+		$gExec = (($perms & 0x0008) && !($perms & 0x0400));
+		$aExec = (($perms & 0x0001) && !($perms & 0x0200));
+
+		// 3 ways to have the permission :
+		// * be the owner and have u+x perm
+		// * not be the owner, be in the file group and have g+x perm
+		// * have o+x perm
+		$execPerm = $aExec
+			|| ($user['name'] === $fileOwner['name'] && $uExec)
+			|| ($user['name'] !== $fileOwner['name'] && in_array($fileGid, $myGids) && $gExec);
+
+		if (!$execPerm) {
+			throw new WrongPermissionsException();
 		}
 
 		$cmd = escapeshellcmd($binaryPath) . ' ' . escapeshellarg('-version');

--- a/lib/Settings/Admin/AdminSettings.php
+++ b/lib/Settings/Admin/AdminSettings.php
@@ -29,6 +29,7 @@ use OCA\Talk\Model\Command;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\CommandService;
+use OCA\Talk\Exceptions\WrongPermissionsException;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -119,9 +120,21 @@ class AdminSettings implements ISettings {
 	}
 
 	protected function initMatterbridge(): void {
+		$error = '';
+		try {
+			$version = (string) $this->bridgeManager->getCurrentVersionFromBinary();
+			if ($version === '') {
+				$error = 'binary';
+			}
+		} catch (WrongPermissionsException $e) {
+			$version = '';
+			$error = 'binary_permissions';
+		}
 		$this->initialStateService->provideInitialState(
-			'talk', 'matterbridge_version',
-			(string) $this->bridgeManager->getCurrentVersionFromBinary()
+			'talk', 'matterbridge_error', $error
+		);
+		$this->initialStateService->provideInitialState(
+			'talk', 'matterbridge_version', $version
 		);
 
 		$this->initialStateService->provideInitialState(


### PR DESCRIPTION
File permissions are not preserved when Php extracts the talk_matterbridge app so the included binaries have 644 rights.

So we can either:
* Do it like this PR: add execution permission to the binary in Talk when checking its version. Might be a little bit repetitive but it's safe.
* Or do it in every talk_matterbridge migration scripts.
* Or do it via a post upgrade script (repair step) in talk_matterbridge.

I prefer the first solution because it's safer. It covers the cases where rights are changed or file is overwritten by a daring user after enabling matterbridge integration.