### PR TITLE
Add some logging to the device selection

### DIFF
--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -228,9 +228,17 @@ MediaDevicesManager.prototype = {
 
 			// Fallback in case we didn't find the previously picked device
 			if (this.attributes.audioInputId === undefined) {
+				if (BrowserStorage.getItem('audioInputId')) {
+					// Couldn't find device by id
+					console.debug('Could not find previous audio device, falling back to default/first device in the list', BrowserStorage.getItem('audioInputId'), this.attributes.devices)
+				}
 				this.attributes.audioInputId = this._fallbackAudioInputId
 			}
 			if (this.attributes.videoInputId === undefined) {
+				if (BrowserStorage.getItem('videoInputId')) {
+					// Couldn't find device by id, try the label
+					console.debug('Could not find previous video device, falling back to default/first device in the list', BrowserStorage.getItem('videoInputId'), this.attributes.devices)
+				}
 				this.attributes.videoInputId = this._fallbackVideoInputId
 			}
 

--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -226,6 +226,14 @@ MediaDevicesManager.prototype = {
 				this._addDevice(addedDevice)
 			})
 
+			// Fallback in case we didn't find the previously picked device
+			if (this.attributes.audioInputId === undefined) {
+				this.attributes.audioInputId = this._fallbackAudioInputId
+			}
+			if (this.attributes.videoInputId === undefined) {
+				this.attributes.videoInputId = this._fallbackVideoInputId
+			}
+
 			// Trigger change events after all the devices are processed to
 			// prevent change events for intermediate states.
 			if (previousAudioInputId !== this.attributes.audioInputId) {
@@ -325,18 +333,12 @@ MediaDevicesManager.prototype = {
 			if (!this._fallbackAudioInputId || addedDevice.deviceId === 'default') {
 				this._fallbackAudioInputId = addedDevice.deviceId
 			}
-			if (this.attributes.audioInputId === undefined) {
-				this.attributes.audioInputId = this._fallbackAudioInputId
-			}
 		} else if (addedDevice.kind === 'videoinput') {
 			if (BrowserStorage.getItem('videoInputId') === addedDevice.deviceId) {
 				this.attributes.videoInputId = addedDevice.deviceId
 			}
 			if (!this._fallbackVideoInputId || addedDevice.deviceId === 'default') {
 				this._fallbackVideoInputId = addedDevice.deviceId
-			}
-			if (this.attributes.videoInputId === undefined) {
-				this.attributes.videoInputId = this._fallbackVideoInputId
 			}
 		}
 


### PR DESCRIPTION
Before this only the deviceId was used to pick a device.
If not it fell back to the first device in the list.
Now we first try to find the previous device based on the label.

Signed-off-by: Joas Schilling <coding@schilljs.com>