### PR TITLE
Grab the token from the correct attribute

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
@@ -97,7 +97,7 @@ export default {
 		onRouteChange({ from, to }) {
 			if (from.name === 'conversation'
 				&& to.name === 'conversation'
-				&& from.token === to.token) {
+				&& from.params.token === to.params.token) {
 				// this is triggered when the hash in the URL changes
 				return
 			}


### PR DESCRIPTION
When the URL changes, the check whether we switched conversations need
to read the token for the correct attribute, which is "params".

Fixes https://github.com/nextcloud/spreed/issues/4631