### PR TITLE
Bump @nextcloud/vue to 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4107,24 +4107,29 @@
 			}
 		},
 		"@nextcloud/vue": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-2.7.0.tgz",
-			"integrity": "sha512-iZxTUWsDvfQdi3FRqEBfv5MGqJPPISk9FEXhX98wnWX37YaDwx9qOpvAQo+/6bjVVwwu8E7oWJN24NE4rxWhBg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-3.1.0.tgz",
+			"integrity": "sha512-BB3/6RM0yPw4+McZvda8CaL0JEFb4lXQ/7l8tZ1zgrY2jDCZpwnEMsizzK16KeX4dzx1HNyt4PPBlWaSoVvfuQ==",
 			"requires": {
 				"@nextcloud/auth": "^1.2.3",
 				"@nextcloud/axios": "^1.3.2",
+				"@nextcloud/browser-storage": "^0.1.1",
 				"@nextcloud/capabilities": "^1.0.2",
-				"@nextcloud/dialogs": "^2.0.1",
+				"@nextcloud/dialogs": "^3.0.0",
 				"@nextcloud/event-bus": "^1.1.4",
 				"@nextcloud/l10n": "^1.2.3",
 				"@nextcloud/router": "^1.0.2",
 				"core-js": "^3.6.5",
 				"debounce": "1.2.0",
 				"emoji-mart-vue-fast": "^7.0.4",
+				"escape-html": "^1.0.3",
 				"hammerjs": "^2.0.8",
 				"linkifyjs": "~2.1.9",
 				"md5": "^2.2.1",
 				"regenerator-runtime": "^0.13.5",
+				"string-length": "^4.0.1",
+				"striptags": "^3.1.1",
+				"tributejs": "^5.1.3",
 				"v-click-outside": "^3.0.1",
 				"v-tooltip": "^2.0.3",
 				"vue": "^2.6.11",
@@ -4134,15 +4139,26 @@
 				"vue2-datepicker": "^3.6.2"
 			},
 			"dependencies": {
-				"@nextcloud/dialogs": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-2.0.1.tgz",
-					"integrity": "sha512-Bme8vcs8n4XT5spBgkDEv1z9zNOE23AIbr5jF1WJ1A2XNMNj5Zvy29RosIh0k7H+1lN0PlU38u+eMV1Ets3E4A==",
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"string-length": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
+					"integrity": "sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==",
 					"requires": {
-						"@nextcloud/l10n": "^1.3.0",
-						"@nextcloud/typings": "^0.2.2",
-						"core-js": "^3.6.4",
-						"toastify-js": "^1.9.1"
+						"char-regex": "^1.0.2",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
 					}
 				}
 			}
@@ -4155,6 +4171,63 @@
 				"@nextcloud/vue": "^2.3.0",
 				"core-js": "^3.6.4",
 				"vue": "^2.6.11"
+			},
+			"dependencies": {
+				"@nextcloud/vue": {
+					"version": "2.8.1",
+					"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-2.8.1.tgz",
+					"integrity": "sha512-6a11iUyOs8cUbmzLdK+WZG7g7gTH2oDESU9o/J16+nKn6g3BlfH0iI/dWaqGiPuNiLy5CAqeQPvhx1UxaL/f5A==",
+					"requires": {
+						"@nextcloud/auth": "^1.2.3",
+						"@nextcloud/axios": "^1.3.2",
+						"@nextcloud/browser-storage": "^0.1.1",
+						"@nextcloud/capabilities": "^1.0.2",
+						"@nextcloud/dialogs": "^3.0.0",
+						"@nextcloud/event-bus": "^1.1.4",
+						"@nextcloud/l10n": "^1.2.3",
+						"@nextcloud/router": "^1.0.2",
+						"core-js": "^3.6.5",
+						"debounce": "1.2.0",
+						"emoji-mart-vue-fast": "^7.0.4",
+						"escape-html": "^1.0.3",
+						"hammerjs": "^2.0.8",
+						"linkifyjs": "~2.1.9",
+						"md5": "^2.2.1",
+						"regenerator-runtime": "^0.13.5",
+						"string-length": "^4.0.1",
+						"striptags": "^3.1.1",
+						"tributejs": "^5.1.3",
+						"v-click-outside": "^3.0.1",
+						"v-tooltip": "^2.0.3",
+						"vue": "^2.6.11",
+						"vue-color": "^2.7.1",
+						"vue-multiselect": "^2.1.6",
+						"vue-visible": "^1.0.2",
+						"vue2-datepicker": "^3.6.2"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"string-length": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
+					"integrity": "sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==",
+					"requires": {
+						"char-regex": "^1.0.2",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				}
 			}
 		},
 		"@nodelib/fs.scandir": {
@@ -4919,6 +4992,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"color-convert": "^2.0.1"
 					}
@@ -4983,6 +5057,7 @@
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"color-name": "~1.1.4"
 					}
@@ -4991,7 +5066,8 @@
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"electron-to-chromium": {
 					"version": "1.3.582",
@@ -5009,7 +5085,8 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
 					"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"escalade": {
 					"version": "3.1.1",
@@ -5298,6 +5375,7 @@
 					"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.0.0-beta.9.tgz",
 					"integrity": "sha512-mu9pg6554GbXDSO8LlxkQM6qUJzUkb/A0FJc9LgRqnU9MCnhzEXwCt1Zx5NObvFpzs2mH2dH/uUCDwL8Qaz9sA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"chalk": "^4.1.0",
 						"hash-sum": "^2.0.0",
@@ -5309,6 +5387,7 @@
 							"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
 							"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"ansi-styles": "^4.1.0",
 								"supports-color": "^7.1.0"
@@ -5319,6 +5398,7 @@
 							"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
 							"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"big.js": "^5.2.2",
 								"emojis-list": "^3.0.0",
@@ -7524,6 +7604,11 @@
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
 			}
+		},
+		"char-regex": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="
 		},
 		"character-entities": {
 			"version": "1.2.4",
@@ -19515,6 +19600,11 @@
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 			"dev": true
 		},
+		"striptags": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
+			"integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
+		},
 		"style-loader": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-2.0.0.tgz",
@@ -20729,6 +20819,11 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"tributejs": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/tributejs/-/tributejs-5.1.3.tgz",
+			"integrity": "sha512-B5CXihaVzXw+1UHhNFyAwUTMDk1EfoLP5Tj1VhD9yybZ1I8DZJEv8tZ1l0RJo0t0tk9ZhR8eG5tEsaCvRigmdQ=="
+		},
 		"trim": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -21667,9 +21762,9 @@
 			"integrity": "sha512-yaX2its9XAJKGuQqf7LsiZHHSkxsIK8rmCOQOvEGEoF41blKRK8qr9my4qYoD6ikdLss4n8tKqYBecmaY0+WJg=="
 		},
 		"vue2-datepicker": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/vue2-datepicker/-/vue2-datepicker-3.6.2.tgz",
-			"integrity": "sha512-J2fCwUmCxIOPUvwQ12e8evFY9cCv6vJmgxRD9fGeUv6JeMMeLwkdpeQZOcqbMf/4mk1cSrY2/9Fr8DaB30LBpA==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/vue2-datepicker/-/vue2-datepicker-3.7.0.tgz",
+			"integrity": "sha512-XB5slJZLXf3sbPIOMxjYPw2UlOI/utX4cHGQwGvRQqyiKzwpsGlPI6M3zUGw412Sm2tv2jMkXd9+k+yOSRf2OQ==",
 			"requires": {
 				"date-fns": "^2.0.1",
 				"date-format-parse": "^0.2.5"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"@nextcloud/l10n": "^1.4.1",
 		"@nextcloud/moment": "^1.1.1",
 		"@nextcloud/router": "^1.2.0",
-		"@nextcloud/vue": "^2.7.0",
+		"@nextcloud/vue": "^3.1.0",
 		"@nextcloud/vue-dashboard": "^1.0.1",
 		"attachmediastream": "^2.1.0",
 		"crypto-js": "^4.0.0",

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -287,4 +287,14 @@ export default {
 	right: 6px !important;
 }
 
+/*
+ * The field will fully overlap the top of the sidebar content so
+ * that elements will scroll behind it
+ */
+.app-navigation-search {
+	top: -10px;
+	margin: -10px;
+	padding: 10px;
+}
+
 </style>

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -27,6 +27,7 @@
 		:title="title"
 		:starred="isFavorited"
 		:title-editable="canModerate && isRenamingConversation"
+		:class="'active-tab-' + activeTab"
 		@update:active="handleUpdateActive"
 		@update:starred="onFavoriteChange"
 		@update:title="handleUpdateTitle"
@@ -112,7 +113,7 @@ export default {
 
 	data() {
 		return {
-			activeTab: null,
+			activeTab: 'participants',
 			contactsLoading: false,
 			// The conversation name (while editing)
 			conversationName: '',
@@ -258,31 +259,6 @@ export default {
  * nextcloud-vue for ".app-sidebar". */
 #app-sidebar {
 	display: flex;
-}
-
-/**
- * Replace padding with margin to make the participant list scroll
- * properly behind the top field
- */
-#tab-participants {
-	margin-top: 10px;
-	padding-top: 0;
-	outline: none; /* remove the weird border that appears on focus */
-}
-
-/* Force scroll bars in tabs content instead of in whole sidebar. */
-::v-deep .app-sidebar-tabs {
-	height: calc(100% - 80px);
-
-	&__content {
-		overflow: hidden;
-
-		section {
-			height: 100%;
-
-			overflow-y: auto;
-		}
-	}
 }
 
 .app-sidebar-tabs__content #tab-chat {


### PR DESCRIPTION
This brings in:
- the new edit component (which we can replace later in https://github.com/nextcloud/spreed/pull/4333)
- Scrollable app sidebar (which is the reason for major bump)
- Avatar caching.
- Other small things

### Todos

- [x] cleanup sidebar css hacks
- [x] ~~potentially blocked by https://github.com/nextcloud/spreed/pull/4195 (issues mentioned there)~~ => https://github.com/nextcloud/spreed/pull/4473#issuecomment-717083734

### Tests

I did a quick test to see if all still works:
- [x] scrolling in left sidebar still works fine
- [x] scrolling in participant list works fine
- [x] sending (typing)/receiving messages still works, with emojis
- [x] remove hacks
- [x] check settings panel for regression
- [x] verify chat scrolling with lots of messages when conversation in sidebar
- [x] verify regular chat scrolling

Obsoletes https://github.com/nextcloud/spreed/pull/4457