### PR TITLE
Fix empty video when blur background model could not be loaded

### DIFF
--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -160,7 +160,7 @@
 					{{ raiseHandButtonLabel }}
 				</ActionButton>
 				<ActionButton
-					v-if="isVirtualBackgroundSupported"
+					v-if="isVirtualBackgroundAvailable"
 					:close-after-click="true"
 					@click="toggleVirtualBackground">
 					<BlurOff
@@ -253,7 +253,6 @@ import NetworkStrength2Alert from 'vue-material-design-icons/NetworkStrength2Ale
 import { Actions, ActionSeparator, ActionButton } from '@nextcloud/vue'
 import { callAnalyzer } from '../../../utils/webrtc/index'
 import { CONNECTION_QUALITY } from '../../../utils/webrtc/analyzers/PeerConnectionAnalyzer'
-import VirtualBackground from '../../../utils/media/pipeline/VirtualBackground'
 import isInCall from '../../../mixins/isInCall'
 
 export default {
@@ -330,8 +329,8 @@ export default {
 			return t('spreed', 'Lower hand (R)')
 		},
 
-		isVirtualBackgroundSupported() {
-			return VirtualBackground.isSupported()
+		isVirtualBackgroundAvailable() {
+			return this.model.attributes.virtualBackgroundAvailable
 		},
 
 		isVirtualBackgroundEnabled() {
@@ -566,7 +565,7 @@ export default {
 				return null
 			}
 
-			const virtualBackgroundEnabled = this.isVirtualBackgroundSupported && this.model.attributes.virtualBackgroundEnabled
+			const virtualBackgroundEnabled = this.isVirtualBackgroundAvailable && this.model.attributes.virtualBackgroundEnabled
 
 			const tooltip = {}
 			if (!this.model.attributes.audioEnabled && this.model.attributes.videoEnabled && virtualBackgroundEnabled && this.model.attributes.localScreen) {

--- a/src/components/DeviceChecker/DeviceChecker.vue
+++ b/src/components/DeviceChecker/DeviceChecker.vue
@@ -189,7 +189,6 @@ import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import CheckboxRadioSwitch from '@nextcloud/vue/dist/Components/CheckboxRadioSwitch'
 import BrowserStorage from '../../services/BrowserStorage'
 import VolumeIndicator from '../VolumeIndicator/VolumeIndicator.vue'
-import VirtualBackground from '../../utils/media/pipeline/VirtualBackground'
 
 export default {
 	name: 'DeviceChecker',
@@ -256,7 +255,7 @@ export default {
 		},
 
 		blurPreviewAvailable() {
-			return VirtualBackground.isSupported()
+			return this.virtualBackground.isAvailable()
 		},
 
 		audioButtonTooltip() {

--- a/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.worker.js
+++ b/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.worker.js
@@ -68,7 +68,7 @@ async function makeTFLite(isSimd) {
 
 	} catch (error) {
 		console.error(error)
-		console.error('JitsiStreamBackgroundEffect.worker: tflite compilation failed.')
+		console.error('JitsiStreamBackgroundEffect.worker: tflite compilation failed. The web server may not be properly configured to send wasm files.')
 	}
 }
 

--- a/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.worker.js
+++ b/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.worker.js
@@ -69,6 +69,8 @@ async function makeTFLite(isSimd) {
 	} catch (error) {
 		console.error(error)
 		console.error('JitsiStreamBackgroundEffect.worker: tflite compilation failed. The web server may not be properly configured to send wasm files.')
+
+		self.postMessage({ message: 'loadFailed' })
 	}
 }
 

--- a/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.worker.js
+++ b/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.worker.js
@@ -62,13 +62,22 @@ async function makeTFLite(isSimd) {
 
 		await self.tflite._loadModel(self.model.byteLength)
 
+		// Even if the wrong tflite file is downloaded (for example, if an HTML
+		// error is downloaded instead of the file) loading the model will
+		// succeed. However, if the model does not have certain values it could
+		// be assumed that the model failed to load.
+		if (!self.tflite._getInputWidth() || !self.tflite._getInputHeight()
+			|| !self.tflite._getOutputWidth() || !self.tflite._getOutputHeight()) {
+			throw new Error('Failed to load tflite model!')
+		}
+
 		self.compiled = true
 
 		self.postMessage({ message: 'loaded' })
 
 	} catch (error) {
 		console.error(error)
-		console.error('JitsiStreamBackgroundEffect.worker: tflite compilation failed. The web server may not be properly configured to send wasm files.')
+		console.error('JitsiStreamBackgroundEffect.worker: tflite compilation failed. The web server may not be properly configured to send wasm and/or tflite files.')
 
 		self.postMessage({ message: 'loadFailed' })
 	}

--- a/src/utils/media/pipeline/VirtualBackground.js
+++ b/src/utils/media/pipeline/VirtualBackground.js
@@ -147,6 +147,10 @@ export default class VirtualBackground extends TrackSinkSource {
 	}
 
 	setEnabled(enabled) {
+		if (!VirtualBackground.isSupported()) {
+			enabled = false
+		}
+
 		if (this.enabled === enabled) {
 			return
 		}

--- a/src/utils/media/pipeline/VirtualBackground.js
+++ b/src/utils/media/pipeline/VirtualBackground.js
@@ -34,10 +34,16 @@ import JitsiStreamBackgroundEffect from '../effects/virtual-background/JitsiStre
  *
  * The virtual background node requires Web Assembly to be enabled in the
  * browser as well as support for canvas filters. Whether the virtual background
- * is supported or not can be checked by calling
- * "VirtualBackground.isSupported()". If a virtual background node is tried to
- * be used when it is not supported its input will be just bypassed to its
- * output.
+ * is available or not can be checked by calling
+ * "VirtualBackground.isSupported()". Besides that, it needs to
+ * download and compile a Tensor Flow Lite model; until the model has not
+ * finished loading or failed to load it is not possible to know for sure if
+ * virtual background is available, so if it is supported it is assumed to be
+ * available unless the model fails to load. In that case "loadFailed" is
+ * emitted and the virtual background is disabled. Whether the virtual
+ * background is available or not can be checked by calling "isAvailable()" on
+ * the object. If a virtual background node is tried to be used when it is not
+ * available its input will be just bypassed to its output.
  *
  * The virtual background is automatically stopped and started again when the
  * input track is disabled and enabled (which changes the output track). The
@@ -140,6 +146,22 @@ export default class VirtualBackground extends TrackSinkSource {
 		}
 
 		this._jitsiStreamBackgroundEffect = new JitsiStreamBackgroundEffect(options)
+		this._jitsiStreamBackgroundEffect.load().catch(() => {
+			this._trigger('loadFailed')
+
+			this.setEnabled(false)
+		})
+	}
+
+	isAvailable() {
+		if (!VirtualBackground.isSupported()) {
+			return false
+		}
+
+		// If VirtualBackground is supported it is assumed to be available
+		// unless the load has failed (so it is seen as available even when
+		// still loading).
+		return !this._jitsiStreamBackgroundEffect.didLoadFail()
 	}
 
 	isEnabled() {
@@ -147,7 +169,7 @@ export default class VirtualBackground extends TrackSinkSource {
 	}
 
 	setEnabled(enabled) {
-		if (!VirtualBackground.isSupported()) {
+		if (!this.isAvailable()) {
 			enabled = false
 		}
 
@@ -174,9 +196,9 @@ export default class VirtualBackground extends TrackSinkSource {
 	}
 
 	_handleInputTrack(trackId, newTrack, oldTrack) {
-		// If not supported or enabled the input track is just bypassed to the
+		// If not available or enabled the input track is just bypassed to the
 		// output.
-		if (!VirtualBackground.isSupported() || !this._enabled) {
+		if (!this.isAvailable() || !this._enabled) {
 			this._setOutputTrack('default', newTrack)
 
 			return
@@ -194,9 +216,9 @@ export default class VirtualBackground extends TrackSinkSource {
 	}
 
 	_handleInputTrackEnabled(trackId, enabled) {
-		// If not supported or enabled the input track is just bypassed to the
+		// If not available or enabled the input track is just bypassed to the
 		// output.
-		if (!VirtualBackground.isSupported() || !this._enabled) {
+		if (!this.isAvailable() || !this._enabled) {
 			this._setOutputTrackEnabled('default', enabled)
 
 			return

--- a/src/utils/webrtc/models/LocalMediaModel.js
+++ b/src/utils/webrtc/models/LocalMediaModel.js
@@ -40,6 +40,7 @@ export default function LocalMediaModel() {
 		volumeThreshold: -100,
 		videoAvailable: false,
 		videoEnabled: false,
+		virtualBackgroundAvailable: false,
 		virtualBackgroundEnabled: false,
 		localScreen: null,
 		token: '',
@@ -61,6 +62,7 @@ export default function LocalMediaModel() {
 	this._handleStoppedSpeakingWhileMutedBound = this._handleStoppedSpeakingWhileMuted.bind(this)
 	this._handleVideoOnBound = this._handleVideoOn.bind(this)
 	this._handleVideoOffBound = this._handleVideoOff.bind(this)
+	this._handleVirtualBackgroundLoadFailedBound = this._handleVirtualBackgroundLoadFailed.bind(this)
 	this._handleVirtualBackgroundOnBound = this._handleVirtualBackgroundOn.bind(this)
 	this._handleVirtualBackgroundOffBound = this._handleVirtualBackgroundOff.bind(this)
 	this._handleLocalScreenBound = this._handleLocalScreen.bind(this)
@@ -101,6 +103,7 @@ LocalMediaModel.prototype = {
 			this._webRtc.webrtc.off('stoppedSpeakingWhileMuted', this._handleStoppedSpeakingWhileMutedBound)
 			this._webRtc.webrtc.off('videoOn', this._handleVideoOnBound)
 			this._webRtc.webrtc.off('videoOff', this._handleVideoOffBound)
+			this._webRtc.webrtc.off('virtualBackgroundLoadFailed', this._handleVirtualBackgroundLoadFailedBound)
 			this._webRtc.webrtc.off('virtualBackgroundOn', this._handleVirtualBackgroundOnBound)
 			this._webRtc.webrtc.off('virtualBackgroundOff', this._handleVirtualBackgroundOffBound)
 			this._webRtc.webrtc.off('localScreen', this._handleLocalScreenBound)
@@ -118,6 +121,7 @@ LocalMediaModel.prototype = {
 		this.set('volumeThreshold', -100)
 		this.set('videoAvailable', false)
 		this.set('videoEnabled', false)
+		this.set('virtualBackgroundAvailable', this._webRtc.webrtc.isVirtualBackgroundAvailable())
 		this.set('virtualBackgroundEnabled', this._webRtc.webrtc.isVirtualBackgroundEnabled())
 		this.set('localScreen', null)
 
@@ -136,6 +140,7 @@ LocalMediaModel.prototype = {
 		this._webRtc.webrtc.on('stoppedSpeakingWhileMuted', this._handleStoppedSpeakingWhileMutedBound)
 		this._webRtc.webrtc.on('videoOn', this._handleVideoOnBound)
 		this._webRtc.webrtc.on('videoOff', this._handleVideoOffBound)
+		this._webRtc.webrtc.on('virtualBackgroundLoadFailed', this._handleVirtualBackgroundLoadFailedBound)
 		this._webRtc.webrtc.on('virtualBackgroundOn', this._handleVirtualBackgroundOnBound)
 		this._webRtc.webrtc.on('virtualBackgroundOff', this._handleVirtualBackgroundOffBound)
 		this._webRtc.webrtc.on('localScreen', this._handleLocalScreenBound)
@@ -315,6 +320,10 @@ LocalMediaModel.prototype = {
 		}
 
 		this.set('videoEnabled', false)
+	},
+
+	_handleVirtualBackgroundLoadFailed() {
+		this.set('virtualBackgroundAvailable', false)
 	},
 
 	_handleVirtualBackgroundOn() {

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -53,6 +53,9 @@ function LocalMedia(opts) {
 	this._videoTrackConstrainer = new TrackConstrainer()
 
 	this._virtualBackground = new VirtualBackground()
+	this._virtualBackground.on('loadFailed', () => {
+		this.emit('virtualBackgroundLoadFailed')
+	})
 
 	this._speakingMonitor = new SpeakingMonitor()
 	this._speakingMonitor.on('speaking', () => {
@@ -361,6 +364,10 @@ LocalMedia.prototype.isVideoEnabled = function() {
 	}
 
 	return enabled
+}
+
+LocalMedia.prototype.isVirtualBackgroundAvailable = function() {
+	return this._virtualBackground.isAvailable()
 }
 
 LocalMedia.prototype.isVirtualBackgroundEnabled = function() {


### PR DESCRIPTION
Follow up to #6322
Fixes #6481

Until now it was checked if the blur background was supported based on whether Web Assembly was available in the browser and whether the browser supported the needed canvas filter. This could be done statically, without having a VirtualBackground object. However, to blur the background once the VirtualBackground object is created it is also needed to download and compile a TFLite model; this could fail, for example, if the web server is not properly configured to send .wasm files. Now if virtual background is supported but the model failed to load it behaves as if virtual background is not supported.

No user facing message is shown if the model could not be loaded, as there might be other reasons other than a server misconfiguration why that could happen. However, the browser console error now shows a hint about that case.

## How to test (scenario 1)

- Remove _apps/spreed/js/tflite.wasm_ and _apps/spreed/js/tflite-simd.wasm_ files
- Force reload Talk in the browser
- Start a call

### Result with this pull request

Blurring the background is not available, but the video is shown.

### Result without this pull request

Blurring the background is available, but if enabled no video is shown.

## How to test (scenario 2)

- Remove _apps/spreed/js/segm_full_v679.tflite_ and _apps/spreed/js/segm_lite_v681.tflite_ files
- Force reload Talk in the browser
- Start a call

### Result with this pull request

Blurring the background is not available, but the video is shown.

### Result without this pull request

Blurring the background is available, but if enabled no video is shown.
