### PR TITLE
Do not force reconnections when starting and stopping media

### DIFF
--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -72,6 +72,17 @@ function arrayDiff(a, b) {
 }
 
 /**
+ * @param {Array} a First array
+ * @param {Array} b Second array
+ * @return {Array} Array with the common elements
+ */
+function arrayCommon(a, b) {
+	return a.filter(function(i) {
+		return b.includes(i)
+	})
+}
+
+/**
  * @param {object} signaling The signaling object
  * @param {string} sessionId The user's sessionId
  */
@@ -270,6 +281,19 @@ function userHasStreams(user) {
 }
 
 /**
+ * @param {object} user The user to check
+ * @return {boolean} True if the user has a Peer object (not closed), or will
+ *         have a Peer object due to a delayed connection
+ */
+function userHasPeer(user) {
+	const sessionId = user.sessionId || user.sessionid
+	const callParticipantModel = callParticipantCollection.get(sessionId)
+
+	return delayedConnectionToPeer[sessionId]
+		|| (callParticipantModel.get('peer') && !callParticipantModel.get('peer').closed)
+}
+
+/**
  * @param {object} signaling The signaling object
  * @param {object} user The participant to create a peer for
  */
@@ -339,9 +363,18 @@ function createPeerForParticipant(signaling, user) {
  * @param {object} signaling The signaling object
  * @param {Array} newUsers Newly added participants
  * @param {Array} disconnectedSessionIds Remove participants
+ * @param {Array} changedPublishers Participants that were already in the call
+ *        and started or stopped publishing
  */
-function usersChanged(signaling, newUsers, disconnectedSessionIds) {
+function usersChanged(signaling, newUsers, disconnectedSessionIds, changedPublishers) {
 	'use strict'
+
+	// The parameter can not be initialised to a default value in strict
+	// functions, so it needs to be done here.
+	if (!changedPublishers) {
+		changedPublishers = []
+	}
+
 	const currentSessionId = signaling.getSessionId()
 
 	let playJoinSound = false
@@ -418,6 +451,31 @@ function usersChanged(signaling, newUsers, disconnectedSessionIds) {
 		// Send shared screen to new participants
 		if (webrtc.getLocalScreen()) {
 			createScreensharingPeer(signaling, sessionId)
+		}
+	})
+
+	changedPublishers.forEach(function(changedPublisher) {
+		// TODO(fancycode): Adjust property name of internal PHP backend to be all lowercase.
+		const sessionId = changedPublisher.sessionId || changedPublisher.sessionid
+		if (!sessionId || sessionId === currentSessionId) {
+			return
+		}
+
+		if (userHasStreams(changedPublisher) && userHasPeer(changedPublisher)) {
+			return
+		}
+
+		if (userHasStreams(changedPublisher)) {
+			createPeerForParticipant(signaling, changedPublisher)
+
+			return
+		}
+
+		webrtc.removePeers(sessionId)
+
+		if (delayedConnectionToPeer[sessionId]) {
+			clearInterval(delayedConnectionToPeer[sessionId])
+			delete delayedConnectionToPeer[sessionId]
 		}
 	})
 
@@ -521,12 +579,22 @@ function usersInCallChanged(signaling, users) {
 
 	const newSessionIds = arrayDiff(currentUsersInRoom, previousUsersInRoom)
 	const disconnectedSessionIds = arrayDiff(previousUsersInRoom, currentUsersInRoom)
+	const unchangedSessionIds = arrayCommon(currentUsersInRoom, previousUsersInRoom)
 	const newUsers = []
 	newSessionIds.forEach(function(sessionId) {
 		newUsers.push(userMapping[sessionId])
 	})
-	if (newUsers.length || disconnectedSessionIds.length) {
-		usersChanged(signaling, newUsers, disconnectedSessionIds)
+	const changedPublishers = []
+	unchangedSessionIds.forEach(function(sessionId) {
+		const user = userMapping[sessionId]
+
+		if ((userHasStreams(user) && !userHasPeer(user))
+			|| (!userHasStreams(user) && userHasPeer(user))) {
+			changedPublishers.push(user)
+		}
+	})
+	if (newUsers.length || disconnectedSessionIds.length || changedPublishers.length) {
+		usersChanged(signaling, newUsers, disconnectedSessionIds, changedPublishers)
 	}
 }
 


### PR DESCRIPTION
Until now, when a participant started to publish media that participant had to force a reconnection. This caused the participant to leave and join the conversation again, which in turn ensured that the clients established a connection to receive the media from that participant (as the participant was treated as a new participant).

Instead of that clients must proactively establish the connection with a participant when the call flags changed (for example, from _IN_CALL_ to _IN_CALL | WITH_AUDIO_). The WebUI will stop forcing a reconnection in those cases in order to have a smoother call experience (once handling the call flags is implemented in the mobile clients as well, but it should not be a very difficult change as shown in the second commit).

Pending:
- [ ] Implement proactive creation of connections based on call flag changes in mobile apps
- [ ] Check if there are other forced reconnections that can be removed
- [ ] Test both with and without HPB, and both starting and stopping media
- [ ] Fix trying to update the connection again and again when the other participant does not have streams and the local one does without HPB
- [ ] Rebase on #6896 to get a full picture
- [ ] Add capability so mobile apps know if they need to force a reconnection or just update the call flags (as publishers)?

## How to test (scenario 1)

- Start a call
- In a private window, join the call and, in the device checker shown before actually starting the call, select no audio device and no video device
- Join the call
- Open the device settings, select a video device and close the device settings
- Enable video

### Result with this pull request

In the original window the video is now visible even if no forced reconnection was triggered

### Result without this pull request

In the private window a forced reconnection was triggered



## How to test (scenario 2)

- Remove audio and video permissions by default in a conversation
- Start a call as a moderator
- In a private window, open the conversation as a guest
- Join the call
- In the original window, grant video permissions to the guest
- In the private window, enable video

### Result with this pull request

In the original window the video is now visible even if no forced reconnection was triggered

### Result without this pull request

In the private window a forced reconnection was triggered
