### PR TITLE
Remove service dependencies in Conversation component

### DIFF
--- a/src/components/ConversationSettings/DangerZone.vue
+++ b/src/components/ConversationSettings/DangerZone.vue
@@ -37,9 +37,7 @@
 </template>
 
 <script>
-import { removeCurrentUserFromConversation } from '../../services/participantsService'
 import { showError } from '@nextcloud/dialogs'
-import { deleteConversation } from '../../services/conversationsService'
 import { emit } from '@nextcloud/event-bus'
 
 export default {
@@ -78,9 +76,7 @@ export default {
 		 */
 		async leaveConversation() {
 			try {
-				await removeCurrentUserFromConversation(this.token)
-				// If successful, deletes the conversation from the store
-				this.$store.dispatch('deleteConversation', this.conversation)
+				await this.$store.dispatch('removeCurrentUserFromConversation', { token: this.token })
 				this.hideConversationSettings()
 			} catch (error) {
 				if (error?.response?.status === 400) {
@@ -109,9 +105,7 @@ export default {
 					}
 
 					try {
-						await deleteConversation(this.token)
-						// If successful, deletes the conversation from the store
-						this.$store.dispatch('deleteConversation', this.conversation)
+						await this.$store.dispatch('deleteConversationFromServer', { token: this.token })
 						// Close the settings
 						this.hideConversationSettings()
 					} catch (error) {

--- a/src/components/ConversationSettings/NotificationsSettings.vue
+++ b/src/components/ConversationSettings/NotificationsSettings.vue
@@ -90,7 +90,6 @@
 
 <script>
 import { PARTICIPANT } from '../../constants'
-import { setNotificationLevel } from '../../services/conversationsService'
 import VolumeHigh from 'vue-material-design-icons/VolumeHigh'
 import Account from 'vue-material-design-icons/Account'
 import VolumeOff from 'vue-material-design-icons/VolumeOff'
@@ -137,9 +136,7 @@ export default {
 		 * @param {int} notificationLevel The notification level to set.
 		 */
 		async setNotificationLevel(notificationLevel) {
-			const token = this.token
-			await setNotificationLevel(token, notificationLevel)
-			this.$store.dispatch('changeNotificationLevel', { token, notificationLevel })
+			await this.$store.dispatch('setNotificationLevel', { token: this.token, notificationLevel })
 		},
 	},
 }

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -113,11 +113,6 @@ import ActionText from '@nextcloud/vue/dist/Components/ActionText'
 import AppContentListItem from './AppContentListItem/AppContentListItem'
 import AppNavigationCounter from '@nextcloud/vue/dist/Components/AppNavigationCounter'
 import ConversationIcon from './../../ConversationIcon'
-import { removeCurrentUserFromConversation } from '../../../services/participantsService'
-import {
-	deleteConversation,
-	setNotificationLevel,
-} from '../../../services/conversationsService'
 import { generateUrl } from '@nextcloud/router'
 import { CONVERSATION, PARTICIPANT } from '../../../constants'
 
@@ -350,9 +345,7 @@ export default {
 					}
 
 					try {
-						await deleteConversation(this.item.token)
-						// If successful, deletes the conversation from the store
-						this.$store.dispatch('deleteConversation', this.item.token)
+						await this.$store.dispatch('deleteConversationFromServer', { token: this.item.token })
 					} catch (error) {
 						console.debug(`error while deleting conversation ${error}`)
 						showError(t('spreed', 'Error while deleting conversation'))
@@ -366,9 +359,7 @@ export default {
 		 */
 		async leaveConversation() {
 			try {
-				await removeCurrentUserFromConversation(this.item.token)
-				// If successful, deletes the conversation from the store
-				this.$store.dispatch('deleteConversation', this.item.token)
+				await this.$store.dispatch('removeCurrentUserFromConversation', { token: this.item.token })
 			} catch (error) {
 				if (error?.response?.status === 400) {
 					showError(t('spreed', 'You need to promote a new moderator before you can leave the conversation.'))
@@ -386,8 +377,7 @@ export default {
 		 * @param {int} level The notification level to set.
 		 */
 		async setNotificationLevel(level) {
-			await setNotificationLevel(this.item.token, level)
-			this.item.notificationLevel = level
+			await this.$store.dispatch('setNotificationLevel', { token: this.item.token, notificationLevel: level })
 		},
 
 		// forward click event

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -33,7 +33,10 @@ import {
 	fetchConversations,
 	fetchConversation,
 	setConversationName,
-	setConversationDescription } from '../services/conversationsService'
+	setConversationDescription,
+	deleteConversation,
+	setNotificationLevel,
+} from '../services/conversationsService'
 import { getCurrentUser } from '@nextcloud/auth'
 import { CONVERSATION, WEBINAR, PARTICIPANT } from '../constants'
 
@@ -118,7 +121,7 @@ const mutations = {
 		Vue.set(state.conversations[token], 'lastMessage', lastMessage)
 	},
 
-	changeNotificationLevel(state, { token, notificationLevel }) {
+	setNotificationLevel(state, { token, notificationLevel }) {
 		Vue.set(state.conversations[token], 'notificationLevel', notificationLevel)
 	},
 }
@@ -167,8 +170,21 @@ const actions = {
 	 * @param {object} token the token of the conversation to be deleted;
 	 */
 	deleteConversation(context, token) {
+		// FIXME: rename to deleteConversationsFromStore or a better name
 		context.dispatch('deleteMessages', token)
 		context.commit('deleteConversation', token)
+	},
+
+	/**
+	 * Delete a conversation from the server.
+	 *
+	 * @param {object} context default store context;
+	 * @param {object} token the token of the conversation to be deleted;
+	 */
+	async deleteConversationFromServer(context, { token }) {
+		await deleteConversation(token)
+		// upon success, also delete from store
+		await context.dispatch('deleteConversation', token)
 	},
 
 	/**
@@ -384,8 +400,10 @@ const actions = {
 		}
 	},
 
-	changeNotificationLevel({ commit }, { token, notificationLevel }) {
-		commit('changeNotificationLevel', { token, notificationLevel })
+	async setNotificationLevel({ commit }, { token, notificationLevel }) {
+		await setNotificationLevel(token, notificationLevel)
+
+		commit('setNotificationLevel', { token, notificationLevel })
 	},
 
 	/**

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -27,6 +27,7 @@ import {
 	resendInvitations,
 	joinConversation,
 	leaveConversation,
+	removeCurrentUserFromConversation,
 } from '../services/participantsService'
 import {
 	generateUrl,
@@ -365,6 +366,12 @@ const actions = {
 		await resendInvitations(token, { attendeeId })
 	},
 
+	/**
+	 * Makes the current user active in the given conversation.
+	 *
+	 * @param {Object} context unused
+	 * @param {string} token conversation token
+	 */
 	async joinConversation(context, { token }) {
 		const forceJoin = SessionStorage.getItem('joined_conversation') === token
 
@@ -447,8 +454,27 @@ const actions = {
 		await context.dispatch('joinConversation', { token })
 	},
 
+	/**
+	 * Makes the current user inactive in the given conversation.
+	 *
+	 * @param {Object} context unused
+	 * @param {string} token conversation token
+	 */
 	async leaveConversation(context, { token }) {
 		await leaveConversation(token)
+	},
+
+	/**
+	 * Removes the current user from the conversation, which
+	 * means the user is not a participant any more.
+	 *
+	 * @param {Object} context unused
+	 * @param {string} token conversation token
+	 */
+	async removeCurrentUserFromConversation(context, { token }) {
+		await removeCurrentUserFromConversation(token)
+		// If successful, deletes the conversation from the store
+		await context.dispatch('deleteConversation', token)
 	},
 }
 

--- a/src/store/participantsStore.spec.js
+++ b/src/store/participantsStore.spec.js
@@ -10,6 +10,7 @@ import {
 	resendInvitations,
 	joinConversation,
 	leaveConversation,
+	removeCurrentUserFromConversation,
 } from '../services/participantsService'
 import {
 	joinCall,
@@ -26,6 +27,7 @@ jest.mock('../services/participantsService', () => ({
 	resendInvitations: jest.fn(),
 	joinConversation: jest.fn(),
 	leaveConversation: jest.fn(),
+	removeCurrentUserFromConversation: jest.fn(),
 }))
 jest.mock('../services/callsService', () => ({
 	joinCall: jest.fn(),
@@ -635,5 +637,18 @@ describe('participantsStore', () => {
 		await store.dispatch('leaveConversation', { token: TOKEN })
 
 		expect(leaveConversation).toHaveBeenCalledWith(TOKEN)
+	})
+
+	test('removes current user from conversation', async() => {
+		removeCurrentUserFromConversation.mockResolvedValue()
+
+		testStoreConfig = cloneDeep(participantsStore)
+		testStoreConfig.actions.deleteConversation = jest.fn()
+		store = new Vuex.Store(testStoreConfig)
+
+		await store.dispatch('removeCurrentUserFromConversation', { token: TOKEN })
+
+		expect(removeCurrentUserFromConversation).toHaveBeenCalledWith(TOKEN)
+		expect(testStoreConfig.actions.deleteConversation).toHaveBeenCalledWith(expect.anything(), TOKEN)
 	})
 })


### PR DESCRIPTION
Move "removeCurrentUserFromConversation" to the participant store.
Move "setNotificationLevel" and "deleteConversation" to the conversations store.
Adjust usages accordingly to use the store instead of the services directly.

This will make it possible to mock these new store actions in https://github.com/nextcloud/spreed/pull/5599

### Manual tests

- [x] TEST: delete from left sidebar then refresh page
- [x] TEST: delete from conversations settings then refresh page
- [x] TEST: leave conversation from sidebar then refresh page
- [x] TEST: leave conversation from sidebar with "please set a moderator" warning
- [x] TEST: leave conversation from conversations settings then refresh page
- [x] TEST: leave conversation from conversations settings with "please set a moderator" warning
- [x] TEST: set notification from sidebar then refresh page
- [x] TEST: set notification from conversations settings then refresh page