### PR TITLE
Never show read marker on the very last message

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
@@ -424,6 +424,7 @@ describe('Message.vue', () => {
 
 		test('displays unread message marker that marks the message seen when visible', () => {
 			messageProps.lastReadMessageId = 123
+			messageProps.nextMessageId = 333
 			const observeVisibility = jest.fn()
 
 			const wrapper = shallowMount(Message, {
@@ -452,6 +453,24 @@ describe('Message.vue', () => {
 			// stays true if it was visible once
 			directiveValue.value(false)
 			expect(wrapper.vm.seen).toEqual(true)
+		})
+
+		test('does not display read marker on the very last message', () => {
+			messageProps.lastReadMessageId = 123
+			messageProps.nextMessageId = null // last message
+			const observeVisibility = jest.fn()
+
+			const wrapper = shallowMount(Message, {
+				localVue,
+				store,
+				directives: {
+					observeVisibility,
+				},
+				propsData: messageProps,
+			})
+
+			const marker = wrapper.find('.new-message-marker')
+			expect(marker.exists()).toBe(false)
 		})
 	})
 

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -402,6 +402,10 @@ export default {
 
 	computed: {
 		isLastReadMessage() {
+			if (!this.nextMessageId) {
+				// never display indicator on the very last message
+				return false
+			}
 			// note: not reading lastReadMessage from the conversation as we want to define it externally
 			// to have closer control on marker's visibility behavior
 			return this.id === this.lastReadMessageId


### PR DESCRIPTION
Added condition to detect the last message when deciding whether to
render the read marker.

Fixes issues when the last message is a deleted one or a command and
where the marker was displayed.

Fixes https://github.com/nextcloud/spreed/issues/5959