### PR TITLE
Fix preview spacing

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -54,7 +54,9 @@
 			<Close class="remove-file__icon" decorative @click="$emit('remove-file', id)" />
 		</button>
 		<ProgressBar v-if="isTemporaryUpload && !isUploadEditor" :value="uploadProgress" />
-		<strong v-if="shouldShowFileName">{{ name }}</strong>
+		<div class="name-container">
+			<strong v-if="shouldShowFileName">{{ name }}</strong>
+		</div>
 	</file-preview>
 </template>
 
@@ -456,17 +458,20 @@ export default {
 		}
 	}
 
-	.mimeicon {
-		min-height: 128px;
-	}
+	.name-container {
+		/* Ellipsis with 100% width */
+		display: table;
+		table-layout: fixed;
+		width: 100%;
 
-	strong {
-		/* As the file preview is an inline block the name is set as a block to
-		force it to be on its own line below the preview. */
-		display: block;
-		overflow: hidden;
-		white-space: nowrap;
-		text-overflow: ellipsis;
+		strong {
+			/* As the file preview is an inline block the name is set as a block to
+			force it to be on its own line below the preview. */
+			display: block;
+			overflow: hidden;
+			white-space: nowrap;
+			text-overflow: ellipsis;
+		}
 	}
 
 	&:not(.file-preview--viewer-available) {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -409,6 +409,15 @@ export default {
 		width: 100%;
 	}
 
+	.mimeicon {
+		min-height: 128px;
+	}
+
+	.mimeicon.preview-small {
+		min-height: auto;
+		height: 32px;
+	}
+
 	.preview {
 		display: inline-block;
 		border-radius: var(--border-radius);

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -47,7 +47,6 @@
 		<span v-if="isLoading"
 			v-tooltip="previewTooltip"
 			class="preview loading" />
-		<strong v-if="shouldShowFileName">{{ name }}</strong>
 		<button v-if="isUploadEditor"
 			tabindex="1"
 			:aria-label="removeAriaLabel"
@@ -55,6 +54,7 @@
 			<Close class="remove-file__icon" decorative @click="$emit('remove-file', id)" />
 		</button>
 		<ProgressBar v-if="isTemporaryUpload && !isUploadEditor" :value="uploadProgress" />
+		<strong v-if="shouldShowFileName">{{ name }}</strong>
 	</file-preview>
 </template>
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -117,9 +117,12 @@ export default {
 			type: String,
 			default: 'no',
 		},
-		previewSize: {
-			type: Number,
-			default: 384,
+		/**
+		 * Whether to render a small preview to embed in replies
+		 */
+		smallPreview: {
+			type: Boolean,
+			default: false,
 		},
 		// In case this component is used to display a file that is being uploaded
 		// this parameter is used to access the file upload status in the store
@@ -199,8 +202,8 @@ export default {
 		},
 		previewImageClass() {
 			let classes = ''
-			if (this.previewSize === 64) {
-				classes += 'preview-64 '
+			if (this.smallPreview) {
+				classes += 'preview-small '
 			} else {
 				classes += 'preview '
 			}
@@ -248,7 +251,11 @@ export default {
 			}
 
 			// use preview provider URL to render a smaller preview
-			const previewSize = Math.ceil(this.previewSize * window.devicePixelRatio)
+			let previewSize = 384
+			if (this.smallPreview) {
+				previewSize = 32
+			}
+			previewSize = Math.ceil(previewSize * window.devicePixelRatio)
 			if (userId === null) {
 				// guest mode: grab token from the link URL
 				// FIXME: use a cleaner way...
@@ -406,11 +413,11 @@ export default {
 		max-width: 100%;
 		max-height: 384px;
 	}
-	.preview-64 {
+	.preview-small {
 		display: inline-block;
 		border-radius: var(--border-radius);
 		max-width: 100%;
-		max-height: 64px;
+		max-height: 32px;
 	}
 
 	.image-container {

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -158,7 +158,7 @@ export default {
 					richParameters[p] = {
 						component: FilePreview,
 						props: Object.assign({
-							previewSize: 64,
+							smallPreview: true,
 						}, this.messageParameters[p]
 						),
 					}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/spreed/issues/4494

- Removes spacing of label under the preview 
- Reduce "small" preview size from 64 to 32 to prevent scrollbars in the reply box
- Attempt to move the preview size values to SCSS variables to be imported also in JS

The latter with SCSS variables doesn't work, the imported structure is always an empty hash.
This should work according to many sources:
- https://til.hashrocket.com/posts/sxbrscjuqu-share-scss-variables-with-javascript
- https://css-tricks.com/getting-javascript-to-talk-to-css-and-sass/
- https://stackoverflow.com/questions/56523785/exporting-scss-variables-to-js-auto-looping-variables
- https://github.com/webpack-contrib/css-loader (search for ":export")

I guess I'll revert the last commit and stick to hard-coded values for now :-/