### PR TITLE
Moved code to specialist method and add fallback to all

### DIFF
--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -546,7 +546,7 @@ class ChatManager {
 			array_unshift($results, [
 				'id' => 'all',
 				'label' => $roomDisplayName,
-				'source' => 'calls',
+				'source' => 'calls'
 			]);
 		}
 		return $results;

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -531,4 +531,37 @@ class ChatManager {
 	public function searchForObjects(string $search,  array $objectIds, string $verb = '', int $offset = 0, int $limit = 50): array {
 		return $this->commentsManager->searchForObjects($search, 'chat', $objectIds, $verb, $offset, $limit);
 	}
+
+	public function addConversationNotify(array $results, string $search, Room $room, Participant $participant): array {
+		if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+			return $results;
+		}
+		$attendee = $participant->getAttendee();
+		if ($attendee->getActorType() === Attendee::ACTOR_USERS) {
+			$roomDisplayName = $room->getDisplayName($attendee->getActorId());
+		} else {
+			$roomDisplayName = $room->getDisplayName('');
+		}
+		if ($search === '' || $this->searchIsPartOfConversationNameOrAtAll($search, $roomDisplayName)) {
+			array_unshift($results, [
+				'id' => 'all',
+				'label' => $roomDisplayName,
+				'source' => 'calls',
+			]);
+		}
+		return $results;
+	}
+
+	private function searchIsPartOfConversationNameOrAtAll(string $search, string $roomDisplayName): bool {
+		if (stripos($roomDisplayName, $search) === 0) {
+			return true;
+		}
+		if (strpos('all', $search) === 0) {
+			return true;
+		}
+		if (strpos('here', $search) === 0) {
+			return true;
+		}
+		return false;
+	}
 }

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -706,26 +706,7 @@ class ChatController extends AEnvironmentAwareController {
 
 		$results = $this->prepareResultArray($results, $statuses);
 
-		$attendee = $this->participant->getAttendee();
-		$userId = $attendee->getActorType() === Attendee::ACTOR_USERS ? $attendee->getActorId() : '';
-		$roomDisplayName = $this->room->getDisplayName($userId);
-		if (($search === '' || strpos('all', $search) !== false || stripos($roomDisplayName, $search) !== false) && $this->room->getType() !== Room::ONE_TO_ONE_CALL) {
-			if ($search === '' ||
-				stripos($roomDisplayName, $search) === 0 ||
-				strpos('all', $search) === 0) {
-				array_unshift($results, [
-					'id' => 'all',
-					'label' => $roomDisplayName,
-					'source' => 'calls',
-				]);
-			} else {
-				$results[] = [
-					'id' => 'all',
-					'label' => $roomDisplayName,
-					'source' => 'calls',
-				];
-			}
-		}
+		$results = $this->chatManager->addConversationNotify($results, $search, $this->room, $this->participant);
 
 		return new DataResponse($results);
 	}

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -1075,6 +1075,10 @@ class ChatControllerTest extends TestCase {
 			->method('asArray')
 			->willReturn($result);
 
+		$this->chatManager->expects($this->once())
+			->method('addConversationNotify')
+			->willReturnArgument(0);
+
 		$this->controller->setRoom($this->room);
 		$this->controller->setParticipant($participant);
 		$response = $this->controller->mentions($search, $limit);


### PR DESCRIPTION
## explaining changes
I moved the logic of add `@all` on the mentions array to a specialist method and refactored the logic to make more clean to add new mentions types and of course, I added `@here`

## To do
- [x] resolve #5357
- [x] tests

## Acceptance criteria
When I do a GET to `/api/{apiVersion}/chat/{token}/mentions` with query string `?search=here`
The response object will need a element on data property with `id: all`
