### PR TITLE
Bring back voice-message icon after chat input is cleared

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -242,7 +242,7 @@ export default {
 		},
 
 		hasText() {
-			return this.text !== ''
+			return this.parsedText !== ''
 		},
 	},
 


### PR DESCRIPTION
Fix #5816 