### PR TITLE
Disallow following self in sidebar mode

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -525,13 +525,16 @@ export default {
 			this.videoContainerAspectRatio = videoContainerWidth / VideoContainerHeight
 		},
 		handleSelectVideo(peerId) {
+			if (this.isSidebar) {
+				return
+			}
 			this.$store.dispatch('setCallViewMode', { isGrid: false })
 			this.$store.dispatch('selectedVideoPeerId', peerId)
 			this.isLocalVideoSelected = false
 		},
 		handleClickLocalVideo() {
 			// DO nothing if no video
-			if (!this.hasLocalVideo) {
+			if (!this.hasLocalVideo || this.isSidebar) {
 				return
 			}
 			// Deselect possible selected video

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -184,7 +184,7 @@ export default {
 		},
 
 		isSelectable() {
-			return this.hasLocalVideo && this.$store.getters.selectedVideoPeerId !== 'local'
+			return !this.isSidebar && this.hasLocalVideo && this.$store.getters.selectedVideoPeerId !== 'local'
 		},
 	},
 


### PR DESCRIPTION
Remove hover effect and ignore clicks on a local video when in sidebar
mode, to prevent following self.

Fixes https://github.com/nextcloud/spreed/issues/4574