### PR TITLE
Avoid double quotes in bridge bot app password

### DIFF
--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -348,8 +348,8 @@ class MatterbridgeManager {
 	}
 
 	private function generatePassword(): string {
-		// remove \ because it messes with Matterbridge toml file parsing
-		$symbols = str_replace('\\', '', ISecureRandom::CHAR_SYMBOLS);
+		// remove \ and " because it messes with Matterbridge toml file parsing
+		$symbols = str_replace(['"', '\\'], '', ISecureRandom::CHAR_SYMBOLS);
 
 		// make sure we have at least one of all categories
 		$upper = $this->random->generate(1, ISecureRandom::CHAR_UPPER);


### PR DESCRIPTION
It can lead to generate an invalid Matterbridge toml config file.