### PR TITLE
Fix handling of unavailable commands

### DIFF
--- a/lib/Chat/Command/Executor.php
+++ b/lib/Chat/Command/Executor.php
@@ -86,7 +86,7 @@ class Executor {
 		return true;
 	}
 
-	public function exec(Room $room, IComment $message, Command $command, string $arguments): void {
+	public function exec(Room $room, IComment $message, Command $command, string $arguments, Participant $participant): void {
 		try {
 			$command = $this->commandService->resolveAlias($command);
 		} catch (DoesNotExistException $e) {
@@ -102,7 +102,7 @@ class Executor {
 		}
 
 		if ($command->getApp() === '' && $command->getCommand() === 'help') {
-			$output = $this->execHelp($room, $message, $arguments);
+			$output = $this->execHelp($room, $message, $arguments, $participant);
 		} elseif ($command->getApp() !== '') {
 			$output = $this->execApp($room, $message, $command, $arguments);
 		} else {
@@ -119,7 +119,7 @@ class Executor {
 		$message->setVerb('command');
 	}
 
-	protected function execHelp(Room $room, IComment $message, string $arguments): string {
+	protected function execHelp(Room $room, IComment $message, string $arguments, Participant $participant): string {
 		if ($arguments !== '' && $arguments !== 'help') {
 			return $this->execHelpSingleCommand($room, $message, $arguments);
 		}
@@ -131,7 +131,8 @@ class Executor {
 			if ($command->getApp() !== '') {
 				$response = $this->execHelpSingleCommand($room, $message, $command->getApp() . ' ' . $command->getCommand());
 			} else {
-				if ($command->getCommand() === 'help' || strpos($command->getScript(),'alias:') !== false) {
+				if ($command->getCommand() === 'help' || strpos($command->getScript(),'alias:') !== false ||
+						!$this->isCommandAvailableForParticipant($command, $participant)) {
 					continue;
 				}
 				$response = $this->execHelpSingleCommand($room, $message, $command->getCommand());

--- a/lib/Chat/Command/Executor.php
+++ b/lib/Chat/Command/Executor.php
@@ -26,6 +26,7 @@ namespace OCA\Talk\Chat\Command;
 use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Events\CommandEvent;
 use OCA\Talk\Model\Command;
+use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\CommandService;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -67,6 +68,22 @@ class Executor {
 		$this->commandService = $commandService;
 		$this->logger = $logger;
 		$this->l = $l;
+	}
+
+	public function isCommandAvailableForParticipant(Command $command, Participant $participant): bool {
+		if ($command->getEnabled() === Command::ENABLED_OFF) {
+			return false;
+		}
+
+		if ($command->getEnabled() === Command::ENABLED_MODERATOR && !$participant->hasModeratorPermissions()) {
+			return false;
+		}
+
+		if ($command->getEnabled() === Command::ENABLED_USERS && $participant->isGuest()) {
+			return false;
+		}
+
+		return true;
 	}
 
 	public function exec(Room $room, IComment $message, Command $command, string $arguments): void {

--- a/lib/Chat/Command/Listener.php
+++ b/lib/Chat/Command/Listener.php
@@ -64,16 +64,9 @@ class Listener {
 				return;
 			}
 
-			if ($command->getEnabled() === Command::ENABLED_OFF) {
-				return;
-			}
-
-			if ($command->getEnabled() === Command::ENABLED_MODERATOR && !$participant->hasModeratorPermissions()) {
-				return;
-			}
-
-			if ($command->getEnabled() === Command::ENABLED_USERS && $participant->isGuest()) {
-				return;
+			if (!$listener->executor->isCommandAvailableForParticipant($command, $participant)) {
+				$command = $listener->commandService->find('', 'help');
+				$arguments = trim($message->getMessage());
 			}
 
 			$listener->executor->exec($event->getRoom(), $message, $command, $arguments);

--- a/lib/Chat/Command/Listener.php
+++ b/lib/Chat/Command/Listener.php
@@ -69,7 +69,7 @@ class Listener {
 				$arguments = trim($message->getMessage());
 			}
 
-			$listener->executor->exec($event->getRoom(), $message, $command, $arguments);
+			$listener->executor->exec($event->getRoom(), $message, $command, $arguments, $participant);
 		});
 	}
 


### PR DESCRIPTION
## How to test (scenario 1)

- Add a Talk command available only for moderators
- Join a conversation as a user or guest
- Send the command

### Result with this pull request

_The command does not exist_ is shown only for that participant

### Result without this pull request

The raw command (for example, _/calc 1+2_) is shown for everyone

## How to test (scenario 2)

- Add a Talk command available only for moderators
- Join a conversation as a user or guest
- Send a "/help" message

### Result with this pull request

Only the commands that the participant is allowed to use are shown

### Result without this pull request

The list of available commands also include those that the participant is not allowed to use