### PR TITLE
Fix screenshare not stopped in receiver participants with HPB

### DIFF
--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -1545,16 +1545,10 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 			return
 		}
 
-		if (ownScreenPeer) {
-			ownScreenPeer = null
-
-			localCallParticipantModel.setScreenPeer(ownScreenPeer)
-
-			signaling.sendRoomMessage({
-				roomType: 'screen',
-				type: 'unshareScreen',
-			})
-		}
+		signaling.sendRoomMessage({
+			roomType: 'screen',
+			type: 'unshareScreen',
+		})
 	})
 
 	webrtc.on('disconnected', function() {


### PR DESCRIPTION
This pull request fixes a regression introduced in https://github.com/nextcloud/spreed/pull/6771/commits/57bca1628062da11f429443b91d47c3bd6d39719

## How to test

- Setup the HPB
- Start a call
- In a private window, join the call
- Share the screen
- Stop sharing the screen

### Result with this pull request

The screenshare is stopped in both participants

### Result without this pull request

The screenshare is not stopped in the receiver participant