### PR TITLE
Disable avatar menu in most conversation lists

### DIFF
--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -27,6 +27,7 @@
 		<Avatar v-else
 			:size="44"
 			:user="item.name"
+			:disable-menu="disableMenu"
 			:display-name="item.displayName"
 			:preloaded-user-status="preloadedUserStatus"
 			menu-container="#content-vue"
@@ -65,6 +66,10 @@ export default {
 		hideCall: {
 			type: Boolean,
 			default: true,
+		},
+		disableMenu: {
+			type: Boolean,
+			default: false,
 		},
 		item: {
 			type: Object,

--- a/src/components/ConversationsOptionsList.vue
+++ b/src/components/ConversationsOptionsList.vue
@@ -29,7 +29,8 @@
 			<template
 				#icon>
 				<ConversationIcon
-					:item="iconData(item)" />
+					:item="iconData(item)"
+					:disable-menu="true" />
 			</template>
 		</AppContentListItem>
 	</ul>

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -30,7 +30,8 @@
 			<ConversationIcon
 				:item="item"
 				:hide-favorite="false"
-				:hide-call="false" />
+				:hide-call="false"
+				:disable-menu="true" />
 		</template>
 		<template #subtitle>
 			<strong v-if="item.unreadMessages">

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -38,7 +38,8 @@
 					<ConversationIcon
 						:item="item"
 						:hide-favorite="true"
-						:hide-call="false" />
+						:hide-call="false"
+						:disable-menu="true" />
 				</template>
 			</DashboardWidgetItem>
 		</template>

--- a/src/views/RoomSelector.vue
+++ b/src/views/RoomSelector.vue
@@ -34,7 +34,8 @@
 							<ConversationIcon
 								:item="room"
 								:hide-call="true"
-								:hide-favorite="false" />
+								:hide-favorite="false"
+								:disable-menu="true" />
 							<span>{{ room.displayName }}</span>
 						</li>
 					</ul>


### PR DESCRIPTION
Disable avatar menu in conversation lists to avoid interaction glitches.
The only place where it's enabled currently is in the top bar.

Tests with one on one conversation:
- [x] dashboard: no menu (see https://github.com/nextcloud/spreed/issues/5834#issuecomment-865659999)
- [x] room selector as triggered from deck: no menu
- [x] left sidebar: no menu
- [x] top bar: menu is clickable

Fixes https://github.com/nextcloud/spreed/issues/5790