### PR TITLE
Fix sorting of users that are online with user status offline

### DIFF
--- a/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
+++ b/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
@@ -145,14 +145,19 @@ export default {
 				return p2IsGroup ? -1 : 1
 			}
 
-			let hasSessions1 = !!participant1.sessionIds.length
-			let hasSessions2 = !!participant2.sessionIds.length
+			const hasSessions1 = !!participant1.sessionIds.length
+			const hasSessions2 = !!participant2.sessionIds.length
+			/**
+			 * For now the user status is not overwriting the online-offline status anymore
+			 * It felt too weird having users appear as offline but they are in the call or chat actively
 			if (participant1.status === 'offline') {
 				hasSessions1 = false
 			}
 			if (participant2.status === 'offline') {
 				hasSessions2 = false
 			}
+			 */
+
 			if (!hasSessions1) {
 				if (hasSessions2) {
 					return 1

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -382,7 +382,12 @@ export default {
 		},
 
 		isOffline() {
-			return /* this.participant.status === 'offline' || */ !this.sessionIds.length
+			/**
+			 * For now the user status is not overwriting the online-offline status anymore
+			 * It felt too weird having users appear as offline but they are in the call or chat actively
+			 return this.participant.status === 'offline' ||  !this.sessionIds.length
+			 */
+			return !this.sessionIds.length
 		},
 		isGuest() {
 			return [PARTICIPANT.TYPE.GUEST, PARTICIPANT.TYPE.GUEST_MODERATOR].indexOf(this.participantType) !== -1


### PR DESCRIPTION
This was missed in https://github.com/nextcloud/spreed/pull/4253

### Steps
1. As a user with Z as first char go into a chat that has other users
2. Set your user status to offline
3. As another user go to the chat and check the sidebar

### Before
User is marked online but sorted at the bottom

Before | After
---|---
![Bildschirmfoto von 2021-04-29 09-18-22](https://user-images.githubusercontent.com/213943/116514916-f3f9e480-a8cb-11eb-9e6c-1e5d304d2cc9.png) | ![Bildschirmfoto von 2021-04-29 09-18-27](https://user-images.githubusercontent.com/213943/116514920-f4927b00-a8cb-11eb-8f3d-8d9f9e0fd963.png)

