### PR TITLE
Fix material design icon sizes

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -30,13 +30,13 @@
 				fill-color="#ffffff"
 				decorative
 				title=""
-				:size="24" />
+				:size="20" />
 			<ChevronUp
 				v-else
 				fill-color="#ffffff"
 				decorative
 				title=""
-				:size="24" />
+				:size="20" />
 		</button>
 		<transition :name="isStripe ? 'slide-down' : ''">
 			<div v-if="!isStripe || stripeOpen" class="wrapper" :style="wrapperStyle">
@@ -50,7 +50,7 @@
 							decorative
 							fill-color="#ffffff"
 							title=""
-							:size="24" />
+							:size="20" />
 					</button>
 					<div
 						ref="grid"
@@ -123,7 +123,7 @@
 							decorative
 							fill-color="#ffffff"
 							title=""
-							:size="24" />
+							:size="20" />
 					</button>
 				</div>
 				<LocalVideo

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -195,11 +195,13 @@
 				:aria-label="t('spreed', 'Lower hand (R)')"
 				@shortkey="toggleHandRaised"
 				@click.stop="toggleHandRaised">
+				<!-- The following icon is much bigger than all the others
+						so we reduce its size -->
 				<HandBackLeft
-					:size="20"
+					decorative
 					title=""
-					fill-color="#ffffff"
-					decorative />
+					:size="18"
+					fill-color="#ffffff" />
 			</button>
 			<Actions
 				v-if="showActions"
@@ -209,11 +211,13 @@
 				<ActionButton
 					:close-after-click="true"
 					@click="toggleHandRaised">
+					<!-- The following icon is much bigger than all the others
+						so we reduce its size -->
 					<HandBackLeft
 						slot="icon"
-						:size="20"
 						decorative
-						title="" />
+						title=""
+						:size="18" />
 					{{ raiseHandButtonLabel }}
 				</ActionButton>
 				<ActionButton

--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -55,13 +55,13 @@
 						@click.stop="forceMute">
 						<Microphone
 							v-if="showMicrophone"
-							:size="24"
+							:size="20"
 							title=""
 							fill-color="#ffffff"
 							decorative />
 						<MicrophoneOff
 							v-if="showMicrophoneOff"
-							:size="24"
+							:size="20"
 							title=""
 							fill-color="#ffffff"
 							decorative />
@@ -72,13 +72,13 @@
 						@click.stop="toggleVideo">
 						<VideoIcon
 							v-if="showVideoButton"
-							:size="24"
+							:size="20"
 							title=""
 							fill-color="#ffffff"
 							decorative />
 						<VideoOff
 							v-if="!showVideoButton"
-							:size="24"
+							:size="20"
 							title=""
 							fill-color="#ffffff"
 							decorative />
@@ -89,7 +89,7 @@
 						:class="screenSharingButtonClass"
 						@click.stop="switchToScreen">
 						<Monitor
-							:size="24"
+							:size="20"
 							title=""
 							fill-color="#ffffff"
 							decorative />
@@ -99,7 +99,7 @@
 						:class="{ 'not-failed': !connectionStateFailedNoRestart }"
 						disabled="true">
 						<AlertCircle
-							:size="24"
+							:size="20"
 							title=""
 							fill-color="#ffffff"
 							decorative />

--- a/src/components/ConversationSettings/NotificationsSettings.vue
+++ b/src/components/ConversationSettings/NotificationsSettings.vue
@@ -30,7 +30,7 @@
 			<VolumeHigh
 				decorative
 				title=""
-				:size="24"
+				:size="20"
 				class="radio-element__icon" />
 			<label
 				class="radio-element__label">
@@ -51,7 +51,7 @@
 			<Account
 				decorative
 				title=""
-				:size="24"
+				:size="20"
 				class="radio-element__icon" />
 			<label
 				class="radio-element__label">
@@ -71,7 +71,7 @@
 			<VolumeOff
 				decorative
 				title=""
-				:size="24"
+				:size="20"
 				class="radio-element__icon" />
 			<label class="radio-element__label">
 				{{ t('spreed', 'Off') }}

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -84,24 +84,26 @@
 			<span class="hidden-visually">{{ callIconTooltip }}</span>
 			<Microphone
 				v-if="callIcon === 'audio'"
-				:size="24"
+				:size="20"
 				title=""
 				decorative />
 			<Phone
 				v-if="callIcon === 'phone'"
-				:size="24"
+				:size="20"
 				title=""
 				decorative />
 			<Video
 				v-if="callIcon === 'video'"
-				:size="24"
+				:size="20"
 				title=""
 				decorative />
+			<!-- The following icon is much bigger than all the others
+						so we reduce its size -->
 			<HandBackLeft
 				v-if="callIcon === 'hand'"
-				:size="24"
+				decorative
 				title=""
-				decorative />
+				:size="18" />
 		</div>
 
 		<!-- Participant's actions menu -->

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -64,14 +64,14 @@
 			<ActionButton @click="leaveCall(false)">
 				<VideoOff
 					slot="icon"
-					:size="24"
+					:size="20"
 					decorative />
 				{{ leaveCallLabel }}
 			</ActionButton>
 			<ActionButton @click="leaveCall(true)">
 				<VideoOff
 					slot="icon"
-					:size="24"
+					:size="20"
 					decorative />
 				{{ t('spreed', 'End meeting for all') }}
 			</ActionButton>


### PR DESCRIPTION
There were still some 24px icons around, this pr gets rid of those.

Signed-off-by: marco <marcoambrosini@pm.me>