### PR TITLE
Fix devices not released when got after the dialog was closed

### DIFF
--- a/src/mixins/devices.js
+++ b/src/mixins/devices.js
@@ -126,7 +126,15 @@ export const devices = {
 
 			this.mediaDevicesManager.getUserMedia({ audio: true })
 				.then(stream => {
-					this.setAudioStream(stream)
+					if (!this.initialized) {
+						// The promise was fulfilled once the stream is no
+						// longer needed, so just discard it.
+						stream.getTracks().forEach((track) => {
+							track.stop()
+						})
+					} else {
+						this.setAudioStream(stream)
+					}
 
 					resetPendingGetUserMediaAudioCount()
 				})
@@ -178,7 +186,15 @@ export const devices = {
 
 			this.mediaDevicesManager.getUserMedia({ video: true })
 				.then(stream => {
-					this.setVideoStream(stream)
+					if (!this.initialized) {
+						// The promise was fulfilled once the stream is no
+						// longer needed, so just discard it.
+						stream.getTracks().forEach((track) => {
+							track.stop()
+						})
+					} else {
+						this.setVideoStream(stream)
+					}
 
 					resetPendingGetUserMediaVideoCount()
 				})


### PR DESCRIPTION
Fixes #6630

Requesting a stream is an asynchronous operation, and it may take a while to be fulfilled (for example, if the user needs to grant the browser permission to use the device). When the Talk settings and the device checker dialogs are closed the streams being used are stopped, but this will have no effect if the promises that returns the streams are fulfilled after that. In that case the streams need to be explicitly stopped once finally got.

The steps below refer to an additional scenario besides what is described in #6630.

## How to test

- If they are granted, revoke permanent permissions in the browser so it asks again when audio or video is requested
- Open Talk settings; the browser will ask for permissions, ignore it for now
  - It can be reproduced too with the device checker
- Close Talk settings
- Now grant the permissions

### Result with this pull request

The audio and/or video devices are not active

### Result without this pull request

The audio and/or video devices are active
