### PR TITLE
Fix key name in collaboration resource listener for add user event

### DIFF
--- a/lib/Collaboration/Resources/Listener.php
+++ b/lib/Collaboration/Resources/Listener.php
@@ -65,8 +65,8 @@ class Listener {
 			$participants = $event->getParticipants();
 			foreach ($participants as $participant) {
 				$user = null;
-				if ($participant['user_id'] !== '') {
-					$user = $userManager->get($participant['user_id']);
+				if ($participant['userId'] !== '') {
+					$user = $userManager->get($participant['userId']);
 				}
 
 				$resourceManager->invalidateAccessCacheForResourceByUser($resource, $user);


### PR DESCRIPTION
## How to test

- In the files app, link a file to a conversation
- In Talk, open that conversation
- Add a user to the conversation

### Result with this pull request

No errors are shown in the logs

### Result without this pull request

Errors `Undefined index: user_id at /var/www/html/apps/spreed/lib/Collaboration/Resources/Listener.php#68` and `#69` are shown in the logs
