### PR TITLE
Decouple conversations and messages services from the global store

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -131,7 +131,6 @@ import debounce from 'debounce'
 import { EventBus } from '../../services/EventBus'
 import {
 	createOneToOneConversation,
-	fetchConversations,
 	searchPossibleConversations,
 	searchListedConversations,
 } from '../../services/conversationsService'
@@ -434,12 +433,8 @@ export default {
 			 * to the store.
 			 */
 			try {
-				const conversations = await fetchConversations()
+				await this.$store.dispatch('fetchConversations')
 				this.initialisedConversations = true
-				this.$store.dispatch('purgeConversationsStore')
-				conversations.data.ocs.data.forEach(conversation => {
-					this.$store.dispatch('addConversation', conversation)
-				})
 				/**
 				 * Emits a global event that is used in App.vue to update the page title once the
 				 * ( if the current route is a conversation and once the conversations are received)

--- a/src/services/conversationsService.js
+++ b/src/services/conversationsService.js
@@ -23,34 +23,12 @@
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 import { CONVERSATION, SHARE } from '../constants'
-import { showError, TOAST_PERMANENT_TIMEOUT } from '@nextcloud/dialogs'
-import store from '../store/index'
-
-let maintenanceWarning = null
 
 /**
  * Fetches the conversations from the server.
  */
 const fetchConversations = async function() {
-	try {
-		const response = await axios.get(generateOcsUrl('apps/spreed/api/v4', 2) + 'room')
-
-		if (maintenanceWarning) {
-			maintenanceWarning.hideToast()
-			maintenanceWarning = null
-		}
-
-		checkTalkVersionHash(response)
-
-		return response
-	} catch (error) {
-		if (error?.response?.status === 503 && !maintenanceWarning) {
-			maintenanceWarning = showError(t('spreed', 'Nextcloud is in maintenance mode, please reload the page'), {
-				timeout: TOAST_PERMANENT_TIMEOUT,
-			})
-		}
-		throw error
-	}
+	return axios.get(generateOcsUrl('apps/spreed/api/v4', 2) + 'room')
 }
 
 /**
@@ -58,34 +36,7 @@ const fetchConversations = async function() {
  * @param {string} token The token of the conversation to be fetched.
  */
 const fetchConversation = async function(token) {
-	try {
-		const response = await axios.get(generateOcsUrl('apps/spreed/api/v4', 2) + `room/${token}`)
-
-		if (maintenanceWarning) {
-			maintenanceWarning.hideToast()
-			maintenanceWarning = null
-		}
-
-		checkTalkVersionHash(response)
-
-		return response
-	} catch (error) {
-		if (error?.response?.status === 503 && !maintenanceWarning) {
-			maintenanceWarning = showError(t('spreed', 'Nextcloud is in maintenance mode, please reload the page'), {
-				timeout: TOAST_PERMANENT_TIMEOUT,
-			})
-		}
-		throw error
-	}
-}
-
-const checkTalkVersionHash = function(response) {
-	const newTalkCacheBusterHash = response.headers['x-nextcloud-talk-hash']
-	if (!newTalkCacheBusterHash) {
-		return
-	}
-
-	store.dispatch('setNextcloudTalkHash', newTalkCacheBusterHash)
+	return axios.get(generateOcsUrl('apps/spreed/api/v4', 2) + `room/${token}`)
 }
 
 /**

--- a/src/services/messagesService.js
+++ b/src/services/messagesService.js
@@ -33,29 +33,17 @@ import Hex from 'crypto-js/enc-hex'
  * @param {string} token the conversation token;
  * @param {object} options options;
  * @param {string} lastKnownMessageId last known message id;
- * @param {int} includeLastKnown whether to include the last known message in the response;
+ * @param {bool} includeLastKnown whether to include the last known message in the response;
  */
 const fetchMessages = async function({ token, lastKnownMessageId, includeLastKnown }, options) {
-	const response = await axios.get(generateOcsUrl('apps/spreed/api/v1/chat', 2) + token, Object.assign(options, {
+	return axios.get(generateOcsUrl('apps/spreed/api/v1/chat', 2) + token, Object.assign(options, {
 		params: {
 			setReadMarker: 0,
 			lookIntoFuture: 0,
 			lastKnownMessageId,
-			// FIXME: change the function arg to boolean then convert to int for the API
-			includeLastKnown: includeLastKnown || 0,
+			includeLastKnown: includeLastKnown ? 1 : 0,
 		},
 	}))
-
-	// TODO: move to action instead
-	if ('x-chat-last-common-read' in response.headers) {
-		const lastCommonReadMessage = parseInt(response.headers['x-chat-last-common-read'], 10)
-		store.dispatch('updateLastCommonReadMessage', {
-			token,
-			lastCommonReadMessage,
-		})
-	}
-
-	return response
 }
 
 /**
@@ -67,7 +55,7 @@ const fetchMessages = async function({ token, lastKnownMessageId, includeLastKno
  * @param {int} lastKnownMessageId The id of the last message in the store.
  */
 const lookForNewMessages = async({ token, lastKnownMessageId }, options) => {
-	const response = await axios.get(generateOcsUrl('apps/spreed/api/v1/chat', 2) + token, Object.assign(options, {
+	return axios.get(generateOcsUrl('apps/spreed/api/v1/chat', 2) + token, Object.assign(options, {
 		params: {
 			setReadMarker: 0,
 			lookIntoFuture: 1,
@@ -75,16 +63,6 @@ const lookForNewMessages = async({ token, lastKnownMessageId }, options) => {
 			includeLastKnown: 0,
 		},
 	}))
-
-	if ('x-chat-last-common-read' in response.headers) {
-		const lastCommonReadMessage = parseInt(response.headers['x-chat-last-common-read'], 10)
-		store.dispatch('updateLastCommonReadMessage', {
-			token,
-			lastCommonReadMessage,
-		})
-	}
-
-	return response
 }
 
 /**

--- a/src/services/messagesService.js
+++ b/src/services/messagesService.js
@@ -22,7 +22,6 @@
 
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
-import store from '../store/index'
 import SHA1 from 'crypto-js/sha1'
 import Hex from 'crypto-js/enc-hex'
 
@@ -76,22 +75,12 @@ const lookForNewMessages = async({ token, lastKnownMessageId }, options) => {
  * @param {object} options request options
  */
 const postNewMessage = async function({ token, message, actorDisplayName, referenceId, parent }, options) {
-	const response = await axios.post(generateOcsUrl('apps/spreed/api/v1/chat', 2) + token, {
+	return axios.post(generateOcsUrl('apps/spreed/api/v1/chat', 2) + token, {
 		message,
 		actorDisplayName,
 		referenceId,
 		replyTo: parent,
 	}, options)
-
-	if ('x-chat-last-common-read' in response.headers) {
-		const lastCommonReadMessage = parseInt(response.headers['x-chat-last-common-read'], 10)
-		store.dispatch('updateLastCommonReadMessage', {
-			token,
-			lastCommonReadMessage,
-		})
-	}
-
-	return response
 }
 
 /**


### PR DESCRIPTION
Removes dodgy global store usage from `messagesService`.

Moves `fetchConversations`, `fetchMessages`, `lookForNewMessages` and `postNewMessages` to the `messagesStore`.

The logic was mostly copy pasted there and rewired to use the correct variable.

- [x] TEST: maintenance mode detection still working
- [x] TEST: conversation list refresh works
- [x] TEST: switching conversations still works and properly cancels fetch messages
- [x] TEST: posting messages still work

- BUG: cancelling the postNewMessage doesn't work after timeout (no exception thrown), but also did not work on master, to be investigated separately => raised as https://github.com/nextcloud/spreed/issues/5527