### PR TITLE
Remove "unsupported browser" warning for Opera

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ If you have suggestions or problems, please [open an issue](https://github.com/n
 |---|---|
 | Firefox | ✔️ 52 or later |
 | Chrome/Chromium | ✔️ 49 or later |
+| Opera | ✔️ 72 or later |
 | Edge | ⚠️ Latest versions <br> 🎤 Speakers are not promoted <br> 🏷 Name changes while a call is on-going are not reflected |
 | Safari | ⚠️ 12 or later <br> ❌ No screensharing support <br> 🖥 Viewing screens of others' work |
 

--- a/src/mixins/browserCheck.js
+++ b/src/mixins/browserCheck.js
@@ -48,6 +48,9 @@ const browserCheck = {
 		isChrome() {
 			return this.browser.name === 'Chrome' || this.browser.name === 'Chromium'
 		},
+		isOpera() {
+			return this.browser.name === 'Opera'
+		},
 		isSafari() {
 			return this.browser.name === 'Safari' || this.browser.name === 'Mobile Safari'
 		},
@@ -65,6 +68,7 @@ const browserCheck = {
 		isFullySupported() {
 			return (this.isFirefox && this.majorVersion >= 52)
 			|| (this.isChrome && this.majorVersion >= 49)
+			|| (this.isOpera && this.majorVersion >= 72)
 			|| (this.isSafari && this.majorVersion >= 12)
 			|| this.isEdge
 		},
@@ -72,12 +76,13 @@ const browserCheck = {
 		blockCalls() {
 			return (this.isFirefox && this.majorVersion < 52)
 			|| (this.isChrome && this.majorVersion < 49)
+			|| (this.isOpera && this.majorVersion < 72)
 			|| (this.isSafari && this.majorVersion < 12)
 			|| this.isIE
 		},
 		// Used both in the toast and in the call button tooltip
 		unsupportedWarning() {
-			return t('spreed', "The browser you're using is not fully supported by Nextcloud Talk. Please use the latest version of Mozilla Firefox, Microsoft Edge, Google Chrome or Apple Safari.")
+			return t('spreed', "The browser you're using is not fully supported by Nextcloud Talk. Please use the latest version of Mozilla Firefox, Microsoft Edge, Google Chrome, Opera or Apple Safari.")
 		},
 		// Used in CallButton.vue
 		callButtonTooltipText() {


### PR DESCRIPTION
This adds Opera to the popup  "The browser you're using is not fully supported by Nextcloud Talk. Please use the latest version of Mozilla Firefox, Microsoft Edge, Google Chrome or Apple Safari." and removes the popup (for Opera).

Note: Opera v36 is based on Chromium v49.