### PR TITLE
Extract common emitter code to mixin

### DIFF
--- a/src/utils/EmitterMixin.js
+++ b/src/utils/EmitterMixin.js
@@ -1,0 +1,108 @@
+/**
+ *
+ * @copyright Copyright (c) 2021, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Emitter of events.
+ *
+ * The mixin can be inherited calling "EmitterMixin.apply(Inheriter.prototype)";
+ * "_superEmitterMixin()" must be called from the constructor. Inheriters of the
+ * mixin can trigger events calling "_trigger('eventName', [arguments])".
+ *
+ * Clients of the emitter can subscribe to events calling "on('eventName',
+ * eventHandler)", and desubscribe calling "off('eventName', eventHandler)". The
+ * event handler should be defined as "eventHandler(emitter, argument0,
+ * argument1...)". The same subscribed event handler must be provided to
+ * desubscribe it, so an inline function would not work (a function stored in a
+ * variable and probably bound to a specific object may need to be used
+ * instead).
+ */
+export default (function() {
+
+	/**
+	 * Mixin constructor.
+	 *
+	 * Adds mixin attributes to objects inheriting the mixin.
+	 *
+	 * This must be called in their constructor by classes inheriting the mixin.
+	 */
+	function _superEmitterMixin() {
+		this._handlers = []
+	}
+
+	/**
+	 * @param {string} event the name of the event
+	 * @param {Function} handler the handler function to register
+	 */
+	function on(event, handler) {
+		if (!Object.prototype.hasOwnProperty.call(this._handlers, event)) {
+			this._handlers[event] = [handler]
+		} else {
+			this._handlers[event].push(handler)
+		}
+	}
+
+	/**
+	 * @param {string} event the name of the event
+	 * @param {Function} handler the handler function to deregister
+	 */
+	function off(event, handler) {
+		const handlers = this._handlers[event]
+		if (!handlers) {
+			return
+		}
+
+		const index = handlers.indexOf(handler)
+		if (index !== -1) {
+			handlers.splice(index, 1)
+		}
+	}
+
+	/**
+	 * @param {string} event the name of the event
+	 * @param {Array} args the arguments of the event
+	 */
+	function _trigger(event, args) {
+		let handlers = this._handlers[event]
+		if (!handlers) {
+			return
+		}
+
+		if (!args) {
+			args = []
+		}
+
+		args.unshift(this)
+
+		handlers = handlers.slice(0)
+		for (let i = 0; i < handlers.length; i++) {
+			const handler = handlers[i]
+			handler.apply(handler, args)
+		}
+	}
+
+	return function() {
+		// Add methods to the prototype from the functions defined above
+		this._superEmitterMixin = _superEmitterMixin
+		this.on = on
+		this.off = off
+		this._trigger = _trigger
+	}
+})()

--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -20,6 +20,7 @@
  */
 
 import BrowserStorage from '../../services/BrowserStorage'
+import EmitterMixin from '../EmitterMixin'
 
 /**
  * Special string to set null device ids in local storage (as only strings are
@@ -74,14 +75,14 @@ const LOCAL_STORAGE_NULL_DEVICE_ID = 'local-storage-null-device-id'
  * (in that case the fallback devices will not be taken into account).
  */
 export default function MediaDevicesManager() {
+	this._superEmitterMixin()
+
 	this.attributes = {
 		devices: [],
 
 		audioInputId: undefined,
 		videoInputId: undefined,
 	}
-
-	this._handlers = []
 
 	this._enabledCount = 0
 
@@ -132,41 +133,6 @@ MediaDevicesManager.prototype = {
 			BrowserStorage.setItem(key, value)
 		} else {
 			BrowserStorage.removeItem(key)
-		}
-	},
-
-	on(event, handler) {
-		if (!Object.prototype.hasOwnProperty.call(this._handlers, event)) {
-			this._handlers[event] = [handler]
-		} else {
-			this._handlers[event].push(handler)
-		}
-	},
-
-	off(event, handler) {
-		const handlers = this._handlers[event]
-		if (!handlers) {
-			return
-		}
-
-		const index = handlers.indexOf(handler)
-		if (index !== -1) {
-			handlers.splice(index, 1)
-		}
-	},
-
-	_trigger(event, args) {
-		let handlers = this._handlers[event]
-		if (!handlers) {
-			return
-		}
-
-		args.unshift(this)
-
-		handlers = handlers.slice(0)
-		for (let i = 0; i < handlers.length; i++) {
-			const handler = handlers[i]
-			handler.apply(handler, args)
 		}
 	},
 
@@ -501,3 +467,5 @@ MediaDevicesManager.prototype = {
 		}
 	},
 }
+
+EmitterMixin.apply(MediaDevicesManager.prototype)

--- a/src/utils/webrtc/analyzers/CallAnalyzer.js
+++ b/src/utils/webrtc/analyzers/CallAnalyzer.js
@@ -19,6 +19,8 @@
  *
  */
 
+import EmitterMixin from '../../EmitterMixin'
+
 import {
 	ParticipantAnalyzer,
 } from './ParticipantAnalyzer'
@@ -50,13 +52,13 @@ import {
  * for the remote participants.
  */
 export default function CallAnalyzer(localMediaModel, localCallParticipantModel, callParticipantCollection) {
+	this._superEmitterMixin()
+
 	this.attributes = {
 		senderConnectionQualityAudio: null,
 		senderConnectionQualityVideo: null,
 		senderConnectionQualityScreen: null,
 	}
-
-	this._handlers = []
 
 	this._localMediaModel = localMediaModel
 	this._localCallParticipantModel = localCallParticipantModel
@@ -87,41 +89,6 @@ CallAnalyzer.prototype = {
 		this._trigger('change:' + key, [value])
 	},
 
-	on(event, handler) {
-		if (!Object.prototype.hasOwnProperty.call(this._handlers, event)) {
-			this._handlers[event] = [handler]
-		} else {
-			this._handlers[event].push(handler)
-		}
-	},
-
-	off(event, handler) {
-		const handlers = this._handlers[event]
-		if (!handlers) {
-			return
-		}
-
-		const index = handlers.indexOf(handler)
-		if (index !== -1) {
-			handlers.splice(index, 1)
-		}
-	},
-
-	_trigger(event, args) {
-		let handlers = this._handlers[event]
-		if (!handlers) {
-			return
-		}
-
-		args.unshift(this)
-
-		handlers = handlers.slice(0)
-		for (let i = 0; i < handlers.length; i++) {
-			const handler = handlers[i]
-			handler.apply(handler, args)
-		}
-	},
-
 	destroy() {
 		if (this._localParticipantAnalyzer) {
 			this._localParticipantAnalyzer.off('change:senderConnectionQualityAudio', this._handleSenderConnectionQualityAudioChangeBound)
@@ -145,3 +112,5 @@ CallAnalyzer.prototype = {
 	},
 
 }
+
+EmitterMixin.apply(CallAnalyzer.prototype)

--- a/src/utils/webrtc/analyzers/ParticipantAnalyzer.js
+++ b/src/utils/webrtc/analyzers/ParticipantAnalyzer.js
@@ -19,6 +19,8 @@
  *
  */
 
+import EmitterMixin from '../../EmitterMixin'
+
 import {
 	PEER_DIRECTION,
 	PeerConnectionAnalyzer,
@@ -57,7 +59,7 @@ import {
  * to stop the analysis.
  */
 function ParticipantAnalyzer() {
-	this._handlers = []
+	this._superEmitterMixin()
 
 	this._localMediaModel = null
 	this._localCallParticipantModel = null
@@ -82,41 +84,6 @@ function ParticipantAnalyzer() {
 	this._handleConnectionQualityScreenChangeBound = this._handleConnectionQualityScreenChange.bind(this)
 }
 ParticipantAnalyzer.prototype = {
-
-	on(event, handler) {
-		if (!Object.prototype.hasOwnProperty.call(this._handlers, event)) {
-			this._handlers[event] = [handler]
-		} else {
-			this._handlers[event].push(handler)
-		}
-	},
-
-	off(event, handler) {
-		const handlers = this._handlers[event]
-		if (!handlers) {
-			return
-		}
-
-		const index = handlers.indexOf(handler)
-		if (index !== -1) {
-			handlers.splice(index, 1)
-		}
-	},
-
-	_trigger(event, args) {
-		let handlers = this._handlers[event]
-		if (!handlers) {
-			return
-		}
-
-		args.unshift(this)
-
-		handlers = handlers.slice(0)
-		for (let i = 0; i < handlers.length; i++) {
-			const handler = handlers[i]
-			handler.apply(handler, args)
-		}
-	},
 
 	destroy() {
 		if (this._localCallParticipantModel) {
@@ -349,6 +316,8 @@ ParticipantAnalyzer.prototype = {
 	},
 
 }
+
+EmitterMixin.apply(ParticipantAnalyzer.prototype)
 
 export {
 	ParticipantAnalyzer,

--- a/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
+++ b/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
@@ -19,6 +19,8 @@
  *
  */
 
+import EmitterMixin from '../../EmitterMixin'
+
 import {
 	STAT_VALUE_TYPE,
 	AverageStatValue,
@@ -72,6 +74,8 @@ const PEER_DIRECTION = {
  * not be enough.
  */
 function PeerConnectionAnalyzer() {
+	this._superEmitterMixin()
+
 	this._packets = {
 		audio: new AverageStatValue(5, STAT_VALUE_TYPE.CUMULATIVE),
 		video: new AverageStatValue(5, STAT_VALUE_TYPE.CUMULATIVE),
@@ -128,8 +132,6 @@ function PeerConnectionAnalyzer() {
 		video: true,
 	}
 
-	this._handlers = []
-
 	this._peerConnection = null
 	this._peerDirection = null
 
@@ -145,41 +147,6 @@ function PeerConnectionAnalyzer() {
 	}
 }
 PeerConnectionAnalyzer.prototype = {
-
-	on(event, handler) {
-		if (!Object.prototype.hasOwnProperty.call(this._handlers, event)) {
-			this._handlers[event] = [handler]
-		} else {
-			this._handlers[event].push(handler)
-		}
-	},
-
-	off(event, handler) {
-		const handlers = this._handlers[event]
-		if (!handlers) {
-			return
-		}
-
-		const index = handlers.indexOf(handler)
-		if (index !== -1) {
-			handlers.splice(index, 1)
-		}
-	},
-
-	_trigger(event, args) {
-		let handlers = this._handlers[event]
-		if (!handlers) {
-			return
-		}
-
-		args.unshift(this)
-
-		handlers = handlers.slice(0)
-		for (let i = 0; i < handlers.length; i++) {
-			const handler = handlers[i]
-			handler.apply(handler, args)
-		}
-	},
 
 	getConnectionQualityAudio() {
 		return this._connectionQuality.audio
@@ -747,6 +714,8 @@ PeerConnectionAnalyzer.prototype = {
 	},
 
 }
+
+EmitterMixin.apply(PeerConnectionAnalyzer.prototype)
 
 export {
 	CONNECTION_QUALITY,

--- a/src/utils/webrtc/models/CallParticipantCollection.js
+++ b/src/utils/webrtc/models/CallParticipantCollection.js
@@ -19,6 +19,8 @@
  *
  */
 
+import EmitterMixin from '../../EmitterMixin'
+
 import CallParticipantModel from './CallParticipantModel'
 
 /**
@@ -26,48 +28,13 @@ import CallParticipantModel from './CallParticipantModel'
  */
 export default function CallParticipantCollection() {
 
-	this.callParticipantModels = []
+	this._superEmitterMixin()
 
-	this._handlers = []
+	this.callParticipantModels = []
 
 }
 
 CallParticipantCollection.prototype = {
-
-	on(event, handler) {
-		if (!Object.prototype.hasOwnProperty.call(this._handlers, event)) {
-			this._handlers[event] = [handler]
-		} else {
-			this._handlers[event].push(handler)
-		}
-	},
-
-	off(event, handler) {
-		const handlers = this._handlers[event]
-		if (!handlers) {
-			return
-		}
-
-		const index = handlers.indexOf(handler)
-		if (index !== -1) {
-			handlers.splice(index, 1)
-		}
-	},
-
-	_trigger(event, args) {
-		let handlers = this._handlers[event]
-		if (!handlers) {
-			return
-		}
-
-		args.unshift(this)
-
-		handlers = handlers.slice(0)
-		for (let i = 0; i < handlers.length; i++) {
-			const handler = handlers[i]
-			handler.apply(handler, args)
-		}
-	},
 
 	add(options) {
 		const callParticipantModel = new CallParticipantModel(options)
@@ -102,3 +69,5 @@ CallParticipantCollection.prototype = {
 	},
 
 }
+
+EmitterMixin.apply(CallParticipantCollection.prototype)

--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -21,6 +21,8 @@
 
 import attachMediaStream from 'attachmediastream'
 
+import EmitterMixin from '../../EmitterMixin'
+
 export const ConnectionState = {
 	NEW: 'new',
 	CHECKING: 'checking',
@@ -39,6 +41,8 @@ export const ConnectionState = {
  * @param {object} options.webRtc The WebRTC connection to the participant
  */
 export default function CallParticipantModel(options) {
+
+	this._superEmitterMixin()
 
 	this.attributes = {
 		peerId: null,
@@ -64,8 +68,6 @@ export default function CallParticipantModel(options) {
 			timestamp: null,
 		},
 	}
-
-	this._handlers = []
 
 	this.set('peerId', options.peerId)
 
@@ -113,45 +115,6 @@ CallParticipantModel.prototype = {
 		this.attributes[key] = value
 
 		this._trigger('change:' + key, [value])
-	},
-
-	on(event, handler) {
-		if (!Object.prototype.hasOwnProperty.call(this._handlers, event)) {
-			this._handlers[event] = [handler]
-		} else {
-			this._handlers[event].push(handler)
-		}
-	},
-
-	off(event, handler) {
-		const handlers = this._handlers[event]
-		if (!handlers) {
-			return
-		}
-
-		const index = handlers.indexOf(handler)
-		if (index !== -1) {
-			handlers.splice(index, 1)
-		}
-	},
-
-	_trigger(event, args) {
-		let handlers = this._handlers[event]
-		if (!handlers) {
-			return
-		}
-
-		if (!args) {
-			args = []
-		}
-
-		args.unshift(this)
-
-		handlers = handlers.slice(0)
-		for (let i = 0; i < handlers.length; i++) {
-			const handler = handlers[i]
-			handler.apply(handler, args)
-		}
 	},
 
 	_handlePeerStreamAdded(peer) {
@@ -385,3 +348,5 @@ CallParticipantModel.prototype = {
 	},
 
 }
+
+EmitterMixin.apply(CallParticipantModel.prototype)

--- a/src/utils/webrtc/models/LocalCallParticipantModel.js
+++ b/src/utils/webrtc/models/LocalCallParticipantModel.js
@@ -19,6 +19,7 @@
  *
  */
 
+import EmitterMixin from '../../EmitterMixin'
 import store from '../../../store/index.js'
 
 import { ConnectionState } from './CallParticipantModel'
@@ -28,6 +29,8 @@ import { ConnectionState } from './CallParticipantModel'
  */
 export default function LocalCallParticipantModel() {
 
+	this._superEmitterMixin()
+
 	this.attributes = {
 		peerId: null,
 		peer: null,
@@ -35,8 +38,6 @@ export default function LocalCallParticipantModel() {
 		guestName: null,
 		connectionState: null,
 	}
-
-	this._handlers = []
 
 	this._handleForcedMuteBound = this._handleForcedMute.bind(this)
 	this._handleExtendedIceConnectionStateChangeBound = this._handleExtendedIceConnectionStateChange.bind(this)
@@ -53,45 +54,6 @@ LocalCallParticipantModel.prototype = {
 		this.attributes[key] = value
 
 		this._trigger('change:' + key, [value])
-	},
-
-	on(event, handler) {
-		if (!Object.prototype.hasOwnProperty.call(this._handlers, event)) {
-			this._handlers[event] = [handler]
-		} else {
-			this._handlers[event].push(handler)
-		}
-	},
-
-	off(event, handler) {
-		const handlers = this._handlers[event]
-		if (!handlers) {
-			return
-		}
-
-		const index = handlers.indexOf(handler)
-		if (index !== -1) {
-			handlers.splice(index, 1)
-		}
-	},
-
-	_trigger(event, args) {
-		let handlers = this._handlers[event]
-		if (!handlers) {
-			return
-		}
-
-		if (!args) {
-			args = []
-		}
-
-		args.unshift(this)
-
-		handlers = handlers.slice(0)
-		for (let i = 0; i < handlers.length; i++) {
-			const handler = handlers[i]
-			handler.apply(handler, args)
-		}
 	},
 
 	setWebRtc(webRtc) {
@@ -193,3 +155,5 @@ LocalCallParticipantModel.prototype = {
 	},
 
 }
+
+EmitterMixin.apply(LocalCallParticipantModel.prototype)

--- a/src/utils/webrtc/models/LocalMediaModel.js
+++ b/src/utils/webrtc/models/LocalMediaModel.js
@@ -19,12 +19,15 @@
  *
  */
 
+import EmitterMixin from '../../EmitterMixin'
 import store from '../../../store/index.js'
 
 /**
  *
  */
 export default function LocalMediaModel() {
+
+	this._superEmitterMixin()
 
 	this.attributes = {
 		localStreamRequestVideoError: null,
@@ -41,8 +44,6 @@ export default function LocalMediaModel() {
 		token: '',
 		raisedHand: false,
 	}
-
-	this._handlers = []
 
 	this._handleLocalStreamRequestedBound = this._handleLocalStreamRequested.bind(this)
 	this._handleLocalStreamBound = this._handleLocalStream.bind(this)
@@ -74,41 +75,6 @@ LocalMediaModel.prototype = {
 		this.attributes[key] = value
 
 		this._trigger('change:' + key, [value])
-	},
-
-	on(event, handler) {
-		if (!Object.prototype.hasOwnProperty.call(this._handlers, event)) {
-			this._handlers[event] = [handler]
-		} else {
-			this._handlers[event].push(handler)
-		}
-	},
-
-	off(event, handler) {
-		const handlers = this._handlers[event]
-		if (!handlers) {
-			return
-		}
-
-		const index = handlers.indexOf(handler)
-		if (index !== -1) {
-			handlers.splice(index, 1)
-		}
-	},
-
-	_trigger(event, args) {
-		let handlers = this._handlers[event]
-		if (!handlers) {
-			return
-		}
-
-		args.unshift(this)
-
-		handlers = handlers.slice(0)
-		for (let i = 0; i < handlers.length; i++) {
-			const handler = handlers[i]
-			handler.apply(handler, args)
-		}
 	},
 
 	getWebRtc() {
@@ -462,3 +428,5 @@ LocalMediaModel.prototype = {
 	},
 
 }
+
+EmitterMixin.apply(LocalMediaModel.prototype)


### PR DESCRIPTION
The EmitterMixin is not a Vue mixin but a raw JavaScript mixin, so it is stored in "src/utils" rather than in "mixins".

The emitter code was almost the same in all classes, except that some classes allowed triggering events without parameters and others did not. The mixin uses the most generic code, that is, the one that also allows triggering events without parameters.
