### PR TITLE
Add support for turn:/turns: schemes on turn server settings

### DIFF
--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -137,21 +137,26 @@ class SignalingController extends OCSController {
 		}
 
 		$stun = [];
-		$stunServer = $this->talkConfig->getStunServer();
-		if ($stunServer) {
+		foreach ($this->talkConfig->getStunServers() as $stunServer) {
+			if (strtolower(substr($stunServer, 0, 5)) !== 'stun:' && strtolower(substr($stunServer, 0, 6)) !== 'stuns:') {
+				$stunServer = 'stun:' . $stunServer;
+			}
 			$stun[] = [
-				'url' => 'stun:' . $stunServer,
+				'url' => $stunServer,
 			];
 		}
 
 		$turn = [];
-		$turnSettings = $this->talkConfig->getTurnSettings();
-		if (!empty($turnSettings['server'])) {
+		foreach ($this->talkConfig->getTurnSettings() as $turnSettings) {
 			$protocols = explode(',', $turnSettings['protocols']);
 			foreach ($protocols as $proto) {
+				$server = $turnSettings['server'];
+				if (strtolower(substr($server, 0, 5)) !== 'turn:' && strtolower(substr($server, 0, 6)) !== 'turns:') {
+					$server = 'turn:' . $server;
+				}
 				$turn[] = [
-					'url' => ['turn:' . $turnSettings['server'] . '?transport=' . $proto],
-					'urls' => ['turn:' . $turnSettings['server'] . '?transport=' . $proto],
+					'url' => [$server . '?transport=' . $proto],
+					'urls' => [$server . '?transport=' . $proto],
 					'username' => $turnSettings['username'],
 					'credential' => $turnSettings['password'],
 				];

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -160,7 +160,11 @@ export default {
 			const urls = []
 			let i
 			for (i = 0; i < protocols.length; i++) {
-				urls.push('turn:' + this.server + '?transport=' + protocols[i])
+				let server = this.server
+				if (!(server.toLowerCase().startsWith('turn:') || server.toLowerCase().startsWith('turns:'))) {
+					server = 'turn:' + server
+				}
+				urls.push(server + '?transport=' + protocols[i])
 			}
 
 			const expires = Math.round((new Date()).getTime() / 1000) + (5 * 60)

--- a/tests/php/ConfigTest.php
+++ b/tests/php/ConfigTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ConfigTest extends TestCase {
-	public function testGetStunServer() {
+	public function testGetStunServers() {
 		$servers = [
 			'stun1.example.com:443',
 			'stun2.example.com:129',
@@ -55,10 +55,10 @@ class ConfigTest extends TestCase {
 			->willReturn(true);
 
 		$helper = new Config($config, $secureRandom, $groupManager, $timeFactory);
-		$this->assertTrue(in_array($helper->getStunServer(), $servers, true));
+		$this->assertSame($servers, $helper->getStunServers());
 	}
 
-	public function testGetDefaultStunServer() {
+	public function testGetDefaultStunServers() {
 		/** @var MockObject|ITimeFactory $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
 		/** @var MockObject|ISecureRandom $secureRandom */
@@ -79,10 +79,10 @@ class ConfigTest extends TestCase {
 			->willReturn(true);
 
 		$helper = new Config($config, $secureRandom, $groupManager, $timeFactory);
-		$this->assertSame('stun.nextcloud.com:443', $helper->getStunServer());
+		$this->assertSame(['stun.nextcloud.com:443'], $helper->getStunServers());
 	}
 
-	public function testGetDefaultStunServerNoInternet() {
+	public function testGetDefaultStunServersNoInternet() {
 		/** @var MockObject|ITimeFactory $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
 		/** @var MockObject|ISecureRandom $secureRandom */
@@ -103,7 +103,7 @@ class ConfigTest extends TestCase {
 			->willReturn(false);
 
 		$helper = new Config($config, $secureRandom, $groupManager, $timeFactory);
-		$this->assertSame('', $helper->getStunServer());
+		$this->assertSame([], $helper->getStunServers());
 	}
 
 	public function testGenerateTurnSettings() {
@@ -147,21 +147,22 @@ class ConfigTest extends TestCase {
 		$helper = new Config($config, $secureRandom, $groupManager, $timeFactory);
 
 		//
-		$server = $helper->getTurnSettings();
-		if ($server['server'] === 'turn.example.org') {
-			$this->assertSame([
-				'server' => 'turn.example.org',
-				'username' => '1479829425:abcdefghijklmnop',
-				'password' => '4VJLVbihLzuxgMfDrm5C3zy8kLQ=',
-				'protocols' => 'udp,tcp',
-			], $server);
-		} else {
-			$this->assertSame([
-				'server' => 'turn2.example.com',
-				'username' => '1479829425:abcdefghijklmnop',
-				'password' => 'Ol9DEqnvyN4g+IAM+vFnqhfWUTE=',
-				'protocols' => 'tcp',
-			], $server);
+		foreach ($helper->getTurnSettings() as $server) {
+			if ($server['server'] === 'turn.example.org') {
+				$this->assertSame([
+					'server' => 'turn.example.org',
+					'username' => '1479829425:abcdefghijklmnop',
+					'password' => '4VJLVbihLzuxgMfDrm5C3zy8kLQ=',
+					'protocols' => 'udp,tcp',
+				], $server);
+			} else {
+				$this->assertSame([
+					'server' => 'turn2.example.com',
+					'username' => '1479829425:abcdefghijklmnop',
+					'password' => 'Ol9DEqnvyN4g+IAM+vFnqhfWUTE=',
+					'protocols' => 'tcp',
+				], $server);
+			}
 		}
 	}
 


### PR DESCRIPTION
This allows administrators to add `turn:` or `turns:` prefixes to the TURN server names in the configuration. 

For backward compatibility, servers without either prefix will still generate 'turn:' URLs, those with the scheme specified will preserve that scheme in the URL.

This allows specifying TURN+TLS or TURN+DTLS to allow traversal of restrictive firewalls. e.g. `turns:turn.example.com:443` will generally be indistinguishable from https traffic.

While I was there, I also added support for `stun:` and `stuns:` prefixes on the STUN server settings, mostly for symmetry and consistency. 

I also removed the code that picks one of the configured TURN or STUN servers randomly. The code now sends all servers to the client in the specified order. This allows administrators to configure more efficient fallback behavior, e.g. specify unencrypted servers first, then fall back to encrypted connections when needed.

Fixes #257

FWIW, I have a TURN server that only allows TCP/UDP connections on port 3478 and TCP+TLS/UDP+DTLS on ports 443 and 5349 that I can make available for testing (as opposed to COTURN's normal behavior of allowing all protocols on all ports).