### PR TITLE
Use renegotiations to update publisher connections

### DIFF
--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -357,7 +357,7 @@ Peer.prototype.offer = function(options) {
 	if (sendVideo && this.enableSimulcast && adapter.browserDetails.browser === 'firefox') {
 		console.debug('Enabling Simulcasting for Firefox (RID)')
 		const sender = this.pc.getSenders().find(function(s) {
-			return s.track.kind === 'video'
+			return s.track && s.track.kind === 'video'
 		})
 		if (sender) {
 			let parameters = sender.getParameters()


### PR DESCRIPTION
Requires strukturag/nextcloud-spreed-signaling#229
Requires https://github.com/nextcloud/talk-ios/pull/731 and https://github.com/nextcloud/talk-ios/pull/732
Requires https://github.com/nextcloud/talk-android/pull/1823

When the HPB supports the ~~`publisher-update`~~ `update-sdp` feature sending an updated offer for a publisher will propagate the renegotiation to the subscribers as well. Therefore, in those cases there is no need to force a reconnection, it is enough to send the new offer to trigger the renegotiation (~~given that all the clients will handle the updated offer using the current connection~~ The mobile apps will require a minor change).

Note that this can be used only to update an existing connection. If a participant is not sending any media and then starts to do it (no matter if a device was now selected or if the permissions were granted) sending an offer to the HPB would establish the publisher connection, but as the other clients do not have a subscriber connection already they will not receive any updated offer, they would need to explicitly request it. This might be doable with just a small change in the clients, but it will be something for [another pull request](https://github.com/nextcloud/spreed/pull/6934).

Similarly, when the HPB is not used sending a new offer might work to establish the connection with the other clients, even without changes in the mobile apps. However, stopping the connection (for example, when the permissions are revoked) would require some changes anyway (it might be possible to send an offer to stop sending media, but that would still keep the connection open, even if no media is being transmitted).

Independently of all that, if the external signaling server does not support the new `update-sdp` feature then forced reconnections will still be used like before.

Pending:
- [X] Adjust to possible changes in strukturag/nextcloud-spreed-signaling#229
- [ ] Adjust the mobile apps to support this
- [ ] Check if renegotiations would work too if the HPB is not used

## How to test (scenario 1)

- Setup the HPB (with strukturag/nextcloud-spreed-signaling#229)
- Start a call
- In a private window, join the call and, in the device checker shown before actually joining the call, select an audio device and no video device
- Join the call
- Open the device settings, select a video device and close the device settings
- Enable video

### Result with this pull request

In the original window the video is now visible even if no forced reconnection was triggered, only a renegotiation

### Result without this pull request

In the private window a forced reconnection was triggered


## How to test (scenario 2)

- Setup the HPB (with strukturag/nextcloud-spreed-signaling#229)
- Remove video permissions by default in a conversation
- Start a call as a moderator
- In a private window, open the conversation as a guest
- Join the call with both audio and video (although the video will be blocked once joined)
- In the original window, grant video permissions to the guest
- In the private window, enable video

### Result with this pull request

In the original window the video is now visible even if no forced reconnection was triggered, only a renegotiation

### Result without this pull request

In the private window a forced reconnection was triggered
