### PR TITLE
Fix height in Talk sidebar in Files app

### DIFF
--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -403,6 +403,19 @@ export default {
 	flex-direction: column;
 }
 
+.emptycontent {
+	/* Override default top margin set in server and center vertically
+	 * instead. */
+	margin-top: unset;
+
+	height: 100%;
+
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+}
+
 .call-button {
 	/* Center button horizontally. */
 	margin-left: auto;

--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -352,10 +352,10 @@ export default {
 		},
 
 		/**
-		 * Dirty hack to set the style in the tabs content container.
+		 * Dirty hack to set the style in the tabs container.
 		 *
-		 * This is needed to force the scroll bars on the tab content instead of
-		 * on the whole sidebar.
+		 * This is needed to force the scroll bars on the tabs container instead
+		 * of on the whole sidebar.
 		 *
 		 * Additionally a minimum height is forced to ensure that the height of
 		 * the chat view will be at least 300px, even if the info view is large
@@ -367,20 +367,25 @@ export default {
 		 *        chat tab or not.
 		 */
 		forceTabsContentStyleWhenChatTabIsActive(isChatTheActiveTab) {
+			const tabs = document.querySelector('.app-sidebar-tabs')
 			const tabsContent = document.querySelector('.app-sidebar-tabs__content')
 
 			if (isChatTheActiveTab) {
-				this.savedTabsContentMinHeight = tabsContent.style.minHeight
+				this.savedTabsMinHeight = tabs.style.minHeight
+				this.savedTabsOverflow = tabs.style.overflow
 				this.savedTabsContentOverflow = tabsContent.style.overflow
 				this.savedTabsContentStyle = true
 
-				tabsContent.style.minHeight = '300px'
+				tabs.style.minHeight = '300px'
+				tabs.style.overflow = 'hidden'
 				tabsContent.style.overflow = 'hidden'
 			} else if (this.savedTabsContentStyle) {
-				tabsContent.style.minHeight = this.savedTabsContentMinHeight
+				tabs.style.minHeight = this.savedTabsMinHeight
+				tabs.style.overflow = this.savedTabsOverflow
 				tabsContent.style.overflow = this.savedTabsContentOverflow
 
-				delete this.savedTabsContentMinHeight
+				delete this.savedTabsMinHeight
+				delete this.savedTabsOverflow
 				delete this.savedTabsContentOverflow
 				this.savedTabsContentStyle = false
 			}


### PR DESCRIPTION
Fixes #4221

Due to [changes in nextcloud-vue 2.4.0](https://github.com/nextcloud/nextcloud-vue/commit/124543828c047bd6852676247e68d5c1fbf4bda3) the scroll bar was shown for the whole sidebar in the Files app. Now it is shown again only for the chat tab.

Besides that, due to [changes in nextcloud-vue 2.0.0](https://github.com/nextcloud/nextcloud-vue/commit/33f4af39f14648429650db6ca3319786188ec3a6) the message and button to join the conversation was shown too low and it had no scroll bar if there was not enough space. Now it is centered in the chat tab and shows a scroll bar if needed.