### PR TITLE
Fix raised hand handler not detached when peer is destroyed

### DIFF
--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -97,6 +97,7 @@ CallParticipantModel.prototype = {
 		this._webRtc.off('mute', this._handleMuteBound)
 		this._webRtc.off('unmute', this._handleUnmuteBound)
 		this._webRtc.off('channelMessage', this._handleChannelMessageBound)
+		this._webRtc.off('raisedHand', this._handleRaisedHandBound)
 	},
 
 	get: function(key) {


### PR DESCRIPTION
This fixes a memory leak, as the reference to the Peer object was retained forever by the webrtc object.

## How to test
- Add `console.log('Handling raised hand')` as the first line inside [`_handleRaisedHand`](https://github.com/nextcloud/spreed/blob/deb2494193a51321273070b39739e625651d40ea/src/utils/webrtc/models/CallParticipantModel.js#L250)
- Start a call
- Open the browser console
- Open the conversation in a private window (all the following steps should be done in the private window)
- Join the call
- Leave the call
- Join the call
- Leave the call
- Join the call
- Raise the hand

### Result with this pull request

In the original window a single _Handling raised hand_ message is printed in the console

### Result without this pull request

In the original window three _Handling raised hand_ messages are printed in the console
