### PR TITLE
Output jest coverage to console

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run jest
-        run: npm run test:unit
+        run: npm run test:coverage

--- a/jest.config.js
+++ b/jest.config.js
@@ -30,6 +30,9 @@ module.exports = {
 		'<rootDir>/src/test-setup.js',
 		'jest-mock-console/dist/setupTestFramework.js',
 	],
+	collectCoverageFrom: [
+		'<rootDir>/src/**/*.{js,vue}',
+	],
 	transform: {
 		// process `*.js` files with `babel-jest`
 		'.*\\.(js)$': 'babel-jest',

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"scripts": {
 		"build": "NODE_ENV=production webpack --progress --config webpack.prod.js",
 		"test:unit": "TZ=UTC vue-cli-service test:unit",
+		"test:coverage": "TZ=UTC vue-cli-service test:unit --coverage",
 		"test:watch": "TZ=UTC vue-cli-service test:unit --watchAll",
 		"lint": "eslint --ext .js,.vue src",
 		"dev": "NODE_ENV=development webpack --config webpack.dev.js",


### PR DESCRIPTION
Add config option for Jest to scan all source files when reporting
coverage.

Note: this will only output coverage info on the build log. Can be useful if we want to have a quick look.
There is no connection to any coverage tool (if we want it, to be discussed separately).