### PR TITLE
Close at-mention dropdown on blur

### DIFF
--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -85,6 +85,7 @@
 			@shortkey="focusInput"
 			@keydown.enter="handleKeydownEnter"
 			@keydown.esc.prevent="handleKeydownEsc"
+			@blur="onBlur"
 			@paste="onPaste" />
 	</At>
 </template>
@@ -249,6 +250,15 @@ export default {
 		EventBus.$off('focusChatInput', this.focusInput)
 	},
 	methods: {
+		onBlur() {
+			// requires a short delay to avoid blocking click event handlers
+			// from vue-at which also have some delay in place...
+			// a setTimeout was recommended by the library author here:
+			// https://github.com/fritx/vue-at/issues/114#issuecomment-565777450
+			setTimeout(() => {
+				this.$refs.at.closePanel()
+			}, 100)
+		},
 		onPaste(e) {
 			e.preventDefault()
 


### PR DESCRIPTION
When clicking outside the at-mention dropdown or exiting the input
field, the at-mention dropdown is now closed automatically.

Fixes https://github.com/nextcloud/spreed/issues/2758

Also see https://github.com/nextcloud/spreed/issues/2758#issuecomment-763488114
