### PR TITLE
Fix chat scrolling

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -55,7 +55,7 @@ get the messagesList array and loop through the list to generate the messages.
 			<button v-show="!isScrolledToBottom"
 				:aria-label="scrollToBottomAriaLabel"
 				class="scroll-to-bottom"
-				@click="scrollToBottom">
+				@click="smoothScrollToBottom">
 				<ChevronDown decorative
 					:size="24" />
 			</button>
@@ -232,12 +232,14 @@ export default {
 	mounted() {
 		this.scrollToBottom()
 		EventBus.$on('scrollChatToBottom', this.handleScrollChatToBottomEvent)
-
+		EventBus.$on('smoothScrollChatToBottom', this.smoothScrollToBottom)
 		subscribe('networkOffline', this.handleNetworkOffline)
 		subscribe('networkOnline', this.handleNetworkOnline)
 	},
 	beforeDestroy() {
 		EventBus.$off('scrollChatToBottom', this.handleScrollChatToBottomEvent)
+		EventBus.$off('smoothScrollChatToBottom', this.smoothScrollToBottom)
+
 		this.cancelLookForNewMessages()
 		// Prevent further lookForNewMessages requests after the component was
 		// destroyed.
@@ -480,7 +482,7 @@ export default {
 
 				// Scroll to the last message if sticky
 				if (this.isSticky) {
-					this.scrollToBottom()
+					this.smoothScrollToBottom()
 				}
 			} catch (exception) {
 				if (Axios.isCancel(exception)) {
@@ -567,13 +569,26 @@ export default {
 		},
 
 		/**
+		 * Scrolls to the bottom of the list smoothly.
+		 */
+		smoothScrollToBottom() {
+			this.$nextTick(function() {
+				this.scroller.scrollTo({
+					top: this.scroller.scrollHeight,
+					behavior: 'smooth',
+					 })
+				this.isScrolledToBottom = true
+			})
+		},
+		/**
 		 * Scrolls to the bottom of the list.
 		 */
 		scrollToBottom() {
 			this.$nextTick(function() {
 				this.scroller.scrollTop = this.scroller.scrollHeight
+				this.isScrolledToBottom = true
 			})
-			this.isScrolledToBottom = true
+
 		},
 
 		/**
@@ -621,7 +636,7 @@ export default {
 .scroller {
 	flex: 1 0;
 	overflow-y: auto;
-	scroll-behavior: smooth;
+	overflow-x: hidden;
 	&__loading {
 		height: 50px;
 		display: flex;

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -259,9 +259,7 @@ export default {
 				this.text = ''
 				this.parsedText = ''
 				// Scrolls the message list to the last added message
-				this.$nextTick(function() {
-					document.querySelector('.scroller').scrollTop = document.querySelector('.scroller').scrollHeight
-				})
+				EventBus.$emit('smoothScrollChatToBottom')
 				// Also remove the message to be replied for this conversation
 				this.$store.dispatch('removeMessageToBeReplied', this.token)
 				try {


### PR DESCRIPTION
fix: #4378 
fix: #4377

Removes global smooth scrolling of the container and smooth scrolls it only when needed

Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>