### PR TITLE
Fix left sidebar click event handling

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
@@ -25,7 +25,7 @@
 			v-for="item of conversationsList"
 			:key="item.id"
 			:item="item"
-			@click.native="handleConversationClick(item)" />
+			@click="handleConversationClick(item)" />
 		<template
 			v-if="!initialisedConversations">
 			<LoadingPlaceholder


### PR DESCRIPTION
Rely on the event chain from the components instead of listening to
native events. The latter's problem is that it would also fire when the
user is clicking on the three dots menu.

Fixes https://github.com/nextcloud/spreed/issues/5100