### PR TITLE
Hide participants without publishing permissions in call view

### DIFF
--- a/docs/call.md
+++ b/docs/call.md
@@ -28,6 +28,7 @@
         `displayName` | string | v3 | | The display name of the attendee
         `lastPing` | int | v1 | | Timestamp of the last ping of the user (should be used for sorting)
         `sessionId` | string | v1 | | 512 character long string
+        `publishingPermissions` | int | v4 | Publishing permissions for the participant (see [constants list](constants.md#participant-publishing-permissions))
 
 ## Join a call
 

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -93,6 +93,7 @@ class CallController extends AEnvironmentAwareController {
 				'token' => $this->room->getToken(),
 				'lastPing' => $participant->getSession()->getLastPing(),
 				'sessionId' => $participant->getSession()->getSessionId(),
+				'publishingPermissions' => $participant->getAttendee()->getPublishingPermissions(),
 			];
 		}
 

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -232,7 +232,12 @@ export default {
 
 				const participantIndex = this.$store.getters.getParticipantIndex(this.token, { sessionId: nextcloudSessionId })
 				if (participantIndex === -1) {
-					return false
+					const peerData = this.$store.getters.getPeer(this.token, nextcloudSessionId)
+					if (!peerData) {
+						return false
+					}
+
+					return peerData.publishingPermissions !== PARTICIPANT.PUBLISHING_PERMISSIONS.NONE
 				}
 
 				const participant = this.$store.getters.getParticipant(this.token, participantIndex)
@@ -451,6 +456,8 @@ export default {
 	},
 	mounted() {
 		EventBus.$on('refresh-peer-list', this.debounceFetchPeers)
+		EventBus.$on('Signaling::participantListChanged', this.debounceFetchPeers)
+		this.debounceFetchPeers()
 
 		callParticipantCollection.on('remove', this._lowerHandWhenParticipantLeaves)
 
@@ -458,6 +465,7 @@ export default {
 	},
 	beforeDestroy() {
 		EventBus.$off('refresh-peer-list', this.debounceFetchPeers)
+		EventBus.$off('Signaling::participantListChanged', this.debounceFetchPeers)
 
 		callParticipantCollection.off('remove', this._lowerHandWhenParticipantLeaves)
 

--- a/src/components/CallView/shared/Video.vue
+++ b/src/components/CallView/shared/Video.vue
@@ -63,6 +63,12 @@
 						:show-user-status="false"
 						:class="avatarClass" />
 				</template>
+				<template v-else-if="model.attributes.subscribersOnlyPlaceholder">
+					<div
+						:class="guestAvatarClass"
+						style="background-size: 100%;"
+						class="avatar icon-contacts" />
+				</template>
 				<template v-else>
 					<VideoBackground
 						:display-name="participantName" />
@@ -252,6 +258,10 @@ export default {
 		},
 
 		participantUserId() {
+			if (this.model.attributes.subscribersOnlyPlaceholder) {
+				return null
+			}
+
 			if (this.model.attributes.userId) {
 				return this.model.attributes.userId
 			}
@@ -275,6 +285,12 @@ export default {
 		},
 
 		participantName() {
+			if (this.model.attributes.subscribersOnlyPlaceholder) {
+				return t('spreed', 'Participants not allowed to publish: {number}', {
+					number: this.model.attributes.subscribersOnlyCount,
+				})
+			}
+
 			if (this.model.attributes.name) {
 				return this.model.attributes.name
 			}


### PR DESCRIPTION
Follow up to #5693

In certain types of calls where only a few participants are expected to publish media while the rest are just listeners it may be better to hide all those listeners (for example, in a webcast or a presentation). This pull request hides the participants without publishing permissions in the call view, and shows just a dummy participant with how many listeners are currently in the call.

On the other hand, there are other types of calls in which even if most participants do not have publishing permissions it would be better to still show all the participants in the call view (for example, in a company call). Therefore this should be configurable somehow.

I would also be fine closing the pull request and always showing all participants; it was just an idea I had while implementing the publishing permission, but I am not strongly attached to this feature ;-)