### PR TITLE
Show error notification also when hello signaling message fails

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -581,10 +581,6 @@ Signaling.Standalone.prototype.connect = function() {
 			this.signalingConnectionWarning.hideToast()
 			this.signalingConnectionWarning = null
 		}
-		if (this.signalingConnectionError !== null) {
-			this.signalingConnectionError.hideToast()
-			this.signalingConnectionError = null
-		}
 		this.reconnectIntervalMs = this.initialReconnectIntervalMs
 		this.sendHello()
 	}.bind(this)
@@ -849,10 +845,21 @@ Signaling.Standalone.prototype.helloResponseReceived = function(data) {
 			return
 		}
 
+		if (this.signalingConnectionError === null) {
+			this.signalingConnectionError = showError(t('spreed', 'Failed to establish signaling connection. Retrying …'), {
+				timeout: TOAST_PERMANENT_TIMEOUT,
+			})
+		}
+
 		// TODO(fancycode): How should this be handled better?
 		console.error('Could not connect to server', data)
 		this.reconnect()
 		return
+	}
+
+	if (this.signalingConnectionError !== null) {
+		this.signalingConnectionError.hideToast()
+		this.signalingConnectionError = null
 	}
 
 	const resumedSession = !!this.resumeId


### PR DESCRIPTION
Until now an error notification was shown if the connection of the websocket to the external signaling server failed. However, if the websocket connection succeeded but then there was an error when actually connecting to the signaling server at an application level (the hello message response was an error) no error notification was shown in the UI. Now the error notification is also shown in that case, and it will not be removed (no matter if originally it happened due to an error in the websocket or in the connection) until the connection has succeeded.

Besides that, several errors in a row in the hello response usually point to a misconfigured signaling server that can not connect to the Nextcloud server. The error message now also takes into account the number of hello response errors in a row and hints at a possible misconfiguration. As this is a very specific issue the UI does not show any other detail regarding the received error, and the message is not reverted to the generic one if the websocket connection fails after the hello response failed; it is just a hint to make an admin look at the browser console or the signaling server logs.

Actually it might be enough to just show the generic message on hello response errors and drop the second commit, as it is nothing solvable by regular users and the generic message might be enough to make an admin open the browser console or the signaling server logs to check what is the problem. Mmm, the more I think about that the more I would prefer to drop the second commit :-P **Opinions?**

## How to test

- Setup the HPB
- Misconfigure it so it can not connect to the Nextcloud server (use a wrong backend, or a wrong secret, or do not skip verification of SSL certificate when Nextcloud is using an invalid one)
- Join a conversation

### Result with this pull request

An error about failing to connect to the signaling server is shown in the UI. Eventually (and if the second commit is not dropped ;-) ) it will also mention that there might be an issue with the signaling server configuration.

### Result without this pull request

No error will be shown in the UI (although it does appear in the browser console).
