### PR TITLE
Improve cache handling in blur filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4789,10 +4789,26 @@
 				"vue-template-es2015-compiler": "^1.9.0"
 			},
 			"dependencies": {
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"dev": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 					"dev": true
 				}
 			}
@@ -8944,6 +8960,24 @@
 				"lru-cache": "^4.1.5",
 				"semver": "^5.6.0",
 				"sigmund": "^1.0.1"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"dev": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"dev": true
+				}
 			}
 		},
 		"ee-first": {
@@ -13797,13 +13831,11 @@
 			"dev": true
 		},
 		"lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-			"dev": true,
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"yallist": "^4.0.0"
 			}
 		},
 		"make-dir": {
@@ -22100,10 +22132,9 @@
 			"dev": true
 		},
 		"yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-			"dev": true
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"yaml": {
 			"version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"escape-html": "^1.0.3",
 		"hark": "^1.2.3",
 		"lodash": "^4.17.20",
+		"lru-cache": "^6.0.0",
 		"mockconsole": "0.0.1",
 		"nextcloud-vue-collections": "^0.9.0",
 		"sdp-transform": "^2.14.1",

--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -51,6 +51,8 @@ import { getBuilder } from '@nextcloud/browser-storage'
 import browserCheck from '../../../mixins/browserCheck'
 import blur from '../../../utils/imageBlurrer'
 
+const LRU = require('lru-cache')
+
 const browserStorage = getBuilder('nextcloud').persist().build()
 
 // note: this info is shared with the Avatar component
@@ -97,7 +99,7 @@ export default {
 			useCssBlurFilter: true,
 			blur: 0,
 			blurredBackgroundImage: null,
-			blurredBackgroundImageCache: {},
+			blurredBackgroundImageCache: new LRU({ max: 5 }),
 			blurredBackgroundImageSource: null,
 			pendingGenerateBlurredBackgroundImageCount: 0,
 			isDestroyed: false,
@@ -254,8 +256,8 @@ export default {
 			}
 
 			const cacheId = this.backgroundImageUrl + '-' + width + '-' + height + '-' + this.backgroundBlur
-			if (this.blurredBackgroundImageCache[cacheId]) {
-				this.blurredBackgroundImage = this.blurredBackgroundImageCache[cacheId]
+			if (this.blurredBackgroundImageCache.get(cacheId)) {
+				this.blurredBackgroundImage = this.blurredBackgroundImageCache.get(cacheId)
 
 				return
 			}
@@ -274,7 +276,7 @@ export default {
 				}
 
 				this.blurredBackgroundImage = image
-				this.blurredBackgroundImageCache[cacheId] = this.blurredBackgroundImage
+				this.blurredBackgroundImageCache.set(cacheId, this.blurredBackgroundImage)
 
 				const generateBlurredBackgroundImageCalledAgain = this.pendingGenerateBlurredBackgroundImageCount > 1
 

--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -51,8 +51,6 @@ import { getBuilder } from '@nextcloud/browser-storage'
 import browserCheck from '../../../mixins/browserCheck'
 import blur from '../../../utils/imageBlurrer'
 
-const LRU = require('lru-cache')
-
 const browserStorage = getBuilder('nextcloud').persist().build()
 
 // note: this info is shared with the Avatar component
@@ -99,7 +97,6 @@ export default {
 			useCssBlurFilter: true,
 			blur: 0,
 			blurredBackgroundImage: null,
-			blurredBackgroundImageCache: new LRU({ max: 5 }),
 			blurredBackgroundImageSource: null,
 			pendingGenerateBlurredBackgroundImageCount: 0,
 			isDestroyed: false,
@@ -151,6 +148,17 @@ export default {
 			}
 
 			return this.backgroundBlur
+		},
+		blurredBackgroundImageCache() {
+			if (!this.user) {
+				return null
+			}
+
+			if (!this.$store.getters.getBlurredBackgroundImageCache(this.user)) {
+				this.$store.dispatch('initializeBlurredBackgroundImageCache', this.user)
+			}
+
+			return this.$store.getters.getBlurredBackgroundImageCache(this.user)
 		},
 	},
 


### PR DESCRIPTION
Fixes #4827
Follow up to #4678

Instead of using an array as the cache now a LRU cache is used, which should prevent overflowing the cache.

Pending:
- [X] Make the cache global so the backgrounds are reused when switching between speaker mode and grid view (as `VideoBackground` is recreated in that case)