### PR TITLE
Ignore sessions older than 30 seconds on notifications again

### DIFF
--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -33,6 +33,7 @@ use OCA\Talk\Model\Session;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\IComment;
 use OCP\IConfig;
 use OCP\Notification\IManager as INotificationManager;
@@ -58,6 +59,8 @@ class Notifier {
 	private $manager;
 	/** @var IConfig */
 	private $config;
+	/** @var ITimeFactory */
+	private $timeFactory;
 	/** @var Util */
 	private $util;
 
@@ -66,12 +69,14 @@ class Notifier {
 								ParticipantService $participantService,
 								Manager $manager,
 								IConfig $config,
+								ITimeFactory $timeFactory,
 								Util $util) {
 		$this->notificationManager = $notificationManager;
 		$this->userManager = $userManager;
 		$this->participantService = $participantService;
 		$this->manager = $manager;
 		$this->config = $config;
+		$this->timeFactory = $timeFactory;
 		$this->util = $util;
 	}
 
@@ -385,7 +390,7 @@ class Notifier {
 
 		if ($participant->getSession() instanceof Session) {
 			// User is online
-			return false;
+			return $participant->getSession()->getLastPing() < $this->timeFactory->getTime() - Session::SESSION_TIMEOUT;
 		}
 
 		return true;

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -67,7 +67,7 @@ class CallController extends AEnvironmentAwareController {
 	 * @return DataResponse
 	 */
 	public function getPeersForCall(): DataResponse {
-		$timeout = $this->timeFactory->getTime() - 30;
+		$timeout = $this->timeFactory->getTime() - Session::SESSION_TIMEOUT;
 		$result = [];
 		$participants = $this->participantService->getParticipantsInCall($this->room, $timeout);
 

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -890,7 +890,7 @@ class RoomController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		$maxPingAge = $this->timeFactory->getTime() - 100;
+		$maxPingAge = $this->timeFactory->getTime() - Session::SESSION_TIMEOUT_KILL;
 		$participants = $this->participantService->getSessionsAndParticipantsForRoom($this->room);
 		$results = $headers = $statuses = [];
 

--- a/lib/Model/Session.php
+++ b/lib/Model/Session.php
@@ -44,7 +44,6 @@ use OCP\AppFramework\Db\Entity;
  * @method int getLastPing()
  */
 class Session extends Entity {
-
 	public const SESSION_TIMEOUT = 30;
 	public const SESSION_TIMEOUT_KILL = self::SESSION_TIMEOUT * 3 + 10;
 

--- a/lib/Model/Session.php
+++ b/lib/Model/Session.php
@@ -45,6 +45,9 @@ use OCP\AppFramework\Db\Entity;
  */
 class Session extends Entity {
 
+	public const SESSION_TIMEOUT = 30;
+	public const SESSION_TIMEOUT_KILL = self::SESSION_TIMEOUT * 3 + 10;
+
 	/** @var int */
 	protected $attendeeId;
 

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1237,6 +1237,7 @@ class ParticipantService {
 			->where($query->expr()->eq('a.room_id', $query->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->isNotNull('s.in_call'))
 			->andWhere($query->expr()->neq('s.in_call', $query->createNamedParameter(Participant::FLAG_DISCONNECTED)))
+			->andWhere($query->expr()->gte('s.last_ping', $query->createNamedParameter($this->timeFactory->getTime() - Session::SESSION_TIMEOUT, IQueryBuilder::PARAM_INT)))
 			->setMaxResults(1);
 		$result = $query->execute();
 		$row = $result->fetch();

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -773,7 +773,7 @@ class ParticipantService {
 			->leftJoin('s', 'talk_attendees', 'a', $query->expr()->eq('s.attendee_id', 'a.id'))
 			->where($query->expr()->eq('a.room_id', $query->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->eq('a.actor_type', $query->createNamedParameter(Attendee::ACTOR_GUESTS)))
-			->andWhere($query->expr()->lte('s.last_ping', $query->createNamedParameter($this->timeFactory->getTime() - 100, IQueryBuilder::PARAM_INT)));
+			->andWhere($query->expr()->lte('s.last_ping', $query->createNamedParameter($this->timeFactory->getTime() - Session::SESSION_TIMEOUT_KILL, IQueryBuilder::PARAM_INT)));
 
 		$sessionTableIds = [];
 		$result = $query->execute();
@@ -1149,6 +1149,7 @@ class ParticipantService {
 				$query->expr()->andX(
 					$query->expr()->eq('s.attendee_id', 'a.id'),
 					$query->expr()->neq('s.in_call', $query->createNamedParameter(Participant::FLAG_DISCONNECTED)),
+					$query->expr()->gte('s.last_ping', $query->createNamedParameter($this->timeFactory->getTime() - Session::SESSION_TIMEOUT, IQueryBuilder::PARAM_INT)),
 				)
 			)
 			->where($query->expr()->eq('a.room_id', $query->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))

--- a/tests/php/Chat/NotifierTest.php
+++ b/tests/php/Chat/NotifierTest.php
@@ -553,7 +553,6 @@ class NotifierTest extends TestCase {
 	 * @param bool $expected
 	 */
 	public function testShouldParticipantBeNotified(string $actorType, string $actorId, ?int $sessionAge, string $commentActorType, string $commentActorId, array $alreadyNotifiedUsers, bool $expected): void {
-
 		$comment = $this->createMock(IComment::class);
 		$comment->method('getActorType')
 			->willReturn($commentActorType);


### PR DESCRIPTION
## Steps to reproduce with iOS
1. As user 1 create a chat with user 2
2. Set the setting to be notified for all messages
2. Join with the android/ios app into a chat
3. Join the call and kill the app
4. Optional: Make sure there is still a session entry in oc_talk_sessions
5. Wait 30 seconds
5. As user 2 open the chat 
6. Write a message into the chat (without mentioning the user)

## Steps to reproduce with hacking DB;
1. As user 1 create a chat with user 2
2. Set the setting to be notified for all messages
2. Switch to a different conversation
3. Manually create a valid session entry in oc_talk_sessions for user 1 with a last_ping far in the past
5. As user 2 open the chat 
6. Write a message into the chat (without mentioning the user)

## Without this PR
No notification for user 1

## With this PR
Notification for user 1
