### PR TITLE
Use a unique index name

### DIFF
--- a/lib/Migration/Version11000Date20201209142525.php
+++ b/lib/Migration/Version11000Date20201209142525.php
@@ -103,7 +103,7 @@ class Version11000Date20201209142525 extends SimpleMigrationStep {
 			]);
 
 			$table->setPrimaryKey(['id']);
-			$table->addUniqueIndex(['session_hash'], 'tg_session_hash');
+			$table->addUniqueIndex(['session_hash'], 'tgn_session_hash');
 			$changedSchema = true;
 		}
 


### PR DESCRIPTION
Regression from #4735 

Only breaks on Oracle and SQLite, where index names have to be database-wide unique

Extracted from #4589 to make sure @jancborchardt can update on sqlite
Not adding a migration as it has not been released.