### PR TITLE
Fix "stopped speaking" events still emitted once started to speak again

### DIFF
--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -793,6 +793,10 @@ LocalMedia.prototype._setupAudioMonitor = function(stream, harkOptions) {
 	})
 
 	audio.on('speaking', function() {
+		if (timeout) {
+			clearTimeout(timeout)
+		}
+
 		self._speaking = true
 
 		if (self._audioEnabled) {


### PR DESCRIPTION
The `stopped speaking` events emitted by the audio monitor are not immediately relayed, but once a grace period of one second has elapsed. However, when the user starts to speak again the timeout was not cleared, so the `stopped speaking` event was emitted even if the user started to speak again.

This could mess with the components that rely on the `stopped speaking` event, like the _speaking while muted_ warner.

## How to test

- Start a call
- Mute yourself
- Say "AAAAAA" to the microphone until the _speaking while muted_ warning appears
- Stop briefly (less than a second)
- Say "AAAAAA" again for some seconds

### Result with this pull request

The _speaking while muted_ warning is kept shown until you stop saying "AAAAAA" for the second time

### Result without this pull request

The _speaking while muted_ warning disappears even if you are saying "AAAAAA" for a second time
