### PR TITLE
cloak password fields

### DIFF
--- a/src/components/AdminSettings/SIPBridge.vue
+++ b/src/components/AdminSettings/SIPBridge.vue
@@ -49,7 +49,7 @@
 		<h3>{{ t('spreed', 'Shared secret') }}</h3>
 
 		<input v-model="sharedSecret"
-			type="text"
+			type="password"
 			name="shared-secret"
 			class="sip-bridge__shared-secret"
 			:disabled="loading"

--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -74,7 +74,7 @@
 		<div class="signaling-secret">
 			<h4>{{ t('spreed', 'Shared secret') }}</h4>
 			<input v-model="secret"
-				type="text"
+				type="password"
 				name="signaling_secret"
 				:disabled="loading"
 				:placeholder="t('spreed', 'Shared secret')"

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -31,7 +31,7 @@
 			:aria-label="t('spreed', 'TURN server URL')"
 			@input="updateServer">
 		<input ref="turn_secret"
-			type="text"
+			type="password"
 			name="turn_secret"
 			placeholder="secret"
 			:value="secret"

--- a/templates/settings/admin-settings.php
+++ b/templates/settings/admin-settings.php
@@ -50,7 +50,7 @@ style('spreed', ['settings-admin']);
 
 		<div class="signaling-secret">
 			<h4><?php p($l->t('Shared secret')) ?></h4>
-			<input type="text" id="signaling_secret"
+			<input type="password" id="signaling_secret"
 				   name="signaling_secret" placeholder="<?php p($l->t('Shared secret')) ?>" aria-label="<?php p($l->t('Shared secret')) ?>"/>
 		</div>
 	</div>


### PR DESCRIPTION
Disclosing passwords can be dangerous when having multiple admins with different trust levels on an instance.
Also, it's quite common to cloak password fields.

Signed-off-by: Sascha Wiswedel <sascha.wiswedel@nextcloud.com>