### PR TITLE
Fix flickering of description overflow when switching between one-to-…

### DIFF
--- a/src/components/RightSidebar/Description/Description.vue
+++ b/src/components/RightSidebar/Description/Description.vue
@@ -211,6 +211,10 @@ export default {
 		},
 	},
 
+	mounted() {
+		this.checkOverflow()
+	},
+
 	watch: {
 		// Each time the prop changes, reflect the changes in the value stored in this component
 		description(newValue) {


### PR DESCRIPTION
…one and a descripted room

### Steps
1. Create a conversation with a description that has 4 lines of text
2. Create a one-to-one conversation
3. Reload the page in the description room
4. Description is overlayed with shadow
5. Switch to one-to-one
6. Switch back
7. Description is still overlayed (was not before)