### PR TITLE
Add conversation-v3 capability for API v3

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -52,8 +52,9 @@ title: Capabilities
 * `conversation-v2` - The conversations API v2 is less load heavy and should be used by clients when available. Check the difference in the [Conversation API documentation](conversation.md).
 * `chat-reference-id` - an optional referenceId can be sent with a chat message to be able to identify it in parallel get requests to earlier fade out a temporary message
 
-## 10.0
-* `sip-support` - Whether conversations API v3 exists and SIP can be configured and enabled by moderators. The conversations API will come with some new values `sipEnabled` which signals whether this conversation has SIP configured as well as `canEnableSIP` to see if a user can enable it. When it is enabled `attendeePin` will contain the unique dial-in code for this user.
+## 10.1
+* `conversation-v3` - Whether conversations API v3 is available
+* `sip-support` - Whether SIP can be configured and enabled by moderators. The conversations API will come with some new values `sipEnabled` which signals whether this conversation has SIP configured as well as `canEnableSIP` to see if a user can enable it. When it is enabled `attendeePin` will contain the unique dial-in code for this user.
 
 ## 11.0
 * `chat-read-status` - On conversation API v3 and the chat API the last common read message is exposed which can be used to update the "read status" flag of own chat messages. The info should be shown only when the user also shares their read status. The user's value can be found in `config => chat => read-privacy`.

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -81,6 +81,7 @@ class Capabilities implements IPublicCapability {
 				'chat-replies',
 				'circles-support',
 				'force-mute',
+				'conversation-v3',
 				'sip-support',
 				'chat-read-status',
 				'phonebook-search',

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -43,12 +43,47 @@ class CapabilitiesTest extends TestCase {
 	protected $talkConfig;
 	/** @var IUserSession|MockObject */
 	protected $userSession;
+	/** @var array */
+	protected $baseFeatures;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->serverConfig = $this->createMock(IConfig::class);
 		$this->talkConfig = $this->createMock(Config::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+
+		$this->baseFeatures = [
+			'audio',
+			'video',
+			'chat-v2',
+			'conversation-v2',
+			'guest-signaling',
+			'empty-group-room',
+			'guest-display-names',
+			'multi-room-users',
+			'favorites',
+			'last-room-activity',
+			'no-ping',
+			'system-messages',
+			'mention-flag',
+			'in-call-flags',
+			'notification-levels',
+			'invite-groups-and-mails',
+			'locked-one-to-one-rooms',
+			'read-only-rooms',
+			'listable-rooms',
+			'chat-read-marker',
+			'webinary-lobby',
+			'start-call-flag',
+			'chat-replies',
+			'circles-support',
+			'force-mute',
+			'conversation-v3',
+			'sip-support',
+			'chat-read-status',
+			'phonebook-search',
+			'raise-hand',
+		];
 	}
 
 	public function testGetCapabilitiesGuest(): void {
@@ -75,37 +110,7 @@ class CapabilitiesTest extends TestCase {
 		$this->assertInstanceOf(IPublicCapability::class, $capabilities);
 		$this->assertSame([
 			'spreed' => [
-				'features' => [
-					'audio',
-					'video',
-					'chat-v2',
-					'conversation-v2',
-					'guest-signaling',
-					'empty-group-room',
-					'guest-display-names',
-					'multi-room-users',
-					'favorites',
-					'last-room-activity',
-					'no-ping',
-					'system-messages',
-					'mention-flag',
-					'in-call-flags',
-					'notification-levels',
-					'invite-groups-and-mails',
-					'locked-one-to-one-rooms',
-					'read-only-rooms',
-					'listable-rooms',
-					'chat-read-marker',
-					'webinary-lobby',
-					'start-call-flag',
-					'chat-replies',
-					'circles-support',
-					'force-mute',
-					'sip-support',
-					'chat-read-status',
-					'phonebook-search',
-					'raise-hand',
-				],
+				'features' => $this->baseFeatures,
 				'config' => [
 					'attachments' => [
 						'allowed' => false,
@@ -183,38 +188,11 @@ class CapabilitiesTest extends TestCase {
 		$this->assertInstanceOf(IPublicCapability::class, $capabilities);
 		$this->assertSame([
 			'spreed' => [
-				'features' => [
-					'audio',
-					'video',
-					'chat-v2',
-					'conversation-v2',
-					'guest-signaling',
-					'empty-group-room',
-					'guest-display-names',
-					'multi-room-users',
-					'favorites',
-					'last-room-activity',
-					'no-ping',
-					'system-messages',
-					'mention-flag',
-					'in-call-flags',
-					'notification-levels',
-					'invite-groups-and-mails',
-					'locked-one-to-one-rooms',
-					'read-only-rooms',
-					'listable-rooms',
-					'chat-read-marker',
-					'webinary-lobby',
-					'start-call-flag',
-					'chat-replies',
-					'circles-support',
-					'force-mute',
-					'sip-support',
-					'chat-read-status',
-					'phonebook-search',
-					'raise-hand',
-					'chat-reference-id',
-				],
+				'features' => array_merge(
+					$this->baseFeatures, [
+						'chat-reference-id'
+					]
+				),
 				'config' => [
 					'attachments' => [
 						'allowed' => true,


### PR DESCRIPTION
Fixes https://github.com/nextcloud/spreed/issues/4834

Added capability to signal the existence of the v3 API.

**NOTES**:
- I changed the docs to say Talk 10.1 for the "sip-support" capability and "conversation-v3" because we only backported these to stable20.1, not stable20.
- the existence of "conversation-v3" doesn't mean that all the other features in v3 are available but only that this endpoint version exists. For specific features, these need to check their corresponding capabilities (ex: "listable-rooms", "chat-read-status")
