### PR TITLE
Disable avatar menu in messages as guest

### DIFF
--- a/src/components/MessagesList/MessagesGroup/AuthorAvatar.vue
+++ b/src/components/MessagesList/MessagesGroup/AuthorAvatar.vue
@@ -25,6 +25,7 @@
 		class="messages__avatar__icon"
 		:user="authorId"
 		:show-user-status="false"
+		:disable-menu="disableMenu"
 		menu-container="#content-vue"
 		menu-position="left"
 		:display-name="displayName" />
@@ -84,6 +85,11 @@ export default {
 		firstLetterOfGuestName() {
 			const customName = this.displayName !== t('spreed', 'Guest') ? this.displayName : '?'
 			return customName.charAt(0)
+		},
+
+		disableMenu() {
+			// disable the menu if accessing the conversation as guest
+			return this.$store.getters.getActorType() === 'guests'
 		},
 	},
 }


### PR DESCRIPTION
When attending a conversation as guest, the menu of the avatars shown
before messages is now disabled. The menu would anyway not show any
entries.

Fixes https://github.com/nextcloud/spreed/issues/5399

- [x] TEST: menu is disabled as guest
- [x] TEST: menu is not disabled as guest
- [x] TEST: guest avatars never display a menu anyway, even for logged in users