### PR TITLE
Make own peer related code more robust

### DIFF
--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -138,7 +138,7 @@ export default {
 			// When there is no sender participant (when the MCU is not used, or
 			// if it is used but no peer object has been set yet) the local
 			// video is shown as connected.
-			return this.localCallParticipantModel.attributes.connectionState !== null
+			return this.localCallParticipantModel.attributes.peerNeeded
 				&& this.localCallParticipantModel.attributes.connectionState !== ConnectionState.CONNECTED && this.localCallParticipantModel.attributes.connectionState !== ConnectionState.COMPLETED
 		},
 

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -1181,6 +1181,10 @@ Signaling.Standalone.prototype.processRoomEvent = function(data) {
 			leftUsers = Object.keys(leftUsers)
 			if (leftUsers.length) {
 				this._trigger('usersLeft', [leftUsers])
+
+				for (i = 0; i < leftUsers.length; i++) {
+					delete this.joinedUsers[leftUsers[i]]
+				}
 			}
 			this._trigger('usersJoined', [joinedUsers])
 			this._trigger('participantListChanged')

--- a/src/utils/webrtc/models/LocalCallParticipantModel.js
+++ b/src/utils/webrtc/models/LocalCallParticipantModel.js
@@ -36,6 +36,7 @@ export default function LocalCallParticipantModel() {
 		peer: null,
 		screenPeer: null,
 		guestName: null,
+		peerNeeded: false,
 		connectionState: null,
 	}
 
@@ -120,6 +121,10 @@ LocalCallParticipantModel.prototype = {
 		this.set('guestName', guestName)
 
 		this._webRtc.webrtc.emit('nickChanged', guestName)
+	},
+
+	setPeerNeeded(peerNeeded) {
+		this.set('peerNeeded', peerNeeded)
 	},
 
 	_handleForcedMute() {

--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -618,6 +618,8 @@ Peer.prototype.end = function() {
 	this.handleStreamRemoved()
 	this.parent.off('localTrackReplaced', this.handleLocalTrackReplacedBound)
 	this.parent.off('localTrackEnabledChanged', this.handleLocalTrackEnabledChangedBound)
+
+	this.parent.emit('peerEnded', this)
 }
 
 Peer.prototype.handleLocalTrackReplaced = function(newTrack, oldTrack, stream) {

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -190,6 +190,15 @@ function checkStartPublishOwnPeer(signaling) {
 			ownPeer.end()
 		}
 
+		if (currentSessionId !== signaling.getSessionId()) {
+			console.debug('No answer received for own peer but current session id changed, not sending offer again')
+
+			clearInterval(delayedConnectionToPeer[currentSessionId])
+			delete delayedConnectionToPeer[currentSessionId]
+
+			return
+		}
+
 		console.debug('No answer received for own peer, sending offer again')
 		createPeer()
 	}, 10000)

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -279,9 +279,6 @@ function usersChanged(signaling, newUsers, disconnectedSessionIds) {
 	const currentSessionId = signaling.getSessionId()
 
 	const useMcu = signaling.hasFeature('mcu')
-	if (useMcu && newUsers.length) {
-		checkStartPublishOwnPeer(signaling)
-	}
 
 	let playJoinSound = false
 	let playLeaveSound = false
@@ -471,6 +468,8 @@ function usersInCallChanged(signaling, users) {
 	}
 
 	if (signaling.hasFeature('mcu') && (ownPeer || (currentUsersInRoom.length > 0 && webrtc.webrtc.localStreams.length))) {
+		checkStartPublishOwnPeer(signaling)
+
 		localCallParticipantModel.setPeerNeeded(true)
 	} else {
 		localCallParticipantModel.setPeerNeeded(false)

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -470,6 +470,12 @@ function usersInCallChanged(signaling, users) {
 		userMapping[sessionId] = user
 	}
 
+	if (signaling.hasFeature('mcu') && (ownPeer || (currentUsersInRoom.length > 0 && webrtc.webrtc.localStreams.length))) {
+		localCallParticipantModel.setPeerNeeded(true)
+	} else {
+		localCallParticipantModel.setPeerNeeded(false)
+	}
+
 	if (previousSelfInCall === PARTICIPANT.CALL_FLAG.DISCONNECTED
 		&& selfInCall !== PARTICIPANT.CALL_FLAG.DISCONNECTED) {
 		Sounds.playJoin(true, Object.keys(userMapping).length === 0)

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -155,10 +155,6 @@ function checkStartPublishOwnPeer(signaling) {
 			delete delayedConnectionToPeer[ownPeer.id]
 		}
 		ownPeer.end()
-
-		// The peer does not need to be nullified in the
-		// localCallParticipantModel as a new peer will be immediately set by
-		// createPeer() below.
 	}
 
 	const createPeer = function() {
@@ -911,9 +907,6 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 				delete delayedConnectionToPeer[ownPeer.id]
 			}
 			ownPeer.end()
-			ownPeer = null
-
-			localCallParticipantModel.setPeer(ownPeer)
 		}
 
 		usersChanged(signaling, [], previousUsersInRoom)
@@ -1227,6 +1220,20 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 
 	webrtc.on('peerStreamRemoved', function(peer) {
 		stopPeerCheckMedia(peer)
+	})
+
+	webrtc.on('peerEnded', function(peer) {
+		if (ownPeer === peer) {
+			ownPeer = null
+
+			localCallParticipantModel.setPeer(ownPeer)
+		}
+
+		if (ownScreenPeer === peer) {
+			ownScreenPeer = null
+
+			localCallParticipantModel.setScreenPeer(ownScreenPeer)
+		}
 	})
 
 	webrtc.webrtc.on('videoOn', function() {
@@ -1554,16 +1561,10 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 			}
 
 			ownPeer.end()
-			ownPeer = null
-
-			localCallParticipantModel.setPeer(ownPeer)
 		}
 
 		if (ownScreenPeer) {
 			ownScreenPeer.end()
-			ownScreenPeer = null
-
-			localCallParticipantModel.setScreenPeer(ownScreenPeer)
 		}
 
 		selfInCall = PARTICIPANT.CALL_FLAG.DISCONNECTED


### PR DESCRIPTION
Fixes #5929

When a participant joins a call with audio but not video and then selects a camera during the call [the call flags are updated](https://github.com/nextcloud/spreed/blob/362b956001c2e20fa128a503f7c3e5f1d6680912/src/utils/webrtc/webrtc.js#L1318) and then [a forced reconnection is used](https://github.com/nextcloud/spreed/blob/362b956001c2e20fa128a503f7c3e5f1d6680912/src/utils/webrtc/webrtc.js#L956) to update the connection (as proper renegotiation is not implemented yet). However, the signaling message that is triggered after the call flags are updated can be received once the forced reconnection has started and [all the participants were already removed](https://github.com/nextcloud/spreed/blob/362b956001c2e20fa128a503f7c3e5f1d6680912/src/utils/webrtc/webrtc.js#L910); as the `participants->update` message includes all the participants in the call this creates new peers for them (including the own peer) and re-establishes the WebRTC connections. The peers are then removed and the connections stopped again [when the call is left](https://github.com/nextcloud/spreed/blob/362b956001c2e20fa128a503f7c3e5f1d6680912/src/utils/webrtc/webrtc.js#L495-L496).

However, if the signaling message about leaving the call is not received by the participant being force reconnected (because it is sent while the socket is being reconnected) different problems arise. The scenarios below force those different problems by delaying certain actions with precise timings, but all the scenarios could happen in the real world depending on how (un)lucky you are (I was very (un)lucky :-P ).

Also, although the problems below happen during forced reconnections the fixes may be valid in other circumstances too (for example, #5929), so this makes the code more robust in general, not only for forced reconnections.



## Common setup for scenarios 1-4

- Setup the HPB
- Prevent automatically leaving the call when rejoining the room by commenting https://github.com/nextcloud/spreed/blob/f4208eff934795b0cad9586293ff78ebb5d958d9/lib/Controller/RoomController.php#L1388 (the call will be explicitly left by the browser anyway, but delaying the signaling messages)
- Delay leaving the call by adding `sleep(4);` just before https://github.com/nextcloud/spreed/blob/56d466029506be73782490ed779fe402c7b39c8f/lib/Controller/CallController.php#L164 (which will cause the signaling messages about the user leaving the call to be sent during the socket reconnection, so the participant being force reconnected will not receive it)
- Delay rejoining the room by adding `sleep(2);` just before https://github.com/nextcloud/spreed/blob/f4208eff934795b0cad9586293ff78ebb5d958d9/lib/Controller/RoomController.php#L1352 (to ensure that the [`participants->update`](https://github.com/nextcloud/spreed/blob/16e17abb2e89c43a4a6061d2bdfda1f298b0fe7e/src/utils/signaling.js#L1254) signaling messages sent [due to the call flags being updated to include video](https://github.com/nextcloud/spreed/blob/362b956001c2e20fa128a503f7c3e5f1d6680912/src/utils/webrtc/webrtc.js#L1318) will be received by the participant being force reconnected before the socket reconnection
- Make the socket reconnection take longer by adding `sleep(4);` just before https://github.com/nextcloud/spreed/blob/a628ef17ab4b19add63f75e45151f0e2815e9082/lib/Controller/SignalingController.php#L483 (as the signaling server needs to authenticate the user against the Nextcloud server again when the socket is reconnected; this will make some signaling messages to be lost by the participant being force reconnected as they will be received during the socket reconnection)
- Delay offers and candidates by replacing https://github.com/nextcloud/spreed/blob/16e17abb2e89c43a4a6061d2bdfda1f298b0fe7e/src/utils/signaling.js#L871 with
```
if (msg.type === "message" && (msg.message.data.type === "offer" || msg.message.data.type === "candidate")) {
	setTimeout(() => {
		if (this.socket && this.connected) {
			this.socket.send(JSON.stringify(msg))
		}
	}, 4000)
} else {
	this.socket.send(JSON.stringify(msg))
}
```
(which will cause peer connections to take longer to be established, in some cases (depending on the other delays) [causing a new offer to be sent again](https://github.com/nextcloud/spreed/blob/362b956001c2e20fa128a503f7c3e5f1d6680912/src/utils/webrtc/webrtc.js#L186))



## How to test (scenario 1)

- Common setup, but without the code to delay offers and candidates
- Use Firefox
- Start call as user A
- In a private window, join call as user B
- In the device selector, select microphone, unselect camera, and continue to the call
- Open the device settings, select the camera and close the device settings

### Result with this pull request

Eventually user B is properly reconnected; there is no spinner on local video for user B, and user A can hear and see user B

### Result without this pull request

User B seems to be reconnected (there is no spinner on local video for user B), but browser console shows _RTCPeerConnection is gone (did you enter Offline mode?)_ repeatedly and user A sees a spinner on user B, without audio nor video



## How to test (scenario 2)

- Common setup
- Start call as user A
- In a private window, join call as user B
- In the device selector, select microphone, unselect camera, and continue to the call
- Open the device settings, select the camera and close the device settings

### Result with this pull request

Eventually user B is properly reconnected; there is no spinner on local video for user B, and user A can hear and see user B

### Result without this pull request

There is a spinner on local video for user B, and user A sees a spinner on user B, without audio nor video



## How to test (scenario 3)

- Common setup, but use `sleep(8);` instead of `sleep(4);` for authentication messages
- Start call as user A
- In a private window, join call as user B
- In the device selector, select microphone, unselect camera, and continue to the call
- Open the device settings, select the camera and close the device settings

### Result with this pull request

Eventually user B is properly reconnected; there is no spinner on local video for user B, and user A can hear and see user B; note that this may take longer than in the other scenarios, and in some cases user B appears as connected even if no media is being sent, although eventually user B gets properly reconnected (it is probably related to the delay in the offers and candidates causing the offer for a previous peer being handled by Janus for a newer peer).

### Result without this pull request

There is a spinner on local video for user B, but user A sees user B as connected, although no audio nor video is received



## How to test (scenario 4)

- Common setup
- Delay joining the room in the signaling by wrapping https://github.com/nextcloud/spreed/blob/16e17abb2e89c43a4a6061d2bdfda1f298b0fe7e/src/utils/signaling.js#L1049-L1060 with
```
setTimeout(() => {
...
}, 4000)
```
(which will cause the offer to be sent again after the socket has reconnected (so the signaling session ID was updated) but before joining the room)
- Start call as user A
- In a private window, join call as user B
- In the device selector, select microphone, unselect camera, and continue to the call
- Open the device settings, select the camera and close the device settings

### Result with this pull request

Eventually user B is properly reconnected; there is no spinner on local video for user B, and user A can hear and see user B

### Result without this pull request

There is a spinner on local video for user B, and user A sees a spinner on user B, without audio nor video; user B also sees an additional participant in the call (the previous session before being reconnected)



## How to test (scenario 5)

- Start call as user A
- In a private window, join call as user B
- In the device selector, select microphone, unselect camera, and continue to the call
- Open the device settings, select the camera and close the device settings
- Wait until the reconnection is done (depending on your luck you may have ended in any of the other four scenarios, it does not matter)
- In the browser console, check the value of `Object.keys(OCA.Talk.SimpleWebRTC.connection.joinedUsers).length`

### Result with this pull request

The result is 2

### Result without this pull request

The result is 3; if the call is left by user B, joined again without camera and then camera is selected the result will be 4, and it will increase by one (the session before the forced reconnection) any time this is done
