### PR TITLE
Ignore current participant when listing rooms if removed concurrently

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -213,6 +213,9 @@ class RoomController extends AEnvironmentAwareController {
 			try {
 				$return[] = $this->formatRoom($room, $room->getParticipant($this->userId));
 			} catch (RoomNotFoundException $e) {
+			} catch (ParticipantNotFoundException $e) {
+				// for example in case the room was deleted concurrently,
+				// the user is not a participant any more
 			} catch (\RuntimeException $e) {
 			}
 		}


### PR DESCRIPTION
When retrieving the conversation list for a user, there is a
time window between retrieving the list and the participant information.
If in that time window, a concurrent request removes the user from the
room, or even the room got deleted, this could cause a
ParticipantNotFoundException.

This fix prevents the latter exception to make the whole call return a
404. Instead, it skips the obsoleted entry and carries on with the list.

Similar race condition like with https://github.com/nextcloud/spreed/issues/5733.
Not reproducible though.