### PR TITLE
Abort integration tests if Talk or helper apps can not be installed

### DIFF
--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -11,8 +11,8 @@ PHPPID=$!
 echo $PHPPID
 
 cp -R ./spreedcheats ../../../spreedcheats
-${ROOT_DIR}/occ app:enable spreed
-${ROOT_DIR}/occ app:enable spreedcheats
+${ROOT_DIR}/occ app:enable spreed || exit 1
+${ROOT_DIR}/occ app:enable spreedcheats || exit 1
 ${ROOT_DIR}/occ app:list | grep spreed
 
 export TEST_SERVER_URL="http://localhost:8080/"


### PR DESCRIPTION
Tested that Drone fails; see results of [removed commits](https://github.com/nextcloud/spreed/compare/dd373519ea65d0a09e1a9026a1467c0c6967e6a9..71304320902ccdea37b84fd8abca30d7dbda4992): https://drone.nextcloud.com/nextcloud/spreed/9501 https://drone.nextcloud.com/nextcloud/spreed/9502