### PR TITLE
New button to disable lobby in sidebar

### DIFF
--- a/src/components/RightSidebar/LobbyStatus.vue
+++ b/src/components/RightSidebar/LobbyStatus.vue
@@ -1,0 +1,65 @@
+<!--
+  - @copyright Copyright (c) 2020 Vincent Petry <vincent@nextcloud.com>
+  -
+  - @author Vincent Petry <vincent@nextcloud.com>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+	<button @click="disableLobby">
+		{{ t('spreed', 'Disable lobby' ) }}
+	</button>
+</template>
+
+<script>
+import { showError, showSuccess } from '@nextcloud/dialogs'
+
+export default {
+	name: 'LobbyStatus',
+
+	props: {
+		token: {
+			type: String,
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			isLobbyStateLoading: false,
+		}
+	},
+
+	methods: {
+		async disableLobby() {
+			this.isLobbyStateLoading = true
+			try {
+				await this.$store.dispatch('toggleLobby', {
+					token: this.token,
+					enableLobby: false,
+				})
+				showSuccess(t('spreed', 'You opened the conversation to everyone'))
+			} catch (e) {
+				console.error('Error occurred when opening the conversation to everyone', e)
+				showError(t('spreed', 'Error occurred when opening the conversation to everyone'))
+			}
+			this.isLobbyStateLoading = false
+		},
+	},
+}
+
+</script>

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -35,16 +35,18 @@
 		@submit-title="handleSubmitTitle"
 		@dismiss-editing="dismissEditing"
 		@close="handleClose">
-		<Description
-			v-if="showDescription"
-			slot="description"
-			:editable="canFullModerate"
-			:description="description"
-			:editing="isEditingDescription"
-			:loading="isDescriptionLoading"
-			:placeholder="t('spreed', 'Add a description for this conversation')"
-			@submit:description="handleUpdateDescription"
-			@update:editing="handleEditDescription" />
+		<template slot="description">
+			<Description
+				v-if="showDescription"
+				:editable="canFullModerate"
+				:description="description"
+				:editing="isEditingDescription"
+				:loading="isDescriptionLoading"
+				:placeholder="t('spreed', 'Add a description for this conversation')"
+				@submit:description="handleUpdateDescription"
+				@update:editing="handleEditDescription" />
+			<LobbyStatus v-if="canFullModerate && hasLobbyEnabled" :token="token" />
+		</template>
 		<AppSidebarTab
 			v-if="showChatInSidebar"
 			id="chat"
@@ -102,6 +104,7 @@ import isInLobby from '../../mixins/isInLobby'
 import SetGuestUsername from '../SetGuestUsername'
 import SipSettings from './SipSettings'
 import Description from './Description/Description'
+import LobbyStatus from './LobbyStatus'
 import { EventBus } from '../../services/EventBus'
 import { showError } from '@nextcloud/dialogs'
 
@@ -116,6 +119,7 @@ export default {
 		SetGuestUsername,
 		SipSettings,
 		Description,
+		LobbyStatus,
 	},
 
 	mixins: [
@@ -222,6 +226,11 @@ export default {
 				return this.description !== ''
 			}
 		},
+
+		hasLobbyEnabled() {
+			return this.conversation.lobbyState === WEBINAR.LOBBY.NON_MODERATORS
+		},
+
 	},
 
 	watch: {
@@ -319,6 +328,10 @@ export default {
  * nextcloud-vue for ".app-sidebar". */
 #app-sidebar {
 	display: flex;
+}
+
+::v-deep .app-sidebar-header__description {
+	flex-direction: column;
 }
 
 .app-sidebar-tabs__content #tab-chat {


### PR DESCRIPTION
<img width="563" alt="image" src="https://user-images.githubusercontent.com/277525/105479435-bbcb8000-5ca4-11eb-88b4-c0df2af02ffc.png">

Fixes https://github.com/nextcloud/spreed/issues/4981
Fixes https://github.com/nextcloud/spreed/issues/4982

Note: I tried adding more information like the remaining time until meeting start, but it would take too much space and make the sidebar look too crowded. Also the moment library doesn't generate nice compact human readable texts for remaining durations. So if we do want this: needs further research.