### PR TITLE
Inject the preloaded user status into the avatar component

### DIFF
--- a/src/components/AvatarWrapper/AvatarWrapper.vue
+++ b/src/components/AvatarWrapper/AvatarWrapper.vue
@@ -35,6 +35,7 @@
 			:disable-menu="disableMenu"
 			:show-user-status="showUserStatus"
 			:show-user-status-compact="showUserStatusCompact"
+			:preloaded-user-status="preloadedUserStatus"
 			:size="size" />
 		<div v-else
 			class="guest"
@@ -92,6 +93,10 @@ export default {
 		showUserStatusCompact: {
 			type: Boolean,
 			default: true,
+		},
+		preloadedUserStatus: {
+			type: Object,
+			default: undefined,
 		},
 	},
 	computed: {

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -40,6 +40,7 @@
 			:size="44"
 			:show-user-status="showUserStatus && !isSearched"
 			:show-user-status-compact="false"
+			:preloaded-user-status="preloadedUserStatus"
 			:name="computedName"
 			:source="participant.source || participant.actorType"
 			:offline="isOffline"
@@ -395,6 +396,25 @@ export default {
 		},
 		canBePromoted() {
 			return this.canModerate && !this.isModerator
+		},
+		preloadedUserStatus() {
+			if (this.participant.hasOwnProperty('statusMessage')) {
+				// We preloaded the status when via participants API
+				return {
+					status: this.participant.status || null,
+					message: this.participant.statusMessage || null,
+					icon: this.participant.statusIcon || null,
+				}
+			}
+			if (this.participant.hasOwnProperty('status')) {
+				// We preloaded the status when via search API
+				return {
+					status: this.participant.status.status || null,
+					message: this.participant.status.message || null,
+					icon: this.participant.status.icon || null,
+				}
+			}
+			return undefined
 		},
 	},
 


### PR DESCRIPTION
- [x] Requires https://github.com/nextcloud/nextcloud-vue/pull/1733

### Steps
1. Create a conversation with 5 people
2. Reload the page with open network tab:
3. Before:
![Bildschirmfoto von 2021-03-02 09-45-30](https://user-images.githubusercontent.com/213943/109622260-36a57780-7b3c-11eb-9044-ae4ed52e3e39.png)
4. After:
![Bildschirmfoto von 2021-03-02 09-45-14](https://user-images.githubusercontent.com/213943/109622279-3d33ef00-7b3c-11eb-80e1-e0acada03809.png)

