### PR TITLE
Upload icon is now material design "attachment"

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -45,7 +45,7 @@
 						:disabled="disabled"
 						:aria-label="t('spreed', 'Share files to the conversation')"
 						:aria-haspopup="true">
-						<Attachment
+						<Paperclip
 							slot="icon"
 							:size="16"
 							decorative
@@ -129,7 +129,7 @@ import EmojiPicker from '@nextcloud/vue/dist/Components/EmojiPicker'
 import { EventBus } from '../../services/EventBus'
 import { shareFile } from '../../services/filesSharingServices'
 import { CONVERSATION } from '../../constants'
-import Attachment from 'vue-material-design-icons/Attachment'
+import Paperclip from 'vue-material-design-icons/Paperclip'
 import EmoticonOutline from 'vue-material-design-icons/EmoticonOutline'
 import Send from 'vue-material-design-icons/Send'
 
@@ -147,7 +147,7 @@ export default {
 		Quote,
 		Actions,
 		ActionButton,
-		Attachment,
+		Paperclip,
 		EmojiPicker,
 		EmoticonOutline,
 		Send,

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -43,9 +43,13 @@
 						ref="uploadMenu"
 						container="#content-vue"
 						:disabled="disabled"
-						default-icon="icon-clip-add-file"
 						:aria-label="t('spreed', 'Share files to the conversation')"
 						:aria-haspopup="true">
+						<Attachment
+							slot="icon"
+							:size="16"
+							decorative
+							title="" />
 						<ActionButton
 							v-if="canUploadFiles"
 							:close-after-click="true"
@@ -125,6 +129,7 @@ import EmojiPicker from '@nextcloud/vue/dist/Components/EmojiPicker'
 import { EventBus } from '../../services/EventBus'
 import { shareFile } from '../../services/filesSharingServices'
 import { CONVERSATION } from '../../constants'
+import Attachment from 'vue-material-design-icons/Attachment'
 import EmoticonOutline from 'vue-material-design-icons/EmoticonOutline'
 import Send from 'vue-material-design-icons/Send'
 
@@ -142,6 +147,7 @@ export default {
 		Quote,
 		Actions,
 		ActionButton,
+		Attachment,
 		EmojiPicker,
 		EmoticonOutline,
 		Send,


### PR DESCRIPTION
Use attachment icon from material design for file uploads.
Also fixes an alignment issue with nextcloud-vue 4.0.0.

Part of https://github.com/nextcloud/spreed/issues/5492 to prepare for the 4.0.0 upgrade.

Before:
<img width="161" alt="image" src="https://user-images.githubusercontent.com/277525/120445309-c4d20980-c388-11eb-86d1-3bd9d3bffc5a.png">

After:
<img width="161" alt="image" src="https://user-images.githubusercontent.com/277525/120445058-863c4f00-c388-11eb-8f00-97337c735c2f.png">

Note: the icon is not visually identical and is rotated differently. If that's an issue we could use CSS to rotate it...
