### PR TITLE
Move the filename of attachments to a tooltip

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -29,17 +29,20 @@
 		@click="handleClick"
 		@keydown.enter="handleClick">
 		<img v-if="(!isLoading && !failed)"
+			v-tooltip.auto="previewTooltip"
 			:class="previewImageClass"
 			class="file-preview__image"
 			alt=""
 			:src="previewUrl">
 		<img v-if="!isLoading && failed"
+			v-tooltip.auto="previewTooltip"
 			:class="previewImageClass"
 			alt=""
 			:src="defaultIconUrl">
 		<span v-if="isLoading"
+			v-tooltip.auto="previewTooltip"
 			class="preview loading" />
-		<strong>{{ name }}</strong>
+		<strong v-if="isUploadEditor">{{ name }}</strong>
 		<button v-if="isUploadEditor"
 			tabindex="1"
 			:aria-label="removeAriaLabel"
@@ -53,6 +56,7 @@
 <script>
 import { generateUrl, imagePath, generateRemoteUrl } from '@nextcloud/router'
 import ProgressBar from '@nextcloud/vue/dist/Components/ProgressBar'
+import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 import Close from 'vue-material-design-icons/Close'
 import { getCapabilities } from '@nextcloud/capabilities'
 
@@ -69,6 +73,10 @@ export default {
 	components: {
 		ProgressBar,
 		Close,
+	},
+
+	directives: {
+		tooltip: Tooltip,
 	},
 
 	props: {
@@ -139,6 +147,13 @@ export default {
 		}
 	},
 	computed: {
+		previewTooltip() {
+			if (this.isUploadEditor) {
+				// no tooltip as the file name is already visible directly
+				return null
+			}
+			return this.name
+		},
 		// This is used to decide which outer element type to use
 		// a or div
 		filePreview() {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -35,14 +35,13 @@
 			alt=""
 			:src="previewUrl">
 		<img v-if="!isLoading && failed"
-			v-tooltip.auto="previewTooltip"
 			:class="previewImageClass"
 			alt=""
 			:src="defaultIconUrl">
 		<span v-if="isLoading"
 			v-tooltip.auto="previewTooltip"
 			class="preview loading" />
-		<strong v-if="isUploadEditor">{{ name }}</strong>
+		<strong v-if="shouldShowFileName">{{ name }}</strong>
 		<button v-if="isUploadEditor"
 			tabindex="1"
 			:aria-label="removeAriaLabel"
@@ -147,8 +146,22 @@ export default {
 		}
 	},
 	computed: {
+		shouldShowFileName() {
+			// display the file name below the preview if the preview
+			// is not easily recognizable, when:
+			return (
+				// the file is not an image
+				!this.mimetype.startsWith('image/')
+				// the image has no preview (ex: disabled on server)
+				|| (this.previewAvailable !== 'yes' && !this.localUrl)
+				// the preview failed loading
+				|| this.failed
+				// always show in upload editor
+				|| this.isUploadEditor
+			)
+		},
 		previewTooltip() {
-			if (this.isUploadEditor) {
+			if (this.shouldShowFileName) {
 				// no tooltip as the file name is already visible directly
 				return null
 			}

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -29,7 +29,7 @@
 		@click="handleClick"
 		@keydown.enter="handleClick">
 		<img v-if="(!isLoading && !failed)"
-			v-tooltip.auto="previewTooltip"
+			v-tooltip="previewTooltip"
 			:class="previewImageClass"
 			class="file-preview__image"
 			alt=""
@@ -39,7 +39,7 @@
 			alt=""
 			:src="defaultIconUrl">
 		<span v-if="isLoading"
-			v-tooltip.auto="previewTooltip"
+			v-tooltip="previewTooltip"
 			class="preview loading" />
 		<strong v-if="shouldShowFileName">{{ name }}</strong>
 		<button v-if="isUploadEditor"
@@ -165,7 +165,11 @@ export default {
 				// no tooltip as the file name is already visible directly
 				return null
 			}
-			return this.name
+			return {
+				content: this.name,
+				delay: { show: 500 },
+				placement: 'left',
+			}
 		},
 		// This is used to decide which outer element type to use
 		// a or div


### PR DESCRIPTION
Instead of displaying file names below attachments in a conversations,
like for images, it is now displayed only on hover in a tooltip.

Howver, in the upload editor the file names are still shown as they can
be helpful in that situation.

This cleans up the message list a bit and also solves some layout issues
with images in narrow views like the sidebar.

~~Fixes https://github.com/nextcloud/spreed/issues/4494~~ the latter ticket will still exist for cases where file name is visible

<img width="298" alt="image" src="https://user-images.githubusercontent.com/277525/98142037-98740e80-1ec7-11eb-83f8-eaeb3471c142.png">
