### PR TITLE
Fix auto-approve for dependabot

### DIFF
--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -1,5 +1,5 @@
 name: Dependabot auto approve
-on: pull_request
+on: pull_request_target
 
 jobs:
   auto-merge:


### PR DESCRIPTION
As suggested by @miaulalala to fix dependabot failures like https://github.com/nextcloud/spreed/pull/5386/checks?check_run_id=2153492914