### PR TITLE
Fix flickering with background blur when changing quality

### DIFF
--- a/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.js
+++ b/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.js
@@ -343,12 +343,33 @@ export default class JitsiStreamBackgroundEffect {
 				timeMs: 1000 / this._frameRate,
 				message: 'this._maskFrameTimerWorker',
 			})
+			this._inputVideoElement.onloadeddata = null
 		}
 
 		this._frameId = -1
 		this._lastFrameId = -1
 
-		return this._outputCanvasElement.captureStream(parseInt(frameRate, 10))
+		this._outputStream = this._outputCanvasElement.captureStream(this._frameRate)
+
+		return this._outputStream
+	}
+
+	updateInputStream() {
+		const firstVideoTrack = this._stream.getVideoTracks()[0]
+		const { height, frameRate, width }
+            = firstVideoTrack.getSettings ? firstVideoTrack.getSettings() : firstVideoTrack.getConstraints()
+
+		this._frameRate = parseInt(frameRate, 10)
+
+		this._outputStream.getVideoTracks()[0].applyConstraints({ frameRate: this._frameRate }).catch(error => {
+			console.error('Frame rate could not be adjusted in background effect', error)
+		})
+
+		this._inputVideoElement.width = parseInt(width, 10)
+		this._inputVideoElement.height = parseInt(height, 10)
+
+		this._frameId = -1
+		this._lastFrameId = -1
 	}
 
 	/**

--- a/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.js
+++ b/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.js
@@ -263,7 +263,7 @@ export default class JitsiStreamBackgroundEffect {
 
 		this._maskFrameTimerWorker.postMessage({
 			id: SET_TIMEOUT,
-			timeMs: 1000 / 30,
+			timeMs: 1000 / this._frameRate,
 			message: 'this._maskFrameTimerWorker',
 		})
 	}
@@ -322,6 +322,8 @@ export default class JitsiStreamBackgroundEffect {
 		const { height, frameRate, width }
             = firstVideoTrack.getSettings ? firstVideoTrack.getSettings() : firstVideoTrack.getConstraints()
 
+		this._frameRate = parseInt(frameRate, 10)
+
 		this._segmentationMask = new ImageData(this._options.width, this._options.height)
 		this._segmentationMaskCanvas = document.createElement('canvas')
 		this._segmentationMaskCanvas.width = this._options.width
@@ -338,7 +340,7 @@ export default class JitsiStreamBackgroundEffect {
 		this._inputVideoElement.onloadeddata = () => {
 			this._maskFrameTimerWorker.postMessage({
 				id: SET_TIMEOUT,
-				timeMs: 1000 / 30,
+				timeMs: 1000 / this._frameRate,
 				message: 'this._maskFrameTimerWorker',
 			})
 		}

--- a/src/utils/media/pipeline/VirtualBackground.js
+++ b/src/utils/media/pipeline/VirtualBackground.js
@@ -222,6 +222,12 @@ export default class VirtualBackground extends TrackSinkSource {
 			return
 		}
 
+		if (newTrack === oldTrack && newTrack !== null) {
+			this._jitsiStreamBackgroundEffect.updateInputStream()
+
+			return
+		}
+
 		this._stopEffect()
 
 		if (!newTrack) {


### PR DESCRIPTION
When the background blur was enabled and the video quality was changed (due to being in a call with more than five participants and started or stopped speaking) the video flickered (a black screen appeared in between).

There are three sources for the flickering:
- A previous segmentation being processed after the input stream was changed but before the input video finished loading
- The output stream being captured before the first frame was drawn
- Changing between two different output streams

Old segmentations are now discarded based on a frame id; when the input stream is changed the frame id is reset, so if the received segmentation data is for a higher frame id it comes from the previous stream and thus can be ignored (that is, the frame is not rendered).

It seems that the flickering when changing between two different output streams can not be avoided. Fortunately, when the constraints of the input stream change it is possible to reconfigure the output stream from the background blur without having to change to a different one. This also fixes the problem of the output stream being captured before the first frame is drawn; as the same canvas and output stream are reused the last frame from the previous stream will be shown again until a new one is calculated. Therefore the flickering was replaced by a temporary freeze, but at least this should be less annoying.

Besides the flickering fixes the load should be slightly reduced in some cases, as now the segmentation is no longer calculated at a fixed rate of 30 FPS but at the same rate as the input stream, and the segmentation is not calculated again if the previous frame did not finish yet.

Pending:
- [X] Fix video sometimes not being rendered when starting a call for the first time - The worker ignores requests until it has finished loading the model, but as the `frameId` was increased before that there was a mismatch in the values
- [X] Check `OverConstrainedError` with Firefox and fake streams - The try/catch had no effect, as `applyConstraints` is async but the try/catch was used in a non-async method
- [ ] Verify if, after an update of the input stream, the segmentation needs to be explicitly deferred until the input video element has loaded the data again
- [ ] Ensure that the segmentation worker is not throttled when the browser tab is not the active one
- [ ] Better handling of errors when adjusting the frame rate in the background blur output fails
- [ ] Test thoroughly, preferably in a real call

Future:
- Check if it is possible to synchronize the input stream with the segmentation data, as due to the use of the worker right now the segmentation might be received when the input stream is already in a different frame
  - It might be possible to do that by saving the input frame data used to do the segmentation and rendering that instead of the current state of the input video, but that could also increase the load and end making the video slower

## How to test

- Expose the `SentVideoQualityThrottler` object by adding:
```
		if (!OCA.Talk) {
			OCA.Talk = {}
		}
		OCA.Talk.sentVideoQualityThrottler = sentVideoQualityThrottler
```
[after it was created](https://github.com/nextcloud/spreed/blob/b7538684b9cce53ff9aa087ec6e00b94934b9001/src/utils/webrtc/index.js#L176)
- Start a call with video and background blur enabled
- In the browser console, force a quality change with:
```
OCA.Talk.sentVideoQualityThrottler._videoConstrainer.applyConstraints(3)
OCA.Talk.sentVideoQualityThrottler._videoConstrainer.applyConstraints(4)
```

### Result with this pull request

The video temporary freezes when changing the quality

### Result without this pull request

The video flickers when changing the quality; sometimes a resized video appears on the black screen
