### PR TITLE
Disable PIP for non-promoted videos

### DIFF
--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -28,6 +28,7 @@
 		<video v-show="localMediaModel.attributes.videoEnabled"
 			id="localVideo"
 			ref="video"
+			disablePictureInPicture="true"
 			:class="videoClass"
 			class="video" />
 		<div v-if="!localMediaModel.attributes.videoEnabled && !isSidebar" class="avatar-container">

--- a/src/components/CallView/shared/Screen.vue
+++ b/src/components/CallView/shared/Screen.vue
@@ -22,6 +22,7 @@
 	<div :id="screenContainerId" class="screenContainer">
 		<video v-show="(localMediaModel && localMediaModel.attributes.localScreen) || (callParticipantModel && callParticipantModel.attributes.screen)"
 			ref="screen"
+			:disablePictureInPicture="!isBig"
 			class="screen"
 			:class="screenClass" />
 		<VideoBottomBar v-if="isBig"

--- a/src/components/CallView/shared/Screen.vue
+++ b/src/components/CallView/shared/Screen.vue
@@ -22,7 +22,7 @@
 	<div :id="screenContainerId" class="screenContainer">
 		<video v-show="(localMediaModel && localMediaModel.attributes.localScreen) || (callParticipantModel && callParticipantModel.attributes.screen)"
 			ref="screen"
-			:disablePictureInPicture="!isBig"
+			:disablePictureInPicture="!isBig ? 'true' : 'false'"
 			class="screen"
 			:class="screenClass" />
 		<VideoBottomBar v-if="isBig"

--- a/src/components/CallView/shared/Video.vue
+++ b/src/components/CallView/shared/Video.vue
@@ -30,6 +30,7 @@
 			<video
 				v-show="showVideo"
 				ref="video"
+				:disablePictureInPicture="!isBig"
 				:class="videoClass"
 				class="video" />
 		</transition>

--- a/src/components/MediaDevicesPreview.vue
+++ b/src/components/MediaDevicesPreview.vue
@@ -74,6 +74,7 @@
 				 reference is always valid once mounted. -->
 			<video v-show="videoPreviewAvailable"
 				ref="video"
+				disablePictureInPicture="true"
 				tabindex="-1" />
 		</div>
 	</div>


### PR DESCRIPTION
Disabled in grid view, own video and also the media settings.

Fixes https://github.com/nextcloud/spreed/issues/4754

Tested in Chromium 87.
You need to right click to see the "Picture in Picture" option.
Note that in grid view for some reason right click doesn't show the same menu, so I used the inspector to verify.
In promoted view the video context menu works and allows picture in picture mode.

Doesn't work in Firefox because of https://bugzilla.mozilla.org/show_bug.cgi?id=1611831
