### PR TITLE
More JS tests for stores

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,8 @@ module.exports = {
 	preset: '@vue/cli-plugin-unit-jest/presets/no-babel',
 	// Allow tests in the src and in tests/unit folders
 	testMatch: ['<rootDir>/src/**/*.(spec|test).(ts|js)'],
+	resetMocks: false,
+	setupFiles: ['jest-localstorage-mock'],
 	setupFilesAfterEnv: ['<rootDir>/src/test-setup.js'],
 	transform: {
 		// process `*.js` files with `babel-jest`

--- a/package-lock.json
+++ b/package-lock.json
@@ -13467,6 +13467,12 @@
 				"pretty-format": "^24.9.0"
 			}
 		},
+		"jest-localstorage-mock": {
+			"version": "2.4.10",
+			"resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.10.tgz",
+			"integrity": "sha512-aTEpZXuuFRtsjivomLg3NqW0iJEUAdxLzqGzBlA7OCEspEb2Qa9duzuhmjNX5rKnPKveFBbtzX9y6Di9ZAUpmg==",
+			"dev": true
+		},
 		"jest-matcher-utils": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
 		"eslint-plugin-promise": "^4.3.1",
 		"eslint-plugin-standard": "^4.1.0",
 		"eslint-plugin-vue": "^5.2.3",
+		"jest-localstorage-mock": "^2.4.10",
 		"jest-mock-axios": "^4.4.0",
 		"node-sass": "^5.0.0",
 		"regenerator-runtime": "^0.13.7",

--- a/src/store/callViewStore.spec.js
+++ b/src/store/callViewStore.spec.js
@@ -1,0 +1,286 @@
+import { createLocalVue } from '@vue/test-utils'
+import storeConfig from './storeConfig'
+import Vuex from 'vuex'
+import { cloneDeep } from 'lodash'
+import {
+	CONVERSATION,
+} from '../constants'
+
+describe('callViewStore', () => {
+	let localVue = null
+	let store = null
+
+	beforeEach(() => {
+		localVue = createLocalVue()
+		localVue.use(Vuex)
+
+		const testStoreConfig = cloneDeep(storeConfig)
+
+		// remove participant store to avoid participant interaction
+		testStoreConfig.modules.participantsStore = {}
+
+		store = new Vuex.Store(testStoreConfig)
+
+		// to fully reset the state between tests, clear the storage
+		localStorage.clear()
+
+		// and reset all mocks
+		jest.clearAllMocks()
+	})
+
+	describe('raised hand', () => {
+		test('get whether participants raised hands with single session id', () => {
+			store.dispatch('setParticipantHandRaised', {
+				sessionId: 'session-id-1',
+				raisedHand: { state: true, timestamp: 1 },
+			})
+			store.dispatch('setParticipantHandRaised', {
+				sessionId: 'session-id-2',
+				raisedHand: { state: true, timestamp: 2 },
+			})
+
+			expect(store.getters.getParticipantRaisedHand(['session-id-1']))
+				.toStrictEqual({ state: true, timestamp: 1 })
+
+			expect(store.getters.getParticipantRaisedHand(['session-id-2']))
+				.toStrictEqual({ state: true, timestamp: 2 })
+
+			expect(store.getters.getParticipantRaisedHand(['session-id-another']))
+				.toStrictEqual({ state: false, timestamp: null })
+		})
+
+		test('get raised hands after lowering', () => {
+			store.dispatch('setParticipantHandRaised', {
+				sessionId: 'session-id-2',
+				raisedHand: { state: true, timestamp: 1 },
+			})
+			store.dispatch('setParticipantHandRaised', {
+				sessionId: 'session-id-2',
+				raisedHand: { state: false, timestamp: 3 },
+			})
+
+			expect(store.getters.getParticipantRaisedHand(['session-id-2']))
+				.toStrictEqual({ state: false, timestamp: null })
+		})
+
+		test('clears raised hands state after leaving call', () => {
+			store.dispatch('setParticipantHandRaised', {
+				sessionId: 'session-id-2',
+				raisedHand: { state: true, timestamp: 1 },
+			})
+			store.dispatch('leaveCall')
+
+			expect(store.getters.getParticipantRaisedHand(['session-id-2']))
+				.toStrictEqual({ state: false, timestamp: null })
+		})
+
+		test('get raised hands with multiple session ids only returns first found', () => {
+			store.dispatch('setParticipantHandRaised', {
+				sessionId: 'session-id-2',
+				raisedHand: { state: true, timestamp: 1 },
+			})
+			store.dispatch('setParticipantHandRaised', {
+				sessionId: 'session-id-3',
+				raisedHand: { state: true, timestamp: 1 },
+			})
+
+			expect(store.getters.getParticipantRaisedHand(['session-id-1', 'session-id-2', 'session-id-3']))
+				.toStrictEqual({ state: true, timestamp: 1 })
+		})
+	})
+
+	describe('call view mode and presentation', () => {
+		test('restores grid state when joining call (true)', () => {
+			localStorage.getItem.mockReturnValueOnce('true')
+
+			store.dispatch('joinCall', { token: 'XXTOKENXX' })
+
+			expect(localStorage.getItem).toHaveBeenCalled()
+			expect(localStorage.getItem.mock.calls[0][0]).toEqual(expect.stringMatching(/callprefs-XXTOKENXX-isgrid$/))
+
+			expect(store.getters.isGrid).toBe(true)
+			expect(store.getters.isStripeOpen).toBe(true)
+		})
+
+		test('restores grid state when joining call (false)', () => {
+			localStorage.getItem.mockReturnValueOnce('false')
+
+			store.dispatch('joinCall', { token: 'XXTOKENXX' })
+
+			expect(localStorage.getItem).toHaveBeenCalled()
+			expect(localStorage.getItem.mock.calls[0][0]).toEqual(expect.stringMatching(/callprefs-XXTOKENXX-isgrid$/))
+
+			expect(store.getters.isGrid).toBe(false)
+			expect(store.getters.isStripeOpen).toBe(true)
+		})
+
+		function testDefaultGridState(conversationType, state) {
+			localStorage.getItem.mockReturnValueOnce(null)
+
+			// using commit instead of dispatch because the action
+			// also processes participants
+			store.commit('addConversation', {
+				token: 'XXTOKENXX',
+				type: conversationType,
+			})
+			store.dispatch('joinCall', { token: 'XXTOKENXX' })
+
+			expect(localStorage.getItem).toHaveBeenCalled()
+			expect(localStorage.getItem.mock.calls[0][0]).toEqual(expect.stringMatching(/callprefs-XXTOKENXX-isgrid$/))
+
+			expect(store.getters.isGrid).toBe(state)
+			expect(store.getters.isStripeOpen).toBe(true)
+		}
+
+		test('sets default grid state when joining call in group conversation', () => {
+			testDefaultGridState(CONVERSATION.TYPE.GROUP, true)
+		})
+
+		test('sets default grid state when joining call in public conversation', () => {
+			testDefaultGridState(CONVERSATION.TYPE.PUBLIC, true)
+		})
+
+		test('sets default grid state when joining call in one to one conversation', () => {
+			testDefaultGridState(CONVERSATION.TYPE.ONE_TO_ONE, false)
+		})
+
+		test('switching call view mode saves in local storage', () => {
+			store.dispatch('updateToken', 'XXTOKENXX')
+
+			store.dispatch('setCallViewMode', {
+				isGrid: true,
+				isStripeOpen: false,
+			})
+
+			expect(store.getters.isGrid).toEqual(true)
+			expect(store.getters.isStripeOpen).toEqual(false)
+
+			expect(localStorage.setItem).toHaveBeenCalled()
+			expect(localStorage.setItem.mock.calls[0][0]).toEqual(expect.stringMatching(/callprefs-XXTOKENXX-isgrid$/))
+			expect(localStorage.setItem.mock.calls[0][1]).toBe(true)
+
+			store.dispatch('setCallViewMode', {
+				isGrid: false,
+				isStripeOpen: true,
+			})
+
+			expect(store.getters.isGrid).toEqual(false)
+			expect(store.getters.isStripeOpen).toEqual(true)
+
+			expect(localStorage.setItem).toHaveBeenCalled()
+			expect(localStorage.setItem.mock.calls[1][0]).toEqual(expect.stringMatching(/callprefs-XXTOKENXX-isgrid$/))
+			expect(localStorage.setItem.mock.calls[1][1]).toBe(false)
+		})
+
+		test('start presentation switches off grid view and restores when it ends', () => {
+			[{
+				isGrid: true,
+				isStripeOpen: true,
+			}, {
+				isGrid: false,
+				isStripeOpen: false,
+			}].forEach((testState) => {
+				store.dispatch('setCallViewMode', testState)
+
+				store.dispatch('startPresentation')
+
+				expect(store.getters.isGrid).toEqual(false)
+				expect(store.getters.isStripeOpen).toEqual(false)
+
+				store.dispatch('stopPresentation')
+
+				expect(store.getters.isGrid).toEqual(testState.isGrid)
+				expect(store.getters.isStripeOpen).toEqual(testState.isStripeOpen)
+			})
+		})
+
+		test('switching modes during presentation does not resets it after it ends', () => {
+			store.dispatch('setCallViewMode', {
+				isGrid: true,
+				isStripeOpen: true,
+			})
+
+			store.dispatch('startPresentation')
+
+			// switch during presentation
+			store.dispatch('setCallViewMode', {
+				isGrid: true,
+				isStripeOpen: true,
+			})
+
+			store.dispatch('stopPresentation')
+
+			// state kept, not restored
+			expect(store.getters.isGrid).toEqual(true)
+			expect(store.getters.isStripeOpen).toEqual(true)
+		})
+
+		test('starting presentation twice does not mess up remembered state', () => {
+			store.dispatch('setCallViewMode', {
+				isGrid: true,
+				isStripeOpen: true,
+			})
+
+			expect(store.getters.presentationStarted).toBe(false)
+
+			store.dispatch('startPresentation')
+
+			expect(store.getters.presentationStarted).toBe(true)
+
+			// switch during presentation
+			store.dispatch('setCallViewMode', {
+				isGrid: true,
+				isStripeOpen: true,
+			})
+
+			store.dispatch('startPresentation')
+
+			// state kept
+			expect(store.getters.isGrid).toEqual(true)
+			expect(store.getters.isStripeOpen).toEqual(true)
+
+			expect(store.getters.presentationStarted).toBe(true)
+
+			store.dispatch('stopPresentation')
+
+			expect(store.getters.presentationStarted).toBe(false)
+
+			// state kept, not restored
+			expect(store.getters.isGrid).toEqual(true)
+			expect(store.getters.isStripeOpen).toEqual(true)
+		})
+
+		test('stopping presentation twice does not mess up remembered state', () => {
+			store.dispatch('setCallViewMode', {
+				isGrid: true,
+				isStripeOpen: true,
+			})
+
+			expect(store.getters.presentationStarted).toBe(false)
+
+			store.dispatch('startPresentation')
+
+			expect(store.getters.presentationStarted).toBe(true)
+
+			store.dispatch('stopPresentation')
+
+			expect(store.getters.presentationStarted).toBe(false)
+
+			expect(store.getters.isGrid).toEqual(true)
+			expect(store.getters.isStripeOpen).toEqual(true)
+
+			store.dispatch('setCallViewMode', {
+				isGrid: false,
+				isStripeOpen: false,
+			})
+
+			store.dispatch('stopPresentation')
+
+			expect(store.getters.presentationStarted).toBe(false)
+
+			// state kept, not reset
+			expect(store.getters.isGrid).toEqual(false)
+			expect(store.getters.isStripeOpen).toEqual(false)
+		})
+	})
+})

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -174,6 +174,7 @@ const actions = {
 	 * @param {object} context default store context;
 	 */
 	purgeConversationsStore(context) {
+		// TODO: also purge messages ??
 		context.commit('purgeConversationsStore')
 	},
 
@@ -200,6 +201,7 @@ const actions = {
 			return
 		}
 
+		// FIXME: logic is reversed
 		if (isFavorite) {
 			await removeFromFavorites(token)
 		} else {

--- a/src/store/conversationsStore.spec.js
+++ b/src/store/conversationsStore.spec.js
@@ -459,9 +459,10 @@ describe('conversationsStore', () => {
 		})
 
 		test('updates last activity', () => {
-			const testTime = new Date('2020-01-01').getTime()
+			const mockDate = new Date('2020-01-01')
 
-			Date.prototype.getTime = jest.fn().mockReturnValueOnce(testTime)
+			jest.spyOn(global, 'Date')
+				.mockImplementation(() => mockDate)
 
 			testConversation.lastActivity = 1200300
 
@@ -472,7 +473,7 @@ describe('conversationsStore', () => {
 			jest.useRealTimers()
 
 			const changedConversation = store.getters.conversation(testToken)
-			expect(changedConversation.lastActivity).toBe(testTime / 1000)
+			expect(changedConversation.lastActivity).toBe(mockDate.getTime() / 1000)
 		})
 	})
 })

--- a/src/store/conversationsStore.spec.js
+++ b/src/store/conversationsStore.spec.js
@@ -1,0 +1,478 @@
+import { createLocalVue } from '@vue/test-utils'
+import storeConfig from './storeConfig'
+import Vuex from 'vuex'
+import { cloneDeep } from 'lodash'
+import {
+	CONVERSATION,
+	WEBINAR,
+	PARTICIPANT,
+	ATTENDEE,
+} from '../constants'
+import {
+	makePublic,
+	makePrivate,
+	addToFavorites,
+	removeFromFavorites,
+	changeLobbyState,
+	changeReadOnlyState,
+	changeListable,
+	setConversationName,
+	setConversationDescription,
+	setSIPEnabled,
+	fetchConversation,
+} from '../services/conversationsService'
+
+jest.mock('../services/conversationsService', () => ({
+	makePublic: jest.fn(),
+	makePrivate: jest.fn(),
+	addToFavorites: jest.fn(),
+	removeFromFavorites: jest.fn(),
+	changeLobbyState: jest.fn(),
+	changeReadOnlyState: jest.fn(),
+	changeListable: jest.fn(),
+	setConversationName: jest.fn(),
+	setConversationDescription: jest.fn(),
+	setSIPEnabled: jest.fn(),
+	fetchConversation: jest.fn(),
+}))
+
+describe('conversationsStore', () => {
+	const testToken = 'XXTOKENXX'
+	let testStoreConfig = null
+	let testConversation
+	let localVue = null
+	let store = null
+	let addParticipantOnceAction = null
+
+	beforeEach(() => {
+		localVue = createLocalVue()
+		localVue.use(Vuex)
+
+		testConversation = {
+			token: testToken,
+			participantFlags: PARTICIPANT.CALL_FLAG.DISCONNECTED,
+			participantType: PARTICIPANT.TYPE.USER,
+			lastPing: 600,
+			sessionId: 'session-id-1',
+			attendeeId: 'attendee-id-1',
+			actorType: ATTENDEE.ACTOR_TYPE.USERS,
+			actorId: 'actor-id',
+		}
+
+		testStoreConfig = cloneDeep(storeConfig)
+
+		addParticipantOnceAction = jest.fn()
+		testStoreConfig.modules.participantsStore.actions.addParticipantOnce = addParticipantOnceAction
+	})
+
+	afterEach(() => {
+		jest.clearAllMocks()
+	})
+
+	describe('conversation list', () => {
+		let deleteMessagesAction = null
+
+		beforeEach(() => {
+			deleteMessagesAction = jest.fn()
+			testStoreConfig.modules.messagesStore.actions.deleteMessages = deleteMessagesAction
+
+			store = new Vuex.Store(testStoreConfig)
+		})
+
+		test('adds conversation to the store, with current user as participant', () => {
+			store.dispatch('setCurrentUser', {
+				uid: 'current-user',
+				displayName: 'display-name',
+			})
+			store.dispatch('addConversation', testConversation)
+
+			expect(store.getters.conversation(testToken)).toBe(testConversation)
+			expect(store.getters.conversation('ANOTHER')).toBeUndefined()
+
+			expect(addParticipantOnceAction).toHaveBeenCalled()
+			expect(addParticipantOnceAction.mock.calls[0][1]).toStrictEqual({
+				token: testToken,
+				participant: {
+					actorId: 'actor-id',
+					actorType: 'users',
+					attendeeId: 'attendee-id-1',
+					displayName: 'display-name',
+					inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
+					lastPing: 600,
+					participantType: PARTICIPANT.TYPE.USER,
+					sessionIds: [
+					  'session-id-1',
+					],
+					userId: 'current-user',
+				},
+			})
+		})
+
+		test('adds conversation to the store, with empty user id for guests', () => {
+			store.dispatch('setCurrentParticipant', {
+				actorId: 'guestActorId',
+				sessionId: 'XXSESSIONIDXX',
+				participantType: PARTICIPANT.TYPE.GUEST,
+			})
+
+			store.dispatch('addConversation', testConversation)
+
+			expect(store.getters.conversation(testToken)).toBe(testConversation)
+
+			expect(addParticipantOnceAction).toHaveBeenCalled()
+			expect(addParticipantOnceAction.mock.calls[0][1]).toStrictEqual({
+				token: testToken,
+				participant: {
+					// the one from the conversation is taken...
+					actorId: 'actor-id',
+					actorType: 'users',
+					attendeeId: 'attendee-id-1',
+					displayName: '',
+					inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
+					lastPing: 600,
+					participantType: PARTICIPANT.TYPE.USER,
+					sessionIds: [
+					  'session-id-1',
+					],
+					userId: '',
+				},
+			})
+		})
+
+		test('deletes messages with conversation', () => {
+			store.dispatch('setCurrentUser', {
+				uid: 'current-user',
+				displayName: 'display-name',
+			})
+			store.dispatch('addConversation', testConversation)
+
+			store.dispatch('deleteConversation', testToken)
+			expect(deleteMessagesAction).toHaveBeenCalled()
+
+			expect(store.getters.conversation(testToken)).toBeUndefined()
+		})
+
+		test('purges all conversations', () => {
+			const testConversation2 = Object.assign({}, testConversation, {
+				token: 'XXANOTHERXX',
+			})
+			store.dispatch('addConversation', testConversation)
+			store.dispatch('addConversation', testConversation2)
+
+			store.dispatch('purgeConversationsStore')
+
+			expect(store.getters.conversation(testToken)).toBeUndefined()
+			expect(store.getters.conversation('XXANOTHERXX')).toBeUndefined()
+		})
+
+		test('fetches a single conversation', async() => {
+			fetchConversation.mockResolvedValue({
+				data: {
+					ocs: {
+						data: testConversation,
+					},
+				},
+			})
+
+			await store.dispatch('fetchConversation', { token: testToken })
+
+			expect(fetchConversation).toHaveBeenCalledWith(testToken)
+
+			const fetchedConversation = store.getters.conversation(testToken)
+			expect(fetchedConversation).toBe(testConversation)
+		})
+	})
+
+	describe('conversation settings', () => {
+		beforeEach(() => {
+			store = new Vuex.Store(testStoreConfig)
+		})
+
+		test('make public', async() => {
+			testConversation.type = CONVERSATION.TYPE.GROUP
+
+			store.dispatch('addConversation', testConversation)
+
+			makePublic.mockResolvedValue()
+
+			await store.dispatch('toggleGuests', {
+				token: testToken,
+				allowGuests: true,
+			})
+
+			expect(makePublic).toHaveBeenCalledWith(testToken)
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.type).toEqual(CONVERSATION.TYPE.PUBLIC)
+		})
+
+		test('make non-public', async() => {
+			testConversation.type = CONVERSATION.TYPE.PUBLIC
+
+			store.dispatch('addConversation', testConversation)
+
+			makePrivate.mockResolvedValue()
+
+			await store.dispatch('toggleGuests', {
+				token: testToken,
+				allowGuests: false,
+			})
+
+			expect(makePrivate).toHaveBeenCalledWith(testToken)
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.type).toEqual(CONVERSATION.TYPE.GROUP)
+		})
+
+		test('set favorite', async() => {
+			testConversation.isFavorite = false
+
+			store.dispatch('addConversation', testConversation)
+
+			addToFavorites.mockResolvedValue()
+
+			await store.dispatch('toggleFavorite', {
+				token: testToken,
+				isFavorite: false,
+			})
+
+			expect(addToFavorites).toHaveBeenCalledWith(testToken)
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.isFavorite).toBe(true)
+		})
+
+		test('unset favorite', async() => {
+			testConversation.isFavorite = true
+
+			store.dispatch('addConversation', testConversation)
+
+			removeFromFavorites.mockResolvedValue()
+
+			await store.dispatch('toggleFavorite', {
+				token: testToken,
+				isFavorite: true,
+			})
+
+			expect(removeFromFavorites).toHaveBeenCalledWith(testToken)
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.isFavorite).toBe(false)
+		})
+
+		test('enable lobby', async() => {
+			testConversation.lobbyState = WEBINAR.LOBBY.NONE
+
+			store.dispatch('addConversation', testConversation)
+
+			changeLobbyState.mockResolvedValue()
+
+			await store.dispatch('toggleLobby', {
+				token: testToken,
+				enableLobby: true,
+			})
+
+			expect(changeLobbyState).toHaveBeenCalledWith(testToken, WEBINAR.LOBBY.NON_MODERATORS)
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.lobbyState).toBe(WEBINAR.LOBBY.NON_MODERATORS)
+		})
+
+		test('disable lobby', async() => {
+			testConversation.lobbyState = WEBINAR.LOBBY.NON_MODERATORS
+
+			store.dispatch('addConversation', testConversation)
+
+			changeLobbyState.mockResolvedValue()
+
+			await store.dispatch('toggleLobby', {
+				token: testToken,
+				enableLobby: false,
+			})
+
+			expect(changeLobbyState).toHaveBeenCalledWith(testToken, WEBINAR.LOBBY.NONE)
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.lobbyState).toBe(WEBINAR.LOBBY.NONE)
+		})
+
+		test('set conversation name', async() => {
+			testConversation.displayName = 'initial name'
+
+			store.dispatch('addConversation', testConversation)
+
+			setConversationName.mockResolvedValue()
+
+			await store.dispatch('setConversationName', {
+				token: testToken,
+				name: 'new name',
+			})
+
+			expect(setConversationName).toHaveBeenCalledWith(testToken, 'new name')
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.displayName).toBe('new name')
+		})
+
+		test('set conversation description', async() => {
+			testConversation.description = 'initial description'
+
+			store.dispatch('addConversation', testConversation)
+
+			setConversationDescription.mockResolvedValue()
+
+			await store.dispatch('setConversationDescription', {
+				token: testToken,
+				description: 'new description',
+			})
+
+			expect(setConversationDescription).toHaveBeenCalledWith(testToken, 'new description')
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.description).toBe('new description')
+		})
+
+		test('enable read-only', async() => {
+			testConversation.readOnly = CONVERSATION.STATE.READ_WRITE
+
+			store.dispatch('addConversation', testConversation)
+
+			changeReadOnlyState.mockResolvedValue()
+
+			await store.dispatch('setReadOnlyState', {
+				token: testToken,
+				readOnly: CONVERSATION.STATE.READ_ONLY,
+			})
+
+			expect(changeReadOnlyState).toHaveBeenCalledWith(testToken, CONVERSATION.STATE.READ_ONLY)
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.readOnly).toBe(CONVERSATION.STATE.READ_ONLY)
+		})
+
+		test('disable read-only', async() => {
+			testConversation.readOnly = CONVERSATION.STATE.READ_ONLY
+
+			store.dispatch('addConversation', testConversation)
+
+			changeReadOnlyState.mockResolvedValue()
+
+			await store.dispatch('setReadOnlyState', {
+				token: testToken,
+				readOnly: CONVERSATION.STATE.READ_WRITE,
+			})
+
+			expect(changeReadOnlyState).toHaveBeenCalledWith(testToken, CONVERSATION.STATE.READ_WRITE)
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.readOnly).toBe(CONVERSATION.STATE.READ_WRITE)
+		})
+
+		test('set listable flag', async() => {
+			testConversation.readOnly = CONVERSATION.LISTABLE.NONE
+
+			store.dispatch('addConversation', testConversation)
+
+			changeListable.mockResolvedValue()
+
+			await store.dispatch('setListable', {
+				token: testToken,
+				listable: CONVERSATION.LISTABLE.ALL,
+			})
+
+			expect(changeListable).toHaveBeenCalledWith(testToken, CONVERSATION.LISTABLE.ALL)
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.listable).toBe(CONVERSATION.LISTABLE.ALL)
+		})
+
+		test('set lobby timer', async() => {
+			testConversation.lobbyState = WEBINAR.LOBBY.NON_MODERATORS
+			testConversation.lobbyTimer = 1200300
+
+			store.dispatch('addConversation', testConversation)
+
+			changeLobbyState.mockResolvedValue()
+
+			await store.dispatch('setLobbyTimer', {
+				token: testToken,
+				timestamp: 2300400,
+			})
+
+			expect(changeLobbyState).toHaveBeenCalledWith(testToken, WEBINAR.LOBBY.NON_MODERATORS, 2300400)
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.lobbyTimer).toBe(2300400)
+		})
+
+		test('set SIP enabled', async() => {
+			testConversation.sipEnabled = false
+
+			store.dispatch('addConversation', testConversation)
+
+			setSIPEnabled.mockResolvedValue()
+
+			await store.dispatch('setSIPEnabled', {
+				token: testToken,
+				state: true,
+			})
+
+			expect(setSIPEnabled).toHaveBeenCalledWith(testToken, true)
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.sipEnabled).toBe(true)
+		})
+	})
+
+	describe('read marker', () => {
+		beforeEach(() => {
+			store = new Vuex.Store(testStoreConfig)
+		})
+
+		test('marks conversation as read by clearing unread counters', () => {
+			testConversation.unreadMessages = 1024
+			testConversation.unreadMention = true
+
+			store.dispatch('addConversation', testConversation)
+
+			store.dispatch('markConversationRead', testToken)
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.unreadMessages).toBe(0)
+			expect(changedConversation.unreadMention).toBe(false)
+		})
+
+		test('updates last common read message', () => {
+			testConversation.lastCommonReadMessage = {
+				id: 999,
+			}
+
+			store.dispatch('addConversation', testConversation)
+
+			store.dispatch('updateLastCommonReadMessage', {
+				token: testToken,
+				lastCommonReadMessage: { id: 1024 },
+			})
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.lastCommonReadMessage.id).toBe(1024)
+		})
+
+		test('updates last activity', () => {
+			const testTime = new Date('2020-01-01').getTime()
+
+			Date.prototype.getTime = jest.fn().mockReturnValueOnce(testTime)
+
+			testConversation.lastActivity = 1200300
+
+			store.dispatch('addConversation', testConversation)
+
+			store.dispatch('updateConversationLastActive', testToken)
+
+			jest.useRealTimers()
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.lastActivity).toBe(testTime / 1000)
+		})
+	})
+})

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -22,48 +22,8 @@
 
 import Vue from 'vue'
 import Vuex, { Store } from 'vuex'
-import actorStore from './actorStore'
-import callViewStore from './callViewStore'
-import conversationsStore from './conversationsStore'
-import fileUploadStore from './fileUploadStore'
-import guestNameStore from './guestNameStore'
-import messagesStore from './messagesStore'
-import newGroupConversationStore from './newGroupConversationStore'
-import participantsStore from './participantsStore'
-import quoteReplyStore from './quoteReplyStore'
-import settingsStore from './settingsStore'
-import sidebarStore from './sidebarStore'
-import soundsStore from './soundsStore'
-import talkHashStore from './talkHashStore'
-import tokenStore from './tokenStore'
-import windowVisibilityStore from './windowVisibilityStore'
-import messageActionsStore from './messageActionsStore'
+import storeConfig from './storeConfig'
 
 Vue.use(Vuex)
 
-const mutations = {}
-
-export default new Store({
-	modules: {
-		actorStore,
-		callViewStore,
-		conversationsStore,
-		fileUploadStore,
-		guestNameStore,
-		messagesStore,
-		newGroupConversationStore,
-		participantsStore,
-		quoteReplyStore,
-		settingsStore,
-		sidebarStore,
-		soundsStore,
-		talkHashStore,
-		tokenStore,
-		windowVisibilityStore,
-		messageActionsStore,
-	},
-
-	mutations,
-
-	strict: process.env.NODE_ENV !== 'production',
-})
+export default new Store(storeConfig)

--- a/src/store/storeConfig.js
+++ b/src/store/storeConfig.js
@@ -1,0 +1,63 @@
+/**
+ * @copyright Copyright (c) 2019 Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @author Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import actorStore from './actorStore'
+import callViewStore from './callViewStore'
+import conversationsStore from './conversationsStore'
+import fileUploadStore from './fileUploadStore'
+import guestNameStore from './guestNameStore'
+import messagesStore from './messagesStore'
+import newGroupConversationStore from './newGroupConversationStore'
+import participantsStore from './participantsStore'
+import quoteReplyStore from './quoteReplyStore'
+import settingsStore from './settingsStore'
+import sidebarStore from './sidebarStore'
+import soundsStore from './soundsStore'
+import talkHashStore from './talkHashStore'
+import tokenStore from './tokenStore'
+import windowVisibilityStore from './windowVisibilityStore'
+import messageActionsStore from './messageActionsStore'
+
+export default {
+	modules: {
+		actorStore,
+		callViewStore,
+		conversationsStore,
+		fileUploadStore,
+		guestNameStore,
+		messagesStore,
+		newGroupConversationStore,
+		participantsStore,
+		quoteReplyStore,
+		settingsStore,
+		sidebarStore,
+		soundsStore,
+		talkHashStore,
+		tokenStore,
+		windowVisibilityStore,
+		messageActionsStore,
+	},
+
+	mutations: {},
+
+	strict: process.env.NODE_ENV !== 'production',
+}


### PR DESCRIPTION
Added more JS tests for stores.
Extracted global store config to a separate file to be able to include it in
tests.

Up to 56 tests now :tada: 