### PR TITLE
Scroll participant list to top on token change

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -49,6 +49,7 @@
 		</AppSidebarTab>
 		<AppSidebarTab v-if="getUserId"
 			id="participants"
+			ref="participantsTab"
 			:order="2"
 			:name="t('spreed', 'Participants')"
 			icon="icon-contacts-dark">
@@ -213,6 +214,7 @@ export default {
 			if (!this.isRenamingConversation) {
 				this.conversationName = this.conversation.displayName
 			}
+			this.$refs.participantsTab.$el.scrollTop = 0
 		},
 	},
 


### PR DESCRIPTION
When switching conversations, the participant list's scroll container is
scrolled back to the top instead of keeping an arbitrary position.

Fixes https://github.com/nextcloud/spreed/issues/5841