### PR TITLE
Fix call button overlap in sidebar chat

### DIFF
--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -39,7 +39,9 @@
 			</button>
 		</div>
 		<template v-else>
-			<CallButton class="call-button" />
+			<div class="call-button-wrapper">
+				<CallButton class="call-button" />
+			</div>
 			<ChatView :token="token" />
 		</template>
 	</div>
@@ -417,13 +419,25 @@ export default {
 	justify-content: center;
 }
 
+.call-button-wrapper {
+	width: 100%;
+	background-color: var(--color-main-background);
+	z-index: 1;
+}
+
 .call-button {
+	display: block;
+
 	/* Center button horizontally. */
 	margin-left: auto;
 	margin-right: auto;
 
 	margin-top: 10px;
 	margin-bottom: 10px;
+}
+
+::v-deep .scroller {
+	margin-top: 64px;
 }
 
 .chatView {


### PR DESCRIPTION
Due to recent changes to the scroll component, the
call button in sidebar chat needs to be
adjusted to float on top of the chat.

Before:
<img width="286" alt="image" src="https://user-images.githubusercontent.com/277525/99065216-56be2480-25a7-11eb-8286-0de8b54c9f27.png">

After:
<img width="286" alt="image" src="https://user-images.githubusercontent.com/277525/99064830-c2ec5880-25a6-11eb-91ac-5d559148cfae.png">

Note: the double scrollbar is unrelated. The bigger scrollbar is the one from the files app as I have enough files to make it scroll.

Fixes https://github.com/nextcloud/spreed/pull/4530#issuecomment-726682617