### PR TITLE
Add changelog 11.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 11.3.3 – 2021-10-22
+### Fixed
+- Fix crash of Chrome/Chromium 95
+  [#6384](https://github.com/nextcloud/spreed/pull/6384)
+
 ## 11.3.2 – 2021-09-17
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>11.3.2</version>
+	<version>11.3.3</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>


### PR DESCRIPTION
### 🐞 Fixed
- Fix crash of Chrome/Chromium 95 [#6384](https://github.com/nextcloud/spreed/pull/6384)