### PR TITLE
Disable use of deprecated "Plan-B" semantics if HPB is used.

### DIFF
--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -535,11 +535,6 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 		enableDataChannels: true,
 		nick: store.getters.getDisplayName(),
 	})
-	if (signaling.hasFeature('mcu')) {
-		// Force "Plan-B" semantics if the MCU is used, which doesn't support
-		// "Unified Plan" with SimpleWebRTC yet.
-		webrtc.webrtc.config.peerConnectionConfig.sdpSemantics = 'plan-b'
-	}
 
 	if (!window.OCA.Talk) {
 		window.OCA.Talk = {}


### PR DESCRIPTION
Only tested with two browsers on Linux, should be also tested between on different OS and browser and mobile apps (cc @Ivansss).

Fixes #3790