### PR TITLE
If there are no sessions, we don't need to run a query

### DIFF
--- a/lib/GuestManager.php
+++ b/lib/GuestManager.php
@@ -142,6 +142,10 @@ class GuestManager {
 	 * @return string[]
 	 */
 	public function getNamesBySessionHashes(array $sessionHashes): array {
+		if (empty($sessionHashes)) {
+			return [];
+		}
+
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
 			->from('talk_guests')


### PR DESCRIPTION
Should remove all those queries from our query log:

```sql
SELECT * FROM `oc_talk_guests` WHERE `session_hash` IN (NULL)
```

Called from
https://github.com/nextcloud/spreed/blob/291e2c75f7b97cd8c1194b5a54cbf6b97193e981/lib/Controller/RoomController.php#L877-L881