### PR TITLE
Don't render extra videos when selecting promoted

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -269,7 +269,7 @@ export default {
 
 		// Show selected video (other than local)
 		showSelected() {
-			return !this.isGrid && this.hasSelectedVideo && !this.showLocalScreen && !this.showLocalVideo
+			return !this.isGrid && this.hasSelectedVideo && !this.showLocalScreen && !this.showLocalVideo && !this.showRemoteScreen
 		},
 
 		// Show the current automatically promoted video


### PR DESCRIPTION
When selecting the already promoted screen, this prevents an additional
video element to be rendered which would duplicate whatever the user is
already seeing.

Fixes https://github.com/nextcloud/spreed/issues/4382

@ma12-co can you verify the reasoning ? Not sure if there are other potential flaws/holes.

I only saw this happen for screen sharing, not regular videos.