### PR TITLE
Allow to delete shared files and objects

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -91,3 +91,4 @@ title: Capabilities
 * `chat-unread` - Whether the API to mark a conversation as unread is available
 * `reactions` - Api reactions to chat message
 * `rich-object-list-media` - When the API to get the chat messages for shared media is available
+* `rich-object-delete` - When the API allows to delete chat messages which are file or rich object shares

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -208,7 +208,7 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 
 ## Deleting a chat message
 
-* Required capability: `delete-messages`
+* Required capability: `delete-messages` - `rich-object-delete` indicates if shared objects can be deleted from the chat
 * Method: `DELETE`
 * Endpoint: `/chat/{token}/{messageId}`
 

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -105,6 +105,7 @@ class Capabilities implements IPublicCapability {
 				'notification-calls',
 				'conversation-permissions',
 				'rich-object-list-media',
+				'rich-object-delete',
 			],
 			'config' => [
 				'attachments' => [

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
@@ -276,10 +276,10 @@ describe('MessageButtonsBar.vue', () => {
 				testDeleteMessageVisible(false)
 			})
 
-			test('hides delete action for file messages', () => {
+			test('show delete action for file messages', () => {
 				messageProps.message = '{file}'
 				messageProps.messageParameters.file = {}
-				testDeleteMessageVisible(false)
+				testDeleteMessageVisible(true)
 			})
 
 			test('hides delete action on other people messages for non-moderators', () => {

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -304,14 +304,9 @@ export default {
 				return false
 			}
 
-			const isObjectShare = this.message === '{object}'
-				&& this.messageParameters?.object
-
 			return (moment(this.timestamp * 1000).add(6, 'h')) > moment()
-				&& this.messageType === 'comment'
+				&& (this.messageType === 'comment' || this.messageType === 'voice-message')
 				&& !this.isDeleting
-				&& !this.isFileShare
-				&& !isObjectShare
 				&& (this.isMyMsg
 					|| (this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE
 						&& (this.participant.participantType === PARTICIPANT.TYPE.OWNER

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1630,6 +1630,9 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			// replies; this is needed to get special messages not explicitly
 			// sent like those for shared files.
 			self::$messages[$message['message']] = $message['id'];
+			if ($message['message'] === '{file}' && isset($message['messageParameters']['file']['name'])) {
+				self::$messages['shared::file::' . $message['messageParameters']['file']['name']] = $message['id'];
+			}
 		}
 
 		if ($formData === null) {

--- a/tests/integration/features/chat/file-share.feature
+++ b/tests/integration/features/chat/file-share.feature
@@ -1,0 +1,25 @@
+Feature: chat/public
+  Background:
+    Given user "participant1" exists
+
+  Scenario: Share a file to a chat
+    Given user "participant1" creates room "public room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    When user "participant1" shares "welcome.txt" with room "public room"
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message  | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | {file}   | "IGNORE"          |
+
+  Scenario: Delete share a file message from a chat
+    Given user "participant1" creates room "public room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    When user "participant1" shares "welcome.txt" with room "public room"
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message  | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | {file}   | "IGNORE"          |
+    And user "participant1" deletes message "shared::file::welcome.txt" from room "public room" with 200
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message                | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | Message deleted by you | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |

--- a/tests/integration/features/chat/rich-object-share.feature
+++ b/tests/integration/features/chat/rich-object-share.feature
@@ -11,6 +11,16 @@ Feature: chat/public
       | room        | actorType | actorId      | actorDisplayName         | message  | messageParameters |
       | public room | users     | participant1 | participant1-displayname | {object} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"object":{"name":"Another room","call-type":"group","type":"call","id":"R4nd0mT0k3n"}} |
 
+  Scenario: Delete a rich object from a chat
+    Given user "participant1" creates room "public room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    When user "participant1" shares rich-object "call" "R4nd0mT0k3n" '{"name":"Another room","call-type":"group"}' to room "public room" with 201 (v1)
+    And user "participant1" deletes message "shared::call::R4nd0mT0k3n" from room "public room" with 200
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message                  | messageParameters | parentMessage |
+      | public room | users     | participant1 | participant1-displayname | Message deleted by you   | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}}                |               |
+
   Scenario: Share an invalid rich object to a chat
     Given user "participant1" creates room "public room" (v4)
       | roomType | 3 |

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -104,6 +104,7 @@ class CapabilitiesTest extends TestCase {
 			'notification-calls',
 			'conversation-permissions',
 			'rich-object-list-media',
+			'rich-object-delete',
 			'reactions',
 		];
 	}


### PR DESCRIPTION
- [x] Implement on API
- [x] Add/adjust unit test
- [x] Add/adjust integration test
- [x] Implement in web UI

Remarks:
- Moderators and owner of the share will unshare the share completely, others can only remove the message
- Files currently always remain available for the owner as per long discussions in the past, because we can not know if the file is used in any other way in parallel.