### PR TITLE
Don't error hard when adding users to room

### DIFF
--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -51,6 +51,7 @@ use OCA\Talk\Webinary;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\IComment;
+use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
@@ -339,15 +340,22 @@ class ParticipantService {
 			$attendee->setParticipantType($participant['participantType'] ?? Participant::USER);
 			$attendee->setLastReadMessage($lastMessage);
 			$attendee->setReadPrivacy($readPrivacy);
-			$this->attendeeMapper->insert($attendee);
-
-			$attendees[] = $attendee;
+			try {
+				$this->attendeeMapper->insert($attendee);
+				$attendees[] = $attendee;
+			} catch (Exception $e) {
+				if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+					throw $e;
+				}
+			}
 		}
 
-		$attendeeEvent = new AttendeesAddedEvent($room, $attendees);
-		$this->dispatcher->dispatchTyped($attendeeEvent);
+		if (!empty($attendees)) {
+			$attendeeEvent = new AttendeesAddedEvent($room, $attendees);
+			$this->dispatcher->dispatchTyped($attendeeEvent);
 
-		$this->dispatcher->dispatch(Room::EVENT_AFTER_USERS_ADD, $event);
+			$this->dispatcher->dispatch(Room::EVENT_AFTER_USERS_ADD, $event);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Happened to me multiple times with the iOS app which sends the add requests in parallel
Can really write a test for it, but the flow is basically the following:

Request to add group with user "test1" | Request to add user "test1"
---|---
Gets list of participants | Gets list of participants
Gets group members | …
… | Adds user
Adds each user 💥 | ✅ 

Before:
```
An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 53-users-admin for key oc_talk_attendees.ta_ident
```