### PR TITLE
Fix: remove warnings on phpunit9.5.6

### DIFF
--- a/tests/php/BackgroundJob/CheckHostedSignalingServerTest.php
+++ b/tests/php/BackgroundJob/CheckHostedSignalingServerTest.php
@@ -81,15 +81,15 @@ class CheckHostedSignalingServerTest extends TestCase {
 	public function testRunWithNoChange() {
 		$backgroundJob = $this->getBackgroundJob();
 
-		$this->config->expects($this->at(0))
+		$this->config
 			->method('getAppValue')
-			->with('spreed', 'hosted-signaling-server-account-id', '')
-			->willReturn('my-account-id');
-		$this->config->expects($this->at(1))
-			->method('getAppValue')
-			->with('spreed', 'hosted-signaling-server-account', '{}')
-			->willReturn('{"status": "pending"}');
-		$this->config->expects($this->at(2))
+			->willReturnCallback(function ($appid, $key, $default) {
+				switch ($key) {
+					case 'hosted-signaling-server-account-id': return 'my-account-id';
+					case 'hosted-signaling-server-account': return '{"status": "pending"}';
+				}
+			});
+		$this->config->expects($this->once())
 			->method('setAppValue')
 			->with('spreed', 'hosted-signaling-server-account-last-checked', null);
 
@@ -110,26 +110,22 @@ class CheckHostedSignalingServerTest extends TestCase {
 			],
 		];
 
-		$this->config->expects($this->at(0))
+		$this->config
 			->method('getAppValue')
-			->with('spreed', 'hosted-signaling-server-account-id', '')
-			->willReturn('my-account-id');
-		$this->config->expects($this->at(1))
-			->method('getAppValue')
-			->with('spreed', 'hosted-signaling-server-account', '{}')
-			->willReturn('{"status": "pending"}');
-		$this->config->expects($this->at(2))
+			->willReturnCallback(function ($appid, $key, $default) {
+				switch ($key) {
+					case 'hosted-signaling-server-account-id': return 'my-account-id';
+					case 'hosted-signaling-server-account': return '{"status": "pending"}';
+				}
+			});
+		$this->config->expects($this->exactly(4))
 			->method('setAppValue')
-			->with('spreed', 'signaling_mode', 'external');
-		$this->config->expects($this->at(3))
-			->method('setAppValue')
-			->with('spreed', 'signaling_servers', '{"servers":[{"server":"signaling-url","verify":true}],"secret":"signaling-secret"}');
-		$this->config->expects($this->at(4))
-			->method('setAppValue')
-			->with('spreed', 'hosted-signaling-server-account', json_encode($newStatus));
-		$this->config->expects($this->at(5))
-			->method('setAppValue')
-			->with('spreed', 'hosted-signaling-server-account-last-checked', null);
+			->withConsecutive(
+				['spreed', 'signaling_mode', 'external'],
+				['spreed', 'signaling_servers', '{"servers":[{"server":"signaling-url","verify":true}],"secret":"signaling-secret"}'],
+				['spreed', 'hosted-signaling-server-account', json_encode($newStatus)],
+				['spreed', 'hosted-signaling-server-account-last-checked', null]
+			);
 
 		$group = $this->createMock(IGroup::class);
 		$this->groupManager->expects($this->once())

--- a/tests/php/BackgroundJob/CheckHostedSignalingServerTest.php
+++ b/tests/php/BackgroundJob/CheckHostedSignalingServerTest.php
@@ -83,12 +83,10 @@ class CheckHostedSignalingServerTest extends TestCase {
 
 		$this->config
 			->method('getAppValue')
-			->willReturnCallback(function ($appid, $key, $default) {
-				switch ($key) {
-					case 'hosted-signaling-server-account-id': return 'my-account-id';
-					case 'hosted-signaling-server-account': return '{"status": "pending"}';
-				}
-			});
+			->will($this->returnValueMap([
+				['spreed', 'hosted-signaling-server-account-id', '', 'my-account-id'],
+				['spreed', 'hosted-signaling-server-account', '{}', '{"status": "pending"}']
+			]));
 		$this->config->expects($this->once())
 			->method('setAppValue')
 			->with('spreed', 'hosted-signaling-server-account-last-checked', null);
@@ -112,12 +110,10 @@ class CheckHostedSignalingServerTest extends TestCase {
 
 		$this->config
 			->method('getAppValue')
-			->willReturnCallback(function ($appid, $key, $default) {
-				switch ($key) {
-					case 'hosted-signaling-server-account-id': return 'my-account-id';
-					case 'hosted-signaling-server-account': return '{"status": "pending"}';
-				}
-			});
+			->will($this->returnValueMap([
+				['spreed', 'hosted-signaling-server-account-id', '', 'my-account-id'],
+				['spreed', 'hosted-signaling-server-account', '{}', '{"status": "pending"}']
+			]));
 		$this->config->expects($this->exactly(4))
 			->method('setAppValue')
 			->withConsecutive(

--- a/tests/php/Chat/SystemMessage/ListenerTest.php
+++ b/tests/php/Chat/SystemMessage/ListenerTest.php
@@ -217,18 +217,21 @@ class ListenerTest extends TestCase {
 		// TODO: add all cases
 		$event = new AddParticipantsEvent($room, $participants);
 
-		foreach ($expectedMessages as $index => $expectedMessage) {
-			$this->chatManager->expects($this->at($index))
+		foreach ($expectedMessages as $expectedMessage) {
+			$consecutive[] = [
+				$room,
+				$expectedMessage['actorType'],
+				$expectedMessage['actorId'],
+				json_encode($expectedMessage['message']),
+				$this->dummyTime,
+				false,
+				self::DUMMY_REFERENCE_ID,
+			];
+		}
+		if (isset($consecutive)) {
+			$this->chatManager
 				->method('addSystemMessage')
-				->with(
-					$room,
-					$expectedMessage['actorType'],
-					$expectedMessage['actorId'],
-					json_encode($expectedMessage['message']),
-					$this->dummyTime,
-					false,
-					self::DUMMY_REFERENCE_ID,
-				);
+				->withConsecutive(...$consecutive);
 		}
 
 		$this->dispatch(Room::EVENT_AFTER_USERS_ADD, $event);

--- a/tests/php/Chat/SystemMessage/ListenerTest.php
+++ b/tests/php/Chat/SystemMessage/ListenerTest.php
@@ -298,18 +298,21 @@ class ListenerTest extends TestCase {
 
 		$event = new ModifyParticipantEvent($room, $participant, '', $newParticipantType, $oldParticipantType);
 
-		foreach ($expectedMessages as $index => $expectedMessage) {
-			$this->chatManager->expects($this->at($index))
+		foreach ($expectedMessages as $expectedMessage) {
+			$consecutive[] = [
+				$room,
+				Attendee::ACTOR_USERS,
+				'alice_actor',
+				json_encode($expectedMessage),
+				$this->dummyTime,
+				false,
+				self::DUMMY_REFERENCE_ID
+			];
+		}
+		if (isset($consecutive)) {
+			$this->chatManager->expects($this->once())
 				->method('addSystemMessage')
-				->with(
-					$room,
-					Attendee::ACTOR_USERS,
-					'alice_actor',
-					json_encode($expectedMessage),
-					$this->dummyTime,
-					false,
-					self::DUMMY_REFERENCE_ID,
-				);
+				->withConsecutive(...$consecutive);
 		}
 
 		$this->dispatch(Room::EVENT_AFTER_PARTICIPANT_TYPE_SET, $event);

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -908,31 +908,29 @@ class NotifierTest extends \Test\TestCase {
 			->willReturn($l);
 
 		$recipient = $this->createMock(IUser::class);
-		$this->userManager->expects($this->at(0))
-			->method('get')
-			->with('recipient')
-			->willReturn($recipient);
+		$userManagerGet['with'][] = ['recipient'];
+		$userManagerGet['willReturn'][] = $recipient;
 
 		$user = $this->createMock(IUser::class);
 		if ($subjectParameters['userType'] === 'users' && !$deletedUser) {
 			$user->expects($this->once())
 				->method('getDisplayName')
 				->willReturn($displayName);
-			$this->userManager->expects($this->at(1))
-				->method('get')
-				->with($subjectParameters['userId'])
-				->willReturn($user);
+			$userManagerGet['with'][] = [$subjectParameters['userId']];
+			$userManagerGet['willReturn'][] = $user;
 		} elseif ($subjectParameters['userType'] === 'users' && $deletedUser) {
 			$user->expects($this->never())
 				->method('getDisplayName');
-			$this->userManager->expects($this->at(1))
-				->method('get')
-				->with($subjectParameters['userId'])
-				->willReturn(null);
+			$userManagerGet['with'][] = [$subjectParameters['userId']];
+			$userManagerGet['willReturn'][] = null;
 		} else {
 			$user->expects($this->never())
 				->method('getDisplayName');
 		}
+		$this->userManager->expects($this->exactly(count($userManagerGet['with'])))
+			->method('get')
+			->withConsecutive(...$userManagerGet['with'])
+			->willReturnOnConsecutiveCalls(...$userManagerGet['willReturn']);
 
 		$comment = $this->createMock(IComment::class);
 		$comment->expects($this->any())

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -158,18 +158,20 @@ class NotifierTest extends \Test\TestCase {
 			->willReturn($l);
 
 		$recipient = $this->createMock(IUser::class);
-		$this->userManager->expects($this->at(0))
-			->method('get')
-			->with('recipient')
-			->willReturn($recipient);
 		$u = $this->createMock(IUser::class);
 		$u->expects($this->exactly(2))
 			->method('getDisplayName')
 			->willReturn($displayName);
-		$this->userManager->expects($this->at(1))
+		$this->userManager->expects($this->exactly(2))
 			->method('get')
-			->with($uid)
-			->willReturn($u);
+			->withConsecutive(
+				['recipient'],
+				[$uid]
+			)
+			->willReturnOnConsecutiveCalls(
+				$recipient,
+				$u
+			);
 
 		$n->expects($this->once())
 			->method('setIcon')
@@ -383,18 +385,20 @@ class NotifierTest extends \Test\TestCase {
 			->willReturn($l);
 
 		$recipient = $this->createMock(IUser::class);
-		$this->userManager->expects($this->at(0))
-			->method('get')
-			->with('recipient')
-			->willReturn($recipient);
 		$u = $this->createMock(IUser::class);
 		$u->expects($this->exactly(2))
 			->method('getDisplayName')
 			->willReturn($displayName);
-		$this->userManager->expects($this->at(1))
+		$this->userManager->expects($this->exactly(2))
 			->method('get')
-			->with($uid)
-			->willReturn($u);
+			->withConsecutive(
+				['recipient'],
+				[$uid]
+			)
+			->willReturnOnConsecutiveCalls(
+				$recipient,
+				$u
+			);
 
 		$n->expects($this->once())
 			->method('setIcon')


### PR DESCRIPTION
# How to reproduce

Run tests using PHPUnit 9.5.6

# Solution

Replaced all calls to method `at` by more specific functions

close #6228