### PR TITLE
Fix notifications based on the notification level

### DIFF
--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -635,7 +635,7 @@ class ParticipantService {
 				$query->expr()->eq('s.attendee_id', 'a.id')
 			)
 			->where($query->expr()->eq('a.room_id', $query->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))
-			->andWhere($query->expr()->eq('notification_level', $query->createNamedParameter($notificationLevel, IQueryBuilder::PARAM_INT)));
+			->andWhere($query->expr()->eq('a.notification_level', $query->createNamedParameter($notificationLevel, IQueryBuilder::PARAM_INT)));
 
 		return $this->getParticipantsFromQuery($query, $room);
 	}

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -629,9 +629,9 @@ class ParticipantService {
 		$helper = new SelectHelper();
 		$helper->selectAttendeesTable($query);
 		$helper->selectSessionsTable($query);
-		$query->from('talk_sessions', 's')
+		$query->from('talk_attendees', 'a')
 			->leftJoin(
-				's', 'talk_attendees', 'a',
+				'a', 'talk_sessions', 's',
 				$query->expr()->eq('s.attendee_id', 'a.id')
 			)
 			->where($query->expr()->eq('a.room_id', $query->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))


### PR DESCRIPTION
The sessions were left joined to the attendees, so all the attendees in the conversation that were not active were not included in the result.

~~Pending:~~ Future:
- Add integration tests ~~(at least, if they can be added quickly)~~ - They require some work, so something for later

## How to test (scenario 1)
- Install and enable the notifications app
- Create a one-to-one conversation with another user
- Change to a different conversation
- In a private window, log in as the other user
- Open the one-to-one conversation
- Write a message

### Result with this pull request
The notification app shows a notification with the written message

### Result without this pull request
No notification is shown

## How to test (scenario 2)
- Install and enable the notifications app
- Create a public conversation
- Set the notification level of the conversation to "All messages"
- Change to a different conversation
- In a private window, open the public conversation
- Write a message

### Result with this pull request
The notification app shows a notification with the written message

### Result without this pull request
No notification is shown