### PR TITLE
Don't fail loading the store when some initial states are not there

### DIFF
--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -69,7 +69,7 @@ const setSIPSettings = async function(sipGroups, sharedSecret, dialInInfo) {
 
 const setPlaySounds = async function(enabled) {
 	const savableValue = enabled ? 'yes' : 'no'
-	if (store.getters.userId) {
+	if (store.getters.getUserId()) {
 		return axios.post(generateOcsUrl('apps/spreed/api/v1/settings', 2) + 'user', {
 			key: 'play_sounds',
 			value: savableValue,

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -23,15 +23,15 @@
 import Vue from 'vue'
 import client from '../services/DavClient'
 import { showError } from '@nextcloud/dialogs'
-import { loadState } from '@nextcloud/initial-state'
+import fromStateOr from './helper'
 import { findUniquePath } from '../utils/fileUpload'
 import createTemporaryMessage from '../utils/temporaryMessage'
 import { EventBus } from '../services/EventBus'
 import { shareFile } from '../services/filesSharingServices'
 
 const state = {
-	attachmentFolder: loadState('spreed', 'attachment_folder'),
-	attachmentFolderFreeSpace: loadState('spreed', 'attachment_folder_free_space'),
+	attachmentFolder: fromStateOr('spreed', 'attachment_folder', ''),
+	attachmentFolderFreeSpace: fromStateOr('spreed', 'attachment_folder_free_space', 0),
 	uploads: {
 	},
 	currentUploadId: undefined,

--- a/src/store/helper.js
+++ b/src/store/helper.js
@@ -1,0 +1,29 @@
+/**
+ * @copyright Copyright (c) 2021 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { loadState } from '@nextcloud/initial-state'
+
+export default (app, key, orValue) => {
+	try {
+		return loadState(app, key)
+	} catch (e) {
+		return orValue
+	}
+}

--- a/src/store/settingsStore.js
+++ b/src/store/settingsStore.js
@@ -18,11 +18,12 @@
  *
  */
 
-import { loadState } from '@nextcloud/initial-state'
+import fromStateOr from './helper'
 import { setReadStatusPrivacy } from '../services/settingsService'
+import { PRIVACY } from '../constants'
 
 const state = {
-	readStatusPrivacy: loadState('spreed', 'read_status_privacy'),
+	readStatusPrivacy: fromStateOr('spreed', 'read_status_privacy', PRIVACY.PRIVATE),
 }
 
 const getters = {

--- a/src/store/soundsStore.js
+++ b/src/store/soundsStore.js
@@ -20,11 +20,11 @@
  *
  */
 
-import { loadState } from '@nextcloud/initial-state'
+import fromStateOr from './helper'
 import BrowserStorage from '../services/BrowserStorage'
 
 const state = {
-	playSoundsUser: loadState('spreed', 'play_sounds'),
+	playSoundsUser: fromStateOr('spreed', 'play_sounds', false),
 	playSoundsGuest: BrowserStorage.getItem('play_sounds') !== 'no',
 }
 


### PR DESCRIPTION
Copied from https://github.com/nextcloud/server/blob/3e624dc39966f54c6d418eee2e8141fc5c21f751/core/src/login.js#L48-L54

Don't know when it started, but the current admin page doesn't load anymore due to combination of things. services now use the store and the store loads initial state, but that is only initialised on the talk controllers, not in settings.... going with a default value now solves this.