### PR TITLE
Hide forward action for guests

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -164,7 +164,7 @@ the main body of the message as well as a quote.
 								{{ t('spreed', 'Go to file') }}
 							</ActionLink>
 							<ActionButton
-								v-if="!isFileShare"
+								v-if="!isCurrentGuest && !isFileShare"
 								:close-after-click="true"
 								@click.stop="showForwarder = true">
 								<Share
@@ -660,6 +660,10 @@ export default {
 				metadata: this.conversation,
 				apiVersion: 'v3',
 			}
+		},
+
+		isCurrentGuest() {
+			return this.$store.getters.getActorType() === 'guests'
 		},
 	},
 


### PR DESCRIPTION
The forward action shows the RoomSelector, which [fetches the room list](https://github.com/nextcloud/spreed/blob/f4f891ad3745f864545d07fb6491257977747e27/src/views/RoomSelector.vue#L125-L130), but that is not allowed for guests.

## How to test
- Create a public conversation
- Join the conversation as a guest
- Send a message
- Show the menu for the message

### Result with this pull request
The _Forward_ action is not shown.

### Result without this pull request
The _Forward_ action is shown. Clicking on it shows an empty room selector.
