### PR TITLE
Offset toastify when top bar is visible

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -451,6 +451,13 @@ export default {
 }
 </script>
 
+<style lang="scss">
+/** override toastify position due to top bar */
+body.has-topbar .toastify-top {
+	top: 65px !important;
+}
+</style>
+
 <style lang="scss" scoped>
 .content {
 	height: 100%;

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -283,6 +283,7 @@ export default {
 	},
 
 	mounted() {
+		document.body.classList.add('has-topbar')
 		document.addEventListener('fullscreenchange', this.fullScreenChanged, false)
 		document.addEventListener('mozfullscreenchange', this.fullScreenChanged, false)
 		document.addEventListener('MSFullscreenChange', this.fullScreenChanged, false)
@@ -294,6 +295,7 @@ export default {
 		document.removeEventListener('mozfullscreenchange', this.fullScreenChanged, false)
 		document.removeEventListener('MSFullscreenChange', this.fullScreenChanged, false)
 		document.removeEventListener('webkitfullscreenchange', this.fullScreenChanged, false)
+		document.body.classList.remove('has-topbar')
 	},
 
 	methods: {


### PR DESCRIPTION
To avoid overlapping with the top bar, the toastify notification is
shifted down.

<img width="424" alt="image" src="https://user-images.githubusercontent.com/277525/122520732-46c26380-d014-11eb-8505-aa5854b20029.png">

Doesn't look that fantastic though, wondering if we should move the notifications to the bottom instead. The latter might need more involved changes as it would require support for global toastify options in nextcloud-dialogs.