### PR TITLE
Update conversation name directly after call returns

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -82,7 +82,6 @@ import { CollectionList } from 'nextcloud-vue-collections'
 import BrowserStorage from '../../services/BrowserStorage'
 import { CONVERSATION, WEBINAR, PARTICIPANT } from '../../constants'
 import ParticipantsTab from './Participants/ParticipantsTab'
-import { setConversationName } from '../../services/conversationsService'
 import MatterbridgeSettings from './Matterbridge/MatterbridgeSettings'
 import isInLobby from '../../mixins/isInLobby'
 import SetGuestUsername from '../SetGuestUsername'
@@ -231,7 +230,10 @@ export default {
 		async handleSubmitTitle(event) {
 			const name = event.target[0].value.trim()
 			try {
-				await setConversationName(this.token, name)
+				await this.$store.dispatch('setConversationName', {
+					token: this.token,
+					name: name,
+				})
 				this.dismissEditing()
 			} catch (exception) {
 				console.debug(exception)

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -26,6 +26,7 @@ import {
 	changeLobbyState,
 	addToFavorites,
 	removeFromFavorites,
+	setConversationName,
 } from '../services/conversationsService'
 import { getCurrentUser } from '@nextcloud/auth'
 import { CONVERSATION, WEBINAR } from '../constants'
@@ -189,6 +190,18 @@ const actions = {
 			await changeLobbyState(token, WEBINAR.LOBBY.NONE)
 			conversation.lobbyState = WEBINAR.LOBBY.NONE
 		}
+
+		commit('addConversation', conversation)
+	},
+
+	async setConversationName({ commit, getters }, { token, name }) {
+		const conversation = Object.assign({}, getters.conversations[token])
+		if (!conversation) {
+			return
+		}
+
+		await setConversationName(token, name)
+		conversation.displayName = name
 
 		commit('addConversation', conversation)
 	},


### PR DESCRIPTION
After renaming a conversation, set the name back into the state for
immediate display instead of waiting for the next signal/event many
seconds later.

I fixed this because it annoyed me to not see the change immediately, made it look broken.

Maybe this implementation is too naive and there is more complexity on the server side than I saw ?
So far I didn't understand the difference between "name", "displayName" and "roomName", but "displayName" is what gets displayed. Are there other scenarios I need to understand and test ?
