### PR TITLE
Use public API of trusted domain helper

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -179,12 +179,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ChristophWurst/nextcloud_composer.git",
-                "reference": "41a648bb7ae5cef50f09399bb80376ebde58e773"
+                "reference": "9b0f84c976df7e9548037762dabc628b4372fe9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_composer/zipball/41a648bb7ae5cef50f09399bb80376ebde58e773",
-                "reference": "41a648bb7ae5cef50f09399bb80376ebde58e773",
+                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_composer/zipball/9b0f84c976df7e9548037762dabc628b4372fe9d",
+                "reference": "9b0f84c976df7e9548037762dabc628b4372fe9d",
                 "shasum": ""
             },
             "require": {
@@ -215,7 +215,7 @@
                 "issues": "https://github.com/ChristophWurst/nextcloud_composer/issues",
                 "source": "https://github.com/ChristophWurst/nextcloud_composer/tree/master"
             },
-            "time": "2021-10-27T01:05:34+00:00"
+            "time": "2021-10-29T01:05:06+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",

--- a/psalm.xml
+++ b/psalm.xml
@@ -25,7 +25,6 @@
 				<referencedClass name="Doctrine\DBAL\Types\Types" />
 				<referencedClass name="GuzzleHttp\Exception\ClientException" />
 				<referencedClass name="OC" />
-				<referencedClass name="OC\Security\TrustedDomainHelper" />
 				<referencedClass name="OCA\Circles\Api\v1\Circles" />
 				<referencedClass name="OCA\Circles\Events\AddingCircleMemberEvent" />
 				<referencedClass name="OCA\Circles\Events\CircleDestroyedEvent" />
@@ -47,7 +46,6 @@
 				<referencedClass name="Doctrine\DBAL\Schema\SchemaException" />
 				<referencedClass name="Doctrine\DBAL\Schema\Table" />
 				<referencedClass name="OC\DB\ConnectionAdapter" />
-				<referencedClass name="OC\Security\TrustedDomainHelper" />
 				<referencedClass name="OCA\Circles\Model\Member" />
 				<referencedClass name="OCA\DAV\CardDAV\PhotoCache" />
 				<referencedClass name="OCA\FederatedFileSharing\AddressHandler" />

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -23,7 +23,6 @@
 
 namespace OCA\Talk\Tests\php\Controller;
 
-use OC\Security\TrustedDomainHelper;
 use OCA\Talk\Chat\AutoComplete\SearchPlugin;
 use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Chat\MessageParser;
@@ -49,6 +48,7 @@ use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\RichObjectStrings\IValidator;
+use OCP\Security\ITrustedDomainHelper;
 use OCP\UserStatus\IManager as IUserStatusManager;
 use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -88,7 +88,7 @@ class ChatControllerTest extends TestCase {
 	protected $timeFactory;
 	/** @var IValidator|MockObject */
 	protected $richObjectValidator;
-	/** @var TrustedDomainHelper|MockObject */
+	/** @var ITrustedDomainHelper|MockObject */
 	protected $trustedDomainHelper;
 	/** @var IL10N|MockObject */
 	private $l;
@@ -121,7 +121,7 @@ class ChatControllerTest extends TestCase {
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->richObjectValidator = $this->createMock(IValidator::class);
-		$this->trustedDomainHelper = $this->createMock(TrustedDomainHelper::class);
+		$this->trustedDomainHelper = $this->createMock(ITrustedDomainHelper::class);
 		$this->l = $this->createMock(IL10N::class);
 
 		$this->room = $this->createMock(Room::class);


### PR DESCRIPTION
Follow up to #6410 based on new public API from server in 23 https://github.com/nextcloud/server/pull/29444

- [x] Requires `composer update christophwurst/nextcloud` after midnight
- [x] Requires https://github.com/nextcloud/server/pull/29525

Fix #6420 