### PR TITLE
Fix stopping waiting sound

### DIFF
--- a/src/utils/sounds.js
+++ b/src/utils/sounds.js
@@ -71,6 +71,7 @@ export const Sounds = {
 			if (this.playedWaiting >= 3) {
 				// Played 3 times, so we stop now.
 				this._stopWaiting()
+				return
 			}
 
 			console.debug('Playing waiting sound')

--- a/src/utils/sounds.js
+++ b/src/utils/sounds.js
@@ -65,6 +65,7 @@ export const Sounds = {
 		this.playedWaiting = 0
 		this.backgroundInterval = setInterval(() => {
 			if (!store.getters.playSounds) {
+				this._stopWaiting()
 				return
 			}
 


### PR DESCRIPTION
Fixes a regression introduced in f90f2e7745d6951a50577f6d931b5bb2dd80339b

I have also noticed that if sounds are disabled once the waiting sound started the interval would not be stopped until something else stops it (like leaving the call or another user joining it). I have added a fix for that too, although it is not a big deal and it could be even argued that the interval should be kept running just in case the user enables the sounds again, so feel free to keep it, change it or drop it :-)

## How to test (scenario 1)

- Start a call
- Open the browser console
- Wait one minute

### Result with this pull request

_Stop waiting sound_ is printed in the console

### Result without this pull request

_Stop waiting sound_ is printed in the console, followed by _Playing waiting sound_ and an error about a null access to `backgroundAudio`



## How to test (scenario 2)

- Start a call
- Open Talk settings and disable sounds
- Wait two minutes
- Enable sounds again

### Result with this pull request

No waiting sound is played again

### Result without this pull request

The waiting sound is played (after some seconds) when enabling the sounds again, which means that the interval had been running all the time that sounds were disabled
