### PR TITLE
Fix lobby date not shown in moderation menu

### DIFF
--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -328,7 +328,7 @@ export default {
 
 			// PHP timestamp is second-based; JavaScript timestamp is
 			// millisecond based.
-			return this.conversation.lobbyTimer * 1000
+			return new Date(this.conversation.lobbyTimer * 1000)
 		},
 
 		dateTimePickerAttrs() {


### PR DESCRIPTION
Fixes #3424

Due to [a change in the underlying component](https://github.com/nextcloud/nextcloud-vue/pull/861) (_@nextcloud/vue_ 1.3.1 works fine in _stable18_, but the issue appears when bumping it to 1.4.0) a date given as a timestamp is no longer automatically converted to a Date object, so it needs to be explicitly done.
