### PR TITLE
Highlight quote after scrolling to it

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -457,9 +457,12 @@ export default {
 	margin: -6px 0;
 }
 
+.hover, .highlight-animation {
+	border-radius: 8px;
+}
+
 .hover {
 	background-color: var(--color-background-hover);
-	border-radius: 8px;
 }
 
 .highlight-animation {

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -463,12 +463,12 @@ export default {
 }
 
 .highlight-animation {
-	animation: highlight-animation 2s 1;
+	animation: highlight-animation 5s 1;
 }
 
-// TODO: define these colors globally (these are borrowed from the files app upload.css)
 @keyframes highlight-animation {
-	0% { background-color: rgba(255, 255, 140, 1); }
-	100% { background-color: rgba(0, 0, 0, 0); }
+	0% { background-color: var(--color-background-hover); }
+	50% { background-color: var(--color-background-hover); }
+	100% { background-color: rgba(var(--color-background-hover), 0); }
 }
 </style>

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -27,6 +27,7 @@ the main body of the message as well as a quote.
 <template>
 	<div
 		:id="`message_${id}`"
+		ref="message"
 		class="message"
 		:class="{'hover': showActions && !isSystemMessage, 'system' : isSystemMessage}"
 		@mouseover="showActions=true"
@@ -336,9 +337,30 @@ export default {
 		if (this.$refs.messageMain.clientHeight > 44) {
 			this.isTallEnough = true
 		}
+
+		// define a function so it can be triggered directly on the DOM element
+		// which can be found with document.getElementById()
+		this.$refs.message.highlightAnimation = () => {
+			this.highlightAnimation()
+		}
+
+		this.$refs.message.addEventListener('animationend', this.highlightAnimationStop)
+	},
+
+	beforeDestroy() {
+		this.$refs.message.removeEventListener('animationend', this.highlightAnimationStop)
 	},
 
 	methods: {
+		highlightAnimation() {
+			// trigger CSS highlight animation by setting a class
+			this.$refs.message.classList.add('highlight-animation')
+		},
+		highlightAnimationStop() {
+			// when the animation ended, remove the class so we can trigger it
+			// again another time
+			this.$refs.message.classList.remove('highlight-animation')
+		},
 		handleReply() {
 			this.$store.dispatch('addMessageToBeReplied', {
 				id: this.id,
@@ -438,5 +460,15 @@ export default {
 .hover {
 	background-color: var(--color-background-hover);
 	border-radius: 8px;
+}
+
+.highlight-animation {
+	animation: highlight-animation 2s 1;
+}
+
+// TODO: define these colors globally (these are borrowed from the files app upload.css)
+@keyframes highlight-animation {
+	0% { background-color: rgba(255, 255, 140, 1); }
+	100% { background-color: rgba(0, 0, 0, 0); }
 }
 </style>

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -234,6 +234,7 @@ export default {
 		EventBus.$on('scrollChatToBottom', this.handleScrollChatToBottomEvent)
 		EventBus.$on('smoothScrollChatToBottom', this.smoothScrollToBottom)
 		EventBus.$on('focusMessage', this.focusMessage)
+		EventBus.$on('routeChange', this.onRouteChange)
 		subscribe('networkOffline', this.handleNetworkOffline)
 		subscribe('networkOnline', this.handleNetworkOnline)
 	},
@@ -241,6 +242,7 @@ export default {
 		EventBus.$off('scrollChatToBottom', this.handleScrollChatToBottomEvent)
 		EventBus.$off('smoothScrollChatToBottom', this.smoothScrollToBottom)
 		EventBus.$off('focusMessage', this.focusMessage)
+		EventBus.$off('routeChange', this.onRouteChange)
 
 		this.cancelLookForNewMessages()
 		// Prevent further lookForNewMessages requests after the component was
@@ -621,7 +623,7 @@ export default {
 			this.$nextTick(async() => {
 				await element.scrollIntoView({
 					behavior: smooth ? 'smooth' : 'auto',
-					block: 'center',
+					block: 'start',
 					inline: 'nearest',
 				})
 				element.focus()
@@ -664,6 +666,20 @@ export default {
 		handleNetworkOnline() {
 			console.debug('Restarting polling of new chat messages')
 			this.getNewMessages()
+		},
+
+		onRouteChange({ from, to }) {
+			if (from.name === 'conversation'
+				&& to.name === 'conversation'
+				&& from.token === to.token
+				&& from.hash !== to.hash) {
+
+				// the hash changed, need to focus/highlight another message
+				if (to.hash && to.hash.startsWith('#message_')) {
+					// scroll to message in URL anchor
+					this.focusMessage(to.hash.substr(9), true)
+				}
+			}
 		},
 	},
 }

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -233,12 +233,14 @@ export default {
 		this.scrollToBottom()
 		EventBus.$on('scrollChatToBottom', this.handleScrollChatToBottomEvent)
 		EventBus.$on('smoothScrollChatToBottom', this.smoothScrollToBottom)
+		EventBus.$on('focusMessage', this.focusMessage)
 		subscribe('networkOffline', this.handleNetworkOffline)
 		subscribe('networkOnline', this.handleNetworkOnline)
 	},
 	beforeDestroy() {
 		EventBus.$off('scrollChatToBottom', this.handleScrollChatToBottomEvent)
 		EventBus.$off('smoothScrollChatToBottom', this.smoothScrollToBottom)
+		EventBus.$off('focusMessage', this.focusMessage)
 
 		this.cancelLookForNewMessages()
 		// Prevent further lookForNewMessages requests after the component was
@@ -589,6 +591,29 @@ export default {
 				this.isScrolledToBottom = true
 			})
 
+		},
+
+		/**
+		 * Temporarily highlight the given message id with a fade out effect.
+		 *
+		 * @param {string} messageId message id
+		 */
+		focusMessage(messageId) {
+			const element = document.getElementById(`message_${messageId}`)
+			if (!element) {
+				console.warn('Message to focus not found in DOM', messageId)
+				return
+			}
+
+			this.$nextTick(async() => {
+				await element.scrollIntoView({
+					behavior: 'smooth',
+					block: 'center',
+					inline: 'nearest',
+				})
+				element.focus()
+				element.highlightAnimation()
+			})
 		},
 
 		/**

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -623,7 +623,7 @@ export default {
 			this.$nextTick(async() => {
 				await element.scrollIntoView({
 					behavior: smooth ? 'smooth' : 'auto',
-					block: 'start',
+					block: 'center',
 					inline: 'nearest',
 				})
 				element.focus()
@@ -676,8 +676,13 @@ export default {
 
 				// the hash changed, need to focus/highlight another message
 				if (to.hash && to.hash.startsWith('#message_')) {
-					// scroll to message in URL anchor
-					this.focusMessage(to.hash.substr(9), true)
+					// need some delay (next tick is too short) to be able to run
+					// after the browser's native "scroll to anchor" from
+					// the hash
+					window.setTimeout(() => {
+						// scroll to message in URL anchor
+						this.focusMessage(to.hash.substr(9), true)
+					}, 2)
 				}
 			}
 		},

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -76,6 +76,7 @@
 					<Quote
 						v-if="messageToBeReplied"
 						:is-new-message-form-quote="true"
+						:parent-id="messageToBeReplied.id"
 						v-bind="messageToBeReplied" />
 					<AdvancedInput
 						ref="advancedInput"

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -214,7 +214,10 @@ export default {
 		},
 
 		handleQuoteClick() {
-			EventBus.$emit('focusMessage', this.parentId)
+			// FIXME: unify quote attributes for the two use cases
+			// - "reply in message list" (this.parentId) and
+			// - "reply quote in new message" (this.id)
+			EventBus.$emit('focusMessage', this.parentId || this.id)
 		},
 	},
 }

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -61,6 +61,7 @@ import Actions from '@nextcloud/vue/dist/Components/Actions'
 import RichText from '@juliushaertl/vue-richtext'
 import FilePreview from './MessagesList/MessagesGroup/Message/MessagePart/FilePreview'
 import DefaultParameter from './MessagesList/MessagesGroup/Message/MessagePart/DefaultParameter'
+import { EventBus } from '../services/EventBus'
 
 export default {
 	name: 'Quote',
@@ -202,11 +203,6 @@ export default {
 				return this.simpleQuotedMessage
 			}
 		},
-
-		parent() {
-			return document.getElementById(`message_${this.parentId}`)
-		},
-
 	},
 	methods: {
 		/**
@@ -217,13 +213,8 @@ export default {
 			this.$store.dispatch('removeMessageToBeReplied', this.token)
 		},
 
-		async handleQuoteClick() {
-			await this.parent.scrollIntoView({
-				behavior: 'smooth',
-				block: 'center',
-				inline: 'nearest',
-			})
-			this.parent.focus()
+		handleQuoteClick() {
+			EventBus.$emit('focusMessage', this.parentId)
 		},
 	},
 }

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -214,10 +214,7 @@ export default {
 		},
 
 		handleQuoteClick() {
-			// FIXME: unify quote attributes for the two use cases
-			// - "reply in message list" (this.parentId) and
-			// - "reply quote in new message" (this.id)
-			EventBus.$emit('focusMessage', this.parentId || this.id)
+			EventBus.$emit('focusMessage', this.parentId)
 		},
 	},
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/spreed/issues/4516

When clicking on a quote, we scroll to it and now there's a new
highlight animation that fades out

The animation and scrolling logic was moved from the Quote vue to the
Message vue. The Quote vue will now only send an event to tell that we
want to focus a specific message.

A DOM-level method was used for triggering the highlight to be able to
access it with document.getElementById() as it's cheaper than trying to
look up the message by id within the collection of MessagesList.

If the latter is not wanted we should then rework the messages structure inside of MessagesList to have the messages in an associative array with message id as key. Or build yet another index-like structure to be able to find the messages. So far for this use case it feels a bit like overkill.

