### PR TITLE
Add padding for local video in last grid page

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -88,6 +88,10 @@
 								Dev mode on ;-)
 							</h1>
 						</template>
+						<div
+							v-for="video in paddingVideos"
+							:key="video"
+							class="video" />
 						<LocalVideo
 							v-if="!isStripe"
 							ref="localVideo"
@@ -135,6 +139,7 @@
 					<p>GRID INFO</p>
 					<p>Videos (total): {{ videosCount }}</p>
 					<p>Displayed videos n: {{ displayedVideos.length }}</p>
+					<p>Padding videos n: {{ paddingVideos.length }}</p>
 					<p>Max per page: ~{{ videosCap }}</p>
 					<p>Grid width: {{ gridWidth }}</p>
 					<p>Grid height: {{ gridHeight }}</p>
@@ -333,6 +338,29 @@ export default {
 			}
 
 			return this.videos.slice(this.currentPage * this.slots, (this.currentPage + 1) * this.slots)
+		},
+
+		// Dummy array to add padding in the last page of the grid view and show
+		// the local video at the same position as in the other pages.
+		// In practice the padding could be added unconditionally, as it would
+		// have effect only in the last page of the main grid, but this should
+		// avoid recomputing the property when not needed.
+		paddingVideos() {
+			if (this.isStripe) {
+				return []
+			}
+
+			if (this.currentPage !== this.numberOfPages - 1) {
+				return []
+			}
+
+			if (this.currentPage === 0) {
+				return []
+			}
+
+			const numberOfPaddingVideos = this.slots - this.displayedVideos.length
+
+			return Array(numberOfPaddingVideos)
 		},
 
 		isLessThanTwoVideos() {


### PR DESCRIPTION
Follow up to #4958
Fixes issue described in https://github.com/nextcloud/spreed/pull/4991#issuecomment-764739118

When the main grid is paginated the last page has less videos than the others. As the local video is shown after the remote videos this caused the local video to be shown at a different position than the rest of the pages. To solve this now empty divs are added to the last page of the grid as padding to fill the empty space in the grid and thus place the local video at the same position as in the other pages.
