### PR TITLE
Fix Chromium performance hit in calls due to blur filter

### DIFF
--- a/lib/Listener/CSPListener.php
+++ b/lib/Listener/CSPListener.php
@@ -50,6 +50,8 @@ class CSPListener implements IEventListener {
 			$csp->addAllowedConnectDomain($server);
 		}
 
+		$csp->addAllowedWorkerSrcDomain('\'self\'');
+
 		$event->addPolicy($csp);
 	}
 }

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -426,7 +426,7 @@ export default {
 
 		// Blur radius for each background in the grid
 		videoBackgroundBlur() {
-			return this.$store.getters.getBlurFilter(this.videoWidth, this.videoHeight)
+			return this.$store.getters.getBlurRadius(this.videoWidth, this.videoHeight)
 		},
 
 		stripeOpen() {

--- a/src/components/CallView/shared/Video.vue
+++ b/src/components/CallView/shared/Video.vue
@@ -159,8 +159,8 @@ export default {
 		},
 		// Calculated once in the grid component for each video background
 		videoBackgroundBlur: {
-			type: String,
-			default: '',
+			type: Number,
+			default: 0,
 		},
 	},
 

--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -96,6 +96,7 @@ export default {
 			useCssBlurFilter: true,
 			blur: 0,
 			blurredBackgroundImage: null,
+			blurredBackgroundImageCache: {},
 			blurredBackgroundImageSource: null,
 		}
 	},
@@ -239,6 +240,13 @@ export default {
 				width = height * sourceAspectRatio
 			}
 
+			const cacheId = this.backgroundImageUrl + '-' + width + '-' + height + '-' + this.backgroundBlur
+			if (this.blurredBackgroundImageCache[cacheId]) {
+				this.blurredBackgroundImage = this.blurredBackgroundImageCache[cacheId]
+
+				return
+			}
+
 			const canvas = document.createElement('canvas')
 			canvas.width = width
 			canvas.height = height
@@ -248,6 +256,7 @@ export default {
 			context.drawImage(this.blurredBackgroundImageSource, 0, 0, canvas.width, canvas.height)
 
 			this.blurredBackgroundImage = canvas.toDataURL()
+			this.blurredBackgroundImageCache[cacheId] = this.blurredBackgroundImage
 		},
 	},
 }

--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -25,14 +25,14 @@
 			ref="darkener"
 			class="darken">
 			<ResizeObserver
-				v-if="gridBlur === ''"
+				v-if="gridBlur === 0"
 				class="observer"
 				@notify="setBlur" />
 		</div>
 		<img
 			v-if="hasPicture"
 			:src="backgroundImage"
-			:style="gridBlur ? gridBlur : blur"
+			:style="backgroundStyle"
 			class="video-background__picture"
 			alt="">
 		<div v-else
@@ -79,15 +79,15 @@ export default {
 			default: '',
 		},
 		gridBlur: {
-			type: String,
-			default: '',
+			type: Number,
+			default: 0,
 		},
 	},
 
 	data() {
 		return {
 			hasPicture: false,
-			blur: '',
+			blur: 0,
 		}
 	},
 
@@ -104,6 +104,11 @@ export default {
 		},
 		backgroundImage() {
 			return generateUrl(`avatar/${this.user}/300`)
+		},
+		backgroundStyle() {
+			return {
+				filter: `blur(${this.gridBlur ? this.gridBlur : this.blur}px)`,
+			}
 		},
 	},
 
@@ -145,7 +150,7 @@ export default {
 	methods: {
 		// Calculate the background blur based on the height of the background element
 		setBlur({ width, height }) {
-			this.blur = this.$store.getters.getBlurFilter(width, height)
+			this.blur = this.$store.getters.getBlurRadius(width, height)
 		},
 	},
 }

--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -105,9 +105,12 @@ export default {
 		backgroundImage() {
 			return generateUrl(`avatar/${this.user}/300`)
 		},
+		backgroundBlur() {
+			return this.gridBlur ? this.gridBlur : this.blur
+		},
 		backgroundStyle() {
 			return {
-				filter: `blur(${this.gridBlur ? this.gridBlur : this.blur}px)`,
+				filter: `blur(${this.backgroundBlur}px)`,
 			}
 		},
 	},

--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -164,7 +164,9 @@ export default {
 
 				const image = new Image()
 				image.onload = () => {
-					this.blurredBackgroundImageSource = image
+					createImageBitmap(image).then(imageBitmap => {
+						this.blurredBackgroundImageSource = imageBitmap
+					})
 				}
 				image.src = this.backgroundImageUrl
 			},

--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -227,18 +227,21 @@ export default {
 			// the element rather than to the previous image being shown.
 			this.$refs.backgroundImage.src = ''
 
-			const canvas = document.createElement('canvas')
-			canvas.width = this.$refs.backgroundImage.width
-			canvas.height = this.$refs.backgroundImage.height
+			let width = this.$refs.backgroundImage.width
+			let height = this.$refs.backgroundImage.height
 
 			const sourceAspectRatio = this.blurredBackgroundImageSource.width / this.blurredBackgroundImageSource.height
-			const canvasAspectRatio = canvas.width / canvas.height
+			const canvasAspectRatio = width / height
 
 			if (canvasAspectRatio > sourceAspectRatio) {
-				canvas.height = canvas.width / sourceAspectRatio
+				height = width / sourceAspectRatio
 			} else if (canvasAspectRatio < sourceAspectRatio) {
-				canvas.width = canvas.height * sourceAspectRatio
+				width = height * sourceAspectRatio
 			}
+
+			const canvas = document.createElement('canvas')
+			canvas.width = width
+			canvas.height = height
 
 			const context = canvas.getContext('2d')
 			context.filter = `blur(${this.backgroundBlur}px)`

--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -99,6 +99,7 @@ export default {
 			blurredBackgroundImage: null,
 			blurredBackgroundImageCache: {},
 			blurredBackgroundImageSource: null,
+			pendingGenerateBlurredBackgroundImageCount: 0,
 			isDestroyed: false,
 		}
 	},
@@ -257,6 +258,14 @@ export default {
 				return
 			}
 
+			if (this.pendingGenerateBlurredBackgroundImageCount) {
+				this.pendingGenerateBlurredBackgroundImageCount++
+
+				return
+			}
+
+			this.pendingGenerateBlurredBackgroundImageCount = 1
+
 			blur(this.blurredBackgroundImageSource, width, height, this.backgroundBlur).then(image => {
 				if (this.isDestroyed) {
 					return
@@ -264,6 +273,14 @@ export default {
 
 				this.blurredBackgroundImage = image
 				this.blurredBackgroundImageCache[cacheId] = this.blurredBackgroundImage
+
+				const generateBlurredBackgroundImageCalledAgain = this.pendingGenerateBlurredBackgroundImageCount > 1
+
+				this.pendingGenerateBlurredBackgroundImageCount = 0
+
+				if (generateBlurredBackgroundImageCalledAgain) {
+					this.generateBlurredBackgroundImage()
+				}
 			})
 		},
 	},

--- a/src/store/callViewStore.js
+++ b/src/store/callViewStore.js
@@ -44,8 +44,12 @@ const getters = {
 	selectedVideoPeerId: (state) => {
 		return state.selectedVideoPeerId
 	},
-	getBlurFilter: (state) => (width, height) => {
-		return `filter: blur(${(width * height * state.videoBackgroundBlur) / 1000}px)`
+	/**
+	 * @param {object} state the width and height to calculate the radius from
+	 * @returns {number} the blur radius to use, in pixels
+	 */
+	getBlurRadius: (state) => (width, height) => {
+		return (width * height * state.videoBackgroundBlur) / 1000
 	},
 }
 

--- a/src/utils/imageBlurrer.js
+++ b/src/utils/imageBlurrer.js
@@ -1,0 +1,34 @@
+/**
+ *
+ * @copyright Copyright (c) 2020, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+export default function blur(image, width, height, blurRadius) {
+	return new Promise((resolve, reject) => {
+		const canvas = document.createElement('canvas')
+		canvas.width = width
+		canvas.height = height
+
+		const context = canvas.getContext('2d')
+		context.filter = `blur(${blurRadius}px)`
+		context.drawImage(image, 0, 0, canvas.width, canvas.height)
+
+		resolve(canvas.toDataURL())
+	})
+}

--- a/src/utils/imageBlurrerWorker.js
+++ b/src/utils/imageBlurrerWorker.js
@@ -1,0 +1,37 @@
+/**
+ *
+ * @copyright Copyright (c) 2020, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+const fileReaderSync = new global.FileReaderSync()
+
+onmessage = function(message) {
+	const offscreenCanvas = new OffscreenCanvas(message.data.width, message.data.height)
+
+	const context = offscreenCanvas.getContext('2d')
+	context.filter = `blur(${message.data.blurRadius}px)`
+	context.drawImage(message.data.image, 0, 0, offscreenCanvas.width, offscreenCanvas.height)
+
+	offscreenCanvas.convertToBlob().then(blob => {
+		postMessage({
+			id: message.data.id,
+			blurredImageAsDataUrl: fileReaderSync.readAsDataURL(blob),
+		})
+	})
+}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -7,6 +7,11 @@ module.exports = {
 	entry: {
 		'admin-settings': path.join(__dirname, 'src', 'mainAdminSettings.js'),
 		'collections': path.join(__dirname, 'src', 'collections.js'),
+		// There is a "worker-loader" plugin for Webpack, but I was not able to
+		// get it to work ("publicPath" uses "output.publicPath" rather than the
+		// one set in the plugin
+		// https://github.com/webpack-contrib/worker-loader/issues/281).
+		'image-blurrer-worker': path.join(__dirname, 'src', 'utils/imageBlurrerWorker.js'),
 		'talk': path.join(__dirname, 'src', 'main.js'),
 		'talk-files-sidebar': [
 			path.join(__dirname, 'src', 'mainFilesSidebar.js'),


### PR DESCRIPTION
The CSS blur filter used in the VideoBackground component causes a severe performance hit in Chromium (the performance hit is higher the larger the image, and the larger the radius (which happens with larger images, the perfect storm :-P )).

To solve that, and given that Chromium has support for OffscreenCanvas, now the blurred background is generated instead using an OffscreenCanvas in a worker. Generating the blurred image in a normal canvas already improves the performance a lot, but it is still somewhat slow, so it needs to be done in a worker to not block the UI thread during the generation. Due to the slowness a cache for blurred backgrounds was added too.

Pending:
- [X] Do not fetch the source image again if the blurred image needs to be generated again
- [X] Probably cache blurred images so they are reused if previously calculated for the same source image and blur radius
- [X] Debounce and ensure that a new blurred image is not generated while a previous one is still being generated
- [X] Use an offscreen canvas when available
  - Although blurring the canvas is way faster in Chromium it still lags a bit, so it might be better to offload the rendering to an offscreen canvas
- [ ] Ensure that no memory leaks were added
- [ ] Check that nothing broke in older browsers

Known issues:
- The blurred background is cached locally in the component instance, and preventing the generation of other blurred backgrounds while a previous one is still being generated is also done per component instance. Due to this switching quickly and several times between the speaker mode and the grid view causes the generation of the last backgrounds to be delayed until the previous ones are ready. However that should not be something common to do, it is an annoyance rather than a big issue and the UI is still responsive while doing that, so I would not invest time on fixing that (or at least not at this moment).

- Grid blur is not set for LocalVideo component, so it always uses its own self-calculated blur radius. It seems that there is something else needed besides propagating the value from LocalVideo to VideoBackground and setting `:video-background-blur="videoBackgroundBlur"` in the LocalVideo components of _Grid.vue_ (probably just guarding against calculating the blur when there are no rows or columns, as `videoWidth` and `videoHeight` may be NaN or Infinity).

Future?:
- Use the blurred canvas approach in other browsers besides Chromium?
  - Offscreen canvas may not be availabe in Firefox (there is a setting to enable or disable it), so a normal canvas would be needed
  - Nevertheless it would be good to do some benchmarks to verify if canvas or CSS filter is better in Firefox
  - Safari does not support canvas filters, so the CSS filter has to be used in that case (or instead of a blurred image the average color of the image returned by https://www.npmjs.com/package/color.js could be used, but if there are no performance issues with the blur in Safari I would rather keep the CSS filter in that case)

## How to test
- Open Talk in Chromium
- Start a call with another user (not a guest)
- In a private window, join the call with the other user
- Disable camera in both participants so the avatar is shown
- Maximize the window (and the bigger the screen, the better)
- Close and open the sidebar

### Result with this pull request
The sidebar closes and opens immediately

### Result without this pull request
The UI is unresponsive (even if audio and video work as expected) for several seconds while the sidebar is closing and opening
