### PR TITLE
Fix media never requested again when changing again to current device

### DIFF
--- a/src/utils/media/pipeline/MediaDevicesSource.js
+++ b/src/utils/media/pipeline/MediaDevicesSource.js
@@ -236,6 +236,8 @@ export default class MediaDevicesSource extends TrackSource {
 		if (this.getOutputTrack('audio')) {
 			const settings = this.getOutputTrack('audio').getSettings()
 			if (settings && settings.deviceId === audioInputId) {
+				resetPendingAudioInputIdChangedCount()
+
 				return
 			}
 		}
@@ -297,6 +299,8 @@ export default class MediaDevicesSource extends TrackSource {
 		if (this.getOutputTrack('video')) {
 			const settings = this.getOutputTrack('video').getSettings()
 			if (settings && settings.deviceId === videoInputId) {
+				resetPendingVideoInputIdChangedCount()
+
 				return
 			}
 		}


### PR DESCRIPTION
This fixes a regression introduced in fc7cbad18a9e1c4dcbcc5209886a3abee6a1cf23

When the MediaDevicesSource node is active and a media device changes the current stream is replaced by a stream from the new selected device. This is an asynchronous operation, so changing the stream again on further device changes is deferred until the previous one finished.

However, when the changed device was the same as the current device the pending request count was not cleared and thus any further device change was ignored until the page was reloaded.

In general the scenario addressed here should not happen. But... in theory it could potentially happen if the browser emitted two `devicechange` events immediately one after the other (the second one should be handled even before a promise triggered by the first one is fulfilled); the first event would need to remove the current device and the second should add it again. If all this happened it could cause that the stream for the current device is requested again, and therefore any further device change would not work (and any other device change would stop the current device).

To sum up, this could explain why sometimes audio is lost and never recovered when using a Bluetooth device, as it might lose and recover the connection again quickly, but it is just a theory :shrug: In any case, even if it does not actually fix that issue, the fix is anyway needed to solve other potential issues.