### PR TITLE
Fix call flags update when track is disabled

### DIFF
--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -935,8 +935,8 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 			if (peer.pc.iceConnectionState !== 'new' && peer.pc.iceConnectionState !== 'checking') {
 				// Update the media flags if needed, as the renegotiation could
 				// have been caused by tracks being added or removed.
-				const audioSender = peer.pc.getSenders().find((sender) => sender.track && sender.track.kind === 'audio')
-				const videoSender = peer.pc.getSenders().find((sender) => sender.track && sender.track.kind === 'video')
+				const audioSender = peer.pc.getSenders().find((sender) => (sender.track && sender.track.kind === 'audio') || (sender.trackDisabled && sender.trackDisabled.kind === 'audio'))
+				const videoSender = peer.pc.getSenders().find((sender) => (sender.track && sender.track.kind === 'video') || (sender.trackDisabled && sender.trackDisabled.kind === 'video'))
 
 				let flags = signaling.getCurrentCallFlags()
 				if (audioSender) {


### PR DESCRIPTION
When the call flags were updated after a renegotiation the senders were checked to decide the flags to set. However, only the track attribute was checked; when a track is disabled the track is nullified in the sender and stored in `trackDisabled` instead, so the call flags were not properly set if any of the tracks was disabled when a new one was added.

Note that when a local track is replaced the call flags are updated and, in that case, the right flags are used, so sometimes this issue could be masked by that.

## How to test

- Comment the code to [update the call flags when a local track is replaced](https://github.com/nextcloud/spreed/blob/43ebbd09a2b9139601b945a1ab77fc95a30a5290/src/utils/webrtc/webrtc.js#L1335-L1339)
- Setup the HPB
- Start a call with audio but no video
- Disable audio (if it was already disabled, enable and disable it again)
- In a private window, join the call
- In the original window, open the device settings and select a camera

### Result with this pull request

The call flags for the participant were set to 7

### Result without this pull request

The call flags for the participant were set to 5
