### PR TITLE
Fix memory and event handler leaks in calls

### DIFF
--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -339,6 +339,10 @@ export default {
 		this.speakingWhileMutedWarner = new SpeakingWhileMutedWarner(this.model, this)
 	},
 
+	beforeDestroy() {
+		this.speakingWhileMutedWarner.destroy()
+	},
+
 	methods: {
 
 		toggleAudio() {

--- a/src/utils/webrtc/SpeakingWhileMutedWarner.js
+++ b/src/utils/webrtc/SpeakingWhileMutedWarner.js
@@ -46,11 +46,18 @@
 	*        "setSpeakingWhileMutedNotification" method
 	*/
 export default function SpeakingWhileMutedWarner(model, view) {
-	model.on('change:speakingWhileMuted', this._handleSpeakingWhileMutedChange.bind(this))
-
+	this._model = model
 	this._view = view
+
+	this._handleSpeakingWhileMutedChangeBound = this._handleSpeakingWhileMutedChange.bind(this)
+
+	this._model.on('change:speakingWhileMuted', this._handleSpeakingWhileMutedChangeBound)
 }
 SpeakingWhileMutedWarner.prototype = {
+
+	destroy: function() {
+		this._model.off('change:speakingWhileMuted', this._handleSpeakingWhileMutedChangeBound)
+	},
 
 	_handleSpeakingWhileMutedChange: function(model, speakingWhileMuted) {
 		if (speakingWhileMuted) {

--- a/src/utils/webrtc/analyzers/CallAnalyzer.js
+++ b/src/utils/webrtc/analyzers/CallAnalyzer.js
@@ -125,6 +125,8 @@ CallAnalyzer.prototype = {
 	destroy: function() {
 		if (this._localParticipantAnalyzer) {
 			this._localParticipantAnalyzer.off('change:senderConnectionQualityAudio', this._handleSenderConnectionQualityAudioChangeBound)
+			this._localParticipantAnalyzer.off('change:senderConnectionQualityVideo', this._handleSenderConnectionQualityVideoChangeBound)
+			this._localParticipantAnalyzer.off('change:senderConnectionQualityScreen', this._handleSenderConnectionQualityScreenChangeBound)
 
 			this._localParticipantAnalyzer.destroy()
 		}

--- a/src/utils/webrtc/analyzers/ParticipantAnalyzer.js
+++ b/src/utils/webrtc/analyzers/ParticipantAnalyzer.js
@@ -121,10 +121,12 @@ ParticipantAnalyzer.prototype = {
 	destroy: function() {
 		if (this._localCallParticipantModel) {
 			this._localCallParticipantModel.off('change:peer', this._handlePeerChangeBound)
+			this._localCallParticipantModel.off('change:screenPeer', this._handleScreenPeerChangeBound)
 		}
 
 		if (this._callParticipantModel) {
 			this._callParticipantModel.off('change:peer', this._handlePeerChangeBound)
+			this._callParticipantModel.off('change:screenPeer', this._handleScreenPeerChangeBound)
 		}
 
 		this._stopListeningToAudioVideoChanges()

--- a/src/utils/webrtc/models/CallParticipantCollection.js
+++ b/src/utils/webrtc/models/CallParticipantCollection.js
@@ -91,6 +91,8 @@ CallParticipantCollection.prototype = {
 			this.callParticipantModels.splice(index, 1)
 
 			this._trigger('remove', [callParticipantModel])
+
+			callParticipantModel.destroy()
 		}
 	},
 

--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -79,6 +79,19 @@ export default function CallParticipantModel(options) {
 
 CallParticipantModel.prototype = {
 
+	destroy: function() {
+		if (this.get('peer')) {
+			this.get('peer').off('extendedIceConnectionStateChange', this._handleExtendedIceConnectionStateChangeBound)
+		}
+
+		this._webRtc.off('peerStreamAdded', this._handlePeerStreamAddedBound)
+		this._webRtc.off('peerStreamRemoved', this._handlePeerStreamRemovedBound)
+		this._webRtc.off('nick', this._handleNickBound)
+		this._webRtc.off('mute', this._handleMuteBound)
+		this._webRtc.off('unmute', this._handleUnmuteBound)
+		this._webRtc.off('channelMessage', this._handleChannelMessageBound)
+	},
+
 	get: function(key) {
 		return this.attributes[key]
 	},


### PR DESCRIPTION
Although this fixes some memory leaks the more relevant fixes are the event handler leaks, as they caused WebRTC events to be dispatched to objects from previous calls (although this **should** not have caused performance issues anyway due to the event handlers being pretty lightweight and the Vue components ignoring the models once they were no longer part of the `CallParticipantCollection`).

There are still some call related leaks, but I do not know yet how to fix them (or if they are actually browser bugs rather than Talk bugs), so something for another pull request.
