### PR TITLE
Focus message field after upload or sharing file

### DIFF
--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -210,6 +210,7 @@ const actions = {
 	 * @param {object} uploadId The unique uploadId
 	 */
 	async uploadFiles({ commit, dispatch, state, getters }, uploadId) {
+		EventBus.$emit('uploadStart')
 
 		// Tag the previously indexed files and add the temporary messages to the
 		// messages list
@@ -266,6 +267,7 @@ const actions = {
 				}
 			}
 		}
+		EventBus.$emit('uploadFinished')
 	},
 	/**
 	 * Set the folder to store new attachments in


### PR DESCRIPTION
After starting an upload or sharing a file, set the focus back to the message field.

- [x] ~~focus happens before the upload dialog is closed~~ => not an issue
- [x] ~~BUG: when inserting emoji, cursor always appears at the beginning~~ => abandoning emoji approach for now until the [new rich input field](https://github.com/nextcloud/nextcloud-vue/pull/1433) is there

### Tests
- [x] TEST: upload file with the button, see that focus is back on the message field
- [x] TEST: upload file with drag and drop, see that focus is back on the message field
- [x] TEST: share a file, see that focus is back on the message field