### PR TITLE
Reuse video background / avatar during call

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -27,7 +27,7 @@
 			<div v-if="showPromoted" ref="videoContainer" class="video__promoted autopilot">
 				<template v-for="callParticipantModel in reversedCallParticipantModels">
 					<Video
-						v-if="sharedDatas[callParticipantModel.attributes.peerId].promoted"
+						v-show="sharedDatas[callParticipantModel.attributes.peerId].promoted"
 						:key="callParticipantModel.attributes.peerId"
 						:token="token"
 						:model="callParticipantModel"
@@ -44,7 +44,7 @@
 			<div v-if="showSelected" ref="videoContainer" class="video__promoted override">
 				<template v-for="callParticipantModel in reversedCallParticipantModels">
 					<Video
-						v-if="callParticipantModel.attributes.peerId === selectedVideoPeerId"
+						v-show="callParticipantModel.attributes.peerId === selectedVideoPeerId"
 						:key="callParticipantModel.attributes.selectedVideoPeerId"
 						:token="token"
 						:model="callParticipantModel"

--- a/src/components/CallView/shared/Video.vue
+++ b/src/components/CallView/shared/Video.vue
@@ -43,7 +43,7 @@
 		</transition>
 		<transition-group name="fade">
 			<div
-				v-if="showBackgroundAndAvatar"
+				v-show="showBackgroundAndAvatar"
 				:key="'backgroundAvatar'"
 				class="avatar-container">
 				<VideoBackground


### PR DESCRIPTION
Whenever a call is running, if the presenter changes we now reuse the
video background and avatar elements to avoid flicker due to reloading.

This is achieved by using v-show instead of v-if for the specified
elements.

Note: when resizing the window if participants disappear and you make them appear again, their avatar is reloaded. I think this is ok. The mini-flicker also happens on first load. Most important was to fix periodic flickering during presenter change when multiple people are speaking.

Fixes https://github.com/nextcloud/spreed/issues/4284