### PR TITLE
Fix empty call view position in sidebar

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -729,6 +729,10 @@ export default {
 	width: 100%;
 }
 
+.empty-call-view {
+	position: relative;
+}
+
 .local-video-stripe {
 	width: 300px;
 }

--- a/src/components/CallView/shared/EmptyCallView.vue
+++ b/src/components/CallView/shared/EmptyCallView.vue
@@ -152,7 +152,7 @@ export default {
 .empty-call-view {
 	height: 100%;
 	width: 100%;
-	position: relative;
+	position: absolute;
 	display: flex;
 	flex-direction: column;
 	align-content: center;


### PR DESCRIPTION
This is meant to be tested with server in fd178b92f63^ (as Talk master is not yet compatible with the Files sidebar changes introduced in nextcloud/server@fd178b9).

Although this became specially noticeable after #4408 it was already broken in previous versions (as the call view height was reduced when someone else joined the call), hence the backport to _stable20_ (it also happens in _stable19_ and _stable18_, so feel free to backport to them too if you want, but as it is "just" a style issue I only backported to _stable20_ to begin with).

**Before:**
![Files-Sidebar-Empty-Call-Before](https://user-images.githubusercontent.com/26858233/96710778-d1c35f00-139c-11eb-939f-3f624586cc21.png)

**After:**
![Files-Sidebar-Empty-Call-After](https://user-images.githubusercontent.com/26858233/96710784-d38d2280-139c-11eb-9cfb-1a1e29441fec.png)
