### PR TITLE
Check share restrictions on one to one conversation

### DIFF
--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1749,21 +1749,22 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
-	 * @Given /^the following app config is set$/
+	 * @Given the following :appId app config is set
 	 *
 	 * @param TableNode $formData
 	 */
-	public function setAppConfig(TableNode $formData): void {
+	public function setAppConfig(string $appId, TableNode $formData): void {
 		$currentUser = $this->currentUser;
 		$this->setCurrentUser('admin');
 		foreach ($formData->getRows() as $row) {
-			$this->sendRequest('POST', '/apps/provisioning_api/api/v1/config/apps/spreed/' . $row[0], [
+			$this->sendRequest('POST', '/apps/provisioning_api/api/v1/config/apps/' . $appId . '/' . $row[0], [
 				'value' => $row[1],
 			]);
-			$this->changedConfigs[] = $row[0];
+			$this->changedConfigs[$appId][] = $row[0];
 		}
 		$this->setCurrentUser($currentUser);
 	}
+
 
 	/**
 	 * @Given /^guest accounts can be created$/
@@ -1811,8 +1812,10 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$currentUser = $this->currentUser;
 		$this->setCurrentUser('admin');
 		$this->sendRequest('DELETE', '/apps/spreedcheats/');
-		foreach ($this->changedConfigs as $config) {
-			$this->sendRequest('DELETE', '/apps/provisioning_api/api/v1/config/apps/spreed/' . $config);
+		foreach ($this->changedConfigs as $appId => $configs) {
+			foreach ($configs as $config) {
+				$this->sendRequest('DELETE', '/apps/provisioning_api/api/v1/config/apps/' . $appId . '/' . $config);
+			}
 		}
 
 		$this->setCurrentUser($currentUser);

--- a/tests/integration/features/conversation-2/one-to-one.feature
+++ b/tests/integration/features/conversation-2/one-to-one.feature
@@ -197,3 +197,13 @@ Feature: one-to-one
       | actorType  | actorId      | participantType |
       | users      | participant1 | 1               |
       | users      | participant2 | 1               |
+
+  Scenario: Check share restrictions on one to one conversatio
+    Given the following "core" app config is set
+      | shareapi_restrict_user_enumeration_full_match | no |
+      | shareapi_allow_share_dialog_user_enumeration | yes |
+      | shareapi_restrict_user_enumeration_to_group | yes |
+      | shareapi_restrict_user_enumeration_to_phone | yes |
+    And user "participant1" creates room "room15" with 403 (v4)
+      | roomType | 1 |
+      | invite   | participant2 |

--- a/tests/integration/features/conversation-2/sip-dialin.feature
+++ b/tests/integration/features/conversation-2/sip-dialin.feature
@@ -7,7 +7,7 @@ Feature: public
     Given user "participant1" is member of group "group1"
 
   Scenario: SIP admin enables SIP
-    Given the following app config is set
+    Given the following "spreed" app config is set
       | sip_bridge_dialin_info | +49-1234-567890 |
       | sip_bridge_shared_secret | 1234567890abcdef |
       | sip_bridge_groups | ["group1"] |
@@ -51,7 +51,7 @@ Feature: public
       | 3               | 0        | users     | participant3      |             |
 
   Scenario: Non-SIP admin tries to enable SIP
-    Given the following app config is set
+    Given the following "spreed" app config is set
       | sip_bridge_dialin_info | +49-1234-567890 |
       | sip_bridge_shared_secret | 1234567890abcdef |
       | sip_bridge_groups | ["group1"] |

--- a/tests/integration/features/conversation/limit-creation.feature
+++ b/tests/integration/features/conversation/limit-creation.feature
@@ -6,7 +6,7 @@ Feature: public
     Given group "group1" exists
 
   Scenario: User can not create group conversations
-    Given the following app config is set
+    Given the following "spreed" app config is set
       | start_conversations | ["group1"] |
     Then user "participant1" creates room "room" with 403 (v4)
       | roomType | 2 |
@@ -17,7 +17,7 @@ Feature: public
       | roomName | room |
 
   Scenario: User can not create public conversations
-    Given the following app config is set
+    Given the following "spreed" app config is set
       | start_conversations | ["group1"] |
     Then user "participant1" creates room "room" with 403 (v4)
       | roomType | 3 |
@@ -28,7 +28,7 @@ Feature: public
       | roomName | room |
 
   Scenario: User can still do one-to-one conversations
-    Given the following app config is set
+    Given the following "spreed" app config is set
       | start_conversations | ["group1"] |
     Then user "participant1" creates room "room" with 201 (v4)
       | roomType | 1 |

--- a/tests/integration/features/federation/invite.feature
+++ b/tests/integration/features/federation/invite.feature
@@ -4,7 +4,7 @@ Feature: federation/invite
     Given user "participant2" exists
 
   Scenario: federation is disabled
-    Given the following app config is set
+    Given the following "spreed" app config is set
       | federation_enabled | no |
     Given user "participant1" creates room "room" (v4)
       | roomType | 3 |
@@ -15,7 +15,7 @@ Feature: federation/invite
       | users      | participant1 | 1               |
 
   Scenario: federation is enabled
-    Given the following app config is set
+    Given the following "spreed" app config is set
       | federation_enabled | yes |
     Given user "participant1" creates room "room" (v4)
       | roomType | 3 |


### PR DESCRIPTION
How test:

Background: user1 and user2 exists

Scenario:
- Login with User1
- Open Talk app
- Search by user2
- Define this app settings values:
  | appid | configkey                                     | configvalue |
  | ----- | --------------------------------------------- | ----------- |
  | core  | shareapi_restrict_user_enumeration_full_match | no          |
  | core  | shareapi_allow_share_dialog_user_enumeration  | yes         |
  | core  | shareapi_restrict_user_enumeration_to_group   | yes         |
  | core  | shareapi_restrict_user_enumeration_to_phone   | yes         |
- Click on user1 on search result
- You will need see 4xx error on Network tab on response of request to create conversation

> **PS**: If you define the app settings before do a search for user2 you will never see the user2