### PR TITLE
No individual leave message when the meeting was ended for all

### DIFF
--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -102,6 +102,10 @@ class Listener implements IEventListener {
 				return;
 			}
 
+			if ($event->getNewValue() === $event->getOldValue()) {
+				return;
+			}
+
 			$room = $event->getRoom();
 
 			$session = $event->getParticipant()->getSession();


### PR DESCRIPTION
After a meeting is ended for all, the individual devices still trigger
the leaveCall routine. This printed a "call_left" message, although
the session has already left due to the moderator.
So in case the call flags of the sessions don't change, we no longer
create those system messages.

### Steps
1. No HPB
2. Create a group conversation with restricted permissions
3. Start a call as a moderator
4. Join with multiple users
5. As moderator and the meeting

### Before

* You started a call
* Bennet Bernetto joined the call
* Carmèn Máría Cruz joined the call
* Ahri Fox joined the call
* Laura Adams ended the call with Ahri Fox, Bennet Bernetto and Carmèn Máría Cruz (Duration 1:08)
* Carmèn Máría Cruz left the call
* Ahri Fox left the call
* Bennet Bernetto left the call

### After

* You started a call
* Ahri Fox joined the call
* Bennet Bernetto joined the call
* Carmèn Máría Cruz joined the call
* Laura Adams ended the call with Ahri Fox, Bennet Bernetto and Carmèn Máría Cruz (Duration 0:12)