### PR TITLE
Fix unneeded checkbox name for checkbox not in group

### DIFF
--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -47,7 +47,6 @@
 				:checked="readStatusPrivacyIsPublic"
 				:disabled="privacyLoading"
 				type="checkbox"
-				name="read_status_privacy"
 				class="checkbox"
 				@update:checked="toggleReadStatusPrivacy">
 				{{ t('spreed', 'Share my read-status and show the read-status of others') }}


### PR DESCRIPTION
Fixes a regression introduced in #6759

## How to test

- Open the browser console
- Open Talk settings

### Result with this pull request

No error is printed in the console

### Result without this pull request

[`Error: When using groups of checkboxes, the updated value will be an array`](https://github.com/nextcloud/nextcloud-vue/blob/866c3c030a4a7ebc8203f3e2597fcf12bfe81be7/src/components/CheckboxRadioSwitch/CheckboxRadioSwitch.vue#L345) is printed in the console
