### PR TITLE
Show the user status message+icon as conversation description in topbar

### DIFF
--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -35,7 +35,11 @@
 				<p class="title">
 					{{ conversation.displayName }}
 				</p>
-				<p v-if="conversation.description"
+				<p v-if="showUserStatusAsDescription"
+					class="description">
+					{{ statusMessage }}
+				</p>
+				<p v-else-if="conversation.description"
 					v-tooltip.bottom="{
 						content: renderedDescription,
 						delay: { show: 500, hide: 500 },
@@ -171,6 +175,7 @@ import { emit } from '@nextcloud/event-bus'
 import ConversationIcon from '../ConversationIcon'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 import richEditor from '@nextcloud/vue/dist/Mixins/richEditor'
+import userStatus from '../../mixins/userStatus'
 
 export default {
 	name: 'TopBar',
@@ -191,7 +196,10 @@ export default {
 		ConversationIcon,
 	},
 
-	mixins: [richEditor],
+	mixins: [
+		richEditor,
+		userStatus,
+	],
 
 	props: {
 		isInCall: {
@@ -293,6 +301,14 @@ export default {
 
 		conversation() {
 			return this.$store.getters.conversation(this.token) || this.$store.getters.dummyConversation
+		},
+
+		showUserStatusAsDescription() {
+			return this.isOneToOneConversation && this.statusMessage
+		},
+
+		statusMessage() {
+			return this.getStatusMessage(this.conversation)
 		},
 
 		unreadMessagesCounter() {


### PR DESCRIPTION
Ref #6364 

Before | After
---|---
![Bildschirmfoto von 2021-10-18 18-17-47](https://user-images.githubusercontent.com/213943/137769903-603c8090-3fe7-4fa1-a695-e906c83f7dc2.png) | ![Bildschirmfoto von 2021-10-18 18-17-11](https://user-images.githubusercontent.com/213943/137769905-81417b10-4278-4e33-80ec-926643610e8e.png)
