### PR TITLE
A few accessibility tweaks

### DIFF
--- a/src/components/Caption.vue
+++ b/src/components/Caption.vue
@@ -20,7 +20,7 @@
 -->
 
 <template>
-	<li class="app-navigation-caption">
+	<li role="heading" class="app-navigation-caption">
 		{{ title }}
 	</li>
 </template>

--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -43,8 +43,12 @@
 			</div>
 		</transition>
 		<MessagesList
+			role="region"
+			:aria-label="t('spreed', 'Conversation messages')"
 			:token="token" />
-		<NewMessageForm />
+		<NewMessageForm
+			role="region"
+			:aria-label="t('spreed', 'Post message')" />
 	</div>
 </template>
 

--- a/src/components/LeftSidebar/ConversationsList/AppContentListItem/AppContentListItem.vue
+++ b/src/components/LeftSidebar/ConversationsList/AppContentListItem/AppContentListItem.vue
@@ -28,7 +28,7 @@
 			:class="{ 'active' : isActive }"
 			href="#"
 			class="acli"
-			:aria-label="t('spreed', 'Conversation, ') + title"
+			:aria-label="conversationLinkAriaLabel"
 			@click="onClick">
 			<!-- default slot for avatar or icon -->
 			<slot name="icon" />
@@ -57,7 +57,7 @@
 		<Actions
 			v-if="hasActions"
 			menu-align="right"
-			:aria-label="t('spreed', 'Conversation settings')"
+			:aria-label="conversationSettingsAriaLabel"
 			class="actions">
 			<slot name="actions" />
 		</Actions>
@@ -138,6 +138,13 @@ export default {
 			}
 		},
 
+		conversationLinkAriaLabel() {
+			return t('spreed', 'Conversation "{conversationName}"', { conversationName: this.title })
+		},
+
+		conversationSettingsAriaLabel() {
+			return t('spreed', 'Settings for conversation "{conversationName}"', { conversationName: this.title })
+		},
 	},
 	methods: {
 		// forward click event

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -37,7 +37,7 @@
 		<template #list class="left-sidebar__list">
 			<Caption v-if="isSearching"
 				:title="t('spreed', 'Conversations')" />
-			<li>
+			<li role="presentation">
 				<ConversationsList
 					:conversations-list="conversationsList"
 					:initialised-conversations="initialisedConversations"

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -20,7 +20,9 @@
 -->
 
 <template>
-	<AppNavigation>
+	<AppNavigation
+		:aria-label="t('spreed', 'Conversation list')"
+		:toggle-aria-label="t('spreed', 'Toggle conversations list')">
 		<div class="new-conversation">
 			<SearchBox
 				v-model="searchText"

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -49,7 +49,7 @@
 				<template v-if="searchResultsUsers.length !== 0">
 					<Caption
 						:title="t('spreed', 'Users')" />
-					<li v-if="searchResultsUsers.length !== 0">
+					<li v-if="searchResultsUsers.length !== 0" role="presentation">
 						<ConversationsOptionsList
 							:items="searchResultsUsers"
 							@click="createAndJoinConversation" />
@@ -66,7 +66,7 @@
 				<template v-if="searchResultsGroups.length !== 0">
 					<Caption
 						:title="t('spreed', 'Groups')" />
-					<li v-if="searchResultsGroups.length !== 0">
+					<li v-if="searchResultsGroups.length !== 0" role="presentation">
 						<ConversationsOptionsList
 							:items="searchResultsGroups"
 							@click="createAndJoinConversation" />
@@ -76,7 +76,7 @@
 				<template v-if="searchResultsCircles.length !== 0">
 					<Caption
 						:title="t('spreed', 'Circles')" />
-					<li v-if="searchResultsCircles.length !== 0">
+					<li v-if="searchResultsCircles.length !== 0" role="presentation">
 						<ConversationsOptionsList
 							:items="searchResultsCircles"
 							@click="createAndJoinConversation" />

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -20,9 +20,7 @@
 -->
 
 <template>
-	<AppNavigation
-		:aria-label="t('spreed', 'Conversation list')"
-		:toggle-aria-label="t('spreed', 'Toggle conversations list')">
+	<AppNavigation :aria-label="t('spreed', 'Conversation list')">
 		<div class="new-conversation">
 			<SearchBox
 				v-model="searchText"

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -25,7 +25,7 @@ the main body of the message as well as a quote.
 </docs>
 
 <template>
-	<div
+	<li
 		:id="`message_${id}`"
 		ref="message"
 		class="message"
@@ -75,7 +75,7 @@ the main body of the message as well as a quote.
 				</Actions>
 			</div>
 		</div>
-	</div>
+	</li>
 </template>
 
 <script>

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -33,7 +33,9 @@ the main body of the message as well as a quote.
 		@mouseover="showActions=true"
 		@mouseleave="showActions=false">
 		<div v-if="isFirstMessage && showAuthor" class="message__author">
-			<h6>{{ actorDisplayName }}</h6>
+			<h6 role="presentation" aria-hidden="true">
+				{{ actorDisplayName }}
+			</h6>
 		</div>
 		<div
 			ref="messageMain"
@@ -56,7 +58,8 @@ the main body of the message as well as a quote.
 			<div class="message__main__right">
 				<div v-if="isTemporary && !isTemporaryUpload" class="icon-loading-small" />
 				<h6 v-if="hasDate"
-					v-tooltip.auto="messageDate">
+					v-tooltip.auto="messageDate"
+					role="presentation">
 					{{ messageTime }}
 				</h6>
 				<Actions

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -32,10 +32,11 @@ the main body of the message as well as a quote.
 		:class="{'hover': showActions && !isSystemMessage, 'system' : isSystemMessage}"
 		@mouseover="showActions=true"
 		@mouseleave="showActions=false">
-		<div v-if="isFirstMessage && showAuthor" class="message__author">
-			<h3 role="heading">
-				{{ actorDisplayName }}
-			</h3>
+		<div v-if="isFirstMessage && showAuthor"
+			class="message__author"
+			role="heading"
+			aria-level="4">
+			{{ actorDisplayName }}
 		</div>
 		<div
 			ref="messageMain"
@@ -57,10 +58,7 @@ the main body of the message as well as a quote.
 			</div>
 			<div class="message__main__right">
 				<div v-if="isTemporary && !isTemporaryUpload" class="icon-loading-small" />
-				<span v-if="hasDate"
-					  v-tooltip.auto="messageDate"/>
-					{{ messageTime }}
-				</span>
+				<span v-if="hasDate" v-tooltip.auto="messageDate">{{ messageTime }}</span>
 				<Actions
 					v-show="showActions && hasActions"
 					class="message__main__right__actions">

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -33,9 +33,9 @@ the main body of the message as well as a quote.
 		@mouseover="showActions=true"
 		@mouseleave="showActions=false">
 		<div v-if="isFirstMessage && showAuthor" class="message__author">
-			<h6 role="heading" aria-level="2">
+			<h3 role="heading">
 				{{ actorDisplayName }}
-			</h6>
+			</h3>
 		</div>
 		<div
 			ref="messageMain"
@@ -57,11 +57,10 @@ the main body of the message as well as a quote.
 			</div>
 			<div class="message__main__right">
 				<div v-if="isTemporary && !isTemporaryUpload" class="icon-loading-small" />
-				<h6 v-if="hasDate"
-					v-tooltip.auto="messageDate"
-					role="presentation">
+				<span v-if="hasDate"
+					  v-tooltip.auto="messageDate"/>
 					{{ messageTime }}
-				</h6>
+				</span>
 				<Actions
 					v-show="showActions && hasActions"
 					class="message__main__right__actions">

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -33,7 +33,7 @@ the main body of the message as well as a quote.
 		@mouseover="showActions=true"
 		@mouseleave="showActions=false">
 		<div v-if="isFirstMessage && showAuthor" class="message__author">
-			<h6 role="presentation" aria-hidden="true">
+			<h6 role="heading" aria-level="2">
 				{{ actorDisplayName }}
 			</h6>
 		</div>

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -31,7 +31,7 @@
 					:author-id="actorId"
 					:display-name="actorDisplayName" />
 			</div>
-			<div class="messages">
+			<ul class="messages">
 				<Message
 					v-for="(message, index) of messages"
 					:key="message.id"
@@ -42,7 +42,7 @@
 					:actor-display-name="actorDisplayName"
 					:show-author="!isSystemMessage"
 					:is-temporary="message.timestamp === 0" />
-			</div>
+			</ul>
 		</div>
 	</div>
 </template>

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -22,7 +22,7 @@
 <template>
 	<div class="message-group">
 		<div v-if="dateSeparator" class="message-group__date-header">
-			<span class="date">{{ dateSeparator }}</span>
+			<span class="date" role="heading" aria-level="1">{{ dateSeparator }}</span>
 		</div>
 		<div class="wrapper">
 			<div class="messages__avatar">

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -22,7 +22,7 @@
 <template>
 	<div class="message-group">
 		<div v-if="dateSeparator" class="message-group__date-header">
-			<span class="date" role="heading" aria-level="1">{{ dateSeparator }}</span>
+			<span class="date" role="heading" aria-level="3">{{ dateSeparator }}</span>
 		</div>
 		<div class="wrapper">
 			<div class="messages__avatar">

--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -78,6 +78,7 @@
 			:contenteditable="activeInput"
 			:placeHolder="placeholderText"
 			role="textbox"
+			:aria-label="ariaLabel"
 			aria-multiline="true"
 			class="new-message-form__advancedinput"
 			@shortkey="focusInput"
@@ -174,6 +175,11 @@ export default {
 		 * The placeholder for the input field
 		 */
 		placeholderText: {
+			type: String,
+			default: '',
+		},
+
+		ariaLabel: {
 			type: String,
 			default: '',
 		},

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -86,6 +86,7 @@
 						:token="token"
 						:active-input="!isReadOnly"
 						:placeholder-text="placeholderText"
+						:aria-label="placeholderText"
 						@update:contentEditable="contentEditableToParsed"
 						@submit="handleSubmit"
 						@files-pasted="handlePastedFiles" />

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -27,6 +27,8 @@
 			ref="fileUploadInput"
 			multiple
 			type="file"
+			tabindex="-1"
+			aria-hidden="true"
 			class="hidden-visually"
 			@change="handleFileInput">
 		<div

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -29,8 +29,8 @@ components.
 		class="quote"
 		@click.prevent="handleQuoteClick">
 		<div class="quote__main">
-			<div class="quote__main__author">
-				<h3>{{ getDisplayName }}</h3>
+			<div class="quote__main__author" role="heading" aria-level="4">
+				{{ getDisplayName }}
 			</div>
 			<div v-if="isFileShareMessage"
 				class="quote__main__text">

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -30,7 +30,7 @@ components.
 		@click.prevent="handleQuoteClick">
 		<div class="quote__main">
 			<div class="quote__main__author">
-				<h6>{{ getDisplayName }}</h6>
+				<h6 role="presentation">{{ getDisplayName }}</h6>
 			</div>
 			<div v-if="isFileShareMessage"
 				class="quote__main__text">

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -30,7 +30,7 @@ components.
 		@click.prevent="handleQuoteClick">
 		<div class="quote__main">
 			<div class="quote__main__author">
-				<h6 role="presentation">{{ getDisplayName }}</h6>
+				<h3>{{ getDisplayName }}</h3>
 			</div>
 			<div v-if="isFileShareMessage"
 				class="quote__main__text">

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -28,7 +28,8 @@
 			'guestUser': isGuest,
 			'isSearched': isSearched,
 			'selected': isSelected }"
-		@click="handleClick">
+		:aria-label="participantAriaLabel"
+		v-on="isSearched ? { click: handleClick } : {}">
 		<AvatarWrapper
 			:id="computedId"
 			:disable-tooltip="true"
@@ -79,7 +80,7 @@
 		</div>
 		<Actions
 			v-if="canModerate && !isSearched"
-			:aria-label="t('spreed', 'Participant settings')"
+			:aria-label="participantSettingsAriaLabel"
 			class="participant-row__actions">
 			<ActionButton v-if="canBeDemoted"
 				icon="icon-rename"
@@ -158,6 +159,17 @@ export default {
 	},
 
 	computed: {
+		participantSettingsAriaLabel() {
+			return t('spreed', 'Settings for participant "{user}"', { user: this.computedName })
+		},
+		participantAriaLabel() {
+			if (this.isSearched) {
+				return t('spreed', 'Add participant {user}', { user: this.computedName })
+			} else {
+				return t('spreed', 'Participant, {user}.', { user: this.computedName })
+			}
+		},
+
 		userTooltipText() {
 			if (!this.isUserNameTooltipVisible) {
 				return false
@@ -327,9 +339,7 @@ export default {
 		},
 		// Used to allow selecting participants in a search.
 		handleClick() {
-			if (this.isSearched) {
-				this.$emit('clickParticipant', this.participant)
-			}
+			this.$emit('clickParticipant', this.participant)
 		},
 		participantTypeIsModerator(participantType) {
 			return [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR].indexOf(participantType) !== -1

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -29,10 +29,14 @@
 			'isSearched': isSearched,
 			'selected': isSelected }"
 		:aria-label="participantAriaLabel"
-		v-on="isSearched ? { click: handleClick } : {}">
+		:role="isSearched ? 'listitem' : ''"
+		:tabindex="isSearched ? 0 : -1"
+		v-on="isSearched ? { click: handleClick, 'keydown.enter': handleClick } : {}"
+		@keydown.enter="handleClick">
 		<AvatarWrapper
 			:id="computedId"
 			:disable-tooltip="true"
+			:disable-menu="isSearched"
 			:size="44"
 			:show-user-status="showUserStatus && !isSearched"
 			:show-user-status-compact="false"
@@ -164,9 +168,9 @@ export default {
 		},
 		participantAriaLabel() {
 			if (this.isSearched) {
-				return t('spreed', 'Add participant {user}', { user: this.computedName })
+				return t('spreed', 'Add participant "{user}"', { user: this.computedName })
 			} else {
-				return t('spreed', 'Participant, {user}.', { user: this.computedName })
+				return t('spreed', 'Participant "{user}"', { user: this.computedName })
 			}
 		},
 
@@ -339,7 +343,9 @@ export default {
 		},
 		// Used to allow selecting participants in a search.
 		handleClick() {
-			this.$emit('clickParticipant', this.participant)
+			if (this.isSearched) {
+				this.$emit('clickParticipant', this.participant)
+			}
 		},
 		participantTypeIsModerator(participantType) {
 			return [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR].indexOf(participantType) !== -1
@@ -384,6 +390,10 @@ export default {
 
 	&.isSearched {
 		cursor: pointer;
+	}
+
+	&:focus {
+		background-color: var(--color-background-hover);
 	}
 
 	&__user-wrapper {

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -56,6 +56,7 @@
 			v-shortkey="['f']"
 			class="top-bar__button"
 			menu-align="right"
+			:aria-label="t('spreed', 'Conversation actions')"
 			@shortkey.native="toggleFullscreen">
 			<ActionButton
 				:icon="iconFullscreen"


### PR DESCRIPTION
See individual commit descriptions.

I originally tried to go further and add invisible text to make it say "Message from Alice: hello" but somehow the screen reader doesn't read it in once sentence.
Also I was hoping that ul/li would make navigation easier like making it read each row in the participant list or messages list, but it rather reads individual blocks inside a row. Maybe we'll need to introduce links there at some point... would make it possible to link to messages. In the conversation list we have links and it works well there.

Needs further separate research.