### PR TITLE
Ignore preference for H.264 when simulcast is used

### DIFF
--- a/lib/TInitialState.php
+++ b/lib/TInitialState.php
@@ -49,11 +49,6 @@ trait TInitialState {
 		// Needed to enable the screensharing extension in Chromium < 72.
 		Util::addHeader('meta', ['id' => 'app', 'class' => 'nc-enable-screensharing-extension']);
 
-		$this->initialState->provideInitialState(
-			'prefer_h264',
-			$this->serverConfig->getAppValue('spreed', 'prefer_h264', 'no') === 'yes'
-		);
-
 		$signalingMode = $this->talkConfig->getSignalingMode();
 		if ($signalingMode === Config::SIGNALING_CLUSTER_CONVERSATION
 			&& !$this->memcacheFactory->isAvailable()

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
 				"lodash": "^4.17.21",
 				"mockconsole": "0.0.1",
 				"nextcloud-vue-collections": "^0.9.0",
-				"sdp-transform": "^2.14.1",
 				"ua-parser-js": "^1.0.2",
 				"url-parse": "^1.5.3",
 				"util": "^0.12.4",
@@ -20973,14 +20972,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/sdp/-/sdp-3.0.2.tgz",
 			"integrity": "sha512-boRjiof+/Ca8kq0dFgHTs9HD3/a5rCAJLDCi9DTFyTq+PerwPXkffVgAyLWAL0KGp9ZpkH1o8GV+vz8UehdPBQ=="
-		},
-		"node_modules/sdp-transform": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.14.1.tgz",
-			"integrity": "sha512-RjZyX3nVwJyCuTo5tGPx+PZWkDMCg7oOLpSlhjDdZfwUoNqG1mM8nyj31IGHyaPWXhjbP7cdK3qZ2bmkJ1GzRw==",
-			"bin": {
-				"sdp-verify": "checker.js"
-			}
 		},
 		"node_modules/select": {
 			"version": "1.1.2",
@@ -44403,11 +44394,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/sdp/-/sdp-3.0.2.tgz",
 			"integrity": "sha512-boRjiof+/Ca8kq0dFgHTs9HD3/a5rCAJLDCi9DTFyTq+PerwPXkffVgAyLWAL0KGp9ZpkH1o8GV+vz8UehdPBQ=="
-		},
-		"sdp-transform": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.14.1.tgz",
-			"integrity": "sha512-RjZyX3nVwJyCuTo5tGPx+PZWkDMCg7oOLpSlhjDdZfwUoNqG1mM8nyj31IGHyaPWXhjbP7cdK3qZ2bmkJ1GzRw=="
 		},
 		"select": {
 			"version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
 		"lodash": "^4.17.21",
 		"mockconsole": "0.0.1",
 		"nextcloud-vue-collections": "^0.9.0",
-		"sdp-transform": "^2.14.1",
 		"ua-parser-js": "^1.0.2",
 		"url-parse": "^1.5.3",
 		"util": "^0.12.4",

--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -1,6 +1,4 @@
 /* global module */
-const initialState = require('@nextcloud/initial-state')
-const sdpTransform = require('sdp-transform')
 
 const adapter = require('webrtc-adapter')
 const util = require('util')
@@ -148,88 +146,6 @@ function Peer(options) {
 }
 
 util.inherits(Peer, WildEmitter)
-
-/**
- * @param {object} signaling the connection/signaling object
- */
-function shouldPreferH264(signaling) {
-	let preferH264
-
-	try {
-		preferH264 = initialState.loadState('spreed', 'prefer_h264')
-	} catch (exception) {
-		// If the state can not be loaded an exception is thrown
-		console.warn('Could not find initial state for H.264 preference')
-		return false
-	}
-
-	if (!preferH264) {
-		return false
-	}
-
-	if (signaling.hasFeature('simulcast')) {
-		console.warn('Ignoring preference for H.264, as it can not be used with simulcast')
-		return false
-	}
-
-	return true
-}
-
-/**
- * @param {string} sessionDescription the session description.
- */
-function preferH264VideoCodecIfAvailable(sessionDescription) {
-	const sdpInfo = sdpTransform.parse(sessionDescription.sdp)
-
-	if (!sdpInfo || !sdpInfo.media) {
-		return sessionDescription
-	}
-
-	// Find video media
-	let videoIndex = -1
-	sdpInfo.media.forEach((media, mediaIndex) => {
-		if (media.type === 'video') {
-			videoIndex = mediaIndex
-		}
-	})
-
-	if (videoIndex === -1 || !sdpInfo.media[videoIndex].rtp) {
-		return sessionDescription
-	}
-
-	// Find all H264 codec videos
-	const h264Rtps = []
-	sdpInfo.media[videoIndex].rtp.forEach((rtp, rtpIndex) => {
-		if (rtp.codec.toLowerCase() === 'h264') {
-			h264Rtps.push(rtp.payload)
-		}
-	})
-
-	if (!h264Rtps.length) {
-		// No H264 codecs found
-		return sessionDescription
-	}
-
-	// Sort the H264 codecs to the front in the payload (which defines the preferred order)
-	const payloads = sdpInfo.media[videoIndex].payloads.split(' ')
-	payloads.sort((a, b) => {
-		if (h264Rtps.indexOf(parseInt(a, 10)) !== -1) {
-			return -1
-		}
-		if (h264Rtps.indexOf(parseInt(b, 10)) !== -1) {
-			return 1
-		}
-		return 0
-	})
-
-	// Write new payload order into video media payload
-	sdpInfo.media[videoIndex].payloads = payloads.join(' ')
-
-	// Write back the sdpInfo into the session description
-	sessionDescription.sdp = sdpTransform.write(sdpInfo)
-
-	return sessionDescription
-}
 
 // Helper method to munge an SDP to enable simulcasting (Chrome only)
 // Taken from janus.js (MIT license).
@@ -470,11 +386,6 @@ Peer.prototype.offer = function(options) {
 		}
 	}
 	this.pc.createOffer(options).then(function(offer) {
-		if (shouldPreferH264(this.parent.config.connection)) {
-			console.debug('Preferring hardware codec H.264 as per global configuration')
-			offer = preferH264VideoCodecIfAvailable(offer)
-		}
-
 		if (sendVideo && this.enableSimulcast) {
 			// This SDP munging only works with Chrome (Safari STP may support it too)
 			if (adapter.browserDetails.browser === 'chrome' || adapter.browserDetails.browser === 'safari') {
@@ -515,10 +426,6 @@ Peer.prototype.handleOffer = function(offer) {
 
 Peer.prototype.answer = function() {
 	this.pc.createAnswer().then(function(answer) {
-		if (shouldPreferH264(this.parent.config.connection)) {
-			console.debug('Preferring hardware codec H.264 as per global configuration')
-			answer = preferH264VideoCodecIfAvailable(answer)
-		}
 		this.pc.setLocalDescription(answer).then(function() {
 			if (this.parent.config.nick) {
 				// The answer is a RTCSessionDescription that only serializes

--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -150,16 +150,29 @@ function Peer(options) {
 util.inherits(Peer, WildEmitter)
 
 /**
- *
+ * @param {object} signaling the connection/signaling object
  */
-function shouldPreferH264() {
+function shouldPreferH264(signaling) {
+	let preferH264
+
 	try {
-		return initialState.loadState('spreed', 'prefer_h264')
+		preferH264 = initialState.loadState('spreed', 'prefer_h264')
 	} catch (exception) {
 		// If the state can not be loaded an exception is thrown
 		console.warn('Could not find initial state for H.264 preference')
 		return false
 	}
+
+	if (!preferH264) {
+		return false
+	}
+
+	if (signaling.hasFeature('simulcast')) {
+		console.warn('Ignoring preference for H.264, as it can not be used with simulcast')
+		return false
+	}
+
+	return true
 }
 
 /**
@@ -457,7 +470,7 @@ Peer.prototype.offer = function(options) {
 		}
 	}
 	this.pc.createOffer(options).then(function(offer) {
-		if (shouldPreferH264()) {
+		if (shouldPreferH264(this.parent.config.connection)) {
 			console.debug('Preferring hardware codec H.264 as per global configuration')
 			offer = preferH264VideoCodecIfAvailable(offer)
 		}
@@ -502,7 +515,7 @@ Peer.prototype.handleOffer = function(offer) {
 
 Peer.prototype.answer = function() {
 	this.pc.createAnswer().then(function(answer) {
-		if (shouldPreferH264()) {
+		if (shouldPreferH264(this.parent.config.connection)) {
 			console.debug('Preferring hardware codec H.264 as per global configuration')
 			answer = preferH264VideoCodecIfAvailable(answer)
 		}


### PR DESCRIPTION
When `prefer_h264` is set the SDP is modified to place H.264 as the preferred codec. However, this change in the SDP clashes with the changes done to enable simulcast with Chromium and sometimes causes creating the offer to fail. Given that preferring H.264 has no effect when the HPB is used (as only VP8 is supported in that case) and that simulcast can be enabled only with the HPB now `prefer_h264` is ignored when simulcast is used.

## How to test

- Set up the HPB (a recent version with support for simulcast)
- Enable preference for H.264 with `occ config:app:set spreed prefer_h264 --value=yes`
- Open a conversation in Chromium
- Start a call with a hardware camera (virtual cameras work fine; maybe some hardware cameras work fine too, I do not know)

### Result with this pull request

The connection is established.

### Result without this pull request

The connection is not established (the loading spinner appears on the local participant); browser console shows _'setLocalDescription' on 'RTCPeerConnection': Failed to set local offer sdp: Failed to set local video description streams for m-section with mid='1'_