### PR TITLE
Allow to respond with modified common read value on "not modified" messages

### DIFF
--- a/docs/chat.md
+++ b/docs/chat.md
@@ -13,6 +13,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
     `lookIntoFuture` | int | `1` Poll and wait for new message or `0` get history of a conversation
     `limit` | int | Number of chat messages to receive (100 by default, 200 at most)
     `lastKnownMessageId` | int | Serves as an offset for the query. The lastKnownMessageId for the next page is available in the `X-Chat-Last-Given` header.
+    `lastCommonReadId` | int | Send the last `X-Chat-Last-Common-Read` header you got, if you are interested in updates of the common read value. A 304 response does not allow custom headers and otherwise the server can not know if your value is modified or not.
     `timeout` | int | `$lookIntoFuture = 1` only, Number of seconds to wait for new messages (30 by default, 60 at most)
     `setReadMarker` | int | `1` to automatically set the read timer after fetching the messages, use `0` when your client calls `Mark chat as read` manually. (Default: `1`)
     `includeLastKnown` | int | `1` to include the last known message as well (Default: `0`)
@@ -29,7 +30,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         field | type | Description
         ------|------|------------
         `X-Chat-Last-Given` | int | Offset (lastKnownMessageId) for the next page.
-        `X-Chat-Last-Common-Read` | int | ID of the last message read by every user that has read privacy set to public. When the user themself has it set to private the value the header is not set (only available with `chat-read-status` capability)
+        `X-Chat-Last-Common-Read` | int | ID of the last message read by every user that has read privacy set to public. When the user themself has it set to private the value the header is not set (only available with `chat-read-status` capability and when lastCommonReadId was sent)
 
     - Data:
         Array of messages, each message has at least:

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -874,7 +874,7 @@ class ChatControllerTest extends TestCase {
 
 		$this->controller->setRoom($this->room);
 		$this->controller->setParticipant($participant);
-		$response = $this->controller->receiveMessages(1, $limit, $offset, $timeout);
+		$response = $this->controller->receiveMessages(1, $limit, $offset, 0, $timeout);
 		$expected = new DataResponse([
 			['id'=>108, 'token'=>'testToken', 'actorType'=>'users', 'actorId'=>'testUser', 'actorDisplayName'=>'User1', 'timestamp'=>1000000004, 'message'=>'testMessage1', 'messageParameters'=>['testMessageParameters1'], 'systemMessage' => '', 'messageType' => 'comment', 'isReplyable' => true],
 			['id'=>109, 'token'=>'testToken', 'actorType'=>'guests', 'actorId'=>'testSpreedSession', 'actorDisplayName'=>'User2', 'timestamp'=>1000000008, 'message'=>'testMessage2', 'messageParameters'=>['testMessageParameters2'], 'systemMessage' => '', 'messageType' => 'comment', 'isReplyable' => true],
@@ -908,7 +908,7 @@ class ChatControllerTest extends TestCase {
 
 		$this->controller->setRoom($this->room);
 		$this->controller->setParticipant($participant);
-		$response = $this->controller->receiveMessages(1, $limit, $offset, $timeout);
+		$response = $this->controller->receiveMessages(1, $limit, $offset, 0, $timeout);
 		$expected = new DataResponse([], Http::STATUS_NOT_MODIFIED);
 
 		$this->assertEquals($expected, $response);


### PR DESCRIPTION
We need to set the status code to 200 when the header is modified,
because as per "section 10.3.5 of RFC 2616" entity headers shall be
stripped out on 304: https://stackoverflow.com/a/17822709
This means the header would not be sent to the clients at all, so
they wouldn't update the read marker when idling in the chat.
For the web interface this is not needed, as we update the info
every 30 seconds with the conversation list refresh and can therefor
save the query
