### PR TITLE
Add tooltip for long room names.

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -25,6 +25,7 @@
 		v-show="opened"
 		id="app-sidebar"
 		:title="title"
+		:title-tooltip="title"
 		:starred="isFavorited"
 		:title-editable="canModerate && isRenamingConversation"
 		:class="'active-tab-' + activeTab"


### PR DESCRIPTION
Added tooltip for room names in case they are too long.
Note: the tooltip appears regardless of length.

- [x] REQUIRES: https://github.com/nextcloud/nextcloud-vue/pull/1555
- [x] REQUIRES: https://github.com/nextcloud/spreed/pull/4567
- [ ] add "is tooltip necessary check" using the same approach like https://github.com/nextcloud/spreed/pull/4548/commits/40d87afa9046632f1a0d3a9ea26d6776614787ac