### PR TITLE
Fix "enable_matterbridge" initial state not set for guests

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -249,7 +249,6 @@ class PageController extends Controller {
 		}
 
 		$this->publishInitialStateForUser($user, $this->rootFolder, $this->appManager);
-		$this->initialStateService->provideInitialState('talk', 'enable_matterbridge', $this->serverConfig->getAppValue('spreed', 'enable_matterbridge', '0') === '1');
 
 		if (class_exists(LoadViewer::class)) {
 			$this->eventDispatcher->dispatchTyped(new LoadViewer());

--- a/lib/TInitialState.php
+++ b/lib/TInitialState.php
@@ -102,6 +102,11 @@ trait TInitialState {
 			'talk', 'attachment_folder',
 			$attachmentFolder
 		);
+
+		$this->initialStateService->provideInitialState(
+			'talk', 'enable_matterbridge',
+			$this->serverConfig->getAppValue('spreed', 'enable_matterbridge', '0') === '1'
+		);
 	}
 
 	protected function publishInitialStateForGuest(): void {
@@ -120,6 +125,11 @@ trait TInitialState {
 		$this->initialStateService->provideInitialState(
 			'talk', 'attachment_folder',
 			''
+		);
+
+		$this->initialStateService->provideInitialState(
+			'talk', 'enable_matterbridge',
+			false
 		);
 	}
 }


### PR DESCRIPTION
The [RightSidebar component always checks the value](https://github.com/nextcloud/spreed/blob/a9eaf55937e5ed84b29d8537605834b4fe78a41f/src/components/RightSidebar/RightSidebar.vue#L122), so even if the setting does not apply for guests it should be explicitly disabled in that case.

## How to test
- Open the browser console
- Join a conversation as a guest

### Result with this pull request

No errors regarding the initial state of _enable_matterbridge_ in the console.

### Result without this pull request

`Could not find initial state enable_matterbridge of talk` is shown in the console.
