### PR TITLE
Keep pending input message per conversation

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -230,11 +230,24 @@ export default {
 		disabled(newValue) {
 			this.$refs.uploadMenu.$refs.menuButton.disabled = newValue
 		},
+
+		text(newValue) {
+			this.$store.dispatch('setCurrentMessageInput', { token: this.token, text: newValue })
+		},
+
+		token(token) {
+			if (token) {
+				this.text = this.$store.getters.currentMessageInput(token) || ''
+			} else {
+				this.text = ''
+			}
+		},
 	},
 
 	mounted() {
 		EventBus.$on('uploadStart', this.handleUploadStart)
 		EventBus.$on('retryMessage', this.handleRetryMessage)
+		this.text = this.$store.getters.currentMessageInput(this.token) || ''
 	},
 
 	beforeDestroy() {

--- a/src/store/quoteReplyStore.js
+++ b/src/store/quoteReplyStore.js
@@ -24,12 +24,23 @@ import Vue from 'vue'
 
 const state = {
 	messagesToBeReplied: {},
+
+	/**
+	 * Cached last message input by conversation token
+	 */
+	currentMessageInput: {},
 }
 
 const getters = {
 	getMessageToBeReplied: (state) => (token) => {
 		if (state.messagesToBeReplied[token]) {
 			return state.messagesToBeReplied[token]
+		}
+	},
+
+	currentMessageInput: (state) => (token) => {
+		if (state.currentMessageInput[token]) {
+			return state.currentMessageInput[token]
 		}
 	},
 }
@@ -46,14 +57,29 @@ const mutations = {
 		Vue.set(state.messagesToBeReplied, [messageToBeReplied.token], messageToBeReplied)
 	},
 	/**
-	 * Add a message to be replied to the store. This message is generated when the
-	 * reply button is clicked.
+	 * Removes message to be replied from the store for the
+	 * given conversation.
 	 *
 	 * @param {object} state current store state;
-	 * @param {object} token The message to be replied;
+	 * @param {string} token The conversation token
 	 */
 	removeMessageToBeReplied(state, token) {
 		Vue.delete(state.messagesToBeReplied, token)
+	},
+
+	/**
+	 * Sets the current message input for a given conversation
+	 *
+	 * @param {object} state Current store state;
+	 * @param {string} token The conversation token;
+	 * @param {string} text Message text to set or null to clear it;
+	 */
+	setCurrentMessageInput(state, { token, text = null }) {
+		if (text !== null) {
+			Vue.set(state.currentMessageInput, token, text)
+		} else {
+			Vue.delete(state.currentMessageInput, token)
+		}
 	},
 }
 
@@ -69,6 +95,7 @@ const actions = {
 	addMessageToBeReplied(context, messageToBeReplied) {
 		context.commit('addMessageToBeReplied', messageToBeReplied)
 	},
+
 	/**
 	 * Remove a message to be replied to the store. This is used either when the message
 	 * has been replied to or the user finally decides to dismiss the reply operation.
@@ -79,6 +106,28 @@ const actions = {
 	 */
 	removeMessageToBeReplied(context, token) {
 		context.commit('removeMessageToBeReplied', token)
+	},
+
+	/**
+	 * Clears current messages from a deleted conversation
+	 *
+	 * @param {object} context default store context;
+	 * @param {string} token the token of the conversation to be deleted;
+	 */
+	deleteMessages(context, token) {
+		context.commit('removeMessageToBeReplied', token)
+		context.commit('setCurrentMessageInput', { token, text: null })
+	},
+
+	/**
+	 * Stores the current message input for a given conversation
+	 *
+	 * @param {object} context default store context;
+	 * @param {string} token the token of the conversation to be deleted;
+	 * @param {string} text string to set or null to clear it;
+	 */
+	setCurrentMessageInput(context, { token, text }) {
+		context.commit('setCurrentMessageInput', { token, text })
 	},
 }
 


### PR DESCRIPTION
### Description

Save the message from the current input field by conversation into the
store.

This makes it possible to keep the message when switching the
conversation.

Also fixes an issue where joining or leaving a call would clear the
message due to the field being destroyed and recreated between the
message list and the sidebar.

### Related issue

Fixes https://github.com/nextcloud/spreed/issues/5372

### Notes

#### Cursor position

There's a small issue: when the field is populated, the cursor appears at the beginning.
Given [how complicated it is to set the cursor at the end](https://stackoverflow.com/questions/4233265/contenteditable-set-caret-at-the-end-of-the-text-cross-browser) we might want to pass on that one, considering that we'll also replace the field with a better version of it in https://github.com/nextcloud/spreed/pull/4333

#### Store module name

The store module is still called "quoteReplyStore", we could rename to "currentMessageStore" or something similar. Not sure if it's the right time now.

### Tests

- [x] TEST: switching to read-only channel like changelog doesn't log errors and the field stays empty
- [x] TEST: switch to conversation A, type text "abc", switch to B, type text "def", switch back to A => the field shows "abc"
- [x] TEST: type text "abc", start call => message stays in sidebar field
- [x] TEST: start call, type text "abc", leave call => message stays in message list field
- [x] TEST: quoted reply is also kept between conversation switch and starting/leaving a call
- [x] TEST: emojis also kept
