### PR TITLE
Clarify participant search box in conversation

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -24,7 +24,7 @@
 		<SearchBox
 			v-if="displaySearchBox"
 			v-model="searchText"
-			:placeholder-text="t('spreed', 'Add participants to the conversation')"
+			:placeholder-text="t('spreed', 'Search or add participants to the conversation')"
 			:is-searching="isSearching"
 			@input="handleInput"
 			@abort-search="abortSearch" />


### PR DESCRIPTION
Adjusted placeholder text of the search box at the top of the
participant list, to make it clearer that one can also simply search for
participants, not only add new ones.

@nickvergessen as discussed when mentioned in the context for the conference with 400+ participants.

Later on we might also want to show that field for regular users just for the search, raised here: https://github.com/nextcloud/spreed/issues/4299