### PR TITLE
Only calculate the room name once instead of loading all participants

### DIFF
--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -232,6 +232,11 @@ class Listener {
 			return;
 		}
 
+		// We know the new participant is in the room,
+		// so skip loading them just to make sure they can read it.
+		// Must be overwritten later on for one-to-one chats.
+		$roomName = $room->getDisplayName($actorId);
+
 		foreach ($participants as $participant) {
 			if ($participant['actorType'] !== Attendee::ACTOR_USERS) {
 				// No user => no activity
@@ -244,7 +249,10 @@ class Listener {
 			}
 
 			try {
-				$roomName = $room->getDisplayName($participant['actorId']);
+				if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+					// Overwrite the room name with the other participant
+					$roomName = $room->getDisplayName($participant['actorId']);
+				}
 				$event
 					->setObject('room', $room->getId(), $roomName)
 					->setSubject('invitation', [


### PR DESCRIPTION

### Steps
1. Create 70 users:
```sh
i=10
while [ $i -ne 70 ]
do
        i=$(($i+1))
        echo "$i"

	USERID=$(uuidgen)
	OC_PASS="123456" occ -vvv user:add --password-from-env --display-name "Dummy #$i" -g "dummies" $USERID
	occ -vvv user:setting $USERID settings email "test$i@yourdomain.tld"

done
```
2. Create a conversation as admin with group "dummies" (and check the database queries of this request)

Left is before, right is with this patch
![Bildschirmfoto von 2022-02-28 12-09-44](https://user-images.githubusercontent.com/213943/155973307-2603a978-9652-42b4-9619-550c6a6883ae.png)
