### PR TITLE
Fix mime icon and failed icon height

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -29,12 +29,13 @@
 		@click="handleClick"
 		@keydown.enter="handleClick">
 		<img v-if="(!isLoading && !failed)"
-			:class="previewSizeClass"
+			:class="previewImageClass"
 			class="file-preview__image"
 			alt=""
 			:src="previewUrl">
 		<img v-if="!isLoading && failed"
-			:class="previewSizeClass"
+			class="mimeicon"
+			:class="previewImageClass"
 			alt=""
 			:src="defaultIconUrl">
 		<span v-if="isLoading"
@@ -159,11 +160,18 @@ export default {
 		defaultIconUrl() {
 			return imagePath('core', 'filetypes/file')
 		},
-		previewSizeClass() {
+		previewImageClass() {
+			let classes = ''
 			if (this.previewSize === 64) {
-				return 'preview-64'
+				classes += 'preview-64 '
+			} else {
+				classes += 'preview '
 			}
-			return 'preview'
+
+			if (this.previewType === PREVIEW_TYPE.MIME_ICON) {
+				classes += 'mimeicon'
+			}
+			return classes
 		},
 		previewType() {
 			if (this.hasTemporaryImageUrl) {
@@ -356,6 +364,10 @@ export default {
 		border-radius: var(--border-radius);
 		max-width: 100%;
 		max-height: 64px;
+	}
+
+	.mimeicon {
+		min-height: 120px;
 	}
 
 	strong {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -34,7 +34,6 @@
 			alt=""
 			:src="previewUrl">
 		<img v-if="!isLoading && failed"
-			class="mimeicon"
 			:class="previewImageClass"
 			alt=""
 			:src="defaultIconUrl">
@@ -168,7 +167,7 @@ export default {
 				classes += 'preview '
 			}
 
-			if (this.previewType === PREVIEW_TYPE.MIME_ICON) {
+			if (this.failed || this.previewType === PREVIEW_TYPE.MIME_ICON) {
 				classes += 'mimeicon'
 			}
 			return classes
@@ -192,13 +191,14 @@ export default {
 		previewUrl() {
 			const userId = this.$store.getters.getUserId()
 
-			switch (this.previewType) {
-			case PREVIEW_TYPE.TEMPORARY:
+			if (this.previewType === PREVIEW_TYPE.TEMPORARY) {
 				return this.localUrl
-			case PREVIEW_TYPE.MIME_ICON:
+			}
+			if (this.previewType === PREVIEW_TYPE.MIME_ICON) {
 				return OC.MimeType.getIconUrl(this.mimetype)
+			}
 			// whether to embed/render the file directly
-			case PREVIEW_TYPE.DIRECT:
+			if (this.previewType === PREVIEW_TYPE.DIRECT) {
 				// return direct image
 				if (userId === null) {
 					// guest mode, use public link download URL
@@ -367,7 +367,7 @@ export default {
 	}
 
 	.mimeicon {
-		min-height: 120px;
+		min-height: 128px;
 	}
 
 	strong {


### PR DESCRIPTION
Follow up to #4472 

## Description
- refactor preview type handling to make it more accessible instead of having to rely on multiple flags
- detect mime icon and failed cases and adjust the icon height accordingly

## Testing
### Steps
1. Create a text file "corrupt-image.txt" with some contents and rename to "corrupt-image.jpg"
1. Create another text file "data.dat"
1. Upload both to a converstion

### Before the fix
Tiny mime type icon and tiny failed icon

### After the fix
Bigger mime type icons

