### PR TITLE
Unify stun and turn server urls

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -62,7 +62,7 @@ return [
 			'url' => '/api/{apiVersion}/signaling/settings',
 			'verb' => 'GET',
 			'requirements' => [
-				'apiVersion' => 'v(1|2)',
+				'apiVersion' => 'v(1|2|3)',
 			],
 		],
 		[

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -62,7 +62,7 @@ return [
 			'url' => '/api/{apiVersion}/signaling/settings',
 			'verb' => 'GET',
 			'requirements' => [
-				'apiVersion' => 'v(1|2|3)',
+				'apiVersion' => 'v(3)',
 			],
 		],
 		[
@@ -70,7 +70,7 @@ return [
 			'url' => '/api/{apiVersion}/signaling/welcome/{serverId}',
 			'verb' => 'GET',
 			'requirements' => [
-				'apiVersion' => 'v(1|2)',
+				'apiVersion' => 'v(3)',
 				'serverId' => '^\d+$',
 			],
 		],
@@ -79,7 +79,7 @@ return [
 			'url' => '/api/{apiVersion}/signaling/backend',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v(1|2)',
+				'apiVersion' => 'v(3)',
 			],
 		],
 		[
@@ -87,7 +87,7 @@ return [
 			'url' => '/api/{apiVersion}/signaling/{token}',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v(1|2)',
+				'apiVersion' => 'v(3)',
 				'token' => '^[a-z0-9]{4,30}$',
 			],
 		],
@@ -96,7 +96,7 @@ return [
 			'url' => '/api/{apiVersion}/signaling/{token}',
 			'verb' => 'GET',
 			'requirements' => [
-				'apiVersion' => 'v(1|2)',
+				'apiVersion' => 'v(3)',
 				'token' => '^[a-z0-9]{4,30}$',
 			],
 		],

--- a/docs/internal-signaling.md
+++ b/docs/internal-signaling.md
@@ -2,6 +2,7 @@
 
 * Base endpoint for API v1 is: `/ocs/v2.php/apps/spreed/api/v1`
 * Base endpoint for API v2 is: `/ocs/v2.php/apps/spreed/api/v2`
+* Base endpoint for API v3 is: `/ocs/v2.php/apps/spreed/api/v3`
 
 ## Get signaling settings
 
@@ -26,18 +27,32 @@
     `turnservers` | array | v1 | TURN servers
     `sipDialinInfo` | string | v2 | Generic SIP dial-in information for this conversation (admin free text containing the phone number etc)
 
-    - STUN server
+    - STUN server (v1|v2)
     
        field | type | Description
        ---|---|---
        `url` | string | STUN server URL
 
-    - TURN server
+    - TURN server (v1|v2)
     
        field | type | Description
        ---|---|---
        `url` | array | One element array with TURN server URL
        `urls` | array | One element array with TURN server URL
+       `username` | string | User name for the TURN server
+       `credential` | string | User password for the TURN server
+
+    - STUN server (v3)
+
+       field | type | Description
+       ------|------|------------
+       `urls` | array | Each element is a STUN server URL as a string
+
+    - TURN server (v3)
+
+       field | type | Description
+       ------|------|------------
+       `urls` | array | Each element is a TURN server URL as a string
        `username` | string | User name for the TURN server
        `credential` | string | User password for the TURN server
 

--- a/docs/internal-signaling.md
+++ b/docs/internal-signaling.md
@@ -1,7 +1,7 @@
 # Signaling API
 
-* Base endpoint for API v1 is: `/ocs/v2.php/apps/spreed/api/v1`
-* Base endpoint for API v2 is: `/ocs/v2.php/apps/spreed/api/v2`
+* Base endpoint for API v1 is: 🏁 Removed with API v3
+* Base endpoint for API v2 is: 🏁 Removed with API v3
 * Base endpoint for API v3 is: `/ocs/v2.php/apps/spreed/api/v3`
 
 ## Get signaling settings
@@ -23,33 +23,18 @@
     `hideWarning` | string | v1 | Don't show a performance warning although internal signaling is used
     `server` | string | v1 | URL of the external signaling server
     `ticket` | string | v1 | Ticket for the external signaling server
-    `stunservers` | array | v1 | STUN servers
-    `turnservers` | array | v1 | TURN servers
+    `stunservers` | array | v3 | STUN servers
+    `turnservers` | array | v3 | TURN servers
     `sipDialinInfo` | string | v2 | Generic SIP dial-in information for this conversation (admin free text containing the phone number etc)
 
-    - STUN server (v1|v2)
+    - STUN server
     
-       field | type | Description
-       ---|---|---
-       `url` | string | STUN server URL
-
-    - TURN server (v1|v2)
-    
-       field | type | Description
-       ---|---|---
-       `url` | array | One element array with TURN server URL
-       `urls` | array | One element array with TURN server URL
-       `username` | string | User name for the TURN server
-       `credential` | string | User password for the TURN server
-
-    - STUN server (v3)
-
        field | type | Description
        ------|------|------------
        `urls` | array | Each element is a STUN server URL as a string
 
-    - TURN server (v3)
-
+    - TURN server
+    
        field | type | Description
        ------|------|------------
        `urls` | array | Each element is a TURN server URL as a string

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -91,6 +91,7 @@ class Capabilities implements IPublicCapability {
 				'rich-object-sharing',
 				'temp-user-avatar-api',
 				'geo-location-sharing',
+				'signaling-v3',
 			],
 			'config' => [
 				'attachments' => [

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -137,16 +137,24 @@ class SignalingController extends OCSController {
 		}
 
 		$stun = [];
+		$stunV3 = [];
+		$stunUrls = [];
 		$stunServers = $this->talkConfig->getStunServers();
 		foreach ($stunServers as $stunServer) {
 			$stun[] = [
 				'url' => 'stun:' . $stunServer,
 			];
+			$stunUrls[] = 'stun:' . $stunServer;
 		}
+		$stunV3[] = [
+			'urls' => $stunUrls
+		];
 
 		$turn = [];
+		$turnV3 = [];
 		$turnSettings = $this->talkConfig->getTurnSettings();
 		foreach ($turnSettings as $turnServer) {
+			$turnUrls = [];
 			$schemes = explode(',', $turnServer['schemes']);
 			$protocols = explode(',', $turnServer['protocols']);
 			foreach ($schemes as $scheme) {
@@ -157,8 +165,15 @@ class SignalingController extends OCSController {
 						'username' => $turnServer['username'],
 						'credential' => $turnServer['password'],
 					];
+					$turnUrls[] = $scheme . ':' . $turnServer['server'] . '?transport=' . $proto;
 				}
 			}
+
+			$turnV3[] = [
+				'urls' => $turnUrls,
+				'username' => $turnServer['username'],
+				'credential' => $turnServer['password'],
+			];
 		}
 
 		$signalingMode = $this->talkConfig->getSignalingMode();
@@ -176,6 +191,11 @@ class SignalingController extends OCSController {
 
 		if ($apiV >= 2) {
 			$data['sipDialinInfo'] = $this->talkConfig->isSIPConfigured() ? $this->talkConfig->getDialInInfo() : '';
+		}
+
+		if ($apiV >= 3) {
+			$data['stunservers'] = $stunV3;
+			$data['turnservers'] = $turnV3;
 		}
 
 		return new DataResponse($data);

--- a/src/services/signalingService.js
+++ b/src/services/signalingService.js
@@ -35,11 +35,11 @@ const fetchSignalingSettings = async({ token }, options) => {
 }
 
 const pullSignalingMessages = async(token, options) => {
-	return axios.get(generateOcsUrl('apps/spreed/api/v2/signaling/{token}', { token }), options)
+	return axios.get(generateOcsUrl('apps/spreed/api/v3/signaling/{token}', { token }), options)
 }
 
 const getWelcomeMessage = async(serverId) => {
-	return axios.get(generateOcsUrl('apps/spreed/api/v2/signaling/welcome/{serverId}', { serverId }))
+	return axios.get(generateOcsUrl('apps/spreed/api/v3/signaling/welcome/{serverId}', { serverId }))
 }
 
 export {

--- a/src/services/signalingService.js
+++ b/src/services/signalingService.js
@@ -27,7 +27,7 @@ import { generateOcsUrl } from '@nextcloud/router'
  * @param {object} options options
  */
 const fetchSignalingSettings = async({ token }, options) => {
-	return axios.get(generateOcsUrl('apps/spreed/api/v2/signaling/settings'), Object.assign(options, {
+	return axios.get(generateOcsUrl('apps/spreed/api/v3/signaling/settings'), Object.assign(options, {
 		params: {
 			token,
 		},

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -362,7 +362,7 @@ Signaling.Internal.prototype._sendMessageWithCallback = function(ev) {
 }
 
 Signaling.Internal.prototype._sendMessages = function(messages) {
-	return axios.post(generateOcsUrl('apps/spreed/api/v1/signaling/{token}', { token: this.currentRoomToken }), {
+	return axios.post(generateOcsUrl('apps/spreed/api/v3/signaling/{token}', { token: this.currentRoomToken }), {
 		messages: JSON.stringify(messages),
 	})
 }
@@ -818,7 +818,7 @@ Signaling.Standalone.prototype.sendHello = function() {
 	} else {
 		// Already reconnected with a new session.
 		this._forceReconnect = false
-		const url = generateOcsUrl('apps/spreed/api/v1/signaling/backend')
+		const url = generateOcsUrl('apps/spreed/api/v3/signaling/backend')
 		msg = {
 			'type': 'hello',
 			'hello': {

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -88,6 +88,7 @@ class CapabilitiesTest extends TestCase {
 			'rich-object-sharing',
 			'temp-user-avatar-api',
 			'geo-location-sharing',
+			'signaling-v3',
 		];
 	}
 


### PR DESCRIPTION
Requires #5491 and #5503

~~This is a breaking change for Talk 12.~~ The settings endpoint version was bumped, so clients can still use the previous API if needed.

The format resembles the `RTCIceServer` format, so the returned values can be directly used by the WebUI like done until now. Mobile clients will need to be adjusted, though.

**Important:** The [RTCIceServer MDN page](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceServer) states that `Avoid specifying an unnecessarily large number of URLs in the urls property; the startup time for your connection will go up substantially. Every server in the list will be contacted and tried out before one is selected to be used for negotiation.` It should be verified whether that applies too when using trickle ICE or not; if it does then it might be needed to rethink the format before merging this.

- **Update:** I have not been able to reproduce the described behaviour (although I have not done any fancy test like delaying packets for a specific server or something like that; I just used real servers, real servers unreachable by a specific protocol and wrong addresses). Even with several servers the connection could be established before the gathering of candidates finished. 

  Internally both [Firefox](https://hg.mozilla.org/releases/mozilla-beta/file/a9556ebc4a0470ad0b4d0d47fccb227b88089bb3/dom/media/webrtc/jsapi/MediaTransportHandler.cpp#l395) and [Chromium](https://chromium.googlesource.com/chromium/src/+/60fe159c56ce23f45fab5326719d6bb386cc434a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc#356) just iterate through all the `urls` and add a separate server for each of them; in practice it seems that it does not make any difference to provide four server elements each with a single url or a single server element with four urls.

  So I guess that the statement above refers only to systems where trickle ICE is not being used :shrug: 

### Before

```
stunservers: [
  [
    url: "stunServer1"
  ],
  [
    url: "stunServer2"
  ],
  [
    url: "stunServer3"
  ]
],
turnservers: [
  [
    url: [ "turnServer1-1" ],
    urls: [ "turnServer1-1" ],
    username: "user1"
    credentials: "credentials1"
  ],
  [
    url: [ "turnServer1-2" ],
    urls: [ "turnServer1-2" ],
    username: "user1"
    credentials: "credentials1"
  ],
  [
    url: [ "turnServer2" ],
    url: [ "turnServer2" ],
    username: "user2"
    credentials: "credentials2"
  ],
]
```

### After

```
stunservers: [
  [
    urls: [ "stunServer1", "stunServer2", "stunServer3" ]
  ],
],
turnservers: [
  [
    urls: [ "turnServer1-1", "turnServer1-2" ],
    username: "user1"
    credentials: "credentials1"
  ],
  [
    url: [ "turnServer2" ],
    username: "user2"
    credentials: "credentials2"
  ],
]
```
