### PR TITLE
Remember selected input devices

### DIFF
--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -19,6 +19,14 @@
  *
  */
 
+import BrowserStorage from '../../services/BrowserStorage'
+
+/**
+ * Special string to set null device ids in local storage (as only strings are
+ * allowed).
+ */
+const LOCAL_STORAGE_NULL_DEVICE_ID = 'local-storage-null-device-id'
+
 /**
  * Wrapper for MediaDevices to simplify its use.
  *
@@ -57,7 +65,9 @@
  * modified.
  *
  * The selected devices will be automatically cleared if they are no longer
- * available. When no device of certain kind is selected and there are other
+ * available, and they will be restored once they are again available
+ * (immediately if events are enabled, or otherwise the next time that devices
+ * are got). When no device of certain kind is selected and there are other
  * devices of that kind the selected device will fall back to the first one
  * found, or to the one with the "default" id (if any). It is possible to
  * explicitly disable devices of certain kind by setting xxxInputId to "null"
@@ -83,6 +93,13 @@ export default function MediaDevicesManager() {
 	this._tracks = []
 
 	this._updateDevicesBound = this._updateDevices.bind(this)
+
+	if (BrowserStorage.getItem('audioInputId') === LOCAL_STORAGE_NULL_DEVICE_ID) {
+		this.attributes.audioInputId = null
+	}
+	if (BrowserStorage.getItem('videoInputId') === LOCAL_STORAGE_NULL_DEVICE_ID) {
+		this.attributes.videoInputId = null
+	}
 }
 MediaDevicesManager.prototype = {
 
@@ -94,6 +111,24 @@ MediaDevicesManager.prototype = {
 		this.attributes[key] = value
 
 		this._trigger('change:' + key, [value])
+
+		this._storeDeviceId(key, value)
+	},
+
+	_storeDeviceId: function(key, value) {
+		if (key !== 'audioInputId' && key !== 'videoInputId') {
+			return
+		}
+
+		if (value === null) {
+			value = LOCAL_STORAGE_NULL_DEVICE_ID
+		}
+
+		if (value) {
+			BrowserStorage.setItem(key, value)
+		} else {
+			BrowserStorage.removeItem(key)
+		}
 	},
 
 	on: function(event, handler) {
@@ -274,9 +309,13 @@ MediaDevicesManager.prototype = {
 		// Always refresh the known device with the latest values.
 		this._knownDevices[addedDevice.kind + '-' + addedDevice.deviceId] = addedDevice
 
-		// Set first available device as fallback, and override any
-		// fallback previously set if the default device is added.
+		// Restore previously selected device if it becomes available again.
+		// Additionally, set first available device as fallback, and override
+		// any fallback previously set if the default device is added.
 		if (addedDevice.kind === 'audioinput') {
+			if (BrowserStorage.getItem('audioInputId') === addedDevice.deviceId) {
+				this.attributes.audioInputId = addedDevice.deviceId
+			}
 			if (!this._fallbackAudioInputId || addedDevice.deviceId === 'default') {
 				this._fallbackAudioInputId = addedDevice.deviceId
 			}
@@ -284,6 +323,9 @@ MediaDevicesManager.prototype = {
 				this.attributes.audioInputId = this._fallbackAudioInputId
 			}
 		} else if (addedDevice.kind === 'videoinput') {
+			if (BrowserStorage.getItem('videoInputId') === addedDevice.deviceId) {
+				this.attributes.videoInputId = addedDevice.deviceId
+			}
 			if (!this._fallbackVideoInputId || addedDevice.deviceId === 'default') {
 				this._fallbackVideoInputId = addedDevice.deviceId
 			}

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -204,6 +204,26 @@ LocalMedia.prototype._handleAudioInputIdChanged = function(mediaDevicesManager, 
 		return
 	}
 
+	this._pendingAudioInputIdChangedCount = 1
+
+	const resetPendingAudioInputIdChangedCount = () => {
+		const audioInputIdChangedAgain = this._pendingAudioInputIdChangedCount > 1
+
+		this._pendingAudioInputIdChangedCount = 0
+
+		if (audioInputIdChangedAgain) {
+			this._handleAudioInputIdChanged(webrtcIndex.mediaDevicesManager.get('audioInputId'))
+		}
+
+		if (!this._pendingAudioInputIdChangedCount && !this._pendingVideoInputIdChangedCount) {
+			this.localStreams.forEach(stream => {
+				if (isAllTracksEnded(stream)) {
+					this._removeStream(stream)
+				}
+			})
+		}
+	}
+
 	const localStreamsChanged = []
 	const localTracksReplaced = []
 
@@ -244,31 +264,15 @@ LocalMedia.prototype._handleAudioInputIdChanged = function(mediaDevicesManager, 
 			this.emit('localTrackReplaced', null, trackStreamPair.track, trackStreamPair.stream)
 		})
 
+		resetPendingAudioInputIdChangedCount()
+
 		return
 	}
 
 	if (localTracksReplaced.length === 0) {
+		resetPendingAudioInputIdChangedCount()
+
 		return
-	}
-
-	this._pendingAudioInputIdChangedCount = 1
-
-	const resetPendingAudioInputIdChangedCount = () => {
-		const audioInputIdChangedAgain = this._pendingAudioInputIdChangedCount > 1
-
-		this._pendingAudioInputIdChangedCount = 0
-
-		if (audioInputIdChangedAgain) {
-			this._handleAudioInputIdChanged(webrtcIndex.mediaDevicesManager.get('audioInputId'))
-		}
-
-		if (!this._pendingAudioInputIdChangedCount && !this._pendingVideoInputIdChangedCount) {
-			this.localStreams.forEach(stream => {
-				if (isAllTracksEnded(stream)) {
-					this._removeStream(stream)
-				}
-			})
-		}
 	}
 
 	webrtcIndex.mediaDevicesManager.getUserMedia({ audio: true }).then(stream => {
@@ -345,6 +349,26 @@ LocalMedia.prototype._handleVideoInputIdChanged = function(mediaDevicesManager, 
 		return
 	}
 
+	this._pendingVideoInputIdChangedCount = 1
+
+	const resetPendingVideoInputIdChangedCount = () => {
+		const videoInputIdChangedAgain = this._pendingVideoInputIdChangedCount > 1
+
+		this._pendingVideoInputIdChangedCount = 0
+
+		if (videoInputIdChangedAgain) {
+			this._handleVideoInputIdChanged(webrtcIndex.mediaDevicesManager.get('videoInputId'))
+		}
+
+		if (!this._pendingAudioInputIdChangedCount && !this._pendingVideoInputIdChangedCount) {
+			this.localStreams.forEach(stream => {
+				if (isAllTracksEnded(stream)) {
+					this._removeStream(stream)
+				}
+			})
+		}
+	}
+
 	const localStreamsChanged = []
 	const localTracksReplaced = []
 
@@ -385,31 +409,15 @@ LocalMedia.prototype._handleVideoInputIdChanged = function(mediaDevicesManager, 
 			this.emit('localTrackReplaced', null, trackStreamPair.track, trackStreamPair.stream)
 		})
 
+		resetPendingVideoInputIdChangedCount()
+
 		return
 	}
 
 	if (localTracksReplaced.length === 0) {
+		resetPendingVideoInputIdChangedCount()
+
 		return
-	}
-
-	this._pendingVideoInputIdChangedCount = 1
-
-	const resetPendingVideoInputIdChangedCount = () => {
-		const videoInputIdChangedAgain = this._pendingVideoInputIdChangedCount > 1
-
-		this._pendingVideoInputIdChangedCount = 0
-
-		if (videoInputIdChangedAgain) {
-			this._handleVideoInputIdChanged(webrtcIndex.mediaDevicesManager.get('videoInputId'))
-		}
-
-		if (!this._pendingAudioInputIdChangedCount && !this._pendingVideoInputIdChangedCount) {
-			this.localStreams.forEach(stream => {
-				if (isAllTracksEnded(stream)) {
-					this._removeStream(stream)
-				}
-			})
-		}
 	}
 
 	webrtcIndex.mediaDevicesManager.getUserMedia({ video: true }).then(stream => {

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -165,7 +165,7 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 			}
 
 			track.addEventListener('ended', function() {
-				if (isAllTracksEnded(stream)) {
+				if (isAllTracksEnded(stream) && !self._pendingAudioInputIdChangedCount && !self._pendingVideoInputIdChangedCount) {
 					self._removeStream(stream)
 				}
 			})
@@ -261,6 +261,14 @@ LocalMedia.prototype._handleAudioInputIdChanged = function(mediaDevicesManager, 
 		if (audioInputIdChangedAgain) {
 			this._handleAudioInputIdChanged(webrtcIndex.mediaDevicesManager.get('audioInputId'))
 		}
+
+		if (!this._pendingAudioInputIdChangedCount && !this._pendingVideoInputIdChangedCount) {
+			this.localStreams.forEach(stream => {
+				if (isAllTracksEnded(stream)) {
+					this._removeStream(stream)
+				}
+			})
+		}
 	}
 
 	webrtcIndex.mediaDevicesManager.getUserMedia({ audio: true }).then(stream => {
@@ -303,7 +311,7 @@ LocalMedia.prototype._handleAudioInputIdChanged = function(mediaDevicesManager, 
 			}
 
 			clonedTrack.addEventListener('ended', () => {
-				if (isAllTracksEnded(stream)) {
+				if (isAllTracksEnded(stream) && !this._pendingAudioInputIdChangedCount && !this._pendingVideoInputIdChangedCount) {
 					this._removeStream(stream)
 				}
 			})
@@ -394,6 +402,14 @@ LocalMedia.prototype._handleVideoInputIdChanged = function(mediaDevicesManager, 
 		if (videoInputIdChangedAgain) {
 			this._handleVideoInputIdChanged(webrtcIndex.mediaDevicesManager.get('videoInputId'))
 		}
+
+		if (!this._pendingAudioInputIdChangedCount && !this._pendingVideoInputIdChangedCount) {
+			this.localStreams.forEach(stream => {
+				if (isAllTracksEnded(stream)) {
+					this._removeStream(stream)
+				}
+			})
+		}
 	}
 
 	webrtcIndex.mediaDevicesManager.getUserMedia({ video: true }).then(stream => {
@@ -423,7 +439,7 @@ LocalMedia.prototype._handleVideoInputIdChanged = function(mediaDevicesManager, 
 			}
 
 			clonedTrack.addEventListener('ended', () => {
-				if (isAllTracksEnded(stream)) {
+				if (isAllTracksEnded(stream) && !this._pendingAudioInputIdChangedCount && !this._pendingVideoInputIdChangedCount) {
 					this._removeStream(stream)
 				}
 			})

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -138,6 +138,12 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 
 	this.emit('localStreamRequested', constraints, context)
 
+	if (!context) {
+		// Try to get the devices list before getting user media.
+		webrtcIndex.mediaDevicesManager.enableDeviceEvents()
+		webrtcIndex.mediaDevicesManager.disableDeviceEvents()
+	}
+
 	webrtcIndex.mediaDevicesManager.getUserMedia(constraints).then(function(stream) {
 		// Although the promise should be resolved only if all the constraints
 		// are met Edge resolves it if both audio and video are requested but


### PR DESCRIPTION
Follow up to #3913

Before the selected input devices were used as long as the device was still available and Talk was still open. However, if the device was disconnected and connected it was not automatically selected again, even if Talk was still open. Now the last selected device of each kind is remembered, so it will be automatically used if available when joining a call, even if it was disconnected and connected or if Talk was closed and opened.
    
Additionally, if audio or video devices were explicitly disabled this will also be remembered and respected when Talk is open again.

Note that the last selected device is automatically used if available when joining a call, but it will not be automatically used if it becomes available during a call. While it would be possible to do that at least for me it felt strange and unexpected (but I would have no problem enabling that if desired).

Besides that this pull request also fixes some related issues that have given me a big headache :-P