### PR TITLE
Provide multiple STUN servers to webrtc client

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -213,24 +213,6 @@ class Config {
 	}
 
 	/**
-	 * @return string
-	 */
-	public function getStunServer(): string {
-		$servers = $this->getStunServers();
-
-		if (empty($servers)) {
-			return '';
-		}
-
-		// For now we use a random server from the list
-		try {
-			return $servers[random_int(0, count($servers) - 1)];
-		} catch (\Exception $e) {
-			return $servers[0];
-		}
-	}
-
-	/**
 	 * Generates a username and password for the TURN server
 	 *
 	 * @return array

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -137,8 +137,8 @@ class SignalingController extends OCSController {
 		}
 
 		$stun = [];
-		$stunServer = $this->talkConfig->getStunServer();
-		if ($stunServer) {
+		$stunServers = $this->talkConfig->getStunServers();
+		foreach ($stunServers as $stunServer) {
 			$stun[] = [
 				'url' => 'stun:' . $stunServer,
 			];

--- a/tests/php/ConfigTest.php
+++ b/tests/php/ConfigTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ConfigTest extends TestCase {
-	public function testGetStunServer() {
+	public function testGetStunServers() {
 		$servers = [
 			'stun1.example.com:443',
 			'stun2.example.com:129',
@@ -55,7 +55,7 @@ class ConfigTest extends TestCase {
 			->willReturn(true);
 
 		$helper = new Config($config, $secureRandom, $groupManager, $timeFactory);
-		$this->assertTrue(in_array($helper->getStunServer(), $servers, true));
+		$this->assertSame($helper->getStunServers(), $servers);
 	}
 
 	public function testGetDefaultStunServer() {
@@ -79,7 +79,7 @@ class ConfigTest extends TestCase {
 			->willReturn(true);
 
 		$helper = new Config($config, $secureRandom, $groupManager, $timeFactory);
-		$this->assertSame('stun.nextcloud.com:443', $helper->getStunServer());
+		$this->assertSame(['stun.nextcloud.com:443'], $helper->getStunServers());
 	}
 
 	public function testGetDefaultStunServerNoInternet() {
@@ -103,7 +103,7 @@ class ConfigTest extends TestCase {
 			->willReturn(false);
 
 		$helper = new Config($config, $secureRandom, $groupManager, $timeFactory);
-		$this->assertSame('', $helper->getStunServer());
+		$this->assertSame([], $helper->getStunServers());
 	}
 
 	public function testGenerateTurnSettings() {


### PR DESCRIPTION
- Provide multiple STUN servers to webrtc client when specified in the nextcloud backend instead of just 1 random one