### PR TITLE
Fix conversation switching lag

### DIFF
--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -70,13 +70,6 @@ export default {
 		NewMessageForm,
 	},
 
-	props: {
-		token: {
-			type: String,
-			required: true,
-		},
-	},
-
 	data: function() {
 		return {
 			isDraggingOver: false,
@@ -108,6 +101,10 @@ export default {
 			} else {
 				return undefined
 			}
+		},
+
+		token() {
+			return this.$store.getters.getToken()
 		},
 	},
 

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -115,7 +115,6 @@ import {
 } from '../../../services/conversationsService'
 import { generateUrl } from '@nextcloud/router'
 import { CONVERSATION, PARTICIPANT } from '../../../constants'
-import { EventBus } from '../../../services/EventBus'
 
 export default {
 	name: 'Conversation',
@@ -373,9 +372,6 @@ export default {
 
 		// forward click event
 		onClick(event) {
-			EventBus.$emit('conversationClicked', {
-				token: this.item.token,
-			})
 			this.$emit('click', event)
 		},
 	},

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -115,6 +115,7 @@ import {
 } from '../../../services/conversationsService'
 import { generateUrl } from '@nextcloud/router'
 import { CONVERSATION, PARTICIPANT } from '../../../constants'
+import { EventBus } from '../../../services/EventBus'
 
 export default {
 	name: 'Conversation',
@@ -372,6 +373,9 @@ export default {
 
 		// forward click event
 		onClick(event) {
+			EventBus.$emit('conversationClicked', {
+				token: this.item.token,
+			})
 			this.$emit('click', event)
 		},
 	},

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -64,7 +64,7 @@
 					<EmojiPicker @select="addEmoji">
 						<button
 							type="button"
-							disabled="disabled"
+							:disabled="disabled"
 							class="nc-button nc-button__main"
 							:aria-label="t('spreed', 'Add emoji')"
 							:aria-haspopup="true">

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -40,6 +40,7 @@
 				<div
 					v-if="canUploadFiles || canShareFiles">
 					<Actions
+						ref="uploadMenu"
 						default-icon="icon-clip-add-file"
 						:aria-label="t('spreed', 'Share files to the conversation')"
 						:aria-haspopup="true">
@@ -59,11 +60,11 @@
 						</ActionButton>
 					</Actions>
 				</div>
-				<div
-					v-if="!isReadOnly">
+				<div>
 					<EmojiPicker @select="addEmoji">
 						<button
 							type="button"
+							disabled="disabled"
 							class="nc-button nc-button__main"
 							:aria-label="t('spreed', 'Add emoji')"
 							:aria-haspopup="true">
@@ -86,7 +87,7 @@
 						ref="advancedInput"
 						v-model="text"
 						:token="token"
-						:active-input="!isReadOnly"
+						:active-input="!disabled"
 						:placeholder-text="placeholderText"
 						:aria-label="placeholderText"
 						@update:contentEditable="contentEditableToParsed"
@@ -94,7 +95,7 @@
 						@files-pasted="handlePastedFiles" />
 				</div>
 				<button
-					:disabled="isReadOnly"
+					:disabled="disabled"
 					type="submit"
 					:aria-label="t('spreed', 'Send message')"
 					class="nc-button nc-button__main"
@@ -175,12 +176,13 @@ export default {
 			}
 		},
 
-		isReadOnly() {
+		disabled() {
 			return this.conversation.readOnly === CONVERSATION.STATE.READ_ONLY
+			|| !this.currentConversationIsJoined
 		},
 
 		placeholderText() {
-			return this.isReadOnly
+			return this.disabled
 				? t('spreed', 'This conversation has been locked')
 				: t('spreed', 'Write message, @ to mention someone …')
 		},
@@ -194,7 +196,7 @@ export default {
 		},
 
 		canShareFiles() {
-			return !this.currentUserIsGuest && !this.isReadOnly
+			return !this.currentUserIsGuest
 		},
 
 		canUploadFiles() {
@@ -206,6 +208,16 @@ export default {
 
 		attachmentFolderFreeSpace() {
 			return this.$store.getters.getAttachmentFolderFreeSpace()
+		},
+
+		currentConversationIsJoined() {
+			return this.$store.getters.currentConversationIsJoined
+		},
+	},
+
+	watch: {
+		disabled(newValue) {
+			this.$refs.uploadMenu.$refs.menuButton.disabled = newValue
 		},
 	},
 

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -176,15 +176,22 @@ export default {
 			}
 		},
 
-		disabled() {
+		isReadOnly() {
 			return this.conversation.readOnly === CONVERSATION.STATE.READ_ONLY
-			|| !this.currentConversationIsJoined
+		},
+
+		disabled() {
+			return this.isReadOnly || !this.currentConversationIsJoined
 		},
 
 		placeholderText() {
-			return this.disabled
-				? t('spreed', 'This conversation has been locked')
-				: t('spreed', 'Write message, @ to mention someone …')
+			if (this.isReadonly) {
+				return t('spreed', 'This conversation has been locked')
+			} else if (!this.currentConversationIsJoined) {
+				return t('spreed', 'Joining conversation …')
+			} else {
+				return t('spreed', 'Write message, @ to mention someone …')
+			}
 		},
 
 		messageToBeReplied() {

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -41,6 +41,7 @@
 					v-if="canUploadFiles || canShareFiles">
 					<Actions
 						ref="uploadMenu"
+						:disabled="disabled"
 						default-icon="icon-clip-add-file"
 						:aria-label="t('spreed', 'Share files to the conversation')"
 						:aria-haspopup="true">

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -98,6 +98,7 @@ export default {
 				|| this.isBlockedByLobby
 				|| this.conversation.readOnly
 				|| this.isNextcloudTalkHashDirty
+				|| !this.currentConversationIsJoined
 		},
 
 		leaveCallLabel() {
@@ -163,6 +164,10 @@ export default {
 		showLeaveCallButton() {
 			return this.conversation.readOnly === CONVERSATION.STATE.READ_WRITE
 				&& this.isInCall
+		},
+
+		currentConversationIsJoined() {
+			return this.$store.getters.currentConversationIsJoined
 		},
 	},
 

--- a/src/init.js
+++ b/src/init.js
@@ -50,5 +50,5 @@ window.OCA.Talk.registerMessageAction = ({ label, callback, icon }) => {
 
 EventBus.$on('Signaling::joinRoom', (payload) => {
 	const token = payload[0]
-	store.dispatch('handleRoomJoined', token)
+	store.dispatch('updateLastJoinedConversationToken', token)
 })

--- a/src/init.js
+++ b/src/init.js
@@ -24,6 +24,7 @@
 // entry points
 
 import store from './store'
+import { EventBus } from './services/EventBus'
 
 if (!window.OCA.Talk) {
 	window.OCA.Talk = {}
@@ -46,3 +47,8 @@ window.OCA.Talk.registerMessageAction = ({ label, callback, icon }) => {
 	}
 	store.dispatch('addMessageAction', messageAction)
 }
+
+EventBus.$on('Signaling::joinRoom', (payload) => {
+	const token = payload[0]
+	store.dispatch('handleRoomJoined', token)
+})

--- a/src/store/tokenStore.js
+++ b/src/store/tokenStore.js
@@ -96,7 +96,7 @@ const actions = {
 		context.commit('updateTokenAndFileIdForToken', { newToken, newFileId })
 	},
 
-	handleRoomJoined({ commit }, token) {
+	updateLastJoinedConversationToken({ commit }, token) {
 		commit('updateLastJoinedConversationToken', { token })
 	},
 }

--- a/src/store/tokenStore.js
+++ b/src/store/tokenStore.js
@@ -23,6 +23,14 @@
 const state = {
 	token: '',
 	fileIdForToken: null,
+	/**
+	 * The joining of a room with the signaling server always lags
+	 * behind the "joining" of it in talk's UI. For this reason we
+	 * might have a  window of time in which we might be in
+	 * conversation B in talk's UI while still leaving conversation
+	 * A in the signaling server.
+	 **/
+	lastJoinedConversationToken: '',
 }
 
 const getters = {
@@ -31,6 +39,9 @@ const getters = {
 	},
 	getFileIdForToken: (state) => () => {
 		return state.fileIdForToken
+	},
+	currentConversationIsJoined() {
+		return state.lastJoinedConversationToken === state.token
 	},
 }
 
@@ -56,6 +67,10 @@ const mutations = {
 		state.token = newToken
 		state.fileIdForToken = newFileId
 	},
+
+	updateLastJoinedConversationToken(state, { token }) {
+		state.lastJoinedConversationToken = token
+	},
 }
 
 const actions = {
@@ -79,6 +94,10 @@ const actions = {
 	 */
 	updateTokenAndFileIdForToken(context, { newToken, newFileId }) {
 		context.commit('updateTokenAndFileIdForToken', { newToken, newFileId })
+	},
+
+	handleRoomJoined({ commit }, token) {
+		commit('updateLastJoinedConversationToken', { token })
 	},
 }
 


### PR DESCRIPTION
Immediately display messages from the clicked conversation even if not joined yet with the signaling server.
In order to avoid errors, the call button and the newmessagegorm components are disabled while opening the new session.

TODO: 
- [x] Emoji button stays disabled;

https://user-images.githubusercontent.com/26852655/107543910-90f88b80-6bc1-11eb-8c58-16d7d43e6000.mp4

