### PR TITLE
l10n: Change "Video" to "Camera"

### DIFF
--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -101,7 +101,7 @@
 				<div>
 					<dt><kbd>V</kbd></dt>
 					<dd class="shortcut-description">
-						{{ t('spreed', 'Video on and off') }}
+						{{ t('spreed', 'Camera on and off') }}
 					</dd>
 				</div>
 				<div>


### PR DESCRIPTION
Changed the word "Video" to "Camera" for the keyboard shortcut in the application options.

![obraz](https://user-images.githubusercontent.com/47037905/146817576-4ae8ba28-9206-4495-aa49-5b8e342d051b.png)


Signed-off-by: Valdnet <47037905+Valdnet@users.noreply.github.com>