### PR TITLE
Fix public page calls

### DIFF
--- a/src/PublicShareAuthSidebar.vue
+++ b/src/PublicShareAuthSidebar.vue
@@ -277,6 +277,7 @@ export default {
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
+	position: relative;
 
 	flex-grow: 1;
 

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -348,6 +348,7 @@ export default {
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
+	position: relative;
 
 	flex-grow: 1;
 

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -222,7 +222,7 @@ export default {
 		},
 
 		isGrid() {
-			return this.$store.getters.isGrid
+			return this.$store.getters.isGrid && !this.isSidebar
 		},
 
 		gridTargetAspectRatio() {


### PR DESCRIPTION
Fixes chat in sidebar for video verification and when chatting about a
file from a public link.

I tried to set "position: relative" for chatView in general but it would then break scrolling during a logged in call, so I went for a more localized solution (for now).

Fixes https://github.com/nextcloud/spreed/issues/4636

Note: the video won't appear in video verification because of that other bug related to "disable grid view in sidebar": https://github.com/nextcloud/spreed/pull/4573
