### PR TITLE
Fix enabled state not updated in device checker

### DIFF
--- a/src/components/DeviceChecker/DeviceChecker.vue
+++ b/src/components/DeviceChecker/DeviceChecker.vue
@@ -213,6 +213,9 @@ export default {
 	watch: {
 		modal(newValue) {
 			if (newValue) {
+				this.audioOn = !localStorage.getItem('audioDisabled_' + this.token)
+				this.videoOn = !localStorage.getItem('videoDisabled_' + this.token)
+
 				this.initializeDevicesMixin()
 			} else {
 				this.stopDevicesMixin()
@@ -231,8 +234,6 @@ export default {
 	mounted() {
 		subscribe('talk:device-checker:show', this.showModal)
 		subscribe('talk:device-checker:hide', this.closeModal)
-		this.audioOn = !localStorage.getItem('audioDisabled_' + this.token)
-		this.videoOn = !localStorage.getItem('videoDisabled_' + this.token)
 	},
 
 	beforeDestroy() {


### PR DESCRIPTION
## How to test (scenario 1)

- Start a call
- Disable audio in the device checker
- Continue to the call
- Enable audio in the call
- Leave the call
- Start the call again

### Result with this pull request

The audio will be enabled in the device checker

### Result without this pull request

The audio will be disabled in the device checker. However, if the call is started the audio will be enabled.



## How to test (scenario 2)

- Create conversation A
- Start a call
- Ensure that audio is enabled in the device checker
- Close the device checker (no need to continue to the call)
- Create conversation B
- Start a call
- Disable audio in the device checker
- Close the device checker (no need to continue to the call)
- Open again conversation A
- Start a call

### Result with this pull request

The audio will be enabled in the device checker

### Result without this pull request

The audio will be disabled in the device checker. However, if the call is started the audio will be enabled.
