### PR TITLE
Hide password hint when guest not allowed

### DIFF
--- a/src/components/ConversationSettings/LinkShareSettings.vue
+++ b/src/components/ConversationSettings/LinkShareSettings.vue
@@ -38,11 +38,11 @@
 				<label for="link_share_settings_toggle_guests">{{ t('spreed', 'Allow guests') }}</label>
 			</div>
 		</div>
-		<div class="app-settings-subsection">
+		<div v-show="isSharedPublicly" class="app-settings-subsection">
 			<div id="link_share_settings_password_hint" class="app-settings-section__hint">
 				{{ t('spreed', 'Set a password to restrict who can use the public link.') }}
 			</div>
-			<div v-show="isSharedPublicly">
+			<div>
 				<input id="link_share_settings_toggle_password"
 					ref="togglePassword"
 					aria-describedby="link_share_settings_password_hint"
@@ -85,7 +85,7 @@
 			<button
 				ref="copyLinkButton"
 				@click.prevent="handleCopyLink">
-				<span class="icon icon-clippy" />{{ t('spreed', 'Copy public link') }}
+				<span class="icon icon-clippy" />{{ t('spreed', 'Copy conversation link') }}
 			</button>
 		</div>
 	</div>


### PR DESCRIPTION
Also rename the button from "Copy public link" to "Copy conversation
link" since now a conversation can also be joined when listable. Or simply when telling someone "let's meet in this room" even when they are already a participant but might not have it open directly.

<img width="393" alt="image" src="https://user-images.githubusercontent.com/277525/102985937-45eec000-4510-11eb-86b2-7eac13732e63.png">

Fixes https://github.com/nextcloud/spreed/issues/4824