### PR TITLE
WIP debug peerId matching

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -495,6 +495,7 @@ export default {
 			}
 
 			// update in callViewStore
+			console.log('received raised hand event from peer: ' + callParticipantModel.attributes.peerId, callParticipantModel)
 			this.$store.dispatch('setParticipantHandRaised', { peerId: callParticipantModel.attributes.peerId, raised: raisedHand })
 		},
 
@@ -576,6 +577,7 @@ export default {
 		},
 
 		debounceFetchPeers: debounce(async function() {
+			console.log('debounceFetchPeers')
 			const token = this.token
 			try {
 				const response = await fetchPeers(token)

--- a/src/components/CallView/shared/Video.vue
+++ b/src/components/CallView/shared/Video.vue
@@ -213,6 +213,7 @@ export default {
 
 		peerData() {
 			let peerData = this.$store.getters.getPeer(this.$store.getters.getToken(), this.peerId)
+			console.log('peerData', this.peerId, peerData)
 			if (!peerData.actorId) {
 				EventBus.$emit('refreshPeerList')
 				peerData = {

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -127,6 +127,7 @@
 
 <script>
 
+import { EventBus } from '../../../../../services/EventBus'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import ActionText from '@nextcloud/vue/dist/Components/ActionText'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
@@ -277,12 +278,24 @@ export default {
 		label() {
 			return this.participant.label
 		},
+		peerId() {
+			const peer = this.$store.getters.getPeer(this.token, this.participant.sessionId)
+			if (!peer?.actorId) {
+				// peer id not known yet, it will likely be after refreshing
+				EventBus.$emit('refreshPeerList')
+				return null
+			}
+
+			console.log('Participant peerId: got peer', peer)
+
+			return peer?.sessionId
+		},
 		raisedHand() {
 			if (this.isSearched || this.participant.inCall === PARTICIPANT.CALL_FLAG_DISCONNECTED) {
 				return false
 			}
 
-			return this.$store.getters.isParticipantRaisedHand(this.participant.sessionId)
+			return this.$store.getters.isParticipantRaisedHand(this.peerId)
 		},
 		callIcon() {
 			if (this.isSearched || this.participant.inCall === PARTICIPANT.CALL_FLAG.DISCONNECTED) {

--- a/src/services/callsService.js
+++ b/src/services/callsService.js
@@ -55,6 +55,7 @@ const leaveCall = async function(token) {
 
 const fetchPeers = async function(token, options) {
 	const response = await axios.get(generateOcsUrl('apps/spreed/api/v3', 2) + `call/${token}`, options)
+	console.log('fetchPeers', token, response)
 	return response
 }
 

--- a/src/store/callViewStore.js
+++ b/src/store/callViewStore.js
@@ -49,7 +49,10 @@ const getters = {
 	getBlurFilter: (state) => (width, height) => {
 		return `filter: blur(${(width * height * state.videoBackgroundBlur) / 1000}px)`
 	},
-	isParticipantRaisedHand: (state) => (peerId) => !!state.participantRaisedHands[peerId],
+	isParticipantRaisedHand: (state) => (peerId) => {
+		console.log('isParticipantRaisedHand', peerId, state.participantRaisedHands)
+		return !!state.participantRaisedHands[peerId]
+	}
 }
 
 const mutations = {
@@ -73,6 +76,7 @@ const mutations = {
 		state.presentationStarted = value
 	},
 	setParticipantHandRaised(state, { peerId, raised }) {
+		console.log('setParticipantHandRaised', peerId, raised)
 		if (raised) {
 			Vue.set(state.participantRaisedHands, peerId, raised)
 		} else {

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -74,11 +74,15 @@ const getters = {
 		return index
 	},
 	getPeer: (state) => (token, sessionId) => {
+		console.log('getPeer', token, sessionId)
 		if (!state.peers[token]) {
 			return {}
 		}
 
+		console.log('getPeer; store entries for token ' + token + ': ', state.peers[token])
+
 		if (state.peers[token].hasOwnProperty(sessionId)) {
+			console.log('getPeer; returning peer ', state.peers[token][sessionId])
 			return state.peers[token][sessionId]
 		}
 


### PR DESCRIPTION
I have two users, admin and Bob.

When bob connects, the admin browser receives this peer (from refreshPeerList):
<img width="364" alt="image" src="https://user-images.githubusercontent.com/277525/102482676-e0a85400-4063-11eb-81f8-dfd30c08618b.png">

However, the signaling message comes from a different peer id:
<img width="280" alt="image" src="https://user-images.githubusercontent.com/277525/102482803-12b9b600-4064-11eb-9b6c-a48e5ad62af3.png">

which matches the one from the callParticipantModel which we use for setting the raised hand state:
<img width="385" alt="image" src="https://user-images.githubusercontent.com/277525/102482919-3f6dcd80-4064-11eb-8d0b-3218434af456.png">


