### PR TITLE
Inject room and attendee into chat notifier

### DIFF
--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -93,7 +93,7 @@ class Notifier {
 	 * @param array[] $alreadyNotifiedUsers
 	 * @psalm-param array<int, array{id: string, type: string}> $alreadyNotifiedUsers
 	 * @return string[] Users that were mentioned
-	 * @psalm-return array<int, array{id: string, type: string}>
+	 * @psalm-return array<int, array{id: string, type: string, ?attendee: Attendee}>
 	 */
 	public function notifyMentionedUsers(Room $chat, IComment $comment, array $alreadyNotifiedUsers): array {
 		$usersToNotify = $this->getUsersToNotify($chat, $comment, $alreadyNotifiedUsers);
@@ -105,7 +105,7 @@ class Notifier {
 		$shouldFlush = $this->notificationManager->defer();
 
 		foreach ($usersToNotify as $mentionedUser) {
-			if ($this->shouldMentionedUserBeNotified($mentionedUser['id'], $comment, $chat)) {
+			if ($this->shouldMentionedUserBeNotified($mentionedUser['id'], $comment, $chat, $mentionedUser['attendee'] ?? null)) {
 				$notification->setUser($mentionedUser['id']);
 				$this->notificationManager->notify($notification);
 				$alreadyNotifiedUsers[] = $mentionedUser;
@@ -125,7 +125,7 @@ class Notifier {
 	 * @param array $alreadyNotifiedUsers
 	 * @psalm-param array<int, array{id: string, type: string}> $alreadyNotifiedUsers
 	 * @return array
-	 * @psalm-return array<int, array{id: string, type: string}>
+	 * @psalm-return array<int, array{id: string, type: string, ?attendee: Attendee}>
 	 */
 	private function getUsersToNotify(Room $chat, IComment $comment, array $alreadyNotifiedUsers): array {
 		$usersToNotify = $this->getMentionedUsers($comment);
@@ -159,7 +159,7 @@ class Notifier {
 	 * @param array $list
 	 * @psalm-param array<int, array{id: string, type: string}> $list
 	 * @return array
-	 * @psalm-return array<int, array{id: string, type: string}>
+	 * @psalm-return array<int, array{id: string, type: string, ?attendee: Attendee}>
 	 */
 	private function addMentionAllToList(Room $chat, array $list): array {
 		$usersToNotify = array_filter($list, static function (array $user): bool {
@@ -170,18 +170,19 @@ class Notifier {
 			return $usersToNotify;
 		}
 
-		$chatParticipants = $this->participantService->getActorsByType($chat, Attendee::ACTOR_USERS);
-		foreach ($chatParticipants as $participant) {
-			$alreadyAddedToNotify = array_filter($list, static function ($user) use ($participant): bool {
-				return $user['id'] === $participant->getActorId();
+		$attendees = $this->participantService->getActorsByType($chat, Attendee::ACTOR_USERS);
+		foreach ($attendees as $attendee) {
+			$alreadyAddedToNotify = array_filter($list, static function ($user) use ($attendee): bool {
+				return $user['id'] === $attendee->getActorId();
 			});
 			if (!empty($alreadyAddedToNotify)) {
 				continue;
 			}
 
 			$usersToNotify[] = [
-				'id' => $participant->getActorId(),
-				'type' => $participant->getActorType()
+				'id' => $attendee->getActorId(),
+				'type' => $attendee->getActorType(),
+				'attendee' => $attendee,
 			];
 		}
 
@@ -238,7 +239,7 @@ class Notifier {
 	 * @param Room $chat
 	 * @param IComment $comment
 	 * @param array[] $alreadyNotifiedUsers
-	 * @psalm-param array<int, array{id: string, type: string}> $alreadyNotifiedUsers
+	 * @psalm-param array<int, array{id: string, type: string, ?attendee: Attendee}> $alreadyNotifiedUsers
 	 */
 	public function notifyOtherParticipant(Room $chat, IComment $comment, array $alreadyNotifiedUsers): void {
 		$participants = $this->participantService->getParticipantsByNotificationLevel($chat, Participant::NOTIFY_ALWAYS);
@@ -427,21 +428,26 @@ class Notifier {
 	 * @param string $userId
 	 * @param IComment $comment
 	 * @param Room $room
+	 * @param Attendee|null $attendee
 	 * @return bool
 	 */
-	protected function shouldMentionedUserBeNotified(string $userId, IComment $comment, Room $room): bool {
+	protected function shouldMentionedUserBeNotified(string $userId, IComment $comment, Room $room, ?Attendee $attendee = null): bool {
 		if ($comment->getActorType() === Attendee::ACTOR_USERS && $userId === $comment->getActorId()) {
 			// Do not notify the user if they mentioned themselves
 			return false;
 		}
 
-		if (!$this->userManager->userExists($userId)) {
-			return false;
-		}
-
 		try {
-			$participant = $room->getParticipant($userId, false);
-			$notificationLevel = $participant->getAttendee()->getNotificationLevel();
+			if (!$attendee instanceof Attendee) {
+				if (!$this->userManager->userExists($userId)) {
+					return false;
+				}
+
+				$participant = $room->getParticipant($userId, false);
+				$attendee = $participant->getAttendee();
+			}
+
+			$notificationLevel = $attendee->getNotificationLevel();
 			if ($notificationLevel === Participant::NOTIFY_DEFAULT) {
 				if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
 					$notificationLevel = Participant::NOTIFY_ALWAYS;

--- a/tests/php/Chat/NotifierTest.php
+++ b/tests/php/Chat/NotifierTest.php
@@ -341,7 +341,15 @@ class NotifierTest extends TestCase {
 			->willReturn($participants);
 
 		$actual = $this->invokePrivate($this->getNotifier(), 'addMentionAllToList', [$room, $usersToNotify]);
-		$this->assertEqualsCanonicalizing($return, $actual);
+		$this->assertCount(count($return), $actual);
+		foreach ($actual as $key => $value) {
+			$this->assertIsArray($value);
+			if (key_exists('attendee', $value)) {
+				$this->assertInstanceOf(Attendee::class, $value['attendee']);
+				unset($value['attendee']);
+			}
+			$this->assertEqualsCanonicalizing($return[$key], $value);
+		}
 	}
 
 	public function dataAddMentionAllToList(): array {


### PR DESCRIPTION
### Steps
1. Create 70 users:
```sh
i=10
while [ $i -ne 70 ]
do
        i=$(($i+1))
        echo "$i"

	USERID=$(cat /proc/sys/kernel/random/uuid)
	OC_PASS="123456" occ -vvv user:add --password-from-env --display-name "Dummy #$i" -g "dummies" $USERID
	occ -vvv user:setting $USERID settings email "test$i@yourdomain.tld"

done
```
2. Create a conversation as admin with group "dummies" (and check the database queries of this request)
3. Post a message with `@all`

### Query count

Message | Before | After
---|---|---
`chat` | 16 | 16
`@employee2` | 23 | 23
`@all` | 367 | 90

Compare query log:
![Bildschirmfoto von 2022-03-04 12-23-08](https://user-images.githubusercontent.com/213943/156755787-981d8e4a-4260-427f-abbc-eceac5050d43.png)

