### PR TITLE
WIP keyboard nav attempt on messages list

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -28,8 +28,13 @@ the main body of the message as well as a quote.
 	<div
 		:id="`message_${id}`"
 		ref="message"
+		tabindex="0"
 		class="message"
 		:class="{'hover': showActions && !isSystemMessage, 'system' : isSystemMessage}"
+		@keydown.up.prevent="jumpToPrevious"
+		@keydown.down.prevent="jumpToNext"
+		@focus="showActions=true"
+		@blur="showActions=false"
 		@mouseover="showActions=true"
 		@mouseleave="showActions=false">
 		<div v-if="isFirstMessage && showAuthor" class="message__author">
@@ -155,6 +160,20 @@ export default {
 		id: {
 			type: [String, Number],
 			required: true,
+		},
+		/**
+		 * Id of the next message
+		 */
+		nextMessage: {
+			type: [String, Number],
+			default: null,
+		},
+		/**
+		 * Id of the previous message
+		 */
+		previousMessage: {
+			type: [String, Number],
+			default: null,
 		},
 		/**
 		 * If true, it displays the message author on top of the message.
@@ -352,6 +371,19 @@ export default {
 	},
 
 	methods: {
+		jumpToPrevious() {
+			const el = document.getElementById('message_' + this.previousMessage)
+			if (el) {
+				el.focus()
+			}
+		},
+		jumpToNext() {
+			const el = document.getElementById('message_' + this.nextMessage)
+			if (el) {
+				el.focus()
+			}
+		},
+
 		highlightAnimation() {
 			// trigger CSS highlight animation by setting a class
 			this.$refs.message.classList.add('highlight-animation')
@@ -390,6 +422,10 @@ export default {
 	padding: 4px;
 	font-size: $chat-font-size;
 	line-height: $chat-line-height;
+	&:focus {
+		background-color: var(--color-background-hover);
+	}
+
 	&__author {
 		color: var(--color-text-maxcontrast);
 	}

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -35,6 +35,8 @@
 				<Message
 					v-for="(message, index) of messages"
 					:key="message.id"
+					:next-message="(messages[index + 1] && messages[index + 1].id) || nextMessage"
+					:previous-message="(index > 0 && messages[index - 1].id) || previousMessage"
 					v-bind="message"
 					:is-first-message="index === 0"
 					:actor-type="actorType"
@@ -67,6 +69,20 @@ export default {
 		id: {
 			type: [String, Number],
 			required: true,
+		},
+		/**
+		 * Id of the next message
+		 */
+		nextMessage: {
+			type: [String, Number],
+			default: null,
+		},
+		/**
+		 * Id of the previous message
+		 */
+		previousMessage: {
+			type: [String, Number],
+			default: null,
 		},
 		/**
 		 * The conversation token.

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -40,11 +40,13 @@ get the messagesList array and loop through the list to generate the messages.
 				class="icon-loading" />
 		</div>
 		<MessagesGroup
-			v-for="item of messagesGroupedByAuthor"
+			v-for="(item, index) of messagesGroupedByAuthor"
 			:key="item[0].id"
 			:style="{ height: item.height + 'px' }"
 			v-bind="item"
 			:messages="item"
+			:next-message="messagesGroupedByAuthor[index + 1] && messagesGroupedByAuthor[index + 1][0].id"
+			:previous-message="index > 0 && messagesGroupedByAuthor[index - 1][messagesGroupedByAuthor[index - 1].length - 1].id"
 			@deleteMessage="handleDeleteMessage" />
 		<template v-if="!messagesGroupedByAuthor.length">
 			<LoadingPlaceholder


### PR DESCRIPTION
Adds keyboard navigation on the messages list:

### Todos
- [x] click a message to focus/select, then arrows to move
- [ ] tab should move to the reply button (it does but invisible)
- [ ] arrow up on NewMessageForm should jump to last message
- [ ] arrow down after last message should jump to NewMessageForm

### Issues
- [ ] tab should not move between messages
- [ ] reply button focus conflict between mouse and keyboard, might need to rework the hover concept
- [ ] warnings in log due to the quick and dirty approach for next-message and previous-message attributes
