### PR TITLE
Fix emoji picker vertical position

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -505,7 +505,7 @@ export default {
 		&__emoji-picker {
 			position: absolute;
 			left: 5px;
-			bottom: 1;
+			bottom: 1px;
 			.emoji-picker-button {
 				opacity: .7;
 				&:hover,


### PR DESCRIPTION
Fix CSS syntax error that prevented the emoji picker to stick to the
bottom.

Before:
<img width="545" alt="image" src="https://user-images.githubusercontent.com/277525/123381724-623bea00-d591-11eb-8593-b978387e7583.png">

After:
<img width="524" alt="image" src="https://user-images.githubusercontent.com/277525/123382114-db3b4180-d591-11eb-80fe-77d423470e69.png">


Please note that if you type multiple lines it will stick at the bottom. Since the "bottom" rule was already there I'll assume that this was already by design, just not activately properly:
<img width="185" alt="image" src="https://user-images.githubusercontent.com/277525/123382194-f1e19880-d591-11eb-930c-b3a42b4fa837.png">

Fixes https://github.com/nextcloud/spreed/issues/5870