### PR TITLE
Call warning + empty call view tweaks

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -23,14 +23,14 @@
 	<div id="call-container">
 		<EmptyCallView
 			v-if="!remoteParticipantsCount && !screenSharingActive && !isGrid"
-			:is-sidebar="isSidebar"
-		/>
+			:is-sidebar="isSidebar" />
 		<div id="videos">
 			<LocalMediaControls
 				v-if="!isGrid"
 				class="local-media-controls"
 				:class="{ 'local-media-controls--sidebar': isSidebar }"
 				:model="localMediaModel"
+				:show-actions="!isSidebar"
 				:local-call-participant-model="localCallParticipantModel"
 				:screen-sharing-button-hidden="isSidebar"
 				@switch-screen-to-id="$emit('switchScreenToId', $event)" />
@@ -791,9 +791,10 @@ export default {
 	right: 0;
 	bottom: 4px;
 	z-index: 10;
+	white-space: nowrap;
 
 	&--sidebar {
-		width: 150px;
+		width: 100%;
 	}
 }
 

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -21,7 +21,10 @@
 
 <template>
 	<div id="call-container">
-		<EmptyCallView v-if="!remoteParticipantsCount && !screenSharingActive && !isGrid" />
+		<EmptyCallView
+			v-if="!remoteParticipantsCount && !screenSharingActive && !isGrid"
+			:is-sidebar="isSidebar"
+		/>
 		<div id="videos">
 			<LocalMediaControls
 				v-if="!isGrid"

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -759,6 +759,7 @@ export default {
 
 .empty-call-view {
 	position: relative;
+	padding: 16px;
 }
 
 .local-video-stripe {

--- a/src/components/CallView/shared/EmptyCallView.vue
+++ b/src/components/CallView/shared/EmptyCallView.vue
@@ -19,7 +19,7 @@
   -->
 
 <template>
-	<div class="empty-call-view">
+	<div class="empty-call-view" :class="{'empty-call-view--sidebar': isSidebar}">
 		<div class="icon" :class="iconClass" />
 		<h2>
 			{{ title }}
@@ -46,6 +46,11 @@ export default {
 
 	props: {
 		isGrid: {
+			type: Boolean,
+			default: false,
+		},
+
+		isSidebar: {
 			type: Boolean,
 			default: false,
 		},
@@ -172,6 +177,20 @@ export default {
 
 	h2, p {
 		color: #ffffff;
+	}
+
+	&--sidebar {
+		padding-bottom: 16px;
+
+		h2, p {
+			font-size: 90%;
+		}
+
+		.icon {
+			transform: scale(0.7);
+			margin-top: 0;
+			margin-bottom: 0;
+		}
 	}
 }
 

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -96,6 +96,7 @@
 					decorative />
 			</button>
 			<Actions
+				v-if="showActions"
 				v-tooltip="t('spreed', 'More actions')"
 				:aria-label="t('spreed', 'More actions')">
 				<ActionButton
@@ -197,6 +198,10 @@ export default {
 		screenSharingButtonHidden: {
 			type: Boolean,
 			default: false,
+		},
+		showActions: {
+			type: Boolean,
+			default: true,
 		},
 	},
 
@@ -771,7 +776,7 @@ export default {
 .network-connection-state {
 	position: absolute;
 	bottom: 3px;
-	right: 45px;
+	right: 12px;
 	width: 32px;
 	height: 32px;
 }


### PR DESCRIPTION
- Fixed call warning icon position as it was overlapping with the new three dots menu
- Removed actions menu (raise hands) from sidebar mode
- Improved empty call view in sidebar mode by reducing the sizes

<img width="249" alt="tweaks-sidebar-empty-call+warning" src="https://user-images.githubusercontent.com/277525/102993267-201be800-451d-11eb-895c-53c01206b656.png">

and here the call warning icon properly positioned in grid view and speaker view:
<img width="393" alt="tweaks-call-warning-grid" src="https://user-images.githubusercontent.com/277525/102993299-32962180-451d-11eb-8e21-bd6b1f760ea3.png">
<img width="262" alt="tweaks-call-warning" src="https://user-images.githubusercontent.com/277525/102993312-3b86f300-451d-11eb-99d1-d993f087eaa6.png">

