### PR TITLE
Remove voice recording for guests

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -105,12 +105,12 @@
 				</div>
 
 				<AudioRecorder
-					v-if="!hasText"
+					v-if="!hasText && canUploadFiles"
 					@recording="handleRecording"
 					@audioFile="handleAudioFile" />
 
 				<button
-					v-if="hasText"
+					v-else
 					:disabled="disabled"
 					type="submit"
 					:aria-label="t('spreed', 'Send message')"


### PR DESCRIPTION
Guests currently have no way of uploading files, pictures, so voice
recordings fall under the same category.

Fixes https://github.com/nextcloud/spreed/issues/5848