### PR TITLE
Fix switching between screenshares

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -298,7 +298,7 @@ export default {
 
 		// Show local screen
 		showLocalScreen() {
-			return this.hasLocalScreen && this.selectedVideoPeerId === null
+			return this.hasLocalScreen && this.selectedVideoPeerId === null && this.screens[0] === localCallParticipantModel.attributes.peerId
 		},
 
 		// Show somebody else's screen. This will show the screen of the last

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -39,8 +39,7 @@
 							:show-talking-highlight="false"
 							:is-grid="true"
 							:is-big="true"
-							:fit-video="true"
-							@switch-screen-to-id="_switchScreenToId" />
+							:fit-video="true" />
 					</template>
 				</div>
 				<!-- Screens -->
@@ -77,8 +76,7 @@
 						:local-media-model="localMediaModel"
 						:video-container-aspect-ratio="videoContainerAspectRatio"
 						:local-call-participant-model="localCallParticipantModel"
-						:is-sidebar="false"
-						@switch-screen-to-id="_switchScreenToId" />
+						:is-sidebar="false" />
 				</div>
 				<!-- Promoted "autopilot" mode -->
 				<div v-else
@@ -96,8 +94,7 @@
 							:fit-video="true"
 							:is-big="true"
 							:is-one-to-one="isOneToOne"
-							:is-sidebar="isSidebar"
-							@switch-screen-to-id="_switchScreenToId" />
+							:is-sidebar="isSidebar" />
 					</template>
 				</div>
 			</template>
@@ -120,7 +117,6 @@
 				:local-call-participant-model="localCallParticipantModel"
 				:shared-datas="sharedDatas"
 				@select-video="handleSelectVideo"
-				@switch-screen-to-id="_switchScreenToId"
 				@click-local-video="handleClickLocalVideo" />
 			<!-- Local video if sidebar -->
 			<LocalVideo v-if="isSidebar && !showLocalVideo"
@@ -135,7 +131,6 @@
 				:video-container-aspect-ratio="videoContainerAspectRatio"
 				:local-call-participant-model="localCallParticipantModel"
 				:is-sidebar="isSidebar"
-				@switch-screen-to-id="_switchScreenToId"
 				@click-video="handleClickLocalVideo" />
 		</div>
 	</div>
@@ -410,6 +405,7 @@ export default {
 		callParticipantCollection.on('remove', this._lowerHandWhenParticipantLeaves)
 
 		subscribe('talk:video:toggled', this.handleToggleVideo)
+		subscribe('switch-screen-to-id', this._switchScreenToId)
 	},
 	beforeDestroy() {
 		EventBus.$off('refresh-peer-list', this.debounceFetchPeers)
@@ -417,6 +413,7 @@ export default {
 		callParticipantCollection.off('remove', this._lowerHandWhenParticipantLeaves)
 
 		unsubscribe('talk:video:toggled', this.handleToggleVideo)
+		unsubscribe('switch-screen-to-id', this._switchScreenToId)
 	},
 	methods: {
 		/**

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -103,7 +103,6 @@
 							:local-media-model="localMediaModel"
 							:video-container-aspect-ratio="videoContainerAspectRatio"
 							:local-call-participant-model="localCallParticipantModel"
-							@switch-screen-to-id="switchScreenToId"
 							@click-video="handleClickLocalVideo" />
 					</div>
 					<button v-if="hasNextPage && gridWidth > 0"
@@ -126,7 +125,6 @@
 					:local-media-model="localMediaModel"
 					:video-container-aspect-ratio="videoContainerAspectRatio"
 					:local-call-participant-model="localCallParticipantModel"
-					@switch-screen-to-id="switchScreenToId"
 					@click-video="handleClickLocalVideo" />
 				<!-- page indicator (disabled) -->
 				<div v-if="numberOfPages !== 0 && hasPagination && false"
@@ -761,10 +759,6 @@ export default {
 
 		handleClickLocalVideo() {
 			this.$emit('click-local-video')
-		},
-
-		switchScreenToId(id) {
-			this.$emit('switch-screen-to-id', id)
 		},
 
 		isSelected(callParticipantModel) {

--- a/src/components/CallView/shared/LocalMediaControls.vue
+++ b/src/components/CallView/shared/LocalMediaControls.vue
@@ -799,7 +799,7 @@ export default {
 
 		showScreen() {
 			if (this.model.attributes.localScreen) {
-				this.$emit('switch-screen-to-id', this.localCallParticipantModel.attributes.peerId)
+				emit('switch-screen-to-id', this.localCallParticipantModel.attributes.peerId)
 			}
 
 			this.screenSharingMenuOpen = false

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -300,10 +300,6 @@ export default {
 			this.$store.dispatch('selectedVideoPeerId', null)
 			this.$store.dispatch('stopPresentation')
 		},
-
-		switchScreenToId(id) {
-			this.$emit('switch-screen-to-id', id)
-		},
 	},
 
 }

--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -263,7 +263,7 @@ export default {
 
 		switchToScreen() {
 			if (!this.sharedData.screenVisible) {
-				this.$emit('switch-screen-to-id', this.model.attributes.peerId)
+				emit('switch-screen-to-id', this.model.attributes.peerId)
 			}
 		},
 


### PR DESCRIPTION
## How to test

- Start a call with user A
- Join the call with user B
- Join the call with user C
- As user A, share a window
- As user B, share a different window
- As user C, share yet another different window (or the whole screen)
- Switch between the screen shares in speaker mode by clicking on the "Show screen" icon on each remote participant or the "Show my screen" menu entry in the top bar

### Result with this pull request

It is possible to switch between the different screen shares.

### Result without this pull request

The local screen share is always shown.
