### PR TITLE
Cancel temporary messages individually and warn before leaving while sending

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -110,7 +110,7 @@ export default {
 		},
 
 		warnLeaving() {
-			return !this.isLeavingAfterSessionIssue && this.isInCall
+			return this.$store.getters.isSendingMessages || (!this.isLeavingAfterSessionIssue && this.isInCall)
 		},
 
 		/**


### PR DESCRIPTION
Map multiple cancel functions to temporary message
    
When sending multiple messages in a row, and all are pending or time out, they each need a specific cancel function to match their specific request.
    
Fixes issue where one message timing out would cancel the other messages as well.

There's now also an unload warning when trying to leave the page while messages are being sent, to avoid potential data loss.

To test, use this patch:
```diff
diff --git a/src/services/messagesService.js b/src/services/messagesService.js
index 630445f23..a938109cf 100644
--- a/src/services/messagesService.js
+++ b/src/services/messagesService.js
@@ -75,6 +75,11 @@ const lookForNewMessages = async({ token, lastKnownMessageId }, options) => {
  * @param {object} options request options
  */
 const postNewMessage = async function({ token, message, actorDisplayName, referenceId, parent }, options) {
+       function sleep(ms) {
+               return new Promise(resolve => setTimeout(resolve, ms));
+       }
+
+       await sleep(15000)
        return axios.post(generateOcsUrl('apps/spreed/api/v1/chat/{token}', { token }), {
                message,
                actorDisplayName,
```