### PR TITLE
Remove pulse animation from call button

### DIFF
--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -235,10 +235,6 @@ export default {
 	.icon {
 		opacity: 1;
 		margin-right: 8px;
-
-		&.icon-incoming-call {
-			animation: pulse 2s infinite;
-		}
 	}
 }
 
@@ -251,18 +247,6 @@ export default {
 	&:focus,
 	&:active {
 		border: 1px solid var(--color-success) !important;
-	}
-}
-
-@keyframes pulse {
-	0% {
-		opacity: .5;
-	}
-	50% {
-		opacity: 1;
-	}
-	100% {
-		opacity: .5;
 	}
 }
 </style>


### PR DESCRIPTION
It causes unnecessary load on Chrome browser.

Discovered and confirmed by @danxuliu