### PR TITLE
Provide multiple TURN servers to webrtc client

### DIFF
--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -146,16 +146,16 @@ class SignalingController extends OCSController {
 
 		$turn = [];
 		$turnSettings = $this->talkConfig->getTurnSettings();
-		if (!empty($turnSettings['server'])) {
-			$schemes = explode(',', $turnSettings['schemes']);
-			$protocols = explode(',', $turnSettings['protocols']);
+		foreach ($turnSettings as $turnServer) {
+			$schemes = explode(',', $turnServer['schemes']);
+			$protocols = explode(',', $turnServer['protocols']);
 			foreach ($schemes as $scheme) {
 				foreach ($protocols as $proto) {
 					$turn[] = [
-						'url' => [$scheme . ':' . $turnSettings['server'] . '?transport=' . $proto],
-						'urls' => [$scheme . ':' . $turnSettings['server'] . '?transport=' . $proto],
-						'username' => $turnSettings['username'],
-						'credential' => $turnSettings['password'],
+						'url' => [$scheme . ':' . $turnServer['server'] . '?transport=' . $proto],
+						'urls' => [$scheme . ':' . $turnServer['server'] . '?transport=' . $proto],
+						'username' => $turnServer['username'],
+						'credential' => $turnServer['password'],
 					];
 				}
 			}

--- a/tests/php/ConfigTest.php
+++ b/tests/php/ConfigTest.php
@@ -117,13 +117,19 @@ class ConfigTest extends TestCase {
 			->willReturn(json_encode([
 				[
 					// No scheme explicitly given
-					'server' => 'turn.example.org',
+					'server' => 'turn.example.org:3478',
 					'secret' => 'thisisasupersecretsecret',
 					'protocols' => 'udp,tcp',
 				],
 				[
 					'schemes' => 'turn,turns',
-					'server' => 'turn2.example.com',
+					'server' => 'turn2.example.com:5349',
+					'secret' => 'ThisIsAlsoSuperSecret',
+					'protocols' => 'udp',
+				],
+				[
+					'schemes' => 'turns',
+					'server' => 'turn-tls.example.com:443',
 					'secret' => 'ThisIsAlsoSuperSecret',
 					'protocols' => 'tcp',
 				],
@@ -149,24 +155,53 @@ class ConfigTest extends TestCase {
 		$helper = new Config($config, $secureRandom, $groupManager, $timeFactory);
 
 		//
-		$server = $helper->getTurnSettings();
-		if ($server['server'] === 'turn.example.org') {
-			$this->assertSame([
-				'schemes' => 'turn',
-				'server' => 'turn.example.org',
-				'username' => '1479829425:abcdefghijklmnop',
-				'password' => '4VJLVbihLzuxgMfDrm5C3zy8kLQ=',
-				'protocols' => 'udp,tcp',
-			], $server);
-		} else {
-			$this->assertSame([
-				'schemes' => 'turn,turns',
-				'server' => 'turn2.example.com',
-				'username' => '1479829425:abcdefghijklmnop',
-				'password' => 'Ol9DEqnvyN4g+IAM+vFnqhfWUTE=',
-				'protocols' => 'tcp',
-			], $server);
-		}
+		$settings = $helper->getTurnSettings();
+		$this->assertEquals(3, count($settings));
+		$this->assertSame([
+			'schemes' => 'turn',
+			'server' => 'turn.example.org:3478',
+			'username' => '1479829425:abcdefghijklmnop',
+			'password' => '4VJLVbihLzuxgMfDrm5C3zy8kLQ=',
+			'protocols' => 'udp,tcp',
+		], $settings[0]);
+		$this->assertSame([
+			'schemes' => 'turn,turns',
+			'server' => 'turn2.example.com:5349',
+			'username' => '1479829425:abcdefghijklmnop',
+			'password' => 'Ol9DEqnvyN4g+IAM+vFnqhfWUTE=',
+			'protocols' => 'udp',
+		], $settings[1]);
+		$this->assertSame([
+			'schemes' => 'turns',
+			'server' => 'turn-tls.example.com:443',
+			'username' => '1479829425:abcdefghijklmnop',
+			'password' => 'Ol9DEqnvyN4g+IAM+vFnqhfWUTE=',
+			'protocols' => 'tcp',
+		], $settings[2]);
+	}
+
+	public function testGenerateTurnSettingsEmpty() {
+		/** @var MockObject|IConfig $config */
+		$config = $this->createMock(IConfig::class);
+		$config
+			->expects($this->once())
+			->method('getAppValue')
+			->with('spreed', 'turn_servers', '')
+			->willReturn(json_encode([]));
+
+		/** @var MockObject|ITimeFactory $timeFactory */
+		$timeFactory = $this->createMock(ITimeFactory::class);
+
+		/** @var MockObject|IGroupManager $secureRandom */
+		$groupManager = $this->createMock(IGroupManager::class);
+
+		/** @var MockObject|ISecureRandom $secureRandom */
+		$secureRandom = $this->createMock(ISecureRandom::class);
+
+		$helper = new Config($config, $secureRandom, $groupManager, $timeFactory);
+
+		$settings = $helper->getTurnSettings();
+		$this->assertEquals(0, count($settings));
 	}
 
 	public function dataGetWebSocketDomainForSignalingServer() {


### PR DESCRIPTION
For now, Nextcloud Talk gets _one_ random turnservers of the specified turnservers in the backend.

This patch provides all in the backend specified turnservers to the client. So the chance might be higher, that calling in restricted cooperate networks will works successfully (btw, it's up to the client which turnserver to use).

Would probably fix https://github.com/nextcloud/spreed/issues/5267
Fix #3676