### PR TITLE
Fix enabling background blur when input track is disabled

### DIFF
--- a/src/utils/media/pipeline/VirtualBackground.js
+++ b/src/utils/media/pipeline/VirtualBackground.js
@@ -204,7 +204,7 @@ export default class VirtualBackground extends TrackSinkSource {
 			return
 		}
 
-		if (!this.getInputTrack()) {
+		if (!this.getInputTrack() || !this.getInputTrack().enabled) {
 			return
 		}
 

--- a/src/utils/media/pipeline/VirtualBackground.spec.js
+++ b/src/utils/media/pipeline/VirtualBackground.spec.js
@@ -219,6 +219,20 @@ describe('VirtualBackground', () => {
 			expect(effectOutputTrack.stop).toHaveBeenCalledTimes(1)
 		})
 
+		test('does nothing if disabled when input track is not enabled', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+
+			inputTrack.enabled = false
+			virtualBackground._setInputTrack('default', inputTrack)
+			virtualBackground.setEnabled(false)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', inputTrack)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
+		})
+
 		test('sets effect output track as its output track if enabled', () => {
 			const inputTrack = newMediaStreamTrackMock('input')
 
@@ -233,6 +247,21 @@ describe('VirtualBackground', () => {
 			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
 			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
 			expect(effectOutputTrack.stop).toHaveBeenCalledTimes(0)
+		})
+
+		test('does nothing if enabled when input track is not enabled', () => {
+			const inputTrack = newMediaStreamTrackMock('input')
+
+			virtualBackground.setEnabled(false)
+			inputTrack.enabled = false
+			virtualBackground._setInputTrack('default', inputTrack)
+			virtualBackground.setEnabled(true)
+
+			expect(virtualBackground._setOutputTrack).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._setOutputTrack).toHaveBeenNthCalledWith(1, 'default', inputTrack)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.startEffect).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.updateInputStream).toHaveBeenCalledTimes(0)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.stopEffect).toHaveBeenCalledTimes(0)
 		})
 	})
 


### PR DESCRIPTION
Fixes #6702

When the background blur was enabled and the input track was disabled the blur effect was started. Starting the effect caused the output track to be enabled (which was just a blurred black stream), and this caused* the local video to be enabled. Now the effect is not started and the output track is not modified if the background blur is enabled when the input track is disabled.

*Things were actually a bit more fun. When participants join a call it is not possible to know when those participants are ready to receive messages, so the current media state is sent several times with an increased delay between each message. This is done by [emitting `videoOn` or `videoOff` depending on whether the video is enabled or not](https://github.com/nextcloud/spreed/blob/362b956001c2e20fa128a503f7c3e5f1d6680912/src/utils/webrtc/webrtc.js#L202-L206), and whether the video is enabled or not is checked [based on the enabled state of the video output track](https://github.com/nextcloud/spreed/blob/7d9867808313f68cba416ffa9d3a40ba5aee2287/src/utils/webrtc/simplewebrtc/localmedia.js#L346-L367). Emitting `videoOn` notifies the remote participants that the video is enabled, and it also updates the enabled state locally. Due to this, enabling the background blur with a disabled input track enabled the video... only once the current media state was sent again to the other participants.

Not only that, but after the video was enabled the next sending of the current media state disabled it again :-P The reason is that, after the video is enabled for the first time, the constraints are automatically applied. Applying the constraints updated the background blur which, as the input track was disabled, now properly bypassed the input track to the output track, and thus the output track was now disabled as it should. Therefore, when the current media state was sent again the output track was now disabled, so the video got disabled again.

In short, to easily reproduce the original bug the background blur had to be enabled around ten seconds after a participant joined the call (and a few seconds later the video was automatically disabled again); if the background blur was enabled more than thirty seconds after a participant joined the call the problem was not visible :shrug:
