### PR TITLE
Handle all user status changes in case of "End meeting for all" in 1 …

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -179,12 +179,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ChristophWurst/nextcloud_composer.git",
-                "reference": "8d20160d6a06f4731acaee1989fd4f81c854ec9a"
+                "reference": "ed583894ecc139b3c8c687cf602e2113ff15ffb9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_composer/zipball/8d20160d6a06f4731acaee1989fd4f81c854ec9a",
-                "reference": "8d20160d6a06f4731acaee1989fd4f81c854ec9a",
+                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_composer/zipball/ed583894ecc139b3c8c687cf602e2113ff15ffb9",
+                "reference": "ed583894ecc139b3c8c687cf602e2113ff15ffb9",
                 "shasum": ""
             },
             "require": {
@@ -215,7 +215,7 @@
                 "issues": "https://github.com/ChristophWurst/nextcloud_composer/issues",
                 "source": "https://github.com/ChristophWurst/nextcloud_composer/tree/master"
             },
-            "time": "2022-02-09T01:16:59+00:00"
+            "time": "2022-02-25T01:19:34+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",

--- a/lib/Events/EndCallForEveryoneEvent.php
+++ b/lib/Events/EndCallForEveryoneEvent.php
@@ -30,6 +30,8 @@ class EndCallForEveryoneEvent extends ModifyRoomEvent {
 
 	/** @var string[] */
 	protected $sessionIds;
+	/** @var string[] */
+	protected $userIds;
 
 	public function __construct(Room $room,
 								?Participant $actor = null) {
@@ -50,5 +52,21 @@ class EndCallForEveryoneEvent extends ModifyRoomEvent {
 	 */
 	public function getSessionIds(): array {
 		return $this->sessionIds;
+	}
+
+	/**
+	 * @param string[] $userIds
+	 * @return void
+	 */
+	public function setUserIds(array $userIds): void {
+		$this->userIds = $userIds;
+	}
+
+	/**
+	 * Only available in the after-event
+	 * @return string[]
+	 */
+	public function getUserIds(): array {
+		return $this->userIds;
 	}
 }

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -913,14 +913,19 @@ class ParticipantService {
 
 		$participants = $this->getParticipantsInCall($room);
 		$changedSessionIds = [];
+		$changedUserIds = [];
 
 		// kick out all participants out of the call
 		foreach ($participants as $participant) {
 			$changedSessionIds[] = $participant->getSession()->getSessionId();
+			if ($participant->getAttendee()->getActorType() === Attendee::ACTOR_USERS) {
+				$changedUserIds[] = $participant->getAttendee()->getActorId();
+			}
 			$this->changeInCall($room, $participant, Participant::FLAG_DISCONNECTED, true);
 		}
 
 		$event->setSessionIds($changedSessionIds);
+		$event->setUserIds($changedUserIds);
 
 		$this->dispatcher->dispatch(Room::EVENT_AFTER_END_CALL_FOR_EVERYONE, $event);
 	}


### PR DESCRIPTION
…execution

- [x] Requires https://github.com/nextcloud/server/pull/31106
- [x] Missing listener call to the correct event
- [x] Needs a lib update