### PR TITLE
Add hover effects for grid collapser

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -847,10 +847,16 @@ button.stripe--collapse {
 	border: 0;
 	background: none;
 	opacity: .7;
+	padding: 0;
 
-	&:hover,
-	&:focus {
-		opacity: 1;
+	.app-content:hover & {
+		background-color: rgba(0, 0, 0, 0.1) !important;
+
+		&:hover,
+		&:focus {
+			opacity: 1;
+			background-color: rgba(0, 0, 0, 0.2) !important;
+		}
 	}
 
 	&:active {


### PR DESCRIPTION
Before | After
---|---
![Peek 2021-01-26 10-56](https://user-images.githubusercontent.com/213943/105829964-3d811d80-5fc5-11eb-8361-4613020601a4.gif) | ![Peek 2021-01-26 10-54](https://user-images.githubusercontent.com/213943/105829969-3e19b400-5fc5-11eb-8e96-011cee4de7bf.gif)

The main problem is when the button is on e.g. white screenshare, see #5016  for screenshots


Fix #5016