### PR TITLE
Allow to share audio of screenshares

### DIFF
--- a/src/components/CallView/shared/Screen.vue
+++ b/src/components/CallView/shared/Screen.vue
@@ -150,7 +150,11 @@ export default {
 				return
 			}
 
+			// The audio is played using an audio element in the model to be
+			// able to hear it even if there is no view for it.
 			attachMediaStream(screen, this.$refs.screen)
+
+			this.$refs.screen.muted = true
 		},
 
 	},

--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -67,6 +67,9 @@ export default function CallParticipantModel(options) {
 		speaking: undefined,
 		videoAvailable: undefined,
 		screen: null,
+		// The audio element is part of the model to ensure that it can be
+		// played if needed even if there is no view for it.
+		screenAudioElement: null,
 		raisedHand: {
 			state: false,
 			timestamp: null,
@@ -139,6 +142,7 @@ CallParticipantModel.prototype = {
 			}
 		} else if (this.get('screenPeer') === peer) {
 			this.set('screen', this.get('screenPeer').stream || null)
+			this.set('screenAudioElement', attachMediaStream(this.get('screen'), null, { audio: true }))
 		}
 	},
 
@@ -151,6 +155,8 @@ CallParticipantModel.prototype = {
 			this.set('speaking', undefined)
 			this.set('videoAvailable', undefined)
 		} else if (this.get('screenPeer') === peer) {
+			this.get('screenAudioElement').srcObject = null
+			this.set('screenAudioElement', null)
 			this.set('screen', null)
 		}
 	},

--- a/src/utils/webrtc/simplewebrtc/getscreenmedia.js
+++ b/src/utils/webrtc/simplewebrtc/getscreenmedia.js
@@ -35,7 +35,16 @@ module.exports = function(mode, constraints, cb) {
 	}
 
 	if (navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia) {
-		navigator.mediaDevices.getDisplayMedia({ video: true }).then(function(stream) {
+		navigator.mediaDevices.getDisplayMedia({
+			video: true,
+			// Disable default audio optimizations, as they are meant to be used
+			// with a microphone input.
+			audio: {
+				echoCancellation: false,
+				autoGainControl: false,
+				noiseSuppression: false,
+			},
+		}).then(function(stream) {
 			callback(null, stream)
 		}).catch(function(error) {
 			callback(error, null)


### PR DESCRIPTION
Currently only works in Chrome and Chrome based browsers
and is limited to sharing a ChromeTab or the full system sound.

Fix #3546 