### PR TITLE
Fix leaving conversation when fetching the conversation fails

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -62,6 +62,7 @@ import browserCheck from './mixins/browserCheck'
 import duplicateSessionHandler from './mixins/duplicateSessionHandler'
 import isInCall from './mixins/isInCall'
 import talkHashCheck from './mixins/talkHashCheck'
+import { showError } from '@nextcloud/dialogs'
 import { generateUrl } from '@nextcloud/router'
 import UploadEditor from './components/UploadEditor'
 import SettingsDialog from './components/SettingsDialog/SettingsDialog'
@@ -92,6 +93,7 @@ export default {
 			defaultPageTitle: false,
 			loading: false,
 			isRefreshingCurrentConversation: false,
+			errorUpdatingConversationToast: null,
 		}
 	},
 
@@ -433,6 +435,11 @@ export default {
 				 */
 				const response = await fetchConversation(token)
 
+				if (this.errorUpdatingConversationToast) {
+					this.errorUpdatingConversationToast.hideToast()
+					this.errorUpdatingConversationToast = null
+				}
+
 				// this.$store.dispatch('purgeConversationsStore')
 				this.$store.dispatch('addConversation', response.data.ocs.data)
 				this.$store.dispatch('markConversationRead', token)
@@ -456,6 +463,10 @@ export default {
 				// TODO Maybe progressively increase debouncing time to avoid
 				// hammering the server if it is already loaded?
 				this.debounceRefreshCurrentConversation()
+
+				if (!this.errorUpdatingConversationToast) {
+					this.errorUpdatingConversationToast = showError(t('spreed', 'An error occurred while updating the conversation'))
+				}
 			} finally {
 				this.isRefreshingCurrentConversation = false
 			}

--- a/src/App.vue
+++ b/src/App.vue
@@ -445,9 +445,17 @@ export default {
 					singleConversation: true,
 				})
 			} catch (exception) {
-				console.info('Conversation received, but the current conversation is not in the list. Redirecting to /apps/spreed')
-				this.$router.push('/apps/spreed/not-found')
-				this.$store.dispatch('hideSidebar')
+				if (exception.response && exception.response.status === 404) {
+					console.info('Conversation received, but the current conversation is not in the list. Redirecting to /apps/spreed')
+					this.$router.push('/apps/spreed/not-found')
+					this.$store.dispatch('hideSidebar')
+
+					return
+				}
+
+				// TODO Maybe progressively increase debouncing time to avoid
+				// hammering the server if it is already loaded?
+				this.debounceRefreshCurrentConversation()
 			} finally {
 				this.isRefreshingCurrentConversation = false
 			}

--- a/src/App.vue
+++ b/src/App.vue
@@ -286,7 +286,11 @@ export default {
 				this.setPageTitle(nextConversationName)
 				// Update current token in the token store
 				this.$store.dispatch('updateToken', to.params.token)
+			} else if (to.name === 'notfound') {
+				this.setPageTitle('')
+				this.$store.dispatch('updateToken', '')
 			}
+
 			/**
 			 * Fires a global event that tells the whole app that the route has changed. The event
 			 * carries the from and to objects as payload


### PR DESCRIPTION
Fixes #4273

Errors other than 404 no longer cause a redirection to `spreed/not-found`. An error notification is shown, though, similar to what happens if [fetching the participant list fails](https://github.com/nextcloud/spreed/blob/d0094567770ef799f039c6f57c1d33ca19f6f60e/src/components/RightSidebar/Participants/ParticipantsTab.vue#L260).

## How to test

- Make [`getSingleRoom` endpoint](https://github.com/nextcloud/spreed/blob/83d7ca9decb8cd1497012b58381458f4d8e9f467/lib/Controller/RoomController.php#L203) randomly return errors by prepending:
```
		if (rand(0, 10) < 7) {
			return new DataResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
		}
```
- Join a call conversation
- In a private window, join and leave that conversation (so the participant list change triggers a conversation update)

### Result with this pull request

_An error occurred while updating the conversation_ notification is shown, but the chat is still open.

### Result without this pull request

The chat is replaced by _The conversation does not exist_. The title page still shows the conversation name.

In the browser console sometimes _NavigationDuplicated: Avoided redundant navigation to current location: "/apps/spreed/not-found"_ appears (it seems to be caused by two `participantListChanged` events emitted quickly in a row, so the second one triggers another fetch of the conversation before the first one returned, and if both fail the second one causes a redundant redirection).
