### PR TITLE
Faster update of left sidebar after marking as unread

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -49,7 +49,6 @@ import RightSidebar from './components/RightSidebar/RightSidebar'
 import { EventBus } from './services/EventBus'
 import BrowserStorage from './services/BrowserStorage'
 import { getCurrentUser } from '@nextcloud/auth'
-import { fetchConversation } from './services/conversationsService'
 import {
 	joinConversation,
 	leaveConversationSync,
@@ -420,13 +419,9 @@ export default {
 
 			try {
 				/**
-				 * Fetches the conversations from the server and then adds them one by one
-				 * to the store.
+				 * Fetches a single conversation
 				 */
-				const response = await fetchConversation(token)
-
-				// this.$store.dispatch('purgeConversationsStore')
-				this.$store.dispatch('addConversation', response.data.ocs.data)
+				await this.$store.dispatch('fetchConversation', { token })
 
 				/**
 				 * Emits a global event that is used in App.vue to update the page title once the

--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -52,7 +52,6 @@
 
 import { EventBus } from './services/EventBus'
 import { getFileConversation } from './services/filesIntegrationServices'
-import { fetchConversation } from './services/conversationsService'
 import {
 	joinConversation,
 	leaveConversation,
@@ -262,8 +261,7 @@ export default {
 				return
 			}
 
-			const response = await fetchConversation(this.token)
-			this.$store.dispatch('addConversation', response.data.ocs.data)
+			await this.$store.dispatch('fetchConversation', { token: this.token })
 		},
 
 		/**

--- a/src/PublicShareAuthSidebar.vue
+++ b/src/PublicShareAuthSidebar.vue
@@ -42,7 +42,6 @@ import CallView from './components/CallView/CallView'
 import ChatView from './components/ChatView'
 import { PARTICIPANT } from './constants'
 import { EventBus } from './services/EventBus'
-import { fetchConversation } from './services/conversationsService'
 import {
 	joinConversation,
 	leaveConversationSync,
@@ -165,15 +164,17 @@ export default {
 			}
 
 			try {
-				const response = await fetchConversation(this.token)
-				this.$store.dispatch('addConversation', response.data.ocs.data)
+				await this.$store.dispatch('fetchConversation', { token: this.token })
 
 				// Although the current participant is automatically added to
 				// the participants store it must be explicitly set in the
 				// actors store.
 				if (!this.$store.getters.getUserId()) {
+					// Set the current actor/participant for guests
+					const conversation = this.$store.getters.conversation(this.token)
+
 					// Setting a guest only uses "sessionId" and "participantType".
-					this.$store.dispatch('setCurrentParticipant', response.data.ocs.data)
+					this.$store.dispatch('setCurrentParticipant', conversation)
 				}
 			} catch (exception) {
 				window.clearInterval(this.fetchCurrentConversationIntervalId)

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -50,7 +50,6 @@ import CallView from './components/CallView/CallView'
 import ChatView from './components/ChatView'
 import CallButton from './components/TopBar/CallButton'
 import { EventBus } from './services/EventBus'
-import { fetchConversation } from './services/conversationsService'
 import { getPublicShareConversationData } from './services/filesIntegrationServices'
 import {
 	joinConversation,
@@ -201,15 +200,17 @@ export default {
 			}
 
 			try {
-				const response = await fetchConversation(this.token)
-				this.$store.dispatch('addConversation', response.data.ocs.data)
+				await this.$store.dispatch('fetchConversation', { token: this.token })
 
 				// Although the current participant is automatically added to
 				// the participants store it must be explicitly set in the
 				// actors store.
 				if (!this.$store.getters.getUserId()) {
+					// Set the current actor/participant for guests
+					const conversation = this.$store.getters.conversation(this.token)
+
 					// Setting a guest only uses "sessionId" and "participantType".
-					this.$store.dispatch('setCurrentParticipant', response.data.ocs.data)
+					this.$store.dispatch('setCurrentParticipant', conversation)
 				}
 			} catch (exception) {
 				window.clearInterval(this.fetchCurrentConversationIntervalId)

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -712,13 +712,16 @@ export default {
 			}
 		},
 
-		handleMarkAsUnread() {
+		async handleMarkAsUnread() {
 			// update in backend + visually
-			this.$store.dispatch('updateLastReadMessage', {
+			await this.$store.dispatch('updateLastReadMessage', {
 				token: this.token,
 				id: this.previousMessageId,
 				updateVisually: true,
 			})
+
+			// reload conversation to update additional attributes that have computed values
+			await this.$store.dispatch('fetchConversation', { token: this.token })
 		},
 	},
 }

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -228,6 +228,10 @@ export default {
 
 	watch: {
 		disabled(newValue) {
+			// the menu is not always available
+			if (!this.$refs.uploadMenu) {
+				return
+			}
 			this.$refs.uploadMenu.$refs.menuButton.disabled = newValue
 		},
 	},

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -29,6 +29,7 @@ import {
 	changeListable,
 	addToFavorites,
 	removeFromFavorites,
+	fetchConversation,
 	setConversationName,
 	setConversationDescription } from '../services/conversationsService'
 import { getCurrentUser } from '@nextcloud/auth'
@@ -333,6 +334,11 @@ const actions = {
 
 	async updateConversationLastReadMessage({ commit }, { token, lastReadMessage }) {
 		commit('updateConversationLastReadMessage', { token, lastReadMessage })
+	},
+
+	async fetchConversation({ dispatch }, { token }) {
+		const response = await fetchConversation(token)
+		dispatch('addConversation', response.data.ocs.data)
 	},
 
 	changeNotificationLevel({ commit }, { token, notificationLevel }) {

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -401,7 +401,10 @@ const actions = {
 			context.commit('setVisualLastReadMessageId', { token, id })
 		}
 
-		await updateLastReadMessage(token, id)
+		if (context.getters.getUserId()) {
+			// only update on server side if there's an actual user, not guest
+			await updateLastReadMessage(token, id)
+		}
 
 		if (updateVisually) {
 			// refetch to get more accurate values for unreadMessages, unreadMention, etc

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -386,7 +386,7 @@ const actions = {
 	 * @param {bool} updateVisually whether to also update the marker visually in the UI;
 	 */
 	async updateLastReadMessage(context, { token, id = 0, updateVisually = false }) {
-		const conversation = Object.assign({}, context.getters.conversations[token])
+		const conversation = context.getters.conversations[token]
 		if (!conversation || conversation.lastReadMessage === id) {
 			return
 		}
@@ -400,7 +400,13 @@ const actions = {
 		if (updateVisually) {
 			context.commit('setVisualLastReadMessageId', { token, id })
 		}
+
 		await updateLastReadMessage(token, id)
+
+		if (updateVisually) {
+			// refetch to get more accurate values for unreadMessages, unreadMention, etc
+			context.dispatch('fetchConversation', { token })
+		}
 	},
 }
 

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -405,11 +405,6 @@ const actions = {
 			// only update on server side if there's an actual user, not guest
 			await updateLastReadMessage(token, id)
 		}
-
-		if (updateVisually) {
-			// refetch to get more accurate values for unreadMessages, unreadMention, etc
-			context.dispatch('fetchConversation', { token })
-		}
 	},
 }
 


### PR DESCRIPTION
This fix re-fetches the current conversation to make sure that harder to compute values are re-fetched from the server like unreadMessages, unreadMention, etc.
    
This introduces a new store action "fetchConversation".
I've adjusted some of the service's "fetchConversation" usage and moved them to use this new store action instead.
(moving the non-store stuff step by step to the store to avoid repeating logic)

Fixes https://github.com/nextcloud/spreed/issues/5375

While testing, I noticed unrelated console errors for guests due to unread marker. I'll fix this separately