### PR TITLE
Remove unneeded SimpleWebRTC code

### DIFF
--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -16,7 +16,6 @@ function SimpleWebRTC(opts) {
 		socketio: {/* 'force new connection':true */},
 		connection: null,
 		debug: false,
-		localVideoEl: '',
 		enableDataChannels: true,
 		enableSimulcast: false,
 		maxBitrates: {
@@ -284,33 +283,12 @@ SimpleWebRTC.prototype.startLocalVideo = function(mediaConstraints) {
 			self.emit('localMediaError', err)
 		} else {
 			self.emit('localMediaStarted', actualConstraints)
-
-			const localVideoContainer = self.getLocalVideoContainer()
-			if (localVideoContainer) {
-				attachMediaStream(stream, localVideoContainer, self.config.localVideo)
-			}
 		}
 	})
 }
 
 SimpleWebRTC.prototype.stopLocalVideo = function() {
 	this.webrtc.stop()
-}
-
-// this accepts either element ID or element
-// and either the video tag itself or a container
-// that will be used to put the video tag into.
-SimpleWebRTC.prototype.getLocalVideoContainer = function() {
-	const el = this.getEl(this.config.localVideoEl)
-	if (el && el.tagName === 'VIDEO') {
-		el.oncontextmenu = function() { return false }
-		return el
-	} else if (el) {
-		const video = document.createElement('video')
-		video.oncontextmenu = function() { return false }
-		el.appendChild(video)
-		return video
-	}
 }
 
 SimpleWebRTC.prototype.shareScreen = function(mode, cb) {

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -13,7 +13,6 @@ function SimpleWebRTC(opts) {
 	const self = this
 	const options = opts || {}
 	const config = this.config = {
-		socketio: {/* 'force new connection':true */},
 		connection: null,
 		debug: false,
 		enableDataChannels: true,
@@ -24,15 +23,9 @@ function SimpleWebRTC(opts) {
 			low: 100000,
 		},
 		autoRequestMedia: false,
-		autoRemoveVideos: true,
 		receiveMedia: {
 			offerToReceiveAudio: 1,
 			offerToReceiveVideo: 1,
-		},
-		localVideo: {
-			autoplay: true,
-			mirror: true,
-			muted: true,
 		},
 	}
 	let item, connection

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -3,7 +3,6 @@
 const WebRTC = require('./webrtc')
 const WildEmitter = require('wildemitter')
 const webrtcSupport = require('webrtcsupport')
-const attachMediaStream = require('attachmediastream')
 const mockconsole = require('mockconsole')
 
 /**
@@ -200,13 +199,7 @@ function SimpleWebRTC(opts) {
 
 	// screensharing events
 	this.webrtc.on('localScreen', function(stream) {
-		const el = document.createElement('video')
-
-		el.oncontextmenu = function() { return false }
-		el.id = 'localScreen'
-		attachMediaStream(stream, el)
-
-		self.emit('localScreenAdded', el)
+		self.emit('localScreenAdded')
 		self.connection.emit('shareScreen')
 
 		// NOTE: we don't create screen peers for existing video peers here,
@@ -282,13 +275,7 @@ SimpleWebRTC.prototype.getLocalScreen = function() {
 
 SimpleWebRTC.prototype.stopScreenShare = function() {
 	this.connection.emit('unshareScreen')
-	const videoEl = document.getElementById('localScreen')
 
-	// a hack to emit the event the removes the video
-	// element that we want
-	if (videoEl) {
-		this.emit('videoRemoved', videoEl)
-	}
 	if (this.getLocalScreen()) {
 		this.webrtc.stopScreenShare()
 	}

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -268,14 +268,6 @@ SimpleWebRTC.prototype.joinCall = function(name, mediaConstraints) {
 	this.emit('joinedRoom', name)
 }
 
-SimpleWebRTC.prototype.getEl = function(idOrEl) {
-	if (typeof idOrEl === 'string') {
-		return document.getElementById(idOrEl)
-	} else {
-		return idOrEl
-	}
-}
-
 SimpleWebRTC.prototype.startLocalVideo = function(mediaConstraints) {
 	const self = this
 	this.webrtc.start(mediaConstraints, function(err, stream, actualConstraints) {

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -26,8 +26,6 @@ function SimpleWebRTC(opts) {
 		},
 		autoRequestMedia: false,
 		autoRemoveVideos: true,
-		adjustPeerVolume: false,
-		peerVolumeWhenSpeaking: 0.25,
 		receiveMedia: {
 			offerToReceiveAudio: 1,
 			offerToReceiveVideo: 1,
@@ -176,12 +174,6 @@ function SimpleWebRTC(opts) {
 		self.connection.emit('message', payload)
 	})
 
-	// echo cancellation attempts
-	if (this.config.adjustPeerVolume) {
-		this.webrtc.on('speaking', this.setVolumeForAll.bind(this, this.config.peerVolumeWhenSpeaking))
-		this.webrtc.on('stoppedSpeaking', this.setVolumeForAll.bind(this, 1))
-	}
-
 	connection.on('stunservers', function(args) {
 		// resets/overrides the config
 		self.webrtc.config.peerConnectionConfig.iceServers = args
@@ -267,15 +259,6 @@ SimpleWebRTC.prototype.disconnect = function() {
 
 SimpleWebRTC.prototype.getDomId = function(peer) {
 	return [peer.id, peer.type, peer.broadcaster ? 'broadcasting' : 'incoming'].join('_')
-}
-
-// set volume on video tag for all peers takse a value between 0 and 1
-SimpleWebRTC.prototype.setVolumeForAll = function(volume) {
-	this.webrtc.peers.forEach(function(peer) {
-		if (peer.audioEl) {
-			peer.audioEl.volume = volume
-		}
-	})
 }
 
 SimpleWebRTC.prototype.joinCall = function(name, mediaConstraints) {

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -426,13 +426,4 @@ SimpleWebRTC.prototype.stopScreenShare = function() {
 	})
 }
 
-SimpleWebRTC.prototype.createRoom = function(name, cb) {
-	this.roomName = name
-	if (arguments.length === 2) {
-		this.connection.emit('create', name, cb)
-	} else {
-		this.connection.emit('create', name)
-	}
-}
-
 module.exports = SimpleWebRTC

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -249,10 +249,6 @@ SimpleWebRTC.prototype.disconnect = function() {
 	this.emit('disconnected')
 }
 
-SimpleWebRTC.prototype.getDomId = function(peer) {
-	return [peer.id, peer.type, peer.broadcaster ? 'broadcasting' : 'incoming'].join('_')
-}
-
 SimpleWebRTC.prototype.joinCall = function(name, mediaConstraints) {
 	if (this.config.autoRequestMedia) {
 		this.startLocalVideo(mediaConstraints)

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -651,7 +651,6 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 	})
 
 	webrtc = new SimpleWebRTC({
-		remoteVideosEl: '',
 		autoRequestMedia: true,
 		debug: false,
 		autoAdjustMic: false,

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -1521,7 +1521,7 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 	})
 
 	// Local screen added.
-	webrtc.on('localScreenAdded', function(/* video */) {
+	webrtc.on('localScreenAdded', function() {
 		const currentSessionId = signaling.getSessionId()
 		for (const sessionId in usersInCallMapping) {
 			if (!Object.prototype.hasOwnProperty.call(usersInCallMapping, sessionId)) {


### PR DESCRIPTION
This pull request just removes some unneeded code; everything should work as before (note that [there are some issues when switching between screenshares](https://github.com/nextcloud/spreed/pull/6831), they are unrelated to the changes here).

The most notable removal is an additional and unneeded video element that was created for local screenshares. Until now this had no noticeable effect, but [now that screen shares can have audio too](https://github.com/nextcloud/spreed/pull/6810) it caused the audio of the local screenshare to be played, which could cause a little echo.
