### PR TITLE
Don't repeat calls to handler when using short keys

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,7 +21,7 @@
 
 <template>
 	<Content
-		v-shortkey="['ctrl', 'f']"
+		v-shortkey.once="['ctrl', 'f']"
 		:class="{ 'icon-loading': loading, 'in-call': isInCall }"
 		app-name="talk"
 		@shortkey.native="handleAppSearch">

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -25,7 +25,7 @@
 			<div id="muteWrapper">
 				<button
 					id="mute"
-					v-shortkey="['m']"
+					v-shortkey.once="['m']"
 					v-tooltip="audioButtonTooltip"
 					:aria-label="audioButtonAriaLabel"
 					:class="audioButtonClass"
@@ -39,7 +39,7 @@
 			</div>
 			<button
 				id="hideVideo"
-				v-shortkey="['v']"
+				v-shortkey.once="['v']"
 				v-tooltip="videoButtonTooltip"
 				:aria-label="videoButtonAriaLabel"
 				:class="videoButtonClass"

--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -74,7 +74,7 @@
 		</template>
 		<div
 			ref="contentEditable"
-			v-shortkey="['c']"
+			v-shortkey.once="['c']"
 			:contenteditable="activeInput"
 			:placeHolder="placeholderText"
 			role="textbox"

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -53,7 +53,7 @@
 		</Popover>
 		<!-- sidebar toggle -->
 		<Actions
-			v-shortkey="['f']"
+			v-shortkey.once="['f']"
 			class="top-bar__button"
 			menu-align="right"
 			:aria-label="t('spreed', 'Conversation actions')"


### PR DESCRIPTION
When holding a shortcut key like "m" for mute, don't repeat the call to
the handler to avoid flickering.

### Steps to reproduce

1. Start a call with a webcam
1. Hold the "v" key

### Before this fix
Disco!

### After
No more disco.

