### PR TITLE
Only scroll to focussed message once

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -459,10 +459,7 @@ export default {
 					})
 
 					// get history + new messages
-					await this.getMessages(true)
-				} else {
-					// get only new messages
-					await this.getMessages(false)
+					await this.getOldMessages(true)
 				}
 
 				// focus on next tick to make sure the DOM elements
@@ -470,6 +467,9 @@ export default {
 				this.$nextTick(() => {
 					this.scrollToFocussedMessage()
 				})
+
+				// get new messages
+				await this.lookForNewMessages()
 			} else {
 				this.$store.dispatch('cancelLookForNewMessages', { requestId: this.chatIdentifier })
 			}
@@ -478,15 +478,8 @@ export default {
 		/**
 		 * Fetches the messages of a conversation given the conversation token. Triggers
 		 * a long-polling request for new messages.
-		 * @param {boolean} loadOldMessages In case it is the first visit of this conversation, we need to load the history
 		 */
-		async getMessages(loadOldMessages) {
-			if (loadOldMessages) {
-				// Gets the history of the conversation.
-				await this.getOldMessages(true)
-				this.scrollToFocussedMessage()
-			}
-
+		async lookForNewMessages() {
 			// Once the history is received, starts looking for new messages.
 			if (this._isBeingDestroyed || this._isDestroyed) {
 				console.debug('Prevent getting new messages on a destroyed MessagesList')


### PR DESCRIPTION
We should scroll as soon as we have the old messages / context loaded.
For newer messages, don't scroll up again to the read marker in case
there is one.

It happened to me on c.nc.com that even though I scrolled down after seeing the read marker, the chat scrolled up again to focus on the read marker. I suspect that it's related to the call I've removed in this PR.

@nickvergessen this is what we discussed yesterday and weren't sure if we wanted to keep. Let's remove it for now.

I'll retest:

- [x] initial scroll to read marker still works
- [x] initial scroll to search result still works
- [x] initial scroll to bottom works when no unread messages