### PR TITLE
Listen to token changes instead of conversation object

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -214,7 +214,12 @@ export default {
 			if (!this.isRenamingConversation) {
 				this.conversationName = this.conversation.displayName
 			}
-			this.$refs.participantsTab.$el.scrollTop = 0
+		},
+
+		token() {
+			if (this.$refs.participantsTab) {
+				this.$refs.participantsTab.$el.scrollTop = 0
+			}
 		},
 	},
 


### PR DESCRIPTION
The converstion watcher is triggered even for attribute changes, so we
now use the token watcher instead for scrolling up so it only happens
when meaningful.

Note: the conversation display name watcher still needs to watch for "conversation" as the name might change while the token doesn't.

Fixes https://github.com/nextcloud/spreed/issues/5904