### PR TITLE
Fix video zoom jump with background blur when changing resolution

### DIFF
--- a/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.js
+++ b/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.js
@@ -154,8 +154,8 @@ export default class JitsiStreamBackgroundEffect {
 	 */
 	runPostProcessing() {
 
-		const track = this._stream.getVideoTracks()[0]
-		const { height, width } = track.getSettings() ?? track.getConstraints()
+		const height = this._inputVideoElement.videoHeight
+		const width = this._inputVideoElement.videoWidth
 		const { backgroundType } = this._options.virtualBackground
 
 		this._outputCanvasElement.height = height
@@ -182,8 +182,8 @@ export default class JitsiStreamBackgroundEffect {
 			this._options.height,
 			0,
 			0,
-			this._inputVideoElement.width,
-			this._inputVideoElement.height
+			this._inputVideoElement.videoWidth,
+			this._inputVideoElement.videoHeight
 		)
 		if (backgroundType === VIRTUAL_BACKGROUND_TYPE.DESKTOP_SHARE) {
 			this._outputCanvasCtx.restore()
@@ -279,8 +279,8 @@ export default class JitsiStreamBackgroundEffect {
 			this._inputVideoElement,
 			0,
 			0,
-			this._inputVideoElement.width,
-			this._inputVideoElement.height,
+			this._inputVideoElement.videoWidth,
+			this._inputVideoElement.videoHeight,
 			0,
 			0,
 			this._options.width,
@@ -333,8 +333,6 @@ export default class JitsiStreamBackgroundEffect {
 		this._outputCanvasElement.width = parseInt(width, 10)
 		this._outputCanvasElement.height = parseInt(height, 10)
 		this._outputCanvasCtx = this._outputCanvasElement.getContext('2d')
-		this._inputVideoElement.width = parseInt(width, 10)
-		this._inputVideoElement.height = parseInt(height, 10)
 		this._inputVideoElement.autoplay = true
 		this._inputVideoElement.srcObject = this._stream
 		this._inputVideoElement.onloadeddata = () => {
@@ -356,7 +354,7 @@ export default class JitsiStreamBackgroundEffect {
 
 	updateInputStream() {
 		const firstVideoTrack = this._stream.getVideoTracks()[0]
-		const { height, frameRate, width }
+		const { frameRate }
             = firstVideoTrack.getSettings ? firstVideoTrack.getSettings() : firstVideoTrack.getConstraints()
 
 		this._frameRate = parseInt(frameRate, 10)
@@ -364,9 +362,6 @@ export default class JitsiStreamBackgroundEffect {
 		this._outputStream.getVideoTracks()[0].applyConstraints({ frameRate: this._frameRate }).catch(error => {
 			console.error('Frame rate could not be adjusted in background effect', error)
 		})
-
-		this._inputVideoElement.width = parseInt(width, 10)
-		this._inputVideoElement.height = parseInt(height, 10)
 
 		this._frameId = -1
 		this._lastFrameId = -1


### PR DESCRIPTION
Follow up to #6569 

The input track is played in a video element which, in turn, is drawn on the canvas used to calculate the segmentation mask and on the output canvas. When the resolution of its input track changes a video element may still play the track using the old resolution for some frames (it happens with real hardware cameras, although apparently not with virtual devices), even if `track.getSettings()` already returns the new resolution.

Due to this mismatch, when the resolution of the input track changed (for example, due to a quality change in a call with several
participants), the video could zoom in and out, as the output canvas size was based on the new size, while the video element drawn on it was still using the old size.

Fortunately, the `videoWidth` and `videoHeight` attributes of the video element seem to reflect the actual size of the video being played, so those values can be used to do the calculations instead of relying on the expected video size.

Pending:
- [X] ~~The `videoWidth` and `videoHeight` attributes reflect the actual size... in Firefox. That does not work in Chromium :cry:~~ - It works in Chromium too; the problem comes from #6592 instead (also in Firefox), but only with this pull request it works fine

## How to test
- Start a call with video and background blur
  - It must be a real hardware camera; with virtual devices it seems that the input video is immediately adjusted, so they do not exhibit the issue
- In the console, change the resolution of the input stream with something like:
```
OCA.Talk.SimpleWebRTC.webrtc._virtualBackground.getInputTrack().applyConstraints({ width: 360, height: 240 })
OCA.Talk.SimpleWebRTC.webrtc._virtualBackground.getInputTrack().applyConstraints({ width: 640, height: 480 })
```
- Repeat the change several times

### Result with this pull request

The video does not zoom in and out

### Result without this pull request

The video zooms in and out whenever the resolution is changed