### PR TITLE
Fix empty call background color

### DIFF
--- a/src/components/CallView/shared/EmptyCallView.vue
+++ b/src/components/CallView/shared/EmptyCallView.vue
@@ -147,7 +147,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 
 .empty-call-view {
 	height: 100%;
@@ -157,7 +157,7 @@ export default {
 	flex-direction: column;
 	align-content: center;
 	justify-content: center;
-	color: var(--color-text-maxcontrast);
+	background-color: var(--color-loading-dark);
 	text-align: center;
 	.icon {
 		background-size: 64px;
@@ -168,5 +168,10 @@ export default {
 	button {
 		margin: 4px auto;
 	}
+
+	h2, p {
+		color: var(--color-primary-text);
+	}
 }
+
 </style>


### PR DESCRIPTION
Make it the same grey like the stripe background and adjust text color
to be readable.

Fixes https://github.com/nextcloud/spreed/issues/4388

<img width="960" alt="image" src="https://user-images.githubusercontent.com/277525/96455414-7ae34b80-121d-11eb-90a8-da89a9fc2151.png">
