### PR TITLE
Fix selecting the own screen in the gridview

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -35,7 +35,7 @@
 					:show-actions="!isSidebar"
 					:local-call-participant-model="localCallParticipantModel"
 					:screen-sharing-button-hidden="isSidebar"
-					@switch-screen-to-id="$emit('switchScreenToId', $event)" />
+					@switch-screen-to-id="_switchScreenToId" />
 
 				<!-- Selected override mode -->
 				<div v-if="showSelected"
@@ -53,7 +53,7 @@
 							:is-grid="true"
 							:is-big="true"
 							:fit-video="true"
-							@switchScreenToId="_switchScreenToId" />
+							@switch-screen-to-id="_switchScreenToId" />
 					</template>
 				</div>
 				<!-- Screens -->
@@ -96,7 +96,7 @@
 						:video-container-aspect-ratio="videoContainerAspectRatio"
 						:local-call-participant-model="localCallParticipantModel"
 						:is-sidebar="false"
-						@switchScreenToId="1" />
+						@switch-screen-to-id="_switchScreenToId" />
 				</div>
 				<!-- Promoted "autopilot" mode -->
 				<div v-else
@@ -115,7 +115,7 @@
 							:fit-video="true"
 							:is-big="true"
 							:is-sidebar="isSidebar"
-							@switchScreenToId="_switchScreenToId" />
+							@switch-screen-to-id="_switchScreenToId" />
 					</template>
 				</div>
 			</template>
@@ -135,6 +135,7 @@
 				:local-call-participant-model="localCallParticipantModel"
 				:shared-datas="sharedDatas"
 				@select-video="handleSelectVideo"
+				@switch-screen-to-id="_switchScreenToId"
 				@click-local-video="handleClickLocalVideo" />
 			<!-- Local video if sidebar -->
 			<LocalVideo
@@ -150,7 +151,7 @@
 				:video-container-aspect-ratio="videoContainerAspectRatio"
 				:local-call-participant-model="localCallParticipantModel"
 				:is-sidebar="isSidebar"
-				@switchScreenToId="1"
+				@switch-screen-to-id="_switchScreenToId"
 				@click-video="handleClickLocalVideo" />
 		</div>
 	</div>
@@ -560,6 +561,8 @@ export default {
 				return
 			}
 
+			this.$store.dispatch('startPresentation')
+			this.$store.dispatch('selectedVideoPeerId', null)
 			this.screens.splice(index, 1)
 			this.screens.unshift(id)
 		},

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -361,7 +361,7 @@ export default {
 			// Everytime a new screen is shared, switch to promoted view
 			if (newValue.length > previousValue.length) {
 				this.$store.dispatch('startPresentation')
-			} else if (newValue.length === 0 && previousValue.length > 0) {
+			} else if (newValue.length === 0 && previousValue.length > 0 && !this.hasLocalScreen) {
 				// last screen share stopped, reopening stripe
 				this.$store.dispatch('stopPresentation')
 			}
@@ -370,7 +370,7 @@ export default {
 			// Everytime the local screen is shared, switch to promoted view
 			if (showLocalScreen) {
 				this.$store.dispatch('startPresentation')
-			} else {
+			} else if (this.callParticipantModelsWithScreen.length === 0) {
 				this.$store.dispatch('stopPresentation')
 			}
 		},

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -116,7 +116,7 @@
 							:local-media-model="localMediaModel"
 							:video-container-aspect-ratio="videoContainerAspectRatio"
 							:local-call-participant-model="localCallParticipantModel"
-							@switchScreenToId="1"
+							@switch-screen-to-id="switchScreenToId"
 							@click-video="handleClickLocalVideo" />
 					</div>
 					<button v-if="hasNextPage && gridWidth > 0 && showVideoOverlay"
@@ -140,7 +140,7 @@
 					:local-media-model="localMediaModel"
 					:video-container-aspect-ratio="videoContainerAspectRatio"
 					:local-call-participant-model="localCallParticipantModel"
-					@switchScreenToId="1"
+					@switch-screen-to-id="switchScreenToId"
 					@click-video="handleClickLocalVideo" />
 				<!-- page indicator (disabled) -->
 				<div
@@ -772,6 +772,10 @@ export default {
 
 		handleClickLocalVideo() {
 			this.$emit('click-local-video')
+		},
+
+		switchScreenToId(id) {
+			this.$emit('switch-screen-to-id', id)
 		},
 
 		isSelected(callParticipantModel) {

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -688,7 +688,7 @@ export default {
 
 		showScreen() {
 			if (this.model.attributes.localScreen) {
-				this.$emit('switchScreenToId', this.localCallParticipantModel.attributes.peerId)
+				this.$emit('switch-screen-to-id', this.localCallParticipantModel.attributes.peerId)
 			}
 
 			this.screenSharingMenuOpen = false

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -62,7 +62,7 @@
 				:model="localMediaModel"
 				:local-call-participant-model="localCallParticipantModel"
 				:screen-sharing-button-hidden="isSidebar"
-				@switch-screen-to-id="$emit('switchScreenToId', $event)" />
+				@switch-screen-to-id="switchScreenToId($event)" />
 		</transition>
 		<div v-if="mouseover && isSelectable" class="hover-shadow" />
 		<div class="bottom-bar">
@@ -313,6 +313,10 @@ export default {
 		handleStopFollowing() {
 			this.$store.dispatch('selectedVideoPeerId', null)
 			this.$store.dispatch('stopPresentation')
+		},
+
+		switchScreenToId(id) {
+			this.$emit('switch-screen-to-id', id)
 		},
 	},
 

--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -270,7 +270,7 @@ export default {
 
 		switchToScreen() {
 			if (!this.sharedData.screenVisible) {
-				this.$emit('switchScreenToId', this.model.attributes.peerId)
+				this.$emit('switch-screen-to-id', this.model.attributes.peerId)
 			}
 		},
 


### PR DESCRIPTION
Fix #5861 


## Steps to reproduce (scenario 1)
1. Start a call (single user)
2. Share your screen (you see it)
3. Swich to grid view (it's hidden)
4. Open the screenshare menu
5. Click on "Show your screen"

### Expected behaviour
You see your screen

### Actual behaviour
Nothing

## Steps to reproduce (scenario 2)
1. Start a call (single user)
2. Share your screen (you see it)
3. Join with user 2
4. Also share the screen (everyone sees the own screen)
5. As user 2 unshare the screen

### Expected behaviour
Everyone sees screen of user 1

### Actual behaviour
user 1 sees the grid view (although they saw their own screen before)
user 2 sees the screen of user 1 but the bottom row is not collapsed




## Talk app

**Talk app version:** 4974b3d1f7e0bb444dabea963db97e3fb860135f
