### PR TITLE
Changelog for 11.3.0, 11.2.2, 10.1.5, 10.0.8 and 9.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,63 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 11.3.0 – 2021-06-04
+### Fixed
+- Inject the preloaded user status into the avatar component
+  [#5694](https://github.com/nextcloud/spreed/pull/5694)
+- Fix switching devices in Firefox
+  [#5580](https://github.com/nextcloud/spreed/pull/5580)
+- Fix switching devices during a call if started without audio nor video
+  [#5662](https://github.com/nextcloud/spreed/pull/5662)
+- Redirect to not-found page while in a call
+  [#5601](https://github.com/nextcloud/spreed/pull/5601)
+- Regenerate session id after entering conversation password
+  [#5638](https://github.com/nextcloud/spreed/pull/5638)
+- Fix a problem when a deleted user is recreated again
+  [#5643](https://github.com/nextcloud/spreed/pull/5643)
+- Encode dav path segments for direct GIF preview
+  [#5674](https://github.com/nextcloud/spreed/pull/5674)
+- Fix raised hand handler not detached when a participant leaves
+  [#5676](https://github.com/nextcloud/spreed/pull/5676)
+- Register flow operation via dedicated instead of legacy event
+  [#5650](https://github.com/nextcloud/spreed/pull/5650)
+
+## 11.2.2 – 2021-06-04
+### Fixed
+- Regenerate session id after entering conversation password
+  [#5639](https://github.com/nextcloud/spreed/pull/5639)
+- Fix a problem when a deleted user is recreated again
+  [#5644](https://github.com/nextcloud/spreed/pull/5644)
+- Encode dav path segments for direct GIF preview
+  [#5692](https://github.com/nextcloud/spreed/pull/5692)
+- Fix raised hand handler not detached when a participant leaves
+  [#5677](https://github.com/nextcloud/spreed/pull/5677)
+- Register flow operation via dedicated instead of legacy event
+  [#5651](https://github.com/nextcloud/spreed/pull/5651)
+
+## 10.1.5 – 2021-06-04
+### Fixed
+- Regenerate session id after entering conversation password
+  [#5640](https://github.com/nextcloud/spreed/pull/5640)
+- Fix quality warning appearing again in certain conditions
+  [#5553](https://github.com/nextcloud/spreed/pull/5553)
+- Fix camera quality starting bad in some cases
+  [#5557](https://github.com/nextcloud/spreed/pull/5557)
+
+## 10.0.8 – 2021-06-04
+### Fixed
+- Regenerate session id after entering conversation password
+  [#5641](https://github.com/nextcloud/spreed/pull/5641)
+- Fix quality warning appearing again in certain conditions
+  [#5555](https://github.com/nextcloud/spreed/pull/5555)
+- Fix camera quality starting bad in some cases
+  [#5559](https://github.com/nextcloud/spreed/pull/5559)
+
+## 9.0.10 – 2021-06-04
+### Fixed
+- Regenerate session id after entering conversation password
+  [#5642](https://github.com/nextcloud/spreed/pull/5642)
+
 ## 11.2.1 – 2021-05-06
 ### Fixed
 - Fix redirect when deleting the current conversation


### PR DESCRIPTION
## 11.3.0 – 2021-06-04
### 🐞 Fixed
- Inject the preloaded user status into the avatar component  [#5694](https://github.com/nextcloud/spreed/pull/5694)
- Fix switching devices in Firefox  [#5580](https://github.com/nextcloud/spreed/pull/5580)
- Fix switching devices during a call if started without audio nor video  [#5662](https://github.com/nextcloud/spreed/pull/5662)
- Redirect to not-found page while in a call  [#5601](https://github.com/nextcloud/spreed/pull/5601)
- Regenerate session id after entering conversation password  [#5638](https://github.com/nextcloud/spreed/pull/5638)
- Fix a problem when a deleted user is recreated again  [#5643](https://github.com/nextcloud/spreed/pull/5643)
- Encode dav path segments for direct GIF preview  [#5674](https://github.com/nextcloud/spreed/pull/5674)
- Fix raised hand handler not detached when a participant leaves  [#5676](https://github.com/nextcloud/spreed/pull/5676)
- Register flow operation via dedicated instead of legacy event  [#5650](https://github.com/nextcloud/spreed/pull/5650)

## 11.2.2 – 2021-06-04
### 🐞 Fixed
- Regenerate session id after entering conversation password  [#5639](https://github.com/nextcloud/spreed/pull/5639)
- Fix a problem when a deleted user is recreated again  [#5644](https://github.com/nextcloud/spreed/pull/5644)
- Encode dav path segments for direct GIF preview  [#5692](https://github.com/nextcloud/spreed/pull/5692)
- Fix raised hand handler not detached when a participant leaves  [#5677](https://github.com/nextcloud/spreed/pull/5677)
- Register flow operation via dedicated instead of legacy event  [#5651](https://github.com/nextcloud/spreed/pull/5651)

## 10.1.5 – 2021-06-04
### 🐞 Fixed
- Regenerate session id after entering conversation password  [#5640](https://github.com/nextcloud/spreed/pull/5640)
- Fix quality warning appearing again in certain conditions  [#5553](https://github.com/nextcloud/spreed/pull/5553)
- Fix camera quality starting bad in some cases  [#5557](https://github.com/nextcloud/spreed/pull/5557)

## 10.0.8 – 2021-06-04
### 🐞 Fixed
- Regenerate session id after entering conversation password  [#5641](https://github.com/nextcloud/spreed/pull/5641)
- Fix quality warning appearing again in certain conditions  [#5555](https://github.com/nextcloud/spreed/pull/5555)
- Fix camera quality starting bad in some cases  [#5559](https://github.com/nextcloud/spreed/pull/5559)

## 9.0.10 – 2021-06-04
### 🐞 Fixed
- Regenerate session id after entering conversation password  [#5642](https://github.com/nextcloud/spreed/pull/5642)
