### PR TITLE
Register visibility observer in all entry points

### DIFF
--- a/src/mainFilesSidebar.js
+++ b/src/mainFilesSidebar.js
@@ -23,6 +23,7 @@
  */
 
 import Vue from 'vue'
+import VueObserveVisibility from 'vue-observe-visibility'
 import FilesSidebarCallViewApp from './FilesSidebarCallViewApp'
 import FilesSidebarTabApp from './FilesSidebarTabApp'
 import './init'
@@ -62,6 +63,7 @@ Vue.prototype.OCA = OCA
 Vue.use(Vuex)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
 Vue.use(vOutsideEvents)
+Vue.use(VueObserveVisibility)
 
 const newCallView = () => new Vue({
 	store,

--- a/src/mainPublicShareAuthSidebar.js
+++ b/src/mainPublicShareAuthSidebar.js
@@ -19,6 +19,7 @@
  */
 
 import Vue from 'vue'
+import VueObserveVisibility from 'vue-observe-visibility'
 import PublicShareAuthRequestPasswordButton from './PublicShareAuthRequestPasswordButton'
 import PublicShareAuthSidebar from './PublicShareAuthSidebar'
 import './init'
@@ -58,6 +59,7 @@ Vue.prototype.OCA = OCA
 Vue.use(Vuex)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
 Vue.use(vOutsideEvents)
+Vue.use(VueObserveVisibility)
 
 /**
  * Wraps all the body contents in its own container.

--- a/src/mainPublicShareSidebar.js
+++ b/src/mainPublicShareSidebar.js
@@ -19,6 +19,7 @@
  */
 
 import Vue from 'vue'
+import VueObserveVisibility from 'vue-observe-visibility'
 import PublicShareSidebar from './PublicShareSidebar'
 import './init'
 
@@ -57,6 +58,7 @@ Vue.prototype.OCA = OCA
 Vue.use(Vuex)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
 Vue.use(vOutsideEvents)
+Vue.use(VueObserveVisibility)
 
 function adjustLayout() {
 	document.querySelector('#app-content').appendChild(document.querySelector('footer'))


### PR DESCRIPTION
The observe-visibility extension was missing in many entry points
resulting in repeated console warnings.

The directive usage in the message list was introduced as part of #3825 