### PR TITLE
Fix eslint warning

### DIFF
--- a/src/components/LobbyScreen.vue
+++ b/src/components/LobbyScreen.vue
@@ -40,7 +40,9 @@
 				</span>
 			</p>
 
-			<p class="lobby__description">{{ conversation.description }}</p>
+			<p class="lobby__description">
+				{{ conversation.description }}
+			</p>
 		</div>
 		<SetGuestUsername v-if="currentUserIsGuest" />
 	</div>


### PR DESCRIPTION
src/components/LobbyScreen.vue
  43:34  warning  Expected 1 line break after opening tag (`<p>`), but no line breaks found    vue/singleline-html-element-content-newline
  43:64  warning  Expected 1 line break before closing tag (`</p>`), but no line breaks found  vue/singleline-html-element-content-newline

Signed-off-by: Joas Schilling <coding@schilljs.com>