### PR TITLE
Fix pending device not requested once current request finishes

### DIFF
--- a/src/utils/media/pipeline/MediaDevicesSource.js
+++ b/src/utils/media/pipeline/MediaDevicesSource.js
@@ -218,7 +218,7 @@ export default class MediaDevicesSource extends TrackSource {
 			this._pendingAudioInputIdChangedCount = 0
 
 			if (audioInputIdChangedAgain) {
-				this._handleAudioInputIdChanged(mediaDevicesManager.get('audioInputId'))
+				this._handleAudioInputIdChanged(mediaDevicesManager, mediaDevicesManager.get('audioInputId'))
 			}
 		}
 
@@ -281,7 +281,7 @@ export default class MediaDevicesSource extends TrackSource {
 			this._pendingVideoInputIdChangedCount = 0
 
 			if (videoInputIdChangedAgain) {
-				this._handleVideoInputIdChanged(mediaDevicesManager.get('videoInputId'))
+				this._handleVideoInputIdChanged(mediaDevicesManager, mediaDevicesManager.get('videoInputId'))
 			}
 		}
 


### PR DESCRIPTION
Requires #6604 (it does not require it, but the test steps do)

This has been wrong [since the beginning](https://github.com/nextcloud/spreed/commit/c81c912488914f699a2f8fa45b75105b6692201e) :facepalm: but in the past it happened to work in most cases due to a lucky code flow. However, [since the refactoring](https://github.com/nextcloud/spreed/commit/b8fc1b28f32ac72cb8212b0a71e2c6a22403efcd) it no longer worked due to requiring both call parameters to be properly defined.

As the method was [recursively called from the handler of the previous "getUserMedia" promise](https://github.com/nextcloud/spreed/blob/43609c705a28cc884b60e8c6189ff66cd308ad5d/src/utils/media/pipeline/MediaDevicesSource.js#L324) trying to [access "getUserMedia()" on a string](https://github.com/nextcloud/spreed/blob/43609c705a28cc884b60e8c6189ff66cd308ad5d/src/utils/media/pipeline/MediaDevicesSource.js#L311) failed silently; the error was caught by the rejected handler of the previous promise and [the output track was stopped and removed](https://github.com/nextcloud/spreed/blob/43609c705a28cc884b60e8c6189ff66cd308ad5d/src/utils/media/pipeline/MediaDevicesSource.js#L326-L331).

## How to test

- Add a virtual device with PulseAudio (for example, with `pactl load-module module-echo-cancel`)
- Start a call
- In the device checker, select the virtual device, enable audio and join the call
- Remove the virtual device with PulseAudio (for the example above, with `pactl unload-module module-echo-cancel`)
  - If Firefox is being used the audio will be now unavailable, if Chromium is being used audio will still appear as available, but that is not relevant for the rest of the test
- Open the device settings, but do not touch anything; this will automatically select one of the available audio devices
- Close the device settings
- Add the virtual device with PulseAudio again
- Open the device settings; the PulseAudio device will be automatically selected again
- Close the device settings

### Result with this pull request

Audio is disabled, but it can be enabled again

### Result without this pull request

Audio is not available, so it can not be enabled again
