### PR TITLE
Fix guest avatar in device checker

### DIFF
--- a/src/components/DeviceChecker/DeviceChecker.vue
+++ b/src/components/DeviceChecker/DeviceChecker.vue
@@ -49,7 +49,7 @@
 						:user="userId"
 						:display-name="displayName" />
 					<div v-if="!userId"
-						class="avatar guest">
+						class="avatar avatar-128px guest">
 						{{ firstLetterOfGuestName }}
 					</div>
 				</div>
@@ -229,6 +229,18 @@ export default {
 	computed: {
 		displayName() {
 			return this.$store.getters.getDisplayName()
+		},
+
+		guestName() {
+			return this.$store.getters.getGuestName(
+				this.$store.getters.getToken(),
+				this.$store.getters.getActorId(),
+			)
+		},
+
+		firstLetterOfGuestName() {
+			const customName = this.guestName !== t('spreed', 'Guest') ? this.guestName : '?'
+			return customName.charAt(0)
 		},
 
 		userId() {


### PR DESCRIPTION
"firstLetterOfGuestName" was not defined, and the "avatar" CSS class needs to include the size to be properly shown.

## How to test

- Open a conversation as a guest
- Start a call
- In the device checker, disable the video

### Result with this pull request

The avatar of the guest is shown

### Result without this pull request

No avatar is shown