### PR TITLE
Fix permissions editor dialog for unnamed guests

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/ParticipantPermissionsEditor/ParticipantPermissionsEditor.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/ParticipantPermissionsEditor/ParticipantPermissionsEditor.vue
@@ -31,6 +31,7 @@
 
 <script>
 import { showError, showSuccess } from '@nextcloud/dialogs'
+import { PARTICIPANT } from '../../../../../../constants'
 import PermissionEditor from '../../../../../PermissionsEditor/PermissionsEditor.vue'
 
 export default {
@@ -63,7 +64,18 @@ export default {
 		 * The participant's name.
 		 */
 		displayName() {
+			if (this.participant.displayName === '' && this.isGuest) {
+				return t('spreed', 'Guest')
+			}
+
 			return this.participant.displayName
+		},
+
+		/**
+		 * Whether the participant is a guest or not.
+		 */
+		isGuest() {
+			return [PARTICIPANT.TYPE.GUEST, PARTICIPANT.TYPE.GUEST_MODERATOR].indexOf(this.participant.participantType) !== -1
 		},
 
 		/**


### PR DESCRIPTION
[`PermissionsEditor` expects that a display name is given when shown for a participant](https://github.com/nextcloud/spreed/blob/0d71899cb3df0c87bbba3c786bacbaa126c20456/src/components/PermissionsEditor/PermissionsEditor.vue#L140). Display name of unnamed guests is empty, so the default "Guest" string needs to be provided in that case.

## How to test

- Open a conversation as a moderator
- In a private window, join the conversation as a guest
- As the moderator, edit permissions for the guest

### Result with this pull request

The permissions editor dialog is shown.

### Result without this pull request

The permissions editor dialog is not shown; `you need to fill either the conversationName or the displayName props` is shown in the browser console