### PR TITLE
Revert "Bump @babel/preset-env from 7.12.10 to 7.12.11"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,7 @@ updates:
     versions:
     - ">= 4.a"
     - "< 5"
+  # remove after fixing https://github.com/nextcloud/spreed/issues/4818
+  - dependency-name: "@babel/preset-env"
+    versions:
+    - ">= 7.12.11"

--- a/package-lock.json
+++ b/package-lock.json
@@ -242,17 +242,12 @@
 				"@babel/types": "^7.12.10"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
 				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
+					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -268,17 +263,12 @@
 				"@babel/types": "^7.10.4"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
 				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
+					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -309,14 +299,14 @@
 					}
 				},
 				"caniuse-lite": {
-					"version": "1.0.30001168",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz",
-					"integrity": "sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ=="
+					"version": "1.0.30001165",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz",
+					"integrity": "sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA=="
 				},
 				"electron-to-chromium": {
-					"version": "1.3.629",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.629.tgz",
-					"integrity": "sha512-iSPPJtPvHrMAvYOt+9cdbDmTasPqwnwz4lkP8Dn200gDNUBQOLQ96xUsWXBwXslAo5XxdoXAoQQ3RAy4uao9IQ=="
+					"version": "1.3.625",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.625.tgz",
+					"integrity": "sha512-CsLk/r0C9dAzVPa9QF74HIXduxaucsaRfqiOYvIv2PRhvyC6EOqc/KbpgToQuDVgPf3sNAFZi3iBu4vpGOwGag=="
 				},
 				"node-releases": {
 					"version": "1.1.67",
@@ -473,21 +463,21 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
-					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.12.10",
-						"@babel/template": "^7.12.7",
-						"@babel/types": "^7.12.11"
+						"@babel/helper-get-function-arity": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
 					}
 				},
 				"@babel/helper-get-function-arity": {
@@ -497,11 +487,6 @@
 					"requires": {
 						"@babel/types": "^7.12.10"
 					}
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
 				},
 				"@babel/highlight": {
 					"version": "7.10.4",
@@ -514,9 +499,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.10.tgz",
+					"integrity": "sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA=="
 				},
 				"@babel/template": {
 					"version": "7.12.7",
@@ -529,11 +514,11 @@
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
+					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -548,17 +533,12 @@
 				"@babel/types": "^7.12.1"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
 				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
+					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -593,17 +573,12 @@
 				"@babel/types": "^7.10.4"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
 				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
+					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -618,17 +593,12 @@
 				"@babel/types": "^7.12.7"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
 				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
+					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -822,17 +792,12 @@
 				"@babel/types": "^7.12.1"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
 				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
+					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -840,42 +805,42 @@
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
-			"integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
+			"integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.12.7",
-				"@babel/helper-optimise-call-expression": "^7.12.10",
-				"@babel/traverse": "^7.12.10",
-				"@babel/types": "^7.12.11"
+				"@babel/helper-member-expression-to-functions": "^7.12.1",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/traverse": "^7.12.5",
+				"@babel/types": "^7.12.5"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.10.tgz",
+					"integrity": "sha512-6mCdfhWgmqLdtTkhXjnIz0LcdVCd26wS2JXRtj2XY0u5klDsXBREA/pG5NVOuVnF2LUrBGNFtQkIqqTbblg0ww==",
 					"requires": {
-						"@babel/types": "^7.12.11",
+						"@babel/types": "^7.12.10",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
-					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.12.10",
-						"@babel/template": "^7.12.7",
-						"@babel/types": "^7.12.11"
+						"@babel/helper-get-function-arity": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
 					}
 				},
 				"@babel/helper-get-function-arity": {
@@ -886,26 +851,13 @@
 						"@babel/types": "^7.12.10"
 					}
 				},
-				"@babel/helper-optimise-call-expression": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
-					"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
-					"requires": {
-						"@babel/types": "^7.12.10"
-					}
-				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-					"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
 					"requires": {
-						"@babel/types": "^7.12.11"
+						"@babel/types": "^7.11.0"
 					}
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
 				},
 				"@babel/highlight": {
 					"version": "7.10.4",
@@ -918,9 +870,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.10.tgz",
+					"integrity": "sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA=="
 				},
 				"@babel/template": {
 					"version": "7.12.7",
@@ -949,11 +901,11 @@
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
+					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -988,17 +940,12 @@
 				"@babel/types": "^7.12.1"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
 				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
+					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -1020,9 +967,9 @@
 			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
 		},
 		"@babel/helper-validator-option": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz",
-			"integrity": "sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw=="
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz",
+			"integrity": "sha512-YpJabsXlJVWP0USHjnC/AQDTLlZERbON577YUVO/wLpqyj6HAtVYnWaQaN0iUN+1/tWn3c+uKKXjRut5115Y2A=="
 		},
 		"@babel/helper-wrap-function": {
 			"version": "7.12.3",
@@ -1036,31 +983,31 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.10.tgz",
+					"integrity": "sha512-6mCdfhWgmqLdtTkhXjnIz0LcdVCd26wS2JXRtj2XY0u5klDsXBREA/pG5NVOuVnF2LUrBGNFtQkIqqTbblg0ww==",
 					"requires": {
-						"@babel/types": "^7.12.11",
+						"@babel/types": "^7.12.10",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
-					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.12.10",
-						"@babel/template": "^7.12.7",
-						"@babel/types": "^7.12.11"
+						"@babel/helper-get-function-arity": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
 					}
 				},
 				"@babel/helper-get-function-arity": {
@@ -1072,17 +1019,12 @@
 					}
 				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-					"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
 					"requires": {
-						"@babel/types": "^7.12.11"
+						"@babel/types": "^7.11.0"
 					}
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
 				},
 				"@babel/highlight": {
 					"version": "7.10.4",
@@ -1095,9 +1037,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.10.tgz",
+					"integrity": "sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA=="
 				},
 				"@babel/template": {
 					"version": "7.12.7",
@@ -1126,11 +1068,11 @@
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
+					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -1715,9 +1657,9 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.11.tgz",
-			"integrity": "sha512-atR1Rxc3hM+VPg/NvNvfYw0npQEAcHuJ+MGZnFn6h3bo+1U3BWXMdFMlvVRApBTWKQMX7SOwRJZA5FBF/JQbvA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.1.tgz",
+			"integrity": "sha512-zJyAC9sZdE60r1nVQHblcfCj29Dh2Y0DOvlMkcqSo0ckqjiCwNiUezUKw+RjOCwGfpLRwnAeQ2XlLpsnGkvv9w==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			},
@@ -1745,21 +1687,21 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
-					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.12.10",
-						"@babel/template": "^7.12.7",
-						"@babel/types": "^7.12.11"
+						"@babel/helper-get-function-arity": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
 					}
 				},
 				"@babel/helper-get-function-arity": {
@@ -1776,17 +1718,12 @@
 					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
 				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-					"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
 					"requires": {
-						"@babel/types": "^7.12.11"
+						"@babel/types": "^7.11.0"
 					}
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
 				},
 				"@babel/highlight": {
 					"version": "7.10.4",
@@ -1799,9 +1736,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.10.tgz",
+					"integrity": "sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA=="
 				},
 				"@babel/template": {
 					"version": "7.12.7",
@@ -1814,11 +1751,11 @@
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
+					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -1927,21 +1864,21 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
-					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.12.10",
-						"@babel/template": "^7.12.7",
-						"@babel/types": "^7.12.11"
+						"@babel/helper-get-function-arity": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
 					}
 				},
 				"@babel/helper-get-function-arity": {
@@ -1957,11 +1894,6 @@
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
 					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
 				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
 				"@babel/highlight": {
 					"version": "7.10.4",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
@@ -1973,9 +1905,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.10.tgz",
+					"integrity": "sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA=="
 				},
 				"@babel/template": {
 					"version": "7.12.7",
@@ -1988,11 +1920,11 @@
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
+					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -2337,15 +2269,15 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.11.tgz",
-			"integrity": "sha512-j8Tb+KKIXKYlDBQyIOy4BLxzv1NUOwlHfZ74rvW+Z0Gp4/cI2IMDPBWAgWceGcE7aep9oL/0K9mlzlMGxA8yNw==",
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.10.tgz",
+			"integrity": "sha512-Gz9hnBT/tGeTE2DBNDkD7BiWRELZt+8lSysHuDwmYXUIvtwZl0zI+D6mZgXZX0u8YBlLS4tmai9ONNY9tjRgRA==",
 			"requires": {
 				"@babel/compat-data": "^7.12.7",
 				"@babel/helper-compilation-targets": "^7.12.5",
 				"@babel/helper-module-imports": "^7.12.5",
 				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-validator-option": "^7.12.11",
+				"@babel/helper-validator-option": "^7.12.1",
 				"@babel/plugin-proposal-async-generator-functions": "^7.12.1",
 				"@babel/plugin-proposal-class-properties": "^7.12.1",
 				"@babel/plugin-proposal-dynamic-import": "^7.12.1",
@@ -2374,7 +2306,7 @@
 				"@babel/plugin-transform-arrow-functions": "^7.12.1",
 				"@babel/plugin-transform-async-to-generator": "^7.12.1",
 				"@babel/plugin-transform-block-scoped-functions": "^7.12.1",
-				"@babel/plugin-transform-block-scoping": "^7.12.11",
+				"@babel/plugin-transform-block-scoping": "^7.12.1",
 				"@babel/plugin-transform-classes": "^7.12.1",
 				"@babel/plugin-transform-computed-properties": "^7.12.1",
 				"@babel/plugin-transform-destructuring": "^7.12.1",
@@ -2404,7 +2336,7 @@
 				"@babel/plugin-transform-unicode-escapes": "^7.12.1",
 				"@babel/plugin-transform-unicode-regex": "^7.12.1",
 				"@babel/preset-modules": "^0.1.3",
-				"@babel/types": "^7.12.11",
+				"@babel/types": "^7.12.10",
 				"core-js-compat": "^3.8.0",
 				"semver": "^5.5.0"
 			},
@@ -2422,17 +2354,12 @@
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
 					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
 				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
 				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
+					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -7885,14 +7812,14 @@
 					}
 				},
 				"caniuse-lite": {
-					"version": "1.0.30001168",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz",
-					"integrity": "sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ=="
+					"version": "1.0.30001165",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz",
+					"integrity": "sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA=="
 				},
 				"electron-to-chromium": {
-					"version": "1.3.629",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.629.tgz",
-					"integrity": "sha512-iSPPJtPvHrMAvYOt+9cdbDmTasPqwnwz4lkP8Dn200gDNUBQOLQ96xUsWXBwXslAo5XxdoXAoQQ3RAy4uao9IQ=="
+					"version": "1.3.625",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.625.tgz",
+					"integrity": "sha512-CsLk/r0C9dAzVPa9QF74HIXduxaucsaRfqiOYvIv2PRhvyC6EOqc/KbpgToQuDVgPf3sNAFZi3iBu4vpGOwGag=="
 				},
 				"node-releases": {
 					"version": "1.1.67",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.12.10",
 		"@babel/plugin-syntax-dynamic-import": "^7.8.3",
-		"@babel/preset-env": "^7.12.11",
+		"@babel/preset-env": "^7.12.10",
 		"@babel/runtime": "^7.12.5",
 		"@nextcloud/browserslist-config": "^1.0.0",
 		"@nextcloud/eslint-config": "^1.2.0",


### PR DESCRIPTION
Reverts nextcloud/spreed#4811

Because of https://github.com/nextcloud/spreed/issues/4818

- [x] fix revert DCO
- [x] also add ignore rule to dependabot