### PR TITLE
Fix scrolling chat when in the background

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -588,11 +588,24 @@ export default {
 		 */
 		smoothScrollToBottom() {
 			this.$nextTick(function() {
-				this.scroller.scrollTo({
-					top: this.scroller.scrollHeight,
-					behavior: 'smooth',
-					 })
-				this.setChatScrolledToBottom(true)
+				if (this.$store.getters.windowIsVisible()) {
+					// scrollTo is used when the user is watching
+					this.scroller.scrollTo({
+						top: this.scroller.scrollHeight,
+						behavior: 'smooth',
+					})
+					this.setChatScrolledToBottom(true)
+				} else {
+					// Otherwise we jump half a message and stop autoscrolling, so the user can read up
+					if (this.scroller.scrollHeight - this.scroller.scrollTop - this.scroller.offsetHeight < 40) {
+						// Single new line from the previous author is 35px so scroll half a line
+						this.scroller.scrollTop += 10
+					} else {
+						// Single new line from the new author is 75px so scroll half an avatar
+						this.scroller.scrollTop += 40
+					}
+					this.setChatScrolledToBottom(false)
+				}
 			})
 		},
 		/**


### PR DESCRIPTION
Before scrollTo() was used, but this does not work when the window is not visible.
So now when the chat is in the background we scroll only half a line and stop following.
The user will see that something happened and have the anchor to jump to the bottom.

Same author (half a line) | New author (half avatar)
---|---
![Bildschirmfoto von 2021-01-20 16-35-17](https://user-images.githubusercontent.com/213943/105198441-f7980580-5b3d-11eb-954f-f4e096ddc378.png) | ![Bildschirmfoto von 2021-01-20 16-33-34](https://user-images.githubusercontent.com/213943/105198382-e4853580-5b3d-11eb-8786-6bdc4ea18f2b.png)

cc @ma12-co @jancborchardt  The main question is if the "scroll only half" behaviour is actually wanted, or if we should just scrolldown fully (as it was attempted to, but didn't do because scrollTo() only works on visible windows)