### PR TITLE
Fix UI feedback when remote participants lose connection

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -686,14 +686,6 @@ export default {
 	vertical-align: top; /* fix white line below video */
 }
 
-#videos .videoContainer.not-connected ::v-deep {
-	video,
-	.avatardiv,
-	.avatar.guest {
-		opacity: 0.5;
-	}
-}
-
 #videos .videoContainer ::v-deep .avatardiv {
 	box-shadow: 0 0 15px var(--color-box-shadow);
 }

--- a/src/components/CallView/shared/Video.vue
+++ b/src/components/CallView/shared/Video.vue
@@ -27,12 +27,15 @@
 		@mouseleave="hideShadow"
 		@click="handleClickVideo">
 		<transition name="fade">
-			<video
-				v-show="showVideo"
-				ref="video"
-				:disablePictureInPicture="!isBig"
-				:class="videoClass"
-				class="video" />
+			<div v-show="showVideo"
+				:class="videoWrapperClass"
+				class="videoWrapper">
+				<video
+					ref="video"
+					:disablePictureInPicture="!isBig"
+					:class="videoClass"
+					class="video" />
+			</div>
 		</transition>
 		<transition name="fade">
 			<Screen
@@ -186,6 +189,12 @@ export default {
 				'video-container-grid': this.isGrid,
 				'video-container-grid--speaking': this.isSpeaking,
 				'video-container-big': this.isBig,
+			}
+		},
+
+		videoWrapperClass() {
+			return {
+				'icon-loading': this.isLoading,
 			}
 		},
 
@@ -488,9 +497,16 @@ export default {
 	align-items: center;
 }
 
+.videoWrapper,
 .video {
 	height: 100%;
 	width: 100%;
+}
+
+.videoWrapper.icon-loading:after {
+	height: 60px;
+	width: 60px;
+	margin: -32px 0 0 -32px;
 }
 
 .video--fit {

--- a/src/components/CallView/shared/Video.vue
+++ b/src/components/CallView/shared/Video.vue
@@ -169,10 +169,14 @@ export default {
 			}
 		},
 
+		isNotConnected() {
+			return this.model.attributes.connectionState !== ConnectionState.CONNECTED && this.model.attributes.connectionState !== ConnectionState.COMPLETED
+		},
+
 		containerClass() {
 			return {
 				'videoContainer-dummy': this.placeholderForPromoted,
-				'not-connected': !this.placeholderForPromoted && this.model.attributes.connectionState !== ConnectionState.CONNECTED && this.model.attributes.connectionState !== ConnectionState.COMPLETED,
+				'not-connected': !this.placeholderForPromoted && this.isNotConnected,
 				'speaking': !this.placeholderForPromoted && this.model.attributes.speaking,
 				'promoted': !this.placeholderForPromoted && this.sharedData.promoted && !this.isGrid,
 				'video-container-grid': this.isGrid,
@@ -187,7 +191,7 @@ export default {
 
 		avatarClass() {
 			return {
-				'icon-loading': this.model.attributes.connectionState !== ConnectionState.CONNECTED && this.model.attributes.connectionState !== ConnectionState.COMPLETED && this.model.attributes.connectionState !== ConnectionState.FAILED_NO_RESTART,
+				'icon-loading': this.isNotConnected && this.model.attributes.connectionState !== ConnectionState.FAILED_NO_RESTART,
 			}
 		},
 

--- a/src/components/CallView/shared/Video.vue
+++ b/src/components/CallView/shared/Video.vue
@@ -439,6 +439,13 @@ export default {
 @include avatar-mixin(64px);
 @include avatar-mixin(128px);
 
+.not-connected {
+	video,
+	.avatar-container {
+		opacity: 0.5;
+	}
+}
+
 .video-container-grid {
 	position: relative;
 	height: 100%;

--- a/src/components/CallView/shared/Video.vue
+++ b/src/components/CallView/shared/Video.vue
@@ -173,6 +173,10 @@ export default {
 			return this.model.attributes.connectionState !== ConnectionState.CONNECTED && this.model.attributes.connectionState !== ConnectionState.COMPLETED
 		},
 
+		isLoading() {
+			return this.isNotConnected && this.model.attributes.connectionState !== ConnectionState.FAILED_NO_RESTART
+		},
+
 		containerClass() {
 			return {
 				'videoContainer-dummy': this.placeholderForPromoted,
@@ -191,7 +195,7 @@ export default {
 
 		avatarClass() {
 			return {
-				'icon-loading': this.isNotConnected && this.model.attributes.connectionState !== ConnectionState.FAILED_NO_RESTART,
+				'icon-loading': this.isLoading,
 			}
 		},
 


### PR DESCRIPTION
When a remote participant loses the connection her avatar and video were expected to be dimmed, but this did not happen due to a bug with the CSS classes.

Besides that this pull request also adds a loading icon on videos too (as a loading icon was already shown on avatars) when the connection is lost. However, the loading icon on videos is twice as large as, at least in my opinion :-) , they looked too small and were not noticeable otherwise (as they are "framed" by the whole video, which is larger than the avatar).

There is another slight difference between the loading icon on videos and avatars: the loading icon on avatars is dimmed, while the icon on videos is not. The right approach would be not to dimm the loading icon on avatars, but for simplicity it was kept like that (it would have required to move the icon to its own element, as the whole avatar container is dimmed).

To check all this (sorry for the lack of screenshots) the easiest is to modify the code so `isNotConnected` always returns `true` (otherwise you would need to disconnect cables, throttle connections or things like that ;-) ).
