### PR TITLE
Reparent file picker and viewer in fullscreen mode

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -446,6 +446,19 @@ export default {
 					},
 				],
 			})
+
+			// FIXME Remove this hack once it is possible to set the parent
+			// element of the viewer.
+			// By default the viewer is a sibling of the fullscreen element, so
+			// it is not visible when in fullscreen mode. It is not possible to
+			// specify the parent nor to know when the viewer was actually
+			// opened, so for the time being it is reparented if needed shortly
+			// after calling it.
+			setTimeout(() => {
+				if (this.$store.getters.isFullscreen()) {
+					document.getElementById('content-vue').appendChild(document.getElementById('viewer'))
+				}
+			}, 1000)
 		},
 	},
 }

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -409,6 +409,19 @@ export default {
 					shareFile(path, this.token)
 					this.$refs.advancedInput.focusInput()
 				})
+
+			// FIXME Remove this hack once it is possible to set the parent
+			// element of the file picker.
+			// By default the file picker is a sibling of the fullscreen
+			// element, so it is not visible when in fullscreen mode. It is not
+			// possible to specify the parent nor to know when the file picker
+			// was actually opened, so for the time being it is reparented if
+			// needed shortly after calling it.
+			setTimeout(() => {
+				if (this.$store.getters.isFullscreen()) {
+					document.getElementById('content-vue').appendChild(document.querySelector('.oc-dialog'))
+				}
+			}, 1000)
 		},
 
 		/**


### PR DESCRIPTION
Follow up to #6119
Work around for #6151 until https://github.com/nextcloud/nextcloud-dialogs/issues/427 and https://github.com/nextcloud/viewer/issues/995 are fixed

By default the file picker and the viewer are siblings of the fullscreen element, so they are not visible when in fullscreen mode. It is not possible to specify the parent nor to know when the file picker or the viewer were actually opened, so for the time being they are reparented if needed shortly after calling them.

This is just a temporary hack until it is possible to specify the parent element, but that would require changes in the Vue library, the viewer and the server dialogs, so this horrible code will have to do for now :cry: 

A slightly better work around would be to look for the element to reparent several times in shorter intervals until it is found rather than just once after one second, but for simplicity I opted for the single timeout (but I can adjust it to the other approach if desired, of course).

## How to test (scenario 1)
- Open a conversation in Talk
- Change to fullscreen mode
- Share a file from Nextcloud

### Result with this pull request
The file picker is shown (with a small lag)

### Result without this pull request
The file picker is not shown until the fullscreen mode is left (for example, by pressing Esc)

## How to test (scenario 2)
- Open a conversation in Talk
- Share a file from Nextcloud
- Change to fullscreen mode
- Click on the file to open the viewer

### Result with this pull request
The viewer is shown (with a small lag)

### Result without this pull request
The viewer is not shown until the fullscreen mode is left (for example, by pressing Esc)