### PR TITLE
Remove unused newMessagePosted event

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
@@ -75,8 +75,6 @@ export default {
 
 	mounted() {
 		EventBus.$on('routeChange', this.onRouteChange)
-		EventBus.$on('newMessagePosted', this.onMessagePosted)
-
 		EventBus.$once('joinedConversation', ({ token }) => {
 			this.scrollToConversation(token)
 		})
@@ -84,7 +82,6 @@ export default {
 
 	beforeDestroy() {
 		EventBus.$off('routeChange', this.onRouteChange)
-		EventBus.$off('newMessagePosted', this.onMessagePosted)
 	},
 
 	methods: {

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -267,8 +267,6 @@ export default {
 					// And adds the complete version of the message received
 					// by the server
 					this.$store.dispatch('processMessage', response.data.ocs.data)
-					// Scrolls the conversationlist to conversation
-					EventBus.$emit('newMessagePosted', { token: this.token, message: temporaryMessage })
 				} catch (error) {
 					let statusCode = null
 					console.debug(`error while submitting message ${error}`, error)


### PR DESCRIPTION
Fixes issue with errors in console due to the missing event handler
function.

Follow up from https://github.com/nextcloud/spreed/pull/4836

Interestingly, the comment above the event shows that there was a past decision to scroll the conversation list on posting. The decision was changed in https://github.com/nextcloud/spreed/issues/4833