### PR TITLE
Don't leave conversation on URL hash change

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
@@ -95,6 +95,13 @@ export default {
 			})
 		},
 		onRouteChange({ from, to }) {
+			if (from.name === 'conversation'
+				&& to.name === 'conversation'
+				&& from.token === to.token) {
+
+				// this is triggered when the hash in the URL changes
+				return
+			}
 			if (from.name === 'conversation') {
 				leaveConversation(from.params.token)
 			}

--- a/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
@@ -98,7 +98,6 @@ export default {
 			if (from.name === 'conversation'
 				&& to.name === 'conversation'
 				&& from.token === to.token) {
-
 				// this is triggered when the hash in the URL changes
 				return
 			}


### PR DESCRIPTION
Whenever only the URL hash changes despite the token staying the same, a
route change event is still triggered.

This fix avoids leaving and re-joining the same conversation.

Fixes an issue where clicking a search result would trigger both the
event that leaves the conversation within a route change and a page
unload event, which also leaves the same conversation.

Fixes https://github.com/nextcloud/spreed/issues/4592

### Test cases

- searching within current conversation: https://github.com/nextcloud/spreed/issues/4592#issue-742379306
- joining non-current conversation X through search link, then clicking X again to clear the hash: https://github.com/nextcloud/spreed/issues/4592#issuecomment-726745488