### PR TITLE
Fix peer user not showing as offline in one-to-one conversations

### DIFF
--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -354,7 +354,7 @@ export default {
 		 * Current actor id
 		 */
 		actorId() {
-			return this.$store.getters.getActorId
+			return this.$store.getters.getActorId()
 		},
 
 		/**


### PR DESCRIPTION
### Steps
1. User A starts 1-to-1 with User B
2. User A sees User B as offline in top bar
3. User A navigates away
4. User B opens the 1-to-1
5. User B sees User A as online (although they are offline)