### PR TITLE
Fix cancelling postNewMessage

### DIFF
--- a/src/services/messagesService.js
+++ b/src/services/messagesService.js
@@ -95,14 +95,15 @@ const lookForNewMessages = async({ token, lastKnownMessageId }, options) => {
  * @param {string} param0.message The message object
  * @param {string} param0.referenceId A reference id to identify the message later again
  * @param {Number} param0.parent The id of the message to be replied to
+ * @param {object} options request options
  */
-const postNewMessage = async function({ token, message, actorDisplayName, referenceId, parent }) {
+const postNewMessage = async function({ token, message, actorDisplayName, referenceId, parent }, options) {
 	const response = await axios.post(generateOcsUrl('apps/spreed/api/v1/chat', 2) + token, {
 		message,
 		actorDisplayName,
 		referenceId,
 		replyTo: parent,
-	})
+	}, options)
 
 	if ('x-chat-last-common-read' in response.headers) {
 		const lastCommonReadMessage = parseInt(response.headers['x-chat-last-common-read'], 10)

--- a/src/services/messagesService.spec.js
+++ b/src/services/messagesService.spec.js
@@ -90,6 +90,8 @@ describe('messagesService', () => {
 			actorDisplayName: 'actor-display-name',
 			referenceId: 'reference-id',
 			parent: 111,
+		}, {
+			dummyOption: true,
 		})
 
 		expect(mockAxios.post).toHaveBeenCalledWith(
@@ -99,6 +101,9 @@ describe('messagesService', () => {
 				actorDisplayName: 'actor-display-name',
 				referenceId: 'reference-id',
 				replyTo: 111,
+			},
+			{
+				dummyOption: true,
 			}
 		)
 	})


### PR DESCRIPTION
For timeout cancelling to work, the options need to be passed to the
request object.

Fixes https://github.com/nextcloud/spreed/issues/5527

We might want to backport.