### PR TITLE
Fix permissions not updated when general permissions change

### DIFF
--- a/lib/Signaling/Listener.php
+++ b/lib/Signaling/Listener.php
@@ -68,6 +68,7 @@ class Listener {
 		$dispatcher->addListener(Room::EVENT_AFTER_SESSION_JOIN_CALL, $listener);
 		$dispatcher->addListener(Room::EVENT_AFTER_SESSION_UPDATE_CALL_FLAGS, $listener);
 		$dispatcher->addListener(Room::EVENT_AFTER_SESSION_LEAVE_CALL, $listener);
+		$dispatcher->addListener(Room::EVENT_AFTER_PERMISSIONS_SET, $listener);
 		$dispatcher->addListener(GuestManager::EVENT_AFTER_NAME_UPDATE, $listener);
 
 		$listener = static function (ParticipantEvent $event): void {

--- a/src/mixins/getParticipants.js
+++ b/src/mixins/getParticipants.js
@@ -59,9 +59,6 @@ const getParticipants = {
 			EventBus.$on('route-change', this.onRouteChange)
 			EventBus.$on('joined-conversation', this.onJoinedConversation)
 
-			EventBus.$on('conversation-permissions-changed', this.debounceUpdateParticipants)
-			EventBus.$on('call-permissions-changed', this.debounceUpdateParticipants)
-
 			// FIXME this works only temporary until signaling is fixed to be only on the calls
 			// Then we have to search for another solution. Maybe the room list which we update
 			// periodically gets a hash of all online sessions?
@@ -71,8 +68,6 @@ const getParticipants = {
 		stopGetParticipantsMixin() {
 			EventBus.$off('route-change', this.onRouteChange)
 			EventBus.$off('joined-conversation', this.onJoinedConversation)
-			EventBus.$off('conversation-permissions-changed', this.debounceUpdateParticipants)
-			EventBus.$off('call-permissions-changed', this.debounceUpdateParticipants)
 			EventBus.$off('signaling-participant-list-changed', this.debounceUpdateParticipants)
 		},
 

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -43,7 +43,6 @@ import {
 } from '../services/conversationsService'
 import { getCurrentUser } from '@nextcloud/auth'
 import { CONVERSATION, WEBINAR, PARTICIPANT } from '../constants'
-import { EventBus } from '../services/EventBus'
 
 const DUMMY_CONVERSATION = {
 	token: '',
@@ -492,15 +491,11 @@ const actions = {
 	async setConversationPermissions(context, { token, permissions }) {
 		await setConversationPermissions(token, permissions)
 		context.commit('setConversationPermissions', { token, permissions })
-
-		EventBus.$emit('conversation-permissions-changed')
 	},
 
 	async setCallPermissions(context, { token, permissions }) {
 		await setCallPermissions(token, permissions)
 		context.commit('setCallPermissions', { token, permissions })
-
-		EventBus.$emit('call-permissions-changed')
 	},
 }
 


### PR DESCRIPTION
When [a participant joins a room](https://github.com/nextcloud/spreed/blob/5b35137d3a2dfce7c26b2570342a6e7808254bf9/lib/Controller/SignalingController.php#L706-L717) or [a participant is modified](https://github.com/nextcloud/spreed/blob/4d2ecfcd96a6df7ed34bddd91dce2484a9750213/lib/Signaling/BackendNotifier.php#L319-L330) the signaling permissions (used by the external signaling server to allow or reject media) are updated for that participant.

When the room or call permissions are set the permissions of all participants could be modified (even if they had custom participant permissions). However, in this case the signaling permissions were not updated, so the signaling server could allow or reject media from participants that were already in the room when the permissions were set.

The current approach could be problematic in conversations with a high number of participants due to the size of the request sent to the external signaling server, so something similar to #6948 would be needed. An alternative could be sending [not only the permissions](#6992) but also the signaling permissions when a participant joins a call (as the publishing permissions are only relevant when the participant is in the call), but this would require a modification in the external signaling server as well to process the signaling permissions in that case.

Independently of all that, I have realized that https://github.com/nextcloud/spreed/pull/6974/commits/99def03db2d5470e4aaf139152c01bf79fc01c48 was a flawed fix, as it only worked for the moderator that changed the permissions; for other moderators the participants were not updated. This was implicitly fixed by updating the participants when the room and call permissions are set, as that causes the participant list to be refreshed. Therefore, the previous fix was reverted in favour of the new approach.

## Common setup for scenarios 1 and 2

- If applied, revert #6992 (as it would cause the client to reconnect and mask the wrong behaviour in the signaling server)
- Ignore permissions and always send media by replacing https://github.com/nextcloud/spreed/blob/a5e699b1804e5f22ea24ee1798fa99b7e1f6b9fb/src/components/TopBar/CallButton.vue#L251-L256 with
```
			flags |= PARTICIPANT.CALL_FLAG.WITH_AUDIO
			flags |= PARTICIPANT.CALL_FLAG.WITH_VIDEO
```
- Try to always establish a connection even if the call flags say that media is not available by commenting `&& userHasStreams(user)` in https://github.com/nextcloud/spreed/blob/43ebbd09a2b9139601b945a1ab77fc95a30a5290/src/utils/webrtc/webrtc.js#L367
- Setup the HPB



## How to test (scenario 1)

- Open a conversation as a moderator
- In a private window, join the conversation as a guest
- In the original window, revoke audio and video permissions by default in the conversation
- In the private window, start a call with audio and video
- In the original window, join the call

### Result with this pull request

The guest is not able to send the media; the HPB logs show messages like _XXX is not allowed to offer video, ignoring (permission "publish-audio" not found)_

### Result without this pull request

The guest is able to send the media and it is received by the other participant, even if the participant does not have custom permissions and the conversation permissions should have prevented that



## How to test (scenario 2)

- Open a conversation as a moderator
- Revoke audio and video permissions by default in the conversation
- In a private window, join the conversation as a guest
- In the original window, grant audio and video permissions by default in the conversation
- In the private window, start a call with audio and video
- In the original window, join the call

### Result with this pull request

The guest is able to send the media and it is received in the original window

### Result without this pull request

The guest is not able to send the media; the HPB logs show messages like _XXX is not allowed to offer video, ignoring (permission "publish-audio" not found)_



## How to test (scenario 3)

- Can be tested with and without HPB
- Open a conversation as a moderator
- If there are none, add a regular user and another moderator to the conversation
- In a private window, open the conversation as the other moderator
- In the original window, set custom permissions for the regular user
- Wait until the icon about custom permissions is shown in the private window
- In the original window, open the conversation settings
- Set some custom permissions in the conversation

### Result with this pull request

In the private window the icon about custom permissions for the user is removed

### Result without this pull request

In the private window the icon about custom permissions for the user is kept, even if setting the conversation permissions reset the user permissions
