### PR TITLE
Allow other apps to register message actions

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -119,6 +119,16 @@ the main body of the message as well as a quote.
 						@click.stop="handleReply">
 						{{ t('spreed', 'Reply') }}
 					</ActionButton>
+					<template
+						v-for="action in messageActions">
+						<ActionButton
+							:key="action.label"
+							:icon="action.icon"
+							:close-after-click="true"
+							@click="action.callback(messageAPIData)">
+							{{ action.label }}
+						</ActionButton>
+					</template>
 				</Actions>
 			</div>
 		</div>
@@ -287,6 +297,10 @@ export default {
 	},
 
 	computed: {
+		messageObject() {
+			return this.$store.getters.message(this.token, this.id)
+		},
+
 		hasActions() {
 			return this.isReplyable && !this.isConversationReadOnly
 		},
@@ -430,6 +444,18 @@ export default {
 				return t('spreed', 'Not enough free space to upload file')
 			}
 			return t('spreed', 'You can not send messages to this conversation at the moment')
+		},
+
+		messageActions() {
+			return this.$store.getters.messageActions
+		},
+
+		messageAPIData() {
+			return {
+				message: this.messageObject,
+				metadata: this.conversation,
+				apiVersion: 'v3',
+			}
 		},
 
 	},

--- a/src/init.js
+++ b/src/init.js
@@ -1,0 +1,48 @@
+/**
+ * @copyright Copyright (c) 2020 John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @author Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// The purpose of this file is to wrap the logic shared by the different talk
+// entry points
+
+import store from './store'
+
+if (!window.OCA.Talk) {
+	window.OCA.Talk = {}
+}
+
+/**
+ * Frontend message API for adding actions to talk messages.
+ * @param {*} Object the wrapping object.
+ * @param {String} label the action label.
+ * @param {Function} callback the callback function. This function will receive
+ * the messageAPIData object as a parameter and be triggered by a click on the
+ * action.
+ * @param {String} icon the action label. E.g. "icon-reply"
+ */
+window.OCA.Talk.registerMessageAction = ({ label, callback, icon }) => {
+	const messageAction = {
+		label,
+		callback,
+		icon,
+	}
+	store.dispatch('addMessageAction', messageAction)
+}

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,7 @@
 
 import Vue from 'vue'
 import App from './App'
+import './init'
 
 // Store
 import Vuex from 'vuex'

--- a/src/mainFilesSidebar.js
+++ b/src/mainFilesSidebar.js
@@ -25,6 +25,7 @@
 import Vue from 'vue'
 import FilesSidebarCallViewApp from './FilesSidebarCallViewApp'
 import FilesSidebarTabApp from './FilesSidebarTabApp'
+import './init'
 
 // Store
 import Vuex from 'vuex'

--- a/src/mainFilesSidebarLoader.js
+++ b/src/mainFilesSidebarLoader.js
@@ -22,6 +22,7 @@
 
 import FilesSidebarCallView from './views/FilesSidebarCallView'
 import { leaveConversation } from './services/participantsService'
+import './init'
 
 const isEnabled = function(fileInfo) {
 	if (fileInfo && !fileInfo.isDirectory()) {

--- a/src/mainPublicShareAuthSidebar.js
+++ b/src/mainPublicShareAuthSidebar.js
@@ -21,6 +21,7 @@
 import Vue from 'vue'
 import PublicShareAuthRequestPasswordButton from './PublicShareAuthRequestPasswordButton'
 import PublicShareAuthSidebar from './PublicShareAuthSidebar'
+import './init'
 
 // Store
 import Vuex from 'vuex'

--- a/src/mainPublicShareSidebar.js
+++ b/src/mainPublicShareSidebar.js
@@ -20,6 +20,7 @@
 
 import Vue from 'vue'
 import PublicShareSidebar from './PublicShareSidebar'
+import './init'
 
 // Store
 import Vuex from 'vuex'

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -36,6 +36,7 @@ import sidebarStore from './sidebarStore'
 import talkHashStore from './talkHashStore'
 import tokenStore from './tokenStore'
 import windowVisibilityStore from './windowVisibilityStore'
+import messageActionsStore from './messageActionsStore'
 
 Vue.use(Vuex)
 
@@ -57,6 +58,7 @@ export default new Store({
 		talkHashStore,
 		tokenStore,
 		windowVisibilityStore,
+		messageActionsStore,
 	},
 
 	mutations,

--- a/src/store/messageActionsStore.js
+++ b/src/store/messageActionsStore.js
@@ -1,0 +1,44 @@
+/**
+ * @copyright Copyright (c) 2020 Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @author Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+const state = {
+	messageActions: [],
+}
+
+const getters = {
+	messageActions: (state) => {
+		return state.messageActions
+	},
+}
+
+const mutations = {
+	addMessageAction(state, messageAction) {
+		state.messageActions.push(messageAction)
+	},
+}
+
+const actions = {
+	addMessageAction({ commit }, messageAction) {
+		commit('addMessageAction', messageAction)
+	},
+}
+
+export default { state, mutations, getters, actions }


### PR DESCRIPTION
How to test: 

* Open the developer console and type:
```
window.OCA.Talk.registerMessageAction({
	label: 'test',
	callback: (messageAPIData) => console.log(messageAPIData),
	icon: 'icon-user',
})
```
* Open a message 3 dot menu;

* Click on the added action;

* Check if the response object is logged in the console

Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>