### PR TITLE
allow some more padding for the search abort button

### DIFF
--- a/src/components/LeftSidebar/SearchBox/SearchBox.vue
+++ b/src/components/LeftSidebar/SearchBox/SearchBox.vue
@@ -139,7 +139,7 @@ export default {
 }
 
 .abort-search {
-	margin-left: -28px;
+	margin-left: -34px;
 	z-index: 1;
 	border: none;
 	background-color: transparent


### PR DESCRIPTION
before

![talk_before](https://user-images.githubusercontent.com/1804221/105179854-21473180-5b2a-11eb-8c5a-471ae6aae0ee.png)

after
![talk_after](https://user-images.githubusercontent.com/1804221/105179859-23a98b80-5b2a-11eb-964c-8ae16d3efdd6.png)
