### PR TITLE
When reselecting the chat tab, reevaluate fileinfo

### DIFF
--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -135,6 +135,8 @@ export default {
 			immediate: true,
 			handler(isChatTheActiveTab) {
 				this.forceTabsContentStyleWhenChatTabIsActive(isChatTheActiveTab)
+				// recheck the file info in case the sharing info was changed
+				this.setTalkSidebarSupportedForFile(this.fileInfo)
 			},
 		},
 	},


### PR DESCRIPTION
When reselecting the chat tab, some changes might have happened in other
tabs like sharing. This refreshes the view when this happens.

### Steps to reproduce the issue

1. Upload a file
2. Open the Chat tab and see the message about sharing the file first
3. Go to sharing tab
4. Share with another user
5. Go back to the sharing tab

### Before the fix
The tab still says that you need to share. Need to refresh the page to fix it.

### After the fix
The chat tab now says "Join this conversation".

I've also checked that switching back and forth while a chat is open keeps the room open and doesn't go back to the "Join the conversation" button.

Note: I think there was a bug report somewhere but couldn't find it any more.
