### PR TITLE
Fix order to reduce eslint warnings

### DIFF
--- a/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
+++ b/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
@@ -72,8 +72,8 @@
 						class="icon icon-edit"
 						@click="showLogContent" />
 					<Modal v-if="logModal"
-						@close="closeLogModal"
-						container="#content-vue">
+						container="#content-vue"
+						@close="closeLogModal">
 						<div class="modal__content">
 							<textarea v-model="processLog" class="log-content" />
 						</div>

--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -35,8 +35,8 @@
 		<!-- New group form -->
 		<Modal
 			v-if="modal"
-			@close="closeModal"
-			container="#content-vue">
+			container="#content-vue"
+			@close="closeModal">
 			<!-- Wrapper for content & navigation -->
 			<div
 				class="new-group-conversation talk-modal">

--- a/src/components/UploadEditor.vue
+++ b/src/components/UploadEditor.vue
@@ -22,8 +22,8 @@
 <template>
 	<Modal v-if="showModal"
 		class="upload-editor"
-		@close="handleDismiss"
-		container="#content-vue">
+		container="#content-vue"
+		@close="handleDismiss">
 		<!--native file picker, hidden -->
 		<input id="file-upload"
 			ref="fileUploadInput"


### PR DESCRIPTION
```
/home/nickv/Nextcloud/22/server/appsbabies/spreed/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
  76:7  warning  Attribute "container" should go before "@close"  vue/attributes-order

/home/nickv/Nextcloud/22/server/appsbabies/spreed/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
  39:4  warning  Attribute "container" should go before "@close"  vue/attributes-order

/home/nickv/Nextcloud/22/server/appsbabies/spreed/src/components/UploadEditor.vue
  26:3  warning  Attribute "container" should go before "@close"  vue/attributes-order
```