### PR TITLE
Remove unused userId in Participant component

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -378,12 +378,6 @@ export default {
 		},
 
 		isSelf() {
-			// User
-			if (this.userId) {
-				return this.$store.getters.getUserId() === this.userId
-			}
-
-			// Guest
 			return this.sessionIds.length && this.sessionIds.indexOf(this.currentParticipant.sessionId) >= 0
 		},
 		selfIsModerator() {


### PR DESCRIPTION
The method isSelf is relying on this.userId which never exists.
However, the method still works because of the session id array check
which works both for guests and logged in users.

Found while working on JS tests in #5637 

An alternative fix could be to use `this.currentParticipant.actorId` instead of `this.userId` but I'm not sure if it's really better and would cause other side effects.

Tests (done with some extra logging):
- [x] TEST: regular user with single session, self is detected properly (no actions shown)
- [x] TEST: regular user with two sessions, self is detected properly (no actions shown in both windows)
- [x] TEST: guest user, self is detected properly (no actions shown)