### PR TITLE
Fix call flags updates

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -123,6 +123,15 @@ return [
 			],
 		],
 		[
+			'name' => 'Call#updateCallFlags',
+			'url' => '/api/{apiVersion}/call/{token}',
+			'verb' => 'PUT',
+			'requirements' => [
+				'apiVersion' => 'v(4)',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
+		[
 			'name' => 'Call#leaveCall',
 			'url' => '/api/{apiVersion}/call/{token}',
 			'verb' => 'DELETE',

--- a/docs/call.md
+++ b/docs/call.md
@@ -47,6 +47,26 @@
         + `404 Not Found` When the user did not join the conversation before
         + `412 Precondition Failed` When the lobby is active and the user is not a moderator
 
+## Update call flags
+
+* Method: `PUT`
+* Endpoint: `/call/{token}`
+* Data:
+
+    field | type | Description
+    ---|---|---
+    `flags` | int | Flags what streams are provided by the participant (see [Constants - Participant in-call flag](constants.md#participant-in-call-flag))
+
+* Response:
+    - Status code:
+        + `200 OK`
+        + `400 Bad Request` When the user is not in the call
+        + `400 Bad Request` When the flags do not contain "in call"
+        + `403 Forbidden` When the conversation is read-only
+        + `404 Not Found` When the conversation could not be found for the participant
+        + `404 Not Found` When the user did not join the conversation before
+        + `412 Precondition Failed` When the lobby is active and the user is not a moderator
+
 ## Leave a call (but staying in the conversation for future calls and chat)
 
 * Method: `DELETE`

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -130,6 +130,28 @@ class CallController extends AEnvironmentAwareController {
 	 * @PublicPage
 	 * @RequireParticipant
 	 *
+	 * @param int flags
+	 * @return DataResponse
+	 */
+	public function updateCallFlags(int $flags): DataResponse {
+		$session = $this->participant->getSession();
+		if (!$session instanceof Session) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		try {
+			$this->participantService->updateCallFlags($this->room, $this->participant, $flags);
+		} catch (\Exception $exception) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
+		return new DataResponse();
+	}
+
+	/**
+	 * @PublicPage
+	 * @RequireParticipant
+	 *
 	 * @return DataResponse
 	 */
 	public function leaveCall(): DataResponse {

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -124,6 +124,8 @@ class Room {
 	public const EVENT_AFTER_GUESTS_CLEAN = self::class . '::postCleanGuests';
 	public const EVENT_BEFORE_SESSION_JOIN_CALL = self::class . '::preSessionJoinCall';
 	public const EVENT_AFTER_SESSION_JOIN_CALL = self::class . '::postSessionJoinCall';
+	public const EVENT_BEFORE_SESSION_UPDATE_CALL_FLAGS = self::class . '::preSessionUpdateCallFlags';
+	public const EVENT_AFTER_SESSION_UPDATE_CALL_FLAGS = self::class . '::postSessionUpdateCallFlags';
 	public const EVENT_BEFORE_SESSION_LEAVE_CALL = self::class . '::preSessionLeaveCall';
 	public const EVENT_AFTER_SESSION_LEAVE_CALL = self::class . '::postSessionLeaveCall';
 	public const EVENT_BEFORE_SIGNALING_PROPERTIES = self::class . '::beforeSignalingProperties';

--- a/lib/Signaling/Listener.php
+++ b/lib/Signaling/Listener.php
@@ -65,6 +65,7 @@ class Listener {
 		$dispatcher->addListener(Room::EVENT_AFTER_ROOM_CONNECT, $listener);
 		$dispatcher->addListener(Room::EVENT_AFTER_GUEST_CONNECT, $listener);
 		$dispatcher->addListener(Room::EVENT_AFTER_SESSION_JOIN_CALL, $listener);
+		$dispatcher->addListener(Room::EVENT_AFTER_SESSION_UPDATE_CALL_FLAGS, $listener);
 		$dispatcher->addListener(Room::EVENT_AFTER_SESSION_LEAVE_CALL, $listener);
 		$dispatcher->addListener(GuestManager::EVENT_AFTER_NAME_UPDATE, $listener);
 
@@ -241,6 +242,7 @@ class Listener {
 			}
 		};
 		$dispatcher->addListener(Room::EVENT_AFTER_SESSION_JOIN_CALL, $listener);
+		$dispatcher->addListener(Room::EVENT_AFTER_SESSION_UPDATE_CALL_FLAGS, $listener);
 		$dispatcher->addListener(Room::EVENT_AFTER_SESSION_LEAVE_CALL, $listener);
 
 		$dispatcher->addListener(Room::EVENT_AFTER_GUESTS_CLEAN, static function (RoomEvent $event) {

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -343,7 +343,7 @@ Signaling.Internal.prototype.forceReconnect = function(newSession, flags) {
 	// FIXME Naive reconnection routine; as the same session is kept peers
 	// must be explicitly ended before the reconnection is forced.
 	this.leaveCall(this.currentCallToken, true)
-	this.joinCall(this.currentCallToken)
+	this.joinCall(this.currentCallToken, this.currentCallFlags)
 }
 
 Signaling.Internal.prototype._sendMessageWithCallback = function(ev) {

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -714,7 +714,33 @@ export default function initWebRTC(signaling, _callParticipantCollection, _local
 			// is established, but forcing a reconnection should be done only
 			// once the connection was established.
 			if (peer.pc.iceConnectionState !== 'new' && peer.pc.iceConnectionState !== 'checking') {
-				forceReconnect(signaling)
+				// Update the media flags if needed, as the renegotiation could
+				// have been caused by tracks being added or removed.
+				const audioSender = peer.pc.getSenders().find((sender) => sender.track && sender.track.kind === 'audio')
+				const videoSender = peer.pc.getSenders().find((sender) => sender.track && sender.track.kind === 'video')
+
+				let flags = signaling.getCurrentCallFlags()
+				if (audioSender) {
+					flags |= PARTICIPANT.CALL_FLAG.WITH_AUDIO
+				} else {
+					flags &= ~PARTICIPANT.CALL_FLAG.WITH_AUDIO
+				}
+				if (videoSender) {
+					flags |= PARTICIPANT.CALL_FLAG.WITH_VIDEO
+				} else {
+					flags &= ~PARTICIPANT.CALL_FLAG.WITH_VIDEO
+				}
+
+				// Negotiation is expected to be needed only when a new track is
+				// added to or removed from a peer. Therefore if the HPB is used
+				// the negotiation will be needed in the own peer, but if the
+				// HPB is not used it will be needed in all peers. However, in
+				// that case as soon as the forced reconnection is triggered all
+				// the peers will be cleared, so in practice there will be just
+				// one forced reconnection even if there are several peers.
+				// FIXME: despite all of the above this is a dirty and ugly hack
+				// that should be fixed with proper renegotiation.
+				forceReconnect(signaling, flags)
 			}
 		})
 	}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -442,7 +442,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	protected function sortAttendees(array $a1, array $a2): int {
-		if ($a1['participantType'] !== $a2['participantType']) {
+		if (array_key_exists('participantType', $a1) && array_key_exists('participantType', $a2) && $a1['participantType'] !== $a2['participantType']) {
 			return $a1['participantType'] <=> $a2['participantType'];
 		}
 		if ($a1['actorType'] !== $a2['actorType']) {
@@ -1081,6 +1081,24 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			self::$sessionIdToUser[sha1($response['sessionId'])] = $user;
 			self::$userToSessionId[$user] = $response['sessionId'];
 		}
+	}
+
+	/**
+	 * @Then /^user "([^"]*)" updates call flags in room "([^"]*)" to "([^"]*)" with (\d+) \((v4)\)$/
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 * @param string $flags
+	 * @param int $statusCode
+	 * @param string $apiVersion
+	 */
+	public function userUpdatesCallFlagsInRoomTo(string $user, string $identifier, string $flags, int $statusCode, string $apiVersion): void {
+		$this->setCurrentUser($user);
+		$this->sendRequest(
+			'PUT', '/apps/spreed/api/' . $apiVersion . '/call/' . self::$identifierToToken[$identifier],
+			new TableNode([['flags', $flags]])
+		);
+		$this->assertStatusCode($this->response, $statusCode);
 	}
 
 	/**

--- a/tests/integration/features/callapi/update-call-flags.feature
+++ b/tests/integration/features/callapi/update-call-flags.feature
@@ -1,0 +1,272 @@
+Feature: callapi/update-call-flags
+  Background:
+    Given user "owner" exists
+    And user "moderator" exists
+    And user "invited user" exists
+    And user "not invited but joined user" exists
+
+  Scenario: all participants can update their call flags when in a call
+    Given user "owner" creates room "public room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "owner" adds user "moderator" to room "public room" with 200 (v4)
+    And user "owner" promotes "moderator" in room "public room" with 200 (v4)
+    And user "owner" adds user "invited user" to room "public room" with 200 (v4)
+    And user "not invited but joined user" joins room "public room" with 200 (v4)
+    And user "guest moderator" joins room "public room" with 200 (v4)
+    And user "owner" promotes "guest moderator" in room "public room" with 200 (v4)
+    And user "guest" joins room "public room" with 200 (v4)
+    And user "owner" joins room "public room" with 200 (v4)
+    And user "moderator" joins room "public room" with 200 (v4)
+    And user "invited user" joins room "public room" with 200 (v4)
+    And user "not invited but joined user" joins room "public room" with 200 (v4)
+    And user "owner" joins call "public room" with 200 (v4)
+    And user "moderator" joins call "public room" with 200 (v4)
+    And user "invited user" joins call "public room" with 200 (v4)
+    And user "not invited but joined user" joins call "public room" with 200 (v4)
+    And user "guest moderator" joins call "public room" with 200 (v4)
+    And user "guest" joins call "public room" with 200 (v4)
+    When user "owner" updates call flags in room "public room" to "1" with 200 (v4)
+    And user "moderator" updates call flags in room "public room" to "1" with 200 (v4)
+    And user "invited user" updates call flags in room "public room" to "1" with 200 (v4)
+    And user "not invited but joined user" updates call flags in room "public room" to "1" with 200 (v4)
+    And user "guest moderator" updates call flags in room "public room" to "1" with 200 (v4)
+    And user "guest" updates call flags in room "public room" to "1" with 200 (v4)
+    Then user "owner" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 1      |
+      | users      | moderator                   | 1      |
+      | users      | invited user                | 1      |
+      | users      | not invited but joined user | 1      |
+      | guests     | "guest moderator"           | 1      |
+      | guests     | "guest"                     | 1      |
+    And user "moderator" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 1      |
+      | users      | moderator                   | 1      |
+      | users      | invited user                | 1      |
+      | users      | not invited but joined user | 1      |
+      | guests     | "guest moderator"           | 1      |
+      | guests     | "guest"                     | 1      |
+    And user "invited user" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 1      |
+      | users      | moderator                   | 1      |
+      | users      | invited user                | 1      |
+      | users      | not invited but joined user | 1      |
+      | guests     | "guest moderator"           | 1      |
+      | guests     | "guest"                     | 1      |
+    And user "not invited but joined user" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 1      |
+      | users      | moderator                   | 1      |
+      | users      | invited user                | 1      |
+      | users      | not invited but joined user | 1      |
+      | guests     | "guest moderator"           | 1      |
+      | guests     | "guest"                     | 1      |
+    And user "guest moderator" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 1      |
+      | users      | moderator                   | 1      |
+      | users      | invited user                | 1      |
+      | users      | not invited but joined user | 1      |
+      | guests     | "guest moderator"           | 1      |
+      | guests     | "guest"                     | 1      |
+
+  Scenario: update call flags with in call does not join the call
+    Given user "owner" creates room "public room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "owner" adds user "moderator" to room "public room" with 200 (v4)
+    And user "owner" promotes "moderator" in room "public room" with 200 (v4)
+    And user "owner" adds user "invited user" to room "public room" with 200 (v4)
+    And user "not invited but joined user" joins room "public room" with 200 (v4)
+    And user "guest moderator" joins room "public room" with 200 (v4)
+    And user "owner" promotes "guest moderator" in room "public room" with 200 (v4)
+    And user "guest" joins room "public room" with 200 (v4)
+    And user "owner" joins room "public room" with 200 (v4)
+    And user "moderator" joins room "public room" with 200 (v4)
+    And user "invited user" joins room "public room" with 200 (v4)
+    And user "not invited but joined user" joins room "public room" with 200 (v4)
+    When user "owner" updates call flags in room "public room" to "1" with 400 (v4)
+    And user "moderator" updates call flags in room "public room" to "1" with 400 (v4)
+    And user "invited user" updates call flags in room "public room" to "1" with 400 (v4)
+    And user "not invited but joined user" updates call flags in room "public room" to "1" with 400 (v4)
+    And user "guest moderator" updates call flags in room "public room" to "1" with 400 (v4)
+    And user "guest" updates call flags in room "public room" to "1" with 400 (v4)
+    Then user "owner" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 0      |
+      | users      | moderator                   | 0      |
+      | users      | invited user                | 0      |
+      | users      | not invited but joined user | 0      |
+      | guests     | "guest moderator"           | 0      |
+      | guests     | "guest"                     | 0      |
+    And user "moderator" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 0      |
+      | users      | moderator                   | 0      |
+      | users      | invited user                | 0      |
+      | users      | not invited but joined user | 0      |
+      | guests     | "guest moderator"           | 0      |
+      | guests     | "guest"                     | 0      |
+    And user "invited user" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 0      |
+      | users      | moderator                   | 0      |
+      | users      | invited user                | 0      |
+      | users      | not invited but joined user | 0      |
+      | guests     | "guest moderator"           | 0      |
+      | guests     | "guest"                     | 0      |
+    And user "not invited but joined user" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 0      |
+      | users      | moderator                   | 0      |
+      | users      | invited user                | 0      |
+      | users      | not invited but joined user | 0      |
+      | guests     | "guest moderator"           | 0      |
+      | guests     | "guest"                     | 0      |
+    And user "guest moderator" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 0      |
+      | users      | moderator                   | 0      |
+      | users      | invited user                | 0      |
+      | users      | not invited but joined user | 0      |
+      | guests     | "guest moderator"           | 0      |
+      | guests     | "guest"                     | 0      |
+
+  Scenario: update call flags with disconnected does not leave the call
+    Given user "owner" creates room "public room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "owner" adds user "moderator" to room "public room" with 200 (v4)
+    And user "owner" promotes "moderator" in room "public room" with 200 (v4)
+    And user "owner" adds user "invited user" to room "public room" with 200 (v4)
+    And user "not invited but joined user" joins room "public room" with 200 (v4)
+    And user "guest moderator" joins room "public room" with 200 (v4)
+    And user "owner" promotes "guest moderator" in room "public room" with 200 (v4)
+    And user "guest" joins room "public room" with 200 (v4)
+    And user "owner" joins room "public room" with 200 (v4)
+    And user "moderator" joins room "public room" with 200 (v4)
+    And user "invited user" joins room "public room" with 200 (v4)
+    And user "not invited but joined user" joins room "public room" with 200 (v4)
+    And user "owner" joins call "public room" with 200 (v4)
+    And user "moderator" joins call "public room" with 200 (v4)
+    And user "invited user" joins call "public room" with 200 (v4)
+    And user "not invited but joined user" joins call "public room" with 200 (v4)
+    And user "guest moderator" joins call "public room" with 200 (v4)
+    And user "guest" joins call "public room" with 200 (v4)
+    When user "owner" updates call flags in room "public room" to "0" with 400 (v4)
+    And user "moderator" updates call flags in room "public room" to "0" with 400 (v4)
+    And user "invited user" updates call flags in room "public room" to "0" with 400 (v4)
+    And user "not invited but joined user" updates call flags in room "public room" to "0" with 400 (v4)
+    And user "guest moderator" updates call flags in room "public room" to "0" with 400 (v4)
+    And user "guest" updates call flags in room "public room" to "0" with 400 (v4)
+    Then user "owner" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 7      |
+      | users      | moderator                   | 7      |
+      | users      | invited user                | 7      |
+      | users      | not invited but joined user | 7      |
+      | guests     | "guest moderator"           | 7      |
+      | guests     | "guest"                     | 7      |
+    And user "moderator" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 7      |
+      | users      | moderator                   | 7      |
+      | users      | invited user                | 7      |
+      | users      | not invited but joined user | 7      |
+      | guests     | "guest moderator"           | 7      |
+      | guests     | "guest"                     | 7      |
+    And user "invited user" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 7      |
+      | users      | moderator                   | 7      |
+      | users      | invited user                | 7      |
+      | users      | not invited but joined user | 7      |
+      | guests     | "guest moderator"           | 7      |
+      | guests     | "guest"                     | 7      |
+    And user "not invited but joined user" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 7      |
+      | users      | moderator                   | 7      |
+      | users      | invited user                | 7      |
+      | users      | not invited but joined user | 7      |
+      | guests     | "guest moderator"           | 7      |
+      | guests     | "guest"                     | 7      |
+    And user "guest moderator" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 7      |
+      | users      | moderator                   | 7      |
+      | users      | invited user                | 7      |
+      | users      | not invited but joined user | 7      |
+      | guests     | "guest moderator"           | 7      |
+      | guests     | "guest"                     | 7      |
+
+  Scenario: update call flags requires in call flag to be set
+    Given user "owner" creates room "public room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "owner" adds user "moderator" to room "public room" with 200 (v4)
+    And user "owner" promotes "moderator" in room "public room" with 200 (v4)
+    And user "owner" adds user "invited user" to room "public room" with 200 (v4)
+    And user "not invited but joined user" joins room "public room" with 200 (v4)
+    And user "guest moderator" joins room "public room" with 200 (v4)
+    And user "owner" promotes "guest moderator" in room "public room" with 200 (v4)
+    And user "guest" joins room "public room" with 200 (v4)
+    And user "owner" joins room "public room" with 200 (v4)
+    And user "moderator" joins room "public room" with 200 (v4)
+    And user "invited user" joins room "public room" with 200 (v4)
+    And user "not invited but joined user" joins room "public room" with 200 (v4)
+    And user "owner" joins call "public room" with 200 (v4)
+    And user "moderator" joins call "public room" with 200 (v4)
+    And user "invited user" joins call "public room" with 200 (v4)
+    And user "not invited but joined user" joins call "public room" with 200 (v4)
+    And user "guest moderator" joins call "public room" with 200 (v4)
+    And user "guest" joins call "public room" with 200 (v4)
+    When user "owner" updates call flags in room "public room" to "2" with 400 (v4)
+    And user "moderator" updates call flags in room "public room" to "2" with 400 (v4)
+    And user "invited user" updates call flags in room "public room" to "2" with 400 (v4)
+    And user "not invited but joined user" updates call flags in room "public room" to "2" with 400 (v4)
+    And user "guest moderator" updates call flags in room "public room" to "2" with 400 (v4)
+    And user "guest" updates call flags in room "public room" to "2" with 400 (v4)
+    Then user "owner" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 7      |
+      | users      | moderator                   | 7      |
+      | users      | invited user                | 7      |
+      | users      | not invited but joined user | 7      |
+      | guests     | "guest moderator"           | 7      |
+      | guests     | "guest"                     | 7      |
+    And user "moderator" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 7      |
+      | users      | moderator                   | 7      |
+      | users      | invited user                | 7      |
+      | users      | not invited but joined user | 7      |
+      | guests     | "guest moderator"           | 7      |
+      | guests     | "guest"                     | 7      |
+    And user "invited user" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 7      |
+      | users      | moderator                   | 7      |
+      | users      | invited user                | 7      |
+      | users      | not invited but joined user | 7      |
+      | guests     | "guest moderator"           | 7      |
+      | guests     | "guest"                     | 7      |
+    And user "not invited but joined user" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 7      |
+      | users      | moderator                   | 7      |
+      | users      | invited user                | 7      |
+      | users      | not invited but joined user | 7      |
+      | guests     | "guest moderator"           | 7      |
+      | guests     | "guest"                     | 7      |
+    And user "guest moderator" sees the following attendees in room "public room" with 200 (v4)
+      | actorType  | actorId                     | inCall |
+      | users      | owner                       | 7      |
+      | users      | moderator                   | 7      |
+      | users      | invited user                | 7      |
+      | users      | not invited but joined user | 7      |
+      | guests     | "guest moderator"           | 7      |
+      | guests     | "guest"                     | 7      |


### PR DESCRIPTION
Note that enable and disable a device refers to switching audio and video between none and a specific device in Talk settings, not to enable and disable audio and video in the controls.

The issues are there also in previous Talk versions. However one of the fixes requires a new endpoint to update the call flags (updating the call flags when a device is disabled), and currently it is just an aesthetic issue (in the future it might be needed to grant and revoke publishing permissions without having to force a reconnection), so (for once :-P ) I would vote to not backport it.

## How to test (scenario 1)
- Do not set up the HPB
- Open Talk settings, enable the audio device and disable the video device
- Start a call
- Open the Network tab in the developer console
- Open Talk settings and enable the video device

### Result with this pull request
The join call endpoint is called with flags = 7 (in call, audio and video)

### Result without this pull request
The join call endpoint is called without flags (in the participant list the video icon will be shown just for sheer luck, as the server sets the default flags, which happen to be 7, when none is given)



## How to test (scenario 2)
- Set up the HPB
- Open Talk settings, enable the audio device and disable the video device
- Start a call
- Open Talk settings and enable the video device

### Result with this pull request
In the participant list the video icon is shown for the current participant

### Result without this pull request
In the participant list the audio icon is shown for the current participant



## How to test (scenario 3)
- Open Talk settings, enable the audio device and the video device
- Start a call
- Open Talk settings and disable the video device

### Result with this pull request
In the participant list the audio icon is shown for the current participant

### Result without this pull request
In the participant list the video icon is shown for the current participant



## How to test (scenario 4)
- Open Talk settings, enable the audio device and the video device
- Start a call
- Open Talk settings
- Enable and disable the video device a few times

### Result with this pull request
In the participant list the audio or video icon is shown depending on the case for the current participant

### Result without this pull request
In the participant list the video icon is shown for the current participant
