### PR TITLE
Adjust empty call view colors

### DIFF
--- a/src/components/CallView/shared/EmptyCallView.vue
+++ b/src/components/CallView/shared/EmptyCallView.vue
@@ -157,7 +157,7 @@ export default {
 	flex-direction: column;
 	align-content: center;
 	justify-content: center;
-	background-color: var(--color-loading-dark);
+	background-color: #444;
 	text-align: center;
 	.icon {
 		background-size: 64px;
@@ -170,7 +170,7 @@ export default {
 	}
 
 	h2, p {
-		color: var(--color-primary-text);
+		color: #ffffff;
 	}
 }
 


### PR DESCRIPTION
Use hard-coded values instead of variables to keep it static regardless
of theme or dark mode.

The final result is the same like in https://github.com/nextcloud/spreed/pull/4408 in regular mode
