### PR TITLE
Allow to mark a conversation as unread

### DIFF
--- a/appinfo/routes/routesChatController.php
+++ b/appinfo/routes/routesChatController.php
@@ -41,6 +41,7 @@ return [
 		['name' => 'Chat#clearHistory', 'url' => '/api/{apiVersion}/chat/{token}', 'verb' => 'DELETE', 'requirements' => $requirements],
 		['name' => 'Chat#deleteMessage', 'url' => '/api/{apiVersion}/chat/{token}/{messageId}', 'verb' => 'DELETE', 'requirements' => $requirementsWithMessageId],
 		['name' => 'Chat#setReadMarker', 'url' => '/api/{apiVersion}/chat/{token}/read', 'verb' => 'POST', 'requirements' => $requirements],
+		['name' => 'Chat#markUnread', 'url' => '/api/{apiVersion}/chat/{token}/read', 'verb' => 'DELETE', 'requirements' => $requirements],
 		['name' => 'Chat#mentions', 'url' => '/api/{apiVersion}/chat/{token}/mentions', 'verb' => 'GET', 'requirements' => $requirements],
 		['name' => 'Chat#shareObjectToChat', 'url' => '/api/{apiVersion}/chat/{token}/share', 'verb' => 'POST', 'requirements' => $requirements],
 	],

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -85,3 +85,6 @@ title: Capabilities
 ## 13
 * `direct-mention-flag` - The conversation list populates the boolean `unreadMentionDirect` when the user was mentioned directly (ignoring @all mentions) since their last visit
 * `notification-calls` - Whether the API to opt out of call notifications is available
+
+## 14
+* `chat-unread` - Whether the API to mark a conversation as unread is available

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -230,6 +230,25 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
         `X-Chat-Last-Common-Read` | int | ID of the last message read by every user that has read privacy set to public. When the user themself has it set to private the value the header is not set (only available with `chat-read-status` capability)
 
 
+## Mark chat as unread
+
+* Required capability: `chat-unread`
+* Method: `DELETE`
+* Endpoint: `/chat/{token}/read`
+
+* Response:
+    - Status code:
+        + `200 OK`
+        + `404 Not Found` When the room could not be found for the participant,
+        or the participant is a guest.
+
+    - Header:
+
+        field | type | Description
+        ---|---|---
+        `X-Chat-Last-Common-Read` | int | ID of the last message read by every user that has read privacy set to public. When the user themself has it set to private the value the header is not set (only available with `chat-read-status` capability)
+
+
 ## Get mention autocomplete suggestions
 
 * Method: `GET`

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -78,6 +78,7 @@ class Capabilities implements IPublicCapability {
 				'read-only-rooms',
 				'listable-rooms',
 				'chat-read-marker',
+				'chat-unread',
 				'webinary-lobby',
 				'start-call-flag',
 				'chat-replies',

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -401,6 +401,31 @@ class ChatManager {
 	}
 
 	/**
+	 * @param Room $chat
+	 * @param int $offset Last known message id
+	 * @param array $verbs
+	 * @param bool $offsetIsVerbMatch
+	 * @return IComment
+	 * @throws NotFoundException
+	 */
+	public function getPreviousMessageWithVerb(Room $chat, int $offset, array $verbs, bool $offsetIsVerbMatch): IComment {
+		$messages = $this->commentsManager->getCommentsWithVerbForObjectSinceComment(
+			'chat',
+			(string) $chat->getId(),
+			$verbs,
+			$offset,
+			'desc',
+			!$offsetIsVerbMatch ? 2 : 1
+		);
+
+		if (empty($messages)) {
+			throw new NotFoundException('No comment with verb found');
+		}
+
+		return array_pop($messages);
+	}
+
+	/**
 	 * If there are currently no messages the response will not be sent
 	 * immediately. Instead, HTTP connection will be kept open waiting for new
 	 * messages to arrive and, when they do, then the response will be sent. The

--- a/lib/Chat/CommentsManager.php
+++ b/lib/Chat/CommentsManager.php
@@ -26,6 +26,7 @@ namespace OCA\Talk\Chat;
 use OC\Comments\Comment;
 use OC\Comments\Manager;
 use OCP\Comments\IComment;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 
 class CommentsManager extends Manager {
 	/**
@@ -38,5 +39,110 @@ class CommentsManager extends Manager {
 		$comment = new Comment($this->normalizeDatabaseData($data));
 		$comment->setMessage($message, ChatManager::MAX_CHAT_LENGTH);
 		return $comment;
+	}
+
+	/**
+	 * TODO Remove when moved to server
+	 *
+	 * @param string $objectType the object type, e.g. 'files'
+	 * @param string $objectId the id of the object
+	 * @param string[] $verbs List of verbs to filter by
+	 * @param int $lastKnownCommentId the last known comment (will be used as offset)
+	 * @param string $sortDirection direction of the comments (`asc` or `desc`)
+	 * @param int $limit optional, number of maximum comments to be returned. if
+	 * set to 0, all comments are returned.
+	 * @param bool $includeLastKnown
+	 * @return IComment[]
+	 * @return array
+	 */
+	public function getCommentsWithVerbForObjectSinceComment(
+		string $objectType,
+		string $objectId,
+		array $verbs,
+		int $lastKnownCommentId,
+		string $sortDirection = 'asc',
+		int $limit = 30,
+		bool $includeLastKnown = false
+	): array {
+		$comments = [];
+
+		$query = $this->dbConn->getQueryBuilder();
+		$query->select('*')
+			->from('comments')
+			->where($query->expr()->eq('object_type', $query->createNamedParameter($objectType)))
+			->andWhere($query->expr()->eq('object_id', $query->createNamedParameter($objectId)))
+			->andWhere($query->expr()->in('verb', $query->createNamedParameter($verbs, IQueryBuilder::PARAM_STR_ARRAY)))
+			->orderBy('creation_timestamp', $sortDirection === 'desc' ? 'DESC' : 'ASC')
+			->addOrderBy('id', $sortDirection === 'desc' ? 'DESC' : 'ASC');
+
+		if ($limit > 0) {
+			$query->setMaxResults($limit);
+		}
+
+		$lastKnownComment = $lastKnownCommentId > 0 ? $this->getLastKnownComment(
+			$objectType,
+			$objectId,
+			$lastKnownCommentId
+		) : null;
+		if ($lastKnownComment instanceof IComment) {
+			$lastKnownCommentDateTime = $lastKnownComment->getCreationDateTime();
+			if ($sortDirection === 'desc') {
+				if ($includeLastKnown) {
+					$idComparison = $query->expr()->lte('id', $query->createNamedParameter($lastKnownCommentId));
+				} else {
+					$idComparison = $query->expr()->lt('id', $query->createNamedParameter($lastKnownCommentId));
+				}
+				$query->andWhere(
+					$query->expr()->orX(
+						$query->expr()->lt(
+							'creation_timestamp',
+							$query->createNamedParameter($lastKnownCommentDateTime, IQueryBuilder::PARAM_DATE),
+							IQueryBuilder::PARAM_DATE
+						),
+						$query->expr()->andX(
+							$query->expr()->eq(
+								'creation_timestamp',
+								$query->createNamedParameter($lastKnownCommentDateTime, IQueryBuilder::PARAM_DATE),
+								IQueryBuilder::PARAM_DATE
+							),
+							$idComparison
+						)
+					)
+				);
+			} else {
+				if ($includeLastKnown) {
+					$idComparison = $query->expr()->gte('id', $query->createNamedParameter($lastKnownCommentId));
+				} else {
+					$idComparison = $query->expr()->gt('id', $query->createNamedParameter($lastKnownCommentId));
+				}
+				$query->andWhere(
+					$query->expr()->orX(
+						$query->expr()->gt(
+							'creation_timestamp',
+							$query->createNamedParameter($lastKnownCommentDateTime, IQueryBuilder::PARAM_DATE),
+							IQueryBuilder::PARAM_DATE
+						),
+						$query->expr()->andX(
+							$query->expr()->eq(
+								'creation_timestamp',
+								$query->createNamedParameter($lastKnownCommentDateTime, IQueryBuilder::PARAM_DATE),
+								IQueryBuilder::PARAM_DATE
+							),
+							$idComparison
+						)
+					)
+				);
+			}
+		}
+
+		$resultStatement = $query->execute();
+		while ($data = $resultStatement->fetch()) {
+			$comment = $this->getCommentFromData($data);
+			$this->cache($comment);
+			$comments[] = $comment;
+		}
+		$resultStatement->closeCursor();
+
+		return $comments;
 	}
 }

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -683,11 +683,17 @@ class ChatController extends AEnvironmentAwareController {
 		$unreadId = 0;
 
 		if ($message instanceof IComment) {
-			$history = $this->chatManager->getHistory($this->room, (int) $message->getId(), 1, false);
-			if (!empty($history)) {
-				/** @var IComment $previousMessage */
-				$previousMessage = array_shift($history);
+			try {
+				$previousMessage = $this->chatManager->getPreviousMessageWithVerb(
+					$this->room,
+					(int)$message->getId(),
+					['comment'],
+					$message->getVerb() === 'comment'
+				);
 				$unreadId = (int) $previousMessage->getId();
+			} catch (NotFoundException $e) {
+				// No chat message found, only system messages.
+				// Marking unread from beginning
 			}
 		}
 

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -673,6 +673,28 @@ class ChatController extends AEnvironmentAwareController {
 	}
 
 	/**
+	 * @NoAdminRequired
+	 * @RequireParticipant
+	 *
+	 * @return DataResponse
+	 */
+	public function markUnread(): DataResponse {
+		$message = $this->room->getLastMessage();
+		$unreadId = 0;
+
+		if ($message instanceof IComment) {
+			$history = $this->chatManager->getHistory($this->room, (int) $message->getId(), 1, false);
+			if (!empty($history)) {
+				/** @var IComment $previousMessage */
+				$previousMessage = array_shift($history);
+				$unreadId = (int) $previousMessage->getId();
+			}
+		}
+
+		return $this->setReadMarker($unreadId);
+	}
+
+	/**
 	 * @PublicPage
 	 * @RequireParticipant
 	 * @RequireReadWriteConversation

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1384,6 +1384,22 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" marks room "([^"]*)" as unread with (\d+)(?: \((v1)\))?$/
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 * @param string $statusCode
+	 * @param string $apiVersion
+	 */
+	public function userMarkUnreadRoom($user, $identifier, $statusCode, $apiVersion = 'v1') {
+		$this->setCurrentUser($user);
+		$this->sendRequest(
+			'DELETE', '/apps/spreed/api/' . $apiVersion . '/chat/' . self::$identifierToToken[$identifier] . '/read',
+		);
+		$this->assertStatusCode($this->response, $statusCode);
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" sends message "([^"]*)" with reference id "([^"]*)" to room "([^"]*)" with (\d+)(?: \((v1)\))?$/
 	 *
 	 * @param string $user

--- a/tests/integration/features/chat/unread-messages.feature
+++ b/tests/integration/features/chat/unread-messages.feature
@@ -133,3 +133,53 @@ Feature: chat/unread-messages
     And user "participant2" is participant of room "group room" (v4)
       | unreadMessages |
       | 0              |
+
+
+
+  Scenario: marking conversation as unread marks last message as unread
+    Given user "participant1" creates room "group room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "group room" with 200 (v4)
+    And user "participant1" sends message "Message 1" to room "group room" with 201
+    And user "participant1" sends message "Message 2" to room "group room" with 201
+    And user "participant1" sends message "Message 3" to room "group room" with 201
+    And user "participant2" reads message "Message 3" in room "group room" with 200
+    When user "participant1" marks room "group room" as unread with 200
+    And user "participant2" marks room "group room" as unread with 200
+    Then user "participant1" is participant of room "group room" (v4)
+      | unreadMessages |
+      | 1              |
+    And user "participant2" is participant of room "group room" (v4)
+      | unreadMessages |
+      | 1              |
+
+  Scenario: marking conversation as unread marks last message as unread ignoring system messages
+    Given user "participant1" creates room "group room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" sends message "Message 1" to room "group room" with 201
+    And user "participant1" sends message "Message 2" to room "group room" with 201
+    And user "participant1" sends message "Message 3" to room "group room" with 201
+    And user "participant1" makes room "group room" public with 200 (v4)
+    And user "participant1" makes room "group room" private with 200 (v4)
+    And user "participant1" makes room "group room" public with 200 (v4)
+    When user "participant1" marks room "group room" as unread with 200
+    Then user "participant1" is participant of room "group room" (v4)
+      | unreadMessages |
+      | 1              |
+
+  Scenario: marking conversation as unread marks last message as unread even if there are other unread messages
+    Given user "participant1" creates room "group room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "group room" with 200 (v4)
+    And user "participant1" sends message "Message 1" to room "group room" with 201
+    And user "participant1" sends message "Message 2" to room "group room" with 201
+    And user "participant1" sends message "Message 3" to room "group room" with 201
+    And user "participant1" sends message "Message 4" to room "group room" with 201
+    And user "participant2" reads message "Message 1" in room "group room" with 200
+    When user "participant2" marks room "group room" as unread with 200
+    Then user "participant2" is participant of room "group room" (v4)
+      | unreadMessages |
+      | 1              |

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -75,6 +75,7 @@ class CapabilitiesTest extends TestCase {
 			'read-only-rooms',
 			'listable-rooms',
 			'chat-read-marker',
+			'chat-unread',
 			'webinary-lobby',
 			'start-call-flag',
 			'chat-replies',


### PR DESCRIPTION
Ref https://github.com/nextcloud/talk-android/pull/1752#issuecomment-1002756845

cc @mahibi @Ivansss shall I create you issues in your repo top use this on the conversation list when the item is fully read?