### PR TITLE
Add ability to collapse the grid view

### DIFF
--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -101,3 +101,26 @@ $chat-line-height: 1.6em;
 		transition: all 150ms ease-in-out;
 	}
 }
+
+.slide-down {
+	&-enter {
+		transform: translateY(50%);
+		opacity: 0;
+	}
+	&-enter-to {
+		transform: translateY(0);
+		opacity: 1;
+	}
+	&-leave {
+		transform: translateY(0);
+		opacity: 1;
+	}
+	&-leave-to {
+		transform: translateY(50%);
+		opacity: 0;
+	}
+	&-enter-active,
+	&-leave-active {
+		transition: all 150ms ease-in-out;
+	}
+}

--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -122,5 +122,7 @@ $chat-line-height: 1.6em;
 	&-enter-active,
 	&-leave-active {
 		transition: all 150ms ease-in-out;
+		/* force top container to resize during animation */
+		position: absolute !important;
 	}
 }

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -92,6 +92,7 @@
 			<Grid
 				v-if="showGrid"
 				v-bind="$attrs"
+				:is-sidebar="isSidebar"
 				:is-stripe="!isGrid"
 				:token="token"
 				:fit-video="true"

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -545,6 +545,7 @@ export default {
 	width: 100%;
 	height: 100%;
 	top: 0;
+	overflow: hidden;
 	display: -webkit-box;
 	display: -moz-box;
 	display: -ms-flexbox;

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -23,6 +23,12 @@
 	<div id="call-container">
 		<EmptyCallView v-if="!remoteParticipantsCount && !screenSharingActive && !isGrid" />
 		<div id="videos">
+			<LocalMediaControls
+				class="local-media-controls"
+				:model="localMediaModel"
+				:local-call-participant-model="localCallParticipantModel"
+				:screen-sharing-button-hidden="isSidebar"
+				@switch-screen-to-id="$emit('switchScreenToId', $event)" />
 			<!-- Promoted "autopilot" mode -->
 			<div v-if="showPromoted" ref="videoContainer" class="video__promoted autopilot">
 				<template v-for="callParticipantModel in reversedCallParticipantModels">
@@ -92,7 +98,6 @@
 			<Grid
 				v-if="showGrid"
 				v-bind="$attrs"
-				:is-sidebar="isSidebar"
 				:is-stripe="!isGrid"
 				:token="token"
 				:fit-video="true"
@@ -125,6 +130,7 @@
 <script>
 import Grid from './Grid/Grid'
 import { localMediaModel, localCallParticipantModel, callParticipantCollection } from '../../utils/webrtc/index'
+import LocalMediaControls from './shared/LocalMediaControls'
 import EmptyCallView from './shared/EmptyCallView'
 import Video from './shared/Video'
 import LocalVideo from './shared/LocalVideo'
@@ -138,6 +144,7 @@ export default {
 		EmptyCallView,
 		Video,
 		LocalVideo,
+		LocalMediaControls,
 		Screen,
 	},
 
@@ -704,5 +711,14 @@ export default {
 	100% {
 		opacity: 1;
 	}
+}
+
+.local-media-controls {
+	position: absolute;
+	width: 300px; /* same as .video-container-stripe */
+	text-align: center;
+	right: 0;
+	bottom: 4px;
+	z-index: 10;
 }
 </style>

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -31,7 +31,10 @@
 				:screen-sharing-button-hidden="isSidebar"
 				@switch-screen-to-id="$emit('switchScreenToId', $event)" />
 			<!-- Promoted "autopilot" mode -->
-			<div v-if="showPromoted" ref="videoContainer" class="video__promoted autopilot">
+			<div v-if="showPromoted"
+				ref="videoContainer"
+				class="video__promoted autopilot"
+				:class="{'full-page': isOneToOne}">
 				<template v-for="callParticipantModel in reversedCallParticipantModels">
 					<Video
 						v-if="sharedDatas[callParticipantModel.attributes.peerId].promoted"
@@ -48,7 +51,10 @@
 				</template>
 			</div>
 			<!-- Selected override mode -->
-			<div v-if="showSelected" ref="videoContainer" class="video__promoted override">
+			<div v-if="showSelected"
+				ref="videoContainer"
+				class="video__promoted autopilot"
+				:class="{'full-page': isOneToOne}">
 				<template v-for="callParticipantModel in reversedCallParticipantModels">
 					<Video
 						v-if="callParticipantModel.attributes.peerId === selectedVideoPeerId"
@@ -64,7 +70,10 @@
 				</template>
 			</div>
 			<!-- Local Video Override mode -->
-			<div v-if="showLocalVideo" ref="videoContainer" class="video__promoted override">
+			<div v-if="showLocalVideo"
+				ref="videoContainer"
+				class="video__promoted autopilot"
+				:class="{'full-page': isOneToOne}">
 				<LocalVideo
 					ref="localVideo"
 					:fit-video="true"
@@ -97,7 +106,7 @@
 			</div>
 			<!-- Stripe or fullscreen grid depending on `isGrid` -->
 			<Grid
-				v-if="showGrid"
+				v-if="!isSidebar"
 				v-bind="$attrs"
 				:is-stripe="!isGrid"
 				:token="token"
@@ -110,9 +119,9 @@
 				:shared-datas="sharedDatas"
 				@select-video="handleSelectVideo"
 				@click-local-video="handleClickLocalVideo" />
-			<!-- Local video if the conversation is 1to1 or if sidebar -->
+			<!-- Local video if sidebar -->
 			<LocalVideo
-				v-if="isOneToOneView && !showLocalVideo"
+				v-if="isSidebar && !showLocalVideo"
 				ref="localVideo"
 				class="local-video"
 				:class="{ 'local-video--sidebar': isSidebar }"
@@ -216,15 +225,6 @@ export default {
 			return this.$store.getters.isGrid
 		},
 
-		showGrid() {
-			return !this.isSidebar
-				&& (
-					!this.isOneToOneView
-					|| this.showLocalScreen
-					|| (this.showRemoteScreen && this.hasRemoteVideo)
-				)
-		},
-
 		gridTargetAspectRatio() {
 			if (this.isGrid) {
 				return 1.5
@@ -244,11 +244,6 @@ export default {
 		isOneToOne() {
 			return this.callParticipantModels.length === 1
 		},
-
-		isOneToOneView() {
-			return (this.isOneToOne && !this.isGrid) || this.isSidebar
-		},
-
 		hasLocalVideo() {
 			return this.localMediaModel.attributes.videoEnabled
 		},
@@ -573,6 +568,11 @@ export default {
 	height: 100%;
 	width: 100%;
 	display: block;
+}
+
+.video__promoted.full-page {
+	/* make the promoted video cover the whole call view */
+	position: static;
 }
 
 .local-video {

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -24,6 +24,7 @@
 		<EmptyCallView v-if="!remoteParticipantsCount && !screenSharingActive && !isGrid" />
 		<div id="videos">
 			<LocalMediaControls
+				v-if="!isGrid"
 				class="local-media-controls"
 				:model="localMediaModel"
 				:local-call-participant-model="localCallParticipantModel"
@@ -115,6 +116,7 @@
 				ref="localVideo"
 				class="local-video"
 				:class="{ 'local-video--sidebar': isSidebar }"
+				:show-controls="false"
 				:fit-video="true"
 				:is-stripe="true"
 				:local-media-model="localMediaModel"
@@ -224,10 +226,10 @@ export default {
 		},
 
 		gridTargetAspectRatio() {
-			if (this.isStripe) {
-				return 1
-			} else {
+			if (this.isGrid) {
 				return 1.5
+			} else {
+				return 1
 			}
 		},
 
@@ -721,4 +723,5 @@ export default {
 	bottom: 4px;
 	z-index: 10;
 }
+
 </style>

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -20,104 +20,122 @@
 -->
 
 <template>
-	<div class="wrapper" :style="wrapperStyle">
-		<div :class="{'pagination-wrapper': isStripe, 'wrapper': !isStripe}">
-			<button v-if="hasPreviousPage && gridWidth > 0 && isStripe && showVideoOverlay"
-				class="grid-navigation grid-navigation__previous"
-				@click="handleClickPrevious">
-				<ChevronLeft decorative
-					:size="24" />
-			</button>
-			<div
-				ref="grid"
-				class="grid"
-				:style="gridStyle"
-				@mousemove="handleMovement"
-				@keydown="handleMovement">
-				<template v-if="!devMode">
-					<EmptyCallView v-if="videos.length === 0 &&!isStripe" class="video" :is-grid="true" />
-					<template v-for="callParticipantModel in displayedVideos">
-						<Video
-							:key="callParticipantModel.attributes.peerId"
-							:class="{'video': !isStripe}"
-							:show-video-overlay="showVideoOverlay"
-							:token="token"
-							:model="callParticipantModel"
-							:is-grid="true"
-							:show-talking-highlight="!isStripe"
-							:is-stripe="isStripe"
-							:is-promoted="sharedDatas[callParticipantModel.attributes.peerId].promoted"
-							:is-selected="isSelected(callParticipantModel)"
-							:fit-video="false"
-							:video-container-aspect-ratio="videoContainerAspectRatio"
-							:video-background-blur="videoBackgroundBlur"
-							:shared-data="sharedDatas[callParticipantModel.attributes.peerId]"
-							@click-video="handleClickVideo($event, callParticipantModel.attributes.peerId)" />
-					</template>
-					<LocalVideo
-						v-if="!isStripe"
-						ref="localVideo"
-						class="video"
-						:is-grid="true"
-						:fit-video="isStripe"
-						:local-media-model="localMediaModel"
-						:video-container-aspect-ratio="videoContainerAspectRatio"
-						:local-call-participant-model="localCallParticipantModel"
-						@switchScreenToId="1"
-						@click-video="handleClickLocalVideo" />
-				</template>
-				<!-- Grid developer mode -->
-				<template v-else>
+	<div class="grid-main-wrapper">
+		<button v-if="isStripe"
+			class="stripe--collapse"
+			@click="stripeOpen = !stripeOpen">
+			<ChevronDown
+				v-if="stripeOpen"
+				fill-color="#ffffff"
+				decorative
+				:size="24" />
+			<ChevronUp
+				v-else
+				fill-color="#ffffff"
+				decorative
+				:size="24" />
+		</button>
+		<transition name="slide-down">
+			<div v-if="!isStripe || stripeOpen" class="wrapper" :style="wrapperStyle">
+				<div :class="{'pagination-wrapper': isStripe, 'wrapper': !isStripe}">
+					<button v-if="hasPreviousPage && gridWidth > 0 && isStripe && showVideoOverlay"
+						class="grid-navigation grid-navigation__previous"
+						@click="handleClickPrevious">
+						<ChevronLeft decorative
+							:size="24" />
+					</button>
 					<div
-						v-for="video in displayedVideos"
-						:key="video"
-						class="dev-mode-video video"
-						v-text="video" />
-					<h1 class="dev-mode__title">
-						Dev mode on ;-)
-					</h1>
-				</template>
+						ref="grid"
+						class="grid"
+						:style="gridStyle"
+						@mousemove="handleMovement"
+						@keydown="handleMovement">
+						<template v-if="!devMode">
+							<EmptyCallView v-if="videos.length === 0 &&!isStripe" class="video" :is-grid="true" />
+							<template v-for="callParticipantModel in displayedVideos">
+								<Video
+									:key="callParticipantModel.attributes.peerId"
+									:class="{'video': !isStripe}"
+									:show-video-overlay="showVideoOverlay"
+									:token="token"
+									:model="callParticipantModel"
+									:is-grid="true"
+									:show-talking-highlight="!isStripe"
+									:is-stripe="isStripe"
+									:is-promoted="sharedDatas[callParticipantModel.attributes.peerId].promoted"
+									:is-selected="isSelected(callParticipantModel)"
+									:fit-video="false"
+									:video-container-aspect-ratio="videoContainerAspectRatio"
+									:video-background-blur="videoBackgroundBlur"
+									:shared-data="sharedDatas[callParticipantModel.attributes.peerId]"
+									@click-video="handleClickVideo($event, callParticipantModel.attributes.peerId)" />
+							</template>
+							<LocalVideo
+								v-if="!isStripe"
+								ref="localVideo"
+								class="video"
+								:is-grid="true"
+								:fit-video="isStripe"
+								:local-media-model="localMediaModel"
+								:video-container-aspect-ratio="videoContainerAspectRatio"
+								:local-call-participant-model="localCallParticipantModel"
+								@switchScreenToId="1"
+								@click-video="handleClickLocalVideo" />
+						</template>
+						<!-- Grid developer mode -->
+						<template v-else>
+							<div
+								v-for="video in displayedVideos"
+								:key="video"
+								class="dev-mode-video video"
+								v-text="video" />
+							<h1 class="dev-mode__title">
+								Dev mode on ;-)
+							</h1>
+						</template>
+					</div>
+					<button v-if="hasNextPage && gridWidth > 0 && isStripe && showVideoOverlay"
+						class="grid-navigation grid-navigation__next"
+						@click="handleClickNext">
+						<ChevronRight decorative
+							:size="24" />
+					</button>
+				</div>
+				<LocalVideo
+					v-if="isStripe"
+					ref="localVideo"
+					class="video"
+					:fit-video="true"
+					:is-stripe="true"
+					:local-media-model="localMediaModel"
+					:video-container-aspect-ratio="videoContainerAspectRatio"
+					:local-call-participant-model="localCallParticipantModel"
+					@switchScreenToId="1"
+					@click-video="handleClickLocalVideo" />
+				<!-- page indicator (disabled) -->
+				<div
+					v-if="numberOfPages !== 0 && hasPagination && false"
+					class="pages-indicator">
+					<div v-for="(page, index) in numberOfPages"
+						:key="index"
+						class="pages-indicator__dot"
+						:class="{'pages-indicator__dot--active': index === currentPage }" />
+				</div>
+				<div v-if="devMode" class="dev-mode__data">
+					<p>GRID INFO</p>
+					<p>Videos (total): {{ videosCount }}</p>
+					<p>Displayed videos n: {{ displayedVideos.length }}</p>
+					<p>Max per page: ~{{ videosCap }}</p>
+					<p>Grid width: {{ gridWidth }}</p>
+					<p>Grid height: {{ gridHeight }}</p>
+					<p>Min video width: {{ minWidth }} </p>
+					<p>Min video Height: {{ minHeight }} </p>
+					<p>Grid aspect ratio: {{ gridAspectRatio }}</p>
+					<p>Number of pages: {{ numberOfPages }}</p>
+					<p>Current page: {{ currentPage }}</p>
+				</div>
 			</div>
-			<button v-if="hasNextPage && gridWidth > 0 && isStripe && showVideoOverlay"
-				class="grid-navigation grid-navigation__next"
-				@click="handleClickNext">
-				<ChevronRight decorative
-					:size="24" />
-			</button>
-		</div>
-		<LocalVideo
-			v-if="isStripe"
-			ref="localVideo"
-			class="video"
-			:fit-video="true"
-			:is-stripe="true"
-			:local-media-model="localMediaModel"
-			:video-container-aspect-ratio="videoContainerAspectRatio"
-			:local-call-participant-model="localCallParticipantModel"
-			@switchScreenToId="1"
-			@click-video="handleClickLocalVideo" />
-		<!-- page indicator (disabled) -->
-		<div
-			v-if="numberOfPages !== 0 && hasPagination && false"
-			class="pages-indicator">
-			<div v-for="(page, index) in numberOfPages"
-				:key="index"
-				class="pages-indicator__dot"
-				:class="{'pages-indicator__dot--active': index === currentPage }" />
-		</div>
-		<div v-if="devMode" class="dev-mode__data">
-			<p>GRID INFO</p>
-			<p>Videos (total): {{ videosCount }}</p>
-			<p>Displayed videos n: {{ displayedVideos.length }}</p>
-			<p>Max per page: ~{{ videosCap }}</p>
-			<p>Grid width: {{ gridWidth }}</p>
-			<p>Grid height: {{ gridHeight }}</p>
-			<p>Min video width: {{ minWidth }} </p>
-			<p>Min video Height: {{ minHeight }} </p>
-			<p>Grid aspect ratio: {{ gridAspectRatio }}</p>
-			<p>Number of pages: {{ numberOfPages }}</p>
-			<p>Current page: {{ currentPage }}</p>
-		</div>
+		</transition>
 	</div>
 </template>
 
@@ -130,6 +148,8 @@ import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import EmptyCallView from '../shared/EmptyCallView'
 import ChevronRight from 'vue-material-design-icons/ChevronRight'
 import ChevronLeft from 'vue-material-design-icons/ChevronLeft'
+import ChevronUp from 'vue-material-design-icons/ChevronUp'
+import ChevronDown from 'vue-material-design-icons/ChevronDown'
 
 export default {
 	name: 'Grid',
@@ -140,6 +160,8 @@ export default {
 		EmptyCallView,
 		ChevronRight,
 		ChevronLeft,
+		ChevronUp,
+		ChevronDown,
 	},
 
 	props: {
@@ -242,6 +264,8 @@ export default {
 			showVideoOverlay: true,
 			// Timer for the videos bottom bar
 			showVideoOverlayTimer: null,
+			// Whether the stripe is open (true) or collapsed (false)
+			stripeOpen: true,
 		}
 	},
 
@@ -655,6 +679,13 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '../../../assets/variables.scss';
+
+.grid-main-wrapper {
+	position: relative;
+	width: 100%;
+	background-color: var(--color-text-maxcontrast);
+}
 
 .wrapper {
 	width: 100%;
@@ -772,6 +803,16 @@ export default {
 			opacity: 100%;
 		}
 	}
+}
+
+/** FIXME: replace with nextcloud-vue button */
+.stripe--collapse, .stripe--collapse:active {
+	position: absolute;
+	top: -50px;
+	right: 0;
+	z-index: 10;
+	border: 0;
+	background: none;
 }
 
 </style>

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -35,6 +35,12 @@
 				decorative
 				:size="24" />
 		</button>
+		<LocalMediaControls
+			class="local-media-controls"
+			:model="localMediaModel"
+			:local-call-participant-model="localCallParticipantModel"
+			:screen-sharing-button-hidden="isSidebar"
+			@switch-screen-to-id="$emit('switchScreenToId', $event)" />
 		<transition name="slide-down">
 			<div v-if="!isStripe || stripeOpen" class="wrapper" :style="wrapperStyle">
 				<div :class="{'pagination-wrapper': isStripe, 'wrapper': !isStripe}">
@@ -143,6 +149,7 @@
 import debounce from 'debounce'
 import Video from '../shared/Video'
 import LocalVideo from '../shared/LocalVideo'
+import LocalMediaControls from '../shared/LocalMediaControls'
 import { EventBus } from '../../../services/EventBus'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import EmptyCallView from '../shared/EmptyCallView'
@@ -157,6 +164,7 @@ export default {
 	components: {
 		Video,
 		LocalVideo,
+		LocalMediaControls,
 		EmptyCallView,
 		ChevronRight,
 		ChevronLeft,
@@ -216,6 +224,10 @@ export default {
 		 * To be set to true when the grid is in the promoted view.
 		 */
 		isStripe: {
+			type: Boolean,
+			default: false,
+		},
+		isSidebar: {
 			type: Boolean,
 			default: false,
 		},
@@ -813,6 +825,15 @@ export default {
 	z-index: 10;
 	border: 0;
 	background: none;
+}
+
+.local-media-controls {
+	position: absolute;
+	width: 300px; /* same as .video-container-stripe */
+	text-align: center;
+	right: 0;
+	bottom: 4px;
+	z-index: 1;
 }
 
 </style>

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -20,7 +20,7 @@
 -->
 
 <template>
-	<div :class="{'grid-main-wrapper': true, 'is-grid': !isStripe}">
+	<div class="grid-main-wrapper" :class="{'is-grid': !isStripe, 'transparent': isLessThanTwo}">
 		<button v-if="isStripe"
 			class="stripe--collapse"
 			@click="stripeOpen = !stripeOpen">
@@ -50,7 +50,7 @@
 						:style="gridStyle"
 						@mousemove="handleMovement"
 						@keydown="handleMovement">
-						<template v-if="!devMode">
+						<template v-if="!devMode && (!isLessThanTwo || !isStripe)">
 							<EmptyCallView v-if="videos.length === 0 &&!isStripe" class="video" :is-grid="true" />
 							<template v-for="callParticipantModel in displayedVideos">
 								<Video
@@ -83,7 +83,7 @@
 								@click-video="handleClickLocalVideo" />
 						</template>
 						<!-- Grid developer mode -->
-						<template v-else>
+						<template v-if="devMode">
 							<div
 								v-for="video in displayedVideos"
 								:key="video"
@@ -107,6 +107,7 @@
 					class="video"
 					:fit-video="true"
 					:is-stripe="true"
+					:show-controls="false"
 					:local-media-model="localMediaModel"
 					:video-container-aspect-ratio="videoContainerAspectRatio"
 					:local-call-participant-model="localCallParticipantModel"
@@ -304,6 +305,11 @@ export default {
 		videoHeight() {
 			return this.gridHeight / this.rows
 		},
+
+		isLessThanTwo() {
+			return this.callParticipantModels.length <= 1
+		},
+
 		// The aspect ratio of the grid (in terms of px)
 		gridAspectRatio() {
 			return (this.gridWidth / this.gridHeight).toPrecision([2])
@@ -689,6 +695,10 @@ export default {
 	position: relative;
 	width: 100%;
 	background-color: var(--color-text-maxcontrast);
+}
+
+.grid-main-wrapper.transparent {
+	background: transparent;
 }
 
 .grid-main-wrapper.is-grid {

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -35,7 +35,7 @@
 				decorative
 				:size="24" />
 		</button>
-		<transition name="slide-down">
+		<transition :name="isStripe ? 'slide-down' : ''">
 			<div v-if="!isStripe || stripeOpen" class="wrapper" :style="wrapperStyle">
 				<div :class="{'pagination-wrapper': isStripe, 'wrapper': !isStripe}">
 					<button v-if="hasPreviousPage && gridWidth > 0 && isStripe && showVideoOverlay"
@@ -438,16 +438,10 @@ export default {
 		 },
 		 */
 		isStripe() {
-			console.debug('isStripe: ', this.isStripe)
-			console.debug('previousGridWidth: ', this.gridWidth, 'previousGridHeight: ', this.gridHeight)
-			console.debug('newGridWidth: ', this.gridWidth, 'newGridHeight: ', this.gridHeight)
-			this.$nextTick(this.makeGrid)
-			if (this.hasPagination) {
-				this.setNumberOfPages()
-				// Set the current page to 0
-				// TODO: add support for keeping position in the videos array when resizing
-				this.currentPage = 0
-			}
+			this.rebuildGrid()
+		},
+		stripeOpen() {
+			this.rebuildGrid()
 		},
 		sidebarStatus() {
 			// Handle the resize after the sidebar animation has completed
@@ -473,6 +467,21 @@ export default {
 	},
 
 	methods: {
+		rebuildGrid() {
+			console.debug('isStripe: ', this.isStripe)
+			console.debug('stripeOpen: ', this.stripeOpen)
+			console.debug('previousGridWidth: ', this.gridWidth, 'previousGridHeight: ', this.gridHeight)
+			console.debug('newGridWidth: ', this.gridWidth, 'newGridHeight: ', this.gridHeight)
+			if (!this.isStripe || this.stripeOpen) {
+				this.$nextTick(this.makeGrid)
+				if (this.hasPagination) {
+					this.setNumberOfPages()
+					// Set the current page to 0
+					// TODO: add support for keeping position in the videos array when resizing or collapsing
+					this.currentPage = 0
+				}
+			}
+		},
 
 		// whenever the document is resized, re-set the 'clientWidth' variable
 		handleResize(event) {

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -35,12 +35,6 @@
 				decorative
 				:size="24" />
 		</button>
-		<LocalMediaControls
-			class="local-media-controls"
-			:model="localMediaModel"
-			:local-call-participant-model="localCallParticipantModel"
-			:screen-sharing-button-hidden="isSidebar"
-			@switch-screen-to-id="$emit('switchScreenToId', $event)" />
 		<transition name="slide-down">
 			<div v-if="!isStripe || stripeOpen" class="wrapper" :style="wrapperStyle">
 				<div :class="{'pagination-wrapper': isStripe, 'wrapper': !isStripe}">
@@ -149,7 +143,6 @@
 import debounce from 'debounce'
 import Video from '../shared/Video'
 import LocalVideo from '../shared/LocalVideo'
-import LocalMediaControls from '../shared/LocalMediaControls'
 import { EventBus } from '../../../services/EventBus'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import EmptyCallView from '../shared/EmptyCallView'
@@ -164,7 +157,6 @@ export default {
 	components: {
 		Video,
 		LocalVideo,
-		LocalMediaControls,
 		EmptyCallView,
 		ChevronRight,
 		ChevronLeft,
@@ -825,15 +817,6 @@ export default {
 	z-index: 10;
 	border: 0;
 	background: none;
-}
-
-.local-media-controls {
-	position: absolute;
-	width: 300px; /* same as .video-container-stripe */
-	text-align: center;
-	right: 0;
-	bottom: 4px;
-	z-index: 1;
 }
 
 </style>

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -824,13 +824,26 @@ export default {
 }
 
 /** FIXME: replace with nextcloud-vue button */
-.stripe--collapse, .stripe--collapse:active {
+button.stripe--collapse {
 	position: absolute;
 	top: -50px;
 	right: 0;
+	width: 44px;
+	height: 44px;
 	z-index: 10;
 	border: 0;
 	background: none;
+	opacity: .7;
+
+	&:hover,
+	&:focus {
+		opacity: 1;
+	}
+
+	&:active {
+		/* needed again to override default active button style */
+		background: none;
+	}
 }
 
 </style>

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -20,7 +20,7 @@
 -->
 
 <template>
-	<div class="grid-main-wrapper">
+	<div :class="{'grid-main-wrapper': true, 'is-grid': !isStripe}">
 		<button v-if="isStripe"
 			class="stripe--collapse"
 			@click="stripeOpen = !stripeOpen">
@@ -689,6 +689,10 @@ export default {
 	position: relative;
 	width: 100%;
 	background-color: var(--color-text-maxcontrast);
+}
+
+.grid-main-wrapper.is-grid {
+	height: 100%;
 }
 
 .wrapper {

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -587,7 +587,7 @@ export default {
 	border-bottom-color: transparent;
 }
 
-.buttons-bar button {
+.buttons-bar button, .buttons-bar button:active {
 	background-color: transparent;
 	border: none;
 	margin: 0;

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -48,25 +48,21 @@
 				{{ firstLetterOfGuestName }}
 			</div>
 		</div>
-		<transition name="fade">
-			<LocalMediaControls
-				ref="localMediaControls"
-				:is-big="isBig"
-				:model="localMediaModel"
-				:local-call-participant-model="localCallParticipantModel"
-				:screen-sharing-button-hidden="isSidebar"
-				:quality-warning-aria-label="qualityWarningAriaLabel"
-				:quality-warning-tooltip="qualityWarningTooltip"
-				@switchScreenToId="$emit('switchScreenToId', $event)" />
-		</transition>
 		<div v-if="mouseover && isSelectable" class="hover-shadow" />
+		<div class="bottom-bar">
+			<button
+				v-if="isBig"
+				class="bottom-bar__button"
+				@click="handleStopFollowing">
+				{{ stopFollowingLabel }}
+			</button>
+		</div>
 	</div>
 </template>
 
 <script>
 import attachMediaStream from 'attachmediastream'
 import Avatar from '@nextcloud/vue/dist/Components/Avatar'
-import LocalMediaControls from './LocalMediaControls'
 import Hex from 'crypto-js/enc-hex'
 import SHA1 from 'crypto-js/sha1'
 import {
@@ -76,8 +72,6 @@ import {
 } from '@nextcloud/dialogs'
 import video from '../../../mixins/video.js'
 import VideoBackground from './VideoBackground'
-import { callAnalyzer } from '../../../utils/webrtc/index'
-import { CONNECTION_QUALITY } from '../../../utils/webrtc/analyzers/PeerConnectionAnalyzer'
 
 export default {
 
@@ -85,7 +79,6 @@ export default {
 
 	components: {
 		Avatar,
-		LocalMediaControls,
 		VideoBackground,
 	},
 
@@ -112,13 +105,6 @@ export default {
 			type: Boolean,
 			default: false,
 		},
-	},
-
-	data() {
-		return {
-			callAnalyzer: callAnalyzer,
-			qualityWarningInGracePeriodTimeout: null,
-		}
 	},
 
 	computed: {
@@ -168,94 +154,6 @@ export default {
 			return this.localMediaModel.attributes.localStream && this.localMediaModel.attributes.localStreamRequestVideoError
 		},
 
-		showQualityWarning() {
-			return this.senderConnectionQualityIsBad || this.qualityWarningInGracePeriodTimeout
-		},
-
-		senderConnectionQualityIsBad() {
-			return this.senderConnectionQualityAudioIsBad
-				|| this.senderConnectionQualityVideoIsBad
-				|| this.senderConnectionQualityScreenIsBad
-		},
-
-		senderConnectionQualityAudioIsBad() {
-			return callAnalyzer
-				&& (callAnalyzer.attributes.senderConnectionQualityAudio === CONNECTION_QUALITY.VERY_BAD
-				 || callAnalyzer.attributes.senderConnectionQualityAudio === CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
-		},
-
-		senderConnectionQualityVideoIsBad() {
-			return callAnalyzer
-				&& (callAnalyzer.attributes.senderConnectionQualityVideo === CONNECTION_QUALITY.VERY_BAD
-				 || callAnalyzer.attributes.senderConnectionQualityVideo === CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
-		},
-
-		senderConnectionQualityScreenIsBad() {
-			return callAnalyzer
-				&& (callAnalyzer.attributes.senderConnectionQualityScreen === CONNECTION_QUALITY.VERY_BAD
-				 || callAnalyzer.attributes.senderConnectionQualityScreen === CONNECTION_QUALITY.NO_TRANSMITTED_DATA)
-		},
-
-		qualityWarningAriaLabel() {
-			let label = ''
-			if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
-				label = t('spreed', 'Bad sent video and screen quality.')
-			} else if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.localScreen) {
-				label = t('spreed', 'Bad sent screen quality.')
-			} else if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.videoEnabled) {
-				label = t('spreed', 'Bad sent video quality.')
-			} else if (this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
-				label = t('spreed', 'Bad sent audio, video and screen quality.')
-			} else if (this.localMediaModel.attributes.localScreen) {
-				label = t('spreed', 'Bad sent audio and screen quality.')
-			} else if (this.localMediaModel.attributes.videoEnabled) {
-				label = t('spreed', 'Bad sent audio and video quality.')
-			} else {
-				label = t('spreed', 'Bad sent audio quality.')
-			}
-
-			return label
-		},
-
-		qualityWarningTooltip() {
-			if (!this.showQualityWarning) {
-				return null
-			}
-
-			const tooltip = {}
-			if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
-				tooltip.content = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you. To improve the situation try to disable your video while doing a screenshare.')
-				tooltip.actionLabel = t('spreed', 'Disable video')
-				tooltip.action = 'disableVideo'
-			} else if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.localScreen) {
-				tooltip.content = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see your screen.')
-				tooltip.actionLabel = ''
-				tooltip.action = ''
-			} else if (!this.localMediaModel.attributes.audioEnabled && this.localMediaModel.attributes.videoEnabled) {
-				tooltip.content = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to see you.')
-				tooltip.actionLabel = ''
-				tooltip.action = ''
-			} else if (this.localMediaModel.attributes.videoEnabled && this.localMediaModel.attributes.localScreen) {
-				tooltip.content = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video while doing a screenshare.')
-				tooltip.actionLabel = t('spreed', 'Disable video')
-				tooltip.action = 'disableVideo'
-			} else if (this.localMediaModel.attributes.localScreen) {
-				tooltip.content = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see your screen. To improve the situation try to disable your screenshare.')
-				tooltip.actionLabel = t('spreed', 'Disable screenshare')
-				tooltip.action = 'disableScreenShare'
-			} else if (this.localMediaModel.attributes.videoEnabled) {
-				tooltip.content = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand and see you. To improve the situation try to disable your video.')
-				tooltip.actionLabel = t('spreed', 'Disable video')
-				tooltip.action = 'disableVideo'
-			} else {
-				tooltip.content = t('spreed', 'Your internet connection or computer are busy and other participants might be unable to understand you.')
-				tooltip.actionLabel = ''
-				tooltip.action = ''
-			}
-
-			return tooltip
-		},
-
 		hasLocalVideo() {
 			return this.localMediaModel.attributes.videoEnabled
 		},
@@ -301,20 +199,6 @@ export default {
 			},
 		},
 
-		senderConnectionQualityIsBad: function(senderConnectionQualityIsBad) {
-			if (!senderConnectionQualityIsBad) {
-				return
-			}
-
-			if (this.qualityWarningInGracePeriodTimeout) {
-				window.clearTimeout(this.qualityWarningInGracePeriodTimeout)
-			}
-
-			this.qualityWarningInGracePeriodTimeout = window.setTimeout(() => {
-				this.qualityWarningInGracePeriodTimeout = null
-			}, 10000)
-		},
-
 	},
 
 	mounted() {
@@ -354,6 +238,9 @@ export default {
 			attachMediaStream(localStream, this.$refs.video, options)
 		},
 
+		handleStopFollowing() {
+			this.$store.dispatch('selectedVideoPeerId', null)
+		},
 	},
 
 }
@@ -417,4 +304,30 @@ export default {
 	box-shadow: inset 0 0 0 3px white;
 	cursor: pointer;
 }
+
+.bottom-bar {
+	position: absolute;
+	bottom: 0;
+	width: 100%;
+	padding: 0 20px 12px 24px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	height: 40px;
+	&--big {
+		justify-content: center;
+		height: 48px;
+	}
+	&__button {
+		opacity: 0.8;
+		margin-left: 4px;
+		border: none;
+		&:hover,
+		&:focus {
+			opacity: 1;
+			border: none;
+		}
+	}
+}
+
 </style>

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -48,6 +48,15 @@
 				{{ firstLetterOfGuestName }}
 			</div>
 		</div>
+		<transition name="fade">
+			<LocalMediaControls
+				v-if="showControls"
+				class="local-media-controls"
+				:model="localMediaModel"
+				:local-call-participant-model="localCallParticipantModel"
+				:screen-sharing-button-hidden="isSidebar"
+				@switch-screen-to-id="$emit('switchScreenToId', $event)" />
+		</transition>
 		<div v-if="mouseover && isSelectable" class="hover-shadow" />
 		<div class="bottom-bar">
 			<button
@@ -63,6 +72,7 @@
 <script>
 import attachMediaStream from 'attachmediastream'
 import Avatar from '@nextcloud/vue/dist/Components/Avatar'
+import LocalMediaControls from './LocalMediaControls'
 import Hex from 'crypto-js/enc-hex'
 import SHA1 from 'crypto-js/sha1'
 import {
@@ -79,6 +89,7 @@ export default {
 
 	components: {
 		Avatar,
+		LocalMediaControls,
 		VideoBackground,
 	},
 
@@ -104,6 +115,10 @@ export default {
 		isSidebar: {
 			type: Boolean,
 			default: false,
+		},
+		showControls: {
+			type: Boolean,
+			default: true,
 		},
 	},
 
@@ -328,6 +343,15 @@ export default {
 			border: none;
 		}
 	}
+}
+
+.local-media-controls {
+	position: absolute;
+	text-align: center;
+	right: 0;
+	bottom: 4px;
+	z-index: 10;
+	width: 100%;
 }
 
 </style>


### PR DESCRIPTION
To be able to focus on the video / screen of the current presenter.

Fixes https://github.com/nextcloud/spreed/issues/4245


### Todos

- [x] Fix design/positioning of button
- [x] Move microphone/video/etc actions to the bottom of the screen when the grid is collapsed
- [x] Test multiple call modes to make sure it looks fine
- [x] Test with sidebar view - blocked by https://github.com/nextcloud/server/issues/23445
