### PR TITLE
Show other persons video when they share their screen

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -186,6 +186,14 @@ export default {
 			return this.callParticipantModels.filter(callParticipantModel => callParticipantModel.attributes.screen)
 		},
 
+		callParticipantModelsWithVideo() {
+			return this.callParticipantModels.filter(callParticipantModel => {
+				return callParticipantModel.attributes.videoAvailable
+					&& this.sharedDatas[callParticipantModel.attributes.peerId].videoEnabled
+					&& (typeof callParticipantModel.attributes.stream === 'object')
+			})
+		},
+
 		localScreen() {
 			return localMediaModel.attributes.localScreen
 		},
@@ -199,7 +207,12 @@ export default {
 		},
 
 		showGrid() {
-			return (!this.isOneToOneView || this.showLocalScreen) && !this.isSidebar
+			return !this.isSidebar
+				&& (
+					!this.isOneToOneView
+					|| this.showLocalScreen
+					|| (this.showRemoteScreen && this.hasRemoteVideo)
+				)
 		},
 
 		gridTargetAspectRatio() {
@@ -228,6 +241,10 @@ export default {
 
 		hasLocalVideo() {
 			return this.localMediaModel.attributes.videoEnabled
+		},
+
+		hasRemoteVideo() {
+			return this.callParticipantModelsWithVideo.length > 0
 		},
 
 		hasLocalScreen() {


### PR DESCRIPTION
Fix #4078 

### Without grid
* Shown when the remote user has no video (before always for remote screenshares)
![Bildschirmfoto von 2020-08-31 15-41-52](https://user-images.githubusercontent.com/213943/91726683-ef482980-eba0-11ea-9235-a126f9f3c211.png)

### With grid
* Shown when the remote user has a screenshare and video
* Shown when you have a screenshare
![Bildschirmfoto von 2020-08-31 15-41-58](https://user-images.githubusercontent.com/213943/91726689-f111ed00-eba0-11ea-8ae0-252125b1ab74.png)
