### PR TITLE
Rework scroll into view of conversation after post

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
@@ -75,13 +75,25 @@ export default {
 
 	mounted() {
 		EventBus.$on('routeChange', this.onRouteChange)
+		EventBus.$on('newMessagePosted', this.onMessagePosted)
 	},
 
 	beforeDestroy() {
 		EventBus.$off('routeChange', this.onRouteChange)
+		EventBus.$off('newMessagePosted', this.onMessagePosted)
 	},
 
 	methods: {
+		onMessagePosted({ token }) {
+			const conversation = document.getElementById(`conversation_${token}`)
+			this.$nextTick(() => {
+				conversation.scrollIntoView({
+					behavior: 'smooth',
+					block: 'start',
+					inline: 'nearest',
+				})
+			})
+		},
 		onRouteChange({ from, to }) {
 			if (from.name === 'conversation') {
 				leaveConversation(from.params.token)

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -180,15 +180,7 @@ export default {
 		},
 	},
 
-	watch: {
-		token(newValue, oldValue) {
-			this.isCurrentConversationIsFirstInList()
-		},
-	},
-
 	mounted() {
-		this.isCurrentConversationIsFirstInList()
-
 		EventBus.$on('uploadStart', this.handleUploadStart)
 	},
 
@@ -271,16 +263,7 @@ export default {
 					// by the server
 					this.$store.dispatch('processMessage', response.data.ocs.data)
 					// Scrolls the conversationlist to conversation
-					if (!this.conversationIsFirstInList) {
-						const conversation = document.getElementById(`conversation_${this.token}`)
-						this.$nextTick(() => {
-							conversation.scrollIntoView({
-								behavior: 'smooth',
-								block: 'center',
-								inline: 'nearest',
-							})
-						})
-					}
+					EventBus.$emit('newMessagePosted', { token: this.token, message: temporaryMessage })
 				} catch (error) {
 					let statusCode = null
 					console.debug(`error while submitting message ${error}`, error)
@@ -386,12 +369,6 @@ export default {
 			this.text = contentEditable.innerHTML
 
 			range.setStartAfter(emojiTextNode)
-		},
-
-		// Check whether the current conversation is the first in the conversations
-		// list and stores the value in the component's data.
-		isCurrentConversationIsFirstInList() {
-			this.conversationIsFirstInList = this.$store.getters.conversationsList.map(conversation => conversation.token).indexOf(this.token) === 0
 		},
 	},
 }


### PR DESCRIPTION
Fixes an issue where a chat in the files sidebar would trigger a warning
because the conversation list element don't exist there. See https://github.com/nextcloud/spreed/pull/4291#issuecomment-708979771

When posting a message, an event is now triggered so other components
could react on it.

The conversation list will now take the responsibility of scrolling the
current conversation into view after posting, instead of the
NewMessageForm.

The behavior is also adjusted to always scroll regardless where the
conversation is located in the list.

@ma12-co not sure why this was limited to only when it moves to the top.
I tested also by clicking on a conversation at the bottom of list, then scrolling up, then posting: it will now scroll down to highlight the conversation even when at the bottom.

Note: I don't understand when a conversation moves to the top and when not, it seemed to be random in my tests... could be another bug.