### PR TITLE
Fix connection analyzer when using simulcast with Chromium

### DIFF
--- a/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
+++ b/src/utils/webrtc/analyzers/PeerConnectionAnalyzer.js
@@ -374,7 +374,7 @@ PeerConnectionAnalyzer.prototype = {
 
 			if (stat.type === 'outbound-rtp') {
 				if ('packetsSent' in stat && 'kind' in stat) {
-					packetsSent[stat.kind] = stat.packetsSent
+					packetsSent[stat.kind] = (packetsSent[stat.kind] === -1) ? stat.packetsSent : packetsSent[stat.kind] + stat.packetsSent
 
 					if ('timestamp' in stat && 'kind' in stat) {
 						timestampSent[stat.kind] = stat.timestamp
@@ -382,17 +382,17 @@ PeerConnectionAnalyzer.prototype = {
 				}
 			} else if (stat.type === 'remote-inbound-rtp') {
 				if ('packetsReceived' in stat && 'kind' in stat) {
-					packetsReceived[stat.kind] = stat.packetsReceived
+					packetsReceived[stat.kind] = (packetsReceived[stat.kind] === -1) ? stat.packetsReceived : packetsReceived[stat.kind] + stat.packetsReceived
 
 					if ('timestamp' in stat && 'kind' in stat) {
 						timestampReceived[stat.kind] = stat.timestamp
 					}
 				}
 				if ('packetsLost' in stat && 'kind' in stat) {
-					packetsLost[stat.kind] = stat.packetsLost
+					packetsLost[stat.kind] = (packetsLost[stat.kind] === -1) ? stat.packetsLost : packetsLost[stat.kind] + stat.packetsLost
 				}
 				if ('roundTripTime' in stat && 'kind' in stat) {
-					roundTripTime[stat.kind] = stat.roundTripTime
+					roundTripTime[stat.kind] = (roundTripTime[stat.kind] === -1) ? stat.roundTripTime : Math.max(roundTripTime[stat.kind], stat.roundTripTime)
 				}
 			}
 		}


### PR DESCRIPTION
Fix #6277 

Besides the fix below there is still another issue found in #6277, but that will be fixed in another pull request (that issue prevents the connection warning from appear, this pull request fixes the connection warning appearing when it should not).

With simulcast the connection stats reported by Firefox only contain one `outbound-rtp` and one `remote-inbound-rtp` stat for video, just like when simulcast is not in use. However, the stats reported by Chromium contain several entries, one for each stream quality. As the PeerConnectionAnalyzer assumed that a single entry of each kind will be reported the stat for the last stream overrode the other ones.

Moreover, in some cases no packets could be sent in one of the streams, yet the others could be working fine, so the receivers would be able to still see the video by falling back to any of the other streams. But if the stopped stream is reported in last place it will override the other values and the connection will be seen as stopped.

Therefore, now the packet count is aggregated between all the `outbound-rtp` and `remote-inbound-rtp` stats; for simplicity (that is, to avoid calculating the average), and as they should be pretty similar, only the longer round trip time is taken into account.