### PR TITLE
Add backend for conversation avatars

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -25,6 +25,7 @@ namespace OCA\Talk\AppInfo;
 
 use OCA\Files_Sharing\Event\BeforeTemplateRenderedEvent;
 use OCA\Talk\Activity\Listener as ActivityListener;
+use OCA\Talk\Avatar\RoomAvatarProvider;
 use OCA\Talk\Capabilities;
 use OCA\Talk\Chat\Changelog\Listener as ChangelogListener;
 use OCA\Talk\Chat\ChatManager;
@@ -102,6 +103,8 @@ class Application extends App implements IBootstrap {
 		$context->registerSearchProvider(MessageSearch::class);
 
 		$context->registerDashboardWidget(TalkWidget::class);
+
+		$context->registerAvatarProvider('room', RoomAvatarProvider::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Avatar/RoomAvatar.php
+++ b/lib/Avatar/RoomAvatar.php
@@ -1,0 +1,308 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @author Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Avatar;
+
+use OCA\Talk\Room;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\Files\SimpleFS\ISimpleFolder;
+use OCP\IAvatar;
+use OCP\IImage;
+use OCP\IL10N;
+use Psr\Log\LoggerInterface;
+
+class RoomAvatar implements IAvatar {
+
+	/** @var ISimpleFolder */
+	private $folder;
+
+	/** @var Room */
+	private $room;
+
+	/** @var IL10N */
+	private $l;
+
+	/** @var LoggerInterface */
+	private $logger;
+
+	/** @var string */
+	private $avatarFileNameId;
+
+	public function __construct(
+			ISimpleFolder $folder,
+			Room $room,
+			IL10N $l,
+			LoggerInterface $logger) {
+		$this->folder = $folder;
+		$this->room = $room;
+		$this->l = $l;
+		$this->logger = $logger;
+		$this->avatarFileNameId = 'avatar-' . $this->room->getToken();
+	}
+
+	/**
+	 * Gets the room avatar
+	 *
+	 * @param int $size size in px of the avatar, avatars are square, defaults to 64, -1 can be used to not scale the image
+	 * @return boolean|\OCP\IImage containing the avatar or false if there's no image
+	 */
+	public function get($size = 64) {
+		$size = (int) $size;
+
+		try {
+			$file = $this->getFile($size);
+		} catch (NotFoundException $e) {
+			return false;
+		}
+
+		$avatar = new \OC_Image();
+		$avatar->loadFromData($file->getContent());
+		return $avatar;
+	}
+
+	/**
+	 * Checks if an avatar exists for the room.
+	 *
+	 * @return bool
+	 */
+	public function exists(): bool {
+		return $this->folder->fileExists($this->avatarFileNameId . '.jpg') || $this->folder->fileExists($this->avatarFileNameId . '.png');
+	}
+
+	/**
+	 * Checks if the avatar of a room is a custom uploaded one.
+	 *
+	 * @return bool
+	 */
+	public function isCustomAvatar(): bool {
+		return $this->exists();
+	}
+
+	/**
+	 * Sets the room avatar
+	 *
+	 * @param \OCP\IImage|resource|string $data An image object, imagedata or path to set a new avatar
+	 * @throws \Exception if the provided file is not a jpg or png image
+	 * @throws \Exception if the provided image is not valid
+	 * @throws \OC\NotSquareException if the image is not square
+	 * @return void
+	 */
+	public function set($data): void {
+		$image = $this->getAvatarImage($data);
+		$data = $image->data();
+
+		$this->validateAvatar($image);
+
+		$this->remove();
+		$type = $this->getAvatarImageType($image);
+		$file = $this->folder->newFile($this->avatarFileNameId . '.' . $type);
+		$file->putContent($data);
+	}
+
+	/**
+	 * Returns an image from several sources.
+	 *
+	 * @param IImage|resource|string $data An image object, imagedata or path to the avatar
+	 * @return IImage
+	 */
+	private function getAvatarImage($data): IImage {
+		if ($data instanceof IImage) {
+			return $data;
+		}
+
+		$image = new \OC_Image();
+		if (is_resource($data) && get_resource_type($data) === 'gd') {
+			$image->setResource($data);
+		} elseif (is_resource($data)) {
+			$image->loadFromFileHandle($data);
+		} else {
+			try {
+				// detect if it is a path or maybe the images as string
+				$result = @realpath($data);
+				if ($result === false || $result === null) {
+					$image->loadFromData($data);
+				} else {
+					$image->loadFromFile($data);
+				}
+			} catch (\Error $e) {
+				$image->loadFromData($data);
+			}
+		}
+
+		return $image;
+	}
+
+	/**
+	 * Returns the avatar image type.
+	 *
+	 * @param IImage $avatar
+	 * @return string
+	 */
+	private function getAvatarImageType(IImage $avatar): string {
+		$type = substr($avatar->mimeType(), -3);
+		if ($type === 'peg') {
+			$type = 'jpg';
+		}
+		return $type;
+	}
+
+	/**
+	 * Validates an avatar image:
+	 * - must be "png" or "jpg"
+	 * - must be "valid"
+	 * - must be in square format
+	 *
+	 * @param IImage $avatar The avatar to validate
+	 * @throws \Exception if the provided file is not a jpg or png image
+	 * @throws \Exception if the provided image is not valid
+	 * @throws \Exception if the image is not square
+	 */
+	private function validateAvatar(IImage $avatar): void {
+		$type = $this->getAvatarImageType($avatar);
+
+		if ($type !== 'jpg' && $type !== 'png') {
+			throw new \Exception($this->l->t('Unknown filetype'));
+		}
+
+		if (!$avatar->valid()) {
+			throw new \Exception($this->l->t('Invalid image'));
+		}
+
+		if (!($avatar->height() === $avatar->width())) {
+			throw new \Exception($this->l->t('Avatar image is not square'));
+		}
+	}
+
+	/**
+	 * Remove the room avatar
+	 *
+	 * @return void
+	 */
+	public function remove(): void {
+		$files = $this->folder->getDirectoryListing();
+
+		// Deletes the original image as well as the resized ones.
+		foreach ($files as $file) {
+			if (substr($file->getName(), 0, strlen($this->avatarFileNameId)) === $this->avatarFileNameId) {
+				$file->delete();
+			}
+		}
+	}
+
+	/**
+	 * Get the file of the avatar
+	 *
+	 * @param int $size -1 can be used to not scale the image
+	 * @return ISimpleFile
+	 * @throws NotFoundException
+	 */
+	public function getFile($size): ISimpleFile {
+		$size = (int) $size;
+
+		$extension = $this->getExtension();
+
+		if ($size === -1) {
+			$path = $this->avatarFileNameId . '.' . $extension;
+		} else {
+			$path = $this->avatarFileNameId . '.' . $size . '.' . $extension;
+		}
+
+		try {
+			$file = $this->folder->getFile($path);
+		} catch (NotFoundException $e) {
+			if ($size <= 0) {
+				throw new NotFoundException;
+			}
+
+			$file = $this->generateResizedAvatarFile($extension, $path, $size);
+		}
+
+		return $file;
+	}
+
+	/**
+	 * Gets the extension of the avatar file.
+	 *
+	 * @return string the extension.
+	 * @throws NotFoundException if there is no avatar.
+	 */
+	private function getExtension(): string {
+		if ($this->folder->fileExists('avatar-' . $this->room->getToken() . '.jpg')) {
+			return 'jpg';
+		} 
+		if ($this->folder->fileExists('avatar-' . $this->room->getToken() . '.png')) {
+			return 'png';
+		}
+		throw new NotFoundException;
+	}
+
+	/**
+	 * Generates a resized avatar file with the given size.
+	 *
+	 * @param string $extension the extension of the original avatar file.
+	 * @param string $path the path to the resized avatar file.
+	 * @param int $size the size of the avatar.
+	 * @return ISimpleFile the resized avatar file.
+	 * @throws NotFoundException if it was not possible to generate the resized
+	 *         avatar file.
+	 */
+	private function generateResizedAvatarFile(string $extension, string $path, int $size): ISimpleFile {
+		$avatar = new \OC_Image();
+		$file = $this->folder->getFile($this->avatarFileNameId . '.' . $extension);
+		$avatar->loadFromData($file->getContent());
+		$avatar->resize($size);
+		$data = $avatar->data();
+
+		try {
+			$file = $this->folder->newFile($path);
+			$file->putContent($data);
+		} catch (NotPermittedException $e) {
+			$this->logger->error('Failed to save avatar for room ' . $this->room->getToken() . ' with size ' . $size);
+			throw new NotFoundException();
+		}
+
+		return $file;
+	}
+
+	/**
+	 * @param string $text
+	 * @return Color Object containting r g b int in the range [0, 255]
+	 */
+	public function avatarBackgroundColor(string $text): Color {
+		// Dummy implementation.
+		return new Color(0, 130, 201); // Nextcloud blue
+	}
+
+	/**
+	 * Ignored.
+	 */
+	public function userChanged($feature, $oldValue, $newValue) {
+	}
+
+}
+

--- a/lib/Avatar/RoomAvatarProvider.php
+++ b/lib/Avatar/RoomAvatarProvider.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @author Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Avatar;
+
+use OCA\Talk\Exceptions\RoomNotFoundException;
+use OCA\Talk\Manager;
+use OCP\Files\IAppData;
+use OCP\Files\NotFoundException;
+use OCP\IAvatar;
+use OCP\IAvatarProvider;
+use OCP\IL10N;
+use Psr\Log\LoggerInterface;
+
+class RoomAvatarProvider implements IAvatarProvider {
+
+	/** @var IAppData */
+	private $appData;
+
+	/** @var Manager */
+	private $manager;
+
+	/** @var IL10N */
+	private $l;
+
+	/** @var LoggerInterface */
+	private $logger;
+
+	public function __construct(
+			IAppData $appData,
+			Manager $manager,
+			IL10N $l,
+			LoggerInterface $logger) {
+		$this->appData = $appData;
+		$this->manager = $manager;
+		$this->l = $l;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Returns a RoomAvatar instance for the given room token.
+	 *
+	 * @param string $id the identifier of the avatar.
+	 * @returns the RoomAvatar.
+	 * @throws RoomNotFoundException if there is no room with the given token.
+	 */
+	public function getAvatar(string $id): IAvatar {
+		$room = $this->manager->getRoomByToken($id);
+
+		try {
+			$folder = $this->appData->getFolder('talk');
+		} catch (NotFoundException $e) {
+			$folder = $this->appData->newFolder('talk');
+		}
+
+		return new RoomAvatar($folder, $room, $this->l, $this->logger);
+	}
+
+}

--- a/tests/integration/features/bootstrap/AvatarTrait.php
+++ b/tests/integration/features/bootstrap/AvatarTrait.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * @copyright Copyright (c) 2020, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @author Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
+
+trait AvatarTrait {
+
+	/** @var string **/
+	private $lastAvatar;
+
+	/** @AfterScenario **/
+	public function cleanupLastAvatar() {
+		$this->lastAvatar = null;
+	}
+
+	private function getLastAvatar() {
+		$this->lastAvatar = '';
+
+		$body = $this->response->getBody();
+		while (!$body->eof()) {
+			$this->lastAvatar .= $body->read(8192);
+		}
+		$body->close();
+	}
+	/**
+	 * @When user :user gets avatar for room :identifier
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 */
+	public function userGetsAvatarForRoom(string $user, string $identifier) {
+		$this->userGetsAvatarForRoomWithSize($user, $identifier, '128');
+	}
+
+	/**
+	 * @When user :user gets avatar for room :identifier with size :size
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 * @param string $size
+	 */
+	public function userGetsAvatarForRoomWithSize(string $user, string $identifier, string $size) {
+		$this->userGetsAvatarForRoomWithSizeWith($user, $identifier, $size, '200');
+	}
+
+	/**
+	 * @When user :user gets avatar for room :identifier with size :size with :statusCode
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 * @param string $size
+	 * @param string $statusCode
+	 */
+	public function userGetsAvatarForRoomWithSizeWith(string $user, string $identifier, string $size, string $statusCode) {
+		$this->setCurrentUser($user);
+		$this->sendRequest('GET', '/core/avatar/room/' . FeatureContext::getTokenForIdentifier($identifier) . '/' . $size, null);
+		$this->assertStatusCode($this->response, $statusCode);
+
+		if ($statusCode !== '200') {
+			return;
+		}
+
+		$this->getLastAvatar();
+	}
+
+	/**
+	 * @When user :user sets avatar for room :identifier from file :source
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 * @param string $source
+	 */
+	public function userSetsAvatarForRoomFromFile(string $user, string $identifier, string $source) {
+		$this->userSetsAvatarForRoomFromFileWith($user, $identifier, $source, '200');
+	}
+
+	/**
+	 * @When user :user sets avatar for room :identifier from file :source with :statusCode
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 * @param string $source
+	 * @param string $statusCode
+	 */
+	public function userSetsAvatarForRoomFromFileWith(string $user, string $identifier, string $source, string $statusCode) {
+		$file = \GuzzleHttp\Psr7\stream_for(fopen($source, 'r'));
+
+		$this->setCurrentUser($user);
+		$this->sendRequest('POST', '/core/avatar/room/' . FeatureContext::getTokenForIdentifier($identifier),
+			[
+				'multipart' => [
+					[
+						'name' => 'files[]',
+						'contents' => $file
+					]
+				]
+			]);
+		$this->assertStatusCode($this->response, $statusCode);
+	}
+
+	/**
+	 * @When user :user deletes avatar for room :identifier
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 */
+	public function userDeletesAvatarForRoom(string $user, string $identifier) {
+		$this->userDeletesAvatarForRoomWith($user, $identifier, '200');
+	}
+
+	/**
+	 * @When user :user deletes avatar for room :identifier with :statusCode
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 * @param string $statusCode
+	 */
+	public function userDeletesAvatarForRoomWith(string $user, string $identifier, string $statusCode) {
+		$this->setCurrentUser($user);
+		$this->sendRequest('DELETE', '/core/avatar/room/' . FeatureContext::getTokenForIdentifier($identifier), null);
+		$this->assertStatusCode($this->response, $statusCode);
+	}
+
+	/**
+	 * @Then last avatar is a default avatar of size :size
+	 *
+	 * @param string size
+	 */
+	public function lastAvatarIsADefaultAvatarOfSize(string $size) {
+		$this->theFollowingHeadersShouldBeSet(new TableNode([
+			[ 'Content-Type', 'image/png' ],
+			[ 'X-NC-IsCustomAvatar', '0' ]
+		]));
+		$this->lastAvatarIsASquareOfSize($size);
+		$this->lastAvatarIsNotASingleColor();
+	}
+
+	/**
+	 * @Then last avatar is a custom avatar of size :size and color :color
+	 *
+	 * @param string size
+	 */
+	public function lastAvatarIsACustomAvatarOfSizeAndColor(string $size, string $color) {
+		$this->theFollowingHeadersShouldBeSet(new TableNode([
+			[ 'Content-Type', 'image/png' ],
+			[ 'X-NC-IsCustomAvatar', '1' ]
+		]));
+		$this->lastAvatarIsASquareOfSize($size);
+		$this->lastAvatarIsASingleColor($color);
+	}
+
+	/**
+	 * @Then last avatar is a square of size :size
+	 *
+	 * @param string size
+	 */
+	public function lastAvatarIsASquareOfSize(string $size) {
+		list($width, $height) = getimagesizefromstring($this->lastAvatar);
+
+		Assert::assertEquals($width, $height, 'Avatar is not a square');
+		Assert::assertEquals($size, $width);
+	}
+
+	/**
+	 * @Then last avatar is not a single color
+	 */
+	public function lastAvatarIsNotASingleColor() {
+		Assert::assertEquals(null, $this->getColorFromLastAvatar());
+	}
+
+	/**
+	 * @Then last avatar is a single :color color
+	 *
+	 * @param string $color
+	 * @param string $size
+	 */
+	public function lastAvatarIsASingleColor(string $color) {
+		$expectedColor = $this->hexStringToRgbColor($color);
+		$colorFromLastAvatar = $this->getColorFromLastAvatar();
+
+		Assert::assertTrue($this->isSameColor($expectedColor, $colorFromLastAvatar),
+			$this->rgbColorToHexString($colorFromLastAvatar) . ' does not match expected ' . $color);
+	}
+
+	private function hexStringToRgbColor($hexString) {
+		// Strip initial "#"
+		$hexString = substr($hexString, 1);
+
+		$rgbColorInt = hexdec($hexString);
+
+		// RGBA hex strings are not supported; the given string is assumed to be
+		// an RGB hex string.
+		return [
+			'red' => ($rgbColorInt >> 16) & 0xFF,
+			'green' => ($rgbColorInt >> 8) & 0xFF,
+			'blue' => $rgbColorInt & 0xFF,
+			'alpha' => 0
+		];
+	}
+
+	private function rgbColorToHexString($rgbColor) {
+		$rgbColorInt = ($rgbColor['red'] << 16) + ($rgbColor['green'] << 8) + ($rgbColor['blue']);
+
+		return '#' . str_pad(strtoupper(dechex($rgbColorInt)), 6, '0', STR_PAD_LEFT);
+	}
+
+	private function getColorFromLastAvatar() {
+		$image = imagecreatefromstring($this->lastAvatar);
+
+		$firstPixelColorIndex = imagecolorat($image, 0, 0);
+		$firstPixelColor = imagecolorsforindex($image, $firstPixelColorIndex);
+
+		for ($i = 0; $i < imagesx($image); $i++) {
+			for ($j = 0; $j < imagesx($image); $j++) {
+				$currentPixelColorIndex = imagecolorat($image, $i, $j);
+				$currentPixelColor = imagecolorsforindex($image, $currentPixelColorIndex);
+
+				// The colors are compared with a small allowed delta, as even
+				// on solid color images the resizing can cause some small
+				// artifacts that slightly modify the color of certain pixels.
+				if (!$this->isSameColor($firstPixelColor, $currentPixelColor)) {
+					imagedestroy($image);
+
+					return null;
+				}
+			}
+		}
+
+		imagedestroy($image);
+
+		return $firstPixelColor;
+	}
+
+	private function isSameColor(array $firstColor, array $secondColor, int $allowedDelta = 1) {
+		if ($this->isSameColorComponent($firstColor['red'], $secondColor['red'], $allowedDelta) &&
+			$this->isSameColorComponent($firstColor['green'], $secondColor['green'], $allowedDelta) &&
+			$this->isSameColorComponent($firstColor['blue'], $secondColor['blue'], $allowedDelta) &&
+			$this->isSameColorComponent($firstColor['alpha'], $secondColor['alpha'], $allowedDelta)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private function isSameColorComponent(int $firstColorComponent, int $secondColorComponent, int $allowedDelta) {
+		if ($firstColorComponent >= ($secondColorComponent - $allowedDelta) &&
+			$firstColorComponent <= ($secondColorComponent + $allowedDelta)) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1467,6 +1467,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		if ($body instanceof TableNode) {
 			$fd = $body->getRowsHash();
 			$options['form_params'] = $fd;
+		} elseif (is_array($body) && array_key_exists('multipart', $body)) {
+			$options = array_merge($options, $body);
 		} elseif (is_array($body)) {
 			$options['form_params'] = $body;
 		}

--- a/tests/integration/features/conversation/avatar.feature
+++ b/tests/integration/features/conversation/avatar.feature
@@ -1,0 +1,430 @@
+Feature: avatar
+
+  Background:
+    Given user "owner" exists
+    Given user "moderator" exists
+    Given user "invited user" exists
+    Given user "not invited but joined user" exists
+    Given user "not joined user" exists
+
+  Scenario: participants can not set avatar in one-to-one room
+    Given user "owner" creates room "one-to-one room"
+      | roomType | 1 |
+      | invite   | moderator |
+    When user "owner" sets avatar for room "one-to-one room" from file "data/green-square-256.png" with 403
+    And user "moderator" sets avatar for room "one-to-one room" from file "data/green-square-256.png" with 403
+    And user "not invited user" sets avatar for room "one-to-one room" from file "data/green-square-256.png" with 404
+    And user "guest" sets avatar for room "one-to-one room" from file "data/green-square-256.png" with 404
+    Then user "owner" gets avatar for room "one-to-one room"
+    And last avatar is a default avatar of size "128"
+    And user "moderator" gets avatar for room "one-to-one room"
+    And last avatar is a default avatar of size "128"
+
+
+
+  Scenario: owner can set avatar in group room
+    Given user "owner" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "owner" adds "moderator" to room "group room" with 200
+    And user "owner" promotes "moderator" in room "group room" with 200
+    And user "owner" adds "invited user" to room "group room" with 200
+    When user "owner" sets avatar for room "group room" from file "data/green-square-256.png"
+    Then user "owner" gets avatar for room "group room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "moderator" gets avatar for room "group room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "invited user" gets avatar for room "group room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+
+  Scenario: moderator can set avatar in group room
+    Given user "owner" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "owner" adds "moderator" to room "group room" with 200
+    And user "owner" promotes "moderator" in room "group room" with 200
+    And user "owner" adds "invited user" to room "group room" with 200
+    When user "moderator" sets avatar for room "group room" from file "data/green-square-256.png"
+    Then user "owner" gets avatar for room "group room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "moderator" gets avatar for room "group room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "invited user" gets avatar for room "group room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+
+  Scenario: others can not set avatar in group room
+    Given user "owner" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "owner" adds "moderator" to room "group room" with 200
+    And user "owner" promotes "moderator" in room "group room" with 200
+    And user "owner" adds "invited user" to room "group room" with 200
+    When user "invited user" sets avatar for room "group room" from file "data/green-square-256.png" with 403
+    And user "not invited user" sets avatar for room "group room" from file "data/green-square-256.png" with 404
+    # Guest user names in tests must being with "guest"
+    And user "guest not joined" sets avatar for room "group room" from file "data/green-square-256.png" with 404
+    Then user "owner" gets avatar for room "group room"
+    And last avatar is a default avatar of size "128"
+    And user "moderator" gets avatar for room "group room"
+    And last avatar is a default avatar of size "128"
+    And user "invited user" gets avatar for room "group room"
+    And last avatar is a default avatar of size "128"
+
+
+
+  Scenario: owner can set avatar in public room
+    Given user "owner" creates room "public room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "owner" adds "moderator" to room "public room" with 200
+    And user "owner" promotes "moderator" in room "public room" with 200
+    And user "owner" adds "invited user" to room "public room" with 200
+    And user "not invited but joined user" joins room "public room" with 200
+    And user "guest moderator" joins room "public room" with 200
+    And user "owner" promotes "guest moderator" in room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    When user "owner" sets avatar for room "public room" from file "data/green-square-256.png"
+    Then user "owner" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "moderator" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "invited user" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "not invited but joined user" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "guest moderator" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "guest" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+
+  Scenario: moderator can set avatar in public room
+    Given user "owner" creates room "public room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "owner" adds "moderator" to room "public room" with 200
+    And user "owner" promotes "moderator" in room "public room" with 200
+    And user "owner" adds "invited user" to room "public room" with 200
+    And user "not invited but joined user" joins room "public room" with 200
+    And user "guest moderator" joins room "public room" with 200
+    And user "owner" promotes "guest moderator" in room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    When user "moderator" sets avatar for room "public room" from file "data/green-square-256.png"
+    Then user "owner" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "moderator" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "invited user" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "not invited but joined user" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "guest moderator" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "guest" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+
+  Scenario: guest moderator can set avatar in public room
+    Given user "owner" creates room "public room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "owner" adds "moderator" to room "public room" with 200
+    And user "owner" promotes "moderator" in room "public room" with 200
+    And user "owner" adds "invited user" to room "public room" with 200
+    And user "not invited but joined user" joins room "public room" with 200
+    And user "guest moderator" joins room "public room" with 200
+    And user "owner" promotes "guest moderator" in room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    When user "guest moderator" sets avatar for room "public room" from file "data/green-square-256.png"
+    Then user "owner" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "moderator" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "invited user" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "not invited but joined user" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "guest moderator" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "guest" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+
+  Scenario: others can not set avatar in public room
+    Given user "owner" creates room "public room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "owner" adds "moderator" to room "public room" with 200
+    And user "owner" promotes "moderator" in room "public room" with 200
+    And user "owner" adds "invited user" to room "public room" with 200
+    And user "not invited but joined user" joins room "public room" with 200
+    And user "guest moderator" joins room "public room" with 200
+    And user "owner" promotes "guest moderator" in room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    When user "invited user" sets avatar for room "public room" from file "data/green-square-256.png" with 403
+    And user "not invited but joined user" sets avatar for room "public room" from file "data/green-square-256.png" with 404
+    And user "not joined user" sets avatar for room "public room" from file "data/green-square-256.png" with 404
+    And user "guest" sets avatar for room "public room" from file "data/green-square-256.png" with 404
+    # Guest user names in tests must being with "guest"
+    And user "guest not joined" sets avatar for room "public room" from file "data/green-square-256.png" with 404
+    Then user "owner" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "moderator" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "invited user" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "not invited but joined user" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "guest moderator" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "guest" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+
+
+
+  Scenario: participants can not set avatar in room for a share
+    # These users are only needed in very specific tests, so they are not
+    # created in the background step.
+    Given user "owner of file" exists
+    And user "user with access to file" exists
+    And user "owner of file" shares "welcome.txt" with user "user with access to file" with OCS 100
+    And user "user with access to file" accepts last share
+    And user "owner of file" shares "welcome.txt" by link with OCS 100
+    And user "guest" gets the room for last share with 200
+    And user "owner of file" joins room "file last share room" with 200
+    And user "user with access to file" joins room "file last share room" with 200
+    And user "guest" joins room "file last share room" with 200
+    When user "owner of file" sets avatar for room "file last share room" from file "data/green-square-256.png" with 404
+    And user "user with access to file" sets avatar for room "file last share room" from file "data/green-square-256.png" with 404
+    And user "guest" sets avatar for room "file last share room" from file "data/green-square-256.png" with 404
+    Then user "owner of file" gets avatar for room "group room"
+    And last avatar is a default avatar of size "128"
+    And user "user with access to file" gets avatar for room "group room"
+    And last avatar is a default avatar of size "128"
+    And user "guest" gets avatar for room "group room"
+    And last avatar is a default avatar of size "128"
+
+
+
+  Scenario: participants can not set avatar in a password request room
+    # The user is only needed in very specific tests, so it is not created in
+    # the background step.
+    Given user "owner of file" exists
+    And user "owner of file" shares "welcome.txt" by link with OCS 100
+      | password | 123456 |
+      | sendPasswordByTalk | true |
+    And user "guest" creates the password request room for last share with 201
+    And user "guest" joins room "password request for last share room" with 200
+    And user "owner of file" joins room "password request for last share room" with 200
+    When user "owner of file" sets avatar for room "file last share room" from file "data/green-square-256.png" with 404
+    And user "guest" sets avatar for room "file last share room" from file "data/green-square-256.png" with 404
+    Then user "owner of file" gets avatar for room "group room"
+    And last avatar is a default avatar of size "128"
+    And user "guest" gets avatar for room "group room"
+    And last avatar is a default avatar of size "128"
+
+
+
+  Scenario: set non squared image as generic user avatar
+    Given user "owner" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    When user "user0" sets avatar for room "group room" from file "data/green-rectangle-256-128.png" with 400
+    Then user "user0" gets avatar for room "group room"
+    And last avatar is a default avatar of size "128"
+
+  Scenario: set not an image as generic user avatar
+    Given user "owner" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    When user "user0" sets avatar for room "group room" from file "data/textfile.txt" with 400
+    Then user "user0" gets avatar for room "group room"
+    And last avatar is a default avatar of size "128"
+
+
+
+  Scenario: owner can delete avatar in group room
+    Given user "owner" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "owner" adds "moderator" to room "group room" with 200
+    And user "owner" promotes "moderator" in room "group room" with 200
+    And user "owner" adds "invited user" to room "group room" with 200
+    And user "owner" sets avatar for room "group room" from file "data/green-square-256.png"
+    And user "owner" gets avatar for room "group room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    Then user "owner" gets avatar for room "group room"
+    And last avatar is a default avatar of size "128"
+    And user "moderator" gets avatar for room "group room"
+    And last avatar is a default avatar of size "128"
+    And user "invited user" gets avatar for room "group room"
+    And last avatar is a default avatar of size "128"
+
+  Scenario: moderator can delete avatar in group room
+    Given user "owner" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "owner" adds "moderator" to room "group room" with 200
+    And user "owner" promotes "moderator" in room "group room" with 200
+    And user "owner" adds "invited user" to room "group room" with 200
+    And user "owner" sets avatar for room "group room" from file "data/green-square-256.png"
+    And user "owner" gets avatar for room "group room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    When user "moderator" deletes avatar for room "group room"
+    Then user "owner" gets avatar for room "group room"
+    And last avatar is a default avatar of size "128"
+    And user "moderator" gets avatar for room "group room"
+    And last avatar is a default avatar of size "128"
+    And user "invited user" gets avatar for room "group room"
+    And last avatar is a default avatar of size "128"
+
+  Scenario: others can not delete avatar in group room
+    Given user "owner" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "owner" adds "moderator" to room "group room" with 200
+    And user "owner" promotes "moderator" in room "group room" with 200
+    And user "owner" adds "invited user" to room "group room" with 200
+    And user "owner" sets avatar for room "group room" from file "data/green-square-256.png"
+    When user "invited user" deletes avatar for room "group room" with 403
+    And user "not invited user" deletes avatar for room "group room" with 404
+    # Guest user names in tests must being with "guest"
+    And user "guest not joined" deletes avatar for room "group room" with 404
+    Then user "owner" gets avatar for room "group room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "moderator" gets avatar for room "group room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "invited user" gets avatar for room "group room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+
+
+
+  Scenario: owner can delete avatar in public room
+    Given user "owner" creates room "public room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "owner" adds "moderator" to room "public room" with 200
+    And user "owner" promotes "moderator" in room "public room" with 200
+    And user "owner" adds "invited user" to room "public room" with 200
+    And user "not invited but joined user" joins room "public room" with 200
+    And user "guest moderator" joins room "public room" with 200
+    And user "owner" promotes "guest moderator" in room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    And user "owner" sets avatar for room "public room" from file "data/green-square-256.png"
+    And user "owner" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    When user "owner" deletes avatar for room "public room"
+    Then user "owner" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "moderator" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "invited user" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "not invited but joined user" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "guest moderator" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "guest" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+
+  Scenario: moderator can delete avatar in public room
+    Given user "owner" creates room "public room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "owner" adds "moderator" to room "public room" with 200
+    And user "owner" promotes "moderator" in room "public room" with 200
+    And user "owner" adds "invited user" to room "public room" with 200
+    And user "not invited but joined user" joins room "public room" with 200
+    And user "guest moderator" joins room "public room" with 200
+    And user "owner" promotes "guest moderator" in room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    And user "owner" sets avatar for room "public room" from file "data/green-square-256.png"
+    And user "owner" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    When user "moderator" deletes avatar for room "public room"
+    Then user "owner" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "moderator" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "invited user" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "not invited but joined user" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "guest moderator" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "guest" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+
+  Scenario: guest moderator can delete avatar in public room
+    Given user "owner" creates room "public room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "owner" adds "moderator" to room "public room" with 200
+    And user "owner" promotes "moderator" in room "public room" with 200
+    And user "owner" adds "invited user" to room "public room" with 200
+    And user "not invited but joined user" joins room "public room" with 200
+    And user "guest moderator" joins room "public room" with 200
+    And user "owner" promotes "guest moderator" in room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    And user "owner" sets avatar for room "public room" from file "data/green-square-256.png"
+    And user "owner" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    When user "guest moderator" deletes avatar for room "public room"
+    Then user "owner" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "moderator" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "invited user" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "not invited but joined user" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "guest moderator" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+    And user "guest" gets avatar for room "public room"
+    And last avatar is a default avatar of size "128"
+
+  Scenario: others can not delete avatar in public room
+    Given user "owner" creates room "public room"
+      | roomType | 3 |
+      | roomName | room |
+    And user "owner" adds "moderator" to room "public room" with 200
+    And user "owner" promotes "moderator" in room "public room" with 200
+    And user "owner" adds "invited user" to room "public room" with 200
+    And user "not invited but joined user" joins room "public room" with 200
+    And user "guest moderator" joins room "public room" with 200
+    And user "owner" promotes "guest moderator" in room "public room" with 200
+    And user "guest" joins room "public room" with 200
+    And user "owner" sets avatar for room "public room" from file "data/green-square-256.png"
+    When user "invited user" deletes avatar for room "public room" with 403
+    And user "not invited but joined user" deletes avatar for room "public room" with 404
+    And user "not joined user" deletes avatar for room "public room" with 404
+    And user "guest" deletes avatar for room "public room" with 404
+    # Guest user names in tests must being with "guest"
+    And user "guest not joined" deletes avatar for room "public room" with 404
+    Then user "owner" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "moderator" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "invited user" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "not invited but joined user" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "guest moderator" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+    And user "guest" gets avatar for room "public room" with size "256"
+    And last avatar is a custom avatar of size "256" and color "#00FF00"
+
+
+
+  Scenario: get room avatar with a larger size than the original one
+    Given user "owner" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "user0" sets avatar for room "group room" from file "data/green-square-256.png"
+    When user "user0" gets avatar for room "group room" with size "512"
+    Then last avatar is a custom avatar of size "512" and color "#00FF00"
+
+  Scenario: get room avatar with a smaller size than the original one
+    Given user "owner" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "user0" sets avatar for room "group room" from file "data/green-square-256.png"
+    When user "user0" gets avatar for room "group room" with size "128"
+    Then last avatar is a custom avatar of size "128" and color "#00FF00"


### PR DESCRIPTION
Requires nextcloud/server#24579

Fixes (the backend part of) #927

Pending:
- [ ] Extend `OC\Avatar\Avatar` instead of implementing `OCP\IAvatar` to get the implementation of (`avatarBackgroundColor`)[https://github.com/nextcloud/server/blob/caff1023ea72bb2ea94130e18a2a6e2ccf819e5f/lib/private/Avatar/Avatar.php#L298]? I am not a fan of extending private classes, but maybe in this case it would be acceptable to avoid code duplication
- [ ] Prevent participants other than moderators to modify the avatar
- [ ] Find a folder name that can not clash with a user id
- [ ] Return default avatars (user avatar in one-to-one, mime type icons in file/password request rooms, public and group icons in others)
- [ ] Convert transparency to white in PNGs
- [ ] Return avatar id (`icon-public`, `icon-group`, `icon-mime-audio`, `icon-mime-text`, `custom`...) when fetching room information
  - This would allow the clients to avoid fetching the same default icons for different rooms
- [ ] Add system message when the room avatar is changed?
