### PR TITLE
Issue templates | Add empty line to details blocks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -72,6 +72,7 @@ You can use the Issue Template application to prefill most of the required infor
 **List of activated apps:**
 
 <details>
+
 ```
 If you have access to your command line run e.g.:
 sudo -u www-data php occ app:list
@@ -82,6 +83,7 @@ from within your server installation folder
 **Nextcloud configuration:**
 
 <details>
+
 ```
 If you have access to your command line run e.g.:
 sudo -u www-data php occ config:list system
@@ -91,6 +93,7 @@ from within your Nextcloud installation folder
 
 ### Server log (data/nextcloud.log)
 <details>
+
 ```
 Insert your server log here
 ```

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -61,6 +61,7 @@ You can use the Issue Template application to prefill most of the required infor
 **List of activated apps:**
 
 <details>
+
 ```
 If you have access to your command line run e.g.:
 sudo -u www-data php occ app:list
@@ -71,6 +72,7 @@ from within your server installation folder
 **Nextcloud configuration:**
 
 <details>
+
 ```
 If you have access to your command line run e.g.:
 sudo -u www-data php occ config:list system
@@ -85,6 +87,7 @@ Make sure to remove all sensitive content such as passwords. (e.g. database pass
 
 ### Server log (data/nextcloud.log)
 <details>
+
 ```
 Insert your server log here
 ```


### PR DESCRIPTION
As a matter of fact, without that additional empty line, the fenced code blocks within the details blocks are not shown correctly on GitHub.