### PR TITLE
Don't remember grid mode in sidebar call

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -312,6 +312,11 @@ export default {
 		},
 	},
 	watch: {
+		isSidebar: (isSidebar) => {
+			// update matching store value
+			this.$store.dispatch('isSidebar', isSidebar)
+		},
+
 		localScreen: function(localScreen) {
 			this._setScreenAvailable(localCallParticipantModel.attributes.peerId, localScreen)
 		},
@@ -359,6 +364,9 @@ export default {
 		// Ensure that data is properly initialized before mounting the
 		// subviews.
 		this.updateDataFromCallParticipantModels(this.callParticipantModels)
+	},
+	mounted() {
+		this.$store.dispatch('isSidebar', this.isSidebar)
 	},
 	methods: {
 		/**

--- a/src/store/callViewStore.js
+++ b/src/store/callViewStore.js
@@ -27,6 +27,7 @@ import {
 
 const state = {
 	isGrid: false,
+	isSidebar: false,
 	selectedVideoPeerId: null,
 	videoBackgroundBlur: 1,
 }
@@ -34,6 +35,9 @@ const state = {
 const getters = {
 	isGrid: (state) => {
 		return state.isGrid
+	},
+	isSidebar: (state) => {
+		return state.isSidebar
 	},
 	selectedVideoPeerId: (state) => {
 		return state.selectedVideoPeerId
@@ -48,6 +52,9 @@ const mutations = {
 	isGrid(state, value) {
 		state.isGrid = value
 	},
+	isSidebar(state, value) {
+		state.isSidebar = value
+	},
 	selectedVideoPeerId(state, value) {
 		state.selectedVideoPeerId = value
 	},
@@ -61,14 +68,22 @@ const actions = {
 	 * @param {bool} value true for enabled grid mode, false for speaker view;
 	 */
 	isGrid(context, value) {
-		BrowserStorage.setItem('callprefs-' + context.getters.getToken() + '-isgrid', value)
+		if (!context.getters.isSidebar()) {
+			BrowserStorage.setItem('callprefs-' + context.getters.getToken() + '-isgrid', value)
+		}
 		context.commit('isGrid', value)
+	},
+	isSidebar(context, value) {
+		context.commit('isSidebar', value)
 	},
 	selectedVideoPeerId(context, value) {
 		context.commit('selectedVideoPeerId', value)
 	},
 
 	joinCall(context, { token }) {
+		if (context.getters.isSidebar()) {
+			context.dispatch('isGrid', false)
+		}
 		let isGrid = BrowserStorage.getItem('callprefs-' + token + '-isgrid')
 		if (isGrid === null) {
 			const conversationType = context.getters.conversations[token].type


### PR DESCRIPTION
Always use speaker mode in sidebar calls, regardless what preference was
stored.

To test, merge with https://github.com/nextcloud/spreed/pull/4291

Not sure if this is enough. Strangely I see a black background for the other participant, regardless whether they joined or not (waiting), maybe there's more that needs fixing:
<img width="292" alt="image" src="https://user-images.githubusercontent.com/277525/98675831-110d1c00-235b-11eb-8199-bb3e9207cdef.png">

and the vuex inspector does tell me that we are not in grid mode.
Not sure what the expected behavior is here, I'll need to compare with Talk 10.0

@danxuliu 