### PR TITLE
Adjust matterbridge config file permissions

### DIFF
--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -253,6 +253,7 @@ class MatterbridgeManager {
 		$configPath = sprintf('/tmp/bridge-%s.toml', $room->getToken());
 		$configContent = $this->generateConfig($newBridge);
 		file_put_contents($configPath, $configContent);
+		chmod($configPath, 0600);
 	}
 
 	/**


### PR DESCRIPTION
This sets 0600 permissions (read and write for owner only) to Matterbridge config files each time they are written.

refs #4776 #4549

@nickvergessen Would you have a hint about a good place to write the config files instead of `/tmp`? We need to know the absolute path to give it to the binary then. I guess the question is: How can we get an absolute path, somewhere in Nextcloud, where it's ok to write the config files?