### PR TITLE
Fix TURN's url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you have suggestions or problems, please [open an issue](https://github.com/n
 
 Nextcloud Talk is really easy to install. You just need to enable the app from the [Nextcloud App Store](https://apps.nextcloud.com/apps/spreed) and everything will work out of the box.
 
-There are some scenarios (users behind strict firewalls / symmetric NATs) where a TURN server is needed. That's a bit more tricky to install. You can [find instructions in our documentation](https://nextcloud-talk.readthedocs.io/en/latest/TURN/) and the team behind the Nextcloud VM has developed a script which takes care of everything for you ([vm-talk.sh](https://github.com/nextcloud/vm/blob/master/apps/talk.sh)). The script is tested on Ubuntu Server 18.04, but should work on 16.04 as well. Please keep in mind that it's developed for the VM specifically and any issues should be reported in that repo, not here.
+There are some scenarios (users behind strict firewalls / symmetric NATs) where a TURN server is needed. That's a bit more tricky to install. You can [find instructions in our documentation](https://nextcloud-talk.readthedocs.io/en/latest/TURN.html) and the team behind the Nextcloud VM has developed a script which takes care of everything for you ([vm-talk.sh](https://github.com/nextcloud/vm/blob/master/apps/talk.sh)). The script is tested on Ubuntu Server 18.04, but should work on 16.04 as well. Please keep in mind that it's developed for the VM specifically and any issues should be reported in that repo, not here.
 
 Here's a short [video](https://youtu.be/KdTsWIy4eN0) on how it's done.
 


### PR DESCRIPTION
The original TURN instruction URL (https://nextcloud-talk.readthedocs.io/en/latest/TURN/) will show this:

<img width="1432" alt="Screen Shot 2021-06-29 at 9 40 07 AM" src="https://user-images.githubusercontent.com/31609554/123724088-4a7ca280-d8be-11eb-8f7e-96cd01b5bbf1.png">

And it should be this (https://nextcloud-talk.readthedocs.io/en/latest/TURN.html):

<img width="1432" alt="Screen Shot 2021-06-29 at 9 40 40 AM" src="https://user-images.githubusercontent.com/31609554/123724058-3cc71d00-d8be-11eb-9603-5bab5e3a90be.png">

