### PR TITLE
Fix "user has avatar" flag set as false for default user avatars

### DIFF
--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -209,13 +209,10 @@ export default {
 		}
 
 		try {
-			const response = await axios.get(generateUrl(`avatar/${this.user}/300`))
-			if (response.headers[`x-nc-iscustomavatar`] === '1') {
-				this.hasPicture = true
-				setUserHasAvatar(this.user, true)
-			} else {
-				setUserHasAvatar(this.user, false)
-			}
+			await axios.get(generateUrl(`avatar/${this.user}/300`))
+
+			this.hasPicture = true
+			setUserHasAvatar(this.user, true)
 		} catch (exception) {
 			console.debug(exception)
 		}


### PR DESCRIPTION
Follow up to #4379

The avatar endpoint returns a picture for both default and custom avatars, and [the Avatar component does not differentiate between them; as long as a picture is returned by the endpoint the "user has avatar" flag is set to true](https://github.com/nextcloud/nextcloud-vue/commit/15c72125d218add990b1d460a15d528b2736321f).

However, the VideoBackground component only considered an avatar as having a picture if it was a custom picture, so it would not show the picture if it was not previously loaded (which should not happen in practice, as Avatar components were loaded before the call was started).
