### PR TITLE
Add Message.vue test for passing in geo-location object

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
@@ -11,6 +11,7 @@ import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import Mention from './MessagePart/Mention'
 import FilePreview from './MessagePart/FilePreview'
 import DeckCard from './MessagePart/DeckCard'
+import Location from './MessagePart/Location'
 import DefaultParameter from './MessagePart/DefaultParameter'
 
 import Message from './Message'
@@ -369,6 +370,24 @@ describe('Message.vue', () => {
 						'deck-card': {
 							component: DeckCard,
 							props: params['deck-card'],
+						},
+					}
+				)
+			})
+
+			test('renders geo locations', () => {
+				const params = {
+					'geo-location': {
+						metadata: '{id:123}',
+						type: 'geo-location',
+					},
+				}
+				renderRichObject(
+					'{geo-location}',
+					params, {
+						'geo-location': {
+							component: Location,
+							props: params['geo-location'],
 						},
 					}
 				)


### PR DESCRIPTION
Note: the metadata is not important in the test, only the fact that we correctly pass it in and associate with a `Location` component.