### PR TITLE
Fix scrolling to bottom in already read conversations

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -485,6 +485,7 @@ export default {
 			if (loadOldMessages) {
 				// Gets the history of the conversation.
 				await this.getOldMessages(true)
+				this.scrollToFocussedMessage()
 			}
 
 			// Once the history is received, starts looking for new messages.


### PR DESCRIPTION
1. Have a one-to-one conversation with some messages
2. Read them
3. Go to another conversation
4. Come back
5. Reload the page

### Before
You are in the middle of the chat

### After
You are at the bottom of the chat