### PR TITLE
Set empty title for material design icons

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -23,6 +23,7 @@
 	<div class="grid-main-wrapper" :class="{'is-grid': !isStripe, 'transparent': isLessThanTwo}">
 		<button v-if="isStripe"
 			class="stripe--collapse"
+			:aria-label="stripeButtonTooltip"
 			@click="handleClickStripeCollapse">
 			<ChevronDown
 				v-if="stripeOpen"
@@ -42,6 +43,7 @@
 				<div :class="{'pagination-wrapper': isStripe, 'wrapper': !isStripe}">
 					<button v-if="hasPreviousPage && gridWidth > 0 && isStripe && showVideoOverlay"
 						class="grid-navigation grid-navigation__previous"
+						:aria-label="t('spreed', 'Previous page of videos')"
 						@click="handleClickPrevious">
 						<ChevronLeft
 							decorative
@@ -100,6 +102,7 @@
 					</div>
 					<button v-if="hasNextPage && gridWidth > 0 && isStripe && showVideoOverlay"
 						class="grid-navigation grid-navigation__next"
+						:aria-label="t('spreed', 'Next page of videos')"
 						@click="handleClickNext">
 						<ChevronRight
 							decorative
@@ -153,6 +156,7 @@ import LocalVideo from '../shared/LocalVideo'
 import { EventBus } from '../../../services/EventBus'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import EmptyCallView from '../shared/EmptyCallView'
+import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 import ChevronRight from 'vue-material-design-icons/ChevronRight'
 import ChevronLeft from 'vue-material-design-icons/ChevronLeft'
 import ChevronUp from 'vue-material-design-icons/ChevronUp'
@@ -169,6 +173,10 @@ export default {
 		ChevronLeft,
 		ChevronUp,
 		ChevronDown,
+	},
+
+	directives: {
+		Tooltip,
 	},
 
 	props: {
@@ -279,6 +287,14 @@ export default {
 	},
 
 	computed: {
+		stripeButtonTooltip() {
+			if (this.stripeOpen) {
+				return t('spreed', 'Collapse stripe')
+			} else {
+				return t('spreed', 'Expand stripe')
+			}
+		},
+
 		// The videos array. This is the total number of grid elements.
 		// Depending on `gridWidthm`, `gridHeight`, `minWidth`, `minHeight` and
 		// `videosCap`, these videos are shown in one or more grid 'pages'.

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -28,11 +28,13 @@
 				v-if="stripeOpen"
 				fill-color="#ffffff"
 				decorative
+				title=""
 				:size="24" />
 			<ChevronUp
 				v-else
 				fill-color="#ffffff"
 				decorative
+				title=""
 				:size="24" />
 		</button>
 		<transition :name="isStripe ? 'slide-down' : ''">
@@ -41,7 +43,9 @@
 					<button v-if="hasPreviousPage && gridWidth > 0 && isStripe && showVideoOverlay"
 						class="grid-navigation grid-navigation__previous"
 						@click="handleClickPrevious">
-						<ChevronLeft decorative
+						<ChevronLeft
+							decorative
+							title=""
 							:size="24" />
 					</button>
 					<div
@@ -97,7 +101,9 @@
 					<button v-if="hasNextPage && gridWidth > 0 && isStripe && showVideoOverlay"
 						class="grid-navigation grid-navigation__next"
 						@click="handleClickNext">
-						<ChevronRight decorative
+						<ChevronRight
+							decorative
+							title=""
 							:size="24" />
 					</button>
 				</div>

--- a/src/components/CallView/shared/Video.vue
+++ b/src/components/CallView/shared/Video.vue
@@ -69,6 +69,7 @@
 				class="placeholder-for-promoted">
 				<AccountCircle v-if="isPromoted || isSelected"
 					decorative
+					title=""
 					fill-color="#FFFFFF"
 					:size="36" />
 			</div>

--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -27,7 +27,9 @@
 			icon=""
 			:aria-label="t('spreed','Create a new group conversation')"
 			@click="showModal">
-			<Plus decorative
+			<Plus
+				decorative
+				title=""
 				:size="24" />
 		</button>
 		<!-- New group form -->

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -51,7 +51,11 @@
 			tabindex="1"
 			:aria-label="removeAriaLabel"
 			class="remove-file primary">
-			<Close class="remove-file__icon" decorative @click="$emit('remove-file', id)" />
+			<Close
+				class="remove-file__icon"
+				decorative
+				title=""
+				@click="$emit('remove-file', id)" />
 		</button>
 		<ProgressBar v-if="isTemporaryUpload && !isUploadEditor" :value="uploadProgress" />
 		<div class="name-container">

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -56,7 +56,9 @@ get the messagesList array and loop through the list to generate the messages.
 				:aria-label="scrollToBottomAriaLabel"
 				class="scroll-to-bottom"
 				@click="smoothScrollToBottom">
-				<ChevronDown decorative
+				<ChevronDown
+					decorative
+					title=""
 					:size="24" />
 			</button>
 		</transition>

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -68,7 +68,8 @@
 							:aria-haspopup="true">
 							<EmoticonOutline
 								:size="20"
-								decorative />
+								decorative
+								title="" />
 						</button>
 					</EmojiPicker>
 				</div>

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -67,14 +67,17 @@
 			<Microphone
 				v-if="callIcon === 'audio'"
 				:size="24"
+				title=""
 				decorative />
 			<Phone
 				v-if="callIcon === 'phone'"
 				:size="24"
+				title=""
 				decorative />
 			<Video
 				v-if="callIcon === 'video'"
 				:size="24"
+				title=""
 				decorative />
 		</div>
 		<Actions

--- a/src/components/UploadEditor.vue
+++ b/src/components/UploadEditor.vue
@@ -47,6 +47,7 @@
 					@click="clickImportInput">
 					<Plus
 						decorative
+						title=""
 						:size="48"
 						class="upload-editor__plus-icon" />
 				</button>


### PR DESCRIPTION
### Description

The vue material design icons library sets a default title to the icon
components. This fix sets this to empty to prevent the browser tooltip
to appear.

### Before
<img width="208" alt="image" src="https://user-images.githubusercontent.com/277525/99514502-1f2af000-298c-11eb-8b20-a0c2a616fcc9.png">

### After
No more tooltip

### Context
Discovered here: https://github.com/nextcloud/spreed/pull/4621#discussion_r525302207

