### PR TITLE
Prevent duplicate call summaries

### DIFF
--- a/lib/Room.php
+++ b/lib/Room.php
@@ -705,7 +705,8 @@ class Room {
 		$query->update('talk_rooms')
 			->set('active_guests', $query->createNamedParameter(0))
 			->set('active_since', $query->createNamedParameter(null, 'datetime'))
-			->where($query->expr()->eq('id', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)));
+			->where($query->expr()->eq('id', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->isNotNull('active_since'));
 
 		$this->activeGuests = 0;
 		$this->activeSince = null;


### PR DESCRIPTION
### Steps
1. Add breakpoint at
https://github.com/nextcloud/spreed/blob/459858a69527311bf60ffa553d45ba2a7eeec032/lib/Activity/Listener.php#L111
2. Add breakpoint at
https://github.com/nextcloud/spreed/blob/459858a69527311bf60ffa553d45ba2a7eeec032/lib/Activity/Listener.php#L125
3. Start a call with 2 users
4. Leave call with both users
5. Wait until both requests are at breakpoint 1
6. Wait until both requests are at breakpoint 2
7. Request 1 step until
https://github.com/nextcloud/spreed/blob/459858a69527311bf60ffa553d45ba2a7eeec032/lib/Activity/Listener.php#L132
8. Request 2 step and and it should return on
https://github.com/nextcloud/spreed/blob/459858a69527311bf60ffa553d45ba2a7eeec032/lib/Activity/Listener.php#L129

Before this PR you will not enter the if in request 2 and therefor generate 2 call summaries