### PR TITLE
Document circles too

### DIFF
--- a/docs/constants.md
+++ b/docs/constants.md
@@ -53,14 +53,16 @@ title: Constants
 ### Attendee types
 * `users` - Logged-in users
 * `groups` - Groups
+* `circles` - [Circle from the Circles app](https://github.com/nextcloud/circles)
 * `guests` - Guest without a login
 * `emails` - A guest invited by email address
 
 ### Actor types of chat messages
 * `guests` - guest users
 * `users` - logged-in users
-* `emails` - users invited by email
+* `emails` - A guest invited by email
 * `groups` - groups
+* `circles` - [Circle from the Circles app](https://github.com/nextcloud/circles)
 * `bots` - used by commands (actor-id is the used `/command`) and the changelog conversation (actor-id is `changelog`)
 
 ## Signaling modes

--- a/docs/conversation.md
+++ b/docs/conversation.md
@@ -35,7 +35,7 @@
         `participantType` | int | v1 | | Permissions level of the current user
         `attendeeId` | int | v3 | | Unique attendee id
         `attendeePin` | string | v3 | | Unique dial-in authentication code for this user, when the conversation has SIP enabled (see `sipEnabled` attribute)
-        `actorType` | string | v3 | | Currently known `users|guests|emails|groups`
+        `actorType` | string | v3 | | Currently known `users|guests|emails|groups|circles`
         `actorId` | string | v3 | | The unique identifier for the given actor type
         `participantInCall` | bool | v1 | v2 | **Removed:** use `participantFlags` instead
         `participantFlags` | int | v1 | | "In call" flags of the user's session making the request (only available with `in-call-flags` capability)

--- a/docs/participant.md
+++ b/docs/participant.md
@@ -28,7 +28,7 @@
         field | type | Added | Removed | Description
         ---|---|---|---|---
         `attendeeId` | int | v3 | | Unique attendee id
-        `actorType` | string | v3 | | Currently known `users|guests|emails|groups`
+        `actorType` | string | v3 | | Currently known `users|guests|emails|groups|circles`
         `actorId` | string | v3 | | The unique identifier for the given actor type
         `displayName` | string | v1 | | Can be empty for guests
         `participantType` | int | v1 | | Permissions level of the participant (see [constants list](constants.md#participant-types))

--- a/lib/Model/Attendee.php
+++ b/lib/Model/Attendee.php
@@ -55,6 +55,7 @@ class Attendee extends Entity {
 	public const ACTOR_GROUPS = 'groups';
 	public const ACTOR_GUESTS = 'guests';
 	public const ACTOR_EMAILS = 'emails';
+	public const ACTOR_CIRCLES = 'circles';
 
 	/** @var int */
 	protected $roomId;

--- a/src/constants.js
+++ b/src/constants.js
@@ -52,6 +52,7 @@ export const ATTENDEE = {
 		GUESTS: 'guests',
 		EMAILS: 'emails',
 		GROUPS: 'groups',
+		CIRCLES: 'circles',
 		BOTS: 'bots',
 	},
 	BRIDGE_BOT_ID: 'bridge-bot',


### PR DESCRIPTION
* Circles are currently not stored and returned due to #5670 
* But by adding them already the mobile clients are future proof and we don't have to update the API with a v5 after the PR is merged