### PR TITLE
Fix reconnections on single media permission changes

### DIFF
--- a/src/utils/media/pipeline/MediaDevicesSource.js
+++ b/src/utils/media/pipeline/MediaDevicesSource.js
@@ -75,7 +75,7 @@ export default class MediaDevicesSource extends TrackSource {
 		// Fallback for users without a camera or with a camera that can not be
 		// accessed, but only if audio is meant to be used.
 		if (error && constraints.audio !== false && constraints.video !== false) {
-			retryNoVideoCallback(constraints, error);
+			retryNoVideoCallback(error);
 
 			[stream, error] = await this._startAudioOnly(constraints)
 		}

--- a/src/utils/media/pipeline/MediaDevicesSource.js
+++ b/src/utils/media/pipeline/MediaDevicesSource.js
@@ -68,6 +68,14 @@ export default class MediaDevicesSource extends TrackSource {
 		this._active = false
 	}
 
+	isAudioAllowed() {
+		return this._audioAllowed
+	}
+
+	isVideoAllowed() {
+		return this._videoAllowed
+	}
+
 	setAudioAllowed(audioAllowed) {
 		if (this._audioAllowed === audioAllowed) {
 			return

--- a/src/utils/media/pipeline/MediaDevicesSource.spec.js
+++ b/src/utils/media/pipeline/MediaDevicesSource.spec.js
@@ -1,0 +1,809 @@
+/**
+ *
+ * @copyright Copyright (c) 2022, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { mediaDevicesManager } from '../../webrtc/index'
+
+import MediaDevicesSource from './MediaDevicesSource'
+
+/**
+ * Helper function to create MediaStreamTrack mocks with just the attributes and
+ * methods used by MediaDevicesSource.
+ *
+ * @param {string} id the ID of the track
+ * @param {kind} kind the kind ("audio" or "video") of the track
+ * @param {deviceId} deviceId the ID of the device that this track belongs to
+ */
+function newMediaStreamTrackMock(id, kind, deviceId = undefined) {
+	/**
+	 * MediaStreamTrackMock constructor.
+	 */
+	function MediaStreamTrackMock() {
+		this._endedEventHandlers = []
+		this.id = id
+		this.kind = kind
+		this.addEventListener = jest.fn((eventName, eventHandler) => {
+			if (eventName !== 'ended') {
+				return
+			}
+
+			this._endedEventHandlers.push(eventHandler)
+		})
+		this.removeEventListener = jest.fn((eventName, eventHandler) => {
+			if (eventName !== 'ended') {
+				return
+			}
+
+			const index = this._endedEventHandlers.indexOf(eventHandler)
+			if (index !== -1) {
+				this._endedEventHandlers.splice(index, 1)
+			}
+		})
+		this.stop = jest.fn()
+		this.getSettings = jest.fn(() => {
+			return {
+				deviceId: deviceId || kind + '-device',
+			}
+		})
+	}
+	return new MediaStreamTrackMock()
+}
+
+/**
+ * Helper function to create MediaStreamTrack mocks with just the attributes and
+ * methods used by MediaDevicesSource.
+ *
+ * @param {string} id the ID of the track
+ */
+function newMediaStreamMock(id) {
+	/**
+	 * MediaStreamMock constructor.
+	 */
+	function MediaStreamMock() {
+		this._tracks = []
+		this.id = id
+		this.getTracks = jest.fn(() => {
+			return this._tracks
+		})
+		this.getAudioTracks = jest.fn(() => {
+			return this._tracks.filter(track => track.kind === 'audio')
+		})
+		this.getVideoTracks = jest.fn(() => {
+			return this._tracks.filter(track => track.kind === 'video')
+		})
+	}
+	return new MediaStreamMock()
+}
+
+describe('MediaDevicesSource', () => {
+	let mediaDevicesSource
+	let constraints
+	let retryNoVideoCallback
+	let getUserMediaAudioTrack
+	let getUserMediaVideoTrack
+	let expectedAudioTrack
+	let expectedVideoTrack
+
+	beforeAll(() => {
+		jest.spyOn(mediaDevicesManager, 'on')
+		jest.spyOn(mediaDevicesManager, 'off')
+
+		mediaDevicesManager._storeDeviceId = jest.fn()
+	})
+
+	beforeEach(() => {
+		mediaDevicesSource = new MediaDevicesSource()
+
+		constraints = {
+			audio: true,
+			video: true,
+		}
+
+		retryNoVideoCallback = jest.fn()
+
+		// Clear event listeners
+		mediaDevicesManager._handlers = []
+		mediaDevicesManager.on.mockClear()
+		mediaDevicesManager.off.mockClear()
+
+		jest.spyOn(mediaDevicesManager, 'getUserMedia').mockImplementation(async (constraints) => {
+			// MediaDevicesManager.getUserMedia() updates the received
+			// constraints if audio or video is requested but no audio or video
+			// device is selected.
+			if (constraints.audio && !getUserMediaAudioTrack) {
+				constraints.audio = false
+			}
+			if (constraints.video && !getUserMediaVideoTrack) {
+				constraints.video = false
+			}
+
+			// MediaDevicesManager.getUserMedia() will throw if the given
+			// constraints reject both audio and video, or if there are no
+			// selected devices.
+			if (!constraints.audio && !constraints.video) {
+				throw new Error('Audio and/or video is required')
+			}
+
+			const stream = newMediaStreamMock(JSON.stringify(constraints))
+
+			if (constraints.audio && getUserMediaAudioTrack) {
+				stream._tracks.push(getUserMediaAudioTrack)
+			}
+			if (constraints.video && getUserMediaVideoTrack) {
+				stream._tracks.push(getUserMediaVideoTrack)
+			}
+
+			return stream
+		})
+
+		getUserMediaAudioTrack = null
+		getUserMediaVideoTrack = null
+		expectedAudioTrack = null
+		expectedVideoTrack = null
+	})
+
+	afterEach(() => {
+		mediaDevicesManager.getUserMedia.mockRestore()
+	})
+
+	afterAll(() => {
+		jest.restoreAllMocks()
+	})
+
+	describe('start', () => {
+
+		/**
+		 * Checks the expected output tracks and event listeners.
+		 */
+		function assertStateAfterStart() {
+			expect(mediaDevicesSource.getOutputTrack('audio')).toBe(expectedAudioTrack)
+			expect(mediaDevicesSource.getOutputTrack('video')).toBe(expectedVideoTrack)
+
+			expect(mediaDevicesManager.on).toHaveBeenCalledTimes(2)
+			expect(mediaDevicesManager.on).toHaveBeenNthCalledWith(1, 'change:audioInputId', mediaDevicesSource._handleAudioInputIdChangedBound)
+			expect(mediaDevicesManager.on).toHaveBeenNthCalledWith(2, 'change:videoInputId', mediaDevicesSource._handleVideoInputIdChangedBound)
+		}
+
+		describe('with audio and video', () => {
+			test('when there are audio and video devices', () => {
+				getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
+				getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
+
+				expectedAudioTrack = getUserMediaAudioTrack
+				expectedVideoTrack = getUserMediaVideoTrack
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are audio and video devices but video could not be got', () => {
+				getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
+				getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
+
+				jest.spyOn(mediaDevicesManager, 'getUserMedia').mockImplementationOnce(async (constraints) => {
+					throw new Error('Video could not be got')
+				})
+
+				expectedAudioTrack = getUserMediaAudioTrack
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(2)
+					expect(retryNoVideoCallback).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).toHaveBeenCalledWith(new Error('Video could not be got'))
+				})
+			})
+
+			test('when there are audio and video devices but none could be got', () => {
+				getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
+				getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
+
+				jest.spyOn(mediaDevicesManager, 'getUserMedia').mockImplementationOnce(async (constraints) => {
+					throw new Error('Audio and video could not be got')
+				})
+				jest.spyOn(mediaDevicesManager, 'getUserMedia').mockImplementationOnce(async (constraints) => {
+					throw new Error('Audio could not be got')
+				})
+
+				expect.hasAssertions()
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(2)
+					expect(retryNoVideoCallback).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).toHaveBeenCalledWith(new Error('Audio and video could not be got'))
+				})
+			})
+
+			test('when there are audio but no video devices', () => {
+				getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
+
+				expectedAudioTrack = getUserMediaAudioTrack
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are audio but no video devices and audio could not be got', () => {
+				getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
+
+				jest.spyOn(mediaDevicesManager, 'getUserMedia').mockImplementationOnce(async (constraints) => {
+					constraints.video = false
+
+					throw new Error('Audio could not be got')
+				})
+
+				expect.hasAssertions()
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are video but no audio devices', () => {
+				getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
+
+				expectedVideoTrack = getUserMediaVideoTrack
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are video but no audio devices and video could not be got', () => {
+				getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
+
+				jest.spyOn(mediaDevicesManager, 'getUserMedia').mockImplementationOnce(async (constraints) => {
+					constraints.audio = false
+
+					throw new Error('Video could not be got')
+				})
+
+				expect.hasAssertions()
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are no audio nor video devices', () => {
+				expect.hasAssertions()
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+		})
+
+		describe('with audio', () => {
+			beforeEach(() => {
+				constraints = {
+					audio: true,
+					video: false,
+				}
+			})
+
+			test('when there are audio and video devices', () => {
+				getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
+				getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
+
+				expectedAudioTrack = getUserMediaAudioTrack
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are audio and video devices but audio could not be got', () => {
+				getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
+				getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
+
+				jest.spyOn(mediaDevicesManager, 'getUserMedia').mockImplementationOnce(async (constraints) => {
+					throw new Error('Audio could not be got')
+				})
+
+				expect.hasAssertions()
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are audio but no video devices', () => {
+				getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
+
+				expectedAudioTrack = getUserMediaAudioTrack
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are audio but no video devices and audio could not be got', () => {
+				getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
+
+				jest.spyOn(mediaDevicesManager, 'getUserMedia').mockImplementationOnce(async (constraints) => {
+					throw new Error('Audio could not be got')
+				})
+
+				expect.hasAssertions()
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are video but no audio devices', () => {
+				getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
+
+				expect.hasAssertions()
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are no audio nor video devices', () => {
+				expect.hasAssertions()
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+		})
+
+		describe('with video', () => {
+			beforeEach(() => {
+				constraints = {
+					audio: false,
+					video: true,
+				}
+			})
+
+			test('when there are audio and video devices', () => {
+				getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
+				getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
+
+				expectedVideoTrack = getUserMediaVideoTrack
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are audio and video devices but video could not be got', () => {
+				getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
+				getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
+
+				jest.spyOn(mediaDevicesManager, 'getUserMedia').mockImplementationOnce(async (constraints) => {
+					throw new Error('Video could not be got')
+				})
+
+				expect.hasAssertions()
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are audio but no video devices', () => {
+				getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
+
+				expect.hasAssertions()
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are video but no audio devices', () => {
+				getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
+
+				expectedVideoTrack = getUserMediaVideoTrack
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are video but no audio devices and video could not be got', () => {
+				getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
+
+				jest.spyOn(mediaDevicesManager, 'getUserMedia').mockImplementationOnce(async (constraints) => {
+					throw new Error('Video could not be got')
+				})
+
+				expect.hasAssertions()
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are no audio nor video devices', () => {
+				expect.hasAssertions()
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+		})
+
+		describe('with no audio nor video', () => {
+			beforeEach(() => {
+				constraints = {
+					audio: false,
+					video: false,
+				}
+			})
+
+			test('when there are audio and video devices', () => {
+				getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
+				getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
+
+				expect.hasAssertions()
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are audio but no video devices', () => {
+				getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
+
+				expect.hasAssertions()
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are video but no audio devices', () => {
+				getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
+
+				expect.hasAssertions()
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+
+			test('when there are no audio nor video devices', () => {
+				expect.hasAssertions()
+
+				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+					assertStateAfterStart()
+
+					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+					expect(retryNoVideoCallback).not.toHaveBeenCalled()
+				})
+			})
+		})
+	})
+
+	describe('change input id in MediaDevicesManager', () => {
+		beforeEach(() => {
+			getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio', 'audio-device')
+			getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video', 'video-device')
+		})
+
+		test('to same device', async () => {
+			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+
+			mediaDevicesManager.set('audioInputId', 'audio-device')
+
+			expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+			expect(mediaDevicesSource.getOutputTrack('audio')).toBe(getUserMediaAudioTrack)
+			expect(getUserMediaAudioTrack.stop).not.toHaveBeenCalled()
+		})
+
+		test('from a device to no device', async () => {
+			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+
+			mediaDevicesManager.set('audioInputId', null)
+
+			expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+			expect(mediaDevicesSource.getOutputTrack('audio')).toBe(null)
+			expect(getUserMediaAudioTrack.stop).toHaveBeenCalledTimes(1)
+		})
+
+		test('from a device to another device', async () => {
+			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+
+			const originalGetUserMediaAudioTrack = getUserMediaAudioTrack
+
+			getUserMediaAudioTrack = newMediaStreamTrackMock('audio-2', 'audio', 'audio-device-2')
+
+			mediaDevicesManager.set('audioInputId', 'audio-device-2')
+
+			// Wait until getUserMedia(), internally called by
+			// MediaDevicesSource when the id is set, finishes.
+			await new Promise(process.nextTick)
+
+			expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(2)
+			expect(mediaDevicesSource.getOutputTrack('audio')).toBe(getUserMediaAudioTrack)
+			expect(getUserMediaAudioTrack.stop).not.toHaveBeenCalled()
+			expect(originalGetUserMediaAudioTrack.stop).toHaveBeenCalledTimes(1)
+		})
+
+		test('from a device to another device but track could not be got', async () => {
+			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+
+			jest.spyOn(mediaDevicesManager, 'getUserMedia').mockImplementationOnce(async (constraints) => {
+				throw new Error('Audio could not be got')
+			})
+
+			mediaDevicesManager.set('audioInputId', 'audio-device-2')
+
+			// Wait until getUserMedia(), internally called by
+			// MediaDevicesSource when the id is set, finishes.
+			await new Promise(process.nextTick)
+
+			expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(2)
+			expect(mediaDevicesSource.getOutputTrack('audio')).toBe(null)
+			expect(getUserMediaAudioTrack.stop).toHaveBeenCalledTimes(1)
+		})
+
+		test('from no device to a device', async () => {
+			getUserMediaAudioTrack = null
+			getUserMediaVideoTrack = null
+
+			try {
+				await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+			} catch (exception) {
+			}
+
+			getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio', 'audio-device')
+
+			mediaDevicesManager.set('audioInputId', 'audio-device')
+
+			// Wait until getUserMedia(), internally called by
+			// MediaDevicesSource when the id is set, finishes.
+			await new Promise(process.nextTick)
+
+			expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(2)
+			expect(mediaDevicesSource.getOutputTrack('audio')).toBe(getUserMediaAudioTrack)
+			expect(getUserMediaAudioTrack.stop).not.toHaveBeenCalled()
+		})
+
+		test('from no device to a device but track could not be got', async () => {
+			getUserMediaAudioTrack = null
+			getUserMediaVideoTrack = null
+
+			try {
+				await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+			} catch (exception) {
+			}
+
+			jest.spyOn(mediaDevicesManager, 'getUserMedia').mockImplementationOnce(async (constraints) => {
+				throw new Error('Audio could not be got')
+			})
+
+			mediaDevicesManager.set('audioInputId', 'audio-device')
+
+			// Wait until getUserMedia(), internally called by
+			// MediaDevicesSource when the id is set, finishes.
+			await new Promise(process.nextTick)
+
+			expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(2)
+			expect(mediaDevicesSource.getOutputTrack('audio')).toBe(null)
+		})
+
+		test('several times in a row before the track for the first one was got', async () => {
+			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+
+			const originalGetUserMediaAudioTrack = getUserMediaAudioTrack
+
+			getUserMediaAudioTrack = newMediaStreamTrackMock('audio-2', 'audio', 'audio-device-2')
+
+			mediaDevicesManager.set('audioInputId', 'audio-device-2')
+
+			const firstChangedGetUserMediaAudioTrack = getUserMediaAudioTrack
+
+			getUserMediaAudioTrack = newMediaStreamTrackMock('audio-3', 'audio', 'audio-device-3')
+
+			mediaDevicesManager.set('audioInputId', 'audio-device-3')
+
+			getUserMediaAudioTrack = newMediaStreamTrackMock('audio-4', 'audio', 'audio-device-4')
+
+			mediaDevicesManager.set('audioInputId', 'audio-device-4')
+
+			getUserMediaAudioTrack = newMediaStreamTrackMock('audio-5', 'audio', 'audio-device-5')
+
+			mediaDevicesManager.set('audioInputId', 'audio-device-5')
+
+			getUserMediaAudioTrack = newMediaStreamTrackMock('audio-6', 'audio', 'audio-device-6')
+
+			mediaDevicesManager.set('audioInputId', 'audio-device-6')
+
+			// Wait until getUserMedia(), internally called by
+			// MediaDevicesSource when the id is set, finishes.
+			await new Promise(process.nextTick)
+
+			expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(3)
+			expect(mediaDevicesSource.getOutputTrack('audio')).toBe(getUserMediaAudioTrack)
+			expect(getUserMediaAudioTrack.stop).not.toHaveBeenCalled()
+			expect(originalGetUserMediaAudioTrack.stop).toHaveBeenCalledTimes(1)
+			expect(firstChangedGetUserMediaAudioTrack.stop).toHaveBeenCalledTimes(1)
+		})
+
+		test('several times in a row before the track for the first one was got finally setting again the first one', async () => {
+			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+
+			const originalGetUserMediaAudioTrack = getUserMediaAudioTrack
+
+			getUserMediaAudioTrack = newMediaStreamTrackMock('audio-2', 'audio', 'audio-device-2')
+
+			mediaDevicesManager.set('audioInputId', 'audio-device-2')
+
+			const firstChangedGetUserMediaAudioTrack = getUserMediaAudioTrack
+
+			getUserMediaAudioTrack = newMediaStreamTrackMock('audio-3', 'audio', 'audio-device-3')
+
+			mediaDevicesManager.set('audioInputId', 'audio-device-3')
+
+			getUserMediaAudioTrack = newMediaStreamTrackMock('audio-4', 'audio', 'audio-device-4')
+
+			mediaDevicesManager.set('audioInputId', 'audio-device-4')
+
+			getUserMediaAudioTrack = newMediaStreamTrackMock('audio-5', 'audio', 'audio-device-5')
+
+			mediaDevicesManager.set('audioInputId', 'audio-device-5')
+
+			mediaDevicesManager.set('audioInputId', 'audio-device-2')
+
+			// Wait until getUserMedia(), internally called by
+			// MediaDevicesSource when the id is set, finishes.
+			await new Promise(process.nextTick)
+
+			expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(2)
+			expect(mediaDevicesSource.getOutputTrack('audio')).toBe(firstChangedGetUserMediaAudioTrack)
+			expect(firstChangedGetUserMediaAudioTrack.stop).not.toHaveBeenCalled()
+			expect(originalGetUserMediaAudioTrack.stop).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	describe('stop', () => {
+		test('with audio and video tracks', async () => {
+			getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
+			getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
+
+			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+
+			mediaDevicesSource.stop()
+
+			expect(mediaDevicesSource.getOutputTrack('audio')).toBe(null)
+			expect(mediaDevicesSource.getOutputTrack('video')).toBe(null)
+			expect(getUserMediaAudioTrack.stop).toHaveBeenCalledTimes(1)
+			expect(getUserMediaVideoTrack.stop).toHaveBeenCalledTimes(1)
+			expect(mediaDevicesManager.off).toHaveBeenCalledTimes(2)
+			expect(mediaDevicesManager.off).toHaveBeenNthCalledWith(1, 'change:audioInputId', mediaDevicesSource._handleAudioInputIdChangedBound)
+			expect(mediaDevicesManager.off).toHaveBeenNthCalledWith(2, 'change:videoInputId', mediaDevicesSource._handleVideoInputIdChangedBound)
+		})
+
+		test('with audio track', async () => {
+			getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
+
+			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+
+			mediaDevicesSource.stop()
+
+			expect(mediaDevicesSource.getOutputTrack('audio')).toBe(null)
+			expect(getUserMediaAudioTrack.stop).toHaveBeenCalledTimes(1)
+			expect(mediaDevicesManager.off).toHaveBeenCalledTimes(2)
+			expect(mediaDevicesManager.off).toHaveBeenNthCalledWith(1, 'change:audioInputId', mediaDevicesSource._handleAudioInputIdChangedBound)
+			expect(mediaDevicesManager.off).toHaveBeenNthCalledWith(2, 'change:videoInputId', mediaDevicesSource._handleVideoInputIdChangedBound)
+		})
+
+		test('with video track', async () => {
+			getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
+
+			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+
+			mediaDevicesSource.stop()
+
+			expect(mediaDevicesSource.getOutputTrack('video')).toBe(null)
+			expect(getUserMediaVideoTrack.stop).toHaveBeenCalledTimes(1)
+			expect(mediaDevicesManager.off).toHaveBeenCalledTimes(2)
+			expect(mediaDevicesManager.off).toHaveBeenNthCalledWith(1, 'change:audioInputId', mediaDevicesSource._handleAudioInputIdChangedBound)
+			expect(mediaDevicesManager.off).toHaveBeenNthCalledWith(2, 'change:videoInputId', mediaDevicesSource._handleVideoInputIdChangedBound)
+		})
+
+		test('with no tracks', async () => {
+			try {
+				await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+			} catch (exception) {
+			}
+
+			mediaDevicesSource.stop()
+
+			expect(mediaDevicesManager.off).toHaveBeenCalledTimes(2)
+			expect(mediaDevicesManager.off).toHaveBeenNthCalledWith(1, 'change:audioInputId', mediaDevicesSource._handleAudioInputIdChangedBound)
+			expect(mediaDevicesManager.off).toHaveBeenNthCalledWith(2, 'change:videoInputId', mediaDevicesSource._handleVideoInputIdChangedBound)
+		})
+	})
+})

--- a/src/utils/media/pipeline/MediaDevicesSource.spec.js
+++ b/src/utils/media/pipeline/MediaDevicesSource.spec.js
@@ -94,7 +94,6 @@ function newMediaStreamMock(id) {
 
 describe('MediaDevicesSource', () => {
 	let mediaDevicesSource
-	let constraints
 	let retryNoVideoCallback
 	let getUserMediaAudioTrack
 	let getUserMediaVideoTrack
@@ -110,11 +109,6 @@ describe('MediaDevicesSource', () => {
 
 	beforeEach(() => {
 		mediaDevicesSource = new MediaDevicesSource()
-
-		constraints = {
-			audio: true,
-			video: true,
-		}
 
 		retryNoVideoCallback = jest.fn()
 
@@ -189,7 +183,7 @@ describe('MediaDevicesSource', () => {
 				expectedAudioTrack = getUserMediaAudioTrack
 				expectedVideoTrack = getUserMediaVideoTrack
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).then(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -207,7 +201,7 @@ describe('MediaDevicesSource', () => {
 
 				expectedAudioTrack = getUserMediaAudioTrack
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).then(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(2)
@@ -229,7 +223,7 @@ describe('MediaDevicesSource', () => {
 
 				expect.hasAssertions()
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).catch(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(2)
@@ -243,7 +237,7 @@ describe('MediaDevicesSource', () => {
 
 				expectedAudioTrack = getUserMediaAudioTrack
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).then(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -262,7 +256,7 @@ describe('MediaDevicesSource', () => {
 
 				expect.hasAssertions()
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).catch(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -275,7 +269,7 @@ describe('MediaDevicesSource', () => {
 
 				expectedVideoTrack = getUserMediaVideoTrack
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).then(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -294,7 +288,7 @@ describe('MediaDevicesSource', () => {
 
 				expect.hasAssertions()
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).catch(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -305,7 +299,7 @@ describe('MediaDevicesSource', () => {
 			test('when there are no audio nor video devices', () => {
 				expect.hasAssertions()
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).catch(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -316,10 +310,7 @@ describe('MediaDevicesSource', () => {
 
 		describe('with audio', () => {
 			beforeEach(() => {
-				constraints = {
-					audio: true,
-					video: false,
-				}
+				mediaDevicesSource.setVideoAllowed(false)
 			})
 
 			test('when there are audio and video devices', () => {
@@ -328,7 +319,7 @@ describe('MediaDevicesSource', () => {
 
 				expectedAudioTrack = getUserMediaAudioTrack
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).then(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -346,7 +337,7 @@ describe('MediaDevicesSource', () => {
 
 				expect.hasAssertions()
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).catch(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -359,7 +350,7 @@ describe('MediaDevicesSource', () => {
 
 				expectedAudioTrack = getUserMediaAudioTrack
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).then(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -376,7 +367,7 @@ describe('MediaDevicesSource', () => {
 
 				expect.hasAssertions()
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).catch(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -389,7 +380,7 @@ describe('MediaDevicesSource', () => {
 
 				expect.hasAssertions()
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).catch(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -400,7 +391,7 @@ describe('MediaDevicesSource', () => {
 			test('when there are no audio nor video devices', () => {
 				expect.hasAssertions()
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).catch(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -411,10 +402,7 @@ describe('MediaDevicesSource', () => {
 
 		describe('with video', () => {
 			beforeEach(() => {
-				constraints = {
-					audio: false,
-					video: true,
-				}
+				mediaDevicesSource.setAudioAllowed(false)
 			})
 
 			test('when there are audio and video devices', () => {
@@ -423,7 +411,7 @@ describe('MediaDevicesSource', () => {
 
 				expectedVideoTrack = getUserMediaVideoTrack
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).then(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -441,7 +429,7 @@ describe('MediaDevicesSource', () => {
 
 				expect.hasAssertions()
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).catch(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -454,7 +442,7 @@ describe('MediaDevicesSource', () => {
 
 				expect.hasAssertions()
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).catch(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -467,7 +455,7 @@ describe('MediaDevicesSource', () => {
 
 				expectedVideoTrack = getUserMediaVideoTrack
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).then(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -484,7 +472,7 @@ describe('MediaDevicesSource', () => {
 
 				expect.hasAssertions()
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).catch(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -495,7 +483,7 @@ describe('MediaDevicesSource', () => {
 			test('when there are no audio nor video devices', () => {
 				expect.hasAssertions()
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).catch(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -506,10 +494,8 @@ describe('MediaDevicesSource', () => {
 
 		describe('with no audio nor video', () => {
 			beforeEach(() => {
-				constraints = {
-					audio: false,
-					video: false,
-				}
+				mediaDevicesSource.setAudioAllowed(false)
+				mediaDevicesSource.setVideoAllowed(false)
 			})
 
 			test('when there are audio and video devices', () => {
@@ -518,7 +504,7 @@ describe('MediaDevicesSource', () => {
 
 				expect.hasAssertions()
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).catch(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -531,7 +517,7 @@ describe('MediaDevicesSource', () => {
 
 				expect.hasAssertions()
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).catch(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -544,7 +530,7 @@ describe('MediaDevicesSource', () => {
 
 				expect.hasAssertions()
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).catch(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -555,7 +541,7 @@ describe('MediaDevicesSource', () => {
 			test('when there are no audio nor video devices', () => {
 				expect.hasAssertions()
 
-				return mediaDevicesSource.start(constraints, retryNoVideoCallback).catch(() => {
+				return mediaDevicesSource.start(retryNoVideoCallback).catch(() => {
 					assertStateAfterStart()
 
 					expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
@@ -572,7 +558,7 @@ describe('MediaDevicesSource', () => {
 		})
 
 		test('to same device', async () => {
-			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+			await mediaDevicesSource.start(retryNoVideoCallback)
 
 			mediaDevicesManager.set('audioInputId', 'audio-device')
 
@@ -582,7 +568,7 @@ describe('MediaDevicesSource', () => {
 		})
 
 		test('from a device to no device', async () => {
-			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+			await mediaDevicesSource.start(retryNoVideoCallback)
 
 			mediaDevicesManager.set('audioInputId', null)
 
@@ -592,7 +578,7 @@ describe('MediaDevicesSource', () => {
 		})
 
 		test('from a device to another device', async () => {
-			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+			await mediaDevicesSource.start(retryNoVideoCallback)
 
 			const originalGetUserMediaAudioTrack = getUserMediaAudioTrack
 
@@ -611,7 +597,7 @@ describe('MediaDevicesSource', () => {
 		})
 
 		test('from a device to another device but track could not be got', async () => {
-			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+			await mediaDevicesSource.start(retryNoVideoCallback)
 
 			jest.spyOn(mediaDevicesManager, 'getUserMedia').mockImplementationOnce(async (constraints) => {
 				throw new Error('Audio could not be got')
@@ -628,12 +614,25 @@ describe('MediaDevicesSource', () => {
 			expect(getUserMediaAudioTrack.stop).toHaveBeenCalledTimes(1)
 		})
 
+		test('from a device to another device when not allowed', async () => {
+			mediaDevicesSource.setAudioAllowed(false)
+
+			await mediaDevicesSource.start(retryNoVideoCallback)
+
+			getUserMediaAudioTrack = newMediaStreamTrackMock('audio-2', 'audio', 'audio-device-2')
+
+			mediaDevicesManager.set('audioInputId', 'audio-device-2')
+
+			expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+			expect(mediaDevicesSource.getOutputTrack('audio')).toBe(null)
+		})
+
 		test('from no device to a device', async () => {
 			getUserMediaAudioTrack = null
 			getUserMediaVideoTrack = null
 
 			try {
-				await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+				await mediaDevicesSource.start(retryNoVideoCallback)
 			} catch (exception) {
 			}
 
@@ -655,7 +654,7 @@ describe('MediaDevicesSource', () => {
 			getUserMediaVideoTrack = null
 
 			try {
-				await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+				await mediaDevicesSource.start(retryNoVideoCallback)
 			} catch (exception) {
 			}
 
@@ -673,8 +672,27 @@ describe('MediaDevicesSource', () => {
 			expect(mediaDevicesSource.getOutputTrack('audio')).toBe(null)
 		})
 
+		test('from no device to a device when not allowed', async () => {
+			getUserMediaAudioTrack = null
+			getUserMediaVideoTrack = null
+
+			try {
+				await mediaDevicesSource.start(retryNoVideoCallback)
+			} catch (exception) {
+			}
+
+			mediaDevicesSource.setAudioAllowed(false)
+
+			getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio', 'audio-device')
+
+			mediaDevicesManager.set('audioInputId', 'audio-device')
+
+			expect(mediaDevicesManager.getUserMedia).toHaveBeenCalledTimes(1)
+			expect(mediaDevicesSource.getOutputTrack('audio')).toBe(null)
+		})
+
 		test('several times in a row before the track for the first one was got', async () => {
-			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+			await mediaDevicesSource.start(retryNoVideoCallback)
 
 			const originalGetUserMediaAudioTrack = getUserMediaAudioTrack
 
@@ -712,7 +730,7 @@ describe('MediaDevicesSource', () => {
 		})
 
 		test('several times in a row before the track for the first one was got finally setting again the first one', async () => {
-			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+			await mediaDevicesSource.start(retryNoVideoCallback)
 
 			const originalGetUserMediaAudioTrack = getUserMediaAudioTrack
 
@@ -752,7 +770,7 @@ describe('MediaDevicesSource', () => {
 			getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
 			getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
 
-			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+			await mediaDevicesSource.start(retryNoVideoCallback)
 
 			mediaDevicesSource.stop()
 
@@ -768,7 +786,7 @@ describe('MediaDevicesSource', () => {
 		test('with audio track', async () => {
 			getUserMediaAudioTrack = newMediaStreamTrackMock('audio', 'audio')
 
-			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+			await mediaDevicesSource.start(retryNoVideoCallback)
 
 			mediaDevicesSource.stop()
 
@@ -782,7 +800,7 @@ describe('MediaDevicesSource', () => {
 		test('with video track', async () => {
 			getUserMediaVideoTrack = newMediaStreamTrackMock('video', 'video')
 
-			await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+			await mediaDevicesSource.start(retryNoVideoCallback)
 
 			mediaDevicesSource.stop()
 
@@ -795,7 +813,7 @@ describe('MediaDevicesSource', () => {
 
 		test('with no tracks', async () => {
 			try {
-				await mediaDevicesSource.start(constraints, retryNoVideoCallback)
+				await mediaDevicesSource.start(retryNoVideoCallback)
 			} catch (exception) {
 			}
 

--- a/src/utils/media/pipeline/MediaDevicesSource.spec.js
+++ b/src/utils/media/pipeline/MediaDevicesSource.spec.js
@@ -161,6 +161,27 @@ describe('MediaDevicesSource', () => {
 		jest.restoreAllMocks()
 	})
 
+	describe('get allowed state', () => {
+		test('audio and video are allowed by default', () => {
+			expect(mediaDevicesSource.isAudioAllowed()).toBe(true)
+			expect(mediaDevicesSource.isVideoAllowed()).toBe(true)
+		})
+
+		test('after modifying the audio state', () => {
+			mediaDevicesSource.setAudioAllowed(false)
+
+			expect(mediaDevicesSource.isAudioAllowed()).toBe(false)
+			expect(mediaDevicesSource.isVideoAllowed()).toBe(true)
+		})
+
+		test('after modifying the video state', () => {
+			mediaDevicesSource.setVideoAllowed(false)
+
+			expect(mediaDevicesSource.isAudioAllowed()).toBe(true)
+			expect(mediaDevicesSource.isVideoAllowed()).toBe(false)
+		})
+	})
+
 	describe('start', () => {
 
 		/**

--- a/src/utils/webrtc/models/LocalMediaModel.js
+++ b/src/utils/webrtc/models/LocalMediaModel.js
@@ -142,13 +142,13 @@ LocalMediaModel.prototype = {
 		this._webRtc.webrtc.on('localScreenStopped', this._handleLocalScreenStoppedBound)
 	},
 
-	_handleLocalStreamRequested(constraints, context) {
+	_handleLocalStreamRequested(context) {
 		if (context !== 'retry-no-video') {
 			this.set('localStreamRequestVideoError', null)
 		}
 	},
 
-	_handleLocalStream(configuration, localStream) {
+	_handleLocalStream(localStream) {
 		// Although there could be several local streams active at the same
 		// time (if the local media is started again before stopping it
 		// first) the methods to control them ("mute", "unmute",
@@ -164,7 +164,7 @@ LocalMediaModel.prototype = {
 		this._setInitialState(localStream)
 	},
 
-	_handleLocalStreamRequestFailedRetryNoVideo(constraints, error) {
+	_handleLocalStreamRequestFailedRetryNoVideo(error) {
 		if (!error || error.name === 'NotFoundError') {
 			return
 		}

--- a/src/utils/webrtc/models/LocalMediaModel.js
+++ b/src/utils/webrtc/models/LocalMediaModel.js
@@ -54,11 +54,13 @@ export default function LocalMediaModel() {
 	this._handleLocalStreamChangedBound = this._handleLocalStreamChanged.bind(this)
 	this._handleLocalTrackEnabledChangedBound = this._handleLocalTrackEnabledChanged.bind(this)
 	this._handleLocalStreamStoppedBound = this._handleLocalStreamStopped.bind(this)
+	this._handleAudioDisallowedBound = this._handleAudioDisallowed.bind(this)
 	this._handleVolumeChangeBound = this._handleVolumeChange.bind(this)
 	this._handleSpeakingBound = this._handleSpeaking.bind(this)
 	this._handleStoppedSpeakingBound = this._handleStoppedSpeaking.bind(this)
 	this._handleSpeakingWhileMutedBound = this._handleSpeakingWhileMuted.bind(this)
 	this._handleStoppedSpeakingWhileMutedBound = this._handleStoppedSpeakingWhileMuted.bind(this)
+	this._handleVideoDisallowedBound = this._handleVideoDisallowed.bind(this)
 	this._handleVirtualBackgroundLoadFailedBound = this._handleVirtualBackgroundLoadFailed.bind(this)
 	this._handleVirtualBackgroundOnBound = this._handleVirtualBackgroundOn.bind(this)
 	this._handleVirtualBackgroundOffBound = this._handleVirtualBackgroundOff.bind(this)
@@ -96,11 +98,13 @@ LocalMediaModel.prototype = {
 			this._webRtc.webrtc.off('localStreamChanged', this._handleLocalStreamChangedBound)
 			this._webRtc.webrtc.off('localTrackEnabledChanged', this._handleLocalTrackEnabledChangedBound)
 			this._webRtc.webrtc.off('localStreamStopped', this._handleLocalStreamStoppedBound)
+			this._webRtc.webrtc.off('audioDisallowed', this._handleAudioDisallowedBound)
 			this._webRtc.webrtc.off('volumeChange', this._handleVolumeChangeBound)
 			this._webRtc.webrtc.off('speaking', this._handleSpeakingBound)
 			this._webRtc.webrtc.off('stoppedSpeaking', this._handleStoppedSpeakingBound)
 			this._webRtc.webrtc.off('speakingWhileMuted', this._handleSpeakingWhileMutedBound)
 			this._webRtc.webrtc.off('stoppedSpeakingWhileMuted', this._handleStoppedSpeakingWhileMutedBound)
+			this._webRtc.webrtc.off('videoDisallowed', this._handleVideoDisallowedBound)
 			this._webRtc.webrtc.off('virtualBackgroundLoadFailed', this._handleVirtualBackgroundLoadFailedBound)
 			this._webRtc.webrtc.off('virtualBackgroundOn', this._handleVirtualBackgroundOnBound)
 			this._webRtc.webrtc.off('virtualBackgroundOff', this._handleVirtualBackgroundOffBound)
@@ -130,11 +134,13 @@ LocalMediaModel.prototype = {
 		this._webRtc.webrtc.on('localStreamChanged', this._handleLocalStreamChangedBound)
 		this._webRtc.webrtc.on('localTrackEnabledChanged', this._handleLocalTrackEnabledChangedBound)
 		this._webRtc.webrtc.on('localStreamStopped', this._handleLocalStreamStoppedBound)
+		this._webRtc.webrtc.on('audioDisallowed', this._handleAudioDisallowedBound)
 		this._webRtc.webrtc.on('volumeChange', this._handleVolumeChangeBound)
 		this._webRtc.webrtc.on('speaking', this._handleSpeakingBound)
 		this._webRtc.webrtc.on('stoppedSpeaking', this._handleStoppedSpeakingBound)
 		this._webRtc.webrtc.on('speakingWhileMuted', this._handleSpeakingWhileMutedBound)
 		this._webRtc.webrtc.on('stoppedSpeakingWhileMuted', this._handleStoppedSpeakingWhileMutedBound)
+		this._webRtc.webrtc.on('videoDisallowed', this._handleVideoDisallowedBound)
 		this._webRtc.webrtc.on('virtualBackgroundLoadFailed', this._handleVirtualBackgroundLoadFailedBound)
 		this._webRtc.webrtc.on('virtualBackgroundOn', this._handleVirtualBackgroundOnBound)
 		this._webRtc.webrtc.on('virtualBackgroundOff', this._handleVirtualBackgroundOffBound)
@@ -244,6 +250,10 @@ LocalMediaModel.prototype = {
 		this.set('videoAvailable', false)
 	},
 
+	_handleAudioDisallowed() {
+		this.disableAudio()
+	},
+
 	_handleVolumeChange(currentVolume, volumeThreshold) {
 		if (!this.get('audioAvailable')) {
 			return
@@ -283,6 +293,10 @@ LocalMediaModel.prototype = {
 		}
 
 		this.set('speakingWhileMuted', false)
+	},
+
+	_handleVideoDisallowed() {
+		this.disableVideo()
 	},
 
 	_handleVirtualBackgroundLoadFailed() {

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -288,6 +288,10 @@ LocalMedia.prototype.stopScreenShare = function() {
 }
 
 // Audio controls
+LocalMedia.prototype.isAudioAllowed = function() {
+	return this._mediaDevicesSource.isAudioAllowed()
+}
+
 LocalMedia.prototype.disallowAudio = function() {
 	this._mediaDevicesSource.setAudioAllowed(false)
 	this.emit('audioDisallowed')
@@ -309,6 +313,10 @@ LocalMedia.prototype.unmute = function() {
 }
 
 // Video controls
+LocalMedia.prototype.isVideoAllowed = function() {
+	return this._mediaDevicesSource.isVideoAllowed()
+}
+
 LocalMedia.prototype.disallowVideo = function() {
 	this._mediaDevicesSource.setVideoAllowed(false)
 	this.emit('videoDisallowed')

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -114,6 +114,9 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 	const self = this
 	const constraints = mediaConstraints || { audio: true, video: true }
 
+	this._mediaDevicesSource.setAudioAllowed(!!constraints.audio)
+	this._mediaDevicesSource.setVideoAllowed(!!constraints.video)
+
 	// If local media is started with neither audio nor video the local media
 	// will not be active (it will not react to changes in the selected media
 	// devices). It is just a special case in which starting succeeds with a
@@ -145,7 +148,7 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 		self.emit('localStreamRequestFailedRetryNoVideo', error)
 	}
 
-	this._mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
+	this._mediaDevicesSource.start(retryNoVideoCallback).then(() => {
 		self.localStreams.push(self._trackToStream.getStream())
 
 		self.emit('localStream', self._trackToStream.getStream())

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -114,8 +114,16 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 	const self = this
 	const constraints = mediaConstraints || { audio: true, video: true }
 
-	this._mediaDevicesSource.setAudioAllowed(!!constraints.audio)
-	this._mediaDevicesSource.setVideoAllowed(!!constraints.video)
+	if (constraints.audio) {
+		this.allowAudio()
+	} else {
+		this.disallowAudio()
+	}
+	if (constraints.video) {
+		this.allowVideo()
+	} else {
+		this.disallowVideo()
+	}
 
 	// If local media is started with neither audio nor video the local media
 	// will not be active (it will not react to changes in the selected media
@@ -280,6 +288,16 @@ LocalMedia.prototype.stopScreenShare = function() {
 }
 
 // Audio controls
+LocalMedia.prototype.disallowAudio = function() {
+	this._mediaDevicesSource.setAudioAllowed(false)
+	this.emit('audioDisallowed')
+}
+
+LocalMedia.prototype.allowAudio = function() {
+	this._mediaDevicesSource.setAudioAllowed(true)
+	this.emit('audioAllowed')
+}
+
 LocalMedia.prototype.mute = function() {
 	this._setAudioEnabled(false)
 	this.emit('audioOff')
@@ -291,6 +309,16 @@ LocalMedia.prototype.unmute = function() {
 }
 
 // Video controls
+LocalMedia.prototype.disallowVideo = function() {
+	this._mediaDevicesSource.setVideoAllowed(false)
+	this.emit('videoDisallowed')
+}
+
+LocalMedia.prototype.allowVideo = function() {
+	this._mediaDevicesSource.setVideoAllowed(true)
+	this.emit('videoAllowed')
+}
+
 LocalMedia.prototype.pauseVideo = function() {
 	this._setVideoEnabled(false)
 	this.emit('videoOff')

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -119,7 +119,7 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 	// devices). It is just a special case in which starting succeeds with a
 	// null stream.
 	if (!constraints.audio && !constraints.video) {
-		self.emit('localStream', constraints, null)
+		self.emit('localStream', null)
 
 		if (cb) {
 			return cb(null, null, constraints)
@@ -139,16 +139,16 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 		return
 	}
 
-	this.emit('localStreamRequested', constraints, context)
+	this.emit('localStreamRequested', context)
 
-	const retryNoVideoCallback = (constraints, error) => {
-		self.emit('localStreamRequestFailedRetryNoVideo', constraints, error)
+	const retryNoVideoCallback = (error) => {
+		self.emit('localStreamRequestFailedRetryNoVideo', error)
 	}
 
 	this._mediaDevicesSource.start(constraints, retryNoVideoCallback).then(() => {
 		self.localStreams.push(self._trackToStream.getStream())
 
-		self.emit('localStream', constraints, self._trackToStream.getStream())
+		self.emit('localStream', self._trackToStream.getStream())
 
 		self._trackToStream.on('streamSet', self._handleStreamSetBound)
 		self._trackToStream.on('trackReplaced', self._handleTrackReplacedBound)
@@ -160,7 +160,7 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 			return cb(null, self._trackToStream.getStream(), constraints)
 		}
 	}).catch(err => {
-		self.emit('localStreamRequestFailed', constraints)
+		self.emit('localStreamRequestFailed')
 
 		self._trackToStream.on('streamSet', self._handleStreamSetBound)
 		self._trackToStream.on('trackReplaced', self._handleTrackReplacedBound)

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -110,6 +110,14 @@ LocalMedia.prototype.isLocalMediaActive = function() {
 	return this._localMediaActive
 }
 
+LocalMedia.prototype.hasAudioTrack = function() {
+	return this._trackToStream.getStream() && this._trackToStream.getStream().getAudioTracks().length > 0
+}
+
+LocalMedia.prototype.hasVideoTrack = function() {
+	return this._trackToStream.getStream() && this._trackToStream.getStream().getVideoTracks().length > 0
+}
+
 LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 	const self = this
 	const constraints = mediaConstraints || { audio: true, video: true }

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -157,7 +157,12 @@ LocalMedia.prototype.start = function(mediaConstraints, cb, context) {
 		self._localMediaActive = true
 
 		if (cb) {
-			return cb(null, self._trackToStream.getStream(), constraints)
+			const actualConstraints = {
+				audio: self._trackToStream.getStream().getAudioTracks().length > 0,
+				video: self._trackToStream.getStream().getVideoTracks().length > 0,
+			}
+
+			return cb(null, self._trackToStream.getStream(), actualConstraints)
 		}
 	}).catch(err => {
 		self.emit('localStreamRequestFailed')

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -59,7 +59,6 @@ let callParticipantCollection = null
 let localCallParticipantModel = null
 let showedTURNWarning = false
 let sendCurrentStateWithRepetitionTimeout = null
-let startedWithMedia
 
 /**
  * @param {Array} a Source object
@@ -677,8 +676,6 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 	})
 
 	webrtc.startMedia = function(token, flags) {
-		startedWithMedia = undefined
-
 		// If no flags are provided try to enable both audio and video.
 		// Otherwise, try to enable only that allowed by the flags.
 		const mediaConstraints = {
@@ -1018,8 +1015,6 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 		if (webrtc.webrtc.isLocalMediaActive()
 			&& !(currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO)
 			&& !(currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_VIDEO)) {
-			startedWithMedia = undefined
-
 			webrtc.stopLocalVideo()
 
 			// If the MCU is used and there is no sending peer there is no need
@@ -1076,8 +1071,6 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 			webrtc.off('localMediaStarted', forceReconnectOnceLocalMediaStarted)
 			webrtc.off('localMediaError', forceReconnectOnceLocalMediaError)
 
-			startedWithMedia = true
-
 			let flags = PARTICIPANT.CALL_FLAG.IN_CALL
 			if (constraints) {
 				if (constraints.audio) {
@@ -1094,8 +1087,6 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 			webrtc.off('localMediaStarted', forceReconnectOnceLocalMediaStarted)
 			webrtc.off('localMediaError', forceReconnectOnceLocalMediaError)
 
-			startedWithMedia = false
-
 			// If the media fails to start there will be no media, so no need to
 			// reconnect. A reconnection will happen once the user selects a
 			// different device.
@@ -1103,8 +1094,6 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 
 		webrtc.on('localMediaStarted', forceReconnectOnceLocalMediaStarted)
 		webrtc.on('localMediaError', forceReconnectOnceLocalMediaError)
-
-		startedWithMedia = undefined
 
 		const constraints = {
 			audio: currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO,
@@ -1314,8 +1303,6 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 		// reconnection is forced to start sending it.
 		signaling.setSendVideoIfAvailable(true)
 
-		startedWithMedia = true
-
 		let flags = signaling.getCurrentCallFlags()
 		flags |= PARTICIPANT.CALL_FLAG.WITH_VIDEO
 
@@ -1464,8 +1451,6 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 	webrtc.on('localMediaStarted', function(/* configuration */) {
 		console.info('localMediaStarted')
 
-		startedWithMedia = true
-
 		clearLocalStreamRequestedTimeoutAndHideNotification()
 
 		if (signaling.hasFeature('mcu')) {
@@ -1475,8 +1460,6 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 
 	webrtc.on('localMediaError', function(error) {
 		console.warn('Access to microphone & camera failed', error)
-
-		startedWithMedia = false
 
 		clearLocalStreamRequestedTimeoutAndHideNotification()
 

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -982,20 +982,41 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 			return
 		}
 
-		if ((currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO)
-			&& (currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_VIDEO)
-			&& webrtc.webrtc.isLocalMediaActive()) {
+		if (webrtc.webrtc.isAudioAllowed() === !!(currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO)
+			&& webrtc.webrtc.isVideoAllowed() === !!(currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_VIDEO)) {
 			return
 		}
 
-		if (!(currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO)
-			&& !(currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_VIDEO)
-			&& !webrtc.webrtc.isLocalMediaActive()) {
-			return
+		let hasAudioSenders = false
+		let hasVideoSenders = false
+
+		webrtc.webrtc.getPeers(null, 'video').forEach(peer => {
+			// Look for any sender of each kind, even if the sender no longer
+			// has a track attached to it.
+			const audioSender = peer.pc.getSenders().find((sender) => sender.kind === 'audio' || (sender.track && sender.track.kind === 'audio') || (sender.trackDisabled && sender.trackDisabled.kind === 'audio'))
+			const videoSender = peer.pc.getSenders().find((sender) => sender.kind === 'video' || (sender.track && sender.track.kind === 'video') || (sender.trackDisabled && sender.trackDisabled.kind === 'video'))
+
+			hasAudioSenders ||= !!audioSender
+			hasVideoSenders ||= !!videoSender
+		})
+
+		const removeSender = (hasAudioSenders && !(currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO))
+							|| (hasVideoSenders && !(currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_VIDEO))
+
+		if (currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO) {
+			webrtc.webrtc.allowAudio()
+		} else {
+			webrtc.webrtc.disallowAudio()
 		}
 
-		// FIXME handle case where only one of the permissions is given
-		if (!(currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO)
+		if (currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_VIDEO) {
+			webrtc.webrtc.allowVideo()
+		} else {
+			webrtc.webrtc.disallowVideo()
+		}
+
+		if (webrtc.webrtc.isLocalMediaActive()
+			&& !(currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO)
 			&& !(currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_VIDEO)) {
 			startedWithMedia = undefined
 
@@ -1008,6 +1029,46 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 				forceReconnect(signaling, PARTICIPANT.CALL_FLAG.IN_CALL)
 			}
 
+			return
+		}
+
+		// If a sender kind is no longer allowed a forced reconnection needs to
+		// be explicitly triggered. Otherwise "removing" the no longer allowed
+		// track will just set it to null in the sender, which does not trigger
+		// a "negotiationneeded" event and thus an automatic forced
+		// reconnection.
+		if (webrtc.webrtc.isLocalMediaActive() && removeSender) {
+			let flags = signaling.getCurrentCallFlags()
+			if (!(currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO)) {
+				flags &= ~PARTICIPANT.CALL_FLAG.WITH_AUDIO
+			}
+			if (!(currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_VIDEO)) {
+				flags &= ~PARTICIPANT.CALL_FLAG.WITH_VIDEO
+			}
+
+			// The flags may be updated later if, besides removing a sender, a
+			// track is also added (for example, when there are both a
+			// microphone and a camera and audio permissions are removed at the
+			// same time that video permissions are added). However, at this
+			// point it is not possible to know if that will happen (getting the
+			// new track is an async operation and it could fail), so the flags
+			// are updated only with the known values.
+			forceReconnect(signaling, flags)
+
+			return
+		}
+
+		// If media is already active and a track is added "negotiationneeded"
+		// will be triggered, which in turn will automatically force a
+		// reconnection.
+		if (webrtc.webrtc.isLocalMediaActive()) {
+			return
+		}
+
+		// If media is not active but the participant does not have publishing
+		// permissions there is no need to start the media nor reconnect.
+		if (!(currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO)
+			&& !(currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_VIDEO)) {
 			return
 		}
 
@@ -1045,7 +1106,11 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 
 		startedWithMedia = undefined
 
-		webrtc.startLocalVideo()
+		const constraints = {
+			audio: currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO,
+			video: currentParticipant.participantPermissions & PARTICIPANT.PERMISSIONS.PUBLISH_VIDEO,
+		}
+		webrtc.startLocalVideo(constraints)
 	}
 
 	signaling.on('usersInRoom', function(users) {

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -1422,49 +1422,43 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 		signaling.updateCurrentCallFlags(expectedCallFlags)
 	})
 
+	/**
+	 * Return whether there are sender peers, either already created or about to
+	 * be created (if there is a pending connection).
+	 *
+	 * If the MCU is used then there will be a single sender peer (the own
+	 * peer). Otherwise every peer is both a sender and a receiver peer.
+	 *
+	 * @return {boolean} true if there are sender peers, false otherwise.
+	 */
+	function hasSenderPeers() {
+		if (signaling.hasFeature('mcu')) {
+			return !!ownPeer
+		}
+
+		return webrtc.webrtc.getPeers(null, 'video').length > 0 || Object.keys(delayedConnectionToPeer).length > 0
+	}
+
 	webrtc.on('localTrackReplaced', function(newTrack, oldTrack/*, stream */) {
-		// Device disabled, just update the call flags.
-		if (!newTrack) {
-			if (oldTrack && oldTrack.kind === 'audio') {
-				signaling.updateCurrentCallFlags(signaling.getCurrentCallFlags() & ~PARTICIPANT.CALL_FLAG.WITH_AUDIO)
-			} else if (oldTrack && oldTrack.kind === 'video') {
-				signaling.updateCurrentCallFlags(signaling.getCurrentCallFlags() & ~PARTICIPANT.CALL_FLAG.WITH_VIDEO)
-			}
+		const callFlags = getCallFlagsFromLocalMedia()
+
+		// A reconnection is not needed if a device is disabled or if there are
+		// no other participants in the call. Even if there are other
+		// participants a reconnection is not needed if there are already sender
+		// peers (as "negotiationneeded" will be automatically triggered by them
+		// if needed, which will cause the reconnection). Only if there are no
+		// sender peers or there are, but the previous call flags were just "in
+		// call", a reconnection is needed to ensure that the other participants
+		// will try to connect with the local one.
+		if (newTrack && previousUsersInRoom.length > 0 && (!hasSenderPeers() || signaling.getCurrentCallFlags() === PARTICIPANT.CALL_FLAG.IN_CALL)) {
+			forceReconnect(signaling, callFlags)
 
 			return
 		}
 
-		// If the call was started with media the connections will be already
-		// established. The flags need to be updated if a device was enabled
-		// (but not if it was switched to another one).
-		if (startedWithMedia) {
-			if (newTrack.kind === 'audio' && !oldTrack) {
-				signaling.updateCurrentCallFlags(signaling.getCurrentCallFlags() | PARTICIPANT.CALL_FLAG.WITH_AUDIO)
-			} else if (newTrack.kind === 'video' && !oldTrack) {
-				signaling.updateCurrentCallFlags(signaling.getCurrentCallFlags() | PARTICIPANT.CALL_FLAG.WITH_VIDEO)
-			}
-
-			return
+		if (signaling.getCurrentCallFlags() !== callFlags) {
+			signaling.updateCurrentCallFlags(callFlags)
 		}
-
-		// If the call has not started with media yet the connections will be
-		// established once started, as well as the flags.
-		if (startedWithMedia === undefined) {
-			return
-		}
-
-		// If the call was originally started without media the participant
-		// needs to reconnect to establish the sender connections.
-		startedWithMedia = true
-
-		let flags = signaling.getCurrentCallFlags()
-		if (newTrack.kind === 'audio') {
-			flags |= PARTICIPANT.CALL_FLAG.WITH_AUDIO
-		} else if (newTrack.kind === 'video') {
-			flags |= PARTICIPANT.CALL_FLAG.WITH_VIDEO
-		}
-
-		forceReconnect(signaling, flags)
 	})
 
 	webrtc.on('localMediaStarted', function(/* configuration */) {


### PR DESCRIPTION
Fixes #7048

Until now the WebUI code treated audio and video permissions as a combined permission: either both were enabled or both were disabled. This was inherited from the initial implementation, but it is no longer the case; it is possible to have audio permissions without video permissions and the other way around.

Besides that this pull request also fixes some other related issues.

Unfortunately there are a lot of possible combinations between permissions and devices, as can be seen by the scenarios below (which only include those that currently fail, there are even more :cry:).

Pending:
- [X] Call `setAudioAllowed` and `setVideoAllowed` depending on the permission change
- [ ] Test without HPB

## How to test (scenario 1a)

- Setup the HPB
- Remove audio and video permissions by default in a conversation
- Start a call as a moderator
- In a private window, open the conversation as a guest
- Join the call with both audio and video (although both will be blocked once joined)
- In the original window, grant video permissions to the guest

### Result with this pull request

In the private window a forced reconnection was triggered, and if the video is enabled it will be visible in the original window

### Result without this pull request

In the private window a forced reconnection was triggered, but the participant is not able to establish the connection again


## How to test (scenario 1b)

- Setup the HPB
- Remove audio and video permissions by default in a conversation
- Start a call as a moderator
- In a private window, open the conversation as a guest
- Join the call with audio but not video (although audio will be blocked once joined)
- In the original window, grant video permissions to the guest

### Result with this pull request

In the private window nothing happened

### Result without this pull request

In the private window a forced reconnection was triggered, but the participant is not able to establish the connection again


## How to test (scenario 1c)

- Setup the HPB
- Remove video permissions by default in a conversation
- Start a call as a moderator
- In a private window, open the conversation as a guest
- Join the call with both audio and video (although the video will be blocked once joined)
- In the original window, grant video permissions to the guest

### Result with this pull request

In the private window a forced reconnection was triggered, and if the video is enabled it will be visible in the original window

### Result without this pull request

In the private window nothing happened


## How to test (scenario 1d)

- Setup the HPB
- Remove video permissions by default in a conversation
- Start a call as a moderator
- In a private window, open the conversation as a guest
- Join the call with video but not audio (although the video will be blocked once joined)
- In the original window, grant video permissions to the guest

### Result with this pull request

In the private window a forced reconnection was triggered, and if the video is enabled it will be visible in the original window

### Result without this pull request

In the private window nothing happened



## How to test (scenario 2)

- Setup the HPB
- Remove video permissions by default in a conversation
- Start a call as a moderator
- In a private window, open the conversation as a guest
- Join the call without audio nor video devices
- Open the device settings and select a camera

### Result with this pull request

Nothing happens

### Result without this pull request

In the private window a forced reconnection is triggered, although the connection is prevented by the HPB and never finishes



## How to test (scenario 3a)

- Setup the HPB
- Enable audio and video permissions by default in a conversation
- Start a call as a moderator
- In a private window, open the conversation as a guest
- Join the call with both audio and video
- In the original window, revoke video permissions for the guest

### Result with this pull request

In the private window a forced reconnection was triggered and video is no longer sent (`OCA.Talk.SimpleWebRTC.webrtc.peers[0].pc.getSenders()` returns sender only for audio)

### Result without this pull request

In the private window a forced reconnection is triggered, although the connection never finishes; _This track is already set on a sender_ error is printed to browser console


## How to test (scenario 3b)

- Setup the HPB
- Enable audio and video permissions by default in a conversation
- Start a call as a moderator
- In a private window, open the conversation as a guest
- Join the call with audio but not video
- In the original window, revoke video permissions for the guest

### Result with this pull request

In the private window nothing happened

### Result without this pull request

In the private window a forced reconnection is triggered, although the connection never finishes; _This track is already set on a sender_ error is printed to browser console


## How to test (scenario 3c)

- Setup the HPB
- Enable audio and video permissions by default in a conversation
- Start a call as a moderator
- In a private window, open the conversation as a guest
- Join the call with video but not audio
- In the original window, revoke video permissions for the guest

### Result with this pull request

In the private window a forced reconnection was triggered and video is no longer sent (`OCA.Talk.SimpleWebRTC.webrtc.peers[0].pc.getSenders()` is empty)

### Result without this pull request

In the private window a forced reconnection is triggered, although the connection never finishes; _This track is already set on a sender_ error is printed to browser console
## How to test (scenario 4a)

- Setup the HPB
- Disable video permissions by default in a conversation
- Start a call as a moderator
- In a private window, open the conversation as a guest
- Join the call with both audio and video (although the video will be blocked once joined)
- In the original window, revoke audio permissions but grant video permissions for the guest

### Result with this pull request

In the private window a forced reconnection was triggered, audio is no longer sent but video is

### Result without this pull request

In the private window a forced reconnection is triggered, although the connection never finishes; _This track is already set on a sender_ error is printed to browser console


## How to test (scenario 4b)

- Setup the HPB
- Disable video permissions by default in a conversation
- Start a call as a moderator
- In a private window, open the conversation as a guest
- Join the call with audio but not video
- In the original window, revoke audio permissions but grant video permissions for the guest

### Result with this pull request

In the private window a forced reconnection was triggered, audio is no longer sent

### Result without this pull request

In the private window a forced reconnection is triggered, although the connection never finishes; _This track is already set on a sender_ error is printed to browser console


## How to test (scenario 4c)

- Setup the HPB
- Disable video permissions by default in a conversation
- Start a call as a moderator
- In a private window, open the conversation as a guest
- Join the call with video but not audio (although the video will be blocked once joined)
- In the original window, revoke audio permissions but grant video permissions for the guest

### Result with this pull request

In the private window a forced reconnection was triggered, audio is no longer sent but video is

### Result without this pull request

In the private window a forced reconnection is triggered, although the connection never finishes; _This track is already set on a sender_ error is printed to browser console


### How to test (scenario 5)

- Start a call with audio and video
- Open the device settings and select no microphone and no camera
- In a private window, join the call
- In the original window, select a microphone or camera

### Result with this pull request

A forced reconnection is triggered in the original window and the original participant can be heard or seen in the private window

### Result without this pull request

Nothing happens and the original participant can not be heard or seen in the private window
