### PR TITLE
Fix null stream given to RTCPeerConnection.addTrack

### DIFF
--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -419,7 +419,7 @@ LocalMedia.prototype._handleAudioInputIdChanged = function(mediaDevicesManager, 
 			})
 
 			this.emit('localStreamChanged', stream)
-			this.emit('localTrackReplaced', clonedTrack, trackStreamPair.track, trackStreamPair.stream)
+			this.emit('localTrackReplaced', clonedTrack, trackStreamPair.track, stream)
 		})
 
 		// After the clones were added to the local streams the original track
@@ -554,7 +554,7 @@ LocalMedia.prototype._handleVideoInputIdChanged = function(mediaDevicesManager, 
 			})
 
 			this.emit('localStreamChanged', stream)
-			this.emit('localTrackReplaced', clonedTrack, trackStreamPair.track, trackStreamPair.stream)
+			this.emit('localTrackReplaced', clonedTrack, trackStreamPair.track, stream)
 		})
 
 		// After the clones were added to the local streams the original track


### PR DESCRIPTION
If a call is started and no audio nor video device is selected there will be no stream in the local media. If a device is then selected a new MediaStream will be created to add the track to it. However, the event did not include the stream that the track was added to but a null object, so when the event was handled [calling `RTCPeerConnection.addTrack()` failed due to being given a null stream](https://github.com/nextcloud/spreed/blob/bf078427d5bf60b65bd60d17e979511c5a28b8e4/src/utils/webrtc/simplewebrtc/peer.js#L878). Now the event includes the stream that the track was added to, which will be either the already existing stream or the one just created.

Although `addTrack` failed in `master` and Talk 12 enabling the device happened to work [due to the exception being swallowed](https://github.com/nextcloud/spreed/blob/bf078427d5bf60b65bd60d17e979511c5a28b8e4/src/utils/webrtc/simplewebrtc/peer.js#L753-L759), which allowed other event handlers of `localTrackChanged` to run and force a reconnection. However, [the change that made the exception to be swallowed](https://github.com/nextcloud/spreed/pull/5660/commits/661d5fd1e897983700f9aa2fb69c3a6673112a80) was not backported to Talk 11 so [the exception was propagated up to the event emitter](https://github.com/nextcloud/spreed/blob/5f20110113f42bcdd3c196ddaf96cba6183241e2/src/utils/webrtc/simplewebrtc/localmedia.js#L422), which aborted the other event handlers and thus prevented the reconnection (so the participant selecting the microphone could not be heard by other participants).

## How to test

- In _master_ and Talk 12 [the forced reconnection in the `localTrackChanged` handler in _webrtc.js_ needs to be commented](https://github.com/nextcloud/spreed/blob/58c639a99a27a649d57975a15b2052a3753c90ee/src/utils/webrtc/webrtc.js#L1290), as the reconnection will hide the fact that `addTrack` failed
- Use Firefox (Chromium sometimes keeps `iceConnectionState` as `new` while changing `connectionState` to `connected`, similar to what happened with `disconnected` and `failed` :shrug:)
- Do not use the HPB
- Start a call
- In a private window, join the conversation
- Open Talk settings and deselect both microphone and camera
- Join the call
- Open Talk settings and select a microphone

### Result with this pull request

The current participant will be reconnected. Note that the connection between the participants may fail after the forced reconnection, but that is a different issue (forced reconnections without the HPB need some love)

### Result without this pull request

The current participant will not be reconnected
