### PR TITLE
Fix remembered grid state per call

### DIFF
--- a/src/store/callViewStore.js
+++ b/src/store/callViewStore.js
@@ -73,8 +73,8 @@ const actions = {
 		if (isGrid === null) {
 			const conversationType = context.getters.conversations[token].type
 			// default to grid view for group/public calls, otherwise speaker view
-			isGrid = (conversationType === CONVERSATION.GROUP
-				|| conversationType === CONVERSATION.PUBLIC)
+			isGrid = (conversationType === CONVERSATION.TYPE.GROUP
+				|| conversationType === CONVERSATION.TYPE.PUBLIC)
 		} else {
 			// BrowserStorage.getItem returns a string instead of a boolean
 			isGrid = (isGrid === 'true')

--- a/src/store/callViewStore.js
+++ b/src/store/callViewStore.js
@@ -75,6 +75,9 @@ const actions = {
 			// default to grid view for group/public calls, otherwise speaker view
 			isGrid = (conversationType === CONVERSATION.GROUP
 				|| conversationType === CONVERSATION.PUBLIC)
+		} else {
+			// BrowserStorage.getItem returns a string instead of a boolean
+			isGrid = (isGrid === 'true')
 		}
 		context.dispatch('isGrid', isGrid)
 	},


### PR DESCRIPTION
Follow up to #4451

- [ ] Ensure that calls in the sidebar are always in speaker mode, even if they were in grid mode in the main Talk UI
