### PR TITLE
Add support for "turns:" scheme

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -243,6 +243,10 @@ class Config {
 			return [];
 		}
 
+		foreach ($servers as $key => $server) {
+			$servers[$key]['schemes'] = $server['schemes'] ?? 'turn';
+		}
+
 		return $servers;
 	}
 
@@ -256,6 +260,7 @@ class Config {
 
 		if (empty($servers)) {
 			return [
+				'schemes' => '',
 				'server' => '',
 				'username' => '',
 				'password' => '',
@@ -278,6 +283,7 @@ class Config {
 		$password = base64_encode(hash_hmac('sha1', $username, $server['secret'], true));
 
 		return [
+			'schemes' => $server['schemes'],
 			'server' => $server['server'],
 			'username' => $username,
 			'password' => $password,

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -147,14 +147,17 @@ class SignalingController extends OCSController {
 		$turn = [];
 		$turnSettings = $this->talkConfig->getTurnSettings();
 		if (!empty($turnSettings['server'])) {
+			$schemes = explode(',', $turnSettings['schemes']);
 			$protocols = explode(',', $turnSettings['protocols']);
-			foreach ($protocols as $proto) {
-				$turn[] = [
-					'url' => ['turn:' . $turnSettings['server'] . '?transport=' . $proto],
-					'urls' => ['turn:' . $turnSettings['server'] . '?transport=' . $proto],
-					'username' => $turnSettings['username'],
-					'credential' => $turnSettings['password'],
-				];
+			foreach ($schemes as $scheme) {
+				foreach ($protocols as $proto) {
+					$turn[] = [
+						'url' => [$scheme . ':' . $turnSettings['server'] . '?transport=' . $proto],
+						'urls' => [$scheme . ':' . $turnSettings['server'] . '?transport=' . $proto],
+						'username' => $turnSettings['username'],
+						'credential' => $turnSettings['password'],
+					];
+				}
 			}
 		}
 

--- a/src/components/AdminSettings/StunServer.vue
+++ b/src/components/AdminSettings/StunServer.vue
@@ -22,6 +22,8 @@
 
 <template>
 	<div class="stun-server">
+		<!-- "stun:" scheme is untranslated -->
+		<span class="scheme">stun:</span>
 		<input ref="stun_server"
 			type="text"
 			name="stun_server"
@@ -96,6 +98,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.scheme {
+	/* Same margin as inputs to keep the style. */
+	margin: 3px 3px 3px 0;
+}
+
 .stun-server {
 	height: 44px;
 	display: flex;

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -39,9 +39,11 @@
 		</select>
 
 		<input ref="turn_server"
+			v-tooltip.auto="turnServerError"
 			type="text"
 			name="turn_server"
 			placeholder="turnserver:port"
+			:class="turnServerClasses"
 			:value="server"
 			:disabled="loading"
 			:aria-label="t('spreed', 'TURN server URL')"
@@ -137,6 +139,18 @@ export default {
 	},
 
 	computed: {
+		turnServerError() {
+			if (this.schemes.includes('turns') && /^(?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?$/.test(this.server.trim())) {
+				return t('spreed', 'turns: scheme must be used with a domain')
+			}
+
+			return false
+		},
+		turnServerClasses() {
+			return {
+				'error': this.turnServerError,
+			}
+		},
 		testIconClasses() {
 			return {
 				'icon-category-monitoring': !this.testing && !this.testingError && !this.testingSuccess,
@@ -313,5 +327,9 @@ export default {
 	height: 44px;
 	display: flex;
 	align-items: center;
+
+	&.error {
+		border: solid 1px var(--color-error);
+	}
 }
 </style>

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -22,6 +22,22 @@
 
 <template>
 	<div class="turn-server">
+		<select class="schemes"
+			:value="schemes"
+			:disabled="loading"
+			:aria-label="t('spreed', 'TURN server schemes')"
+			@input="updateSchemes">
+			<option value="turn,turns">
+				{{ t('spreed', 'turn: and turns:') }}
+			</option>
+			<option value="turn">
+				{{ t('spreed', 'turn: only') }}
+			</option>
+			<option value="turns">
+				{{ t('spreed', 'turns: only') }}
+			</option>
+		</select>
+
 		<input ref="turn_server"
 			type="text"
 			name="turn_server"
@@ -81,6 +97,11 @@ export default {
 	},
 
 	props: {
+		schemes: {
+			type: String,
+			default: '',
+			required: true,
+		},
 		server: {
 			type: String,
 			default: '',
@@ -152,15 +173,17 @@ export default {
 			this.testingError = false
 			this.testingSuccess = false
 
+			const schemes = this.schemes.split(',')
 			const protocols = this.protocols.split(',')
-			if (!this.server || !this.secret || !protocols.length) {
+			if (!schemes.length || !this.server || !this.secret || !protocols.length) {
 				return
 			}
 
 			const urls = []
-			let i
-			for (i = 0; i < protocols.length; i++) {
-				urls.push('turn:' + this.server + '?transport=' + protocols[i])
+			for (let i = 0; i < schemes.length; i++) {
+				for (let j = 0; j < protocols.length; j++) {
+					urls.push(schemes[i] + ':' + this.server + '?transport=' + protocols[j])
+				}
 			}
 
 			const expires = Math.round((new Date()).getTime() / 1000) + (5 * 60)
@@ -264,6 +287,10 @@ export default {
 
 		removeServer() {
 			this.$emit('removeServer', this.index)
+		},
+		updateSchemes(event) {
+			this.$emit('update:schemes', event.target.value)
+			this.debounceTestServer()
 		},
 		updateServer(event) {
 			this.$emit('update:server', event.target.value)

--- a/src/components/AdminSettings/TurnServers.vue
+++ b/src/components/AdminSettings/TurnServers.vue
@@ -41,12 +41,14 @@
 				<TurnServer
 					v-for="(server, index) in servers"
 					:key="`server${index}`"
+					:schemes.sync="servers[index].schemes"
 					:server.sync="servers[index].server"
 					:secret.sync="servers[index].secret"
 					:protocols.sync="servers[index].protocols"
 					:index="index"
 					:loading="loading"
 					@removeServer="removeServer"
+					@update:schemes="debounceUpdateServers"
 					@update:server="debounceUpdateServers"
 					@update:secret="debounceUpdateServers"
 					@update:protocols="debounceUpdateServers" />
@@ -100,6 +102,7 @@ export default {
 
 		newServer() {
 			this.servers.push({
+				schemes: 'turn', // default to turn only
 				server: '',
 				secret: '',
 				protocols: 'udp,tcp', // default to udp AND tcp
@@ -115,6 +118,7 @@ export default {
 
 			this.servers.forEach((server) => {
 				const data = {
+					schemes: server.schemes,
 					server: server.server,
 					secret: server.secret,
 					protocols: server.protocols,

--- a/tests/php/ConfigTest.php
+++ b/tests/php/ConfigTest.php
@@ -116,11 +116,13 @@ class ConfigTest extends TestCase {
 			->with('spreed', 'turn_servers', '')
 			->willReturn(json_encode([
 				[
+					// No scheme explicitly given
 					'server' => 'turn.example.org',
 					'secret' => 'thisisasupersecretsecret',
 					'protocols' => 'udp,tcp',
 				],
 				[
+					'schemes' => 'turn,turns',
 					'server' => 'turn2.example.com',
 					'secret' => 'ThisIsAlsoSuperSecret',
 					'protocols' => 'tcp',
@@ -150,6 +152,7 @@ class ConfigTest extends TestCase {
 		$server = $helper->getTurnSettings();
 		if ($server['server'] === 'turn.example.org') {
 			$this->assertSame([
+				'schemes' => 'turn',
 				'server' => 'turn.example.org',
 				'username' => '1479829425:abcdefghijklmnop',
 				'password' => '4VJLVbihLzuxgMfDrm5C3zy8kLQ=',
@@ -157,6 +160,7 @@ class ConfigTest extends TestCase {
 			], $server);
 		} else {
 			$this->assertSame([
+				'schemes' => 'turn,turns',
 				'server' => 'turn2.example.com',
 				'username' => '1479829425:abcdefghijklmnop',
 				'password' => 'Ol9DEqnvyN4g+IAM+vFnqhfWUTE=',


### PR DESCRIPTION
Until now no scheme could be configured to connect to the TURN server, so `turn:` was used by default. The `turns:` scheme defines a connection over TLS, which in some cases is needed by clients behind a very restrictive firewall that only allows TLS connections. However, encrypted TURN connections also require a certificate to be set in the TURN server, which may not be always available. Moreover, encrypted TURN connections also require a domain. Due to all this now it is possible to set the TURN server scheme to `turn:`, `turns:` or both, so the administrator can set the best suiting one.
    
Already configured TURN servers that have no scheme configured yet defaults to `turn:` to keep the same behaviour as before. New configured TURN servers also default to `turn:`, as `turns:` has some additional restrictions as explained above.

Besides that a literal `stun:` was added in front of the STUN server input to clarify that the scheme is fixed and does not need to be set in that case.

Follow up pull request:
- Add documentation about TURNS