### PR TITLE
Unregister "refreshPeerList" event when CallView is destroyed

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -377,7 +377,7 @@ export default {
 	mounted() {
 		EventBus.$on('refreshPeerList', this.debounceFetchPeers)
 	},
-	unmounted() {
+	beforeDestroy() {
 		EventBus.$off('refreshPeerList', this.debounceFetchPeers)
 	},
 	methods: {


### PR DESCRIPTION
Follow up to #4685

[There is no `unmounted` lifecycle hook in Vue](https://vuejs.org/v2/guide/instance.html#Lifecycle-Diagram); after a component is mounted it can only be destroyed.

This fixes a memory leak of the CallView, as the reference was retained forever by the EventBus.
