### PR TITLE
Fix getting messages again after the component was destroyed

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -239,6 +239,9 @@ export default {
 	beforeDestroy() {
 		EventBus.$off('scrollChatToBottom', this.handleScrollChatToBottomEvent)
 		this.cancelLookForNewMessages()
+		// Prevent further lookForNewMessages requests after the component was
+		// destroyed.
+		this.cancelLookForNewMessages = null
 
 		unsubscribe('networkOffline', this.handleNetworkOffline)
 		unsubscribe('networkOnline', this.handleNetworkOnline)
@@ -355,7 +358,7 @@ export default {
 				} else {
 					this.getMessages(false)
 				}
-			} else {
+			} else if (this.cancelLookForNewMessages) {
 				this.cancelLookForNewMessages()
 			}
 		},
@@ -443,6 +446,10 @@ export default {
 		 * Creates a long polling request for a new message.
 		 */
 		async getNewMessages() {
+			if (!this.cancelLookForNewMessages) {
+				return
+			}
+
 			// Clear previous requests if there's one pending
 			this.cancelLookForNewMessages('canceled')
 			// Get a new cancelable request function and cancel function pair
@@ -595,7 +602,9 @@ export default {
 
 		handleNetworkOffline() {
 			console.debug('Canceling message request as we are offline')
-			this.cancelLookForNewMessages()
+			if (this.cancelLookForNewMessages) {
+				this.cancelLookForNewMessages()
+			}
 		},
 
 		handleNetworkOnline() {


### PR DESCRIPTION
When getting new messages, [no matter if it succeeds or fails](https://github.com/nextcloud/spreed/blob/bbd0277f1057fb5c2cbe5431349c43cbfa6eec18/src/components/MessagesList/MessagesList.vue#L488-L509), another request is triggered again after a small delay. When the `MessagesList` component is destroyed the current request is cancelled, which [would stop further requests](https://github.com/nextcloud/spreed/blob/bbd0277f1057fb5c2cbe5431349c43cbfa6eec18/src/components/MessagesList/MessagesList.vue#L479-L482). However, if the `MessagesList` is destroyed during that delay there will be no current request yet, so once the timeout ends the request will start anyway, and thus the request loop will continue again and again.

This can be typically triggered [if the lobby is enabled while the user is in a conversation](https://github.com/nextcloud/spreed/blob/389d7b6bfc16a29ced52cb41b0e7fbb5facbb4c9/src/views/MainView.vue#L3-L4), and sometimes depending on how (un)lucky you are when [joining](https://github.com/nextcloud/spreed/blob/389d7b6bfc16a29ced52cb41b0e7fbb5facbb4c9/src/views/MainView.vue#L8) or [leaving](https://github.com/nextcloud/spreed/blob/a9eaf55937e5ed84b29d8537605834b4fe78a41f/src/components/RightSidebar/RightSidebar.vue#L37) a conversation. In both cases this will cause a memory leak of the chat view as well as duplicated requests to get new messages.
