### PR TITLE
Limit the session list on the database instead of selecting all attendees

### DIFF
--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -69,16 +69,9 @@ class CallController extends AEnvironmentAwareController {
 	public function getPeersForCall(): DataResponse {
 		$timeout = $this->timeFactory->getTime() - 30;
 		$result = [];
-		$participants = $this->participantService->getParticipantsInCall($this->room);
+		$participants = $this->participantService->getParticipantsInCall($this->room, $timeout);
 
 		foreach ($participants as $participant) {
-			/** @var Session $session */
-			$session = $participant->getSession();
-			if ($session->getLastPing() < $timeout) {
-				// User is not active in call
-				continue;
-			}
-
 			if ($this->getAPIVersion() >= 3) {
 				$displayName = $participant->getAttendee()->getActorId();
 				if ($participant->getAttendee()->getActorType() === Attendee::ACTOR_USERS) {
@@ -99,8 +92,8 @@ class CallController extends AEnvironmentAwareController {
 					'actorId' => $participant->getAttendee()->getActorId(),
 					'displayName' => $displayName,
 					'token' => $this->room->getToken(),
-					'lastPing' => $session->getLastPing(),
-					'sessionId' => $session->getSessionId(),
+					'lastPing' => $participant->getSession()->getLastPing(),
+					'sessionId' => $participant->getSession()->getSessionId(),
 				];
 			} else {
 				$userId = '';
@@ -111,8 +104,8 @@ class CallController extends AEnvironmentAwareController {
 				$result[] = [
 					'userId' => $userId,
 					'token' => $this->room->getToken(),
-					'lastPing' => $session->getLastPing(),
-					'sessionId' => $session->getSessionId(),
+					'lastPing' => $participant->getSession()->getLastPing(),
+					'sessionId' => $participant->getSession()->getSessionId(),
 				];
 			}
 		}

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -624,9 +624,10 @@ class ParticipantService {
 
 	/**
 	 * @param Room $room
+	 * @param int $maxAge
 	 * @return Participant[]
 	 */
-	public function getParticipantsInCall(Room $room): array {
+	public function getParticipantsInCall(Room $room, int $maxAge = 0): array {
 		$query = $this->connection->getQueryBuilder();
 
 		$helper = new SelectHelper();
@@ -639,6 +640,10 @@ class ParticipantService {
 			)
 			->where($query->expr()->eq('a.room_id', $query->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->neq('s.in_call', $query->createNamedParameter(Participant::FLAG_DISCONNECTED)));
+
+		if ($maxAge > 0) {
+			$query->andWhere($query->expr()->gte('s.last_ping', $query->createNamedParameter($maxAge, IQueryBuilder::PARAM_INT)));
+		}
 
 		return $this->getParticipantsFromQuery($query, $room);
 	}


### PR DESCRIPTION
Should save some load as we don't create objects and select items we then throw away


- [x] Need to check whether this breaks the index