### PR TITLE
Fix uploading same file twice in a row in Chromium

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -326,6 +326,10 @@ export default {
 			const files = Object.values(event.target.files)
 
 			this.handleFiles(files)
+
+			// Clear input to ensure that the change event will be emitted if
+			// the same file is picked again.
+			event.target.value = ''
 		},
 
 		/**


### PR DESCRIPTION
To upload files a hidden file input is "clicked", which shows the browser dialog to pick the files, and [the `change` event of the file input is listened to to know the selected files](https://github.com/nextcloud/spreed/blob/6a92e53b8c8556d25c5504ac7e3e414867438be0/src/components/NewMessageForm/NewMessageForm.vue#L31).

However, although Firefox always emits the `change` event when files are selected, Chromium only emits the `change` event if the selected files have changed since the last time. Due to this if a file was uploaded and then the same file was tried to be uploaded again nothing happened.

Now the value of the file input is cleared (which also clears the files from the file input) after the files are handled to ensure that there is no previous state when the browser dialog is shown again, and thus the selected files always change.

## How to test
- Open a conversation in Chromium
- Upload a file (or dismiss the Talk dialog to confirm the files to upload)
- Try to upload the same file again

### Result with this pull request

The Talk dialog to confirm the files is shown and the file can be uploaded.

### Result without this pull request

The browser dialog to select the files is shown, but not the Talk dialog to confirm the files.
