### PR TITLE
Change the upload button name from upload to send

### DIFF
--- a/src/components/UploadEditor.vue
+++ b/src/components/UploadEditor.vue
@@ -54,10 +54,10 @@
 		</transition-group>
 		<div class="upload-editor__actions">
 			<button @click="handleDismiss">
-				Dismiss
+				{{ t('spreed', 'Dismiss') }}
 			</button>
 			<button class="primary" @click="handleUpload">
-				Send
+				{{ t('spreed', 'Send') }}
 			</button>
 		</div>
 	</Modal>

--- a/src/components/UploadEditor.vue
+++ b/src/components/UploadEditor.vue
@@ -57,7 +57,7 @@
 				Dismiss
 			</button>
 			<button class="primary" @click="handleUpload">
-				Upload
+				Send
 			</button>
 		</div>
 	</Modal>


### PR DESCRIPTION
I think its more clear if we name the upload button at the second step of sending a file to chat as send, instead of upload, since it give you the impression you will upload a new file and not send it to the chat.

![uploadbutton](https://user-images.githubusercontent.com/12728974/93893447-ee14a300-fced-11ea-96ab-4ad97a8522ee.png)
