### PR TITLE
[stable21] Fix find-listed integration test outline

### DIFF
--- a/tests/integration/features/conversation/find-listed.feature
+++ b/tests/integration/features/conversation/find-listed.feature
@@ -14,7 +14,7 @@ Feature: conversation/find-listed
       | roomName | public-room |
     When user "creator" allows listing room "group-room" for "none" with 200
     And user "creator" allows listing room "public-room" for "none" with 200
-    Then user "creator" cannot find any listed rooms (v3)
+    Then user "<user>" cannot find any listed rooms (v3)
     Examples:
       | user                   |
       | creator                |


### PR DESCRIPTION
Fix the test to actually use the variable from the example list.

