### PR TITLE
[stable20.1] Fix local video not shown in grid view

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -64,18 +64,18 @@
 					<h1 class="dev-mode__title">
 						Dev mode on ;-)
 					</h1>
-					<LocalVideo
-						v-if="!isStripe"
-						ref="localVideo"
-						class="video"
-						:is-grid="true"
-						:fit-video="isStripe"
-						:local-media-model="localMediaModel"
-						:video-container-aspect-ratio="videoContainerAspectRatio"
-						:local-call-participant-model="localCallParticipantModel"
-						@switchScreenToId="1"
-						@click-video="handleClickLocalVideo" />
 				</template>
+				<LocalVideo
+					v-if="!isStripe"
+					ref="localVideo"
+					class="video"
+					:is-grid="true"
+					:fit-video="isStripe"
+					:local-media-model="localMediaModel"
+					:video-container-aspect-ratio="videoContainerAspectRatio"
+					:local-call-participant-model="localCallParticipantModel"
+					@switchScreenToId="1"
+					@click-video="handleClickLocalVideo" />
 			</div>
 			<button v-if="hasNextPage && gridWidth > 0 && showVideoOverlay"
 				class="grid-navigation grid-navigation__next"


### PR DESCRIPTION
Regression introduced in 14b4630ff790 during the backport (the component was placed inside the v-else instead of after it).

## How to test

- Start a public call
- In a private window, join the call
- Switch to grid view

### Result with this pull request

The local video is shown in the grid.

### Result without this pull request

The local video is not shown in the grid.
