### PR TITLE
Fix row wrapping on hover

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -57,9 +57,10 @@ the main body of the message as well as a quote.
 				<RichText :text="message" :arguments="richParameters" :autolink="true" />
 			</div>
 			<div class="message__main__right">
-				<span v-if="hasDate"
+				<span
 					v-tooltip.auto="messageDate"
 					class="date"
+					:style="{'visibility': hasDate ? 'visible' : 'hidden'}"
 					:class="{'date--self': showSentIcon}">{{ messageTime }}</span>
 				<!-- Message delivery status indicators -->
 				<div v-if="isTemporary && !isTemporaryUpload"


### PR DESCRIPTION
The time element is part of the layout and is what is making the
messagte text wrap. So when we hide the time we need to keep its element
visible to also keep the layout. This is achieved now by using
"visibility:hidden" instead of removing the element completely.

Fixes https://github.com/nextcloud/spreed/issues/4823