### PR TITLE
[stable20] Update nextcloud-vue from 2.6.8 to 2.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3325,24 +3325,29 @@
 			}
 		},
 		"@nextcloud/vue": {
-			"version": "2.6.8",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-2.6.8.tgz",
-			"integrity": "sha512-9yi9V4gX4Y1uxh2hNxCAlTHaS9zolzAy7x1sowII/WZfxMysF/yIGmEsnYGyz6CZ5eYCzxNUgrU5p/HQ21/09Q==",
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-2.8.2.tgz",
+			"integrity": "sha512-1k4tWcmGj/zHql9nLFRV6y6pJPxqGveTScT0oNvqaPP5zesOBZbge4z+xsuPdOlHWsl26q/r8UyaYFqE09yNXw==",
 			"requires": {
 				"@nextcloud/auth": "^1.2.3",
 				"@nextcloud/axios": "^1.3.2",
+				"@nextcloud/browser-storage": "^0.1.1",
 				"@nextcloud/capabilities": "^1.0.2",
-				"@nextcloud/dialogs": "^2.0.1",
+				"@nextcloud/dialogs": "^3.0.0",
 				"@nextcloud/event-bus": "^1.1.4",
 				"@nextcloud/l10n": "^1.2.3",
 				"@nextcloud/router": "^1.0.2",
 				"core-js": "^3.6.5",
 				"debounce": "1.2.0",
-				"emoji-mart-vue-fast": "^7.0.4",
+				"emoji-mart-vue-fast": "^7.0.7",
+				"escape-html": "^1.0.3",
 				"hammerjs": "^2.0.8",
 				"linkifyjs": "~2.1.9",
 				"md5": "^2.2.1",
 				"regenerator-runtime": "^0.13.5",
+				"string-length": "^4.0.1",
+				"striptags": "^3.1.1",
+				"tributejs": "^5.1.3",
 				"v-click-outside": "^3.0.1",
 				"v-tooltip": "^2.0.3",
 				"vue": "^2.6.11",
@@ -3350,6 +3355,49 @@
 				"vue-multiselect": "^2.1.6",
 				"vue-visible": "^1.0.2",
 				"vue2-datepicker": "^3.6.2"
+			},
+			"dependencies": {
+				"@nextcloud/dialogs": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-3.0.0.tgz",
+					"integrity": "sha512-5FVP0RSxIpKTKdSUlQ4osDDz/oCx2/4+InliB5MX2EcrjDe6q3fZMabSGnFTnIAu0CXRTzBk7RpneaIFGv+d5A==",
+					"requires": {
+						"@nextcloud/l10n": "^1.3.0",
+						"@nextcloud/typings": "^1.0.0",
+						"core-js": "^3.6.4",
+						"toastify-js": "^1.9.1"
+					}
+				},
+				"@nextcloud/typings": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.0.0.tgz",
+					"integrity": "sha512-r8SRvXszWTyKWEhVd3gx7eBAcCKwdoLlr+ZrR8hrSxs2nfH00de/QoGdo0n/Rcv/9mMtX/haJNd71KwODM2+uQ==",
+					"requires": {
+						"@types/jquery": "2.0.54"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"string-length": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
+					"integrity": "sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==",
+					"requires": {
+						"char-regex": "^1.0.2",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				}
 			}
 		},
 		"@nextcloud/vue-dashboard": {
@@ -4120,13 +4168,12 @@
 					"dev": true
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -4534,39 +4581,38 @@
 					}
 				},
 				"vue-loader-v16": {
-					"version": "npm:vue-loader@16.0.0-beta.7",
-					"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.0.0-beta.7.tgz",
-					"integrity": "sha512-xQ8/GZmRPdQ3EinnE0IXwdVoDzh7Dowo0MowoyBuScEBXrRabw6At5/IdtD3waKklKW5PGokPsm8KRN6rvQ1cw==",
+					"version": "npm:vue-loader@16.0.0-beta.9",
+					"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.0.0-beta.9.tgz",
+					"integrity": "sha512-mu9pg6554GbXDSO8LlxkQM6qUJzUkb/A0FJc9LgRqnU9MCnhzEXwCt1Zx5NObvFpzs2mH2dH/uUCDwL8Qaz9sA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"@types/mini-css-extract-plugin": "^0.9.1",
-						"chalk": "^3.0.0",
+						"chalk": "^4.1.0",
 						"hash-sum": "^2.0.0",
-						"loader-utils": "^1.2.3",
-						"merge-source-map": "^1.1.0",
-						"source-map": "^0.6.1"
+						"loader-utils": "^2.0.0"
 					},
 					"dependencies": {
-						"@types/mini-css-extract-plugin": {
-							"version": "0.9.1",
-							"resolved": "https://registry.npmjs.org/@types/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.1.tgz",
-							"integrity": "sha512-+mN04Oszdz9tGjUP/c1ReVwJXxSniLd7lF++sv+8dkABxVNthg6uccei+4ssKxRHGoMmPxdn7uBdJWONSJGTGQ==",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"@types/webpack": "*"
-							}
-						},
 						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+							"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 							"dev": true,
 							"optional": true,
 							"requires": {
 								"ansi-styles": "^4.1.0",
 								"supports-color": "^7.1.0"
+							}
+						},
+						"loader-utils": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+							"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"big.js": "^5.2.2",
+								"emojis-list": "^3.0.0",
+								"json5": "^2.1.2"
 							}
 						}
 					}
@@ -6741,6 +6787,11 @@
 				"supports-color": "^5.3.0"
 			}
 		},
+		"char-regex": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="
+		},
 		"character-entities": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
@@ -8833,9 +8884,9 @@
 			}
 		},
 		"emoji-mart-vue-fast": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-7.0.5.tgz",
-			"integrity": "sha512-+ayg30hhxqqM9oMtN9uUG470hT9gtOdFenByJJBm3XTfzI2QMVJ69euwk+xF55OphLfKZxQG7mnVz13lDOjb3g==",
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-7.0.7.tgz",
+			"integrity": "sha512-Nrk4IOjKcKKYyMnRm4lreEiPpvDX+h3FKI86SYs05dCFZ0WZIMTGok26dtWvJqseTThS1UghsNEjM4HrfDjIJg==",
 			"requires": {
 				"@babel/polyfill": "7.2.5",
 				"@babel/runtime": "7.3.4",
@@ -18785,6 +18836,11 @@
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 			"dev": true
 		},
+		"striptags": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
+			"integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
+		},
 		"style-loader": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.3.0.tgz",
@@ -19943,6 +19999,11 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"tributejs": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/tributejs/-/tributejs-5.1.3.tgz",
+			"integrity": "sha512-B5CXihaVzXw+1UHhNFyAwUTMDk1EfoLP5Tj1VhD9yybZ1I8DZJEv8tZ1l0RJo0t0tk9ZhR8eG5tEsaCvRigmdQ=="
+		},
 		"trim": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -20819,9 +20880,9 @@
 			"integrity": "sha512-yaX2its9XAJKGuQqf7LsiZHHSkxsIK8rmCOQOvEGEoF41blKRK8qr9my4qYoD6ikdLss4n8tKqYBecmaY0+WJg=="
 		},
 		"vue2-datepicker": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/vue2-datepicker/-/vue2-datepicker-3.6.2.tgz",
-			"integrity": "sha512-J2fCwUmCxIOPUvwQ12e8evFY9cCv6vJmgxRD9fGeUv6JeMMeLwkdpeQZOcqbMf/4mk1cSrY2/9Fr8DaB30LBpA==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/vue2-datepicker/-/vue2-datepicker-3.7.0.tgz",
+			"integrity": "sha512-XB5slJZLXf3sbPIOMxjYPw2UlOI/utX4cHGQwGvRQqyiKzwpsGlPI6M3zUGw412Sm2tv2jMkXd9+k+yOSRf2OQ==",
 			"requires": {
 				"date-fns": "^2.0.1",
 				"date-format-parse": "^0.2.5"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"@nextcloud/l10n": "^1.4.1",
 		"@nextcloud/moment": "^1.1.1",
 		"@nextcloud/router": "^1.2.0",
-		"@nextcloud/vue": "^2.6.8",
+		"@nextcloud/vue": "^2.8.2",
 		"@nextcloud/vue-dashboard": "^1.0.1",
 		"attachmediastream": "^2.1.0",
 		"crypto-js": "^4.0.0",

--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -47,6 +47,19 @@ import usernameToColor from '@nextcloud/vue/dist/Functions/usernameToColor'
 import { generateUrl } from '@nextcloud/router'
 import { ResizeObserver } from 'vue-resize'
 
+// note: this info is shared with the Avatar component
+function getUserHasAvatar(userId) {
+	const flag = window.sessionStorage.getItem('userHasAvatar-' + userId)
+	if (typeof flag === 'string') {
+		return Boolean(flag)
+	}
+	return null
+}
+
+function setUserHasAvatar(userId, flag) {
+	window.sessionStorage.setItem('userHasAvatar-' + userId, flag)
+}
+
 export default {
 	name: 'VideoBackground',
 	components: {
@@ -96,10 +109,20 @@ export default {
 			return
 		}
 
+		// check if hasAvatar info is already known
+		const userHasAvatar = getUserHasAvatar(this.user)
+		if (typeof userHasAvatar === 'boolean') {
+			this.hasPicture = userHasAvatar
+			return
+		}
+
 		try {
 			const response = await axios.get(generateUrl(`avatar/${this.user}/300`))
 			if (response.headers[`x-nc-iscustomavatar`] === '1') {
 				this.hasPicture = true
+				setUserHasAvatar(this.user, true)
+			} else {
+				setUserHasAvatar(this.user, false)
 			}
 		} catch (exception) {
 			console.debug(exception)

--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -46,10 +46,13 @@ import axios from '@nextcloud/axios'
 import usernameToColor from '@nextcloud/vue/dist/Functions/usernameToColor'
 import { generateUrl } from '@nextcloud/router'
 import { ResizeObserver } from 'vue-resize'
+import { getBuilder } from '@nextcloud/browser-storage'
+
+const browserStorage = getBuilder('nextcloud').persist().build()
 
 // note: this info is shared with the Avatar component
 function getUserHasAvatar(userId) {
-	const flag = window.sessionStorage.getItem('userHasAvatar-' + userId)
+	const flag = browserStorage.getItem('user-has-avatar.' + userId)
 	if (typeof flag === 'string') {
 		return Boolean(flag)
 	}
@@ -57,7 +60,7 @@ function getUserHasAvatar(userId) {
 }
 
 function setUserHasAvatar(userId, flag) {
-	window.sessionStorage.setItem('userHasAvatar-' + userId, flag)
+	browserStorage.setItem('user-has-avatar.' + userId, flag)
 }
 
 export default {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/spreed/issues/4501

Brings in:
- fix for high energy impact: https://github.com/nextcloud/spreed/issues/4501
- fix for avatar flickering (caching hasAvatar): https://github.com/nextcloud/spreed/issues/4284
- backport of background avatar flickering: https://github.com/nextcloud/spreed/pull/4379 (because it goes with the above)

Regression testing:
- [x] smoke test dialogs, like settings
- [x] smoke test emoji picker
- [x] app sidebar padding / scrolling / loading state

Test for additions:
- [x] energy impact low
- [x] avatar caching works: no more flickering