### PR TITLE
Allow regular users to filter participants

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -22,19 +22,19 @@
 <template>
 	<div>
 		<SearchBox
-			v-if="displaySearchBox"
+			v-if="canSearch"
 			v-model="searchText"
-			:placeholder-text="t('spreed', 'Search or add participants to the conversation')"
+			:placeholder-text="searchBoxPlaceholder"
 			:is-searching="isSearching"
 			@input="handleInput"
 			@abort-search="abortSearch" />
-		<Caption v-if="isSearching"
+		<Caption v-if="isSearching && canAdd"
 			:title="t('spreed', 'Participants')" />
 		<CurrentParticipants
 			:search-text="searchText"
 			:participants-initialised="participantsInitialised" />
 		<ParticipantsSearchResults
-			v-if="isSearching"
+			v-if="canAdd && isSearching"
 			:search-results="searchResults"
 			:contacts-loading="contactsLoading"
 			:no-results="noResults"
@@ -78,7 +78,11 @@ export default {
 	],
 
 	props: {
-		displaySearchBox: {
+		canSearch: {
+			type: Boolean,
+			required: true,
+		},
+		canAdd: {
 			type: Boolean,
 			required: true,
 		},
@@ -100,6 +104,11 @@ export default {
 	},
 
 	computed: {
+		searchBoxPlaceholder() {
+			return this.canAdd
+				? t('spreed', 'Search or add participants')
+				: t('spreed', 'Search participants')
+		},
 		show() {
 			return this.$store.getters.getSidebarStatus
 		},

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -48,7 +48,9 @@
 			:order="2"
 			:name="t('spreed', 'Participants')"
 			icon="icon-contacts-dark">
-			<ParticipantsTab :display-search-box="displaySearchBox" />
+			<ParticipantsTab
+				:can-search="canSearchParticipants"
+				:can-add="canAddParticipants" />
 		</AppSidebarTab>
 		<AppSidebarTab
 			id="settings-tab"
@@ -161,9 +163,11 @@ export default {
 			return this.conversation.isFavorite
 		},
 
-		displaySearchBox() {
-			return this.canFullModerate
-				&& (this.conversation.type === CONVERSATION.TYPE.GROUP
+		canAddParticipants() {
+			return this.canFullModerate && this.canSearchParticipants
+		},
+		canSearchParticipants() {
+			return (this.conversation.type === CONVERSATION.TYPE.GROUP
 					|| this.conversation.type === CONVERSATION.TYPE.PUBLIC)
 		},
 		isSearching() {


### PR DESCRIPTION
In the conversation view, regular users can now also search/filter in
the sidebar. They don't get the option to add participants like
moderators do.

Fixes https://github.com/nextcloud/spreed/issues/4299

### Moderator view
Can search and add.
<img width="225" alt="image" src="https://user-images.githubusercontent.com/277525/99120283-e4772f80-25fa-11eb-9586-84e0b27d9079.png">

### Regular user view
Can only search/filter.

<img width="225" alt="image" src="https://user-images.githubusercontent.com/277525/99120357-096ba280-25fb-11eb-94a9-448408f5a331.png">
<img width="225" alt="image" src="https://user-images.githubusercontent.com/277525/99120335-01136780-25fb-11eb-9aad-b14d9ee442e0.png">

Note: the "Participants" header is removed as it doesn't make sense with only one result section.

### One on one view
No search box, as before.
<img width="225" alt="image" src="https://user-images.githubusercontent.com/277525/99120239-cf020580-25fa-11eb-8a52-e87b8b738169.png">

