### PR TITLE
Adjust call icon positioning in participant list

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -37,7 +37,7 @@
 			:name="computedName"
 			:source="participant.source || participant.actorType"
 			:offline="isOffline" />
-		<div class="participant-row__user-wrapper">
+		<div class="participant-row__user-wrapper" :class="{ 'has-call-icon': callIcon }">
 			<div
 				ref="userName"
 				class="participant-row__user-descriptor"
@@ -369,9 +369,15 @@ export default {
 	&__user-wrapper {
 		margin-top: -4px;
 		margin-left: 12px;
-		width: calc(100% - 96px);
+		width: calc(100% - 100px);
 		display: flex;
 		flex-direction: column;
+
+		&.has-call-icon {
+			/** make room for the call icon */
+			width: calc(100% - 100px - 24px);
+			padding-right: 5px;
+		}
 	}
 	&__user-name {
 		vertical-align: middle;
@@ -408,8 +414,8 @@ export default {
 	&__callstate-icon {
 		opacity: .4;
 		display: inline-block;
-		height: 44px;
-		width: 44px;
+		/** FIXME: use a better way for vertical align */
+		margin-top: 4px;
 	}
 }
 

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -386,9 +386,6 @@ export default {
 		&.has-call-icon {
 			/** reduce text width to have some distance from call icon */
 			padding-right: 5px;
-		}
-
-		&.has-call-icon {
 			/** call icon on the right most column */
 			width: calc(100% - 90px);
 		}

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -26,6 +26,7 @@
 			'offline': isOffline,
 			'currentUser': isSelf,
 			'guestUser': isGuest,
+			'isSearched': isSearched,
 			'selected': isSelected }"
 		@click="handleClick">
 		<AvatarWrapper
@@ -360,11 +361,15 @@ export default {
 .participant-row {
 	display: flex;
 	align-items: center;
-	cursor: pointer;
+	cursor: default;
 	margin: 4px 0;
 	border-radius: 22px;
 	height: 56px;
 	padding: 0 4px;
+
+	&.isSearched {
+		cursor: pointer;
+	}
 
 	&__user-wrapper {
 		margin-top: -4px;
@@ -382,7 +387,6 @@ export default {
 	&__user-name {
 		vertical-align: middle;
 		line-height: normal;
-		cursor: pointer;
 	}
 	&__guest-indicator,
 	&__moderator-indicator {
@@ -417,6 +421,10 @@ export default {
 		/** FIXME: use a better way for vertical align */
 		margin-top: 4px;
 	}
+}
+
+.participant-row.isSearched .participant-row__user-name {
+	cursor: pointer;
 }
 
 .utils {

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -38,7 +38,12 @@
 			:name="computedName"
 			:source="participant.source || participant.actorType"
 			:offline="isOffline" />
-		<div class="participant-row__user-wrapper" :class="{ 'has-call-icon': callIcon }">
+		<div
+			class="participant-row__user-wrapper"
+			:class="{
+				'has-call-icon': callIcon,
+				'has-menu-icon': canModerate && !isSearched
+			}">
 			<div
 				ref="userName"
 				class="participant-row__user-descriptor"
@@ -379,9 +384,18 @@ export default {
 		flex-direction: column;
 
 		&.has-call-icon {
-			/** make room for the call icon */
-			width: calc(100% - 100px - 24px);
+			/** reduce text width to have some distance from call icon */
 			padding-right: 5px;
+		}
+
+		&.has-call-icon {
+			/** call icon on the right most column */
+			width: calc(100% - 90px);
+		}
+
+		&.has-call-icon.has-menu-icon {
+			/** make room for the call icon + menu icon */
+			width: calc(100% - 124px);
 		}
 	}
 	&__user-name {
@@ -417,9 +431,8 @@ export default {
 
 	&__callstate-icon {
 		opacity: .4;
-		display: inline-block;
-		/** FIXME: use a better way for vertical align */
-		margin-top: 4px;
+		display: flex;
+		align-items: center;
 	}
 }
 


### PR DESCRIPTION
Fixed call icon vertical alignment.
Adjusted ellipsis width calculation to take the icon into account when
present.

@nickvergessen as discussed

### Before:
<img width="217" alt="image" src="https://user-images.githubusercontent.com/277525/99415360-ff49ec80-28f7-11eb-9b63-9d756ff01c61.png">

### After:
<img width="217" alt="image" src="https://user-images.githubusercontent.com/277525/99415232-e2adb480-28f7-11eb-8cad-c3a2343f56ea.png">

with status line:
<img width="210" alt="image" src="https://user-images.githubusercontent.com/277525/99417371-21dd0500-28fa-11eb-933f-fec2e5dbe34d.png">


