### PR TITLE
Fix connection quality warning shown due to stalled stats

### DIFF
--- a/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
+++ b/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
@@ -203,6 +203,10 @@ PeerConnectionAnalyzer.prototype = {
 	},
 
 	setAnalysisEnabledAudio(analysisEnabledAudio) {
+		if (this._analysisEnabled.audio === analysisEnabledAudio) {
+			return
+		}
+
 		this._analysisEnabled.audio = analysisEnabledAudio
 
 		if (!analysisEnabledAudio) {
@@ -213,6 +217,10 @@ PeerConnectionAnalyzer.prototype = {
 	},
 
 	setAnalysisEnabledVideo(analysisEnabledVideo) {
+		if (this._analysisEnabled.video === analysisEnabledVideo) {
+			return
+		}
+
 		this._analysisEnabled.video = analysisEnabledVideo
 
 		if (!analysisEnabledVideo) {

--- a/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
+++ b/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
@@ -121,8 +121,10 @@ function PeerConnectionAnalyzer() {
 	this._handleIceConnectionStateChangedBound = this._handleIceConnectionStateChanged.bind(this)
 	this._processStatsBound = this._processStats.bind(this)
 
-	this._connectionQualityAudio = CONNECTION_QUALITY.UNKNOWN
-	this._connectionQualityVideo = CONNECTION_QUALITY.UNKNOWN
+	this._connectionQuality = {
+		audio: CONNECTION_QUALITY.UNKNOWN,
+		video: CONNECTION_QUALITY.UNKNOWN,
+	}
 }
 PeerConnectionAnalyzer.prototype = {
 
@@ -162,28 +164,28 @@ PeerConnectionAnalyzer.prototype = {
 	},
 
 	getConnectionQualityAudio() {
-		return this._connectionQualityAudio
+		return this._connectionQuality.audio
 	},
 
 	getConnectionQualityVideo() {
-		return this._connectionQualityVideo
+		return this._connectionQuality.video
 	},
 
 	_setConnectionQualityAudio(connectionQualityAudio) {
-		if (this._connectionQualityAudio === connectionQualityAudio) {
+		if (this._connectionQuality.audio === connectionQualityAudio) {
 			return
 		}
 
-		this._connectionQualityAudio = connectionQualityAudio
+		this._connectionQuality.audio = connectionQualityAudio
 		this._trigger('change:connectionQualityAudio', [connectionQualityAudio])
 	},
 
 	_setConnectionQualityVideo(connectionQualityVideo) {
-		if (this._connectionQualityVideo === connectionQualityVideo) {
+		if (this._connectionQuality.video === connectionQualityVideo) {
 			return
 		}
 
-		this._connectionQualityVideo = connectionQualityVideo
+		this._connectionQuality.video = connectionQualityVideo
 		this._trigger('change:connectionQualityVideo', [connectionQualityVideo])
 	},
 

--- a/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
+++ b/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
@@ -399,39 +399,7 @@ PeerConnectionAnalyzer.prototype = {
 				packetsLost[kind] = this._packetsLost[kind].getLastRawValue()
 			}
 
-			if (packets[kind] >= 0) {
-				this._packets[kind].add(packets[kind])
-			}
-			if (packetsLost[kind] >= 0) {
-				this._packetsLost[kind].add(packetsLost[kind])
-			}
-			if (packets[kind] >= 0 && packetsLost[kind] >= 0) {
-				// The packet stats are cumulative values, so the isolated
-				// values are got from the helper object.
-				// If there were no transmitted packets in the last stats the
-				// ratio is higher than 1 both to signal that and to force the
-				// quality towards a very bad quality faster, but not
-				// immediately.
-				let packetsLostRatio = 1.5
-				if (this._packets[kind].getLastRelativeValue() > 0) {
-					packetsLostRatio = this._packetsLost[kind].getLastRelativeValue() / this._packets[kind].getLastRelativeValue()
-				}
-				this._packetsLostRatio[kind].add(packetsLostRatio)
-			}
-			if (timestamp[kind] >= 0) {
-				this._timestamps[kind].add(timestamp[kind])
-				this._timestampsForLogs[kind].add(timestamp[kind])
-			}
-			if (packets[kind] >= 0 && timestamp[kind] >= 0) {
-				const elapsedSeconds = this._timestamps[kind].getLastRelativeValue() / 1000
-				// The packet stats are cumulative values, so the isolated
-				// values are got from the helper object.
-				const packetsPerSecond = this._packets[kind].getLastRelativeValue() / elapsedSeconds
-				this._packetsPerSecond[kind].add(packetsPerSecond)
-			}
-			if (roundTripTime[kind] >= 0) {
-				this._roundTripTime[kind].add(roundTripTime[kind])
-			}
+			this._addStats(kind, packets[kind], packetsLost[kind], timestamp[kind], roundTripTime[kind])
 		}
 	},
 
@@ -490,36 +458,42 @@ PeerConnectionAnalyzer.prototype = {
 				packetsLost[kind] = this._packetsLost[kind].getLastRawValue()
 			}
 
-			if (packets[kind] >= 0) {
-				this._packets[kind].add(packets[kind])
+			this._addStats(kind, packets[kind], packetsLost[kind], timestamp[kind])
+		}
+	},
+
+	_addStats(kind, packets, packetsLost, timestamp, roundTripTime) {
+		if (packets >= 0) {
+			this._packets[kind].add(packets)
+		}
+		if (packetsLost >= 0) {
+			this._packetsLost[kind].add(packetsLost)
+		}
+		if (packets >= 0 && packetsLost >= 0) {
+			// The packet stats are cumulative values, so the isolated values
+			// are got from the helper object.
+			// If there were no transmitted packets in the last stats the ratio
+			// is higher than 1 both to signal that and to force the quality
+			// towards a very bad quality faster, but not immediately.
+			let packetsLostRatio = 1.5
+			if (this._packets[kind].getLastRelativeValue() > 0) {
+				packetsLostRatio = this._packetsLost[kind].getLastRelativeValue() / this._packets[kind].getLastRelativeValue()
 			}
-			if (packetsLost[kind] >= 0) {
-				this._packetsLost[kind].add(packetsLost[kind])
-			}
-			if (packets[kind] >= 0 && packetsLost[kind] >= 0) {
-				// The packet stats are cumulative values, so the isolated
-				// values are got from the helper object.
-				// If there were no transmitted packets in the last stats the
-				// ratio is higher than 1 both to signal that and to force the
-				// quality towards a very bad quality faster, but not
-				// immediately.
-				let packetsLostRatio = 1.5
-				if (this._packets[kind].getLastRelativeValue() > 0) {
-					packetsLostRatio = this._packetsLost[kind].getLastRelativeValue() / this._packets[kind].getLastRelativeValue()
-				}
-				this._packetsLostRatio[kind].add(packetsLostRatio)
-			}
-			if (timestamp[kind] >= 0) {
-				this._timestamps[kind].add(timestamp[kind])
-				this._timestampsForLogs[kind].add(timestamp[kind])
-			}
-			if (packets[kind] >= 0 && timestamp[kind] >= 0) {
-				const elapsedSeconds = this._timestamps[kind].getLastRelativeValue() / 1000
-				// The packet stats are cumulative values, so the isolated
-				// values are got from the helper object.
-				const packetsPerSecond = this._packets[kind].getLastRelativeValue() / elapsedSeconds
-				this._packetsPerSecond[kind].add(packetsPerSecond)
-			}
+			this._packetsLostRatio[kind].add(packetsLostRatio)
+		}
+		if (timestamp >= 0) {
+			this._timestamps[kind].add(timestamp)
+			this._timestampsForLogs[kind].add(timestamp)
+		}
+		if (packets >= 0 && timestamp >= 0) {
+			const elapsedSeconds = this._timestamps[kind].getLastRelativeValue() / 1000
+			// The packet stats are cumulative values, so the isolated
+			// values are got from the helper object.
+			const packetsPerSecond = this._packets[kind].getLastRelativeValue() / elapsedSeconds
+			this._packetsPerSecond[kind].add(packetsPerSecond)
+		}
+		if (roundTripTime !== undefined && roundTripTime >= 0) {
+			this._roundTripTime[kind].add(roundTripTime)
 		}
 	},
 

--- a/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
+++ b/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
@@ -524,14 +524,18 @@ PeerConnectionAnalyzer.prototype = {
 	},
 
 	_calculateConnectionQualityAudio() {
-		return this._calculateConnectionQuality(this._packetsLostRatio.audio, this._packetsPerSecond.audio, this._roundTripTime.audio, 'audio')
+		return this._calculateConnectionQuality('audio')
 	},
 
 	_calculateConnectionQualityVideo() {
-		return this._calculateConnectionQuality(this._packetsLostRatio.video, this._packetsPerSecond.video, this._roundTripTime.video, 'video')
+		return this._calculateConnectionQuality('video')
 	},
 
-	_calculateConnectionQuality(packetsLostRatio, packetsPerSecond, roundTripTime, kind) {
+	_calculateConnectionQuality(kind) {
+		const packetsLostRatio = this._packetsLostRatio[kind]
+		const packetsPerSecond = this._packetsPerSecond[kind]
+		const roundTripTime = this._roundTripTime[kind]
+
 		if (!packetsLostRatio.hasEnoughData() || !packetsPerSecond.hasEnoughData()) {
 			return CONNECTION_QUALITY.UNKNOWN
 		}


### PR DESCRIPTION
Requires #5884 ~~(kept as draft until that is merged, but ready for review nevertheless)~~

The stats reported by the browser can sometimes stall for a second (it is unclear whether the browser does not update the stats or Janus does not send them, though). When that happens the stats are still reported, but with the same values as in the previous report. As there were no transmitted packets the "very bad quality" state was (wrongly) triggered.

To solve this now if there were no transmitted packets in the last report the analysis is kept on hold. If in the next report the number of packets has changed then the previous report is considered to have stalled and the new values are distributed between the previous and current report. If the number of packets is still zero then the previous report is considered to have been legit and the previous and current values are added as normal.

Besides the main fix this pull request also fixes the stats being wrongly reset when calling "setAnalysisEnabledXXX(true)" twice. This happens whenever the audio or video is enabled while being already enabled. This happens, for example, when another participant joins and the current media state is sent; whether that should happen or not is a different matter, but in any case, calling "setAnalysisEnabledXXX(true)" twice should not reset the stats.

## How to test
- Add a log to know when the stats reported zero transmitted packets (without this pull request, by adding [an else clause](https://github.com/nextcloud/spreed/blob/2bba6b48760ead80bdc0ec1abba4a28f49703f6f/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js#L401); with this pull request, by using [the else clause in `_addStats()`](https://github.com/nextcloud/spreed/commit/ae7df361616930c9ee3715439d10e73c4ae83f5b#diff-7a158e361f2d1d4260e85fa2256fcd4d4b64d2db206d3bf3406cd6366c01cabfR507))
- Setup the HPB
- Start a call
- Leave the call running for a while; sometimes joining and leaving the call with another participant causes the stats to stall

### Result with this pull request
Eventually the logs will show that the stats were stalled (zero transmitted packets in a single report), but there will be no logs about the connection quality warning

### Result with this pull request
Eventually the logs will show that the stats were stalled (zero transmitted packets in a single report) and there will be logs about the connection quality warning (high lost packet ratio, ~0.45 and then ~0.375, the lost packet ratio values will be similar to _[0, 0, 0, 0, 1.5]_ and then _[0, 0, 0, 1.5, 0]_)
