### PR TITLE
Don't show big screen share while in grid mode

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -86,7 +86,7 @@
 					@switchScreenToId="1" />
 			</div>
 			<!-- Screens -->
-			<div v-if="!isSidebar && (showLocalScreen || showRemoteScreen)" id="screens">
+			<div v-if="!isSidebar && !isGrid && (showLocalScreen || showRemoteScreen)" id="screens">
 				<!-- local screen -->
 				<Screen v-show="showLocalScreen"
 					:token="token"


### PR DESCRIPTION
### Steps to reproduce

1. Setup a call with three participants
1. Have participant 1 share the screen
1. Wait for screen share to appear
1. Have participant 2 switch to grid view

### Before the fix
The screen share appears both in the grid and big on top of it.

### After the fix
The screen share does not appear big on top but only inside the grid.

Regression from Talk 10.0
