### PR TITLE
Fix closing MessageButtonsBar on Firefox

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -450,9 +450,9 @@ export default {
 			this.$emit('update:isReactionsMenuOpen', true)
 		},
 
+		// Making sure that the click is outside the MessageButtonsBar
 		handleClickOutside(event) {
-			// Making sure that the click is outside the MessageButtonsBar
-			if (event.path.indexOf(this.$el) !== -1) {
+			if (event.composedPath().indexOf(this.$el) !== -1) {
 				return
 			}
 			this.closeReactionsMenu()


### PR DESCRIPTION
using event.composedPath() instead of event.path to fix

````
Uncaught TypeError: event.path is undefined
    handleClickOutside MessageButtonsBar.vue:483
    c vue-outside-events.min.js:9
    bind vue-outside-events.min.js:9
    VueJS 25


