### PR TITLE
Only populate permissions for moderators and self

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -956,9 +956,15 @@ class RoomController extends AEnvironmentAwareController {
 				'actorId' => $participant->getAttendee()->getActorId(),
 				'actorType' => $participant->getAttendee()->getActorType(),
 				'displayName' => $participant->getAttendee()->getActorId(),
-				'permissions' => $participant->getPermissions(),
+				'permissions' => 0,
 				'attendeePin' => '',
 			];
+
+			if ($this->participant->hasModeratorPermissions(false)
+				|| $this->participant->getAttendee()->getId() === $participant->getAttendee()->getId()) {
+				$result['permissions'] = $participant->getPermissions();
+			}
+
 			if ($this->talkConfig->isSIPConfigured()
 				&& $this->room->getSIPEnabled() === Webinary::SIP_ENABLED
 				&& ($this->participant->hasModeratorPermissions(false)


### PR DESCRIPTION
In a room with:
* User A
* User B
* Moderator C

Only User A and Moderator C should see the permissions of User A. User B should not be aware of User A permissions?
Or should they so they can stop the streams, etc?