### PR TITLE
Fix the secondary buttons with the style of old buttons

### DIFF
--- a/src/assets/buttons.scss
+++ b/src/assets/buttons.scss
@@ -54,5 +54,16 @@
 			background-color: var(--color-background-darker);
 		}
 	}
+}
 
+.button-vue--vue-secondary {
+	color: var(--color-main-text);
+	background-color: var(--color-background-dark);
+	border: 1px solid var(--color-border-dark);
+
+	&:hover {
+		color: var(--color-main-text);
+		background-color: var(--color-background-dark);
+		border-color: var(--color-primary-element);
+	}
 }

--- a/src/components/LeftSidebar/NewGroupConversation/Confirmation/Confirmation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/Confirmation/Confirmation.vue
@@ -121,6 +121,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '../../../../assets/buttons';
 .confirmation {
 	display: flex;
 	flex-direction: column;

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -206,6 +206,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+	@import '../assets/buttons';
+
 	::v-deep .item-list__entry {
 		position: relative;
 	}


### PR DESCRIPTION
### Before
Theme `#BA0013` | Before 
---|---
Dark | ![Bildschirmfoto von 2022-03-19 22-23-42](https://user-images.githubusercontent.com/213943/159138867-e7083b46-12e6-4260-adb3-82e3d22f5ff0.png)
Bright | ![Bildschirmfoto von 2022-03-19 22-23-26](https://user-images.githubusercontent.com/213943/159138869-7c976fa7-e226-4153-ae29-15f7e4623baf.png)


### After - Looking like a normal `<button>` in 23
Theme `#BA0013` | Normal | Hover
---|---|---
Dark | ![Bildschirmfoto von 2022-03-19 22-17-50](https://user-images.githubusercontent.com/213943/159138797-40021b96-3009-4c11-975c-70823e9352cd.png) | ![Bildschirmfoto von 2022-03-19 22-17-53](https://user-images.githubusercontent.com/213943/159138796-75d3da77-1fb7-4381-895b-d5adf2eb12e5.png)
Bright | ![Bildschirmfoto von 2022-03-19 22-21-00](https://user-images.githubusercontent.com/213943/159138802-1c0ed418-cacf-44f3-b275-33e063d4f381.png) | ![Bildschirmfoto von 2022-03-19 22-21-03](https://user-images.githubusercontent.com/213943/159138804-f617ceb2-9fd8-4d74-a4b7-d06789a78a92.png)

 
Maybe we can apply this in the vue lib even as a temp fix for 24? It would allow to migrate all buttons to the component already and later with an update we can make it shiny?