### PR TITLE
Update Room object last message after setting

### DIFF
--- a/lib/Room.php
+++ b/lib/Room.php
@@ -724,6 +724,9 @@ class Room {
 			->set('last_message', $query->createNamedParameter((int) $message->getId()))
 			->where($query->expr()->eq('id', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)));
 		$query->execute();
+
+		$this->lastMessage = $message;
+		$this->lastMessageId = (int) $message->getId();
 	}
 
 	public function resetActiveSince(): bool {


### PR DESCRIPTION
### Description

When updating the last_read_message in the database, we now also update it in
the Room object like it is done for other properties.

Fixes an issue when creating a room with participants that the latter
received a last_read_message id of zero. This is because the code path for
creation is done within a single API call, and while the room got
created, the last message id in Room was still 0 when read out for
setting to the participants in addUsers().

### References

Indirectly related to https://github.com/nextcloud/spreed/pull/3825 and affects its proper functioning.

### Testing
#### Steps
1. Copy this SQL query for testing: `select token, actor_id, last_read_message, (select message from oc_comments c where c.id=a.last_read_message) message, last_mention_message, last_message from oc_talk_attendees a, oc_talk_rooms r where r.id=a.room_id;`
2. Create room with occ (to avoid triggering a last message refresh through UI access): `occ talk:room:create --user admin --user alice --user bob --moderator admin test-occ`

#### Before the fix
Running the SQL query will show that last_read_message is zero for the users who got added during creation.

The values will adjust themselves on next access. But this will change in https://github.com/nextcloud/spreed/pull/3825 where we disable automatic update during that query as we want finer control.

Adding more participants in the UI automatically sets that value to the last message for the newly added participants.

#### After the fix
Running the SQL query will show that the last_read_message is updated and points at the initial system messages.

### Issues

- [ ] should we add a repair step ? currently on master that field will get updated automatically to the last ever message on access. But it won't be the case any more in https://github.com/nextcloud/spreed/pull/3825
