### PR TITLE
Correctly use the displayname for groups in admin settings

### DIFF
--- a/lib/Settings/Admin/AdminSettings.php
+++ b/lib/Settings/Admin/AdminSettings.php
@@ -111,9 +111,13 @@ class AdminSettings implements ISettings {
 	}
 
 	protected function initAllowedGroups(): void {
-		$this->initialStateService->provideInitialState('talk', 'start_conversations', $this->talkConfig->getAllowedConversationsGroupIds());
 		$this->initialStateService->provideInitialState('talk', 'start_calls', (int) $this->serverConfig->getAppValue('spreed', 'start_calls', Room::START_CALL_EVERYONE));
-		$this->initialStateService->provideInitialState('talk', 'allowed_groups', $this->talkConfig->getAllowedTalkGroupIds());
+
+		$groups = $this->getGroupDetailsArray($this->talkConfig->getAllowedConversationsGroupIds());
+		$this->initialStateService->provideInitialState('talk', 'start_conversations', $groups);
+
+		$groups = $this->getGroupDetailsArray($this->talkConfig->getAllowedTalkGroupIds());
+		$this->initialStateService->provideInitialState('talk', 'allowed_groups', $groups);
 	}
 
 	protected function initCommands(): void {
@@ -475,7 +479,14 @@ class AdminSettings implements ISettings {
 	}
 
 	protected function initSIPBridge(): void {
-		$gids = $this->talkConfig->getSIPGroups();
+		$groups = $this->getGroupDetailsArray($this->talkConfig->getSIPGroups());
+
+		$this->initialStateService->provideInitialState('talk', 'sip_bridge_groups', $groups);
+		$this->initialStateService->provideInitialState('talk', 'sip_bridge_shared_secret', $this->talkConfig->getSIPSharedSecret());
+		$this->initialStateService->provideInitialState('talk', 'sip_bridge_dialin_info', $this->talkConfig->getDialInInfo());
+	}
+
+	protected function getGroupDetailsArray(array $gids): array {
 		$groups = [];
 		foreach ($gids as $gid) {
 			$group = $this->groupManager->get($gid);
@@ -487,9 +498,7 @@ class AdminSettings implements ISettings {
 			}
 		}
 
-		$this->initialStateService->provideInitialState('talk', 'sip_bridge_groups', $groups);
-		$this->initialStateService->provideInitialState('talk', 'sip_bridge_shared_secret', $this->talkConfig->getSIPSharedSecret());
-		$this->initialStateService->provideInitialState('talk', 'sip_bridge_dialin_info', $this->talkConfig->getDialInInfo());
+		return $groups;
 	}
 
 	/**


### PR DESCRIPTION
Fix #4683

To create such a group use Nextcloud 18 or higher occ:
```
GROUPID=$(uuidgen)
GROUPID="group${GROUPID:8:28}"

./occ -vvv group:add $GROUPID --display-name "Dragon Crew"
```

Before | After
---|---
![Bildschirmfoto vom 2021-01-13 16-52-21](https://user-images.githubusercontent.com/213943/104475848-dd9b7780-55bf-11eb-809e-04fb54476b5a.png) | ![Bildschirmfoto vom 2021-01-13 16-51-50](https://user-images.githubusercontent.com/213943/104475856-decca480-55bf-11eb-809f-62151ea12e31.png)

