### PR TITLE
Help psalm find context when running single files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,10 @@
 {
+	"autoload-dev": {
+		"psr-4": {
+			"OCP\\": "vendor/christophwurst/nextcloud/OCP",
+			"OCA\\Talk\\": "lib/"
+		}
+	},
 	"scripts": {
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"cs:fix": "php-cs-fixer fix",


### PR DESCRIPTION
### Steps to reproduce

1. Run `composer install`
2. Run `psalm --threads=1 lib/Controller/SignalingController.php`

### Expected result

No errors

### Before the fix

```
ERROR: UndefinedClass - lib/Controller/SignalingController.php:53:35 - Class or interface OCP\AppFramework\OCSController does not exist (see https://psalm.dev/019)
class SignalingController extends OCSController {


------------------------------
1 errors found
------------------------------

Checks took 0.69 seconds and used 115.912MB of memory
Psalm was able to infer types for 95.2155% of the codebase
```

### After the fix

No errors reported.

### Explanation

This is because passing in a single file makes it ignore the directories that are included in psalm.xml.

According to the psalm docs, it uses the autoloader from composer to locate those packages. However, our autoloader did not include neither "christophwurst/nextcloud" nor "lib", probably because we normally rely on the server's autoloader when the app is deployed.

Adding the entries from this PR to composer.json in "autoload-dev" section makes it work.

### Why bother ?

Some IDEs are able to run psalm or psalm-language-server to report issues, but they are using single file mode so they'd always report the errors above.
