### PR TITLE
Safely import lodash function

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -78,7 +78,7 @@ import debounce from 'debounce'
 import { EventBus } from '../../services/EventBus'
 import LoadingPlaceholder from '../LoadingPlaceholder'
 import ChevronDown from 'vue-material-design-icons/ChevronDown'
-import { uniqueId } from 'lodash'
+import uniqueId from 'lodash/uniqueId'
 
 export default {
 	name: 'MessagesList',


### PR DESCRIPTION
Fixes side effects that seem to affect the files app.

Fixes https://github.com/nextcloud/spreed/issues/5858

I've also verified the whole codebase and didn't find any other such imports to fix.
We are already using `isEqual` in two places and it was already imported safely.
