### PR TITLE
Reduce the set of avatar sizes used

### DIFF
--- a/src/components/CallView/shared/VideoBackground.vue
+++ b/src/components/CallView/shared/VideoBackground.vue
@@ -106,7 +106,7 @@ export default {
 				return null
 			}
 
-			return generateUrl(`avatar/${this.user}/300`)
+			return generateUrl(`avatar/${this.user}/64`)
 		},
 	},
 
@@ -146,7 +146,7 @@ export default {
 		}
 
 		try {
-			await axios.get(generateUrl(`avatar/${this.user}/300`))
+			await axios.get(generateUrl(`avatar/${this.user}/64`))
 
 			this.hasPicture = true
 			setUserHasAvatar(this.user, true)


### PR DESCRIPTION
Since we don't blur the avatar anymore, I wonder if we should get rid of that request and just use the default color from the two letter avatar.
Yes it's less related to the avatar image, but it helps with performance and most other solutions just use a black background.