### PR TITLE
Fix Actions menus in fullscreen mode

### DIFF
--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -135,6 +135,7 @@
 			<Actions
 				v-if="showActions"
 				v-tooltip="t('spreed', 'More actions')"
+				container="#content-vue"
 				:aria-label="t('spreed', 'More actions')">
 				<ActionButton
 					:close-after-click="true"

--- a/src/components/LeftSidebar/ConversationsList/AppContentListItem/AppContentListItem.vue
+++ b/src/components/LeftSidebar/ConversationsList/AppContentListItem/AppContentListItem.vue
@@ -56,6 +56,7 @@
 		</a>
 		<Actions
 			v-if="hasActions"
+			container="#content-vue"
 			menu-align="right"
 			:aria-label="conversationSettingsAriaLabel"
 			class="actions">

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -114,6 +114,7 @@ the main body of the message as well as a quote.
 				<Actions
 					v-show="showActions && hasActions"
 					class="message__main__right__actions"
+					container="#content-vue"
 					:class="{ 'tall' : isTallEnough }">
 					<ActionButton
 						v-if="isReplyable"

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -41,6 +41,7 @@
 					v-if="canUploadFiles || canShareFiles">
 					<Actions
 						ref="uploadMenu"
+						container="#content-vue"
 						:disabled="disabled"
 						default-icon="icon-clip-add-file"
 						:aria-label="t('spreed', 'Share files to the conversation')"

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -94,6 +94,7 @@
 		</div>
 		<Actions
 			v-if="canModerate && !isSearched"
+			container="#content-vue"
 			:aria-label="participantSettingsAriaLabel"
 			class="participant-row__actions">
 			<ActionText

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -23,7 +23,10 @@
 	<div class="top-bar" :class="{ 'in-call': isInCall }">
 		<CallButton class="top-bar__button" />
 		<!-- Call layout switcher -->
-		<Actions slot="trigger" class="forced-background">
+		<Actions
+			slot="trigger"
+			class="forced-background"
+			container="#content-vue">
 			<ActionButton v-if="isInCall"
 				:icon="changeViewIconClass"
 				@click="changeView">
@@ -36,6 +39,7 @@
 			class="top-bar__button forced-background"
 			menu-align="right"
 			:aria-label="t('spreed', 'Conversation actions')"
+			container="#content-vue"
 			@shortkey.native="toggleFullscreen">
 			<ActionButton
 				:icon="iconFullscreen"
@@ -93,7 +97,8 @@
 		</Actions>
 		<Actions v-if="showOpenSidebarButton"
 			class="top-bar__button forced-background"
-			close-after-click="true">
+			close-after-click="true"
+			container="#content-vue">
 			<ActionButton
 				:icon="iconMenuPeople"
 				@click="openSidebar" />


### PR DESCRIPTION
Fullscreen mode is applied on the "#content-vue" container, so now all
relevant Actions components are using that as container too.

This makes the actions menu visible also in fullscreen mode.

Partial fix for https://github.com/nextcloud/spreed/issues/5027 only for the Actions components.
Others will need nextcloud-vue updates, see https://github.com/nextcloud/spreed/issues/5027#issuecomment-786675267

Note: the property explicitly wants a String selector