### PR TITLE
New messages indicator while in call

### DIFF
--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -130,7 +130,7 @@
 					@click="openSidebar">
 					<MessageText
 						slot="icon"
-						:size="24"
+						:size="16"
 						title=""
 						fill-color="#ffffff"
 						decorative />
@@ -320,11 +320,7 @@ export default {
 
 			// new messages arrived
 			if (newValue > 0 && oldValue === 0) {
-				if (this.hasUnreadMentions) {
-					showMessage(t('spreed', 'You have been mentioned in the chat.'))
-				} else {
-					showMessage(t('spreed', 'You have new unread messages in the chat.'))
-				}
+				showMessage(t('spreed', 'You have new unread messages in the chat.'))
 			}
 		},
 
@@ -333,6 +329,7 @@ export default {
 				return
 			}
 
+			// prevent duplicate notification caused by unreadMessagesCounter in case of mention
 			if (newValue && this.unreadMessagesCounter > 0) {
 				showMessage(t('spreed', 'You have been mentioned in the chat.'))
 			}

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -125,6 +125,19 @@
 				close-after-click="true"
 				container="#content-vue">
 				<ActionButton
+					v-if="isInCall"
+					key="openSideBarButtonMessageText"
+					@click="openSidebar">
+					<MessageText
+						slot="icon"
+						:size="24"
+						title=""
+						fill-color="#ffffff"
+						decorative />
+				</ActionButton>
+				<ActionButton
+					v-else
+					key="openSideBarButtonMenuPeople"
 					:icon="iconMenuPeople"
 					@click="openSidebar" />
 			</Actions>
@@ -147,6 +160,7 @@ import CallButton from './CallButton'
 import BrowserStorage from '../../services/BrowserStorage'
 import ActionLink from '@nextcloud/vue/dist/Components/ActionLink'
 import ActionSeparator from '@nextcloud/vue/dist/Components/ActionSeparator'
+import MessageText from 'vue-material-design-icons/MessageText'
 import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff'
 import { CONVERSATION, PARTICIPANT } from '../../constants'
 import { generateUrl } from '@nextcloud/router'
@@ -170,6 +184,7 @@ export default {
 		CounterBubble,
 		CallButton,
 		ActionSeparator,
+		MessageText,
 		MicrophoneOff,
 		ConversationIcon,
 	},
@@ -318,11 +333,7 @@ export default {
 				return
 			}
 
-			// in some cases the user already had unread messages and saw the other notification
-			// but then got mentionned
-			// the limit of "> 1" is here to avoid seeing two notifications, one for the first non-mention
-			// unread message and the second for the mention
-			if (newValue && this.unreadMessagesCounter > 1) {
+			if (newValue && this.unreadMessagesCounter > 0) {
 				showMessage(t('spreed', 'You have been mentioned in the chat.'))
 			}
 		},
@@ -476,6 +487,7 @@ export default {
 		position: absolute;
 		top: 40px;
 		right: 10px;
+		pointer-events: none;
 	}
 }
 

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -495,9 +495,6 @@ export default {
 		display: flex;
 		align-items: center;
 		white-space: nowrap;
-		svg {
-			margin-right: 4px !important;
-		}
 		.icon {
 			margin-right: 4px !important;
 		}
@@ -506,7 +503,7 @@ export default {
 	.unread-messages-counter {
 		position: absolute;
 		top: 40px;
-		right: 10px;
+		right: 4px;
 		pointer-events: none;
 	}
 }

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -121,6 +121,10 @@ const mutations = {
 		Vue.set(state.conversations[token], 'lastMessage', lastMessage)
 	},
 
+	updateUnreadMessages(state, { token, unreadMessages = 0 }) {
+		Vue.set(state.conversations[token], 'unreadMessages', unreadMessages)
+	},
+
 	setNotificationLevel(state, { token, notificationLevel }) {
 		Vue.set(state.conversations[token], 'notificationLevel', notificationLevel)
 	},

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -121,8 +121,13 @@ const mutations = {
 		Vue.set(state.conversations[token], 'lastMessage', lastMessage)
 	},
 
-	updateUnreadMessages(state, { token, unreadMessages = 0 }) {
-		Vue.set(state.conversations[token], 'unreadMessages', unreadMessages)
+	updateUnreadMessages(state, { token, unreadMessages, unreadMention }) {
+		if (unreadMessages !== undefined) {
+			Vue.set(state.conversations[token], 'unreadMessages', unreadMessages)
+		}
+		if (unreadMention !== undefined) {
+			Vue.set(state.conversations[token], 'unreadMention', unreadMention)
+		}
 	},
 
 	setNotificationLevel(state, { token, notificationLevel }) {

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -687,8 +687,10 @@ const actions = {
 			// in case we encounter an already read message, reset the counter
 			// this is probably unlikely to happen unless one starts browsing from
 			// an earlier page and scrolls down
-			if (conversation.lastReadMessage.id === message.id) {
+			if (conversation.lastReadMessage === message.id) {
+				// discard counters
 				countNewMessages = 0
+				hasNewMention = conversation.unreadMention
 			}
 		})
 
@@ -708,8 +710,8 @@ const actions = {
 			context.commit('updateUnreadMessages', {
 				token,
 				unreadMessages: conversation.unreadMessages + countNewMessages,
-				// only update the value if it's true
-				unreadMention: hasNewMention || undefined,
+				// only update the value if it's been changed to true
+				unreadMention: conversation.unreadMention !== hasNewMention ? hasNewMention : undefined,
 			})
 		}
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/spreed/issues/3110

- [x] requires https://github.com/nextcloud/nextcloud-vue/pull/1895

When the sidebar is closed while in call, there will be an unread messages counter on top of the "open sidebar" button:
![image](https://user-images.githubusercontent.com/277525/116516181-92d31080-a8cd-11eb-974e-e6d870645d01.png)

It is blue for new mentions and grey if there are no mentions.

Additionally, the first time a new unread message arrives or a new mention, a notification will be displayed.
