### PR TITLE
Use something more stable so we don't toggle the chatIdentifier when …

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -220,12 +220,16 @@ export default {
 			return !!this.$store.getters.findParticipant(this.token, this.$store.getters.getParticipantIdentifier())
 		},
 
+		getAttendeeId() {
+			return this.$store.getters.getAttendeeId()
+		},
+
 		conversation() {
 			return this.$store.getters.conversation(this.token)
 		},
 
 		chatIdentifier() {
-			return this.token + ':' + this.isParticipant + ':' + this.isInLobby + ':' + this.viewId
+			return this.token + ':' + this.getAttendeeId + ':' + this.isInLobby + ':' + this.viewId
 		},
 
 		scrollToBottomAriaLabel() {


### PR DESCRIPTION
…the participant list is reloaded

Adding some logging of the values in https://github.com/nextcloud/spreed/blob/7d61dad0ddf2c1908cbee7b1cd61328ca0291d17/src/components/MessagesList/MessagesList.vue#L255-L260 revealed that it triggered the change/cancel way too often. E.g. everytime the participant list got reloaded `isParticipant` toggles from `true` to `false` and back again.

Before | After
---|---
![Bildschirmfoto von 2021-12-10 08-33-59](https://user-images.githubusercontent.com/213943/145535660-4007a370-cb7e-4e34-935b-808ee5ed3406.png) | ![Bildschirmfoto von 2021-12-10 08-34-39](https://user-images.githubusercontent.com/213943/145535666-508061bf-6f31-4bac-ad38-1d637f9982cf.png)
