### PR TITLE
Fix exports issue related to nextcloud-event-bus

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -59,7 +59,6 @@ module.exports = {
 					'hot-patcher',
 					'nextcloud-vue-collections',
 					'semver',
-					'@nextcloud/event-bus',
 					'webdav',
 				]),
 			},


### PR DESCRIPTION
- [x] check that it still runs in Edge

This is a partial revert of https://github.com/nextcloud/spreed/pull/3961 so better not backport to versions that need to support IE11.

Fixes https://github.com/nextcloud/spreed/issues/4818