### PR TITLE
Update @babel/preset-env and fix commonjs loading

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,3 @@ updates:
     versions:
     - ">= 4.a"
     - "< 5"
-  # remove after fixing https://github.com/nextcloud/spreed/issues/4818
-  - dependency-name: "@babel/preset-env"
-    versions:
-    - ">= 7.12.11"

--- a/package-lock.json
+++ b/package-lock.json
@@ -242,12 +242,17 @@
 				"@babel/types": "^7.12.10"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+				},
 				"@babel/types": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
-					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -263,12 +268,17 @@
 				"@babel/types": "^7.10.4"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+				},
 				"@babel/types": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
-					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -284,35 +294,6 @@
 				"@babel/helper-validator-option": "^7.12.1",
 				"browserslist": "^4.14.5",
 				"semver": "^5.5.0"
-			},
-			"dependencies": {
-				"browserslist": {
-					"version": "4.16.0",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
-					"integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
-					"requires": {
-						"caniuse-lite": "^1.0.30001165",
-						"colorette": "^1.2.1",
-						"electron-to-chromium": "^1.3.621",
-						"escalade": "^3.1.1",
-						"node-releases": "^1.1.67"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30001165",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz",
-					"integrity": "sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA=="
-				},
-				"electron-to-chromium": {
-					"version": "1.3.625",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.625.tgz",
-					"integrity": "sha512-CsLk/r0C9dAzVPa9QF74HIXduxaucsaRfqiOYvIv2PRhvyC6EOqc/KbpgToQuDVgPf3sNAFZi3iBu4vpGOwGag=="
-				},
-				"node-releases": {
-					"version": "1.1.67",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-					"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
-				}
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
@@ -463,21 +444,21 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.10.4",
-						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.10.4"
+						"@babel/helper-get-function-arity": "^7.12.10",
+						"@babel/template": "^7.12.7",
+						"@babel/types": "^7.12.11"
 					}
 				},
 				"@babel/helper-get-function-arity": {
@@ -487,6 +468,11 @@
 					"requires": {
 						"@babel/types": "^7.12.10"
 					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
 				},
 				"@babel/highlight": {
 					"version": "7.10.4",
@@ -499,9 +485,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.10.tgz",
-					"integrity": "sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA=="
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
 				},
 				"@babel/template": {
 					"version": "7.12.7",
@@ -514,11 +500,11 @@
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
-					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -533,12 +519,17 @@
 				"@babel/types": "^7.12.1"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+				},
 				"@babel/types": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
-					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -573,12 +564,17 @@
 				"@babel/types": "^7.10.4"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+				},
 				"@babel/types": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
-					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -593,12 +589,17 @@
 				"@babel/types": "^7.12.7"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+				},
 				"@babel/types": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
-					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -792,12 +793,17 @@
 				"@babel/types": "^7.12.1"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+				},
 				"@babel/types": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
-					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -805,42 +811,42 @@
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
-			"integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+			"integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.12.1",
-				"@babel/helper-optimise-call-expression": "^7.10.4",
-				"@babel/traverse": "^7.12.5",
-				"@babel/types": "^7.12.5"
+				"@babel/helper-member-expression-to-functions": "^7.12.7",
+				"@babel/helper-optimise-call-expression": "^7.12.10",
+				"@babel/traverse": "^7.12.10",
+				"@babel/types": "^7.12.11"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.10.tgz",
-					"integrity": "sha512-6mCdfhWgmqLdtTkhXjnIz0LcdVCd26wS2JXRtj2XY0u5klDsXBREA/pG5NVOuVnF2LUrBGNFtQkIqqTbblg0ww==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
 					"requires": {
-						"@babel/types": "^7.12.10",
+						"@babel/types": "^7.12.11",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.10.4",
-						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.10.4"
+						"@babel/helper-get-function-arity": "^7.12.10",
+						"@babel/template": "^7.12.7",
+						"@babel/types": "^7.12.11"
 					}
 				},
 				"@babel/helper-get-function-arity": {
@@ -851,13 +857,26 @@
 						"@babel/types": "^7.12.10"
 					}
 				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+					"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
 					"requires": {
-						"@babel/types": "^7.11.0"
+						"@babel/types": "^7.12.10"
 					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+					"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+					"requires": {
+						"@babel/types": "^7.12.11"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
 				},
 				"@babel/highlight": {
 					"version": "7.10.4",
@@ -870,9 +889,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.10.tgz",
-					"integrity": "sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA=="
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
 				},
 				"@babel/template": {
 					"version": "7.12.7",
@@ -885,27 +904,27 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
-					"integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+					"integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
 					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.12.10",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.12.10",
-						"@babel/types": "^7.12.10",
+						"@babel/code-frame": "^7.12.11",
+						"@babel/generator": "^7.12.11",
+						"@babel/helper-function-name": "^7.12.11",
+						"@babel/helper-split-export-declaration": "^7.12.11",
+						"@babel/parser": "^7.12.11",
+						"@babel/types": "^7.12.12",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
-					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -940,12 +959,17 @@
 				"@babel/types": "^7.12.1"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+				},
 				"@babel/types": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
-					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -983,31 +1007,31 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.10.tgz",
-					"integrity": "sha512-6mCdfhWgmqLdtTkhXjnIz0LcdVCd26wS2JXRtj2XY0u5klDsXBREA/pG5NVOuVnF2LUrBGNFtQkIqqTbblg0ww==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
 					"requires": {
-						"@babel/types": "^7.12.10",
+						"@babel/types": "^7.12.11",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.10.4",
-						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.10.4"
+						"@babel/helper-get-function-arity": "^7.12.10",
+						"@babel/template": "^7.12.7",
+						"@babel/types": "^7.12.11"
 					}
 				},
 				"@babel/helper-get-function-arity": {
@@ -1019,12 +1043,17 @@
 					}
 				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+					"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
 					"requires": {
-						"@babel/types": "^7.11.0"
+						"@babel/types": "^7.12.11"
 					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
 				},
 				"@babel/highlight": {
 					"version": "7.10.4",
@@ -1037,9 +1066,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.10.tgz",
-					"integrity": "sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA=="
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
 				},
 				"@babel/template": {
 					"version": "7.12.7",
@@ -1052,27 +1081,27 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
-					"integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+					"integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
 					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.12.10",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.12.10",
-						"@babel/types": "^7.12.10",
+						"@babel/code-frame": "^7.12.11",
+						"@babel/generator": "^7.12.11",
+						"@babel/helper-function-name": "^7.12.11",
+						"@babel/helper-split-export-declaration": "^7.12.11",
+						"@babel/parser": "^7.12.11",
+						"@babel/types": "^7.12.12",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
-					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -1204,9 +1233,9 @@
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz",
-			"integrity": "sha512-d+/o30tJxFxrA1lhzJqiUcEJdI6jKlNregCv5bASeGf2Q4MXmnwH7viDo7nhx1/ohf09oaH8j1GVYG/e3Yqk6A==",
+			"version": "7.12.12",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.12.tgz",
+			"integrity": "sha512-nrz9y0a4xmUrRq51bYkWJIO5SBZyG2ys2qinHsN0zHDHVsUaModrkpyWWWXfGqYQmOL3x9sQIcTNN/pBGpo09A==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/helper-remap-async-to-generator": "^7.12.1",
@@ -1657,9 +1686,9 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.1.tgz",
-			"integrity": "sha512-zJyAC9sZdE60r1nVQHblcfCj29Dh2Y0DOvlMkcqSo0ckqjiCwNiUezUKw+RjOCwGfpLRwnAeQ2XlLpsnGkvv9w==",
+			"version": "7.12.12",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.12.tgz",
+			"integrity": "sha512-VOEPQ/ExOVqbukuP7BYJtI5ZxxsmegTwzZ04j1aF0dkSypGo9XpDHuOrABsJu+ie+penpSJheDJ11x1BEZNiyQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			},
@@ -1687,21 +1716,21 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.10.4",
-						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.10.4"
+						"@babel/helper-get-function-arity": "^7.12.10",
+						"@babel/template": "^7.12.7",
+						"@babel/types": "^7.12.11"
 					}
 				},
 				"@babel/helper-get-function-arity": {
@@ -1718,12 +1747,17 @@
 					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
 				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+					"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
 					"requires": {
-						"@babel/types": "^7.11.0"
+						"@babel/types": "^7.12.11"
 					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
 				},
 				"@babel/highlight": {
 					"version": "7.10.4",
@@ -1736,9 +1770,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.10.tgz",
-					"integrity": "sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA=="
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
 				},
 				"@babel/template": {
 					"version": "7.12.7",
@@ -1751,11 +1785,11 @@
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
-					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -1864,21 +1898,21 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.10.4",
-						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.10.4"
+						"@babel/helper-get-function-arity": "^7.12.10",
+						"@babel/template": "^7.12.7",
+						"@babel/types": "^7.12.11"
 					}
 				},
 				"@babel/helper-get-function-arity": {
@@ -1894,6 +1928,11 @@
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
 					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
 				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+				},
 				"@babel/highlight": {
 					"version": "7.10.4",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
@@ -1905,9 +1944,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.10.tgz",
-					"integrity": "sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA=="
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
 				},
 				"@babel/template": {
 					"version": "7.12.7",
@@ -1920,11 +1959,11 @@
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
-					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -2269,15 +2308,15 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.12.10",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.10.tgz",
-			"integrity": "sha512-Gz9hnBT/tGeTE2DBNDkD7BiWRELZt+8lSysHuDwmYXUIvtwZl0zI+D6mZgXZX0u8YBlLS4tmai9ONNY9tjRgRA==",
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.11.tgz",
+			"integrity": "sha512-j8Tb+KKIXKYlDBQyIOy4BLxzv1NUOwlHfZ74rvW+Z0Gp4/cI2IMDPBWAgWceGcE7aep9oL/0K9mlzlMGxA8yNw==",
 			"requires": {
 				"@babel/compat-data": "^7.12.7",
 				"@babel/helper-compilation-targets": "^7.12.5",
 				"@babel/helper-module-imports": "^7.12.5",
 				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-validator-option": "^7.12.1",
+				"@babel/helper-validator-option": "^7.12.11",
 				"@babel/plugin-proposal-async-generator-functions": "^7.12.1",
 				"@babel/plugin-proposal-class-properties": "^7.12.1",
 				"@babel/plugin-proposal-dynamic-import": "^7.12.1",
@@ -2306,7 +2345,7 @@
 				"@babel/plugin-transform-arrow-functions": "^7.12.1",
 				"@babel/plugin-transform-async-to-generator": "^7.12.1",
 				"@babel/plugin-transform-block-scoped-functions": "^7.12.1",
-				"@babel/plugin-transform-block-scoping": "^7.12.1",
+				"@babel/plugin-transform-block-scoping": "^7.12.11",
 				"@babel/plugin-transform-classes": "^7.12.1",
 				"@babel/plugin-transform-computed-properties": "^7.12.1",
 				"@babel/plugin-transform-destructuring": "^7.12.1",
@@ -2336,7 +2375,7 @@
 				"@babel/plugin-transform-unicode-escapes": "^7.12.1",
 				"@babel/plugin-transform-unicode-regex": "^7.12.1",
 				"@babel/preset-modules": "^0.1.3",
-				"@babel/types": "^7.12.10",
+				"@babel/types": "^7.12.11",
 				"core-js-compat": "^3.8.0",
 				"semver": "^5.5.0"
 			},
@@ -2354,12 +2393,22 @@
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
 					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
 				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+				},
+				"@babel/helper-validator-option": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz",
+					"integrity": "sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw=="
+				},
 				"@babel/types": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
-					"integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -4278,7 +4327,8 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
 					"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"find-cache-dir": {
 					"version": "3.3.1",
@@ -4627,6 +4677,7 @@
 					"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
 					"integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"chalk": "^4.1.0",
 						"hash-sum": "^2.0.0",
@@ -4638,6 +4689,7 @@
 							"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
 							"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"ansi-styles": "^4.1.0",
 								"supports-color": "^7.1.0"
@@ -4647,13 +4699,15 @@
 							"version": "4.0.0",
 							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 							"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"loader-utils": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
 							"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"big.js": "^5.2.2",
 								"emojis-list": "^3.0.0",
@@ -4665,6 +4719,7 @@
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 							"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"has-flag": "^4.0.0"
 							}
@@ -6529,7 +6584,6 @@
 			"version": "4.16.1",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.1.tgz",
 			"integrity": "sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==",
-			"dev": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30001173",
 				"colorette": "^1.2.1",
@@ -6541,14 +6595,12 @@
 				"caniuse-lite": {
 					"version": "1.0.30001173",
 					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001173.tgz",
-					"integrity": "sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw==",
-					"dev": true
+					"integrity": "sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw=="
 				},
 				"electron-to-chromium": {
 					"version": "1.3.635",
 					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.635.tgz",
-					"integrity": "sha512-RRriZOLs9CpW6KTLmgBqyUdnY0QNqqWs0HOtuQGGEMizOTNNn1P7sGRBxARnUeLejOsgwjDyRqT3E/CSst02ZQ==",
-					"dev": true
+					"integrity": "sha512-RRriZOLs9CpW6KTLmgBqyUdnY0QNqqWs0HOtuQGGEMizOTNNn1P7sGRBxARnUeLejOsgwjDyRqT3E/CSst02ZQ=="
 				}
 			}
 		},
@@ -7789,41 +7841,14 @@
 			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
 		},
 		"core-js-compat": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.1.tgz",
-			"integrity": "sha512-a16TLmy9NVD1rkjUGbwuyWkiDoN0FDpAwrfLONvHFQx0D9k7J9y0srwMT8QP/Z6HE3MIFaVynEeYwZwPX1o5RQ==",
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.2.tgz",
+			"integrity": "sha512-LO8uL9lOIyRRrQmZxHZFl1RV+ZbcsAkFWTktn5SmH40WgLtSNYN4m4W2v9ONT147PxBY/XrRhrWq8TlvObyUjQ==",
 			"requires": {
-				"browserslist": "^4.15.0",
+				"browserslist": "^4.16.0",
 				"semver": "7.0.0"
 			},
 			"dependencies": {
-				"browserslist": {
-					"version": "4.16.0",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
-					"integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
-					"requires": {
-						"caniuse-lite": "^1.0.30001165",
-						"colorette": "^1.2.1",
-						"electron-to-chromium": "^1.3.621",
-						"escalade": "^3.1.1",
-						"node-releases": "^1.1.67"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30001165",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz",
-					"integrity": "sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA=="
-				},
-				"electron-to-chromium": {
-					"version": "1.3.625",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.625.tgz",
-					"integrity": "sha512-CsLk/r0C9dAzVPa9QF74HIXduxaucsaRfqiOYvIv2PRhvyC6EOqc/KbpgToQuDVgPf3sNAFZi3iBu4vpGOwGag=="
-				},
-				"node-releases": {
-					"version": "1.1.67",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-					"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
-				},
 				"semver": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
@@ -14782,8 +14807,7 @@
 		"node-releases": {
 			"version": "1.1.69",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.69.tgz",
-			"integrity": "sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA==",
-			"dev": true
+			"integrity": "sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA=="
 		},
 		"node-sass": {
 			"version": "5.0.0",
@@ -17187,9 +17211,9 @@
 			"integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A=="
 		},
 		"regjsparser": {
-			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
-			"integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.6.tgz",
+			"integrity": "sha512-jjyuCp+IEMIm3N1H1LLTJW1EISEJV9+5oHdEyrt43Pg9cDSb6rrLZei2cVWpl0xTjmmlpec/lEQGYgM7xfpGCQ==",
 			"requires": {
 				"jsesc": "~0.5.0"
 			},

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.12.10",
 		"@babel/plugin-syntax-dynamic-import": "^7.8.3",
-		"@babel/preset-env": "^7.12.10",
+		"@babel/preset-env": "^7.12.11",
 		"@babel/runtime": "^7.12.5",
 		"@nextcloud/browserslist-config": "^1.0.0",
 		"@nextcloud/eslint-config": "^1.2.0",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -62,6 +62,17 @@ module.exports = {
 					'@nextcloud/event-bus',
 					'webdav',
 				]),
+				options: {
+					plugins: ['add-module-exports'],
+					presets: [
+						/**
+						 * From "add-module-exports" documentation:
+						 * "webpack doesn't perform commonjs transformation for
+						 * codesplitting. Need to set commonjs conversion."
+						 */
+						['@babel/env', { modules: 'commonjs' }],
+					],
+				},
 			},
 			{
 				/**


### PR DESCRIPTION
Update @babel/preset-env to 7.12.11 has revealed an issue with the event
bus library related to the CommonJS format.

The webpack config was adjusted to properly load CommonJS libraries.

Fixes https://github.com/nextcloud/spreed/issues/4818