### PR TITLE
l10n: Change word

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -402,7 +402,7 @@ class SystemMessage {
 				&& $parsedParameters['object']['type'] === 'geo-location'
 				&& !preg_match(ChatManager::GEO_LOCATION_VALIDATOR, $parsedParameters['object']['id'])) {
 				$parsedParameters = [];
-				$parsedMessage = $this->l->t('The shared location is malformed');
+				$parsedMessage = $this->l->t('The shared location is inaccurate');
 			}
 
 			$chatMessage->setMessageType('comment');


### PR DESCRIPTION
Changed word "malformed" to "inaccurate" because the location cannot be garbled, only inaccurate.

Signed-off-by: Valdnet <47037905+Valdnet@users.noreply.github.com>