### PR TITLE
Reuse the participant information if we have a userId

### DIFF
--- a/src/components/CallView/shared/Video.vue
+++ b/src/components/CallView/shared/Video.vue
@@ -224,7 +224,7 @@ export default {
 		},
 
 		peerData() {
-			let peerData = this.$store.getters.getPeer(this.$store.getters.getToken(), this.peerId)
+			let peerData = this.$store.getters.getPeer(this.$store.getters.getToken(), this.peerId, this.model.attributes.userId)
 			if (!peerData.actorId) {
 				EventBus.$emit('refresh-peer-list')
 				peerData = {

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -94,13 +94,19 @@ const getters = {
 
 		return index
 	},
-	getPeer: (state) => (token, sessionId) => {
-		if (!state.peers[token]) {
-			return {}
+	getPeer: (state) => (token, sessionId, userId) => {
+		if (state.peers[token]) {
+			if (Object.prototype.hasOwnProperty.call(state.peers[token], sessionId)) {
+				return state.peers[token][sessionId]
+			}
 		}
 
-		if (Object.prototype.hasOwnProperty.call(state.peers[token], sessionId)) {
-			return state.peers[token][sessionId]
+		// Fallback to the participant list, if we have a user id that should be easy
+		if (state.participants[token] && userId) {
+			const index = state.participants[token].findIndex(participant => participant.actorId === userId && participant.actorType === 'users')
+			if (index !== -1) {
+				return state.participants[token][index]
+			}
 		}
 
 		return {}


### PR DESCRIPTION
All information required by the code calling getPeer()
is also available in the participants data, so we
don't run the request to get the data from "GET /call"

Signed-off-by: Joas Schilling <coding@schilljs.com>