### PR TITLE
Replace call icons in buttons bar with material design icons

### DIFF
--- a/css/icons.scss
+++ b/css/icons.scss
@@ -64,12 +64,6 @@
 		&.icon-grid-view {
 			background-image: url(icon-color-path('toggle-pictures', 'actions', 'fff', 1, true));
 		}
-		&.icon-audio {
-			background-image: url(icon-color-path('audio', 'actions', 'fff', 1, true));
-		}
-		&.icon-audio-off {
-			background-image: url(icon-color-path('audio-off', 'actions', 'fff', 1, true));
-		}
 		&.icon-video {
 			background-image: url(icon-color-path('video', 'actions', 'fff', 1, true));
 		}

--- a/css/icons.scss
+++ b/css/icons.scss
@@ -64,12 +64,6 @@
 		&.icon-grid-view {
 			background-image: url(icon-color-path('toggle-pictures', 'actions', 'fff', 1, true));
 		}
-		&.icon-video {
-			background-image: url(icon-color-path('video', 'actions', 'fff', 1, true));
-		}
-		&.icon-video-off {
-			background-image: url(icon-color-path('video-off', 'actions', 'fff', 1, true));
-		}
 		&.icon-screen {
 			background-image: url(icon-color-path('screen', 'actions', 'fff', 1, true));
 		}

--- a/src/PublicShareAuthRequestPasswordButton.vue
+++ b/src/PublicShareAuthRequestPasswordButton.vue
@@ -113,7 +113,6 @@ export default {
 
 .request-password-wrapper .icon {
 	position: absolute;
-	top: 23px;
 	right: 23px;
 	pointer-events: none;
 }

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -782,7 +782,7 @@ export default {
 }
 
 #videos .videoContainer.speaking:not(.videoView) ::v-deep .nameIndicator,
-#videos .videoContainer.videoView.speaking ::v-deep .nameIndicator .icon-audio {
+#videos .videoContainer.videoView.speaking ::v-deep .nameIndicator .microphone-icon {
 	animation: pulse 1s;
 	animation-iteration-count: infinite;
 }

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -60,8 +60,21 @@
 				v-tooltip="screenSharingButtonTooltip"
 				:aria-label="screenSharingButtonAriaLabel"
 				:class="screenSharingButtonClass"
-				class="app-navigation-entry-utils-menu-button forced-white"
-				@click="toggleScreenSharingMenu" />
+				class="app-navigation-entry-utils-menu-button"
+				@click.stop="toggleScreenSharingMenu">
+				<Monitor
+					v-if="model.attributes.localScreen"
+					:size="24"
+					title=""
+					fill-color="#ffffff"
+					decorative />
+				<MonitorOff
+					v-if="!model.attributes.localScreen"
+					:size="24"
+					title=""
+					fill-color="#ffffff"
+					decorative />
+			</button>
 			<div id="screensharing-menu" :class="{ open: screenSharingMenuOpen }" class="app-navigation-entry-menu">
 				<ul>
 					<li v-if="!model.attributes.localScreen && splitScreenSharingMenu" id="share-screen-entry">
@@ -174,6 +187,8 @@ import Hand from 'vue-material-design-icons/Hand'
 import Microphone from 'vue-material-design-icons/Microphone'
 import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff'
 import MicrophoneOutline from 'vue-material-design-icons/MicrophoneOutline'
+import Monitor from 'vue-material-design-icons/Monitor'
+import MonitorOff from 'vue-material-design-icons/MonitorOff'
 import Video from 'vue-material-design-icons/Video'
 import VideoOff from 'vue-material-design-icons/VideoOff'
 import VideoOutline from 'vue-material-design-icons/VideoOutline'
@@ -206,6 +221,8 @@ export default {
 		'VideoIcon': Video,
 		VideoOff,
 		VideoOutline,
+		Monitor,
+		MonitorOff,
 	},
 
 	props: {
@@ -365,9 +382,7 @@ export default {
 
 		screenSharingButtonClass() {
 			return {
-				'icon-screen': this.model.attributes.localScreen,
 				'screensharing-disabled': !this.model.attributes.localScreen,
-				'icon-screen-off': !this.model.attributes.localScreen,
 			}
 		},
 
@@ -715,13 +730,9 @@ export default {
 <style lang="scss" scoped>
 @import '../../../assets/variables.scss';
 
-.forced-white {
-	filter: drop-shadow(1px 1px 4px var(--color-box-shadow));
-}
-
 #screensharing-menu {
 	bottom: 44px;
-	left: calc(50% - 40px);
+	left: calc(50% - 64px);
 	right: initial;
 	color: initial;
 	text-shadow: initial;
@@ -745,9 +756,7 @@ export default {
 	background-color: transparent;
 	border: none;
 	margin: 0;
-	width: 44px;
-	height: 44px;
-	background-size: 24px;
+	padding: 0 12px;
 }
 
 .buttons-bar #screensharing-menu button {

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -28,9 +28,14 @@
 					v-tooltip="audioButtonTooltip"
 					:aria-label="audioButtonAriaLabel"
 					:class="audioButtonClass"
-					class="forced-white"
 					@shortkey="toggleAudio"
-					@click="toggleAudio" />
+					@click="toggleAudio">
+					<component :is="audioButtonComponent"
+						:size="24"
+						title=""
+						fill-color="#ffffff"
+						decorative />
+				</button>
 				<span v-show="model.attributes.audioAvailable"
 					ref="volumeIndicator"
 					class="volume-indicator" />
@@ -161,6 +166,9 @@ import escapeHtml from 'escape-html'
 import { emit } from '@nextcloud/event-bus'
 import { showMessage } from '@nextcloud/dialogs'
 import Hand from 'vue-material-design-icons/Hand'
+import Microphone from 'vue-material-design-icons/Microphone'
+import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff'
+import MicrophoneOutline from 'vue-material-design-icons/MicrophoneOutline'
 import Popover from '@nextcloud/vue/dist/Components/Popover'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 import SpeakingWhileMutedWarner from '../../../utils/webrtc/SpeakingWhileMutedWarner'
@@ -184,6 +192,9 @@ export default {
 		ActionSeparator,
 		ActionButton,
 		Hand,
+		Microphone,
+		MicrophoneOff,
+		MicrophoneOutline,
 	},
 
 	props: {
@@ -231,11 +242,19 @@ export default {
 
 		audioButtonClass() {
 			return {
-				'icon-audio': this.model.attributes.audioAvailable && this.model.attributes.audioEnabled,
 				'audio-disabled': this.model.attributes.audioAvailable && !this.model.attributes.audioEnabled,
-				'icon-audio-off': !this.model.attributes.audioAvailable || !this.model.attributes.audioEnabled,
 				'no-audio-available': !this.model.attributes.audioAvailable,
 			}
+		},
+
+		audioButtonComponent() {
+			if (this.model.attributes.audioAvailable) {
+				if (this.model.attributes.audioEnabled) {
+					return 'Microphone'
+				}
+				return 'MicrophoneOff'
+			}
+			return 'MicrophoneOutline'
 		},
 
 		audioButtonTooltip() {
@@ -770,7 +789,7 @@ export default {
 	opacity: 0.7;
 }
 
-#muteWrapper .icon-audio-off + .volume-indicator {
+#muteWrapper .microphone-off-icon + .volume-indicator {
 	background: linear-gradient(0deg, gray, white 36px);
 }
 

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -30,7 +30,14 @@
 					:class="audioButtonClass"
 					@shortkey="toggleAudio"
 					@click.stop="toggleAudio">
-					<component :is="audioButtonComponent"
+					<Microphone
+						v-if="showMicrophoneOn"
+						:size="24"
+						title=""
+						fill-color="#ffffff"
+						decorative />
+					<MicrophoneOff
+						v-else
 						:size="24"
 						title=""
 						fill-color="#ffffff"
@@ -48,7 +55,14 @@
 				:class="videoButtonClass"
 				@shortkey="toggleVideo"
 				@click.stop="toggleVideo">
-				<component :is="videoButtonComponent"
+				<VideoIcon
+					v-if="showVideoOn"
+					:size="24"
+					title=""
+					fill-color="#ffffff"
+					decorative />
+				<VideoOff
+					v-else
 					:size="24"
 					title=""
 					fill-color="#ffffff"
@@ -186,12 +200,10 @@ import { showMessage } from '@nextcloud/dialogs'
 import Hand from 'vue-material-design-icons/Hand'
 import Microphone from 'vue-material-design-icons/Microphone'
 import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff'
-import MicrophoneOutline from 'vue-material-design-icons/MicrophoneOutline'
 import Monitor from 'vue-material-design-icons/Monitor'
 import MonitorOff from 'vue-material-design-icons/MonitorOff'
 import Video from 'vue-material-design-icons/Video'
 import VideoOff from 'vue-material-design-icons/VideoOff'
-import VideoOutline from 'vue-material-design-icons/VideoOutline'
 import Popover from '@nextcloud/vue/dist/Components/Popover'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 import SpeakingWhileMutedWarner from '../../../utils/webrtc/SpeakingWhileMutedWarner'
@@ -217,10 +229,8 @@ export default {
 		Hand,
 		Microphone,
 		MicrophoneOff,
-		MicrophoneOutline,
 		'VideoIcon': Video,
 		VideoOff,
-		VideoOutline,
 		Monitor,
 		MonitorOff,
 	},
@@ -275,14 +285,8 @@ export default {
 			}
 		},
 
-		audioButtonComponent() {
-			if (this.model.attributes.audioAvailable) {
-				if (this.model.attributes.audioEnabled) {
-					return 'Microphone'
-				}
-				return 'MicrophoneOff'
-			}
-			return 'MicrophoneOutline'
+		showMicrophoneOn() {
+			return this.model.attributes.audioAvailable && this.model.attributes.audioEnabled
 		},
 
 		audioButtonTooltip() {
@@ -338,14 +342,8 @@ export default {
 			}
 		},
 
-		videoButtonComponent() {
-			if (this.model.attributes.videoAvailable) {
-				if (this.model.attributes.videoEnabled) {
-					return 'VideoIcon'
-				}
-				return 'VideoOff'
-			}
-			return 'VideoOutline'
+		showVideoOn() {
+			return this.model.attributes.videoAvailable && this.model.attributes.videoEnabled
 		},
 
 		videoButtonTooltip() {

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -29,7 +29,7 @@
 					:aria-label="audioButtonAriaLabel"
 					:class="audioButtonClass"
 					@shortkey="toggleAudio"
-					@click="toggleAudio">
+					@click.stop="toggleAudio">
 					<component :is="audioButtonComponent"
 						:size="24"
 						title=""
@@ -46,9 +46,14 @@
 				v-tooltip="videoButtonTooltip"
 				:aria-label="videoButtonAriaLabel"
 				:class="videoButtonClass"
-				class="forced-white"
 				@shortkey="toggleVideo"
-				@click="toggleVideo" />
+				@click.stop="toggleVideo">
+				<component :is="videoButtonComponent"
+					:size="24"
+					title=""
+					fill-color="#ffffff"
+					decorative />
+			</button>
 			<button
 				v-if="!screenSharingButtonHidden"
 				id="screensharing-button"
@@ -169,6 +174,9 @@ import Hand from 'vue-material-design-icons/Hand'
 import Microphone from 'vue-material-design-icons/Microphone'
 import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff'
 import MicrophoneOutline from 'vue-material-design-icons/MicrophoneOutline'
+import Video from 'vue-material-design-icons/Video'
+import VideoOff from 'vue-material-design-icons/VideoOff'
+import VideoOutline from 'vue-material-design-icons/VideoOutline'
 import Popover from '@nextcloud/vue/dist/Components/Popover'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 import SpeakingWhileMutedWarner from '../../../utils/webrtc/SpeakingWhileMutedWarner'
@@ -195,6 +203,9 @@ export default {
 		Microphone,
 		MicrophoneOff,
 		MicrophoneOutline,
+		'VideoIcon': Video,
+		VideoOff,
+		VideoOutline,
 	},
 
 	props: {
@@ -305,11 +316,19 @@ export default {
 
 		videoButtonClass() {
 			return {
-				'icon-video': this.model.attributes.videoAvailable && this.model.attributes.videoEnabled,
 				'video-disabled': this.model.attributes.videoAvailable && !this.model.attributes.videoEnabled,
-				'icon-video-off': !this.model.attributes.videoAvailable || !this.model.attributes.videoEnabled,
 				'no-video-available': !this.model.attributes.videoAvailable,
 			}
+		},
+
+		videoButtonComponent() {
+			if (this.model.attributes.videoAvailable) {
+				if (this.model.attributes.videoEnabled) {
+					return 'VideoIcon'
+				}
+				return 'VideoOff'
+			}
+			return 'VideoOutline'
 		},
 
 		videoButtonTooltip() {
@@ -755,8 +774,10 @@ export default {
 
 .buttons-bar button.no-audio-available,
 .buttons-bar button.no-video-available {
-	opacity: .7;
-	cursor: not-allowed;
+	&, & * {
+		opacity: .7;
+		cursor: not-allowed;
+	}
 }
 
 .buttons-bar button.no-audio-available:active,

--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -95,9 +95,15 @@
 							decorative />
 					</button>
 					<button v-show="connectionStateFailedNoRestart"
-						class="iceFailedIndicator forced-white icon-error"
+						class="iceFailedIndicator"
 						:class="{ 'not-failed': !connectionStateFailedNoRestart }"
-						disabled="true" />
+						disabled="true">
+						<AlertCircle
+							:size="24"
+							title=""
+							fill-color="#ffffff"
+							decorative />
+					</button>
 				</div>
 			</transition>
 			<button v-if="hasSelectedVideo && isBig"
@@ -112,6 +118,7 @@
 <script>
 import { ConnectionState } from '../../../utils/webrtc/models/CallParticipantModel'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
+import AlertCircle from 'vue-material-design-icons/AlertCircle'
 import Microphone from 'vue-material-design-icons/Microphone'
 import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff'
 import Monitor from 'vue-material-design-icons/Monitor'
@@ -124,6 +131,7 @@ export default {
 	name: 'VideoBottomBar',
 
 	components: {
+		AlertCircle,
 		Hand,
 		Microphone,
 		MicrophoneOff,
@@ -329,7 +337,8 @@ export default {
 .handIndicator,
 .muteIndicator,
 .hideRemoteVideo,
-.screensharingIndicator {
+.screensharingIndicator,
+.iceFailedIndicator {
 	position: relative;
 	display: inline-block;
 	background-color: transparent !important;
@@ -338,18 +347,7 @@ export default {
 }
 
 .iceFailedIndicator {
-	position: relative;
-	display: inline-block;
-	background-color: transparent !important;
-	border: none;
-	width: 32px;
-	height: 32px;
-	background-size: 22px;
 	opacity: .8 !important;
-
-	&.hidden {
-		display: none;
-	}
 }
 
 .screensharingIndicator.screen-off,

--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -85,9 +85,15 @@
 					</button>
 					<button v-show="!connectionStateFailedNoRestart"
 						v-tooltip="t('spreed', 'Show screen')"
-						class="screensharingIndicator forced-white icon-screen"
+						class="screensharingIndicator"
 						:class="screenSharingButtonClass"
-						@click="switchToScreen" />
+						@click.stop="switchToScreen">
+						<Monitor
+							:size="24"
+							title=""
+							fill-color="#ffffff"
+							decorative />
+					</button>
 					<button v-show="connectionStateFailedNoRestart"
 						class="iceFailedIndicator forced-white icon-error"
 						:class="{ 'not-failed': !connectionStateFailedNoRestart }"
@@ -108,6 +114,7 @@ import { ConnectionState } from '../../../utils/webrtc/models/CallParticipantMod
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 import Microphone from 'vue-material-design-icons/Microphone'
 import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff'
+import Monitor from 'vue-material-design-icons/Monitor'
 import Video from 'vue-material-design-icons/Video'
 import VideoOff from 'vue-material-design-icons/VideoOff'
 import { PARTICIPANT } from '../../../constants'
@@ -120,6 +127,7 @@ export default {
 		Hand,
 		Microphone,
 		MicrophoneOff,
+		Monitor,
 		'VideoIcon': Video,
 		VideoOff,
 	},
@@ -321,7 +329,14 @@ export default {
 .handIndicator,
 .muteIndicator,
 .hideRemoteVideo,
-.screensharingIndicator,
+.screensharingIndicator {
+	position: relative;
+	display: inline-block;
+	background-color: transparent !important;
+	border: none;
+	padding: 0 12px;
+}
+
 .iceFailedIndicator {
 	position: relative;
 	display: inline-block;
@@ -330,6 +345,7 @@ export default {
 	width: 32px;
 	height: 32px;
 	background-size: 22px;
+	opacity: .8 !important;
 
 	&.hidden {
 		display: none;
@@ -351,10 +367,6 @@ export default {
 	&:focus {
 		opacity: 1;
 	}
-}
-
-.iceFailedIndicator {
-	opacity: .8 !important;
 }
 
 </style>

--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -48,11 +48,24 @@
 					v-show="showVideoOverlay"
 					class="bottom-bar__mediaIndicator">
 					<button v-show="!connectionStateFailedNoRestart"
+						v-if="showMicrophone || showMicrophoneOff"
 						v-tooltip="audioButtonTooltip"
-						class="muteIndicator forced-white"
-						:class="audioButtonClass"
+						class="muteIndicator"
 						:disabled="!model.attributes.audioAvailable || !selfIsModerator"
-						@click="forceMute" />
+						@click.stop="forceMute">
+						<Microphone
+							v-if="showMicrophone"
+							:size="24"
+							title=""
+							fill-color="#ffffff"
+							decorative />
+						<MicrophoneOff
+							v-if="showMicrophoneOff"
+							:size="24"
+							title=""
+							fill-color="#ffffff"
+							decorative />
+					</button>
 					<button v-show="!connectionStateFailedNoRestart && model.attributes.videoAvailable"
 						v-tooltip="videoButtonTooltip"
 						class="hideRemoteVideo forced-white"
@@ -81,6 +94,8 @@
 <script>
 import { ConnectionState } from '../../../utils/webrtc/models/CallParticipantModel'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
+import Microphone from 'vue-material-design-icons/Microphone'
+import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff'
 import { PARTICIPANT } from '../../../constants'
 import Hand from 'vue-material-design-icons/Hand'
 
@@ -89,6 +104,8 @@ export default {
 
 	components: {
 		Hand,
+		Microphone,
+		MicrophoneOff,
 	},
 
 	directives: {
@@ -136,16 +153,16 @@ export default {
 	},
 
 	computed: {
+		showMicrophone() {
+			return this.model.attributes.audioAvailable && this.selfIsModerator
+		},
+
+		showMicrophoneOff() {
+			return !this.model.attributes.audioAvailable && this.model.attributes.audioAvailable !== undefined
+		},
 
 		connectionStateFailedNoRestart() {
 			return this.model.attributes.connectionState === ConnectionState.FAILED_NO_RESTART
-		},
-
-		audioButtonClass() {
-			return {
-				'icon-audio': this.model.attributes.audioAvailable && this.selfIsModerator,
-				'icon-audio-off': !this.model.attributes.audioAvailable && this.model.attributes.audioAvailable !== undefined,
-			}
 		},
 
 		audioButtonTooltip() {
@@ -306,13 +323,12 @@ export default {
 	}
 }
 
-.muteIndicator:not(.icon-audio):not(.icon-audio-off),
 .screensharingIndicator.screen-off,
 .iceFailedIndicator.not-failed {
 	display: none;
 }
 
-.muteIndicator.icon-audio-off,
+.muteIndicator[disabled],
 .hideRemoteVideo {
 	opacity: .7;
 }

--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -68,9 +68,21 @@
 					</button>
 					<button v-show="!connectionStateFailedNoRestart && model.attributes.videoAvailable"
 						v-tooltip="videoButtonTooltip"
-						class="hideRemoteVideo forced-white"
-						:class="videoButtonClass"
-						@click="toggleVideo" />
+						class="hideRemoteVideo"
+						@click.stop="toggleVideo">
+						<VideoIcon
+							v-if="showVideoButton"
+							:size="24"
+							title=""
+							fill-color="#ffffff"
+							decorative />
+						<VideoOff
+							v-if="!showVideoButton"
+							:size="24"
+							title=""
+							fill-color="#ffffff"
+							decorative />
+					</button>
 					<button v-show="!connectionStateFailedNoRestart"
 						v-tooltip="t('spreed', 'Show screen')"
 						class="screensharingIndicator forced-white icon-screen"
@@ -96,6 +108,8 @@ import { ConnectionState } from '../../../utils/webrtc/models/CallParticipantMod
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 import Microphone from 'vue-material-design-icons/Microphone'
 import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff'
+import Video from 'vue-material-design-icons/Video'
+import VideoOff from 'vue-material-design-icons/VideoOff'
 import { PARTICIPANT } from '../../../constants'
 import Hand from 'vue-material-design-icons/Hand'
 
@@ -106,6 +120,8 @@ export default {
 		Hand,
 		Microphone,
 		MicrophoneOff,
+		'VideoIcon': Video,
+		VideoOff,
 	},
 
 	directives: {
@@ -173,11 +189,8 @@ export default {
 			return null
 		},
 
-		videoButtonClass() {
-			return {
-				'icon-video': this.sharedData.videoEnabled,
-				'icon-video-off': !this.sharedData.videoEnabled,
-			}
+		showVideoButton() {
+			return this.sharedData.videoEnabled
 		},
 
 		videoButtonTooltip() {

--- a/src/components/MediaDevicesPreview.vue
+++ b/src/components/MediaDevicesPreview.vue
@@ -69,10 +69,16 @@
 				class="preview-not-available">
 				<div v-if="videoStreamError"
 					class="icon icon-error" />
-				<div v-else-if="!videoInputId"
-					class="icon icon-video-off" />
-				<div v-else-if="!enabled"
-					class="icon icon-video" />
+				<VideoOff
+					v-else-if="!videoInputId"
+					:size="64"
+					title=""
+					fill-color="#999" />
+				<VideoIcon
+					v-else-if="!enabled"
+					:size="64"
+					title=""
+					fill-color="#999" />
 				<div v-else-if="!videoStream"
 					class="icon icon-loading" />
 				<p v-if="videoStreamErrorMessage">
@@ -94,6 +100,8 @@ import attachMediaStream from 'attachmediastream'
 import hark from 'hark'
 import Microphone from 'vue-material-design-icons/Microphone'
 import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff'
+import Video from 'vue-material-design-icons/Video'
+import VideoOff from 'vue-material-design-icons/VideoOff'
 import { mediaDevicesManager } from '../utils/webrtc/index'
 import MediaDevicesSelector from './MediaDevicesSelector'
 
@@ -105,6 +113,8 @@ export default {
 		MediaDevicesSelector,
 		Microphone,
 		MicrophoneOff,
+		'VideoIcon': Video,
+		VideoOff,
 	},
 
 	props: {

--- a/src/components/MediaDevicesPreview.vue
+++ b/src/components/MediaDevicesPreview.vue
@@ -30,10 +30,16 @@
 				class="preview-not-available">
 				<div v-if="audioStreamError"
 					class="icon icon-error" />
-				<div v-else-if="!audioInputId"
-					class="icon icon-audio-off" />
-				<div v-else-if="!enabled"
-					class="icon icon-audio" />
+				<MicrophoneOff
+					v-else-if="!audioInputId"
+					:size="64"
+					title=""
+					fill-color="#999" />
+				<Microphone
+					v-else-if="!enabled"
+					:size="64"
+					title=""
+					fill-color="#999" />
 				<div v-else-if="!audioStream"
 					class="icon icon-loading" />
 				<p v-if="audioStreamErrorMessage">
@@ -44,7 +50,10 @@
 				 reference is always valid once mounted. -->
 			<div v-show="audioPreviewAvailable"
 				class="volume-indicator-wrapper">
-				<div class="icon icon-audio" />
+				<Microphone
+					:size="64"
+					title=""
+					fill-color="#999" />
 				<span ref="volumeIndicator"
 					class="volume-indicator"
 					:style="{ 'height': currentVolumeIndicatorHeight + 'px' }" />
@@ -83,6 +92,8 @@
 <script>
 import attachMediaStream from 'attachmediastream'
 import hark from 'hark'
+import Microphone from 'vue-material-design-icons/Microphone'
+import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff'
 import { mediaDevicesManager } from '../utils/webrtc/index'
 import MediaDevicesSelector from './MediaDevicesSelector'
 
@@ -92,6 +103,8 @@ export default {
 
 	components: {
 		MediaDevicesSelector,
+		Microphone,
+		MicrophoneOff,
 	},
 
 	props: {

--- a/src/components/MediaDevicesPreview.vue
+++ b/src/components/MediaDevicesPreview.vue
@@ -28,8 +28,11 @@
 		<div class="preview preview-audio">
 			<div v-if="!audioPreviewAvailable"
 				class="preview-not-available">
-				<div v-if="audioStreamError"
-					class="icon icon-error" />
+				<AlertCircle
+					v-if="audioStreamError"
+					:size="64"
+					title=""
+					fill-color="#999" />
 				<MicrophoneOff
 					v-else-if="!audioInputId"
 					:size="64"
@@ -67,8 +70,11 @@
 		<div class="preview preview-video">
 			<div v-if="!videoPreviewAvailable"
 				class="preview-not-available">
-				<div v-if="videoStreamError"
-					class="icon icon-error" />
+				<AlertCircle
+					v-if="videoStreamError"
+					:size="64"
+					title=""
+					fill-color="#999" />
 				<VideoOff
 					v-else-if="!videoInputId"
 					:size="64"
@@ -98,6 +104,7 @@
 <script>
 import attachMediaStream from 'attachmediastream'
 import hark from 'hark'
+import AlertCircle from 'vue-material-design-icons/AlertCircle'
 import Microphone from 'vue-material-design-icons/Microphone'
 import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff'
 import Video from 'vue-material-design-icons/Video'
@@ -110,6 +117,7 @@ export default {
 	name: 'MediaDevicesPreview',
 
 	components: {
+		AlertCircle,
 		MediaDevicesSelector,
 		Microphone,
 		MicrophoneOff,

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -72,9 +72,13 @@
 				v-if="showModerationOptions && canFullModerate && isInCall">
 				<ActionSeparator />
 				<ActionButton
-					icon="icon-audio"
 					:close-after-click="true"
 					@click="forceMuteOthers">
+					<MicrophoneOff
+						slot="icon"
+						:size="16"
+						decorative
+						title="" />
 					{{ t('spreed', 'Mute others') }}
 				</ActionButton>
 			</template>
@@ -106,6 +110,7 @@ import CallButton from './CallButton'
 import BrowserStorage from '../../services/BrowserStorage'
 import ActionLink from '@nextcloud/vue/dist/Components/ActionLink'
 import ActionSeparator from '@nextcloud/vue/dist/Components/ActionSeparator'
+import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff'
 import { CONVERSATION, PARTICIPANT } from '../../constants'
 import { generateUrl } from '@nextcloud/router'
 import { callParticipantCollection } from '../../utils/webrtc/index'
@@ -120,6 +125,7 @@ export default {
 		ActionLink,
 		CallButton,
 		ActionSeparator,
+		MicrophoneOff,
 	},
 
 	props: {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/spreed/issues/5021

- [x] settings page
   - [x] replace
   - [x] test some of the "no audio available" cases
- [x] video bottom bar
   - [x] replace
   - [x] test
- [x] local media controls
   - [x] replace
   - [x] fix container alignment
- [ ] replace icons in screen share menu => move to actions menu as the icons currently don't align well, but switching to actions menu require support for material design icon as trigger button (TODO: raise)
- [x] "alert-circle" for ICE fail and other icon-error instances
- [x] ~~"signal" for connection speed problem~~ there's already a material design icon there
- [x] force mute in menu
- [x] test all in dark mode
- [x] test in speaker view
- [x] test in grid view
- [x] test in sidebar mode
- [x] test in video verification mode

