### PR TITLE
Integration tests use occ guests:add to create guests

### DIFF
--- a/tests/integration/features/bootstrap/CommandLineTrait.php
+++ b/tests/integration/features/bootstrap/CommandLineTrait.php
@@ -43,9 +43,10 @@ trait CommandLineTrait {
 	 * Invokes an OCC command
 	 *
 	 * @param []string $args OCC command, the part behind "occ". For example: "files:transfer-ownership"
+	 * @param []string $env environment variables
 	 * @return int exit code
 	 */
-	public function runOcc($args = []) {
+	public function runOcc($args = [], $env = null) {
 		// Set UTF-8 locale to ensure that escapeshellarg will not strip
 		// multibyte characters.
 		setlocale(LC_CTYPE, "C.UTF-8");
@@ -61,7 +62,7 @@ trait CommandLineTrait {
 			1 => ['pipe', 'w'],
 			2 => ['pipe', 'w'],
 		];
-		$process = proc_open('php console.php ' . $args, $descriptor, $pipes, $this->ocPath);
+		$process = proc_open('php console.php ' . $args, $descriptor, $pipes, $this->ocPath, $env);
 		$this->lastStdOut = stream_get_contents($pipes[1]);
 		$this->lastStdErr = stream_get_contents($pipes[2]);
 		$this->lastCode = proc_close($process);

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1583,11 +1583,23 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->setCurrentUser('admin');
 		// in case it exists
 		$this->deleteUser($user);
-		$this->sendRequest('POST', '/apps/spreedcheats/guest-users', [
-			'userid' => $user,
-			'password' => self::TEST_PASSWORD,
+
+		$lastCode = $this->runOcc([
+			'guests:add',
+			// creator user
+			'admin',
+			// guest user id
+			$user,
+			// email
+			$user . '@localhost',
+			'--display-name',
+			$user . '-displayname',
+			'--password-from-env',
+		], [
+			'OC_PASS' => self::TEST_PASSWORD,
 		]);
-		$this->assertStatusCode($this->response, 200);
+		Assert::assertEquals(0, $lastCode, 'Guest creation succeeded for ' . $user);
+
 		$this->createdGuestAccountUsers[] = $user;
 		$this->setCurrentUser($currentUser);
 	}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1576,31 +1576,29 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 
 	/**
 	 * @Given /^user "([^"]*)" is a guest account user/
-	 * @param string $user
+	 * @param string $email email address
 	 */
-	public function createGuestUser($user) {
+	public function createGuestUser($email) {
 		$currentUser = $this->currentUser;
 		$this->setCurrentUser('admin');
 		// in case it exists
-		$this->deleteUser($user);
+		$this->deleteUser($email);
 
 		$lastCode = $this->runOcc([
 			'guests:add',
 			// creator user
 			'admin',
-			// guest user id
-			$user,
 			// email
-			$user . '@localhost',
+			$email,
 			'--display-name',
-			$user . '-displayname',
+			$email . '-displayname',
 			'--password-from-env',
 		], [
 			'OC_PASS' => self::TEST_PASSWORD,
 		]);
-		Assert::assertEquals(0, $lastCode, 'Guest creation succeeded for ' . $user);
+		Assert::assertEquals(0, $lastCode, 'Guest creation succeeded for ' . $email);
 
-		$this->createdGuestAccountUsers[] = $user;
+		$this->createdGuestAccountUsers[] = $email;
 		$this->setCurrentUser($currentUser);
 	}
 

--- a/tests/integration/features/conversation/find-listed.feature
+++ b/tests/integration/features/conversation/find-listed.feature
@@ -3,7 +3,7 @@ Feature: conversation/find-listed
     Given user "creator" exists
     And user "regular-user" exists
     And guest accounts can be created
-    And user "user-guest" is a guest account user
+    And user "user-guest@example.com" is a guest account user
 
   Scenario Outline: Nobody can find non-listed rooms
     Given user "creator" creates room "group-room"
@@ -16,10 +16,10 @@ Feature: conversation/find-listed
     And user "creator" allows listing room "public-room" for "none" with 200
     Then user "creator" cannot find any listed rooms (v3)
     Examples:
-      | user         |
-      | creator      |
-      | regular-user |
-      | user-guest   |
+      | user                   |
+      | creator                |
+      | regular-user           |
+      | user-guest@example.com |
 
   Scenario: Regular users can find user-listed rooms
     Given user "creator" creates room "group-room"
@@ -34,7 +34,7 @@ Feature: conversation/find-listed
       | name        | listable |
       | group-room  | 1        |
       | public-room | 1        |
-    And user "user-guest" cannot find any listed rooms (v3)
+    And user "user-guest@example.com" cannot find any listed rooms (v3)
 
   Scenario: All users can find all-listed rooms
     Given user "creator" creates room "group-room"
@@ -49,7 +49,7 @@ Feature: conversation/find-listed
       | name        | listable |
       | group-room  | 2        |
       | public-room | 2        |
-    And user "user-guest" can find listed rooms (v3)
+    And user "user-guest@example.com" can find listed rooms (v3)
       | name        | listable |
       | group-room  | 2        |
       | public-room | 2        |
@@ -101,7 +101,7 @@ Feature: conversation/find-listed
       | name                 | listable |
       | group-the-cool-room  | 2        |
       | public-the-cool-room | 2        |
-    And user "user-guest" can find listed rooms with term "cool" (v3)
+    And user "user-guest@example.com" can find listed rooms with term "cool" (v3)
       | name                 | listable |
       | group-the-cool-room  | 2        |
       | public-the-cool-room | 2        |
@@ -112,7 +112,7 @@ Feature: conversation/find-listed
       | roomName | group-room  |
     When user "creator" allows listing room "group-room" for "all" with 200
     Then user "regular-user" cannot find any listed rooms with term "cool" (v3)
-    And user "user-guest" cannot find any listed rooms with term "cool" (v3)
+    And user "user-guest@example.com" cannot find any listed rooms with term "cool" (v3)
 
   Scenario: Guest users without accounts cannot search for listed rooms
     Given user "creator" creates room "public-room"

--- a/tests/integration/features/conversation/join-listable.feature
+++ b/tests/integration/features/conversation/join-listable.feature
@@ -3,7 +3,7 @@ Feature: conversation/join-listable
     Given user "creator" exists
     And user "regular-user" exists
     And guest accounts can be created
-    And user "user-guest" is a guest account user
+    And user "user-guest@example.com" is a guest account user
     # implicit: And user "guest" is a guest user with no account
 
   # -----------------------------------------------------------------------------
@@ -15,7 +15,7 @@ Feature: conversation/join-listable
       | roomName | room |
     When user "creator" allows listing room "room" for "none" with 200
     Then user "regular-user" joins room "room" with 404
-    And user "user-guest" joins room "room" with 404
+    And user "user-guest@example.com" joins room "room" with 404
     And user "guest" joins room "room" with 404
 
   Scenario: Anyone can join a non-listed public room
@@ -24,14 +24,14 @@ Feature: conversation/join-listable
       | roomName | room |
     And user "creator" allows listing room "room" for "none" with 200
     When user "regular-user" joins room "room" with 200
-    And user "user-guest" joins room "room" with 200
+    And user "user-guest@example.com" joins room "room" with 200
     And user "guest" joins room "room" with 200
     Then user "creator" sees the following attendees in room "room" with 200 (v3)
-      | actorId      | participantType   | actorType |
-      | creator      | OWNER             | users     |
-      | regular-user | USER_SELF_JOINED  | users     |
-      | user-guest   | USER_SELF_JOINED  | users     |
-      | "guest"      | GUEST             | guests    |
+      | actorId                | participantType   | actorType |
+      | creator                | OWNER             | users     |
+      | regular-user           | USER_SELF_JOINED  | users     |
+      | user-guest@example.com | USER_SELF_JOINED  | users     |
+      | "guest"                | GUEST             | guests    |
 
   # -----------------------------------------------------------------------------
   # User-listed rooms
@@ -42,7 +42,7 @@ Feature: conversation/join-listable
       | roomName | room |
     And user "creator" allows listing room "room" for "users" with 200
     When user "regular-user" joins room "room" with 200
-    And user "user-guest" joins room "room" with 404
+    And user "user-guest@example.com" joins room "room" with 404
     And user "guest" joins room "room" with 404
     Then user "creator" sees the following attendees in room "room" with 200 (v3)
       | actorId       | participantType | actorType |
@@ -55,14 +55,14 @@ Feature: conversation/join-listable
       | roomName | room |
     And user "creator" allows listing room "room" for "users" with 200
     When user "regular-user" joins room "room" with 200
-    And user "user-guest" joins room "room" with 200
+    And user "user-guest@example.com" joins room "room" with 200
     And user "guest" joins room "room" with 200
     Then user "creator" sees the following attendees in room "room" with 200 (v3)
-      | actorId      | participantType   | actorType |
-      | creator      | OWNER             | users     |
-      | regular-user | USER              | users     |
-      | user-guest   | USER_SELF_JOINED  | users     |
-      | "guest"      | GUEST             | guests    |
+      | actorId                | participantType   | actorType |
+      | creator                | OWNER             | users     |
+      | regular-user           | USER              | users     |
+      | user-guest@example.com | USER_SELF_JOINED  | users     |
+      | "guest"                | GUEST             | guests    |
 
   # -----------------------------------------------------------------------------
   # All-listed rooms
@@ -73,13 +73,13 @@ Feature: conversation/join-listable
       | roomName | room |
     And user "creator" allows listing room "room" for "all" with 200
     When user "regular-user" joins room "room" with 200
-    And user "user-guest" joins room "room" with 200
+    And user "user-guest@example.com" joins room "room" with 200
     And user "guest" joins room "room" with 404
     Then user "creator" sees the following attendees in room "room" with 200 (v3)
-      | actorId      | participantType   | actorType |
-      | creator      | OWNER             | users     |
-      | regular-user | USER              | users     |
-      | user-guest   | USER              | users     |
+      | actorId                | participantType   | actorType |
+      | creator                | OWNER             | users     |
+      | regular-user           | USER              | users     |
+      | user-guest@example.com | USER              | users     |
 
   Scenario: Anyone can join an all-listed public room
     Given user "creator" creates room "room"
@@ -87,11 +87,11 @@ Feature: conversation/join-listable
       | roomName | room |
     And user "creator" allows listing room "room" for "all" with 200
     When user "regular-user" joins room "room" with 200
-    And user "user-guest" joins room "room" with 200
+    And user "user-guest@example.com" joins room "room" with 200
     And user "guest" joins room "room" with 200
     Then user "creator" sees the following attendees in room "room" with 200 (v3)
-      | actorId      | participantType   | actorType |
-      | creator      | OWNER             | users     |
-      | regular-user | USER              | users     |
-      | user-guest   | USER              | users     |
-      | "guest"      | GUEST             | guests    |
+      | actorId                | participantType   | actorType |
+      | creator                | OWNER             | users     |
+      | regular-user           | USER              | users     |
+      | user-guest@example.com | USER              | users     |
+      | "guest"                | GUEST             | guests    |

--- a/tests/integration/features/conversation/set-listable.feature
+++ b/tests/integration/features/conversation/set-listable.feature
@@ -29,16 +29,16 @@ Feature: conversation/set-listable
       | roomName | room |
     And user "moderator" exists
     And guest accounts can be created
-    And user "user-guest" is a guest account user
+    And user "user-guest@example.com" is a guest account user
     And user "creator" adds "regular-user" to room "room" with 200
     And user "creator" adds "moderator" to room "room" with 200
     And user "creator" allows listing room "room" for "all" with 200
     When user "creator" promotes "moderator" in room "room" with 200
-    And user "user-guest" joins room "room" with 200
+    And user "user-guest@example.com" joins room "room" with 200
     And user "guest" joins room "room" with 200
     Then user "moderator" allows listing room "room" for "none" with 200
     And user "regular-user" allows listing room "room" for "users" with 403
-    And user "user-guest" allows listing room "room" for "users" with 403
+    And user "user-guest@example.com" allows listing room "room" for "users" with 403
     And user "guest" allows listing room "room" for "users" with 401
 
   Scenario: Cannot change listable attribute of one to one conversations

--- a/tests/integration/spreedcheats/appinfo/routes.php
+++ b/tests/integration/spreedcheats/appinfo/routes.php
@@ -26,6 +26,5 @@ declare(strict_types=1);
 return [
 	'ocs' => [
 		['name' => 'Api#resetSpreed', 'url' => '/', 'verb' => 'DELETE'],
-		['name' => 'Api#createGuestAppUser', 'url' => '/guest-users', 'verb' => 'POST'],
 	],
 ];

--- a/tests/integration/spreedcheats/lib/Controller/ApiController.php
+++ b/tests/integration/spreedcheats/lib/Controller/ApiController.php
@@ -29,7 +29,6 @@ use OCP\AppFramework\OCSController;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IDBConnection;
 use OCP\IRequest;
-use OCP\IUserManager;
 use OCP\Share\IShare;
 
 class ApiController extends OCSController {
@@ -37,13 +36,9 @@ class ApiController extends OCSController {
 	/** @var IDBConnection */
 	private $db;
 
-	/** @var IUserManager */
-	private $userManager;
-
 	public function __construct(string $appName,
 								IRequest $request,
-								IDBConnection $db,
-								IUserManager $userManager
+								IDBConnection $db
 	) {
 		parent::__construct($appName, $request);
 		$this->db = $db;
@@ -78,26 +73,6 @@ class ApiController extends OCSController {
 				$query->expr()->eq('share_type', $query->createNamedParameter(11 /*RoomShareProvider::SHARE_TYPE_USERROOM*/))
 			))
 			->execute();
-
-		return new DataResponse();
-	}
-
-	/**
-	 * @NoCSRFRequired
-	 *
-	 * @return DataResponse
-	 */
-	public function createGuestAppUser(string $userid, string $password): DataResponse {
-		$guestAppContainer = \OC::$server->getRegisteredAppContainer('guests');
-		$guestManager = $guestAppContainer->query('\OCA\Guests\GuestManager');
-		$guestManager->createGuest(
-			\OC::$server->getUserSession()->getUser(),
-			$userid,
-			$userid . '@localhost',
-			$userid . '-displayname'
-		);
-
-		$this->userManager->get($userid)->setPassword($password);
 
 		return new DataResponse();
 	}


### PR DESCRIPTION
Removed cheat that used GuestManager directly from the guests app.
Now using occ guests:add to create guest account users.

- [x] REQUIRES https://github.com/nextcloud/guests/pull/510