### PR TITLE
accept SHA256 hash sums for reference id as documented

### DIFF
--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -133,7 +133,7 @@ class ChatManager {
 		$comment->setMessage($message, self::MAX_CHAT_LENGTH);
 		$comment->setCreationDateTime($creationDateTime);
 		if ($referenceId !== null) {
-			$referenceId = trim(substr($referenceId, 0, 40));
+			$referenceId = trim(substr($referenceId, 0, 64));
 			if ($referenceId !== '') {
 				$comment->setReferenceId($referenceId);
 			}
@@ -220,7 +220,7 @@ class ChatManager {
 			$comment->setParentId($replyTo->getId());
 		}
 
-		$referenceId = trim(substr($referenceId, 0, 40));
+		$referenceId = trim(substr($referenceId, 0, 64));
 		if ($referenceId !== '') {
 			$comment->setReferenceId($referenceId);
 		}

--- a/src/services/messagesService.js
+++ b/src/services/messagesService.js
@@ -22,7 +22,7 @@
 
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
-import SHA1 from 'crypto-js/sha1'
+import SHA256 from 'crypto-js/sha256'
 import Hex from 'crypto-js/enc-hex'
 
 /**
@@ -110,7 +110,7 @@ const deleteMessage = async function({ token, id }) {
 const postRichObjectToConversation = async function(token, { objectType, objectId, metaData, referenceId }) {
 	if (!referenceId) {
 		const tempId = 'richobject-' + objectType + '-' + objectId + '-' + token + '-' + (new Date().getTime())
-		referenceId = Hex.stringify(SHA1(tempId))
+		referenceId = Hex.stringify(SHA256(tempId))
 	}
 	return axios.post(generateOcsUrl('apps/spreed/api/v1/chat/{token}/share', { token }), {
 		objectType,

--- a/src/services/messagesService.spec.js
+++ b/src/services/messagesService.spec.js
@@ -151,7 +151,7 @@ describe('messagesService', () => {
 		expect(lastReq.data.objectType).toBe('deck')
 		expect(lastReq.data.objectId).toBe(999)
 		expect(lastReq.data.metaData).toBe('{"x":1}')
-		expect(lastReq.data.referenceId).toEqual(expect.stringMatching(/^[a-z0-9]{40}$/))
+		expect(lastReq.data.referenceId).toEqual(expect.stringMatching(/^[a-z0-9]{64}$/))
 	})
 
 	test('updateLastReadMessage calls the chat API endpoint', () => {

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -28,7 +28,7 @@ import {
 	postNewMessage,
 } from '../services/messagesService'
 
-import SHA1 from 'crypto-js/sha1'
+import SHA256 from 'crypto-js/sha256'
 import Hex from 'crypto-js/enc-hex'
 import CancelableRequest from '../utils/cancelableRequest'
 import { showError } from '@nextcloud/dialogs'
@@ -427,6 +427,7 @@ const actions = {
 				index,
 			}
 		}
+
 		const message = Object.assign({}, {
 			id: tempId,
 			actorId: context.getters.getActorId(),
@@ -440,7 +441,7 @@ const actions = {
 			token,
 			isReplyable: false,
 			sendingFailure: '',
-			referenceId: Hex.stringify(SHA1(tempId)),
+			referenceId: Hex.stringify(SHA256(tempId)),
 		})
 
 		/**

--- a/src/store/messagesStore.spec.js
+++ b/src/store/messagesStore.spec.js
@@ -313,7 +313,7 @@ describe('messagesStore', () => {
 				token: TOKEN,
 				isReplyable: false,
 				sendingFailure: '',
-				referenceId: expect.stringMatching(/^[a-zA-Z0-9]{40}$/),
+				referenceId: expect.stringMatching(/^[a-zA-Z0-9]{64}$/),
 			})
 		})
 
@@ -345,7 +345,7 @@ describe('messagesStore', () => {
 				token: TOKEN,
 				isReplyable: false,
 				sendingFailure: '',
-				referenceId: expect.stringMatching(/^[a-zA-Z0-9]{40}$/),
+				referenceId: expect.stringMatching(/^[a-zA-Z0-9]{64}$/),
 				parent: 123,
 			})
 		})
@@ -389,7 +389,7 @@ describe('messagesStore', () => {
 				token: TOKEN,
 				isReplyable: false,
 				sendingFailure: '',
-				referenceId: expect.stringMatching(/^[a-zA-Z0-9]{40}$/),
+				referenceId: expect.stringMatching(/^[a-zA-Z0-9]{64}$/),
 			})
 		})
 
@@ -418,7 +418,7 @@ describe('messagesStore', () => {
 				token: TOKEN,
 				isReplyable: false,
 				sendingFailure: '',
-				referenceId: expect.stringMatching(/^[a-zA-Z0-9]{40}$/),
+				referenceId: expect.stringMatching(/^[a-zA-Z0-9]{64}$/),
 			}])
 
 			expect(updateConversationLastActiveAction).toHaveBeenCalledWith(expect.anything(), TOKEN)
@@ -440,7 +440,7 @@ describe('messagesStore', () => {
 				token: TOKEN,
 				isReplyable: false,
 				sendingFailure: '',
-				referenceId: expect.stringMatching(/^[a-zA-Z0-9]{40}$/),
+				referenceId: expect.stringMatching(/^[a-zA-Z0-9]{64}$/),
 			}])
 		})
 
@@ -473,7 +473,7 @@ describe('messagesStore', () => {
 				token: TOKEN,
 				isReplyable: false,
 				sendingFailure: 'failure-reason',
-				referenceId: expect.stringMatching(/^[a-zA-Z0-9]{40}$/),
+				referenceId: expect.stringMatching(/^[a-zA-Z0-9]{64}$/),
 			}])
 		})
 
@@ -518,7 +518,7 @@ describe('messagesStore', () => {
 				token: TOKEN,
 				isReplyable: false,
 				sendingFailure: '',
-				referenceId: expect.stringMatching(/^[a-zA-Z0-9]{40}$/),
+				referenceId: expect.stringMatching(/^[a-zA-Z0-9]{64}$/),
 			}])
 		})
 	})

--- a/tests/integration/features/chat/reference-id.feature
+++ b/tests/integration/features/chat/reference-id.feature
@@ -28,9 +28,9 @@ Feature: chat/reference-id
     Given user "participant1" creates room "group room" (v4)
       | roomType | 2 |
       | roomName | room |
-    When user "participant1" sends message "Message 1" with reference id "1234567890123456789012345678901234567890" to room "group room" with 201
-    When user "participant1" sends message "Message 2" with reference id "too long ref is cut off 123456789012345678901234567890" to room "group room" with 201
+    When user "participant1" sends message "Message 1" with reference id "f0a1611b73992b57a8533c7f618bbd145b17ef62238ece5bda548f47c76c02b2" to room "group room" with 201
+    When user "participant1" sends message "Message 2" with reference id "too long ref is cut off f0a1611b73992b57a8533c7f618bbd145b17ef62238ece5bda548f47c76c02b2" to room "group room" with 201
     Then user "participant1" sees the following messages in room "group room" with 200
       | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters | referenceId |
-      | group room | users     | participant1 | participant1-displayname | Message 2 | []                | too long ref is cut off 1234567890123456 |
-      | group room | users     | participant1 | participant1-displayname | Message 1 | []                | 1234567890123456789012345678901234567890 |
+      | group room | users     | participant1 | participant1-displayname | Message 2 | []                | too long ref is cut off f0a1611b73992b57a8533c7f618bbd145b17ef62 |
+      | group room | users     | participant1 | participant1-displayname | Message 1 | []                | f0a1611b73992b57a8533c7f618bbd145b17ef62238ece5bda548f47c76c02b2 |


### PR DESCRIPTION
- also use them for chat
- cf. https://github.com/nextcloud/spreed/blob/40caf331092c9dd5d23f1365d7fb4f0768d06b50/docs/chat.md

(Greetings from off-duty me, found it while wondering why the reference ids didn't match while hacking on https://codeberg.org/blizzz/harbour-nextcloud-talk/pulls/34)