### PR TITLE
Fix notifications based on the participants not in a call

### DIFF
--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -687,9 +687,9 @@ class ParticipantService {
 		$query = $this->connection->getQueryBuilder();
 
 		$query->select('a.actor_id')
-			->from('talk_sessions', 's')
+			->from('talk_attendees', 'a')
 			->leftJoin(
-				's', 'talk_attendees', 'a',
+				'a', 'talk_sessions', 's',
 				$query->expr()->eq('s.attendee_id', 'a.id')
 			)
 			->where($query->expr()->eq('a.room_id', $query->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))


### PR DESCRIPTION
Similar to #4825

The sessions were left joined to the attendees, so all the attendees in the conversation that were not active were not included in the result.

## How to test
- Install and enable the notifications app
- Create a public conversation
- Change to a different conversation
- In a private window, open the public conversation
- Start a call

### Result with this pull request
The notification app shows a notification about a started call

### Result without this pull request
No notification is shown