### PR TITLE
Bump @nextcloud/vue from 3.6.0 to 3.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4273,9 +4273,9 @@
 			}
 		},
 		"@nextcloud/vue": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-3.6.0.tgz",
-			"integrity": "sha512-xF2tRODigYjxk1dPeCq9Qry5nXNVdxwkJ85aFChW1xrzTDUi167jRSeMNgrmtqBd31jx3SF0UVYM7XmDvGYCJA==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-3.7.0.tgz",
+			"integrity": "sha512-uuytX0G+duUOY9l2fYG5vl8GRoxrXgNS2SgKS7a7ulaRUfwxgU269flWPTVMhP2q57+AxG3IwXNwP1td7VWjTQ==",
 			"requires": {
 				"@nextcloud/auth": "^1.2.3",
 				"@nextcloud/axios": "^1.3.2",
@@ -5209,7 +5209,8 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
 					"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"find-cache-dir": {
 					"version": "3.3.1",
@@ -5496,6 +5497,7 @@
 					"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
 					"integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"chalk": "^4.1.0",
 						"hash-sum": "^2.0.0",
@@ -5507,6 +5509,7 @@
 							"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
 							"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"ansi-styles": "^4.1.0",
 								"supports-color": "^7.1.0"
@@ -5516,13 +5519,15 @@
 							"version": "4.0.0",
 							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 							"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"loader-utils": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
 							"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"big.js": "^5.2.2",
 								"emojis-list": "^3.0.0",
@@ -5534,6 +5539,7 @@
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 							"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"has-flag": "^4.0.0"
 							}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"@nextcloud/l10n": "^1.4.1",
 		"@nextcloud/moment": "^1.1.1",
 		"@nextcloud/router": "^1.2.0",
-		"@nextcloud/vue": "^3.6.0",
+		"@nextcloud/vue": "^3.7.0",
 		"@nextcloud/vue-dashboard": "^1.0.1",
 		"attachmediastream": "^2.1.0",
 		"color.js": "^1.2.0",


### PR DESCRIPTION
Unblocks https://github.com/nextcloud/spreed/pull/5288 and https://github.com/nextcloud/spreed/pull/5291