### PR TITLE
Fix "Copy link" button not clickable in empty calls

### DIFF
--- a/src/components/CallView/shared/EmptyCallView.vue
+++ b/src/components/CallView/shared/EmptyCallView.vue
@@ -167,6 +167,7 @@ export default {
 	}
 	button {
 		margin: 4px auto;
+		z-index: 1;
 	}
 
 	h2, p {


### PR DESCRIPTION
This fixes https://github.com/nextcloud/spreed/issues/4311 by adding "z-index: 1;" to the "empty-call-view button" css.