### PR TITLE
Adjust local media control position in sidebar

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -26,6 +26,7 @@
 			<LocalMediaControls
 				v-if="!isGrid"
 				class="local-media-controls"
+				:class="{ 'local-media-controls--sidebar': isSidebar }"
 				:model="localMediaModel"
 				:local-call-participant-model="localCallParticipantModel"
 				:screen-sharing-button-hidden="isSidebar"
@@ -752,6 +753,10 @@ export default {
 	right: 0;
 	bottom: 4px;
 	z-index: 10;
+
+	&--sidebar {
+		width: 150px;
+	}
 }
 
 </style>


### PR DESCRIPTION
When in sidebar, use the same size as the video for properly centering
the media controls.

Fixes https://github.com/nextcloud/spreed/issues/4668

This was caused by the changes related to the stripe collapsing.