### PR TITLE
Make tests fail when deprecated php functions are used

### DIFF
--- a/tests/php/phpunit.xml
+++ b/tests/php/phpunit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <phpunit bootstrap="bootstrap.php"
 		 verbose="true"
+		 convertDeprecationsToExceptions="true"
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"
 		 timeoutForLargeTests="900"


### PR DESCRIPTION
Following the sample of https://github.com/nextcloud/server/pull/31750