### PR TITLE
Fix infinite loop when the constraints can not be decreased

### DIFF
--- a/src/utils/webrtc/VideoConstrainer.js
+++ b/src/utils/webrtc/VideoConstrainer.js
@@ -297,7 +297,7 @@ VideoConstrainer.prototype = {
 		let changed = false
 
 		if (constraints.frameRate && constraints.frameRate.min) {
-			const previousFrameRateMin = constraints.frameRate.max
+			const previousFrameRateMin = constraints.frameRate.min
 			constraints.frameRate.min = Math.min(Math.round(constraints.frameRate.min / 1.5), 1)
 			changed = previousFrameRateMin !== constraints.frameRate.min
 		}

--- a/src/utils/webrtc/VideoConstrainer.js
+++ b/src/utils/webrtc/VideoConstrainer.js
@@ -268,13 +268,13 @@ VideoConstrainer.prototype = {
 
 		if (constraints.width && constraints.width.min) {
 			const previousWidthMin = constraints.width.min
-			constraints.width.min = Math.min(Math.round(constraints.width.min / 1.5), 64)
+			constraints.width.min = Math.max(Math.round(constraints.width.min / 1.5), 64)
 			changed = previousWidthMin !== constraints.width.min
 		}
 
 		if (constraints.height && constraints.height.min) {
 			const previousHeightMin = constraints.height.min
-			constraints.height.min = Math.min(Math.round(constraints.height.min / 1.5), 64)
+			constraints.height.min = Math.max(Math.round(constraints.height.min / 1.5), 64)
 			changed = previousHeightMin !== constraints.height.min
 		}
 
@@ -298,7 +298,7 @@ VideoConstrainer.prototype = {
 
 		if (constraints.frameRate && constraints.frameRate.min) {
 			const previousFrameRateMin = constraints.frameRate.min
-			constraints.frameRate.min = Math.min(Math.round(constraints.frameRate.min / 1.5), 1)
+			constraints.frameRate.min = Math.max(Math.round(constraints.frameRate.min / 1.5), 1)
 			changed = previousFrameRateMin !== constraints.frameRate.min
 		}
 


### PR DESCRIPTION
The previous minimum frame rate was wrongly got from the maximum frame rate, so when the minimum frame rate was compared after decreasing it it was always seen as changed. Due to this the constraints will be applied again even if they did not actually change due to having reached the minimum capped value, which would end in an infinite loop if the constraints could not be applied and the minimum frame rate was (tried to be) decreased again.
    
Besides that, the minimum value of the constraints was wrongly capped using `min` instead of `max`, so in practice the first time that the value was decreased it was already set to the minimum capped value.