### PR TITLE
Fix menu position for left sidebar avatars

### DIFF
--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -28,6 +28,7 @@
 			:size="44"
 			:user="item.name"
 			:display-name="item.displayName"
+			menu-position="left"
 			class="conversation-icon__avatar" />
 		<div v-if="showCall"
 			class="overlap-icon">


### PR DESCRIPTION
Before | After
---|---
![Bildschirmfoto von 2020-10-06 19-11-02](https://user-images.githubusercontent.com/213943/95237132-19c47c80-0808-11eb-913b-dbff115ba303.png) | ![Bildschirmfoto von 2020-10-06 19-10-19](https://user-images.githubusercontent.com/213943/95237138-1af5a980-0808-11eb-923f-d559b5b5d3af.png)

