### PR TITLE
Update favorite dark icon

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -162,7 +162,7 @@ export default {
 		},
 
 		iconFavorite() {
-			return this.item.isFavorite ? 'icon-star-dark' : 'icon-starred'
+			return this.item.isFavorite ? 'icon-favorite' : 'icon-starred'
 		},
 
 		labelFavorite() {


### PR DESCRIPTION
As proposed by Jan here: https://github.com/nextcloud/mail/pull/4382#issuecomment-771586047 
all menu action items should have the same colour when they are dark.