### PR TITLE
Allow single video in stripe if screen share in progress

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -118,6 +118,7 @@
 				:fit-video="true"
 				:has-pagination="true"
 				:call-participant-models="callParticipantModels"
+				:screens="screens"
 				:target-aspect-ratio="gridTargetAspectRatio"
 				:local-media-model="localMediaModel"
 				:local-call-participant-model="localCallParticipantModel"

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -20,7 +20,7 @@
 -->
 
 <template>
-	<div class="grid-main-wrapper" :class="{'is-grid': !isStripe, 'transparent': isLessThanTwo}">
+	<div class="grid-main-wrapper" :class="{'is-grid': !isStripe, 'transparent': isLessThanTwoVideos}">
 		<button v-if="isStripe"
 			class="stripe--collapse"
 			:aria-label="stripeButtonTooltip"
@@ -56,8 +56,8 @@
 						:style="gridStyle"
 						@mousemove="handleMovement"
 						@keydown="handleMovement">
-						<template v-if="!devMode && (!isLessThanTwo || !isStripe)">
-							<EmptyCallView v-if="videos.length === 0 &&!isStripe" class="video" :is-grid="true" />
+						<template v-if="!devMode && (!isLessThanTwoVideos || !isStripe)">
+							<EmptyCallView v-if="videos.length === 0 && !isStripe" class="video" :is-grid="true" />
 							<template v-for="callParticipantModel in displayedVideos">
 								<Video
 									:key="callParticipantModel.attributes.peerId"
@@ -262,6 +262,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		screens: {
+			type: Array,
+			default: () => [],
+		},
 	},
 
 	data() {
@@ -326,8 +330,11 @@ export default {
 			return this.gridHeight / this.rows
 		},
 
-		isLessThanTwo() {
-			return this.callParticipantModels.length <= 1
+		isLessThanTwoVideos() {
+			// without screen share, we don't want to duplicate videos if we were to show them in the stripe
+			// however, if a screen share is in progress, it means the video of the presenting user is not visible
+			// so we can show it in the stripe
+			return this.callParticipantModels.length <= 1 && !this.screens.length
 		},
 
 		// The aspect ratio of the grid (in terms of px)


### PR DESCRIPTION
So far, the stripe was designed to not duplicate the video of whoever is
displayed in the top. However, when a screen share is in progress, that
user's video must move to the stripe so we can see them.

Fixes https://github.com/nextcloud/spreed/issues/4817

<img width="960" alt="Screenshot_20210113_154128" src="https://user-images.githubusercontent.com/277525/104466744-da9b8980-55b5-11eb-89ec-7283b5e852da.png">

Left side is the user sharing the screen (admin). Own video is visible in the stripe and also the green video from the other user.
Right side is the user receiving the screen share (alice). The video of "admin" is visible also in the stripe.

So far so good, however when you expand the window width, it looks bad:
<img width="738" alt="Screenshot_20210113_154320" src="https://user-images.githubusercontent.com/277525/104467033-264e3300-55b6-11eb-95ed-fb5505f566b7.png">

Thoughts @ma12-co ?