### PR TITLE
Cache hasAvatar to avoid call background flickering

### DIFF
--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -47,6 +47,19 @@ import usernameToColor from '@nextcloud/vue/dist/Functions/usernameToColor'
 import { generateUrl } from '@nextcloud/router'
 import { ResizeObserver } from 'vue-resize'
 
+// note: this info is shared with the Avatar component
+function getUserHasAvatar(userId) {
+	const flag = window.sessionStorage.getItem('userHasAvatar-' + userId)
+	if (typeof flag === 'string') {
+		return Boolean(flag)
+	}
+	return null
+}
+
+function setUserHasAvatar(userId, flag) {
+	window.sessionStorage.setItem('userHasAvatar-' + userId, flag)
+}
+
 export default {
 	name: 'VideoBackground',
 	components: {
@@ -96,10 +109,20 @@ export default {
 			return
 		}
 
+		// check if hasAvatar info is already known
+		const userHasAvatar = getUserHasAvatar(this.user)
+		if (typeof userHasAvatar === 'boolean') {
+			this.hasPicture = userHasAvatar
+			return
+		}
+
 		try {
 			const response = await axios.get(generateUrl(`avatar/${this.user}/300`))
 			if (response.headers[`x-nc-iscustomavatar`] === '1') {
 				this.hasPicture = true
+				setUserHasAvatar(this.user, true)
+			} else {
+				setUserHasAvatar(this.user, false)
 			}
 		} catch (exception) {
 			console.debug(exception)

--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -46,10 +46,13 @@ import axios from '@nextcloud/axios'
 import usernameToColor from '@nextcloud/vue/dist/Functions/usernameToColor'
 import { generateUrl } from '@nextcloud/router'
 import { ResizeObserver } from 'vue-resize'
+import { getBuilder } from '@nextcloud/browser-storage'
+
+const browserStorage = getBuilder('nextcloud').persist().build()
 
 // note: this info is shared with the Avatar component
 function getUserHasAvatar(userId) {
-	const flag = window.sessionStorage.getItem('userHasAvatar-' + userId)
+	const flag = browserStorage.getItem('user-has-avatar.' + userId)
 	if (typeof flag === 'string') {
 		return Boolean(flag)
 	}
@@ -57,7 +60,7 @@ function getUserHasAvatar(userId) {
 }
 
 function setUserHasAvatar(userId, flag) {
-	window.sessionStorage.setItem('userHasAvatar-' + userId, flag)
+	browserStorage.setItem('user-has-avatar.' + userId, flag)
 }
 
 export default {


### PR DESCRIPTION
Whenever the speaker changes, the avatar background can flicker due to
HTTP calls. This fix improves it a bit by caching the information
whether the user has an avatar or not, so allows a less delayed loading of
the avatar background.

This only affects the avatar background.
For the avatar itself, you also need https://github.com/nextcloud/nextcloud-vue/pull/1457 in place.
Best is to test both together.