### PR TITLE
Listen to the user status event to update the status immediately

### DIFF
--- a/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
+++ b/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
@@ -30,6 +30,7 @@
 import ParticipantsList from '../ParticipantsList/ParticipantsList'
 import { PARTICIPANT } from '../../../../constants'
 import UserStatus from '../../../../mixins/userStatus'
+import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 
 export default {
 	name: 'CurrentParticipants',
@@ -75,7 +76,28 @@ export default {
 		},
 	},
 
+	mounted() {
+		subscribe('user_status:status.updated', this.userStatusUpdated)
+	},
+
+	beforeDestroyed() {
+		unsubscribe('user_status:status.updated', this.userStatusUpdated)
+	},
+
 	methods: {
+		userStatusUpdated(state) {
+			this.$store.dispatch('updateUser', {
+				token: this.token,
+				participantIdentifier: {
+					userId: state.userId,
+				},
+				updatedData: {
+					status: state.status,
+					statusIcon: state.icon,
+					statusMessage: state.message,
+				},
+			})
+		},
 
 		/**
 		 * Sort two participants by:

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -219,6 +219,16 @@ const actions = {
 		commit('updateParticipant', { token, index, updatedData })
 	},
 
+	updateUser({ commit, getters }, { token, participantIdentifier, updatedData }) {
+		const index = getters.getParticipantIndex(token, participantIdentifier)
+		if (index === -1) {
+			console.error('Participant not found', participantIdentifier)
+			return
+		}
+
+		commit('updateParticipant', { token, index, updatedData })
+	},
+
 	async joinCall({ commit, getters }, { token, participantIdentifier, flags }) {
 		const index = getters.getParticipantIndex(token, participantIdentifier)
 		if (index === -1) {


### PR DESCRIPTION
### Steps
1. Go to any page that uses the Avatar component to show your own avatar, e.g. a Talk conversation participant tab
2. Change your status
3. Wait until your avatar shows the new status :skull_and_crossbones: 

With this PR the text + emoji-icon will update. The dot-icon on the avatar will work after https://github.com/nextcloud/nextcloud-vue/pull/1405

Relevant event is emitted in server:
https://github.com/nextcloud/server/pull/22801

Fix #4132 