### PR TITLE
Chat previews now expanded with aspect ratio

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -162,9 +162,9 @@ export default {
 			}
 
 			const previewSize = Math.ceil(this.previewSize * window.devicePixelRatio)
-			return generateUrl('/core/preview?fileId={fileId}&x={width}&y={height}', {
+			// expand width but keep a max height
+			return generateUrl('/core/preview?fileId={fileId}&x=-1&y={height}&a=1', {
 				fileId: this.id,
-				width: previewSize,
 				height: previewSize,
 			})
 		},
@@ -290,14 +290,18 @@ export default {
 		object-fit: cover;
 	}
 
+	.loading {
+		display: inline-block;
+		height: 128px;
+		margin-left: 32px;
+	}
+
 	.preview {
-		display: block;
-		width: 128px;
+		display: inline-block;
 		height: 128px;
 	}
 	.preview-64 {
-		display: block;
-		width: 64px;
+		display: inline-block;
 		height: 64px;
 	}
 
@@ -308,7 +312,6 @@ export default {
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;
-		margin-top: 4px;
 	}
 
 	&:not(.file-preview--viewer-available) {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -292,6 +292,7 @@ export default {
 
 	.loading {
 		display: inline-block;
+		width: 100%;
 		margin-left: 32px;
 	}
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -94,7 +94,7 @@ export default {
 		},
 		previewSize: {
 			type: Number,
-			default: 128,
+			default: 384,
 		},
 		// In case this component is used to display a file that is being uploaded
 		// this parameter is used to access the file upload status in the store
@@ -292,13 +292,12 @@ export default {
 
 	.loading {
 		display: inline-block;
-		height: 128px;
 		margin-left: 32px;
 	}
 
 	.preview {
 		display: inline-block;
-		height: 128px;
+		height: 384px;
 	}
 	.preview-64 {
 		display: inline-block;


### PR DESCRIPTION
Instead of cropping the previews in the conversation to a square, they
are now using a limited height but their width is computed based on
aspect ratio. This is done by passing different arguments to the
previews endpoint so it delivers a preview with the matching size.

Adjusted styles around the preview to make it look better.

Fixes https://github.com/nextcloud/spreed/issues/3746

This was mentionned in https://github.com/nextcloud/spreed/issues/1805#issuecomment-716571572

<img width="496" alt="image" src="https://user-images.githubusercontent.com/277525/97189815-4afbf100-17a5-11eb-9747-97608e30f3fb.png">

### Manual Tests

- [x] wide pictures
- [x] narrow pictures
- [x] loading icon looks fine
- [x] reduced preview when using reply in pic
