### PR TITLE
Fix guests without a name in system messages

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -536,6 +536,9 @@ class SystemMessage {
 		try {
 			$participant = $room->getParticipantByActor(Attendee::ACTOR_GUESTS, $actorId, false);
 			$name = $participant->getAttendee()->getDisplayName();
+			if ($name === '') {
+				return $this->l->t('Guest');
+			}
 			return $this->l->t('%s (guest)', [$name]);
 		} catch (ParticipantNotFoundException $e) {
 			return $this->l->t('Guest');


### PR DESCRIPTION
Before | After
---|---
![Bildschirmfoto von 2021-05-11 14-30-47](https://user-images.githubusercontent.com/213943/117815301-9d928b80-b265-11eb-8a5e-dde58acbe214.png) | ![Bildschirmfoto von 2021-05-11 14-28-55](https://user-images.githubusercontent.com/213943/117815309-9ec3b880-b265-11eb-8684-19a77e8de4ca.png)

