### PR TITLE
Bump @nextcloud/vue from 3.5.3 to 3.5.4 and fix scrollbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3251,9 +3251,9 @@
 			}
 		},
 		"@nextcloud/vue": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-3.5.3.tgz",
-			"integrity": "sha512-jw1H27ExPtj5R+LqsDydKGx60yZblQVpUaFyme7nxeNxhD3sPv8QkeO6pX5/ebtb2ybB/BAVwOjthh0t+Pdkfw==",
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-3.5.4.tgz",
+			"integrity": "sha512-Rsli88Osx1upQHGls/Lpxzn9x4m0T9EaXsMIIxmxggblxsSn4IVoPiqqYIrgP2+p2fDMYYmPup6WMQ7F0Qul4A==",
 			"requires": {
 				"@nextcloud/auth": "^1.2.3",
 				"@nextcloud/axios": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"@nextcloud/l10n": "^1.4.1",
 		"@nextcloud/moment": "^1.1.1",
 		"@nextcloud/router": "^1.2.0",
-		"@nextcloud/vue": "^3.5.3",
+		"@nextcloud/vue": "^3.5.4",
 		"@nextcloud/vue-dashboard": "^1.0.1",
 		"attachmediastream": "^2.1.0",
 		"color.js": "^1.2.0",


### PR DESCRIPTION
Fixes scrollbar issue due to old workaround for popovers, which was
removed in that version.

Fixes https://github.com/nextcloud/spreed/issues/5045
