### PR TITLE
Fix blur background tooltip not updated in device checker

### DIFF
--- a/src/components/DeviceChecker/DeviceChecker.vue
+++ b/src/components/DeviceChecker/DeviceChecker.vue
@@ -260,7 +260,7 @@ export default {
 		},
 
 		blurButtonTooltip() {
-			return this.videoOn ? t('spreed', 'Disable background blur') : t('spreed', 'Blur background')
+			return this.blurOn ? t('spreed', 'Disable background blur') : t('spreed', 'Blur background')
 		},
 	},
 


### PR DESCRIPTION
The tooltip depended on the wrong property, so it was not updated as needed.