### PR TITLE
Show message about problems in the connection with another participant

### DIFF
--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -849,6 +849,15 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 	/**
 	 * @param {object} peer The peer connection to handle the state on
 	 */
+	function setHandlerForSignalingStateChange(peer) {
+		peer.pc.addEventListener('signalingstatechange', function() {
+			peer.emit('signalingStateChange', peer.pc.signalingState)
+		})
+	}
+
+	/**
+	 * @param {object} peer The peer connection to handle the state on
+	 */
 	function setHandlerForOwnIceConnectionStateChange(peer) {
 		peer.pc.addEventListener('iceconnectionstatechange', function() {
 			peer.emit('extendedIceConnectionStateChange', peer.pc.iceConnectionState)
@@ -1067,6 +1076,7 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 			} else {
 				setHandlerForIceConnectionStateChange(peer)
 				setHandlerForConnectionStateChange(peer)
+				setHandlerForSignalingStateChange(peer)
 			}
 
 			setHandlerForNegotiationNeeded(peer)


### PR DESCRIPTION
**Reviewers:** please note that this adds _translateable_ strings!

Until now when a participant was not connected a loading spinner was shown on that participant. Now an explicit message is shown when there are connection problems (which may heal by themselves) and when the connection is tried to be established again to solve the problems (either because the connection actually failed, or because the problems did not heal by themselves after several seconds, even if the connection has not failed yet).

`.connection-message` needs to take into account whether the video or the avatar is shown to place the message at the right height.

**Example with video:**
![Talk-Call-Remote-Participant-Connection-Problems](https://user-images.githubusercontent.com/26858233/141184074-33270003-a398-4c4f-a724-0c49969aad28.png)

**Example with avatar:**
![Talk-Call-Remote-Participant-Reconnection](https://user-images.githubusercontent.com/26858233/141184085-e654464a-8b75-4331-a655-b99295ae4d5f.png)

## How to test (scenario 1)

- Do not setup the HPB
- Start a call
- In a different machine, join the call
- Unplug the Internet cable from the second machine

### Result with this pull request

On the remote participant a message about the connection having problems and, after some time, trying to reconnect is shown.

Note that if the Internet cable is plugged again the connection will not be restored, but that it is a different issue when the HPB is not used.

### Result without this pull request

Only the loading spinner is shown.


## How to test (scenario 2)

- Setup the HPB
- Start a call
- In a different machine, join the call without audio nor video (so no sender connection is created and there is no forced reconnection once the sender connection fails)
- Unplug the Internet cable from the second machine

### Result with this pull request

On the remote participant a message about the connection having problems and, after some time, trying to reconnect is shown.

### Result without this pull request

Only the loading spinner is shown.
