### PR TITLE
Bump vue-dashboard library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3353,9 +3353,9 @@
 			}
 		},
 		"@nextcloud/vue-dashboard": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue-dashboard/-/vue-dashboard-0.1.8.tgz",
-			"integrity": "sha512-OGr1oK/WF9+bYHK8dE8Vjwh3IDNamN+9MSti1VO7zuUSm5A9EGCzAghR7zzCG4O43rAJEDcvnQwsYIiA6g4Yrw==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue-dashboard/-/vue-dashboard-1.0.0.tgz",
+			"integrity": "sha512-9Ncksq+2iJocI5n+ElT+m9bL+fTNq8XxVPUPwEL5xZZi3jCKibRjAVyE5QRCSPhSh65W19KqyfelQebp33YqmQ==",
 			"requires": {
 				"@nextcloud/vue": "^2.3.0",
 				"core-js": "^3.6.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"@nextcloud/moment": "^1.1.1",
 		"@nextcloud/router": "^1.2.0",
 		"@nextcloud/vue": "^2.6.5",
-		"@nextcloud/vue-dashboard": "^0.1.8",
+		"@nextcloud/vue-dashboard": "^1.0.0",
 		"attachmediastream": "^2.1.0",
 		"crypto-js": "^4.0.0",
 		"debounce": "^1.2.0",


### PR DESCRIPTION
Now with 5 items on the half empty content view

![Bildschirmfoto von 2020-09-11 15-37-47](https://user-images.githubusercontent.com/213943/92932171-ca777000-f444-11ea-83d7-122eac78bdc8.png)

Unluckily we didn't add the button option in the dashboard when it is completly empty, so can't get rid of that yet.