### PR TITLE
Store and use display name from attendees table

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -46,6 +46,7 @@ use OCA\Talk\Listener\CSPListener;
 use OCA\Talk\Listener\FeaturePolicyListener;
 use OCA\Talk\Listener\RestrictStartingCalls as RestrictStartingCallsListener;
 use OCA\Talk\Listener\UserDeletedListener;
+use OCA\Talk\Listener\UserDisplayNameListener;
 use OCA\Talk\Middleware\CanUseTalkMiddleware;
 use OCA\Talk\Middleware\InjectionMiddleware;
 use OCA\Talk\Notification\Listener as NotificationListener;
@@ -75,6 +76,7 @@ use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 use OCP\Security\FeaturePolicy\AddFeaturePolicyEvent;
 use OCP\Settings\IManager;
 use OCP\User\Events\BeforeUserLoggedOutEvent;
+use OCP\User\Events\UserChangedEvent;
 use OCP\User\Events\UserDeletedEvent;
 
 class Application extends App implements IBootstrap {
@@ -96,6 +98,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(BeforeTemplateRenderedEvent::class, PublicShareTemplateLoader::class);
 		$context->registerEventListener(BeforeTemplateRenderedEvent::class, PublicShareAuthTemplateLoader::class);
 		$context->registerEventListener(\OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent::class, UnifiedSearchCSSLoader::class);
+		$context->registerEventListener(UserChangedEvent::class, UserDisplayNameListener::class);
 
 		$context->registerSearchProvider(ConversationSearch::class);
 		$context->registerSearchProvider(CurrentMessageSearch::class);

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -104,9 +104,13 @@ class CallController extends AEnvironmentAwareController {
 			if ($this->getAPIVersion() >= 3) {
 				$displayName = $participant->getAttendee()->getActorId();
 				if ($participant->getAttendee()->getActorType() === Attendee::ACTOR_USERS) {
-					$user = $this->userManager->get($participant->getAttendee()->getActorId());
-					if ($user instanceof IUser) {
-						$displayName = $user->getDisplayName();
+					if ($participant->getAttendee()->getDisplayName()) {
+						$displayName = $participant->getAttendee()->getDisplayName();
+					} else {
+						$user = $this->userManager->get($participant->getAttendee()->getActorId());
+						if ($user instanceof IUser) {
+							$displayName = $user->getDisplayName();
+						}
 					}
 				} else {
 					$displayName = $guestNames[$participant->getAttendee()->getActorId()] ?? $displayName;

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1161,11 +1161,6 @@ class RoomController extends AEnvironmentAwareController {
 
 			if ($participant->getAttendee()->getActorType() === Attendee::ACTOR_USERS) {
 				$userId = $participant->getAttendee()->getActorId();
-				$user = $this->userManager->get($userId);
-				if (!$user instanceof IUser) {
-					continue;
-				}
-
 				if ($result['lastPing'] > 0 && $result['lastPing'] <= $maxPingAge) {
 					$this->participantService->leaveRoomAsSession($this->room, $participant);
 				}
@@ -1173,7 +1168,14 @@ class RoomController extends AEnvironmentAwareController {
 				if ($this->getAPIVersion() < 3) {
 					$result['userId'] = $participant->getAttendee()->getActorId();
 				}
-				$result['displayName'] = (string) $user->getDisplayName();
+				$result['displayName'] = $participant->getAttendee()->getDisplayName();
+				if (!$result['displayName']) {
+					$user = $this->userManager->get($userId);
+					if (!$user instanceof IUser) {
+						continue;
+					}
+					$result['displayName'] = $user->getDisplayName();
+				}
 
 				if (isset($statuses[$userId])) {
 					$result['status'] = $statuses[$userId]->getStatus();

--- a/lib/Listener/UserDisplayNameListener.php
+++ b/lib/Listener/UserDisplayNameListener.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Listener;
+
+use OCA\Talk\Model\Attendee;
+use OCA\Talk\Service\ParticipantService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\User\Events\UserChangedEvent;
+
+class UserDisplayNameListener implements IEventListener {
+
+	/** @var ParticipantService */
+	private $participantService;
+
+	public function __construct(ParticipantService $participantService) {
+		$this->participantService = $participantService;
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof UserChangedEvent)) {
+			// Unrelated
+			return;
+		}
+
+		if ($event->getFeature() !== 'displayName') {
+			// Unrelated
+			return;
+		}
+
+		$this->participantService->updateDisplayNameForActor(
+			Attendee::ACTOR_USERS,
+			$event->getUser()->getUID(),
+			(string) $event->getValue()
+		);
+	}
+}

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -519,6 +519,15 @@ class ParticipantService {
 		$query->execute();
 	}
 
+	public function updateDisplayNameForActor(string $actorType, string $actorId, string $displayName): void {
+		$query = $this->connection->getQueryBuilder();
+		$query->update('talk_attendees')
+			->set('display_name', $query->createNamedParameter($displayName))
+			->where($query->expr()->eq('actor_type', $query->createNamedParameter($actorType)))
+			->andWhere($query->expr()->eq('actor_id', $query->createNamedParameter($actorId)));
+		$query->execute();
+	}
+
 	public function getLastCommonReadChatMessage(Room $room): int {
 		$query = $this->connection->getQueryBuilder();
 		$query->selectAlias($query->func()->min('last_read_message'), 'last_common_read_message')


### PR DESCRIPTION
Could help a bit with https://github.com/nextcloud/server/pull/25440

Next step (for follow up PR) is to store the guest name also in this table and retain the attendee instead of the guests_name entry, so we can get rid of that table all together, but I don't want to backport that really.