### PR TITLE
Less participant queries

### DIFF
--- a/lib/Collaboration/Resources/ConversationProvider.php
+++ b/lib/Collaboration/Resources/ConversationProvider.php
@@ -54,8 +54,9 @@ class ConversationProvider implements IProvider {
 
 	public function getResourceRichObject(IResource $resource): array {
 		try {
-			$room = $this->manager->getRoomByToken($resource->getId());
 			$user = $this->userSession->getUser();
+			$userId = $user instanceof IUser ? $user->getUID() : '';
+			$room = $this->manager->getRoomByToken($resource->getId(), $userId);
 
 			$iconURL = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('spreed', 'app-dark.svg'));
 			/**
@@ -68,7 +69,7 @@ class ConversationProvider implements IProvider {
 			return [
 				'type' => 'room',
 				'id' => $resource->getId(),
-				'name' => $room->getDisplayName($user instanceof IUser ? $user->getUID() : ''),
+				'name' => $room->getDisplayName($userId),
 				'call-type' => $this->getRoomType($room),
 				'iconUrl' => $iconURL,
 				'link' => $this->urlGenerator->linkToRouteAbsolute('spreed.Page.showCall', ['token' => $room->getToken()])

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -185,7 +185,7 @@ class PageController extends Controller {
 		if ($token !== '') {
 			$room = null;
 			try {
-				$room = $this->manager->getRoomByToken($token);
+				$room = $this->manager->getRoomByToken($token, $this->userId);
 				$notification = $this->notificationManager->createNotification();
 				$shouldFlush = $this->notificationManager->defer();
 				try {

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -505,7 +505,7 @@ class SignalingController extends OCSController {
 		$action = !empty($roomRequest['action']) ? $roomRequest['action'] : 'join';
 
 		try {
-			$room = $this->manager->getRoomByToken($roomId);
+			$room = $this->manager->getRoomByToken($roomId, $userId);
 		} catch (RoomNotFoundException $e) {
 			return new DataResponse([
 				'type' => 'error',

--- a/lib/Share/Helper/DeletedShareAPIController.php
+++ b/lib/Share/Helper/DeletedShareAPIController.php
@@ -64,7 +64,7 @@ class DeletedShareAPIController {
 		$result = [];
 
 		try {
-			$room = $this->manager->getRoomByToken($share->getSharedWith());
+			$room = $this->manager->getRoomByToken($share->getSharedWith(), $this->userId);
 		} catch (RoomNotFoundException $e) {
 			return $result;
 		}

--- a/lib/Share/Helper/ShareAPIController.php
+++ b/lib/Share/Helper/ShareAPIController.php
@@ -79,7 +79,7 @@ class ShareAPIController {
 		$result = [];
 
 		try {
-			$room = $this->manager->getRoomByToken($share->getSharedWith());
+			$room = $this->manager->getRoomByToken($share->getSharedWith(), $this->userId);
 		} catch (RoomNotFoundException $e) {
 			return $result;
 		}
@@ -161,7 +161,7 @@ class ShareAPIController {
 	 */
 	public function canAccessShare(IShare $share, string $user): bool {
 		try {
-			$room = $this->manager->getRoomByToken($share->getSharedWith());
+			$room = $this->manager->getRoomByToken($share->getSharedWith(), $user);
 		} catch (RoomNotFoundException $e) {
 			return false;
 		}

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -153,7 +153,7 @@ class RoomShareProvider implements IShareProvider {
 	 */
 	public function create(IShare $share): IShare {
 		try {
-			$room = $this->manager->getRoomByToken($share->getSharedWith());
+			$room = $this->manager->getRoomByToken($share->getSharedWith(), $share->getSharedBy());
 		} catch (RoomNotFoundException $e) {
 			throw new GenericShareException('Room not found', $this->l->t('Conversation not found'), 404);
 		}

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -1023,6 +1023,7 @@ class NotifierTest extends \Test\TestCase {
 		return [
 			['Incorrect app', 'invalid-app', null, null, null, null, null],
 			'User can not use Talk' => [AlreadyProcessedException::class, 'spreed', true, null, null, null, null],
+			'Invalid room' => [AlreadyProcessedException::class, 'spreed', false, false, null, null, null, '12345'],
 			'Invalid room' => [AlreadyProcessedException::class, 'spreed', false, false, null, null, null],
 			['Unknown subject', 'spreed', false, true, 'invalid-subject', null, null],
 			['Unknown object type', 'spreed', false, true, 'invitation', null, 'invalid-object-type'],
@@ -1041,8 +1042,9 @@ class NotifierTest extends \Test\TestCase {
 	 * @param string|null $subject
 	 * @param array|null $params
 	 * @param string|null $objectType
+	 * @param string $token
 	 */
-	public function testPrepareThrows($message, $app, $isDisabledForUser, $validRoom, $subject, $params, $objectType) {
+	public function testPrepareThrows($message, $app, $isDisabledForUser, $validRoom, $subject, $params, $objectType, $token = 'roomToken') {
 		/** @var INotification|MockObject $n */
 		$n = $this->createMock(INotification::class);
 		$l = $this->createMock(IL10N::class);
@@ -1056,20 +1058,20 @@ class NotifierTest extends \Test\TestCase {
 				->method('getType');
 			$n->expects($this->once())
 				->method('getObjectId')
-				->willReturn('roomToken');
+				->willReturn($token);
 			$this->manager->expects($this->once())
 				->method('getRoomByToken')
-				->with('roomToken')
+				->with($token)
 				->willReturn($room);
 		} elseif ($validRoom === false) {
 			$n->expects($this->once())
 				->method('getObjectId')
-				->willReturn('roomToken');
+				->willReturn($token);
 			$this->manager->expects($this->once())
 				->method('getRoomByToken')
-				->with('roomToken')
+				->with($token)
 				->willThrowException(new RoomNotFoundException());
-			$this->manager->expects($this->once())
+			$this->manager->expects($token !== 'roomToken' ? $this->once() : $this->never())
 				->method('getRoomById')
 				->willThrowException(new RoomNotFoundException());
 		}


### PR DESCRIPTION
Should reduce the number of those queries a lot:

```sql
SELECT * FROM `oc_talk_participants` WHERE (`user_id` = 'xxx') AND (`room_id` = '1234')
```

and will instead left join the participant on the initial query. That in itself is not a big help. But in case we ask for the same participant more than once (hint, happens every time), we save N-1 queries

it was 1122 queries of the 7873 in our query log