### PR TITLE
Allow line breaks and links in the description

### DIFF
--- a/src/components/RightSidebar/Description/Description.vue
+++ b/src/components/RightSidebar/Description/Description.vue
@@ -242,8 +242,8 @@ export default {
 			if (!this.canSubmit) {
 				return
 			}
-			// Remove newlines and whitespaces.
-			this.descriptionText = this.descriptionText.replace(/\r\n|\n|\r/gm, '').trim()
+			// Remove leading/trailing whitespaces.
+			this.descriptionText = this.descriptionText.replace(/\r\n|\n|\r/gm, '\n').trim()
 			// Submit description
 			this.$emit('submit:description', this.descriptionText)
 			/**


### PR DESCRIPTION
- [x] Allow line breaks in descriptions as discussed with @jancborchardt 
- [x] Make links clickable
    - [x] Requires vue update https://github.com/nextcloud/nextcloud-vue/pull/1669

Fix #4950 