### PR TITLE
When locking a conversation, kick out everyone

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1515,6 +1515,15 @@ class RoomController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
+		if ($state === Room::READ_ONLY) {
+			$participants = $this->participantService->getParticipantsInCall($this->room);
+
+			// kick out all participants out of the call
+			foreach ($participants as $participant) {
+				$this->participantService->changeInCall($this->room, $participant, Participant::FLAG_DISCONNECTED);
+			}
+		}
+
 		return new DataResponse();
 	}
 

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -490,6 +490,10 @@ class ParticipantService {
 			return;
 		}
 
+		if ($session->getInCall() === $flags) {
+			return;
+		}
+
 		$event = new ModifyParticipantEvent($room, $participant, 'inCall', $flags, $session->getInCall());
 		if ($flags !== Participant::FLAG_DISCONNECTED) {
 			$this->dispatcher->dispatch(Room::EVENT_BEFORE_SESSION_JOIN_CALL, $event);

--- a/src/components/ConversationSettings/LobbySettings.vue
+++ b/src/components/ConversationSettings/LobbySettings.vue
@@ -24,6 +24,7 @@
 		<div class="app-settings-subsection">
 			<div id="moderation_settings_enable_lobby_hint" class="app-settings-section__hint">
 				{{ t('spreed', 'Enabling the lobby only allows moderators to post messages.') }}
+				{{ t('spreed', 'This will also remove non-moderators from ongoing calls.') }}
 			</div>
 			<div>
 				<input id="moderation_settings_enable_lobby_checkbox"

--- a/src/components/ConversationSettings/LobbySettings.vue
+++ b/src/components/ConversationSettings/LobbySettings.vue
@@ -24,7 +24,9 @@
 		<div class="app-settings-subsection">
 			<div id="moderation_settings_enable_lobby_hint" class="app-settings-section__hint">
 				{{ t('spreed', 'Enabling the lobby only allows moderators to post messages.') }}
-				{{ t('spreed', 'This will also remove non-moderators from ongoing calls.') }}
+			</div>
+			<div v-if="hasCall" class="app-settings-section__hint">
+				{{ t('spreed', 'This will also remove non-moderators from the ongoing call.') }}
 			</div>
 			<div>
 				<input id="moderation_settings_enable_lobby_checkbox"
@@ -94,6 +96,10 @@ export default {
 	},
 
 	computed: {
+		hasCall() {
+			return this.conversation.hasCall
+		},
+
 		conversation() {
 			return this.$store.getters.conversation(this.token) || this.$store.getters.dummyConversation
 		},

--- a/src/components/ConversationSettings/LockingSettings.vue
+++ b/src/components/ConversationSettings/LockingSettings.vue
@@ -23,7 +23,9 @@
 	<div class="app-settings-subsection">
 		<div id="moderation_settings_lock_conversation_hint" class="app-settings-section__hint">
 			{{ t('spreed', 'Locking the conversation prevents anyone to post messages or start calls.') }}
-			{{ t('spreed', 'This will also terminate ongoing calls.') }}
+		</div>
+		<div v-if="hasCall" class="app-settings-section__hint">
+			{{ t('spreed', 'This will also terminate the ongoing call.') }}
 		</div>
 		<div>
 			<input id="moderation_settings_lock_conversation_checkbox"
@@ -60,6 +62,10 @@ export default {
 	},
 
 	computed: {
+		hasCall() {
+			return this.conversation.hasCall
+		},
+
 		conversation() {
 			return this.$store.getters.conversation(this.token) || this.$store.getters.dummyConversation
 		},

--- a/src/components/ConversationSettings/LockingSettings.vue
+++ b/src/components/ConversationSettings/LockingSettings.vue
@@ -23,6 +23,7 @@
 	<div class="app-settings-subsection">
 		<div id="moderation_settings_lock_conversation_hint" class="app-settings-section__hint">
 			{{ t('spreed', 'Locking the conversation prevents anyone to post messages or start calls.') }}
+			{{ t('spreed', 'This will also terminate ongoing calls.') }}
 		</div>
 		<div>
 			<input id="moderation_settings_lock_conversation_checkbox"


### PR DESCRIPTION
Also only trigger events and update the session flags
if they actually changed, as some callers might not check for differences.

- [x] add ~~confirmation dialog (separately is also ok if not urgent)~~ warning in text