### PR TITLE
Use generic syntax when calling 'ps' command

### DIFF
--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -682,7 +682,7 @@ class MatterbridgeManager {
 	 */
 	public function killZombieBridges(bool $killAll = false): void {
 		// get list of running matterbridge processes
-		$cmd = 'ps -ux | grep "commands/matterbridge" | grep -v grep | awk \'{print $2}\'';
+		$cmd = 'ps x -o user,pid,args | grep "commands/matterbridge" | grep -v grep | awk \'{print $2}\'';
 		exec($cmd, $output, $ret);
 		$runningPidList = [];
 		foreach ($output as $o) {

--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -682,7 +682,7 @@ class MatterbridgeManager {
 	 */
 	public function killZombieBridges(bool $killAll = false): void {
 		// get list of running matterbridge processes
-		$cmd = 'ps x -o user,pid,args | grep "commands/matterbridge" | grep -v grep | awk \'{print $2}\'';
+		$cmd = 'ps x -o user,pid,args | grep "matterbridge" | grep -v grep | awk \'{print $2}\'';
 		exec($cmd, $output, $ret);
 		$runningPidList = [];
 		foreach ($output as $o) {

--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -744,7 +744,7 @@ class MatterbridgeManager {
 	 */
 	private function isRunning(int $pid): bool {
 		try {
-			$result = shell_exec(sprintf('ps x -o user,pid,args | awk \'{print $2}\' | grep %d | wc -l', $pid));
+			$result = shell_exec(sprintf('ps x -o user,pid,args | awk \'{print $2}\' | grep "^%d$" | wc -l', $pid));
 			if ((int) $result > 0) {
 				return true;
 			}

--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -744,8 +744,8 @@ class MatterbridgeManager {
 	 */
 	private function isRunning(int $pid): bool {
 		try {
-			$result = shell_exec(sprintf('ps %d', $pid));
-			if (count(explode("\n", $result)) > 2) {
+			$result = shell_exec(sprintf('ps x -o user,pid,args | awk \'{print $2}\' | grep %d | wc -l', $pid));
+			if ((int) $result > 0) {
 				return true;
 			}
 		} catch (\Exception $e) {


### PR DESCRIPTION
On Busybox (used by Alpine Linux used by Nextcloud Docker image), `ps` command has a slightly different syntax.

* fix `ps` call when tying to kill zombie bridge processes
* use a larger filter when searching for zombie processes
* fix `ps` call when determining if a process is running

This syntax has been tested on Alpine Linux, Debian and Ubuntu.

refs #4337 
