### PR TITLE
Don't redirect to not-found page if user switched away

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -233,8 +233,7 @@ export default {
 					this.refreshCurrentConversation()
 				} else {
 					console.info('Conversation received, but the current conversation is not in the list. Redirecting to not found page')
-					this.$router.push({ name: 'notfound', params: { skipLeaveWarning: true } })
-					this.$store.dispatch('updateToken', '')
+					EventBus.$emit('deletedSessionDetected', { token: this.token })
 				}
 			}
 		})
@@ -437,9 +436,8 @@ export default {
 					singleConversation: true,
 				})
 			} catch (exception) {
-				console.info('Conversation received, but the current conversation is not in the list. Redirecting to /apps/spreed')
-				this.$router.push({ name: 'notfound', params: { skipLeaveWarning: true } })
-				this.$store.dispatch('updateToken', '')
+				console.info('Conversation received, but the current conversation is not in the list')
+				EventBus.$emit('deletedSessionDetected', { token })
 				this.$store.dispatch('hideSidebar')
 			} finally {
 				this.isRefreshingCurrentConversation = false

--- a/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
@@ -111,9 +111,11 @@ export default {
 				return
 			}
 			if (from.name === 'conversation') {
+				console.log('### leaveConversation: ' + from.params.token)
 				leaveConversation(from.params.token)
 			}
 			if (to.name === 'conversation') {
+				console.log('### joinConversation: ' + to.params.token)
 				joinConversation(to.params.token)
 				this.$store.dispatch('markConversationRead', to.params.token)
 			}

--- a/src/mixins/sessionIssueHandler.js
+++ b/src/mixins/sessionIssueHandler.js
@@ -64,6 +64,7 @@ const sessionIssueHandler = {
 			}
 
 			console.debug(`Deleted session detected for token ${token}, redirecting to not found page`)
+			debugger
 			this.$router.push({ name: 'notfound', params: { skipLeaveWarning: true } })
 			this.$store.dispatch('updateToken', '')
 		},

--- a/src/mixins/sessionIssueHandler.js
+++ b/src/mixins/sessionIssueHandler.js
@@ -55,7 +55,15 @@ const sessionIssueHandler = {
 			})
 		},
 
-		deletedSessionTriggered() {
+		deletedSessionTriggered({ token }) {
+			if (token !== this.$route.params.token) {
+				console.debug(`Deleted session detected for token ${token}, but user already switched to another conversation: ignoring`)
+				// if user already moved away from the "missing or deleted conversation"
+				// don't bother redirecting to the not found page
+				return
+			}
+
+			console.debug(`Deleted session detected for token ${token}, redirecting to not found page`)
 			this.$router.push({ name: 'notfound', params: { skipLeaveWarning: true } })
 			this.$store.dispatch('updateToken', '')
 		},

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -448,7 +448,7 @@ Signaling.Internal.prototype._startPullingMessages = function() {
 			} else if (error.response && (error.response.status === 404 || error.response.status === 403)) {
 				// Conversation was deleted or the user was removed
 				console.error('Conversation was not found anymore')
-				EventBus.$emit('deletedSessionDetected')
+				EventBus.$emit('deletedSessionDetected', { token })
 			} else if (token) {
 				if (this.pullMessagesFails === 1) {
 					this.pullMessageErrorToast = showError(t('spreed', 'Lost connection to signaling server. Trying to reconnect.'), {
@@ -1130,7 +1130,7 @@ Signaling.Standalone.prototype.processRoomListEvent = function(data) {
 				return
 			}
 			console.error('User or session was removed from the conversation, redirecting')
-			EventBus.$emit('deletedSessionDetected')
+			EventBus.$emit('deletedSessionDetected', { token: this.currentRoomToken })
 			break
 		}
 		// eslint-disable-next-line no-fallthrough


### PR DESCRIPTION
Whenever a request is running in the background and might detect
that the current conversation or session is gone, it would prompt the
app to redirect to the not found page.

In some cases, the user already switched away to another page while the
request was running. The fix detects such situations and skips the not
found page redirect.

Fixes https://github.com/nextcloud/spreed/issues/4670

- [ ] BUG: switching back and forth quickly will confuse the new logic which will think that we're still in the old instance/session and would redirect to not-found 