### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/docs/Talkbuchet.js
+++ b/docs/Talkbuchet.js
@@ -242,13 +242,13 @@ class Signaling extends EventTarget {
 	}
 
 	sanitizeSignalingUrl(url) {
-		if (url.indexOf('https://') === 0) {
-			url = 'wss://' + url.substr(8)
-		} else if (url.indexOf('http://') === 0) {
-			url = 'ws://' + url.substr(7)
+		if (url.startsWith('https://')) {
+			url = 'wss://' + url.slice(8)
+		} else if (url.startsWith('http://')) {
+			url = 'ws://' + url.slice(7)
 		}
-		if (url[url.length - 1] === '/') {
-			url = url.substr(0, url.length - 1)
+		if (url.endsWith('/')) {
+			url = url.slice(0, -1)
 		}
 
 		return url + '/spreed'

--- a/src/components/AdminSettings/StunServer.vue
+++ b/src/components/AdminSettings/StunServer.vue
@@ -73,9 +73,9 @@ export default {
 
 			// Remove HTTP or HTTPS protocol, if provided
 			if (server.startsWith('https://')) {
-				server = server.substr(8)
+				server = server.slice(8)
 			} else if (server.startsWith('http://')) {
-				server = server.substr(7)
+				server = server.slice(7)
 			}
 
 			const parts = server.split(':')

--- a/src/components/AdminSettings/StunServers.vue
+++ b/src/components/AdminSettings/StunServers.vue
@@ -113,9 +113,9 @@ export default {
 			this.servers.forEach((server) => {
 
 				if (server.startsWith('https://')) {
-					server = server.substr(8)
+					server = server.slice(8)
 				} else if (server.startsWith('http://')) {
-					server = server.substr(7)
+					server = server.slice(7)
 				}
 
 				servers.push(server)

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -277,7 +277,7 @@ export default {
 		parseCandidate(text) {
 			const candidateStr = 'candidate:'
 			const pos = text.indexOf(candidateStr) + candidateStr.length
-			const parts = text.substr(pos).split(' ')
+			const parts = text.slice(pos).split(' ')
 
 			return {
 				component: parts[1],

--- a/src/components/AdminSettings/TurnServers.vue
+++ b/src/components/AdminSettings/TurnServers.vue
@@ -125,9 +125,9 @@ export default {
 				}
 
 				if (data.server.startsWith('https://')) {
-					data.server = data.server.substr(8)
+					data.server = data.server.slice(8)
 				} else if (data.server.startsWith('http://')) {
-					data.server = data.server.substr(7)
+					data.server = data.server.slice(7)
 				}
 
 				if (data.secret === '') {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -331,7 +331,7 @@ export default {
 			if (userId === null) {
 				// guest mode: grab token from the link URL
 				// FIXME: use a cleaner way...
-				const token = this.link.substr(this.link.lastIndexOf('/') + 1)
+				const token = this.link.slice(this.link.lastIndexOf('/') + 1)
 				return generateUrl('/apps/files_sharing/publicpreview/{token}?x=-1&y={height}&a=1', {
 					token,
 					height: previewSize,

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -393,7 +393,7 @@ export default {
 			let focussed = null
 			if (this.$route?.hash?.startsWith('#message_')) {
 				// scroll to message in URL anchor
-				focussed = this.focusMessage(this.$route.hash.substr(9), false)
+				focussed = this.focusMessage(this.$route.hash.slice(9), false)
 			}
 
 			if (!focussed && this.visualLastReadMessageId) {
@@ -873,7 +873,7 @@ export default {
 					// the hash
 					window.setTimeout(() => {
 						// scroll to message in URL anchor
-						this.focusMessage(to.hash.substr(9), true)
+						this.focusMessage(to.hash.slice(9), true)
 					}, 2)
 				}
 			}

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -379,7 +379,7 @@ export default {
 				await this.sleep(randomNumber)
 
 				const loremIpsum = 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.\n\nDuis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.'
-				this.parsedText = loremIpsum.substr(0, 25 + randomNumber)
+				this.parsedText = loremIpsum.slice(0, 25 + randomNumber)
 				await this.handleSubmit()
 			}
 		},
@@ -488,7 +488,7 @@ export default {
 				// is added the div content will be "<br><br>"), so the emoji
 				// has to be added before the last "<br>" (if any).
 				if (this.text.endsWith('<br>')) {
-					this.text = this.text.substr(0, this.text.lastIndexOf('<br>')) + emoji + '<br>'
+					this.text = this.text.slice(0, this.text.lastIndexOf('<br>')) + emoji + '<br>'
 				} else {
 					this.text += emoji
 				}

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -566,13 +566,13 @@ function Standalone(settings, urls) {
 	// TODO(jojo): Try other server if connection fails.
 	let url = urls[idx]
 	// Make sure we are using websocket urls.
-	if (url.indexOf('https://') === 0) {
-		url = 'wss://' + url.substr(8)
-	} else if (url.indexOf('http://') === 0) {
-		url = 'ws://' + url.substr(7)
+	if (url.startsWith('https://')) {
+		url = 'wss://' + url.slice(8)
+	} else if (url.startsWith('http://')) {
+		url = 'ws://' + url.slice(7)
 	}
-	if (url[url.length - 1] === '/') {
-		url = url.substr(0, url.length - 1)
+	if (url.endsWith('/')) {
+		url = url.slice(0, -1)
 	}
 	this.url = url + '/spreed'
 	this.initialReconnectIntervalMs = 1000


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.