### PR TITLE
Remove store usage in settingsService

### DIFF
--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -23,7 +23,6 @@
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 import BrowserStorage from './BrowserStorage'
-import store from '../store/index'
 
 /**
  * Sets the attachment folder setting for the user
@@ -67,9 +66,9 @@ const setSIPSettings = async function(sipGroups, sharedSecret, dialInInfo) {
 	})
 }
 
-const setPlaySounds = async function(enabled) {
+const setPlaySounds = async function(isGuest, enabled) {
 	const savableValue = enabled ? 'yes' : 'no'
-	if (store.getters.getUserId()) {
+	if (!isGuest) {
 		return axios.post(generateOcsUrl('apps/spreed/api/v1/settings', 2) + 'user', {
 			key: 'play_sounds',
 			value: savableValue,

--- a/src/store/soundsStore.js
+++ b/src/store/soundsStore.js
@@ -73,9 +73,9 @@ const actions = {
 	 * @param {object} context default store context;
 	 * @param {boolean} enabled Whether sounds should be played
 	 */
-	async setPlaySounds({ commit }, enabled) {
-		await setPlaySounds(status)
-		commit('setPlaySounds', enabled)
+	async setPlaySounds(context, enabled) {
+		await setPlaySounds(!context.state.userId, status)
+		context.commit('setPlaySounds', enabled)
 	},
 }
 


### PR DESCRIPTION
Adjust setPlaySounds service function to not rely on the store.

This will make it possible to write JS unit tests without having to inject a global store mock.