### PR TITLE
Add a default on NotNull column

### DIFF
--- a/lib/Migration/Version2001Date20180103144447.php
+++ b/lib/Migration/Version2001Date20180103144447.php
@@ -94,7 +94,7 @@ class Version2001Date20180103144447 extends SimpleMigrationStep {
 			$table->addColumn('session_id', Type::STRING, [
 				'notnull' => true,
 				'length' => 255,
-				'default' => '',
+				'default' => '0',
 			]);
 			$table->addColumn('participant_type', Type::SMALLINT, [
 				'notnull' => true,


### PR DESCRIPTION
Ref https://github.com/nextcloud/server/pull/22643

Since we always set it to `'0'` anyway, this is only an issue when updating from a previous version on Oracle. Since it didn't install, that is a non issue and we don't need to update the default on current versions.