### PR TITLE
[stable21.1] Encode dav path segments for direct preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3234,6 +3234,14 @@
 				}
 			}
 		},
+		"@nextcloud/paths": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/paths/-/paths-2.0.0.tgz",
+			"integrity": "sha512-JhrZM8Cz/X6+Q98PinkCua4W2UPROpkVFXq7S3Zzm/JmHEe6bH7zzHfK6VS7twxpXwWIkjLkH/K0MUuLpY9/8g==",
+			"requires": {
+				"core-js": "^3.6.4"
+			}
+		},
 		"@nextcloud/router": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-1.2.0.tgz",
@@ -4187,7 +4195,8 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
 					"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"find-cache-dir": {
 					"version": "3.3.1",
@@ -4470,10 +4479,11 @@
 					}
 				},
 				"vue-loader-v16": {
-					"version": "npm:vue-loader@16.1.2",
-					"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
-					"integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
+					"version": "npm:vue-loader@16.2.0",
+					"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.2.0.tgz",
+					"integrity": "sha512-TitGhqSQ61RJljMmhIGvfWzJ2zk9m1Qug049Ugml6QP3t0e95o0XJjk29roNEiPKJQBEi8Ord5hFuSuELzSp8Q==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"chalk": "^4.1.0",
 						"hash-sum": "^2.0.0",
@@ -4481,10 +4491,11 @@
 					},
 					"dependencies": {
 						"chalk": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-							"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+							"version": "4.1.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+							"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"ansi-styles": "^4.1.0",
 								"supports-color": "^7.1.0"
@@ -4494,13 +4505,15 @@
 							"version": "4.0.0",
 							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 							"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"loader-utils": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
 							"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"big.js": "^5.2.2",
 								"emojis-list": "^3.0.0",
@@ -4512,6 +4525,7 @@
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 							"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"has-flag": "^4.0.0"
 							}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"@nextcloud/initial-state": "^1.2.0",
 		"@nextcloud/l10n": "^1.4.1",
 		"@nextcloud/moment": "^1.1.1",
+		"@nextcloud/paths": "^2.0.0",
 		"@nextcloud/router": "^1.2.0",
 		"@nextcloud/vue": "^3.5.4",
 		"@nextcloud/vue-dashboard": "^1.0.1",

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -70,6 +70,7 @@ import ProgressBar from '@nextcloud/vue/dist/Components/ProgressBar'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 import Close from 'vue-material-design-icons/Close'
 import { getCapabilities } from '@nextcloud/capabilities'
+import { encodePath } from '@nextcloud/paths'
 
 const PREVIEW_TYPE = {
 	TEMPORARY: 0,
@@ -248,10 +249,10 @@ export default {
 				// return direct image
 				if (userId === null) {
 					// guest mode, use public link download URL
-					return this.link + '/download/' + this.name
+					return this.link + '/download/' + encodePath(this.name)
 				} else {
 					// use direct DAV URL
-					return generateRemoteUrl(`dav/files/${userId}`) + this.internalAbsolutePath
+					return generateRemoteUrl(`dav/files/${userId}`) + encodePath(this.internalAbsolutePath)
 				}
 			}
 


### PR DESCRIPTION
Backport of https://github.com/nextcloud/spreed/pull/5673 to stable21.1.

Conflicts solved:
- package.json + package-lock.json
- I've removed the test file