### PR TITLE
Use visual last read message id in scroll handler

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -145,12 +145,12 @@ export default {
 		},
 
 		/**
-		 * Finds the first unread message element
+		 * Finds the first visual unread message element
 		 *
 		 * @returns {object} DOM element of the first unread message
 		 */
 		unreadMessageElement() {
-			let el = document.getElementById('message_' + this.conversation.lastReadMessage)
+			let el = document.getElementById('message_' + this.visualLastReadMessageId)
 			if (el) {
 				el = el.closest('.message')
 			}


### PR DESCRIPTION
The scroll handler checks if the unread marker was seen before doing
updates after scrolling down. After updating the read marker in the
store, its value becomes different than the visual one. Because of this,
the check for seen was done on the wrong element and would always be
false.

This fix makes the handler use the visual marker instead of the store
one when checking for update. This makes sure that the marker will
continue to be updated when scrolling down, but will only allow
increasing the message id past the non-visual one to prevent bringing
the marker back up.

For reference, here is where the check is done: https://github.com/nextcloud/spreed/blob/bugfix/5814/fix-unread-marker-discrepancy/src/components/MessagesList/MessagesList.vue#L698

Fixes https://github.com/nextcloud/spreed/issues/5814