### PR TITLE
Always use CommentsManager from the app

### DIFF
--- a/lib/Chat/AutoComplete/Sorter.php
+++ b/lib/Chat/AutoComplete/Sorter.php
@@ -23,15 +23,16 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Chat\AutoComplete;
 
-use OCP\Comments\ICommentsManager;
+use OCA\Talk\Chat\CommentsManager;
 use OCP\Collaboration\AutoComplete\ISorter;
+use OCP\Comments\ICommentsManager;
 
 class Sorter implements ISorter {
 
 	/** @var ICommentsManager */
 	protected $commentsManager;
 
-	public function __construct(ICommentsManager $commentsManager) {
+	public function __construct(CommentsManager $commentsManager) {
 		$this->commentsManager = $commentsManager;
 	}
 

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -59,7 +59,7 @@ class ChatManager {
 
 	public const MAX_CHAT_LENGTH = 32000;
 
-	/** @var CommentsManager|ICommentsManager */
+	/** @var ICommentsManager */
 	private $commentsManager;
 	/** @var IEventDispatcher */
 	private $dispatcher;

--- a/lib/Chat/Parser/UserMention.php
+++ b/lib/Chat/Parser/UserMention.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Chat\Parser;
 
-use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\GuestManager;
 use OCA\Talk\Model\Message;
@@ -39,7 +38,13 @@ use OCP\IUserManager;
  */
 class UserMention {
 
-	/** @var ICommentsManager */
+	/**
+	 * Do NOT inject OCA\Talk\Chat\CommentsManager here
+	 * otherwise the display name resolvers are lost
+	 * and mentions are not replaced anymore.
+	 *
+	 * @var ICommentsManager
+	 */
 	private $commentsManager;
 	/** @var IUserManager */
 	private $userManager;

--- a/lib/Chat/Parser/UserMention.php
+++ b/lib/Chat/Parser/UserMention.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Chat\Parser;
 
+use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\GuestManager;
 use OCA\Talk\Model\Message;

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace OCA\Talk;
 
-use OCA\Talk\Chat\Changelog;
 use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Events\CreateRoomTokenEvent;
 use OCA\Talk\Events\RoomEvent;
@@ -31,6 +30,7 @@ use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Exceptions\RoomNotFoundException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\IComment;
+use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -54,7 +54,7 @@ class Manager {
 	private $secureRandom;
 	/** @var IUserManager */
 	private $userManager;
-	/** @var CommentsManager */
+	/** @var ICommentsManager */
 	private $commentsManager;
 	/** @var TalkSession */
 	private $talkSession;
@@ -192,6 +192,7 @@ class Manager {
 	}
 
 	public function createCommentObject(array $row): ?IComment {
+		/** @psalm-suppress UndefinedInterfaceMethod */
 		return $this->commentsManager->getCommentFromData([
 			'id'				=> $row['comment_id'],
 			'parent_id'			=> $row['comment_parent_id'],

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -32,6 +32,7 @@ use OCA\Talk\GuestManager;
 use OCA\Talk\Manager;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
+use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -66,7 +67,7 @@ class Notifier implements INotifier {
 	protected $manager;
 	/** @var INotificationManager */
 	protected $notificationManager;
-	/** @var CommentsManager */
+	/** @var ICommentsManager */
 	protected $commentManager;
 	/** @var MessageParser */
 	protected $messageParser;

--- a/psalm.xml
+++ b/psalm.xml
@@ -32,4 +32,7 @@
 			</errorLevel>
 		</UndefinedDocblockClass>
 	</issueHandlers>
+	<stubs>
+		<file name="tests/stubs/oc_comments_manager.php" />
+	</stubs>
 </psalm>

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -14,46 +14,9 @@
       <code>SchemaWrapper</code>
     </UndefinedClass>
   </file>
-  <file src="lib/Chat/AutoComplete/Sorter.php">
-    <MissingDependency occurrences="3">
-      <code>$this-&gt;commentsManager</code>
-      <code>CommentsManager</code>
-      <code>CommentsManager</code>
-    </MissingDependency>
-  </file>
   <file src="lib/Chat/ChatManager.php">
-    <MissingDependency occurrences="18">
-      <code>$this-&gt;commentsManager</code>
-      <code>$this-&gt;commentsManager</code>
-      <code>$this-&gt;commentsManager</code>
-      <code>$this-&gt;commentsManager</code>
-      <code>$this-&gt;commentsManager</code>
-      <code>$this-&gt;commentsManager</code>
-      <code>$this-&gt;commentsManager</code>
-      <code>$this-&gt;commentsManager</code>
-      <code>$this-&gt;commentsManager</code>
-      <code>$this-&gt;commentsManager</code>
-      <code>$this-&gt;commentsManager</code>
-      <code>$this-&gt;commentsManager</code>
-      <code>$this-&gt;commentsManager</code>
-      <code>$this-&gt;commentsManager</code>
-      <code>$this-&gt;commentsManager</code>
-      <code>$this-&gt;commentsManager</code>
-      <code>CommentsManager</code>
-      <code>CommentsManager|ICommentsManager</code>
-    </MissingDependency>
     <UndefinedClass occurrences="1">
       <code>NullCache</code>
-    </UndefinedClass>
-    <UndefinedInterfaceMethod occurrences="3">
-      <code>getLastCommentBeforeDate</code>
-      <code>getNumberOfCommentsForObjectSinceComment</code>
-      <code>searchForObjects</code>
-    </UndefinedInterfaceMethod>
-  </file>
-  <file src="lib/Chat/CommentsManager.php">
-    <UndefinedClass occurrences="1">
-      <code>Manager</code>
     </UndefinedClass>
   </file>
   <file src="lib/Chat/MessageParser.php">
@@ -293,12 +256,6 @@
   </file>
   <file src="lib/Manager.php">
     <InvalidArgument occurrences="4"/>
-    <MissingDependency occurrences="4">
-      <code>$this-&gt;commentsManager</code>
-      <code>$this-&gt;commentsManager</code>
-      <code>CommentsManager</code>
-      <code>CommentsManager</code>
-    </MissingDependency>
   </file>
   <file src="lib/MatterbridgeManager.php">
     <UndefinedClass occurrences="4">
@@ -516,10 +473,7 @@
       <code>$this-&gt;rooms</code>
       <code>$this-&gt;rooms</code>
     </InvalidPropertyAssignmentValue>
-    <MissingDependency occurrences="4">
-      <code>$this-&gt;commentManager</code>
-      <code>CommentsManager</code>
-      <code>CommentsManager</code>
+    <MissingDependency occurrences="1">
       <code>ShareNotFound</code>
     </MissingDependency>
   </file>

--- a/tests/stubs/oc_comments_manager.php
+++ b/tests/stubs/oc_comments_manager.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace OC\Comments {
+	class Manager implements \OCP\Comments\ICommentsManager {
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/spreed/issues/4481

The application's container will now always map ICommentsManager to
the app's CommentsManager instance instead of the one from server.

All the usages were replaced to use ICommentsManager now except for
lib/Manager which requires access to the extra method.

This made it possible to reduce the number of skipped Psalm warnings and
made sure there is no possible mix up of manager classes.

Signed-off-by: Vincent Petry <vincent@nextcloud.com>