### PR TITLE
Fix grid when the number of videos is below the limit

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -650,7 +650,7 @@ export default {
 			// video components would occupy only the first 2 slots and be too small.
 			// To solve this, we shrink this 'max grid' we've just created to fit the
 			// number of videos that we have.
-			if (this.videosCap !== 0) {
+			if (this.videosCap !== 0 && this.videosCount > this.videosCap) {
 				this.shrinkGrid(this.videosCap)
 			} else {
 				this.shrinkGrid(this.videosCount)


### PR DESCRIPTION
Follow up to #6419

When `videosCap` is set it was always applied, no matter the actual number of videos. Due to this, even if there was just a single remote video, as the available size was calculated based on the limit rather than on the actual number of videos a mostly empty grid was shown.

## How to test

- Start a call
- In a private window, join the call

### Result with this pull request

The space is equally distributed between the remote user and the local user

### Result without this pull request

A mostly empty grid is shown; the remote and local participants are each shown in a small area
