### PR TITLE
Show name for bridged messages

### DIFF
--- a/docs/constants.md
+++ b/docs/constants.md
@@ -67,6 +67,7 @@ title: Constants
 * `users` - Logged-in users
 * `guests` - Guest users (attendee type `guests` and `emails`)
 * `bots` - Used by commands (actor-id is the used `/command`) and the changelog conversation (actor-id is `changelog`)
+* `bridged` - Users whose messages are bridged in by the [Matterbridge integration](matterbridge.md)
 
 ## Signaling modes
 * `internal` No external signaling server is used

--- a/lib/Chat/MessageParser.php
+++ b/lib/Chat/MessageParser.php
@@ -26,6 +26,7 @@ namespace OCA\Talk\Chat;
 
 use OCA\Talk\Events\ChatMessageEvent;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
+use OCA\Talk\MatterbridgeManager;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\Message;
 use OCA\Talk\Participant;
@@ -73,12 +74,14 @@ class MessageParser {
 	protected function setActor(Message $message): void {
 		$comment = $message->getComment();
 
+		$actorId = $comment->getActorId();
 		$displayName = '';
 		if ($comment->getActorType() === Attendee::ACTOR_USERS) {
 			$user = $this->userManager->get($comment->getActorId());
 			$displayName = $user instanceof IUser ? $user->getDisplayName() : $comment->getActorId();
 		} elseif ($comment->getActorType() === Attendee::ACTOR_BRIDGED) {
 			$displayName = $comment->getActorId();
+			$actorId = MatterbridgeManager::BRIDGE_BOT_USERID;
 		} elseif ($comment->getActorType() === Attendee::ACTOR_GUESTS) {
 			if (isset($guestNames[$comment->getActorId()])) {
 				$displayName = $this->guestNames[$comment->getActorId()];
@@ -96,7 +99,7 @@ class MessageParser {
 
 		$message->setActor(
 			$comment->getActorType(),
-			$comment->getActorId(),
+			$actorId,
 			$displayName
 		);
 	}

--- a/lib/Chat/MessageParser.php
+++ b/lib/Chat/MessageParser.php
@@ -77,6 +77,8 @@ class MessageParser {
 		if ($comment->getActorType() === Attendee::ACTOR_USERS) {
 			$user = $this->userManager->get($comment->getActorId());
 			$displayName = $user instanceof IUser ? $user->getDisplayName() : $comment->getActorId();
+		} elseif ($comment->getActorType() === Attendee::ACTOR_BRIDGED) {
+			$displayName = $comment->getActorId();
 		} elseif ($comment->getActorType() === Attendee::ACTOR_GUESTS) {
 			if (isset($guestNames[$comment->getActorId()])) {
 				$displayName = $this->guestNames[$comment->getActorId()];

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -160,7 +160,7 @@ class ChatController extends AEnvironmentAwareController {
 			if ($actorDisplayName) {
 				$this->guestManager->updateName($this->room, $this->participant, $actorDisplayName);
 			}
-		} elseif ($this->userId === MatterbridgeManager::BRIDGE_BOT_USERID) {
+		} elseif ($this->userId === MatterbridgeManager::BRIDGE_BOT_USERID && $actorDisplayName) {
 			$actorType = Attendee::ACTOR_BRIDGED;
 			$actorId = str_replace(["/", "\""], "", $actorDisplayName);
 		} else {

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -160,7 +160,7 @@ class ChatController extends AEnvironmentAwareController {
 			if ($actorDisplayName) {
 				$this->guestManager->updateName($this->room, $this->participant, $actorDisplayName);
 			}
-		} else if ($this->userId === MatterbridgeManager::BRIDGE_BOT_USERID) {
+		} elseif ($this->userId === MatterbridgeManager::BRIDGE_BOT_USERID) {
 			$actorType = Attendee::ACTOR_BRIDGED;
 			$actorId = str_replace(["/", "\""], "", $actorDisplayName);
 		} else {

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -556,6 +556,9 @@ class ChatController extends AEnvironmentAwareController {
 		$attendee = $this->participant->getAttendee();
 		$isOwnMessage = $message->getActorType() === $attendee->getActorType()
 			&& $message->getActorId() === $attendee->getActorId();
+
+		// Special case for if the message is a bridged message, then the message is the bridge bot's message.
+		$isOwnMessage = $isOwnMessage || ($message->getActorType() === Attendee::ACTOR_BRIDGED && $attendee->getActorId() === MatterbridgeManager::BRIDGE_BOT_USERID);
 		if (!$isOwnMessage
 			&& (!$this->participant->hasModeratorPermissions(false)
 				|| $this->room->getType() === Room::ONE_TO_ONE_CALL)) {

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -160,6 +160,9 @@ class ChatController extends AEnvironmentAwareController {
 			if ($actorDisplayName) {
 				$this->guestManager->updateName($this->room, $this->participant, $actorDisplayName);
 			}
+		} else if ($this->userId === MatterbridgeManager::BRIDGE_BOT_USERID) {
+			$actorType = Attendee::ACTOR_BRIDGED;
+			$actorId = str_replace(["/", "\""], "", $actorDisplayName);
 		} else {
 			$actorType = Attendee::ACTOR_USERS;
 			$actorId = $this->userId;

--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -395,7 +395,7 @@ class MatterbridgeManager {
 				$content .= sprintf('	Login = "%s"', $part['login']) . "\n";
 				$content .= sprintf('	Password = "%s"', $part['password']) . "\n";
 				$content .= '	PrefixMessagesWithNick = true' . "\n";
-				$content .= '	RemoteNickFormat="[{PROTOCOL}] <{NICK}>"' . "\n\n";
+				$content .= '	RemoteNickFormat="[{PROTOCOL}] <{NICK}> "' . "\n\n";
 			} elseif ($type === 'mattermost') {
 				// remove protocol from server URL
 				if (preg_match('/^https?:/', $part['server'])) {

--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -387,6 +387,7 @@ class MatterbridgeManager {
 					$serverUrl = $part['server'];
 				} else {
 					$serverUrl = preg_replace('/\/+$/', '', $this->urlGenerator->getAbsoluteURL(''));
+					$content .= "	SeparateDisplayName = true" ."\n";
 					// TODO remove that
 					//$serverUrl = preg_replace('/https:/', 'http:', $serverUrl);
 				}
@@ -394,7 +395,7 @@ class MatterbridgeManager {
 				$content .= sprintf('	Login = "%s"', $part['login']) . "\n";
 				$content .= sprintf('	Password = "%s"', $part['password']) . "\n";
 				$content .= '	PrefixMessagesWithNick = true' . "\n";
-				$content .= '	RemoteNickFormat="[{PROTOCOL}] <{NICK}> "' . "\n\n";
+				$content .= '	RemoteNickFormat="[{PROTOCOL}] <{NICK}>"' . "\n\n";
 			} elseif ($type === 'mattermost') {
 				// remove protocol from server URL
 				if (preg_match('/^https?:/', $part['server'])) {

--- a/lib/Model/Attendee.php
+++ b/lib/Model/Attendee.php
@@ -58,6 +58,7 @@ class Attendee extends Entity {
 	public const ACTOR_GUESTS = 'guests';
 	public const ACTOR_EMAILS = 'emails';
 	public const ACTOR_CIRCLES = 'circles';
+	public const ACTOR_BRIDGED = 'bridged';
 
 	public const PUBLISHING_PERMISSIONS_NONE = 0;
 	public const PUBLISHING_PERMISSIONS_AUDIO = 1;

--- a/src/components/MessagesList/MessagesGroup/AuthorAvatar.vue
+++ b/src/components/MessagesList/MessagesGroup/AuthorAvatar.vue
@@ -47,6 +47,7 @@
 
 <script>
 import Avatar from '@nextcloud/vue/dist/Components/Avatar'
+import { ATTENDEE } from '../../../constants'
 
 export default {
 	name: 'AuthorAvatar',
@@ -73,7 +74,7 @@ export default {
 			return this.authorType === 'bots' && this.authorId === 'changelog'
 		},
 		isUser() {
-			return this.authorType === 'users'
+			return this.authorType === 'users' || this.authorType === ATTENDEE.ACTOR_TYPE.BRIDGED
 		},
 		isDeletedUser() {
 			return this.authorType === 'deleted_users'

--- a/src/components/MessagesList/MessagesGroup/AuthorAvatar.vue
+++ b/src/components/MessagesList/MessagesGroup/AuthorAvatar.vue
@@ -90,7 +90,8 @@ export default {
 
 		disableMenu() {
 			// disable the menu if accessing the conversation as guest
-			return this.$store.getters.getActorType() === 'guests'
+			// or the message sender is a bridged user
+			return this.$store.getters.getActorType() === 'guests' || this.authorType === ATTENDEE.ACTOR_TYPE.BRIDGED
 		},
 	},
 }

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -304,12 +304,14 @@ export default {
 		 * @param {string} message1.id The ID of the new message
 		 * @param {string} message1.actorType Actor type of the new message
 		 * @param {string} message1.actorId Actor id of the new message
+		 * @param {string} message1.actorDisplayName Actor displayname of the new message
 		 * @param {string} message1.systemMessage System message content of the new message
 		 * @param {int} message1.timestamp Timestamp of the new message
 		 * @param {null|object} message2 The previous message
 		 * @param {string} message2.id The ID of the second message
 		 * @param {string} message2.actorType Actor type of the previous message
 		 * @param {string} message2.actorId Actor id of the previous message
+		 * @param {string} message2.actorDisplayName Actor display name of previous message
 		 * @param {string} message2.systemMessage System message content of the previous message
 		 * @param {int} message2.timestamp Timestamp of the second message
 		 * @returns {boolean} Boolean if the messages should be grouped or not
@@ -333,8 +335,10 @@ export default {
 			}
 
 			if (!message1IsSystem // System messages are grouped independent from author
-				&& (message1.actorType !== message2.actorType // Otherwise the type and id need to match
-					|| message1.actorId !== message2.actorId)) {
+				&& ((message1.actorType !== message2.actorType // Otherwise the type and id need to match
+					|| message1.actorId !== message2.actorId)
+				|| (message1.actorType === ATTENDEE.ACTOR_TYPE.BRIDGED // Or, if the message is bridged, display names also need to match
+					&& message1.actorDisplayName !== message2.actorDisplayName))) {
 				return false
 			}
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -54,6 +54,7 @@ export const ATTENDEE = {
 		GROUPS: 'groups',
 		CIRCLES: 'circles',
 		BOTS: 'bots',
+		BRIDGED: 'bridged',
 	},
 	BRIDGE_BOT_ID: 'bridge-bot',
 	CHANGELOG_BOT_ID: 'changelog',


### PR DESCRIPTION
~~Requires https://github.com/42wim/matterbridge/pull/1506.~~ **Now merged!**

The way the current iteration works is that messages received from the `bridge-bot` user is labeled as Actor Type `bridged`. Actor Type `bridged` messages store the message author name in the Actor Id field in `oc_comments`. When serving to the frontend, this is slightly changed to put what is in Actor Id into Actor Display Name and set the Actor Id to `bridge-bot` (the reason it was done this way was to simplify the changes that would need to be made to clients).

**As far as clients have to care, the only difference is the addition of the Actor Type `bridged` and that for `bridged` messages, the Actor Display Name can be different for every message.**

### Screenshots
![Screenshot 2021-05-28 at 09-52-29 Element  20  Test Room](https://user-images.githubusercontent.com/47195730/119994435-2f88eb00-bfff-11eb-8e87-a6deb3bf7f0e.png)
![Screenshot 2021-05-28 at 09-51-48 Test 2 - Talk - Nextcloud](https://user-images.githubusercontent.com/47195730/119994439-30218180-bfff-11eb-943f-6c04cf78e094.png)
