### PR TITLE
docs(readme): point to SimpleWebRTC library

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 * 👥 **Private, group, public and password protected calls!** Invite someone, a whole group or send a public link to invite to a call.
 * 💻 **Screen sharing!** Share your screen with participants of your call. You just need to use Firefox version 66 (or newer), latest Edge or Chrome 72 (or newer, also possible using Chrome 49 with this [Chrome extension](https://chrome.google.com/webstore/detail/screensharing-for-nextclo/kepnpjhambipllfmgmbapncekcmabkol)).
 * 🚀 **Integration with other Nextcloud apps** like Files, Calendar, User status, Dashboard, Flow, Contacts and Deck, with more to come.
-* 🎡 **We’re not reinventing the wheel!** Based on the great [simpleWebRTC](https://simplewebrtc.com/) library.
+* 🎡 **We’re not reinventing the wheel!** Based on the great [simpleWebRTC](https://github.com/simplewebrtc/SimpleWebRTC) library.
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 
 More in the works for the [coming versions](https://github.com/nextcloud/spreed/milestones/).


### PR DESCRIPTION
The readme previously pointed to the commercial SimpleWebRTC product, that has little in common with the deprecated open source library.