### PR TITLE
Populate user status for one to one conversations via the backend call already

### DIFF
--- a/docs/conversation.md
+++ b/docs/conversation.md
@@ -9,6 +9,12 @@
 
 * Method: `GET`
 * Endpoint: `/room`
+* Data:
+
+    field | type | Description
+    ---|---|---
+    `noStatusUpdate` | int | Whether the "online" user status of the current user should be "kept-alive" (`1`) or not (`0`) (defaults to `0`)
+    `includeStatus` | bool | Whether the user status information of all one-to-one conversations should be loaded (default false)
 
 * Response:
     - Status code:
@@ -66,6 +72,9 @@
         `lastMessage` | message | v1 | | Last message in a conversation if available, otherwise empty
         `objectType` | string | v1 | | The type of object that the conversation is associated with; "share:password" if the conversation is used to request a password for a share, otherwise empty
         `objectId` | string | v1 | | Share token if "objectType" is "share:password", otherwise empty
+        `status` | string | v4 | | Optional: Only available for one-to-one conversations and when  `includeStatus=true` is set
+        `statusIcon` | string | v4 | | Optional: Only available for one-to-one conversations and when  `includeStatus=true` is set
+        `statusMessage` | string | v4 | | Optional: Only available for one-to-one conversations and when  `includeStatus=true` is set
         `participants` | array | v1 | v2 | **Removed**
         `guestList` | string | v1 | v2 | **Removed**
 

--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -28,6 +28,7 @@
 			:size="44"
 			:user="item.name"
 			:display-name="item.displayName"
+			:preloaded-user-status="preloadedUserStatus"
 			menu-container="#content-vue"
 			menu-position="left"
 			class="conversation-icon__avatar" />
@@ -100,6 +101,17 @@ export default {
 			}
 
 			return ''
+		},
+		preloadedUserStatus() {
+			if (Object.prototype.hasOwnProperty.call(this.item, 'statusMessage')) {
+				// We preloaded the status
+				return {
+					status: this.item.status || null,
+					message: this.item.statusMessage || null,
+					icon: this.item.statusIcon || null,
+				}
+			}
+			return undefined
 		},
 	},
 }

--- a/src/services/conversationsService.js
+++ b/src/services/conversationsService.js
@@ -26,9 +26,13 @@ import { CONVERSATION, SHARE } from '../constants'
 
 /**
  * Fetches the conversations from the server.
+ * @param {object} options options
  */
-const fetchConversations = async function() {
-	return axios.get(generateOcsUrl('apps/spreed/api/v4/room'))
+const fetchConversations = async function(options) {
+	options = options || {}
+	options.params = options.params || {}
+	options.params.includeStatus = true
+	return await axios.get(generateOcsUrl('apps/spreed/api/v4/room'), options)
 }
 
 /**


### PR DESCRIPTION
### Steps
1. Open Talk
2. Create one-to-one conversations with X users
3. Reload talk front page

### Before
X requests for user statuses (most with 404)

### After
User status is preloaded via conversations API and no additional requests are needed