### PR TITLE
[stable20] Fix toast timeout

### DIFF
--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -72,7 +72,6 @@ import SHA1 from 'crypto-js/sha1'
 import {
 	showError,
 	showInfo,
-	TOAST_PERMANENT_TIMEOUT,
 } from '@nextcloud/dialogs'
 import video from '../../../mixins/video.js'
 import VideoBackground from './VideoBackground'
@@ -300,12 +299,12 @@ export default {
 					} else if (error.name === 'NotReadableError' || error.name === 'AbortError') {
 						// when camera in use, Chrome gives NotReadableError, Firefox gives AbortError
 						this.notificationHandle = showError(t('spreed', 'Error while accessing camera: it is likely in use by another program'), {
-							timeout: TOAST_PERMANENT_TIMEOUT,
+							timeout: -1,
 						})
 					} else {
 						console.error('Error while accessing camera: ', error.message, error.name)
 						this.notificationHandle = showError(t('spreed', 'Error while accessing camera'), {
-							timeout: TOAST_PERMANENT_TIMEOUT,
+							timeout: -1,
 						})
 					}
 				}

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -31,8 +31,6 @@ import { PARTICIPANT } from '../../constants.js'
 import store from '../../store/index.js'
 import {
 	showError,
-	TOAST_PERMANENT_TIMEOUT,
-	TOAST_DEFAULT_TIMEOUT,
 } from '@nextcloud/dialogs'
 
 let webrtc
@@ -897,7 +895,7 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 		clearLocalStreamRequestedTimeoutAndHideNotification()
 
 		let message
-		let timeout = TOAST_PERMANENT_TIMEOUT
+		let timeout = -1
 		if ((error.name === 'NotSupportedError'
 				&& webrtc.capabilities.supportRTCPeerConnection)
 			|| (error.name === 'NotAllowedError'
@@ -906,7 +904,7 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 			message += ': ' + t('spreed', 'Please move your setup to HTTPS')
 		} else if (error.name === 'NotAllowedError') {
 			message = t('spreed', 'Access to microphone & camera was denied')
-			timeout = TOAST_DEFAULT_TIMEOUT
+			timeout = 7
 		} else if (!webrtc.capabilities.support) {
 			console.error('WebRTC not supported')
 


### PR DESCRIPTION
`TOAST_PERMANENT_TIMEOUT` and `TOAST_DEFAULT_TIMEOUT` [were introduced in @nextcloud/dialogs v3.0.0](https://github.com/nextcloud/nextcloud-dialogs/pull/210/files#diff-5ee1d2d88420bdeb09a041d59aa56371580418b4c010624dba16594ea0f463a4R36-R37), so they are not available yet in [the version used by Talk 10](https://github.com/nextcloud/spreed/blob/v10.0.6/package.json#L23).

Note too that the timeout units was changed from seconds to milliseconds in v3.0.0, so the default timeout here needs to be specified in seconds.
