### PR TITLE
Prevent submitting the message when the user is composing

### DIFF
--- a/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
+++ b/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue
@@ -321,6 +321,12 @@ export default {
 				return
 			}
 
+			// If the user is stil composing by an input method,
+			// we should not submit the message
+			if (event.isComposing) {
+				return
+			}
+
 			// TODO: add support for CTRL+ENTER new line
 			if (!(event.shiftKey)) {
 				event.preventDefault()


### PR DESCRIPTION
Resolved https://github.com/nextcloud/spreed/issues/5937

I am not sure if this will cause incompatible between different browsers,
but at least I tested it on Chrome it seems great!

Signed-off-by: Jim Lin <b04705003@ntu.edu.tw>

Related information: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing