### PR TITLE
Store the last "comment" message in the rooms table to compare it with the unread counter

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>13.0.0-dev</version>
+	<version>13.0.0-dev.1</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -532,8 +532,8 @@ class RoomController extends AEnvironmentAwareController {
 					$lastReadMessage = $this->chatManager->getLastReadMessageFromLegacy($room, $currentUser);
 					$this->participantService->updateLastReadMessage($currentParticipant, $lastReadMessage);
 				}
-				if ($room->getLastMessage() && $lastReadMessage === (int) $room->getLastMessage()->getId()) {
-					// When the last message is the last read message, there are no unread messages,
+				if ($lastReadMessage >= $room->getLastCommentId()) {
+					// When the last "comment" message is the last read message, there are no unread messages,
 					// so we can save the query.
 					$roomData['unreadMessages'] = 0;
 				} else {

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -191,6 +191,7 @@ class Manager {
 			$lastActivity,
 			(int) $row['last_message'],
 			$lastMessage,
+			(int) $row['last_comment'],
 			$lobbyTimer,
 			(string) $row['object_type'],
 			(string) $row['object_id']

--- a/lib/Migration/Version12001Date20210702125755.php
+++ b/lib/Migration/Version12001Date20210702125755.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\Types;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version12001Date20210702125755 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('talk_rooms');
+		if (!$table->hasColumn('last_comment')) {
+			$table->addColumn('last_comment', Types::BIGINT, [
+				'notnull' => false,
+				'default' => 0,
+			]);
+
+			return $schema;
+		}
+
+		return null;
+	}
+}

--- a/lib/Model/SelectHelper.php
+++ b/lib/Model/SelectHelper.php
@@ -45,6 +45,7 @@ class SelectHelper {
 			->addSelect($alias . 'call_flag')
 			->addSelect($alias . 'last_activity')
 			->addSelect($alias . 'last_message')
+			->addSelect($alias . 'last_comment')
 			->addSelect($alias . 'lobby_timer')
 			->addSelect($alias . 'object_type')
 			->addSelect($alias . 'object_id')


### PR DESCRIPTION
Before a chat that was "read" but had a system message afterwards (like a user leaving)
would trigger another query to the oc_comments table to check for the unread message count,
although the "comment" counter could still be 0 as only "unreadable" messages were posted.
