### PR TITLE
Allow to set default publishing permissions in a conversation

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>13.0.0-dev.1</version>
+	<version>13.0.0-dev.2</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -318,6 +318,15 @@ return [
 			],
 		],
 		[
+			'name' => 'Room#setPublishingAllowed',
+			'url' => '/api/{apiVersion}/room/{token}/publishing-allowed',
+			'verb' => 'PUT',
+			'requirements' => [
+				'apiVersion' => 'v(4)',
+				'token' => '^[a-z0-9]{4,30}$',
+			],
+		],
+		[
 			'name' => 'Room#getParticipants',
 			'url' => '/api/{apiVersion}/room/{token}/participants',
 			'verb' => 'GET',

--- a/docs/constants.md
+++ b/docs/constants.md
@@ -23,6 +23,10 @@ title: Constants
 * `0` No lobby
 * `1` Lobby for non moderators
 
+### Publishing allowed
+* `0` Everyone
+* `1` Moderators
+
 ## Participants
 
 ### Participant types

--- a/docs/conversation.md
+++ b/docs/conversation.md
@@ -55,6 +55,7 @@
         `hasPassword` | bool | v1 | | Flag if the conversation has a password
         `hasCall` | bool | v1 | | Flag if the conversation has an active call
         `callFlag` | int | v3 | | Combined flag of all participants in the current call (see [constants list](constants.md#participant-in-call-flag), only available with `conversation-call-flags` capability)
+        `publishingAllowed` | int | v4 | Flag about which kind of participants are allowed to publish in a call (see [constants list](constants.md#publishing-allowed))
         `canStartCall` | bool | v1 | | Flag if the user can start a new call in this conversation (joining is always possible) (only available with `start-call-flag` capability)
         `canDeleteConversation` | bool | v2 | | Flag if the user can delete the conversation for everyone (not possible without moderator permissions or in one-to-one conversations)
         `canLeaveConversation` | bool | v2 | | Flag if the user can leave the conversation (not possible for the last user with moderator permissions)
@@ -245,6 +246,23 @@
         + `200 OK`
         + `403 Forbidden` When the current user is not a moderator or owner
         + `403 Forbidden` When the conversation is not a public conversation
+        + `404 Not Found` When the conversation could not be found for the participant
+
+## Set publishing allowed for a conversation
+
+* Method: `PUT`
+* Endpoint: `/room/{token}/publishing-allowed`
+* Data:
+
+    field | type | Description
+    ---|---|---
+    `state` | int | New state for the conversation, see [constants list](constants.md#publishing-allowed)
+
+* Response:
+    - Status code:
+        + `200 OK`
+        + `400 Bad Request` When the conversation type does not support setting publishing allowed (only group and public conversations without an on-going call)
+        + `403 Forbidden` When the current user is not a moderator/owner
         + `404 Not Found` When the conversation could not be found for the participant
 
 ## Add conversation to favorites

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -403,6 +403,7 @@ class RoomController extends AEnvironmentAwareController {
 			'lastCommonReadMessage' => 0,
 			'listable' => Room::LISTABLE_NONE,
 			'callFlag' => Participant::FLAG_DISCONNECTED,
+			'publishingAllowed' => Room::PUBLISHING_ALLOWED_EVERYONE,
 		];
 
 		$lastActivity = $room->getLastActivity();
@@ -435,6 +436,7 @@ class RoomController extends AEnvironmentAwareController {
 				'lobbyTimer' => $lobbyTimer,
 				'sipEnabled' => $room->getSIPEnabled(),
 				'listable' => $room->getListable(),
+				'publishingAllowed' => $room->getPublishingAllowed(),
 			]);
 		}
 
@@ -465,6 +467,7 @@ class RoomController extends AEnvironmentAwareController {
 			'publishingPermissions' => $attendee->getPublishingPermissions(),
 			'description' => $room->getDescription(),
 			'listable' => $room->getListable(),
+			'publishingAllowed' => $room->getPublishingAllowed(),
 		]);
 
 		if ($currentParticipant->getAttendee()->getReadPrivacy() === Participant::PRIVACY_PUBLIC) {

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1270,6 +1270,21 @@ class RoomController extends AEnvironmentAwareController {
 
 	/**
 	 * @PublicPage
+	 * @RequireLoggedInModeratorParticipant
+	 *
+	 * @param int $state
+	 * @return DataResponse
+	 */
+	public function setPublishingAllowed(int $state): DataResponse {
+		if (!$this->room->setPublishingAllowed($state)) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
+		return new DataResponse();
+	}
+
+	/**
+	 * @PublicPage
 	 * @UseSession
 	 *
 	 * @param string $token

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -195,7 +195,8 @@ class Manager {
 			$lastMessage,
 			$lobbyTimer,
 			(string) $row['object_type'],
-			(string) $row['object_id']
+			(string) $row['object_id'],
+			(int) $row['publishing_allowed']
 		);
 	}
 

--- a/lib/Migration/Version13000Date20210901132118.php
+++ b/lib/Migration/Version13000Date20210901132118.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021, Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * @author Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\Types;
+use OCA\Talk\Room;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version13000Date20210901132118 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('talk_rooms');
+		if (!$table->hasColumn('publishing_allowed')) {
+			$table->addColumn('publishing_allowed', Types::INTEGER, [
+				'default' => Room::PUBLISHING_ALLOWED_EVERYONE,
+			]);
+
+			return $schema;
+		}
+
+		return null;
+	}
+}

--- a/lib/Model/SelectHelper.php
+++ b/lib/Model/SelectHelper.php
@@ -50,6 +50,7 @@ class SelectHelper {
 			->addSelect($alias . 'object_id')
 			->addSelect($alias . 'listable')
 			->addSelect($alias . 'server_url')
+			->addSelect($alias . 'publishing_allowed')
 			->selectAlias($alias . 'id', 'r_id');
 	}
 

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -94,6 +94,9 @@ class Room {
 	public const START_CALL_USERS = 1;
 	public const START_CALL_MODERATORS = 2;
 
+	public const PUBLISHING_ALLOWED_EVERYONE = 0;
+	public const PUBLISHING_ALLOWED_MODERATORS = 1;
+
 	public const PARTICIPANT_REMOVED = 'remove';
 	public const PARTICIPANT_LEFT = 'leave';
 
@@ -198,6 +201,8 @@ class Room {
 	private $objectType;
 	/** @var string */
 	private $objectId;
+	/** @var int */
+	private $publishingAllowed;
 
 	/** @var string */
 	protected $currentUser;
@@ -229,7 +234,8 @@ class Room {
 								?IComment $lastMessage,
 								?\DateTime $lobbyTimer,
 								string $objectType,
-								string $objectId) {
+								string $objectId,
+								int $publishingAllowed) {
 		$this->manager = $manager;
 		$this->db = $db;
 		$this->dispatcher = $dispatcher;
@@ -256,6 +262,7 @@ class Room {
 		$this->lobbyTimer = $lobbyTimer;
 		$this->objectType = $objectType;
 		$this->objectId = $objectId;
+		$this->publishingAllowed = $publishingAllowed;
 	}
 
 	public function getId(): int {
@@ -371,6 +378,10 @@ class Room {
 
 	public function getObjectId(): string {
 		return $this->objectId;
+	}
+
+	public function getPublishingAllowed(): int {
+		return $this->publishingAllowed;
 	}
 
 	public function hasPassword(): bool {

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.spec.js
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.spec.js
@@ -739,6 +739,206 @@ describe('Participant.vue', () => {
 				expect(actionTexts.exists()).toBe(false)
 			})
 		})
+		describe('grant publishing permissions', () => {
+			let setPublishingPermissionsAction
+
+			beforeEach(() => {
+				setPublishingPermissionsAction = jest.fn()
+
+				testStoreConfig.modules.participantsStore.actions.setPublishingPermissions = setPublishingPermissionsAction
+				store = new Vuex.Store(testStoreConfig)
+			})
+
+			async function testCanGrantPublishingPermissions() {
+				const wrapper = mountParticipant(participant)
+				const actionButton = findActionButton(wrapper, 'Grant publishing permissions')
+				expect(actionButton.exists()).toBe(true)
+
+				await actionButton.find('button').trigger('click')
+
+				expect(setPublishingPermissionsAction).toHaveBeenCalledWith(expect.anything(), {
+					token: 'current-token',
+					attendeeId: 'alice-attendee-id',
+					state: PARTICIPANT.PUBLISHING_PERMISSIONS.ALL,
+				})
+			}
+
+			async function testCannotGrantPublishingPermissions() {
+				const wrapper = mountParticipant(participant)
+				const actionButton = findActionButton(wrapper, 'Grant publishing permissions')
+				expect(actionButton.exists()).toBe(false)
+			}
+
+			test('allows a moderator to grant publishing permissions to an owner', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.NONE
+				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
+				participant.participantType = PARTICIPANT.TYPE.OWNER
+				await testCanGrantPublishingPermissions()
+			})
+
+			test('allows a moderator to grant publishing permissions to a moderator', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.NONE
+				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
+				participant.participantType = PARTICIPANT.TYPE.MODERATOR
+				await testCanGrantPublishingPermissions()
+			})
+
+			test('allows a moderator to grant publishing permissions to a user', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.NONE
+				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
+				participant.participantType = PARTICIPANT.TYPE.USER
+				await testCanGrantPublishingPermissions()
+			})
+
+			test('allows a moderator to grant publishing permissions to a guest', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.NONE
+				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
+				participant.participantType = PARTICIPANT.TYPE.GUEST
+				await testCanGrantPublishingPermissions()
+			})
+
+			test('allows a moderator to grant publishing permissions to a self joined-user', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.NONE
+				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
+				participant.participantType = PARTICIPANT.TYPE.USER_SELF_JOINED
+				await testCanGrantPublishingPermissions()
+			})
+
+			test('allows a moderator to grant publishing permissions to a guest moderator', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.NONE
+				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
+				participant.participantType = PARTICIPANT.TYPE.GUEST_MODERATOR
+				await testCanGrantPublishingPermissions()
+			})
+
+			test('allows an owner to grant publishing permissions to a user', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.NONE
+				conversation.participantType = PARTICIPANT.TYPE.OWNER
+				participant.participantType = PARTICIPANT.TYPE.USER
+				await testCanGrantPublishingPermissions()
+			})
+
+			test('allows a guest moderator to grant publishing permissions to a user', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.NONE
+				conversation.participantType = PARTICIPANT.TYPE.GUEST_MODERATOR
+				participant.participantType = PARTICIPANT.TYPE.USER
+				await testCanGrantPublishingPermissions()
+			})
+
+			test('does not allow a non-moderator to grant publishing permissions to a user', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.NONE
+				conversation.participantType = PARTICIPANT.TYPE.USER
+				participant.participantType = PARTICIPANT.TYPE.USER
+				await testCannotGrantPublishingPermissions()
+			})
+
+			test('does not allow a moderator to grant publishing permissions to a user with permissions', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.ALL
+				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
+				participant.participantType = PARTICIPANT.TYPE.USER
+				await testCannotGrantPublishingPermissions()
+			})
+		})
+		describe('revoke publishing permissions', () => {
+			let setPublishingPermissionsAction
+
+			beforeEach(() => {
+				setPublishingPermissionsAction = jest.fn()
+
+				testStoreConfig.modules.participantsStore.actions.setPublishingPermissions = setPublishingPermissionsAction
+				store = new Vuex.Store(testStoreConfig)
+			})
+
+			async function testCanRevokePublishingPermissions() {
+				const wrapper = mountParticipant(participant)
+				const actionButton = findActionButton(wrapper, 'Revoke publishing permissions')
+				expect(actionButton.exists()).toBe(true)
+
+				await actionButton.find('button').trigger('click')
+
+				expect(setPublishingPermissionsAction).toHaveBeenCalledWith(expect.anything(), {
+					token: 'current-token',
+					attendeeId: 'alice-attendee-id',
+					state: PARTICIPANT.PUBLISHING_PERMISSIONS.NONE,
+				})
+			}
+
+			async function testCannotRevokePublishingPermissions() {
+				const wrapper = mountParticipant(participant)
+				const actionButton = findActionButton(wrapper, 'Revoke publishing permissions')
+				expect(actionButton.exists()).toBe(false)
+			}
+
+			test('allows a moderator to revoke publishing permissions to an owner', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.ALL
+				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
+				participant.participantType = PARTICIPANT.TYPE.OWNER
+				await testCanRevokePublishingPermissions()
+			})
+
+			test('allows a moderator to revoke publishing permissions to a moderator', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.ALL
+				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
+				participant.participantType = PARTICIPANT.TYPE.MODERATOR
+				await testCanRevokePublishingPermissions()
+			})
+
+			test('allows a moderator to revoke publishing permissions to a user', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.ALL
+				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
+				participant.participantType = PARTICIPANT.TYPE.USER
+				await testCanRevokePublishingPermissions()
+			})
+
+			test('allows a moderator to revoke publishing permissions to a guest', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.ALL
+				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
+				participant.participantType = PARTICIPANT.TYPE.GUEST
+				await testCanRevokePublishingPermissions()
+			})
+
+			test('allows a moderator to revoke publishing permissions to a self joined-user', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.ALL
+				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
+				participant.participantType = PARTICIPANT.TYPE.USER_SELF_JOINED
+				await testCanRevokePublishingPermissions()
+			})
+
+			test('allows a moderator to revoke publishing permissions to a guest moderator', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.ALL
+				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
+				participant.participantType = PARTICIPANT.TYPE.GUEST_MODERATOR
+				await testCanRevokePublishingPermissions()
+			})
+
+			test('allows an owner to revoke publishing permissions to a user', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.ALL
+				conversation.participantType = PARTICIPANT.TYPE.OWNER
+				participant.participantType = PARTICIPANT.TYPE.USER
+				await testCanRevokePublishingPermissions()
+			})
+
+			test('allows a guest moderator to revoke publishing permissions to a user', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.ALL
+				conversation.participantType = PARTICIPANT.TYPE.GUEST_MODERATOR
+				participant.participantType = PARTICIPANT.TYPE.USER
+				await testCanRevokePublishingPermissions()
+			})
+
+			test('does not allow a non-moderator to revoke publishing permissions to a user', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.ALL
+				conversation.participantType = PARTICIPANT.TYPE.USER
+				participant.participantType = PARTICIPANT.TYPE.USER
+				await testCannotRevokePublishingPermissions()
+			})
+
+			test('does not allow a moderator to revoke publishing permissions to a user without permissions', async () => {
+				participant.publishingPermissions = PARTICIPANT.PUBLISHING_PERMISSIONS.NONE
+				conversation.participantType = PARTICIPANT.TYPE.MODERATOR
+				participant.participantType = PARTICIPANT.TYPE.USER
+				await testCannotRevokePublishingPermissions()
+			})
+		})
 	})
 
 	describe('as search result', () => {

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -96,7 +96,7 @@
 				decorative />
 		</div>
 		<Actions
-			v-if="canBeModerated && !isSearched"
+			v-if="(canBeModerated || canBeGrantedPublishingPermissions || canBeRevokedPublishingPermissions) && !isSearched"
 			:container="container"
 			:aria-label="participantSettingsAriaLabel"
 			:force-menu="true"
@@ -119,6 +119,18 @@
 				@click="promoteToModerator">
 				{{ t('spreed', 'Promote to moderator') }}
 			</ActionButton>
+			<ActionButton v-if="canBeGrantedPublishingPermissions"
+				icon="icon-audio"
+				:close-after-click="true"
+				@click="grantPublishingPermissions">
+				{{ t('spreed', 'Grant publishing permissions') }}
+			</ActionButton>
+			<ActionButton v-if="canBeRevokedPublishingPermissions"
+				icon="icon-audio-off"
+				:close-after-click="true"
+				@click="revokePublishingPermissions">
+				{{ t('spreed', 'Revoke publishing permissions') }}
+			</ActionButton>
 			<ActionButton v-if="canResendInvitation"
 				icon="icon-mail"
 				:close-after-click="true"
@@ -126,7 +138,7 @@
 				{{ t('spreed', 'Resend invitation') }}
 			</ActionButton>
 			<ActionSeparator
-				v-if="(canSeeAttendeePin || canBePromoted || canBeDemoted || canResendInvitation) && canBeModerated" />
+				v-if="(canSeeAttendeePin || canBePromoted || canBeDemoted || canBeGrantedPublishingPermissions || canBeRevokedPublishingPermissions || canResendInvitation) && canBeModerated" />
 			<ActionButton
 				v-if="canBeModerated"
 				icon="icon-delete"
@@ -436,6 +448,16 @@ export default {
 				&& !this.isModerator
 				&& !this.isGroup
 		},
+		canBeGrantedPublishingPermissions() {
+			return this.participant.publishingPermissions !== PARTICIPANT.PUBLISHING_PERMISSIONS.ALL
+				&& this.selfIsModerator
+				&& !this.isBridgeBotUser
+		},
+		canBeRevokedPublishingPermissions() {
+			return this.participant.publishingPermissions !== PARTICIPANT.PUBLISHING_PERMISSIONS.NONE
+				&& this.selfIsModerator
+				&& !this.isBridgeBotUser
+		},
 		canResendInvitation() {
 			return this.canBeModerated
 				&& this.isEmailActor
@@ -492,6 +514,20 @@ export default {
 			await this.$store.dispatch('demoteFromModerator', {
 				token: this.token,
 				attendeeId: this.participant.attendeeId,
+			})
+		},
+		async grantPublishingPermissions() {
+			await this.$store.dispatch('setPublishingPermissions', {
+				token: this.token,
+				attendeeId: this.participant.attendeeId,
+				state: PARTICIPANT.PUBLISHING_PERMISSIONS.ALL,
+			})
+		},
+		async revokePublishingPermissions() {
+			await this.$store.dispatch('setPublishingPermissions', {
+				token: this.token,
+				attendeeId: this.participant.attendeeId,
+				state: PARTICIPANT.PUBLISHING_PERMISSIONS.NONE,
 			})
 		},
 		async resendInvitation() {

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -102,7 +102,7 @@
 			:force-menu="true"
 			class="participant-row__actions">
 			<ActionText
-				v-if="attendeePin"
+				v-if="canSeeAttendeePin"
 				:title="t('spreed', 'Dial-in PIN')"
 				icon="icon-password">
 				{{ attendeePin }}
@@ -119,15 +119,16 @@
 				@click="promoteToModerator">
 				{{ t('spreed', 'Promote to moderator') }}
 			</ActionButton>
-			<ActionButton v-if="isEmailActor"
+			<ActionButton v-if="canResendInvitation"
 				icon="icon-mail"
 				:close-after-click="true"
 				@click="resendInvitation">
 				{{ t('spreed', 'Resend invitation') }}
 			</ActionButton>
 			<ActionSeparator
-				v-if="attendeePin || canBePromoted || canBeDemoted || isEmailActor" />
+				v-if="(canSeeAttendeePin || canBePromoted || canBeDemoted || canResendInvitation) && canBeModerated" />
 			<ActionButton
+				v-if="canBeModerated"
 				icon="icon-delete"
 				:close-after-click="true"
 				@click="removeParticipant">
@@ -421,6 +422,10 @@ export default {
 				&& this.selfIsModerator
 				&& !this.isBridgeBotUser
 		},
+		canSeeAttendeePin() {
+			return this.canBeModerated
+				&& this.attendeePin
+		},
 		canBeDemoted() {
 			return this.canBeModerated
 				&& [PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR].indexOf(this.participantType) !== -1
@@ -430,6 +435,10 @@ export default {
 			return this.canBeModerated
 				&& !this.isModerator
 				&& !this.isGroup
+		},
+		canResendInvitation() {
+			return this.canBeModerated
+				&& this.isEmailActor
 		},
 		preloadedUserStatus() {
 			if (Object.prototype.hasOwnProperty.call(this.participant, 'statusMessage')) {

--- a/src/services/participantsService.js
+++ b/src/services/participantsService.js
@@ -132,6 +132,11 @@ const demoteFromModerator = async (token, options) => {
 	return response
 }
 
+const setPublishingPermissions = async (token, options) => {
+	const response = await axios.put(generateOcsUrl('apps/spreed/api/v4/room/{token}/attendees/publishing-permissions', { token }), options)
+	return response
+}
+
 const fetchParticipants = async (token, options) => {
 	options = options || {}
 	options.params = options.params || {}
@@ -170,6 +175,7 @@ export {
 	removeAttendeeFromConversation,
 	promoteToModerator,
 	demoteFromModerator,
+	setPublishingPermissions,
 	fetchParticipants,
 	setGuestUserName,
 	resendInvitations,

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -23,6 +23,7 @@ import Vue from 'vue'
 import {
 	promoteToModerator,
 	demoteFromModerator,
+	setPublishingPermissions,
 	removeAttendeeFromConversation,
 	resendInvitations,
 	joinConversation,
@@ -250,6 +251,22 @@ const actions = {
 		// FIXME: don't demote already demoted, use server response instead
 		const updatedData = {
 			participantType: participant.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR ? PARTICIPANT.TYPE.GUEST : PARTICIPANT.TYPE.USER,
+		}
+		commit('updateParticipant', { token, index, updatedData })
+	},
+	async setPublishingPermissions({ commit, getters }, { token, attendeeId, state }) {
+		const index = getters.getParticipantIndex(token, { attendeeId })
+		if (index === -1) {
+			return
+		}
+
+		await setPublishingPermissions(token, {
+			attendeeId,
+			state,
+		})
+
+		const updatedData = {
+			publishingPermissions: state,
 		}
 		commit('updateParticipant', { token, index, updatedData })
 	},

--- a/tests/integration/features/conversation-2/set-publishing-allowed.feature
+++ b/tests/integration/features/conversation-2/set-publishing-allowed.feature
@@ -1,0 +1,246 @@
+Feature: set-publishing-allowed
+  Background:
+    Given user "owner" exists
+    Given user "moderator" exists
+    Given user "invited user" exists
+    Given user "not invited user" exists
+    Given user "not invited but joined user" exists
+    Given user "not joined user" exists
+
+  Scenario: publishing allowed can not be set while a call is active
+    Given user "owner" creates room "group room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "owner" joins room "group room" with 200 (v4)
+    And user "owner" joins call "group room" with 200 (v4)
+    When user "owner" sets publishing allowed for room "group room" to "MODERATORS" with 400 (v4)
+    Then user "owner" is participant of room "group room" (v4)
+      | publishingAllowed |
+      | EVERYONE          |
+
+
+
+  Scenario: owner can not set publishing allowed in one-to-one room
+    Given user "owner" creates room "one-to-one room" (v4)
+      | roomType | 1 |
+      | invite   | moderator |
+    When user "owner" sets publishing allowed for room "one-to-one room" to "MODERATORS" with 400 (v4)
+    And user "moderator" sets publishing allowed for room "one-to-one room" to "MODERATORS" with 400 (v4)
+    Then user "owner" is participant of room "one-to-one room" (v4)
+      | publishingAllowed |
+      | EVERYONE          |
+    And user "moderator" is participant of room "one-to-one room" (v4)
+      | publishingAllowed |
+      | EVERYONE          |
+
+
+
+  Scenario: owner can set publishing allowed in group room
+    Given user "owner" creates room "group room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "owner" adds user "moderator" to room "group room" with 200 (v4)
+    And user "owner" promotes "moderator" in room "group room" with 200 (v4)
+    And user "owner" adds user "invited user" to room "group room" with 200 (v4)
+    When user "owner" sets publishing allowed for room "group room" to "MODERATORS" with 200 (v4)
+    Then user "owner" is participant of room "group room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "moderator" is participant of room "group room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "invited user" is participant of room "group room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+
+  Scenario: moderator can set publishing allowed in group room
+    Given user "owner" creates room "group room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "owner" adds user "moderator" to room "group room" with 200 (v4)
+    And user "owner" promotes "moderator" in room "group room" with 200 (v4)
+    And user "owner" adds user "invited user" to room "group room" with 200 (v4)
+    When user "moderator" sets publishing allowed for room "group room" to "MODERATORS" with 200 (v4)
+    Then user "owner" is participant of room "group room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "moderator" is participant of room "group room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "invited user" is participant of room "group room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+
+  Scenario: others can not set publishing allowed in group room
+    Given user "owner" creates room "group room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "owner" adds user "moderator" to room "group room" with 200 (v4)
+    And user "owner" promotes "moderator" in room "group room" with 200 (v4)
+    And user "owner" adds user "invited user" to room "group room" with 200 (v4)
+    And user "owner" sets publishing allowed for room "group room" to "MODERATORS" with 200 (v4)
+    When user "invited user" sets publishing allowed for room "group room" to "EVERYONE" with 403 (v4)
+    And user "not invited user" sets publishing allowed for room "group room" to "EVERYONE" with 404 (v4)
+    # Guest user names in tests must begin with "guest"
+    And user "guest not joined" sets publishing allowed for room "group room" to "EVERYONE" with 404 (v4)
+    Then user "owner" is participant of room "group room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "moderator" is participant of room "group room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "invited user" is participant of room "group room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+
+
+
+  Scenario: owner can set publishing allowed in public room
+    Given user "owner" creates room "public room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "owner" adds user "moderator" to room "public room" with 200 (v4)
+    And user "owner" promotes "moderator" in room "public room" with 200 (v4)
+    And user "owner" adds user "invited user" to room "public room" with 200 (v4)
+    And user "not invited but joined user" joins room "public room" with 200 (v4)
+    And user "guest moderator" joins room "public room" with 200 (v4)
+    And user "owner" promotes "guest moderator" in room "public room" with 200 (v4)
+    And user "guest" joins room "public room" with 200 (v4)
+    When user "owner" sets publishing allowed for room "public room" to "MODERATORS" with 200 (v4)
+    Then user "owner" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "moderator" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "invited user" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "not invited but joined user" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "guest moderator" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "guest" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+
+  Scenario: moderator can set publishing allowed in public room
+    Given user "owner" creates room "public room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "owner" adds user "moderator" to room "public room" with 200 (v4)
+    And user "owner" promotes "moderator" in room "public room" with 200 (v4)
+    And user "owner" adds user "invited user" to room "public room" with 200 (v4)
+    And user "not invited but joined user" joins room "public room" with 200 (v4)
+    And user "guest moderator" joins room "public room" with 200 (v4)
+    And user "owner" promotes "guest moderator" in room "public room" with 200 (v4)
+    And user "guest" joins room "public room" with 200 (v4)
+    When user "moderator" sets publishing allowed for room "public room" to "MODERATORS" with 200 (v4)
+    Then user "owner" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "moderator" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "invited user" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "not invited but joined user" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "guest moderator" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "guest" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+
+  Scenario: others can not set publishing allowed in public room
+    Given user "owner" creates room "public room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "owner" adds user "moderator" to room "public room" with 200 (v4)
+    And user "owner" promotes "moderator" in room "public room" with 200 (v4)
+    And user "owner" adds user "invited user" to room "public room" with 200 (v4)
+    And user "not invited but joined user" joins room "public room" with 200 (v4)
+    And user "guest moderator" joins room "public room" with 200 (v4)
+    And user "owner" promotes "guest moderator" in room "public room" with 200 (v4)
+    And user "guest" joins room "public room" with 200 (v4)
+    And user "owner" sets publishing allowed for room "public room" to "MODERATORS" with 200 (v4)
+    When user "invited user" sets publishing allowed for room "public room" to "EVERYONE" with 403 (v4)
+    And user "not invited but joined user" sets publishing allowed for room "public room" to "EVERYONE" with 403 (v4)
+    And user "not joined user" sets publishing allowed for room "public room" to "EVERYONE" with 404 (v4)
+    # Guest user names in tests must begin with "guest"
+    And user "guest moderator" sets publishing allowed for room "public room" to "EVERYONE" with 404 (v4)
+    And user "guest" sets publishing allowed for room "public room" to "EVERYONE" with 404 (v4)
+    And user "guest not joined" sets publishing allowed for room "public room" to "EVERYONE" with 404 (v4)
+    Then user "owner" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "moderator" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "invited user" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "not invited but joined user" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "guest moderator" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "guest" is participant of room "public room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+
+
+
+  Scenario: participants can not set publishing allowed in room for a share
+    # These users are only needed in very specific tests, so they are not
+    # created in the background step.
+    Given user "owner of file" exists
+    And user "user with access to file" exists
+    And user "owner of file" shares "welcome.txt" with user "user with access to file" with OCS 100
+    And user "user with access to file" accepts last share
+    And user "owner of file" shares "welcome.txt" by link with OCS 100
+    And user "guest" gets the room for last share with 200 (v1)
+    And user "owner of file" joins room "file last share room" with 200 (v4)
+    And user "user with access to file" joins room "file last share room" with 200 (v4)
+    And user "guest" joins room "file last share room" with 200 (v4)
+    When user "owner of file" sets publishing allowed for room "file last share room" to "MODERATORS" with 403 (v4)
+    And user "user with access to file" sets publishing allowed for room "file last share room" to "MODERATORS" with 403 (v4)
+    And user "guest" sets publishing allowed for room "file last share room" to "MODERATORS" with 404 (v4)
+    Then user "owner of file" is participant of room "file last share room" (v4)
+      | publishingAllowed |
+      | EVERYONE          |
+    And user "user with access to file" is participant of room "file last share room" (v4)
+      | publishingAllowed |
+      | EVERYONE          |
+    And user "guest" is participant of room "file last share room" (v4)
+      | publishingAllowed |
+      | EVERYONE          |
+
+
+
+  # Although it is technically possible to set publishing allowed in a password
+  # request room in practice it will not, as there will be always an on-going
+  # call.
+  Scenario: owner can set publishing allowed in a password request room
+    # The user is only needed in very specific tests, so it is not created in
+    # the background step.
+    Given user "owner of file" exists
+    And user "owner of file" shares "welcome.txt" by link with OCS 100
+      | password | 123456 |
+      | sendPasswordByTalk | true |
+    And user "guest" creates the password request room for last share with 201 (v1)
+    And user "guest" joins room "password request for last share room" with 200 (v4)
+    And user "owner of file" joins room "password request for last share room" with 200 (v4)
+    When user "owner of file" sets publishing allowed for room "password request for last share room" to "MODERATORS" with 200 (v4)
+    Then user "owner of file" is participant of room "password request for last share room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |
+    And user "guest" is participant of room "password request for last share room" (v4)
+      | publishingAllowed |
+      | MODERATORS        |

--- a/tests/php/RoomTest.php
+++ b/tests/php/RoomTest.php
@@ -79,7 +79,8 @@ class RoomTest extends TestCase {
 			null,
 			null,
 			'',
-			''
+			'',
+			ROOM::PUBLISHING_ALLOWED_EVERYONE
 		);
 		$verificationResult = $room->verifyPassword('1234');
 		$this->assertSame($verificationResult, ['result' => true, 'url' => '']);


### PR DESCRIPTION
Follow up to #5693 

In #5693 publishing permissions can be set for each participant. However, by default all participants have publishing permissions, and they need to be explicitly revoked. This pull request introduces a setting for conversations to define whether everyone or only moderators should be able to publish by default in the conversation.

For now this just contains some commits salvaged from a previous version of #5693, but they might be useful to implement the feature.