### PR TITLE
Fix new conversation dialog when no item is selected

### DIFF
--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -204,21 +204,26 @@ export default {
 	},
 
 	mounted() {
-		EventBus.$on('NewGroupConversationDialog', this.showModal)
+		EventBus.$on('NewGroupConversationDialog', this.showModalForItem)
 	},
 
 	destroyed() {
-		EventBus.$off('NewGroupConversationDialog', this.showModal)
+		EventBus.$off('NewGroupConversationDialog', this.showModalForItem)
 	},
 
 	methods: {
-		showModal(item) {
+		showModal() {
+			this.modal = true
+		},
+
+		showModalForItem(item) {
 			if (item) {
 				// Preload the conversation name from group selection
 				this.conversationNameInput = item.label
 				this.$store.dispatch('updateSelectedParticipants', item)
 			}
-			this.modal = true
+
+			this.showModal()
 		},
 		/** Reinitialise the component to it's initial state. This is necessary
 		 * because once the component is mounted it's data would persist even if


### PR DESCRIPTION
Follow up to #5059

`showModal()` was being called as the handler for the `on-click` event and the `EventBus.$on('NewGroupConversationDialog')`. As the first one always provides the event as the first parameter the item was always defined, but it never contained a label, so the model became undefined and thus the dialog failed to open.

Now the method was split in two, one to be used to just show the modal and another one that also takes into account the item being given.

## How to test
- Open Talk
- Click the button to create a new conversation

### Result with this pull request
The dialog is opened.

### Result without this pull request
The dialog is not opened.
