### PR TITLE
Use a more descriptive displayId

### DIFF
--- a/lib/Profile/TalkAction.php
+++ b/lib/Profile/TalkAction.php
@@ -76,7 +76,7 @@ class TalkAction implements ILinkAction {
 	}
 
 	public function getDisplayId(): string {
-		return $this->l->t('Talk');
+		return $this->l->t('Contact via Talk');
 	}
 
 	public function getTitle(): string {


### PR DESCRIPTION
Use a more descriptive displayId for the profile action, "Reach me via Talk" instead of just "Talk", so that it's clearer when users are configuring their profile settings, as suggested by @nimishavijay

- [x] Requires https://github.com/nextcloud/server/pull/29482 to allow for the displayId to be changed dynamically and not just written to the database

i.e.
![image](https://user-images.githubusercontent.com/24800714/140431566-ab3b9beb-9078-43d7-874a-d7229a188f4a.png)
