### PR TITLE
Try setting only full group by option integration

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -77,7 +77,8 @@ local PipelineMySQL(test_set) = Pipeline(
 			command: [
 				"--innodb_large_prefix=true",
 				"--innodb_file_format=barracuda",
-				"--innodb_file_per_table=true"
+				"--innodb_file_per_table=true",
+				"--sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
 			],
 			tmpfs: [
 				"/var/lib/mysql"

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -41,7 +41,7 @@ local Pipeline(test_set, database, services) = {
 			"stable*"
 		],
 		event: (
-			if database == "sqlite" then ["pull_request", "push"] else ["push"]
+			if database == "mysql" then ["pull_request", "push"] else ["push"]
 		)
 	}
 };

--- a/.drone.yml
+++ b/.drone.yml
@@ -271,6 +271,7 @@ services:
   - --innodb_large_prefix=true
   - --innodb_file_format=barracuda
   - --innodb_file_per_table=true
+  - --sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
   environment:
     MYSQL_DATABASE: oc_autotest
     MYSQL_PASSWORD: owncloud
@@ -314,6 +315,7 @@ services:
   - --innodb_large_prefix=true
   - --innodb_file_format=barracuda
   - --innodb_file_per_table=true
+  - --sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
   environment:
     MYSQL_DATABASE: oc_autotest
     MYSQL_PASSWORD: owncloud
@@ -357,6 +359,7 @@ services:
   - --innodb_large_prefix=true
   - --innodb_file_format=barracuda
   - --innodb_file_per_table=true
+  - --sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
   environment:
     MYSQL_DATABASE: oc_autotest
     MYSQL_PASSWORD: owncloud
@@ -400,6 +403,7 @@ services:
   - --innodb_large_prefix=true
   - --innodb_file_format=barracuda
   - --innodb_file_per_table=true
+  - --sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
   environment:
     MYSQL_DATABASE: oc_autotest
     MYSQL_PASSWORD: owncloud
@@ -444,6 +448,7 @@ services:
   - --innodb_large_prefix=true
   - --innodb_file_format=barracuda
   - --innodb_file_per_table=true
+  - --sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
   environment:
     MYSQL_DATABASE: oc_autotest
     MYSQL_PASSWORD: owncloud
@@ -488,6 +493,7 @@ services:
   - --innodb_large_prefix=true
   - --innodb_file_format=barracuda
   - --innodb_file_per_table=true
+  - --sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
   environment:
     MYSQL_DATABASE: oc_autotest
     MYSQL_PASSWORD: owncloud
@@ -531,6 +537,7 @@ services:
   - --innodb_large_prefix=true
   - --innodb_file_format=barracuda
   - --innodb_file_per_table=true
+  - --sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
   environment:
     MYSQL_DATABASE: oc_autotest
     MYSQL_PASSWORD: owncloud
@@ -574,6 +581,7 @@ services:
   - --innodb_large_prefix=true
   - --innodb_file_format=barracuda
   - --innodb_file_per_table=true
+  - --sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
   environment:
     MYSQL_DATABASE: oc_autotest
     MYSQL_PASSWORD: owncloud
@@ -617,6 +625,7 @@ services:
   - --innodb_large_prefix=true
   - --innodb_file_format=barracuda
   - --innodb_file_per_table=true
+  - --sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
   environment:
     MYSQL_DATABASE: oc_autotest
     MYSQL_PASSWORD: owncloud

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,6 @@ trigger:
   - master
   - stable*
   event:
-  - pull_request
   - push
 ---
 kind: pipeline
@@ -56,7 +55,6 @@ trigger:
   - master
   - stable*
   event:
-  - pull_request
   - push
 ---
 kind: pipeline
@@ -86,7 +84,6 @@ trigger:
   - master
   - stable*
   event:
-  - pull_request
   - push
 ---
 kind: pipeline
@@ -117,7 +114,6 @@ trigger:
   - master
   - stable*
   event:
-  - pull_request
   - push
 ---
 kind: pipeline
@@ -148,7 +144,6 @@ trigger:
   - master
   - stable*
   event:
-  - pull_request
   - push
 ---
 kind: pipeline
@@ -178,7 +173,6 @@ trigger:
   - master
   - stable*
   event:
-  - pull_request
   - push
 ---
 kind: pipeline
@@ -208,7 +202,6 @@ trigger:
   - master
   - stable*
   event:
-  - pull_request
   - push
 ---
 kind: pipeline
@@ -238,7 +231,6 @@ trigger:
   - master
   - stable*
   event:
-  - pull_request
   - push
 ---
 kind: pipeline
@@ -268,7 +260,6 @@ trigger:
   - master
   - stable*
   event:
-  - pull_request
   - push
 ---
 kind: pipeline
@@ -311,6 +302,7 @@ trigger:
   - master
   - stable*
   event:
+  - pull_request
   - push
 ---
 kind: pipeline
@@ -353,6 +345,7 @@ trigger:
   - master
   - stable*
   event:
+  - pull_request
   - push
 ---
 kind: pipeline
@@ -395,6 +388,7 @@ trigger:
   - master
   - stable*
   event:
+  - pull_request
   - push
 ---
 kind: pipeline
@@ -438,6 +432,7 @@ trigger:
   - master
   - stable*
   event:
+  - pull_request
   - push
 ---
 kind: pipeline
@@ -481,6 +476,7 @@ trigger:
   - master
   - stable*
   event:
+  - pull_request
   - push
 ---
 kind: pipeline
@@ -523,6 +519,7 @@ trigger:
   - master
   - stable*
   event:
+  - pull_request
   - push
 ---
 kind: pipeline
@@ -565,6 +562,7 @@ trigger:
   - master
   - stable*
   event:
+  - pull_request
   - push
 ---
 kind: pipeline
@@ -607,6 +605,7 @@ trigger:
   - master
   - stable*
   event:
+  - pull_request
   - push
 ---
 kind: pipeline
@@ -649,6 +648,7 @@ trigger:
   - master
   - stable*
   event:
+  - pull_request
   - push
 ---
 kind: pipeline


### PR DESCRIPTION
- [x] 72927bc627cdac14efbc8021aac053ef5c4fe173 drop before merge or we accept the switch from sqlite to mysql by default, I think it makes sense given the story behind this PR
- [x] 3bb0cc543856022f967d14cd559818d6f1c38508 merge with 5f7a75432c1a24a32406c7cac1d61b56ca4f3567
- [x] All other commits are to be dropped as they are cherry-picked from https://github.com/nextcloud/spreed/pull/7031
- [x] Rebase after https://github.com/nextcloud/spreed/pull/7031 is merged