### PR TITLE
Fix loaded values in permission dialog for participants

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/ParticipantPermissionsEditor/ParticipantPermissionsEditor.spec.js
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/ParticipantPermissionsEditor/ParticipantPermissionsEditor.spec.js
@@ -24,7 +24,7 @@ describe('ParticipantPermissionsEditor.vue', () => {
 			actorId: 'alice-actor-id',
 			actorType: ATTENDEE.ACTOR_TYPE.USERS,
 			participantType: PARTICIPANT.TYPE.USER,
-			attendeePermissions: PARTICIPANT.PERMISSIONS.CALL_START
+			permissions: PARTICIPANT.PERMISSIONS.CALL_START
 				| PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO
 				| PARTICIPANT.PERMISSIONS.PUBLISH_VIDEO
 				| PARTICIPANT.PERMISSIONS.CUSTOM,
@@ -98,7 +98,7 @@ describe('ParticipantPermissionsEditor.vue', () => {
 		})
 
 		test('Properly renders the checkboxes with default permissions', async () => {
-			participant.attendeePermissions = PARTICIPANT.PERMISSIONS.DEFAULT
+			participant.permissions = PARTICIPANT.PERMISSIONS.DEFAULT
 			const wrapper = await mountParticipantPermissionsEditor(participant)
 			const callStartCheckbox = wrapper.findComponent(PermissionsEditor).findComponent({ ref: 'callStart' })
 			expect(callStartCheckbox.vm.$options.propsData.checked).toBe(true)

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/ParticipantPermissionsEditor/ParticipantPermissionsEditor.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/ParticipantPermissionsEditor/ParticipantPermissionsEditor.vue
@@ -22,7 +22,7 @@
 <template>
 	<div class="wrapper">
 		<PermissionEditor :display-name="displayName"
-			:permissions="attendeePermissions"
+			:permissions="permissions"
 			v-on="$listeners"
 			@submit="handleSubmitPermissions" />
 	</div>
@@ -86,11 +86,11 @@ export default {
 		},
 
 		/**
-		 * Permisssions of the current participant, from the participants
-		 * store.
+		 * Combined final permissions of the current participant, from the
+		 * participants store.
 		 */
-		attendeePermissions() {
-			return this.participant.attendeePermissions
+		permissions() {
+			return this.participant.permissions
 		},
 	},
 

--- a/src/mixins/getParticipants.js
+++ b/src/mixins/getParticipants.js
@@ -59,6 +59,9 @@ const getParticipants = {
 			EventBus.$on('route-change', this.onRouteChange)
 			EventBus.$on('joined-conversation', this.onJoinedConversation)
 
+			EventBus.$on('conversation-permissions-changed', this.debounceUpdateParticipants)
+			EventBus.$on('call-permissions-changed', this.debounceUpdateParticipants)
+
 			// FIXME this works only temporary until signaling is fixed to be only on the calls
 			// Then we have to search for another solution. Maybe the room list which we update
 			// periodically gets a hash of all online sessions?
@@ -68,6 +71,8 @@ const getParticipants = {
 		stopGetParticipantsMixin() {
 			EventBus.$off('route-change', this.onRouteChange)
 			EventBus.$off('joined-conversation', this.onJoinedConversation)
+			EventBus.$off('conversation-permissions-changed', this.debounceUpdateParticipants)
+			EventBus.$off('call-permissions-changed', this.debounceUpdateParticipants)
 			EventBus.$off('signaling-participant-list-changed', this.debounceUpdateParticipants)
 		},
 

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -43,6 +43,7 @@ import {
 } from '../services/conversationsService'
 import { getCurrentUser } from '@nextcloud/auth'
 import { CONVERSATION, WEBINAR, PARTICIPANT } from '../constants'
+import { EventBus } from '../services/EventBus'
 
 const DUMMY_CONVERSATION = {
 	token: '',
@@ -491,11 +492,15 @@ const actions = {
 	async setConversationPermissions(context, { token, permissions }) {
 		await setConversationPermissions(token, permissions)
 		context.commit('setConversationPermissions', { token, permissions })
+
+		EventBus.$emit('conversation-permissions-changed')
 	},
 
 	async setCallPermissions(context, { token, permissions }) {
 		await setCallPermissions(token, permissions)
 		context.commit('setCallPermissions', { token, permissions })
+
+		EventBus.$emit('call-permissions-changed')
 	},
 }
 

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -584,7 +584,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	private function mapPermissionsAPIOutput($permissions): string {
 		$permissions = (int) $permissions;
 
-		$permissionsString = '';
+		$permissionsString = !$permissions ? 'D' : '';
 		foreach (self::$permissionsMap as $char => $int) {
 			if ($permissions & $int) {
 				$permissionsString .= $char;

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -473,6 +473,9 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 				if (isset($expectedKeys['permissions'])) {
 					$data['permissions'] = (string) $attendee['permissions'];
 				}
+				if (isset($expectedKeys['attendeePermissions'])) {
+					$data['attendeePermissions'] = (string) $attendee['attendeePermissions'];
+				}
 
 				if (!isset(self::$userToAttendeeId[$attendee['actorType']])) {
 					self::$userToAttendeeId[$attendee['actorType']] = [];
@@ -500,6 +503,9 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			$result = array_map(function ($attendee) {
 				if (isset($attendee['permissions'])) {
 					$attendee['permissions'] = $this->mapPermissionsAPIOutput($attendee['permissions']);
+				}
+				if (isset($attendee['attendeePermissions'])) {
+					$attendee['attendeePermissions'] = $this->mapPermissionsAPIOutput($attendee['attendeePermissions']);
 				}
 				return $attendee;
 			}, $result);

--- a/tests/integration/features/conversation-2/set-permissions.feature
+++ b/tests/integration/features/conversation-2/set-permissions.feature
@@ -86,3 +86,53 @@ Feature: set-publishing-permissions
       | actorType  | actorId      | permissions |
       | users      | owner        | SJLAVP      |
       | users      | invited user | SJAVP       |
+
+
+
+  Scenario: setting call permissions resets participant permissions
+    Given user "owner" creates room "group room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "owner" adds user "invited user" to room "group room" with 200 (v4)
+    And user "owner" sets permissions for "invited user" in room "group room" to "V" with 200 (v4)
+    And user "owner" sees the following attendees in room "group room" with 200 (v4)
+      | actorType  | actorId      | permissions | attendeePermissions |
+      | users      | owner        | SJLAVP      | D                   |
+      | users      | invited user | CV          | CV                  |
+    When user "owner" sets call permissions for room "group room" to "A" with 200 (v4)
+    Then user "owner" sees the following attendees in room "group room" with 200 (v4)
+      | actorType  | actorId      | permissions | attendeePermissions |
+      | users      | owner        | SJLAVP      | D                   |
+      | users      | invited user | CA          | D                   |
+
+  Scenario: setting default permissions resets participant permissions
+    Given user "owner" creates room "group room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "owner" adds user "invited user" to room "group room" with 200 (v4)
+    And user "owner" sets permissions for "invited user" in room "group room" to "V" with 200 (v4)
+    And user "owner" sees the following attendees in room "group room" with 200 (v4)
+      | actorType  | actorId      | permissions | attendeePermissions |
+      | users      | owner        | SJLAVP      | D                   |
+      | users      | invited user | CV          | CV                  |
+    When user "owner" sets default permissions for room "group room" to "A" with 200 (v4)
+    Then user "owner" sees the following attendees in room "group room" with 200 (v4)
+      | actorType  | actorId      | permissions | attendeePermissions |
+      | users      | owner        | SJLAVP      | D                   |
+      | users      | invited user | CA          | D                   |
+
+  Scenario: setting default permissions does not reset call permissions
+    Given user "owner" creates room "group room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "owner" adds user "invited user" to room "group room" with 200 (v4)
+    And user "owner" sets call permissions for room "group room" to "V" with 200 (v4)
+    And user "owner" sees the following attendees in room "group room" with 200 (v4)
+      | actorType  | actorId      | permissions | attendeePermissions |
+      | users      | owner        | SJLAVP      | D                   |
+      | users      | invited user | CV          | D                   |
+    When user "owner" sets default permissions for room "group room" to "A" with 200 (v4)
+    Then user "owner" sees the following attendees in room "group room" with 200 (v4)
+      | actorType  | actorId      | permissions | attendeePermissions |
+      | users      | owner        | SJLAVP      | D                   |
+      | users      | invited user | CV          | D                   |


### PR DESCRIPTION
The permissions dialog for participants was using `attendeePermissions` rather than `permissions`, so the dialog showed the default permissions for participants without specific permissions even if conversation permissions were set.

Besides that, the participant list is now reloaded on conversation and call permissions change, as due to the permission chain the actual participant permissions may have changed.

Finally, I have added some integration tests for setting conversation permissions when participant permissions are set; I found a bit surprising that this resets the participant permissions, so better have an explicit test for that behaviour :-)


## How to test (scenario 1)

- Join a conversation as a moderator
- If there is none, add a regular user to the conversation
- Open the conversation settings
- Set some custom permissions in the conversation
- Close the conversation settings
- Reload the page
- In the sidebar, open the permission settings for the regular user

### Result with this pull request

The permissions shown for the participant are the conversation permissions

### Result without this pull request

The permissions shown for the participant are the original default permissions, which do not match the actual permissions of the user (which are the conversation permissions)



## How to test (scenario 2)

- Join a conversation as a moderator
- If there is none, add a regular user to the conversation
- Set some custom permissions for the regular user
- Open the conversation settings
- Set some custom permissions in the conversation

### Result with this pull request

The icon about custom permissions for the user is removed

### Result without this pull request

The icon about custom permissions for the user is kept, even if setting the conversation permissions reset the user permissions
