### PR TITLE
Store guest display names on attendees

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>12.0.0-dev.4</version>
+	<version>12.0.0-dev.5</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/lib/Chat/MessageParser.php
+++ b/lib/Chat/MessageParser.php
@@ -88,7 +88,8 @@ class MessageParser {
 				$displayName = $this->guestNames[$comment->getActorId()];
 			} else {
 				try {
-					$displayName = $this->guestManager->getNameBySessionHash($comment->getActorId());
+					$participant = $message->getRoom()->getParticipantByActor(Attendee::ACTOR_GUESTS, $comment->getActorId());
+					$displayName = $participant->getAttendee()->getDisplayName();
 				} catch (ParticipantNotFoundException $e) {
 				}
 				$this->guestNames[$comment->getActorId()] = $displayName;

--- a/lib/Chat/MessageParser.php
+++ b/lib/Chat/MessageParser.php
@@ -26,7 +26,6 @@ namespace OCA\Talk\Chat;
 
 use OCA\Talk\Events\ChatMessageEvent;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
-use OCA\Talk\GuestManager;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\Message;
 use OCA\Talk\Participant;
@@ -49,18 +48,13 @@ class MessageParser {
 	/** @var IUserManager */
 	private $userManager;
 
-	/** @var GuestManager */
-	private $guestManager;
-
 	/** @var array */
 	protected $guestNames = [];
 
 	public function __construct(IEventDispatcher $dispatcher,
-								IUserManager $userManager,
-								GuestManager $guestManager) {
+								IUserManager $userManager) {
 		$this->dispatcher = $dispatcher;
 		$this->userManager = $userManager;
-		$this->guestManager = $guestManager;
 	}
 
 	public function createMessage(Room $room, Participant $participant, IComment $comment, IL10N $l): Message {

--- a/lib/Chat/Parser/UserMention.php
+++ b/lib/Chat/Parser/UserMention.php
@@ -132,7 +132,8 @@ class UserMention {
 				];
 			} elseif ($mention['type'] === 'guest') {
 				try {
-					$displayName = $this->guestManager->getNameBySessionHash(substr($mention['id'], strlen('guest/')));
+					$participant = $chatMessage->getRoom()->getParticipantByActor(Attendee::ACTOR_GUESTS, substr($mention['id'], strlen('guest/')));
+					$displayName = $participant->getAttendee()->getDisplayName();
 				} catch (ParticipantNotFoundException $e) {
 					$displayName = $this->l->t('Guest');
 				}

--- a/lib/Chat/Parser/UserMention.php
+++ b/lib/Chat/Parser/UserMention.php
@@ -133,7 +133,7 @@ class UserMention {
 			} elseif ($mention['type'] === 'guest') {
 				try {
 					$participant = $chatMessage->getRoom()->getParticipantByActor(Attendee::ACTOR_GUESTS, substr($mention['id'], strlen('guest/')));
-					$displayName = $participant->getAttendee()->getDisplayName();
+					$displayName = $participant->getAttendee()->getDisplayName() ?: $this->l->t('Guest');
 				} catch (ParticipantNotFoundException $e) {
 					$displayName = $this->l->t('Guest');
 				}

--- a/lib/Controller/GuestController.php
+++ b/lib/Controller/GuestController.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Controller;
 
-use Doctrine\DBAL\Exception;
 use OCA\Talk\GuestManager;
 use OCA\Talk\Participant;
 use OCP\AppFramework\Http;
@@ -61,11 +60,7 @@ class GuestController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		try {
-			$this->guestManager->updateName($this->getRoom(), $participant, $displayName);
-		} catch (Exception $e) {
-			return new DataResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
-		}
+		$this->guestManager->updateName($this->getRoom(), $participant, $displayName);
 
 		return new DataResponse();
 	}

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1128,17 +1128,7 @@ class RoomController extends AEnvironmentAwareController {
 			$headers['X-Nextcloud-Has-User-Statuses'] = true;
 		}
 
-		$guestSessions = array_filter(array_map(static function (Participant $participant) {
-			$session = $participant->getSession();
-			if (!$session || $participant->getAttendee()->getActorType() !== Attendee::ACTOR_GUESTS) {
-				return null;
-			}
-
-			return sha1($session->getSessionId());
-		}, $participants));
-
 		$cleanGuests = false;
-		$guestNames = $this->guestManager->getNamesBySessionHashes($guestSessions);
 
 		/** @var Participant[] $participants */
 		foreach ($participants as $participant) {
@@ -1202,7 +1192,7 @@ class RoomController extends AEnvironmentAwareController {
 				if ($this->getAPIVersion() < 3) {
 					$result['userId'] = '';
 				}
-				$result['displayName'] = $guestNames[$participant->getAttendee()->getActorId()] ?? '';
+				$result['displayName'] = $participant->getAttendee()->getDisplayName();
 			} elseif ($this->getAPIVersion() >= 3) {
 				// Other types are only reported on v3 or later
 				$result['displayName'] = $participant->getAttendee()->getActorId();

--- a/lib/GuestManager.php
+++ b/lib/GuestManager.php
@@ -111,36 +111,6 @@ class GuestManager {
 		}
 	}
 
-	/**
-	 * @param string[] $sessionHashes
-	 * @return string[]
-	 */
-	public function getNamesBySessionHashes(array $sessionHashes): array {
-		if (empty($sessionHashes)) {
-			return [];
-		}
-
-		$query = $this->connection->getQueryBuilder();
-		$query->select('*')
-			->from('talk_guestnames')
-			->where($query->expr()->in('session_hash', $query->createNamedParameter($sessionHashes, IQueryBuilder::PARAM_STR_ARRAY)));
-
-		$result = $query->execute();
-
-		$map = [];
-
-		while ($row = $result->fetch()) {
-			if ($row['display_name'] === '') {
-				continue;
-			}
-
-			$map[$row['session_hash']] = $row['display_name'];
-		}
-		$result->closeCursor();
-
-		return $map;
-	}
-
 	public function sendEmailInvitation(Room $room, Participant $participant): void {
 		if ($participant->getAttendee()->getActorType() !== Attendee::ACTOR_EMAILS) {
 			throw new \InvalidArgumentException('Cannot send email for non-email participant actor type');

--- a/lib/GuestManager.php
+++ b/lib/GuestManager.php
@@ -112,29 +112,6 @@ class GuestManager {
 	}
 
 	/**
-	 * @param string $sessionHash
-	 * @param bool $allowEmpty
-	 * @return string
-	 * @throws ParticipantNotFoundException
-	 */
-	public function getNameBySessionHash(string $sessionHash, bool $allowEmpty = false): string {
-		$query = $this->connection->getQueryBuilder();
-		$query->select('display_name')
-			->from('talk_guestnames')
-			->where($query->expr()->eq('session_hash', $query->createNamedParameter($sessionHash)));
-
-		$result = $query->execute();
-		$row = $result->fetch();
-		$result->closeCursor();
-
-		if (isset($row['display_name']) && ($allowEmpty || $row['display_name'] !== '')) {
-			return $row['display_name'];
-		}
-
-		throw new ParticipantNotFoundException();
-	}
-
-	/**
 	 * @param string[] $sessionHashes
 	 * @return string[]
 	 */

--- a/lib/GuestManager.php
+++ b/lib/GuestManager.php
@@ -23,16 +23,12 @@ declare(strict_types=1);
 
 namespace OCA\Talk;
 
-use Doctrine\DBAL\Exception;
 use OCA\Talk\Events\AddEmailEvent;
 use OCA\Talk\Events\ModifyParticipantEvent;
 use OCA\Talk\Model\Attendee;
-use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Service\ParticipantService;
-use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
@@ -44,9 +40,6 @@ class GuestManager {
 	public const EVENT_BEFORE_EMAIL_INVITE = self::class . '::preInviteByEmail';
 	public const EVENT_AFTER_EMAIL_INVITE = self::class . '::postInviteByEmail';
 	public const EVENT_AFTER_NAME_UPDATE = self::class . '::updateName';
-
-	/** @var IDBConnection */
-	protected $connection;
 
 	/** @var Config */
 	protected $talkConfig;
@@ -72,8 +65,7 @@ class GuestManager {
 	/** @var IEventDispatcher */
 	protected $dispatcher;
 
-	public function __construct(IDBConnection $connection,
-								Config $talkConfig,
+	public function __construct(Config $talkConfig,
 								IMailer $mailer,
 								Defaults $defaults,
 								IUserSession $userSession,
@@ -81,7 +73,6 @@ class GuestManager {
 								IURLGenerator $url,
 								IL10N $l,
 								IEventDispatcher $dispatcher) {
-		$this->connection = $connection;
 		$this->talkConfig = $talkConfig;
 		$this->mailer = $mailer;
 		$this->defaults = $defaults;

--- a/lib/Migration/Version11000Date20201209142525.php
+++ b/lib/Migration/Version11000Date20201209142525.php
@@ -28,19 +28,10 @@ namespace OCA\Talk\Migration;
 use Closure;
 use Doctrine\DBAL\Types\Types;
 use OCP\DB\ISchemaWrapper;
-use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version11000Date20201209142525 extends SimpleMigrationStep {
-	/** @var IDBConnection */
-	protected $connection;
-
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
-	}
-
-
 	/**
 	 * @param IOutput $output
 	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
@@ -108,18 +99,5 @@ class Version11000Date20201209142525 extends SimpleMigrationStep {
 		}
 
 		return $changedSchema ? $schema : null;
-	}
-
-	/**
-	 * @param IOutput $output
-	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
-	 * @param array $options
-	 */
-	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
-		/**
-		 * Table is dropped in favor of talk_attendees::display_name
-		 * We can't link the data to a room and therefor create a related
-		 * attendee, so unluckily it makes no sense to take over the data
-		 */
 	}
 }

--- a/lib/Migration/Version11000Date20201209142525.php
+++ b/lib/Migration/Version11000Date20201209142525.php
@@ -116,29 +116,10 @@ class Version11000Date20201209142525 extends SimpleMigrationStep {
 	 * @param array $options
 	 */
 	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
-		if (!$this->connection->tableExists('talk_guests')) {
-			return;
-		}
-
-		$insert = $this->connection->getQueryBuilder();
-		$insert->insert('talk_guestnames')
-			->values([
-				'session_hash' => $insert->createParameter('session_hash'),
-				'display_name' => $insert->createParameter('display_name'),
-			]);
-
-		$query = $this->connection->getQueryBuilder();
-		$query->select('*')
-			->from('talk_guests');
-
-		$result = $query->execute();
-		while ($row = $result->fetch()) {
-			$insert
-				->setParameter('session_hash', (string) $row['session_hash'])
-				->setParameter('display_name', (string) $row['display_name'])
-			;
-			$insert->execute();
-		}
-		$result->closeCursor();
+		/**
+		 * Table is dropped in favor of talk_attendees::display_name
+		 * We can't link the data to a room and therefor create a related
+		 * attendee, so unluckily it makes no sense to take over the data
+		 */
 	}
 }

--- a/lib/Migration/Version11001Date20210212105406.php
+++ b/lib/Migration/Version11001Date20210212105406.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021, Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version11001Date20210212105406 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		if ($schema->hasTable('talk_guestnames')) {
+			$schema->dropTable('talk_guestnames');
+			return $schema;
+		}
+		return null;
+	}
+}

--- a/lib/Migration/Version11001Date20210212105406.php
+++ b/lib/Migration/Version11001Date20210212105406.php
@@ -41,6 +41,11 @@ class Version11001Date20210212105406 extends SimpleMigrationStep {
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
+		/**
+		 * Table is dropped in favor of talk_attendees::display_name
+		 * We can't link the data to a room and therefor create a related
+		 * attendee, so unluckily it makes no sense to take over the data
+		 */
 		if ($schema->hasTable('talk_guestnames')) {
 			$schema->dropTable('talk_guestnames');
 			return $schema;

--- a/lib/Model/Attendee.php
+++ b/lib/Model/Attendee.php
@@ -33,9 +33,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setActorId(string $actorId)
  * @method string getActorId()
  * @method void setDisplayName(string $displayName)
- * @method string getDisplayName()
  * @method void setPin(string $pin)
- * @method string getPin()
+ * @method null|string getPin()
  * @method void setParticipantType(int $participantType)
  * @method int getParticipantType()
  * @method void setFavorite(bool $favorite)
@@ -65,10 +64,10 @@ class Attendee extends Entity {
 	/** @var string */
 	protected $actorId;
 
-	/** @var string */
+	/** @var null|string */
 	protected $displayName;
 
-	/** @var string */
+	/** @var null|string */
 	protected $pin;
 
 	/** @var int */
@@ -107,6 +106,10 @@ class Attendee extends Entity {
 		$this->addType('readPrivacy', 'int');
 	}
 
+	public function getDisplayName(): string {
+		return (string) $this->displayName;
+	}
+
 	/**
 	 * @return array
 	 */
@@ -116,7 +119,7 @@ class Attendee extends Entity {
 			'room_id' => $this->getRoomId(),
 			'actor_type' => $this->getActorType(),
 			'actor_id' => $this->getActorId(),
-			// FIXME 'display_name' => $this->getDisplayName(),
+			'display_name' => $this->getDisplayName(),
 			'pin' => $this->getPin(),
 			'participant_type' => $this->getParticipantType(),
 			'favorite' => $this->isFavorite(),

--- a/lib/Model/AttendeeMapper.php
+++ b/lib/Model/AttendeeMapper.php
@@ -143,6 +143,7 @@ class AttendeeMapper extends QBMapper {
 			'room_id' => $row['room_id'],
 			'actor_type' => $row['actor_type'],
 			'actor_id' => $row['actor_id'],
+			'display_name' => (string) $row['display_name'],
 			'pin' => $row['pin'],
 			'participant_type' => (int) $row['participant_type'],
 			'favorite' => (bool) $row['favorite'],

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -30,6 +30,7 @@ use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Exceptions\RoomNotFoundException;
 use OCA\Talk\GuestManager;
 use OCA\Talk\Manager;
+use OCA\Talk\Model\Attendee;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
@@ -365,7 +366,7 @@ class Notifier implements INotifier {
 				$subject = $l->t('Deleted user in {call}') . "\n{message}";
 			} else {
 				try {
-					$richSubjectParameters['guest'] = $this->getGuestParameter($comment->getActorId());
+					$richSubjectParameters['guest'] = $this->getGuestParameter($room, $comment->getActorId());
 					$subject = $l->t('{guest} (guest) in {call}') . "\n{message}";
 				} catch (ParticipantNotFoundException $e) {
 					$subject = $l->t('Guest in {call}') . "\n{message}";
@@ -380,7 +381,7 @@ class Notifier implements INotifier {
 				$subject = $l->t('A deleted user sent a message in conversation {call}');
 			} else {
 				try {
-					$richSubjectParameters['guest'] = $this->getGuestParameter($comment->getActorId());
+					$richSubjectParameters['guest'] = $this->getGuestParameter($room, $comment->getActorId());
 					$subject = $l->t('{guest} (guest) sent a message in conversation {call}');
 				} catch (ParticipantNotFoundException $e) {
 					$subject = $l->t('A guest sent a message in conversation {call}');
@@ -395,7 +396,7 @@ class Notifier implements INotifier {
 				$subject = $l->t('A deleted user replied to your message in conversation {call}');
 			} else {
 				try {
-					$richSubjectParameters['guest'] = $this->getGuestParameter($comment->getActorId());
+					$richSubjectParameters['guest'] = $this->getGuestParameter($room, $comment->getActorId());
 					$subject = $l->t('{guest} (guest) replied to your message in conversation {call}');
 				} catch (ParticipantNotFoundException $e) {
 					$subject = $l->t('A guest replied to your message in conversation {call}');
@@ -409,7 +410,7 @@ class Notifier implements INotifier {
 			$subject = $l->t('A deleted user mentioned you in conversation {call}');
 		} else {
 			try {
-				$richSubjectParameters['guest'] = $this->getGuestParameter($comment->getActorId());
+				$richSubjectParameters['guest'] = $this->getGuestParameter($room, $comment->getActorId());
 				$subject = $l->t('{guest} (guest) mentioned you in conversation {call}');
 			} catch (ParticipantNotFoundException $e) {
 				$subject = $l->t('A guest mentioned you in conversation {call}');
@@ -434,12 +435,14 @@ class Notifier implements INotifier {
 	}
 
 	/**
+	 * @param Room $room
 	 * @param string $actorId
 	 * @return array
 	 * @throws ParticipantNotFoundException
 	 */
-	protected function getGuestParameter(string $actorId): array {
-		$name = $this->guestManager->getNameBySessionHash($actorId);
+	protected function getGuestParameter(Room $room, string $actorId): array {
+		$participant = $room->getParticipantByActor(Attendee::ACTOR_GUESTS, $actorId);
+		$name = $participant->getAttendee()->getDisplayName();
 		if (trim($name) === '') {
 			throw new ParticipantNotFoundException('Empty name');
 		}

--- a/tests/integration/spreedcheats/lib/Controller/ApiController.php
+++ b/tests/integration/spreedcheats/lib/Controller/ApiController.php
@@ -60,9 +60,6 @@ class ApiController extends OCSController {
 		$query->delete('talk_attendees')->execute();
 
 		$query = $this->db->getQueryBuilder();
-		$query->delete('talk_guestnames')->execute();
-
-		$query = $this->db->getQueryBuilder();
 		$query->delete('talk_sessions')->execute();
 
 		$query = $this->db->getQueryBuilder();

--- a/tests/php/Chat/Parser/UserMentionTest.php
+++ b/tests/php/Chat/Parser/UserMentionTest.php
@@ -27,6 +27,7 @@ namespace OCA\Talk\Tests\php\Chat\Parser;
 use OCA\Talk\Chat\Parser\UserMention;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\GuestManager;
+use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\Message;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
@@ -443,9 +444,8 @@ class UserMentionTest extends \Test\TestCase {
 		/** @var IL10N|MockObject $l */
 		$l = $this->createMock(IL10N::class);
 
-		$this->guestManager->expects($this->once())
-			->method('getNameBySessionHash')
-			->with('123456')
+		$room->method('getParticipantByActor')
+			->with(Attendee::ACTOR_GUESTS, '123456')
 			->willThrowException(new ParticipantNotFoundException());
 		$this->l->expects($this->any())
 			->method('t')
@@ -483,9 +483,8 @@ class UserMentionTest extends \Test\TestCase {
 		/** @var IL10N|MockObject $l */
 		$l = $this->createMock(IL10N::class);
 
-		$this->guestManager->expects($this->once())
-			->method('getNameBySessionHash')
-			->with('123456')
+		$room->method('getParticipantByActor')
+			->with(Attendee::ACTOR_GUESTS, '123456')
 			->willThrowException(new ParticipantNotFoundException());
 		$this->l->expects($this->any())
 			->method('t')
@@ -523,10 +522,17 @@ class UserMentionTest extends \Test\TestCase {
 		/** @var IL10N|MockObject $l */
 		$l = $this->createMock(IL10N::class);
 
-		$this->guestManager->expects($this->once())
-			->method('getNameBySessionHash')
-			->with('abcdef')
-			->willReturn('Name');
+		$attendee = Attendee::fromRow([
+			'actor_type' => 'guests',
+			'actor_id' => 'abcdef',
+			'display_name' => 'Name',
+		]);
+		$participant->method('getAttendee')
+			->willReturn($attendee);
+
+		$room->method('getParticipantByActor')
+			->with(Attendee::ACTOR_GUESTS, 'abcdef')
+			->willReturn($participant);
 		$this->l->expects($this->any())
 			->method('t')
 			->willReturnCallback(function ($text, $parameters = []) {

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -28,6 +28,7 @@ use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Exceptions\RoomNotFoundException;
 use OCA\Talk\GuestManager;
 use OCA\Talk\Manager;
+use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\Message;
 use OCA\Talk\Notification\Notifier;
 use OCA\Talk\Participant;
@@ -937,14 +938,20 @@ class NotifierTest extends \Test\TestCase {
 			->willReturn($comment);
 
 		if (is_string($guestName)) {
-			$this->guestManager->expects($this->once())
-				->method('getNameBySessionHash')
-				->with('random-hash')
-				->willReturn($guestName);
+			$room->method('getParticipantByActor')
+				->with(Attendee::ACTOR_GUESTS, 'random-hash')
+				->willReturn($participant);
+
+			$attendee = Attendee::fromRow([
+				'actor_type' => 'guests',
+				'actor_id' => 'random-hash',
+				'display_name' => $guestName,
+			]);
+			$participant->method('getAttendee')
+				->willReturn($attendee);
 		} else {
-			$this->guestManager->expects($this->any())
-				->method('getNameBySessionHash')
-				->with('random-hash')
+			$room->method('getParticipantByActor')
+				->with(Attendee::ACTOR_GUESTS, 'random-hash')
 				->willThrowException(new ParticipantNotFoundException());
 		}
 


### PR DESCRIPTION
* ⚠️ Warning for changelog: This drops the guest names on existing chat messages and there is nothing we can do about it.

- [x] Store the guest names in attendee display name
- [x] Use the display name from attendees instead of querying it manually
- [x] Drop old table

Purely internal changes, frontend and mobile apps should not be affected as the public API is unchanged.