### PR TITLE
Feature/noid/center system messages

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -463,6 +463,8 @@ export default {
 
 			&.system-message {
 				color: var(--color-text-maxcontrast);
+				text-align: center;
+				padding: 0 20px;
 			}
 
 			::v-deep .rich-text--wrapper {

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -465,6 +465,7 @@ export default {
 				color: var(--color-text-maxcontrast);
 				text-align: center;
 				padding: 0 20px;
+				width: 100%;
 			}
 
 			::v-deep .rich-text--wrapper {

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -24,9 +24,10 @@
 		<div v-if="dateSeparator" class="message-group__date-header">
 			<span class="date" role="heading" aria-level="3">{{ dateSeparator }}</span>
 		</div>
-		<div class="wrapper">
-			<div class="messages__avatar">
-				<AuthorAvatar v-if="!isSystemMessage"
+		<div class="wrapper"
+			:class="{'wrapper--system': isSystemMessage}">
+			<div v-if="!isSystemMessage" class="messages__avatar">
+				<AuthorAvatar
 					:author-type="actorType"
 					:author-id="actorId"
 					:display-name="actorDisplayName" />
@@ -169,6 +170,9 @@ export default {
 	display: flex;
 	margin: auto;
 	padding: 0;
+	&--system {
+		padding-left: $clickable-area + 8px;
+	}
 	&:focus {
 		background-color: rgba(47, 47, 47, 0.068);
 	}

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -21,8 +21,11 @@
 
 <template>
 	<div class="message-group">
-		<div v-if="dateSeparator" class="message-group__date-header">
-			<span class="date" role="heading" aria-level="3">{{ dateSeparator }}</span>
+		<div v-if="dateSeparator"
+			class="message-group__date-header">
+			<span class="date"
+				role="heading"
+				aria-level="3">{{ dateSeparator }}</span>
 		</div>
 		<div class="wrapper"
 			:class="{'wrapper--system': isSystemMessage}">
@@ -142,25 +145,17 @@ export default {
 	&__date-header {
 		display: block;
 		text-align: center;
-
-		margin: 40px 15px 0;
-		border-top: 1px solid var(--color-border);
 		padding-top: 20px;
 		position: relative;
-
+		margin: 20px 0;
 		.date {
+			margin-right: $clickable-area * 2;
 			content: attr(data-date);
-			position: absolute;
-			top: 0;
+			padding: 4px 12px;
 			left: 50%;
-			transform: translateX(-50%) translateY(-50%);
-			padding: 0 7px 0 7px;
-
-			text-align: center;
-			white-space: nowrap;
-
 			color: var(--color-text-maxcontrast);
-			background-color: var(--color-main-background);
+			background-color: var(--color-background-dark);
+			border-radius: var(--border-radius-pill);
 		}
 	}
 }
@@ -183,6 +178,7 @@ export default {
 	display: flex;
 	padding: 8px 0 8px 0;
 	flex-direction: column;
+	width: 100%;
 	&__avatar {
 		position: sticky;
 		top: 0;


### PR DESCRIPTION
As discussed some time ago with @jancborchardt, let's center align the text for system message and add some padding to the sides, in order to create a visual separation between real chat messages and system ones. 

based on #4741 

Before | After
---|---
![Peek 2020-12-17 13-11](https://user-images.githubusercontent.com/26852655/102486491-667ace00-4069-11eb-834f-56ebe1ab0a2f.gif) | ![Peek 2020-12-17 13-07](https://user-images.githubusercontent.com/26852655/102486144-e48aa500-4068-11eb-84c2-26ae4a46ae5e.gif)


