### PR TITLE
Delete messages from store for deleted conversation

### DIFF
--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -216,7 +216,7 @@ export default {
 
 			// Remove the conversation to ensure that the old data is not used
 			// before fetching it again if this conversation is joined again.
-			this.$store.dispatch('deleteConversationByToken', this.token)
+			this.$store.dispatch('deleteConversation', this.token)
 			// Remove the participant to ensure that it will be set again fresh
 			// if this conversation is joined again.
 			this.$store.dispatch('purgeParticipantsStore', this.token)

--- a/src/PublicShareAuthSidebar.vue
+++ b/src/PublicShareAuthSidebar.vue
@@ -179,7 +179,7 @@ export default {
 			} catch (exception) {
 				window.clearInterval(this.fetchCurrentConversationIntervalId)
 
-				this.$store.dispatch('deleteConversationByToken', this.token)
+				this.$store.dispatch('deleteConversation', this.token)
 				this.$store.dispatch('updateToken', '')
 			}
 		},

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -215,7 +215,7 @@ export default {
 			} catch (exception) {
 				window.clearInterval(this.fetchCurrentConversationIntervalId)
 
-				this.$store.dispatch('deleteConversationByToken', this.token)
+				this.$store.dispatch('deleteConversation', this.token)
 				this.$store.dispatch('updateToken', '')
 			}
 

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -331,7 +331,7 @@ export default {
 					try {
 						await deleteConversation(this.item.token)
 						// If successful, deletes the conversation from the store
-						this.$store.dispatch('deleteConversation', this.item)
+						this.$store.dispatch('deleteConversation', this.item.token)
 					} catch (error) {
 						console.debug(`error while deleting conversation ${error}`)
 					}
@@ -346,7 +346,7 @@ export default {
 			try {
 				await removeCurrentUserFromConversation(this.item.token)
 				// If successful, deletes the conversation from the store
-				this.$store.dispatch('deleteConversation', this.item)
+				this.$store.dispatch('deleteConversation', this.item.token)
 			} catch (error) {
 				if (error.response && error.response.status === 400) {
 					showError(t('spreed', 'You need to promote a new moderator before you can leave the conversation.'))

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -152,6 +152,7 @@ const actions = {
 	 * @param {object} token the token of the conversation to be deleted;
 	 */
 	deleteConversation(context, token) {
+		context.dispatch('deleteMessages', token)
 		context.commit('deleteConversation', token)
 	},
 

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -146,22 +146,12 @@ const actions = {
 	},
 
 	/**
-	 * Delete a object
-	 *
-	 * @param {object} context default store context;
-	 * @param {object} conversation the conversation to be deleted;
-	 */
-	deleteConversation(context, conversation) {
-		context.commit('deleteConversation', conversation.token)
-	},
-
-	/**
-	 * Delete a object
+	 * Delete a conversation from the store.
 	 *
 	 * @param {object} context default store context;
 	 * @param {object} token the token of the conversation to be deleted;
 	 */
-	deleteConversationByToken(context, token) {
+	deleteConversation(context, token) {
 		context.commit('deleteConversation', token)
 	},
 

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -159,7 +159,7 @@ const mutations = {
 	 * @param {object} state current store state
 	 * @param {string} token Token of the conversation
 	 */
-	deleteConversation(state, token) {
+	deleteMessages(state, token) {
 		if (state.firstKnown[token]) {
 			Vue.delete(state.firstKnown, token)
 		}
@@ -247,8 +247,8 @@ const actions = {
 	 * @param {object} context default store context;
 	 * @param {object} token the token of the conversation to be deleted;
 	 */
-	deleteConversation(context, token) {
-		context.commit('deleteConversation', token)
+	deleteMessages(context, token) {
+		context.commit('deleteMessages', token)
 	},
 }
 

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -22,12 +22,18 @@
 import Vue from 'vue'
 
 const state = {
-	messages: {
-	},
-	firstKnown: {
-	},
-	lastKnown: {
-	},
+	/**
+	 * Map of conversation token to message list
+	 */
+	messages: {},
+	/**
+	 * Map of conversation token to first known message id
+	 */
+	firstKnown: {},
+	/**
+	 * Map of conversation token to last known message id
+	 */
+	lastKnown: {},
 }
 
 const getters = {
@@ -146,6 +152,24 @@ const mutations = {
 	setLastKnownMessageId(state, { token, id }) {
 		Vue.set(state.lastKnown, token, id)
 	},
+
+	/**
+	 * Deletes the messages entry for the deleted conversation.
+	 *
+	 * @param {object} state current store state
+	 * @param {string} token Token of the conversation
+	 */
+	deleteConversationByToken(state, token) {
+		if (state.firstKnown[token]) {
+			Vue.delete(state.firstKnown, token)
+		}
+		if (state.lastKnown[token]) {
+			Vue.delete(state.lastKnown, token)
+		}
+		if (state.messages[token]) {
+			Vue.delete(state.messages, token)
+		}
+	},
 }
 
 const actions = {
@@ -215,6 +239,26 @@ const actions = {
 	 */
 	setLastKnownMessageId(context, { token, id }) {
 		context.commit('setLastKnownMessageId', { token, id })
+	},
+
+	/**
+	 * Deletes the messages of a conversation
+	 *
+	 * @param {object} context default store context;
+	 * @param {object} conversation the conversation to be deleted;
+	 */
+	deleteConversation(context, conversation) {
+		context.commit('deleteConversationByToken', conversation.token)
+	},
+
+	/**
+	 * Deletes the messages of a conversation
+	 *
+	 * @param {object} context default store context;
+	 * @param {object} token the token of the conversation to be deleted;
+	 */
+	deleteConversationByToken(context, token) {
+		context.commit('deleteConversationByToken', token)
 	},
 }
 

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -154,12 +154,12 @@ const mutations = {
 	},
 
 	/**
-	 * Deletes the messages entry for the deleted conversation.
+	 * Deletes the messages entry from the store for the given conversation token.
 	 *
 	 * @param {object} state current store state
 	 * @param {string} token Token of the conversation
 	 */
-	deleteConversationByToken(state, token) {
+	deleteConversation(state, token) {
 		if (state.firstKnown[token]) {
 			Vue.delete(state.firstKnown, token)
 		}
@@ -245,20 +245,10 @@ const actions = {
 	 * Deletes the messages of a conversation
 	 *
 	 * @param {object} context default store context;
-	 * @param {object} conversation the conversation to be deleted;
-	 */
-	deleteConversation(context, conversation) {
-		context.commit('deleteConversationByToken', conversation.token)
-	},
-
-	/**
-	 * Deletes the messages of a conversation
-	 *
-	 * @param {object} context default store context;
 	 * @param {object} token the token of the conversation to be deleted;
 	 */
-	deleteConversationByToken(context, token) {
-		context.commit('deleteConversationByToken', token)
+	deleteConversation(context, token) {
+		context.commit('deleteConversation', token)
 	},
 }
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/spreed/issues/4572

When a conversation is deleted through an action, also delete the matching messages for consistency.
    
This also prevents the corresponding vues to try to access the deleted conversation.

Note: the proposed code works by defining an action in messagesStore with the same name as the one in the conversationsStore. The dispatching of actions will trigger on all the stores, which then makes this magic happen :-)

I noticed also that "purgeConversations" is also not clearing the messagesStore but decided against adding it here, as it might have side effects. I'll raise a tech debt ticket later to discuss this unrelated bit.

