### PR TITLE
Introduce participant mixin

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -53,7 +53,6 @@ import {
 	joinConversation,
 	leaveConversationSync,
 } from './services/participantsService'
-import { PARTICIPANT } from './constants'
 import {
 	signalingKill,
 } from './utils/webrtc/index'
@@ -61,6 +60,7 @@ import { emit } from '@nextcloud/event-bus'
 import browserCheck from './mixins/browserCheck'
 import duplicateSessionHandler from './mixins/duplicateSessionHandler'
 import isInCall from './mixins/isInCall'
+import participant from './mixins/participant'
 import talkHashCheck from './mixins/talkHashCheck'
 import { generateUrl } from '@nextcloud/router'
 import UploadEditor from './components/UploadEditor'
@@ -84,6 +84,7 @@ export default {
 		talkHashCheck,
 		duplicateSessionHandler,
 		isInCall,
+		participant,
 	],
 
 	data() {
@@ -105,23 +106,6 @@ export default {
 
 		getUserId() {
 			return this.$store.getters.getUserId()
-		},
-
-		participant() {
-			if (typeof this.token === 'undefined') {
-				return {
-					inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
-				}
-			}
-
-			const participantIndex = this.$store.getters.getParticipantIndex(this.token, this.$store.getters.getParticipantIdentifier())
-			if (participantIndex !== -1) {
-				return this.$store.getters.getParticipant(this.token, participantIndex)
-			}
-
-			return {
-				inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
-			}
 		},
 
 		warnLeaving() {

--- a/src/FilesSidebarCallViewApp.vue
+++ b/src/FilesSidebarCallViewApp.vue
@@ -31,11 +31,11 @@
 </template>
 
 <script>
-import { PARTICIPANT } from './constants'
 import CallView from './components/CallView/CallView'
 import PreventUnload from 'vue-prevent-unload'
 import duplicateSessionHandler from './mixins/duplicateSessionHandler'
 import isInCall from './mixins/isInCall'
+import participant from './mixins/participant'
 import talkHashCheck from './mixins/talkHashCheck'
 import '@nextcloud/dialogs/styles/toast.scss'
 
@@ -51,6 +51,7 @@ export default {
 	mixins: [
 		duplicateSessionHandler,
 		isInCall,
+		participant,
 		talkHashCheck,
 	],
 
@@ -104,17 +105,6 @@ export default {
 			}
 
 			return this.isInCall
-		},
-
-		participant() {
-			const participantIndex = this.$store.getters.getParticipantIndex(this.token, this.$store.getters.getParticipantIdentifier())
-			if (participantIndex === -1) {
-				return {
-					inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
-				}
-			}
-
-			return this.$store.getters.getParticipant(this.token, participantIndex)
 		},
 
 		warnLeaving() {

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -49,7 +49,6 @@ import { loadState } from '@nextcloud/initial-state'
 import CallView from './components/CallView/CallView'
 import ChatView from './components/ChatView'
 import CallButton from './components/TopBar/CallButton'
-import { PARTICIPANT } from './constants'
 import { EventBus } from './services/EventBus'
 import { fetchConversation } from './services/conversationsService'
 import { getPublicShareConversationData } from './services/filesIntegrationServices'
@@ -61,6 +60,7 @@ import { signalingKill } from './utils/webrtc/index'
 import browserCheck from './mixins/browserCheck'
 import duplicateSessionHandler from './mixins/duplicateSessionHandler'
 import isInCall from './mixins/isInCall'
+import participant from './mixins/participant'
 import talkHashCheck from './mixins/talkHashCheck'
 import '@nextcloud/dialogs/styles/toast.scss'
 
@@ -79,6 +79,7 @@ export default {
 		browserCheck,
 		duplicateSessionHandler,
 		isInCall,
+		participant,
 		talkHashCheck,
 	],
 
@@ -112,17 +113,6 @@ export default {
 
 		isOpen() {
 			return this.state.isOpen
-		},
-
-		participant() {
-			const participantIndex = this.$store.getters.getParticipantIndex(this.token, this.$store.getters.getParticipantIdentifier())
-			if (participantIndex === -1) {
-				return {
-					inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
-				}
-			}
-
-			return this.$store.getters.getParticipant(this.token, participantIndex)
 		},
 
 		warnLeaving() {

--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -189,6 +189,7 @@ export default {
 		},
 
 		participant() {
+			// TODO: use participant mixin ??
 			if (this.$store.getters.getToken()) {
 				return {
 					inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,

--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -133,7 +133,8 @@ import {
 } from '../../../services/conversationsService'
 import { generateUrl } from '@nextcloud/router'
 import PasswordProtect from './PasswordProtect/PasswordProtect'
-import { PARTICIPANT } from '../../../constants'
+import isInCall from '../../../mixins/isInCall'
+import participant from '../../../mixins/participant'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 
 export default {
@@ -153,6 +154,11 @@ export default {
 		PasswordProtect,
 		Plus,
 	},
+
+	mixins: [
+		isInCall,
+		participant,
+	],
 
 	data() {
 		return {
@@ -186,28 +192,6 @@ export default {
 		},
 		selectedParticipants() {
 			return this.$store.getters.selectedParticipants
-		},
-
-		participant() {
-			// TODO: use participant mixin ??
-			if (this.$store.getters.getToken()) {
-				return {
-					inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
-				}
-			}
-
-			const participantIndex = this.$store.getters.getParticipantIndex(this.$store.getters.getToken(), this.$store.getters.getParticipantIdentifier())
-			if (participantIndex !== -1) {
-				return this.$store.getters.getParticipant(this.$store.getters.getToken(), participantIndex)
-			}
-
-			return {
-				inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
-			}
-		},
-
-		isInCall() {
-			return this.participant.inCall !== PARTICIPANT.CALL_FLAG.DISCONNECTED
 		},
 	},
 

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -85,6 +85,7 @@ import FilePreview from './MessagePart/FilePreview'
 import Mention from './MessagePart/Mention'
 import RichText from '@juliushaertl/vue-richtext'
 import Quote from '../../../Quote'
+import participant from '../../../../mixins/participant'
 import { EventBus } from '../../../../services/EventBus'
 import emojiRegex from 'emoji-regex'
 import { PARTICIPANT, CONVERSATION } from '../../../../constants'
@@ -96,6 +97,10 @@ export default {
 	directives: {
 		tooltip: Tooltip,
 	},
+
+	mixins: [
+		participant,
+	],
 
 	components: {
 		Actions,
@@ -244,17 +249,6 @@ export default {
 
 		conversation() {
 			return this.$store.getters.conversation(this.token)
-		},
-
-		participant() {
-			const participantIndex = this.$store.getters.getParticipantIndex(this.token, this.$store.getters.getParticipantIdentifier())
-			if (participantIndex !== -1) {
-				return this.$store.getters.getParticipant(this.token, participantIndex)
-			}
-
-			return {
-				inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
-			}
 		},
 
 		messagesList() {

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -98,10 +98,6 @@ export default {
 		tooltip: Tooltip,
 	},
 
-	mixins: [
-		participant,
-	],
-
 	components: {
 		Actions,
 		ActionButton,
@@ -109,6 +105,11 @@ export default {
 		Quote,
 		RichText,
 	},
+
+	mixins: [
+		participant,
+	],
+
 	inheritAttrs: false,
 
 	props: {

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -52,6 +52,7 @@
 import { CONVERSATION, PARTICIPANT, WEBINAR } from '../../constants'
 import browserCheck from '../../mixins/browserCheck'
 import isInCall from '../../mixins/isInCall'
+import participant from '../../mixins/participant'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 import { emit } from '@nextcloud/event-bus'
 
@@ -65,6 +66,7 @@ export default {
 	mixins: [
 		browserCheck,
 		isInCall,
+		participant,
 	],
 
 	data() {
@@ -92,19 +94,6 @@ export default {
 				hasCall: false,
 				canStartCall: false,
 				lobbyState: WEBINAR.LOBBY.NONE,
-			}
-		},
-
-		participant() {
-			const participantIndex = this.$store.getters.getParticipantIndex(this.token, this.$store.getters.getParticipantIdentifier())
-			if (participantIndex !== -1) {
-				console.debug('Current participant found')
-				return this.$store.getters.getParticipant(this.token, participantIndex)
-			}
-
-			console.debug('Current participant not found')
-			return {
-				inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
 			}
 		},
 

--- a/src/mixins/isInCall.js
+++ b/src/mixins/isInCall.js
@@ -26,7 +26,7 @@ import { EventBus } from '../services/EventBus'
 /**
  * A mixin to check whether the current session of a user is in a call or not.
  *
- * Components using this mixin require a "token" property and a "participant" property with, at least, the "inCall" property.
+ * Components using this mixin require a "participant" property with, at least, the "inCall" property.
  */
 export default {
 
@@ -38,7 +38,7 @@ export default {
 
 	computed: {
 		isInCall() {
-			return this.sessionStorageJoinedConversation === this.token
+			return this.sessionStorageJoinedConversation === this.$store.getters.getToken()
 				&& this.participant.inCall !== PARTICIPANT.CALL_FLAG.DISCONNECTED
 		},
 	},

--- a/src/mixins/participant.js
+++ b/src/mixins/participant.js
@@ -23,27 +23,26 @@ import { PARTICIPANT } from '../constants'
 
 /**
  * A mixin to check retrieve the current participant object
- *
- * Components using this mixin require a "token" property.
  */
 export default {
 
 	computed: {
 		participant() {
-			if (typeof this.token === 'undefined') {
+			const token = this.$store.getters.getToken()
+			if (typeof token === 'undefined') {
 				return {
 					inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
 				}
 			}
 
-			const participantIndex = this.$store.getters.getParticipantIndex(this.token, this.$store.getters.getParticipantIdentifier())
+			const participantIndex = this.$store.getters.getParticipantIndex(token, this.$store.getters.getParticipantIdentifier())
 			if (participantIndex === -1) {
 				return {
 					inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
 				}
 			}
 
-			return this.$store.getters.getParticipant(this.token, participantIndex)
+			return this.$store.getters.getParticipant(token, participantIndex)
 		},
 	},
 }

--- a/src/mixins/participant.js
+++ b/src/mixins/participant.js
@@ -1,0 +1,49 @@
+/**
+ *
+ * @copyright Copyright (c) 2020 Vincent Petry <vincent@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { PARTICIPANT } from '../constants'
+
+/**
+ * A mixin to check retrieve the current participant object
+ *
+ * Components using this mixin require a "token" property.
+ */
+export default {
+
+	computed: {
+		participant() {
+			if (typeof this.token === 'undefined') {
+				return {
+					inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
+				}
+			}
+
+			const participantIndex = this.$store.getters.getParticipantIndex(this.token, this.$store.getters.getParticipantIdentifier())
+			if (participantIndex === -1) {
+				return {
+					inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
+				}
+			}
+
+			return this.$store.getters.getParticipant(this.token, participantIndex)
+		},
+	},
+}

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -23,6 +23,7 @@ import TopBar from '../components/TopBar/TopBar'
 import { PARTICIPANT } from '../constants'
 import isInLobby from '../mixins/isInLobby'
 import isInCall from '../mixins/isInCall'
+import participant from '../mixins/participant'
 
 export default {
 	name: 'MainView',
@@ -36,6 +37,7 @@ export default {
 	mixins: [
 		isInLobby,
 		isInCall,
+		participant,
 	],
 
 	props: {
@@ -48,23 +50,6 @@ export default {
 	computed: {
 		conversation() {
 			return this.$store.getters.conversation(this.token)
-		},
-
-		participant() {
-			if (typeof this.token === 'undefined') {
-				return {
-					inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
-				}
-			}
-
-			const participantIndex = this.$store.getters.getParticipantIndex(this.token, this.$store.getters.getParticipantIdentifier())
-			if (participantIndex !== -1) {
-				return this.$store.getters.getParticipant(this.token, participantIndex)
-			}
-
-			return {
-				inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
-			}
 		},
 
 		showChatInSidebar() {


### PR DESCRIPTION
To remove duplication of the "get current participant" logic all over
the place and also for future use.

Open issue:
- [x] seems one of the participant method was not implemented like the other, could be a bug ?! see https://github.com/nextcloud/spreed/pull/4672/files#r530502314 => I've fixed it, the below test will show if it worked

Tested based on the diff:
- [x] files sidebar call
- [x] public share sidebar
- [x] conversation messages
- [x] call button
- [x] app.vue: warn leaving when in call
- [x] mainview.vue: is in lobby check
- [x] newgroupconversation.vue: test creating a conversation while being in a call

