### PR TITLE
Fix output track when disabling virtual background

### DIFF
--- a/src/utils/media/pipeline/TrackSourceMixin.js
+++ b/src/utils/media/pipeline/TrackSourceMixin.js
@@ -58,8 +58,10 @@
  * sinks will be automatically updated when those methods are called.
  *
  * Note that ended tracks are automatically removed; the output track does not
- * need to be automatically set to null in that case. However, removing a track
- * does not automatically stop it; that needs to be explicitly done if needed.
+ * need to be automatically set to null in that case. If needed, this can be
+ * prevented by calling "_disableRemoveTrackWhenEnded(track)". However, removing
+ * a track does not automatically stop it; that needs to be explicitly done if
+ * needed.
  */
 export default (function() {
 
@@ -174,6 +176,20 @@ export default (function() {
 	}
 
 	/**
+	 * @param {MediaStreamTrack} track the track to prevent being automatically
+	 *        removed when ended
+	 */
+	function _disableRemoveTrackWhenEnded(track) {
+		const trackIds = Object.keys(this._outputTracks)
+
+		trackIds.forEach(trackId => {
+			if (this._outputTracks[trackId] === track) {
+				this._outputTracks[trackId].removeEventListener('ended', this._removeTrackWhenEndedHandlers[this._outputTracks[trackId].id])
+			}
+		})
+	}
+
+	/**
 	 * @param {MediaStreamTrack} track the ended track to remove
 	 */
 	function _removeTrackWhenEnded(track) {
@@ -225,6 +241,7 @@ export default (function() {
 		this._addOutputTrackSlot = this._addOutputTrackSlot || _addOutputTrackSlot
 		this._removeOutputTrackSlot = this._removeOutputTrackSlot || _removeOutputTrackSlot
 		this._setOutputTrack = this._setOutputTrack || _setOutputTrack
+		this._disableRemoveTrackWhenEnded = this._disableRemoveTrackWhenEnded || _disableRemoveTrackWhenEnded
 		this._removeTrackWhenEnded = this._removeTrackWhenEnded || _removeTrackWhenEnded
 		this._setOutputTrackEnabled = this._setOutputTrackEnabled || _setOutputTrackEnabled
 	}

--- a/src/utils/media/pipeline/VirtualBackground.js
+++ b/src/utils/media/pipeline/VirtualBackground.js
@@ -197,7 +197,9 @@ export default class VirtualBackground extends TrackSinkSource {
 			this._stopEffect()
 
 			// If not enabled the input track is just bypassed to the output.
-			this._setOutputTrack('default', this.getInputTrack())
+			if (this.getOutputTrack() !== this.getInputTrack()) {
+				this._setOutputTrack('default', this.getInputTrack())
+			}
 
 			return
 		}

--- a/src/utils/media/pipeline/VirtualBackground.js
+++ b/src/utils/media/pipeline/VirtualBackground.js
@@ -220,7 +220,7 @@ export default class VirtualBackground extends TrackSinkSource {
 			return
 		}
 
-		if (newTrack === oldTrack && newTrack !== null) {
+		if (newTrack === oldTrack && newTrack !== null && newTrack.enabled) {
 			this._jitsiStreamBackgroundEffect.updateInputStream()
 
 			return
@@ -228,8 +228,8 @@ export default class VirtualBackground extends TrackSinkSource {
 
 		this._stopEffect()
 
-		if (!newTrack) {
-			this._setOutputTrack('default', null)
+		if (!newTrack || !newTrack.enabled) {
+			this._setOutputTrack('default', this.getInputTrack())
 
 			return
 		}

--- a/src/utils/media/pipeline/VirtualBackground.js
+++ b/src/utils/media/pipeline/VirtualBackground.js
@@ -280,6 +280,8 @@ export default class VirtualBackground extends TrackSinkSource {
 
 		this._jitsiStreamBackgroundEffect.stopEffect()
 		this._outputStream.getTracks().forEach(track => {
+			this._disableRemoveTrackWhenEnded(track)
+
 			track.stop()
 		})
 

--- a/src/utils/media/pipeline/VirtualBackground.spec.js
+++ b/src/utils/media/pipeline/VirtualBackground.spec.js
@@ -1,0 +1,207 @@
+/**
+ *
+ * @copyright Copyright (c) 2021, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import VirtualBackground from './VirtualBackground'
+
+/**
+ * Helper function to create MediaStreamTrack mocks with just the attributes and
+ * methods used by VirtualBackground.
+ *
+ * @param {string} id the ID of the track
+ */
+function newMediaStreamTrackMock(id) {
+	/**
+	 * MediaStreamTrackMock constructor.
+	 */
+	function MediaStreamTrackMock() {
+		this._endedEventHandlers = []
+		this.id = id
+		this.enabled = true
+		this.addEventListener = jest.fn((eventName, eventHandler) => {
+			if (eventName !== 'ended') {
+				return
+			}
+
+			this._endedEventHandlers.push(eventHandler)
+		})
+		this.removeEventListener = jest.fn((eventName, eventHandler) => {
+			if (eventName !== 'ended') {
+				return
+			}
+
+			const index = this._endedEventHandlers.indexOf(eventHandler)
+			if (index !== -1) {
+				this._endedEventHandlers.splice(index, 1)
+			}
+		})
+		this.stop = jest.fn(() => {
+			for (let i = 0; i < this._endedEventHandlers.length; i++) {
+				const handler = this._endedEventHandlers[i]
+				handler.apply(handler)
+			}
+		})
+	}
+	return new MediaStreamTrackMock()
+}
+
+describe('VirtualBackground', () => {
+	let virtualBackground
+	let available
+	let effectOutputTrackCount
+	let effectOutputTrack
+
+	beforeAll(() => {
+		// MediaStream is used in VirtualBackground but not implemented in
+		// jsdom, so a stub is needed.
+		window.MediaStream = function() {
+			this.addTrack = jest.fn()
+		}
+
+		jest.spyOn(VirtualBackground.prototype, '_initJitsiStreamBackgroundEffect').mockImplementation(function() {
+			this._jitsiStreamBackgroundEffect = {
+				startEffect: jest.fn((inputStream) => {
+					effectOutputTrackCount++
+					const effectOutputTrackLocal = newMediaStreamTrackMock('output' + effectOutputTrackCount)
+					effectOutputTrack = effectOutputTrackLocal
+
+					return {
+						getVideoTracks: jest.fn(() => {
+							return [effectOutputTrackLocal]
+						}),
+						getTracks: jest.fn(() => {
+							return [effectOutputTrackLocal]
+						}),
+					}
+				}),
+				updateInputStream: jest.fn(() => {
+				}),
+				stopEffect: jest.fn(() => {
+				}),
+			}
+		})
+		jest.spyOn(VirtualBackground.prototype, 'isAvailable').mockImplementation(function() {
+			return available
+		})
+	})
+
+	beforeEach(() => {
+		available = true
+		effectOutputTrackCount = 0
+		effectOutputTrack = undefined
+
+		virtualBackground = new VirtualBackground()
+
+		jest.spyOn(virtualBackground, '_setOutputTrack')
+	})
+
+	afterAll(() => {
+		jest.restoreAllMocks()
+	})
+
+	test('is enabled by default', () => {
+		expect(virtualBackground.isEnabled()).toBe(true)
+	})
+
+	describe('enable/disable virtual background', () => {
+		test('is disabled if enabled when not available', () => {
+			available = false
+			virtualBackground.setEnabled(true)
+
+			expect(virtualBackground.isEnabled()).toBe(false)
+		})
+	})
+
+	describe('set input track', () => {
+		test('sets effect output track as its output track when setting input track', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+
+			virtualBackground._setInputTrack('default', inputTrack)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', effectOutputTrack)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
+		})
+
+		test('sets input track as its output track if not available when setting input track', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+
+			available = false
+			virtualBackground._setInputTrack('default', inputTrack)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', inputTrack)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
+		})
+
+		test('sets input track as its output track if not enabled when setting input track', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+
+			virtualBackground.setEnabled(false)
+			virtualBackground._setInputTrack('default', inputTrack)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(2)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', null)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(2, 'default', inputTrack)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
+		})
+	})
+
+	describe('enable/disable virtual background after setting input track', () => {
+		test('sets effect output track as its output track if enabled', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+
+			virtualBackground.setEnabled(false)
+			virtualBackground._setInputTrack('default', inputTrack)
+			virtualBackground.setEnabled(true)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(3)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', null)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(2, 'default', inputTrack)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(3, 'default', effectOutputTrack)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
+			expect(effectOutputTrack.stop).toHaveBeenCalledTimes(0)
+		})
+	})
+
+	describe('update input track', () => {
+		test('updates effect output track when setting same input track again', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+
+			virtualBackground._setInputTrack('default', inputTrack)
+			virtualBackground._setInputTrack('default', inputTrack)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', effectOutputTrack)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
+			expect(effectOutputTrack.stop).toHaveBeenCalledTimes(0)
+		})
+	})
+})

--- a/src/utils/media/pipeline/VirtualBackground.spec.js
+++ b/src/utils/media/pipeline/VirtualBackground.spec.js
@@ -188,6 +188,19 @@ describe('VirtualBackground', () => {
 			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
 			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
 		})
+
+		test('sets input track as its output track if input track is not enabled when setting input track', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+
+			inputTrack.enabled = false
+			virtualBackground._setInputTrack('default', inputTrack)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', inputTrack)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
+		})
 	})
 
 	describe('enable/disable virtual background after setting input track', () => {
@@ -208,6 +221,41 @@ describe('VirtualBackground', () => {
 		})
 	})
 
+	describe('enable/disable input track', () => {
+		test('sets effect output track as its output track if input track is enabled', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+
+			inputTrack.enabled = false
+			virtualBackground._setInputTrack('default', inputTrack)
+			virtualBackground._setInputTrackEnabled('default', true)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(2)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', inputTrack)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(2, 'default', effectOutputTrack)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
+			expect(effectOutputTrack.stop).toHaveBeenCalledTimes(0)
+		})
+	})
+
+	describe('remove input track', () => {
+		test('removes output track when removing disabled input track', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+
+			inputTrack.enabled = false
+			virtualBackground._setInputTrack('default', inputTrack)
+			virtualBackground._setInputTrack('default', null)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(2)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', inputTrack)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(2, 'default', null)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
+		})
+	})
+
 	describe('update input track', () => {
 		test('updates effect output track when setting same input track again', () => {
 			const inputTrack = newMediaStreamTrackMock('input')
@@ -219,6 +267,38 @@ describe('VirtualBackground', () => {
 			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', effectOutputTrack)
 			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(1)
 			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
+			expect(effectOutputTrack.stop).toHaveBeenCalledTimes(0)
+		})
+
+		test('sets input track as its output track when setting same disabled input track again', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+
+			inputTrack.enabled = false
+			virtualBackground._setInputTrack('default', inputTrack)
+			virtualBackground._setInputTrack('default', inputTrack)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(2)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', inputTrack)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(2, 'default', inputTrack)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
+		})
+
+		test('sets effect output track as its output track when setting another now enabled input track', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+			const inputTrack2 = newMediaStreamTrackMock('input2')
+
+			inputTrack.enabled = false
+			virtualBackground._setInputTrack('default', inputTrack)
+			virtualBackground._setInputTrack('default', inputTrack2)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(2)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', inputTrack)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(2, 'default', effectOutputTrack)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
 			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
 			expect(effectOutputTrack.stop).toHaveBeenCalledTimes(0)
 		})

--- a/src/utils/media/pipeline/VirtualBackground.spec.js
+++ b/src/utils/media/pipeline/VirtualBackground.spec.js
@@ -204,6 +204,21 @@ describe('VirtualBackground', () => {
 	})
 
 	describe('enable/disable virtual background after setting input track', () => {
+		test('sets input track as its output track if disabled', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+
+			virtualBackground._setInputTrack('default', inputTrack)
+			virtualBackground.setEnabled(false)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(2)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', effectOutputTrack)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(2, 'default', inputTrack)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(1)
+			expect(effectOutputTrack.stop).toHaveBeenCalledTimes(1)
+		})
+
 		test('sets effect output track as its output track if enabled', () => {
 			const inputTrack = newMediaStreamTrackMock('input')
 
@@ -222,6 +237,21 @@ describe('VirtualBackground', () => {
 	})
 
 	describe('enable/disable input track', () => {
+		test('sets input track as its output track if input track is disabled', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+
+			virtualBackground._setInputTrack('default', inputTrack)
+			virtualBackground._setInputTrackEnabled('default', false)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(2)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', effectOutputTrack)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(2, 'default', inputTrack)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(1)
+			expect(effectOutputTrack.stop).toHaveBeenCalledTimes(1)
+		})
+
 		test('sets effect output track as its output track if input track is enabled', () => {
 			const inputTrack = newMediaStreamTrackMock('input')
 
@@ -240,6 +270,21 @@ describe('VirtualBackground', () => {
 	})
 
 	describe('remove input track', () => {
+		test('removes output track when removing input track', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+
+			virtualBackground._setInputTrack('default', inputTrack)
+			virtualBackground._setInputTrack('default', null)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(2)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', effectOutputTrack)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(2, 'default', null)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(1)
+			expect(effectOutputTrack.stop).toHaveBeenCalledTimes(1)
+		})
+
 		test('removes output track when removing disabled input track', () => {
 			const inputTrack = newMediaStreamTrackMock('input')
 
@@ -284,6 +329,42 @@ describe('VirtualBackground', () => {
 			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(0)
 			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
 			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
+		})
+
+		test('sets new effect output track as its output track when setting another input track', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+			const inputTrack2 = newMediaStreamTrackMock('input2')
+
+			virtualBackground._setInputTrack('default', inputTrack)
+			const originalEffectOutputTrack = effectOutputTrack
+			virtualBackground._setInputTrack('default', inputTrack2)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(2)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', originalEffectOutputTrack)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(2, 'default', effectOutputTrack)
+			expect(effectOutputTrack).not.toBe(originalEffectOutputTrack)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(2)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(1)
+			expect(originalEffectOutputTrack.stop).toHaveBeenCalledTimes(1)
+			expect(effectOutputTrack.stop).toHaveBeenCalledTimes(0)
+		})
+
+		test('sets input track as its output track when setting another now disabled input track', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+			const inputTrack2 = newMediaStreamTrackMock('input2')
+
+			virtualBackground._setInputTrack('default', inputTrack)
+			inputTrack2.enabled = false
+			virtualBackground._setInputTrack('default', inputTrack2)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(2)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', effectOutputTrack)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(2, 'default', inputTrack2)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(1)
+			expect(effectOutputTrack.stop).toHaveBeenCalledTimes(1)
 		})
 
 		test('sets effect output track as its output track when setting another now enabled input track', () => {

--- a/src/utils/media/pipeline/VirtualBackground.spec.js
+++ b/src/utils/media/pipeline/VirtualBackground.spec.js
@@ -121,6 +121,27 @@ describe('VirtualBackground', () => {
 	})
 
 	describe('enable/disable virtual background', () => {
+		test('does nothing if disabled when there is no input track', () => {
+			virtualBackground.setEnabled(false)
+
+			expect(virtualBackground.isEnabled()).toBe(false)
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
+		})
+
+		test('does nothing if enabled when there is no input track', () => {
+			virtualBackground.setEnabled(false)
+			virtualBackground.setEnabled(true)
+
+			expect(virtualBackground.isEnabled()).toBe(true)
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
+		})
+
 		test('is disabled if enabled when not available', () => {
 			available = false
 			virtualBackground.setEnabled(true)
@@ -161,9 +182,8 @@ describe('VirtualBackground', () => {
 			virtualBackground.setEnabled(false)
 			virtualBackground._setInputTrack('default', inputTrack)
 
-			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(2)
-			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', null)
-			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(2, 'default', inputTrack)
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', inputTrack)
 			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(0)
 			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
 			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
@@ -178,10 +198,9 @@ describe('VirtualBackground', () => {
 			virtualBackground._setInputTrack('default', inputTrack)
 			virtualBackground.setEnabled(true)
 
-			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(3)
-			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', null)
-			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(2, 'default', inputTrack)
-			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(3, 'default', effectOutputTrack)
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(2)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', inputTrack)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(2, 'default', effectOutputTrack)
 			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(1)
 			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
 			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)


### PR DESCRIPTION
Fixes #6650

When an output track was stopped it was automatically removed. When the virtual background is disabled the input track is bypassed to the output, but first the effect is stopped. This caused a null track to be temporary set as the output track before setting the input track which, in turn, caused different issues in other parts of the code (like causing the video to hang in the device checker due to the stream being removed, disabling the video during calls when disabling the background blur due to the null stream being handled as "no video", or reconnecting when disabling the video during calls if background blur was enabled due to a loop in the event handling which caused the events to be handled in the wrong order).

To prevent all that now, when the virtual background is disabled, its input track is immediately bypassed to its output, without setting a null track first. Besides that this pull request also includes fixes for other wrong behaviours (although they were not currently causing any bug as far as I know).

Besides the scenario described in #6650 below there are other scenarios also fixed by this pull request.

## How to test (scenario 2)

- Start a call
- In a private window, join the call with video and background blur enabled
- Disable background blur

### Result with this pull request

Background blur is disabled

### Result without this pull request

Video is disabled



## How to test (scenario 3)

- Setup the HPB
- Start a call
- In a private window, join the call with video and background blur enabled
- Disable video

### Result with this pull request

Video is disabled

### Result without this pull request

The participant is reconnected; it is not possible to enable video again
