### PR TITLE
Use container property to fix popups in fulllscreen mode

### DIFF
--- a/src/components/AvatarWrapper/AvatarWrapper.vue
+++ b/src/components/AvatarWrapper/AvatarWrapper.vue
@@ -29,6 +29,7 @@
 		<Avatar v-else-if="id"
 			:user="id"
 			:display-name="name"
+			menu-container="#content-vue"
 			menu-position="left"
 			:disable-tooltip="disableTooltip"
 			:disable-menu="disableMenu"

--- a/src/components/AvatarWrapper/AvatarWrapperSmall.vue
+++ b/src/components/AvatarWrapper/AvatarWrapperSmall.vue
@@ -29,6 +29,7 @@
 		<Avatar v-else-if="id"
 			:user="id"
 			:display-name="name"
+			menu-container="#content-vue"
 			menu-position="left"
 			:show-user-status="showUserStatus"
 			:disable-tooltip="disableTooltip"

--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -28,6 +28,7 @@
 			:size="44"
 			:user="item.name"
 			:display-name="item.displayName"
+			menu-container="#content-vue"
 			menu-position="left"
 			class="conversation-icon__avatar" />
 		<div v-if="showCall"

--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -24,7 +24,8 @@
 		role="dialog"
 		:aria-label="t('spreed', 'Conversation settings')"
 		:open.sync="showSettings"
-		:show-navigation="true">
+		:show-navigation="true"
+		container="#content-vue">
 		<!-- Notifications settings -->
 		<AppSettingsSection
 			:title="t('spreed', 'Chat notifications')"

--- a/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
+++ b/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
@@ -72,7 +72,8 @@
 						class="icon icon-edit"
 						@click="showLogContent" />
 					<Modal v-if="logModal"
-						@close="closeLogModal">
+						@close="closeLogModal"
+						container="#content-vue">
 						<div class="modal__content">
 							<textarea v-model="processLog" class="log-content" />
 						</div>

--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -35,7 +35,8 @@
 		<!-- New group form -->
 		<Modal
 			v-if="modal"
-			@close="closeModal">
+			@close="closeModal"
+			container="#content-vue">
 			<!-- Wrapper for content & navigation -->
 			<div
 				class="new-group-conversation talk-modal">

--- a/src/components/MessagesList/MessagesGroup/AuthorAvatar.vue
+++ b/src/components/MessagesList/MessagesGroup/AuthorAvatar.vue
@@ -25,6 +25,7 @@
 		class="messages__avatar__icon"
 		:user="authorId"
 		:show-user-status="false"
+		menu-container="#content-vue"
 		menu-position="left"
 		:display-name="displayName" />
 	<div v-else-if="isDeletedUser"

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -63,7 +63,9 @@
 					</Actions>
 				</div>
 				<div>
-					<EmojiPicker @select="addEmoji">
+					<EmojiPicker
+						container="#content-vue"
+						@select="addEmoji">
 						<button
 							type="button"
 							:disabled="disabled"

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -42,7 +42,8 @@
 			:show-user-status-compact="false"
 			:name="computedName"
 			:source="participant.source || participant.actorType"
-			:offline="isOffline" />
+			:offline="isOffline"
+			menu-container="#content-vue" />
 		<div
 			class="participant-row__user-wrapper"
 			:class="{

--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -20,7 +20,11 @@
 -->
 
 <template>
-	<AppSettingsDialog :open.sync="showSettings" :show-navigation="true" first-selected-section="keyboard shortcuts">
+	<AppSettingsDialog
+		:open.sync="showSettings"
+		:show-navigation="true"
+		first-selected-section="keyboard shortcuts"
+		container="#content-vue">
 		<AppSettingsSection :title="t('spreed', 'Choose devices')"
 			class="app-settings-section">
 			<MediaDevicesPreview />

--- a/src/components/UploadEditor.vue
+++ b/src/components/UploadEditor.vue
@@ -22,7 +22,8 @@
 <template>
 	<Modal v-if="showModal"
 		class="upload-editor"
-		@close="handleDismiss">
+		@close="handleDismiss"
+		container="#content-vue">
 		<!--native file picker, hidden -->
 		<input id="file-upload"
 			ref="fileUploadInput"


### PR DESCRIPTION
Many popup components are usually appending themselves to the document
body. This doesn't work in fullscreen mode where we use another
component as the root.

This fix sets the "container" property for all relevant popup components
to make sure they can be visible in fullscreen mode.

- [x] REQUIRES: https://github.com/nextcloud/nextcloud-vue/pull/1734
- [x] nextcloud-vue release + update

Partial fix of https://github.com/nextcloud/spreed/issues/5027