### PR TITLE
Allow to post in completely empty chats

### DIFF
--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -124,7 +124,9 @@ const mutations = {
 	 * @param {object} message the message;
 	 */
 	deleteMessage(state, message) {
-		Vue.delete(state.messages[message.token], message.id)
+		if (state.messages[message.token][message.id]) {
+			Vue.delete(state.messages[message.token], message.id)
+		}
 	},
 
 	/**
@@ -133,6 +135,9 @@ const mutations = {
 	 * @param {object} message the temporary message;
 	 */
 	addTemporaryMessage(state, message) {
+		if (!state.messages[message.token]) {
+			Vue.set(state.messages, message.token, {})
+		}
 		Vue.set(state.messages[message.token], message.id, message)
 	},
 


### PR DESCRIPTION
### Steps
1. Create a one to one chat
2. Delete all messages from `oc_comments`
3. Update last_message field in `oc_talk_rooms` to 0
4. Open the chat in the UI again
5. Try to post something

### Expected
📤

### Actual
💥 
```
[Vue warn]: Error in v-on handler (Promise/async): "TypeError: right-hand side of 'in' should be an object, got undefined"

found in

---> <AdvancedInput> at src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
       <NewMessageForm> at src/components/NewMessageForm/NewMessageForm.vue
         <ChatView> at src/components/ChatView.vue
           <MainView> at src/views/MainView.vue
             <AppContent>
               <Content>
                 <App> at src/App.vue
                   <Root>
```


This can currently only happen with conversations that where created be before we had chat.
But might be relevant in the future again when we allow to truncate the complete chat (for that we should also revisit the loading indicator thing, as it will always show atm when the messages array is empty, even though it is loaded already.