### PR TITLE
Remember call view state during presentation

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -336,14 +336,18 @@ export default {
 		'callParticipantModelsWithScreen': function(newValue, previousValue) {
 			// Everytime a new screen is shared, switch to promoted view
 			if (newValue.length > previousValue.length) {
-
-				this.$store.dispatch('isGrid', false)
+				this.$store.dispatch('startPresentation')
+			} else if (newValue.length === 0 && previousValue.length > 0) {
+				// last screen share stopped, reopening stripe
+				this.$store.dispatch('stopPresentation')
 			}
 		},
 		'showLocalScreen': function(showLocalScreen) {
 			// Everytime the local screen is shared, switch to promoted view
 			if (showLocalScreen) {
-				this.$store.dispatch('isGrid', false)
+				this.$store.dispatch('startPresentation')
+			} else {
+				this.$store.dispatch('stopPresentation')
 			}
 		},
 		'hasLocalVideo': function(newValue) {
@@ -512,7 +516,7 @@ export default {
 			this.videoContainerAspectRatio = videoContainerWidth / VideoContainerHeight
 		},
 		handleSelectVideo(peerId) {
-			this.$store.dispatch('isGrid', false)
+			this.$store.dispatch('setCallViewMode', { isGrid: false })
 			this.$store.dispatch('selectedVideoPeerId', peerId)
 			this.isLocalVideoSelected = false
 		},
@@ -523,7 +527,7 @@ export default {
 			}
 			// Deselect possible selected video
 			this.$store.dispatch('selectedVideoPeerId', 'local')
-			this.$store.dispatch('isGrid', false)
+			this.$store.dispatch('setCallViewMode', { isGrid: false })
 		},
 	},
 }

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -23,7 +23,7 @@
 	<div class="grid-main-wrapper" :class="{'is-grid': !isStripe, 'transparent': isLessThanTwo}">
 		<button v-if="isStripe"
 			class="stripe--collapse"
-			@click="stripeOpen = !stripeOpen">
+			@click="handleClickStripeCollapse">
 			<ChevronDown
 				v-if="stripeOpen"
 				fill-color="#ffffff"
@@ -269,8 +269,6 @@ export default {
 			showVideoOverlay: true,
 			// Timer for the videos bottom bar
 			showVideoOverlayTimer: null,
-			// Whether the stripe is open (true) or collapsed (false)
-			stripeOpen: true,
 		}
 	},
 
@@ -407,6 +405,10 @@ export default {
 		// Blur radius for each background in the grid
 		videoBackgroundBlur() {
 			return this.$store.getters.getBlurFilter(this.videoWidth, this.videoHeight)
+		},
+
+		stripeOpen() {
+			return this.$store.getters.isStripeOpen
 		},
 	},
 
@@ -665,6 +667,10 @@ export default {
 			console.debug('handleclickprevious, ', 'currentPage ', this.currentPage, 'slots ', this.slots, 'videos.length ', this.videos.length)
 			this.displayedVideos = this.videos.slice((this.currentPage) * this.slots, (this.currentPage + 1) * this.slots)
 			console.debug('slicevalues', (this.currentPage) * this.slots, (this.currentPage + 1) * this.slots)
+		},
+
+		handleClickStripeCollapse() {
+			this.$store.dispatch('setCallViewMode', { isStripeOpen: !this.stripeOpen })
 		},
 
 		handleMovement() {

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -440,7 +440,7 @@ export default {
 		},
 
 		changeView() {
-			this.$store.dispatch('isGrid', !this.isGrid)
+			this.$store.dispatch('setCallViewMode', { isGrid: !this.isGrid })
 			this.$store.dispatch('selectedVideoPeerId', null)
 			this.showLayoutHint = false
 		},


### PR DESCRIPTION
When a presentation starts (screen share), remember the grid + stripe
state then switch to presenter mode (no grid + no stripe).

When the presentation stops (last screen share stops), restores the grid
+ stripe state, unless the user has changed the state during the
presentation.

Stripe mode is now also remembered for each call.

Fixes https://github.com/nextcloud/spreed/issues/4441

- [x] will conflict with https://github.com/nextcloud/spreed/pull/4542, let's wait for the latter to be merged
