### PR TITLE
Add a flag for the direct mentions

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>13.0.0-dev.1</version>
+	<version>13.0.0-dev.2</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -81,3 +81,6 @@ title: Capabilities
 
 ## 12.1
 * `clear-history` - Whether chat API has the endpoint so moderators can clear the complete history of a chat
+
+## 13
+* `direct-mention-flag` - The conversation list populates the boolean `unreadMentionDirect` when the user was mentioned directly (ignoring @all mentions) since their last visit

--- a/docs/conversation.md
+++ b/docs/conversation.md
@@ -67,6 +67,7 @@
         `canEnableSIP` | int | v3 | | Whether the given user can enable SIP for this conversation. Note that when the token is not-numeric only, SIP can not be enabled even if the user is permitted and a moderator of the conversation
         `unreadMessages` | int | v1 | | Number of unread chat messages in the conversation (only available with `chat-v2` capability)
         `unreadMention` | bool | v1 | | Flag if the user was mentioned since their last visit
+        `unreadMentionDirect` | bool | v4 | | Flag if the user was mentioned directly (ignoring @all mentions) since their last visit (only available with `direct-mention-flag` capability)
         `lastReadMessage` | int | v1 | | ID of the last read message in a room (only available with `chat-read-marker` capability)
         `lastCommonReadMessage` | int | v3 | | ID of the last message read by every user that has read privacy set to public in a room. When the user themself has it set to private the value is `0` (only available with `chat-read-status` capability)
         `lastMessage` | message | v1 | | Last message in a conversation if available, otherwise empty

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -95,6 +95,7 @@ class Capabilities implements IPublicCapability {
 				'signaling-v3',
 				'publishing-permissions',
 				'clear-history',
+				'direct-mention-flag',
 			],
 			'config' => [
 				'attachments' => [

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -239,13 +239,17 @@ class ChatManager {
 			}
 
 			$alreadyNotifiedUsers = [];
+			$usersDirectlyMentioned = $this->notifier->getMentionedUserIds($comment);
 			if ($replyTo instanceof IComment) {
 				$alreadyNotifiedUsers = $this->notifier->notifyReplyToAuthor($chat, $comment, $replyTo);
+				if ($replyTo->getActorType() === Attendee::ACTOR_USERS) {
+					$usersDirectlyMentioned[] = $replyTo->getActorId();
+				}
 			}
 
 			$alreadyNotifiedUsers = $this->notifier->notifyMentionedUsers($chat, $comment, $alreadyNotifiedUsers);
 			if (!empty($alreadyNotifiedUsers)) {
-				$this->participantService->markUsersAsMentioned($chat, $alreadyNotifiedUsers, (int) $comment->getId());
+				$this->participantService->markUsersAsMentioned($chat, $alreadyNotifiedUsers, (int) $comment->getId(), $usersDirectlyMentioned);
 			}
 
 			// User was not mentioned, send a normal notification

--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -251,7 +251,7 @@ class Notifier {
 	 * @param IComment $comment
 	 * @return string[] the mentioned user IDs
 	 */
-	private function getMentionedUserIds(IComment $comment): array {
+	public function getMentionedUserIds(IComment $comment): array {
 		$mentions = $comment->getMentions();
 
 		if (empty($mentions)) {

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -383,6 +383,7 @@ class RoomController extends AEnvironmentAwareController {
 			'lastReadMessage' => 0,
 			'unreadMessages' => 0,
 			'unreadMention' => false,
+			'unreadMentionDirect' => false,
 			'isFavorite' => false,
 			'canLeaveConversation' => false,
 			'canDeleteConversation' => false,
@@ -540,7 +541,9 @@ class RoomController extends AEnvironmentAwareController {
 				}
 
 				$lastMention = $attendee->getLastMentionMessage();
+				$lastMentionDirect = $attendee->getLastMentionDirect();
 				$roomData['unreadMention'] = $lastMention !== 0 && $lastReadMessage < $lastMention;
+				$roomData['unreadMentionDirect'] = $lastMentionDirect !== 0 && $lastReadMessage < $lastMentionDirect;
 				$roomData['lastReadMessage'] = $lastReadMessage;
 
 				$roomData['canDeleteConversation'] = $room->getType() !== Room::ONE_TO_ONE_CALL

--- a/lib/Migration/Version13000Date20210901164235.php
+++ b/lib/Migration/Version13000Date20210901164235.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021, Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\Types;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version13000Date20210901164235 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('talk_attendees');
+		if (!$table->hasColumn('last_mention_direct')) {
+			$table->addColumn('last_mention_direct', Types::BIGINT, [
+				'default' => 0,
+			]);
+			return $schema;
+		}
+
+		return null;
+	}
+}

--- a/lib/Model/Attendee.php
+++ b/lib/Model/Attendee.php
@@ -47,6 +47,8 @@ use OCP\AppFramework\Db\Entity;
  * @method int getLastReadMessage()
  * @method void setLastMentionMessage(int $lastMentionMessage)
  * @method int getLastMentionMessage()
+ * @method void setLastMentionDirect(int $lastMentionDirect)
+ * @method int getLastMentionDirect()
  * @method void setReadPrivacy(int $readPrivacy)
  * @method int getReadPrivacy()
  * @method void setPublishingPermissions(int $publishingPermissions)
@@ -105,6 +107,9 @@ class Attendee extends Entity {
 	protected $lastMentionMessage;
 
 	/** @var int */
+	protected $lastMentionDirect;
+
+	/** @var int */
 	protected $readPrivacy;
 
 	/** @var int */
@@ -128,6 +133,7 @@ class Attendee extends Entity {
 		$this->addType('lastJoinedCall', 'int');
 		$this->addType('lastReadMessage', 'int');
 		$this->addType('lastMentionMessage', 'int');
+		$this->addType('lastMentionDirect', 'int');
 		$this->addType('readPrivacy', 'int');
 		$this->addType('publishingPermissions', 'int');
 		$this->addType('accessToken', 'string');
@@ -155,6 +161,7 @@ class Attendee extends Entity {
 			'last_joined_call' => $this->getLastJoinedCall(),
 			'last_read_message' => $this->getLastReadMessage(),
 			'last_mention_message' => $this->getLastMentionMessage(),
+			'last_mention_direct' => $this->getLastMentionDirect(),
 			'read_privacy' => $this->getReadPrivacy(),
 			'publishing_permissions' => $this->getPublishingPermissions(),
 			'access_token' => $this->getAccessToken(),

--- a/lib/Model/AttendeeMapper.php
+++ b/lib/Model/AttendeeMapper.php
@@ -174,6 +174,7 @@ class AttendeeMapper extends QBMapper {
 			'last_joined_call' => (int) $row['last_joined_call'],
 			'last_read_message' => (int) $row['last_read_message'],
 			'last_mention_message' => (int) $row['last_mention_message'],
+			'last_mention_direct' => (int) $row['last_mention_direct'],
 			'read_privacy' => (int) $row['read_privacy'],
 			'publishing_permissions' => (int) $row['publishing_permissions'],
 			'access_token' => (string) $row['access_token'],

--- a/lib/Model/SelectHelper.php
+++ b/lib/Model/SelectHelper.php
@@ -69,6 +69,7 @@ class SelectHelper {
 			->addSelect($alias . 'last_joined_call')
 			->addSelect($alias . 'last_read_message')
 			->addSelect($alias . 'last_mention_message')
+			->addSelect($alias . 'last_mention_direct')
 			->addSelect($alias . 'read_privacy')
 			->addSelect($alias . 'publishing_permissions')
 			->addSelect($alias . 'access_token')

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -302,6 +302,12 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			if (isset($expectedRoom['lastMessage'])) {
 				$data['lastMessage'] = $room['lastMessage'] ? $room['lastMessage']['message'] : '';
 			}
+			if (isset($expectedRoom['unreadMention'])) {
+				$data['unreadMention'] = (int) $room['unreadMention'];
+			}
+			if (isset($expectedRoom['unreadMentionDirect'])) {
+				$data['unreadMentionDirect'] = (int) $room['unreadMentionDirect'];
+			}
 			if (isset($expectedRoom['participants'])) {
 				throw new \Exception('participants key needs to be checked via participants endpoint');
 			}

--- a/tests/integration/features/chat/mentions.feature
+++ b/tests/integration/features/chat/mentions.feature
@@ -534,3 +534,92 @@ Feature: chat/mentions
     When user "participant1" sends message "hi @participant3" to room "file last share room" with 201
     And user "participant3" leaves room "file last share room" with 200 (v4)
     Then user "participant3" is not participant of room "file last share room" (v4)
+
+  Scenario: check direct mention marker after room mention
+    When user "participant1" creates room "group room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "group room" with 200 (v4)
+    And user "participant1" adds user "participant3" to room "group room" with 200 (v4)
+    And user "participant1" sends message "Room mention @all no direct mention" to room "group room" with 201
+    And user "participant2" is participant of the following rooms (v4)
+      | id         | unreadMention | unreadMentionDirect |
+      | group room | 1             | 0                   |
+    And user "participant3" is participant of the following rooms (v4)
+      | id         | unreadMention | unreadMentionDirect |
+      | group room | 1             | 0                   |
+
+  Scenario: check direct mention marker after user mention
+    When user "participant1" creates room "group room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "group room" with 200 (v4)
+    And user "participant1" adds user "participant3" to room "group room" with 200 (v4)
+    And user "participant1" sends message "Direction mention for @participant3 only" to room "group room" with 201
+    And user "participant2" is participant of the following rooms (v4)
+      | id         | unreadMention | unreadMentionDirect |
+      | group room | 0             | 0                   |
+    And user "participant3" is participant of the following rooms (v4)
+      | id         | unreadMention | unreadMentionDirect |
+      | group room | 1             | 1                   |
+
+  Scenario: check direct mention marker after mixed mention
+    When user "participant1" creates room "group room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "group room" with 200 (v4)
+    And user "participant1" adds user "participant3" to room "group room" with 200 (v4)
+    And user "participant1" sends message "Direction mention for @participant3 and @all for participant2" to room "group room" with 201
+    And user "participant2" is participant of the following rooms (v4)
+      | id         | unreadMention | unreadMentionDirect |
+      | group room | 1             | 0                   |
+    And user "participant3" is participant of the following rooms (v4)
+      | id         | unreadMention | unreadMentionDirect |
+      | group room | 1             | 1                   |
+    When user "participant3" reads message "Direction mention for @participant3 and @all for participant2" in room "group room" with 200
+    And user "participant2" is participant of the following rooms (v4)
+      | id         | unreadMention | unreadMentionDirect |
+      | group room | 1             | 0                   |
+    And user "participant3" is participant of the following rooms (v4)
+      | id         | unreadMention | unreadMentionDirect |
+      | group room | 0             | 0                   |
+
+  Scenario: check direct mention marker after reading partly
+    When user "participant1" creates room "group room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "group room" with 200 (v4)
+    And user "participant1" adds user "participant3" to room "group room" with 200 (v4)
+    And user "participant1" sends message "Test @participant3 #1" to room "group room" with 201
+    And user "participant1" sends message "Test @participant3 #2" to room "group room" with 201
+    And user "participant3" is participant of the following rooms (v4)
+      | id         | unreadMention | unreadMentionDirect |
+      | group room | 1             | 1                   |
+    When user "participant3" reads message "Test @participant3 #1" in room "group room" with 200
+    And user "participant3" is participant of the following rooms (v4)
+      | id         | unreadMention | unreadMentionDirect |
+      | group room | 1             | 1                   |
+    When user "participant3" reads message "Test @participant3 #2" in room "group room" with 200
+    And user "participant3" is participant of the following rooms (v4)
+      | id         | unreadMention | unreadMentionDirect |
+      | group room | 0             | 0                   |
+
+  Scenario: check direct mention marker after reading partly with mixed mention
+    When user "participant1" creates room "group room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "group room" with 200 (v4)
+    And user "participant1" adds user "participant3" to room "group room" with 200 (v4)
+    And user "participant1" sends message "Test @participant3 #1" to room "group room" with 201
+    And user "participant1" sends message "Test @all" to room "group room" with 201
+    And user "participant3" is participant of the following rooms (v4)
+      | id         | unreadMention | unreadMentionDirect |
+      | group room | 1             | 1                   |
+    When user "participant3" reads message "Test @participant3 #1" in room "group room" with 200
+    And user "participant3" is participant of the following rooms (v4)
+      | id         | unreadMention | unreadMentionDirect |
+      | group room | 1             | 0                   |
+    When user "participant3" reads message "Test @all" in room "group room" with 200
+    And user "participant3" is participant of the following rooms (v4)
+      | id         | unreadMention | unreadMentionDirect |
+      | group room | 0             | 0                   |

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -92,6 +92,7 @@ class CapabilitiesTest extends TestCase {
 			'signaling-v3',
 			'publishing-permissions',
 			'clear-history',
+			'direct-mention-flag',
 		];
 	}
 


### PR DESCRIPTION
This allows the UI can show the user bubble depending on user vs. all mentions

Backend for #4623

- [x] Expose whether there are personal mentions
- [x] Update the counter when a user was mentioned directly
- [x] Add docs
- [ ] Add unit tests
- [x] Add integration tests