### PR TITLE
Temporary OCS API for user avatar upload and delete

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -600,5 +600,17 @@ return [
 				'apiVersion' => 'v1',
 			],
 		],
+
+
+		[
+			'name' => 'TempAvatar#postAvatar',
+			'url' => '/temp-user-avatar',
+			'verb' => 'POST',
+		],
+		[
+			'name' => 'TempAvatar#deleteAvatar',
+			'url' => '/temp-user-avatar',
+			'verb' => 'DELETE',
+		],
 	],
 ];

--- a/composer.lock
+++ b/composer.lock
@@ -173,12 +173,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ChristophWurst/nextcloud_composer.git",
-                "reference": "245bf545b36a4519f96e33bed3e1e9a2673216de"
+                "reference": "5f551b047b50f96e8edb0131904b6a117ca18b86"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_composer/zipball/245bf545b36a4519f96e33bed3e1e9a2673216de",
-                "reference": "245bf545b36a4519f96e33bed3e1e9a2673216de",
+                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_composer/zipball/5f551b047b50f96e8edb0131904b6a117ca18b86",
+                "reference": "5f551b047b50f96e8edb0131904b6a117ca18b86",
                 "shasum": ""
             },
             "require": {
@@ -204,7 +204,7 @@
                 }
             ],
             "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
-            "time": "2021-03-05T23:26:19+00:00"
+            "time": "2021-03-22T23:34:54+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -89,6 +89,7 @@ class Capabilities implements IPublicCapability {
 				'raise-hand',
 				'room-description',
 				'rich-object-sharing',
+				'temp-user-avatar-api',
 			],
 			'config' => [
 				'attachments' => [

--- a/lib/Controller/TempAvatarController.php
+++ b/lib/Controller/TempAvatarController.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2016 Lukas Reschke <lukas@statuscode.ch>
+ *
+ * @author Lukas Reschke <lukas@statuscode.ch>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Controller;
+
+use OC\Files\Filesystem;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
+use OCP\IAvatarManager;
+use OCP\IL10N;
+use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+
+class TempAvatarController extends OCSController {
+
+	/** @var IAvatarManager */
+	private $avatarManager;
+	/** @var IL10N */
+	private $l;
+	/** @var LoggerInterface */
+	private $logger;
+	/** @var string */
+	private $userId;
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		IAvatarManager $avatarManager,
+		IL10N $l,
+		LoggerInterface $logger,
+		string $userId
+	) {
+		parent::__construct($appName, $request);
+		$this->avatarManager = $avatarManager;
+		$this->logger = $logger;
+		$this->l = $l;
+		$this->userId = $userId;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @return DataResponse
+	 */
+	public function postAvatar(): DataResponse {
+		$files = $this->request->getUploadedFile('files');
+
+		if (is_null($files)) {
+			return new DataResponse(
+				['message' => $this->l->t('No image file provided')],
+				Http::STATUS_BAD_REQUEST
+			);
+		}
+
+		if (
+			$files['error'][0] === 0 &&
+			is_uploaded_file($files['tmp_name'][0]) &&
+			!Filesystem::isFileBlacklisted($files['tmp_name'][0])
+		) {
+			if ($files['size'][0] > 20 * 1024 * 1024) {
+				return new DataResponse(
+					['message' => $this->l->t('File is too big')],
+					Http::STATUS_BAD_REQUEST
+				);
+			}
+			$content = file_get_contents($files['tmp_name'][0]);
+			unlink($files['tmp_name'][0]);
+		} else {
+			return new DataResponse(
+				['message' => $this->l->t('Invalid file provided')],
+				Http::STATUS_BAD_REQUEST
+			);
+		}
+
+		try {
+			$image = new \OC_Image();
+			$image->loadFromData($content);
+			$image->readExif($content);
+			$image->fixOrientation();
+
+			if (!$image->valid()) {
+				return new DataResponse(
+					['data' => ['message' => $this->l->t('Invalid image')]],
+					Http::STATUS_BAD_REQUEST
+				);
+			}
+
+			$mimeType = $image->mimeType();
+			if ($mimeType !== 'image/jpeg' && $mimeType !== 'image/png') {
+				return new DataResponse(
+					['data' => ['message' => $this->l->t('Unknown filetype')]],
+					Http::STATUS_BAD_REQUEST
+				);
+			}
+
+			$avatar = $this->avatarManager->getAvatar($this->userId);
+			$avatar->set($image);
+			return new DataResponse();
+		} catch (\Exception $e) {
+			$this->logger->error('Failed to delete avatar', [
+				'exception' => $e,
+			]);
+
+			return new DataResponse(['message' => $this->l->t('An error occurred. Please contact your admin.')], Http::STATUS_BAD_REQUEST);
+		}
+	}
+
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @return DataResponse
+	 */
+	public function deleteAvatar(): DataResponse {
+		try {
+			$avatar = $this->avatarManager->getAvatar($this->userId);
+			$avatar->remove();
+			return new DataResponse();
+		} catch (\Exception $e) {
+			$this->logger->error('Failed to delete avatar', [
+				'exception' => $e,
+			]);
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+	}
+}

--- a/lib/Controller/TempAvatarController.php
+++ b/lib/Controller/TempAvatarController.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Controller;
 
 use OC\Files\Filesystem;
+use OC\NotSquareException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
@@ -119,8 +120,10 @@ class TempAvatarController extends OCSController {
 			$avatar = $this->avatarManager->getAvatar($this->userId);
 			$avatar->set($image);
 			return new DataResponse();
+		} catch (NotSquareException $e) {
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		} catch (\Exception $e) {
-			$this->logger->error('Failed to delete avatar', [
+			$this->logger->error('Failed to post avatar', [
 				'exception' => $e,
 			]);
 

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -86,6 +86,7 @@ class CapabilitiesTest extends TestCase {
 			'raise-hand',
 			'room-description',
 			'rich-object-sharing',
+			'temp-user-avatar-api',
 		];
 	}
 

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -212,6 +212,11 @@
       <code>\GuzzleHttp\Exception\ConnectException</code>
     </UndefinedClass>
   </file>
+  <file src="lib/Controller/TempAvatarController.php">
+    <UndefinedClass occurrences="1">
+      <code>Filesystem</code>
+    </UndefinedClass>
+  </file>
   <file src="lib/Files/TemplateLoader.php">
     <MissingDependency occurrences="2">
       <code>IRootFolder</code>
@@ -239,9 +244,6 @@
   <file src="lib/Flow/Operation.php">
     <InvalidArgument occurrences="1"/>
   </file>
-  <file src="lib/Manager.php">
-    <InvalidArgument occurrences="10"/>
-  </file>
   <file src="lib/MatterbridgeManager.php">
     <UndefinedClass occurrences="3">
       <code>IAuthTokenProvider</code>
@@ -259,12 +261,6 @@
     <InvalidArrayAccess occurrences="1">
       <code>$return['num_rooms']</code>
     </InvalidArrayAccess>
-  </file>
-  <file src="lib/Migration/Version7000Date20190724121136.php">
-    <InvalidArgument occurrences="1"/>
-  </file>
-  <file src="lib/Migration/Version7000Date20190724121137.php">
-    <InvalidArgument occurrences="1"/>
   </file>
   <file src="lib/Notification/Notifier.php">
     <InvalidPropertyAssignmentValue occurrences="3">


### PR DESCRIPTION
### Upload an avatar
```
curl -k -H "OCS-APIRequest: true" -u admin:admin 'https://nextcloud22.local/ocs/v2.php/apps/spreed/temp-user-avatar' -X POST -F 'files[]=@/home/nickv/avatar.jpg'
```

### Delete an avatar
```
curl -k -H "OCS-APIRequest: true" -u admin:admin 'https://nextcloud22.local/ocs/v2.php/apps/spreed/temp-user-avatar' -X DELETE
```

Not adding documentation because it's being wiped soon again and will be removed without any close done time once the one from server is there.