### PR TITLE
[stable19] Add changelog for 9.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 9.0.9 – 2021-02-22
+### Fixed
+- Fix collaboration resource options not loading
+  [#5143](https://github.com/nextcloud/spreed/pull/5143)
+- Fixed a bug that would prevent attachments going into the Talk/ folder
+  [#5080](https://github.com/nextcloud/spreed/pull/5080)
+
 ## 9.0.8 – 2021-01-08
 ### Fixed
 - Don't remove a chat when a self-joined user leaves

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>9.0.8</version>
+	<version>9.0.9</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>


### PR DESCRIPTION
## 9.0.9 – 2021-02-22
### 🐞 Fixed
- Fix collaboration resource options not loading  [#5143](https://github.com/nextcloud/spreed/pull/5143)
- Fixed a bug that would prevent attachments going into the Talk/ folder  [#5080](https://github.com/nextcloud/spreed/pull/5080)