### PR TITLE
Enable pagination for main grid view

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -454,11 +454,6 @@ export default {
 		// If the video array size changes, rebuild the grid
 		'videos.length': function() {
 			this.makeGrid()
-			if (this.hasPagination) {
-				// Set the current page to 0
-				// TODO: add support for keeping position in the videos array when resizing
-				this.currentPage = 0
-			}
 		},
 		// TODO: rebuild the grid to have optimal for last page
 		// Exception for when navigating in and away from the last page of the
@@ -488,6 +483,12 @@ export default {
 			// Handle the resize after the sidebar animation has completed
 			setTimeout(this.handleResize, 500)
 		},
+
+		numberOfPages() {
+			if (this.currentPage >= this.numberOfPages) {
+				this.currentPage = this.numberOfPages - 1
+			}
+		},
 	},
 
 	// bind event handlers to the `handleResize` method
@@ -495,11 +496,6 @@ export default {
 		window.addEventListener('resize', this.handleResize)
 		subscribe('navigation-toggled', this.handleResize)
 		this.makeGrid()
-		if (this.hasPagination) {
-			// Set the current page to 0
-			// TODO: add support for keeping position in the videos array when resizing
-			this.currentPage = 0
-		}
 	},
 	beforeDestroy() {
 		window.removeEventListener('resize', this.handleResize)
@@ -514,11 +510,6 @@ export default {
 			console.debug('newGridWidth: ', this.gridWidth, 'newGridHeight: ', this.gridHeight)
 			if (!this.isStripe || this.stripeOpen) {
 				this.$nextTick(this.makeGrid)
-				if (this.hasPagination) {
-					// Set the current page to 0
-					// TODO: add support for keeping position in the videos array when resizing or collapsing
-					this.currentPage = 0
-				}
 			}
 		},
 
@@ -529,11 +520,6 @@ export default {
 			// current position in the videos array is lost (first element
 			// in the grid goes back to be first video)
 			debounce(this.makeGrid(), 200)
-			if (this.hasPagination) {
-				// Set the current page to 0
-				// TODO: add support for keeping position in the videos array when resizing
-				this.currentPage = 0
-			}
 		},
 
 		// Find the right size if the grid in rows and columns (we already know

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -562,15 +562,11 @@ export default {
 			}
 			// Send event to display hint in the topbar component if there's an
 			// overflow of videos (only if in full-grid mode, not stripe)
-			if (this.hasVideoOverflow) {
-				if (!this.isStripe) {
-					EventBus.$emit('toggleLayoutHint', true)
-				} else {
-				// Remove the hint if user resizes
-					EventBus.$emit('toggleLayoutHint', false)
-				}
+			if (!this.hasVideoOverflow || this.isStripe) {
+				EventBus.$emit('toggleLayoutHint', false)
+			} else {
+				EventBus.$emit('toggleLayoutHint', true)
 			}
-
 		},
 
 		// Fine tune the number of rows and columns of the grid

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -276,8 +276,6 @@ export default {
 			columns: 0,
 			// Rows of the grid at any given moment
 			rows: 0,
-			// Grid pages at any given moment
-			numberOfPages: 0,
 			// The current page
 			currentPage: 0,
 			// Videos controls and name
@@ -377,6 +375,11 @@ export default {
 			return this.isStripe ? this.rows * this.columns : this.rows * this.columns - 1
 		},
 
+		// Grid pages at any given moment
+		numberOfPages() {
+			return Math.ceil(this.videosCount / this.slots)
+		},
+
 		// Hides or displays the `grid-navigation next` button
 		hasNextPage() {
 			if (this.displayedVideos.length !== 0 && this.hasPagination) {
@@ -452,7 +455,6 @@ export default {
 		'videos.length': function() {
 			this.makeGrid()
 			if (this.hasPagination) {
-				this.setNumberOfPages()
 				// Set the current page to 0
 				// TODO: add support for keeping position in the videos array when resizing
 				this.currentPage = 0
@@ -494,7 +496,6 @@ export default {
 		subscribe('navigation-toggled', this.handleResize)
 		this.makeGrid()
 		if (this.hasPagination) {
-			this.setNumberOfPages()
 			// Set the current page to 0
 			// TODO: add support for keeping position in the videos array when resizing
 			this.currentPage = 0
@@ -514,7 +515,6 @@ export default {
 			if (!this.isStripe || this.stripeOpen) {
 				this.$nextTick(this.makeGrid)
 				if (this.hasPagination) {
-					this.setNumberOfPages()
 					// Set the current page to 0
 					// TODO: add support for keeping position in the videos array when resizing or collapsing
 					this.currentPage = 0
@@ -530,7 +530,6 @@ export default {
 			// in the grid goes back to be first video)
 			debounce(this.makeGrid(), 200)
 			if (this.hasPagination) {
-				this.setNumberOfPages()
 				// Set the current page to 0
 				// TODO: add support for keeping position in the videos array when resizing
 				this.currentPage = 0
@@ -664,11 +663,6 @@ export default {
 
 			this.columns = currentColumns
 			this.rows = currentRows
-		},
-
-		// Set the current number of pages
-		setNumberOfPages() {
-			this.numberOfPages = Math.ceil(this.videosCount / this.slots)
 		},
 
 		// The last grid page is very likely not to have the same number of

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -40,7 +40,7 @@
 		</button>
 		<transition :name="isStripe ? 'slide-down' : ''">
 			<div v-if="!isStripe || stripeOpen" class="wrapper" :style="wrapperStyle">
-				<div :class="{'pagination-wrapper': isStripe, 'wrapper': !isStripe}">
+				<div :class="{'stripe-wrapper': isStripe, 'wrapper': !isStripe}">
 					<button v-if="hasPreviousPage && gridWidth > 0 && isStripe && showVideoOverlay"
 						class="grid-navigation grid-navigation__previous"
 						:aria-label="t('spreed', 'Previous page of videos')"
@@ -757,7 +757,7 @@ export default {
 	width: 300px;
 }
 
-.pagination-wrapper {
+.stripe-wrapper {
 	width: calc(100% - 300px);
 	position:relative
 }

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -448,6 +448,21 @@ export default {
 		stripeOpen() {
 			return this.$store.getters.isStripeOpen
 		},
+
+		// Special boolean property to watch and emit the "toggleLayoutHint"
+		// event to display hint in the topbar component if there is an overflow
+		// of videos (only if in full-grid mode, not stripe)
+		toggleLayoutHint() {
+			if (!this.hasVideoOverflow) {
+				return false
+			}
+
+			if (this.isStripe) {
+				return false
+			}
+
+			return true
+		},
 	},
 
 	watch: {
@@ -488,6 +503,13 @@ export default {
 			if (this.currentPage >= this.numberOfPages) {
 				this.currentPage = this.numberOfPages - 1
 			}
+		},
+
+		toggleLayoutHint: {
+			immediate: true,
+			handler() {
+				EventBus.$emit('toggleLayoutHint', this.toggleLayoutHint)
+			},
 		},
 	},
 
@@ -559,13 +581,6 @@ export default {
 				this.shrinkGrid(this.videosCap)
 			} else {
 				this.shrinkGrid(this.videosCount)
-			}
-			// Send event to display hint in the topbar component if there's an
-			// overflow of videos (only if in full-grid mode, not stripe)
-			if (!this.hasVideoOverflow || this.isStripe) {
-				EventBus.$emit('toggleLayoutHint', false)
-			} else {
-				EventBus.$emit('toggleLayoutHint', true)
 			}
 		},
 

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -272,9 +272,6 @@ export default {
 		return {
 			gridWidth: 0,
 			gridHeight: 0,
-			// Array of videos that are being displayed in the grid at any
-			// given moment
-			displayedVideos: [],
 			// Columns of the grid at any given moment
 			columns: 0,
 			// Rows of the grid at any given moment
@@ -324,6 +321,21 @@ export default {
 		},
 		videoHeight() {
 			return this.gridHeight / this.rows
+		},
+
+		// Array of videos that are being displayed in the grid at any given
+		// moment
+		displayedVideos() {
+			if (!this.slots) {
+				return []
+			}
+
+			// Slice the `videos` array to display the current page of videos
+			if (((this.currentPage + 1) * this.slots) >= this.videos.length) {
+				return this.videos.slice(this.currentPage * this.slots)
+			}
+
+			return this.videos.slice(this.currentPage * this.slots, (this.currentPage + 1) * this.slots)
 		},
 
 		isLessThanTwoVideos() {
@@ -537,7 +549,6 @@ export default {
 			if (this.videos.length === 0) {
 				this.columns = 0
 				this.rows = 0
-				this.displayedVideos = []
 				return
 			}
 
@@ -564,8 +575,6 @@ export default {
 			} else {
 				this.shrinkGrid(this.videosCount)
 			}
-			// Once the grid is done, populate it with video components
-			this.displayedVideos = this.videos.slice(0, this.slots)
 			// Send event to display hint in the topbar component if there's an
 			// overflow of videos (only if in full-grid mode, not stripe)
 			if (this.hasVideoOverflow) {
@@ -673,23 +682,13 @@ export default {
 		// this.shrinkGrid(this.displayedVideos.length)
 		// },
 
-		// Slice the `videos` array to display the next set of videos
 		handleClickNext() {
 			this.currentPage++
 			console.debug('handleclicknext, ', 'currentPage ', this.currentPage, 'slots ', this.slot, 'videos.length ', this.videos.length)
-			if (((this.currentPage + 1) * this.slots) >= this.videos.length) {
-				this.displayedVideos = this.videos.slice(this.currentPage * this.slots)
-			} else {
-				this.displayedVideos = this.videos.slice(this.currentPage * this.slots, (this.currentPage + 1) * this.slots)
-			}
-			console.debug('slicevalues', (this.currentPage) * this.slots, this.currentPage * this.slots)
 		},
-		// Slice the `videos` array to display the previous set of videos
 		handleClickPrevious() {
 			this.currentPage--
 			console.debug('handleclickprevious, ', 'currentPage ', this.currentPage, 'slots ', this.slots, 'videos.length ', this.videos.length)
-			this.displayedVideos = this.videos.slice((this.currentPage) * this.slots, (this.currentPage + 1) * this.slots)
-			console.debug('slicevalues', (this.currentPage) * this.slots, (this.currentPage + 1) * this.slots)
 		},
 
 		handleClickStripeCollapse() {

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -565,12 +565,7 @@ export default {
 				this.shrinkGrid(this.videosCount)
 			}
 			// Once the grid is done, populate it with video components
-			if (this.isStripe) {
-				this.displayedVideos = this.videos.slice(0, this.rows * this.columns)
-			} else {
-				// `- 1` because we a ccount for the localVideo component (see template)
-				this.displayedVideos = this.videos.slice(0, this.rows * this.columns - 1)
-			}
+			this.displayedVideos = this.videos.slice(0, this.slots)
 			// Send event to display hint in the topbar component if there's an
 			// overflow of videos (only if in full-grid mode, not stripe)
 			if (this.hasVideoOverflow) {

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -41,7 +41,7 @@
 		<transition :name="isStripe ? 'slide-down' : ''">
 			<div v-if="!isStripe || stripeOpen" class="wrapper" :style="wrapperStyle">
 				<div :class="{'stripe-wrapper': isStripe, 'wrapper': !isStripe}">
-					<button v-if="hasPreviousPage && gridWidth > 0 && isStripe && showVideoOverlay"
+					<button v-if="hasPreviousPage && gridWidth > 0 && showVideoOverlay"
 						class="grid-navigation grid-navigation__previous"
 						:aria-label="t('spreed', 'Previous page of videos')"
 						@click="handleClickPrevious">
@@ -100,7 +100,7 @@
 							@switchScreenToId="1"
 							@click-video="handleClickLocalVideo" />
 					</div>
-					<button v-if="hasNextPage && gridWidth > 0 && isStripe && showVideoOverlay"
+					<button v-if="hasNextPage && gridWidth > 0 && showVideoOverlay"
 						class="grid-navigation grid-navigation__next"
 						:aria-label="t('spreed', 'Next page of videos')"
 						@click="handleClickNext">
@@ -812,7 +812,8 @@ export default {
 	height: 44px;
 	background-color: white;
 	opacity: 0.6 !important;
-	top: 12px;
+	/* Center icons vertically in the grid view */
+	top: calc(50% - 22px);
 	z-index: 2;
 	box-shadow: 0 0 4px var(--color-box-shadow);
 	padding: 0;
@@ -830,6 +831,10 @@ export default {
 	&__next {
 		right: 12px;
 	}
+}
+
+.stripe-wrapper .grid-navigation {
+	top: 12px;
 }
 
 .pages-indicator {

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -426,10 +426,6 @@ export default {
 				return 'height: 100%'
 			}
 		},
-		// Determines when to show the stripe navigation buttons
-		showNavigation() {
-			return this.gridWidth > 0 && this.isStripe && this.videosCount > 0 && this.showVideoOverlay
-		},
 
 		// Blur radius for each background in the grid
 		videoBackgroundBlur() {

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -310,18 +310,14 @@ export default {
 			}
 		},
 
-		// Number of video components (includes localvideo if not stripe)
+		// Number of video components (it does not include the local video)
 		videosCount() {
-			if (this.isStripe) {
-				return this.videos.length
-			} else {
+			if (!this.isStripe && this.videos.length === 0) {
 				// Count the emptycontent as a grid element
-				if (this.videos.length === 0) {
-					return 2
-				}
-				// Add the local video to the count
-				return this.videos.length + 1
+				return 1
 			}
+
+			return this.videos.length
 		},
 		videoWidth() {
 			return this.gridWidth / this.columns
@@ -363,8 +359,10 @@ export default {
 		},
 
 		// Number of grid slots at any given moment
+		// The local video always takes one slot if the grid view is not shown
+		// as a stripe.
 		slots() {
-			return this.rows * this.columns
+			return this.isStripe ? this.rows * this.columns : this.rows * this.columns - 1
 		},
 
 		// Hides or displays the `grid-navigation next` button
@@ -599,7 +597,7 @@ export default {
 
 			let currentColumns = this.columns
 			let currentRows = this.rows
-			let currentSlots = currentColumns * currentRows
+			let currentSlots = this.isStripe ? currentColumns * currentRows : currentColumns * currentRows - 1
 
 			// Run this code only if we don't have an 'overflow' of videos. If the
 			// videos are populating the grid, there's no point in shrinking it.
@@ -632,7 +630,7 @@ export default {
 						currentColumns--
 					}
 
-					currentSlots = currentColumns * currentRows
+					currentSlots = this.isStripe ? currentColumns * currentRows : currentColumns * currentRows - 1
 
 					// Check that there are still enough slots available
 					if (numberOfVideos > currentSlots) {
@@ -645,7 +643,7 @@ export default {
 						currentRows--
 					}
 
-					currentSlots = currentColumns * currentRows
+					currentSlots = this.isStripe ? currentColumns * currentRows : currentColumns * currentRows - 1
 
 					// Check that there are still enough slots available
 					if (numberOfVideos > currentSlots) {

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -759,7 +759,7 @@ export default {
 
 .stripe-wrapper {
 	width: calc(100% - 300px);
-	position:relative
+	position: relative;
 }
 
 .dev-mode-video {

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -472,6 +472,10 @@ export default {
 		 */
 		isStripe() {
 			this.rebuildGrid()
+
+			// Reset current page when switching between stripe and full grid,
+			// as the previous page is meaningless in the new mode.
+			this.currentPage = 0
 		},
 
 		stripeOpen() {

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -76,17 +76,6 @@
 									:shared-data="sharedDatas[callParticipantModel.attributes.peerId]"
 									@click-video="handleClickVideo($event, callParticipantModel.attributes.peerId)" />
 							</template>
-							<LocalVideo
-								v-if="!isStripe"
-								ref="localVideo"
-								class="video"
-								:is-grid="true"
-								:fit-video="isStripe"
-								:local-media-model="localMediaModel"
-								:video-container-aspect-ratio="videoContainerAspectRatio"
-								:local-call-participant-model="localCallParticipantModel"
-								@switchScreenToId="1"
-								@click-video="handleClickLocalVideo" />
 						</template>
 						<!-- Grid developer mode -->
 						<template v-if="devMode">
@@ -99,6 +88,17 @@
 								Dev mode on ;-)
 							</h1>
 						</template>
+						<LocalVideo
+							v-if="!isStripe"
+							ref="localVideo"
+							class="video"
+							:is-grid="true"
+							:fit-video="isStripe"
+							:local-media-model="localMediaModel"
+							:video-container-aspect-ratio="videoContainerAspectRatio"
+							:local-call-participant-model="localCallParticipantModel"
+							@switchScreenToId="1"
+							@click-video="handleClickLocalVideo" />
 					</div>
 					<button v-if="hasNextPage && gridWidth > 0 && isStripe && showVideoOverlay"
 						class="grid-navigation grid-navigation__next"
@@ -310,9 +310,9 @@ export default {
 			}
 		},
 
-		// Number of video components (includes localvideo if not in dev mode)
+		// Number of video components (includes localvideo if not stripe)
 		videosCount() {
-			if (this.devMode || this.isStripe) {
+			if (this.isStripe) {
 				return this.videos.length
 			} else {
 				// Count the emptycontent as a grid element
@@ -571,7 +571,7 @@ export default {
 				this.shrinkGrid(this.videosCount)
 			}
 			// Once the grid is done, populate it with video components
-			if (this.devMode || this.isStripe) {
+			if (this.isStripe) {
 				this.displayedVideos = this.videos.slice(0, this.rows * this.columns)
 			} else {
 				// `- 1` because we a ccount for the localVideo component (see template)

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -153,7 +153,6 @@
 import debounce from 'debounce'
 import Video from '../shared/Video'
 import LocalVideo from '../shared/LocalVideo'
-import { EventBus } from '../../../services/EventBus'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import EmptyCallView from '../shared/EmptyCallView'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
@@ -448,21 +447,6 @@ export default {
 		stripeOpen() {
 			return this.$store.getters.isStripeOpen
 		},
-
-		// Special boolean property to watch and emit the "toggleLayoutHint"
-		// event to display hint in the topbar component if there is an overflow
-		// of videos (only if in full-grid mode, not stripe)
-		toggleLayoutHint() {
-			if (!this.hasVideoOverflow) {
-				return false
-			}
-
-			if (this.isStripe) {
-				return false
-			}
-
-			return true
-		},
 	},
 
 	watch: {
@@ -503,13 +487,6 @@ export default {
 			if (this.currentPage >= this.numberOfPages) {
 				this.currentPage = this.numberOfPages - 1
 			}
-		},
-
-		toggleLayoutHint: {
-			immediate: true,
-			handler() {
-				EventBus.$emit('toggleLayoutHint', this.toggleLayoutHint)
-			},
 		},
 	},
 

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -334,7 +334,7 @@ export default {
 			// without screen share, we don't want to duplicate videos if we were to show them in the stripe
 			// however, if a screen share is in progress, it means the video of the presenting user is not visible
 			// so we can show it in the stripe
-			return this.callParticipantModels.length <= 1 && !this.screens.length
+			return this.videos.length <= 1 && !this.screens.length
 		},
 
 		// The aspect ratio of the grid (in terms of px)

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -23,34 +23,13 @@
 	<div class="top-bar" :class="{ 'in-call': isInCall }">
 		<CallButton class="top-bar__button" />
 		<!-- Call layout switcher -->
-		<Popover v-if="isInCall"
-			class="top-bar__button"
-			trigger="manual"
-			:open="showLayoutHint && !hintDismissed"
-			@auto-hide="showLayoutHint=false">
-			<Actions slot="trigger">
-				<ActionButton v-if="isInCall"
-					:icon="changeViewIconClass"
-					@click="changeView">
-					{{ changeViewText }}
-				</actionbutton>
-			</Actions>
-			<div class="hint">
-				{{ layoutHintText }}
-				<div class="hint__actions">
-					<button
-						class="hint__button"
-						@click="showLayoutHint=false, hintDismissed=true">
-						{{ t('spreed', 'Dismiss') }}
-					</button>
-					<button
-						class="hint__button primary"
-						@click="changeView">
-						{{ t('spreed', 'Use speaker view') }}
-					</button>
-				</div>
-			</div>
-		</Popover>
+		<Actions slot="trigger">
+			<ActionButton v-if="isInCall"
+				:icon="changeViewIconClass"
+				@click="changeView">
+				{{ changeViewText }}
+			</actionbutton>
+		</Actions>
 		<!-- sidebar toggle -->
 		<Actions
 			v-shortkey.once="['f']"
@@ -122,10 +101,8 @@
 <script>
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
-import Popover from '@nextcloud/vue/dist/Components/Popover'
 import Actions from '@nextcloud/vue/dist/Components/Actions'
 import CallButton from './CallButton'
-import { EventBus } from '../../services/EventBus'
 import BrowserStorage from '../../services/BrowserStorage'
 import ActionLink from '@nextcloud/vue/dist/Components/ActionLink'
 import ActionSeparator from '@nextcloud/vue/dist/Components/ActionSeparator'
@@ -142,7 +119,6 @@ export default {
 		Actions,
 		ActionLink,
 		CallButton,
-		Popover,
 		ActionSeparator,
 	},
 
@@ -151,13 +127,6 @@ export default {
 			type: Boolean,
 			required: true,
 		},
-	},
-
-	data() {
-		return {
-			showLayoutHint: false,
-			hintDismissed: false,
-		}
 	},
 
 	computed: {
@@ -205,9 +174,6 @@ export default {
 			}
 		},
 
-		layoutHintText() {
-			return t('Spreed', 'Too many videos to fit in the window. Maximize the window or switch to "speaker view" for a better experience.')
-		},
 		isFileConversation() {
 			return this.conversation.objectType === 'file' && this.conversation.objectId
 		},
@@ -264,8 +230,6 @@ export default {
 		document.addEventListener('mozfullscreenchange', this.fullScreenChanged, false)
 		document.addEventListener('MSFullscreenChange', this.fullScreenChanged, false)
 		document.addEventListener('webkitfullscreenchange', this.fullScreenChanged, false)
-		// Add call layout hint listener
-		EventBus.$on('toggleLayoutHint', this.handleToggleLayoutHint)
 	},
 
 	beforeDestroy() {
@@ -273,8 +237,6 @@ export default {
 		document.removeEventListener('mozfullscreenchange', this.fullScreenChanged, false)
 		document.removeEventListener('MSFullscreenChange', this.fullScreenChanged, false)
 		document.removeEventListener('webkitfullscreenchange', this.fullScreenChanged, false)
-		// Remove call layout hint listener
-		EventBus.$off('toggleLayoutHint', this.handleToggleLayoutHint)
 	},
 
 	methods: {
@@ -333,7 +295,6 @@ export default {
 		changeView() {
 			this.$store.dispatch('setCallViewMode', { isGrid: !this.isGrid })
 			this.$store.dispatch('selectedVideoPeerId', null)
-			this.showLayoutHint = false
 		},
 
 		async handleCopyLink() {
@@ -347,9 +308,6 @@ export default {
 		handleRenameConversation() {
 			this.$store.dispatch('isRenamingConversation', true)
 			this.$store.dispatch('showSidebar')
-		},
-		handleToggleLayoutHint(display) {
-			this.showLayoutHint = display
 		},
 		forceMuteOthers() {
 			callParticipantCollection.callParticipantModels.forEach(callParticipantModel => {
@@ -389,20 +347,6 @@ export default {
 		.icon {
 			margin-right: 4px !important;
 		}
-	}
-}
-
-.hint {
-	padding: 12px;
-	max-width: 300px;
-	text-align: left;
-	&__button {
-		height: $clickable-area;
-	}
-	&__actions{
-		display: flex;
-		justify-content: space-between;
-		padding-top:4px;
 	}
 }
 </style>


### PR DESCRIPTION
Although the grid component is capable of performing pagination until now it was enabled only in stripe mode. When the call view was in grid mode and the participants did not fit a notification was shown to the user, but the buttons to change between grid view pages were not shown. However, (with some tweaks) the pagination does not require the grid view to be in stripe mode to work, so the buttons are now shown when needed also in the main grid view (centered vertically instead of close to the top, as they would clash with the top bar buttons).

The notification was removed too, as now it does not make sense, at least with its previous message. However I wonder if we should still show the notification with a different message (something like "Too many participants to fit in the window. Please use the buttons in the grid to change between different sets of participants.") when a new page is added so the user realizes it (as just showing the buttons may not be noticeable enough, and they could be hidden if the user has not recently interacted with the grid view).

Note that I tested all this using the `devMode` of the grid view. It should be the same when using real participants, but it would be better to test it to ensure that the local participant is still always shown as expected in all pages.

Besides that this pull request also fixes the grid view jumping back to the first page when the window is resized or a participant joins or leaves, and it also cleans a bit the code.

Pending:
  - [X] Reset current page when changing between speaker mode and grid view
  - [X] Do not focus previous page button when changing from first page to second page - I gave up, it is not related to the changes in this pull request, I spent enough time already and I am still clueless, so I just [opened an issue](https://github.com/nextcloud/spreed/issues/4961)
  - [ ] Bring back the layout hint notification but with a different text?
