### PR TITLE
Fix laggy high resolution videos in Chromium

### DIFF
--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -152,6 +152,12 @@ LocalMedia.prototype.isLocalMediaActive = function() {
  * resolution, so if the camera does not have such resolution it will still
  * return the highest resolution available without failing.
  *
+ * A high frame rate needs to be requested too, as some cameras offer high
+ * resolution but with low frame rates, so Chromium could end providing a laggy
+ * high resolution video. If the frame rate is requested too then Chromium needs
+ * to balance all the constraints and thus provide a video without the highest
+ * resolution but with an acceptable frame rate.
+ *
  * @param {object} constraints the constraints to be adjusted
  */
 LocalMedia.prototype._adjustVideoConstraintsForChromium = function(constraints) {
@@ -177,6 +183,7 @@ LocalMedia.prototype._adjustVideoConstraintsForChromium = function(constraints) 
 
 	constraints.video.width = 1920
 	constraints.video.height = 1200
+	constraints.video.frameRate = 60
 }
 
 LocalMedia.prototype.start = function(mediaConstraints, cb, context) {


### PR DESCRIPTION
Fixes #6093 
Regression from #5932 

[Chromium does not allow to increase the resolution of a video stream once the video stream is cloned](https://bugs.chromium.org/p/chromium/issues/detail?id=946490). If a video stream is requested without any constraint, the video stream is returned with a resolution around 640x480. Therefore, when Chromium is used the streams needs to be explicitly requested with a high resolution to be able to increase the resolution later as needed.

As the requested resolution is a loose constraint the resolution was requested as 1920x1200 instead of the more common 1920x1080 to try to cover most cases. However, if a camera does not exactly provide 1920x1200 but 1920x1080 and also an even higher resolution Chromium may choose to crop and scale that higher resolution video rather than using the 1920x1080 video.

The problem is that Chromium may choose to do that even if the higher resolution video has an incredibly low frame rate (for example, Chromium is able to get 2304x1296 and 2304x1536 videos from the Logitech C920, but only at 2 FPS). Moreover, it seems that once the stream is cloned Chromium is not able to then get a lower resolution but higher frame rate video; it seems to be stuck with the original stream and just scale it as needed, so the lower frame rate is still kept.

To fix this now the initial stream is requested with both a high resolution and a high frame rate. This way Chromium needs to balance both constraints and thus provide a video without the hightest resolution but with an acceptable frame rate.
