### PR TITLE
Use async import for vue component on collections entrypoint

### DIFF
--- a/src/collections.js
+++ b/src/collections.js
@@ -21,7 +21,6 @@
  */
 
 import Vue from 'vue'
-import RoomSelector from './views/RoomSelector'
 
 // eslint-disable-next-line no-unexpected-multiline
 (function(OCP, OC) {
@@ -42,6 +41,7 @@ import RoomSelector from './views/RoomSelector'
 				container.id = 'spreed-room-select'
 				const body = document.getElementById('body-user')
 				body.appendChild(container)
+				const RoomSelector = () => import('./views/RoomSelector')
 				const ComponentVM = new Vue({
 					render: h => h(RoomSelector),
 				})


### PR DESCRIPTION
Use async loading of the roomlist component for the collections endpoint as otherwise the imports of dependent components from `@nextcloud/vue` takes up quite some time when loading the files app initially without triggering the display of the room selector.

![image](https://user-images.githubusercontent.com/3404133/124887812-d0db6780-dfd5-11eb-9e66-ea4c911577a3.png)

| Before | After | 
| ------ | ----- |
| ![talk-collections-old](https://user-images.githubusercontent.com/3404133/124887875-e2247400-dfd5-11eb-8bae-1f773024ef85.png) | ![talk-collections-new](https://user-images.githubusercontent.com/3404133/124887877-e2247400-dfd5-11eb-85fb-a67d292782af.png) |
