### PR TITLE
Prevent current page in grid to become negative

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -483,7 +483,7 @@ export default {
 
 		numberOfPages() {
 			if (this.currentPage >= this.numberOfPages) {
-				this.currentPage = this.numberOfPages - 1
+				this.currentPage = Math.max(0, this.numberOfPages - 1)
 			}
 		},
 	},


### PR DESCRIPTION
Regression introduced in #4958

If the number of pages was -1 (which happens if there are no remote videos and thus "slots" becomes -1) the current page became -2.

## How to test

- Start a public call
- In a private window, join the call
- Leave the call
- Join the call again

### Result with this pull request

In the original window the guest is shown.

### Result without this pull request

In the original window the guest is not shown. Changing to speaker mode and then back to grid view shows the guest again (because that resets currentPage to 0).
