### PR TITLE
Hide upload button with zero quota

### DIFF
--- a/lib/TInitialState.php
+++ b/lib/TInitialState.php
@@ -98,17 +98,23 @@ trait TInitialState {
 		);
 
 		$attachmentFolder = $this->talkConfig->getAttachmentFolder($user->getUID());
+		$freeSpace = 0;
 
 		if ($attachmentFolder) {
 			try {
 				$userFolder = $rootFolder->getUserFolder($user->getUID());
 
-				if (!$userFolder->nodeExists($attachmentFolder)) {
-					$userFolder->newFolder($attachmentFolder);
+				try {
+					if (!$userFolder->nodeExists($attachmentFolder)) {
+						$userFolder->newFolder($attachmentFolder);
+					}
+
+					$freeSpace = $userFolder->get($attachmentFolder)->getFreeSpace();
+				} catch (NotPermittedException $e) {
+					$attachmentFolder = '/';
+					$this->serverConfig->setUserValue($user->getUID(), 'spreed', 'attachment_folder', '/');
+					$freeSpace = $userFolder->getFreeSpace();
 				}
-			} catch (NotPermittedException $e) {
-				$attachmentFolder = '/';
-				$this->serverConfig->setUserValue($user->getUID(), 'spreed', 'attachment_folder', '/');
 			} catch (NoUserException $e) {
 			}
 		}
@@ -116,6 +122,11 @@ trait TInitialState {
 		$this->initialState->provideInitialState(
 			'attachment_folder',
 			$attachmentFolder
+		);
+
+		$this->initialState->provideInitialState(
+			'attachment_folder_free_space',
+			$freeSpace
 		);
 
 		$this->initialState->provideInitialState(
@@ -144,6 +155,11 @@ trait TInitialState {
 
 		$this->initialState->provideInitialState(
 			'attachment_folder',
+			''
+		);
+
+		$this->initialState->provideInitialState(
+			'attachment_folder_free_space',
 			''
 		);
 

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -45,14 +45,14 @@
 						:aria-label="t('spreed', 'Share files to the conversation')"
 						:aria-haspopup="true">
 						<ActionButton
-							v-if="canShareAndUploadFiles"
+							v-if="canUploadFiles"
 							:close-after-click="true"
 							icon="icon-upload"
 							@click.prevent="clickImportInput">
 							{{ t('spreed', 'Upload new files') }}
 						</ActionButton>
 						<ActionButton
-							v-if="canShareAndUploadFiles"
+							v-if="canShareFiles"
 							:close-after-click="true"
 							icon="icon-folder"
 							@click.prevent="handleFileShare">
@@ -195,13 +195,19 @@ export default {
 			return this.$store.getters.getUserId() === null
 		},
 
-		canShareAndUploadFiles() {
-			const allowed = getCapabilities()?.spreed?.config?.attachments?.allowed
-			return allowed && !this.currentUserIsGuest && !this.isReadOnly
+		canShareFiles() {
+			return !this.currentUserIsGuest && !this.isReadOnly
 		},
 
-		attachmentFolder() {
-			return this.$store.getters.getAttachmentFolder()
+		canUploadFiles() {
+			const allowed = getCapabilities()?.spreed?.config?.attachments?.allowed
+			return allowed
+				&& this.attachmentFolderFreeSpace !== 0
+				&& this.canShareFiles
+		},
+
+		attachmentFolderFreeSpace() {
+			return this.$store.getters.getAttachmentFolderFreeSpace()
 		},
 	},
 

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -38,6 +38,7 @@
 				class="new-message-form"
 				@submit.prevent>
 				<div
+					v-if="canUploadFiles || canShareFiles"
 					class="new-message-form__button">
 					<Actions
 						default-icon="icon-clip-add-file"

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -31,6 +31,7 @@ import { shareFile } from '../services/filesSharingServices'
 
 const state = {
 	attachmentFolder: loadState('spreed', 'attachment_folder'),
+	attachmentFolderFreeSpace: loadState('spreed', 'attachment_folder_free_space'),
 	uploads: {
 	},
 	currentUploadId: undefined,
@@ -74,6 +75,11 @@ const getters = {
 	// gets the current attachment folder
 	getAttachmentFolder: (state) => () => {
 		return state.attachmentFolder
+	},
+
+	// gets the current attachment folder
+	getAttachmentFolderFreeSpace: (state) => () => {
+		return state.attachmentFolderFreeSpace
 	},
 
 	uploadProgress: (state) => (uploadId, index) => {


### PR DESCRIPTION
Whenever a user has zero quota, for example like guest app users, don't
display the upload button.

The quota value is retrieved for the attachment folder.

Fixes https://github.com/nextcloud/spreed/issues/4138