### PR TITLE
Reuse attendee for guests

### DIFF
--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -120,14 +120,13 @@ class Listener {
 
 		$duration = $this->timeFactory->getTime() - $activeSince->getTimestamp();
 		$userIds = $this->participantService->getParticipantUserIds($room, $activeSince);
+		$numGuests = $this->participantService->getGuestCount($room, $activeSince);
 
-		if ((\count($userIds) + $room->getActiveGuests()) === 1) {
+		if ((\count($userIds) + $numGuests) === 1) {
 			// Single user pinged or guests only => no summary/activity
 			$room->resetActiveSince();
 			return false;
 		}
-
-		$numGuests = $room->getActiveGuests();
 
 		if (!$room->resetActiveSince()) {
 			// Race-condition, the room was already reset.

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -37,7 +37,6 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\SessionService;
-use OCA\Talk\TalkSession;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
@@ -64,9 +63,6 @@ class ChatController extends AEnvironmentAwareController {
 
 	/** @var IUserManager */
 	private $userManager;
-
-	/** @var TalkSession */
-	private $session;
 
 	/** @var IAppManager */
 	private $appManager;
@@ -120,7 +116,6 @@ class ChatController extends AEnvironmentAwareController {
 								?string $UserId,
 								IRequest $request,
 								IUserManager $userManager,
-								TalkSession $session,
 								IAppManager $appManager,
 								ChatManager $chatManager,
 								ParticipantService $participantService,
@@ -140,7 +135,6 @@ class ChatController extends AEnvironmentAwareController {
 
 		$this->userId = $UserId;
 		$this->userManager = $userManager;
-		$this->session = $session;
 		$this->appManager = $appManager;
 		$this->chatManager = $chatManager;
 		$this->participantService = $participantService;
@@ -161,15 +155,9 @@ class ChatController extends AEnvironmentAwareController {
 	protected function getActorInfo(string $actorDisplayName = ''): array {
 		if ($this->userId === null) {
 			$actorType = Attendee::ACTOR_GUESTS;
-			$sessionId = $this->session->getSessionForRoom($this->room->getToken());
-			// The character limit for actorId is 64, but the spreed-session is
-			// 256 characters long, so it has to be hashed to get an ID that
-			// fits (except if there is no session, as the actorId should be
-			// empty in that case but sha1('') would generate a hash too
-			// instead of returning an empty string).
-			$actorId = $sessionId ? sha1($sessionId) : 'failed-to-get-session';
+			$actorId = $this->participant->getAttendee()->getActorId();
 
-			if ($sessionId && $actorDisplayName) {
+			if ($actorDisplayName) {
 				$this->guestManager->updateName($this->room, $this->participant, $actorDisplayName);
 			}
 		} else {

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1618,7 +1618,7 @@ class RoomController extends AEnvironmentAwareController {
 				$participant = $this->participantService->joinRoom($room, $user, $password, $result['result']);
 				$this->participantService->generatePinForParticipant($room, $participant);
 			} else {
-				$participant = $this->participantService->joinRoomAsNewGuest($room, $password, $result['result']);
+				$participant = $this->participantService->joinRoomAsNewGuest($room, $password, $result['result'], $previousParticipant);
 			}
 		} catch (InvalidPasswordException $e) {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);

--- a/lib/Model/AttendeeMapper.php
+++ b/lib/Model/AttendeeMapper.php
@@ -79,6 +79,30 @@ class AttendeeMapper extends QBMapper {
 
 	/**
 	 * @param int $roomId
+	 * @param string $actorType
+	 * @param int|null $lastJoinedCall
+	 * @return int
+	 */
+	public function getActorsCountByType(int $roomId, string $actorType, ?int $lastJoinedCall = null): int {
+		$query = $this->db->getQueryBuilder();
+		$query->select($query->func()->count('*', 'num_actors'))
+			->from($this->getTableName())
+			->where($query->expr()->eq('room_id', $query->createNamedParameter($roomId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('actor_type', $query->createNamedParameter($actorType)));
+
+		if ($lastJoinedCall !== null) {
+			$query->andWhere($query->expr()->gte('last_joined_call', $query->createNamedParameter($lastJoinedCall, IQueryBuilder::PARAM_INT)));
+		}
+
+		$result = $query->execute();
+		$count = (int) $result->fetchOne();
+		$result->closeCursor();
+
+		return $count;
+	}
+
+	/**
+	 * @param int $roomId
 	 * @param int[] $participantType
 	 * @return int
 	 */

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -318,6 +318,10 @@ class Room {
 		return $this->description;
 	}
 
+	/**
+	 * @deprecated Use ParticipantService::getGuestCount() instead
+	 * @return int
+	 */
 	public function getActiveGuests(): int {
 		return $this->activeGuests;
 	}

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -213,11 +213,12 @@ class ParticipantService {
 	 * @param Room $room
 	 * @param string $password
 	 * @param bool $passedPasswordProtection
+	 * @param ?Participant $previousParticipant
 	 * @return Participant
 	 * @throws InvalidPasswordException
 	 * @throws UnauthorizedException
 	 */
-	public function joinRoomAsNewGuest(Room $room, string $password, bool $passedPasswordProtection = false): Participant {
+	public function joinRoomAsNewGuest(Room $room, string $password, bool $passedPasswordProtection = false, ?Participant $previousParticipant = null): Participant {
 		$event = new JoinRoomGuestEvent($room, $password, $passedPasswordProtection);
 		$this->dispatcher->dispatch(Room::EVENT_BEFORE_GUEST_CONNECT, $event);
 
@@ -234,21 +235,27 @@ class ParticipantService {
 			$lastMessage = (int) $room->getLastMessage()->getId();
 		}
 
-		$randomActorId = $this->secureRandom->generate(255);
+		if ($previousParticipant instanceof Participant) {
+			$attendee = $previousParticipant->getAttendee();
+		} else {
+			$randomActorId = $this->secureRandom->generate(255);
 
-		$attendee = new Attendee();
-		$attendee->setRoomId($room->getId());
-		$attendee->setActorType(Attendee::ACTOR_GUESTS);
-		$attendee->setActorId($randomActorId);
-		$attendee->setParticipantType(Participant::GUEST);
-		$attendee->setLastReadMessage($lastMessage);
-		$this->attendeeMapper->insert($attendee);
+			$attendee = new Attendee();
+			$attendee->setRoomId($room->getId());
+			$attendee->setActorType(Attendee::ACTOR_GUESTS);
+			$attendee->setActorId($randomActorId);
+			$attendee->setParticipantType(Participant::GUEST);
+			$attendee->setLastReadMessage($lastMessage);
+			$this->attendeeMapper->insert($attendee);
+		}
 
 		$session = $this->sessionService->createSessionForAttendee($attendee);
 
-		// Update the random guest id
-		$attendee->setActorId(sha1($session->getSessionId()));
-		$this->attendeeMapper->update($attendee);
+		if (!$previousParticipant instanceof Participant) {
+			// Update the random guest id
+			$attendee->setActorId(sha1($session->getSessionId()));
+			$this->attendeeMapper->update($attendee);
+		}
 
 		$this->dispatcher->dispatch(Room::EVENT_AFTER_GUEST_CONNECT, $event);
 
@@ -381,8 +388,7 @@ class ParticipantService {
 			$this->sessionMapper->deleteByAttendeeId($participant->getAttendee()->getId());
 		}
 
-		if ($participant->getAttendee()->getActorType() === Attendee::ACTOR_GUESTS
-			|| $participant->getAttendee()->getParticipantType() === Participant::USER_SELF_JOINED) {
+		if ($participant->getAttendee()->getParticipantType() === Participant::USER_SELF_JOINED) {
 			$this->attendeeMapper->delete($participant->getAttendee());
 		}
 

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -706,6 +706,20 @@ class ParticipantService {
 
 	/**
 	 * @param Room $room
+	 * @param \DateTime|null $maxLastJoined
+	 * @return int
+	 */
+	public function getGuestCount(Room $room, \DateTime $maxLastJoined = null): int {
+		$maxLastJoinedTimestamp = null;
+		if ($maxLastJoined !== null) {
+			$maxLastJoinedTimestamp = $maxLastJoined->getTimestamp();
+		}
+
+		return $this->attendeeMapper->getActorsCountByType($room->getId(), Attendee::ACTOR_GUESTS, $maxLastJoinedTimestamp);
+	}
+
+	/**
+	 * @param Room $room
 	 * @return string[]
 	 */
 	public function getParticipantUserIdsNotInCall(Room $room): array {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
@@ -70,8 +70,13 @@ export default {
 			return this.type === 'guest'
 		},
 		isCurrentGuest() {
+			// On mention bubbles the id is actually "guest/ACTOR_ID" for guests
+			// This is to make sure guests can never collide with users,
+			// while storing them as "… @id …" in chat messages.
+			// So when comparing a guest we have to prefix "guest/"
+			// when comparing the id
 			return this.$store.getters.getActorType() === 'guests'
-				&& this.id === ('guest/' + this.$store.getters.getSessionHash())
+				&& this.id === ('guest/' + this.$store.getters.getActorId())
 		},
 		isCurrentUser() {
 			return this.$store.getters.getActorType() === 'users'

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -151,12 +151,7 @@ export default {
 		},
 
 		isOwnMessageQuoted() {
-			let actorId = this.actorId
-			if (this.actorType === 'guests') {
-				actorId = 'guest/' + actorId
-			}
-
-			return actorId === this.$store.getters.getActorId()
+			return this.actorId === this.$store.getters.getActorId()
 				&& this.actorType === this.$store.getters.getActorType()
 		},
 

--- a/src/components/SetGuestUsername.vue
+++ b/src/components/SetGuestUsername.vue
@@ -111,7 +111,7 @@ export default {
 				this.$store.dispatch('setDisplayName', this.guestUserName)
 				this.$store.dispatch('forceGuestName', {
 					token: this.token,
-					actorId: this.$store.getters.getActorId().substring(6),
+					actorId: this.$store.getters.getActorId(),
 					actorDisplayName: this.guestUserName,
 				})
 				await setGuestUserName(this.token, this.guestUserName)
@@ -125,7 +125,7 @@ export default {
 				this.$store.dispatch('setDisplayName', previousName)
 				this.$store.dispatch('forceGuestName', {
 					token: this.token,
-					actorId: this.$store.getters.getActorId().substring(6),
+					actorId: this.$store.getters.getActorId(),
 					actorDisplayName: previousName,
 				})
 				console.debug(exception)

--- a/src/store/actorStore.js
+++ b/src/store/actorStore.js
@@ -27,13 +27,11 @@
  * If an as no userId, they are a guest and identified by actorType + sessionId.
  */
 
-import sha1 from 'crypto-js/sha1'
 import { PARTICIPANT } from '../constants'
 
 const state = {
 	userId: null,
 	sessionId: null,
-	sessionHash: null,
 	actorId: null,
 	actorType: null,
 	displayName: '',
@@ -46,9 +44,6 @@ const getters = {
 	getSessionId: (state) => () => {
 		return state.sessionId
 	},
-	getSessionHash: (state) => () => {
-		return state.sessionHash
-	},
 	getActorId: (state) => () => {
 		return state.actorId
 	},
@@ -59,14 +54,8 @@ const getters = {
 		return state.displayName
 	},
 	getParticipantIdentifier: (state) => () => {
-		if (state.actorType === 'guests') {
-			return {
-				actorType: 'guests',
-				sessionId: state.sessionId,
-			}
-		}
 		return {
-			actorType: 'users',
+			actorType: state.actorType,
 			actorId: state.actorId,
 		}
 	},
@@ -91,7 +80,6 @@ const mutations = {
 	 */
 	setSessionId(state, sessionId) {
 		state.sessionId = sessionId
-		state.sessionHash = sha1(sessionId)
 	},
 	/**
 	 * Set the actorId
@@ -146,6 +134,7 @@ const actions = {
 	 * @param {object} participant The participant data
 	 * @param {int} participant.participantType The type of the participant
 	 * @param {string} participant.sessionId The session id of the participant
+	 * @param {string} participant.actorId The actor id of the participant
 	 */
 	setCurrentParticipant(context, participant) {
 		context.commit('setSessionId', participant.sessionId)
@@ -154,7 +143,7 @@ const actions = {
 			|| participant.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR) {
 			context.commit('setUserId', null)
 			context.commit('setActorType', 'guests')
-			context.commit('setActorId', 'guest/' + context.getters.getSessionHash())
+			context.commit('setActorId', participant.actorId)
 			// FIXME context.commit('setDisplayName', '')
 		}
 	},

--- a/src/utils/temporaryMessage.js
+++ b/src/utils/temporaryMessage.js
@@ -59,11 +59,6 @@ const createTemporaryMessage = (text, token, uploadId, index, file, localUrl) =>
 		referenceId: Hex.stringify(SHA1(tempId)),
 	})
 
-	if (store.getters.getActorType() === 'guests') {
-		// Strip off "guests/" from the sessionHash
-		message.actorId = store.getters.getActorId().substring(6)
-	}
-
 	/**
 	 * If the current message is a quote-reply message, add the parent key to the
 	 * temporary message object.


### PR DESCRIPTION
- [x] Depends on #5118 
- [x] Stop the abuse of the `sha1(sessionId)` as actorId in the web UI
  - [x] Notify/check Android mobile clients
  - [x] Notify/check iOS mobile clients
- [x] Reuse existing attendees when a guest refreshes
  - [x] Extend the creation/join event with the participant info if needed
- [x] Make the call summary reuse the attendee table also for guests, so we don't have "and 132 guests" when a guest rejoins with a weak internet connection

### Follow ups
- Move the storing of the displayname from oc_talk_guestnames to oc_talk_attendees for guests as well
- Make clicking a SIP link identify the guest as the invited email attendee (will break current SIP dual-join work around)