### PR TITLE
Stop sent streams when media is disabled

### DIFF
--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -634,8 +634,8 @@ LocalMedia.prototype.resume = function() {
 LocalMedia.prototype._setAudioEnabled = function(bool) {
 	this._audioEnabled = bool
 
-	this.localStreams.forEach(function(stream) {
-		stream.getAudioTracks().forEach(function(track) {
+	this.localStreams.forEach(stream => {
+		stream.getAudioTracks().forEach(track => {
 			track.enabled = !!bool
 		})
 	})
@@ -643,8 +643,8 @@ LocalMedia.prototype._setAudioEnabled = function(bool) {
 LocalMedia.prototype._setVideoEnabled = function(bool) {
 	this._videoEnabled = bool
 
-	this.localStreams.forEach(function(stream) {
-		stream.getVideoTracks().forEach(function(track) {
+	this.localStreams.forEach(stream => {
+		stream.getVideoTracks().forEach(track => {
 			track.enabled = !!bool
 		})
 	})

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -637,6 +637,10 @@ LocalMedia.prototype._setAudioEnabled = function(bool) {
 	this.localStreams.forEach(stream => {
 		stream.getAudioTracks().forEach(track => {
 			track.enabled = !!bool
+
+			// MediaStreamTrack does not emit an event when the enabled property
+			// changes, so it needs to be explicitly notified.
+			this.emit('localTrackEnabledChanged', track, stream)
 		})
 	})
 }
@@ -646,6 +650,10 @@ LocalMedia.prototype._setVideoEnabled = function(bool) {
 	this.localStreams.forEach(stream => {
 		stream.getVideoTracks().forEach(track => {
 			track.enabled = !!bool
+
+			// MediaStreamTrack does not emit an event when the enabled property
+			// changes, so it needs to be explicitly notified.
+			this.emit('localTrackEnabledChanged', track, stream)
 		})
 	})
 }

--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -50,7 +50,7 @@ function Peer(options) {
 	this.pc.addEventListener('negotiationneeded', this.emit.bind(this, 'negotiationNeeded'))
 	this.pc.addEventListener('iceconnectionstatechange', this.emit.bind(this, 'iceConnectionStateChange'))
 	this.pc.addEventListener('iceconnectionstatechange', function() {
-		if (self.pc.iceConnectionState !== 'new') {
+		if (!options.receiverOnly && self.pc.iceConnectionState !== 'new') {
 			self._processPendingReplaceTracks().then(finished => {
 				if (finished === false || self._initialStreamSetup) {
 					return


### PR DESCRIPTION
Requires #5659 (actually it does not require it, but touches same code)

When the media is disabled now the sent track for the device is replaced by a null track. As it just replaces a track no reconnection is needed, and the previous connection is kept open, although without sending data.

At least, in theory. In practice this does not make any difference in Firefox, as Firefox automatically stops the streams as much as possible when the device is disabled. Unfortunately even without audio and video tracks if the connection is open Firefox still uses around ~5 KB/s (apparently depends on the video resolution).

On the other hand, Chromium seems to properly stop the data stream, as the bandwidth is now reduced from ~8 KB/s to ~300 B/s when both audio and video are disabled. Thus in a 30 minutes call with 20 participants (all with Chromium and with video but disabled) the received data for each participant would be ~280 MB lower (thus ~5,6 GB overall).

Although initially the idea was to stop only video streams it seems that, as the connection is kept open, stopping and starting the audio stream is fast enough to not cause any interruption when re-enabling it. Due to this both audio and video sent streams are stopped when their media is disabled.

What I still find I little unsettling is that Chromium does not automatically stop the streams when media is disabled, so maybe there is a good reason to not do it... But at least in my tests everything worked as expected :shrug:

Please note that I only tested with Firefox and Chromium. Tests with Safari and also with mobile apps as receivers are very much welcome.

Pending:
- [X] Fix switching devices (as the previous track is not found in the senders, which causes a new track to be added, this needs a renegotiation and ends in a reconnection)
