### PR TITLE
Improve setting initial audio and video status when the HPB is used

### DIFF
--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -121,7 +121,7 @@ function SimpleWebRTC(opts) {
 			}
 		} else if (peers.length) {
 			peers.forEach(function(peer) {
-				if (message.sid) {
+				if (message.sid && !self.connection.hasFeature('mcu')) {
 					if (peer.sid === message.sid) {
 						peer.handleMessage(message)
 					}

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -260,7 +260,6 @@ SimpleWebRTC.prototype.disconnect = function() {
 }
 
 SimpleWebRTC.prototype.handlePeerStreamAdded = function(peer) {
-	const self = this
 	const container = this.getRemoteVideoContainer()
 	if (container) {
 		// If there is a video track Chromium does not play audio in a video element
@@ -291,19 +290,6 @@ SimpleWebRTC.prototype.handlePeerStreamAdded = function(peer) {
 
 		this.emit('videoAdded', video, audio, peer)
 	}
-
-	// send our mute status to new peer if we're muted
-	// currently called with a small delay because it arrives before
-	// the video element is created otherwise (which happens after
-	// the async setRemoteDescription-createAnswer)
-	window.setTimeout(function() {
-		if (!self.webrtc.isAudioEnabled()) {
-			peer.send('mute', { name: 'audio' })
-		}
-		if (!self.webrtc.isVideoEnabled()) {
-			peer.send('mute', { name: 'video' })
-		}
-	}, 250)
 }
 
 SimpleWebRTC.prototype.handlePeerStreamRemoved = function(peer) {

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -486,14 +486,14 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 		// Send the current information about the video and microphone
 		// state.
 		if (!webrtc.webrtc.isVideoEnabled()) {
-			webrtc.emit('videoOff')
+			webrtc.webrtc.emit('videoOff')
 		} else {
-			webrtc.emit('videoOn')
+			webrtc.webrtc.emit('videoOn')
 		}
 		if (!webrtc.webrtc.isAudioEnabled()) {
-			webrtc.emit('audioOff')
+			webrtc.webrtc.emit('audioOff')
 		} else {
-			webrtc.emit('audioOn')
+			webrtc.webrtc.emit('audioOn')
 		}
 		if (signaling.settings.userId === null) {
 			const currentGuestNick = store.getters.getDisplayName()

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -759,11 +759,19 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 		})
 	}
 
-	function stopPeerCheckMedia(peer) {
+	function stopPeerCheckAudioMedia(peer) {
 		clearInterval(peer.check_audio_interval)
 		peer.check_audio_interval = null
+	}
+
+	function stopPeerCheckVideoMedia(peer) {
 		clearInterval(peer.check_video_interval)
 		peer.check_video_interval = null
+	}
+
+	function stopPeerCheckMedia(peer) {
+		stopPeerCheckAudioMedia(peer)
+		stopPeerCheckVideoMedia(peer)
 		stopSendingNick(peer)
 	}
 
@@ -772,8 +780,7 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 		peer.check_video_interval = setInterval(function() {
 			stream.getVideoTracks().forEach(function(video) {
 				checkPeerMedia(peer, video, 'video').then(function() {
-					clearInterval(peer.check_video_interval)
-					peer.check_video_interval = null
+					stopPeerCheckVideoMedia(peer)
 				}).catch(() => {
 				})
 			})
@@ -781,8 +788,7 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 		peer.check_audio_interval = setInterval(function() {
 			stream.getAudioTracks().forEach(function(audio) {
 				checkPeerMedia(peer, audio, 'audio').then(function() {
-					clearInterval(peer.check_audio_interval)
-					peer.check_audio_interval = null
+					stopPeerCheckAudioMedia(peer)
 				}).catch(() => {
 				})
 			})

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -760,14 +760,10 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 	}
 
 	function stopPeerCheckMedia(peer) {
-		if (peer.check_audio_interval) {
-			clearInterval(peer.check_audio_interval)
-			peer.check_audio_interval = null
-		}
-		if (peer.check_video_interval) {
-			clearInterval(peer.check_video_interval)
-			peer.check_video_interval = null
-		}
+		clearInterval(peer.check_audio_interval)
+		peer.check_audio_interval = null
+		clearInterval(peer.check_video_interval)
+		peer.check_video_interval = null
 		stopSendingNick(peer)
 	}
 

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -233,6 +233,17 @@ function usersChanged(signaling, newUsers, disconnectedSessionIds) {
 		if ((signaling.hasFeature('mcu') && user && !userHasStreams(user))
 				|| (!signaling.hasFeature('mcu') && user && !userHasStreams(user) && !webrtc.webrtc.localStreams.length)) {
 			callParticipantModel.setPeer(null)
+
+			// As there is no Peer for the other participant the current media
+			// state will not be sent once it is connected, so it needs to be
+			// sent now.
+			// When there is no MCU this is not needed; as the local participant
+			// has no streams it will be automatically marked with audio and
+			// video not available on the other end, so there is no need to send
+			// the media state.
+			if (signaling.hasFeature('mcu')) {
+				sendCurrentMediaStateWithRepetition()
+			}
 		}
 
 		const createPeer = function() {

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -769,6 +769,28 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 		peer.check_video_interval = null
 	}
 
+	function stopPeerIdCheckMediaType(peerId, mediaType) {
+		// There should be just one video peer with that id, but iterating is
+		// safer.
+		const peers = webrtc.getPeers(peerId, 'video')
+		peers.forEach(function(peer) {
+			if (mediaType === 'audio') {
+				stopPeerCheckAudioMedia(peer)
+			} else if (mediaType === 'video') {
+				stopPeerCheckVideoMedia(peer)
+			}
+		})
+	}
+
+	if (signaling.hasFeature('mcu')) {
+		webrtc.on('mute', function(data) {
+			stopPeerIdCheckMediaType(data.id, data.name)
+		})
+		webrtc.on('unmute', function(data) {
+			stopPeerIdCheckMediaType(data.id, data.name)
+		})
+	}
+
 	function stopPeerCheckMedia(peer) {
 		stopPeerCheckAudioMedia(peer)
 		stopPeerCheckVideoMedia(peer)

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -141,6 +141,19 @@ function checkStartPublishOwnPeer(signaling) {
 	localCallParticipantModel.setPeer(ownPeer)
 }
 
+function sendCurrentMediaState() {
+	if (!webrtc.webrtc.isVideoEnabled()) {
+		webrtc.webrtc.emit('videoOff')
+	} else {
+		webrtc.webrtc.emit('videoOn')
+	}
+	if (!webrtc.webrtc.isAudioEnabled()) {
+		webrtc.webrtc.emit('audioOff')
+	} else {
+		webrtc.webrtc.emit('audioOn')
+	}
+}
+
 function userHasStreams(user) {
 	let flags = user
 	if (flags.hasOwnProperty('inCall')) {
@@ -485,16 +498,8 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 	function handleIceConnectionStateConnected(peer) {
 		// Send the current information about the video and microphone
 		// state.
-		if (!webrtc.webrtc.isVideoEnabled()) {
-			webrtc.webrtc.emit('videoOff')
-		} else {
-			webrtc.webrtc.emit('videoOn')
-		}
-		if (!webrtc.webrtc.isAudioEnabled()) {
-			webrtc.webrtc.emit('audioOff')
-		} else {
-			webrtc.webrtc.emit('audioOn')
-		}
+		sendCurrentMediaState()
+
 		if (signaling.settings.userId === null) {
 			const currentGuestNick = store.getters.getDisplayName()
 			sendDataChannelToAll('status', 'nickChanged', currentGuestNick)


### PR DESCRIPTION
When the HPB is used it is possible to know when the local participant has established a connection with a remote participant, but it is not possible to know when a remote participant established a connection with the local one.  The initial state (audio and video on or off) was sent just once when the local participant establishes a connection with the remote one, which caused that, in some cases, the message was received by the remote participant before a connection was established with the local one and thus ignored.

Even if there is code to try to locally detect the initial media state of the remote participant it has shown to not be as reliable as desirable, which causes a wrong media state to be sometimes shown for remote participants until the participant changes it again (or another user joins and the messages are sent again to everyone).

However, even if it is not possible to know when a remote participant established a connection with the local one it is safe to assume that it happened in a "reasonable" amount of time since the local participant has established a connection with the remote one.

Due to this now the initial media state is first sent when that happens, and then it is sent again several times (with an increasing interval) in the next 30 seconds. If a connection is established with another participant in the meantime the cycle starts again.

This pull request also fixes getting the initial media state of other participants when a participant has no audio nor video, as in that case there will be no peer for that participant and the initial media state was sent only when a connection was established with the remote peer.

Additionally the initial media state is now sent also through signaling (all the media state changes were sent both through signaling and data channels except for the initial ones). Signaling media state messages are also correctly handled now (they were ignored due to a bug), although the data channel messages still need to be sent for now for compatibility with the mobile apps.

In a similar way locally checking the initial media state still needs to be done until the mobile apps implement the repetition of the messages, although the check is now stopped as soon as the media state was received from the other participant (until now for example the video check never stopped if the other peer had no camera).
