### PR TITLE
Fix sidebar chat scroll container + size

### DIFF
--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -131,10 +131,12 @@ export default {
 
 <style lang="scss" scoped>
 .chatView {
+	width: 100%;
 	height: 100%;
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;
+	position: absolute;
 }
 
 .dragover {


### PR DESCRIPTION
This brings back the scrolling behavior to the "scroller" element, so
that the matching logic can rely on it.

This also makes the message form align to the bottom whenever there are
not enough chat messages to expand the container vertically.

Fixes https://github.com/nextcloud/spreed/issues/4527
Obsoletes https://github.com/nextcloud/spreed/pull/4529
