### PR TITLE
Decouple participantsService from the store

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -50,7 +50,6 @@ import { EventBus } from './services/EventBus'
 import BrowserStorage from './services/BrowserStorage'
 import { getCurrentUser } from '@nextcloud/auth'
 import {
-	joinConversation,
 	leaveConversationSync,
 } from './services/participantsService'
 import {
@@ -204,7 +203,7 @@ export default {
 			// Update current token in the token store
 			this.$store.dispatch('updateToken', this.$route.params.token)
 			// Automatically join the conversation as well
-			joinConversation(this.$route.params.token)
+			this.$store.dispatch('joinConversation', { token: this.$route.params.token })
 		}
 
 		window.addEventListener('resize', this.onResize)

--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -53,8 +53,6 @@
 import { EventBus } from './services/EventBus'
 import { getFileConversation } from './services/filesIntegrationServices'
 import {
-	joinConversation,
-	leaveConversation,
 	leaveConversationSync,
 } from './services/participantsService'
 import CancelableRequest from './utils/cancelableRequest'
@@ -184,7 +182,7 @@ export default {
 				return
 			}
 
-			await joinConversation(this.token)
+			await this.$store.dispatch('joinConversation', { token: this.token })
 
 			// The current participant (which is automatically set when fetching
 			// the current conversation) is needed for the MessagesList to start
@@ -218,6 +216,8 @@ export default {
 			EventBus.$off('Signaling::participantListChanged', OCA.Talk.fetchCurrentConversationWrapper)
 			window.clearInterval(OCA.Talk.fetchCurrentConversationIntervalId)
 
+			// TODO: move to store under a special action ?
+
 			// Remove the conversation to ensure that the old data is not used
 			// before fetching it again if this conversation is joined again.
 			this.$store.dispatch('deleteConversation', this.token)
@@ -225,7 +225,7 @@ export default {
 			// if this conversation is joined again.
 			this.$store.dispatch('purgeParticipantsStore', this.token)
 
-			leaveConversation(this.token)
+			this.$store.dispatch('leaveConversation', { token: this.token })
 
 			this.$store.dispatch('updateTokenAndFileIdForToken', {
 				newToken: null,

--- a/src/PublicShareAuthSidebar.vue
+++ b/src/PublicShareAuthSidebar.vue
@@ -43,7 +43,6 @@ import ChatView from './components/ChatView'
 import { PARTICIPANT } from './constants'
 import { EventBus } from './services/EventBus'
 import {
-	joinConversation,
 	leaveConversationSync,
 } from './services/participantsService'
 import { signalingKill } from './utils/webrtc/index'
@@ -120,7 +119,7 @@ export default {
 				this.$store.dispatch('setCurrentUser', getCurrentUser())
 			}
 
-			await joinConversation(this.token)
+			await this.$store.dispatch('joinConversation', { token: this.token })
 
 			// Fetching the conversation needs to be done once the user has
 			// joined the conversation (otherwise only limited data would be

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -52,7 +52,6 @@ import CallButton from './components/TopBar/CallButton'
 import { EventBus } from './services/EventBus'
 import { getPublicShareConversationData } from './services/filesIntegrationServices'
 import {
-	joinConversation,
 	leaveConversationSync,
 } from './services/participantsService'
 import { signalingKill } from './utils/webrtc/index'
@@ -142,7 +141,7 @@ export default {
 
 			await this.getPublicShareConversationData()
 
-			await joinConversation(this.token)
+			await this.$store.dispatch('joinConversation', { token: this.token })
 
 			// No need to wait for it, but fetching the conversation needs to be
 			// done once the user has joined the conversation (otherwise only

--- a/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
@@ -40,7 +40,6 @@
 import Conversation from './Conversation'
 import Hint from '../../Hint'
 import LoadingPlaceholder from '../../LoadingPlaceholder'
-import { joinConversation, leaveConversation } from '../../../services/participantsService'
 import { EventBus } from '../../../services/EventBus'
 
 export default {
@@ -111,10 +110,10 @@ export default {
 				return
 			}
 			if (from.name === 'conversation') {
-				leaveConversation(from.params.token)
+				this.$store.dispatch('leaveConversation', { token: from.params.token })
 			}
 			if (to.name === 'conversation') {
-				joinConversation(to.params.token)
+				this.$store.dispatch('joinConversation', { token: to.params.token })
 			}
 		},
 

--- a/src/mainFilesSidebarLoader.js
+++ b/src/mainFilesSidebarLoader.js
@@ -21,7 +21,6 @@
  */
 
 import FilesSidebarCallView from './views/FilesSidebarCallView'
-import { leaveConversation } from './services/participantsService'
 import './init'
 
 const isEnabled = function(fileInfo) {
@@ -35,7 +34,7 @@ const isEnabled = function(fileInfo) {
 	// left; this must be done here because "setFileInfo" will not get
 	// called with the new file if the tab can not be displayed.
 	if (token) {
-		leaveConversation(token)
+		OCA.Talk.store.dispatch('leaveConversation', { token: token })
 	}
 
 	OCA.Talk.store.dispatch('updateTokenAndFileIdForToken', {

--- a/src/services/participantsService.js
+++ b/src/services/participantsService.js
@@ -22,108 +22,30 @@
 
 import axios from '@nextcloud/axios'
 import {
-	generateUrl,
 	generateOcsUrl,
 } from '@nextcloud/router'
-import { showError } from '@nextcloud/dialogs'
 import {
 	signalingJoinConversation,
 	signalingLeaveConversation,
 } from '../utils/webrtc/index'
-import { EventBus } from './EventBus'
-import SessionStorage from './SessionStorage'
-import { PARTICIPANT } from '../constants'
-import store from '../store/index'
 
 /**
  * Joins the current user to a conversation specified with
  * the token.
  *
  * @param {string} token The conversation token;
+ * @param {options} options request options;
+ * @param {bool} forceJoin whether to force join;
  */
-const joinConversation = async(token) => {
-	// FIXME: move complex logic to a store action instead, a service should not call the store
-	// When the token is in the last joined conversation, the user is reloading or force joining
-	const forceJoin = SessionStorage.getItem('joined_conversation') === token
+const joinConversation = async({ token, forceJoin = false }, options) => {
+	const response = await axios.post(generateOcsUrl('apps/spreed/api/v4', 2) + `room/${token}/participants/active`, {
+		force: forceJoin,
+	}, options)
 
-	try {
-		const response = await axios.post(generateOcsUrl('apps/spreed/api/v4', 2) + `room/${token}/participants/active`, {
-			force: forceJoin,
-		})
+	// FIXME Signaling should not be synchronous
+	await signalingJoinConversation(token, response.data.ocs.data.sessionId)
 
-		// Update the participant and actor session after a force join
-		store.dispatch('setCurrentParticipant', response.data.ocs.data)
-		store.dispatch('addConversation', response.data.ocs.data)
-		store.dispatch('updateSessionId', {
-			token: token,
-			participantIdentifier: store.getters.getParticipantIdentifier(),
-			sessionId: response.data.ocs.data.sessionId,
-		})
-
-		// FIXME Signaling should not be synchronous
-		await signalingJoinConversation(token, response.data.ocs.data.sessionId)
-		SessionStorage.setItem('joined_conversation', token)
-		EventBus.$emit('joinedConversation', { token })
-		return response
-	} catch (error) {
-		if (error?.response?.status === 409 && error?.response?.data?.ocs?.data) {
-			const responseData = error.response.data.ocs.data
-			let maxLastPingAge = new Date().getTime() / 1000 - 40
-			if (responseData.inCall !== PARTICIPANT.CALL_FLAG.DISCONNECTED) {
-				// When the user is/was in a call, we accept 20 seconds more delay
-				maxLastPingAge -= 20
-			}
-			if (maxLastPingAge > responseData.lastPing) {
-				console.debug('Force joining automatically because the old session didn\'t ping for 40 seconds')
-				await forceJoinConversation(token)
-			} else {
-				await confirmForceJoinConversation(token)
-			}
-		} else {
-			console.debug(error)
-			showError(t('spreed', 'Failed to join the conversation. Try to reload the page.'))
-		}
-	}
-}
-
-const confirmForceJoinConversation = async(token) => {
-	// Little hack to check if the close button was used which we can't disable,
-	// not listen to when it was used.
-	const interval = setInterval(function() {
-		// eslint-disable-next-line no-undef
-		if ($('.oc-dialog-dim').length === 0) {
-			clearInterval(interval)
-			EventBus.$emit('duplicateSessionDetected')
-			window.location = generateUrl('/apps/spreed')
-		}
-	}, 3000)
-
-	await OC.dialogs.confirmDestructive(
-		t('spreed', 'You are trying to join a conversation while having an active session in another window or device. This is currently not supported by Nextcloud Talk. What do you want to do?'),
-		t('spreed', 'Duplicate session'),
-		{
-			type: OC.dialogs.YES_NO_BUTTONS,
-			confirm: t('spreed', 'Join here'),
-			confirmClasses: 'error',
-			cancel: t('spreed', 'Leave this page'),
-		},
-		decision => {
-			clearInterval(interval)
-			if (!decision) {
-				// Cancel
-				EventBus.$emit('duplicateSessionDetected')
-				window.location = generateUrl('/apps/spreed')
-			} else {
-				// Confirm
-				forceJoinConversation(token)
-			}
-		}
-	)
-}
-
-const forceJoinConversation = async(token) => {
-	SessionStorage.setItem('joined_conversation', token)
-	await joinConversation(token)
+	return response
 }
 
 /**
@@ -150,6 +72,7 @@ const leaveConversation = async function(token) {
 		return response
 	} catch (error) {
 		console.debug(error)
+		// FIXME: should throw
 	}
 }
 


### PR DESCRIPTION
Moved joinConversation, leaveConversation and a few other dependencies
to the participantsStore.
Removes the dependency to the store from participantsService.

There's a slight change of behavior: joinConversation in the service now
also connects to signaling, and only when this is done the first
action dispatch are done. In the previous implementation the store
already received some updates before we even connected to signaling, see https://github.com/nextcloud/spreed/pull/5529/files#diff-e0f25089223beb2eb4703995c475f60ab752fa3a0053b63b848a03bff7cd5c16R46

Tests:
- [x] TEST: regular join and conversation switching
- [x] TEST: guest join and leave
- [x] TEST: file conversation
- [x] TEST: video verification