### PR TITLE
Fix initial camera quality with Chromium

### DIFF
--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -149,7 +149,12 @@ LocalMedia.prototype._adjustVideoConstraintsForChromium = function(constraints) 
 	const parser = new UAParser()
 	const browserName = parser.getBrowser().name
 
-	if (browserName !== 'Chrome' && browserName !== 'Chromium') {
+	if (browserName !== 'Chrome'
+		&& browserName !== 'Chromium'
+		&& browserName !== 'Opera'
+		&& browserName !== 'Safari'
+		&& browserName !== 'Mobile Safari'
+		&& browserName !== 'Edge') {
 		return
 	}
 

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -5,6 +5,7 @@ const hark = require('hark')
 const getScreenMedia = require('./getscreenmedia')
 const WildEmitter = require('wildemitter')
 const mockconsole = require('mockconsole')
+const UAParser = require('ua-parser-js')
 // Only mediaDevicesManager is used, but it can not be assigned here due to not
 // being initialized yet.
 const webrtcIndex = require('../index.js')
@@ -132,6 +133,38 @@ LocalMedia.prototype.isLocalMediaActive = function() {
 	return this._localMediaActive
 }
 
+/**
+ * Adjusts video constraints to work around bug in Chromium.
+ *
+ * In Chromium it is not possible to increase the resolution of a track once it
+ * has been cloned, so the track needs to be initialized with a high resolution
+ * (otherwise real devices are initialized with a resolution around 640x480).
+ * Therefore, the video is requested with a loose constraint for a high
+ * resolution, so if the camera does not have such resolution it will still
+ * return the highest resolution available without failing.
+ *
+ * @param {Object} constraints the constraints to be adjusted
+ */
+LocalMedia.prototype._adjustVideoConstraintsForChromium = function(constraints) {
+	const parser = new UAParser()
+	const browserName = parser.getBrowser().name
+
+	if (browserName !== 'Chrome' && browserName !== 'Chromium') {
+		return
+	}
+
+	if (!constraints.video) {
+		return
+	}
+
+	if (!(constraints.video instanceof Object)) {
+		constraints.video = {}
+	}
+
+	constraints.video.width = 1920
+	constraints.video.height = 1200
+}
+
 LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 	const self = this
 	const constraints = mediaConstraints || { audio: true, video: true }
@@ -168,6 +201,8 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 		webrtcIndex.mediaDevicesManager.enableDeviceEvents()
 		webrtcIndex.mediaDevicesManager.disableDeviceEvents()
 	}
+
+	this._adjustVideoConstraintsForChromium(constraints)
 
 	// The handlers for "change:audioInputId" and "change:videoInputId" events
 	// expect the initial "getUserMedia" call to have been completed before
@@ -462,7 +497,10 @@ LocalMedia.prototype._handleVideoInputIdChanged = function(mediaDevicesManager, 
 		return
 	}
 
-	webrtcIndex.mediaDevicesManager.getUserMedia({ video: true }).then(stream => {
+	const constraints = { video: true }
+	this._adjustVideoConstraintsForChromium(constraints)
+
+	webrtcIndex.mediaDevicesManager.getUserMedia(constraints).then(stream => {
 		// According to the specification "getUserMedia({ video: true })" will
 		// return a single video track.
 		const track = stream.getTracks()[0]


### PR DESCRIPTION
Follow up to #5551

Due to [a bug in Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=946490) it is not possible to increase the resolution of a track once it has been cloned.

When the video was initially requested by Talk no resolution was specified, so Chromium returned a video track with a ~640x480 resolution, no matter the maximum resolution of the camera. As the track was immediately cloned, due to the bug, the maximum resolution of the track was limited to ~640x480.

Now, if Chromium or a derived browser is used, the video is requested with a loose constraint for a high resolution, so if the camera does not have such resolution it will still return the highest resolution available without failing. If the track is then cloned then it will be possible to decrease and increase again the track resolution as desired instead of being locked to a maximum resolution of ~640x480.

Note that this only happens with real video devices; virtual video devices, like those created with v4l2loopback, do not have that issue.

You can verify all that with the following tests:
- Bug:
  - Connect an HD camera
  - Open a private window in Chromium/Edge
  - Open the browser console
  - Run the following lines in the console one by one:
```
stream = await navigator.mediaDevices.getUserMedia({ video: true })
console.log(stream.getTracks()[0].getSettings()) // The resolution will be 640x480 or 640x360
stream.getTracks()[0].applyConstraints({ width: { exact: 1280 } })
console.log(stream.getTracks()[0].getSettings()) // The resolution will be higher, probably 1280x960 or 1280x720
stream.getTracks()[0].applyConstraints({ width: 640 })
console.log(stream.getTracks()[0].getSettings()) // The resolution will be again 640x480 or 640x360
clonedTrack = stream.getTracks()[0].clone()
stream.getTracks()[0].applyConstraints({ width: { exact: 1280 } }) // This will fail as over constrained
```

- Workaround:
  - Connect an HD camera
  - Open a private window in Chromium/Edge
  - Open the browser console
  - Run the following lines in the console one by one:
```
stream = await navigator.mediaDevices.getUserMedia({ video: { width: 1920, height: 1200 })
console.log(stream.getTracks()[0].getSettings()) // The resolution will be higher than 640x480 or 640x360
clonedTrack = stream.getTracks()[0].clone()
stream.getTracks()[0].applyConstraints({ width: 640 })
console.log(stream.getTracks()[0].getSettings()) // The resolution will be 640x480 or 640x360
stream.getTracks()[0].applyConstraints({ width: { exact: 1280 } })
console.log(stream.getTracks()[0].getSettings()) // The resolution will be higher again, probably 1280x960 or 1280x720, even if the track was cloned
```

Please note that this time **I could not test** the pull request myself. Also please test with a Chromium derived browser, like Edge, to ensure that the user agent check works in that case too. And if you have two cameras try to switch between them during a call and check that the resolution worked as expected. Thanks :-)

## How to test

- Connect an HD or Full HD camera
- Start a conversation in Chromium
- Open the browser console and check the current resolution of the video (it is assumed that there is also audio; if there is no audio use `getSenders()[0]` instead):
`OCA.Talk.SimpleWebRTC.webrtc.peers[0].pc.getSenders()[1].track.getSettings()`
- Try to increase the resolution of the video to a higher but valid resolution:
`OCA.Talk.SimpleWebRTC.webrtc.peers[0].pc.getSenders()[1].track.applyConstraints({ width: { exact: 1280 } }).then(() => { console.log("Success") }).catch(error => { console.log(error) })`

### Result with this pull request

The resolution of the video will be [at least 720x540](https://github.com/nextcloud/spreed/blob/master/src/utils/webrtc/VideoConstrainer.js#L165-L172), and trying to increase it will succeed.

### Result without this pull request

The resolution of the video will be 640x480, and trying to increase it will fail.
