### PR TITLE
Fix message list scroll container in sidebar

### DIFF
--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -43,7 +43,8 @@
 			</div>
 		</transition>
 		<MessagesList
-			:token="token" />
+			:token="token"
+			:scroll-container="scrollContainer" />
 		<NewMessageForm />
 	</div>
 </template>
@@ -67,6 +68,17 @@ export default {
 		token: {
 			type: String,
 			required: true,
+		},
+
+		/**
+		 * The scroll container.
+		 *
+		 * Can be different depending on containment
+		 */
+		scrollContainer: {
+			type: HTMLElement,
+			required: false,
+			default: null,
 		},
 	},
 

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -37,10 +37,11 @@
 		<AppSidebarTab
 			v-if="showChatInSidebar"
 			id="chat"
+			ref="chatTab"
 			:order="1"
 			:name="t('spreed', 'Chat')"
 			icon="icon-comment">
-			<ChatView :token="token" />
+			<ChatView :token="token" :scroll-container="scrollContainer" />
 		</AppSidebarTab>
 		<AppSidebarTab v-if="getUserId"
 			id="participants"
@@ -124,6 +125,16 @@ export default {
 	},
 
 	computed: {
+		scrollContainer() {
+			// note: these conditions are needed for reactivity to make sure
+			// the chatTab is actually rendered at this time
+			if (this.opened && this.showChatInSidebar && this.$refs.chatTab) {
+				return this.$refs.chatTab.$el
+			} else {
+				return null
+			}
+		},
+
 		show() {
 			return this.$store.getters.getSidebarStatus
 		},


### PR DESCRIPTION
When embedded into the right sidebar, the scrolling is achieved by a
parent element instead of the MessagesList itself.

To be able to listen to and control the scrolling, now a reference to
the scroll container is passed in.

Fixes https://github.com/nextcloud/spreed/issues/4527

This issue was due to the recent changes in scrollbar containment in the sidebar.

### Manual tests
#### Scrolling
- [x] scroll up in main chat view: chevron-down button appears
- [x] scroll up in call sidebar chat view: chevron-down button appears
- [ ] scroll up in files sidebar chat view: chevron-down button appears
- [x] auto scroll to bottom works in main chat view (sticky)
- [x] auto scroll to bottom works in call sidebar chat view (sticky)
- [ ] auto scroll to bottom works in files sidebar chat view (sticky)

#### Layout
- [ ] call sidebar has proper height when few messages
- [ ] files sidebar has proper height when few messages