### PR TITLE
Differentiate between direct mentions and group nmentions

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
@@ -276,9 +276,10 @@ describe('Conversation.vue', () => {
 		/**
 		 * @param {object} item Conversation data
 		 * @param {string} expectedCounterText The expected unread counter
+		 * @param expectedOutlined
 		 * @param {boolean} expectedHighlighted Whether or not the unread counter is highlighted with primary color
 		 */
-		function testCounter(item, expectedCounterText, expectedHighlighted) {
+		function testCounter(item, expectedCounterText, expectedOutlined, expectedHighlighted) {
 			const wrapper = mount(Conversation, {
 				localVue,
 				store,
@@ -295,23 +296,38 @@ describe('Conversation.vue', () => {
 			expect(el.exists()).toBe(true)
 
 			expect(el.props('counterNumber')).toBe(expectedCounterText)
-			expect(el.props('counterHighlighted')).toBe(expectedHighlighted)
+			if (expectedOutlined) {
+				expect(el.props('counterType')).toBe('outlined')
+			}
+			if (expectedHighlighted) {
+				expect(el.props('counterType')).toBe('highlighted')
+			}
 		}
 
 		test('renders unread messages counter', () => {
 			item.unreadMessages = 5
-			testCounter(item, 5, false)
+			item.unreadMention = false
+			item.unreadMentionDirect = false
+			testCounter(item, 5, false, false)
 		})
 		test('renders unread mentions highlighted for non one-to-one conversations', () => {
 			item.unreadMessages = 5
 			item.unreadMention = true
-			testCounter(item, 5, true)
+			item.unreadMentionDirect = true
+			testCounter(item, 5, false, true)
+		})
+		test('renders group mentions outlined for non one-to-one conversations', () => {
+			item.unreadMessages = 5
+			item.unreadMention = true
+			item.unreadMentionDirect = false
+			testCounter(item, 5, true, false)
 		})
 		test('renders unread mentions always highlighted for one-to-one conversations', () => {
 			item.unreadMessages = 5
 			item.unreadMention = false
+			item.unreadMentionDirect = false
 			item.type = CONVERSATION.TYPE.ONE_TO_ONE
-			testCounter(item, 5, true)
+			testCounter(item, 5, false, true)
 		})
 
 		test('does not render counter when no unread messages', () => {

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -27,7 +27,7 @@
 		:to="to"
 		:bold="!!item.unreadMessages"
 		:counter-number="item.unreadMessages"
-		:counter-highlighted="counterShouldBePrimary"
+		:counter-type="counterType"
 		@click="onClick">
 		<template #icon>
 			<ConversationIcon
@@ -157,8 +157,14 @@ export default {
 
 	computed: {
 
-		counterShouldBePrimary() {
-			return this.item.unreadMention || (this.item.unreadMessages !== 0 && this.item.type === CONVERSATION.TYPE.ONE_TO_ONE)
+		counterType() {
+			if (this.item.unreadMentionDirect || (this.item.unreadMessages !== 0 && this.item.type === CONVERSATION.TYPE.ONE_TO_ONE)) {
+				return 'highlighted'
+			} else if (this.item.unreadMention) {
+				return 'outlined'
+			} else {
+				return ''
+			}
 		},
 
 		linkToConversation() {


### PR DESCRIPTION
Fix #4623 

requires https://github.com/nextcloud/nextcloud-vue/pull/2208 to be released

<img width="314" alt="Screenshot 2021-09-28 at 10 39 56 1" src="https://user-images.githubusercontent.com/26852655/135054284-45fb1640-0728-44df-9720-024a1b3dec1b.png">


Signed-off-by: marco <marcoambrosini@pm.me>
