### PR TITLE
Only enable devices when the device selection is shown

### DIFF
--- a/src/components/DeviceChecker/DeviceChecker.vue
+++ b/src/components/DeviceChecker/DeviceChecker.vue
@@ -299,13 +299,13 @@ export default {
 		},
 
 		audioInputId(audioInputId) {
-			if (audioInputId && !this.audioOn) {
+			if (this.showDeviceSelection && audioInputId && !this.audioOn) {
 				this.toggleAudio()
 			}
 		},
 
 		videoInputId(videoInputId) {
-			if (videoInputId && !this.videoOn) {
+			if (this.showDeviceSelection && videoInputId && !this.videoOn) {
 				this.toggleVideo()
 			}
 		},


### PR DESCRIPTION
Otherwise this is a false positive from initially loading the device list

Fix #6500 