### PR TITLE
Slow down the participant list update when not visible

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -86,6 +86,10 @@ export default {
 			type: Boolean,
 			required: true,
 		},
+		isActive: {
+			type: Boolean,
+			required: true,
+		},
 	},
 
 	data() {
@@ -183,11 +187,27 @@ export default {
 			}
 		}, 250),
 
-		debounceUpdateParticipants: debounce(function() {
+		debounceUpdateParticipants() {
+			if (!this.$store.getters.windowIsVisible()
+				|| !this.$store.getters.getSidebarStatus
+				|| !this.isActive) {
+				this.debounceSlowUpdateParticipants()
+			}
+
+			this.debounceFastUpdateParticipants()
+		},
+
+		debounceSlowUpdateParticipants: debounce(function() {
 			if (!this.fetchingParticipants) {
 				this.cancelableGetParticipants()
 			}
-		}, 2000),
+		}, 15000),
+
+		debounceFastUpdateParticipants: debounce(function() {
+			if (!this.fetchingParticipants) {
+				this.cancelableGetParticipants()
+			}
+		}, 3000),
 
 		async fetchSearchResults() {
 			try {

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -52,6 +52,7 @@
 			:name="t('spreed', 'Participants')"
 			icon="icon-contacts-dark">
 			<ParticipantsTab
+				:is-active="activeTab === 'participants'"
 				:can-search="canSearchParticipants"
 				:can-add="canAddParticipants" />
 		</AppSidebarTab>


### PR DESCRIPTION
There is not a lot use in updating the participant list every 2 seconds,
when the list is not display, the sidebar closed or even the window hidden.
