### PR TITLE
Fix unneeded top margin in Files sidebar chat

### DIFF
--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -39,9 +39,7 @@
 			</button>
 		</div>
 		<template v-else>
-			<div class="call-button-wrapper">
-				<CallButton class="call-button" />
-			</div>
+			<CallButton class="call-button" />
 			<ChatView />
 			<UploadEditor />
 		</template>
@@ -421,25 +419,13 @@ export default {
 	justify-content: center;
 }
 
-.call-button-wrapper {
-	width: 100%;
-	background-color: var(--color-main-background);
-	z-index: 1;
-}
-
 .call-button {
-	display: block;
-
 	/* Center button horizontally. */
 	margin-left: auto;
 	margin-right: auto;
 
 	margin-top: 10px;
 	margin-bottom: 10px;
-}
-
-::v-deep .scroller {
-	margin-top: 64px;
 }
 
 .chatView {


### PR DESCRIPTION
This reverts commit 81d76dde09a89a68b113a0288583c964d13b8758.

The changes were needed due to the chat view having an absolute position. [Since Talk 12 that is no longer the case](https://github.com/nextcloud/spreed/commit/7daf60f53833d1d7eb2bf49b054d3e968854add3#diff-3836025d8a95ea6ee32db4350094d4371beeee2384ff8752007852ef0572cc47L160), so these changes just caused an unneeded margin.

**Reviewers:** the height of the button seems to be slightly smaller now, but I do not know why.

**Before:**
![Talk-Files-Chat-Margin-Top-Before](https://user-images.githubusercontent.com/26858233/131390237-717127ec-2ce2-43bd-899a-548b136d1129.png)

**After:**
![Talk-Files-Chat-Margin-Top-After](https://user-images.githubusercontent.com/26858233/131390270-c847fac6-f949-43a9-aeb4-f929ad16ad15.png)
