### PR TITLE
Reduce the bluring so it's not "You on a single color" and disable by default

### DIFF
--- a/src/components/DeviceChecker/DeviceChecker.vue
+++ b/src/components/DeviceChecker/DeviceChecker.vue
@@ -282,7 +282,7 @@ export default {
 			if (newValue) {
 				this.audioOn = !localStorage.getItem('audioDisabled_' + this.token)
 				this.videoOn = !localStorage.getItem('videoDisabled_' + this.token)
-				this.blurOn = !localStorage.getItem('virtualBackgroundDisabled_' + this.token)
+				this.blurOn = !!localStorage.getItem('virtualBackgroundEnabled_' + this.token)
 
 				this.initializeDevicesMixin()
 			} else {
@@ -357,10 +357,10 @@ export default {
 
 		toggleBlur() {
 			if (!this.blurOn) {
-				localStorage.removeItem('virtualBackgroundDisabled_' + this.token)
+				localStorage.setItem('virtualBackgroundEnabled_' + this.token, 'true')
 				this.blurOn = true
 			} else {
-				localStorage.setItem('virtualBackgroundDisabled_' + this.token, 'true')
+				localStorage.removeItem('virtualBackgroundEnabled_' + this.token)
 				this.blurOn = false
 			}
 		},

--- a/src/utils/media/pipeline/VirtualBackground.js
+++ b/src/utils/media/pipeline/VirtualBackground.js
@@ -155,7 +155,7 @@ export default class VirtualBackground extends TrackSinkSource {
 
 		const virtualBackground = {
 			type: VIRTUAL_BACKGROUND_TYPE.NONE,
-			blurValue: 32,
+			blurValue: 10,
 		}
 		const options = {
 			...isSimd ? segmentationDimensions.model144 : segmentationDimensions.model96,

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -191,7 +191,7 @@ async function signalingJoinCall(token, flags) {
 			// it should be saved now.
 			const enableAudio = !localStorage.getItem('audioDisabled_' + token)
 			const enableVideo = !localStorage.getItem('videoDisabled_' + token)
-			const enableVirtualBackground = !localStorage.getItem('virtualBackgroundDisabled_' + token)
+			const enableVirtualBackground = !!localStorage.getItem('virtualBackgroundEnabled_' + token)
 
 			const startCallOnceLocalMediaStarted = (configuration) => {
 				webRtc.off('localMediaStarted', startCallOnceLocalMediaStarted)

--- a/src/utils/webrtc/models/LocalMediaModel.js
+++ b/src/utils/webrtc/models/LocalMediaModel.js
@@ -405,7 +405,7 @@ LocalMediaModel.prototype = {
 			throw new Error('WebRtc not initialized yet')
 		}
 
-		localStorage.removeItem('virtualBackgroundDisabled_' + this.get('token'))
+		localStorage.setItem('virtualBackgroundEnabled_' + this.get('token'), 'true')
 
 		this._webRtc.enableVirtualBackground()
 	},
@@ -415,7 +415,7 @@ LocalMediaModel.prototype = {
 			throw new Error('WebRtc not initialized yet')
 		}
 
-		localStorage.setItem('virtualBackgroundDisabled_' + this.get('token'), 'true')
+		localStorage.removeItem('virtualBackgroundEnabled_' + this.get('token'))
 
 		this._webRtc.disableVirtualBackground()
 	},


### PR DESCRIPTION
Before | After
---|---
![Bildschirmfoto von 2021-11-17 14-44-26](https://user-images.githubusercontent.com/213943/142213355-51931177-a5bd-408c-9049-2fae23854366.png) | ![Bildschirmfoto von 2021-11-17 14-45-32](https://user-images.githubusercontent.com/213943/142213361-27ff5495-cca0-4645-9559-b133747f7104.png)

Should still be enough but it's not just a blurry almost single color soup around you, as discussed with @marcoambrosini 
Also background blur is now disabled by default due to it's performance impact.