### PR TITLE
Fix open conversations heading

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -47,7 +47,7 @@
 			<template v-if="isSearching">
 				<template v-if="!listedConversationsLoading && searchResultsListedConversations.length > 0">
 					<Caption
-						:title="t('spreed', 'Listed conversations')" />
+						:title="t('spreed', 'Open conversations')" />
 					<Conversation
 						v-for="item of searchResultsListedConversations"
 						:key="item.id"
@@ -329,7 +329,7 @@ export default {
 				if (CancelableRequest.isCancel(exception)) {
 					return
 				}
-				console.error('Error searching for listed conversations', exception)
+				console.error('Error searching for open conversations', exception)
 				showError(t('spreed', 'An error occurred while performing the search'))
 			}
 		},


### PR DESCRIPTION
### Steps
1. Open a conversation:
![Bildschirmfoto von 2021-01-19 16-56-29](https://user-images.githubusercontent.com/213943/105059293-69594c00-5a77-11eb-9be1-a05c09eab9b5.png)

2. Search as another user:
![Bildschirmfoto von 2021-01-19 16-56-36](https://user-images.githubusercontent.com/213943/105059316-6fe7c380-5a77-11eb-900b-1ba331eac465.png)

### Before
It said "Listed conversations"

Was missed in #4771 