### PR TITLE
Fix casing of exported initWebRTC function

### DIFF
--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -420,7 +420,7 @@ function usersInCallChanged(signaling, users) {
 	}
 }
 
-export default function initWebRTC(signaling, _callParticipantCollection, _localCallParticipantModel) {
+export default function initWebRtc(signaling, _callParticipantCollection, _localCallParticipantModel) {
 	callParticipantCollection = _callParticipantCollection
 	localCallParticipantModel = _localCallParticipantModel
 


### PR DESCRIPTION
In webrtc/index.js we import the function as WebRtc.
The name of the function at export time is semantically irrelevant but
having it correct might help when grepping.

In theory we could also remove that name altogether.

Tested with HPB to make sure this doesn't break.
