### PR TITLE
Improve call error messages UX

### DIFF
--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -122,6 +122,12 @@ export default {
 		},
 	},
 
+	data() {
+		return {
+			notificationHandle: null,
+		}
+	},
+
 	computed: {
 
 		videoContainerClass() {
@@ -208,15 +214,15 @@ export default {
 			handler: function(error) {
 				if (error) {
 					if (error.name === 'NotAllowedError') {
-						showError(t('spreed', 'Access to camera was denied'))
+						this.notificationHandle = showError(t('spreed', 'Access to camera was denied'))
 					} else if (error.name === 'NotReadableError' || error.name === 'AbortError') {
 						// when camera in use, Chrome gives NotReadableError, Firefox gives AbortError
-						showError(t('spreed', 'Error while accessing camera: it is likely in use by another program'), {
+						this.notificationHandle = showError(t('spreed', 'Error while accessing camera: it is likely in use by another program'), {
 							timeout: TOAST_PERMANENT_TIMEOUT,
 						})
 					} else {
 						console.error('Error while accessing camera: ', error.message, error.name)
-						showError(t('spreed', 'Error while accessing camera'), {
+						this.notificationHandle = showError(t('spreed', 'Error while accessing camera'), {
 							timeout: TOAST_PERMANENT_TIMEOUT,
 						})
 					}
@@ -232,6 +238,9 @@ export default {
 	},
 
 	destroyed() {
+		if (this.notificationHandle) {
+			this.notificationHandle.hideToast()
+		}
 		if (this.localCallParticipantModel) {
 			this.localCallParticipantModel.off('forcedMute', this._handleForcedMute)
 		}

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -78,7 +78,7 @@ import SHA1 from 'crypto-js/sha1'
 import {
 	showError,
 	showInfo,
-	TOAST_DEFAULT_TIMEOUT,
+	TOAST_PERMANENT_TIMEOUT,
 } from '@nextcloud/dialogs'
 import video from '../../../mixins/video.js'
 import VideoBackground from './VideoBackground'
@@ -205,11 +205,21 @@ export default {
 		localStreamVideoError: {
 			immediate: true,
 
-			handler: function(localStreamVideoError) {
-				if (localStreamVideoError) {
-					showError(t('spreed', 'Error while accessing camera'), {
-						timeout: TOAST_DEFAULT_TIMEOUT,
-					})
+			handler: function(error) {
+				if (error) {
+					if (error.name === 'NotAllowedError') {
+						showError(t('spreed', 'Access to camera was denied'))
+					} else if (error.name === 'NotReadableError' || error.name === 'AbortError') {
+						// when camera in use, Chrome gives NotReadableError, Firefox gives AbortError
+						showError(t('spreed', 'Error while accessing camera: it is likely in use by another program'), {
+							timeout: TOAST_PERMANENT_TIMEOUT,
+						})
+					} else {
+						console.error('Error while accessing camera: ', error.message, error.name)
+						showError(t('spreed', 'Error while accessing camera'), {
+							timeout: TOAST_PERMANENT_TIMEOUT,
+						})
+					}
 				}
 			},
 		},

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -78,7 +78,7 @@ import SHA1 from 'crypto-js/sha1'
 import {
 	showError,
 	showInfo,
-	TOAST_PERMANENT_TIMEOUT,
+	TOAST_DEFAULT_TIMEOUT,
 } from '@nextcloud/dialogs'
 import video from '../../../mixins/video.js'
 import VideoBackground from './VideoBackground'
@@ -208,7 +208,7 @@ export default {
 			handler: function(localStreamVideoError) {
 				if (localStreamVideoError) {
 					showError(t('spreed', 'Error while accessing camera'), {
-						timeout: TOAST_PERMANENT_TIMEOUT,
+						timeout: TOAST_DEFAULT_TIMEOUT,
 					})
 				}
 			},

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -401,6 +401,7 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 			return
 		}
 
+		clearErrorNotification()
 		webrtc.leaveCall()
 	})
 
@@ -871,6 +872,8 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 	let localStreamRequestedTimeout = null
 	let localStreamRequestedTimeoutNotification = null
 
+	let errorNotificationHandle = null
+
 	const clearLocalStreamRequestedTimeoutAndHideNotification = function() {
 		clearTimeout(localStreamRequestedTimeout)
 		localStreamRequestedTimeout = null
@@ -878,6 +881,14 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 		if (localStreamRequestedTimeoutNotification) {
 			localStreamRequestedTimeoutNotification.hideToast()
 			localStreamRequestedTimeoutNotification = null
+		}
+
+	}
+
+	const clearErrorNotification = function() {
+		if (errorNotificationHandle) {
+			errorNotificationHandle.hideToast()
+			errorNotificationHandle = null
 		}
 	}
 
@@ -901,6 +912,7 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 	signaling.on('leaveRoom', function(token) {
 		if (signaling.currentRoomToken === token) {
 			clearLocalStreamRequestedTimeoutAndHideNotification()
+			clearErrorNotification()
 		}
 	})
 
@@ -942,7 +954,7 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 			console.error('Error while accessing microphone & camera: ', error.message, error.name)
 		}
 
-		showError(message, {
+		errorNotificationHandle = showError(message, {
 			timeout: timeout,
 		})
 	})

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -32,6 +32,7 @@ import store from '../../store/index.js'
 import {
 	showError,
 	TOAST_PERMANENT_TIMEOUT,
+	TOAST_DEFAULT_TIMEOUT,
 } from '@nextcloud/dialogs'
 
 let webrtc
@@ -919,6 +920,7 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 		clearLocalStreamRequestedTimeoutAndHideNotification()
 
 		let message
+		let timeout = TOAST_PERMANENT_TIMEOUT
 		if ((error.name === 'NotSupportedError'
 				&& webrtc.capabilities.supportRTCPeerConnection)
 			|| (error.name === 'NotAllowedError'
@@ -927,6 +929,7 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 			message += ': ' + t('spreed', 'Please move your setup to HTTPS')
 		} else if (error.name === 'NotAllowedError') {
 			message = t('spreed', 'Access to microphone & camera was denied')
+			timeout = TOAST_DEFAULT_TIMEOUT
 		} else if (!webrtc.capabilities.support) {
 			console.error('WebRTC not supported')
 
@@ -935,10 +938,11 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 		} else {
 			message = t('spreed', 'Error while accessing microphone & camera')
 			console.error('Error while accessing microphone & camera: ', error.message || error.name)
+			timeout = TOAST_DEFAULT_TIMEOUT
 		}
 
 		showError(message, {
-			timeout: TOAST_PERMANENT_TIMEOUT,
+			timeout: timeout,
 		})
 	})
 

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -936,9 +936,10 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 			message = t('spreed', 'WebRTC is not supported in your browser')
 			message += ': ' + t('spreed', 'Please use a different browser like Firefox or Chrome')
 		} else {
+			// Mostly happens in Chrome (NotFoundError): when no audio device available
+			// not sure what else can cause this
 			message = t('spreed', 'Error while accessing microphone & camera')
-			console.error('Error while accessing microphone & camera: ', error.message || error.name)
-			timeout = TOAST_DEFAULT_TIMEOUT
+			console.error('Error while accessing microphone & camera: ', error.message, error.name)
 		}
 
 		showError(message, {


### PR DESCRIPTION
Added default timeout instead of permanent for messages related to
denied permissions.

Fixes https://github.com/nextcloud/spreed/issues/4407