### PR TITLE
Fix long participant name + status in participant list with tooltip

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -39,13 +39,15 @@
 			:offline="isOffline" />
 		<div class="participant-row__user-wrapper">
 			<div class="participant-row__user-descriptor">
-				<span class="participant-row__user-name">{{ computedName }}</span>
+				<span
+					v-tooltip.auto="userTooltip"
+					class="participant-row__user-name">{{ computedName }}</span>
 				<span v-if="showModeratorLabel" class="participant-row__moderator-indicator">({{ t('spreed', 'moderator') }})</span>
 				<span v-if="isGuest" class="participant-row__guest-indicator">({{ t('spreed', 'guest') }})</span>
 			</div>
-			<div v-if="getStatusMessage(participant)"
+			<div v-if="statusMessage"
 				class="participant-row__status">
-				<span>{{ getStatusMessage(participant) }}</span>
+				<span v-tooltip.auto="statusMessage">{{ statusMessage }}</span>
 			</div>
 		</div>
 		<div v-if="callIcon"
@@ -90,6 +92,7 @@
 <script>
 
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
+import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 import Actions from '@nextcloud/vue/dist/Components/Actions'
 import Microphone from 'vue-material-design-icons/Microphone'
 import Phone from 'vue-material-design-icons/Phone'
@@ -109,6 +112,10 @@ export default {
 		Microphone,
 		Phone,
 		Video,
+	},
+
+	directives: {
+		tooltip: Tooltip,
 	},
 
 	mixins: [
@@ -132,6 +139,21 @@ export default {
 	},
 
 	computed: {
+		userTooltip() {
+			let text = this.computedName
+			if (this.showModeratorLabel) {
+				text += ' (' + t('spreed', 'moderator') + ')'
+			}
+			if (this.isGuest) {
+				text += ' (' + t('spreed', 'guest') + ')'
+			}
+			return text
+		},
+
+		statusMessage() {
+			return this.getStatusMessage(this.participant)
+		},
+
 		/**
 		 * Check if the current participant belongs to the selected participants array
 		 * in the store
@@ -369,4 +391,5 @@ export default {
 		color: var(--color-text-maxcontrast);
 	}
 }
+
 </style>

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -318,7 +318,6 @@ export default {
 		flex-direction: column;
 	}
 	&__user-name {
-		display: inline-block;
 		vertical-align: middle;
 		line-height: normal;
 		cursor: pointer;
@@ -328,6 +327,11 @@ export default {
 		color: var(--color-text-maxcontrast);
 		font-weight: 300;
 		padding-left: 5px;
+	}
+	&__user-descriptor {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 	&__status {
 		color: var(--color-text-maxcontrast);
@@ -365,5 +369,4 @@ export default {
 		color: var(--color-text-maxcontrast);
 	}
 }
-
 </style>

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -38,16 +38,22 @@
 			:source="participant.source || participant.actorType"
 			:offline="isOffline" />
 		<div class="participant-row__user-wrapper">
-			<div class="participant-row__user-descriptor">
+			<div
+				ref="userName"
+				class="participant-row__user-descriptor"
+				@mouseover="updateUserNameNeedsTooltip()">
 				<span
-					v-tooltip.auto="userTooltip"
+					v-tooltip.auto="userTooltipText"
 					class="participant-row__user-name">{{ computedName }}</span>
 				<span v-if="showModeratorLabel" class="participant-row__moderator-indicator">({{ t('spreed', 'moderator') }})</span>
 				<span v-if="isGuest" class="participant-row__guest-indicator">({{ t('spreed', 'guest') }})</span>
 			</div>
-			<div v-if="statusMessage"
-				class="participant-row__status">
-				<span v-tooltip.auto="statusMessage">{{ statusMessage }}</span>
+			<div
+				v-if="statusMessage"
+				ref="statusMessage"
+				class="participant-row__status"
+				@mouseover="updateStatusNeedsTooltip()">
+				<span v-tooltip.auto="statusMessageTooltip">{{ statusMessage }}</span>
 			</div>
 		</div>
 		<div v-if="callIcon"
@@ -138,8 +144,18 @@ export default {
 		},
 	},
 
+	data() {
+		return {
+			isUserNameTooltipVisible: false,
+			isStatusTooltipVisible: false,
+		}
+	},
+
 	computed: {
-		userTooltip() {
+		userTooltipText() {
+			if (!this.isUserNameTooltipVisible) {
+				return false
+			}
 			let text = this.computedName
 			if (this.showModeratorLabel) {
 				text += ' (' + t('spreed', 'moderator') + ')'
@@ -152,6 +168,14 @@ export default {
 
 		statusMessage() {
 			return this.getStatusMessage(this.participant)
+		},
+
+		statusMessageTooltip() {
+			if (!this.isStatusTooltipVisible) {
+				return false
+			}
+
+			return this.statusMessage
 		},
 
 		/**
@@ -285,6 +309,16 @@ export default {
 	},
 
 	methods: {
+		updateUserNameNeedsTooltip() {
+			// check if ellipsized
+			const e = this.$refs.userName
+			this.isUserNameTooltipVisible = (e && e.offsetWidth < e.scrollWidth)
+		},
+		updateStatusNeedsTooltip() {
+			// check if ellipsized
+			const e = this.$refs.statusMessage
+			this.isStatusTooltipVisible = (e && e.offsetWidth < e.scrollWidth)
+		},
 		// Used to allow selecting participants in a search.
 		handleClick() {
 			if (this.isSearched) {


### PR DESCRIPTION
## Description

Added ellipsis on long participant names.
Added conditional tooltip on participant + status:
    
Whenever the participant name or status is ellipsized, a tooltip will be available for those entries.    
To check the "is ellipsized" condition, a ResizeObserver is used to update. To avoid trying to measure and update too many participants in the list, the observer only activates after 10+ characters, which is the limit of chinese characters that still fit within the sidebar minimum width of 300px.
Note that in the future once we use virtual scroll for the participant list, we likely won't need to worry about resize optimization.

Fixes https://github.com/nextcloud/spreed/issues/4500

## Tests
### Long status ellipsis + tooltip
<img width="226" alt="image" src="https://user-images.githubusercontent.com/277525/98358737-742f4380-2027-11eb-99b1-7ffa4fcf40cd.png">

### Long user name + tooltip
<img width="309" alt="image" src="https://user-images.githubusercontent.com/277525/98358795-87daaa00-2027-11eb-9353-2bff018ec3d0.png">

Note: if the user name has no space, the tooltip breaks the layout, this is a bug in the tooltip library and needs to be addressed there.

