### PR TITLE
Fix isolated modules in Files app sidebar

### DIFF
--- a/lib/Files/TemplateLoader.php
+++ b/lib/Files/TemplateLoader.php
@@ -93,7 +93,6 @@ class TemplateLoader implements IEventListener {
 
 		Util::addStyle(Application::APP_ID, 'merged-files');
 		Util::addScript(Application::APP_ID, 'talk-files-sidebar');
-		Util::addScript(Application::APP_ID, 'talk-files-sidebar-loader');
 
 		$user = $this->userSession->getUser();
 		if ($user instanceof IUser) {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -8,8 +8,10 @@ module.exports = {
 		'admin-settings': path.join(__dirname, 'src', 'mainAdminSettings.js'),
 		'collections': path.join(__dirname, 'src', 'collections.js'),
 		'talk': path.join(__dirname, 'src', 'main.js'),
-		'talk-files-sidebar': path.join(__dirname, 'src', 'mainFilesSidebar.js'),
-		'talk-files-sidebar-loader': path.join(__dirname, 'src', 'mainFilesSidebarLoader.js'),
+		'talk-files-sidebar': [
+			path.join(__dirname, 'src', 'mainFilesSidebar.js'),
+			path.join(__dirname, 'src', 'mainFilesSidebarLoader.js'),
+		],
 		'talk-public-share-auth-sidebar': path.join(__dirname, 'src', 'mainPublicShareAuthSidebar.js'),
 		'talk-public-share-sidebar': path.join(__dirname, 'src', 'mainPublicShareSidebar.js'),
 		'flow': path.join(__dirname, 'src', 'flow.js'),


### PR DESCRIPTION
`mainFilesSidebar.js` and `mainFilesSidebarLoader.js` were both bundled in separate files, and both files were loaded on their own. Due to this each loaded file had its own instance of the JavaScript modules instead of using a shared one, which for example caused conversations to not be properly left when the sidebar of a folder was opened. Now both files are bundled in a single file, so all the elements act on the same shared state.

Note that the steps below refer to one scenario in which the bug can be noticed, but there are others (for example, with the HPB it prevents joining calls when opening the chat tab of a file again after opening the sidebar in a directory). And independently of those issues it causes an unneeded built JavaScript file of 1MiB to be loaded in the Files app. Due to all that the backport also to _stable18_ (in which the scenario below does not cause a redirection, because conflict handling was not added yet).

## How to test

- Checkout server in fd178b92f63^ (as Talk master is not yet compatible with the Files sidebar changes introduced in nextcloud/server@fd178b92f63)
- Ensure that no external signaling server is set in Talk settings
- Open the Files app
- Create a file and a directory
- Share the file
- Refresh (due to the bug in the Files app that causes the FileInfo to not be updated)
- Open the sidebar for the file
- Join the conversation
- Open the sidebar for the directory

### Result with this pull request

Nothing strange happens.

### Result without this pull request

[The browser redirects to the duplicated session page](https://github.com/nextcloud/spreed/blob/4212258b13a73e492e73e4fd1cb1e6c253eb31fb/src/utils/signaling.js#L447) because (even if [`leaveConversation`](https://github.com/nextcloud/spreed/blob/c029e395864e04d32ad9378f962889b3c87b5e3c/src/mainFilesSidebarLoader.js#L38) is called on a different module instance) [the participant left the conversation](https://github.com/nextcloud/spreed/blob/913583ce04e8997ff8f3833f678eea3f766c4879/src/services/participantsService.js#L147), but the signaling is not stopped (in this case the [different module instance matters](https://github.com/nextcloud/spreed/blob/70ae94e640fbff3277f9af8d636c4f189d365f70/src/utils/webrtc/index.js#L212)) and [it keeps pulling messages](https://github.com/nextcloud/spreed/blob/9a599f12ce266fbac430be412c4e1bdb1a4cb87e/lib/Controller/SignalingController.php#L329-L330).
