### PR TITLE
Move createOneToOneConversation to store

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -130,7 +130,6 @@ import SearchBox from './SearchBox/SearchBox'
 import debounce from 'debounce'
 import { EventBus } from '../../services/EventBus'
 import {
-	createOneToOneConversation,
 	searchPossibleConversations,
 	searchListedConversations,
 } from '../../services/conversationsService'
@@ -355,16 +354,13 @@ export default {
 		 * @param {string} item.source The source of the target (e.g. users, groups, circle)
 		 */
 		async createAndJoinConversation(item) {
-			let response
 			if (item.source === 'users') {
 				// Create one-to-one conversation directly
-				response = await createOneToOneConversation(item.id)
-				const conversation = response.data.ocs.data
+				const conversation = await this.$store.dispatch('createOneToOneConversation', item.id)
 				this.abortSearch()
 				EventBus.$once('joinedConversation', ({ token }) => {
 					this.$refs.conversationsList.scrollToConversation(token)
 				})
-				this.$store.dispatch('addConversation', conversation)
 				this.$router.push({ name: 'conversation', params: { token: conversation.token } }).catch(err => console.debug(`Error while pushing the new conversation's route: ${err}`))
 			} else {
 				// For other types we start the conversation creation dialog

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -213,7 +213,6 @@ import {
 	showWarning,
 	TOAST_DEFAULT_TIMEOUT,
 } from '@nextcloud/dialogs'
-import { createOneToOneConversation } from '../../../../services/conversationsService'
 import { generateUrl } from '@nextcloud/router'
 
 export default {
@@ -699,9 +698,7 @@ export default {
 		},
 		async handlePrivateReply() {
 			// open the 1:1 conversation
-			const response = await createOneToOneConversation(this.actorId)
-			const conversation = response.data.ocs.data
-			this.$store.dispatch('addConversation', conversation)
+			const conversation = await this.$store.dispatch('createOneToOneConversation', this.actorId)
 			this.$router.push({ name: 'conversation', params: { token: conversation.token } }).catch(err => console.debug(`Error while pushing the new conversation's route: ${err}`))
 		},
 

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -27,6 +27,7 @@ import {
 	changeLobbyState,
 	changeReadOnlyState,
 	changeListable,
+	createOneToOneConversation,
 	addToFavorites,
 	removeFromFavorites,
 	fetchConversations,
@@ -385,6 +386,21 @@ const actions = {
 
 	changeNotificationLevel({ commit }, { token, notificationLevel }) {
 		commit('changeNotificationLevel', { token, notificationLevel })
+	},
+
+	/**
+	 * Creates a new one to one conversation in the backend
+	 * with the given actor then adds it to the store.
+	 *
+	 * @param {object} context default store context;
+	 * @param {string} actorId actor id;
+	 */
+	async createOneToOneConversation(context, actorId) {
+		const response = await createOneToOneConversation(actorId)
+		const conversation = response.data.ocs.data
+		context.dispatch('addConversation', conversation)
+
+		return conversation
 	},
 }
 

--- a/src/store/conversationsStore.spec.js
+++ b/src/store/conversationsStore.spec.js
@@ -16,6 +16,7 @@ import {
 	changeLobbyState,
 	changeReadOnlyState,
 	changeListable,
+	createOneToOneConversation,
 	setConversationName,
 	setConversationDescription,
 	setSIPEnabled,
@@ -31,6 +32,7 @@ jest.mock('../services/conversationsService', () => ({
 	changeLobbyState: jest.fn(),
 	changeReadOnlyState: jest.fn(),
 	changeListable: jest.fn(),
+	createOneToOneConversation: jest.fn(),
 	setConversationName: jest.fn(),
 	setConversationDescription: jest.fn(),
 	setSIPEnabled: jest.fn(),
@@ -545,6 +547,33 @@ describe('conversationsStore', () => {
 
 			const changedConversation = store.getters.conversation(testToken)
 			expect(changedConversation.lastActivity).toBe(mockDate.getTime() / 1000)
+		})
+	})
+
+	describe('creating conversations', () => {
+		test('creates one to one conversation', async() => {
+			const newConversation = {
+				id: 999,
+				token: 'new-token',
+				type: CONVERSATION.TYPE.ONE_TO_ONE,
+			}
+
+			const response = {
+				data: {
+					ocs: {
+						data: newConversation,
+					},
+				},
+			}
+
+			createOneToOneConversation.mockResolvedValueOnce(response)
+
+			await store.dispatch('createOneToOneConversation', 'target-actor-id')
+
+			expect(createOneToOneConversation).toHaveBeenCalledWith('target-actor-id')
+
+			const addedConversation = store.getters.conversation('new-token')
+			expect(addedConversation).toBe(newConversation)
 		})
 	})
 })


### PR DESCRIPTION
Instead of calling the service createOneToOneConversation directly,
move it to a store action instead which also takes care of adding it to
the store.

Needed for https://github.com/nextcloud/spreed/pull/5570 to simplify mocking.

I've manually retested the following:
- [x] TEST: create 1-1 conversation from left sidebar
- [x] TEST: create 1-1 with "reply privately" in a conversation