### PR TITLE
Make background blur proportional to the input video size

### DIFF
--- a/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.js
+++ b/src/utils/media/effects/virtual-background/JitsiStreamBackgroundEffect.js
@@ -41,6 +41,8 @@ export default class JitsiStreamBackgroundEffect {
 	 *
 	 * @class
 	 * @param {object} options - Segmentation dimensions.
+	 * @param {number} options.virtualBackground.blurValue the blur to apply on
+	 *                 a 720p video; it will be automatically scaled as needed.
 	 */
 	constructor(options) {
 		const isSimd = options.simd
@@ -158,6 +160,10 @@ export default class JitsiStreamBackgroundEffect {
 		const width = this._inputVideoElement.videoWidth
 		const { backgroundType } = this._options.virtualBackground
 
+		const scaledBlurFactor = width / 720.0
+		const backgroundBlurValue = this._options.virtualBackground.blurValue * scaledBlurFactor
+		const edgesBlurValue = (backgroundType === VIRTUAL_BACKGROUND_TYPE.IMAGE ? 4 : 8) * scaledBlurFactor
+
 		this._outputCanvasElement.height = height
 		this._outputCanvasElement.width = width
 		this._outputCanvasCtx.globalCompositeOperation = 'copy'
@@ -165,7 +171,7 @@ export default class JitsiStreamBackgroundEffect {
 		// Draw segmentation mask.
 
 		// Smooth out the edges.
-		this._outputCanvasCtx.filter = backgroundType === VIRTUAL_BACKGROUND_TYPE.IMAGE ? 'blur(4px)' : 'blur(8px)'
+		this._outputCanvasCtx.filter = `blur(${edgesBlurValue}px)`
 		if (backgroundType === VIRTUAL_BACKGROUND_TYPE.DESKTOP_SHARE) {
 			// Save current context before applying transformations.
 			this._outputCanvasCtx.save()
@@ -220,7 +226,7 @@ export default class JitsiStreamBackgroundEffect {
 				this._outputCanvasElement.height
 			)
 		} else {
-			this._outputCanvasCtx.filter = `blur(${this._options.virtualBackground.blurValue}px)`
+			this._outputCanvasCtx.filter = `blur(${backgroundBlurValue}px)`
 			this._outputCanvasCtx.drawImage(this._inputVideoElement, 0, 0)
 		}
 	}


### PR DESCRIPTION
The blur value was a fixed value that did not change depending on the input video size. Due to this the background of lower resolution videos looked more blurry than the background of higher resolution videos, and this was specially noticeable when the same video changed its resolution. Now the blur is proportional to the input video size, so the blurred background always looks the same even if the resolution changes (provided the same aspect ratio is kept between the different resolutions).

**Reviewers:** The blur factor is based on a 720 pixels wide video. The [default blur value](https://github.com/nextcloud/spreed/blob/c3721fde8fb481412d44364424b3080af6fa3110/src/utils/media/pipeline/VirtualBackground.js#L154) might need to be [adjusted again](https://github.com/nextcloud/spreed/pull/6533) due to that, keep it in mind while testing and please change it if needed :-)

## How to test

- Start a call with video and background blur
- In the console, change the resolution of the input stream with something like:
```
OCA.Talk.SimpleWebRTC.webrtc._virtualBackground.getInputTrack().applyConstraints({ width: 320, height: 240 })
```
```
OCA.Talk.SimpleWebRTC.webrtc._virtualBackground.getInputTrack().applyConstraints({ width: 640, height: 480 })
```
- Repeat the change several times

### Result with this pull request

The background has the same blur independently of the resolution. Note that even if the amount of blur is the same its appearance can change if the aspect ratio between the resolutions change.

### Result without this pull request

The background is more or less blurred depending on the resolution