### PR TITLE
Fix follow self + remember state after unfollowing + collapse stripe

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -530,7 +530,7 @@ export default {
 			if (this.isSidebar) {
 				return
 			}
-			this.$store.dispatch('setCallViewMode', { isGrid: false })
+			this.$store.dispatch('startPresentation')
 			this.$store.dispatch('selectedVideoPeerId', peerId)
 			this.isLocalVideoSelected = false
 		},
@@ -541,7 +541,7 @@ export default {
 			}
 			// Deselect possible selected video
 			this.$store.dispatch('selectedVideoPeerId', 'local')
-			this.$store.dispatch('setCallViewMode', { isGrid: false })
+			this.$store.dispatch('startPresentation')
 		},
 
 		debounceFetchPeers: debounce(async function() {

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -70,7 +70,7 @@
 						@switchScreenToId="_switchScreenToId" />
 				</template>
 			</div>
-			<!-- Local Video Override mode -->
+			<!-- Local Video Override mode (following own video) -->
 			<div v-if="showLocalVideo"
 				ref="videoContainer"
 				class="video__promoted autopilot"
@@ -79,6 +79,7 @@
 					ref="localVideo"
 					:fit-video="true"
 					:is-stripe="false"
+					:show-controls="false"
 					:is-big="true"
 					:local-media-model="localMediaModel"
 					:video-container-aspect-ratio="videoContainerAspectRatio"

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -277,6 +277,7 @@ export default {
 
 		handleStopFollowing() {
 			this.$store.dispatch('selectedVideoPeerId', null)
+			this.$store.dispatch('stopPresentation')
 		},
 	},
 

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -129,6 +129,9 @@ export default {
 	},
 
 	computed: {
+		stopFollowingLabel() {
+			return t('spreed', 'Back')
+		},
 
 		videoContainerClass() {
 			return {

--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -209,6 +209,7 @@ export default {
 		},
 
 		handleStopFollowing() {
+			this.$store.dispatch('stopPresentation')
 			this.$store.dispatch('selectedVideoPeerId', null)
 		},
 	},


### PR DESCRIPTION
Don't show controls when following own video.
Fix missing label for going back.

Fixes https://github.com/nextcloud/spreed/issues/4688

After seeing this I was bothered that my own video was still visible, so I directly looked into hiding it, which led me to do this for all the follow modes:

After following, start presentation mode which will internally remember the last state. When unfollowing, stop presentation mode which will restore the previous state, unless tempered with previously.
    
This will now also automatically collapse the stripe and the own video when following.

This adresses the comment in https://github.com/nextcloud/spreed/issues/3518#issuecomment-676600694
