### PR TITLE
Allow to enable SIP without individual pin requirement

### DIFF
--- a/appinfo/routes/routesRoomController.php
+++ b/appinfo/routes/routesRoomController.php
@@ -92,6 +92,8 @@ return [
 		['name' => 'Room#getParticipantByDialInPin', 'url' => '/api/{apiVersion}/room/{token}/pin/{pin}', 'verb' => 'GET', 'requirements' => array_merge($requirementsWithToken, [
 			'pin' => '^\d{7,32}$',
 		])],
+		/** @see \OCA\Talk\Controller\RoomController::createGuestByDialIn() */
+		['name' => 'Room#createGuestByDialIn', 'url' => '/api/{apiVersion}/room/{token}/open-dial-in', 'verb' => 'POST', 'requirements' => $requirementsWithToken],
 		/** @see \OCA\Talk\Controller\RoomController::setNotificationLevel() */
 		['name' => 'Room#setNotificationLevel', 'url' => '/api/{apiVersion}/room/{token}/notify', 'verb' => 'POST', 'requirements' => $requirementsWithToken],
 		/** @see \OCA\Talk\Controller\RoomController::setNotificationCalls() */

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -95,3 +95,4 @@ title: Capabilities
 
 ## 15
 * `chat-permission` - When permission 128 is required to post chat messages, reaction or share items to the conversation
+* `sip-support-nopin` - Whether SIP can be configured to not require a custom attendee PIN

--- a/docs/constants.md
+++ b/docs/constants.md
@@ -23,6 +23,11 @@ title: Constants
 * `0` No lobby
 * `1` Lobby for non moderators
 
+### SIP states
+* `0` Disabled
+* `1` Enabled (Each participant needs a unique PIN)
+* `2` Enabled without PIN (Only the conversation token is required)
+
 ## Participants
 
 ### Participant types

--- a/docs/conversation.md
+++ b/docs/conversation.md
@@ -66,7 +66,7 @@
         `notificationLevel` | int | v1 | | The notification level for the user (See [Participant notification levels](constants.md#Participant-notification-levels))
         `lobbyState` | int | v1 | | Webinar lobby restriction (0-1), if the participant is a moderator they can always join the conversation (only available with `webinary-lobby` capability) (See [Webinar lobby states](constants.md#webinar-lobby-states))
         `lobbyTimer` | int | v1 | | Timestamp when the lobby will be automatically disabled (only available with `webinary-lobby` capability)
-        `sipEnabled` | int | v3 | | SIP enable status (0-1)
+        `sipEnabled` | int | v3 | | SIP enable status (see [constants list](constants.md#sip-states))
         `canEnableSIP` | int | v3 | | Whether the given user can enable SIP for this conversation. Note that when the token is not-numeric only, SIP can not be enabled even if the user is permitted and a moderator of the conversation
         `unreadMessages` | int | v1 | | Number of unread chat messages in the conversation (only available with `chat-v2` capability)
         `unreadMention` | bool | v1 | | Flag if the user was mentioned since their last visit

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -85,6 +85,7 @@ class Capabilities implements IPublicCapability {
 				'circles-support',
 				'force-mute',
 				'sip-support',
+				'sip-support-nopin',
 				'chat-read-status',
 				'phonebook-search',
 				'raise-hand',

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -476,7 +476,7 @@ class RoomController extends AEnvironmentAwareController {
 
 		if ($this->talkConfig->isSIPConfigured()) {
 			$roomData['sipEnabled'] = $room->getSIPEnabled();
-			if ($room->getSIPEnabled() === Webinary::SIP_ENABLED) {
+			if ($room->getSIPEnabled() !== Webinary::SIP_DISABLED) {
 				// Generate a PIN if the attendee is a user and doesn't have one.
 				$this->participantService->generatePinForParticipant($room, $currentParticipant);
 
@@ -973,7 +973,7 @@ class RoomController extends AEnvironmentAwareController {
 				'attendeePin' => '',
 			];
 			if ($this->talkConfig->isSIPConfigured()
-				&& $this->room->getSIPEnabled() === Webinary::SIP_ENABLED
+				&& $this->room->getSIPEnabled() !== Webinary::SIP_DISABLED
 				&& ($this->participant->hasModeratorPermissions(false)
 					|| $this->participant->getAttendee()->getId() === $participant->getAttendee()->getId())) {
 				// Generate a PIN if the attendee is a user and doesn't have one.

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1422,6 +1422,30 @@ class RoomController extends AEnvironmentAwareController {
 
 	/**
 	 * @PublicPage
+	 * @RequireRoom
+	 *
+	 * @return DataResponse
+	 */
+	public function createGuestByDialIn(): DataResponse {
+		try {
+			if (!$this->validateSIPBridgeRequest($this->room->getToken())) {
+				return new DataResponse([], Http::STATUS_UNAUTHORIZED);
+			}
+		} catch (UnauthorizedException $e) {
+			return new DataResponse([], Http::STATUS_UNAUTHORIZED);
+		}
+
+		if ($this->room->getSIPEnabled() !== Webinary::SIP_ENABLED_NO_PIN) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
+		$participant = $this->participantService->joinRoomAsNewGuest($this->roomService, $this->room, '', true);
+
+		return new DataResponse($this->formatRoom($this->room, $participant));
+	}
+
+	/**
+	 * @PublicPage
 	 * @UseSession
 	 *
 	 * @param string $token

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -974,7 +974,7 @@ class Room {
 			return false;
 		}
 
-		if (!in_array($newSipEnabled, [Webinary::SIP_ENABLED, Webinary::SIP_DISABLED], true)) {
+		if (!in_array($newSipEnabled, [Webinary::SIP_ENABLED_NO_PIN, Webinary::SIP_ENABLED, Webinary::SIP_DISABLED], true)) {
 			return false;
 		}
 

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -640,7 +640,7 @@ class ParticipantService {
 		$attendee->setActorType(Attendee::ACTOR_EMAILS);
 		$attendee->setActorId($email);
 
-		if ($room->getSIPEnabled() === Webinary::SIP_ENABLED
+		if ($room->getSIPEnabled() !== Webinary::SIP_DISABLED
 			&& $this->talkConfig->isSIPConfigured()) {
 			$attendee->setPin($this->generatePin());
 		}
@@ -658,7 +658,7 @@ class ParticipantService {
 
 	public function generatePinForParticipant(Room $room, Participant $participant): void {
 		$attendee = $participant->getAttendee();
-		if ($room->getSIPEnabled() === Webinary::SIP_ENABLED
+		if ($room->getSIPEnabled() !== Webinary::SIP_DISABLED
 			&& $this->talkConfig->isSIPConfigured()
 			&& ($attendee->getActorType() === Attendee::ACTOR_USERS || $attendee->getActorType() === Attendee::ACTOR_EMAILS)
 			&& !$attendee->getPin()) {

--- a/lib/Webinary.php
+++ b/lib/Webinary.php
@@ -29,4 +29,5 @@ class Webinary {
 
 	public const SIP_DISABLED = 0;
 	public const SIP_ENABLED = 1;
+	public const SIP_ENABLED_NO_PIN = 2;
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -124,6 +124,7 @@ export const WEBINAR = {
 	SIP: {
 		DISABLED: 0,
 		ENABLED: 1,
+		ENABLED_NO_PIN: 2,
 	},
 }
 export const SHARE = {

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -364,7 +364,6 @@ const actions = {
 			return
 		}
 
-		// The backend requires the state and timestamp to be set together.
 		await setSIPEnabled(token, state)
 		conversation.sipEnabled = state
 

--- a/src/store/conversationsStore.spec.js
+++ b/src/store/conversationsStore.spec.js
@@ -510,7 +510,7 @@ describe('conversationsStore', () => {
 		})
 
 		test('set SIP enabled', async () => {
-			testConversation.sipEnabled = false
+			testConversation.sipEnabled = WEBINAR.SIP.DISABLED
 
 			store.dispatch('addConversation', testConversation)
 
@@ -518,13 +518,31 @@ describe('conversationsStore', () => {
 
 			await store.dispatch('setSIPEnabled', {
 				token: testToken,
-				state: true,
+				state: WEBINAR.SIP.ENABLED,
 			})
 
-			expect(setSIPEnabled).toHaveBeenCalledWith(testToken, true)
+			expect(setSIPEnabled).toHaveBeenCalledWith(testToken, WEBINAR.SIP.ENABLED)
 
 			const changedConversation = store.getters.conversation(testToken)
-			expect(changedConversation.sipEnabled).toBe(true)
+			expect(changedConversation.sipEnabled).toBe(WEBINAR.SIP.ENABLED)
+		})
+
+		test('set SIP enabled no individual PIN', async () => {
+			testConversation.sipEnabled = WEBINAR.SIP.ENABLED
+
+			store.dispatch('addConversation', testConversation)
+
+			setSIPEnabled.mockResolvedValue()
+
+			await store.dispatch('setSIPEnabled', {
+				token: testToken,
+				state: WEBINAR.SIP.ENABLED_NO_PIN,
+			})
+
+			expect(setSIPEnabled).toHaveBeenCalledWith(testToken, WEBINAR.SIP.ENABLED_NO_PIN)
+
+			const changedConversation = store.getters.conversation(testToken)
+			expect(changedConversation.sipEnabled).toBe(WEBINAR.SIP.ENABLED_NO_PIN)
 		})
 
 		test('set notification level', async () => {

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1096,6 +1096,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			$SIPState = 0;
 		} elseif ($SIPStateString === 'enabled') {
 			$SIPState = 1;
+		} elseif ($SIPStateString === 'no pin') {
+			$SIPState = 2;
 		} else {
 			Assert::fail('Invalid SIP state');
 		}

--- a/tests/integration/features/conversation-2/sip-dialin.feature
+++ b/tests/integration/features/conversation-2/sip-dialin.feature
@@ -49,6 +49,14 @@ Feature: public
       | 1               | 0        | users     | participant1      |             |
       | 3               | 0        | users     | participant2      |             |
       | 3               | 0        | users     | participant3      |             |
+    When user "participant1" sets SIP state for room "room" to "no pin" with 200 (v4)
+    Then user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | participantType | inCall   | actorType | actorId           | attendeePin |
+      | 4               | 0        | emails    | test@example.tld  | **PIN**     |
+      | 4               | 0        | guests    | "guest"           |             |
+      | 1               | 0        | users     | participant1      | **PIN**     |
+      | 3               | 0        | users     | participant2      | **PIN**     |
+      | 3               | 0        | users     | participant3      | **PIN**     |
 
   Scenario: Non-SIP admin tries to enable SIP
     Given the following "spreed" app config is set

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -88,6 +88,7 @@ class CapabilitiesTest extends TestCase {
 			'circles-support',
 			'force-mute',
 			'sip-support',
+			'sip-support-nopin',
 			'chat-read-status',
 			'phonebook-search',
 			'raise-hand',


### PR DESCRIPTION
Fix #4957 

- [x] Allow setting SIP without PIN on the API
- [x] Add an option for the moderator to disable individual pin requirements

### Idea
When `sipEnabled` on the getRoom request is set to:
* `0` SIP is disabled
* `1` a user pin is required (current)
* `2` no pin is required, just the conversation token