### PR TITLE
Fix scroll to bottom aria label

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -81,7 +81,8 @@
 			<button v-if="hasNextPage && gridWidth > 0 && isStripe && showVideoOverlay"
 				class="grid-navigation grid-navigation__next"
 				@click="handleClickNext">
-				<ChevronRight decorative :size="24" />
+				<ChevronRight decorative
+					:size="24" />
 			</button>
 		</div>
 		<LocalVideo

--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -28,7 +28,7 @@
 			:aria-label="t('spreed','Create a new group conversation')"
 			@click="showModal">
 			<Plus decorative
-				size="24" />
+				:size="24" />
 		</button>
 		<!-- New group form -->
 		<Modal

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -53,7 +53,7 @@ get the messagesList array and loop through the list to generate the messages.
 		</template>
 		<transition name="fade">
 			<button v-show="!isScrolledToBottom"
-				:aria-label="scrollTobottomAriaLabel"
+				:aria-label="scrollToBottomAriaLabel"
 				class="scroll-to-bottom"
 				@click="scrollToBottom">
 				<ChevronDown decorative


### PR DESCRIPTION
>  [Vue warn]: Property or method "scrollTobottomAriaLabel" is not defined on the instance but referenced during render. Make sure that this property is reactive, either in the data option, or for class-based components, by initializing the property. See: https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties.
>  [Vue warn]: Invalid prop: type check failed for prop "size". Expected Number with value 24, got String with value "24".