### PR TITLE
Do not add tracks for receiver only peers

### DIFF
--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -62,26 +62,28 @@ function Peer(options) {
 	this.pc.addEventListener('signalingstatechange', this.emit.bind(this, 'signalingStateChange'))
 	this.logger = this.parent.logger
 
-	// handle screensharing/broadcast mode
-	if (options.type === 'screen') {
-		if (this.parent.localScreen && this.sharemyscreen) {
-			this.logger.log('adding local screen stream to peer connection')
-			this.pc.addStream(this.parent.localScreen)
-			this.broadcaster = options.broadcaster
-		}
-	} else {
-		this.parent.localStreams.forEach(function(stream) {
-			stream.getTracks().forEach(function(track) {
-				if (track.kind !== 'video' || self.sendVideoIfAvailable) {
-					self.pc.addTrack(track, stream)
-				}
+	if (!options.receiverOnly) {
+		// handle screensharing/broadcast mode
+		if (options.type === 'screen') {
+			if (this.parent.localScreen && this.sharemyscreen) {
+				this.logger.log('adding local screen stream to peer connection')
+				this.pc.addStream(this.parent.localScreen)
+				this.broadcaster = options.broadcaster
+			}
+		} else {
+			this.parent.localStreams.forEach(function(stream) {
+				stream.getTracks().forEach(function(track) {
+					if (track.kind !== 'video' || self.sendVideoIfAvailable) {
+						self.pc.addTrack(track, stream)
+					}
+				})
 			})
-		})
 
-		this.handleLocalTrackReplacedBound = this.handleLocalTrackReplaced.bind(this)
-		// TODO What would happen if the track is replaced while the peer is
-		// still negotiating the offer and answer?
-		this.parent.on('localTrackReplaced', this.handleLocalTrackReplacedBound)
+			this.handleLocalTrackReplacedBound = this.handleLocalTrackReplaced.bind(this)
+			// TODO What would happen if the track is replaced while the peer is
+			// still negotiating the offer and answer?
+			this.parent.on('localTrackReplaced', this.handleLocalTrackReplacedBound)
+		}
 	}
 
 	// proxy events to parent

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -104,6 +104,7 @@ function SimpleWebRTC(opts) {
 					sharemyscreen: message.roomType === 'screen' && !message.broadcaster,
 					broadcaster: message.roomType === 'screen' && !message.broadcaster ? self.connection.getSessionId() : null,
 					sendVideoIfAvailable: self.connection.getSendVideoIfAvailable(),
+					receiverOnly: self.connection.hasFeature('mcu'),
 				})
 				self.emit('createdPeer', peer)
 			}


### PR DESCRIPTION
When the HPB is used the peer connections for the other participants only receive the media, but do not send any on them (the data is sent on a single dedicated sending peer). Therefore there is no need to add tracks to those peers, nor listen to changes in the local tracks to update them.

The "broadcaster" property was already set before only on sending peers, so nothing is changed in that regard either.

Note that this should not change anything performance wise, as the browser is expected to be clever enough to do nothing with the streams if the peer is not sending them. But you never know :-P