### PR TITLE
Fix color of screen share menu icons

### DIFF
--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -115,7 +115,6 @@
 						slot="icon"
 						:size="24"
 						title=""
-						fill-color="#ffffff"
 						decorative />
 					{{ t('spreed', 'Show your screen') }}
 				</ActionButton>
@@ -126,7 +125,6 @@
 						slot="icon"
 						:size="24"
 						title=""
-						fill-color="#ffffff"
 						decorative />
 					{{ t('spreed', 'Stop screensharing') }}
 				</ActionButton>


### PR DESCRIPTION
Remove fill color to avoid white on grey.

Before:
<img width="170" alt="image" src="https://user-images.githubusercontent.com/277525/120446879-44140d00-c38a-11eb-9804-1dd790d89da8.png">

After:
<img width="170" alt="image" src="https://user-images.githubusercontent.com/277525/120446721-2050c700-c38a-11eb-9fff-d340c10c535e.png">
