### PR TITLE
Set focus to message only when anchor is set

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -779,7 +779,7 @@ export default {
 		 *
 		 * @param {string} messageId message id
 		 * @param {boolean} smooth true to smooth scroll, false to jump directly
-		 * @param {boolean} highlightAnimation true to highlight the focussed message
+		 * @param {boolean} highlightAnimation true to highlight and set focus to the message
 		 * @returns {bool} true if element was found, false otherwise
 		 */
 		focusMessage(messageId, smooth = true, highlightAnimation = true) {
@@ -801,8 +801,8 @@ export default {
 					// scroll the viewport slightly further to make sure the element is about 1/3 from the top
 					this.scroller.scrollTop += this.scroller.offsetHeight / 4
 				}
-				element.focus()
 				if (highlightAnimation) {
+					element.focus()
 					element.highlightAnimation()
 				}
 			})

--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -237,18 +237,15 @@ export default {
 	},
 
 	mounted() {
-		this.focusInput()
 		/**
 		 * Listen to routeChange global events and focus on the
 		 */
-		EventBus.$on('routeChange', this.focusInput)
 		EventBus.$on('focusChatInput', this.focusInput)
 
 		this.atWhoPanelExtraClasses = 'talk candidate-mentions'
 	},
 
 	beforeDestroy() {
-		EventBus.$off('routeChange', this.focusInput)
 		EventBus.$off('focusChatInput', this.focusInput)
 	},
 

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -247,6 +247,10 @@ export default {
 	},
 
 	watch: {
+		currentConversationIsJoined(newValue) {
+			this.$refs.advancedInput.focusInput()
+		},
+
 		disabled(newValue) {
 			// the menu is not always available
 			if (!this.$refs.uploadMenu) {


### PR DESCRIPTION
Don't set focus on message element when scrolling to the first unread
message as this conflicts with focusInput() from the message form.
