### PR TITLE
Allow SIP dial-in in non-public conversations too

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -266,7 +266,7 @@ class RoomController extends AEnvironmentAwareController {
 		$includeLastMessage = !$isSIPBridgeRequest;
 
 		try {
-			$room = $this->manager->getRoomForUserByToken($token, $this->userId, $includeLastMessage);
+			$room = $this->manager->getRoomForUserByToken($token, $this->userId, $includeLastMessage, $isSIPBridgeRequest);
 
 			$participant = null;
 			try {

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -483,10 +483,11 @@ class Manager {
 	 * @param string $token
 	 * @param string|null $userId
 	 * @param bool $includeLastMessage
+	 * @param bool $isSIPBridgeRequest
 	 * @return Room
 	 * @throws RoomNotFoundException
 	 */
-	public function getRoomForUserByToken(string $token, ?string $userId, bool $includeLastMessage = false): Room {
+	public function getRoomForUserByToken(string $token, ?string $userId, bool $includeLastMessage = false, bool $isSIPBridgeRequest = false): Room {
 		$query = $this->db->getQueryBuilder();
 		$helper = new SelectHelper();
 		$helper->selectRoomsTable($query);
@@ -530,7 +531,7 @@ class Manager {
 			$room->setParticipant($row['actor_id'], $this->createParticipantObject($room, $row));
 		}
 
-		if ($room->getType() === Room::PUBLIC_CALL) {
+		if ($isSIPBridgeRequest || $room->getType() === Room::PUBLIC_CALL) {
 			return $room;
 		}
 


### PR DESCRIPTION
### Steps
1. Create a group conversation
2. Enable SIP
3. Try to dial-in
4. On the SIP server see `DEBUG:workflow.YeAltb1L5mKn:The meeting number '7979592938' is not valid ({'success': False, 'error': 'conference_not_found'})` 💥 

