### PR TITLE
Convert to null coalescing assignment operator

### DIFF
--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -970,12 +970,12 @@ class RoomShareProvider implements IShareProvider {
 
 				$userList = $this->participantService->getParticipantUserIds($room);
 				foreach ($userList as $uid) {
-					$users[$uid] = $users[$uid] ?? [];
+					$users[$uid] ??= [];
 					$users[$uid][$row['id']] = $row;
 				}
 			} elseif ($type === self::SHARE_TYPE_USERROOM && $currentAccess === true) {
 				$uid = $row['share_with'];
-				$users[$uid] = $users[$uid] ?? [];
+				$users[$uid] ??= [];
 				$users[$uid][$row['id']] = $row;
 			}
 		}


### PR DESCRIPTION
## Background
[Null coalescing assignment operator](https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.null-coalescing-assignment-operator) was implemented on PHP7.4 and make the code more clean.

## Steps
* [x] Configured Rector to apply this change
```php
return static function (ContainerConfigurator $containerConfigurator): void {
	$parameters = $containerConfigurator->parameters();
	$parameters->set(Option::PATHS, [
		__DIR__ . '/lib',
		__DIR__ . '/tests/php',
	]);

	$parameters->set(Option::BOOTSTRAP_FILES, [
		__DIR__ . '/vendor/autoload.php',
		__DIR__ . '/../../lib/composer/autoload.php',
		__DIR__ . '/../../3rdparty/autoload.php',
	]);

	$services = $containerConfigurator->services();
	$services->set(NullCoalescingOperatorRector::class);
};
```
* [x] Apply Rector rule `vendor/bin/rector`