### PR TITLE
Api reactions to message

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -178,6 +178,43 @@ trigger:
 
 ---
 kind: pipeline
+name: int-sqlite-reaction
+
+steps:
+  - name: integration-reaction
+    image: ghcr.io/nextcloud/continuous-integration-php8.0:latest
+    environment:
+      APP_NAME: spreed
+      CORE_BRANCH: master
+      GUESTS_BRANCH: master
+      DATABASEHOST: sqlite
+    commands:
+      - bash tests/drone-run-integration-tests.sh || exit 0
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
+      - cd ../server
+      - git clone --depth 1 -b "$GUESTS_BRANCH" https://github.com/nextcloud/guests apps/guests
+      - ./occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
+
+      # Run integration tests
+      - cd tests/integration/
+      - bash run.sh features/reaction
+
+services:
+  - name: cache
+    image: ghcr.io/nextcloud/continuous-integration-redis:latest
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+    - pull_request
+    - push
+
+---
+kind: pipeline
 name: int-sqlite-sharing
 
 steps:
@@ -452,6 +489,53 @@ steps:
       # Run integration tests
       - cd tests/integration/
       - bash run.sh features/conversation-2
+
+services:
+  - name: cache
+    image: ghcr.io/nextcloud/continuous-integration-redis:latest
+  - name: mysql
+    image: ghcr.io/nextcloud/continuous-integration-mariadb-10.4:10.4
+    environment:
+      MYSQL_ROOT_PASSWORD: owncloud
+      MYSQL_USER: oc_autotest
+      MYSQL_PASSWORD: owncloud
+      MYSQL_DATABASE: oc_autotest
+    command: [ "--innodb_large_prefix=true", "--innodb_file_format=barracuda", "--innodb_file_per_table=true" ]
+    tmpfs:
+      - /var/lib/mysql
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+#    - pull_request
+    - push
+
+---
+kind: pipeline
+name: int-mysql-reaction
+
+steps:
+  - name: integration-reaction
+    image: ghcr.io/nextcloud/continuous-integration-php8.0:latest
+    environment:
+      APP_NAME: spreed
+      CORE_BRANCH: master
+      GUESTS_BRANCH: master
+      DATABASEHOST: mysql
+    commands:
+      - bash tests/drone-run-integration-tests.sh || exit 0
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
+      - cd ../server
+      - git clone --depth 1 -b "$GUESTS_BRANCH" https://github.com/nextcloud/guests apps/guests
+      - ./occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
+
+      # Run integration tests
+      - cd tests/integration/
+      - bash run.sh features/reaction
 
 services:
   - name: cache
@@ -767,6 +851,52 @@ steps:
       # Run integration tests
       - cd tests/integration/
       - bash run.sh features/conversation-2
+
+services:
+  - name: cache
+    image: ghcr.io/nextcloud/continuous-integration-redis:latest
+  - name: pgsql
+    image: ghcr.io/nextcloud/continuous-integration-postgres-13:postgres-13
+    environment:
+      POSTGRES_USER: oc_autotest
+      POSTGRES_DB: oc_autotest_dummy
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_PASSWORD:
+    tmpfs:
+      - /var/lib/postgresql/data
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+#    - pull_request
+    - push
+
+---
+kind: pipeline
+name: int-pgsql-reaction
+
+steps:
+  - name: integration-reaction
+    image: ghcr.io/nextcloud/continuous-integration-php8.0:latest
+    environment:
+      APP_NAME: spreed
+      CORE_BRANCH: master
+      GUESTS_BRANCH: master
+      DATABASEHOST: pgsql
+    commands:
+      - bash tests/drone-run-integration-tests.sh || exit 0
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
+      - cd ../server
+      - git clone --depth 1 -b "$GUESTS_BRANCH" https://github.com/nextcloud/guests apps/guests
+      - ./occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
+
+      # Run integration tests
+      - cd tests/integration/
+      - bash run.sh features/reaction
 
 services:
   - name: cache

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -36,6 +36,7 @@ return array_merge_recursive(
 	include(__DIR__ . '/routes/routesMatterbridgeSettingsController.php'),
 	include(__DIR__ . '/routes/routesPageController.php'),
 	include(__DIR__ . '/routes/routesPublicShareAuthController.php'),
+	include(__DIR__ . '/routes/routesReactionController.php'),
 	include(__DIR__ . '/routes/routesRoomController.php'),
 	include(__DIR__ . '/routes/routesSettingsController.php'),
 	include(__DIR__ . '/routes/routesSignalingController.php'),

--- a/appinfo/routes/routesReactionController.php
+++ b/appinfo/routes/routesReactionController.php
@@ -33,5 +33,9 @@ return [
 			'apiVersion' => 'v1',
 			'token' => '^[a-z0-9]{4,30}$',
 		]],
+		['name' => 'Reaction#getReactions', 'url' => '/api/{apiVersion}/reaction/{token}/{messageId}', 'verb' => 'GET', 'requirements' => [
+			'apiVersion' => 'v1',
+			'token' => '^[a-z0-9]{4,30}$',
+		]],
 	],
 ];

--- a/appinfo/routes/routesReactionController.php
+++ b/appinfo/routes/routesReactionController.php
@@ -29,5 +29,9 @@ return [
 			'apiVersion' => 'v1',
 			'token' => '^[a-z0-9]{4,30}$',
 		]],
+		['name' => 'Reaction#delete', 'url' => '/api/{apiVersion}/reaction/{token}/{messageId}', 'verb' => 'DELETE', 'requirements' => [
+			'apiVersion' => 'v1',
+			'token' => '^[a-z0-9]{4,30}$',
+		]],
 	],
 ];

--- a/appinfo/routes/routesReactionController.php
+++ b/appinfo/routes/routesReactionController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Vitor Mattos <vitor@php.rio>
+ *
+ * @author Vitor Mattos <vitor@php.rio>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+return [
+	'ocs' => [
+		['name' => 'Reaction#react', 'url' => '/api/{apiVersion}/reaction/{token}/{messageId}', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v1',
+			'token' => '^[a-z0-9]{4,30}$',
+		]],
+	],
+];

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -89,3 +89,4 @@ title: Capabilities
 
 ## 14
 * `chat-unread` - Whether the API to mark a conversation as unread is available
+* `reactions` - Api reactions to chat message

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -50,6 +50,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         `message` | string | Message string with placeholders (see [Rich Object String](https://github.com/nextcloud/server/issues/1706))
         `messageParameters` | array | Message parameters for `message` (see [Rich Object String](https://github.com/nextcloud/server/issues/1706))
         `parent` | array | **Optional:** See `Parent data` below
+        `reactions` | array | **Optional:** An array map with relation between reaction emoji and total of reactions with this emoji
 
 #### Parent data
 
@@ -324,3 +325,4 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 * `matterbridge_config_removed` - {actor} removed the Matterbridge configuration
 * `matterbridge_config_enabled` - {actor} started Matterbridge
 * `matterbridge_config_disabled` - {actor} stopped Matterbridge
+

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -50,7 +50,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         `message` | string | Message string with placeholders (see [Rich Object String](https://github.com/nextcloud/server/issues/1706))
         `messageParameters` | array | Message parameters for `message` (see [Rich Object String](https://github.com/nextcloud/server/issues/1706))
         `parent` | array | **Optional:** See `Parent data` below
-        `reactions` | array | **Optional:** An array map with relation between reaction emoji and total of reactions with this emoji
+        `reactions` | array | **Optional:** An array map with relation between reaction emoji and total count of reactions with this emoji
 
 #### Parent data
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@
 * [Participant API](participant.md)
 * [Call API](call.md)
 * [Chat API](chat.md)
+* [Reaction API](reaction.md)
 * [Webinar API](webinar.md)
 * [Internal Signaling API](internal-signaling.md)
 * [Standalone Signaling API](https://nextcloud-spreed-signaling.readthedocs.io/en/latest/)

--- a/docs/reaction.md
+++ b/docs/reaction.md
@@ -22,7 +22,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 ## Delete a reaction
 
 * Method: `DELETE`
-* Endpoint: `/chat/{token}/{messageId}`
+* Endpoint: `/reaction/{token}/{messageId}`
 * Data:
 
     field | type | Description

--- a/docs/reaction.md
+++ b/docs/reaction.md
@@ -17,7 +17,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
     - Status code:
         + `200 OK` Reaction already exists
         + `201 Created`
-        + `400 Bad Request` In case of any other error
+        + `400 Bad Request` In case of no reaction support, message out of reactions context or any other error
         + `404 Not Found` When the conversation or message to react could not be found for the participant
         + `409 Conflict` User already did this reaction to this message
 
@@ -35,7 +35,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 * Response:
     - Status code:
         + `201 Created`
-        + `400 Bad Request` In case of any other error
+        + `400 Bad Request` In case of no reaction support, message out of reactions context or any other error
         + `404 Not Found` When the conversation or message to react or reaction could not be found for the participant
 
 ## Retrieve reactions of a message by type
@@ -52,6 +52,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 * Response:
     - Status code:
         + `200 OK`
+        + `400 Bad Request` In case of no reaction support, message out of reactions context or any other error
         + `404 Not Found` When the conversation or message to react could not be found for the participant
 
     - Data:

--- a/docs/reaction.md
+++ b/docs/reaction.md
@@ -5,7 +5,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 ## React to a message
 
 * Method: `POST`
-* Endpoint: `/chat/{token}/{messageId}`
+* Endpoint: `/reaction/{token}/{messageId}`
 * Data:
 
     field | type | Description

--- a/docs/reaction.md
+++ b/docs/reaction.md
@@ -14,6 +14,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 
 * Response:
     - Status code:
+        + `200 OK` Reaction already exists
         + `201 Created`
         + `400 Bad Request` In case of any other error
         + `404 Not Found` When the conversation or message to react could not be found for the participant

--- a/docs/reaction.md
+++ b/docs/reaction.md
@@ -38,7 +38,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 ## Retrieve reactions of a message by type
 
 * Method: `GET`
-* Endpoint: `/chat/{token}/{messageId}/?reaction=`
+* Endpoint: `/reaction/{token}/{messageId}`
 * Data:
 
     field | type | Description

--- a/docs/reaction.md
+++ b/docs/reaction.md
@@ -18,3 +18,19 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         + `400 Bad Request` In case of any other error
         + `404 Not Found` When the conversation or message to react could not be found for the participant
         + `409 Conflict` User already did this reaction to this message
+
+## Delete a reaction
+
+* Method: `DELETE`
+* Endpoint: `/chat/{token}/{messageId}`
+* Data:
+
+    field | type | Description
+    ---|---|---
+    `reaction` | string | the reaction emoji
+
+* Response:
+    - Status code:
+        + `201 Created`
+        + `400 Bad Request` In case of any other error
+        + `404 Not Found` When the conversation or message to react or reaction could not be found for the participant

--- a/docs/reaction.md
+++ b/docs/reaction.md
@@ -4,6 +4,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 
 ## React to a message
 
+* Required capability: `reactions`
 * Method: `POST`
 * Endpoint: `/reaction/{token}/{messageId}`
 * Data:
@@ -22,6 +23,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 
 ## Delete a reaction
 
+* Required capability: `reactions`
 * Method: `DELETE`
 * Endpoint: `/reaction/{token}/{messageId}`
 * Data:
@@ -38,6 +40,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 
 ## Retrieve reactions of a message by type
 
+* Required capability: `reactions`
 * Method: `GET`
 * Endpoint: `/reaction/{token}/{messageId}`
 * Data:
@@ -57,6 +60,6 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         field | type | Description
         ---|---|---
         `actorType` | string | `guests` or `users`
-        `actorId` | string | User id of the reaction author
+        `actorId` | string | Actor id of the reacting participant
         `actorDisplayName` | string | Display name of the reaction author
         `timestamp` | int | Timestamp in seconds and UTC time zone

--- a/docs/reaction.md
+++ b/docs/reaction.md
@@ -1,0 +1,20 @@
+# Reaction API
+
+Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
+
+## React to a message
+
+* Method: `POST`
+* Endpoint: `/chat/{token}/{messageId}`
+* Data:
+
+    field | type | Description
+    ---|---|---
+    `reaction` | string | the reaction emoji
+
+* Response:
+    - Status code:
+        + `201 Created`
+        + `400 Bad Request` In case of any other error
+        + `404 Not Found` When the conversation or message to react could not be found for the participant
+        + `409 Conflict` User already did this reaction to this message

--- a/docs/reaction.md
+++ b/docs/reaction.md
@@ -34,3 +34,28 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
         + `201 Created`
         + `400 Bad Request` In case of any other error
         + `404 Not Found` When the conversation or message to react or reaction could not be found for the participant
+
+## Retrieve reactions of a message by type
+
+* Method: `GET`
+* Endpoint: `/chat/{token}/{messageId}/?reaction=`
+* Data:
+
+    field | type | Description
+    ---|---|---
+    `reaction` | string | **Optional:** the reaction emoji
+
+* Response:
+    - Status code:
+        + `200 OK`
+        + `404 Not Found` When the conversation or message to react could not be found for the participant
+
+    - Data:
+        Array with data of reactions:
+
+        field | type | Description
+        ---|---|---
+        `actorType` | string | `guests` or `users`
+        `actorId` | string | User id of the reaction author
+        `actorDisplayName` | string | Display name of the reaction author
+        `timestamp` | int | Timestamp in seconds and UTC time zone

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -27,6 +27,7 @@ namespace OCA\Talk;
 
 use OCA\Talk\Chat\ChatManager;
 use OCP\Capabilities\IPublicCapability;
+use OCP\Comments\ICommentsManager;
 use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -37,14 +38,18 @@ class Capabilities implements IPublicCapability {
 	protected $serverConfig;
 	/** @var Config */
 	protected $talkConfig;
+	/** @var ICommentsManager */
+	protected $commentsManager;
 	/** @var IUserSession */
 	protected $userSession;
 
 	public function __construct(IConfig $serverConfig,
 								Config $talkConfig,
+								ICommentsManager $commentsManager,
 								IUserSession $userSession) {
 		$this->serverConfig = $serverConfig;
 		$this->talkConfig = $talkConfig;
+		$this->commentsManager = $commentsManager;
 		$this->userSession = $userSession;
 	}
 
@@ -114,6 +119,10 @@ class Capabilities implements IPublicCapability {
 				],
 			],
 		];
+
+		if ($this->commentsManager->supportReactions()) {
+			$capabilities['features'][] = 'reactions';
+		}
 
 		if ($user instanceof IUser) {
 			$capabilities['config']['attachments']['folder'] = $this->talkConfig->getAttachmentFolder($user->getUID());

--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -200,10 +200,11 @@ class Notifier {
 	 * @param Room $chat
 	 * @param IComment $comment
 	 * @param IComment $replyTo
+	 * @param string $subject
 	 * @return array[] Actor that was replied to
 	 * @psalm-return array<int, array{id: string, type: string}>
 	 */
-	public function notifyReplyToAuthor(Room $chat, IComment $comment, IComment $replyTo): array {
+	public function notifyReplyToAuthor(Room $chat, IComment $comment, IComment $replyTo, string $subject = 'reply'): array {
 		if ($replyTo->getActorType() !== Attendee::ACTOR_USERS) {
 			// No reply notification when the replyTo-author was not a user
 			return [];
@@ -213,7 +214,7 @@ class Notifier {
 			return [];
 		}
 
-		$notification = $this->createNotification($chat, $comment, 'reply');
+		$notification = $this->createNotification($chat, $comment, $subject);
 		$notification->setUser($replyTo->getActorId());
 		$this->notificationManager->notify($notification);
 
@@ -263,6 +264,24 @@ class Notifier {
 				$notification->setUser($participant->getAttendee()->getActorId());
 				$this->notificationManager->notify($notification);
 			}
+		}
+	}
+
+	public function notifyReacted(Room $chat, IComment $comment, $authorId): void {
+		if ($comment->getActorType() !== Attendee::ACTOR_USERS || $comment->getActorId() === $authorId) {
+			return;
+		}
+
+		$defaultGroupNotification = $this->getDefaultGroupNotification();
+
+		$isOneToOne = $defaultGroupNotification === Participant::NOTIFY_DEFAULT
+			&& $chat->getType() === Room::TYPE_ONE_TO_ONE;
+		$isAlways = $defaultGroupNotification === Participant::NOTIFY_ALWAYS;
+
+		if ($isOneToOne || $isAlways) {
+			$notification = $this->createNotification($chat, $comment, 'reaction');
+			$notification->setUser($comment->getActorId());
+			$this->notificationManager->notify($notification);
 		}
 	}
 

--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -274,11 +274,11 @@ class Notifier {
 
 		$defaultGroupNotification = $this->getDefaultGroupNotification();
 
-		$isOneToOne = $defaultGroupNotification === Participant::NOTIFY_DEFAULT
+		$notifyOneToOne = $defaultGroupNotification === Participant::NOTIFY_DEFAULT
 			&& $chat->getType() === Room::TYPE_ONE_TO_ONE;
-		$isAlways = $defaultGroupNotification === Participant::NOTIFY_ALWAYS;
+		$notifyAlways = $defaultGroupNotification === Participant::NOTIFY_ALWAYS;
 
-		if ($isOneToOne || $isAlways) {
+		if ($notifyOneToOne || $notifyAlways) {
 			$notification = $this->createNotification($chat, $comment, 'reaction');
 			$notification->setUser($comment->getActorId());
 			$this->notificationManager->notify($notification);

--- a/lib/Chat/Parser/Listener.php
+++ b/lib/Chat/Parser/Listener.php
@@ -100,7 +100,7 @@ class Listener {
 		$dispatcher->addListener(MessageParser::EVENT_MESSAGE_PARSE, static function (ChatMessageEvent $event) {
 			$chatMessage = $event->getMessage();
 
-			if ($chatMessage->getMessageType() !== 'reaction') {
+			if ($chatMessage->getMessageType() !== 'reaction' && $chatMessage->getMessageType() !== 'reaction_deleted') {
 				return;
 			}
 

--- a/lib/Chat/Parser/Listener.php
+++ b/lib/Chat/Parser/Listener.php
@@ -100,6 +100,18 @@ class Listener {
 		$dispatcher->addListener(MessageParser::EVENT_MESSAGE_PARSE, static function (ChatMessageEvent $event) {
 			$chatMessage = $event->getMessage();
 
+			if ($chatMessage->getMessageType() !== 'reaction') {
+				return;
+			}
+
+			/** @var ReactionParser $parser */
+			$parser = \OC::$server->get(ReactionParser::class);
+			$parser->parseMessage($chatMessage);
+		});
+
+		$dispatcher->addListener(MessageParser::EVENT_MESSAGE_PARSE, static function (ChatMessageEvent $event) {
+			$chatMessage = $event->getMessage();
+
 			if ($chatMessage->getMessageType() !== 'comment_deleted') {
 				return;
 			}

--- a/lib/Chat/Parser/ReactionParser.php
+++ b/lib/Chat/Parser/ReactionParser.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Vitor Mattos <vitor@php.rio>
+ *
+ * @author Vitor Mattos <vitor@php.rio>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Chat\Parser;
+
+use OCA\Talk\Model\Message;
+
+class ReactionParser {
+	/**
+	 * @param Message $message
+	 * @throws \OutOfBoundsException
+	 */
+	public function parseMessage(Message $message): void {
+		$comment = $message->getComment();
+		if (!in_array($comment->getVerb(), ['reaction'])) {
+			throw new \OutOfBoundsException('Not a reaction');
+		}
+		$message->setMessageType('system');
+		$message->setMessage($message->getMessage(), [], $comment->getVerb());
+	}
+}

--- a/lib/Chat/Parser/ReactionParser.php
+++ b/lib/Chat/Parser/ReactionParser.php
@@ -26,18 +26,27 @@ declare(strict_types=1);
 namespace OCA\Talk\Chat\Parser;
 
 use OCA\Talk\Model\Message;
+use OCP\IL10N;
 
 class ReactionParser {
+	/** @var IL10N|null */
+	private $l;
 	/**
 	 * @param Message $message
 	 * @throws \OutOfBoundsException
 	 */
 	public function parseMessage(Message $message): void {
 		$comment = $message->getComment();
-		if (!in_array($comment->getVerb(), ['reaction'])) {
+		if (!in_array($comment->getVerb(), ['reaction', 'reaction_deleted'])) {
 			throw new \OutOfBoundsException('Not a reaction');
 		}
+		$this->l = $message->getL10n();
 		$message->setMessageType('system');
-		$message->setMessage($message->getMessage(), [], $comment->getVerb());
+		if ($comment->getVerb() === 'reaction_deleted') {
+			// This message is necessary to make compatible with old clients
+			$message->setMessage($this->l->t('Message deleted by author'), [], $comment->getVerb());
+		} else {
+			$message->setMessage($message->getMessage(), [], $comment->getVerb());
+		}
 	}
 }

--- a/lib/Chat/ReactionManager.php
+++ b/lib/Chat/ReactionManager.php
@@ -114,17 +114,15 @@ class ReactionManager {
 			$comments = $this->commentsManager->retrieveAllReactions($messageId);
 		}
 
-		$reactions = [];
 		foreach ($comments as $comment) {
 			$message = $this->messageParser->createMessage($chat, $participant, $comment, $this->l);
 			$this->messageParser->parseMessage($message);
 
-			$reactions[] = [
+			$reactions[$comment->getMessage()][] = [
 				'actorType' => $comment->getActorType(),
 				'actorId' => $comment->getActorId(),
 				'actorDisplayName' => $message->getActorDisplayName(),
 				'timestamp' => $comment->getCreationDateTime()->getTimestamp(),
-				'reaction' => $comment->getMessage(),
 			];
 		}
 		return $reactions;

--- a/lib/Chat/ReactionManager.php
+++ b/lib/Chat/ReactionManager.php
@@ -82,7 +82,7 @@ class ReactionManager {
 		$comment->setVerb('reaction');
 		$this->commentsManager->save($comment);
 
-		$this->notifier->notifyReacted($chat, $parentMessage, $participant->getAttendee()->getActorType(), $participant->getAttendee()->getActorId());
+		$this->notifier->notifyReacted($chat, $parentMessage, $comment);
 		return $comment;
 	}
 

--- a/lib/Chat/ReactionManager.php
+++ b/lib/Chat/ReactionManager.php
@@ -82,7 +82,7 @@ class ReactionManager {
 		$comment->setVerb('reaction');
 		$this->commentsManager->save($comment);
 
-		$this->notifier->notifyReacted($chat, $parentMessage, $comment->getActorId());
+		$this->notifier->notifyReacted($chat, $parentMessage, $participant->getAttendee()->getActorType(), $participant->getAttendee()->getActorId());
 		return $comment;
 	}
 

--- a/lib/Chat/ReactionManager.php
+++ b/lib/Chat/ReactionManager.php
@@ -26,6 +26,8 @@ declare(strict_types=1);
 namespace OCA\Talk\Chat;
 
 use OCA\Talk\Exceptions\ReactionAlreadyExistsException;
+use OCA\Talk\Exceptions\ReactionNotSupportedException;
+use OCA\Talk\Exceptions\ReactionOutOfContextException;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -128,16 +130,24 @@ class ReactionManager {
 		return $reactions;
 	}
 
+	/**
+	 * @param Room $chat
+	 * @param string $messageId
+	 * @return IComment
+	 * @throws NotFoundException
+	 * @throws ReactionNotSupportedException
+	 * @throws ReactionOutOfContextException
+	 */
 	public function getCommentToReact(Room $chat, string $messageId): IComment {
 		if (!$this->commentsManager->supportReactions()) {
-			throw new NotFoundException('Reactions unsupported');
+			throw new ReactionNotSupportedException();
 		}
 		$comment = $this->commentsManager->get($messageId);
 
 		if ($comment->getObjectType() !== 'chat'
 			|| $comment->getObjectId() !== (string) $chat->getId()
 			|| $comment->getVerb() !== 'comment') {
-			throw new NotFoundException('Message not found in the right context');
+			throw new ReactionOutOfContextException();
 		}
 
 		return $comment;

--- a/lib/Chat/ReactionManager.php
+++ b/lib/Chat/ReactionManager.php
@@ -30,6 +30,7 @@ use OCA\Talk\Room;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
+use OCP\Comments\NotFoundException;
 use OCP\IL10N;
 
 class ReactionManager {
@@ -106,5 +107,17 @@ class ReactionManager {
 			];
 		}
 		return $reactions;
+	}
+
+	public function getCommentToReact(Room $chat, string $messageId): IComment {
+		$comment = $this->commentsManager->get($messageId);
+
+		if ($comment->getObjectType() !== 'chat'
+			|| $comment->getObjectId() !== (string) $chat->getId()
+			|| $comment->getVerb() !== 'comment') {
+			throw new NotFoundException('Message not found in the right context');
+		}
+
+		return $comment;
 	}
 }

--- a/lib/Chat/ReactionManager.php
+++ b/lib/Chat/ReactionManager.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Vitor Mattos <vitor@php.rio>
+ *
+ * @author Vitor Mattos <vitor@php.rio>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Chat;
+
+use OCA\Talk\Participant;
+use OCA\Talk\Room;
+use OCP\Comments\IComment;
+use OCP\Comments\ICommentsManager;
+
+class ReactionManager {
+	/** @var ICommentsManager|CommentsManager */
+	private $commentsManager;
+
+	public function __construct(CommentsManager $commentsManager) {
+		$this->commentsManager = $commentsManager;
+	}
+
+	public function addReactionMessage(Room $chat, Participant $participant, int $messageId, string $reaction): IComment {
+		$comment = $this->commentsManager->create(
+			$participant->getAttendee()->getActorType(),
+			$participant->getAttendee()->getActorId(),
+			'chat',
+			(string) $chat->getId()
+		);
+		$comment->setParentId((string) $messageId);
+		$comment->setMessage($reaction);
+		$comment->setVerb('reaction');
+		$this->commentsManager->save($comment);
+		return $comment;
+	}
+}

--- a/lib/Chat/ReactionManager.php
+++ b/lib/Chat/ReactionManager.php
@@ -130,7 +130,7 @@ class ReactionManager {
 
 	public function getCommentToReact(Room $chat, string $messageId): IComment {
 		if (!$this->commentsManager->supportReactions()) {
-			throw new NotFoundException('Reactions unsuported');
+			throw new NotFoundException('Reactions unsupported');
 		}
 		$comment = $this->commentsManager->get($messageId);
 

--- a/lib/Chat/ReactionManager.php
+++ b/lib/Chat/ReactionManager.php
@@ -110,6 +110,9 @@ class ReactionManager {
 	}
 
 	public function getCommentToReact(Room $chat, string $messageId): IComment {
+		if (!$this->commentsManager->supportReactions()) {
+			throw new NotFoundException('Reactions unsuported');
+		}
 		$comment = $this->commentsManager->get($messageId);
 
 		if ($comment->getObjectType() !== 'chat'

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -27,6 +27,7 @@ namespace OCA\Talk\Controller;
 use OCA\Talk\Chat\AutoComplete\SearchPlugin;
 use OCA\Talk\Chat\AutoComplete\Sorter;
 use OCA\Talk\Chat\ChatManager;
+use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Chat\MessageParser;
 use OCA\Talk\GuestManager;
 use OCA\Talk\MatterbridgeManager;
@@ -67,6 +68,9 @@ class ChatController extends AEnvironmentAwareController {
 
 	/** @var IAppManager */
 	private $appManager;
+
+	/** @var CommentsManager */
+	private $commentsManager;
 
 	/** @var ChatManager */
 	private $chatManager;
@@ -121,6 +125,7 @@ class ChatController extends AEnvironmentAwareController {
 								IRequest $request,
 								IUserManager $userManager,
 								IAppManager $appManager,
+								CommentsManager $commentsManager,
 								ChatManager $chatManager,
 								ParticipantService $participantService,
 								SessionService $sessionService,
@@ -141,6 +146,7 @@ class ChatController extends AEnvironmentAwareController {
 		$this->userId = $UserId;
 		$this->userManager = $userManager;
 		$this->appManager = $appManager;
+		$this->commentsManager = $commentsManager;
 		$this->chatManager = $chatManager;
 		$this->participantService = $participantService;
 		$this->sessionService = $sessionService;

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -27,7 +27,6 @@ namespace OCA\Talk\Controller;
 use OCA\Talk\Chat\AutoComplete\SearchPlugin;
 use OCA\Talk\Chat\AutoComplete\Sorter;
 use OCA\Talk\Chat\ChatManager;
-use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Chat\MessageParser;
 use OCA\Talk\GuestManager;
 use OCA\Talk\MatterbridgeManager;
@@ -68,9 +67,6 @@ class ChatController extends AEnvironmentAwareController {
 
 	/** @var IAppManager */
 	private $appManager;
-
-	/** @var CommentsManager */
-	private $commentsManager;
 
 	/** @var ChatManager */
 	private $chatManager;
@@ -125,7 +121,6 @@ class ChatController extends AEnvironmentAwareController {
 								IRequest $request,
 								IUserManager $userManager,
 								IAppManager $appManager,
-								CommentsManager $commentsManager,
 								ChatManager $chatManager,
 								ParticipantService $participantService,
 								SessionService $sessionService,
@@ -146,7 +141,6 @@ class ChatController extends AEnvironmentAwareController {
 		$this->userId = $UserId;
 		$this->userManager = $userManager;
 		$this->appManager = $appManager;
-		$this->commentsManager = $commentsManager;
 		$this->chatManager = $chatManager;
 		$this->participantService = $participantService;
 		$this->sessionService = $sessionService;

--- a/lib/Controller/ReactionController.php
+++ b/lib/Controller/ReactionController.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Vitor Mattos <vitor@php.rio>
+ *
+ * @author Vitor Mattos <vitor@php.rio>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Controller;
+
+use OCA\Talk\Chat\ChatManager;
+use OCA\Talk\Chat\CommentsManager;
+use OCA\Talk\Chat\ReactionManager;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\Comments\NotFoundException;
+use OCP\IRequest;
+
+class ReactionController extends AEnvironmentAwareController {
+	/** @var CommentsManager */
+	private $commentsManager;
+	/** @var ChatManager */
+	private $chatManager;
+	/** @var ReactionManager */
+	private $reactionManager;
+
+	public function __construct(string $appName,
+								IRequest $request,
+								CommentsManager $commentsManager,
+								ChatManager $chatManager,
+								ReactionManager $reactionManager) {
+		parent::__construct($appName, $request);
+
+		$this->commentsManager = $commentsManager;
+		$this->chatManager = $chatManager;
+		$this->reactionManager = $reactionManager;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @RequireParticipant
+	 * @RequireReadWriteConversation
+	 * @RequireModeratorOrNoLobby
+	 *
+	 * @param int $messageId for reaction
+	 * @param string $reaction the reaction emoji
+	 * @return DataResponse
+	 */
+	public function react(int $messageId, string $reaction): DataResponse {
+		$participant = $this->getParticipant();
+		try {
+			// Verify that messageId is part of the room
+			$this->chatManager->getComment($this->getRoom(), (string) $messageId);
+		} catch (NotFoundException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		try {
+			// Verify already reacted whith the same reaction
+			$this->commentsManager->getReactionComment(
+				$messageId,
+				$participant->getAttendee()->getActorType(),
+				$participant->getAttendee()->getActorId(),
+				$reaction
+			);
+			return new DataResponse([], Http::STATUS_CONFLICT);
+		} catch (NotFoundException $e) {
+		}
+
+		try {
+			$this->reactionManager->addReactionMessage($this->getRoom(), $participant, $messageId, $reaction);
+		} catch (\Exception $e) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
+		return new DataResponse([], Http::STATUS_CREATED);
+	}
+}

--- a/lib/Controller/ReactionController.php
+++ b/lib/Controller/ReactionController.php
@@ -79,7 +79,7 @@ class ReactionController extends AEnvironmentAwareController {
 				$participant->getAttendee()->getActorId(),
 				$reaction
 			);
-			return new DataResponse([], Http::STATUS_CONFLICT);
+			return new DataResponse([], Http::STATUS_OK);
 		} catch (NotFoundException $e) {
 		}
 

--- a/lib/Controller/ReactionController.php
+++ b/lib/Controller/ReactionController.php
@@ -105,7 +105,7 @@ class ReactionController extends AEnvironmentAwareController {
 	public function delete(int $messageId, string $reaction): DataResponse {
 		$participant = $this->getParticipant();
 		try {
-			// Verify if messageId is of room
+			// Verify that messageId is part of the room
 			$this->chatManager->getComment($this->getRoom(), (string) $messageId);
 		} catch (NotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
@@ -138,7 +138,7 @@ class ReactionController extends AEnvironmentAwareController {
 	 */
 	public function getReactions(int $messageId, ?string $reaction): DataResponse {
 		try {
-			// Verify if messageId is of room
+			// Verify that messageId is part of the room
 			$this->chatManager->getComment($this->getRoom(), (string) $messageId);
 		} catch (NotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);

--- a/lib/Controller/ReactionController.php
+++ b/lib/Controller/ReactionController.php
@@ -25,7 +25,6 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Controller;
 
-use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Chat\ReactionManager;
 use OCA\Talk\Exceptions\ReactionAlreadyExistsException;
 use OCP\AppFramework\Http;
@@ -34,17 +33,13 @@ use OCP\Comments\NotFoundException;
 use OCP\IRequest;
 
 class ReactionController extends AEnvironmentAwareController {
-	/** @var ChatManager */
-	private $chatManager;
 	/** @var ReactionManager */
 	private $reactionManager;
 
 	public function __construct(string $appName,
 								IRequest $request,
-								ChatManager $chatManager,
 								ReactionManager $reactionManager) {
 		parent::__construct($appName, $request);
-		$this->chatManager = $chatManager;
 		$this->reactionManager = $reactionManager;
 	}
 
@@ -62,7 +57,7 @@ class ReactionController extends AEnvironmentAwareController {
 		try {
 			$chat = $this->getRoom();
 			$participant = $this->getParticipant();
-			$parentMessage = $this->chatManager->getComment($chat, (string) $messageId);
+			$parentMessage = $this->reactionManager->getCommentToReact($chat, (string) $messageId);
 			$this->reactionManager->addReactionMessage($chat, $participant, $parentMessage, $reaction);
 		} catch (NotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
@@ -88,7 +83,7 @@ class ReactionController extends AEnvironmentAwareController {
 		$participant = $this->getParticipant();
 		try {
 			// Verify that messageId is part of the room
-			$this->chatManager->getComment($this->getRoom(), (string) $messageId);
+			$this->reactionManager->getCommentToReact($this->getRoom(), (string) $messageId);
 		} catch (NotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
@@ -121,7 +116,7 @@ class ReactionController extends AEnvironmentAwareController {
 	public function getReactions(int $messageId, ?string $reaction): DataResponse {
 		try {
 			// Verify that messageId is part of the room
-			$this->chatManager->getComment($this->getRoom(), (string) $messageId);
+			$this->reactionManager->getCommentToReact($this->getRoom(), (string) $messageId);
 		} catch (NotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}

--- a/lib/Controller/ReactionController.php
+++ b/lib/Controller/ReactionController.php
@@ -125,4 +125,27 @@ class ReactionController extends AEnvironmentAwareController {
 
 		return new DataResponse([], Http::STATUS_CREATED);
 	}
+
+	/**
+	 * @NoAdminRequired
+	 * @RequireParticipant
+	 * @RequireReadWriteConversation
+	 * @RequireModeratorOrNoLobby
+	 *
+	 * @param int $messageId for reaction
+	 * @param string|null $reaction the reaction emoji
+	 * @return DataResponse
+	 */
+	public function getReactions(int $messageId, ?string $reaction): DataResponse {
+		try {
+			// Verify if messageId is of room
+			$this->chatManager->getComment($this->getRoom(), (string) $messageId);
+		} catch (NotFoundException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		$reactions = $this->reactionManager->retrieveReactionMessages($this->getRoom(), $this->getParticipant(), $messageId, $reaction);
+
+		return new DataResponse($reactions, Http::STATUS_OK);
+	}
 }

--- a/lib/Controller/ReactionController.php
+++ b/lib/Controller/ReactionController.php
@@ -123,7 +123,7 @@ class ReactionController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
-		return new DataResponse([], Http::STATUS_CREATED);
+		return new DataResponse([], Http::STATUS_OK);
 	}
 
 	/**

--- a/lib/Controller/ReactionController.php
+++ b/lib/Controller/ReactionController.php
@@ -27,6 +27,8 @@ namespace OCA\Talk\Controller;
 
 use OCA\Talk\Chat\ReactionManager;
 use OCA\Talk\Exceptions\ReactionAlreadyExistsException;
+use OCA\Talk\Exceptions\ReactionNotSupportedException;
+use OCA\Talk\Exceptions\ReactionOutOfContextException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\Comments\NotFoundException;
@@ -63,7 +65,7 @@ class ReactionController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		} catch (ReactionAlreadyExistsException $e) {
 			return new DataResponse([], Http::STATUS_OK);
-		} catch (\Exception $e) {
+		} catch (ReactionNotSupportedException | ReactionOutOfContextException | \Exception $e) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 		return new DataResponse([], Http::STATUS_CREATED);
@@ -84,7 +86,7 @@ class ReactionController extends AEnvironmentAwareController {
 		try {
 			// Verify that messageId is part of the room
 			$this->reactionManager->getCommentToReact($this->getRoom(), (string) $messageId);
-		} catch (NotFoundException $e) {
+		} catch (ReactionNotSupportedException | ReactionOutOfContextException | NotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
@@ -117,7 +119,7 @@ class ReactionController extends AEnvironmentAwareController {
 		try {
 			// Verify that messageId is part of the room
 			$this->reactionManager->getCommentToReact($this->getRoom(), (string) $messageId);
-		} catch (NotFoundException $e) {
+		} catch (ReactionNotSupportedException | ReactionOutOfContextException | NotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 

--- a/lib/Exceptions/ReactionAlreadyExistsException.php
+++ b/lib/Exceptions/ReactionAlreadyExistsException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Vitor Mattos <vitor@php.rio>
+ *
+ * @author Vitor Mattos <vitor@php.rio>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Exceptions;
+
+class ReactionAlreadyExistsException extends \OutOfBoundsException {
+}

--- a/lib/Exceptions/ReactionNotSupportedException.php
+++ b/lib/Exceptions/ReactionNotSupportedException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022, Vitor Mattos <vitor@php.rio>
+ *
+ * @author Vitor Mattos <vitor@php.rio>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Exceptions;
+
+class ReactionNotSupportedException extends \Exception {
+}

--- a/lib/Exceptions/ReactionOutOfContextException.php
+++ b/lib/Exceptions/ReactionOutOfContextException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022, Vitor Mattos <vitor@php.rio>
+ *
+ * @author Vitor Mattos <vitor@php.rio>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Exceptions;
+
+class ReactionOutOfContextException extends \Exception {
+}

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -233,6 +233,7 @@ class Manager {
 			'reference_id' => $row['comment_reference_id'] ?? null,
 			'creation_timestamp' => $row['comment_creation_timestamp'],
 			'latest_child_timestamp' => $row['comment_latest_child_timestamp'],
+			'reactions' => $row['comment_reactions'],
 		]);
 	}
 
@@ -1185,5 +1186,6 @@ class Manager {
 		}
 		$query->selectAlias('c.creation_timestamp', 'comment_creation_timestamp');
 		$query->selectAlias('c.latest_child_timestamp', 'comment_latest_child_timestamp');
+		$query->selectAlias('c.reactions', 'comment_reactions');
 	}
 }

--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -163,6 +163,7 @@ class Message {
 		return $this->getMessageType() !== 'system' &&
 			$this->getMessageType() !== 'command' &&
 			$this->getMessageType() !== 'comment_deleted' &&
+			$this->getMessageType() !== 'reaction' &&
 			\in_array($this->getActorType(), [Attendee::ACTOR_USERS, Attendee::ACTOR_GUESTS]);
 	}
 
@@ -180,6 +181,7 @@ class Message {
 			'messageType' => $this->getMessageType(),
 			'isReplyable' => $this->isReplyable(),
 			'referenceId' => (string) $this->getComment()->getReferenceId(),
+			'reactions' => $this->getComment()->getReactions(),
 		];
 
 		if ($this->getMessageType() === 'comment_deleted') {

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -260,7 +260,7 @@ class Notifier implements INotifier {
 			}
 			return $this->parseCall($notification, $room, $l);
 		}
-		if ($subject === 'reply' || $subject === 'mention' || $subject === 'chat') {
+		if ($subject === 'reply' || $subject === 'mention' || $subject === 'chat' || $subject === 'reaction') {
 			return $this->parseChatMessage($notification, $room, $participant, $l);
 		}
 
@@ -454,6 +454,27 @@ class Notifier implements INotifier {
 					$subject = $l->t('{guest} (guest) replied to your message in conversation {call}');
 				} catch (ParticipantNotFoundException $e) {
 					$subject = $l->t('A guest replied to your message in conversation {call}');
+				}
+			}
+		} elseif ($notification->getSubject() === 'reaction') {
+			$richSubjectParameters['reaction'] = [
+				'type' => 'highlight',
+				'id' => $subjectParameters['reaction'],
+				'name' => $subjectParameters['reaction'],
+			];
+
+			if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+				$subject = $l->t('{user} reacted with {reaction} to your private message');
+			} elseif ($richSubjectUser) {
+				$subject = $l->t('{user} reacted with {reaction} to your message in conversation {call}');
+			} elseif (!$isGuest) {
+				$subject = $l->t('A deleted user reacted with {reaction} to your message in conversation {call}');
+			} else {
+				try {
+					$richSubjectParameters['guest'] = $this->getGuestParameter($room, $comment->getActorId());
+					$subject = $l->t('{guest} (guest) reacted with {reaction} to your message in conversation {call}');
+				} catch (ParticipantNotFoundException $e) {
+					$subject = $l->t('A guest reacted with {reaction} to your message in conversation {call}');
 				}
 			}
 		} elseif ($room->getType() === Room::TYPE_ONE_TO_ONE) {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
       - 'Participants management': 'participant.md'
       - 'Call management': 'call.md'
       - 'Chat management': 'chat.md'
+      - 'Reaction management': 'reaction.md'
       - 'Webinar management': 'webinar.md'
       - 'Settings': 'settings.md'
       - 'Integration by other apps': 'integration.md'

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2100,11 +2100,12 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	/**
 	 * @Given /^user "([^"]*)" retrieve reactions "([^"]*)" of message "([^"]*)" in room "([^"]*)" with (\d+)(?: \((v1)\))?$/
 	 */
-	public function userRetrieveReactionsOfMessageInRoomWith(string $user, string $emoji, string $message, string $identifier, int $statusCode, string $apiVersion = 'v1', TableNode $formData): void {
+	public function userRetrieveReactionsOfMessageInRoomWith(string $user, string $reaction, string $message, string $identifier, int $statusCode, string $apiVersion = 'v1', TableNode $formData): void {
 		$token = self::$identifierToToken[$identifier];
 		$messageId = self::$messages[$message];
 		$this->setCurrentUser($user);
-		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/reaction/' . $token . '/' . $messageId . '?emoji=' . $emoji);
+		$reaction = $reaction !== 'all' ? '?reaction=' . $reaction : '';
+		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/reaction/' . $token . '/' . $messageId . $reaction);
 		$this->assertStatusCode($this->response, $statusCode);
 		$this->assertReactionList($formData);
 	}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2084,13 +2084,14 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" react with "([^"]*)" on message "([^"]*)" to room "([^"]*)" with (\d+)(?: \((v1)\))?$/
+	 * @Given /^user "([^"]*)" (delete react|react) with "([^"]*)" on message "([^"]*)" to room "([^"]*)" with (\d+)(?: \((v1)\))?$/
 	 */
-	public function userReactWithOnMessageToRoomWith(string $user, string $reaction, string $message, string $identifier, int $statusCode, string $apiVersion = 'v1'): void {
+	public function userReactWithOnMessageToRoomWith(string $user, string $action, string $reaction, string $message, string $identifier, int $statusCode, string $apiVersion = 'v1'): void {
 		$token = self::$identifierToToken[$identifier];
 		$messageId = self::$messages[$message];
 		$this->setCurrentUser($user);
-		$this->sendRequest('POST', '/apps/spreed/api/' . $apiVersion . '/reaction/' . $token . '/' . $messageId, [
+		$verb = $action === 'react' ? 'POST' : 'DELETE';
+		$this->sendRequest($verb, '/apps/spreed/api/' . $apiVersion . '/reaction/' . $token . '/' . $messageId, [
 			'reaction' => $reaction
 		]);
 		$this->assertStatusCode($this->response, $statusCode);

--- a/tests/integration/features/reaction/react.feature
+++ b/tests/integration/features/reaction/react.feature
@@ -44,3 +44,25 @@ Feature: reaction/react
     Then user "participant1" sees the following messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | message   | messageParameters | reactions |
       | room | users     | participant1 | participant1-displayname | Message 1 | []                | []        |
+
+  Scenario: Retrieve reactions of a message
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    And user "participant1" sends message "Message 1" to room "room" with 201
+    And user "participant1" react with "👍" on message "Message 1" to room "room" with 201
+    And user "participant2" react with "👍" on message "Message 1" to room "room" with 201
+    And user "participant2" react with "👎" on message "Message 1" to room "room" with 201
+    Then user "participant1" retrieve reactions "👍" of message "Message 1" in room "room" with 200
+      | actorType | actorId      | actorDisplayName         |
+      | users     | participant1 | participant1-displayname |
+      | users     | participant2 | participant2-displayname |
+    And user "participant1" retrieve reactions "👎" of message "Message 1" in room "room" with 200
+      | actorType | actorId      | actorDisplayName         |
+      | users     | participant2 | participant2-displayname |
+    And user "participant1" retrieve reactions "all" of message "Message 1" in room "room" with 200
+      | actorType | actorId      | actorDisplayName         | reaction |
+      | users     | participant1 | participant1-displayname | 👍       |
+      | users     | participant2 | participant2-displayname | 👎       |
+      | users     | participant2 | participant2-displayname | 👍       |

--- a/tests/integration/features/reaction/react.feature
+++ b/tests/integration/features/reaction/react.feature
@@ -25,7 +25,7 @@ Feature: reaction/react
     And user "participant1" adds user "participant2" to room "room" with 200 (v4)
     And user "participant1" sends message "Message 1" to room "room" with 201
     And user "participant2" react with "👍" on message "Message 1" to room "room" with 201
-    And user "participant2" react with "👍" on message "Message 1" to room "room" with 409
+    And user "participant2" react with "👍" on message "Message 1" to room "room" with 200
     Then user "participant1" sees the following messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | message   | messageParameters | reactions |
       | room | users     | participant1 | participant1-displayname | Message 1 | []                | {"👍":1}  |
@@ -40,7 +40,7 @@ Feature: reaction/react
     Then user "participant1" sees the following messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | message   | messageParameters | reactions |
       | room | users     | participant1 | participant1-displayname | Message 1 | []                | {"👍":1}  |
-    And user "participant2" delete react with "👍" on message "Message 1" to room "room" with 201
+    And user "participant2" delete react with "👍" on message "Message 1" to room "room" with 200
     Then user "participant1" sees the following messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | message   | messageParameters | reactions |
       | room | users     | participant1 | participant1-displayname | Message 1 | []                | []        |
@@ -53,14 +53,14 @@ Feature: reaction/react
     And user "participant1" sends message "Message 1" to room "room" with 201
     And user "participant1" react with "👍" on message "Message 1" to room "room" with 201
     And user "participant2" react with "👍" on message "Message 1" to room "room" with 201
-    And user "participant2" react with "👎" on message "Message 1" to room "room" with 201
     Then user "participant1" retrieve reactions "👍" of message "Message 1" in room "room" with 200
-      | actorType | actorId      | actorDisplayName         |
-      | users     | participant1 | participant1-displayname |
-      | users     | participant2 | participant2-displayname |
+      | actorType | actorId      | actorDisplayName         | reaction |
+      | users     | participant1 | participant1-displayname | 👍       |
+      | users     | participant2 | participant2-displayname | 👍       |
+    And user "participant2" react with "👎" on message "Message 1" to room "room" with 201
     And user "participant1" retrieve reactions "👎" of message "Message 1" in room "room" with 200
-      | actorType | actorId      | actorDisplayName         |
-      | users     | participant2 | participant2-displayname |
+      | actorType | actorId      | actorDisplayName         | reaction |
+      | users     | participant2 | participant2-displayname | 👎       |
     And user "participant1" retrieve reactions "all" of message "Message 1" in room "room" with 200
       | actorType | actorId      | actorDisplayName         | reaction |
       | users     | participant1 | participant1-displayname | 👍       |

--- a/tests/integration/features/reaction/react.feature
+++ b/tests/integration/features/reaction/react.feature
@@ -1,0 +1,31 @@
+Feature: reaction/react
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+
+  Scenario: React to message with success
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    And user "participant1" sends message "Message 1" to room "room" with 201
+    And user "participant2" react with "👍" on message "Message 1" to room "room" with 201
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message   | messageParameters | reactions |
+      | room | users     | participant1 | participant1-displayname | Message 1 | []                | {"👍":1}  |
+    And user "participant1" react with "👍" on message "Message 1" to room "room" with 201
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message   | messageParameters | reactions |
+      | room | users     | participant1 | participant1-displayname | Message 1 | []                | {"👍":2}  |
+
+  Scenario: React two times to same message with the same reaction
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    And user "participant1" sends message "Message 1" to room "room" with 201
+    And user "participant2" react with "👍" on message "Message 1" to room "room" with 201
+    And user "participant2" react with "👍" on message "Message 1" to room "room" with 409
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message   | messageParameters | reactions |
+      | room | users     | participant1 | participant1-displayname | Message 1 | []                | {"👍":1}  |

--- a/tests/integration/features/reaction/react.feature
+++ b/tests/integration/features/reaction/react.feature
@@ -29,3 +29,18 @@ Feature: reaction/react
     Then user "participant1" sees the following messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | message   | messageParameters | reactions |
       | room | users     | participant1 | participant1-displayname | Message 1 | []                | {"👍":1}  |
+
+  Scenario: Delete reaction to message with success
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    And user "participant1" sends message "Message 1" to room "room" with 201
+    And user "participant2" react with "👍" on message "Message 1" to room "room" with 201
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message   | messageParameters | reactions |
+      | room | users     | participant1 | participant1-displayname | Message 1 | []                | {"👍":1}  |
+    And user "participant2" delete react with "👍" on message "Message 1" to room "room" with 201
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message   | messageParameters | reactions |
+      | room | users     | participant1 | participant1-displayname | Message 1 | []                | []        |

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Tests\Unit;
 
 use OCA\Talk\Capabilities;
+use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Config;
 use OCA\Talk\Participant;
 use OCP\Capabilities\IPublicCapability;
@@ -41,6 +42,8 @@ class CapabilitiesTest extends TestCase {
 	protected $serverConfig;
 	/** @var Config|MockObject */
 	protected $talkConfig;
+	/** @var CommentsManager|MockObject */
+	protected $commentsManager;
 	/** @var IUserSession|MockObject */
 	protected $userSession;
 	/** @var array */
@@ -50,7 +53,11 @@ class CapabilitiesTest extends TestCase {
 		parent::setUp();
 		$this->serverConfig = $this->createMock(IConfig::class);
 		$this->talkConfig = $this->createMock(Config::class);
+		$this->commentsManager = $this->createMock(CommentsManager::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+		$this->commentsManager->expects($this->any())
+			->method('supportReactions')
+			->willReturn(true);
 
 		$this->baseFeatures = [
 			'audio',
@@ -104,6 +111,7 @@ class CapabilitiesTest extends TestCase {
 		$capabilities = new Capabilities(
 			$this->serverConfig,
 			$this->talkConfig,
+			$this->commentsManager,
 			$this->userSession
 		);
 
@@ -161,6 +169,7 @@ class CapabilitiesTest extends TestCase {
 		$capabilities = new Capabilities(
 			$this->serverConfig,
 			$this->talkConfig,
+			$this->commentsManager,
 			$this->userSession
 		);
 
@@ -247,6 +256,7 @@ class CapabilitiesTest extends TestCase {
 		$capabilities = new Capabilities(
 			$this->serverConfig,
 			$this->talkConfig,
+			$this->commentsManager,
 			$this->userSession
 		);
 

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -96,6 +96,7 @@ class CapabilitiesTest extends TestCase {
 			'direct-mention-flag',
 			'notification-calls',
 			'conversation-permissions',
+			'reactions',
 		];
 	}
 

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -25,6 +25,7 @@ namespace OCA\Talk\Tests\php\Controller;
 
 use OCA\Talk\Chat\AutoComplete\SearchPlugin;
 use OCA\Talk\Chat\ChatManager;
+use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Chat\MessageParser;
 use OCA\Talk\Controller\ChatController;
 use OCA\Talk\GuestManager;
@@ -62,6 +63,8 @@ class ChatControllerTest extends TestCase {
 	protected $userManager;
 	/** @var IAppManager|MockObject */
 	private $appManager;
+	/** @var CommentsManager|MockObject */
+	protected $commentsManager;
 	/** @var ChatManager|MockObject */
 	protected $chatManager;
 	/** @var ParticipantService|MockObject */
@@ -108,6 +111,7 @@ class ChatControllerTest extends TestCase {
 		$this->userId = 'testUser';
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->appManager = $this->createMock(IAppManager::class);
+		$this->commentsManager = $this->createMock(CommentsManager::class);
 		$this->chatManager = $this->createMock(ChatManager::class);
 		$this->participantService = $this->createMock(ParticipantService::class);
 		$this->sessionService = $this->createMock(SessionService::class);
@@ -143,6 +147,7 @@ class ChatControllerTest extends TestCase {
 			$this->createMock(IRequest::class),
 			$this->userManager,
 			$this->appManager,
+			$this->commentsManager,
 			$this->chatManager,
 			$this->participantService,
 			$this->sessionService,

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -25,7 +25,6 @@ namespace OCA\Talk\Tests\php\Controller;
 
 use OCA\Talk\Chat\AutoComplete\SearchPlugin;
 use OCA\Talk\Chat\ChatManager;
-use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Chat\MessageParser;
 use OCA\Talk\Controller\ChatController;
 use OCA\Talk\GuestManager;
@@ -63,8 +62,6 @@ class ChatControllerTest extends TestCase {
 	protected $userManager;
 	/** @var IAppManager|MockObject */
 	private $appManager;
-	/** @var CommentsManager|MockObject */
-	protected $commentsManager;
 	/** @var ChatManager|MockObject */
 	protected $chatManager;
 	/** @var ParticipantService|MockObject */
@@ -111,7 +108,6 @@ class ChatControllerTest extends TestCase {
 		$this->userId = 'testUser';
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->appManager = $this->createMock(IAppManager::class);
-		$this->commentsManager = $this->createMock(CommentsManager::class);
 		$this->chatManager = $this->createMock(ChatManager::class);
 		$this->participantService = $this->createMock(ParticipantService::class);
 		$this->sessionService = $this->createMock(SessionService::class);
@@ -147,7 +143,6 @@ class ChatControllerTest extends TestCase {
 			$this->createMock(IRequest::class),
 			$this->userManager,
 			$this->appManager,
-			$this->commentsManager,
 			$this->chatManager,
 			$this->participantService,
 			$this->sessionService,


### PR DESCRIPTION
Implement #1920

- [x] blocked by https://github.com/nextcloud/server/pull/30379

## Compatibility with old versions of clients
* When get messages from API, the API will return one more property on message (reaction)
* The reaction message is returned as system message and marked to don't reply
* When the author of reaction delete the reaction, the message will be displayed on on clients same as deleted message

## TODO on new clients
* Don't display messages of type `reaction` and `reaction_deleted`
* When receive the response of endpoint `GET /api/{apiVersion}/chat/{token}` (`receiveMessages`) with `reaction` or `reaction_deleted`, get the id of parent message on reaction and update this.
  > **P.S.**: Use the `delete` message type as example to change the reactions counter:
  > https://github.com/nextcloud/spreed/blob/091575237c17945b37c7c72ba53c5ad85b1961ae/src/store/messagesStore.js#L255-L258


## How client's developers can do review on this PR
* Look the tests scenarios on [tests/integration/features/reaction/react.feature](https://github.com/nextcloud/spreed/blob/542ec3d1f7811564b9d8af96555cf9144db2303c/tests/integration/features/reaction/react.feature)
* Search on [Files changed](https://github.com/nextcloud/spreed/pull/6730/files) by `.md` and look the changes on current endpoints and the new endpoints documentation.