### PR TITLE
Add missing aria label on new message form

### DIFF
--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -78,6 +78,7 @@
 			:contenteditable="activeInput"
 			:placeHolder="placeholderText"
 			role="textbox"
+			:aria-label="ariaLabel"
 			aria-multiline="true"
 			class="new-message-form__advancedinput"
 			@shortkey="focusInput"
@@ -174,6 +175,11 @@ export default {
 		 * The placeholder for the input field
 		 */
 		placeholderText: {
+			type: String,
+			default: '',
+		},
+
+		ariaLabel: {
 			type: String,
 			default: '',
 		},

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -84,6 +84,7 @@
 						:token="token"
 						:active-input="!isReadOnly"
 						:placeholder-text="placeholderText"
+						:aria-label="placeholderText"
 						@update:contentEditable="contentEditableToParsed"
 						@submit="handleSubmit"
 						@files-pasted="handlePastedFiles" />


### PR DESCRIPTION
Tested with screen reader on orca + firefox.

It will now read out the placeholder text when focusing on the new message form.