### PR TITLE
Add UI feedback when local participant is not connected

### DIFF
--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -25,12 +25,15 @@
 		@mouseover="showShadow"
 		@mouseleave="hideShadow"
 		@click="handleClickVideo">
-		<video v-show="localMediaModel.attributes.videoEnabled"
-			id="localVideo"
-			ref="video"
-			disablePictureInPicture="true"
-			:class="videoClass"
-			class="video" />
+		<div v-show="localMediaModel.attributes.videoEnabled"
+			class="videoWrapper">
+			<video
+				id="localVideo"
+				ref="video"
+				disablePictureInPicture="true"
+				:class="videoClass"
+				class="video" />
+		</div>
 		<div v-if="!localMediaModel.attributes.videoEnabled && !isSidebar" class="avatar-container">
 			<VideoBackground
 				v-if="isGrid || isStripe"
@@ -314,6 +317,7 @@ export default {
 	flex-direction: column;
 }
 
+.videoWrapper,
 .video {
 	height: 100%;
 	width: 100%;

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -44,7 +44,7 @@
 				:user="userId"
 				:display-name="displayName" />
 			<div v-if="!userId"
-				:class="avatarSizeClass"
+				:class="guestAvatarClass"
 				class="avatar guest">
 				{{ firstLetterOfGuestName }}
 			</div>
@@ -176,8 +176,8 @@ export default {
 			return this.useConstrainedLayout ? 64 : 128
 		},
 
-		avatarSizeClass() {
-			return 'avatar-' + this.avatarSize + 'px'
+		guestAvatarClass() {
+			return 'avatar-' + this.avatarSize + 'px']
 		},
 
 		localStreamVideoError() {


### PR DESCRIPTION
When the connection with other participants is lost those participants are shown dimmed and with a loading spinner. However, when the MCU is used that only covers receiving audio and video from those participants. Other participants can not hear or see the local participant until the sender peer object has connected. Therefore now the local video / avatar is dimmed and shows a loading spinner like done with the remote participants when the sender peer object is not connected.

When the MCU is not used the connections are peer to peer between partipants, so the already existing dimming and loading spinner on the remote participants views already show whether those participants can hear and see the local participant or not.

Note that currently if you are alone in a call and a forced reconnection to the signaling server is triggered the sender peer object will not be reconnected, although it will be automatically reconnected once someone else joins the call. So if you leave Janus stopped for long enough in the test steps below you could see that the dimming and the loading spinner disappear. Nevertheless they will reappear until the connection is established once another participant joins the call.

**Before:**
![Local-Participant-Disconnected-Before](https://user-images.githubusercontent.com/26858233/122080877-ea3a2b00-cdfe-11eb-8e70-7b85de68dba9.png)

**After:**
![Local-Participant-Disconnected-After](https://user-images.githubusercontent.com/26858233/122080898-eefedf00-cdfe-11eb-9908-72dc24dc1f1b.png)

## How to test
- Setup the HPB
- Start a call
- Stop Janus

### Result with this pull request
Eventually the local video / avatar is dimmed and a loading spinner is shown on it

### Result without this pull request
The local video is shown as before
