### PR TITLE
Fix raised hand detection for multiple session, adjusted participant list response

### DIFF
--- a/docs/participant.md
+++ b/docs/participant.md
@@ -35,7 +35,8 @@
         `lastPing` | int | * | Timestamp of the last ping of the user (should be used for sorting)
         `inCall` | int | * | Call flags the user joined with (see [constants list](constants.md#participant-in-call-flag))
         `sessionId` | string | * | `'0'` if not connected, otherwise a 512 character long string
-        `status` | string | * | Optional: Only available with `includeStatus=true`, for users with a set status and when there are less than 100 participants in the conversation 
+        `sessionIds` | array | * | array of session ids, each are 512 character long strings, or empty if no session
+        `status` | string | * | Optional: Only available with `includeStatus=true`, for users with a set status and when there are less than 100 participants in the conversation
         `statusIcon` | string | * | Optional: Only available with `includeStatus=true`, for users with a set status and when there are less than 100 participants in the conversation
         `statusMessage` | string | * | Optional: Only available with `includeStatus=true`, for users with a set status and when there are less than 100 participants in the conversation
 

--- a/docs/participant.md
+++ b/docs/participant.md
@@ -34,7 +34,6 @@
         `participantType` | int | * | Permissions level of the participant (see [constants list](constants.md#participant-types))
         `lastPing` | int | * | Timestamp of the last ping of the user (should be used for sorting)
         `inCall` | int | * | Call flags the user joined with (see [constants list](constants.md#participant-in-call-flag))
-        `sessionId` | string | * | `'0'` if not connected, otherwise a 512 character long string
         `sessionIds` | array | * | array of session ids, each are 512 character long strings, or empty if no session
         `status` | string | * | Optional: Only available with `includeStatus=true`, for users with a set status and when there are less than 100 participants in the conversation
         `statusIcon` | string | * | Optional: Only available with `includeStatus=true`, for users with a set status and when there are less than 100 participants in the conversation

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -922,6 +922,7 @@ class RoomController extends AEnvironmentAwareController {
 				$results[$attendeeId]['inCall'] |= $session->getInCall();
 				$results[$attendeeId]['lastPing'] = max($results[$attendeeId]['lastPing'], $session->getLastPing());
 				$results[$attendeeId]['sessionId'] = $results[$attendeeId]['sessionId'] !== '0' ? $results[$attendeeId]['sessionId'] : $session->getSessionId();
+				$results[$attendeeId]['sessionIds'][] = $session->getSessionId();
 				continue;
 			}
 
@@ -929,6 +930,7 @@ class RoomController extends AEnvironmentAwareController {
 				'inCall' => Participant::FLAG_DISCONNECTED,
 				'lastPing' => 0,
 				'sessionId' => '0', // FIXME empty string or null?
+				'sessionIds' => [],
 				'participantType' => $participant->getAttendee()->getParticipantType(),
 				'attendeeId' => $attendeeId,
 				'actorId' => $participant->getAttendee()->getActorId(),
@@ -950,6 +952,7 @@ class RoomController extends AEnvironmentAwareController {
 				$result['inCall'] = $participant->getSession()->getInCall();
 				$result['lastPing'] = $participant->getSession()->getLastPing();
 				$result['sessionId'] = $participant->getSession()->getSessionId();
+				$result['sessionIds'] = [$participant->getSession()->getSessionId()];
 			}
 
 			if ($participant->getAttendee()->getActorType() === Attendee::ACTOR_USERS) {

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -921,7 +921,6 @@ class RoomController extends AEnvironmentAwareController {
 				// Combine the session values: All inCall bit flags, newest lastPing and any sessionId (for online checking)
 				$results[$attendeeId]['inCall'] |= $session->getInCall();
 				$results[$attendeeId]['lastPing'] = max($results[$attendeeId]['lastPing'], $session->getLastPing());
-				$results[$attendeeId]['sessionId'] = $results[$attendeeId]['sessionId'] !== '0' ? $results[$attendeeId]['sessionId'] : $session->getSessionId();
 				$results[$attendeeId]['sessionIds'][] = $session->getSessionId();
 				continue;
 			}
@@ -929,7 +928,6 @@ class RoomController extends AEnvironmentAwareController {
 			$result = [
 				'inCall' => Participant::FLAG_DISCONNECTED,
 				'lastPing' => 0,
-				'sessionId' => '0', // FIXME empty string or null?
 				'sessionIds' => [],
 				'participantType' => $participant->getAttendee()->getParticipantType(),
 				'attendeeId' => $attendeeId,
@@ -951,7 +949,6 @@ class RoomController extends AEnvironmentAwareController {
 			if ($participant->getSession() instanceof Session) {
 				$result['inCall'] = $participant->getSession()->getInCall();
 				$result['lastPing'] = $participant->getSession()->getLastPing();
-				$result['sessionId'] = $participant->getSession()->getSessionId();
 				$result['sessionIds'] = [$participant->getSession()->getSessionId()];
 			}
 

--- a/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
+++ b/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
@@ -145,19 +145,19 @@ export default {
 				return p2IsGroup ? -1 : 1
 			}
 
-			let session1 = participant1.sessionId
-			let session2 = participant2.sessionId
+			let hasSessions1 = !!participant1.sessionIds.length
+			let hasSessions2 = !!participant2.sessionIds.length
 			if (participant1.status === 'offline') {
-				session1 = '0'
+				hasSessions1 = false
 			}
 			if (participant2.status === 'offline') {
-				session2 = '0'
+				hasSessions2 = false
 			}
-			if (session1 === '0') {
-				if (session2 !== '0') {
+			if (!hasSessions1) {
+				if (hasSessions2) {
 					return 1
 				}
-			} else if (session2 === '0') {
+			} else if (!hasSessions2) {
 				return -1
 			}
 
@@ -167,8 +167,8 @@ export default {
 				return p1inCall ? -1 : 1
 			}
 
-			const p1HandRaised = this.$store.getters.getParticipantRaisedHand(session1)
-			const p2HandRaised = this.$store.getters.getParticipantRaisedHand(session2)
+			const p1HandRaised = this.$store.getters.getParticipantRaisedHand(participant1.sessionIds)
+			const p2HandRaised = this.$store.getters.getParticipantRaisedHand(participant2.sessionIds)
 			if (p1HandRaised.state !== p2HandRaised.state) {
 				return p1HandRaised.state ? -1 : 1
 			}

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -305,12 +305,20 @@ export default {
 			return this.participant.label
 		},
 		isHandRaised() {
+			let aggregatedState = false
 			if (this.isSearched || this.participant.inCall === PARTICIPANT.CALL_FLAG.DISCONNECTED) {
 				return false
 			}
 
-			const state = this.$store.getters.isParticipantRaisedHand(this.participant.sessionId)
-			return state
+			// show hand icon if at least one session has a raised hand
+			this.participant.sessionIds.forEach((sessionId) => {
+				const state = this.$store.getters.isParticipantRaisedHand(sessionId)
+				if (state === true) {
+					aggregatedState = true
+				}
+			})
+
+			return aggregatedState
 		},
 		callIcon() {
 			if (this.isSearched || this.participant.inCall === PARTICIPANT.CALL_FLAG.DISCONNECTED) {

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -305,20 +305,12 @@ export default {
 			return this.participant.label
 		},
 		isHandRaised() {
-			let aggregatedState = false
 			if (this.isSearched || this.participant.inCall === PARTICIPANT.CALL_FLAG.DISCONNECTED) {
 				return false
 			}
 
-			// show hand icon if at least one session has a raised hand
-			this.participant.sessionIds.forEach((sessionId) => {
-				const state = this.$store.getters.isParticipantRaisedHand(sessionId)
-				if (state === true) {
-					aggregatedState = true
-				}
-			})
-
-			return aggregatedState
+			const raisedState = this.$store.getters.getParticipantRaisedHand(this.participant.sessionIds)
+			return raisedState.state
 		},
 		callIcon() {
 			if (this.isSearched || this.participant.inCall === PARTICIPANT.CALL_FLAG.DISCONNECTED) {
@@ -352,8 +344,8 @@ export default {
 		participantType() {
 			return this.participant.participantType
 		},
-		sessionId() {
-			return this.participant.sessionId
+		sessionIds() {
+			return this.participant.sessionIds || []
 		},
 		lastPing() {
 			return this.participant.lastPing
@@ -383,14 +375,14 @@ export default {
 			}
 
 			// Guest
-			return this.sessionId !== '0' && this.sessionId === this.currentParticipant.sessionId
+			return this.sessionIds.length && this.sessionIds.indexOf(this.currentParticipant.sessionId) >= 0
 		},
 		selfIsModerator() {
 			return this.participantTypeIsModerator(this.currentParticipant.participantType)
 		},
 
 		isOffline() {
-			return /* this.participant.status === 'offline' || */ this.sessionId === '0'
+			return /* this.participant.status === 'offline' || */ !this.sessionIds.length
 		},
 		isGuest() {
 			return [PARTICIPANT.TYPE.GUEST, PARTICIPANT.TYPE.GUEST_MODERATOR].indexOf(this.participantType) !== -1

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -256,7 +256,7 @@ export default {
 						|| participant.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR) {
 						this.$store.dispatch('forceGuestName', {
 							token: token,
-							actorId: Hex.stringify(SHA1(participant.sessionId)),
+							actorId: Hex.stringify(SHA1(participant.sessionIds[0])),
 							actorDisplayName: participant.displayName,
 						})
 					} else if (participant.actorType === 'users' && hasUserStatuses) {

--- a/src/store/callViewStore.js
+++ b/src/store/callViewStore.js
@@ -46,11 +46,15 @@ const getters = {
 	selectedVideoPeerId: (state) => {
 		return state.selectedVideoPeerId
 	},
-	getParticipantRaisedHand: (state) => (sessionId) => {
-		return state.participantRaisedHands[sessionId] || { state: false, timestamp: null }
-	},
-	isParticipantRaisedHand: (state) => (sessionId) => {
-		return state.participantRaisedHands[sessionId]?.state
+	getParticipantRaisedHand: (state) => (sessionIds) => {
+		for (let i = 0; i < sessionIds.length; i++) {
+			if (state.participantRaisedHands[sessionIds[i]]) {
+				// note: only the raised states are stored, so no need to confirm
+				return state.participantRaisedHands[sessionIds[i]]
+			}
+		}
+
+		return { state: false, timestamp: null }
 	},
 	getCachedBackgroundImageAverageColor: (state) => (videoBackgroundId) => {
 		return state.backgroundImageAverageColorCache[videoBackgroundId]

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -147,7 +147,7 @@ const actions = {
 			participant: {
 				inCall: conversation.participantFlags,
 				lastPing: conversation.lastPing,
-				sessionId: conversation.sessionId,
+				sessionIds: [conversation.sessionId],
 				participantType: conversation.participantType,
 				attendeeId: conversation.attendeeId,
 				actorType: conversation.actorType,


### PR DESCRIPTION
### Description 

- Expose session ids as array in participants API
- The sessionId attribute is now removed from the participant list API response in favor of the sessionIds array.
- The raised hand state in the participant list is now retrieved based on the multiple sessions of a participant

As discussed in https://github.com/nextcloud/spreed/issues/5349#issuecomment-795624906, v4 of the API has not crystalized yet so it's ok to make changes in this PR.

### Related tickets

Fixes https://github.com/nextcloud/spreed/issues/5349

### Tests

Testing if raised hand appears when triggered from both sessions of a single user:

- [x] TEST: regular users with HPB
- [x] TEST: regular users without HPB
- [x] TEST: guests with HPB
- [x] TEST: guests without HPB