### PR TITLE
Fix unsubscribing listener for status updates

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -220,16 +220,12 @@ export default {
 			return !!this.$store.getters.findParticipant(this.token, this.$store.getters.getParticipantIdentifier())
 		},
 
-		getAttendeeId() {
-			return this.$store.getters.getAttendeeId()
-		},
-
 		conversation() {
 			return this.$store.getters.conversation(this.token)
 		},
 
 		chatIdentifier() {
-			return this.token + ':' + this.getAttendeeId + ':' + this.isInLobby + ':' + this.viewId
+			return this.token + ':' + this.isParticipant + ':' + this.isInLobby + ':' + this.viewId
 		},
 
 		scrollToBottomAriaLabel() {

--- a/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
+++ b/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
@@ -90,7 +90,7 @@ export default {
 		subscribe('user_status:status.updated', this.userStatusUpdated)
 	},
 
-	beforeDestroyed() {
+	beforeDestroy() {
 		unsubscribe('user_status:status.updated', this.userStatusUpdated)
 	},
 

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -266,11 +266,11 @@ export default {
 				const { request, cancel } = CancelableRequest(fetchParticipants)
 				this.cancelGetParticipants = cancel
 				const participants = await request(token)
-				await this.$store.dispatch('purgeParticipantsStore', token)
+				this.$store.dispatch('purgeParticipantsStore', token)
 
 				const hasUserStatuses = !!participants.headers['x-nextcloud-has-user-statuses']
-				for (const participant of participants.data.ocs.data) {
-					await this.$store.dispatch('addParticipant', {
+				participants.data.ocs.data.forEach(participant => {
+					this.$store.dispatch('addParticipant', {
 						token,
 						participant,
 					})
@@ -290,7 +290,7 @@ export default {
 							userId: participant.actorId,
 						})
 					}
-				}
+				})
 				this.participantsInitialised = true
 			} catch (exception) {
 				if (!Axios.isCancel(exception)) {


### PR DESCRIPTION
Reverts #6686
Reverts #6641

Please refer to the commit messages for details.

## How to test

- Create a public conversation and add user A
- Create a one to one conversation with user B
- Create a public conversation and add user B
- In a private window, log in as user A
- In another browser, log in as user B
- In the original window, open the main Talk view (_apps/spreed/_)
- Join the first public conversation
- Join the one to one conversation
- Join the second public conversation again
- Join the one to one conversation
- Join the first public conversation

### Result with this pull request

There are no errors

### Result without this pull request

`Participant not found in conversation XXX` is shown in the console, where XXX is the one to one conversation token and the participant is user A
