### PR TITLE
Move conversation icon out of conversation header

### DIFF
--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -21,14 +21,15 @@
 
 <template>
 	<div class="top-bar" :class="{ 'in-call': isInCall }">
+		<ConversationIcon
+			class="conversation-icon"
+			:item="conversation"
+			:hide-favorite="false"
+			:hide-call="false" />
 		<!-- conversation header -->
 		<a v-if="!isInCall"
 			class="conversation-header"
 			@click="openConversationSettings">
-			<ConversationIcon
-				:item="conversation"
-				:hide-favorite="false"
-				:hide-call="false" />
 			<div class="conversation-header__text">
 				<p class="title">
 					{{ conversation.displayName }}
@@ -510,12 +511,15 @@ export default {
 	}
 }
 
+.conversation-icon {
+	margin-left: 48px;
+}
+
 .conversation-header {
 	position: relative;
 	display: flex;
 	overflow-x: hidden;
 	overflow-y: clip;
-	margin-left: 48px;
 	white-space: nowrap;
 	width: 100%;
 	cursor: pointer;


### PR DESCRIPTION
Move the conversation icon outside of the conversation header so that it
doesn't get cut.

Fixes issue where the status icon was cut.
Fixes issue where clicking the avatar would open the settings dialog
instead of the avatar menu. (mentioned in https://github.com/nextcloud/spreed/issues/5790#issuecomment-865280442)

Fixes https://github.com/nextcloud/spreed/issues/5826

Tests:
- [x] description is still truncated properly, no layout issue
- [x] avatar menu working again
- [x] status icon is not cut
- [x] hamburger menu working correctly in narrow window or wide window