### PR TITLE
Fix connection quality stats not reset when setting a new peer connection

### DIFF
--- a/src/utils/webrtc/analyzers/ParticipantAnalyzer.js
+++ b/src/utils/webrtc/analyzers/ParticipantAnalyzer.js
@@ -257,12 +257,18 @@ ParticipantAnalyzer.prototype = {
 			this._senderScreenPeerConnectionAnalyzer.setPeerConnection(this._screenPeer.pc, PEER_DIRECTION.SENDER)
 
 			this._senderScreenPeerConnectionAnalyzer.on('change:connectionQualityVideo', this._handleConnectionQualityScreenChangeBound)
+
+			this._senderScreenPeerConnectionAnalyzer.setAnalysisEnabledAudio(false)
+			this._senderScreenPeerConnectionAnalyzer.setAnalysisEnabledVideo(true)
 		}
 
 		if (this._callParticipantModel) {
 			this._receiverScreenPeerConnectionAnalyzer.setPeerConnection(this._screenPeer.pc, PEER_DIRECTION.RECEIVER)
 
 			this._receiverScreenPeerConnectionAnalyzer.on('change:connectionQualityVideo', this._handleConnectionQualityScreenChangeBound)
+
+			this._receiverScreenPeerConnectionAnalyzer.setAnalysisEnabledAudio(false)
+			this._receiverScreenPeerConnectionAnalyzer.setAnalysisEnabledVideo(true)
 		}
 	},
 

--- a/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
+++ b/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
@@ -244,6 +244,17 @@ PeerConnectionAnalyzer.prototype = {
 			return
 		}
 
+		// When a connection is started the stats must be reset, as a different
+		// peer connection could have been used before and its stats would be
+		// unrelated to the new one.
+		// When a connection is restarted the reported stats continue from the
+		// last values. However, during the reconnection the stats will not be
+		// updated, so the timestamps will suddenly increase once the connection
+		// is ready again. This could cause a wrong analysis, so the stats
+		// should be reset too in that case.
+		this._resetStats('audio')
+		this._resetStats('video')
+
 		this._getStatsInterval = window.setInterval(() => {
 			this._peerConnection.getStats().then(this._processStatsBound)
 		}, 1000)

--- a/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
+++ b/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
@@ -204,11 +204,7 @@ PeerConnectionAnalyzer.prototype = {
 		if (!analysisEnabledAudio) {
 			this._setConnectionQualityAudio(CONNECTION_QUALITY.UNKNOWN)
 		} else {
-			this._packets['audio'].reset()
-			this._packetsLost['audio'].reset()
-			this._packetsLostRatio['audio'].reset()
-			this._packetsPerSecond['audio'].reset()
-			this._timestamps['audio'].reset()
+			this._resetStats('audio')
 		}
 	},
 
@@ -218,12 +214,16 @@ PeerConnectionAnalyzer.prototype = {
 		if (!analysisEnabledVideo) {
 			this._setConnectionQualityVideo(CONNECTION_QUALITY.UNKNOWN)
 		} else {
-			this._packets['video'].reset()
-			this._packetsLost['video'].reset()
-			this._packetsLostRatio['video'].reset()
-			this._packetsPerSecond['video'].reset()
-			this._timestamps['video'].reset()
+			this._resetStats('video')
 		}
+	},
+
+	_resetStats: function(kind) {
+		this._packets[kind].reset()
+		this._packetsLost[kind].reset()
+		this._packetsLostRatio[kind].reset()
+		this._packetsPerSecond[kind].reset()
+		this._timestamps[kind].reset()
 	},
 
 	_handleIceConnectionStateChanged: function() {


### PR DESCRIPTION
~~Still in draft; I need to check if there is a better place to reset the stats (for example, when the ICE connection state changes), and check if it also works as expected when switching devices.~~ - It is better to reset the stats just before the analysis is started. 

Regarding switching devices I found a different issue related to stats being reset when they should not (when it is sent to other participants whether audio and video is enabled or disabled), so this needs to be fixed first before being able to check switching devices. Anyway, this will be done in another pull request.

## How to test
- Setup the HPB
- Start a call
- In a private window, join the call
- Share the screen
- Wait 10-15 seconds and stop the screen share
- Share the screen again

### Result with this pull request
The connection quality warning will not be shown.

### Result without this pull request
The connection quality warning will be shown.