### PR TITLE
Add meaningful conversation info to topbar. 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -457,9 +457,10 @@ export default {
 .content {
 	height: 100%;
 
+	//FIXME: remove this v-deep once nextcloud vue v4 is adopted
 	::v-deep .app-navigation-toggle {
-		top: 10px;
-		right: -10px;
+		top: 8px;
+		right: -8px;
 		border-radius: var(--border-radius-pill);
 	}
 

--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -68,7 +68,7 @@ $message-utils-width: 100px;
 //message form max height
 $message-form-max-height: 180px;
 
-$top-bar-height: 60px;
+$top-bar-height: 61px;
 
 $color-call-background: #444444;
 $color-guests-avatar: #ffffff;

--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -153,11 +153,10 @@ export default {
 <style lang="scss" scoped>
 .chatView {
 	width: 100%;
-	height: 100%;
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;
-	position: absolute;
+	min-height: 0;
 }
 
 .dragover {

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -443,8 +443,6 @@ export default {
 @import '../../assets/buttons';
 
 .wrapper {
-	position: sticky;
-	bottom: 0;
 	display: flex;
 	justify-content: center;
 	padding: 12px 0;

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -277,6 +277,7 @@ export default {
 .app-sidebar-tabs__content #tab-chat {
 	/* Remove padding to maximize the space for the chat view. */
 	padding: 0;
+	height: 100%;
 }
 
 </style>

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -33,7 +33,12 @@
 				<p class="title">
 					{{ conversation.displayName }}
 				</p>
-				<p v-if="conversation.description" class="description">
+				<p v-if="conversation.description"
+					v-tooltip.bottom="{
+						content: conversation.description,
+						delay: { show: 500, hide: 100 },
+					}"
+					class="description">
 					{{ conversation.description }}
 				</p>
 			</div>
@@ -139,9 +144,14 @@ import { generateUrl } from '@nextcloud/router'
 import { callParticipantCollection } from '../../utils/webrtc/index'
 import { emit } from '@nextcloud/event-bus'
 import ConversationIcon from '../ConversationIcon'
+import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 
 export default {
 	name: 'TopBar',
+
+	directives: {
+		Tooltip,
+	},
 
 	components: {
 		ActionButton,

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -26,7 +26,7 @@
 <template>
 	<div class="top-bar" :class="{ 'in-call': isInCall }">
 		<!-- conversation header -->
-		<a
+		<a v-if="!isInCall"
 			class="conversation-header"
 			@click="openConversationSettings">
 			<ConversationIcon

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -6,7 +6,11 @@
   - @license GNU AGPL version 3 or any later version
   -
   - This program is free software: you can redistribute it and/or modify
+<<<<<<< HEAD
   - it under the terms of the GNU Affero General Public auoLicense as
+=======
+  - it under the terms of the GNU Affero General Public /*  */License as
+>>>>>>> 42d78e46e (fixup! fixup! Fix MainView Layout)
   - published by the Free Software Foundation, either version 3 of the
   - License, or (at your option) any later version.
   -
@@ -359,7 +363,6 @@ export default {
 
 .top-bar {
 	height: $top-bar-height;
-	top: 0;
 	right: 12px; /* needed so we can still use the scrollbar */
 	display: flex;
 	z-index: 10;
@@ -371,6 +374,11 @@ export default {
 
 	&.in-call {
 		right: 0;
+		background-color: transparent;
+		border: none;
+		position: absolute;
+		top: 0;
+		left:0;
 		.forced-background {
 			background-color: rgba(0,0,0,0.1) !important;
 			border-radius: var(--border-radius-pill);
@@ -423,7 +431,7 @@ export default {
 	.description {
 		overflow: hidden;
 		text-overflow: ellipsis;
-		color: var(--color-text-lighter)
+		color: var(--color-text-lighter);
 	}
 }
 </style>

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -22,7 +22,9 @@
 <template>
 	<div class="top-bar" :class="{ 'in-call': isInCall }">
 		<!-- conversation header -->
-		<div class="conversation-header">
+		<a
+			class="conversation-header"
+			@click="openConversationSettings">
 			<ConversationIcon
 				:item="conversation"
 				:hide-favorite="false"
@@ -35,7 +37,7 @@
 					{{ conversation.description }}
 				</p>
 			</div>
-		</div>
+		</a>
 		<div class="top-bar__buttons">
 			<CallButton class="top-bar__button" />
 			<!-- Call layout switcher -->
@@ -343,6 +345,10 @@ export default {
 				callParticipantModel.forceMute()
 			})
 		},
+
+		openConversationSettings() {
+			emit('show-conversation-settings')
+		},
 	},
 }
 </script>
@@ -392,12 +398,14 @@ export default {
 }
 
 .conversation-header {
+	position: relative;
 	display: flex;
 	overflow-x: hidden;
 	overflow-y: clip;
 	margin-left: 48px;
 	white-space: nowrap;
 	width: 100%;
+	cursor: pointer;
 	&__text {
 		display: flex;
 		flex-direction:column;

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -6,11 +6,7 @@
   - @license GNU AGPL version 3 or any later version
   -
   - This program is free software: you can redistribute it and/or modify
-<<<<<<< HEAD
-  - it under the terms of the GNU Affero General Public auoLicense as
-=======
-  - it under the terms of the GNU Affero General Public /*  */License as
->>>>>>> 42d78e46e (fixup! fixup! Fix MainView Layout)
+  - it under the terms of the GNU Affero General Public License as
   - published by the Free Software Foundation, either version 3 of the
   - License, or (at your option) any later version.
   -

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -35,8 +35,10 @@
 				</p>
 				<p v-if="conversation.description"
 					v-tooltip.bottom="{
-						content: conversation.description,
-						delay: { show: 500, hide: 100 },
+						content: renderedDescription,
+						delay: { show: 500, hide: 500 },
+						autoHide: false,
+						html: true,
 					}"
 					class="description">
 					{{ conversation.description }}
@@ -145,6 +147,7 @@ import { callParticipantCollection } from '../../utils/webrtc/index'
 import { emit } from '@nextcloud/event-bus'
 import ConversationIcon from '../ConversationIcon'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
+import richEditor from '@nextcloud/vue/dist/Mixins/richEditor'
 
 export default {
 	name: 'TopBar',
@@ -162,6 +165,8 @@ export default {
 		MicrophoneOff,
 		ConversationIcon,
 	},
+
+	mixins: [richEditor],
 
 	props: {
 		isInCall: {
@@ -218,9 +223,11 @@ export default {
 		isFileConversation() {
 			return this.conversation.objectType === 'file' && this.conversation.objectId
 		},
+
 		isOneToOneConversation() {
 			return this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE
 		},
+
 		linkToFile() {
 			if (this.isFileConversation) {
 				return window.location.protocol + '//' + window.location.host + generateUrl('/f/' + this.conversation.objectId)
@@ -240,15 +247,19 @@ export default {
 		canModerate() {
 			return this.canFullModerate || this.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR
 		},
+
 		showModerationOptions() {
 			return !this.isOneToOneConversation && this.canModerate
 		},
+
 		token() {
 			return this.$store.getters.getToken()
 		},
+
 		conversation() {
 			return this.$store.getters.conversation(this.token) || this.$store.getters.dummyConversation
 		},
+
 		linkToConversation() {
 			if (this.token !== '') {
 				return window.location.protocol + '//' + window.location.host + generateUrl('/call/' + this.token)
@@ -256,6 +267,7 @@ export default {
 				return ''
 			}
 		},
+
 		conversationHasSettings() {
 			return this.conversation.type === CONVERSATION.TYPE.GROUP
 				|| this.conversation.type === CONVERSATION.TYPE.PUBLIC
@@ -263,6 +275,10 @@ export default {
 
 		isGrid() {
 			return this.$store.getters.isGrid
+		},
+
+		renderedDescription() {
+			return this.renderContent(this.conversation.description)
 		},
 	},
 
@@ -437,6 +453,7 @@ export default {
 	.description {
 		overflow: hidden;
 		text-overflow: ellipsis;
+		max-width: fit-content;
 		color: var(--color-text-lighter);
 	}
 }

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -6,7 +6,7 @@
   - @license GNU AGPL version 3 or any later version
   -
   - This program is free software: you can redistribute it and/or modify
-  - it under the terms of the GNU Affero General Public License as
+  - it under the terms of the GNU Affero General Public auoLicense as
   - published by the Free Software Foundation, either version 3 of the
   - License, or (at your option) any later version.
   -
@@ -21,88 +21,105 @@
 
 <template>
 	<div class="top-bar" :class="{ 'in-call': isInCall }">
-		<CallButton class="top-bar__button" />
-		<!-- Call layout switcher -->
-		<Actions
-			slot="trigger"
-			class="forced-background"
-			container="#content-vue">
-			<ActionButton v-if="isInCall"
-				:icon="changeViewIconClass"
-				@click="changeView">
-				{{ changeViewText }}
-			</actionbutton>
-		</Actions>
-		<!-- sidebar toggle -->
-		<Actions
-			v-shortkey.once="['f']"
-			class="top-bar__button forced-background"
-			menu-align="right"
-			:aria-label="t('spreed', 'Conversation actions')"
-			container="#content-vue"
-			@shortkey.native="toggleFullscreen">
-			<ActionButton
-				:icon="iconFullscreen"
-				:aria-label="t('spreed', 'Toggle fullscreen')"
-				:close-after-click="true"
-				@click="toggleFullscreen">
-				{{ labelFullscreen }}
-			</ActionButton>
-			<ActionSeparator
-				v-if="showModerationOptions" />
-			<ActionLink
-				v-if="isFileConversation"
-				icon="icon-text"
-				:href="linkToFile">
-				{{ t('spreed', 'Go to file') }}
-			</ActionLink>
-			<template
-				v-if="showModerationOptions">
+		<!-- conversation header -->
+		<div class="conversation-header">
+			<ConversationIcon
+				:item="conversation"
+				:hide-favorite="false"
+				:hide-call="false" />
+			<div class="conversation-header__text">
+				<p class="title">
+					{{ conversation.displayName }}
+				</p>
+				<p v-if="conversation.description" class="description">
+					{{ conversation.description }}
+				</p>
+			</div>
+		</div>
+		<div class="top-bar__buttons">
+			<CallButton class="top-bar__button" />
+			<!-- Call layout switcher -->
+			<Actions
+				slot="trigger"
+				class="forced-background"
+				container="#content-vue">
+				<ActionButton v-if="isInCall"
+					:icon="changeViewIconClass"
+					@click="changeView">
+					{{ changeViewText }}
+				</actionbutton>
+			</Actions>
+			<!-- sidebar toggle -->
+			<Actions
+				v-shortkey.once="['f']"
+				class="top-bar__button forced-background"
+				menu-align="right"
+				:aria-label="t('spreed', 'Conversation actions')"
+				container="#content-vue"
+				@shortkey.native="toggleFullscreen">
 				<ActionButton
+					:icon="iconFullscreen"
+					:aria-label="t('spreed', 'Toggle fullscreen')"
 					:close-after-click="true"
-					icon="icon-rename"
-					@click="handleRenameConversation">
-					{{ t('spreed', 'Rename conversation') }}
+					@click="toggleFullscreen">
+					{{ labelFullscreen }}
 				</ActionButton>
-			</template>
-			<ActionButton
-				v-if="!isOneToOneConversation"
-				icon="icon-clippy"
-				:close-after-click="true"
-				@click="handleCopyLink">
-				{{ t('spreed', 'Copy link') }}
-			</ActionButton>
-			<template
-				v-if="showModerationOptions && canFullModerate && isInCall">
-				<ActionSeparator />
+				<ActionSeparator
+					v-if="showModerationOptions" />
+				<ActionLink
+					v-if="isFileConversation"
+					icon="icon-text"
+					:href="linkToFile">
+					{{ t('spreed', 'Go to file') }}
+				</ActionLink>
+				<template
+					v-if="showModerationOptions">
+					<ActionButton
+						:close-after-click="true"
+						icon="icon-rename"
+						@click="handleRenameConversation">
+						{{ t('spreed', 'Rename conversation') }}
+					</ActionButton>
+				</template>
 				<ActionButton
+					v-if="!isOneToOneConversation"
+					icon="icon-clippy"
 					:close-after-click="true"
-					@click="forceMuteOthers">
-					<MicrophoneOff
-						slot="icon"
-						:size="16"
-						decorative
-						title="" />
-					{{ t('spreed', 'Mute others') }}
+					@click="handleCopyLink">
+					{{ t('spreed', 'Copy link') }}
 				</ActionButton>
-			</template>
-			<ActionSeparator
-				v-if="showModerationOptions" />
-			<ActionButton
-				icon="icon-settings"
-				:close-after-click="true"
-				@click="showConversationSettings">
-				{{ t('spreed', 'Conversation settings') }}
-			</ActionButton>
-		</Actions>
-		<Actions v-if="showOpenSidebarButton"
-			class="top-bar__button forced-background"
-			close-after-click="true"
-			container="#content-vue">
-			<ActionButton
-				:icon="iconMenuPeople"
-				@click="openSidebar" />
-		</Actions>
+				<template
+					v-if="showModerationOptions && canFullModerate && isInCall">
+					<ActionSeparator />
+					<ActionButton
+						:close-after-click="true"
+						@click="forceMuteOthers">
+						<MicrophoneOff
+							slot="icon"
+							:size="16"
+							decorative
+							title="" />
+						{{ t('spreed', 'Mute others') }}
+					</ActionButton>
+				</template>
+				<ActionSeparator
+					v-if="showModerationOptions" />
+				<ActionButton
+					icon="icon-settings"
+					:close-after-click="true"
+					@click="showConversationSettings">
+					{{ t('spreed', 'Conversation settings') }}
+				</ActionButton>
+			</Actions>
+			<Actions v-if="showOpenSidebarButton"
+				class="top-bar__button forced-background"
+				close-after-click="true"
+				container="#content-vue">
+				<ActionButton
+					:icon="iconMenuPeople"
+					@click="openSidebar" />
+			</Actions>
+		</div>
 	</div>
 </template>
 
@@ -119,6 +136,7 @@ import { CONVERSATION, PARTICIPANT } from '../../constants'
 import { generateUrl } from '@nextcloud/router'
 import { callParticipantCollection } from '../../utils/webrtc/index'
 import { emit } from '@nextcloud/event-bus'
+import ConversationIcon from '../ConversationIcon'
 
 export default {
 	name: 'TopBar',
@@ -130,6 +148,7 @@ export default {
 		CallButton,
 		ActionSeparator,
 		MicrophoneOff,
+		ConversationIcon,
 	},
 
 	props: {
@@ -334,13 +353,15 @@ export default {
 
 .top-bar {
 	height: $top-bar-height;
-	position: absolute;
 	top: 0;
 	right: 12px; /* needed so we can still use the scrollbar */
 	display: flex;
 	z-index: 10;
 	justify-content: flex-end;
 	padding: 8px;
+	width: 100%;
+	background-color: var(--color-main-background);
+	border-bottom: 1px solid var(--color-border);
 
 	&.in-call {
 		right: 0;
@@ -350,17 +371,51 @@ export default {
 		}
 	}
 
+	&__buttons {
+		display: flex;
+		margin-left: 8px;
+	}
+
 	&__button {
 		margin: 0 2px;
 		align-self: center;
 		display: flex;
 		align-items: center;
+		white-space: nowrap;
 		svg {
 			margin-right: 4px !important;
 		}
 		.icon {
 			margin-right: 4px !important;
 		}
+	}
+}
+
+.conversation-header {
+	display: flex;
+	overflow-x: hidden;
+	overflow-y: clip;
+	margin-left: 48px;
+	white-space: nowrap;
+	width: 100%;
+	&__text {
+		display: flex;
+		flex-direction:column;
+		flex-grow: 1;
+		margin-left: 8px;
+		justify-content: center;
+		width: 100%;
+		overflow: hidden;
+	}
+	.title {
+		font-weight: bold;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	.description {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		color: var(--color-text-lighter)
 	}
 }
 </style>

--- a/src/store/sidebarStore.spec.js
+++ b/src/store/sidebarStore.spec.js
@@ -20,7 +20,7 @@ describe('sidebarStore', () => {
 	})
 
 	test('defaults are off', () => {
-		expect(store.getters.getSidebarStatus).toBe(false)
+		expect(store.getters.getSidebarStatus).toBe(true)
 		expect(store.getters.isRenamingConversation).toBe(false)
 	})
 

--- a/src/store/sidebarStore.spec.js
+++ b/src/store/sidebarStore.spec.js
@@ -20,7 +20,7 @@ describe('sidebarStore', () => {
 	})
 
 	test('defaults are off', () => {
-		expect(store.getters.getSidebarStatus).toBe(true)
+		expect(store.getters.getSidebarStatus).toBe(false)
 		expect(store.getters.isRenamingConversation).toBe(false)
 	})
 


### PR DESCRIPTION
- [x] Display conversation avatar, name and description;
- [x] Open conversation settings on click;
- [x] Default with sidebar closed now that the conversation info is displayed (cc @nickvergessen);  

https://user-images.githubusercontent.com/26852655/117680564-32837f00-b1a9-11eb-9e8f-40bd4f1aabed.mp4

