### PR TITLE
Fix blocked audio recording preview when Talk is embedded in the sidebar

### DIFF
--- a/lib/Listener/CSPListener.php
+++ b/lib/Listener/CSPListener.php
@@ -47,6 +47,7 @@ class CSPListener implements IEventListener {
 
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedImageDomain('https://*.tile.openstreetmap.org');
+		$csp->addAllowedMediaDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain("'self'");
 		$csp->addAllowedChildSrcDomain('blob:');


### PR DESCRIPTION
Audio recording previews use a blob, so the Content Security Policy must allow media from blobs to be able to play it.

This was not a problem in the main Talk UI, as in that case the Content Security Policy [already allowed media from blobs](https://github.com/nextcloud/spreed/blob/63fe1ac0d71cd660bee3df5ff3d304d5aca4871e/lib/Controller/PageController.php#L264).

## How to test
- Open the Files app
- Share a file
- Open the _Chat_ tab
- Start a conversation
- Record an audio message

### Result with this pull request

The preview dialog is shown and the audio recording can be played.

### Result without this pull request

The preview dialog is shown but the audio recording can not be played. Browser console shows an error similar to `The page’s settings blocked the loading of a resource at blob:https://192.168.57.21:8443/5a589af9-ab9f-4e6e-8785-fa3da9684ee7 (“media-src”).`
