### PR TITLE
Fix event handler deregistration in TopBar

### DIFF
--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -359,9 +359,7 @@ export default {
 		document.addEventListener('MSFullscreenChange', this.fullScreenChanged, false)
 		document.addEventListener('webkitfullscreenchange', this.fullScreenChanged, false)
 		// Add call layout hint listener
-		EventBus.$on('toggleLayoutHint', (display) => {
-			this.showLayoutHint = display
-		})
+		EventBus.$on('toggleLayoutHint', this.handleToggleLayoutHint)
 	},
 
 	beforeDestroy() {
@@ -370,9 +368,7 @@ export default {
 		document.removeEventListener('MSFullscreenChange', this.fullScreenChanged, false)
 		document.removeEventListener('webkitfullscreenchange', this.fullScreenChanged, false)
 		// Remove call layout hint listener
-		EventBus.$off('toggleLayoutHint', (display) => {
-			this.showLayoutHint = display
-		})
+		EventBus.$off('toggleLayoutHint', this.handleToggleLayoutHint)
 	},
 
 	methods: {
@@ -488,6 +484,9 @@ export default {
 		handleRenameConversation() {
 			this.$store.dispatch('isRenamingConversation', true)
 			this.$store.dispatch('showSidebar')
+		},
+		handleToggleLayoutHint(display) {
+			this.showLayoutHint = display
 		},
 		forceMuteOthers() {
 			callParticipantCollection.callParticipantModels.forEach(callParticipantModel => {


### PR DESCRIPTION
Even if their code is identical two arrow functions are different instances, so the original one was not properly deregistered.

This caused a memory leak of the chat view or call view if the lobby is enabled while the user is in a conversation (due to the parent component reference of Vue, as that causes [the siblings of the `TopBar`](https://github.com/nextcloud/spreed/blob/389d7b6bfc16a29ced52cb41b0e7fbb5facbb4c9/src/views/MainView.vue#L5-L13) to be retained too).
