### PR TITLE
Fix read marker and counter issues with pending pages

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -469,7 +469,7 @@ export default {
 				let hasScrolled = false
 				// if lookForNewMessages will long poll instead of returning existing messages,
 				// scroll right away to avoid delays
-				if (this.$store.getters.getLastKnownMessageId(this.token) === this.conversation.lastMessage.id) {
+				if (!this.$store.getters.hasMoreMessagesToLoad(this.token)) {
 					hasScrolled = true
 					await this.$nextTick(() => {
 						this.scrollToFocussedMessage()
@@ -658,6 +658,9 @@ export default {
 		 * Also see updateReadMarkerPosition() for the backend update.
 		 */
 		refreshReadMarkerPosition() {
+			if (!this.conversation) {
+				return
+			}
 			console.debug('setVisualLastReadMessageId token=' + this.token + ' id=' + this.conversation.lastReadMessage)
 			this.$store.dispatch('setVisualLastReadMessageId', {
 				token: this.token,
@@ -699,8 +702,8 @@ export default {
 				return
 			}
 
-			// if we're at bottom of the chat, then simply clear the marker
-			if (this.isSticky) {
+			// if we're at bottom of the chat with no more new messages to load, then simply clear the marker
+			if (this.isSticky && !this.$store.getters.hasMoreMessagesToLoad()) {
 				console.debug('clearLastReadMessage because of isSticky token=' + this.token)
 				this.$store.dispatch('clearLastReadMessage', { token: this.token })
 				return

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -703,7 +703,7 @@ export default {
 			}
 
 			// if we're at bottom of the chat with no more new messages to load, then simply clear the marker
-			if (this.isSticky && !this.$store.getters.hasMoreMessagesToLoad()) {
+			if (this.isSticky && !this.$store.getters.hasMoreMessagesToLoad(this.token)) {
 				console.debug('clearLastReadMessage because of isSticky token=' + this.token)
 				this.$store.dispatch('clearLastReadMessage', { token: this.token })
 				return

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -115,7 +115,7 @@ const getters = {
 	 * Returns whether more messages can be loaded, which means that the current
 	 * message list doesn't yet contain all future messages.
 	 * If false, the next call to "lookForNewMessages" will be blocking/long-polling.
-
+	 *
 	 * @param {object} state the state object.
 	 * @param {object} getters the getters object.
 	 * @returns {bool} true if more messages exist that needs loading, false otherwise


### PR DESCRIPTION
Whenever there are several pages of unread messages, the
"lookForNewMessages()" call will not return all the results at once.

In case there are results left to load, the read marker is not reset by
the false when "isSticky" (aka scrolled to bottom) happens.

When loading new messages, we now only increase the conversation counter
when the latter was out of sync with the current messages list.

Fixes https://github.com/nextcloud/spreed/issues/5960

Make sure to check the steps there when testing as it requires 300+ messages as lookForNewMessages only returns 100 results at a time.