### PR TITLE
Fix participants list search box overlap

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -258,6 +258,16 @@ export default {
 	display: flex;
 }
 
+/**
+ * Replace padding with margin to make the participant list scroll
+ * properly behind the top field
+ */
+#tab-participants {
+	margin-top: 10px;
+	padding-top: 0;
+	outline: none; /* remove the weird border that appears on focus */
+}
+
 /* Force scroll bars in tabs content instead of in whole sidebar. */
 ::v-deep .app-sidebar-tabs {
 	height: calc(100% - 80px);


### PR DESCRIPTION
When scrolling up, the participants are not visible any more above the
search box.

![image](https://user-images.githubusercontent.com/277525/94931546-2a06ef80-04c8-11eb-9ee6-b9acfa7d774f.png)

This is a minimal quick-fix.

A proper way might need to reconsider the structure of the panel and move the scrolling container to start below the search box (vertically).
