### PR TITLE
Fix duplicated registration of audio encoder

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -66,8 +66,6 @@ import UploadEditor from './components/UploadEditor'
 import SettingsDialog from './components/SettingsDialog/SettingsDialog'
 import ConversationSettingsDialog from './components/ConversationSettings/ConversationSettingsDialog'
 import '@nextcloud/dialogs/styles/toast.scss'
-import { register } from 'extendable-media-recorder'
-import { connect } from 'extendable-media-recorder-wav-encoder'
 import { CONVERSATION } from './constants'
 
 export default {
@@ -363,8 +361,6 @@ export default {
 		} else if (BrowserStorage.getItem('sidebarOpen') === 'true') {
 			this.$store.dispatch('showSidebar')
 		}
-
-		register(await connect())
 	},
 
 	methods: {

--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -66,8 +66,6 @@ import ChatView from './components/ChatView'
 import sessionIssueHandler from './mixins/sessionIssueHandler'
 import browserCheck from './mixins/browserCheck'
 import '@nextcloud/dialogs/styles/toast.scss'
-import { register } from 'extendable-media-recorder'
-import { connect } from 'extendable-media-recorder-wav-encoder'
 
 export default {
 
@@ -138,11 +136,6 @@ export default {
 				this.setTalkSidebarSupportedForFile(this.fileInfo)
 			},
 		},
-	},
-
-	async mounted() {
-		// Initialise audiorecorder encoder
-		register(await connect())
 	},
 
 	created() {

--- a/src/PublicShareAuthSidebar.vue
+++ b/src/PublicShareAuthSidebar.vue
@@ -47,8 +47,6 @@ import {
 import { signalingKill } from './utils/webrtc/index'
 import sessionIssueHandler from './mixins/sessionIssueHandler'
 import talkHashCheck from './mixins/talkHashCheck'
-import { register } from 'extendable-media-recorder'
-import { connect } from 'extendable-media-recorder-wav-encoder'
 
 export default {
 
@@ -97,11 +95,6 @@ export default {
 				window.setTimeout(() => { this.isWaitingToClose = false }, 5000)
 			}
 		},
-	},
-
-	async mounted() {
-		// Initialise audiorecorder encoder
-		register(await connect())
 	},
 
 	beforeMount() {

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -61,8 +61,6 @@ import isInCall from './mixins/isInCall'
 import participant from './mixins/participant'
 import talkHashCheck from './mixins/talkHashCheck'
 import '@nextcloud/dialogs/styles/toast.scss'
-import { register } from 'extendable-media-recorder'
-import { connect } from 'extendable-media-recorder-wav-encoder'
 
 export default {
 
@@ -131,11 +129,6 @@ export default {
 				}
 			}
 		})
-	},
-
-	async mounted() {
-		// Initialise audiorecorder encoder
-		await register(await connect())
 	},
 
 	methods: {


### PR DESCRIPTION
[The audio encoder is initialized when the AudioRecorder component is mounted](https://github.com/nextcloud/spreed/pull/5970), and the store keeps track of whether the audio encoder was already initialized to not do it again.

However, [the audio encoder was also unconditionally registered in the main components of the main and sidebar Talk UIs](https://github.com/nextcloud/spreed/pull/5966) (ironically to also fix the duplicated registration :-P ), which caused a duplicated registration when the audio encoder was initialized (as the store did not "know" that it was already registered).

Due to all this the unconditional registration is removed (which also avoids registering the audio encoder when it will not be needed, like when the current user is a guest without upload permissions).
