### PR TITLE
Don't select own video when opening settings

### DIFF
--- a/src/mixins/video.js
+++ b/src/mixins/video.js
@@ -69,6 +69,10 @@ const video = {
 			if (e.target.localName === 'button') {
 				return
 			}
+			// Prevent clicks on the "settings icon" of the popover/actions menu to trigger a video selection
+			if (e.target.localName === 'svg') {
+				return
+			}
 			this.$emit('click-video')
 		},
 	},


### PR DESCRIPTION
Regression from when the vue lib moved to SVGs

### Steps
1. Open a call and have your video on
![Bildschirmfoto von 2021-08-27 13-43-30](https://user-images.githubusercontent.com/213943/131122323-993e6afd-becd-4ac7-909b-c82e4ab23b7b.png)
2. Make sure you are in grid view
3. Click on "More actions"

### Without this PR
Your video is selected, settings are still closed

### With this PR
Selection stays as is and settings are opened