### PR TITLE
Update image in script to run local integration tests in Docker

### DIFF
--- a/tests/integration/run-docker.sh
+++ b/tests/integration/run-docker.sh
@@ -214,8 +214,9 @@ trap cleanUp EXIT
 cd "$(dirname $0)"
 
 # "--image XXX" option can be provided to set the Docker image to use to run
-# the integration tests (one of the "nextcloudci/phpX.Y:phpX.Y-Z" images).
-NEXTCLOUD_LOCAL_IMAGE="nextcloudci/php7.3:php7.3-5"
+# the integration tests (one of the "nextcloudci/phpX.Y:phpX.Y-Z" or
+# "ghcr.io/nextcloud/continuous-integration-phpX.Y:latest" images).
+NEXTCLOUD_LOCAL_IMAGE="ghcr.io/nextcloud/continuous-integration-php8.0:latest"
 if [ "$1" = "--image" ]; then
 	NEXTCLOUD_LOCAL_IMAGE=$2
 


### PR DESCRIPTION
PHP 7.3 support was dropped for Nextcloud 24. The Docker image is updated to the same image used for integration tests in CI (personally I would prefer an explicit tag rather than `latest`, but they are not available :shrug:).