### PR TITLE
Fix "Talk/ folder not working for attachments"

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>12.0.0-dev.1</version>
+	<version>12.0.0-dev.2</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>
@@ -30,6 +30,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 	<namespace>Talk</namespace>
 
 	<types>
+		<dav />
 		<prevent_group_restriction />
 	</types>
 


### PR DESCRIPTION
So I'm pretty sure this is the fix.
Attachment folder worked 100% of the time I tested deck, which does everything exactly the same, but is already registered as "dav" because it uses the dav API of comments?
https://github.com/nextcloud/deck/blob/b0135a71ede5eb1d95d9aa9b1b6ceb458c8198ce/appinfo/info.xml#L25

After some logging and debugging I could confirm that in the broken cases the write was ALWAYS on a propfind from the desktop client and logging at:
https://github.com/nextcloud/server/blob/d89a75be0b01f0423a7c1ad2d58aac73c3cc1f3a/apps/files_sharing/lib/SharedMount.php#L119
Confirmed `OC_App::isAppLoaded()` is false for "spreed" and true for "deck". I uploaded 3 more files after changing this on c.nc.c and they all worked, even though the request was from the client.
So the problem was Talk didn't react on the event and change the path to `Talk/`, but was still invoked to update the share afterwards (which made me assume it should be working, but reality now proofed different) `¯\_(ツ)_/¯`