### PR TITLE
Stop sending the nick through data channels after some time

### DIFF
--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -174,7 +174,6 @@ CallParticipantModel.prototype = {
 			return
 		}
 
-		this.set('userId', data.userid || null)
 		this.set('name', data.name || null)
 	},
 

--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -170,7 +170,8 @@ CallParticipantModel.prototype = {
 	},
 
 	_handleNick: function(data) {
-		if (!this.get('peer') || this.get('peer').id !== data.id) {
+		// The nick could be changed even if there is no Peer object.
+		if (this.get('peerId') !== data.id) {
 			return
 		}
 

--- a/src/utils/webrtc/models/LocalCallParticipantModel.js
+++ b/src/utils/webrtc/models/LocalCallParticipantModel.js
@@ -125,7 +125,7 @@ LocalCallParticipantModel.prototype = {
 
 		this.set('guestName', guestName)
 
-		this._webRtc.sendDirectlyToAll('status', 'nickChanged', guestName)
+		this._webRtc.webrtc.emit('nickChanged', guestName)
 	},
 
 	_handleForcedMute: function() {

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -119,6 +119,10 @@ function SimpleWebRTC(opts) {
 					self.emit('mute', { id: message.payload.peerId })
 				}
 			}
+		} else if (message.type === 'nickChanged') {
+			// "nickChanged" can be received from a participant without a Peer
+			// object if that participant is not sending audio nor video.
+			self.emit('nick', { id: message.from, name: message.payload.name })
 		} else if (peers.length) {
 			peers.forEach(function(peer) {
 				if (message.sid && !self.connection.hasFeature('mcu')) {

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -957,6 +957,14 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 	})
 
 	// Send the nick changed event via data channel and signaling
+	//
+	// The message format is different in each case. Due to historical reasons
+	// the payload of the data channel message is either a string that contains
+	// the name (if the participant is a guest) or an object with "name" and
+	// "userid" string fields (when the participant is a user).
+	//
+	// In the newer signaling message, on the other hand, the payload is always
+	// an object with only a "name" string field.
 	webrtc.on('nickChanged', function(name) {
 		let payload
 		if (signaling.settings.userId === null) {

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -245,15 +245,17 @@ function usersChanged(signaling, newUsers, disconnectedSessionIds) {
 				|| (!signaling.hasFeature('mcu') && user && !userHasStreams(user) && !webrtc.webrtc.localStreams.length)) {
 			callParticipantModel.setPeer(null)
 
-			// As there is no Peer for the other participant the current media
-			// state will not be sent once it is connected, so it needs to be
-			// sent now.
-			// When there is no MCU this is not needed; as the local participant
-			// has no streams it will be automatically marked with audio and
-			// video not available on the other end, so there is no need to send
-			// the media state.
+			// As there is no Peer for the other participant the current state
+			// will not be sent once it is connected, so it needs to be sent
+			// now.
+			// When there is no MCU this is only needed for the nick; as the
+			// local participant has no streams it will be automatically marked
+			// with audio and video not available on the other end, so there is
+			// no need to send the media state.
 			if (signaling.hasFeature('mcu')) {
 				sendCurrentStateWithRepetition()
+			} else {
+				sendCurrentNick()
 			}
 		}
 

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -544,11 +544,6 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 			sendCurrentMediaStateWithRepetition()
 		}
 
-		if (signaling.settings.userId === null) {
-			const currentGuestNick = store.getters.getDisplayName()
-			sendDataChannelToAll('status', 'nickChanged', currentGuestNick)
-		}
-
 		// Reset ice restart counter for peer
 		if (spreedPeerConnectionTable[peer.id] > 0) {
 			spreedPeerConnectionTable[peer.id] = 0

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -522,16 +522,7 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 
 		stopSendingNick()
 		ownPeer.nickInterval = setInterval(function() {
-			let payload
-			if (signaling.settings.userId === null) {
-				payload = store.getters.getDisplayName()
-			} else {
-				payload = {
-					'name': store.getters.getDisplayName(),
-					'userid': signaling.settings.userId,
-				}
-			}
-			ownPeer.sendDirectly('status', 'nickChanged', payload)
+			webrtc.webrtc.emit('nickChanged', store.getters.getDisplayName())
 		}, 1000)
 	}
 
@@ -991,6 +982,21 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 	})
 	webrtc.on('videoOff', function() {
 		sendDataChannelToAll('status', 'videoOff')
+	})
+
+	// Send the nick changed event via data channel
+	webrtc.on('nickChanged', function(name) {
+		let payload
+		if (signaling.settings.userId === null) {
+			payload = name
+		} else {
+			payload = {
+				'name': name,
+				'userid': signaling.settings.userId,
+			}
+		}
+
+		sendDataChannelToAll('status', 'nickChanged', payload)
 	})
 
 	// Local screen added.

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -920,12 +920,8 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 			} else if (data.type === 'videoOff') {
 				webrtc.emit('mute', { id: peer.id, name: 'video' })
 			} else if (data.type === 'nickChanged') {
-				const payload = data.payload || ''
-				if (typeof (payload) === 'string') {
-					webrtc.emit('nick', { id: peer.id, name: data.payload })
-				} else {
-					webrtc.emit('nick', { id: peer.id, name: payload.name, userid: payload.userid })
-				}
+				const name = typeof (data.payload) === 'string' ? data.payload : data.payload.name
+				webrtc.emit('nick', { id: peer.id, name: name })
 			} else if (data.type === 'speaking' || data.type === 'stoppedSpeaking') {
 				// Valid known messages, but handled elsewhere
 			} else {

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -46,7 +46,7 @@ const delayedConnectionToPeer = []
 let callParticipantCollection = null
 let localCallParticipantModel = null
 let showedTURNWarning = false
-let sendCurrentMediaStateWithRepetitionTimeout = null
+let sendCurrentStateWithRepetitionTimeout = null
 
 function arrayDiff(a, b) {
 	return a.filter(function(i) {
@@ -158,14 +158,14 @@ function sendCurrentMediaState() {
 	}
 }
 
-function sendCurrentMediaStateWithRepetition(timeout) {
+function sendCurrentStateWithRepetition(timeout) {
 	if (!timeout) {
 		timeout = 0
 
-		clearTimeout(sendCurrentMediaStateWithRepetitionTimeout)
+		clearTimeout(sendCurrentStateWithRepetitionTimeout)
 	}
 
-	sendCurrentMediaStateWithRepetitionTimeout = setTimeout(function() {
+	sendCurrentStateWithRepetitionTimeout = setTimeout(function() {
 		sendCurrentMediaState()
 
 		if (!timeout) {
@@ -175,11 +175,11 @@ function sendCurrentMediaStateWithRepetition(timeout) {
 		}
 
 		if (timeout > 16000) {
-			sendCurrentMediaStateWithRepetitionTimeout = null
+			sendCurrentStateWithRepetitionTimeout = null
 			return
 		}
 
-		sendCurrentMediaStateWithRepetition(timeout)
+		sendCurrentStateWithRepetition(timeout)
 	}, timeout)
 }
 
@@ -245,7 +245,7 @@ function usersChanged(signaling, newUsers, disconnectedSessionIds) {
 			// video not available on the other end, so there is no need to send
 			// the media state.
 			if (signaling.hasFeature('mcu')) {
-				sendCurrentMediaStateWithRepetition()
+				sendCurrentStateWithRepetition()
 			}
 		}
 
@@ -532,7 +532,7 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 		if (!signaling.hasFeature('mcu')) {
 			sendCurrentMediaState()
 		} else {
-			sendCurrentMediaStateWithRepetition()
+			sendCurrentStateWithRepetition()
 		}
 
 		// Reset ice restart counter for peer

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -507,21 +507,21 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 	// TODO: The name for the avatar should come from the participant list
 	// which already has all information and get rid of using the
 	// DataChannel for this.
-	function stopSendingNick(peer) {
-		if (!peer.nickInterval) {
+	function stopSendingNick() {
+		if (!ownPeer.nickInterval) {
 			return
 		}
 
-		clearInterval(peer.nickInterval)
-		peer.nickInterval = null
+		clearInterval(ownPeer.nickInterval)
+		ownPeer.nickInterval = null
 	}
-	function startSendingNick(peer) {
+	function startSendingNick() {
 		if (!signaling.hasFeature('mcu')) {
 			return
 		}
 
-		stopSendingNick(peer)
-		peer.nickInterval = setInterval(function() {
+		stopSendingNick()
+		ownPeer.nickInterval = setInterval(function() {
 			let payload
 			if (signaling.settings.userId === null) {
 				payload = store.getters.getDisplayName()
@@ -531,7 +531,7 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 					'userid': signaling.settings.userId,
 				}
 			}
-			peer.sendDirectly('status', 'nickChanged', payload)
+			ownPeer.sendDirectly('status', 'nickChanged', payload)
 		}, 1000)
 	}
 
@@ -715,7 +715,7 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 			if (peer.id === signaling.getSessionId()) {
 				console.debug('Not adding ICE connection state handler for own peer', peer)
 
-				startSendingNick(peer)
+				startSendingNick()
 			} else {
 				setHandlerForIceConnectionStateChange(peer)
 			}
@@ -797,7 +797,6 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 	function stopPeerCheckMedia(peer) {
 		stopPeerCheckAudioMedia(peer)
 		stopPeerCheckVideoMedia(peer)
-		stopSendingNick(peer)
 	}
 
 	function startPeerCheckMedia(peer, stream) {
@@ -838,6 +837,10 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 
 	webrtc.on('peerStreamRemoved', function(peer) {
 		stopPeerCheckMedia(peer)
+
+		if (peer.id === signaling.getSessionId()) {
+			stopSendingNick()
+		}
 	})
 
 	webrtc.webrtc.on('videoOn', function() {


### PR DESCRIPTION
Requires #4181

~~(Kept as draft until #4181 is merged, but ready to review nevertheless)~~

Since the introduction of the HPB the nick has been sent over and over again every second, as it is not possible to know when other participants have established a data channel connection (and neither to associate a signaling id with a Nextcloud id to get the nick from the participant list).
    
However, it is possible to know when other participants join the call, and it is safe to assume that the other participant established a connection with the local one after a "reasonable" amount of time.
    
As sending the nick every second is too aggressive (specially in calls with a lot of users) now the nick is sent when the local participant establishes a connection with the remote one and, as that does not guarantee that the remote one has established a connection with the local one, the nick is sent again several times (with an increasing interval) in the next 30 seconds. If a connection is established with another participant in the meantime the cycle starts again.

Additionally a `nickChanged` signaling message* is now sent along with the data channel message. The signaling message is needed for those cases in which there is no Peer object for a participant, as in that case it is not possible to send data channel messages. However, the data channel messages still need to be sent to keep compatibility with the mobile apps.

*An unknown signaling message is just ignored by the mobile apps, but it should not break anything; tested in iOS by @ivansss, although just my guess from checking the Android app code (but I have not actually tested it).
