### PR TITLE
Changelog for 11.2.0, 11.1.2, 10.1.4 and 10.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,56 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 11.2.0 – 2021-04-12
+### Added
+- Added a temporary OCS Api for clients to upload avatars
+  [#5401](https://github.com/nextcloud/spreed/pull/5401)
+
+### Changed
+- Direct reply button in message row
+  [#5361](https://github.com/nextcloud/spreed/pull/5361)
+
+### Fixed
+- Show error notification also when hello signaling message fails
+  [#5344](https://github.com/nextcloud/spreed/pull/5344)
+- Fix UI feedback when remote participants lose connection
+  [#5345](https://github.com/nextcloud/spreed/pull/5345)
+- Handle failed server requests more gracefully
+  [#5455](https://github.com/nextcloud/spreed/pull/5455)
+
+- Only use the local file as preview for some types when uploading
+  [#5424](https://github.com/nextcloud/spreed/pull/5424)
+- Fix an issue with the migration to the new attendees table
+  [#5428](https://github.com/nextcloud/spreed/pull/5428)
+- Fix the background job checking the schema
+  [#5374](https://github.com/nextcloud/spreed/pull/5374)
+- Fix a bug with the raised hand of users that disconnect
+  [#5418](https://github.com/nextcloud/spreed/pull/5418)
+
+## 11.1.2 – 2021-04-12
+### Fixed
+- Only use the local file as preview for some types when uploading
+  [#5423](https://github.com/nextcloud/spreed/pull/5423)
+- Fix an issue with the migration to the new attendees table
+  [#5428](https://github.com/nextcloud/spreed/pull/5427)
+- Fix the background job checking the schema
+  [#5373](https://github.com/nextcloud/spreed/pull/5373)
+- Fix a bug with the raised hand of users that disconnect
+  [#5419](https://github.com/nextcloud/spreed/pull/5419)
+
+## 10.1.4 – 2021-04-12
+### Fixed
+- Only use the local file as preview for some types when uploading
+  [#5425](https://github.com/nextcloud/spreed/pull/5425)
+- Fix an issue with the migration to the new attendees table
+  [#5245](https://github.com/nextcloud/spreed/pull/5245)
+  [#5429](https://github.com/nextcloud/spreed/pull/5429)
+
+## 10.0.7 – 2021-04-12
+### Fixed
+- Only use the local file as preview for some types when uploading
+  [#5426](https://github.com/nextcloud/spreed/pull/5426)
+
 ## 11.1.1 – 2021-03-04
 ### Fixed
 - Fixed a bug in the migration that could prevent copying all participants to the attendee table

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ All notable changes to this project will be documented in this file.
   [#5455](https://github.com/nextcloud/spreed/pull/5455)
 
 - Only use the local file as preview for some types when uploading
-  [#5424](https://github.com/nextcloud/spreed/pull/5424)
+  [#5423](https://github.com/nextcloud/spreed/pull/5423)
 - Fix an issue with the migration to the new attendees table
-  [#5428](https://github.com/nextcloud/spreed/pull/5428)
+  [#5427](https://github.com/nextcloud/spreed/pull/5427)
 - Fix the background job checking the schema
   [#5374](https://github.com/nextcloud/spreed/pull/5374)
 - Fix a bug with the raised hand of users that disconnect
@@ -30,9 +30,9 @@ All notable changes to this project will be documented in this file.
 ## 11.1.2 – 2021-04-12
 ### Fixed
 - Only use the local file as preview for some types when uploading
-  [#5423](https://github.com/nextcloud/spreed/pull/5423)
+  [#5424](https://github.com/nextcloud/spreed/pull/5424)
 - Fix an issue with the migration to the new attendees table
-  [#5428](https://github.com/nextcloud/spreed/pull/5427)
+  [#5428](https://github.com/nextcloud/spreed/pull/5428)
 - Fix the background job checking the schema
   [#5373](https://github.com/nextcloud/spreed/pull/5373)
 - Fix a bug with the raised hand of users that disconnect


### PR DESCRIPTION
## 11.2.0 – 2021-04-12
### ✅ Added
- Added a temporary OCS Api for clients to upload avatars  [#5401](https://github.com/nextcloud/spreed/pull/5401)

### 🔧 Changed
- Direct reply button in message row  [#5361](https://github.com/nextcloud/spreed/pull/5361)

### 🐞 Fixed
- Show error notification also when hello signaling message fails  [#5344](https://github.com/nextcloud/spreed/pull/5344)
- Fix UI feedback when remote participants lose connection  [#5345](https://github.com/nextcloud/spreed/pull/5345)
- Handle failed server requests more gracefully  [#5455](https://github.com/nextcloud/spreed/pull/5455)

- Only use the local file as preview for some types when uploading  [#5423](https://github.com/nextcloud/spreed/pull/5423)
- Fix an issue with the migration to the new attendees table  [#5427](https://github.com/nextcloud/spreed/pull/5427)
- Fix the background job checking the schema  [#5374](https://github.com/nextcloud/spreed/pull/5374)
- Fix a bug with the raised hand of users that disconnect  [#5418](https://github.com/nextcloud/spreed/pull/5418)

## 11.1.2 – 2021-04-12
### 🐞 Fixed
- Only use the local file as preview for some types when uploading  [#5424](https://github.com/nextcloud/spreed/pull/5424)
- Fix an issue with the migration to the new attendees table  [#5428](https://github.com/nextcloud/spreed/pull/5428)
- Fix the background job checking the schema  [#5373](https://github.com/nextcloud/spreed/pull/5373)
- Fix a bug with the raised hand of users that disconnect  [#5419](https://github.com/nextcloud/spreed/pull/5419)

## 10.1.4 – 2021-04-12
### 🐞 Fixed
- Only use the local file as preview for some types when uploading  [#5425](https://github.com/nextcloud/spreed/pull/5425)
- Fix an issue with the migration to the new attendees table  [#5245](https://github.com/nextcloud/spreed/pull/5245)  [#5429](https://github.com/nextcloud/spreed/pull/5429)

## 10.0.7 – 2021-04-12
### 🐞 Fixed
- Only use the local file as preview for some types when uploading  [#5426](https://github.com/nextcloud/spreed/pull/5426)
