### PR TITLE
Remove leftover routeChange handlers

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -95,7 +95,6 @@ import isInLobby from '../../mixins/isInLobby'
 import SetGuestUsername from '../SetGuestUsername'
 import SipSettings from './SipSettings'
 import LobbyStatus from './LobbyStatus'
-import { EventBus } from '../../services/EventBus'
 
 export default {
 	name: 'RightSidebar',
@@ -213,14 +212,6 @@ export default {
 				this.conversationName = this.conversation.displayName
 			}
 		},
-	},
-
-	mounted() {
-		EventBus.$on('routeChange', this.handleRouteChange)
-	},
-
-	beforeDestroy() {
-		EventBus.$off('routeChange', this.handleRouteChange)
 	},
 
 	methods: {


### PR DESCRIPTION
Fixes a JS error due to missing handlers.

This was missing from https://github.com/nextcloud/spreed/pull/5605

Fixes https://github.com/nextcloud/spreed/issues/5631
