### PR TITLE
Save the query to count the user for moderators per room every 30sec

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -512,8 +512,7 @@ class RoomController extends AEnvironmentAwareController {
 
 			$roomData['canDeleteConversation'] = $room->getType() !== Room::ONE_TO_ONE_CALL
 				&& $currentParticipant->hasModeratorPermissions(false);
-			$roomData['canLeaveConversation'] = !$roomData['canDeleteConversation']
-				|| ($room->getType() !== Room::ONE_TO_ONE_CALL && $room->getNumberOfParticipants() > 1);
+			$roomData['canLeaveConversation'] = true;
 		}
 
 		// FIXME This should not be done, but currently all the clients use it to get the avatar of the user …


### PR DESCRIPTION
The idea of this option was to not show the "leave" button when
you are the last "non-guest" user, so you need to delete it instead.
However this "neat" functionality could be out of date info,
if the other user already left in parallel.
So it doesn't qualify for the O(n) queries every 30 seconds.
