### PR TITLE
Fix unload warning with pending messages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -31,7 +31,7 @@
 		</AppContent>
 		<RightSidebar
 			:show-chat-in-sidebar="isInCall" />
-		<PreventUnload :when="warnLeaving" />
+		<PreventUnload :when="warnLeaving || isSendingMessages" />
 		<UploadEditor />
 		<SettingsDialog />
 		<ConversationSettingsDialog />
@@ -109,8 +109,12 @@ export default {
 			return this.$store.getters.getUserId()
 		},
 
+		isSendingMessages() {
+			return this.$store.getters.isSendingMessages
+		},
+
 		warnLeaving() {
-			return this.$store.getters.isSendingMessages || (!this.isLeavingAfterSessionIssue && this.isInCall)
+			return !this.isLeavingAfterSessionIssue && this.isInCall
 		},
 
 		/**


### PR DESCRIPTION
Only display a warning when leaving the page completely, which would
abort pending sending operations.

Switching between conversations will keep sending in the background so
no warning is needed.

Fixes: https://github.com/nextcloud/spreed/issues/5842

Test:
- [x] switching conversations with pending messages does not show warning
- [x] switching apps with pending messages shows a browser warning