### PR TITLE
Bump @nextcloud-vue to 3.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3251,9 +3251,9 @@
 			}
 		},
 		"@nextcloud/vue": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-3.4.0.tgz",
-			"integrity": "sha512-xUI2CHQwNxmr42ewqlgWBUCUqH4PKsbMloE0S8y1NYYihth5MA0cutRJigP2qDv8n412YiHbrFfeoTh44f9loA==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-3.5.0.tgz",
+			"integrity": "sha512-2hDn9sPwQ6J0zxqXOYZYglhUynO4VojGa95/FLp+XHVCd+wmEKRZBw4yoQ61vQASMLYpjxgloQGr9CL2wuU3nw==",
 			"requires": {
 				"@nextcloud/auth": "^1.2.3",
 				"@nextcloud/axios": "^1.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3251,9 +3251,9 @@
 			}
 		},
 		"@nextcloud/vue": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-3.5.0.tgz",
-			"integrity": "sha512-2hDn9sPwQ6J0zxqXOYZYglhUynO4VojGa95/FLp+XHVCd+wmEKRZBw4yoQ61vQASMLYpjxgloQGr9CL2wuU3nw==",
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-3.5.1.tgz",
+			"integrity": "sha512-ML9ufnZzIpFaA3EFNBsbs8DsFUSUV5odmDxEv+AIN0vXQAOpvAbRMyytDoMEKlWy1xQ9l83xJHig4NcCL5t99Q==",
 			"requires": {
 				"@nextcloud/auth": "^1.2.3",
 				"@nextcloud/axios": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"@nextcloud/l10n": "^1.4.1",
 		"@nextcloud/moment": "^1.1.1",
 		"@nextcloud/router": "^1.2.0",
-		"@nextcloud/vue": "^3.4.0",
+		"@nextcloud/vue": "^3.5.0",
 		"@nextcloud/vue-dashboard": "^1.0.1",
 		"attachmediastream": "^2.1.0",
 		"crypto-js": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"@nextcloud/l10n": "^1.4.1",
 		"@nextcloud/moment": "^1.1.1",
 		"@nextcloud/router": "^1.2.0",
-		"@nextcloud/vue": "^3.5.0",
+		"@nextcloud/vue": "^3.5.1",
 		"@nextcloud/vue-dashboard": "^1.0.1",
 		"attachmediastream": "^2.1.0",
 		"crypto-js": "^4.0.0",


### PR DESCRIPTION
Brings in the updated Avatar component which now uses Popover.

Fixes issue with dropdown menu overlap with other avatars in the
messages list.

Fixes https://github.com/nextcloud/spreed/issues/4147