### PR TITLE
Fix quality warning tooltip not staying dismissed

### DIFF
--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -219,7 +219,7 @@
 						<button
 							v-if="!isQualityWarningTooltipDismissed"
 							class="hint__button"
-							@click="isQualityWarningTooltipDismissed = true">
+							@click="dismissQualityWarningTooltip">
 							{{ t('spreed', 'Dismiss') }}
 						</button>
 					</div>
@@ -299,7 +299,6 @@ export default {
 			screenSharingMenuOpen: false,
 			splitScreenSharingMenu: false,
 			boundaryElement: document.querySelector('.main-view'),
-			isQualityWarningTooltipDismissed: false,
 			mouseover: false,
 			callAnalyzer: callAnalyzer,
 			qualityWarningInGracePeriodTimeout: null,
@@ -436,6 +435,10 @@ export default {
 			}
 
 			return (this.model.attributes.localScreen || this.splitScreenSharingMenu) ? t('spreed', 'Screensharing options') : t('spreed', 'Enable screensharing')
+		},
+
+		isQualityWarningTooltipDismissed() {
+			return this.$store.getters.isQualityWarningTooltipDismissed
 		},
 
 		showQualityWarningTooltip() {
@@ -753,11 +756,15 @@ export default {
 			}
 			if (this.qualityWarningTooltip.action === 'disableScreenShare') {
 				this.model.stopSharingScreen()
-				this.isQualityWarningTooltipDismissed = true
+				this.dismissQualityWarningTooltip()
 			} else if (this.qualityWarningTooltip.action === 'disableVideo') {
 				this.model.disableVideo()
-				this.isQualityWarningTooltipDismissed = true
+				this.dismissQualityWarningTooltip()
 			}
+		},
+
+		dismissQualityWarningTooltip() {
+			this.$store.dispatch('dismissQualityWarningTooltip')
 		},
 	},
 }

--- a/src/store/callViewStore.js
+++ b/src/store/callViewStore.js
@@ -33,6 +33,7 @@ const state = {
 	lastIsStripeOpen: null,
 	presentationStarted: false,
 	selectedVideoPeerId: null,
+	qualityWarningTooltipDismissed: false,
 	participantRaisedHands: {},
 	backgroundImageAverageColorCache: {},
 }
@@ -46,6 +47,7 @@ const getters = {
 	selectedVideoPeerId: (state) => {
 		return state.selectedVideoPeerId
 	},
+	isQualityWarningTooltipDismissed: (state) => state.qualityWarningTooltipDismissed,
 	getParticipantRaisedHand: (state) => (sessionIds) => {
 		for (let i = 0; i < sessionIds.length; i++) {
 			if (state.participantRaisedHands[sessionIds[i]]) {
@@ -80,6 +82,9 @@ const mutations = {
 	},
 	presentationStarted(state, value) {
 		state.presentationStarted = value
+	},
+	setQualityWarningTooltipDismissed(state, { qualityWarningTooltipDismissed }) {
+		state.qualityWarningTooltipDismissed = qualityWarningTooltipDismissed
 	},
 	setParticipantHandRaised(state, { sessionId, raisedHand }) {
 		if (!sessionId) {
@@ -119,6 +124,8 @@ const actions = {
 			isGrid = (isGrid === 'true')
 		}
 		context.dispatch('setCallViewMode', { isGrid: isGrid, isStripeOpen: true })
+
+		context.commit('setQualityWarningTooltipDismissed', { qualityWarningTooltipDismissed: false })
 	},
 
 	leaveCall(context) {
@@ -209,6 +216,10 @@ const actions = {
 			isStripeOpen: context.getters.lastIsStripeOpen,
 		})
 		context.commit('presentationStarted', false)
+	},
+
+	dismissQualityWarningTooltip(context) {
+		context.commit('setQualityWarningTooltipDismissed', { qualityWarningTooltipDismissed: true })
 	},
 }
 


### PR DESCRIPTION
The flag that keep track of whether the quality warning tooltip was dismissed was a local data of the _LocalMediaControls_ component, so it was reset when a new instance of the component was created again. As a new instance could be created several times during the same call (for example, when switching between speaker and grid mode) the warning tooltip could appear again after being dismissed. Now the flag is kept in the store and shared between different instances.

## How to test

- Start a call on a flaky connection
- Wait until the quality warning is shown and dismiss it
- Switch between speaker mode and grid mode

### Result with this pull request

The quality warning icon is shown again, but the tooltip is not shown (unless hovering on the icon)

### Result with this pull request

The quality warning tooltip appears again
