### PR TITLE
Fix background blur mask not synchronized with video

### DIFF
--- a/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.js
+++ b/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.js
@@ -156,8 +156,15 @@ export default class JitsiStreamBackgroundEffect {
 	 */
 	runPostProcessing() {
 
-		const height = this._inputVideoElement.videoHeight
-		const width = this._inputVideoElement.videoWidth
+		let height
+		let width
+		if (this._syncMaskWithVideo) {
+			height = this._inputVideoSnapshotCanvas.height
+			width = this._inputVideoSnapshotCanvas.width
+		} else {
+			height = this._inputVideoElement.videoHeight
+			width = this._inputVideoElement.videoWidth
+		}
 		const { backgroundType } = this._options.virtualBackground
 
 		this._outputCanvasElement.height = height
@@ -184,8 +191,8 @@ export default class JitsiStreamBackgroundEffect {
 			this._options.height,
 			0,
 			0,
-			this._inputVideoElement.videoWidth,
-			this._inputVideoElement.videoHeight
+			width,
+			height
 		)
 		if (backgroundType === VIRTUAL_BACKGROUND_TYPE.DESKTOP_SHARE) {
 			this._outputCanvasCtx.restore()

--- a/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.js
+++ b/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.js
@@ -381,6 +381,45 @@ export default class JitsiStreamBackgroundEffect {
 		this._frameId = -1
 		this._lastFrameId = -1
 
+		this._frameIdBaseShort = this._lastFrameId
+		this._frameIdBaseLong = this._lastFrameId
+		this._frameIdBaseVeryLong = this._lastFrameId
+		this._fpsBaseTimeShort = Date.now()
+		this._fpsBaseTimeLong = Date.now()
+		this._fpsBaseTimeVeryLong = Date.now()
+		this._fpsLogCount = 0
+
+		if (this._fpsLogTimeout) {
+			clearTimeout(this._fpsLogTimeout)
+		}
+		this._fpsLogTimeout = setInterval(() => {
+			this._fpsLogCount++
+
+			const now = Date.now()
+
+			const elapsedFramesShort = this._lastFrameId - this._frameIdBaseShort
+			console.log('FPS (3s): ', elapsedFramesShort / ((now - this._fpsBaseTimeShort) / 1000))
+
+			this._frameIdBaseShort = this._lastFrameId
+			this._fpsBaseTimeShort = now
+
+			if ((this._fpsLogCount % 4) === 0) {
+				const elapsedFramesLong = this._lastFrameId - this._frameIdBaseLong
+				console.log('FPS (12s): ', elapsedFramesLong / ((now - this._fpsBaseTimeLong) / 1000))
+
+				this._frameIdBaseLong = this._lastFrameId
+				this._fpsBaseTimeLong = now
+			}
+
+			if ((this._fpsLogCount % 20) === 0) {
+				const elapsedFramesVeryLong = this._lastFrameId - this._frameIdBaseVeryLong
+				console.log('FPS (60s): ', elapsedFramesVeryLong / ((now - this._fpsBaseTimeVeryLong) / 1000))
+
+				this._frameIdBaseVeryLong = this._lastFrameId
+				this._fpsBaseTimeVeryLong = now
+			}
+		}, 3000)
+
 		this._outputStream = this._outputCanvasElement.captureStream(this._frameRate)
 
 		return this._outputStream
@@ -413,6 +452,10 @@ export default class JitsiStreamBackgroundEffect {
 		})
 
 		this._maskFrameTimerWorker.terminate()
+
+		if (this._fpsLogTimeout) {
+			clearTimeout(this._fpsLogTimeout)
+		}
 	}
 
 }


### PR DESCRIPTION
Follow up to #6569

Requires #6591

The input track is played in a video element which, in turn, is drawn on the canvas used to calculate the segmentation mask and on the output canvas. However, the segmentation mask canvas is drawn first, then the segmentation mask is calculated, and then once the calculation is finished the mask it used to draw the video on the output canvas. The mask calculation is done in a worker and thus asynchronously, so when the resulting mask is received the input video might be in a different frame than the one used to calculate the mask.

To solve this now a snapshot of the input video is taken when the segmentation mask is calculated, and that snapshot, instead of the real video, is then used to draw on the output canvas.

Due to this now the video with the blurred background might lag some frames behind the actual video, although now the blur should "exactly" match only the background.

For now the synchronization is behind a flag (enabled by default) to be able to check the difference between synchronization and no synchronization, both regarding the introduced lag and a possible increased CPU load / reduced FPS. The synchronization can be enabled and disabled by setting `OCA.Talk.SimpleWebRTC.webrtc._virtualBackground._jitsiStreamBackgroundEffect._syncMaskWithVideo = true` or `false`.

Pending:
- [ ] Remove the testing code (`this._syncMaskWithVideo` flag and logs)
- [ ] Test and decide whether the lag, and maybe load, is worth the accuracy of the mask
