### PR TITLE
Direct reply button in message row

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -111,43 +111,47 @@ the main body of the message as well as a quote.
 						:size="16" />
 				</div>
 				<!-- Message Actions -->
-				<Actions
-					v-show="showActions && hasActions"
+				<div
+					v-show="showActions"
 					class="message__main__right__actions"
-					container="#content-vue"
 					:class="{ 'tall' : isTallEnough }">
-					<ActionButton
-						v-if="isReplyable"
-						icon="icon-reply"
-						:close-after-click="true"
-						@click.stop="handleReply">
-						{{ t('spreed', 'Reply') }}
-					</ActionButton>
-					<ActionButton
-						v-if="isPrivateReplyable"
-						icon="icon-user"
-						:close-after-click="true"
-						@click.stop="handlePrivateReply">
-						{{ t('spreed', 'Reply privately') }}
-					</ActionButton>
-					<template
-						v-for="action in messageActions">
+					<Actions
+						v-show="isReplyable">
 						<ActionButton
-							:key="action.label"
-							:icon="action.icon"
-							:close-after-click="true"
-							@click="action.callback(messageAPIData)">
-							{{ action.label }}
+							icon="icon-reply"
+							@click.stop="handleReply">
+							{{ t('spreed', 'Reply') }}
 						</ActionButton>
-					</template>
-					<ActionButton
-						v-if="isDeleteable"
-						icon="icon-delete"
-						:close-after-click="true"
-						@click.stop="handleDelete">
-						{{ t('spreed', 'Delete') }}
-					</ActionButton>
-				</Actions>
+					</Actions>
+					<Actions
+						v-show="hasActionsMenu"
+						container="#content-vue">
+						<ActionButton
+							v-if="isPrivateReplyable"
+							icon="icon-user"
+							:close-after-click="true"
+							@click.stop="handlePrivateReply">
+							{{ t('spreed', 'Reply privately') }}
+						</ActionButton>
+						<template
+							v-for="action in messageActions">
+							<ActionButton
+								:key="action.label"
+								:icon="action.icon"
+								:close-after-click="true"
+								@click="action.callback(messageAPIData)">
+								{{ action.label }}
+							</ActionButton>
+						</template>
+						<ActionButton
+							v-if="isDeleteable"
+							icon="icon-delete"
+							:close-after-click="true"
+							@click.stop="handleDelete">
+							{{ t('spreed', 'Delete') }}
+						</ActionButton>
+					</Actions>
+				</div>
 			</div>
 		</div>
 	</li>
@@ -334,8 +338,8 @@ export default {
 			return this.$store.getters.message(this.token, this.id)
 		},
 
-		hasActions() {
-			return (this.isReplyable || this.isDeleteable) && !this.isConversationReadOnly
+		hasActionsMenu() {
+			return (this.isPrivateReplyable || this.isDeleteable || this.messageActions.length > 0) && !this.isConversationReadOnly
 		},
 
 		isConversationReadOnly() {
@@ -696,7 +700,8 @@ export default {
 			font-size: $chat-font-size;
 			flex: 1 0 auto;
 			padding: 0 8px 0 8px;
-			&__actions.action-item {
+			&__actions {
+				display: flex;
 				position: absolute;
 				top: -8px;
 				right: 50px;

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -125,6 +125,7 @@ the main body of the message as well as a quote.
 					</Actions>
 					<Actions
 						v-show="hasActionsMenu"
+						:force-menu="true"
 						container="#content-vue">
 						<ActionButton
 							v-if="isPrivateReplyable"


### PR DESCRIPTION
Moved reply button outside the actions menu in the message row.
This way it is quicker for the user to find and click.

Fixes https://github.com/nextcloud/spreed/issues/5297

Regular row:
<img width="310" alt="image" src="https://user-images.githubusercontent.com/277525/109830388-bca9e700-7c3e-11eb-85f0-34d4e3a81a9d.png">

Tall row:
<img width="310" alt="image" src="https://user-images.githubusercontent.com/277525/109830452-cc293000-7c3e-11eb-8a95-669bf0689767.png">

As menu:
<img width="305" alt="image" src="https://user-images.githubusercontent.com/277525/109831787-0e06a600-7c40-11eb-91b6-78f6952ba925.png">

