### PR TITLE
Fix empty name for unnamed guests in permissions change notifications

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -680,18 +680,18 @@ export default {
 		grantAllPermissions() {
 			try {
 				this.$store.dispatch('grantAllPermissionsToParticipant', { token: this.token, attendeeId: this.attendeeId })
-				showSuccess(t('spreed', 'Permissions granted to {displayName}', { displayName: this.participant.displayName }))
+				showSuccess(t('spreed', 'Permissions granted to {displayName}', { displayName: this.computedName }))
 			} catch (error) {
-				showError(t('spreed', 'Could not modify permissions for {displayName}', { displayName: this.participant.displayName }))
+				showError(t('spreed', 'Could not modify permissions for {displayName}', { displayName: this.computedName }))
 			}
 		},
 
 		removeAllPermissions() {
 			try {
 				this.$store.dispatch('removeAllPermissionsFromParticipant', { token: this.token, attendeeId: this.attendeeId })
-				showSuccess(t('spreed', 'Permissions removed for {displayName}', { displayName: this.participant.displayName }))
+				showSuccess(t('spreed', 'Permissions removed for {displayName}', { displayName: this.computedName }))
 			} catch (error) {
-				showError(t('spreed', 'Could not modify permissions for {displayName}', { displayName: this.participant.displayName }))
+				showError(t('spreed', 'Could not modify permissions for {displayName}', { displayName: this.computedName }))
 			}
 		},
 
@@ -706,9 +706,9 @@ export default {
 		applyDefaultPermissions() {
 			try {
 				this.$store.dispatch('setPermissions', { token: this.token, attendeeId: this.attendeeId, permissions: PARTICIPANT.PERMISSIONS.DEFAULT })
-				showSuccess(t('spreed', 'Permissions set to default for {displayName}', { displayName: this.participant.displayName }))
+				showSuccess(t('spreed', 'Permissions set to default for {displayName}', { displayName: this.computedName }))
 			} catch (error) {
-				showError(t('spreed', 'Could not modify permissions for {displayName}', { displayName: this.participant.displayName }))
+				showError(t('spreed', 'Could not modify permissions for {displayName}', { displayName: this.computedName }))
 			}
 		},
 	},


### PR DESCRIPTION
The display name is not set for unnamed guests, so the computed name (which is the one shown in the participant list) should be used instead.

## How to test

- Create a public conversation
- In a private window, join the conversation as a guest
- In the original window, grant all permissions to the guest

### Result with this pull request

The notification shows `Permissions granted to Guest`

### Result without this pull request

The notification shows `Permissions granted to`
