### PR TITLE
Remove play button in reply to for video previews

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -32,7 +32,7 @@
 			v-if="!isLoading"
 			class="image-container"
 			:class="{'playable': isPlayable}">
-			<span v-if="isPlayable" class="play-video-button">
+			<span v-if="isPlayable && !smallPreview" class="play-video-button">
 				<PlayCircleOutline
 					:size="48"
 					decorative


### PR DESCRIPTION
The reply to box is too small to contain a play button, so remove it
there.

Before:
<img width="254" alt="image" src="https://user-images.githubusercontent.com/277525/116439560-fb7ba800-a84f-11eb-9fba-14e7c75d18de.png">

After:
<img width="254" alt="image" src="https://user-images.githubusercontent.com/277525/116439467-df780680-a84f-11eb-8f7f-c9e2e137dae6.png">
