### PR TITLE
Remove request password button when verif disabled

### DIFF
--- a/lib/PublicShareAuth/TemplateLoader.php
+++ b/lib/PublicShareAuth/TemplateLoader.php
@@ -67,6 +67,12 @@ class TemplateLoader implements IEventListener {
 			return;
 		}
 
+		// Check if "Video verification" option was set
+		$share = $event->getShare();
+		if (!$share->getSendPasswordByTalk()) {
+			return;
+		}
+
 		Util::addStyle('spreed', 'merged-share-auth');
 		Util::addScript('spreed', 'talk-public-share-auth-sidebar');
 


### PR DESCRIPTION
Whenever the video verification has not been set for a share, do not
display the button "Request password" in the public link page.

Somehow it looks like there was no test anywhere before, maybe it was always missing ?

Fixes https://github.com/nextcloud/spreed/issues/4523

- [x] TEST: no button when video verif was not ticked
- [x] TEST: button appears when video verif is ticked
- [x] TEST: verified that the talk sidebar still appears for link file share when video verif is off