### PR TITLE
Bring up the "new group conv" dialog for group results

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -123,7 +123,6 @@ import SearchBox from './SearchBox/SearchBox'
 import debounce from 'debounce'
 import { EventBus } from '../../services/EventBus'
 import {
-	createGroupConversation,
 	createOneToOneConversation,
 	fetchConversations,
 	searchPossibleConversations,

--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -141,6 +141,7 @@ import ListableSettings from '../../ConversationSettings/ListableSettings'
 import isInCall from '../../../mixins/isInCall'
 import participant from '../../../mixins/participant'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
+import { EventBus } from '../../../services/EventBus'
 
 export default {
 
@@ -202,8 +203,21 @@ export default {
 		},
 	},
 
+	mounted() {
+		EventBus.$on('NewGroupConversationDialog', this.showModal)
+	},
+
+	destroyed() {
+		EventBus.$off('NewGroupConversationDialog', this.showModal)
+	},
+
 	methods: {
-		showModal() {
+		showModal(item) {
+			if (item) {
+				// Preload the conversation name from group selection
+				this.conversationNameInput = item.label
+				this.$store.dispatch('updateSelectedParticipants', item)
+			}
 			this.modal = true
 		},
 		/** Reinitialise the component to it's initial state. This is necessary


### PR DESCRIPTION
Before | After
---|---
![Peek 2021-02-01 16-47](https://user-images.githubusercontent.com/213943/106481943-3c605c80-64ad-11eb-98ec-a8799a3252fa.gif) | ![Peek 2021-02-01 16-46](https://user-images.githubusercontent.com/213943/106481950-3d918980-64ad-11eb-8673-d4eb2cf16513.gif)

Should prevent some group conversations that are created by accident from time to time, when you think you are just searching for it.

* Prefills the conversation name with the search result label
* Selects the group/circle already as participant
