### PR TITLE
Fix forced reconnections when the HPB is not used

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -398,8 +398,9 @@ Signaling.Internal.prototype.forceReconnect = function(newSession, flags) {
 
 	// FIXME Naive reconnection routine; as the same session is kept peers
 	// must be explicitly ended before the reconnection is forced.
-	this.leaveCall(this.currentCallToken, true)
-	this.joinCall(this.currentCallToken, this.currentCallFlags)
+	this.leaveCall(this.currentCallToken, true).then(() => {
+		this.joinCall(this.currentCallToken, this.currentCallFlags)
+	})
 }
 
 Signaling.Internal.prototype._sendMessageWithCallback = function(ev) {


### PR DESCRIPTION
When a forced reconnection is triggered and the HPB is not used there are several race conditions that can prevent the participant from automatically joining the call again, or prevent other participants to establish the connection again with that participant.

First, when the call was joined again it was not waited for the call to be left first, so it could happen that the leave and join request were sent and the join request ended being processed first, so once the leave call request was processed the participant did not join.

Second, if joining the call takes too long the `inCall` property for the participant who is reconnecting could be _not in the call_ when the `usersInRoom` signaling message is sent. If that happens the WebUI could understand that as [the call having being ended by a moderator](https://github.com/nextcloud/spreed/blob/8c7461590e726f927e9266ef794f4e5d2c55f3a0/src/utils/webrtc/webrtc.js#L493) and then cause the participant to leave the call, ignoring the response to the join request received later.

Finally, if the `inCall` property for the participant who is reconnecting never becomes _not in the call_ other participants would not notice that the participant in fact reconnected (as without HPB the same session ID is used) and then not update their connection with that participant (for example, to stop it if the participant is no longer publishing). -> [This will be fixed at a later point](https://github.com/nextcloud/spreed/pull/7089).

Pending:
- [X] Fix scenario 2
- [ ] Fix scenario 3 -> [Deferred for later](https://github.com/nextcloud/spreed/issues/7089)

## How to test (scenario 1)

- Delay handling the leave call request by adding `sleep(5);` before https://github.com/nextcloud/spreed/blob/56d466029506be73782490ed779fe402c7b39c8f/lib/Controller/CallController.php#L164
- Remove audio and video permissions by default in a conversation
- Start a call as a moderator
- In a private window, join the call with audio and/or video (although audio and video will be blocked)
- In the original window, add all permissions to the other participant

### Result with this pull request

The participant in the private window leaves and then automatically joins the call again.

### Result without this pull request

The participant in the private window leaves but does not join the call again.


## How to test (scenario 2)

- Delay handling the join call request by adding `sleep(5);` before https://github.com/nextcloud/spreed/blob/56d466029506be73782490ed779fe402c7b39c8f/lib/Controller/CallController.php#L113
- Remove audio and video permissions by default in a conversation
- Start a call as a moderator
- In a private window, join the call with audio and/or video (although audio and video will be blocked)
- In the original window, add all permissions to the other participant

### Result with this pull request

The participant in the private window leaves and then automatically joins the call again.

### Result without this pull request

The participant in the private window leaves but does not join the call again. The browser console shows _Force leaving the call for current participant_.
