### PR TITLE
Auto-rename pasted files

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -337,7 +337,7 @@ export default {
 			// Create a unique id for the upload operation
 			const uploadId = new Date().getTime()
 			// Uploads and shares the files
-			await processFiles(files, this.token, uploadId)
+			await processFiles(files, this.token, uploadId, true)
 		},
 
 		/**

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -231,7 +231,7 @@ const actions = {
 			// userRoot path
 			const userRoot = '/files/' + getters.getUserId()
 			// Candidate rest of the path
-			const path = getters.getAttachmentFolder() + '/' + currentFile.name
+			const path = getters.getAttachmentFolder() + '/' + (currentFile.newName || currentFile.name)
 			// Get a unique relative path based on the previous path variable
 			const uniquePath = await findUniquePath(client, userRoot, path)
 			try {

--- a/src/utils/temporaryMessage.js
+++ b/src/utils/temporaryMessage.js
@@ -36,7 +36,7 @@ const createTemporaryMessage = (text, token, uploadId, index, file, localUrl) =>
 			'file': file,
 			'mimetype': file.type,
 			'id': tempId,
-			'name': file.name,
+			'name': file.newName || file.name,
 			// index, will be the id from now on
 			uploadId,
 			localUrl,


### PR DESCRIPTION
Use the modified date and extension from the file itself
to generate a new file name.

This is a better alternative than accepting the default name
"image.png".

Fixes https://github.com/nextcloud/spreed/issues/3543

<img width="322" alt="image" src="https://user-images.githubusercontent.com/277525/97472313-0198d680-194a-11eb-86b6-be8411051a15.png">
