### PR TITLE
Add an integration test for when the last moderator leaves

### DIFF
--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -761,6 +761,20 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" gets room "([^"]*)" with (\d+)(?: \((v(1|2|3))\))?$/
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 * @param string $statusCode
+	 * @param string $apiVersion
+	 */
+	public function userGetsRoom($user, $identifier, $statusCode, $apiVersion = 'v1') {
+		$this->setCurrentUser($user);
+		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/room/' . self::$identifierToToken[$identifier]);
+		$this->assertStatusCode($this->response, $statusCode);
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" renames room "([^"]*)" to "([^"]*)" with (\d+)(?: \((v(1|2|3))\))?$/
 	 *
 	 * @param string $user

--- a/tests/integration/features/conversation/remove-self.feature
+++ b/tests/integration/features/conversation/remove-self.feature
@@ -31,6 +31,13 @@ Feature: public
     Then user "participant1" is participant of room "room"
     And user "participant2" is not participant of room "room"
 
+  Scenario: Last moderator removes the room from their room list
+    Given user "participant1" creates room "room"
+      | roomType | 3 |
+      | roomName | room |
+    When user "participant1" removes themselves from room "room" with 200
+    Then user "participant2" gets room "room" with 404 (v3)
+
   Scenario: User removes the room from their room list
     Given user "participant1" creates room "room"
       | roomType | 3 |


### PR DESCRIPTION
Fix #4490 

To check out it works, revert https://github.com/nextcloud/spreed/pull/4489 and run the test:

Without #4489 
```
    Then user "participant2" gets room "room" with 404 (v3)               # FeatureContext::userGetsRoom()
      Failed asserting that 200 matches expected 404.
💥
```
```
    Then user "participant2" gets room "room" with 404 (v3)               # FeatureContext::userGetsRoom()
✔️
```