### PR TITLE
Fix saving sound settings

### DIFF
--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -230,7 +230,7 @@ export default {
 			this.playSoundsLoading = true
 			try {
 				try {
-					await this.$store.dispatch('setPlaySounds', status)
+					await this.$store.dispatch('setPlaySounds', !this.playSounds)
 				} catch (e) {
 					showError(t('spreed', 'Failed to save sounds setting'))
 				}

--- a/src/store/soundsStore.js
+++ b/src/store/soundsStore.js
@@ -74,7 +74,7 @@ const actions = {
 	 * @param {boolean} enabled Whether sounds should be played
 	 */
 	async setPlaySounds(context, enabled) {
-		await setPlaySounds(!context.state.userId, status)
+		await setPlaySounds(!context.state.userId, enabled)
 		context.commit('setPlaySounds', enabled)
 	},
 }


### PR DESCRIPTION
Use the correct attributes and values when saving.

Strange that eslint didn't complain in both cases...