### PR TITLE
📅 End meeting for all

### DIFF
--- a/docs/chat.md
+++ b/docs/chat.md
@@ -271,6 +271,7 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 * `call_joined` - {actor} joined the call
 * `call_left` - {actor} left the call
 * `call_ended` - Call with {user1}, {user2}, {user3}, {user4} and {user5} (Duration 30:23)
+* `call_ended_everyone` - {user1} ended the call with {user2}, {user3}, {user4} and {user5} (Duration 30:23)
 * `call_missed` - You missed a call from {user}
 * `call_tried` - You tried to call {user}
 * `read_only_off` - {actor} unlocked the conversation

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -177,8 +177,8 @@ class SystemMessage {
 			}
 		} elseif ($message === 'call_missed') {
 			[$parsedMessage, $parsedParameters, $message] = $this->parseMissedCall($room, $parameters, $currentActorId);
-		} elseif ($message === 'call_ended') {
-			[$parsedMessage, $parsedParameters] = $this->parseCall($parameters);
+		} elseif ($message === 'call_ended' || $message === 'call_ended_everyone') {
+			[$parsedMessage, $parsedParameters] = $this->parseCall($message, $parameters, $parsedParameters);
 		} elseif ($message === 'read_only_off') {
 			$parsedMessage = $this->l->t('{actor} unlocked the conversation');
 			if ($currentUserIsActor) {
@@ -734,50 +734,103 @@ class SystemMessage {
 	}
 
 
-	protected function parseCall(array $parameters): array {
+	protected function parseCall(string $message, array $parameters, array $params): array {
+		if ($message === 'call_ended_everyone') {
+			if ($params['actor']['type'] === 'user') {
+				$flipped = array_flip($parameters['users']);
+				unset($flipped[$params['actor']['id']]);
+				$parameters['users'] = array_flip($flipped);
+			} else {
+				$parameters['guests']--;
+			}
+		}
 		sort($parameters['users']);
 		$numUsers = \count($parameters['users']);
 		$displayedUsers = $numUsers;
 
 		switch ($numUsers) {
 			case 0:
-				$subject = $this->l->n(
-					'Call with %n guest (Duration {duration})',
-					'Call with %n guests (Duration {duration})',
-					$parameters['guests']
-				);
+				if ($message === 'call_ended') {
+					$subject = $this->l->n(
+						'Call with %n guest (Duration {duration})',
+						'Call with %n guests (Duration {duration})',
+						$parameters['guests']
+					);
+				} else {
+					$subject = $this->l->n(
+						'{actor} ended the call with %n guest (Duration {duration})',
+						'{actor} ended the call with %n guests (Duration {duration})',
+						$parameters['guests']
+					);
+				}
 				break;
 			case 1:
-				$subject = $this->l->t('Call with {user1} and {user2} (Duration {duration})');
+				if ($message === 'call_ended') {
+					$subject = $this->l->t('Call with {user1} and {user2} (Duration {duration})');
+				} else {
+					if ($parameters['guests'] === 0) {
+						$subject = $this->l->t('{actor} ended the call with {user1} (Duration {duration})');
+					} else {
+						$subject = $this->l->t('{actor} ended the call with {user1} and {user2} (Duration {duration})');
+					}
+				}
 				$subject = str_replace('{user2}', $this->l->n('%n guest', '%n guests', $parameters['guests']), $subject);
 				break;
 			case 2:
 				if ($parameters['guests'] === 0) {
-					$subject = $this->l->t('Call with {user1} and {user2} (Duration {duration})');
+					if ($message === 'call_ended') {
+						$subject = $this->l->t('Call with {user1} and {user2} (Duration {duration})');
+					} else {
+						$subject = $this->l->t('{actor} ended the call with {user1} and {user2} (Duration {duration})');
+					}
 				} else {
-					$subject = $this->l->t('Call with {user1}, {user2} and {user3} (Duration {duration})');
+					if ($message === 'call_ended') {
+						$subject = $this->l->t('Call with {user1}, {user2} and {user3} (Duration {duration})');
+					} else {
+						$subject = $this->l->t('{actor} ended the call with {user1}, {user2} and {user3} (Duration {duration})');
+					}
 					$subject = str_replace('{user3}', $this->l->n('%n guest', '%n guests', $parameters['guests']), $subject);
 				}
 				break;
 			case 3:
 				if ($parameters['guests'] === 0) {
-					$subject = $this->l->t('Call with {user1}, {user2} and {user3} (Duration {duration})');
+					if ($message === 'call_ended') {
+						$subject = $this->l->t('Call with {user1}, {user2} and {user3} (Duration {duration})');
+					} else {
+						$subject = $this->l->t('{actor} ended the call with {user1}, {user2} and {user3} (Duration {duration})');
+					}
 				} else {
-					$subject = $this->l->t('Call with {user1}, {user2}, {user3} and {user4} (Duration {duration})');
+					if ($message === 'call_ended') {
+						$subject = $this->l->t('Call with {user1}, {user2}, {user3} and {user4} (Duration {duration})');
+					} else {
+						$subject = $this->l->t('{actor} ended the call with {user1}, {user2}, {user3} and {user4} (Duration {duration})');
+					}
 					$subject = str_replace('{user4}', $this->l->n('%n guest', '%n guests', $parameters['guests']), $subject);
 				}
 				break;
 			case 4:
 				if ($parameters['guests'] === 0) {
-					$subject = $this->l->t('Call with {user1}, {user2}, {user3} and {user4} (Duration {duration})');
+					if ($message === 'call_ended') {
+						$subject = $this->l->t('Call with {user1}, {user2}, {user3} and {user4} (Duration {duration})');
+					} else {
+						$subject = $this->l->t('{actor} ended the call with {user1}, {user2}, {user3} and {user4} (Duration {duration})');
+					}
 				} else {
-					$subject = $this->l->t('Call with {user1}, {user2}, {user3}, {user4} and {user5} (Duration {duration})');
+					if ($message === 'call_ended') {
+						$subject = $this->l->t('Call with {user1}, {user2}, {user3}, {user4} and {user5} (Duration {duration})');
+					} else {
+						$subject = $this->l->t('{actor} ended the call with {user1}, {user2}, {user3}, {user4} and {user5} (Duration {duration})');
+					}
 					$subject = str_replace('{user5}', $this->l->n('%n guest', '%n guests', $parameters['guests']), $subject);
 				}
 				break;
 			case 5:
 			default:
-				$subject = $this->l->t('Call with {user1}, {user2}, {user3}, {user4} and {user5} (Duration {duration})');
+				if ($message === 'call_ended') {
+					$subject = $this->l->t('Call with {user1}, {user2}, {user3}, {user4} and {user5} (Duration {duration})');
+				} else {
+					$subject = $this->l->t('{actor} ended the call with {user1}, {user2}, {user3}, {user4} and {user5} (Duration {duration})');
+				}
 				if ($numUsers === 5 && $parameters['guests'] === 0) {
 					$displayedUsers = 5;
 				} else {
@@ -787,7 +840,6 @@ class SystemMessage {
 				}
 		}
 
-		$params = [];
 		if ($displayedUsers > 0) {
 			for ($i = 1; $i <= $displayedUsers; $i++) {
 				$params['user' . $i] = $this->getUser($parameters['users'][$i - 1]);

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -27,6 +27,7 @@ use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Events\AddParticipantsEvent;
 use OCA\Talk\Events\AttendeesAddedEvent;
 use OCA\Talk\Events\AttendeesRemovedEvent;
+use OCA\Talk\Events\ModifyEveryoneEvent;
 use OCA\Talk\Events\ModifyLobbyEvent;
 use OCA\Talk\Events\ModifyParticipantEvent;
 use OCA\Talk\Events\ModifyRoomEvent;
@@ -96,6 +97,11 @@ class Listener implements IEventListener {
 			}
 		});
 		$dispatcher->addListener(Room::EVENT_AFTER_SESSION_LEAVE_CALL, static function (ModifyParticipantEvent $event) {
+			if ($event instanceof ModifyEveryoneEvent) {
+				// No individual system message if the call is ended for everyone
+				return;
+			}
+
 			$room = $event->getRoom();
 
 			$session = $event->getParticipant()->getSession();

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -167,12 +167,7 @@ class CallController extends AEnvironmentAwareController {
 		}
 
 		if ($all && $this->participant->hasModeratorPermissions()) {
-			$participants = $this->participantService->getParticipantsInCall($this->room);
-
-			// kick out all participants out of the call
-			foreach ($participants as $participant) {
-				$this->participantService->changeInCall($this->room, $participant, Participant::FLAG_DISCONNECTED);
-			}
+			$this->participantService->endCallForEveryone($this->room, $this->participant);
 		} else {
 			$this->participantService->changeInCall($this->room, $this->participant, Participant::FLAG_DISCONNECTED);
 		}

--- a/lib/Events/ModifyEveryoneEvent.php
+++ b/lib/Events/ModifyEveryoneEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Events;
+
+class ModifyEveryoneEvent extends ModifyParticipantEvent {
+}

--- a/lib/Events/ModifyRoomEvent.php
+++ b/lib/Events/ModifyRoomEvent.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Events;
 
+use OCA\Talk\Participant;
 use OCA\Talk\Room;
 
 class ModifyRoomEvent extends RoomEvent {
@@ -33,21 +34,22 @@ class ModifyRoomEvent extends RoomEvent {
 	protected $newValue;
 	/** @var int|string|bool|null */
 	protected $oldValue;
+	/** @var Participant|null */
+	protected $actor;
 
 
 	public function __construct(Room $room,
 								string $parameter,
 								$newValue,
-								$oldValue = null) {
+								$oldValue = null,
+								?Participant $actor = null) {
 		parent::__construct($room);
 		$this->parameter = $parameter;
 		$this->newValue = $newValue;
 		$this->oldValue = $oldValue;
+		$this->actor = $actor;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getParameter(): string {
 		return $this->parameter;
 	}
@@ -64,5 +66,9 @@ class ModifyRoomEvent extends RoomEvent {
 	 */
 	public function getOldValue() {
 		return $this->oldValue;
+	}
+
+	public function getActor(): ?Participant {
+		return $this->actor;
 	}
 }

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -114,6 +114,8 @@ class Room {
 	public const EVENT_AFTER_LISTABLE_SET = self::class . '::postSetListable';
 	public const EVENT_BEFORE_LOBBY_STATE_SET = self::class . '::preSetLobbyState';
 	public const EVENT_AFTER_LOBBY_STATE_SET = self::class . '::postSetLobbyState';
+	public const EVENT_BEFORE_END_CALL_FOR_EVERYONE = self::class . '::preEndCallForEveryone';
+	public const EVENT_AFTER_END_CALL_FOR_EVERYONE = self::class . '::postEndCallForEveryone';
 	public const EVENT_BEFORE_SIP_ENABLED_SET = self::class . '::preSetSIPEnabled';
 	public const EVENT_AFTER_SIP_ENABLED_SET = self::class . '::postSetSIPEnabled';
 	public const EVENT_BEFORE_PERMISSIONS_SET = self::class . '::preSetPermissions';

--- a/src/services/callsService.js
+++ b/src/services/callsService.js
@@ -54,10 +54,11 @@ const joinCall = async function(token, flags) {
  * Leave a call as participant
  *
  * @param {string} token The token of the call to be left
+ * @param {boolean} all Whether to end the meeting for all
  */
-const leaveCall = async function(token) {
+const leaveCall = async function(token, all = false) {
 	try {
-		await signalingLeaveCall(token)
+		await signalingLeaveCall(token, all)
 	} catch (error) {
 		console.debug('Error while leaving call: ', error)
 	}

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -398,7 +398,7 @@ const actions = {
 		}, 10000)
 	},
 
-	async leaveCall({ commit, getters }, { token, participantIdentifier }) {
+	async leaveCall({ commit, getters }, { token, participantIdentifier, all = false }) {
 		if (!participantIdentifier?.sessionId) {
 			console.error('Trying to leave call without sessionId')
 		}
@@ -409,7 +409,7 @@ const actions = {
 			return
 		}
 
-		await leaveCall(token)
+		await leaveCall(token, all)
 
 		const updatedData = {
 			inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,

--- a/src/store/participantsStore.spec.js
+++ b/src/store/participantsStore.spec.js
@@ -469,7 +469,7 @@ describe('participantsStore', () => {
 			},
 		})
 
-		expect(leaveCall).toHaveBeenCalledWith(TOKEN)
+		expect(leaveCall).toHaveBeenCalledWith(TOKEN, false)
 		expect(store.getters.isInCall(TOKEN)).toBe(false)
 		expect(store.getters.isConnecting(TOKEN)).toBe(false)
 		expect(store.getters.participantsList(TOKEN)).toStrictEqual([

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -266,6 +266,8 @@ Signaling.Base.prototype._joinCallSuccess = function(/* token */) {
 
 Signaling.Base.prototype.joinCall = function(token, flags) {
 	return new Promise((resolve, reject) => {
+		this._trigger('beforeJoinCall', [token])
+
 		axios.post(generateOcsUrl('apps/spreed/api/v4/call/{token}', { token }), {
 			flags,
 		})
@@ -317,6 +319,8 @@ Signaling.Base.prototype.leaveCall = function(token, keepToken, all = false) {
 			reject(new Error())
 			return
 		}
+
+		this._trigger('beforeLeaveCall', [token, keepToken])
 
 		axios.delete(generateOcsUrl('apps/spreed/api/v4/call/{token}', { token }), {
 			data: {

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -311,14 +311,18 @@ Signaling.Base.prototype.updateCallFlags = function(token, flags) {
 	})
 }
 
-Signaling.Base.prototype.leaveCall = function(token, keepToken) {
+Signaling.Base.prototype.leaveCall = function(token, keepToken, all = false) {
 	return new Promise((resolve, reject) => {
 		if (!token) {
 			reject(new Error())
 			return
 		}
 
-		axios.delete(generateOcsUrl('apps/spreed/api/v4/call/{token}', { token }))
+		axios.delete(generateOcsUrl('apps/spreed/api/v4/call/{token}', { token }), {
+			data: {
+				all,
+			},
+		})
 			.then(function() {
 				this._trigger('leaveCall', [token, keepToken])
 				this._leaveCallSuccess(token)

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -236,9 +236,10 @@ async function signalingJoinCall(token, flags) {
  * Leave the call of the given conversation
  *
  * @param {string} token Conversation to leave the call
+ * @param {boolean} all Whether to end the meeting for all
  * @return {Promise<void>}
  */
-async function signalingLeaveCall(token) {
+async function signalingLeaveCall(token, all = false) {
 	sentVideoQualityThrottler.destroy()
 	sentVideoQualityThrottler = null
 
@@ -246,7 +247,7 @@ async function signalingLeaveCall(token) {
 	callAnalyzer = null
 
 	if (tokensInSignaling[token]) {
-		await signaling.leaveCall(token)
+		await signaling.leaveCall(token, false, all)
 	}
 }
 

--- a/tests/php/Chat/Parser/SystemMessageTest.php
+++ b/tests/php/Chat/Parser/SystemMessageTest.php
@@ -492,7 +492,7 @@ class SystemMessageTest extends TestCase {
 		if ($message === 'call_ended') {
 			$parser->expects($this->once())
 				->method('parseCall')
-				->with($parameters)
+				->with($message, $parameters, ['actor' => ['id' => 'actor', 'type' => 'user']])
 				->willReturn([$expectedMessage, $expectedParameters]);
 		} else {
 			$parser->expects($this->never())
@@ -1099,80 +1099,221 @@ class SystemMessageTest extends TestCase {
 	public function dataParseCall(): array {
 		return [
 			'1 user + guests' => [
+				'call_ended',
 				['users' => ['user1'], 'guests' => 3, 'duration' => 42],
+				['type' => 'user', 'id' => 'admin', 'name' => 'Admin'],
 				[
 					'Call with {user1} and 3 guests (Duration "duration")',
 					['user1' => ['data' => 'user1']],
 				],
 			],
 			'2 users' => [
+				'call_ended',
 				['users' => ['user1', 'user2'], 'guests' => 0, 'duration' => 42],
+				['type' => 'user', 'id' => 'admin', 'name' => 'Admin'],
 				[
 					'Call with {user1} and {user2} (Duration "duration")',
 					['user1' => ['data' => 'user1'], 'user2' => ['data' => 'user2']],
 				],
 			],
 			'2 users + guests' => [
+				'call_ended',
 				['users' => ['user1', 'user2'], 'guests' => 1, 'duration' => 42],
+				['type' => 'user', 'id' => 'admin', 'name' => 'Admin'],
 				[
 					'Call with {user1}, {user2} and 1 guest (Duration "duration")',
 					['user1' => ['data' => 'user1'], 'user2' => ['data' => 'user2']],
 				],
 			],
 			'3 users' => [
+				'call_ended',
 				['users' => ['user1', 'user2', 'user3'], 'guests' => 0, 'duration' => 42],
+				['type' => 'user', 'id' => 'admin', 'name' => 'Admin'],
 				[
 					'Call with {user1}, {user2} and {user3} (Duration "duration")',
 					['user1' => ['data' => 'user1'], 'user2' => ['data' => 'user2'], 'user3' => ['data' => 'user3']],
 				],
 			],
 			'3 users + guests' => [
+				'call_ended',
 				['users' => ['user1', 'user2', 'user3'], 'guests' => 22, 'duration' => 42],
+				['type' => 'user', 'id' => 'admin', 'name' => 'Admin'],
 				[
 					'Call with {user1}, {user2}, {user3} and 22 guests (Duration "duration")',
 					['user1' => ['data' => 'user1'], 'user2' => ['data' => 'user2'], 'user3' => ['data' => 'user3']],
 				],
 			],
 			'4 users' => [
+				'call_ended',
 				['users' => ['user1', 'user2', 'user3', 'user4'], 'guests' => 0, 'duration' => 42],
+				['type' => 'user', 'id' => 'admin', 'name' => 'Admin'],
 				[
 					'Call with {user1}, {user2}, {user3} and {user4} (Duration "duration")',
 					['user1' => ['data' => 'user1'], 'user2' => ['data' => 'user2'], 'user3' => ['data' => 'user3'], 'user4' => ['data' => 'user4']],
 				],
 			],
 			'4 users + guests' => [
+				'call_ended',
 				['users' => ['user1', 'user2', 'user3', 'user4'], 'guests' => 4, 'duration' => 42],
+				['type' => 'user', 'id' => 'admin', 'name' => 'Admin'],
 				[
 					'Call with {user1}, {user2}, {user3}, {user4} and 4 guests (Duration "duration")',
 					['user1' => ['data' => 'user1'], 'user2' => ['data' => 'user2'], 'user3' => ['data' => 'user3'], 'user4' => ['data' => 'user4']],
 				],
 			],
 			'5 users' => [
+				'call_ended',
 				['users' => ['user1', 'user2', 'user3', 'user4', 'user5'], 'guests' => 0, 'duration' => 42],
+				['type' => 'user', 'id' => 'admin', 'name' => 'Admin'],
 				[
 					'Call with {user1}, {user2}, {user3}, {user4} and {user5} (Duration "duration")',
 					['user1' => ['data' => 'user1'], 'user2' => ['data' => 'user2'], 'user3' => ['data' => 'user3'], 'user4' => ['data' => 'user4'], 'user5' => ['data' => 'user5']],
 				],
 			],
 			'5 users + guests' => [
+				'call_ended',
 				['users' => ['user1', 'user2', 'user3', 'user4', 'user5'], 'guests' => 1, 'duration' => 42],
+				['type' => 'user', 'id' => 'admin', 'name' => 'Admin'],
 				[
 					'Call with {user1}, {user2}, {user3}, {user4} and 2 others (Duration "duration")',
 					['user1' => ['data' => 'user1'], 'user2' => ['data' => 'user2'], 'user3' => ['data' => 'user3'], 'user4' => ['data' => 'user4']],
 				],
 			],
 			'6 users' => [
+				'call_ended',
 				['users' => ['user1', 'user2', 'user3', 'user4', 'user5', 'user6'], 'guests' => 0, 'duration' => 42],
+				['type' => 'user', 'id' => 'admin', 'name' => 'Admin'],
 				[
 					'Call with {user1}, {user2}, {user3}, {user4} and 2 others (Duration "duration")',
 					['user1' => ['data' => 'user1'], 'user2' => ['data' => 'user2'], 'user3' => ['data' => 'user3'], 'user4' => ['data' => 'user4']],
 				],
 			],
 			'6 users + guests' => [
+				'call_ended',
 				['users' => ['user1', 'user2', 'user3', 'user4', 'user5', 'user6'], 'guests' => 2, 'duration' => 42],
+				['type' => 'user', 'id' => 'admin', 'name' => 'Admin'],
 				[
 					'Call with {user1}, {user2}, {user3}, {user4} and 4 others (Duration "duration")',
 					['user1' => ['data' => 'user1'], 'user2' => ['data' => 'user2'], 'user3' => ['data' => 'user3'], 'user4' => ['data' => 'user4']],
+				],
+			],
+
+			// Meetings
+			'meeting guests only' => [
+				'call_ended_everyone',
+				['users' => [], 'guests' => 33, 'duration' => 42],
+				['type' => 'guest', 'id' => sha1('guest1'), 'name' => 'guest1'],
+				[
+					'{actor} ended the call with 32 guests (Duration "duration")',
+					[],
+				],
+			],
+			'meeting 2 user' => [
+				'call_ended_everyone',
+				['users' => ['user1', 'user2'], 'guests' => 3, 'duration' => 42],
+				['type' => 'user', 'id' => 'user1', 'name' => 'user1'],
+				[
+					'{actor} ended the call with {user1} and 3 guests (Duration "duration")',
+					['user1' => ['data' => 'user2']],
+				],
+			],
+			'meeting 1 user + guests' => [
+				'call_ended_everyone',
+				['users' => ['user1'], 'guests' => 3, 'duration' => 42],
+				['type' => 'user', 'id' => 'user1', 'name' => 'user1'],
+				[
+					'{actor} ended the call with 3 guests (Duration "duration")',
+					[],
+				],
+			],
+			'meeting 3 users' => [
+				'call_ended_everyone',
+				['users' => ['user1', 'user2', 'user3'], 'guests' => 0, 'duration' => 42],
+				['type' => 'user', 'id' => 'user1', 'name' => 'user1'],
+				[
+					'{actor} ended the call with {user1} and {user2} (Duration "duration")',
+					['user1' => ['data' => 'user2'], 'user2' => ['data' => 'user3']],
+				],
+			],
+			'meeting 2 users + guests' => [
+				'call_ended_everyone',
+				['users' => ['user1', 'user2'], 'guests' => 1, 'duration' => 42],
+				['type' => 'user', 'id' => 'user1', 'name' => 'user1'],
+				[
+					'{actor} ended the call with {user1} and 1 guest (Duration "duration")',
+					['user1' => ['data' => 'user2']],
+				],
+			],
+			'meeting 4 users' => [
+				'call_ended_everyone',
+				['users' => ['user1', 'user2', 'user3', 'user4'], 'guests' => 0, 'duration' => 42],
+				['type' => 'user', 'id' => 'user1', 'name' => 'user1'],
+				[
+					'{actor} ended the call with {user1}, {user2} and {user3} (Duration "duration")',
+					['user1' => ['data' => 'user2'], 'user2' => ['data' => 'user3'], 'user3' => ['data' => 'user4']],
+				],
+			],
+			'meeting 3 users + guests' => [
+				'call_ended_everyone',
+				['users' => ['user1', 'user2', 'user3'], 'guests' => 22, 'duration' => 42],
+				['type' => 'user', 'id' => 'user1', 'name' => 'user1'],
+				[
+					'{actor} ended the call with {user1}, {user2} and 22 guests (Duration "duration")',
+					['user1' => ['data' => 'user2'], 'user2' => ['data' => 'user3']],
+				],
+			],
+			'meeting 5 users' => [
+				'call_ended_everyone',
+				['users' => ['user1', 'user2', 'user3', 'user4', 'user5'], 'guests' => 0, 'duration' => 42],
+				['type' => 'user', 'id' => 'user1', 'name' => 'user1'],
+				[
+					'{actor} ended the call with {user1}, {user2}, {user3} and {user4} (Duration "duration")',
+					['user1' => ['data' => 'user2'], 'user2' => ['data' => 'user3'], 'user3' => ['data' => 'user4'], 'user4' => ['data' => 'user5']],
+				],
+			],
+			'meeting 4 users + guests' => [
+				'call_ended_everyone',
+				['users' => ['user1', 'user2', 'user3', 'user4'], 'guests' => 4, 'duration' => 42],
+				['type' => 'user', 'id' => 'user1', 'name' => 'user1'],
+				[
+					'{actor} ended the call with {user1}, {user2}, {user3} and 4 guests (Duration "duration")',
+					['user1' => ['data' => 'user2'], 'user2' => ['data' => 'user3'], 'user3' => ['data' => 'user4']],
+				],
+			],
+			'meeting 6 users' => [
+				'call_ended_everyone',
+				['users' => ['user1', 'user2', 'user3', 'user4', 'user5', 'user6'], 'guests' => 0, 'duration' => 42],
+				['type' => 'user', 'id' => 'user1', 'name' => 'user1'],
+				[
+					'{actor} ended the call with {user1}, {user2}, {user3}, {user4} and {user5} (Duration "duration")',
+					['user1' => ['data' => 'user2'], 'user2' => ['data' => 'user3'], 'user3' => ['data' => 'user4'], 'user4' => ['data' => 'user5'], 'user5' => ['data' => 'user6']],
+				],
+			],
+			'meeting 5 users + guests' => [
+				'call_ended_everyone',
+				['users' => ['user1', 'user2', 'user3', 'user4', 'user5'], 'guests' => 1, 'duration' => 42],
+				['type' => 'user', 'id' => 'user1', 'name' => 'user1'],
+				[
+					'{actor} ended the call with {user1}, {user2}, {user3}, {user4} and 1 guest (Duration "duration")',
+					['user1' => ['data' => 'user2'], 'user2' => ['data' => 'user3'], 'user3' => ['data' => 'user4'], 'user4' => ['data' => 'user5']],
+				],
+			],
+			'meeting 7 users' => [
+				'call_ended_everyone',
+				['users' => ['user1', 'user2', 'user3', 'user4', 'user5', 'user6', 'user7'], 'guests' => 0, 'duration' => 42],
+				['type' => 'user', 'id' => 'user1', 'name' => 'user1'],
+				[
+					'{actor} ended the call with {user1}, {user2}, {user3}, {user4} and 2 others (Duration "duration")',
+					['user1' => ['data' => 'user2'], 'user2' => ['data' => 'user3'], 'user3' => ['data' => 'user4'], 'user4' => ['data' => 'user5']],
+				],
+			],
+			'meeting 6 users + guests' => [
+				'call_ended_everyone',
+				['users' => ['user1', 'user2', 'user3', 'user4', 'user5', 'user6'], 'guests' => 2, 'duration' => 42],
+				['type' => 'user', 'id' => 'user1', 'name' => 'user1'],
+				[
+					'{actor} ended the call with {user1}, {user2}, {user3}, {user4} and 3 others (Duration "duration")',
+					['user1' => ['data' => 'user2'], 'user2' => ['data' => 'user3'], 'user3' => ['data' => 'user4'], 'user4' => ['data' => 'user5']],
 				],
 			],
 		];
@@ -1183,7 +1324,7 @@ class SystemMessageTest extends TestCase {
 	 * @param array $parameters
 	 * @param array $expected
 	 */
-	public function testParseCall(array $parameters, array $expected) {
+	public function testParseCall(string $message, array $parameters, array $actor, array $expected) {
 		$parser = $this->getParser(['getDuration', 'getUser']);
 		$parser->expects($this->once())
 			->method('getDuration')
@@ -1196,7 +1337,10 @@ class SystemMessageTest extends TestCase {
 				return ['data' => $user];
 			});
 
-		$this->assertSame($expected, self::invokePrivate($parser, 'parseCall', [$parameters]));
+		// Prepend the actor
+		$expected[1]['actor'] = $actor;
+
+		$this->assertEquals($expected, self::invokePrivate($parser, 'parseCall', [$message, $parameters, ['actor' => $actor]]));
 	}
 
 	public function dataGetDuration(): array {


### PR DESCRIPTION
- [x] backend impl (based on read-only mode kicking out users)
- [x] PHP tests
- [x] frontend button
- [x] vuex store action + backend call
- [x] only moderators or guest moderators can end for all
- [x] also send signaling message to kick people out more quickly ?
- [x] system message for "X has ended the call" instead of "you left the call"
- [x] Jest tests
- [x] Test with Android
- [x] Test with iOS

---

- [x] @marcoambrosini for the button design
- [x] @danxuliu for terminating the call screen as another user in `src/utils/webrtc/webrtc.js` (ref https://github.com/nextcloud/spreed/pull/5981#issuecomment-907206782 )
- [x] @nickvergessen for changing the system message and call summary

---

- [x] TEST: without HPB: end meeting for all :no_entry_sign:  does not kick out user from another browser
- [x] TEST: HPB: end meeting for all :no_entry_sign:  does not kick out user from another browser


Fixes https://github.com/nextcloud/spreed/issues/5395