### PR TITLE
Sort participants by raised hands

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -409,7 +409,7 @@ export default {
 				this.raisedHandUnwatchers[removedModelId]()
 				// Not reactive, but not a problem
 				delete this.raisedHandUnwatchers[removedModelId]
-				this.$store.dispatch('setParticipantHandRaised', { peerId: removedModelId, raised: false })
+				this.$store.dispatch('setParticipantHandRaised', { peerId: removedModelId, raisedHand: { state: false } })
 
 				const index = this.speakers.findIndex(speaker => speaker.id === removedModelId)
 				this.speakers.splice(index, 1)
@@ -488,17 +488,20 @@ export default {
 			const nickName = callParticipantModel.attributes.name || callParticipantModel.attributes.userId
 			// sometimes the nick name is not available yet...
 			if (nickName) {
-				if (raisedHand) {
+				if (raisedHand?.state) {
 					showMessage(t('spreed', 'Participant {nickName} raised their hand.', { nickName: nickName }))
 				}
 			} else {
-				if (raisedHand) {
+				if (raisedHand?.state) {
 					showMessage(t('spreed', 'A participant raised their hand.'))
 				}
 			}
 
 			// update in callViewStore
-			this.$store.dispatch('setParticipantHandRaised', { peerId: callParticipantModel.attributes.peerId, raised: raisedHand })
+			this.$store.dispatch('setParticipantHandRaised', {
+				peerId: callParticipantModel.attributes.peerId,
+				raisedHand: raisedHand,
+			})
 		},
 
 		_setScreenAvailable(id, screen) {

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -409,7 +409,8 @@ export default {
 				this.raisedHandUnwatchers[removedModelId]()
 				// Not reactive, but not a problem
 				delete this.raisedHandUnwatchers[removedModelId]
-				this.$store.dispatch('setParticipantHandRaised', { peerId: removedModelId, raisedHand: { state: false } })
+				// FIXME: when using HPB sessionId doesn't match
+				this.$store.dispatch('setParticipantHandRaised', { sessionId: removedModelId, raisedHand: { state: false } })
 
 				const index = this.speakers.findIndex(speaker => speaker.id === removedModelId)
 				this.speakers.splice(index, 1)
@@ -499,7 +500,8 @@ export default {
 
 			// update in callViewStore
 			this.$store.dispatch('setParticipantHandRaised', {
-				peerId: callParticipantModel.attributes.peerId,
+				// FIXME: when using HPB sessionId doesn't match
+				sessionId: callParticipantModel.attributes.peerId,
 				raisedHand: raisedHand,
 			})
 		},

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -490,7 +490,7 @@ export default {
 			// sometimes the nick name is not available yet...
 			if (nickName) {
 				if (raisedHand?.state) {
-					showMessage(t('spreed', 'Participant {nickName} raised their hand.', { nickName: nickName }))
+					showMessage(t('spreed', '{nickName} raised their hand.', { nickName: nickName }))
 				}
 			} else {
 				if (raisedHand?.state) {

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -500,8 +500,8 @@ export default {
 
 			// update in callViewStore
 			this.$store.dispatch('setParticipantHandRaised', {
-				// FIXME: when using HPB sessionId doesn't match
-				sessionId: callParticipantModel.attributes.peerId,
+				// FIXME: this is a bit hacky to fix the HPB session mismatch
+				sessionId: raisedHand?.sessionId ? raisedHand?.sessionId : callParticipantModel.attributes.peerId,
 				raisedHand: raisedHand,
 			})
 		},

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -84,8 +84,8 @@
 				v-shortkey.once="['r']"
 				v-tooltip="t('spreed', 'Lower hand')"
 				class="lower-hand"
-				:class="model.attributes.raisedHand ? '' : 'hidden-visually'"
-				:tabindex="model.attributes.raisedHand ? 0 : -1"
+				:class="model.attributes.raisedHand.state ? '' : 'hidden-visually'"
+				:tabindex="model.attributes.raisedHand.state ? 0 : -1"
 				:aria-label="t('spreed', 'Lower hand')"
 				@shortkey="toggleHandRaised"
 				@click.stop="toggleHandRaised">
@@ -218,13 +218,12 @@ export default {
 			qualityWarningInGracePeriodTimeout: null,
 			audioEnabledBeforeSpacebarKeydown: undefined,
 			spacebarKeyDown: false,
-			raisingHandNotification: null,
 		}
 	},
 
 	computed: {
 		raiseHandButtonLabel() {
-			if (!this.model.attributes.raisedHand) {
+			if (!this.model.attributes.raisedHand.state) {
 				return t('spreed', 'Raise hand')
 			}
 			return t('spreed', 'Lower hand')
@@ -578,13 +577,15 @@ export default {
 		},
 
 		toggleHandRaised() {
-			const raisedHand = !this.model.attributes.raisedHand
-			if (this.raisingHandNotification) {
-				this.raisingHandNotification.hideToast()
-				this.raisingHandNotification = null
-			}
-			this.model.toggleHandRaised(raisedHand)
-			this.$store.dispatch('setParticipantHandRaised', { peerId: this.localCallParticipantModel.attributes.peerId, raised: raisedHand })
+			const state = !this.model.attributes.raisedHand?.state
+			this.model.toggleHandRaised(state)
+			this.$store.dispatch(
+				'setParticipantHandRaised',
+				{
+					peerId: this.localCallParticipantModel.attributes.peerId,
+					raisedHand: this.model.attributes.raisedHand,
+				}
+			)
 		},
 
 		shareScreen() {

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -582,7 +582,8 @@ export default {
 			this.$store.dispatch(
 				'setParticipantHandRaised',
 				{
-					peerId: this.localCallParticipantModel.attributes.peerId,
+					// FIXME: when using HPB these don't match
+					sessionId: this.localCallParticipantModel.attributes.peerId,
 					raisedHand: this.model.attributes.raisedHand,
 				}
 			)

--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -26,7 +26,7 @@
 			:class="{'bottom-bar--video-on' : hasShadow, 'bottom-bar--big': isBig }">
 			<transition name="fade">
 				<div
-					v-if="!connectionStateFailedNoRestart && model.attributes.raisedHand"
+					v-if="!connectionStateFailedNoRestart && model.attributes.raisedHand.state"
 					class="bottom-bar__statusIndicator">
 					<Hand
 						class="handIndicator"

--- a/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
+++ b/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
@@ -114,6 +114,7 @@ export default {
 		 * Sort two participants by:
 		 * - online status
 		 * - in call
+		 * - who raised hand first
 		 * - type (moderators before normal participants)
 		 * - user status (dnd at the end)
 		 * - display name
@@ -149,6 +150,22 @@ export default {
 			const p2inCall = participant2.inCall !== PARTICIPANT.CALL_FLAG.DISCONNECTED
 			if (p1inCall !== p2inCall) {
 				return p1inCall ? -1 : 1
+			}
+
+			const p1HandRaised = this.$store.getters.getParticipantRaisedHand(session1)
+			const p2HandRaised = this.$store.getters.getParticipantRaisedHand(session2)
+			if (p1HandRaised.state !== p2HandRaised.state) {
+				return p1HandRaised.state ? -1 : 1
+			}
+			// both had raised hands, then pick whoever raised hand first
+			if (p1HandRaised) {
+				// use MAX_VALUE if not defined to avoid zeroes making it look like
+				// one raised their hands at the birth of time...
+				const t1 = p1HandRaised.timestamp || Number.MAX_VALUE
+				const t2 = p2HandRaised.timestamp || Number.MAX_VALUE
+				if (t1 !== t2) {
+					return t1 - t2
+				}
 			}
 
 			const moderatorTypes = [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR]

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -277,18 +277,19 @@ export default {
 		label() {
 			return this.participant.label
 		},
-		raisedHand() {
+		isHandRaised() {
 			if (this.isSearched || this.participant.inCall === PARTICIPANT.CALL_FLAG_DISCONNECTED) {
 				return false
 			}
 
-			return this.$store.getters.isParticipantRaisedHand(this.participant.sessionId)
+			const state = this.$store.getters.isParticipantRaisedHand(this.participant.sessionId)
+			return state
 		},
 		callIcon() {
 			if (this.isSearched || this.participant.inCall === PARTICIPANT.CALL_FLAG.DISCONNECTED) {
 				return ''
 			}
-			if (this.raisedHand) {
+			if (this.isHandRaised) {
 				return 'hand'
 			}
 			const withVideo = this.participant.inCall & PARTICIPANT.CALL_FLAG.WITH_VIDEO

--- a/src/store/callViewStore.js
+++ b/src/store/callViewStore.js
@@ -53,7 +53,9 @@ const getters = {
 	getBlurRadius: (state) => (width, height) => {
 		return (width * height * state.videoBackgroundBlur) / 1000
 	},
-	isParticipantRaisedHand: (state) => (peerId) => !!state.participantRaisedHands[peerId],
+	isParticipantRaisedHand: (state) => (peerId) => {
+		return state.participantRaisedHands[peerId]?.state
+	},
 }
 
 const mutations = {
@@ -76,9 +78,12 @@ const mutations = {
 	presentationStarted(state, value) {
 		state.presentationStarted = value
 	},
-	setParticipantHandRaised(state, { peerId, raised }) {
-		if (raised) {
-			Vue.set(state.participantRaisedHands, peerId, raised)
+	setParticipantHandRaised(state, { peerId, raisedHand }) {
+		if (!peerId) {
+			throw new Error('Missing or empty peerId argument in call to setParticipantHandRaised')
+		}
+		if (raisedHand && raisedHand.state) {
+			Vue.set(state.participantRaisedHands, peerId, raisedHand)
 		} else {
 			Vue.delete(state.participantRaisedHands, peerId)
 		}
@@ -140,8 +145,8 @@ const actions = {
 		}
 	},
 
-	setParticipantHandRaised(context, { peerId, raised }) {
-		context.commit('setParticipantHandRaised', { peerId, raised })
+	setParticipantHandRaised(context, { peerId, raisedHand }) {
+		context.commit('setParticipantHandRaised', { peerId, raisedHand })
 	},
 
 	/**

--- a/src/store/callViewStore.js
+++ b/src/store/callViewStore.js
@@ -53,8 +53,11 @@ const getters = {
 	getBlurRadius: (state) => (width, height) => {
 		return (width * height * state.videoBackgroundBlur) / 1000
 	},
-	isParticipantRaisedHand: (state) => (peerId) => {
-		return state.participantRaisedHands[peerId]?.state
+	getParticipantRaisedHand: (state) => (sessionId) => {
+		return state.participantRaisedHands[sessionId] || { state: false, timestamp: null }
+	},
+	isParticipantRaisedHand: (state) => (sessionId) => {
+		return state.participantRaisedHands[sessionId]?.state
 	},
 }
 
@@ -78,14 +81,14 @@ const mutations = {
 	presentationStarted(state, value) {
 		state.presentationStarted = value
 	},
-	setParticipantHandRaised(state, { peerId, raisedHand }) {
-		if (!peerId) {
-			throw new Error('Missing or empty peerId argument in call to setParticipantHandRaised')
+	setParticipantHandRaised(state, { sessionId, raisedHand }) {
+		if (!sessionId) {
+			throw new Error('Missing or empty sessionId argument in call to setParticipantHandRaised')
 		}
 		if (raisedHand && raisedHand.state) {
-			Vue.set(state.participantRaisedHands, peerId, raisedHand)
+			Vue.set(state.participantRaisedHands, sessionId, raisedHand)
 		} else {
-			Vue.delete(state.participantRaisedHands, peerId)
+			Vue.delete(state.participantRaisedHands, sessionId)
 		}
 	},
 	clearParticipantHandRaised(state) {
@@ -145,8 +148,8 @@ const actions = {
 		}
 	},
 
-	setParticipantHandRaised(context, { peerId, raisedHand }) {
-		context.commit('setParticipantHandRaised', { peerId, raisedHand })
+	setParticipantHandRaised(context, { sessionId, raisedHand }) {
+		context.commit('setParticipantHandRaised', { sessionId, raisedHand })
 	},
 
 	/**

--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -53,7 +53,10 @@ export default function CallParticipantModel(options) {
 		speaking: undefined,
 		videoAvailable: undefined,
 		screen: null,
-		raisedHand: false,
+		raisedHand: {
+			state: false,
+			timestamp: null,
+		},
 	}
 
 	this._handlers = []

--- a/src/utils/webrtc/models/LocalMediaModel.js
+++ b/src/utils/webrtc/models/LocalMediaModel.js
@@ -228,7 +228,7 @@ LocalMediaModel.prototype = {
 			this.set('videoAvailable', false)
 		}
 
-		this.set('raisedHand', false)
+		this.set('raisedHand', { state: false, timestamp: Date.now() })
 	},
 
 	_handleLocalStreamChanged: function(localStream) {
@@ -441,11 +441,16 @@ LocalMediaModel.prototype = {
 			throw new Error('WebRtc not initialized yet')
 		}
 
-		this._webRtc.sendToAll('raiseHand', { raised: raised })
+		const raisedHand = {
+			state: raised,
+			timestamp: Date.now(),
+		}
+
+		this._webRtc.sendToAll('raiseHand', raisedHand)
 
 		// Set state locally too, as even when sending to all the sender will not
 		// receive the message.
-		this.set('raisedHand', raised)
+		this.set('raisedHand', raisedHand)
 	},
 
 }

--- a/src/utils/webrtc/models/LocalMediaModel.js
+++ b/src/utils/webrtc/models/LocalMediaModel.js
@@ -444,6 +444,7 @@ LocalMediaModel.prototype = {
 		const raisedHand = {
 			state: raised,
 			timestamp: Date.now(),
+			sessionId: this._webRtc.connection?.nextcloudSessionId,
 		}
 
 		this._webRtc.sendToAll('raiseHand', raisedHand)

--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -256,7 +256,7 @@ Peer.prototype.handleMessage = function(message) {
 		this.parent.emit('unshareScreen', { id: message.from })
 		this.end()
 	} else if (message.type === 'raiseHand') {
-		this.parent.emit('raisedHand', { id: message.from, raised: message.payload.raised })
+		this.parent.emit('raisedHand', { id: message.from, raised: message.payload })
 	}
 }
 

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -409,7 +409,10 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 		if (callParticipantModel) {
 			callParticipantModel.set('speaking', (event.flags & PARTICIPANT.SIP_FLAG.SPEAKING) > 0)
 			callParticipantModel.set('audioAvailable', (event.flags & PARTICIPANT.SIP_FLAG.MUTE_MICROPHONE) === 0)
-			callParticipantModel.set('raisedHand', (event.flags & PARTICIPANT.SIP_FLAG.RAISE_HAND) === 0)
+			callParticipantModel.set('raisedHand', {
+				state: (event.flags & PARTICIPANT.SIP_FLAG.RAISE_HAND) === 0,
+				timestamp: Date.now(),
+			})
 		}
 	})
 	signaling.on('usersInRoom', function(users) {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/spreed/issues/4770

Participants who raised their hand will appear on top of the list.
For this, the "raisedHand" state was exended to also include a timestamp. The timestamp is sent by whoever raised the hand to have consistent values across participants.

Tested with regular users and also guest users without accounts.

Please use internal signaling when testing because with HPB it doesn't work because of https://github.com/nextcloud/spreed/issues/4777