### PR TITLE
Use an exception which is translated in the middleware

### DIFF
--- a/lib/PublicShareAuth/Listener.php
+++ b/lib/PublicShareAuth/Listener.php
@@ -29,6 +29,7 @@ use OCA\Talk\Events\JoinRoomGuestEvent;
 use OCA\Talk\Events\JoinRoomUserEvent;
 use OCA\Talk\Events\RoomEvent;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
+use OCA\Talk\Exceptions\RoomNotFoundException;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
@@ -81,7 +82,7 @@ class Listener {
 	 *
 	 * @param Room $room
 	 * @param string $userId
-	 * @throws \OverflowException
+	 * @throws RoomNotFoundException
 	 */
 	public static function preventExtraUsersFromJoining(Room $room, string $userId): void {
 		if ($room->getObjectType() !== 'share:password') {
@@ -98,7 +99,7 @@ class Listener {
 
 		$participantService = \OC::$server->get(ParticipantService::class);
 		if ($participantService->getNumberOfActors($room) > 1) {
-			throw new \OverflowException('Only the owner and another participant are allowed in rooms to request the password for a share');
+			throw new RoomNotFoundException('Only the owner and another participant are allowed in rooms to request the password for a share');
 		}
 	}
 
@@ -109,7 +110,7 @@ class Listener {
 	 * This method should be called before a guest joins a room.
 	 *
 	 * @param Room $room
-	 * @throws \OverflowException
+	 * @throws RoomNotFoundException
 	 */
 	public static function preventExtraGuestsFromJoining(Room $room): void {
 		if ($room->getObjectType() !== 'share:password') {
@@ -118,7 +119,7 @@ class Listener {
 
 		$participantService = \OC::$server->get(ParticipantService::class);
 		if ($participantService->getNumberOfActors($room) > 1) {
-			throw new \OverflowException('Only the owner and another participant are allowed in rooms to request the password for a share');
+			throw new RoomNotFoundException('Only the owner and another participant are allowed in rooms to request the password for a share');
 		}
 	}
 
@@ -130,7 +131,7 @@ class Listener {
 	 *
 	 * @param Room $room
 	 * @param array[] $participants
-	 * @throws \OverflowException
+	 * @throws RoomNotFoundException
 	 */
 	public static function preventExtraUsersFromBeingAdded(Room $room, array $participants): void {
 		if ($room->getObjectType() !== 'share:password') {
@@ -145,12 +146,12 @@ class Listener {
 		// when the owner is added during room creation or a user self-joins the
 		// event will always have just one participant.
 		if (count($participants) > 1) {
-			throw new \OverflowException('Only the owner and another participant are allowed in rooms to request the password for a share');
+			throw new RoomNotFoundException('Only the owner and another participant are allowed in rooms to request the password for a share');
 		}
 
 		$participant = $participants[0];
 		if ($participant['participantType'] !== Participant::OWNER && $participant['participantType'] !== Participant::USER_SELF_JOINED) {
-			throw new \OverflowException('Only the owner and another participant are allowed in rooms to request the password for a share');
+			throw new RoomNotFoundException('Only the owner and another participant are allowed in rooms to request the password for a share');
 		}
 	}
 


### PR DESCRIPTION
* Failing integration tests `features/conversation-2/password-request.feature:87` since https://github.com/nextcloud/server/pull/29382
* New exception is properly translated to 404 in https://github.com/nextcloud/spreed/blob/390ae657a18523bb0b39f6531fa27de9bb075410/lib/Middleware/InjectionMiddleware.php#L222-L227

### Before 

```
[Mon Oct 25 11:28:28 2021] 127.0.0.1:50792 [500]: POST /ocs/v2.php/apps/spreed/api/v4/room/6r2tf6tj/participants/active
    When user "guest2" joins room "password request for last share room" with 404 (v4)        # FeatureContext::userJoinsRoom()
      Server error: `POST http://localhost:8080/ocs/v2.php/apps/spreed/api/v4/room/6r2tf6tj/participants/active` resulted in a `500 Internal Server Error` response:
      <?xml version="1.0"?>
      <ocs>
       <meta>
        <status>failure</status>
        <statuscode>500</statuscode>
        <message>Internal Server (truncated...)
       (GuzzleHttp\Exception\ServerException)
```