### PR TITLE
Add missing parent::__construct() call to all background jobs

### DIFF
--- a/lib/BackgroundJob/ExpireSignalingMessage.php
+++ b/lib/BackgroundJob/ExpireSignalingMessage.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\BackgroundJob;
 
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use OCA\Talk\Signaling\Messages;
 
@@ -36,7 +37,10 @@ class ExpireSignalingMessage extends TimedJob {
 	/** @var Messages */
 	protected $messages;
 
-	public function __construct(Messages $messages) {
+	public function __construct(ITimeFactory $timeFactory,
+								Messages $messages) {
+		parent::__construct($timeFactory);
+
 		// Every 5 minutes
 		$this->setInterval(60 * 5);
 

--- a/lib/BackgroundJob/RemoveEmptyRooms.php
+++ b/lib/BackgroundJob/RemoveEmptyRooms.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\BackgroundJob;
 
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use OCA\Talk\Manager;
 use OCA\Talk\Room;
@@ -43,8 +44,11 @@ class RemoveEmptyRooms extends TimedJob {
 
 	protected $numDeletedRooms = 0;
 
-	public function __construct(Manager $manager,
+	public function __construct(ITimeFactory $timeFactory,
+								Manager $manager,
 								LoggerInterface $logger) {
+		parent::__construct($timeFactory);
+
 		// Every 5 minutes
 		$this->setInterval(60 * 5);
 


### PR DESCRIPTION
Signed-off-by: Joas Schilling <coding@schilljs.com>