### PR TITLE
Fix telegram channel config key

### DIFF
--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -504,7 +504,9 @@ class MatterbridgeManager {
 				$content .= "\n";
 			} elseif ($type === 'msteams') {
 				$content .= sprintf('	threadId = "%s"', $part['threadid']) . "\n\n";
-			} elseif (in_array($type, ['telegram', 'steam'])) {
+			} elseif ($type === 'telegram') {
+				$content .= sprintf('	channel = "%s"', $part['channel']) . "\n\n";
+			} elseif ($type === 'steam') {
 				$content .= sprintf('	chatid = "%s"', $part['chatid']) . "\n\n";
 			}
 		}

--- a/src/components/RightSidebar/Matterbridge/MatterbridgeSettings.vue
+++ b/src/components/RightSidebar/Matterbridge/MatterbridgeSettings.vue
@@ -299,9 +299,9 @@ export default {
 							placeholder: t('spreed', 'API token'),
 							icon: 'icon-category-auth',
 						},
-						chatid: {
+						channel: {
 							type: 'text',
-							placeholder: t('spreed', 'Chat ID'),
+							placeholder: t('spreed', 'Channel'),
 							icon: 'icon-group',
 						},
 					},


### PR DESCRIPTION
[Matterbridge sample config file](https://github.com/42wim/matterbridge/blob/0d7315249d20bf9856605068074a7b6c6bcce835/matterbridge.toml.sample#L1825) mentions an incorrect config key for the channel.

This fix has been tested in #4719.
