### PR TITLE
Fix console error about missing hash in sidebar mode

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -382,7 +382,7 @@ export default {
 				// Gets the history of the conversation.
 				await this.getOldMessages(true)
 
-				if (this.$route.hash && this.$route.hash.startsWith('#message_')) {
+				if (this.$route?.hash?.startsWith('#message_')) {
 					// scroll to message in URL anchor
 					focussed = this.focusMessage(this.$route.hash.substr(9), false)
 				}


### PR DESCRIPTION
The sidebar chat mode doesn't have `this.$route` defined, probably because the main page is the files app which is not Vue JS.

To avoid the error, this fix adds a "?" to make it conditional and avoid the warning.
We don't have a way to link to and focus messages in sidebar mode anyway.

