### PR TITLE
Enable devices when selecting them in the device checker

### DIFF
--- a/src/components/DeviceChecker/DeviceChecker.vue
+++ b/src/components/DeviceChecker/DeviceChecker.vue
@@ -262,6 +262,18 @@ export default {
 			}
 		},
 
+		audioInputId(audioInputId) {
+			if (audioInputId && !this.audioOn) {
+				this.toggleAudio()
+			}
+		},
+
+		videoInputId(videoInputId) {
+			if (videoInputId && !this.videoOn) {
+				this.toggleVideo()
+			}
+		},
+
 		blurOn() {
 			this.virtualBackground.setEnabled(this.blurOn)
 		},


### PR DESCRIPTION
Fixes #6350

This pull request enables also the audio, not only the video. Moreover, they are enabled whenever a device is selected, not only when changing from _None_ to a device (as in the interstitial I think that it makes sense to do it like that).

In any case, I am not sure if it would be good to also explicitly disable the device when selecting _None_ (it will be implicitly done when starting the call, but maybe it would be good to do in the interstitial too).
