### PR TITLE
Fix switching devices during a call if started without audio nor video

### DIFF
--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -144,6 +144,10 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 		webrtcIndex.mediaDevicesManager.disableDeviceEvents()
 	}
 
+	// The handlers for "change:audioInputId" and "change:videoInputId" events
+	// expect the initial "getUserMedia" call to have been completed before
+	// being used, so they must be set when the promise is resolved or rejected.
+
 	webrtcIndex.mediaDevicesManager.getUserMedia(constraints).then(function(stream) {
 		// Although the promise should be resolved only if all the constraints
 		// are met Edge resolves it if both audio and video are requested but
@@ -196,6 +200,9 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 		}
 
 		self.emit('localStreamRequestFailed', constraints)
+
+		webrtcIndex.mediaDevicesManager.on('change:audioInputId', self._handleAudioInputIdChangedBound)
+		webrtcIndex.mediaDevicesManager.on('change:videoInputId', self._handleVideoInputIdChangedBound)
 
 		if (cb) {
 			return cb(err, null)
@@ -484,10 +491,8 @@ LocalMedia.prototype.stop = function(stream) {
 	this.stopStream(stream)
 	this.stopScreenShare(stream)
 
-	if (!this.localStreams.length) {
-		webrtcIndex.mediaDevicesManager.off('change:audioInputId', this._handleAudioInputIdChangedBound)
-		webrtcIndex.mediaDevicesManager.off('change:videoInputId', this._handleVideoInputIdChangedBound)
-	}
+	webrtcIndex.mediaDevicesManager.off('change:audioInputId', this._handleAudioInputIdChangedBound)
+	webrtcIndex.mediaDevicesManager.off('change:videoInputId', this._handleVideoInputIdChangedBound)
 }
 
 LocalMedia.prototype.stopStream = function(stream) {

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -191,8 +191,8 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 		}
 	}).catch(function(err) {
 		// Fallback for users without a camera or with a camera that can not be
-		// accessed.
-		if (self.config.audioFallback && constraints.video !== false) {
+		// accessed, but only if audio is meant to be used.
+		if (constraints.audio !== false && self.config.audioFallback && constraints.video !== false) {
 			self.emit('localStreamRequestFailedRetryNoVideo', constraints, err)
 			constraints.video = false
 			self.start(constraints, cb, 'retry-no-video')

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -988,6 +988,12 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 
 		clearLocalStreamRequestedTimeoutAndHideNotification()
 
+		if (error.name === 'TypeError') {
+			// Both audio and video were explicitly disabled, no need to show an
+			// error.
+			return
+		}
+
 		let message
 		let timeout = TOAST_PERMANENT_TIMEOUT
 		if ((error.name === 'NotSupportedError'

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -49,6 +49,7 @@ let callParticipantCollection = null
 let localCallParticipantModel = null
 let showedTURNWarning = false
 let sendCurrentStateWithRepetitionTimeout = null
+let startedWithMedia
 
 function arrayDiff(a, b) {
 	return a.filter(function(i) {
@@ -552,6 +553,8 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 	})
 
 	webrtc.startMedia = function(token) {
+		startedWithMedia = undefined
+
 		webrtc.joinCall(token)
 	}
 
@@ -872,6 +875,8 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 		// reconnection is forced to start sending it.
 		signaling.setSendVideoIfAvailable(true)
 
+		startedWithMedia = true
+
 		let flags = signaling.getCurrentCallFlags()
 		flags |= PARTICIPANT.CALL_FLAG.WITH_VIDEO
 
@@ -937,8 +942,37 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 		}
 	})
 
+	webrtc.on('localTrackReplaced', function(newTrack /*, oldTrack, stream */) {
+		// Device disabled, nothing to do here.
+		if (!newTrack) {
+			return
+		}
+
+		// If the call was started with media the connections will be already
+		// established. If it has not started yet the connections will be
+		// established once started.
+		if (startedWithMedia || startedWithMedia === undefined) {
+			return
+		}
+
+		// If the call was originally started without media the participant
+		// needs to reconnect to establish the sender connections.
+		startedWithMedia = true
+
+		let flags = signaling.getCurrentCallFlags()
+		if (newTrack.kind === 'audio') {
+			flags |= PARTICIPANT.CALL_FLAG.WITH_AUDIO
+		} else if (newTrack.kind === 'video') {
+			flags |= PARTICIPANT.CALL_FLAG.WITH_VIDEO
+		}
+
+		forceReconnect(signaling, flags)
+	})
+
 	webrtc.on('localMediaStarted', function(/* configuration */) {
 		console.info('localMediaStarted')
+
+		startedWithMedia = true
 
 		clearLocalStreamRequestedTimeoutAndHideNotification()
 
@@ -949,6 +983,8 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 
 	webrtc.on('localMediaError', function(error) {
 		console.warn('Access to microphone & camera failed', error)
+
+		startedWithMedia = false
 
 		clearLocalStreamRequestedTimeoutAndHideNotification()
 


### PR DESCRIPTION
Forced reconnections, which are needed to start sending audio or video if the call was joined without audio or video, do not always work if the HPB is not used. This is unrelated to this pull request and it will be addressed separately.

## How to test (scenario 1)
- Open Talk settings
- Disable both audio and video
- Join a call

### Result with this pull request

No error is shown, as both devices were explicitly disabled

### Result without this pull request

An error about not being able to access microphone nor camera is shown

## How to test (scenario 2)
- Open Talk settings
- Disable both audio and video
- Join a call
- Open Talk settings
- Select audio and/or video devices

### Result with this pull request

In the local video the audio and video buttons are enabled. Clicking on them enables audio and/or video (which requires a reconnection)

### Result without this pull request

In the local video the audio and video buttons are kept disabled, so neither audio nor video can be enabled
