### PR TITLE
Silence exec()/shell_exec() in MatterbridgeManager

### DIFF
--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -696,7 +696,7 @@ class MatterbridgeManager {
 	 */
 	public function killZombieBridges(bool $killAll = false): void {
 		// get list of running matterbridge processes
-		$cmd = 'ps x -o user,pid,args | grep "matterbridge" | grep -v grep | awk \'{print $2}\'';
+		$cmd = 'ps x -o user,pid,args 2>/dev/null | grep "matterbridge" | grep -v grep | awk \'{print $2}\'';
 		exec($cmd, $output, $ret);
 		$runningPidList = [];
 		foreach ($output as $o) {
@@ -758,7 +758,7 @@ class MatterbridgeManager {
 	 */
 	private function isRunning(int $pid): bool {
 		try {
-			$result = shell_exec(sprintf('ps x -o user,pid,args | awk \'{print $2}\' | grep "^%d$" | wc -l', $pid));
+			$result = shell_exec(sprintf('ps x -o user,pid,args 2>/dev/null | awk \'{print $2}\' | grep "^%d$" | wc -l', $pid));
 			if ((int) $result > 0) {
 				return true;
 			}


### PR DESCRIPTION
My webhoster's shell doesn't provide `ps`, so I'm receiving mails with `sh: ps: command not found` errors every 20 minutes. Tracking this down to Talk was great... :unamused: 

This is a quick fix. You should neither use `exec()`, nor `shell_exec()`, `system()`, or `passthru()`. This is a fix specifically made for my setup which doesn't provide `ps`. For an actual solution you'll have to silence STDERR for every single command you call - including piped commands. You can't be sure that they don't print to STDERR.

Using pipes makes things way harder, thus you shouldn't rely on `grep`, `awk`, `sed` and others. Rather process the output in PHP. Use `proc_open()` instead - or one of the many great libraries relying on `proc_open()`, like [`symfony/process`](https://github.com/symfony/process).