### PR TITLE
Fix compatibility with nextcloud-vue v4.0.0 alpha

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -42,9 +42,6 @@ module.exports = {
 			{
 				test: /\.vue$/,
 				loader: 'vue-loader',
-				exclude: babelLoaderExcludeNodeModulesExcept([
-					'vue-material-design-icons',
-				]),
 			},
 			{
 				test: /\.js$/,


### PR DESCRIPTION
The material design icon loaders were affected by a recent change and we
need to stop excluding them for the compilation to work again.

Fixes https://github.com/nextcloud/spreed/issues/5489.

Thanks @juliushaertl for this solution.

I've tested with nextcloud-vue master as per steps in the ticket and it works fine with npm link.
Also retested with v3.9.0 from the original package.json and it works fine.

I've verified in both cases that the material design icons in the call view appear properly.

