### PR TITLE
Fix not sending signaling messages to participants without a Peer object

### DIFF
--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -249,7 +249,8 @@ CallParticipantModel.prototype = {
 	},
 
 	_handleRaisedHand: function(data) {
-		if (!this.get('peer') || this.get('peer').id !== data.id) {
+		// The hand could be raised even if there is no Peer object.
+		if (this.get('peerId') !== data.id) {
 			return
 		}
 

--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -250,8 +250,6 @@ Peer.prototype.handleMessage = function(message) {
 	} else if (message.type === 'unshareScreen') {
 		this.parent.emit('unshareScreen', { id: message.from })
 		this.end()
-	} else if (message.type === 'raiseHand') {
-		this.parent.emit('raisedHand', { id: message.from, raised: message.payload })
 	}
 }
 

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -123,6 +123,10 @@ function SimpleWebRTC(opts) {
 			// "nickChanged" can be received from a participant without a Peer
 			// object if that participant is not sending audio nor video.
 			self.emit('nick', { id: message.from, name: message.payload.name })
+		} else if (message.type === 'raiseHand') {
+			// "raisedHand" can be received from a participant without a Peer
+			// object if that participant is not sending audio nor video.
+			self.emit('raisedHand', { id: message.from, raised: message.payload })
 		} else if (peers.length) {
 			peers.forEach(function(peer) {
 				if (message.sid && !self.connection.hasFeature('mcu')) {

--- a/src/utils/webrtc/simplewebrtc/webrtc.js
+++ b/src/utils/webrtc/simplewebrtc/webrtc.js
@@ -112,6 +112,8 @@ WebRTC.prototype.sendToAll = function(message, payload) {
 	this.peers.forEach(function(peer) {
 		peer.send(message, payload)
 	})
+
+	this.emit('sendToAll', message, payload)
 }
 
 // sends message to all using a datachannel


### PR DESCRIPTION
`webrtc.sendToAll` only sends the signaling message to participants for which there is a Peer object. Due to this now it also emits and event that is handled by the WebRTC wrapper to send the message too to the rest of participants in the call that do not have a Peer object.

Sending signaling messages to participants without peers is currently needed for "raise hand" messages, and it will be needed for mute/unmute messages once the data channels are removed.

This pull request also fixes receiving raised hand events from participants without a Peer object, which could be useful in the webcast mode.

~~Besides the fix also some unneeded code was removed.~~ Extracted to its own [pull request](https://github.com/nextcloud/spreed/pull/5679).

Pending:
- [X] Fix signaling message sent also to own peer when the HPB is used (previously existing bug, not introduced here, but I have just noticed it)? The signaling server seems to just drop the message, so it is not a big trouble, it would be just for tidyness - Turns out that the code is uglier with that change, so let's keep it as is.
- [X] Set a proper `roomType` in signaling messages to participants without peers
- [ ] Ensure that mobile apps will not choke if a mute/unmute message is received from a participant without audio and video
- [ ] Rebase on master and check that everything works as expected with SIP
- [ ] Test thoroughly

## How to test (scenario 1)
- Setup the HPB
- As user A, start a call with audio and/or video
- As user B, in a private window open the conversation
- Open Talk settings and disable both audio and video
- Join the call
- As user A, raise the hand

### Result with this pull request

User B sees that user A raised the hand

### Result without this pull request

User B does not see that user A raised the hand

## How to test (scenario 2)
- Setup the HPB
- As user A, start a call with audio and/or video
- As user B, in a private window open the conversation
- Open Talk settings and disable both audio and video
- Join the call
- Raise the hand

### Result with this pull request

User A sees that user B raised the hand

### Result without this pull request

User A does not see that user B raised the hand

## How to test (scenario 3)
- Do not setup the HPB
- As user A, open Talk settings and disable both audio and video
- Start a call with audio and/or video
- As user B, in a private window open the conversation
- Open Talk settings and disable both audio and video
- Join the call
- Raise the hand

### Result with this pull request

User A sees that user B raised the hand

### Result without this pull request

User A does not see that user B raised the hand
