### PR TITLE
Don't trigger leave event when deleting conversation

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
@@ -475,30 +475,6 @@ describe('Conversation.vue', () => {
 				expect(updateTokenAction).not.toHaveBeenCalled()
 			})
 
-			test('redirects when deleting current conversation', async() => {
-				const actionHandler = jest.fn().mockResolvedValueOnce()
-				const updateTokenAction = jest.fn()
-				testStoreConfig.modules.conversationsStore.actions.deleteConversationFromServer = actionHandler
-				testStoreConfig.modules.tokenStore.getters.getToken = jest.fn().mockReturnValue(() => TOKEN)
-				testStoreConfig.modules.tokenStore.actions.updateToken = updateTokenAction
-
-				OC.dialogs.confirm = jest.fn()
-
-				const action = shallowMountAndGetAction('Delete conversation')
-				expect(action.exists()).toBe(true)
-
-				await action.find('button').trigger('click')
-
-				expect(OC.dialogs.confirm).toHaveBeenCalled()
-
-				// call callback directly
-				OC.dialogs.confirm.mock.calls[0][2](true)
-
-				expect(actionHandler).toHaveBeenCalledWith(expect.anything(), { token: TOKEN })
-				expect($router.push).toHaveBeenCalled()
-				expect(updateTokenAction).toHaveBeenCalledWith(expect.anything(), '')
-			})
-
 			test('does not delete conversation when not confirmed', async() => {
 				const actionHandler = jest.fn().mockResolvedValueOnce()
 				const updateTokenAction = jest.fn()

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -342,13 +342,6 @@ export default {
 						return
 					}
 
-					// TODO: verify if this is already happening automatically after deletion,
-					// just like when leaving a conversation
-					if (this.item.token === this.$store.getters.getToken()) {
-						this.$router.push({ name: 'root', params: { skipLeaveWarning: true } })
-						this.$store.dispatch('updateToken', '')
-					}
-
 					try {
 						await this.$store.dispatch('deleteConversationFromServer', { token: this.item.token })
 					} catch (error) {


### PR DESCRIPTION
When deleting a conversation, the route change would implicitly trigger
a leave request which ran in parallel to the conversation deletion one,
causing random issues in some systems like the latter returning a 404
instead of proceeding with the deletion.

This fix removes the route change on deletion. The new behavior will
implicitly redirect to the "not-found" page since the session does not
exist any more. The latter behavior is now aligned with the "Leave
conversation" action which also redirects to "not-found" page.

Fixes https://github.com/nextcloud/spreed/issues/5733
See ticket for details about the race condition and also alternative approaches that were considered but discarded.