### PR TITLE
Adjust viewer and sidebar to changes in Nextcloud 22

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -34,6 +34,7 @@
 		@update:title="handleUpdateTitle"
 		@submit-title="handleSubmitTitle"
 		@dismiss-editing="dismissEditing"
+		@closed="handleClosed"
 		@close="handleClose">
 		<template slot="description">
 			<LobbyStatus v-if="canFullModerate && hasLobbyEnabled" :token="token" />
@@ -258,6 +259,10 @@ export default {
 
 		showSettings() {
 			emit('show-settings')
+		},
+
+		handleClosed() {
+			emit('files:sidebar:closed')
 		},
 	},
 }

--- a/src/main.js
+++ b/src/main.js
@@ -160,6 +160,10 @@ Sidebar.prototype.close = function() {
 	store.dispatch('hideSidebar')
 	this.state.file = ''
 }
+Sidebar.prototype.setFullScreenMode = function(isFullScreen) {
+	// Sidebar style is not changed in Talk when the viewer is opened; this is
+	// needed only for compatibility with OCA.Files.Sidebar interface.
+}
 
 Object.assign(window.OCA.Files, {
 	Sidebar: new Sidebar(),

--- a/src/main.js
+++ b/src/main.js
@@ -37,6 +37,7 @@ import router from './router/router'
 // Utils
 import { generateFilePath } from '@nextcloud/router'
 import { getRequestToken } from '@nextcloud/auth'
+import { emit } from '@nextcloud/event-bus'
 
 // Directives
 import VueClipboard from 'vue-clipboard2'
@@ -121,6 +122,8 @@ const waitForSidebarToBeOpen = function(sidebarElement, resolve) {
 
 			sidebarElement.removeEventListener('transitionend', resolveOnceSidebarWidthHasChanged)
 
+			emit('files:sidebar:opened')
+
 			resolve()
 		}
 
@@ -133,6 +136,8 @@ const waitForSidebarToBeOpen = function(sidebarElement, resolve) {
 		setTimeout(() => {
 			console.debug('ontransitionend is not supported; the sidebar should have been fully shown by now')
 
+			emit('files:sidebar:opened')
+
 			resolve()
 		}, Number.parseInt(animationQuickValue) + 200)
 	}
@@ -141,6 +146,8 @@ const waitForSidebarToBeOpen = function(sidebarElement, resolve) {
 Sidebar.prototype.open = function(path) {
 	// The sidebar is already open, so this can return immediately.
 	if (this.state.file) {
+		emit('files:sidebar:opened')
+
 		return
 	}
 


### PR DESCRIPTION
Fixes #5810 

In Nextcloud 22 [`setFullScreenMode()` was added to `OCA.Files.Sidebar`](https://github.com/nextcloud/server/blob/c03a14934b543c6734e5458f814997e419cf808b/apps/files/src/sidebar.js#L61). That method [is expected and used by the viewer](https://github.com/nextcloud/viewer/blob/eba1a1bd3240ad825cd324254871438bebf0d587/src/views/Viewer.vue#L369), so it needs to be there even if the sidebar style is not changed to put it in full screen mode.

Besides that, in Nextcloud 22 [the viewer also reacts to `files:sidebar:opened` and `files:sidebar:closed` events](https://github.com/nextcloud/viewer/blob/eba1a1bd3240ad825cd324254871438bebf0d587/src/views/Viewer.vue#L343-L344) to adjust its width based on the sidebar.

At least for me the "opened" event from `AppSidebar` component does not seem to work reliably (it seems that sometimes in Firefox it is emitted before the sidebar has finished opening, so the viewer ends overlapping the sidebar due to getting its width when it is not fully opened), so for now the custom detection of when the sidebar has finished opening is still used.

Follow ups:
- Adjust the sidebar style to cover the top bar when the viewer is opened? Personally in Talk I would prefer not to alter the sidebar style when the viewer is opened, but fine by me too if you prefer the full screen mode.
- Investigate why emitting the `opened` event directly in the `RightSidebar` based on `AppSidebar` events is unreliable. Is it an issue with how it is done in Talk? Or is it an issue in the `AppSidebar` component?

## How to test
- Upload an image to the conversation
- Click on the image to open the viewer

### Result with this pull request
The viewer is opened. Closing and opening the sidebar again from the viewer works as expected too.

### Result without this pull request
The viewer is not opened.