### PR TITLE
Fix toastify offset approach

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -454,7 +454,7 @@ export default {
 <style lang="scss">
 /** override toastify position due to top bar */
 body.has-topbar .toastify-top {
-	top: 65px !important;
+	margin-top: 105px;
 }
 </style>
 


### PR DESCRIPTION
Use margin-top to avoid overriding the top value which has different
values depending on how many notifications are visible.

Fixes https://github.com/nextcloud/spreed/issues/5819
