### PR TITLE
Work around Chromium bug of iceConnectionState stuck as "disconnected"

### DIFF
--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -282,7 +282,13 @@ CallParticipantModel.prototype = {
 		}
 
 		// Reset state that depends on the Peer object.
-		this._handleExtendedIceConnectionStateChange(this.get('peer').pc.iceConnectionState)
+		if (this.get('peer').pc.connectionState === 'failed' && this.get('peer').pc.iceConnectionState === 'disconnected') {
+			// Work around Chromium bug where "iceConnectionState" gets stuck as
+			// "disconnected" even if the connection already failed.
+			this._handleExtendedIceConnectionStateChange(this.get('peer').pc.connectionState)
+		} else {
+			this._handleExtendedIceConnectionStateChange(this.get('peer').pc.iceConnectionState)
+		}
 		this._handlePeerStreamAdded(this.get('peer'))
 
 		this.get('peer').on('extendedIceConnectionStateChange', this._handleExtendedIceConnectionStateChangeBound)

--- a/src/utils/webrtc/models/LocalCallParticipantModel.js
+++ b/src/utils/webrtc/models/LocalCallParticipantModel.js
@@ -127,7 +127,13 @@ LocalCallParticipantModel.prototype = {
 		}
 
 		// Reset state that depends on the Peer object.
-		this._handleExtendedIceConnectionStateChange(this.get('peer').pc.iceConnectionState)
+		if (this.get('peer').pc.connectionState === 'failed' && this.get('peer').pc.iceConnectionState === 'disconnected') {
+			// Work around Chromium bug where "iceConnectionState" gets stuck as
+			// "disconnected" even if the connection already failed.
+			this._handleExtendedIceConnectionStateChange(this.get('peer').pc.connectionState)
+		} else {
+			this._handleExtendedIceConnectionStateChange(this.get('peer').pc.iceConnectionState)
+		}
 
 		this.get('peer').on('extendedIceConnectionStateChange', this._handleExtendedIceConnectionStateChangeBound)
 	},

--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -92,6 +92,25 @@ function Peer(options) {
 			break
 		}
 	})
+	this.pc.addEventListener('connectionstatechange', function() {
+		if (self.pc.connectionState !== 'failed') {
+			return
+		}
+
+		if (self.pc.iceConnectionState === 'failed') {
+			return
+		}
+
+		// Work around Chromium bug where "iceConnectionState" never changes to
+		// "failed" (it stays as "disconnected"). When that happens
+		// "connectionState" actually does change to "failed", so the normal
+		// handling of "iceConnectionState === failed" is triggered here.
+
+		if (self.pc.localDescription.type === 'offer') {
+			self.parent.emit('iceFailed', self)
+			self.send('connectivityError')
+		}
+	})
 	this.pc.addEventListener('signalingstatechange', this.emit.bind(this, 'signalingStateChange'))
 	this.logger = this.parent.logger
 

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -789,6 +789,30 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 	/**
 	 * @param peer
 	 */
+	function setHandlerForConnectionStateChange(peer) {
+		peer.pc.addEventListener('connectionstatechange', function() {
+			if (peer.pc.connectionState !== 'failed') {
+				return
+			}
+
+			if (peer.pc.iceConnectionState === 'failed') {
+				return
+			}
+
+			// Work around Chromium bug where "iceConnectionState" never changes
+			// to "failed" (it stays as "disconnected"). When that happens
+			// "connectionState" actually does change to "failed", so the normal
+			// handling of "iceConnectionState === failed" is triggered here.
+
+			peer.emit('extendedIceConnectionStateChange', peer.pc.connectionState)
+
+			handleIceConnectionStateFailed(peer)
+		})
+	}
+
+	/**
+	 * @param peer
+	 */
 	function setHandlerForOwnIceConnectionStateChange(peer) {
 		peer.pc.addEventListener('iceconnectionstatechange', function() {
 			peer.emit('extendedIceConnectionStateChange', peer.pc.iceConnectionState)
@@ -1000,6 +1024,7 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 				setHandlerForOwnIceConnectionStateChange(peer)
 			} else {
 				setHandlerForIceConnectionStateChange(peer)
+				setHandlerForConnectionStateChange(peer)
 			}
 
 			setHandlerForNegotiationNeeded(peer)


### PR DESCRIPTION
Due to a bug in Chromium (probably [because "failed" is remapped to "disconnected"](https://chromium.googlesource.com/chromium/src/+/c6c955531d2b7ef3f38c149edc6fbaa537e1564b/third_party/blink/renderer/modules/peerconnection/rtc_ice_transport.cc#439), although I have not checked if that is actually the reason) the "iceConnectionState" of a RTCPeerConnection may get stuck as "disconnected" even if the connection has already failed. However, in that case "connectionState" does change to "failed", so now its listened too to changes in "connectionState" to handle that case.

~~Note that listeners to "iceConnectionState" still needs to be kept, as "connectionState" was added to Firefox only in recent versions.~~ -> Turns out that MDN fooled me and it was already available at least in Firefox 68 (I have not checked previous versions).

This fixes reconnections with other participants when Chromium is used, as reconnections are based on "iceConnectionState" changing to state "failed".

## How to test

- Set up the HPB
- Start a call
- In another machine, open Talk as another user with Chromium
- Remove both audio and video (so the user will join the call just as a receiver)
- Join the call
- Disconnect the computer from the network
- In the developer console, run `OCA.Talk.SimpleWebRTC.webrtc.peers.forEach(peer => { if (peer.pc.iceConnectionState != 'connected' && peer.pc.iceConnectionState != 'completed' ) { console.log(peer.pc.connectionState) } })` until it says "failed"
- Connect the computer again to the network

### Result with this pull request
The connection with the other participant is eventually established again.

### Result without this pull request
The other participant keeps spinning forever.
