### PR TITLE
Make tooltips work in fullscreen mode

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -44,6 +44,7 @@ import { translate, translatePlural } from '@nextcloud/l10n'
 import VueObserveVisibility from 'vue-observe-visibility'
 import VueShortKey from 'vue-shortkey'
 import vOutsideEvents from 'vue-outside-events'
+import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 
 // Styles
 import '@nextcloud/dialogs/styles/toast.scss'
@@ -70,6 +71,8 @@ Vue.use(VueClipboard)
 Vue.use(VueObserveVisibility)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
 Vue.use(vOutsideEvents)
+
+Tooltip.options.defaultContainer = '#content-vue'
 
 const instance = new Vue({
 	el: '#content',


### PR DESCRIPTION
Fixes https://github.com/nextcloud/spreed/issues/5027

This sets the default tooltip container to not be the body but the Vue element that we select in fullscreen mode.

I've verified that the scope of this default is only available in the talk app by adding log statements in the notifications app and log that setting while in the talk app. In the notifications app the default stays body.
This confirms that library specific globals are only available in the library scope in which it was included/compiled and since every app bundle its own version of nextcloud/vue with the tooltip, then we're fine.

