### PR TITLE
Fix switching devices in Firefox

### DIFF
--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -383,7 +383,7 @@ MediaDevicesManager.prototype = {
 				if (!(constraints.audio instanceof Object)) {
 					constraints.audio = {}
 				}
-				constraints.audio.deviceId = this.attributes.audioInputId
+				constraints.audio.deviceId = { exact: this.attributes.audioInputId }
 			} else if (this.attributes.audioInputId === null) {
 				constraints.audio = false
 			}
@@ -394,7 +394,7 @@ MediaDevicesManager.prototype = {
 				if (!(constraints.video instanceof Object)) {
 					constraints.video = {}
 				}
-				constraints.video.deviceId = this.attributes.videoInputId
+				constraints.video.deviceId = { exact: this.attributes.videoInputId }
 			} else if (this.attributes.videoInputId === null) {
 				constraints.video = false
 			}
@@ -429,15 +429,17 @@ MediaDevicesManager.prototype = {
 	_stopIncompatibleTracks: function(constraints) {
 		this._tracks.forEach(track => {
 			if (constraints.audio && constraints.audio.deviceId && track.kind === 'audio') {
+				const constraintsAudioDeviceId = constraints.audio.deviceId.exact || constraints.audio.deviceId.ideal || constraints.audio.deviceId
 				const settings = track.getSettings()
-				if (settings && settings.deviceId !== constraints.audio.deviceId) {
+				if (settings && settings.deviceId !== constraintsAudioDeviceId) {
 					track.stop()
 				}
 			}
 
 			if (constraints.video && constraints.video.deviceId && track.kind === 'video') {
+				const constraintsVideoDeviceId = constraints.video.deviceId.exact || constraints.video.deviceId.ideal || constraints.video.deviceId
 				const settings = track.getSettings()
-				if (settings && settings.deviceId !== constraints.video.deviceId) {
+				if (settings && settings.deviceId !== constraintsVideoDeviceId) {
 					track.stop()
 				}
 			}


### PR DESCRIPTION
Fixes #4414

If a device is currently active and a different one is requested Firefox returns the currently active device. To overcome this [all the tracks of the same device kind as the requested one are stopped before performing the request](https://github.com/nextcloud/spreed/blob/0926044bca3b2ffb1d4c254b4e398a33ea9592d1/src/utils/webrtc/MediaDevicesManager.js#L403).

However, a device is also "active" as long as any other device returned in the same `getUserMedia` request is active. Both audio and video are requested at once when a call is started, so during calls it was needed to stop both devices first to be able to switch just one of them.

Moreover, since Firefox 88 [there is a grace period for requesting again the media permissions to the user once a track stops](https://bugzilla.mozilla.org/show_bug.cgi?id=1693677). During that grace period the device is also "active" and it is not possible to switch to another device even if the previous one was requested on its own, without any other device. In this case the permissions have to be manually revoked to be able to switch to another device before the grace period ended.

To solve all that now the ID of the requested device is marked as a required constraint instead of an optional one, which forces Firefox to honour the requested device and return it instead of the active one.

But (there is always a _but_ :-) ) forcing a specific device sometimes causes [audio requests to fail with `Concurrent mic process limit`](https://bugzilla.mozilla.org/show_bug.cgi?id=1675538). This can happen even if the previous tracks are stopped before requesting the new device; my guess is that it is a race condition in Firefox guts, so even if the streams are stopped from the JavaScript side sometimes something is still running internally, which causes the two audio devices to be active at the same time.

As much as I tried I never had that error with the previous constraints, although that could have been sheer luck :shrug: The error itself only happens from time to time and it is not reliably reproducible, and except in one occasion in which I had to reload the page just disabling the audio device and setting it again was enough to solve it. Also I never had the error during a call, but again it could be just luck.

In the end it seems to be trading one bug for another, although on the bright side this one should be less problematic.

So **please test** by switching between audio devices several times to see if it is a common issue in other machines or not. Note that you may also find that after changing a device the loading spinner never stops; that is unrelated to the changes here and is caused by a stalled `getUserMedia` request (a problem in the browser itself and the reason why back in the day [we added a warning when starting a call if it took too long](https://github.com/nextcloud/spreed/blob/a7e58c30afd301d5145374b793f2626b9eb7a63c/src/utils/webrtc/webrtc.js#L916-L931)).

An alternative to changing the constraints would be to just show a message with the (cumbersome and not very user friendly) instructions to the user. But (here it is the _but_ again) disabling the device, waiting 50 seconds until the grace period expired and then selecting the new device, besides being terrible, would be valid only on Firefox 88. For Firefox 89 [the grace period is going to be extended from 50 seconds to 1 hour](https://bugzilla.mozilla.org/show_bug.cgi?id=1697284), so this does not work.

The grace period is aborted when the permissions are revoked, so the user could be instructed to do that. But (I can see a pattern here :-P ) revoking audio permissions also revokes video permissions (and the other way around), so you would lose your video when changing your audio device (and the other way around). Also handling revoking and granting permissions again during a call will probably need some changes.

Besides all that I have tested this with Firefox and Chromium. It should work without problems in Safari too... but **please test** it to be sure :-)


## How to test (scenario 1)

- Use Firefox < 88 in a computer with both audio and video devices, and with more than one audio or video device
- Open Talk settings and enable both audio and video
- Start a call
- Open Talk settings and switch one of the devices

### Result with this pull request

The device is switched.

### Result without this pull request

The previous device is selected again.


## How to test (scenario 2)

- Use Firefox 88 in a computer with more than one audio or video device
- Open Talk settings and switch one of the devices

### Result with this pull request

The device is switched.

### Result without this pull request

The previous device is selected again.
