### PR TITLE
Changelog for 11.0 and 11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 11.1.0 – 2021-02-23
+### Added
+- Integrate with Deck to allow posting Deck cards to Talk conversations
+  [#5201](https://github.com/nextcloud/spreed/pull/5201)
+  [#5202](https://github.com/nextcloud/spreed/pull/5202)
+  [#5203](https://github.com/nextcloud/spreed/pull/5203)
+- Allow other apps to register message actions, e.g. Deck can create a Deck card out of a chat message
+  [#5204](https://github.com/nextcloud/spreed/pull/5204)
+- Allow to delete chat messages
+  [#5205](https://github.com/nextcloud/spreed/pull/5205)
+  [#5206](https://github.com/nextcloud/spreed/pull/5206)
+- Add information about callFlags of a conversation to the API so mobile clients can show if it's a audio or video call
+  [#5208](https://github.com/nextcloud/spreed/pull/5208)
+
+### Fixed
+- Prevent loading old messages twice on scroll which could skip some messages
+  [#5209](https://github.com/nextcloud/spreed/pull/5209)
+
 ## 11.0.0 – 2021-02-22
 ### Added
 - Implement read status for messages including a privacy setting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,48 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 11.0.0-RC.1 – 2021-02-12
+## 11.0.0 – 2021-02-22
+### Added
+- Implement read status for messages including a privacy setting
+  [#4231](https://github.com/nextcloud/spreed/pull/4231)
+- Allow moderators to "open" conversations so users can join themselves
+  [#4706](https://github.com/nextcloud/spreed/pull/4706)
+- Add conversation descriptions
+  [#4546](https://github.com/nextcloud/spreed/pull/4546)
+- Allow pagination for main grid view
+  [#4958](https://github.com/nextcloud/spreed/pull/4958)
+- Allow to send messages again when they failed
+  [#4975](https://github.com/nextcloud/spreed/pull/4975)
+- You can now push to talk/mute with the space key
+  [#4328](https://github.com/nextcloud/spreed/pull/4328)
+- Added support for turns:// protocol
+  [#5087](https://github.com/nextcloud/spreed/pull/5087)
+- Add basic support for Opera
+  [#4974](https://github.com/nextcloud/spreed/pull/4974)
+- Allow resending email invitations
+  [#5052](https://github.com/nextcloud/spreed/pull/5052)
+- Allow to collapse the video strip to focus more on the promoted speaker or screenshare
+  [#4363](https://github.com/nextcloud/spreed/pull/4363)
+- Improve previews of images and allow animation of gifs
+  [#4472](https://github.com/nextcloud/spreed/pull/4472)
+- Allow to "Raise hand" in a call
+  [#4569](https://github.com/nextcloud/spreed/pull/4569)
+- Compatibility with Nextcloud 21
+
+### Changed
+- Bring up the conversation creation-dialog when clicking on a group to prevent accidentally spam
+  [#5062](https://github.com/nextcloud/spreed/pull/5062)
+- User different border color when own message is quoted
+  [#4940](https://github.com/nextcloud/spreed/pull/4940)
+- Move matterbridge settings into the conversation settings dialog
+  [#4907](https://github.com/nextcloud/spreed/pull/4907)
+- Updated database structure so all tables have a primary key for database cluster support
+  [#4735](https://github.com/nextcloud/spreed/pull/4735)
+
+### Fixed
+- For more details look at the changelog of the alphas and the rc
+
+## 11.0.0-rc.1 – 2021-02-12
 ### Added
 - Allow resending email invitations
   [#5052](https://github.com/nextcloud/spreed/pull/5052)
@@ -162,7 +203,7 @@ All notable changes to this project will be documented in this file.
   [#4195](https://github.com/nextcloud/spreed/pull/4195)
 - Updated database structure so all tables have a primary key for database cluster support
   [#4735](https://github.com/nextcloud/spreed/pull/4735)
-  
+
 ### Fixed
 - Diff against alpha.1: Revert update of @babel/preset-env which breaks the compiled JS
   [#4808](https://github.com/nextcloud/spreed/pull/4808)

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -65,7 +65,7 @@ title: Capabilities
 * `config => chat => read-privacy` - See `chat-read-status`
 * `config => previews => max-gif-size` - Maximum size in bytes below which a GIF can be embedded directly in the page at render time. Bigger files will be rendered statically using the preview endpoint instead. Can be set with `occ config:app:set spreed max-gif-size --value=X` where X is the new value in bytes. Defaults to 3 MB.
 
-## 12.0
+## 11.1
 * `delete-messages` - Allows to delete chat messages up to 6 hours for your own messages or when being a moderator. On deleting the message text will be replaced and a follow up system message will make sure clients and users update it in their cache and storage.
 * `rich-object-sharing` - Rich objects can be shared to chats. See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob/master/lib/public/RichObjectStrings/Definitions.php) for more details on supported rich objects and required data.
 * `conversation-call-flags` - Whether the room api provides the `callFlag` to tell apart video and audio calls


### PR DESCRIPTION
## 11.1.0 – 2021-02-23
### ✅ Added
- Integrate with Deck to allow posting Deck cards to Talk conversations  [#5201](https://github.com/nextcloud/spreed/pull/5201)  [#5202](https://github.com/nextcloud/spreed/pull/5202)  [#5203](https://github.com/nextcloud/spreed/pull/5203)
- Allow other apps to register message actions, e.g. Deck can create a Deck card out of a chat message  [#5204](https://github.com/nextcloud/spreed/pull/5204)
- Allow to delete chat messages  [#5205](https://github.com/nextcloud/spreed/pull/5205)  [#5206](https://github.com/nextcloud/spreed/pull/5206)
- Add information about callFlags of a conversation to the API so mobile clients can show if it's a audio or video call  [#5208](https://github.com/nextcloud/spreed/pull/5208)

### 🐞 Fixed
- Prevent loading old messages twice on scroll which could skip some messages  [#5209](https://github.com/nextcloud/spreed/pull/5209)

## 11.0.0 – 2021-02-22
### ✅ Added
- Implement read status for messages including a privacy setting  [#4231](https://github.com/nextcloud/spreed/pull/4231)
- Allow moderators to "open" conversations so users can join themselves  [#4706](https://github.com/nextcloud/spreed/pull/4706)
- Add conversation descriptions  [#4546](https://github.com/nextcloud/spreed/pull/4546)
- Allow pagination for main grid view  [#4958](https://github.com/nextcloud/spreed/pull/4958)
- Allow to send messages again when they failed  [#4975](https://github.com/nextcloud/spreed/pull/4975)
- You can now push to talk/mute with the space key  [#4328](https://github.com/nextcloud/spreed/pull/4328)
- Added support for turns:// protocol  [#5087](https://github.com/nextcloud/spreed/pull/5087)
- Add basic support for Opera  [#4974](https://github.com/nextcloud/spreed/pull/4974)
- Allow resending email invitations  [#5052](https://github.com/nextcloud/spreed/pull/5052)
- Allow to collapse the video strip to focus more on the promoted speaker or screenshare  [#4363](https://github.com/nextcloud/spreed/pull/4363)
- Improve previews of images and allow animation of gifs  [#4472](https://github.com/nextcloud/spreed/pull/4472)
- Allow to "Raise hand" in a call  [#4569](https://github.com/nextcloud/spreed/pull/4569)
- Compatibility with Nextcloud 21

### 🔧 Changed
- Bring up the conversation creation-dialog when clicking on a group to prevent accidentally spam  [#5062](https://github.com/nextcloud/spreed/pull/5062)
- User different border color when own message is quoted  [#4940](https://github.com/nextcloud/spreed/pull/4940)
- Move matterbridge settings into the conversation settings dialog  [#4907](https://github.com/nextcloud/spreed/pull/4907)
- Updated database structure so all tables have a primary key for database cluster support  [#4735](https://github.com/nextcloud/spreed/pull/4735)

### 🐞 Fixed
- For more details look at the changelog of the alphas and the rc