### PR TITLE
Do not emit "change" events if attribute did not change

### DIFF
--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -118,6 +118,10 @@ CallParticipantModel.prototype = {
 	},
 
 	set(key, value) {
+		if (this.attributes[key] === value) {
+			return
+		}
+
 		this.attributes[key] = value
 
 		this._trigger('change:' + key, [value])

--- a/src/utils/webrtc/models/LocalCallParticipantModel.js
+++ b/src/utils/webrtc/models/LocalCallParticipantModel.js
@@ -51,6 +51,10 @@ LocalCallParticipantModel.prototype = {
 	},
 
 	set(key, value) {
+		if (this.attributes[key] === value) {
+			return
+		}
+
 		this.attributes[key] = value
 
 		this._trigger('change:' + key, [value])

--- a/src/utils/webrtc/models/LocalMediaModel.js
+++ b/src/utils/webrtc/models/LocalMediaModel.js
@@ -77,6 +77,10 @@ LocalMediaModel.prototype = {
 	},
 
 	set(key, value) {
+		if (this.attributes[key] === value) {
+			return
+		}
+
 		this.attributes[key] = value
 
 		this._trigger('change:' + key, [value])


### PR DESCRIPTION
Fixes #6527

`change:XXX` events should be emitted only if XXX actually changed. In most cases the duplicated events were not a problem, but when background blur was enabled in a call with more than 5 participants it could cause the browser to crash.

SentVideoQualityThrottler starts listening to events when video becomes available, so if `change:videoAvailable(true)` was emitted again the event handlers were duplicated. One of the handlers was set for the `speaking` event, which causes the video quality to be adjusted if needed. When background blur is enabled adjusting the video quality restarts the effect, which causes the video stream to be recreated, which in turn caused `change:videoAvailable(true)` to be emitted.

Due to all this, whenever the user spoke in a large call after another user had spoken the event handlers for the `speaking` event were duplicated, and each handler execution reset the background blur. Eventually there were so many event handlers for the `speaking` event that stopping and starting again the background blur so many times at once temporary ate all the available memory, even if the objects would have been garbage collected and the memory freed in a normal way later.

According to #6527 the memory leak happens only with Chromium. However, it could have been just a coincidence of @nickvergessen not speaking when testing it with Firefox... or maybe there is something else going on :shrug: 

## How to test
- Expose the `SentVideoQualityThrottler` object by adding:
``` 
		if (!OCA.Talk) {
			OCA.Talk = {}
		}
		OCA.Talk.sentVideoQualityThrottler = sentVideoQualityThrottler
```
[after it was created](https://github.com/nextcloud/spreed/blob/b7538684b9cce53ff9aa087ec6e00b94934b9001/src/utils/webrtc/index.js#L176)
- Start a call with video and background blur enabled
- In the browser console, force a quality change with:
```
OCA.Talk.sentVideoQualityThrottler._videoConstrainer._currentQuality = 3
OCA.Talk.sentVideoQualityThrottler._localMediaModel._trigger('change:speaking', [true])
```
- Repeat those commands several times

### Result with this pull request

The quality is changed just once

### Result without this pull request

Several `Changed quality to 4` messages are printed; every time that the commands are executed the printed messages double. More memory is used when more messages are printed, although if it is waited a while without executing the commands again the memory is freed.
