### PR TITLE
Allow to specify meta-data for sharing

### DIFF
--- a/docs/chat.md
+++ b/docs/chat.md
@@ -131,6 +131,28 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
     - Data:
         The full message array of the new message, as defined in [Receive chat messages of a conversation](#receive-chat-messages-of-a-conversation)
 
+## Share a file to the chat
+
+* Method: `POST`
+* Endpoint: `ocs/v2.php/apps/files_sharing/api/v1/shares`
+* Data:
+
+    field | type | Description
+    ---|---|---
+    `shareType` | int | `10` means share to a conversation
+    `shareWith` | string | The token of the conversation to share the file to
+    `path` | string | The file path inside the user's root to share
+    `referenceId` | string | A reference string to be able to identify the generated chat message again in a "get messages" request, should be a random sha256 (only available with `chat-reference-id` capability)
+    `talkMetaData` | string | JSON encoded array of the meta data
+
+* `talkMetaData` array:
+
+    field | type | Description
+    ---|---|---
+    `messageType` | string | A message type to show the message in different styles. Currently known: `voice-message` and `comment`
+
+* Response: [See official OCS Share API docs](https://docs.nextcloud.com/server/latest/developer_manual/client_apis/OCS/ocs-share-api.html?highlight=sharing#create-a-new-share)
+
 ## Deleting a chat message
 
 * Required capability: `delete-messages`

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -308,7 +308,10 @@ class Listener {
 			$manager = \OC::$server->query(Manager::class);
 
 			$room = $manager->getRoomByToken($share->getSharedWith());
-			$listener->sendSystemMessage($room, 'file_shared', ['share' => $share->getId()]);
+			$metaData = \OC::$server->getRequest()->getParam('talkMetaData') ?? '';
+			$metaData = json_decode($metaData, true);
+			$metaData = is_array($metaData) ? $metaData : [];
+			$listener->sendSystemMessage($room, 'file_shared', ['share' => $share->getId(), 'metaData' => $metaData]);
 		};
 		/**
 		 * @psalm-suppress UndefinedClass

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -29,7 +29,7 @@
       <code>$this-&gt;rootFolder</code>
       <code>IRootFolder</code>
       <code>IRootFolder</code>
-      <code>\OCP\Share\Exceptions\ShareNotFound</code>
+      <code>ShareNotFound</code>
     </MissingDependency>
     <UndefinedClass occurrences="1">
       <code>\OC_Util</code>
@@ -203,9 +203,6 @@
       <code>IRootFolder</code>
       <code>IRootFolder</code>
     </MissingDependency>
-    <UndefinedClass occurrences="1">
-      <code>SharedStorage</code>
-    </UndefinedClass>
   </file>
   <file src="lib/Controller/SignalingController.php">
     <UndefinedClass occurrences="1">
@@ -237,9 +234,6 @@
       <code>ShareNotFound</code>
       <code>ShareNotFound</code>
     </MissingDependency>
-    <UndefinedClass occurrences="1">
-      <code>GroupFolderStorage</code>
-    </UndefinedClass>
   </file>
   <file src="lib/Flow/Operation.php">
     <InvalidArgument occurrences="1"/>


### PR DESCRIPTION
- [x] Store `meta-data=voice-message` when a share is "turned into a chat message"
- [x] Make the messageType of the message `voice-message` on rendering
- [x] Update documentation for both cases

Ref #1576 