### PR TITLE
Hide call icon when blocked by lobby

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -447,6 +447,7 @@ class RoomController extends AEnvironmentAwareController {
 		if ($room->getLobbyState() === Webinary::LOBBY_NON_MODERATORS &&
 			!$currentParticipant->hasModeratorPermissions()) {
 			// No participants and chat messages for users in the lobby.
+			$roomData['hasCall'] = false;
 			return $roomData;
 		}
 
@@ -700,6 +701,7 @@ class RoomController extends AEnvironmentAwareController {
 		if ($room->getLobbyState() === Webinary::LOBBY_NON_MODERATORS &&
 			!$currentParticipant->hasModeratorPermissions()) {
 			// No participants and chat messages for users in the lobby.
+			$roomData['hasCall'] = false;
 			return $roomData;
 		}
 


### PR DESCRIPTION
When a user is blocked by the lobby, they now don't see the call icon in
case moderators are having one.

Fixes https://github.com/nextcloud/spreed/issues/5214