### PR TITLE
Fix not joining call again on reconnection with HPB

### DIFF
--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -490,10 +490,6 @@ class ParticipantService {
 			return;
 		}
 
-		if ($session->getInCall() === $flags) {
-			return;
-		}
-
 		$event = new ModifyParticipantEvent($room, $participant, 'inCall', $flags, $session->getInCall());
 		if ($flags !== Participant::FLAG_DISCONNECTED) {
 			$this->dispatcher->dispatch(Room::EVENT_BEFORE_SESSION_JOIN_CALL, $event);


### PR DESCRIPTION
This fixes a regression introduced in 3bfb611d9d

When the connection between a client and the external signaling server is interrupted [the signaling server may unregister its session](https://github.com/strukturag/nextcloud-spreed-signaling/blob/043691d7037049eb8a9144f8dcada49b1beb187e/src/signaling/hub.go#L1902-L1904), even if the Nextcloud session is still active. Once the client reconnects it will join the room again, which will generate a new signaling session for it.

If the connection between the browser and the external signaling server is interrupted during a call [the browser will automatically rejoin the call after joining the conversation again](https://github.com/nextcloud/spreed/blob/2999b5d66559817e57f52be5e02f9cd859da8cc0/src/utils/signaling.js#L998) (I have not checked the mobile clients, but they should do that too ;-) ). However, it will still use the same Nextcloud session, and that Nextcloud session may still be seen as "in the call" if [the signaling server has not closed yet the expired session](https://github.com/strukturag/nextcloud-spreed-signaling/blob/043691d7037049eb8a9144f8dcada49b1beb187e/src/signaling/hub.go#L552-L553) (which is different from unregistering it, as [closing the signaling session causes the Nextcloud session to leave the room too](https://github.com/nextcloud/spreed/blob/a347cf23752aec0f08b95ccdbdee5a44b9f9a0f0/lib/Controller/SignalingController.php#L638-L648)).

Due to this it must be possible to set the "in call" flags again to the same value, as even if it does not change the Nextcloud session status [it may change the signaling session status](https://github.com/nextcloud/spreed/blob/a347cf23752aec0f08b95ccdbdee5a44b9f9a0f0/lib/Signaling/BackendNotifier.php#L309).

## How to test
- Start a call with user A in computer A
- Join the call with user B in computer B
- "Disconnect the Internet cable" from computer B (you can use a VM, block packets... whatever is easier ;-) )
- Wait around 30 seconds (or until `Unregister XXX` is shown in the signaling server logs) and connect the cable again

### Result with this pull request

User B joins the call again.

### Result without this pull request

User B does not join the call again (the UI will be show the user as being alone in the call).

Note that if `Closing expired session XXX` appears in the logs before the new session is registered the UI of user B will show the dialog to stay in the call or leave it. It is a different bug that will be addressed in a different pull request.

Maybe it would be good to also add a unit or integration test to ensure that the in call flag can be set again :thinking: Anyway it can be done at a later point.
