### PR TITLE
Don't refresh the room when the participant list changes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -186,7 +186,6 @@ export default {
 		if (!getCurrentUser()) {
 			EventBus.$off('shouldRefreshConversations', this.debounceRefreshCurrentConversation)
 		}
-		EventBus.$off('Signaling::participantListChanged', this.debounceRefreshCurrentConversation)
 		document.removeEventListener('visibilitychange', this.changeWindowVisibility)
 	},
 
@@ -197,7 +196,6 @@ export default {
 			})
 			EventBus.$on('shouldRefreshConversations', this.debounceRefreshCurrentConversation)
 		}
-		EventBus.$on('Signaling::participantListChanged', this.debounceRefreshCurrentConversation)
 
 		if (this.$route.name === 'conversation') {
 			// Update current token in the token store


### PR DESCRIPTION
Currently when a call with 40 people is started and they join one by one
with 3.1s difference, each of the participant will fetch the conversation
40 times resulting in 1.6k requests.
At the same time the info doesn't really change anymore as the participant
details of other participants have been removed from the room API with
version 3. A refreshing of the room therefor only makes sense once
to update the hasCall and callFlag attributes.

The conversations callFlag however is not used at the moment and the worst
that could happen without the refreshing is the values updating on the next
refreshing of the complete room list which is done every 30 seconds.
