### PR TITLE
Add logs for connection quality warning

### DIFF
--- a/src/utils/webrtc/analyzers/AverageStatValue.js
+++ b/src/utils/webrtc/analyzers/AverageStatValue.js
@@ -55,6 +55,9 @@ const STAT_VALUE_TYPE = {
  * the raw value that was added or the relative one after the conversion (which,
  * for non cumulative values, will be the raw value too).
  *
+ * A string representation of the current relative values can be got by calling
+ * "toString()".
+ *
  * @param {int} count the number of instances to take into account.
  * @param {STAT_VALUE_TYPE} type whether the value is cumulative or relative.
  * @param {int} lastValueWeight the value to calculate the weights of all the
@@ -125,6 +128,22 @@ AverageStatValue.prototype = {
 		}
 
 		return weightedValues / weightsSum
+	},
+
+	toString() {
+		if (!this._relativeValues.length) {
+			return '[]'
+		}
+
+		let relativeValuesAsString = '[' + this._relativeValues[0]
+
+		for (let i = 1; i < this._relativeValues.length; i++) {
+			relativeValuesAsString += ', ' + this._relativeValues[i]
+		}
+
+		relativeValuesAsString += ']'
+
+		return relativeValuesAsString
 	},
 
 }

--- a/src/utils/webrtc/analyzers/AverageStatValue.spec.js
+++ b/src/utils/webrtc/analyzers/AverageStatValue.spec.js
@@ -35,6 +35,43 @@ describe('AverageStatValue', () => {
 		})
 	})
 
+	describe('to string', () => {
+		test('no values', () => {
+			const stat = new AverageStatValue(3, STAT_VALUE_TYPE.CUMULATIVE, 3)
+			const stat2 = new AverageStatValue(3, STAT_VALUE_TYPE.RELATIVE, 3)
+
+			expect(stat.toString()).toBe('[]')
+			expect(stat2.toString()).toBe('[]')
+		})
+
+		test('single value', () => {
+			const stat = new AverageStatValue(3, STAT_VALUE_TYPE.CUMULATIVE, 3)
+			const stat2 = new AverageStatValue(3, STAT_VALUE_TYPE.RELATIVE, 3)
+
+			stat.add(42)
+			stat2.add(42)
+
+			// The first cumulative value is treated as 0 as it is the base from
+			// which the rest of the values will be calculated.
+			expect(stat.toString()).toBe('[0]')
+			expect(stat2.toString()).toBe('[42]')
+		})
+
+		test('several values', () => {
+			const testValues = [100, 200, 150, 123, 30, 50, 22, 33]
+			const stat = new AverageStatValue(3, STAT_VALUE_TYPE.CUMULATIVE, 3)
+			const stat2 = new AverageStatValue(3, STAT_VALUE_TYPE.RELATIVE, 3)
+
+			testValues.forEach((val, index) => {
+				stat.add(val)
+				stat2.add(val)
+			})
+
+			expect(stat.toString()).toBe('[20, -28, 11]')
+			expect(stat2.toString()).toBe('[50, 22, 33]')
+		})
+	})
+
 	describe('cumulative average', () => {
 		test('returns the last relative value', () => {
 			const testValues = [


### PR DESCRIPTION
Fixes #5362

The logs are printed when the PeerConnectionAnalyzer changes to a state that causes a connection quality warning to be shown (very bad quality or not transmitted data).
    
Currently the connection quality is analyzed only when the HPB is used and only for the sender participant, so there will be at most a single PeerConnectionAnalyzer. Due to this, for simplicity, for now the stats are logged without any participant identifier.
