### PR TITLE
Unregister refreshPeerList on unmount

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -371,7 +371,7 @@ export default {
 		EventBus.$on('refreshPeerList', this.debounceFetchPeers)
 	},
 	unmounted() {
-		EventBus.$on('refreshPeerList', this.debounceFetchPeers)
+		EventBus.$off('refreshPeerList', this.debounceFetchPeers)
 	},
 	methods: {
 		/**


### PR DESCRIPTION
Fix copy-paste issue, replacing "$on" with "$off" when unmounting the
call view.

Might need a backport or cherry-pick in case this will be part of a bigger backport related to SIP.