### PR TITLE
Do not load the blurred background source if not needed

### DIFF
--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -138,6 +138,15 @@ export default {
 			}
 		},
 		// Special computed property to combine the properties that should be
+		// watched to set (or not) the blurred background image source.
+		backgroundImageUrlToBlur() {
+			if (this.useCssBlurFilter) {
+				return null
+			}
+
+			return this.backgroundImageUrl
+		},
+		// Special computed property to combine the properties that should be
 		// watched to generate (or not) the blurred background image.
 		generatedBackgroundBlur() {
 			if (!this.hasPicture || this.useCssBlurFilter) {
@@ -153,12 +162,12 @@ export default {
 	},
 
 	watch: {
-		backgroundImageUrl: {
+		backgroundImageUrlToBlur: {
 			immediate: true,
 			handler() {
 				this.blurredBackgroundImageSource = null
 
-				if (!this.backgroundImageUrl) {
+				if (!this.backgroundImageUrlToBlur) {
 					return
 				}
 
@@ -168,7 +177,7 @@ export default {
 						this.blurredBackgroundImageSource = imageBitmap
 					})
 				}
-				image.src = this.backgroundImageUrl
+				image.src = this.backgroundImageUrlToBlur
 			},
 		},
 		generatedBackgroundBlur: {


### PR DESCRIPTION
Follow up to #4678

`blurredBackgroundImageSource` is not used when the CSS blur filter is used, so there is no need to load it in that case.

This also fixes an error shown in older Edge versions (not Chromium-based) due to `createImageBitmap` not being available.
