### PR TITLE
Delete chat messages

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -154,6 +154,16 @@ return [
 			],
 		],
 		[
+			'name' => 'Chat#deleteMessage',
+			'url' => '/api/{apiVersion}/chat/{token}/{messageId}',
+			'verb' => 'DELETE',
+			'requirements' => [
+				'apiVersion' => 'v1',
+				'token' => '^[a-z0-9]{4,30}$',
+				'messageId' => '^[0-9]+$',
+			],
+		],
+		[
 			'name' => 'Chat#setReadMarker',
 			'url' => '/api/{apiVersion}/chat/{token}/read',
 			'verb' => 'POST',

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -64,3 +64,6 @@ title: Capabilities
 * `room-description` - A description can be get and set for conversations.
 * `config => chat => read-privacy` - See `chat-read-status`
 * `config => previews => max-gif-size` - Maximum size in bytes below which a GIF can be embedded directly in the page at render time. Bigger files will be rendered statically using the preview endpoint instead. Can be set with `occ config:app:set spreed max-gif-size --value=X` where X is the new value in bytes. Defaults to 3 MB.
+
+## 12.0
+* `delete-messages` - Allows to delete chat messages up to 6 hours for your own messages or when being a moderator. On deleting the message text will be replaced and a follow up system message will make sure clients and users update it in their cache and storage.

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -96,6 +96,34 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
     - Data:
         The full message array of the new message, as defined in [Receive chat messages of a conversation](#receive-chat-messages-of-a-conversation)
 
+
+## Deleting a chat message
+
+* Method: `DELETE`
+* Endpoint: `/chat/{token}/{messageId}`
+
+* Response:
+    - Status code:
+        + `200 OK` - When deleting was successful
+        + `202 Accepted` - When deleting was successful but Matterbridge is enabled so the message was leaked to other services
+        + `400 Bad Request` The message is already older than 6 hours
+        + `403 Forbidden` When the message is not from the current user and the user not a moderator
+        + `403 Forbidden` When the conversation is read-only
+        + `404 Not Found` When the conversation or chat message could not be found for the participant
+        + `412 Precondition Failed` When the lobby is active and the user is not a moderator
+
+    - Header:
+
+        field | type | Description
+        ------|------|------------
+        `X-Chat-Last-Common-Read` | int | ID of the last message read by every user that has read privacy set to public. When the user themself has it set to private the value the header is not set (only available with `chat-read-status` capability)
+
+    - Data:
+        The full message array of the new system message "You deleted a message", as defined in [Receive chat messages of a conversation](#receive-chat-messages-of-a-conversation)
+        The parent message is the object of the deleted message with the replaced text "Message deleted by you".
+        This message should not be displayed to the user but instead be used to remove the original message from any cache/storage of the device.
+
+
 ## Mark chat as read
 
 * Method: `POST`
@@ -117,7 +145,6 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         field | type | Description
         ------|------|------------
         `X-Chat-Last-Common-Read` | int | ID of the last message read by every user that has read privacy set to public. When the user themself has it set to private the value the header is not set (only available with `chat-read-status` capability)
-
 
 
 ## Get mention autocomplete suggestions

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -44,7 +44,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         `actorDisplayName` | string | Display name of the message author
         `timestamp` | int | Timestamp in seconds and UTC time zone
         `systemMessage` | string | empty for normal chat message or the type of the system message (untranslated)
-        `messageType` | string | Currently known types are `comment`, `system` and `command`
+        `messageType` | string | Currently known types are `comment`, `comment_deleted`, `system` and `command`
         `isReplyable` | bool | True if the user can post a reply to this message (only available with `chat-replies` capability)
         `referenceId` | string | A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability)
         `message` | string | Message string with placeholders (see [Rich Object String](https://github.com/nextcloud/server/issues/1706))
@@ -177,3 +177,4 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 * `moderator_demoted` - {actor} demoted {user} from moderator
 * `guest_moderator_promoted` - {actor} promoted {user} to moderator
 * `guest_moderator_demoted` - {actor} demoted {user} from moderator
+* `message_deleted` - Message deleted by {actor} (Should not be shown to the user)

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -110,6 +110,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         + `403 Forbidden` When the message is not from the current user and the user not a moderator
         + `403 Forbidden` When the conversation is read-only
         + `404 Not Found` When the conversation or chat message could not be found for the participant
+        + `405 Method Not Allowed` When the message is not a normal chat message
         + `412 Precondition Failed` When the lobby is active and the user is not a moderator
 
     - Header:

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -68,6 +68,7 @@ class Capabilities implements IPublicCapability {
 				'last-room-activity',
 				'no-ping',
 				'system-messages',
+				'delete-messages',
 				'mention-flag',
 				'in-call-flags',
 				'notification-levels',

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -247,6 +247,22 @@ class ChatManager {
 		return $comment;
 	}
 
+	/**
+	 * @param Room $chat
+	 * @param string $messageId
+	 * @return IComment
+	 * @throws NotFoundException
+	 */
+	public function getComment(Room $chat, string $messageId): IComment {
+		$comment = $this->commentsManager->get($messageId);
+
+		if ($comment->getObjectType() !== 'chat' || $comment->getObjectId() !== (string) $chat->getId()) {
+			throw new NotFoundException('Message not found in the right context');
+		}
+
+		return $comment;
+	}
+
 	public function getLastReadMessageFromLegacy(Room $chat, IUser $user): int {
 		$marker = $this->commentsManager->getReadMark('chat', $chat->getId(), $user);
 		if ($marker === null) {

--- a/lib/Chat/Parser/Listener.php
+++ b/lib/Chat/Parser/Listener.php
@@ -96,5 +96,25 @@ class Listener {
 				$event->stopPropagation();
 			}
 		});
+
+		$dispatcher->addListener(MessageParser::EVENT_MESSAGE_PARSE, static function (ChatMessageEvent $event) {
+			$chatMessage = $event->getMessage();
+
+			if ($chatMessage->getMessageType() !== 'comment_deleted') {
+				return;
+			}
+
+			/** @var SystemMessage $parser */
+			$parser = \OC::$server->query(SystemMessage::class);
+
+			try {
+				$parser->parseDeletedMessage($chatMessage);
+				$event->stopPropagation();
+			} catch (\OutOfBoundsException $e) {
+				// Unknown message, ignore
+			} catch (\RuntimeException $e) {
+				$event->stopPropagation();
+			}
+		}, 9999);// First things first
 	}
 }

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -354,6 +354,11 @@ class SystemMessage {
 			if ($currentUserIsActor) {
 				$parsedMessage = $this->l->t('You stopped Matterbridge.');
 			}
+		} elseif ($message === 'message_deleted') {
+			$parsedMessage = $this->l->t('{actor} deleted a message');
+			if ($currentUserIsActor) {
+				$parsedMessage = $this->l->t('You deleted a message');
+			}
 		} else {
 			throw new \OutOfBoundsException('Unknown subject');
 		}

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -401,9 +401,9 @@ class SystemMessage {
 
 			if (!$authorIsActor) {
 				$parsedMessage = $this->l->t('Message deleted by {actor}');
-				if ($currentUserIsActor) {
-					$parsedMessage = $this->l->t('Message deleted by you');
-				}
+			}
+			if ($currentUserIsActor) {
+				$parsedMessage = $this->l->t('Message deleted by you');
 			}
 		} else {
 			throw new \OutOfBoundsException('Unknown subject');

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -490,6 +490,13 @@ class ChatController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
+		$maxDeleteAge = $this->timeFactory->getDateTime();
+		$maxDeleteAge->sub(new \DateInterval('PT6H'));
+		if ($message->getCreationDateTime() < $maxDeleteAge) {
+			// Message is too old
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
 		$systemMessageComment = $this->chatManager->deleteMessage(
 			$this->room,
 			$messageId,

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -484,16 +484,25 @@ class ChatController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		$this->chatManager->addSystemMessage(
+		$systemMessageComment = $this->chatManager->deleteMessage(
 			$this->room,
+			$messageId,
 			$attendee->getActorType(),
 			$attendee->getActorId(),
-			json_encode(['message' => 'message_deleted', 'parameters' => ['message' => $messageId]]),
-			$this->timeFactory->getDateTime(),
-			false
+			$this->timeFactory->getDateTime()
 		);
 
-		return new DataResponse();
+		$systemMessage = $this->messageParser->createMessage($this->room, $this->participant, $systemMessageComment, $this->l);
+		$this->messageParser->parseMessage($systemMessage);
+
+		$comment = $this->chatManager->getComment($this->room, (string) $messageId);
+		$message = $this->messageParser->createMessage($this->room, $this->participant, $comment, $this->l);
+		$this->messageParser->parseMessage($message);
+
+		$data = $systemMessage->toArray();
+		$data['parent'] = $message->toArray();
+
+		return new DataResponse($data);
 	}
 
 	/**

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -471,6 +471,8 @@ class ChatController extends AEnvironmentAwareController {
 	/**
 	 * @NoAdminRequired
 	 * @RequireParticipant
+	 * @RequireReadWriteConversation
+	 * @RequireModeratorOrNoLobby
 	 *
 	 * @param int $messageId
 	 * @return DataResponse
@@ -516,7 +518,12 @@ class ChatController extends AEnvironmentAwareController {
 		$data['parent'] = $message->toArray();
 
 		$bridge = $this->matterbridgeManager->getBridgeOfRoom($this->room);
-		return new DataResponse($data, $bridge['enabled'] ? Http::STATUS_ACCEPTED: Http::STATUS_OK);
+
+		$response = new DataResponse($data, $bridge['enabled'] ? Http::STATUS_ACCEPTED: Http::STATUS_OK);
+		if ($this->participant->getAttendee()->getReadPrivacy() === Participant::PRIVACY_PUBLIC) {
+			$response->addHeader('X-Chat-Last-Common-Read', $this->chatManager->getLastCommonReadMessage($this->room));
+		}
+		return $response;
 	}
 
 	/**

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -492,6 +492,11 @@ class ChatController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
+		if ($message->getVerb() !== 'comment') {
+			// System message or file share (since the message is not parsed, it has type "system")
+			return new DataResponse([], Http::STATUS_METHOD_NOT_ALLOWED);
+		}
+
 		$maxDeleteAge = $this->timeFactory->getDateTime();
 		$maxDeleteAge->sub(new \DateInterval('PT6H'));
 		if ($message->getCreationDateTime() < $maxDeleteAge) {

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -29,6 +29,7 @@ use OCA\Talk\Chat\AutoComplete\Sorter;
 use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Chat\MessageParser;
 use OCA\Talk\GuestManager;
+use OCA\Talk\MatterbridgeManager;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\Message;
 use OCA\Talk\Model\Session;
@@ -92,6 +93,9 @@ class ChatController extends AEnvironmentAwareController {
 	/** @var IUserStatusManager */
 	private $statusManager;
 
+	/** @var MatterbridgeManager */
+	protected $matterbridgeManager;
+
 	/** @var SearchPlugin */
 	private $searchPlugin;
 
@@ -120,6 +124,7 @@ class ChatController extends AEnvironmentAwareController {
 								MessageParser $messageParser,
 								IManager $autoCompleteManager,
 								IUserStatusManager $statusManager,
+								MatterbridgeManager $matterbridgeManager,
 								SearchPlugin $searchPlugin,
 								ISearchResult $searchResult,
 								ITimeFactory $timeFactory,
@@ -138,6 +143,7 @@ class ChatController extends AEnvironmentAwareController {
 		$this->messageParser = $messageParser;
 		$this->autoCompleteManager = $autoCompleteManager;
 		$this->statusManager = $statusManager;
+		$this->matterbridgeManager = $matterbridgeManager;
 		$this->searchPlugin = $searchPlugin;
 		$this->searchResult = $searchResult;
 		$this->timeFactory = $timeFactory;
@@ -502,7 +508,8 @@ class ChatController extends AEnvironmentAwareController {
 		$data = $systemMessage->toArray();
 		$data['parent'] = $message->toArray();
 
-		return new DataResponse($data);
+		$bridge = $this->matterbridgeManager->getBridgeOfRoom($this->room);
+		return new DataResponse($data, $bridge['enabled'] ? Http::STATUS_ACCEPTED: Http::STATUS_OK);
 	}
 
 	/**

--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -162,7 +162,7 @@ class Message {
 	}
 
 	public function toArray(): array {
-		return [
+		$data = [
 			'id' => (int) $this->getComment()->getId(),
 			'token' => $this->getRoom()->getToken(),
 			'actorType' => $this->getActorType(),
@@ -176,5 +176,11 @@ class Message {
 			'isReplyable' => $this->isReplyable(),
 			'referenceId' => (string) $this->getComment()->getReferenceId(),
 		];
+
+		if ($this->getMessageType() === 'comment_deleted') {
+			$data['deleted'] = true;
+		}
+
+		return $data;
 	}
 }

--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -158,6 +158,7 @@ class Message {
 	public function isReplyable(): bool {
 		return $this->getMessageType() !== 'system' &&
 			$this->getMessageType() !== 'command' &&
+			$this->getMessageType() !== 'comment_deleted' &&
 			\in_array($this->getActorType(), [Attendee::ACTOR_USERS, Attendee::ACTOR_GUESTS]);
 	}
 

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -129,6 +129,13 @@ the main body of the message as well as a quote.
 							{{ action.label }}
 						</ActionButton>
 					</template>
+					<ActionButton
+						v-if="isDeleteable"
+						icon="icon-delete"
+						:close-after-click="true"
+						@click.stop="handleDelete">
+						{{ t('spreed', 'Delete') }}
+					</ActionButton>
 				</Actions>
 			</div>
 		</div>
@@ -446,6 +453,18 @@ export default {
 			return t('spreed', 'You can not send messages to this conversation at the moment')
 		},
 
+		isMyMsg() {
+			return this.actorId === this.$store.getters.getActorId() && this.actorType === this.$store.getters.getActorType()
+		},
+
+		isDeleteable() {
+			return (moment(this.timestamp * 1000).add(6, 'h')) > moment()
+				&& this.messageType === 'comment'
+				&& (this.participant.participantType === PARTICIPANT.TYPE.OWNER
+					|| this.participant.participantType === PARTICIPANT.TYPE.MODERATOR
+					|| this.isMyMsg)
+		},
+
 		messageActions() {
 			return this.$store.getters.messageActions
 		},
@@ -457,7 +476,6 @@ export default {
 				apiVersion: 'v3',
 			}
 		},
-
 	},
 
 	watch: {
@@ -516,7 +534,10 @@ export default {
 			EventBus.$emit('focusChatInput')
 		},
 		handleDelete() {
-			this.$store.dispatch('deleteMessage', this.message)
+			this.$store.dispatch('deleteMessage', {
+				token: this.token,
+				id: this.id,
+			})
 		},
 	},
 }

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -326,7 +326,7 @@ export default {
 		},
 
 		hasActions() {
-			return this.isReplyable && !this.isConversationReadOnly
+			return (this.isReplyable || this.isDeleteable) && !this.isConversationReadOnly
 		},
 
 		isConversationReadOnly() {
@@ -481,9 +481,13 @@ export default {
 		},
 
 		isDeleteable() {
+			const isFileShare = this.message === '{file}'
+				&& this.messageParameters?.file
+
 			return (moment(this.timestamp * 1000).add(6, 'h')) > moment()
 				&& this.messageType === 'comment'
 				&& !this.isDeleting
+				&& !isFileShare
 				&& (this.participant.participantType === PARTICIPANT.TYPE.OWNER
 					|| this.participant.participantType === PARTICIPANT.TYPE.MODERATOR
 					|| this.isMyMsg)
@@ -578,6 +582,8 @@ export default {
 			} catch (e) {
 				if (e?.response?.status === 400) {
 					showError(t('spreed', 'Message could not be deleted because it is too old'))
+				} else if (e?.response?.status === 405) {
+					showError(t('spreed', 'Only normal chat messages can be deleted'))
 				} else {
 					showError(t('spreed', 'An error occurred while deleting the message'))
 					console.error(e)

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -52,6 +52,9 @@ the main body of the message as well as a quote.
 				<RichText :text="message" :arguments="richParameters" :autolink="true" />
 				<CallButton />
 			</div>
+			<div v-else-if="isDeletedMessage" class="message__main__text deleted-message">
+				<RichText :text="message" :arguments="richParameters" :autolink="true" />
+			</div>
 			<div v-else class="message__main__text" :class="{'system-message': isSystemMessage}">
 				<Quote v-if="parent" :parent-id="parent" v-bind="quote" />
 				<RichText :text="message" :arguments="richParameters" :autolink="true" />
@@ -282,6 +285,13 @@ export default {
 			required: true,
 		},
 		/**
+		 * The type of the message.
+		 */
+		messageType: {
+			type: String,
+			required: true,
+		},
+		/**
 		 * The parent message's id.
 		 */
 		parent: {
@@ -318,6 +328,10 @@ export default {
 
 		isSystemMessage() {
 			return this.systemMessage !== ''
+		},
+
+		isDeletedMessage() {
+			return this.messageType === 'comment_deleted'
 		},
 
 		messageTime() {
@@ -578,6 +592,13 @@ export default {
 				text-align: center;
 				padding: 0 20px;
 				width: 100%;
+			}
+
+			&.deleted-message {
+				background-color: var(--color-background-dark);
+				color: var(--color-text-lighter);
+				padding: var(--border-radius) var(--border-radius-large);
+				border-radius: var(--border-radius-large);
 			}
 
 			::v-deep .rich-text--wrapper {

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -90,7 +90,7 @@ the main body of the message as well as a quote.
 						title=""
 						:size="16" />
 				</div>
-				<div v-else-if="isTemporary && !isTemporaryUpload"
+				<div v-else-if="isTemporary && !isTemporaryUpload || isDeleting"
 					v-tooltip.auto="loadingIconTooltip"
 					class="icon-loading-small message-status"
 					:aria-label="loadingIconTooltip" />
@@ -310,6 +310,7 @@ export default {
 			// Is tall enough for both actions and date upon hovering
 			isTallEnough: false,
 			showReloadButton: false,
+			isDeleting: false,
 		}
 	},
 
@@ -358,6 +359,7 @@ export default {
 		showSentIcon() {
 			return !this.isSystemMessage
 				&& !this.isTemporary
+				&& !this.isDeleting
 				&& this.actorType === this.participant.actorType
 				&& this.actorId === this.participant.actorId
 		},
@@ -429,7 +431,7 @@ export default {
 
 		// Determines whether the date has to be displayed or not
 		hasDate() {
-			if (this.isTemporary || this.sendingFailure) {
+			if (this.isTemporary || this.isDeleting || this.sendingFailure) {
 				// Never on temporary or failed messages
 				return false
 			}
@@ -468,12 +470,14 @@ export default {
 		},
 
 		isMyMsg() {
-			return this.actorId === this.$store.getters.getActorId() && this.actorType === this.$store.getters.getActorType()
+			return this.actorId === this.$store.getters.getActorId()
+				&& this.actorType === this.$store.getters.getActorType()
 		},
 
 		isDeleteable() {
 			return (moment(this.timestamp * 1000).add(6, 'h')) > moment()
 				&& this.messageType === 'comment'
+				&& !this.isDeleting
 				&& (this.participant.participantType === PARTICIPANT.TYPE.OWNER
 					|| this.participant.participantType === PARTICIPANT.TYPE.MODERATOR
 					|| this.isMyMsg)
@@ -547,11 +551,16 @@ export default {
 			})
 			EventBus.$emit('focusChatInput')
 		},
-		handleDelete() {
-			this.$store.dispatch('deleteMessage', {
-				token: this.token,
-				id: this.id,
+		async handleDelete() {
+			this.isDeleting = true
+			await this.$store.dispatch('deleteMessage', {
+				message: {
+					token: this.token,
+					id: this.id,
+				},
+				placeholder: t('spreed', 'Deleting message'),
 			})
+			this.isDeleting = false
 		},
 	},
 }

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -162,6 +162,10 @@ export default {
 			const groups = []
 			let lastMessage = null
 			for (const message of this.messagesList) {
+				if (message.systemMessage === 'message_deleted') {
+					continue
+				}
+
 				if (!this.messagesShouldBeGrouped(message, lastMessage)) {
 					// Add the date separator for different days
 					if (this.messagesHaveDifferentDate(message, lastMessage)) {

--- a/src/services/messagesService.js
+++ b/src/services/messagesService.js
@@ -104,7 +104,7 @@ const postNewMessage = async function({ token, message, actorDisplayName, refere
 }
 
 /**
- * Posts a new messageto the server.
+ * Deletes a message from the server.
  *
  * @param {object} param0 The message object that is destructured
  * @param {string} token The conversation token

--- a/src/services/messagesService.js
+++ b/src/services/messagesService.js
@@ -103,8 +103,20 @@ const postNewMessage = async function({ token, message, actorDisplayName, refere
 	return response
 }
 
+/**
+ * Posts a new messageto the server.
+ *
+ * @param {object} param0 The message object that is destructured
+ * @param {string} token The conversation token
+ * @param {string} id The id of the message to be deleted
+ */
+const deleteMessage = async function({ token, id }) {
+	return axios.delete(generateOcsUrl('apps/spreed/api/v1/chat', 2) + token + '/' + id)
+}
+
 export {
 	fetchMessages,
 	lookForNewMessages,
 	postNewMessage,
+	deleteMessage,
 }

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -134,7 +134,7 @@ const mutations = {
 	 * Deletes a message from the store.
 	 * @param {object} state current store state;
 	 * @param {object} message the message;
-	 * @param {string} tempMessage Placeholder message until deleting finished
+	 * @param {string} placeholder Placeholder message until deleting finished
 	 */
 	markMessageAsDeleting(state, { message, placeholder }) {
 		Vue.set(state.messages[message.token][message.id], 'messageType', 'comment_deleted')

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -131,6 +131,16 @@ const mutations = {
 	},
 
 	/**
+	 * Deletes a message from the store.
+	 * @param {object} state current store state;
+	 * @param {object} message the message;
+	 * @param {string} tempMessage Placeholder message until deleting finished
+	 */
+	markMessageAsDeleted(state, { message, placeholder }) {
+		Vue.set(state.messages[message.token][message.id], 'messageType', 'comment_deleted')
+		Vue.set(state.messages[message.token][message.id], 'message', placeholder)
+	},
+	/**
 	 * Adds a temporary message to the store.
 	 * @param {object} state current store state;
 	 * @param {object} message the temporary message;
@@ -222,11 +232,19 @@ const actions = {
 	 * Delete a message
 	 *
 	 * @param {object} context default store context;
-	 * @param {string} message the message to be deleted;
+	 * @param {object} message the message to be deleted;
+	 * @param {string} placeholder Placeholder message until deleting finished
 	 */
-	deleteMessage(context, message) {
-		context.commit('deleteMessage', message)
-		deleteMessage(message)
+	async deleteMessage(context, { message, placeholder }) {
+		context.commit('markMessageAsDeleted', { message, placeholder })
+		const response = await deleteMessage(message)
+
+		if (response.parent) {
+			context.commit('addMessage', response.parent)
+			response.parent = response.parent.id
+		}
+
+		context.commit('addMessage', response)
 	},
 
 	/**

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -20,6 +20,7 @@
  *
  */
 import Vue from 'vue'
+import { deleteMessage } from '../services/messagesService'
 
 const state = {
 	/**
@@ -225,6 +226,7 @@ const actions = {
 	 */
 	deleteMessage(context, message) {
 		context.commit('deleteMessage', message)
+		deleteMessage(message)
 	},
 
 	/**

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -976,7 +976,6 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	 * @param string $apiVersion
 	 */
 	public function userAddAttendeeToRoom($user, $newType, $newId, $identifier, $statusCode, $apiVersion = 'v1') {
-		var_dump($newType);
 		$this->setCurrentUser($user);
 		$this->sendRequest(
 			'POST', '/apps/spreed/api/' . $apiVersion . '/room/' . self::$identifierToToken[$identifier] . '/participants',
@@ -1104,6 +1103,24 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" deletes message "([^"]*)" from room "([^"]*)" with (\d+)(?: \((v(1|2|3))\))?$/
+	 *
+	 * @param string $user
+	 * @param string $message
+	 * @param string $identifier
+	 * @param string $statusCode
+	 * @param string $apiVersion
+	 */
+	public function userDeletesMessageFromRoom($user, $message, $identifier, $statusCode, $apiVersion = 'v1') {
+		$this->setCurrentUser($user);
+		$this->sendRequest(
+			'DELETE', '/apps/spreed/api/' . $apiVersion . '/chat/' . self::$identifierToToken[$identifier] . '/' . self::$messages[$message],
+			new TableNode([['message', $message]])
+		);
+		$this->assertStatusCode($this->response, $statusCode);
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" reads message "([^"]*)" in room "([^"]*)" with (\d+)(?: \((v(1|2|3))\))?$/
 	 *
 	 * @param string $user
@@ -1192,18 +1209,43 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" received a system messages in room "([^"]*)" to delete "([^"]*)"(?: \((v(1|2|3))\))?$/
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 * @param string $message
+	 * @param string $apiVersion
+	 */
+	public function userReceivedDeleteMessage($user, $identifier, $message, $apiVersion = 'v1') {
+		$this->setCurrentUser($user);
+		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/chat/' . self::$identifierToToken[$identifier] . '?lookIntoFuture=0');
+		$this->assertStatusCode($this->response, 200);
+
+		$actual = $this->getDataFromResponse($this->response);
+
+		foreach ($actual as $m) {
+			if ($m['systemMessage'] === 'message_deleted') {
+				if (isset($m['parent']['id']) && $m['parent']['id'] === self::$messages[$message]) {
+					return;
+				}
+			}
+		}
+		Assert::fail('Missing message_deleted system message for "' . $message . '"');
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" sees the following messages in room "([^"]*)" starting with "([^"]*)" with (\d+)(?: \((v(1|2|3))\))?$/
 	 *
 	 * @param string $user
 	 * @param string $identifier
-	 * @param string $knwonMessage
+	 * @param string $knownMessage
 	 * @param string $statusCode
 	 * @param string $apiVersion
 	 * @param TableNode|null $formData
 	 */
-	public function userAwaitsTheFollowingMessagesInRoom($user, $identifier, $knwonMessage, $statusCode, $apiVersion = 'v1', TableNode $formData = null) {
+	public function userAwaitsTheFollowingMessagesInRoom($user, $identifier, $knownMessage, $statusCode, $apiVersion = 'v1', TableNode $formData = null) {
 		$this->setCurrentUser($user);
-		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/chat/' . self::$identifierToToken[$identifier] . '?lookIntoFuture=1&includeLastKnown=1&lastKnownMessageId=' . self::$messages[$knwonMessage]);
+		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/chat/' . self::$identifierToToken[$identifier] . '?lookIntoFuture=1&includeLastKnown=1&lastKnownMessageId=' . self::$messages[$knownMessage]);
 		$this->assertStatusCode($this->response, $statusCode);
 
 		$this->compareDataResponse($formData);

--- a/tests/integration/features/chat/delete.feature
+++ b/tests/integration/features/chat/delete.feature
@@ -1,0 +1,148 @@
+Feature: chat/reply
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+
+  Scenario: moderator deletes their own message
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "group room" with 200
+    And user "participant1" sends message "Message 1" to room "group room" with 201
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | Message 1   | []                |               |
+    Then user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | Message 1   | []                |               |
+    And user "participant1" deletes message "Message 1" from room "group room" with 200
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | Message deleted by you   | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}}                |               |
+    Then user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | Message deleted by author   | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}}                |               |
+    Then user "participant1" received a system messages in room "group room" to delete "Message 1"
+    Then user "participant2" received a system messages in room "group room" to delete "Message 1"
+
+  Scenario: user deletes their own message
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "group room" with 200
+    And user "participant2" sends message "Message 1" to room "group room" with 201
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant2 | participant2-displayname | Message 1   | []                |               |
+    Then user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant2 | participant2-displayname | Message 1   | []                |               |
+    And user "participant2" deletes message "Message 1" from room "group room" with 200
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant2 | participant2-displayname | Message deleted by author   | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname"}}                |               |
+    Then user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant2 | participant2-displayname | Message deleted by you   | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname"}}                |               |
+    Then user "participant1" received a system messages in room "group room" to delete "Message 1"
+    Then user "participant2" received a system messages in room "group room" to delete "Message 1"
+
+  Scenario: moderator deletes other user message
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "group room" with 200
+    And user "participant2" sends message "Message 1" to room "group room" with 201
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant2 | participant2-displayname | Message 1   | []                |               |
+    And user "participant1" deletes message "Message 1" from room "group room" with 200
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant2 | participant2-displayname | Message deleted by you   | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}}                |               |
+    Then user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant2 | participant2-displayname | Message deleted by {actor}   | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}}                |               |
+    Then user "participant1" received a system messages in room "group room" to delete "Message 1"
+    Then user "participant2" received a system messages in room "group room" to delete "Message 1"
+
+  Scenario: moderator deletes their own message which got replies
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "group room" with 200
+    And user "participant2" sends message "Message 1" to room "group room" with 201
+    When user "participant1" sends reply "Message 1-1" on message "Message 1" to room "group room" with 201
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | Message 1-1 | []                | Message 1     |
+      | group room | users     | participant2 | participant2-displayname | Message 1   | []                |               |
+    Then user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | Message 1-1 | []                | Message 1     |
+      | group room | users     | participant2 | participant2-displayname | Message 1   | []                |               |
+    And user "participant1" deletes message "Message 1" from room "group room" with 200
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | Message 1-1 | []                | Message deleted by you     |
+      | group room | users     | participant2 | participant2-displayname | Message deleted by you   | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}}                |               |
+    Then user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | Message 1-1 | []                | Message deleted by {actor}     |
+      | group room | users     | participant2 | participant2-displayname | Message deleted by {actor}   | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}}                |               |
+    Then user "participant1" received a system messages in room "group room" to delete "Message 1"
+    Then user "participant2" received a system messages in room "group room" to delete "Message 1"
+
+  Scenario: user deletes their own message which got replies
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "group room" with 200
+    And user "participant2" sends message "Message 1" to room "group room" with 201
+    When user "participant1" sends reply "Message 1-1" on message "Message 1" to room "group room" with 201
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | Message 1-1 | []                | Message 1     |
+      | group room | users     | participant2 | participant2-displayname | Message 1   | []                |               |
+    Then user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | Message 1-1 | []                | Message 1     |
+      | group room | users     | participant2 | participant2-displayname | Message 1   | []                |               |
+    And user "participant2" deletes message "Message 1" from room "group room" with 200
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | Message 1-1 | []                | Message deleted by author     |
+      | group room | users     | participant2 | participant2-displayname | Message deleted by author   | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname"}}                |               |
+    Then user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | Message 1-1 | []                | Message deleted by you     |
+      | group room | users     | participant2 | participant2-displayname | Message deleted by you   | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname"}}                |               |
+    Then user "participant1" received a system messages in room "group room" to delete "Message 1"
+    Then user "participant2" received a system messages in room "group room" to delete "Message 1"
+
+  Scenario: moderator deletes other user message
+    Given user "participant1" creates room "group room"
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "group room" with 200
+    And user "participant2" sends message "Message 1" to room "group room" with 201
+    When user "participant1" sends reply "Message 1-1" on message "Message 1" to room "group room" with 201
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | Message 1-1 | []                | Message 1     |
+      | group room | users     | participant2 | participant2-displayname | Message 1   | []                |               |
+    Then user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | Message 1-1 | []                | Message 1     |
+      | group room | users     | participant2 | participant2-displayname | Message 1   | []                |               |
+    And user "participant1" deletes message "Message 1" from room "group room" with 200
+    Then user "participant1" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | Message 1-1 | []                | Message deleted by you     |
+      | group room | users     | participant2 | participant2-displayname | Message deleted by you   | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}}                |               |
+    Then user "participant2" sees the following messages in room "group room" with 200
+      | room       | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | group room | users     | participant1 | participant1-displayname | Message 1-1 | []                | Message deleted by {actor}     |
+      | group room | users     | participant2 | participant2-displayname | Message deleted by {actor}   | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}}                |               |
+    Then user "participant1" received a system messages in room "group room" to delete "Message 1"
+    Then user "participant2" received a system messages in room "group room" to delete "Message 1"

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -65,6 +65,7 @@ class CapabilitiesTest extends TestCase {
 			'last-room-activity',
 			'no-ping',
 			'system-messages',
+			'delete-messages',
 			'mention-flag',
 			'in-call-flags',
 			'notification-levels',

--- a/tests/php/Chat/Parser/SystemMessageTest.php
+++ b/tests/php/Chat/Parser/SystemMessageTest.php
@@ -399,10 +399,21 @@ class SystemMessageTest extends TestCase {
 
 		/** @var IComment|MockObject $comment */
 		$comment = $this->createMock(IComment::class);
+		if ($recipientId && strpos($recipientId, 'guest::') !== false) {
+			$comment->method('getActorType')
+				->willReturn('guests');
+			$comment->method('getActorId')
+				->willReturn(substr($recipientId, strlen('guest::')));
+		} else {
+			$comment->method('getActorType')
+				->willReturn('users');
+			$comment->method('getActorId')
+				->willReturn($recipientId);
+		}
 
-		$parser = $this->getParser(['getActor', 'getUser', 'getGuest', 'parseCall', 'getFileFromShare']);
+		$parser = $this->getParser(['getActorFromComment', 'getUser', 'getGuest', 'parseCall', 'getFileFromShare']);
 		$parser->expects($this->once())
-			->method('getActor')
+			->method('getActorFromComment')
 			->with($comment)
 			->willReturn(['id' => 'actor', 'type' => 'user']);
 		$parser->expects($this->any())
@@ -475,9 +486,9 @@ class SystemMessageTest extends TestCase {
 		/** @var IComment|MockObject $comment */
 		$comment = $this->createMock(IComment::class);
 
-		$parser = $this->getParser(['getActor']);
+		$parser = $this->getParser(['getActorFromComment']);
 		$parser->expects($this->any())
-			->method('getActor')
+			->method('getActorFromComment')
 			->with($comment)
 			->willReturn(['id' => 'actor', 'type' => 'user']);
 
@@ -808,7 +819,7 @@ class SystemMessageTest extends TestCase {
 				->willReturn($userData);
 		}
 
-		$this->assertSame($expected, self::invokePrivate($parser, 'getActor', [$chatMessage]));
+		$this->assertSame($expected, self::invokePrivate($parser, 'getActorFromComment', [$chatMessage]));
 	}
 
 	public function dataGetUser(): array {

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -28,6 +28,7 @@ use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Chat\MessageParser;
 use OCA\Talk\Controller\ChatController;
 use OCA\Talk\GuestManager;
+use OCA\Talk\MatterbridgeManager;
 use OCA\Talk\Model\Message;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
@@ -75,6 +76,8 @@ class ChatControllerTest extends TestCase {
 	protected $autoCompleteManager;
 	/** @var IUserStatusManager|MockObject */
 	protected $statusManager;
+	/** @var MatterbridgeManager|MockObject */
+	protected $matterbridgeManager;
 	/** @var SearchPlugin|MockObject */
 	protected $searchPlugin;
 	/** @var ISearchResult|MockObject */
@@ -109,6 +112,7 @@ class ChatControllerTest extends TestCase {
 		$this->messageParser = $this->createMock(MessageParser::class);
 		$this->autoCompleteManager = $this->createMock(IManager::class);
 		$this->statusManager = $this->createMock(IUserStatusManager::class);
+		$this->matterbridgeManager = $this->createMock(MatterbridgeManager::class);
 		$this->searchPlugin = $this->createMock(SearchPlugin::class);
 		$this->searchResult = $this->createMock(ISearchResult::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
@@ -142,6 +146,7 @@ class ChatControllerTest extends TestCase {
 			$this->messageParser,
 			$this->autoCompleteManager,
 			$this->statusManager,
+			$this->matterbridgeManager,
 			$this->searchPlugin,
 			$this->searchResult,
 			$this->timeFactory,


### PR DESCRIPTION
Fix #774


Todo
 - [x] Delete message content from database
 - [x] Add a system message so the old one can be deleted/updated in stores (web ui and mobile clients)
 - [x] Currently limited to 6h old messages
 - [x] Show a warning if matterbridge is active
 - [x] Write integration tests
 - [x] Add capability
 - [x] Adjust documentation
 - [x] change delete possibility: Only my messages within 6 hours after sending can be deleted