### PR TITLE
Don't select timestamp but selecting messages

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -425,6 +425,7 @@ export default {
 			justify-self: flex-start;
 			justify-content:  space-between;
 			position: relative;
+			user-select: none;
 			display: flex;
 			color: var(--color-text-maxcontrast);
 			font-size: $chat-font-size;


### PR DESCRIPTION
Fixes copying of multiple messages.
Now only the message bodies are included and no more timestamps.

### Steps to reproduce

1. Send a message "one message"
2. Send a message "second line"
3. Send a message "third, repeat"
4. With the mouse, start dragging before the "o" and down to the end of "repeat" to select the messages
5. Right click + copy
6. Paste into a text editor

### Before:
Timestamps included:
```
one message

second line
15:41
third, repeat
```

### After:
No more timestamps:
```
one message
second line
third, repeat
```
