### PR TITLE
Group on PHP level as MariaDB can not handle this correctly

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -103,6 +103,11 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 5
 
     steps:
+      - name: Enable ONLY_FULL_GROUP_BY MySQL option
+        run: |
+          echo "SET GLOBAL sql_mode=(SELECT CONCAT(@@sql_mode,',ONLY_FULL_GROUP_BY'));" | mysql -h 127.0.0.1 -P 4444 -u root -prootpassword
+          echo "SELECT @@sql_mode;" | mysql -h 127.0.0.1 -P 4444 -u root -prootpassword
+
       - name: Checkout server
         uses: actions/checkout@v2
         with:

--- a/lib/Chat/MessageParser.php
+++ b/lib/Chat/MessageParser.php
@@ -92,7 +92,7 @@ class MessageParser {
 				$displayName = $this->guestNames[$comment->getActorId()];
 			} else {
 				try {
-					$participant = $message->getRoom()->getParticipantByActor(Attendee::ACTOR_GUESTS, $comment->getActorId(), false);
+					$participant = $message->getRoom()->getParticipantByActor(Attendee::ACTOR_GUESTS, $comment->getActorId());
 					$displayName = $participant->getAttendee()->getDisplayName();
 				} catch (ParticipantNotFoundException $e) {
 				}

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -700,7 +700,7 @@ class SystemMessage {
 
 	protected function getGuestName(Room $room, string $actorId): string {
 		try {
-			$participant = $room->getParticipantByActor(Attendee::ACTOR_GUESTS, $actorId, false);
+			$participant = $room->getParticipantByActor(Attendee::ACTOR_GUESTS, $actorId);
 			$name = $participant->getAttendee()->getDisplayName();
 			if ($name === '') {
 				return $this->l->t('Guest');

--- a/lib/Chat/Parser/UserMention.php
+++ b/lib/Chat/Parser/UserMention.php
@@ -132,7 +132,7 @@ class UserMention {
 				];
 			} elseif ($mention['type'] === 'guest') {
 				try {
-					$participant = $chatMessage->getRoom()->getParticipantByActor(Attendee::ACTOR_GUESTS, substr($mention['id'], strlen('guest/')), false);
+					$participant = $chatMessage->getRoom()->getParticipantByActor(Attendee::ACTOR_GUESTS, substr($mention['id'], strlen('guest/')));
 					$displayName = $participant->getAttendee()->getDisplayName() ?: $this->l->t('Guest');
 				} catch (ParticipantNotFoundException $e) {
 					$displayName = $this->l->t('Guest');

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1508,15 +1508,8 @@ class RoomController extends AEnvironmentAwareController {
 		}
 
 		// Prevent users/moderators modifying themselves
-		if ($attendee->getActorType() === Attendee::ACTOR_USERS) {
-			if ($attendee->getActorId() === $this->userId) {
-				return new DataResponse([], Http::STATUS_FORBIDDEN);
-			}
-		} elseif ($attendee->getActorType() === Attendee::ACTOR_GUESTS) {
-			$session = $targetParticipant->getSession();
-			$currentSessionId = $this->session->getSessionForRoom($this->room->getToken());
-
-			if ($session instanceof Session && $currentSessionId === $session->getSessionId()) {
+		if ($attendee->getActorType() === $this->participant->getAttendee()->getActorType()) {
+			if ($attendee->getActorId() === $this->participant->getAttendee()->getActorId()) {
 				return new DataResponse([], Http::STATUS_FORBIDDEN);
 			}
 		} elseif ($attendee->getActorType() === Attendee::ACTOR_GROUPS) {

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -601,14 +601,14 @@ class SignalingController extends OCSController {
 						// If the user joins the session might not be known to the server yet.
 						// In this case we load by actor information and use the session id as new session.
 						try {
-							$participant = $room->getParticipantByActor($actorType, $actorId, false);
+							$participant = $room->getParticipantByActor($actorType, $actorId);
 						} catch (ParticipantNotFoundException $e) {
 						}
 					}
 				}
 			} else {
 				try {
-					$participant = $room->getParticipantByActor($actorType, $actorId, false);
+					$participant = $room->getParticipantByActor($actorType, $actorId);
 				} catch (ParticipantNotFoundException $e) {
 				}
 			}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -516,7 +516,7 @@ class Notifier implements INotifier {
 	 * @throws ParticipantNotFoundException
 	 */
 	protected function getGuestParameter(Room $room, string $actorId): array {
-		$participant = $room->getParticipantByActor(Attendee::ACTOR_GUESTS, $actorId, false);
+		$participant = $room->getParticipantByActor(Attendee::ACTOR_GUESTS, $actorId);
 		$name = $participant->getAttendee()->getDisplayName();
 		if (trim($name) === '') {
 			throw new ParticipantNotFoundException('Empty name');

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -567,13 +567,10 @@ class Room {
 
 	/**
 	 * @param int $attendeeId
-	 * @param string|null|false $sessionId Set to false if you don't want to load a session (and save resources),
-	 *                                     string to try loading a specific session
-	 *                                     null to try loading "any"
 	 * @return Participant
 	 * @throws ParticipantNotFoundException When the pin is not valid (has no participant assigned)
 	 */
-	public function getParticipantByAttendeeId(int $attendeeId, $sessionId = null): Participant {
+	public function getParticipantByAttendeeId(int $attendeeId): Participant {
 		$query = $this->db->getQueryBuilder();
 		$helper = new SelectHelper();
 		$helper->selectAttendeesTable($query);
@@ -581,20 +578,6 @@ class Room {
 			->where($query->expr()->eq('a.id', $query->createNamedParameter($attendeeId, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->eq('a.room_id', $query->createNamedParameter($this->getId())))
 			->setMaxResults(1);
-
-		if ($sessionId !== false) {
-			if ($sessionId !== null) {
-				$helper->selectSessionsTable($query);
-				$query->leftJoin('a', 'talk_sessions', 's', $query->expr()->andX(
-					$query->expr()->eq('s.session_id', $query->createNamedParameter($sessionId)),
-					$query->expr()->eq('a.id', 's.attendee_id')
-				));
-			} else {
-				$helper->selectSessionsTableMax($query);
-				$query->groupBy('a.id');
-				$query->leftJoin('a', 'talk_sessions', 's', $query->expr()->eq('a.id', 's.attendee_id'));
-			}
-		}
 
 		$result = $query->executeQuery();
 		$row = $result->fetch();

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1226,7 +1226,7 @@ class ParticipantService {
 
 		$helper = new SelectHelper();
 		$helper->selectAttendeesTable($query);
-		$helper->selectSessionsTableMax($query);
+		$helper->selectSessionsTable($query);
 		$query->from('talk_attendees', 'a')
 			// Currently we only care if the user has a session at all, so we can select any: #ThisIsFine
 			->leftJoin(
@@ -1234,10 +1234,16 @@ class ParticipantService {
 				$query->expr()->eq('s.attendee_id', 'a.id')
 			)
 			->where($query->expr()->eq('a.room_id', $query->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))
-			->andWhere($query->expr()->eq('a.notification_level', $query->createNamedParameter($notificationLevel, IQueryBuilder::PARAM_INT)))
-			->groupBy('a.id');
+			->andWhere($query->expr()->eq('a.notification_level', $query->createNamedParameter($notificationLevel, IQueryBuilder::PARAM_INT)));
 
-		return $this->getParticipantsFromQuery($query, $room);
+		$participants = $this->getParticipantsFromQuery($query, $room);
+
+		$uniqueAttendees = [];
+		foreach ($participants as $participant) {
+			$uniqueAttendees[$participant->getAttendee()->getId()] = $participant;
+		}
+
+		return array_values($uniqueAttendees);
 	}
 
 	/**

--- a/tests/php/Service/ParticipantServiceTest.php
+++ b/tests/php/Service/ParticipantServiceTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Tests\php\Service;
+
+use OCA\Talk\Config;
+use OCA\Talk\Federation\Notifications;
+use OCA\Talk\Model\Attendee;
+use OCA\Talk\Model\AttendeeMapper;
+use OCA\Talk\Model\Session;
+use OCA\Talk\Model\SessionMapper;
+use OCA\Talk\Participant;
+use OCA\Talk\Room;
+use OCA\Talk\Service\MembershipService;
+use OCA\Talk\Service\ParticipantService;
+use OCA\Talk\Service\SessionService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\ICacheFactory;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class ParticipantServiceTest extends TestCase {
+
+	/** @var IConfig|MockObject */
+	protected $serverConfig;
+	/** @var Config|MockObject */
+	protected $talkConfig;
+	/** @var AttendeeMapper */
+	protected $attendeeMapper;
+	/** @var SessionMapper */
+	protected $sessionMapper;
+	/** @var SessionService|MockObject */
+	protected $sessionService;
+	/** @var ISecureRandom|MockObject */
+	protected $secureRandom;
+	/** @var IEventDispatcher|MockObject */
+	protected $dispatcher;
+	/** @var IUserManager|MockObject */
+	protected $userManager;
+	/** @var IGroupManager|MockObject */
+	protected $groupManager;
+	/** @var MembershipService|MockObject */
+	protected $membershipService;
+	/** @var Notifications|MockObject */
+	protected $federationNotifications;
+	/** @var ITimeFactory|MockObject */
+	protected $time;
+	/** @var ICacheFactory|MockObject */
+	protected $cacheFactory;
+	/** @var ParticipantService */
+	private $service;
+
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->serverConfig = $this->createMock(IConfig::class);
+		$this->talkConfig = $this->createMock(Config::class);
+		$this->attendeeMapper = new AttendeeMapper(\OC::$server->getDatabaseConnection());
+		$this->sessionMapper = new SessionMapper(\OC::$server->getDatabaseConnection());
+		$this->sessionService = $this->createMock(SessionService::class);
+		$this->secureRandom = $this->createMock(ISecureRandom::class);
+		$this->dispatcher = $this->createMock(IEventDispatcher::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->membershipService = $this->createMock(MembershipService::class);
+		$this->federationNotifications = $this->createMock(Notifications::class);
+		$this->time = $this->createMock(ITimeFactory::class);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->service = new ParticipantService(
+			$this->serverConfig,
+			$this->talkConfig,
+			$this->attendeeMapper,
+			$this->sessionMapper,
+			$this->sessionService,
+			$this->secureRandom,
+			\OC::$server->getDatabaseConnection(),
+			$this->dispatcher,
+			$this->userManager,
+			$this->groupManager,
+			$this->membershipService,
+			$this->federationNotifications,
+			$this->time,
+			$this->cacheFactory
+		);
+	}
+
+	public function tearDown(): void {
+		try {
+			$attendee = $this->attendeeMapper->findByActor(123456789, Attendee::ACTOR_USERS, 'test');
+			$this->sessionMapper->deleteByAttendeeId($attendee->getId());
+			$this->attendeeMapper->delete($attendee);
+		} catch (DoesNotExistException $exception) {
+		}
+
+		parent::tearDown();
+	}
+
+	public function testGetParticipantsByNotificationLevel(): void {
+		$attendee = new Attendee();
+		$attendee->setActorType(Attendee::ACTOR_USERS);
+		$attendee->setActorId('test');
+		$attendee->setRoomId(123456789);
+		$attendee->setNotificationLevel(Participant::NOTIFY_MENTION);
+		$this->attendeeMapper->insert($attendee);
+
+		$session1 = new Session();
+		$session1->setAttendeeId($attendee->getId());
+		$session1->setSessionId(self::getUniqueID('session1'));
+		$this->sessionMapper->insert($session1);
+
+		$session2 = new Session();
+		$session2->setAttendeeId($attendee->getId());
+		$session2->setSessionId(self::getUniqueID('session2'));
+		$this->sessionMapper->insert($session2);
+
+		$room = $this->createMock(Room::class);
+		$room->method('getId')
+			->willReturn(123456789);
+		$participants = $this->service->getParticipantsByNotificationLevel($room, Participant::NOTIFY_MENTION);
+		self::assertCount(1, $participants);
+	}
+}


### PR DESCRIPTION
MySQL docs:
> Reject queries for which the select list, HAVING condition, or ORDER BY
list refer to nonaggregated columns that are neither named in the GROUP BY
clause **nor are functionally dependent on (uniquely determined by) GROUP BY columns**.

MariaDB docs:
> For SELECT ... GROUP BY queries, disallow SELECTing columns which are
not referred to in the GROUP BY clause, unless they are passed to an
aggregate function like COUNT() or MAX(). Produce a 1055 error.
