### PR TITLE
Changed spelling of OpenStreetMap

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Location.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Location.vue
@@ -121,7 +121,7 @@ export default {
 		},
 
 		linkAriaLabel() {
-			return t('spreed', 'Open this location in Openstreetmap')
+			return t('spreed', 'Open this location in OpenStreetMap')
 		},
 	},
 }


### PR DESCRIPTION
Reported at Transifex.

Signed-off-by: rakekniven <2069590+rakekniven@users.noreply.github.com>