### PR TITLE
Fix redirect when deleting current conversation

### DIFF
--- a/src/FilesSidebarCallViewApp.vue
+++ b/src/FilesSidebarCallViewApp.vue
@@ -33,7 +33,7 @@
 <script>
 import CallView from './components/CallView/CallView'
 import PreventUnload from 'vue-prevent-unload'
-import duplicateSessionHandler from './mixins/duplicateSessionHandler'
+import sessionIssueHandler from './mixins/sessionIssueHandler'
 import isInCall from './mixins/isInCall'
 import participant from './mixins/participant'
 import talkHashCheck from './mixins/talkHashCheck'
@@ -49,7 +49,7 @@ export default {
 	},
 
 	mixins: [
-		duplicateSessionHandler,
+		sessionIssueHandler,
 		isInCall,
 		participant,
 		talkHashCheck,
@@ -108,7 +108,7 @@ export default {
 		},
 
 		warnLeaving() {
-			return !this.isLeavingAfterSessionConflict && this.showCallView
+			return !this.isLeavingAfterSessionIssue && this.showCallView
 		},
 	},
 

--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -66,7 +66,7 @@ import Axios from '@nextcloud/axios'
 import UploadEditor from './components/UploadEditor'
 import CallButton from './components/TopBar/CallButton'
 import ChatView from './components/ChatView'
-import duplicateSessionHandler from './mixins/duplicateSessionHandler'
+import sessionIssueHandler from './mixins/sessionIssueHandler'
 import browserCheck from './mixins/browserCheck'
 import '@nextcloud/dialogs/styles/toast.scss'
 
@@ -82,7 +82,7 @@ export default {
 
 	mixins: [
 		browserCheck,
-		duplicateSessionHandler,
+		sessionIssueHandler,
 	],
 
 	data() {
@@ -164,7 +164,7 @@ export default {
 				// We have to do this synchronously, because in unload and beforeunload
 				// Promises, async and await are prohibited.
 				signalingKill()
-				if (!this.isLeavingAfterSessionConflict) {
+				if (!this.isLeavingAfterSessionIssue) {
 					leaveConversationSync(this.token)
 				}
 			}

--- a/src/PublicShareAuthSidebar.vue
+++ b/src/PublicShareAuthSidebar.vue
@@ -48,7 +48,7 @@ import {
 	leaveConversationSync,
 } from './services/participantsService'
 import { signalingKill } from './utils/webrtc/index'
-import duplicateSessionHandler from './mixins/duplicateSessionHandler'
+import sessionIssueHandler from './mixins/sessionIssueHandler'
 import talkHashCheck from './mixins/talkHashCheck'
 
 export default {
@@ -61,7 +61,7 @@ export default {
 	},
 
 	mixins: [
-		duplicateSessionHandler,
+		sessionIssueHandler,
 		talkHashCheck,
 	],
 
@@ -107,7 +107,7 @@ export default {
 				// We have to do this synchronously, because in unload and beforeunload
 				// Promises, async and await are prohibited.
 				signalingKill()
-				if (!this.isLeavingAfterSessionConflict) {
+				if (!this.isLeavingAfterSessionIssue) {
 					leaveConversationSync(this.token)
 				}
 			}

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -58,7 +58,7 @@ import {
 } from './services/participantsService'
 import { signalingKill } from './utils/webrtc/index'
 import browserCheck from './mixins/browserCheck'
-import duplicateSessionHandler from './mixins/duplicateSessionHandler'
+import sessionIssueHandler from './mixins/sessionIssueHandler'
 import isInCall from './mixins/isInCall'
 import participant from './mixins/participant'
 import talkHashCheck from './mixins/talkHashCheck'
@@ -77,7 +77,7 @@ export default {
 
 	mixins: [
 		browserCheck,
-		duplicateSessionHandler,
+		sessionIssueHandler,
 		isInCall,
 		participant,
 		talkHashCheck,
@@ -116,7 +116,7 @@ export default {
 		},
 
 		warnLeaving() {
-			return !this.isLeavingAfterSessionConflict && this.isInCall
+			return !this.isLeavingAfterSessionIssue && this.isInCall
 		},
 	},
 
@@ -126,7 +126,7 @@ export default {
 				// We have to do this synchronously, because in unload and beforeunload
 				// Promises, async and await are prohibited.
 				signalingKill()
-				if (!this.isLeavingAfterSessionConflict) {
+				if (!this.isLeavingAfterSessionIssue) {
 					leaveConversationSync(this.token)
 				}
 			}

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -84,11 +84,13 @@
 			<ActionSeparator />
 
 			<ActionButton v-if="canLeaveConversation"
+				:close-after-click="true"
 				:icon="iconLeaveConversation"
 				@click.prevent.exact="leaveConversation">
 				{{ t('spreed', 'Leave conversation') }}
 			</ActionButton>
 			<ActionButton v-if="canDeleteConversation"
+				:close-after-click="true"
 				icon="icon-delete-critical"
 				class="critical"
 				@click.prevent.exact="deleteConversation">
@@ -324,7 +326,7 @@ export default {
 					}
 
 					if (this.item.token === this.$store.getters.getToken()) {
-						this.$router.push('/apps/spreed')
+						this.$router.push({ name: 'root', params: { skipLeaveWarning: true } })
 						this.$store.dispatch('updateToken', '')
 					}
 

--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -256,7 +256,9 @@ export default {
 			// a setTimeout was recommended by the library author here:
 			// https://github.com/fritx/vue-at/issues/114#issuecomment-565777450
 			setTimeout(() => {
-				this.$refs.at.closePanel()
+				if (this.$refs.at) {
+					this.$refs.at.closePanel()
+				}
 			}, 100)
 		},
 		onPaste(e) {

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -448,7 +448,7 @@ Signaling.Internal.prototype._startPullingMessages = function() {
 			} else if (error.response && (error.response.status === 404 || error.response.status === 403)) {
 				// Conversation was deleted or the user was removed
 				console.error('Conversation was not found anymore')
-				window.location = generateUrl('/apps/spreed/not-found')
+				EventBus.$emit('deletedSessionDetected')
 			} else if (token) {
 				if (this.pullMessagesFails === 1) {
 					this.pullMessageErrorToast = showError(t('spreed', 'Lost connection to signaling server. Trying to reconnect.'), {
@@ -1130,7 +1130,7 @@ Signaling.Standalone.prototype.processRoomListEvent = function(data) {
 				return
 			}
 			console.error('User or session was removed from the conversation, redirecting')
-			EventBus.$emit('duplicateSessionDetected')
+			EventBus.$emit('deletedSessionDetected')
 			break
 		}
 		// eslint-disable-next-line no-fallthrough


### PR DESCRIPTION
When the current conversation was deleted while in a call, the redirect
now targets the not-found page instead of the one about duplicate
session.

Added event bus handler for the not found page which now also removes
the session store's conversation token.

Fixes https://github.com/nextcloud/spreed/issues/4552