### PR TITLE
Only add the share_with_link url when the link is accessible

### DIFF
--- a/lib/Share/Helper/ShareAPIController.php
+++ b/lib/Share/Helper/ShareAPIController.php
@@ -87,16 +87,17 @@ class ShareAPIController {
 		$result['share_with_displayname'] = $room->getDisplayName($this->userId);
 		try {
 			$room->getParticipant($this->userId, false);
+			$result['share_with_link'] = $this->urlGenerator->linkToRouteAbsolute('spreed.Page.showCall', ['token' => $room->getToken()]);
 		} catch (ParticipantNotFoundException $e) {
 			// Removing the conversation token from the leaked data if not a participant.
 			// Adding some unique but reproducable part to the share_with here
 			// so the avatars for conversations are distinguishable
 			$result['share_with'] = 'private_conversation_' . substr(sha1($room->getName() . $room->getId()), 0, 6);
+			$result['share_with_link'] = '';
 		}
 		if ($room->getType() === Room::TYPE_PUBLIC) {
 			$result['token'] = $share->getToken();
 		}
-		$result['share_with_link'] = $this->urlGenerator->linkToRouteAbsolute('spreed.Page.showCall', ['token' => $room->getToken()]);
 
 		return $result;
 	}

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -596,7 +596,8 @@ class SharingContext implements Context {
 			'item_source' => 'A_NUMBER',
 			'file_source' => 'A_NUMBER',
 			'file_parent' => 'A_NUMBER',
-			'mail_send' => '0'
+			'mail_send' => '0',
+			'share_with_link' => 'URL',
 		];
 		$expectedFields = array_merge($defaultExpectedFields, $body->getRowsHash());
 
@@ -614,9 +615,14 @@ class SharingContext implements Context {
 				array_key_exists('share_with', $expectedFields)) {
 			if ($expectedFields['share_with'] === 'private_conversation') {
 				$expectedFields['share_with'] = 'REGEXP /^private_conversation_[0-9a-f]{6}$/';
+				$expectedFields['share_with_link'] = '';
 			} else {
 				$expectedFields['share_with'] = FeatureContext::getTokenForIdentifier($expectedFields['share_with']);
 			}
+		}
+
+		if ($expectedFields['share_with_link'] === 'URL') {
+			$expectedFields['share_with_link'] = $this->baseUrl . 'index.php/call/' . $expectedFields['share_with'];
 		}
 
 		foreach ($expectedFields as $field => $value) {

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -597,9 +597,14 @@ class SharingContext implements Context {
 			'file_source' => 'A_NUMBER',
 			'file_parent' => 'A_NUMBER',
 			'mail_send' => '0',
-			'share_with_link' => 'URL',
 		];
-		$expectedFields = array_merge($defaultExpectedFields, $body->getRowsHash());
+
+		$fields = $body->getRowsHash();
+		if (isset($fields['share_type']) && ($fields['share_type'] === '10' || $fields['share_type'] === '11')) {
+			$defaultExpectedFields['share_with_link'] = 'URL';
+		}
+
+		$expectedFields = array_merge($defaultExpectedFields, $fields);
 
 		if (!array_key_exists('uid_file_owner', $expectedFields) &&
 				array_key_exists('uid_owner', $expectedFields)) {
@@ -621,8 +626,13 @@ class SharingContext implements Context {
 			}
 		}
 
-		if ($expectedFields['share_with_link'] === 'URL') {
-			$expectedFields['share_with_link'] = $this->baseUrl . 'index.php/call/' . $expectedFields['share_with'];
+		if (array_key_exists('share_with_link', $expectedFields) &&
+			$expectedFields['share_with_link'] === 'URL') {
+			if (array_key_exists('share_with', $expectedFields)) {
+				$expectedFields['share_with_link'] = $this->baseUrl . 'index.php/call/' . $expectedFields['share_with'];
+			} else {
+				$expectedFields['share_with_link'] = 'REGEXP ' . '/\/call\//';
+			}
 		}
 
 		foreach ($expectedFields as $field => $value) {


### PR DESCRIPTION
Otherwise the comment from the catch block applies:
"Removing the conversation token from the leaked data if not a participant ..."

- [x] Should add an integration test