### PR TITLE
Fix memory leak in message list

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -233,14 +233,8 @@ export default {
 		this.scrollToBottom()
 		EventBus.$on('scrollChatToBottom', this.handleScrollChatToBottomEvent)
 
-		subscribe('networkOffline', () => {
-			console.debug('Canceling message request as we are offline')
-			this.cancelLookForNewMessages()
-		})
-		subscribe('networkOnline', () => {
-			console.debug('Restarting polling of new chat messages')
-			this.getNewMessages()
-		})
+		subscribe('networkOffline', this.handleNetworkOffline)
+		subscribe('networkOnline', this.handleNetworkOnline)
 	},
 	beforeDestroy() {
 		EventBus.$off('scrollChatToBottom', this.handleScrollChatToBottomEvent)
@@ -594,6 +588,16 @@ export default {
 		 */
 		getFirstKnownMessageId() {
 			return this.messagesList[0].id.toString()
+		},
+
+		handleNetworkOffline() {
+			console.debug('Canceling message request as we are offline')
+			this.cancelLookForNewMessages()
+		},
+
+		handleNetworkOnline() {
+			console.debug('Restarting polling of new chat messages')
+			this.getNewMessages()
 		},
 	},
 }

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -69,7 +69,7 @@ import MessagesGroup from './MessagesGroup/MessagesGroup'
 import { fetchMessages, lookForNewMessages } from '../../services/messagesService'
 import CancelableRequest from '../../utils/cancelableRequest'
 import Axios from '@nextcloud/axios'
-import { subscribe } from '@nextcloud/event-bus'
+import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import isInLobby from '../../mixins/isInLobby'
 import debounce from 'debounce'
 import { EventBus } from '../../services/EventBus'
@@ -239,6 +239,9 @@ export default {
 	beforeDestroy() {
 		EventBus.$off('scrollChatToBottom', this.handleScrollChatToBottomEvent)
 		this.cancelLookForNewMessages()
+
+		unsubscribe('networkOffline', this.handleNetworkOffline)
+		unsubscribe('networkOnline', this.handleNetworkOnline)
 	},
 
 	methods: {


### PR DESCRIPTION
Besides the memory leak fixed here, which was always reproducible, there seems to be another one related to the message list that happens sometimes (and apparently with Chromium, but not with Firefox :shrug:). After a lot of time and effort I have not been able to reproduce it reliably nor find why it happens either (it seems to be related to XMLHttpRequests/Axios and `getNewMessages()`, but other than that I am still clueless), so I give up for now :-(

## How to test

- In Firefox, open a conversation with lots of messages
- Open the developer tools
- Take a memory snapshot; its size will be around 100MB
- Start and leave a call five times in a row
- In a different tab, open _about:memory_ and trigger a garbage collection (_Free memory -> GC_)
- In the previous tab, take another memory snapshot

### Result with this pull request

The size of the new memory snapshot will be around the same value as the previous one

### Result without this pull request

The size of the new memory snapshot will be much higher (around 300MB)
