### PR TITLE
Add checkbox for locking conversation

### DIFF
--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -44,7 +44,7 @@
 		</transition>
 		<MessagesList
 			:token="token" />
-		<NewMessageForm v-if="!isReadOnly" />
+		<NewMessageForm />
 	</div>
 </template>
 

--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -44,7 +44,7 @@
 		</transition>
 		<MessagesList
 			:token="token" />
-		<NewMessageForm />
+		<NewMessageForm v-if="!isReadOnly" />
 	</div>
 </template>
 
@@ -84,7 +84,7 @@ export default {
 			if (this.isGuest) {
 				return t('spreed', 'You need to be logged in to upload files')
 			} else if (this.isReadOnly) {
-				return t('spreed', 'This conversation is read only')
+				return t('spreed', 'This conversation is read-only')
 			} else {
 				return t('spreed', 'Drop your files to upload')
 			}

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -59,7 +59,7 @@ the main body of the message as well as a quote.
 					{{ messageTime }}
 				</h6>
 				<Actions
-					v-show="showActions && hasActions"
+					v-show="showActions && hasActions && !isConversationReadOnly"
 					class="message__main__right__actions">
 					<ActionButton
 						v-if="isReplyable"
@@ -86,7 +86,7 @@ import RichText from '@juliushaertl/vue-richtext'
 import Quote from '../../../Quote'
 import { EventBus } from '../../../../services/EventBus'
 import emojiRegex from 'emoji-regex'
-import { PARTICIPANT } from '../../../../constants'
+import { PARTICIPANT, CONVERSATION } from '../../../../constants'
 import moment from '@nextcloud/moment'
 
 export default {
@@ -218,6 +218,11 @@ export default {
 	computed: {
 		hasActions() {
 			return this.isReplyable
+		},
+
+		isConversationReadOnly() {
+			const conversation = this.$store.getters.conversation(this.token)
+			return conversation.readOnly === CONVERSATION.STATE.READ_ONLY
 		},
 
 		isSystemMessage() {

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -59,7 +59,7 @@ the main body of the message as well as a quote.
 					{{ messageTime }}
 				</h6>
 				<Actions
-					v-show="showActions && hasActions && !isConversationReadOnly"
+					v-show="showActions && hasActions"
 					class="message__main__right__actions">
 					<ActionButton
 						v-if="isReplyable"
@@ -217,7 +217,7 @@ export default {
 
 	computed: {
 		hasActions() {
-			return this.isReplyable
+			return this.isReplyable && !this.isConversationReadOnly
 		},
 
 		isConversationReadOnly() {

--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -175,7 +175,7 @@ export default {
 		 */
 		placeholderText: {
 			type: String,
-			default: t('spreed', 'Write message, @ to mention someone …'),
+			default: '',
 		},
 
 		/**

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -96,7 +96,7 @@
 
 <script>
 import AdvancedInput from './AdvancedInput/AdvancedInput'
-import { getFilePickerBuilder } from '@nextcloud/dialogs'
+import { getFilePickerBuilder, showError } from '@nextcloud/dialogs'
 import { postNewMessage } from '../../services/messagesService'
 import Quote from '../Quote'
 import Actions from '@nextcloud/vue/dist/Components/Actions'
@@ -277,15 +277,9 @@ export default {
 					}
 					// 403 when room is read-only, 412 when switched to lobby mode
 					if (statusCode === 403 || statusCode === 412) {
-						OC.Notification.show(
-							t('spreed', 'No permission to post messages in this room'),
-							{ type: 'error' }
-						)
+						showError(t('spreed', 'No permission to post messages in this conversation'))
 					} else {
-						OC.Notification.show(
-							t('spreed', 'Could not post message: {errorMessage}', { errorMessage: error.message || error }),
-							{ type: 'error' }
-						)
+						showError(t('spreed', 'Could not post message: {errorMessage}', { errorMessage: error.message || error }))
 					}
 
 					// restore message to allow re-sending

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -58,6 +58,7 @@
 					</Actions>
 				</div>
 				<div
+					v-if="!isReadOnly"
 					class="new-message-form__button">
 					<EmojiPicker @select="addEmoji">
 						<button
@@ -80,11 +81,14 @@
 						ref="advancedInput"
 						v-model="text"
 						:token="token"
+						:active-input="!isReadOnly"
+						:placeholder-text="placeholderText"
 						@update:contentEditable="contentEditableToParsed"
 						@submit="handleSubmit"
 						@files-pasted="handleFiles" />
 				</div>
 				<button
+					:disabled="isReadOnly"
 					type="submit"
 					:aria-label="t('spreed', 'Send message')"
 					class="new-message-form__button submit icon-confirm-fade"
@@ -149,6 +153,16 @@ export default {
 			}
 		},
 
+		isReadOnly() {
+			return this.conversation.readOnly === CONVERSATION.STATE.READ_ONLY
+		},
+
+		placeholderText() {
+			return this.isReadOnly
+				? t('spreed', 'This conversation has been locked')
+				: t('spreed', 'Write message, @ to mention someone …')
+		},
+
 		messageToBeReplied() {
 			return this.$store.getters.getMessageToBeReplied(this.token)
 		},
@@ -158,7 +172,7 @@ export default {
 		},
 
 		canShareAndUploadFiles() {
-			return !this.currentUserIsGuest && this.conversation.readOnly === CONVERSATION.STATE.READ_WRITE
+			return !this.currentUserIsGuest && !this.isReadOnly
 		},
 
 		attachmentFolder() {

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -117,6 +117,7 @@ export default {
 			return (!this.conversation.canStartCall
 					&& !this.conversation.hasCall)
 				|| this.isBlockedByLobby
+				|| this.conversation.readOnly
 				|| this.isNextcloudTalkHashDirty
 		},
 

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -119,6 +119,12 @@
 				</ActionInput>
 				<ActionSeparator />
 				<ActionCheckbox
+					:checked="isReadOnly"
+					:disabled="readOnlyStateLoading"
+					@change="toggleReadOnly">
+					{{ t('spreed', 'Lock conversation') }}
+				</ActionCheckbox>
+				<ActionCheckbox
 					:checked="hasLobbyEnabled"
 					@change="toggleLobby">
 					{{ t('spreed', 'Enable lobby') }}
@@ -204,6 +210,7 @@ export default {
 			// Switch for the password-editing operation
 			isEditingPassword: false,
 			lobbyTimerLoading: false,
+			readOnlyStateLoading: false,
 		}
 	},
 
@@ -316,6 +323,9 @@ export default {
 		},
 		hasLobbyEnabled() {
 			return this.conversation.lobbyState === WEBINAR.LOBBY.NON_MODERATORS
+		},
+		isReadOnly() {
+			return this.conversation.readOnly === CONVERSATION.STATE.READ_ONLY
 		},
 		isPasswordProtected() {
 			return this.conversation.hasPassword
@@ -457,6 +467,16 @@ export default {
 
 			this.lobbyTimerLoading = false
 		},
+
+		async toggleReadOnly() {
+			this.readOnlyStateLoading = true
+			await this.$store.dispatch('setReadOnlyState', {
+				token: this.token,
+				readOnly: this.isReadOnly ? CONVERSATION.STATE.READ_WRITE : CONVERSATION.STATE.READ_ONLY,
+			})
+			this.readOnlyStateLoading = false
+		},
+
 		async handlePasswordDisable() {
 			// disable the password protection for the current conversation
 			if (this.conversation.hasPassword) {

--- a/src/services/conversationsService.js
+++ b/src/services/conversationsService.js
@@ -297,6 +297,22 @@ const changeLobbyState = async function(token, newState, timestamp) {
 	}
 }
 
+/**
+ * Change the read-only state
+ * @param {string} token The token of the conversation to be modified
+ * @param {int} readOnly The new read-only state to set
+ */
+const changeReadOnlyState = async function(token, readOnly) {
+	try {
+		const response = await axios.put(generateOcsUrl('apps/spreed/api/v2', 2) + `room/${token}/read-only`, {
+			state: readOnly,
+		})
+		return response
+	} catch (error) {
+		console.debug('Error while updating read-only state: ', error)
+	}
+}
+
 export {
 	fetchConversations,
 	fetchConversation,
@@ -312,6 +328,7 @@ export {
 	makePublic,
 	makePrivate,
 	changeLobbyState,
+	changeReadOnlyState,
 	setConversationPassword,
 	setConversationName,
 }

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -24,6 +24,7 @@ import {
 	makePublic,
 	makePrivate,
 	changeLobbyState,
+	changeReadOnlyState,
 	addToFavorites,
 	removeFromFavorites,
 	setConversationName,
@@ -202,6 +203,18 @@ const actions = {
 
 		await setConversationName(token, name)
 		conversation.displayName = name
+
+		commit('addConversation', conversation)
+	},
+
+	async setReadOnlyState({ commit, getters }, { token, readOnly }) {
+		const conversation = Object.assign({}, getters.conversations[token])
+		if (!conversation) {
+			return
+		}
+
+		await changeReadOnlyState(token, readOnly)
+		conversation.readOnly = readOnly
 
 		commit('addConversation', conversation)
 	},


### PR DESCRIPTION
Added logic for setting a conversation to read-only.

Fixes https://github.com/nextcloud/spreed/issues/1647

### Todos

- [x] read-only switch
- [x] proper error handling when sending a message and it doesn't go through: put it back
- [x] hide "Start call" button when read-only
- [x] hide "NewMessageForm" when read-only or leave visible but disabled ?
- [x] remove "Reply" buttons in messages list
- [ ] add "(read-only)" text in conversation title
   - to be discussed as one might prefer to call it "(locked)", "(archived)" or whatever and the suffix interferes with renaming. maybe lock icon still better

### Manual Tests
- [x] check that read-only checkbox not visible for non-moderators
- [x] test removed actions:
   - [x] start call
   - [x] reply
   - [x] upload by drag and drop
- [x] check that guests get the same read-only experience

### Automated Tests
- [x] check what scenarios could be added => seems read-only backend integration tests already exist
