### PR TITLE
Fix initial camera quality

### DIFF
--- a/src/utils/webrtc/VideoConstrainer.js
+++ b/src/utils/webrtc/VideoConstrainer.js
@@ -45,9 +45,9 @@ const QUALITY = {
 function VideoConstrainer(localMediaModel) {
 	this._localMediaModel = localMediaModel
 
-	// By default the constraints used when getting the video try to get the
-	// highest quality
-	this._currentQuality = QUALITY.HIGH
+	// The current quality is undefined until the constraints are applied at
+	// least once.
+	this._currentQuality = undefined
 
 	this._knownValidConstraintsForQuality = {}
 }


### PR DESCRIPTION
When a call started and the _VideoConstrainer_ was created the video track was assumed to be already in high quality, so when the _VideoConstrainer_ was asked to apply again the high quality constraints it just ignored the request. However, in some cases the browser does not initialize the camera in high quality, so the camera was kept in a lower quality for as long as the high quality was kept being requested.

Moreover, even if the browser initialized the camera with high quality that quality might not be exactly the same as the one set when applying the high quality constraints, so even in those cases the constraints should be applied anyway for consistency.

## How to test

- Connect a high quality camera
- Start a call
- Enable the video
- In the browser console, run `OCA.Talk.SimpleWebRTC.webrtc.peers[0].pc.getSenders()[1].track.getSettings()`

### Result with this pull request

The resolution will be equal to or larger than 720x540 (probably it will be an HD resolution, 1280x720).

In some cases Chromium fails to apply the new constraints; I am still investigating this, but in any case it seemss unrelated to the changes here.

Besides that, note that due to how media constraints work even if the camera is a Full HD camera the resolution might not be the maximum resolution of the camera.

### Result without this pull request

The resolution will be (probably) an VGA resolution (640x480 or 640x360).

Note that, depending on the browser, camera, operating system... even without this pull request the initial quality could be high :shrug:
