### PR TITLE
Fix connection quality warning still shown after media is stopped

### DIFF
--- a/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
+++ b/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
@@ -215,6 +215,9 @@ PeerConnectionAnalyzer.prototype = {
 		this._peerConnection = peerConnection
 		this._peerDirection = peerDirection
 
+		this._setConnectionQualityAudio(CONNECTION_QUALITY.UNKNOWN)
+		this._setConnectionQualityVideo(CONNECTION_QUALITY.UNKNOWN)
+
 		if (this._peerConnection) {
 			this._peerConnection.addEventListener('iceconnectionstatechange', this._handleIceConnectionStateChangedBound)
 			this._handleIceConnectionStateChangedBound()


### PR DESCRIPTION
When the audio/video or the screen peers were cleared the connection quality data was not reset. Due to this the connection quality warning would be kept shown if, for example, the screen share was stopped while the warning was being shown.

Pending:
- [X] Check if there is a better way to reset the values (for example, by using the `setAnalysisEnabledAudio/Video` methods) -> There was: reset the connection quality in `setPeerConnection()`.

## How to test

- Setup the HPB
- Use Firefox (Chromium stops the screen sharing when the shared window is closed, but [Firefox does not do that yet](https://bugzilla.mozilla.org/show_bug.cgi?id=1682232))
- Start a call
- In a private window, join the call
- Share the screen
- Close the shared window
- Wait until the connection quality warning appears (the warning appears because no more data is being sent, although the screen share is still active)
- Stop the screen share

### Result with this pull request

The connection quality warning is hidden

### Result without this pull request

The connection quality warning is still shown
