### PR TITLE
Only show the conflict warning when the session was in a call

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1229,8 +1229,8 @@ class RoomController extends AEnvironmentAwareController {
 		}
 
 		if ($previousSession instanceof Participant && $previousSession->getSessionId() !== '0') {
-			// Previous session was active
-			if ($force === false) {
+			if ($force === false && $previousSession->getInCallFlags() !== Participant::FLAG_DISCONNECTED) {
+				// Previous session was active in the call, show a warning
 				return new DataResponse([
 					'sessionId' => $previousSession->getSessionId(),
 					'inCall' => $previousSession->getInCallFlags(),

--- a/src/App.vue
+++ b/src/App.vue
@@ -369,7 +369,11 @@ export default {
 			this.$store.dispatch('setWindowVisibility', !document.hidden)
 			if (this.windowIsVisible) {
 				// Remove the potential "*" marker for unread chat messages
-				this.setPageTitle(this.getConversationName(this.token), false)
+				let title = this.getConversationName(this.token)
+				if (window.document.title.indexOf(t('spreed', 'Duplicate session')) === 0) {
+					title = t('spreed', 'Duplicate session')
+				}
+				this.setPageTitle(title, false)
 			} else {
 				// Copy the last message map to the saved version,
 				// this will be our reference to check if any chat got a new
@@ -388,6 +392,10 @@ export default {
 				// On the first load we store the current page title "Talk - Nextcloud",
 				// so we can append it every time again
 				this.defaultPageTitle = window.document.title
+				// Coming from a "Duplicate session - Talk - …" page?
+				if (this.defaultPageTitle.indexOf(' - ' + t('spreed', 'Talk') + ' - ') !== -1) {
+					this.defaultPageTitle = this.defaultPageTitle.substring(this.defaultPageTitle.indexOf(' - ' + t('spreed', 'Talk') + ' - ') + 3)
+				}
 				// When a conversation is opened directly, the "Talk - " part is
 				// missing from the title
 				if (this.defaultPageTitle.indexOf(t('spreed', 'Talk') + ' - ') !== 0) {

--- a/src/views/SessionConflictView.vue
+++ b/src/views/SessionConflictView.vue
@@ -11,5 +11,15 @@
 <script>
 export default {
 	name: 'SessionConflictView',
+
+	mounted() {
+		this.setPageTitle()
+	},
+
+	methods: {
+		setPageTitle() {
+			window.document.title = t('spreed', 'Duplicate session') + ' - ' + window.document.title
+		},
+	},
 }
 </script>


### PR DESCRIPTION
Fix #4366 