### PR TITLE
Define if job is time sensitive

### DIFF
--- a/lib/BackgroundJob/CheckHostedSignalingServer.php
+++ b/lib/BackgroundJob/CheckHostedSignalingServer.php
@@ -29,6 +29,7 @@ use OCA\Talk\DataObjects\AccountId;
 use OCA\Talk\Exceptions\HostedSignalingServerAPIException;
 use OCA\Talk\Service\HostedSignalingServerService;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;
 use OCP\IConfig;
 use OCP\IGroup;
@@ -60,7 +61,11 @@ class CheckHostedSignalingServer extends TimedJob {
 								IURLGenerator $urlGenerator,
 								LoggerInterface $logger) {
 		parent::__construct($timeFactory);
+
+		// Every hour
 		$this->setInterval(3600);
+		$this->setTimeSensitivity(IJob::TIME_SENSITIVE);
+
 		$this->hostedSignalingServerService = $hostedSignalingServerService;
 		$this->config = $config;
 		$this->notificationManager = $notificationManager;

--- a/lib/BackgroundJob/CheckMatterbridges.php
+++ b/lib/BackgroundJob/CheckMatterbridges.php
@@ -25,6 +25,7 @@ namespace OCA\Talk\BackgroundJob;
 
 use OCA\Talk\MatterbridgeManager;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;
 use OCP\IConfig;
 use Psr\Log\LoggerInterface;
@@ -53,6 +54,7 @@ class CheckMatterbridges extends TimedJob {
 
 		// Every 15 minutes
 		$this->setInterval(60 * 15);
+		$this->setTimeSensitivity(IJob::TIME_SENSITIVE);
 
 		$this->serverConfig = $serverConfig;
 		$this->bridgeManager = $bridgeManager;

--- a/lib/BackgroundJob/CheckReferenceIdColumn.php
+++ b/lib/BackgroundJob/CheckReferenceIdColumn.php
@@ -26,6 +26,7 @@ namespace OCA\Talk\BackgroundJob;
 use OC\DB\ConnectionAdapter;
 use OC\DB\SchemaWrapper;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\TimedJob;
 use OCP\IConfig;
@@ -53,7 +54,10 @@ class CheckReferenceIdColumn extends TimedJob {
 		$this->jobList = $jobList;
 		$this->serverConfig = $serverConfig;
 		$this->connection = $connection;
+
+		// Every hour
 		$this->setInterval(3600);
+		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
 	}
 
 	protected function run($argument): void {

--- a/lib/BackgroundJob/ExpireSignalingMessage.php
+++ b/lib/BackgroundJob/ExpireSignalingMessage.php
@@ -26,6 +26,7 @@ namespace OCA\Talk\BackgroundJob;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use OCA\Talk\Signaling\Messages;
+use OCP\BackgroundJob\IJob;
 
 /**
  * Class ExpireSignalingMessage
@@ -43,11 +44,13 @@ class ExpireSignalingMessage extends TimedJob {
 
 		// Every 5 minutes
 		$this->setInterval(60 * 5);
+		$this->setTimeSensitivity(IJob::TIME_SENSITIVE);
 
 		$this->messages = $messages;
 	}
 
 	protected function run($argument): void {
+		// Older than 5 minutes
 		$this->messages->expireOlderThan(5 * 60);
 	}
 }

--- a/lib/BackgroundJob/RemoveEmptyRooms.php
+++ b/lib/BackgroundJob/RemoveEmptyRooms.php
@@ -28,6 +28,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use OCA\Talk\Manager;
 use OCA\Talk\Room;
+use OCP\BackgroundJob\IJob;
 use OCP\Files\Config\IUserMountCache;
 use Psr\Log\LoggerInterface;
 
@@ -61,6 +62,7 @@ class RemoveEmptyRooms extends TimedJob {
 
 		// Every 5 minutes
 		$this->setInterval(60 * 5);
+		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
 
 		$this->manager = $manager;
 		$this->participantService = $participantService;

--- a/lib/BackgroundJob/ResetAssignedSignalingServer.php
+++ b/lib/BackgroundJob/ResetAssignedSignalingServer.php
@@ -26,6 +26,7 @@ namespace OCA\Talk\BackgroundJob;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use OCA\Talk\Manager;
+use OCP\BackgroundJob\IJob;
 use OCP\ICache;
 use OCP\ICacheFactory;
 
@@ -43,6 +44,7 @@ class ResetAssignedSignalingServer extends TimedJob {
 
 		// Every 5 minutes
 		$this->setInterval(60 * 5);
+		$this->setTimeSensitivity(IJob::TIME_SENSITIVE);
 
 		$this->manager = $manager;
 		$this->cache = $cacheFactory->createDistributed('hpb_servers');


### PR DESCRIPTION
Close #6874

| Job                          | interval | status           | detail                                                |
| ---------------------------- | -------- | ---------------- | ----------------------------------------------------- |
| CheckHostedSignalingServer   | 1 hour   | TIME_SENSITIVE   | Check the status of hosted signalign servers          |
| CheckMatterbridges           | 15 min   | TIME_SENSITIVE | Kill zombie bridges                                   |
| CheckReferenceIdColumn       | 1 hour   | TIME_INSENSITIVE | Check if column reference_id exists on comment table. |
| ExpireSignalingMessage       | 5 min    | TIME_SENSITIVE   | Expire signaling message                              |
| RemoveEmptyRooms             | 5 min    | TIME_INSENSITIVE | Remove empty rooms                                    |
| ResetAssignedSignalingServer | 5 min    | TIME_SENSITIVE   | Unassign empty rooms from signalign server            |
| RetryJob                     | ?        | null             | Not timed job                                         |