### PR TITLE
Make sure that project resources scripts event is properly emitted

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -44,6 +44,7 @@ use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\Template\PublicTemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\EventDispatcher\GenericEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
 use OCP\ICacheFactory;
@@ -255,6 +256,7 @@ class PageController extends Controller {
 			$this->eventDispatcher->dispatchTyped(new LoadViewer());
 		}
 
+		$this->eventDispatcher->dispatch('\OCP\Collaboration\Resources::loadAdditionalScripts', new GenericEvent());
 		$response = new TemplateResponse($this->appName, 'index');
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedConnectDomain('*');

--- a/templates/index.php
+++ b/templates/index.php
@@ -1,11 +1,6 @@
 <?php
 
-/** @var \OCP\IL10N $l */
-/** @var array $_ */
+declare(strict_types=1);
 
 script('spreed', 'talk');
-
 style('spreed', 'merged');
-if (($_['user_uid'] ?? '') !== '') {
-	\OC::$server->getEventDispatcher()->dispatch('\OCP\Collaboration\Resources::loadAdditionalScripts');
-}


### PR DESCRIPTION
`user_uid` doesn't seem to be set automatically, so the event to dispatch for loading scripts for the projects integration is never emitted (in [tempates/index.php](https://github.com/nextcloud/spreed/blob/84d42604e60aa1c31ecf698dcc069f36c494148a/templates/index.php#L10))

I can't find where this broke currently so there might be a different way to solve this depending on what changed, however this at least makes it work again :)