### PR TITLE
Use PHP7.4 property typehinting where possible

### DIFF
--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -41,24 +41,17 @@ use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 class Listener {
+	protected IManager $activityManager;
 
-	/** @var IManager */
-	protected $activityManager;
+	protected IUserSession $userSession;
 
-	/** @var IUserSession */
-	protected $userSession;
+	protected ChatManager $chatManager;
 
-	/** @var ChatManager */
-	protected $chatManager;
+	protected ParticipantService $participantService;
 
-	/** @var ParticipantService */
-	protected $participantService;
+	protected LoggerInterface $logger;
 
-	/** @var LoggerInterface */
-	protected $logger;
-
-	/** @var ITimeFactory */
-	protected $timeFactory;
+	protected ITimeFactory $timeFactory;
 
 	public function __construct(IManager $activityManager,
 								IUserSession $userSession,

--- a/lib/Activity/Provider/Base.php
+++ b/lib/Activity/Provider/Base.php
@@ -36,22 +36,15 @@ use OCP\IUserManager;
 use OCP\L10N\IFactory;
 
 abstract class Base implements IProvider {
-
-	/** @var IFactory */
-	protected $languageFactory;
-	/** @var IURLGenerator */
-	protected $url;
-	/** @var Config */
-	protected $config;
-	/** @var IManager */
-	protected $activityManager;
-	/** @var IUserManager */
-	protected $userManager;
-	/** @var Manager */
-	protected $manager;
+	protected IFactory $languageFactory;
+	protected IURLGenerator $url;
+	protected Config $config;
+	protected IManager $activityManager;
+	protected IUserManager $userManager;
+	protected Manager $manager;
 
 	/** @var string[] */
-	protected $displayNames = [];
+	protected array $displayNames = [];
 
 	public function __construct(IFactory $languageFactory,
 								IURLGenerator $url,

--- a/lib/Activity/Setting.php
+++ b/lib/Activity/Setting.php
@@ -27,9 +27,7 @@ use OCP\Activity\ActivitySettings;
 use OCP\IL10N;
 
 class Setting extends ActivitySettings {
-
-	/** @var IL10N */
-	protected $l;
+	protected IL10N $l;
 
 	public function __construct(IL10N $l) {
 		$this->l = $l;

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\AppInfo;
 
+use OCP\Util;
 use OCA\Circles\Events\AddingCircleMemberEvent;
 use OCA\Circles\Events\CircleDestroyedEvent;
 use OCA\Circles\Events\RemovingCircleMemberEvent;
@@ -184,7 +185,7 @@ class Application extends App implements IBootstrap {
 		$resourceManager = $server->get(IProviderManager::class);
 		$resourceManager->registerResourceProvider(ConversationProvider::class);
 		$server->getEventDispatcher()->addListener('\OCP\Collaboration\Resources::loadAdditionalScripts', function () {
-			\OCP\Util::addScript(self::APP_ID, 'talk-collections');
+			Util::addScript(self::APP_ID, 'talk-collections');
 		});
 	}
 

--- a/lib/BackgroundJob/CheckHostedSignalingServer.php
+++ b/lib/BackgroundJob/CheckHostedSignalingServer.php
@@ -39,19 +39,12 @@ use OCP\Notification\IManager;
 use Psr\Log\LoggerInterface;
 
 class CheckHostedSignalingServer extends TimedJob {
-
-	/** @var HostedSignalingServerService */
-	private $hostedSignalingServerService;
-	/** @var IConfig */
-	private $config;
-	/** @var IManager */
-	private $notificationManager;
-	/** @var IGroupManager */
-	private $groupManager;
-	/** @var IURLGenerator */
-	private $urlGenerator;
-	/** @var LoggerInterface */
-	private $logger;
+	private HostedSignalingServerService $hostedSignalingServerService;
+	private IConfig $config;
+	private IManager $notificationManager;
+	private IGroupManager $groupManager;
+	private IURLGenerator $urlGenerator;
+	private LoggerInterface $logger;
 
 	public function __construct(ITimeFactory $timeFactory,
 								HostedSignalingServerService $hostedSignalingServerService,

--- a/lib/BackgroundJob/CheckMatterbridges.php
+++ b/lib/BackgroundJob/CheckMatterbridges.php
@@ -36,15 +36,11 @@ use Psr\Log\LoggerInterface;
  * @package OCA\Talk\BackgroundJob
  */
 class CheckMatterbridges extends TimedJob {
+	protected IConfig $serverConfig;
 
-	/** @var IConfig */
-	protected $serverConfig;
+	protected MatterbridgeManager $bridgeManager;
 
-	/** @var MatterbridgeManager */
-	protected $bridgeManager;
-
-	/** @var LoggerInterface */
-	protected $logger;
+	protected LoggerInterface $logger;
 
 	public function __construct(ITimeFactory $time,
 								IConfig $serverConfig,

--- a/lib/BackgroundJob/CheckReferenceIdColumn.php
+++ b/lib/BackgroundJob/CheckReferenceIdColumn.php
@@ -38,11 +38,8 @@ use OCP\IDBConnection;
  * @package OCA\Talk\BackgroundJob
  */
 class CheckReferenceIdColumn extends TimedJob {
-
-	/** @var IJobList */
-	protected $jobList;
-	/** @var IConfig */
-	protected $serverConfig;
+	protected IJobList $jobList;
+	protected IConfig $serverConfig;
 	/** @var IDBConnection|ConnectionAdapter */
 	protected $connection;
 

--- a/lib/BackgroundJob/ExpireSignalingMessage.php
+++ b/lib/BackgroundJob/ExpireSignalingMessage.php
@@ -34,9 +34,7 @@ use OCP\BackgroundJob\IJob;
  * @package OCA\Talk\BackgroundJob
  */
 class ExpireSignalingMessage extends TimedJob {
-
-	/** @var Messages */
-	protected $messages;
+	protected Messages $messages;
 
 	public function __construct(ITimeFactory $timeFactory,
 								Messages $messages) {

--- a/lib/BackgroundJob/RemoveEmptyRooms.php
+++ b/lib/BackgroundJob/RemoveEmptyRooms.php
@@ -38,20 +38,15 @@ use Psr\Log\LoggerInterface;
  * @package OCA\Talk\BackgroundJob
  */
 class RemoveEmptyRooms extends TimedJob {
+	protected Manager $manager;
 
-	/** @var Manager */
-	protected $manager;
+	protected ParticipantService $participantService;
 
-	/** @var ParticipantService */
-	protected $participantService;
+	protected LoggerInterface $logger;
 
-	/** @var LoggerInterface */
-	protected $logger;
+	protected IUserMountCache $userMountCache;
 
-	/** @var IUserMountCache */
-	protected $userMountCache;
-
-	protected $numDeletedRooms = 0;
+	protected int $numDeletedRooms = 0;
 
 	public function __construct(ITimeFactory $timeFactory,
 								Manager $manager,

--- a/lib/BackgroundJob/ResetAssignedSignalingServer.php
+++ b/lib/BackgroundJob/ResetAssignedSignalingServer.php
@@ -31,11 +31,8 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 
 class ResetAssignedSignalingServer extends TimedJob {
-
-	/** @var Manager */
-	protected $manager;
-	/** @var ICache */
-	protected $cache;
+	protected Manager $manager;
+	protected ICache $cache;
 
 	public function __construct(ITimeFactory $time,
 								Manager $manager,

--- a/lib/BackgroundJob/RetryJob.php
+++ b/lib/BackgroundJob/RetryJob.php
@@ -45,11 +45,10 @@ use OCP\ILogger;
  * @package OCA\Talk\BackgroundJob
  */
 class RetryJob extends Job {
-	/** @var Notifications */
-	private $notifications;
+	private Notifications $notifications;
 
 	/** @var int max number of attempts to send the request */
-	private $maxTry = 20;
+	private int $maxTry = 20;
 
 
 	public function __construct(Notifications $notifications,

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -33,15 +33,10 @@ use OCP\IUser;
 use OCP\IUserSession;
 
 class Capabilities implements IPublicCapability {
-
-	/** @var IConfig */
-	protected $serverConfig;
-	/** @var Config */
-	protected $talkConfig;
-	/** @var ICommentsManager */
-	protected $commentsManager;
-	/** @var IUserSession */
-	protected $userSession;
+	protected IConfig $serverConfig;
+	protected Config $talkConfig;
+	protected ICommentsManager $commentsManager;
+	protected IUserSession $userSession;
 
 	public function __construct(IConfig $serverConfig,
 								Config $talkConfig,

--- a/lib/Chat/AutoComplete/SearchPlugin.php
+++ b/lib/Chat/AutoComplete/SearchPlugin.php
@@ -37,24 +37,15 @@ use OCP\IUser;
 use OCP\IUserManager;
 
 class SearchPlugin implements ISearchPlugin {
+	protected IUserManager $userManager;
+	protected GuestManager $guestManager;
+	protected TalkSession $talkSession;
+	protected ParticipantService $participantService;
+	protected Util $util;
+	protected ?string $userId;
+	protected IL10N $l;
 
-	/** @var IUserManager */
-	protected $userManager;
-	/** @var GuestManager */
-	protected $guestManager;
-	/** @var TalkSession */
-	protected $talkSession;
-	/** @var ParticipantService */
-	protected $participantService;
-	/** @var Util */
-	protected $util;
-	/** @var string|null */
-	protected $userId;
-	/** @var IL10N */
-	protected $l;
-
-	/** @var Room */
-	protected $room;
+	protected ?Room $room = null;
 
 	public function __construct(IUserManager $userManager,
 								GuestManager $guestManager,

--- a/lib/Chat/AutoComplete/Sorter.php
+++ b/lib/Chat/AutoComplete/Sorter.php
@@ -28,9 +28,7 @@ use OCP\Collaboration\AutoComplete\ISorter;
 use OCP\Comments\ICommentsManager;
 
 class Sorter implements ISorter {
-
-	/** @var ICommentsManager */
-	protected $commentsManager;
+	protected ICommentsManager $commentsManager;
 
 	public function __construct(CommentsManager $commentsManager) {
 		$this->commentsManager = $commentsManager;

--- a/lib/Chat/Changelog/Listener.php
+++ b/lib/Chat/Changelog/Listener.php
@@ -38,8 +38,7 @@ class Listener {
 		}, -100);
 	}
 
-	/** @var Manager */
-	protected $manager;
+	protected Manager $manager;
 
 	public function __construct(Manager $manager) {
 		$this->manager = $manager;

--- a/lib/Chat/Changelog/Manager.php
+++ b/lib/Chat/Changelog/Manager.php
@@ -31,19 +31,12 @@ use OCP\IDBConnection;
 use OCP\IL10N;
 
 class Manager {
-
-	/** @var IConfig */
-	protected $config;
-	/** @var IDBConnection */
-	protected $connection;
-	/** @var RoomManager */
-	protected $roomManager;
-	/** @var ChatManager */
-	protected $chatManager;
-	/** @var ITimeFactory */
-	protected $timeFactory;
-	/** @var IL10N */
-	protected $l;
+	protected IConfig $config;
+	protected IDBConnection $connection;
+	protected RoomManager $roomManager;
+	protected ChatManager $chatManager;
+	protected ITimeFactory $timeFactory;
+	protected IL10N $l;
 
 	public function __construct(IConfig $config,
 								IDBConnection $connection,

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -72,26 +72,16 @@ class ChatManager {
 	/** @var ICommentsManager|CommentsManager
 	 */
 	private $commentsManager;
-	/** @var IEventDispatcher */
-	private $dispatcher;
-	/** @var IDBConnection */
-	private $connection;
-	/** @var INotificationManager */
-	private $notificationManager;
-	/** @var IManager */
-	private $shareManager;
-	/** @var RoomShareProvider */
-	private $shareProvider;
-	/** @var ParticipantService */
-	private $participantService;
-	/** @var Notifier */
-	private $notifier;
-	/** @var ITimeFactory */
-	protected $timeFactory;
-	/** @var ICache */
-	protected $cache;
-	/** @var ICache */
-	protected $unreadCountCache;
+	private IEventDispatcher $dispatcher;
+	private IDBConnection $connection;
+	private INotificationManager $notificationManager;
+	private \OCP\Share\IManager $shareManager;
+	private RoomShareProvider $shareProvider;
+	private ParticipantService $participantService;
+	private Notifier $notifier;
+	protected ITimeFactory $timeFactory;
+	protected ICache $cache;
+	protected ICache $unreadCountCache;
 	protected AttachmentService $attachmentService;
 
 	public function __construct(CommentsManager $commentsManager,

--- a/lib/Chat/Command/Executor.php
+++ b/lib/Chat/Command/Executor.php
@@ -44,20 +44,15 @@ class Executor {
 	public const PLACEHOLDER_ARGUMENTS = '{ARGUMENTS}';
 	public const PLACEHOLDER_ARGUMENTS_DOUBLEQUOTE_ESCAPED = '{ARGUMENTS_DOUBLEQUOTE_ESCAPED}';
 
-	/** @var IEventDispatcher */
-	protected $dispatcher;
+	protected IEventDispatcher $dispatcher;
 
-	/** @var ShellExecutor */
-	protected $shellExecutor;
+	protected ShellExecutor $shellExecutor;
 
-	/** @var CommandService */
-	protected $commandService;
+	protected CommandService $commandService;
 
-	/** @var LoggerInterface */
-	protected $logger;
+	protected LoggerInterface $logger;
 
-	/** @var IL10N */
-	protected $l;
+	protected IL10N $l;
 
 	public function __construct(IEventDispatcher $dispatcher,
 								ShellExecutor $shellExecutor,

--- a/lib/Chat/Command/Executor.php
+++ b/lib/Chat/Command/Executor.php
@@ -115,7 +115,7 @@ class Executor {
 		$message->setVerb('command');
 	}
 
-	protected function execHelp(Room $room, IComment $message, string $arguments, Participant $participant): string {
+	protected function execHelp(Room $room, IComment $message, string $arguments, Participant $participant): ?string {
 		if ($arguments !== '' && $arguments !== 'help') {
 			return $this->execHelpSingleCommand($room, $message, $arguments);
 		}
@@ -160,7 +160,7 @@ class Executor {
 		return implode("\n", $helps);
 	}
 
-	protected function execHelpSingleCommand(Room $room, IComment $message, string $arguments): string {
+	protected function execHelpSingleCommand(Room $room, IComment $message, string $arguments): ?string {
 		try {
 			$input = explode(' ', $arguments, 2);
 			if (count($input) === 1) {
@@ -186,7 +186,7 @@ class Executor {
 		}
 	}
 
-	protected function execApp(Room $room, IComment $message, Command $command, string $arguments): string {
+	protected function execApp(Room $room, IComment $message, Command $command, string $arguments): ?string {
 		$event = $this->createEvent($room, $message, $command, $arguments);
 		$this->dispatcher->dispatch(self::EVENT_APP_EXECUTE, $event);
 		return $event->getOutput();

--- a/lib/Chat/Command/Listener.php
+++ b/lib/Chat/Command/Listener.php
@@ -31,11 +31,8 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\EventDispatcher\IEventDispatcher;
 
 class Listener {
-
-	/** @var CommandService */
-	protected $commandService;
-	/** @var Executor */
-	protected $executor;
+	protected CommandService $commandService;
+	protected Executor $executor;
 
 	public function __construct(CommandService $commandService,
 								Executor $executor) {

--- a/lib/Chat/CommentsManager.php
+++ b/lib/Chat/CommentsManager.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Chat;
 
+use OCP\DB\Exception;
 use OC\Comments\Comment;
 use OC\Comments\Manager;
 use OCP\Comments\IComment;
@@ -44,7 +45,7 @@ class CommentsManager extends Manager {
 	/**
 	 * @param string[] $ids
 	 * @return IComment[]
-	 * @throws \OCP\DB\Exception
+	 * @throws Exception
 	 */
 	public function getCommentsById(array $ids): array {
 		$commentIds = array_map('intval', $ids);

--- a/lib/Chat/MessageParser.php
+++ b/lib/Chat/MessageParser.php
@@ -43,14 +43,11 @@ use OCP\IUserManager;
 class MessageParser {
 	public const EVENT_MESSAGE_PARSE = self::class . '::parseMessage';
 
-	/** @var IEventDispatcher */
-	private $dispatcher;
+	private IEventDispatcher $dispatcher;
 
-	/** @var IUserManager */
-	private $userManager;
+	private IUserManager $userManager;
 
-	/** @var array */
-	protected $guestNames = [];
+	protected array $guestNames = [];
 
 	public function __construct(IEventDispatcher $dispatcher,
 								IUserManager $userManager) {

--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -47,21 +47,13 @@ use OCP\Notification\INotification;
  * prepares the notifications for display.
  */
 class Notifier {
-
-	/** @var INotificationManager */
-	private $notificationManager;
-	/** @var IUserManager */
-	private $userManager;
-	/** @var ParticipantService */
-	private $participantService;
-	/** @var Manager */
-	private $manager;
-	/** @var IConfig */
-	private $config;
-	/** @var ITimeFactory */
-	private $timeFactory;
-	/** @var Util */
-	private $util;
+	private INotificationManager $notificationManager;
+	private IUserManager $userManager;
+	private ParticipantService $participantService;
+	private Manager $manager;
+	private IConfig $config;
+	private ITimeFactory $timeFactory;
+	private Util $util;
 
 	public function __construct(INotificationManager $notificationManager,
 								IUserManager $userManager,

--- a/lib/Chat/Parser/ReactionParser.php
+++ b/lib/Chat/Parser/ReactionParser.php
@@ -29,8 +29,7 @@ use OCA\Talk\Model\Message;
 use OCP\IL10N;
 
 class ReactionParser {
-	/** @var IL10N|null */
-	private $l;
+	private ?IL10N $l = null;
 	/**
 	 * @param Message $message
 	 * @throws \OutOfBoundsException

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -49,38 +49,29 @@ use OCP\Share\Exceptions\ShareNotFound;
 use Sabre\VObject\Reader;
 
 class SystemMessage {
-
-	/** @var IUserManager */
-	protected $userManager;
-	/** @var IGroupManager */
-	protected $groupManager;
-	/** @var GuestManager */
-	protected $guestManager;
-	/** @var IPreviewManager */
-	protected $previewManager;
-	/** @var RoomShareProvider */
-	protected $shareProvider;
+	protected IUserManager $userManager;
+	protected IGroupManager $groupManager;
+	protected GuestManager $guestManager;
+	protected IPreviewManager $previewManager;
+	protected RoomShareProvider $shareProvider;
 	/** @var PhotoCache */
 	protected $photoCache;
-	/** @var IRootFolder */
-	protected $rootFolder;
-	/** @var IURLGenerator */
-	protected $url;
-	/** @var IL10N */
-	protected $l;
+	protected IRootFolder $rootFolder;
+	protected IURLGenerator $url;
+	protected ?IL10N $l = null;
 
 	/**
 	 * @psalm-var array<array-key, null|string>
 	 */
-	protected $displayNames = [];
+	protected array $displayNames = [];
 	/** @var string[] */
-	protected $groupNames = [];
+	protected array $groupNames = [];
 	/** @var string[] */
-	protected $circleNames = [];
+	protected array $circleNames = [];
 	/** @var string[] */
-	protected $circleLinks = [];
+	protected array $circleLinks = [];
 	/** @var string[] */
-	protected $guestNames = [];
+	protected array $guestNames = [];
 
 	public function __construct(IUserManager $userManager,
 								IGroupManager $groupManager,

--- a/lib/Chat/Parser/UserMention.php
+++ b/lib/Chat/Parser/UserMention.php
@@ -43,16 +43,11 @@ class UserMention {
 	 * Do NOT inject OCA\Talk\Chat\CommentsManager here
 	 * otherwise the display name resolvers are lost
 	 * and mentions are not replaced anymore.
-	 *
-	 * @var ICommentsManager
 	 */
-	private $commentsManager;
-	/** @var IUserManager */
-	private $userManager;
-	/** @var GuestManager */
-	private $guestManager;
-	/** @var IL10N */
-	private $l;
+	private ICommentsManager $commentsManager;
+	private IUserManager $userManager;
+	private GuestManager $guestManager;
+	private IL10N $l;
 
 	public function __construct(ICommentsManager $commentsManager,
 								IUserManager $userManager,

--- a/lib/Chat/ReactionManager.php
+++ b/lib/Chat/ReactionManager.php
@@ -37,18 +37,13 @@ use OCP\Comments\NotFoundException;
 use OCP\IL10N;
 
 class ReactionManager {
-	/** @var ChatManager */
-	private $chatManager;
+	private ChatManager $chatManager;
 	/** @var ICommentsManager|CommentsManager */
 	private $commentsManager;
-	/** @var IL10N */
-	private $l;
-	/** @var MessageParser */
-	private $messageParser;
-	/** @var Notifier */
-	private $notifier;
-	/** @var ITimeFactory */
-	protected $timeFactory;
+	private IL10N $l;
+	private MessageParser $messageParser;
+	private Notifier $notifier;
+	protected ITimeFactory $timeFactory;
 
 	public function __construct(ChatManager $chatManager,
 								CommentsManager $commentsManager,

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -55,19 +55,12 @@ use OCP\Share\IShare;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Listener implements IEventListener {
-
-	/** @var IRequest */
-	protected $request;
-	/** @var ChatManager */
-	protected $chatManager;
-	/** @var TalkSession */
-	protected $talkSession;
-	/** @var ISession */
-	protected $session;
-	/** @var IUserSession */
-	protected $userSession;
-	/** @var ITimeFactory */
-	protected $timeFactory;
+	protected IRequest $request;
+	protected ChatManager $chatManager;
+	protected TalkSession $talkSession;
+	protected ISession $session;
+	protected IUserSession $userSession;
+	protected ITimeFactory $timeFactory;
 
 	public function __construct(IRequest $request,
 								ChatManager $chatManager,

--- a/lib/Collaboration/Collaborators/Listener.php
+++ b/lib/Collaboration/Collaborators/Listener.php
@@ -38,19 +38,13 @@ use OCP\IUser;
 use OCP\IUserManager;
 
 class Listener {
-
-	/** @var Manager */
-	protected $manager;
-	/** @var IUserManager */
-	protected $userManager;
-	/** @var Config */
-	protected $config;
+	protected Manager $manager;
+	protected IUserManager $userManager;
+	protected Config $config;
 	/** @var string[] */
-	protected $allowedGroupIds = [];
-	/** @var string */
-	protected $roomToken;
-	/** @var Room */
-	protected $room;
+	protected array $allowedGroupIds = [];
+	protected string $roomToken;
+	protected ?Room $room = null;
 
 	public function __construct(Manager $manager,
 								IUserManager $userManager,

--- a/lib/Collaboration/Collaborators/RoomPlugin.php
+++ b/lib/Collaboration/Collaborators/RoomPlugin.php
@@ -33,12 +33,9 @@ use OCP\IUserSession;
 use OCP\Share\IShare;
 
 class RoomPlugin implements ISearchPlugin {
+	private Manager $manager;
 
-	/** @var Manager */
-	private $manager;
-
-	/** @var IUserSession */
-	private $userSession;
+	private IUserSession $userSession;
 
 	public function __construct(Manager $manager,
 								IUserSession $userSession) {

--- a/lib/Collaboration/Resources/ConversationProvider.php
+++ b/lib/Collaboration/Resources/ConversationProvider.php
@@ -36,13 +36,9 @@ use OCP\IUser;
 use OCP\IUserSession;
 
 class ConversationProvider implements IProvider {
-
-	/** @var Manager */
-	protected $manager;
-	/** @var IUserSession */
-	protected $userSession;
-	/** @var IURLGenerator */
-	protected $urlGenerator;
+	protected Manager $manager;
+	protected IUserSession $userSession;
+	protected IURLGenerator $urlGenerator;
 
 	public function __construct(Manager $manager,
 								IUserSession $userSession,

--- a/lib/Command/ActiveCalls.php
+++ b/lib/Command/ActiveCalls.php
@@ -31,12 +31,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ActiveCalls extends Base {
+	public IDBConnection $connection;
 
-	/** @var IDBConnection */
-	public $connection;
-
-	/** @var Manager */
-	public $manager;
+	public Manager $manager;
 
 	public function __construct(IDBConnection $connection) {
 		parent::__construct();

--- a/lib/Command/Command/Add.php
+++ b/lib/Command/Command/Add.php
@@ -32,8 +32,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Add extends Base {
 	use TRenderCommand;
 
-	/** @var CommandService */
-	private $service;
+	private CommandService $service;
 
 	public function __construct(CommandService $service) {
 		parent::__construct();

--- a/lib/Command/Command/AddSamples.php
+++ b/lib/Command/Command/AddSamples.php
@@ -35,12 +35,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 class AddSamples extends Base {
 	use TRenderCommand;
 
-	/** @var CommandService */
-	private $service;
-	/** @var IAppManager */
-	protected $appManager;
+	private CommandService $service;
+	protected IAppManager $appManager;
 
-	protected $commands = [];
+	protected array $commands = [];
 
 	public function __construct(CommandService $service, IAppManager $appManager) {
 		parent::__construct();

--- a/lib/Command/Command/Delete.php
+++ b/lib/Command/Command/Delete.php
@@ -31,9 +31,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Delete extends Base {
-
-	/** @var CommandService */
-	private $service;
+	private CommandService $service;
 
 	public function __construct(CommandService $service) {
 		parent::__construct();

--- a/lib/Command/Command/ListCommand.php
+++ b/lib/Command/Command/ListCommand.php
@@ -32,8 +32,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ListCommand extends Base {
 	use TRenderCommand;
 
-	/** @var CommandService */
-	private $service;
+	private CommandService $service;
 
 	public function __construct(CommandService $service) {
 		parent::__construct();

--- a/lib/Command/Command/Update.php
+++ b/lib/Command/Command/Update.php
@@ -33,8 +33,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Update extends Base {
 	use TRenderCommand;
 
-	/** @var CommandService */
-	private $service;
+	private CommandService $service;
 
 	public function __construct(CommandService $service) {
 		parent::__construct();

--- a/lib/Command/Signaling/Add.php
+++ b/lib/Command/Signaling/Add.php
@@ -33,9 +33,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Add extends Base {
-
-	/** @var IConfig */
-	private $config;
+	private IConfig $config;
 
 	public function __construct(IConfig $config) {
 		parent::__construct();

--- a/lib/Command/Signaling/Delete.php
+++ b/lib/Command/Signaling/Delete.php
@@ -32,9 +32,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Delete extends Base {
-
-	/** @var IConfig */
-	private $config;
+	private IConfig $config;
 
 	public function __construct(IConfig $config) {
 		parent::__construct();

--- a/lib/Command/Signaling/ListCommand.php
+++ b/lib/Command/Signaling/ListCommand.php
@@ -31,9 +31,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Base {
-
-	/** @var IConfig */
-	private $config;
+	private IConfig $config;
 
 	public function __construct(IConfig $config) {
 		parent::__construct();

--- a/lib/Command/Stun/Add.php
+++ b/lib/Command/Stun/Add.php
@@ -32,9 +32,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Add extends Base {
-
-	/** @var IConfig */
-	private $config;
+	private IConfig $config;
 
 	public function __construct(IConfig $config) {
 		parent::__construct();

--- a/lib/Command/Stun/Delete.php
+++ b/lib/Command/Stun/Delete.php
@@ -32,9 +32,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Delete extends Base {
-
-	/** @var IConfig */
-	private $config;
+	private IConfig $config;
 
 	public function __construct(IConfig $config) {
 		parent::__construct();

--- a/lib/Command/Stun/ListCommand.php
+++ b/lib/Command/Stun/ListCommand.php
@@ -31,9 +31,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Base {
-
-	/** @var IConfig */
-	private $config;
+	private IConfig $config;
 
 	public function __construct(IConfig $config) {
 		parent::__construct();

--- a/lib/Command/Turn/Add.php
+++ b/lib/Command/Turn/Add.php
@@ -33,9 +33,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Add extends Base {
-
-	/** @var IConfig */
-	private $config;
+	private IConfig $config;
 
 	public function __construct(IConfig $config) {
 		parent::__construct();

--- a/lib/Command/Turn/Delete.php
+++ b/lib/Command/Turn/Delete.php
@@ -32,9 +32,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Delete extends Base {
-
-	/** @var IConfig */
-	private $config;
+	private IConfig $config;
 
 	public function __construct(IConfig $config) {
 		parent::__construct();

--- a/lib/Command/Turn/ListCommand.php
+++ b/lib/Command/Turn/ListCommand.php
@@ -31,9 +31,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Base {
-
-	/** @var IConfig */
-	private $config;
+	private IConfig $config;
 
 	public function __construct(IConfig $config) {
 		parent::__construct();

--- a/lib/Command/User/Remove.php
+++ b/lib/Command/User/Remove.php
@@ -33,10 +33,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Remove extends Base {
-	/** @var IUserManager */
-	private $userManager;
-	/** @var Manager */
-	private $manager;
+	private IUserManager $userManager;
+	private Manager $manager;
 
 	public function __construct(IUserManager $userManager,
 								Manager $manager) {

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -36,19 +36,13 @@ class Config {
 	public const SIGNALING_EXTERNAL = 'external';
 	public const SIGNALING_CLUSTER_CONVERSATION = 'conversation_cluster';
 
-	/** @var IConfig */
-	protected $config;
-	/** @var ITimeFactory */
-	protected $timeFactory;
-	/** @var IGroupManager */
-	private $groupManager;
-	/** @var ISecureRandom */
-	private $secureRandom;
-	/** @var IEventDispatcher */
-	private $dispatcher;
+	protected IConfig $config;
+	protected ITimeFactory $timeFactory;
+	private IGroupManager $groupManager;
+	private ISecureRandom $secureRandom;
+	private IEventDispatcher $dispatcher;
 
-	/** @var array */
-	protected $canEnableSIP = [];
+	protected array $canEnableSIP = [];
 
 	public function __construct(IConfig $config,
 								ISecureRandom $secureRandom,

--- a/lib/ContactsMenu/Providers/CallProvider.php
+++ b/lib/ContactsMenu/Providers/CallProvider.php
@@ -36,17 +36,11 @@ use OCP\IUser;
 use OCP\IUserManager;
 
 class CallProvider implements IProvider {
-
-	/** @var IActionFactory */
-	private $actionFactory;
-	/** @var IURLGenerator */
-	private $urlGenerator;
-	/** @var IUserManager */
-	private $userManager;
-	/** @var IL10N */
-	private $l10n;
-	/** @var Config */
-	private $config;
+	private IActionFactory $actionFactory;
+	private IURLGenerator $urlGenerator;
+	private IUserManager $userManager;
+	private IL10N $l10n;
+	private Config $config;
 
 	public function __construct(IActionFactory $actionFactory,
 								IURLGenerator $urlGenerator,

--- a/lib/Controller/AEnvironmentAwareController.php
+++ b/lib/Controller/AEnvironmentAwareController.php
@@ -32,13 +32,9 @@ use OCA\Talk\Room;
 use OCP\AppFramework\OCSController;
 
 abstract class AEnvironmentAwareController extends OCSController {
-
-	/** @var int */
-	protected $apiVersion = 1;
-	/** @var Room */
-	protected $room;
-	/** @var Participant */
-	protected $participant;
+	protected int $apiVersion = 1;
+	protected ?Room $room = null;
+	protected ?Participant $participant = null;
 
 	public function setAPIVersion(int $apiVersion): void {
 		$this->apiVersion = $apiVersion;

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -39,13 +39,9 @@ use OCP\IUser;
 use OCP\IUserManager;
 
 class CallController extends AEnvironmentAwareController {
-
-	/** @var ParticipantService */
-	private $participantService;
-	/** @var IUserManager */
-	private $userManager;
-	/** @var ITimeFactory */
-	private $timeFactory;
+	private ParticipantService $participantService;
+	private IUserManager $userManager;
+	private ITimeFactory $timeFactory;
 
 	public function __construct(string $appName,
 								IRequest $request,

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -61,65 +61,46 @@ use OCP\UserStatus\IManager as IUserStatusManager;
 use OCP\UserStatus\IUserStatus;
 
 class ChatController extends AEnvironmentAwareController {
+	private ?string $userId;
 
-	/** @var null|string */
-	private $userId;
+	private IUserManager $userManager;
 
-	/** @var IUserManager */
-	private $userManager;
+	private IAppManager $appManager;
 
-	/** @var IAppManager */
-	private $appManager;
+	private ChatManager $chatManager;
 
-	/** @var ChatManager */
-	private $chatManager;
+	private ParticipantService $participantService;
 
-	/** @var ParticipantService */
-	private $participantService;
-
-	/** @var SessionService */
-	private $sessionService;
+	private SessionService $sessionService;
 
 	protected AttachmentService $attachmentService;
 
-	/** @var GuestManager */
-	private $guestManager;
+	private GuestManager $guestManager;
 
 	/** @var string[] */
-	protected $guestNames;
+	protected array $guestNames;
 
-	/** @var MessageParser */
-	private $messageParser;
+	private MessageParser $messageParser;
 
-	/** @var IManager */
-	private $autoCompleteManager;
+	private \OCP\Collaboration\AutoComplete\IManager $autoCompleteManager;
 
-	/** @var IUserStatusManager */
-	private $statusManager;
+	private IUserStatusManager $statusManager;
 
-	/** @var MatterbridgeManager */
-	protected $matterbridgeManager;
+	protected MatterbridgeManager $matterbridgeManager;
 
-	/** @var SearchPlugin */
-	private $searchPlugin;
+	private SearchPlugin $searchPlugin;
 
-	/** @var ISearchResult */
-	private $searchResult;
+	private ISearchResult $searchResult;
 
-	/** @var ITimeFactory */
-	protected $timeFactory;
+	protected ITimeFactory $timeFactory;
 
-	/** @var IEventDispatcher */
-	protected $eventDispatcher;
+	protected IEventDispatcher $eventDispatcher;
 
-	/** @var IValidator */
-	protected $richObjectValidator;
+	protected IValidator $richObjectValidator;
 
-	/** @var ITrustedDomainHelper */
-	protected $trustedDomainHelper;
+	protected ITrustedDomainHelper $trustedDomainHelper;
 
-	/** @var IL10N */
-	private $l;
+	private IL10N $l;
 
 	public function __construct(string $appName,
 								?string $UserId,

--- a/lib/Controller/CommandController.php
+++ b/lib/Controller/CommandController.php
@@ -30,9 +30,7 @@ use OCP\AppFramework\OCSController;
 use OCP\IRequest;
 
 class CommandController extends OCSController {
-
-	/** @var CommandService */
-	protected $commandService;
+	protected CommandService $commandService;
 
 	/**
 	 * @param string $appName

--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -40,14 +40,11 @@ use OCP\IUser;
 use OCP\IUserSession;
 
 class FederationController extends OCSController {
-	/** @var FederationManager */
-	private $federationManager;
+	private FederationManager $federationManager;
 
-	/** @var Manager */
-	private $talkManager;
+	private Manager $talkManager;
 
-	/** @var IUserSession */
-	private $userSession;
+	private IUserSession $userSession;
 
 	public function __construct(IRequest $request,
 								FederationManager $federationManager,

--- a/lib/Controller/FilesIntegrationController.php
+++ b/lib/Controller/FilesIntegrationController.php
@@ -47,25 +47,15 @@ use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager as IShareManager;
 
 class FilesIntegrationController extends OCSController {
-
-	/** @var Manager */
-	private $manager;
-	/** @var RoomService */
-	private $roomService;
-	/** @var IShareManager */
-	private $shareManager;
-	/** @var ISession */
-	private $session;
-	/** @var IUserSession */
-	private $userSession;
-	/** @var TalkSession */
-	private $talkSession;
-	/** @var Util */
-	private $util;
-	/** @var IConfig */
-	private $config;
-	/** @var IL10N */
-	private $l;
+	private Manager $manager;
+	private RoomService $roomService;
+	private IShareManager $shareManager;
+	private ISession $session;
+	private IUserSession $userSession;
+	private TalkSession $talkSession;
+	private Util $util;
+	private IConfig $config;
+	private IL10N $l;
 
 	public function __construct(
 			string $appName,

--- a/lib/Controller/GuestController.php
+++ b/lib/Controller/GuestController.php
@@ -31,9 +31,7 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
 
 class GuestController extends AEnvironmentAwareController {
-
-	/** @var GuestManager */
-	private $guestManager;
+	private GuestManager $guestManager;
 
 	public function __construct(string $appName,
 								IRequest $request,

--- a/lib/Controller/HostedSignalingServerController.php
+++ b/lib/Controller/HostedSignalingServerController.php
@@ -40,17 +40,11 @@ use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
 class HostedSignalingServerController extends OCSController {
-
-	/** @var IClientService */
-	protected $clientService;
-	/** @var IL10N */
-	protected $l10n;
-	/** @var IConfig */
-	protected $config;
-	/** @var LoggerInterface */
-	protected $logger;
-	/** @var HostedSignalingServerService */
-	private $hostedSignalingServerService;
+	protected IClientService $clientService;
+	protected IL10N $l10n;
+	protected IConfig $config;
+	protected LoggerInterface $logger;
+	private HostedSignalingServerService $hostedSignalingServerService;
 
 	public function __construct(string $appName,
 								IRequest $request,

--- a/lib/Controller/MatterbridgeController.php
+++ b/lib/Controller/MatterbridgeController.php
@@ -33,12 +33,9 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
 
 class MatterbridgeController extends AEnvironmentAwareController {
-	/** @var string|null */
-	protected $userId;
-	/** @var Manager */
-	protected $manager;
-	/** @var MatterbridgeManager */
-	protected $bridgeManager;
+	protected ?string $userId;
+	protected Manager $manager;
+	protected MatterbridgeManager $bridgeManager;
 
 	public function __construct(string $appName,
 								?string $UserId,

--- a/lib/Controller/MatterbridgeSettingsController.php
+++ b/lib/Controller/MatterbridgeSettingsController.php
@@ -34,8 +34,7 @@ use OCP\AppFramework\OCSController;
 use OCP\IRequest;
 
 class MatterbridgeSettingsController extends OCSController {
-	/** @var MatterbridgeManager */
-	protected $bridgeManager;
+	protected MatterbridgeManager $bridgeManager;
 
 	public function __construct(string $appName,
 								IRequest $request,

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -59,28 +59,17 @@ use Psr\Log\LoggerInterface;
 class PageController extends Controller {
 	use TInitialState;
 
-	/** @var string|null */
-	private $userId;
-	/** @var IEventDispatcher */
-	private $eventDispatcher;
-	/** @var RoomController */
-	private $api;
-	/** @var TalkSession */
-	private $talkSession;
-	/** @var IUserSession */
-	private $userSession;
-	/** @var LoggerInterface */
-	private $logger;
-	/** @var Manager */
-	private $manager;
-	/** @var IURLGenerator */
-	private $url;
-	/** @var INotificationManager */
-	private $notificationManager;
-	/** @var IAppManager */
-	private $appManager;
-	/** @var IRootFolder */
-	private $rootFolder;
+	private ?string $userId;
+	private IEventDispatcher $eventDispatcher;
+	private RoomController $api;
+	private TalkSession $talkSession;
+	private IUserSession $userSession;
+	private LoggerInterface $logger;
+	private Manager $manager;
+	private IURLGenerator $url;
+	private INotificationManager $notificationManager;
+	private IAppManager $appManager;
+	private IRootFolder $rootFolder;
 
 	public function __construct(string $appName,
 								IRequest $request,

--- a/lib/Controller/PublicShareAuthController.php
+++ b/lib/Controller/PublicShareAuthController.php
@@ -38,15 +38,10 @@ use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IShare;
 
 class PublicShareAuthController extends OCSController {
-
-	/** @var IUserManager */
-	private $userManager;
-	/** @var IShareManager */
-	private $shareManager;
-	/** @var IUserSession */
-	private $userSession;
-	/** @var RoomService */
-	private $roomService;
+	private IUserManager $userManager;
+	private IShareManager $shareManager;
+	private IUserSession $userSession;
+	private RoomService $roomService;
 
 	public function __construct(
 			string $appName,

--- a/lib/Controller/ReactionController.php
+++ b/lib/Controller/ReactionController.php
@@ -35,8 +35,7 @@ use OCP\Comments\NotFoundException;
 use OCP\IRequest;
 
 class ReactionController extends AEnvironmentAwareController {
-	/** @var ReactionManager */
-	private $reactionManager;
+	private ReactionManager $reactionManager;
 
 	public function __construct(string $appName,
 								IRequest $request,

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -71,49 +71,28 @@ use Psr\Log\LoggerInterface;
 class RoomController extends AEnvironmentAwareController {
 	public const EVENT_BEFORE_ROOMS_GET = self::class . '::preGetRooms';
 
-	/** @var string|null */
-	protected $userId;
-	/** @var IAppManager */
-	protected $appManager;
-	/** @var TalkSession */
-	protected $session;
-	/** @var IUserManager */
-	protected $userManager;
-	/** @var IGroupManager */
-	protected $groupManager;
-	/** @var Manager */
-	protected $manager;
-	/** @var ICloudIdManager */
-	protected $cloudIdManager;
-	/** @var RoomService */
-	protected $roomService;
-	/** @var ParticipantService */
-	protected $participantService;
-	/** @var SessionService */
-	protected $sessionService;
-	/** @var GuestManager */
-	protected $guestManager;
-	/** @var IUserStatusManager */
-	protected $statusManager;
-	/** @var ChatManager */
-	protected $chatManager;
-	/** @var IEventDispatcher */
-	protected $dispatcher;
-	/** @var MessageParser */
-	protected $messageParser;
-	/** @var ITimeFactory */
-	protected $timeFactory;
-	/** @var IL10N */
-	protected $l10n;
-	/** @var IConfig */
-	protected $config;
-	/** @var Config */
-	protected $talkConfig;
-	/** @var LoggerInterface */
-	protected $logger;
+	protected ?string $userId;
+	protected IAppManager $appManager;
+	protected TalkSession $session;
+	protected IUserManager $userManager;
+	protected IGroupManager $groupManager;
+	protected Manager $manager;
+	protected ICloudIdManager $cloudIdManager;
+	protected RoomService $roomService;
+	protected ParticipantService $participantService;
+	protected SessionService $sessionService;
+	protected GuestManager $guestManager;
+	protected IUserStatusManager $statusManager;
+	protected ChatManager $chatManager;
+	protected IEventDispatcher $dispatcher;
+	protected MessageParser $messageParser;
+	protected ITimeFactory $timeFactory;
+	protected IL10N $l10n;
+	protected IConfig $config;
+	protected Config $talkConfig;
+	protected LoggerInterface $logger;
 
-	/** @var array */
-	protected $commonReadMessages = [];
+	protected array $commonReadMessages = [];
 
 	public function __construct(string $appName,
 								?string $UserId,

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -43,19 +43,12 @@ use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
 class SettingsController extends OCSController {
-
-	/** @var IRootFolder */
-	protected $rootFolder;
-	/** @var IConfig */
-	protected $config;
-	/** @var IGroupManager */
-	protected $groupManager;
-	/** @var ParticipantService */
-	protected $participantService;
-	/** @var LoggerInterface */
-	protected $logger;
-	/** @var string|null */
-	protected $userId;
+	protected IRootFolder $rootFolder;
+	protected IConfig $config;
+	protected IGroupManager $groupManager;
+	protected ParticipantService $participantService;
+	protected LoggerInterface $logger;
+	protected ?string $userId;
 
 	public function __construct(string $appName,
 								IRequest $request,

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Controller;
 
+use GuzzleHttp\Exception\ConnectException;
 use OCA\Talk\Config;
 use OCA\Talk\Events\SignalingEvent;
 use OCA\Talk\Exceptions\RoomNotFoundException;
@@ -58,34 +59,20 @@ class SignalingController extends OCSController {
 
 	public const EVENT_BACKEND_SIGNALING_ROOMS = self::class . '::signalingBackendRoom';
 
-	/** @var Config */
-	private $talkConfig;
-	/** @var \OCA\Talk\Signaling\Manager */
-	private $signalingManager;
-	/** @var TalkSession */
-	private $session;
-	/** @var Manager */
-	private $manager;
-	/** @var ParticipantService */
-	private $participantService;
-	/** @var SessionService */
-	private $sessionService;
-	/** @var IDBConnection */
-	private $dbConnection;
-	/** @var Messages */
-	private $messages;
-	/** @var IUserManager */
-	private $userManager;
-	/** @var IEventDispatcher */
-	private $dispatcher;
-	/** @var ITimeFactory */
-	private $timeFactory;
-	/** @var IClientService */
-	private $clientService;
-	/** @var LoggerInterface */
-	private $logger;
-	/** @var string|null */
-	private $userId;
+	private Config $talkConfig;
+	private \OCA\Talk\Signaling\Manager $signalingManager;
+	private TalkSession $session;
+	private Manager $manager;
+	private ParticipantService $participantService;
+	private SessionService $sessionService;
+	private IDBConnection $dbConnection;
+	private Messages $messages;
+	private IUserManager $userManager;
+	private IEventDispatcher $dispatcher;
+	private ITimeFactory $timeFactory;
+	private IClientService $clientService;
+	private LoggerInterface $logger;
+	private ?string $userId;
 
 	public function __construct(string $appName,
 								IRequest $request,
@@ -240,7 +227,7 @@ class SignalingController extends OCSController {
 			}
 
 			return new DataResponse($data);
-		} catch (\GuzzleHttp\Exception\ConnectException $e) {
+		} catch (ConnectException $e) {
 			return new DataResponse(['error' => 'CAN_NOT_CONNECT'], Http::STATUS_INTERNAL_SERVER_ERROR);
 		} catch (\Exception $e) {
 			return new DataResponse(['error' => $e->getCode()], Http::STATUS_INTERNAL_SERVER_ERROR);

--- a/lib/Controller/TempAvatarController.php
+++ b/lib/Controller/TempAvatarController.php
@@ -36,15 +36,10 @@ use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
 class TempAvatarController extends OCSController {
-
-	/** @var IAvatarManager */
-	private $avatarManager;
-	/** @var IL10N */
-	private $l;
-	/** @var LoggerInterface */
-	private $logger;
-	/** @var string */
-	private $userId;
+	private IAvatarManager $avatarManager;
+	private IL10N $l;
+	private LoggerInterface $logger;
+	private string $userId;
 
 	public function __construct(
 		string $appName,

--- a/lib/Dashboard/TalkWidget.php
+++ b/lib/Dashboard/TalkWidget.php
@@ -31,11 +31,8 @@ use OCP\IURLGenerator;
 use OCP\Util;
 
 class TalkWidget implements IWidget {
-
-	/** @var IURLGenerator */
-	private $url;
-	/** @var IL10N */
-	private $l10n;
+	private IURLGenerator $url;
+	private IL10N $l10n;
 
 	public function __construct(
 		IURLGenerator $url,

--- a/lib/DataObjects/AccountId.php
+++ b/lib/DataObjects/AccountId.php
@@ -26,9 +26,7 @@ declare(strict_types=1);
 namespace OCA\Talk\DataObjects;
 
 class AccountId {
-
-	/** @var string */
-	private $accountId;
+	private string $accountId;
 
 	public function __construct(string $accountId) {
 		$this->accountId = $accountId;

--- a/lib/DataObjects/RegisterAccountData.php
+++ b/lib/DataObjects/RegisterAccountData.php
@@ -26,16 +26,11 @@ declare(strict_types=1);
 namespace OCA\Talk\DataObjects;
 
 class RegisterAccountData {
-	/** @var string */
-	private $url;
-	/** @var string */
-	private $name;
-	/** @var string */
-	private $email;
-	/** @var string */
-	private $language;
-	/** @var string */
-	private $country;
+	private string $url;
+	private string $name;
+	private string $email;
+	private string $language;
+	private string $country;
 
 	public function __construct(string $url, string $name, string $email, string $language, string $country) {
 		$this->url = $url;

--- a/lib/Deck/DeckPluginLoader.php
+++ b/lib/Deck/DeckPluginLoader.php
@@ -30,8 +30,7 @@ use OCP\IRequest;
 use OCP\Util;
 
 class DeckPluginLoader implements IEventListener {
-	/** @var IRequest */
-	private $request;
+	private IRequest $request;
 
 	public function __construct(IRequest $request) {
 		$this->request = $request;

--- a/lib/Events/AddEmailEvent.php
+++ b/lib/Events/AddEmailEvent.php
@@ -26,9 +26,7 @@ namespace OCA\Talk\Events;
 use OCA\Talk\Room;
 
 class AddEmailEvent extends RoomEvent {
-
-	/** @var string */
-	protected $email;
+	protected string $email;
 
 
 	public function __construct(Room $room,

--- a/lib/Events/AddParticipantsEvent.php
+++ b/lib/Events/AddParticipantsEvent.php
@@ -27,15 +27,11 @@ use OCA\Talk\Room;
 use OCP\Comments\IComment;
 
 class AddParticipantsEvent extends RoomEvent {
+	protected array $participants;
 
-	/** @var array */
-	protected $participants;
+	protected bool $skipLastMessageUpdate;
 
-	/** @var bool */
-	protected $skipLastMessageUpdate;
-
-	/** @var IComment|null */
-	protected $lastMessage;
+	protected ?IComment $lastMessage = null;
 
 	public function __construct(Room $room,
 								array $participants,

--- a/lib/Events/AttendeesEvent.php
+++ b/lib/Events/AttendeesEvent.php
@@ -28,7 +28,7 @@ use OCA\Talk\Room;
 
 class AttendeesEvent extends RoomEvent {
 	/** @var Attendee[] */
-	protected $attendees;
+	protected array $attendees;
 
 	public function __construct(Room $room,
 								array $attendees) {

--- a/lib/Events/ChatEvent.php
+++ b/lib/Events/ChatEvent.php
@@ -27,12 +27,9 @@ use OCA\Talk\Room;
 use OCP\Comments\IComment;
 
 class ChatEvent extends RoomEvent {
+	protected IComment $comment;
 
-	/** @var IComment */
-	protected $comment;
-
-	/** @var bool */
-	protected $skipLastActivityUpdate;
+	protected bool $skipLastActivityUpdate;
 
 	public function __construct(Room $room,
 								IComment $comment,

--- a/lib/Events/ChatMessageEvent.php
+++ b/lib/Events/ChatMessageEvent.php
@@ -26,9 +26,7 @@ namespace OCA\Talk\Events;
 use OCA\Talk\Model\Message;
 
 class ChatMessageEvent extends ChatEvent {
-
-	/** @var Message */
-	protected $message;
+	protected Message $message;
 
 
 	public function __construct(Message $message) {

--- a/lib/Events/ChatParticipantEvent.php
+++ b/lib/Events/ChatParticipantEvent.php
@@ -28,9 +28,7 @@ use OCA\Talk\Room;
 use OCP\Comments\IComment;
 
 class ChatParticipantEvent extends ChatEvent {
-
-	/** @var Participant */
-	protected $participant;
+	protected Participant $participant;
 
 
 	public function __construct(Room $room, IComment $message, Participant $participant) {

--- a/lib/Events/CommandEvent.php
+++ b/lib/Events/CommandEvent.php
@@ -51,7 +51,7 @@ class CommandEvent extends ChatEvent {
 		$this->output = $output;
 	}
 
-	public function getOutput(): string {
+	public function getOutput(): ?string {
 		return $this->output;
 	}
 }

--- a/lib/Events/CommandEvent.php
+++ b/lib/Events/CommandEvent.php
@@ -28,13 +28,9 @@ use OCA\Talk\Room;
 use OCP\Comments\IComment;
 
 class CommandEvent extends ChatEvent {
-
-	/** @var Command */
-	protected $command;
-	/** @var string */
-	protected $arguments;
-	/** @var string */
-	protected $output;
+	protected Command $command;
+	protected string $arguments;
+	protected ?string $output = null;
 
 
 	public function __construct(Room $room, IComment $message, Command $command, string $arguments) {

--- a/lib/Events/CreateRoomTokenEvent.php
+++ b/lib/Events/CreateRoomTokenEvent.php
@@ -26,13 +26,9 @@ namespace OCA\Talk\Events;
 use OCP\EventDispatcher\Event;
 
 class CreateRoomTokenEvent extends Event {
-
-	/** @var int */
-	protected $entropy;
-	/** @var string */
-	protected $chars;
-	/** @var string */
-	protected $token;
+	protected int $entropy;
+	protected string $chars;
+	protected string $token;
 
 
 	public function __construct(int $entropy,

--- a/lib/Events/EndCallForEveryoneEvent.php
+++ b/lib/Events/EndCallForEveryoneEvent.php
@@ -48,9 +48,8 @@ class EndCallForEveryoneEvent extends ModifyRoomEvent {
 
 	/**
 	 * Only available in the after-event
-	 * @return string[]
 	 */
-	public function getSessionIds(): array {
+	public function getSessionIds(): ?array {
 		return $this->sessionIds;
 	}
 
@@ -64,9 +63,8 @@ class EndCallForEveryoneEvent extends ModifyRoomEvent {
 
 	/**
 	 * Only available in the after-event
-	 * @return string[]
 	 */
-	public function getUserIds(): array {
+	public function getUserIds(): ?array {
 		return $this->userIds;
 	}
 }

--- a/lib/Events/EndCallForEveryoneEvent.php
+++ b/lib/Events/EndCallForEveryoneEvent.php
@@ -29,9 +29,9 @@ use OCA\Talk\Room;
 class EndCallForEveryoneEvent extends ModifyRoomEvent {
 
 	/** @var string[] */
-	protected $sessionIds;
+	protected ?array $sessionIds = null;
 	/** @var string[] */
-	protected $userIds;
+	protected ?array $userIds = null;
 
 	public function __construct(Room $room,
 								?Participant $actor = null) {

--- a/lib/Events/GetTurnServersEvent.php
+++ b/lib/Events/GetTurnServersEvent.php
@@ -26,9 +26,7 @@ namespace OCA\Talk\Events;
 use OCP\EventDispatcher\Event;
 
 class GetTurnServersEvent extends Event {
-
-	/** @var array */
-	protected $servers;
+	protected array $servers;
 
 	public function __construct(array $servers) {
 		parent::__construct();

--- a/lib/Events/JoinRoomGuestEvent.php
+++ b/lib/Events/JoinRoomGuestEvent.php
@@ -26,13 +26,9 @@ namespace OCA\Talk\Events;
 use OCA\Talk\Room;
 
 class JoinRoomGuestEvent extends RoomEvent {
-
-	/** @var bool */
-	protected $cancelJoin;
-	/** @var string */
-	protected $password;
-	/** @var bool */
-	protected $passedPasswordProtection;
+	protected bool $cancelJoin;
+	protected string $password;
+	protected bool $passedPasswordProtection;
 
 
 	public function __construct(Room $room,

--- a/lib/Events/JoinRoomUserEvent.php
+++ b/lib/Events/JoinRoomUserEvent.php
@@ -27,15 +27,10 @@ use OCA\Talk\Room;
 use OCP\IUser;
 
 class JoinRoomUserEvent extends RoomEvent {
-
-	/** @var IUser */
-	protected $user;
-	/** @var bool */
-	protected $cancelJoin;
-	/** @var string */
-	protected $password;
-	/** @var bool */
-	protected $passedPasswordProtection;
+	protected IUser $user;
+	protected bool $cancelJoin;
+	protected string $password;
+	protected bool $passedPasswordProtection;
 
 
 	public function __construct(Room $room,

--- a/lib/Events/ModifyLobbyEvent.php
+++ b/lib/Events/ModifyLobbyEvent.php
@@ -26,11 +26,8 @@ namespace OCA\Talk\Events;
 use OCA\Talk\Room;
 
 class ModifyLobbyEvent extends ModifyRoomEvent {
-
-	/** @var \DateTime|null */
-	protected $lobbyTimer;
-	/** @var bool */
-	protected $timerReached;
+	protected ?\DateTime $lobbyTimer;
+	protected bool $timerReached;
 
 	public function __construct(Room $room,
 								string $parameter,

--- a/lib/Events/ModifyParticipantEvent.php
+++ b/lib/Events/ModifyParticipantEvent.php
@@ -27,9 +27,7 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 
 class ModifyParticipantEvent extends ParticipantEvent {
-
-	/** @var string */
-	protected $parameter;
+	protected string $parameter;
 	/** @var int|string|bool */
 	protected $newValue;
 	/** @var int|string|bool|null */

--- a/lib/Events/ModifyRoomEvent.php
+++ b/lib/Events/ModifyRoomEvent.php
@@ -27,15 +27,12 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 
 class ModifyRoomEvent extends RoomEvent {
-
-	/** @var string */
-	protected $parameter;
+	protected string $parameter;
 	/** @var int|string|bool */
 	protected $newValue;
 	/** @var int|string|bool|null */
 	protected $oldValue;
-	/** @var Participant|null */
-	protected $actor;
+	protected ?Participant $actor;
 
 
 	public function __construct(Room $room,

--- a/lib/Events/ParticipantEvent.php
+++ b/lib/Events/ParticipantEvent.php
@@ -27,9 +27,7 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 
 class ParticipantEvent extends RoomEvent {
-
-	/** @var Participant */
-	protected $participant;
+	protected Participant $participant;
 
 
 	public function __construct(Room $room,

--- a/lib/Events/RemoveParticipantEvent.php
+++ b/lib/Events/RemoveParticipantEvent.php
@@ -28,12 +28,10 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 
 class RemoveParticipantEvent extends ParticipantEvent {
-
-	/** @var string */
-	protected $reason;
+	protected string $reason;
 
 	/** @var Session[] */
-	protected $sessions;
+	protected array $sessions;
 
 	public function __construct(Room $room,
 								Participant $participant,

--- a/lib/Events/RemoveUserEvent.php
+++ b/lib/Events/RemoveUserEvent.php
@@ -28,9 +28,7 @@ use OCA\Talk\Room;
 use OCP\IUser;
 
 class RemoveUserEvent extends RemoveParticipantEvent {
-
-	/** @var IUser */
-	protected $user;
+	protected IUser $user;
 
 	public function __construct(Room $room,
 								Participant $participant,

--- a/lib/Events/RoomEvent.php
+++ b/lib/Events/RoomEvent.php
@@ -27,9 +27,7 @@ use OCA\Talk\Room;
 use OCP\EventDispatcher\Event;
 
 class RoomEvent extends Event {
-
-	/** @var Room */
-	protected $room;
+	protected Room $room;
 
 
 	public function __construct(Room $room) {

--- a/lib/Events/SignalingEvent.php
+++ b/lib/Events/SignalingEvent.php
@@ -27,9 +27,7 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 
 class SignalingEvent extends ParticipantEvent {
-
-	/** @var string */
-	protected $action;
+	protected string $action;
 	/** @var mixed */
 	protected $session;
 

--- a/lib/Events/SignalingRoomPropertiesEvent.php
+++ b/lib/Events/SignalingRoomPropertiesEvent.php
@@ -26,11 +26,8 @@ namespace OCA\Talk\Events;
 use OCA\Talk\Room;
 
 class SignalingRoomPropertiesEvent extends RoomEvent {
-
-	/** @var string|null */
-	protected $userId;
-	/** @var array */
-	protected $properties;
+	protected ?string $userId;
+	protected array $properties;
 
 	public function __construct(Room $room, ?string $userId, array $properties) {
 		parent::__construct($room);

--- a/lib/Events/UserEvent.php
+++ b/lib/Events/UserEvent.php
@@ -26,9 +26,7 @@ namespace OCA\Talk\Events;
 use OCP\EventDispatcher\Event;
 
 class UserEvent extends Event {
-
-	/** @var string */
-	protected $userId;
+	protected string $userId;
 
 
 	public function __construct(string $userId) {

--- a/lib/Events/VerifyRoomPasswordEvent.php
+++ b/lib/Events/VerifyRoomPasswordEvent.php
@@ -26,13 +26,9 @@ namespace OCA\Talk\Events;
 use OCA\Talk\Room;
 
 class VerifyRoomPasswordEvent extends RoomEvent {
-
-	/** @var string */
-	protected $password;
-	/** @var bool|null */
-	protected $isPasswordValid;
-	/** @var string */
-	protected $redirectUrl = '';
+	protected string $password;
+	protected ?bool $isPasswordValid = null;
+	protected string $redirectUrl = '';
 
 
 	public function __construct(Room $room,

--- a/lib/Federation/CloudFederationProviderTalk.php
+++ b/lib/Federation/CloudFederationProviderTalk.php
@@ -51,33 +51,24 @@ use OCP\Notification\IManager as INotificationManager;
 use OCP\Share\Exceptions\ShareNotFound;
 
 class CloudFederationProviderTalk implements ICloudFederationProvider {
-
-	/** @var IUserManager */
-	private $userManager;
+	private IUserManager $userManager;
 
 	/** @var AddressHandler */
 	private $addressHandler;
 
-	/** @var FederationManager */
-	private $federationManager;
+	private FederationManager $federationManager;
 
-	/** @var Config */
-	private $config;
+	private Config $config;
 
-	/** @var INotificationManager */
-	private $notificationManager;
+	private INotificationManager $notificationManager;
 
-	/** @var IURLGenerator */
-	private $urlGenerator;
+	private IURLGenerator $urlGenerator;
 
-	/** @var ParticipantService  */
-	private $participantService;
+	private ParticipantService $participantService;
 
-	/** @var AttendeeMapper  */
-	private $attendeeMapper;
+	private AttendeeMapper $attendeeMapper;
 
-	/** @var Manager  */
-	private $manager;
+	private Manager $manager;
 
 	public function __construct(
 		IUserManager $userManager,

--- a/lib/Federation/FederationManager.php
+++ b/lib/Federation/FederationManager.php
@@ -53,20 +53,15 @@ class FederationManager {
 	public const TALK_PROTOCOL_NAME = 'nctalk';
 	public const TOKEN_LENGTH = 15;
 
-	/** @var IConfig */
-	private $config;
+	private IConfig $config;
 
-	/** @var Manager */
-	private $manager;
+	private Manager $manager;
 
-	/** @var ParticipantService */
-	private $participantService;
+	private ParticipantService $participantService;
 
-	/** @var InvitationMapper */
-	private $invitationMapper;
+	private InvitationMapper $invitationMapper;
 
-	/** @var Notifications */
-	private $notifications;
+	private Notifications $notifications;
 
 	public function __construct(
 		IConfig $config,

--- a/lib/Federation/Notifications.php
+++ b/lib/Federation/Notifications.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Federation;
 
+use OCP\DB\Exception;
 use OCA\FederatedFileSharing\AddressHandler;
 use OCA\Talk\AppInfo\Application;
 use OCA\Talk\BackgroundJob\RetryJob;
@@ -41,20 +42,15 @@ use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 class Notifications {
-	/** @var ICloudFederationFactory */
-	private $cloudFederationFactory;
+	private ICloudFederationFactory $cloudFederationFactory;
 
-	/** @var LoggerInterface */
-	private $logger;
+	private LoggerInterface $logger;
 
-	/** @var ICloudFederationProviderManager */
-	private $federationProviderManager;
+	private ICloudFederationProviderManager $federationProviderManager;
 
-	/** @var IJobList */
-	private $jobList;
+	private IJobList $jobList;
 
-	/** @var IUserManager */
-	private $userManager;
+	private IUserManager $userManager;
 
 	/** @var AddressHandler */
 	private $addressHandler;
@@ -78,7 +74,7 @@ class Notifications {
 	/**
 	 * @throws HintException
 	 * @throws RoomHasNoModeratorException
-	 * @throws \OCP\DB\Exception
+	 * @throws Exception
 	 */
 	public function sendRemoteShare(string $providerId, string $token, string $shareWith, string $sharedBy,
 									string $sharedByFederatedId, string $shareType, Room $room, Attendee $roomOwnerAttendee): bool {

--- a/lib/Files/Listener.php
+++ b/lib/Files/Listener.php
@@ -52,15 +52,10 @@ use OCP\IUserManager;
  * events.
  */
 class Listener {
-
-	/** @var Util */
-	protected $util;
-	/** @var ParticipantService */
-	protected $participantService;
-	/** @var IUserManager */
-	protected $userManager;
-	/** @var TalkSession */
-	protected $talkSession;
+	protected Util $util;
+	protected ParticipantService $participantService;
+	protected IUserManager $userManager;
+	protected TalkSession $talkSession;
 
 	public function __construct(Util $util,
 								ParticipantService $participantService,

--- a/lib/Files/TemplateLoader.php
+++ b/lib/Files/TemplateLoader.php
@@ -46,12 +46,9 @@ use OCP\Util;
 class TemplateLoader implements IEventListener {
 	use TInitialState;
 
-	/** @var IAppManager */
-	private $appManager;
-	/** @var IRootFolder */
-	private $rootFolder;
-	/** @var IUserSession */
-	private $userSession;
+	private IAppManager $appManager;
+	private IRootFolder $rootFolder;
+	private IUserSession $userSession;
 
 	public function __construct(IInitialState $initialState,
 								ICacheFactory $memcacheFactory,

--- a/lib/Files/Util.php
+++ b/lib/Files/Util.php
@@ -35,19 +35,14 @@ use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager as IShareManager;
 
 class Util {
-
-	/** @var IRootFolder */
-	private $rootFolder;
-	/** @var ISession */
-	private $session;
-	/** @var IShareManager */
-	private $shareManager;
-	/** @var IUserMountCache */
-	private $userMountCache;
+	private IRootFolder $rootFolder;
+	private ISession $session;
+	private IShareManager $shareManager;
+	private IUserMountCache $userMountCache;
 	/** @var array[] */
-	private $accessLists = [];
+	private array $accessLists = [];
 	/** @var bool[] */
-	private $publicAccessLists = [];
+	private array $publicAccessLists = [];
 
 	public function __construct(IRootFolder $rootFolder,
 			ISession $session,

--- a/lib/Flow/Operation.php
+++ b/lib/Flow/Operation.php
@@ -53,16 +53,11 @@ class Operation implements IOperation {
 		'ROOM_MENTION' => 3,
 	];
 
-	/** @var IL10N */
-	private $l;
-	/** @var IURLGenerator */
-	private $urlGenerator;
-	/** @var TalkManager */
-	private $talkManager;
-	/** @var IUserSession */
-	private $session;
-	/** @var ChatManager */
-	private $chatManager;
+	private IL10N $l;
+	private IURLGenerator $urlGenerator;
+	private TalkManager $talkManager;
+	private IUserSession $session;
+	private ChatManager $chatManager;
 
 	public function __construct(
 		IL10N $l,

--- a/lib/Flow/RegisterOperationsListener.php
+++ b/lib/Flow/RegisterOperationsListener.php
@@ -29,9 +29,7 @@ use OCP\Util;
 use OCP\WorkflowEngine\Events\RegisterOperationsEvent;
 
 class RegisterOperationsListener implements IEventListener {
-
-	/** @var Operation */
-	private $operation;
+	private Operation $operation;
 
 	public function __construct(Operation $operation) {
 		$this->operation = $operation;

--- a/lib/GuestManager.php
+++ b/lib/GuestManager.php
@@ -41,29 +41,21 @@ class GuestManager {
 	public const EVENT_AFTER_EMAIL_INVITE = self::class . '::postInviteByEmail';
 	public const EVENT_AFTER_NAME_UPDATE = self::class . '::updateName';
 
-	/** @var Config */
-	protected $talkConfig;
+	protected Config $talkConfig;
 
-	/** @var IMailer */
-	protected $mailer;
+	protected IMailer $mailer;
 
-	/** @var Defaults */
-	protected $defaults;
+	protected Defaults $defaults;
 
-	/** @var IUserSession */
-	protected $userSession;
+	protected IUserSession $userSession;
 
-	/** @var ParticipantService */
-	private $participantService;
+	private ParticipantService $participantService;
 
-	/** @var IURLGenerator */
-	protected $url;
+	protected IURLGenerator $url;
 
-	/** @var IL10N */
-	protected $l;
+	protected IL10N $l;
 
-	/** @var IEventDispatcher */
-	protected $dispatcher;
+	protected IEventDispatcher $dispatcher;
 
 	public function __construct(Config $talkConfig,
 								IMailer $mailer,

--- a/lib/Listener/AMembershipListener.php
+++ b/lib/Listener/AMembershipListener.php
@@ -38,15 +38,10 @@ use OCP\IUser;
 use Psr\Log\LoggerInterface;
 
 abstract class AMembershipListener implements IEventListener {
-
-	/** @var Manager */
-	protected $manager;
-	/** @var IAppManager */
-	protected $appManager;
-	/** @var IGroupManager */
-	protected $groupManager;
-	/** @var ParticipantService */
-	protected $participantService;
+	protected Manager $manager;
+	protected IAppManager $appManager;
+	protected IGroupManager $groupManager;
+	protected ParticipantService $participantService;
 
 	public function __construct(Manager $manager,
 								IAppManager $appManager,

--- a/lib/Listener/BeforeUserLoggedOutListener.php
+++ b/lib/Listener/BeforeUserLoggedOutListener.php
@@ -35,13 +35,9 @@ use OCP\IUser;
 use OCP\User\Events\BeforeUserLoggedOutEvent;
 
 class BeforeUserLoggedOutListener implements IEventListener {
-
-	/** @var Manager */
-	private $manager;
-	/** @var ParticipantService */
-	private $participantService;
-	/** @var TalkSession */
-	private $talkSession;
+	private Manager $manager;
+	private ParticipantService $participantService;
+	private TalkSession $talkSession;
 
 	public function __construct(Manager $manager,
 								ParticipantService $participantService,

--- a/lib/Listener/CSPListener.php
+++ b/lib/Listener/CSPListener.php
@@ -32,9 +32,7 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 
 class CSPListener implements IEventListener {
-
-	/** @var Config */
-	private $config;
+	private Config $config;
 
 	public function __construct(Config $config) {
 		$this->config = $config;

--- a/lib/Listener/CircleDeletedListener.php
+++ b/lib/Listener/CircleDeletedListener.php
@@ -32,11 +32,8 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
 class CircleDeletedListener implements IEventListener {
-
-	/** @var Manager */
-	private $manager;
-	/** @var ParticipantService */
-	private $participantService;
+	private Manager $manager;
+	private ParticipantService $participantService;
 
 	public function __construct(Manager $manager,
 								ParticipantService $participantService) {

--- a/lib/Listener/CircleMembershipListener.php
+++ b/lib/Listener/CircleMembershipListener.php
@@ -39,10 +39,8 @@ use OCP\IUser;
 use OCP\IUserManager;
 
 class CircleMembershipListener extends AMembershipListener {
-	/** @var ISession */
-	private $session;
-	/** @var IUserManager */
-	private $userManager;
+	private ISession $session;
+	private IUserManager $userManager;
 
 	public function __construct(Manager $manager,
 								IAppManager $appManager,

--- a/lib/Listener/GroupDeletedListener.php
+++ b/lib/Listener/GroupDeletedListener.php
@@ -33,13 +33,9 @@ use OCP\Group\Events\GroupDeletedEvent;
 use OCP\IConfig;
 
 class GroupDeletedListener implements IEventListener {
-
-	/** @var IConfig */
-	private $config;
-	/** @var Manager */
-	private $manager;
-	/** @var ParticipantService */
-	private $participantService;
+	private IConfig $config;
+	private Manager $manager;
+	private ParticipantService $participantService;
 
 	public function __construct(IConfig $config,
 								Manager $manager,

--- a/lib/Listener/RestrictStartingCalls.php
+++ b/lib/Listener/RestrictStartingCalls.php
@@ -31,12 +31,9 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 
 class RestrictStartingCalls {
+	protected IConfig $config;
 
-	/** @var IConfig */
-	protected $config;
-
-	/** @var ParticipantService */
-	protected $participantService;
+	protected ParticipantService $participantService;
 
 	public function __construct(IConfig $config,
 								ParticipantService $participantService) {

--- a/lib/Listener/UserDeletedListener.php
+++ b/lib/Listener/UserDeletedListener.php
@@ -29,9 +29,7 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\User\Events\UserDeletedEvent;
 
 class UserDeletedListener implements IEventListener {
-
-	/** @var Manager */
-	private $manager;
+	private Manager $manager;
 
 	public function __construct(Manager $manager) {
 		$this->manager = $manager;

--- a/lib/Listener/UserDisplayNameListener.php
+++ b/lib/Listener/UserDisplayNameListener.php
@@ -30,9 +30,7 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\User\Events\UserChangedEvent;
 
 class UserDisplayNameListener implements IEventListener {
-
-	/** @var ParticipantService */
-	private $participantService;
+	private ParticipantService $participantService;
 
 	public function __construct(ParticipantService $participantService) {
 		$this->participantService = $participantService;

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -53,38 +53,22 @@ use OCP\Security\ISecureRandom;
 class Manager {
 	public const EVENT_TOKEN_GENERATE = self::class . '::generateNewToken';
 
-	/** @var IDBConnection */
-	private $db;
-	/** @var IConfig */
-	private $config;
-	/** @var Config */
-	private $talkConfig;
-	/** @var IAppManager */
-	private $appManager;
-	/** @var AttendeeMapper */
-	private $attendeeMapper;
-	/** @var SessionMapper */
-	private $sessionMapper;
-	/** @var ParticipantService */
-	private $participantService;
-	/** @var ISecureRandom */
-	private $secureRandom;
-	/** @var IUserManager */
-	private $userManager;
-	/** @var IGroupManager */
-	private $groupManager;
-	/** @var ICommentsManager */
-	private $commentsManager;
-	/** @var TalkSession */
-	private $talkSession;
-	/** @var IEventDispatcher */
-	private $dispatcher;
-	/** @var ITimeFactory */
-	protected $timeFactory;
-	/** @var IHasher */
-	private $hasher;
-	/** @var IL10N */
-	private $l;
+	private IDBConnection $db;
+	private IConfig $config;
+	private Config $talkConfig;
+	private IAppManager $appManager;
+	private AttendeeMapper $attendeeMapper;
+	private SessionMapper $sessionMapper;
+	private ParticipantService $participantService;
+	private ISecureRandom $secureRandom;
+	private IUserManager $userManager;
+	private IGroupManager $groupManager;
+	private ICommentsManager $commentsManager;
+	private TalkSession $talkSession;
+	private IEventDispatcher $dispatcher;
+	protected ITimeFactory $timeFactory;
+	private IHasher $hasher;
+	private IL10N $l;
 
 	public function __construct(IDBConnection $db,
 								IConfig $config,

--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -46,30 +46,18 @@ use Psr\Log\LoggerInterface;
 class MatterbridgeManager {
 	public const BRIDGE_BOT_USERID = 'bridge-bot';
 
-	/** @var IDBConnection */
-	private $db;
-	/** @var IConfig */
-	private $config;
-	/** @var IURLGenerator */
-	private $urlGenerator;
-	/** @var IUserManager */
-	private $userManager;
-	/** @var Manager */
-	private $manager;
-	/** @var ParticipantService */
-	private $participantService;
-	/** @var ChatManager */
-	private $chatManager;
-	/** @var IAuthTokenProvider */
-	private $tokenProvider;
-	/** @var ISecureRandom */
-	private $random;
-	/** @var IAvatarManager */
-	private $avatarManager;
-	/** @var LoggerInterface */
-	private $logger;
-	/** @var ITimeFactory */
-	private $timeFactory;
+	private IDBConnection $db;
+	private IConfig $config;
+	private IURLGenerator $urlGenerator;
+	private IUserManager $userManager;
+	private Manager $manager;
+	private ParticipantService $participantService;
+	private ChatManager $chatManager;
+	private IAuthTokenProvider $tokenProvider;
+	private ISecureRandom $random;
+	private IAvatarManager $avatarManager;
+	private LoggerInterface $logger;
+	private ITimeFactory $timeFactory;
 
 	public function __construct(IDBConnection $db,
 								IConfig $config,

--- a/lib/Middleware/CanUseTalkMiddleware.php
+++ b/lib/Middleware/CanUseTalkMiddleware.php
@@ -37,11 +37,8 @@ use OCP\IUser;
 use OCP\IUserSession;
 
 class CanUseTalkMiddleware extends Middleware {
-
-	/** @var IUserSession */
-	private $userSession;
-	/** @var Config */
-	private $config;
+	private IUserSession $userSession;
+	private Config $config;
 
 	public function __construct(IUserSession $userSession,
 								Config $config) {

--- a/lib/Middleware/InjectionMiddleware.php
+++ b/lib/Middleware/InjectionMiddleware.php
@@ -46,17 +46,11 @@ use OCP\AppFramework\Utility\IControllerMethodReflector;
 use OCP\IRequest;
 
 class InjectionMiddleware extends Middleware {
-
-	/** @var IRequest */
-	private $request;
-	/** @var IControllerMethodReflector */
-	private $reflector;
-	/** @var TalkSession */
-	private $talkSession;
-	/** @var Manager */
-	private $manager;
-	/** @var ?string */
-	private $userId;
+	private IRequest $request;
+	private IControllerMethodReflector $reflector;
+	private TalkSession $talkSession;
+	private Manager $manager;
+	private ?string $userId;
 
 	public function __construct(IRequest $request,
 								IControllerMethodReflector $reflector,

--- a/lib/Migration/CacheUserDisplayNames.php
+++ b/lib/Migration/CacheUserDisplayNames.php
@@ -31,11 +31,8 @@ use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
 class CacheUserDisplayNames implements IRepairStep {
-
-	/** @var IDBConnection */
-	protected $connection;
-	/** @var IUserManager */
-	protected $userManager;
+	protected IDBConnection $connection;
+	protected IUserManager $userManager;
 
 	public function __construct(IDBConnection $connection,
 								IUserManager $userManager) {

--- a/lib/Migration/ClearResourceAccessCache.php
+++ b/lib/Migration/ClearResourceAccessCache.php
@@ -34,12 +34,9 @@ use OCP\Migration\IRepairStep;
 class ClearResourceAccessCache implements IRepairStep {
 	protected const INVALIDATIONS = 1;
 
-	/** @var IConfig */
-	protected $config;
-	/** @var IManager */
-	protected $manager;
-	/** @var ConversationProvider */
-	protected $provider;
+	protected IConfig $config;
+	protected IManager $manager;
+	protected ConversationProvider $provider;
 
 	public function __construct(IConfig $config,
 								IManager $manager,

--- a/lib/Migration/CreateHelpCommand.php
+++ b/lib/Migration/CreateHelpCommand.php
@@ -30,9 +30,7 @@ use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
 class CreateHelpCommand implements IRepairStep {
-
-	/** @var CommandService */
-	protected $service;
+	protected CommandService $service;
 
 	public function __construct(CommandService $service) {
 		$this->service = $service;

--- a/lib/Migration/FixNamespaceInDatabaseTables.php
+++ b/lib/Migration/FixNamespaceInDatabaseTables.php
@@ -28,9 +28,7 @@ use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
 class FixNamespaceInDatabaseTables implements IRepairStep {
-
-	/** @var IDBConnection */
-	protected $connection;
+	protected IDBConnection $connection;
 
 	public function __construct(IDBConnection $connection) {
 		$this->connection = $connection;

--- a/lib/Migration/Version10000Date20201015134000.php
+++ b/lib/Migration/Version10000Date20201015134000.php
@@ -43,10 +43,8 @@ use OCP\Migration\SimpleMigrationStep;
  * email addresses, etc the sessions had to be decoupled from the participants
  */
 class Version10000Date20201015134000 extends SimpleMigrationStep {
-	/** @var IDBConnection */
-	protected $connection;
-	/** @var ITimeFactory */
-	protected $timeFactory;
+	protected IDBConnection $connection;
+	protected ITimeFactory $timeFactory;
 
 	public function __construct(IDBConnection $connection,
 								ITimeFactory $timeFactory) {

--- a/lib/Migration/Version11000Date20200922161218.php
+++ b/lib/Migration/Version11000Date20200922161218.php
@@ -34,9 +34,7 @@ use OCP\IDBConnection;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 
 class Version11000Date20200922161218 extends SimpleMigrationStep {
-
-	/** @var IDBConnection */
-	protected $connection;
+	protected IDBConnection $connection;
 
 	public function __construct(IDBConnection $connection) {
 		$this->connection = $connection;

--- a/lib/Migration/Version14000Date20220217115327.php
+++ b/lib/Migration/Version14000Date20220217115327.php
@@ -30,9 +30,7 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version14000Date20220217115327 extends SimpleMigrationStep {
-
-	/** @var IConfig */
-	protected $config;
+	protected IConfig $config;
 
 	public function __construct(IConfig $config) {
 		$this->config = $config;

--- a/lib/Migration/Version2000Date20171026140256.php
+++ b/lib/Migration/Version2000Date20171026140256.php
@@ -32,15 +32,11 @@ use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
 class Version2000Date20171026140256 extends SimpleMigrationStep {
+	protected IDBConnection $connection;
 
-	/** @var IDBConnection */
-	protected $connection;
+	protected IConfig $config;
 
-	/** @var IConfig */
-	protected $config;
-
-	/** @var IGroupManager */
-	protected $groupManager;
+	protected IGroupManager $groupManager;
 
 	public function __construct(IDBConnection $connection,
 								IConfig $config,

--- a/lib/Migration/Version2000Date20171026140257.php
+++ b/lib/Migration/Version2000Date20171026140257.php
@@ -32,18 +32,14 @@ use OCP\Migration\IOutput;
 use OCP\Security\ISecureRandom;
 
 class Version2000Date20171026140257 extends SimpleMigrationStep {
+	protected IDBConnection $connection;
 
-	/** @var IDBConnection */
-	protected $connection;
+	protected IConfig $config;
 
-	/** @var IConfig */
-	protected $config;
-
-	/** @var ISecureRandom */
-	protected $secureRandom;
+	protected ISecureRandom $secureRandom;
 
 	/** @var string[] */
-	protected $tokens;
+	protected array $tokens;
 
 	public function __construct(IDBConnection $connection,
 								IConfig $config,

--- a/lib/Migration/Version2001Date20170707115443.php
+++ b/lib/Migration/Version2001Date20170707115443.php
@@ -36,12 +36,9 @@ use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
 class Version2001Date20170707115443 extends SimpleMigrationStep {
+	protected IDBConnection $db;
 
-	/** @var IDBConnection */
-	protected $db;
-
-	/** @var IConfig */
-	protected $config;
+	protected IConfig $config;
 
 	public function __construct(IDBConnection $db,
 								IConfig $config) {

--- a/lib/Migration/Version2001Date20170929092606.php
+++ b/lib/Migration/Version2001Date20170929092606.php
@@ -29,9 +29,7 @@ use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
 class Version2001Date20170929092606 extends SimpleMigrationStep {
-
-	/** @var IConfig */
-	protected $config;
+	protected IConfig $config;
 
 	public function __construct(IConfig $config) {
 		$this->config = $config;

--- a/lib/Migration/Version2001Date20171026134605.php
+++ b/lib/Migration/Version2001Date20171026134605.php
@@ -36,12 +36,9 @@ use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
 class Version2001Date20171026134605 extends SimpleMigrationStep {
+	protected IDBConnection $connection;
 
-	/** @var IDBConnection */
-	protected $connection;
-
-	/** @var IConfig */
-	protected $config;
+	protected IConfig $config;
 
 	public function __construct(IDBConnection $connection,
 								IConfig $config) {

--- a/lib/Migration/Version2001Date20180103144447.php
+++ b/lib/Migration/Version2001Date20180103144447.php
@@ -33,12 +33,9 @@ use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
 class Version2001Date20180103144447 extends SimpleMigrationStep {
+	protected IDBConnection $connection;
 
-	/** @var IDBConnection */
-	protected $connection;
-
-	/** @var IConfig */
-	protected $config;
+	protected IConfig $config;
 
 	public function __construct(IDBConnection $connection,
 								IConfig $config) {

--- a/lib/Migration/Version3003Date20180718112436.php
+++ b/lib/Migration/Version3003Date20180718112436.php
@@ -32,9 +32,7 @@ use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
 class Version3003Date20180718112436 extends SimpleMigrationStep {
-
-	/** @var IDBConnection */
-	protected $connection;
+	protected IDBConnection $connection;
 
 	public function __construct(IDBConnection $connection) {
 		$this->connection = $connection;

--- a/lib/Migration/Version3003Date20180718133519.php
+++ b/lib/Migration/Version3003Date20180718133519.php
@@ -29,9 +29,7 @@ use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
 class Version3003Date20180718133519 extends SimpleMigrationStep {
-
-	/** @var IDBConnection */
-	protected $connection;
+	protected IDBConnection $connection;
 
 	public function __construct(IDBConnection $connection) {
 		$this->connection = $connection;

--- a/lib/Migration/Version7000Date20190724121136.php
+++ b/lib/Migration/Version7000Date20190724121136.php
@@ -33,9 +33,7 @@ use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
 class Version7000Date20190724121136 extends SimpleMigrationStep {
-
-	/** @var IDBConnection */
-	protected $connection;
+	protected IDBConnection $connection;
 
 	public function __construct(IDBConnection $connection) {
 		$this->connection = $connection;

--- a/lib/Migration/Version7000Date20190724121137.php
+++ b/lib/Migration/Version7000Date20190724121137.php
@@ -30,9 +30,7 @@ use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
 class Version7000Date20190724121137 extends SimpleMigrationStep {
-
-	/** @var IDBConnection */
-	protected $connection;
+	protected IDBConnection $connection;
 
 	public function __construct(IDBConnection $connection) {
 		$this->connection = $connection;

--- a/lib/Notification/Listener.php
+++ b/lib/Notification/Listener.php
@@ -38,24 +38,15 @@ use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 class Listener {
+	protected IDBConnection $connection;
+	protected IManager $notificationManager;
+	protected ParticipantService $participantsService;
+	protected IEventDispatcher $dispatcher;
+	protected IUserSession $userSession;
+	protected ITimeFactory $timeFactory;
+	protected LoggerInterface $logger;
 
-	/** @var IDBConnection */
-	protected $connection;
-	/** @var IManager */
-	protected $notificationManager;
-	/** @var ParticipantService */
-	protected $participantsService;
-	/** @var IEventDispatcher */
-	protected $dispatcher;
-	/** @var IUserSession */
-	protected $userSession;
-	/** @var ITimeFactory */
-	protected $timeFactory;
-	/** @var LoggerInterface */
-	protected $logger;
-
-	/** @var bool */
-	protected $shouldSendCallNotification = false;
+	protected bool $shouldSendCallNotification = false;
 
 	public function __construct(IDBConnection $connection,
 								IManager $notificationManager,

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -54,38 +54,25 @@ use OCP\Share\IManager as IShareManager;
 use OCP\Share\IShare;
 
 class Notifier implements INotifier {
-
-	/** @var IFactory */
-	protected $lFactory;
-	/** @var IURLGenerator */
-	protected $url;
-	/** @var Config */
-	protected $config;
-	/** @var IUserManager */
-	protected $userManager;
-	/** @var GuestManager */
-	protected $guestManager;
-	/** @var IShareManager */
-	private $shareManager;
-	/** @var Manager */
-	protected $manager;
-	/** @var ParticipantService */
-	protected $participantService;
-	/** @var INotificationManager */
-	protected $notificationManager;
-	/** @var ICommentsManager */
-	protected $commentManager;
-	/** @var MessageParser */
-	protected $messageParser;
-	/** @var Definitions */
-	protected $definitions;
+	protected IFactory $lFactory;
+	protected IURLGenerator $url;
+	protected Config $config;
+	protected IUserManager $userManager;
+	protected GuestManager $guestManager;
+	private IShareManager $shareManager;
+	protected Manager $manager;
+	protected ParticipantService $participantService;
+	protected INotificationManager $notificationManager;
+	protected ICommentsManager $commentManager;
+	protected MessageParser $messageParser;
+	protected Definitions $definitions;
 	/** @var AddressHandler */
 	protected $addressHandler;
 
 	/** @var Room[] */
-	protected $rooms = [];
+	protected array $rooms = [];
 	/** @var Participant[][] */
-	protected $participants = [];
+	protected array $participants = [];
 
 	public function __construct(IFactory $lFactory,
 								IURLGenerator $url,

--- a/lib/Participant.php
+++ b/lib/Participant.php
@@ -54,12 +54,9 @@ class Participant {
 	public const PRIVACY_PUBLIC = 0;
 	public const PRIVACY_PRIVATE = 1;
 
-	/** @var Room */
-	protected $room;
-	/** @var Attendee */
-	protected $attendee;
-	/** @var Session|null */
-	protected $session;
+	protected Room $room;
+	protected Attendee $attendee;
+	protected ?Session $session;
 
 	public function __construct(Room $room,
 								Attendee $attendee,

--- a/lib/Profile/TalkAction.php
+++ b/lib/Profile/TalkAction.php
@@ -35,21 +35,16 @@ use OCP\IUserSession;
 use OCP\Profile\ILinkAction;
 
 class TalkAction implements ILinkAction {
+	private ?IUser $targetUser = null;
 
-	/** @var IUser */
-	private $targetUser;
+	private Config $config;
 
-	/** @var Config */
-	private $config;
-
-	/** @var IL10N */
-	private $l;
+	private IL10N $l;
 
 	/** @var IUrlGenerator */
 	private $urlGenerator;
 
-	/** @var IUserSession */
-	private $userSession;
+	private IUserSession $userSession;
 
 	public function __construct(
 		Config $config,

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -149,70 +149,39 @@ class Room {
 
 	public const DESCRIPTION_MAXIMUM_LENGTH = 500;
 
-	/** @var Manager */
-	private $manager;
-	/** @var IDBConnection */
-	private $db;
-	/** @var IEventDispatcher */
-	private $dispatcher;
-	/** @var ITimeFactory */
-	private $timeFactory;
-	/** @var IHasher */
-	private $hasher;
+	private Manager $manager;
+	private IDBConnection $db;
+	private IEventDispatcher $dispatcher;
+	private ITimeFactory $timeFactory;
+	private IHasher $hasher;
 
-	/** @var int */
-	private $id;
-	/** @var int */
-	private $type;
-	/** @var int */
-	private $readOnly;
-	/** @var int */
-	private $listable;
-	/** @var int */
-	private $lobbyState;
-	/** @var int */
-	private $sipEnabled;
-	/** @var int|null */
-	private $assignedSignalingServer;
-	/** @var \DateTime|null */
-	private $lobbyTimer;
-	/** @var string */
-	private $token;
-	/** @var string */
-	private $name;
-	/** @var string */
-	private $description;
-	/** @var string */
-	private $password;
-	/** @var string */
-	private $remoteServer;
-	/** @var string */
-	private $remoteToken;
-	/** @var int */
-	private $activeGuests;
-	/** @var int */
-	private $defaultPermissions;
-	/** @var int */
-	private $callPermissions;
-	/** @var int */
-	private $callFlag;
-	/** @var \DateTime|null */
-	private $activeSince;
-	/** @var \DateTime|null */
-	private $lastActivity;
-	/** @var int */
-	private $lastMessageId;
-	/** @var IComment|null */
-	private $lastMessage;
-	/** @var string */
-	private $objectType;
-	/** @var string */
-	private $objectId;
+	private int $id;
+	private int $type;
+	private int $readOnly;
+	private int $listable;
+	private int $lobbyState;
+	private int $sipEnabled;
+	private ?int $assignedSignalingServer;
+	private ?\DateTime $lobbyTimer;
+	private string $token;
+	private string $name;
+	private string $description;
+	private string $password;
+	private string $remoteServer;
+	private string $remoteToken;
+	private int $activeGuests;
+	private int $defaultPermissions;
+	private int $callPermissions;
+	private int $callFlag;
+	private ?\DateTime $activeSince;
+	private ?\DateTime $lastActivity;
+	private int $lastMessageId;
+	private ?IComment $lastMessage;
+	private string $objectType;
+	private string $objectId;
 
-	/** @var string */
-	protected $currentUser;
-	/** @var Participant|null */
-	protected $participant;
+	protected ?string $currentUser = null;
+	protected ?Participant $participant = null;
 
 	public function __construct(Manager $manager,
 								IDBConnection $db,

--- a/lib/Search/ConversationSearch.php
+++ b/lib/Search/ConversationSearch.php
@@ -35,13 +35,9 @@ use OCP\Search\SearchResult;
 use OCP\Search\SearchResultEntry;
 
 class ConversationSearch implements IProvider {
-
-	/** @var Manager */
-	protected $manager;
-	/** @var IURLGenerator */
-	protected $url;
-	/** @var IL10N */
-	protected $l;
+	protected Manager $manager;
+	protected IURLGenerator $url;
+	protected IL10N $l;
 
 	public function __construct(
 		Manager $manager,

--- a/lib/Search/MessageSearch.php
+++ b/lib/Search/MessageSearch.php
@@ -41,17 +41,11 @@ use OCP\Search\SearchResult;
 use OCP\Search\SearchResultEntry;
 
 class MessageSearch implements IProvider {
-
-	/** @var RoomManager */
-	protected $roomManager;
-	/** @var ChatManager */
-	protected $chatManager;
-	/** @var MessageParser */
-	protected $messageParser;
-	/** @var IURLGenerator */
-	protected $url;
-	/** @var IL10N */
-	protected $l;
+	protected RoomManager $roomManager;
+	protected ChatManager $chatManager;
+	protected MessageParser $messageParser;
+	protected IURLGenerator $url;
+	protected IL10N $l;
 
 	public function __construct(
 		RoomManager $roomManager,

--- a/lib/Service/CommandService.php
+++ b/lib/Service/CommandService.php
@@ -29,12 +29,9 @@ use OCA\Talk\Model\CommandMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 
 class CommandService {
+	protected CommandMapper $mapper;
 
-	/** @var CommandMapper */
-	protected $mapper;
-
-	/** @var ShellExecutor */
-	protected $shellExecutor;
+	protected ShellExecutor $shellExecutor;
 
 	public function __construct(CommandMapper $mapper, ShellExecutor $shellExecutor) {
 		$this->mapper = $mapper;

--- a/lib/Service/HostedSignalingServerService.php
+++ b/lib/Service/HostedSignalingServerService.php
@@ -243,7 +243,7 @@ class HostedSignalingServerService {
 	 *
 	 * @return (\ArrayAccess|array|mixed)[]|\ArrayAccess
 	 *
-	 * @psalm-return list<created: mixed, owner: <array>, status: mixed, signaling: <array>>
+	 * @psalm-return \ArrayAccess|array{created: mixed, owner: \ArrayAccess|array, status: mixed, signaling?: \ArrayAccess|array}
 	 */
 	public function fetchAccountInfo(AccountId $accountId) {
 		try {

--- a/lib/Service/HostedSignalingServerService.php
+++ b/lib/Service/HostedSignalingServerService.php
@@ -38,19 +38,13 @@ use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
 class HostedSignalingServerService {
-
-	/** @var IConfig */
-	private $config;
+	private IConfig $config;
 	/** @var mixed */
 	private $apiServerUrl;
-	/** @var IClientService */
-	private $clientService;
-	/** @var LoggerInterface */
-	private $logger;
-	/** @var IL10N */
-	private $l10n;
-	/** @var ISecureRandom */
-	private $secureRandom;
+	private IClientService $clientService;
+	private LoggerInterface $logger;
+	private IL10N $l10n;
+	private ISecureRandom $secureRandom;
 
 	public function __construct(IConfig $config,
 								IClientService $clientService,

--- a/lib/Service/MembershipService.php
+++ b/lib/Service/MembershipService.php
@@ -35,13 +35,9 @@ use OCP\IUser;
 use Psr\Log\LoggerInterface;
 
 class MembershipService {
-
-	/** @var IAppManager */
-	protected $appManager;
-	/** @var IGroupManager */
-	protected $groupManager;
-	/** @var AttendeeMapper */
-	protected $attendeeMapper;
+	protected IAppManager $appManager;
+	protected IGroupManager $groupManager;
+	protected AttendeeMapper $attendeeMapper;
 
 	public function __construct(IAppManager $appManager,
 								IGroupManager $groupManager,

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Service;
 
+use OCA\Talk\Manager;
 use OCA\Circles\CirclesManager;
 use OCA\Circles\Model\Circle;
 use OCA\Circles\Model\Member;
@@ -71,34 +72,20 @@ use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
 
 class ParticipantService {
-	/** @var IConfig */
-	protected $serverConfig;
-	/** @var Config */
-	protected $talkConfig;
-	/** @var AttendeeMapper */
-	protected $attendeeMapper;
-	/** @var SessionMapper */
-	protected $sessionMapper;
-	/** @var SessionService */
-	protected $sessionService;
-	/** @var ISecureRandom */
-	private $secureRandom;
-	/** @var IDBConnection */
-	protected $connection;
-	/** @var IEventDispatcher */
-	private $dispatcher;
-	/** @var IUserManager */
-	private $userManager;
-	/** @var IGroupManager */
-	private $groupManager;
-	/** @var MembershipService */
-	private $membershipService;
-	/** @var Notifications */
-	private $notifications;
-	/** @var ITimeFactory */
-	private $timeFactory;
-	/** @var ICacheFactory */
-	private $cacheFactory;
+	protected IConfig $serverConfig;
+	protected Config $talkConfig;
+	protected AttendeeMapper $attendeeMapper;
+	protected SessionMapper $sessionMapper;
+	protected SessionService $sessionService;
+	private ISecureRandom $secureRandom;
+	protected IDBConnection $connection;
+	private IEventDispatcher $dispatcher;
+	private IUserManager $userManager;
+	private IGroupManager $groupManager;
+	private MembershipService $membershipService;
+	private Notifications $notifications;
+	private ITimeFactory $timeFactory;
+	private ICacheFactory $cacheFactory;
 
 	public function __construct(IConfig $serverConfig,
 								Config $talkConfig,
@@ -268,7 +255,7 @@ class ParticipantService {
 			$attendee = $this->attendeeMapper->findByActor($room->getId(), Attendee::ACTOR_USERS, $user->getUID());
 		} catch (DoesNotExistException $e) {
 			// queried here to avoid loop deps
-			$manager = \OC::$server->get(\OCA\Talk\Manager::class);
+			$manager = \OC::$server->get(Manager::class);
 			$isListableByUser = $manager->isRoomListableByUser($room, $user->getUID());
 
 			if (!$isListableByUser && !$event->getPassedPasswordProtection() && !$room->verifyPassword($password)['result']) {

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -35,15 +35,10 @@ use OCP\IUser;
 use OCP\Share\IManager as IShareManager;
 
 class RoomService {
-
-	/** @var Manager */
-	protected $manager;
-	/** @var ParticipantService */
-	protected $participantService;
-	/** @var IShareManager */
-	protected $shareManager;
-	/** @var IEventDispatcher */
-	private $dispatcher;
+	protected Manager $manager;
+	protected ParticipantService $participantService;
+	protected IShareManager $shareManager;
+	private IEventDispatcher $dispatcher;
 
 	public function __construct(Manager $manager,
 								ParticipantService $participantService,

--- a/lib/Service/SessionService.php
+++ b/lib/Service/SessionService.php
@@ -32,12 +32,9 @@ use OCP\IDBConnection;
 use OCP\Security\ISecureRandom;
 
 class SessionService {
-	/** @var SessionMapper */
-	protected $sessionMapper;
-	/** @var IDBConnection */
-	protected $connection;
-	/** @var ISecureRandom */
-	protected $secureRandom;
+	protected SessionMapper $sessionMapper;
+	protected IDBConnection $connection;
+	protected ISecureRandom $secureRandom;
 
 	public function __construct(SessionMapper $sessionMapper,
 								IDBConnection $connection,

--- a/lib/Settings/Admin/AdminSettings.php
+++ b/lib/Settings/Admin/AdminSettings.php
@@ -43,27 +43,16 @@ use OCP\L10N\IFactory;
 use OCP\Settings\ISettings;
 
 class AdminSettings implements ISettings {
-
-	/** @var Config */
-	private $talkConfig;
-	/** @var IConfig */
-	private $serverConfig;
-	/** @var CommandService */
-	private $commandService;
-	/** @var IInitialState */
-	private $initialState;
-	/** @var ICacheFactory */
-	private $memcacheFactory;
-	/** @var IGroupManager */
-	private $groupManager;
-	/** @var MatterbridgeManager */
-	private $bridgeManager;
-	/** @var null|IUser */
-	private $currentUser;
-	/** @var IL10N */
-	private $l10n;
-	/** @var IFactory */
-	private $l10nFactory;
+	private Config $talkConfig;
+	private IConfig $serverConfig;
+	private CommandService $commandService;
+	private IInitialState $initialState;
+	private ICacheFactory $memcacheFactory;
+	private IGroupManager $groupManager;
+	private MatterbridgeManager $bridgeManager;
+	private ?IUser $currentUser = null;
+	private IL10N $l10n;
+	private IFactory $l10nFactory;
 
 	public function __construct(Config $talkConfig,
 								IConfig $serverConfig,

--- a/lib/Settings/Admin/Section.php
+++ b/lib/Settings/Admin/Section.php
@@ -28,12 +28,9 @@ use OCP\IURLGenerator;
 use OCP\Settings\IIconSection;
 
 class Section implements IIconSection {
+	private IL10N $l;
 
-	/** @var IL10N */
-	private $l;
-
-	/** @var IURLGenerator */
-	private $url;
+	private IURLGenerator $url;
 
 	public function __construct(IURLGenerator $url, IL10N $l) {
 		$this->url = $url;

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -30,9 +30,7 @@ use OCP\IConfig;
 use OCP\Settings\ISettings;
 
 class Personal implements ISettings {
-
-	/** @var IConfig */
-	private $config;
+	private IConfig $config;
 
 	public function __construct(IConfig $config) {
 		$this->config = $config;

--- a/lib/Share/Helper/DeletedShareAPIController.php
+++ b/lib/Share/Helper/DeletedShareAPIController.php
@@ -37,11 +37,8 @@ use OCP\Share\IShare;
  * perform actions or checks specific to room shares.
  */
 class DeletedShareAPIController {
-
-	/** @var string */
-	private $userId;
-	/** @var Manager */
-	private $manager;
+	private string $userId;
+	private Manager $manager;
 
 	public function __construct(
 			string $UserId,

--- a/lib/Share/Helper/ShareAPIController.php
+++ b/lib/Share/Helper/ShareAPIController.php
@@ -41,17 +41,11 @@ use OCP\Share\IShare;
  * actions or checks specific to room shares.
  */
 class ShareAPIController {
-
-	/** @var string */
-	private $userId;
-	/** @var Manager */
-	private $manager;
-	/** @var ITimeFactory */
-	protected $timeFactory;
-	/** @var IL10N */
-	private $l;
-	/** @var IURLGenerator */
-	private $urlGenerator;
+	private string $userId;
+	private Manager $manager;
+	protected ITimeFactory $timeFactory;
+	private IL10N $l;
+	private IURLGenerator $urlGenerator;
 
 	public function __construct(
 			string $UserId,

--- a/lib/Share/Listener.php
+++ b/lib/Share/Listener.php
@@ -51,8 +51,7 @@ class Listener {
 		$listener->overwriteMountPoint($event);
 	}
 
-	/** @var Config */
-	protected $config;
+	protected Config $config;
 
 	public function __construct(Config $config) {
 		$this->config = $config;

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -73,24 +73,15 @@ class RoomShareProvider implements IShareProvider {
 	public const TALK_FOLDER = '/Talk';
 	public const TALK_FOLDER_PLACEHOLDER = '/{TALK_PLACEHOLDER}';
 
-	/** @var IDBConnection */
-	private $dbConnection;
-	/** @var ISecureRandom */
-	private $secureRandom;
-	/** @var IShareManager */
-	private $shareManager;
-	/** @var EventDispatcherInterface */
-	private $dispatcher;
-	/** @var Manager */
-	private $manager;
-	/** @var ParticipantService */
-	private $participantService;
-	/** @var ITimeFactory */
-	protected $timeFactory;
-	/** @var IL10N */
-	private $l;
-	/** @var IMimeTypeLoader */
-	private $mimeTypeLoader;
+	private IDBConnection $dbConnection;
+	private ISecureRandom $secureRandom;
+	private IShareManager $shareManager;
+	private EventDispatcherInterface $dispatcher;
+	private Manager $manager;
+	private ParticipantService $participantService;
+	protected ITimeFactory $timeFactory;
+	private IL10N $l;
+	private IMimeTypeLoader $mimeTypeLoader;
 
 	public function __construct(
 			IDBConnection $connection,
@@ -192,7 +183,7 @@ class RoomShareProvider implements IShareProvider {
 		$share->setToken(
 			$this->secureRandom->generate(
 				15, // \OC\Share\Constants::TOKEN_LENGTH
-				\OCP\Security\ISecureRandom::CHAR_HUMAN_READABLE
+				ISecureRandom::CHAR_HUMAN_READABLE
 			)
 		);
 

--- a/lib/Signaling/BackendNotifier.php
+++ b/lib/Signaling/BackendNotifier.php
@@ -37,18 +37,12 @@ use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
 class BackendNotifier {
-	/** @var Config */
-	private $config;
-	/** @var LoggerInterface */
-	private $logger;
-	/** @var IClientService */
-	private $clientService;
-	/** @var ISecureRandom */
-	private $secureRandom;
-	/** @var Manager */
-	private $signalingManager;
-	/** @var ParticipantService */
-	private $participantService;
+	private Config $config;
+	private LoggerInterface $logger;
+	private IClientService $clientService;
+	private ISecureRandom $secureRandom;
+	private Manager $signalingManager;
+	private ParticipantService $participantService;
 	/** @var IUrlGenerator */
 	private $urlGenerator;
 

--- a/lib/Signaling/Manager.php
+++ b/lib/Signaling/Manager.php
@@ -33,12 +33,9 @@ use OCP\IConfig;
 class Manager {
 	public const FEATURE_HEADER = 'X-Spreed-Signaling-Features';
 
-	/** @var IConfig */
-	protected $serverConfig;
-	/** @var Config */
-	protected $talkConfig;
-	/** @var ICache */
-	private $cache;
+	protected IConfig $serverConfig;
+	protected Config $talkConfig;
+	private ICache $cache;
 
 	public function __construct(IConfig $serverConfig,
 								Config $talkConfig,

--- a/lib/Signaling/Messages.php
+++ b/lib/Signaling/Messages.php
@@ -34,14 +34,11 @@ use OCP\IDBConnection;
 class Messages {
 	use TTransactional;
 
-	/** @var IDBConnection */
-	protected $db;
+	protected IDBConnection $db;
 
-	/** @var ParticipantService */
-	protected $participantService;
+	protected ParticipantService $participantService;
 
-	/** @var ITimeFactory */
-	protected $timeFactory;
+	protected ITimeFactory $timeFactory;
 
 	public function __construct(IDBConnection $db,
 								ParticipantService $participantService,

--- a/lib/Status/Listener.php
+++ b/lib/Status/Listener.php
@@ -36,8 +36,7 @@ use OCP\UserStatus\IManager;
 use OCP\UserStatus\IUserStatus;
 
 class Listener {
-	/** @var IManager $statusManager */
-	public $statusManager;
+	public IManager $statusManager;
 
 	public function __construct(IManager $statusManager) {
 		$this->statusManager = $statusManager;

--- a/lib/TalkSession.php
+++ b/lib/TalkSession.php
@@ -26,9 +26,7 @@ namespace OCA\Talk;
 use OCP\ISession;
 
 class TalkSession {
-
-	/** @var ISession */
-	protected $session;
+	protected ISession $session;
 
 	public function __construct(ISession $session) {
 		$this->session = $session;

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -46,8 +46,7 @@ class CapabilitiesTest extends TestCase {
 	protected $commentsManager;
 	/** @var IUserSession|MockObject */
 	protected $userSession;
-	/** @var array */
-	protected $baseFeatures;
+	protected ?array $baseFeatures = null;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/php/Chat/AutoComplete/SearchPluginTest.php
+++ b/tests/php/Chat/AutoComplete/SearchPluginTest.php
@@ -21,6 +21,7 @@
 
 namespace OCA\Talk\Tests\php\Chat\AutoComplete;
 
+use Test\TestCase;
 use OCA\Talk\Chat\AutoComplete\SearchPlugin;
 use OCA\Talk\Files\Util;
 use OCA\Talk\GuestManager;
@@ -36,7 +37,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class SearchPluginTest extends \Test\TestCase {
+class SearchPluginTest extends TestCase {
 
 	/** @var IUserManager|MockObject */
 	protected $userManager;
@@ -50,10 +51,8 @@ class SearchPluginTest extends \Test\TestCase {
 	protected $util;
 	/** @var IL10N|MockObject */
 	protected $l;
-	/** @var string */
-	protected $userId;
-	/** @var SearchPlugin */
-	protected $plugin;
+	protected ?string $userId = null;
+	protected SearchPlugin $plugin;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/php/Chat/AutoComplete/SorterTest.php
+++ b/tests/php/Chat/AutoComplete/SorterTest.php
@@ -23,22 +23,21 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Tests\php\Chat;
 
+use Test\TestCase;
 use OCA\Talk\Chat\AutoComplete\Sorter;
 use OCA\Talk\Chat\CommentsManager;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class SorterTest extends \Test\TestCase {
+class SorterTest extends TestCase {
 
 	/** @var CommentsManager|MockObject */
 	protected $commentsManager;
 
-	/** @var string */
-	protected $userId;
+	protected string $userId;
 
-	/** @var Sorter */
-	protected $sorter;
+	protected ?Sorter $sorter = null;
 
-	protected $user1 = [
+	protected array $user1 = [
 		'label' => 'Seattle',
 		'value' => [
 			'shareType' => 'user',
@@ -46,7 +45,7 @@ class SorterTest extends \Test\TestCase {
 		],
 	];
 
-	protected $user2 = [
+	protected array $user2 = [
 		'label' => 'New York',
 		'value' => [
 			'shareType' => 'user',
@@ -54,7 +53,7 @@ class SorterTest extends \Test\TestCase {
 		],
 	];
 
-	protected $user3 = [
+	protected array $user3 = [
 		'label' => 'ttle Sea',
 		'value' => [
 			'shareType' => 'user',

--- a/tests/php/Chat/ChatManagerTest.php
+++ b/tests/php/Chat/ChatManagerTest.php
@@ -70,8 +70,7 @@ class ChatManagerTest extends TestCase {
 	protected $timeFactory;
 	/** @var AttachmentService|MockObject */
 	protected $attachmentService;
-	/** @var ChatManager */
-	protected $chatManager;
+	protected ?ChatManager $chatManager = null;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/php/Chat/Command/ExecutorTest.php
+++ b/tests/php/Chat/Command/ExecutorTest.php
@@ -53,8 +53,7 @@ class ExecutorTest extends TestCase {
 	/** @var IL10N|MockObject */
 	protected $l10n;
 
-	/** @var Executor */
-	protected $executor;
+	protected ?Executor $executor = null;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/php/Chat/NotifierTest.php
+++ b/tests/php/Chat/NotifierTest.php
@@ -59,8 +59,7 @@ class NotifierTest extends TestCase {
 	/** @var Util|MockObject */
 	protected $util;
 
-	/** @var Notifier */
-	protected $notifier;
+	protected Notifier $notifier;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/php/Chat/Parser/UserMentionTest.php
+++ b/tests/php/Chat/Parser/UserMentionTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Tests\php\Chat\Parser;
 
+use Test\TestCase;
 use OCA\Talk\Chat\Parser\UserMention;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\GuestManager;
@@ -38,7 +39,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class UserMentionTest extends \Test\TestCase {
+class UserMentionTest extends TestCase {
 
 	/** @var ICommentsManager|MockObject */
 	protected $commentsManager;
@@ -49,8 +50,7 @@ class UserMentionTest extends \Test\TestCase {
 	/** @var IL10N|MockObject */
 	protected $l;
 
-	/** @var UserMention */
-	protected $parser;
+	protected ?UserMention $parser = null;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/php/Chat/SystemMessage/ListenerTest.php
+++ b/tests/php/Chat/SystemMessage/ListenerTest.php
@@ -44,8 +44,7 @@ use Test\TestCase;
 class ListenerTest extends TestCase {
 	public const DUMMY_REFERENCE_ID = 'DUMMY_REFERENCE_ID';
 
-	/** @var Listener */
-	protected $listener;
+	protected ?Listener $listener = null;
 
 	/** @var IRequest|MockObject */
 	protected $request;
@@ -61,10 +60,8 @@ class ListenerTest extends TestCase {
 	protected $timeFactory;
 	/** @var IEventDispatcher|MockObject */
 	protected $eventDispatcher;
-	/** @var array */
-	protected $handlers;
-	/** @var \DateTime */
-	protected $dummyTime;
+	protected ?array $handlers = null;
+	protected ?\DateTime $dummyTime = null;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/php/Collaboration/Collaborators/RoomPluginTest.php
+++ b/tests/php/Collaboration/Collaborators/RoomPluginTest.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Tests\php\Collaboration\Collaborators;
 
+use Test\TestCase;
 use OCA\Talk\Collaboration\Collaborators\RoomPlugin;
 use OCA\Talk\Manager;
 use OCA\Talk\Room;
@@ -34,22 +35,16 @@ use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Share\IShare;
 
-class RoomPluginTest extends \Test\TestCase {
+class RoomPluginTest extends TestCase {
+	protected ?Manager $manager = null;
 
-	/** @var Manager */
-	protected $manager;
+	protected ?IUserSession $userSession = null;
 
-	/** @var IUserSession */
-	protected $userSession;
+	protected ?IUser $user = null;
 
-	/** @var IUser */
-	protected $user;
+	protected ?ISearchResult $searchResult = null;
 
-	/** @var ISearchResult */
-	protected $searchResult;
-
-	/** @var RoomPlugin */
-	protected $plugin;
+	protected ?RoomPlugin $plugin = null;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/php/Collaboration/Resources/ConversationProviderTest.php
+++ b/tests/php/Collaboration/Resources/ConversationProviderTest.php
@@ -46,8 +46,7 @@ class ConversationProviderTest extends TestCase {
 	protected $userSession;
 	/** @var IURLGenerator|MockObject */
 	protected $urlGenerator;
-	/** @var ConversationProvider */
-	protected $provider;
+	protected ?ConversationProvider $provider = null;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -56,9 +56,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ChatControllerTest extends TestCase {
-
-	/** @var string */
-	private $userId;
+	private ?string $userId = null;
 	/** @var IUserManager|MockObject */
 	protected $userManager;
 	/** @var IAppManager|MockObject */
@@ -99,8 +97,7 @@ class ChatControllerTest extends TestCase {
 	/** @var Room|MockObject */
 	protected $room;
 
-	/** @var ChatController */
-	private $controller;
+	private ?ChatController $controller = null;
 
 	/** @var Callback */
 	private $newMessageDateTimeConstraint;

--- a/tests/php/Controller/SignalingControllerTest.php
+++ b/tests/php/Controller/SignalingControllerTest.php
@@ -22,6 +22,8 @@
 
 namespace OCA\Talk\Tests\php\Controller;
 
+use Test\TestCase;
+use OCP\IRequest;
 use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Config;
 use OCA\Talk\Controller\SignalingController;
@@ -67,10 +69,8 @@ class CustomInputSignalingController extends SignalingController {
 /**
  * @group DB
  */
-class SignalingControllerTest extends \Test\TestCase {
-
-	/** @var Config */
-	private $config;
+class SignalingControllerTest extends TestCase {
+	private ?Config $config = null;
 	/** @var TalkSession|MockObject */
 	private $session;
 	/** @var \OCA\Talk\Signaling\Manager|MockObject */
@@ -91,17 +91,13 @@ class SignalingControllerTest extends \Test\TestCase {
 	protected $timeFactory;
 	/** @var IClientService|MockObject */
 	protected $clientService;
-	/** @var string */
-	private $userId;
-	/** @var ISecureRandom */
-	private $secureRandom;
-	/** @var IEventDispatcher */
-	private $dispatcher;
+	private ?string $userId = null;
+	private ?ISecureRandom $secureRandom = null;
+	private ?IEventDispatcher $dispatcher = null;
 	/** @var LoggerInterface|MockObject */
 	private $logger;
 
-	/** @var CustomInputSignalingController */
-	private $controller;
+	private ?\OCA\Talk\Tests\php\Controller\CustomInputSignalingController $controller = null;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -135,7 +131,7 @@ class SignalingControllerTest extends \Test\TestCase {
 	private function recreateSignalingController() {
 		$this->controller = new CustomInputSignalingController(
 			'spreed',
-			$this->createMock(\OCP\IRequest::class),
+			$this->createMock(IRequest::class),
 			$this->config,
 			$this->signalingManager,
 			$this->session,

--- a/tests/php/Federation/FederationTest.php
+++ b/tests/php/Federation/FederationTest.php
@@ -48,11 +48,9 @@ use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class FederationTest extends TestCase {
-	/** @var FederationManager */
-	protected $federationManager;
+	protected ?FederationManager $federationManager = null;
 
-	/** @var Notifications */
-	protected $notifications;
+	protected ?Notifications $notifications = null;
 
 	/** @var ICloudFederationProviderManager|MockObject */
 	protected $cloudFederationProviderManager;
@@ -66,8 +64,7 @@ class FederationTest extends TestCase {
 	/** @var AddressHandler|MockObject */
 	protected $addressHandler;
 
-	/** @var CloudFederationProviderTalk */
-	protected $cloudFederationProvider;
+	protected ?CloudFederationProviderTalk $cloudFederationProvider = null;
 
 	/** @var IUserManager|MockObject */
 	protected $userManager;

--- a/tests/php/Listener/RestrictStartingCallsTest.php
+++ b/tests/php/Listener/RestrictStartingCallsTest.php
@@ -41,8 +41,7 @@ class RestrictStartingCallsTest extends TestCase {
 	protected $serverConfig;
 	/** @var ParticipantService|MockObject */
 	protected $participantService;
-	/** @var RestrictStartingCalls */
-	protected $listener;
+	protected ?RestrictStartingCalls $listener = null;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/php/Model/AttendeeMapperTest.php
+++ b/tests/php/Model/AttendeeMapperTest.php
@@ -33,9 +33,7 @@ use Test\TestCase;
  * @group DB
  */
 class AttendeeMapperTest extends TestCase {
-
-	/** @var AttendeeMapper */
-	protected $attendeeMapper;
+	protected ?AttendeeMapper $attendeeMapper = null;
 
 
 	public function setUp(): void {

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -21,6 +21,7 @@
 
 namespace OCA\Talk\Tests\php\Notifications;
 
+use Test\TestCase;
 use OCA\FederatedFileSharing\AddressHandler;
 use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Chat\MessageParser;
@@ -48,7 +49,7 @@ use OCP\RichObjectStrings\Definitions;
 use OCP\Share\IManager as IShareManager;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class NotifierTest extends \Test\TestCase {
+class NotifierTest extends TestCase {
 
 	/** @var IFactory|MockObject */
 	protected $lFactory;
@@ -74,8 +75,7 @@ class NotifierTest extends \Test\TestCase {
 	protected $messageParser;
 	/** @var Definitions|MockObject */
 	protected $definitions;
-	/** @var Notifier */
-	protected $notifier;
+	protected ?Notifier $notifier = null;
 	/** @var AddressHandler|MockObject */
 	protected $addressHandler;
 

--- a/tests/php/Service/ParticipantServiceTest.php
+++ b/tests/php/Service/ParticipantServiceTest.php
@@ -54,10 +54,8 @@ class ParticipantServiceTest extends TestCase {
 	protected $serverConfig;
 	/** @var Config|MockObject */
 	protected $talkConfig;
-	/** @var AttendeeMapper */
-	protected $attendeeMapper;
-	/** @var SessionMapper */
-	protected $sessionMapper;
+	protected ?AttendeeMapper $attendeeMapper = null;
+	protected ?SessionMapper $sessionMapper = null;
 	/** @var SessionService|MockObject */
 	protected $sessionService;
 	/** @var ISecureRandom|MockObject */
@@ -76,8 +74,7 @@ class ParticipantServiceTest extends TestCase {
 	protected $time;
 	/** @var ICacheFactory|MockObject */
 	protected $cacheFactory;
-	/** @var ParticipantService */
-	private $service;
+	private ?ParticipantService $service = null;
 
 
 	public function setUp(): void {

--- a/tests/php/Service/RoomServiceTest.php
+++ b/tests/php/Service/RoomServiceTest.php
@@ -46,8 +46,7 @@ class RoomServiceTest extends TestCase {
 	protected $shareManager;
 	/** @var IEventDispatcher|MockObject */
 	protected $dispatcher;
-	/** @var RoomService */
-	private $service;
+	private ?RoomService $service = null;
 
 
 	public function setUp(): void {

--- a/tests/php/Settings/Admin/AdminSettingsTest.php
+++ b/tests/php/Settings/Admin/AdminSettingsTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Tests\php\Settings\Admin;
 
+use Test\TestCase;
 use OCA\Talk\Config;
 use OCA\Talk\MatterbridgeManager;
 use OCA\Talk\Service\CommandService;
@@ -36,7 +37,7 @@ use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class AdminSettingsTest extends \Test\TestCase {
+class AdminSettingsTest extends TestCase {
 
 	/** @var Config|MockObject */
 	protected $talkConfig;
@@ -58,8 +59,7 @@ class AdminSettingsTest extends \Test\TestCase {
 	protected $l10n;
 	/** @var IFactory|MockObject  */
 	protected $l10nFactory;
-	/** @var AdminSettings */
-	protected $admin;
+	protected ?AdminSettings $admin = null;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/php/Settings/Admin/SectionTest.php
+++ b/tests/php/Settings/Admin/SectionTest.php
@@ -23,19 +23,19 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Tests\php\Settings\Admin;
 
+use Test\TestCase;
 use OCA\Talk\Settings\Admin\Section;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class SectionTest extends \Test\TestCase {
+class SectionTest extends TestCase {
 
 	/** @var IURLGenerator|MockObject */
 	protected $url;
 	/** @var IL10N|MockObject */
 	protected $l;
-	/** @var Section */
-	protected $admin;
+	protected ?Section $admin = null;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -22,6 +22,7 @@
 
 namespace OCA\Talk\Tests\php\Signaling;
 
+use Test\TestCase;
 use OCA\Talk\AppInfo\Application;
 use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Config;
@@ -51,7 +52,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
 class CustomBackendNotifier extends BackendNotifier {
-	private $requests = [];
+	private array $requests = [];
 
 	public function getRequests(): array {
 		return $this->requests;
@@ -72,12 +73,9 @@ class CustomBackendNotifier extends BackendNotifier {
 /**
  * @group DB
  */
-class BackendNotifierTest extends \Test\TestCase {
-
-	/** @var Config */
-	private $config;
-	/** @var ISecureRandom */
-	private $secureRandom;
+class BackendNotifierTest extends TestCase {
+	private ?Config $config = null;
+	private ?ISecureRandom $secureRandom = null;
 	/** @var ITimeFactory|MockObject */
 	private $timeFactory;
 	/** @var ParticipantService|MockObject */
@@ -86,25 +84,17 @@ class BackendNotifierTest extends \Test\TestCase {
 	private $signalingManager;
 	/** @var IURLGenerator|MockObject */
 	private $urlGenerator;
-	/** @var CustomBackendNotifier */
-	private $controller;
+	private ?\OCA\Talk\Tests\php\Signaling\CustomBackendNotifier $controller = null;
 
-	/** @var Manager */
-	private $manager;
+	private ?Manager $manager = null;
 
-	/** @var string */
-	private $userId;
-	/** @var string */
-	private $signalingSecret;
-	/** @var string */
-	private $baseUrl;
+	private ?string $userId = null;
+	private ?string $signalingSecret = null;
+	private ?string $baseUrl = null;
 
-	/** @var Application */
-	protected $app;
-	/** @var BackendNotifier */
-	protected $originalBackendNotifier;
-	/** @var IEventDispatcher */
-	private $dispatcher;
+	protected Application $app;
+	protected BackendNotifier $originalBackendNotifier;
+	private ?IEventDispatcher $dispatcher = null;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/php/TalkSessionTest.php
+++ b/tests/php/TalkSessionTest.php
@@ -35,8 +35,7 @@ class TalkSessionTest extends TestCase {
 	/** @var ISession|MockObject */
 	protected $session;
 
-	/** @var TalkSession */
-	protected $talkSession;
+	protected ?TalkSession $talkSession = null;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.10.0@916b098b008f6de4543892b1e0651c1c3b92cbfa">
+<files psalm-version="4.22.0@fc2c6ab4d5fa5d644d8617089f012f3bb84b8703">
   <file src="lib/AppInfo/Application.php">
     <UndefinedClass occurrences="2">
       <code>BeforeTemplateRenderedEvent</code>
@@ -8,7 +8,6 @@
     <UndefinedInterfaceMethod occurrences="1">
       <code>getSettingsManager</code>
     </UndefinedInterfaceMethod>
-    <InvalidArgument occurrences="16"/>
   </file>
   <file src="lib/BackgroundJob/CheckReferenceIdColumn.php">
     <UndefinedClass occurrences="1">
@@ -26,11 +25,10 @@
     </UndefinedVariable>
   </file>
   <file src="lib/Chat/Parser/SystemMessage.php">
-    <MissingDependency occurrences="4">
+    <MissingDependency occurrences="3">
       <code>$this-&gt;rootFolder</code>
       <code>IRootFolder</code>
       <code>IRootFolder</code>
-      <code>ShareNotFound</code>
     </MissingDependency>
     <UndefinedClass occurrences="1">
       <code>\OC_Util</code>
@@ -164,38 +162,16 @@
     <NullArgument occurrences="1">
       <code>null</code>
     </NullArgument>
-    <ParadoxicalCondition occurrences="1">
-      <code>\in_array($mode, $validModes, true)</code>
-    </ParadoxicalCondition>
   </file>
   <file src="lib/Controller/ChatController.php">
     <InvalidArrayOffset occurrences="1">
       <code>$commentIdToIndex[$parentId]</code>
     </InvalidArrayOffset>
   </file>
-  <file src="lib/Controller/FilesIntegrationController.php">
-    <InvalidCatch occurrences="1"/>
-    <MissingDependency occurrences="2">
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
-    </MissingDependency>
-  </file>
   <file src="lib/Controller/PageController.php">
     <MissingDependency occurrences="2">
       <code>IRootFolder</code>
       <code>IRootFolder</code>
-    </MissingDependency>
-    <UndefinedDocblockClass occurrences="4">
-      <code>HintException</code>
-      <code>HintException</code>
-      <code>HintException</code>
-      <code>HintException</code>
-    </UndefinedDocblockClass>
-  </file>
-  <file src="lib/Controller/PublicShareAuthController.php">
-    <InvalidCatch occurrences="1"/>
-    <MissingDependency occurrences="1">
-      <code>ShareNotFound</code>
     </MissingDependency>
   </file>
   <file src="lib/Controller/SettingsController.php">
@@ -209,20 +185,12 @@
     </InvalidArgument>
   </file>
   <file src="lib/Controller/SignalingController.php">
-    <UndefinedClass occurrences="1">
-      <code>\GuzzleHttp\Exception\ConnectException</code>
-    </UndefinedClass>
+    <UndefinedClass occurrences="1"/>
   </file>
   <file src="lib/Controller/TempAvatarController.php">
     <UndefinedClass occurrences="1">
       <code>Filesystem</code>
     </UndefinedClass>
-  </file>
-  <file src="lib/Federation/CloudFederationProviderTalk.php">
-    <MissingDependency occurrences="19">
-      <code>ShareNotFound</code>
-      <code>AuthenticationFailedException</code>
-    </MissingDependency>
   </file>
   <file src="lib/Files/TemplateLoader.php">
     <MissingDependency occurrences="2">
@@ -235,32 +203,22 @@
     </UndefinedClass>
   </file>
   <file src="lib/Files/Util.php">
-    <InvalidCatch occurrences="1"/>
-    <MissingDependency occurrences="7">
+    <MissingDependency occurrences="5">
       <code>$this-&gt;rootFolder</code>
       <code>$this-&gt;rootFolder</code>
       <code>$this-&gt;rootFolder</code>
       <code>IRootFolder</code>
       <code>IRootFolder</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
     </MissingDependency>
     <InvalidArgument occurrences="1">
       <code>SharedStorage::class</code>
     </InvalidArgument>
   </file>
   <file src="lib/MatterbridgeManager.php">
-    <UndefinedClass occurrences="3">
+    <UndefinedClass occurrences="7">
       <code>IAuthTokenProvider</code>
-      <code>IToken</code>
       <code>IToken</code>
     </UndefinedClass>
-    <UndefinedDocblockClass occurrences="4">
-      <code>$this-&gt;tokenProvider</code>
-      <code>$this-&gt;tokenProvider</code>
-      <code>$this-&gt;tokenProvider</code>
-      <code>IAuthTokenProvider</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="lib/Migration/Version2001Date20170707115443.php">
     <InvalidArrayAccess occurrences="1">
@@ -273,10 +231,6 @@
       <code>$this-&gt;rooms</code>
       <code>$this-&gt;rooms</code>
     </InvalidPropertyAssignmentValue>
-    <MissingDependency occurrences="1">
-      <code>ShareNotFound</code>
-    </MissingDependency>
-    <InvalidCatch occurrences="1"/>
   </file>
   <file src="lib/PublicShare/TemplateLoader.php">
     <UndefinedClass occurrences="1">
@@ -287,19 +241,6 @@
     <UndefinedClass occurrences="1">
       <code>BeforeTemplateRenderedEvent</code>
     </UndefinedClass>
-  </file>
-  <file src="lib/Service/HostedSignalingServerService.php">
-    <InvalidReturnStatement occurrences="1">
-      <code>$data</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>array</code>
-    </InvalidReturnType>
-  </file>
-  <file src="lib/Settings/Admin/AdminSettings.php">
-    <UndefinedInterfaceMethod occurrences="1">
-      <code>getLanguages</code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Share/Listener.php">
     <InvalidArgument occurrences="1">
@@ -320,23 +261,6 @@
       <code>new GenericEvent($existingShare)</code>
       <code>self::class . '::' . 'share_file_again'</code>
     </InvalidArgument>
-    <MissingDependency occurrences="15">
-      <code>GenericShareException</code>
-      <code>GenericShareException</code>
-      <code>GenericShareException</code>
-      <code>GenericShareException</code>
-      <code>GenericShareException</code>
-      <code>GenericShareException</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
-    </MissingDependency>
     <UndefinedClass occurrences="1">
       <code>Cache</code>
     </UndefinedClass>
@@ -345,8 +269,5 @@
     <MissingDependency occurrences="1">
       <code>IRootFolder</code>
     </MissingDependency>
-    <UndefinedClass occurrences="1">
-      <code>HintException</code>
-    </UndefinedClass>
   </file>
 </files>


### PR DESCRIPTION
## Background

I used [rector](https://github.com/rectorphp/rector) to do this big refactor with this code on rector.php:
```php
return static function (ContainerConfigurator $containerConfigurator): void {
	$parameters = $containerConfigurator->parameters();
	$parameters->set(Option::PATHS, [
		__DIR__ . '/lib',
		__DIR__ . '/tests/php',
	]);

	$parameters->set(Option::BOOTSTRAP_FILES, [
		__DIR__ . '/vendor/autoload.php',
		__DIR__ . '/../../lib/composer/autoload.php',
		__DIR__ . '/../../3rdparty/autoload.php',
	]);

	$parameters->set(Option::AUTO_IMPORT_NAMES, true);
	$parameters->set(Option::IMPORT_SHORT_CLASSES, false);

	$services = $containerConfigurator->services();
	$services->set(TypedPropertyRector::class)
		->configure([
			TypedPropertyRector::INLINE_PUBLIC => true,
		]);
};
```
I don't versioned this code (implementation of rector) because I think is very specific to do refactors, but is a good point to check if is necessary version.

## Steps
* [x] Fix the problems identified on PHPUnit.
* [x] Fix phpcs issues
* [x] Fix psalm issues 

Close #7079