### PR TITLE
Add CLI to run Talkbuchet

### DIFF
--- a/docs/Talkbuchet-cli.py
+++ b/docs/Talkbuchet-cli.py
@@ -544,6 +544,8 @@ class Talkbuchet:
         window.setSentVideoStreamEnabled = setSentVideoStreamEnabled
         window.checkPublishersConnections = checkPublishersConnections
         window.checkSubscribersConnections = checkSubscribersConnections
+        window.printPublisherStats = printPublisherStats
+        window.printSubscriberStats = printSubscriberStats
         window.setCredentials = setCredentials
         window.setToken = setToken
         window.setPublishersAndSubscribersCount = setPublishersAndSubscribersCount
@@ -660,6 +662,24 @@ class Talkbuchet:
         """
 
         self.seleniumHelper.execute('checkSubscribersConnections()')
+
+    def printPublisherStats(self, publisherSessionId):
+        """
+        Prints the stats of the given publisher connection.
+
+        :param publisherSessionId: the session ID of the publisher.
+        """
+
+        self.seleniumHelper.executeAsync('await printPublisherStats(\'' + publisherSessionId + '\', true)')
+
+    def printSubscriberStats(self, index):
+        """
+        Prints the stats of the given subscriber connection.
+
+        :param index: the index of the subscriber in the list of subscribers.
+        """
+
+        self.seleniumHelper.executeAsync('await printSubscriberStats(' + str(index) + ', true)')
 
     def setPublishersAndSubscribersCount(self, publishersCount, subscribersPerPublisherCount):
         """

--- a/docs/Talkbuchet-cli.py
+++ b/docs/Talkbuchet-cli.py
@@ -525,6 +525,8 @@ class TalkbuchetCommon:
         # Explicitly assign all the needed functions defined in Talkbuchet.js to
         # the Window object to be able to access them at a later point.
         talkbuchet = talkbuchet + '''
+        window.getPublishers = getPublishers
+        window.getSubscribers = getSubscribers
         window.closeConnections = closeConnections
         window.setAudioEnabled = setAudioEnabled
         window.setVideoEnabled = setVideoEnabled
@@ -540,6 +542,7 @@ class TalkbuchetCommon:
         window.startMedia = startMedia
         window.setConnectionWarningTimeout = setConnectionWarningTimeout
         window.siege = siege
+        window.getVirtualParticipant = getVirtualParticipant
         window.startVirtualParticipant = startVirtualParticipant
         window.stopVirtualParticipant = stopVirtualParticipant
         window.sendMediaEnabledStateThroughDataChannel = sendMediaEnabledStateThroughDataChannel

--- a/docs/Talkbuchet-cli.py
+++ b/docs/Talkbuchet-cli.py
@@ -1,0 +1,356 @@
+#
+# @copyright Copyright (c) 2022, Daniel Calviño Sánchez (danxuliu@gmail.com)
+#
+# @license GNU AGPL version 3 or any later version
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Helper script that provides a command line interface for Talkbuchet, the helper
+tool for load/stress testing of Nextcloud Talk.
+
+Talkbuchet is a JavaScript script (Talkbuchet.js), and it is run using a web
+browser. A Python script (Talkbuchet-cli.py) is provided to launch a web
+browser, load Talkbuchet and control it from a command line interface (which
+requires Selenium and certain Python packages to be available in the system).
+
+Please refer to the documentation in Talkbuchet.js for information on
+Talkbuchet.
+
+Talkbuchet-cli.py provides a wrapper class to start and interact with
+Talkbuchet.js instances. Creating an object of the wrapper class launches a new
+browser instance, opens the given Nextcloud URL and loads Talkbuchet.js on it.
+After that the methods in the object call their counterpart in the wrapped
+Talkbuchet.js instance; the wrapper objects provide full control of their
+wrapped Talkbuchet.js instance.
+"""
+
+import atexit
+
+from pathlib import Path
+from selenium import webdriver
+from shutil import disk_usage
+
+
+class SeleniumHelper:
+    """
+    Helper class to start a browser and execute scripts in it using Selenium.
+
+    By default the browser will be started in headless mode, so the browser will
+    not be visible. It is not possible to make it visible once the browser was
+    launched; in order to show it the browser has to be started again in
+    non-headless mode.
+
+    The browser, as well as the Selenium server, are expected to be available in
+    the local system. A remote Selenium server can be used instead by specifying
+    the URL when starting the browser. However, when a remote Selenium server is
+    used its session timeout (which is independent from the timeouts set in the
+    driver) must be kept in mind, as it can cause the browser to "unexpectedly"
+    close.
+    """
+
+    def __init__(self):
+        self.driver = None
+
+    def __del__(self):
+        if self.driver:
+            # The session must be explicitly quit to remove the temporary files
+            # created in "/tmp".
+            self.driver.quit()
+
+    def startChrome(self, headless = True, remoteSeleniumUrl = None):
+        """
+        Starts a Chrome instance.
+
+        :param headless: whether the browser will be started in headless mode or
+            not; headless mode is used by default.
+        :param remoteSeleniumUrl: the URL of the Selenium server to connect to;
+            the local server is used by default.
+        """
+
+        options = webdriver.ChromeOptions()
+        options.set_capability("goog:loggingPrefs", { 'browser': 'ALL' })
+        options.add_argument('--use-fake-device-for-media-stream')
+        options.add_argument('--use-fake-ui-for-media-stream')
+
+        # Headless mode uses a little less memory on each instance.
+        if headless:
+            options.add_argument('--headless')
+
+        if remoteSeleniumUrl:
+            self.driver = webdriver.Remote(
+                command_executor=remoteSeleniumUrl,
+                options=options
+            )
+        else:
+            # Error messages like "Failed to fetch" or crashes when starting the
+            # driver are usually caused by not having enough space in "/dev/shm"
+            # or in "/tmp".
+            # Using "/dev/shm" provides better performance, but it is not
+            # strictly needed, so it can be disabled if there is not enough free
+            # space. The limit is set to 64 MiB just based on the memory usage
+            # observed during some tests.
+            if disk_usage('/dev/shm').free < 67108864:
+                print('Less than 64 MiB available in "/dev/shm", usage disabled')
+
+                options.add_argument("--disable-dev-shm-usage")
+
+            if disk_usage('/tmp').free < 134217728:
+                print('Warning: less than 128 MiB available in "/tmp", strange failures may occur')
+
+            self.driver = webdriver.Chrome(
+                options=options
+            )
+
+    def clearLogs(self):
+        """
+        Clears browser logs not printed yet.
+
+        This does not affect the logs in the browser itself, only the ones
+        received by the SeleniumHelper.
+        """
+
+        self.driver.get_log('browser')
+
+    def printLogs(self):
+        """
+        Prints browser logs received since last print.
+        """
+
+        for log in self.driver.get_log('browser'):
+            print(log['message'])
+
+    def execute(self, script):
+        """
+        Executes the given script.
+        """
+
+        self.driver.execute_script(script)
+
+        self.printLogs()
+
+
+class Talkbuchet:
+    """
+    Wrapper for Talkbuchet.
+
+    Talkbuchet wrappers load Talkbuchet on a given Nextcloud URL and provide
+    methods to call the different Talkbuchet functions in the browser.
+    """
+
+    def __init__(self, nextcloudUrl, headless = True, remoteSeleniumUrl = None):
+        """
+        Loads Talkbuchet on the given Nextcloud URL.
+
+        :param nextcloudUrl: the URL of the Nextcloud instance to load
+            Talkbuchet on.
+        :param headless: whether the browser will be started in headless mode or
+            not; headless mode is used by default.
+        :param remoteSeleniumUrl: the URL of the Selenium server to connect to;
+            the local server is used by default.
+        """
+
+        # Set default values from Talkbuchet.js.
+        self.publishersCount = 5
+        self.subscribersPerPublisherCount = 40
+        self.connectionWarningTimeout = 5000
+
+        self.seleniumHelper = SeleniumHelper()
+
+        self.seleniumHelper.startChrome(headless, remoteSeleniumUrl)
+
+        self.seleniumHelper.driver.get(nextcloudUrl)
+
+        self.__loadTalkbuchet()
+
+    def __loadTalkbuchet(self):
+        talkbuchet = Path('Talkbuchet.js').read_text()
+
+        # Explicitly assign all the needed functions defined in Talkbuchet.js to
+        # the Window object to be able to access them at a later point.
+        talkbuchet = talkbuchet + '''
+        window.closeConnections = closeConnections
+        window.setAudioEnabled = setAudioEnabled
+        window.setVideoEnabled = setVideoEnabled
+        window.setSentAudioStreamEnabled = setSentAudioStreamEnabled
+        window.setSentVideoStreamEnabled = setSentVideoStreamEnabled
+        window.checkPublishersConnections = checkPublishersConnections
+        window.checkSubscribersConnections = checkSubscribersConnections
+        window.setCredentials = setCredentials
+        window.setToken = setToken
+        window.setPublishersAndSubscribersCount = setPublishersAndSubscribersCount
+        window.startMedia = startMedia
+        window.setConnectionWarningTimeout = setConnectionWarningTimeout
+        window.siege = siege
+        '''
+
+        # Clear previous logs
+        self.seleniumHelper.clearLogs()
+
+        self.seleniumHelper.execute(talkbuchet)
+
+    def setAudioEnabled(self, audioEnabled):
+        """
+        Sets the enabled state of the audio track in the media stream.
+
+        :param audioEnabled: True to enable, False to disable.
+        """
+
+        self.seleniumHelper.execute('setAudioEnabled(' + ('true' if audioEnabled else 'false') + ')')
+
+    def setVideoEnabled(self, videoEnabled):
+        """
+        Sets the enabled state of the video track in the media stream.
+
+        :param videoEnabled: True to enable, False to disable.
+        """
+
+        self.seleniumHelper.execute('setVideoEnabled(' + ('true' if videoEnabled else 'false') + ')')
+
+    def setSentAudioStreamEnabled(self, sentAudioStreamEnabled):
+        """
+        Sets whether the audio track is sent or not.
+
+        :param sentAudioStreamEnabled: True to send the actual track, False to
+            send a null track.
+        """
+
+        self.seleniumHelper.execute('setSentAudioStreamEnabled(' + ('true' if sentAudioStreamEnabled else 'false') + ')')
+
+    def setSentVideoStreamEnabled(self, sentVideoStreamEnabled):
+        """
+        Sets whether the video track is sent or not.
+
+        :param sentVideoStreamEnabled: True to send the actual track, False to
+            send a null track.
+        """
+
+        self.seleniumHelper.execute('setSentVideoStreamEnabled(' + ('true' if sentVideoStreamEnabled else 'false') + ')')
+
+    def setCredentials(self, user, appToken):
+        """
+        The user and app token to use.
+
+        An app token/password can be generated in the Security section of the
+        personal settings (index.php/settings/user/security).
+
+        The credentials always need to be set.
+
+        :param user: the user ID.
+        :param appToken: the app token for the user.
+        """
+
+        self.seleniumHelper.execute('setCredentials(\'' + user + '\', \'' + appToken + '\')')
+
+    def setToken(self, token):
+        """
+        Sets the conversation token to use.
+
+        This should be set only when conversation clustering is enabled in the
+        server.
+
+        :param token: the conversation token.
+        """
+
+        self.seleniumHelper.execute('setToken(\'' + token + '\')')
+
+    def startMedia(self, audio, video):
+        """
+        Starts the media stream to be used by publishers.
+
+        By default audio will be used.
+
+        Only one media stream can be active at the same time, so any previous
+        stream is stopped when starting a new one. This should be done only when
+        the siege is not active.
+
+        :param audio: True to start audio, False otherwise
+        :param video: True to start video, False otherwise
+        """
+
+        self.seleniumHelper.execute('await startMedia(' + ('true' if audio else 'false') + ', ' + ('true' if video else 'false') + ')')
+
+    def closeConnections(self):
+        """
+        Stops the siege by closing the publisher and subscriber connections
+
+        As the media stream is no longer needed it is also stopped.
+        """
+
+        self.seleniumHelper.execute('closeConnections()')
+
+    def checkPublishersConnections(self):
+        """
+        Prints the state of the publisher connections.
+        """
+
+        self.seleniumHelper.execute('checkPublishersConnections()')
+
+    def checkSubscribersConnections(self):
+        """
+        Prints the state of the subscriber connections.
+        """
+
+        self.seleniumHelper.execute('checkSubscribersConnections()')
+
+    def setPublishersAndSubscribersCount(self, publishersCount, subscribersPerPublisherCount):
+        """
+        Sets the number of publishers and subscribers per publisher to use.
+
+        If not explicitly set the default number from Talkbuchet.js is used,
+        which is 5 publishers and 40 subscribers per publisher.
+
+        :param publishersCount: the number of publishers.
+        :param subscribersPerPublisherCount: the number of subscribers for each
+            publisher.
+        """
+
+        self.publishersCount = publishersCount
+        self.subscribersPerPublisherCount = subscribersPerPublisherCount
+
+        self.seleniumHelper.execute('setPublishersAndSubscribersCount(' + str(publishersCount) + ', ' + str(subscribersPerPublisherCount) + ')')
+
+    def setConnectionWarningTimeout(self, connectionWarningTimeout):
+        """
+        Sets the milliseconds to wait before warning about connection problems.
+
+        A message is printed when a connection was not established after or has
+        been disconnected for more than the given time. However, note that the
+        message might not be printed in CLI until another command is executed.
+
+        :param connectionWarningTimeout: the milliseconds to wait before
+            warning about connection issues.
+        """
+
+        self.connectionWarningTimeout = connectionWarningTimeout
+
+        self.seleniumHelper.execute('setConnectionWarningTimeout(' + str(connectionWarningTimeout) + ')')
+
+    def siege(self):
+        """
+        Starts a siege.
+        """
+
+        savedScriptTimeout = self.seleniumHelper.driver.timeouts.script
+
+        # Adjust script timeout to prevent it from ending before the siege has
+        # started.
+        scriptTimeout = (self.publishersCount + self.publishersCount * self.subscribersPerPublisherCount) * (self.connectionWarningTimeout / 1000)
+        if scriptTimeout > savedScriptTimeout:
+            self.seleniumHelper.driver.set_script_timeout(scriptTimeout)
+
+        self.seleniumHelper.execute('await siege()')
+
+        self.seleniumHelper.driver.set_script_timeout(savedScriptTimeout)

--- a/docs/Talkbuchet-cli.py
+++ b/docs/Talkbuchet-cli.py
@@ -24,10 +24,13 @@ tool for load/stress testing of Nextcloud Talk.
 Talkbuchet is a JavaScript script (Talkbuchet.js), and it is run using a web
 browser. A Python script (Talkbuchet-cli.py) is provided to launch a web
 browser, load Talkbuchet and control it from a command line interface (which
-requires Selenium and certain Python packages to be available in the system).
+requires Selenium and certain Python packages to be available in the system). A
+Bash script (Talkbuchet-run.sh) is provided to set up a Docker container with
+Selenium, a web browser and all the needed Python dependencies for
+Talkbuchet-cli.py.
 
-Please refer to the documentation in Talkbuchet.js for information on
-Talkbuchet.
+Please refer to the documentation in Talkbuchet.js and Talkbuchet-run.sh for
+information on Talkbuchet and on how to easily run it.
 
 Talkbuchet-cli.py provides a wrapper class to start and interact with
 Talkbuchet.js instances. Creating an object of the wrapper class launches a new

--- a/docs/Talkbuchet-run.sh
+++ b/docs/Talkbuchet-run.sh
@@ -135,9 +135,15 @@ Options (all options can be omitted, but when present they must appear in the
 following order):
 --help prints this help and exits.
 --container CONTAINER_NAME the name to assign to the container. Defaults to
-  talkbuchet-selenium.
---selenium-image SELENIUM_IMAGE the name of the Selenium image to use. If not
-  given a Chrome image will be used by default.
+  talkbuchet-selenium, talkbuchet-selenium-chrome or talkbuchet-selenium-firefox
+  depending on the image options.
+--selenium-image SELENIUM_IMAGE or --chrome or --firefox:
+  --selenium-image SELENIUM_IMAGE the name of the Selenium image to use. No
+    matter the image, the default container name will be talkbuchet-selenium. If
+    no specific image is given a Firefox image will be used by default (and
+    talkbuchet-selenium-firefox will be used as the default container name).
+  --chrome use a Selenium image with Chrome.
+  --firefox use a Selenium image with Firefox.
 --vnc-port PORT_NUMBER the port used to map the VNC server in the host. Defaults
   to 5900.
 --web-vnc-port PORT_NUMBER the port used to map the web VNC server in the host.
@@ -150,21 +156,43 @@ if [ "$1" = "--help" ]; then
 	exit 0
 fi
 
-CONTAINER="talkbuchet-selenium"
+CUSTOM_CONTAINER_NAME=false
+CONTAINER="talkbuchet-selenium-firefox"
 if [ "$1" = "--container" ]; then
 	CONTAINER="$2"
+	CUSTOM_CONTAINER_NAME=true
 
 	shift 2
 fi
 
 CUSTOM_CONTAINER_OPTIONS=false
 
-SELENIUM_IMAGE="selenium/standalone-chrome:101.0-20220427"
+SELENIUM_IMAGE="selenium/standalone-firefox:99.0-20220427"
 if [ "$1" = "--selenium-image" ]; then
 	SELENIUM_IMAGE="$2"
 	CUSTOM_CONTAINER_OPTIONS=true
 
+	if ! $CUSTOM_CONTAINER_NAME; then
+		CONTAINER="talkbuchet-selenium"
+	fi
+
 	shift 2
+elif [ "$1" = "--chrome" ]; then
+	SELENIUM_IMAGE="selenium/standalone-chrome:101.0-20220427"
+
+	if $CUSTOM_CONTAINER_NAME; then
+		CUSTOM_CONTAINER_OPTIONS=true
+	else
+		CONTAINER="talkbuchet-selenium-chrome"
+	fi
+
+	shift 1
+elif [ "$1" = "--firefox" ]; then
+	if $CUSTOM_CONTAINER_NAME; then
+		CUSTOM_CONTAINER_OPTIONS=true
+	fi
+
+	shift 1
 fi
 
 VNC_PORT="5900"

--- a/docs/Talkbuchet-run.sh
+++ b/docs/Talkbuchet-run.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+
+# @copyright Copyright (c) 2022, Daniel Calviño Sánchez (danxuliu@gmail.com)
+#
+# @license GNU AGPL version 3 or any later version
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Helper script to run Talkbuchet, the helper tool for load/stress testing of
+# Nextcloud Talk.
+#
+# Talkbuchet is a JavaScript script (Talkbuchet.js), and it is run using a web
+# browser. A Python script (Talkbuchet-cli.py) is provided to launch a web
+# browser, load Talkbuchet and control it from a command line interface (which
+# requires Selenium and certain Python packages to be available in the system).
+# A Bash script (Talkbuchet-run.sh) is provided to set up a Docker container
+# with Selenium, a web browser and all the needed Python dependencies for
+# Talkbuchet-cli.py.
+#
+# Please refer to the documentation in Talkbuchet.js and Talkbuchet-cli.py for
+# information on Talkbuchet and how to control it.
+#
+# Talkbuchet-run.sh creates a Selenium container, installs all the needed
+# dependencies in it and executes Talkbuchet-cli.py inside the container. The
+# command line interface will automatically use the Selenium server from the
+# container, so as soon as the command line interface is shown Talkbuchet is
+# ready to be used. If the container exists already the previous container will
+# be reused and Talkbuchet-run.sh will simply execute Talkbuchet-cli.py in it.
+#
+# Due to that the Docker container will not be stopped nor removed when the
+# script exits (except when the container was created but it could not be
+# started); that must be explicitly done once the container is no longer needed.
+# If the Selenium container can not be started then the script will be exited
+# immediately with an error state; the most common cause for the Selenium
+# container to fail to start is that another process is already using the mapped
+# ports in the host.
+#
+# As the web browsers are run inside the Docker container they are not visible
+# by default. However, they can be viewed using VNC (for example,
+# "vncviewer 127.0.0.1:5900"). The Selenium Docker images also support web VNC,
+# so the web browsers can also be viewed navigating to "http://127.0.0.1:7900"
+# in a web browser outside the Docker container. In both cases, when asked for
+# the password use "secret".
+#
+# Besides that, by default Talkbuchet-cli.py starts the web browsers in headless
+# mode, so "setHeadless(False)" should be called in the command line interface
+# before starting a web browser to be able to view it.
+#
+#
+#
+# DOCKER AND PERMISSIONS
+#
+# To perform its job, this script requires the "docker" command to be available.
+#
+# The Docker Command Line Interface (the "docker" command) requires special
+# permissions to talk to the Docker daemon, and those permissions are typically
+# available only to the root user. Please see the Docker documentation to find
+# out how to give access to a regular user to the Docker daemon:
+# https://docs.docker.com/engine/installation/linux/linux-postinstall/
+#
+# Note, however, that being able to communicate with the Docker daemon is the
+# same as being able to get root privileges for the system. Therefore, you must
+# give access to the Docker daemon (and thus run this script as) ONLY to trusted
+# and secure users:
+# https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface
+
+# Sets the variables that abstract the differences in command names and options
+# between operating systems.
+#
+# Switches between timeout on GNU/Linux and gtimeout on macOS (same for mktemp
+# and gmktemp).
+function setOperatingSystemAbstractionVariables() {
+	case "$OSTYPE" in
+		darwin*)
+			if [ "$(which gtimeout)" == "" ]; then
+				echo "Please install coreutils (brew install coreutils)"
+				exit 1
+			fi
+
+			MKTEMP=gmktemp
+			TIMEOUT=gtimeout
+			DOCKER_OPTIONS="-e no_proxy=localhost "
+			;;
+		linux*)
+			MKTEMP=mktemp
+			TIMEOUT=timeout
+			DOCKER_OPTIONS=" "
+			;;
+		*)
+			echo "Operating system ($OSTYPE) not supported"
+			exit 1
+			;;
+	esac
+}
+
+# Removes Docker container if it was created but failed to start.
+function cleanUp() {
+	# Disable (yes, "+" disables) exiting immediately on errors to ensure that
+	# all the cleanup commands are executed (well, no errors should occur during
+	# the cleanup anyway, but just in case).
+	set +o errexit
+
+	# The name filter must be specified as "^/XXX$" to get an exact match; using
+	# just "XXX" would match every name that contained "XXX".
+	if [ -n "$(docker ps --all --quiet --filter status=created --filter name="^/$CONTAINER$")" ]; then
+		echo "Removing Docker container $CONTAINER"
+		docker rm --volumes --force $CONTAINER
+	fi
+}
+
+# Exit immediately on errors.
+set -o errexit
+
+# Execute cleanUp when the script exits, either normally or due to an error.
+trap cleanUp EXIT
+
+# Ensure working directory is script directory, as some actions (like copying
+# Talkbuchet to the container) expect that.
+cd "$(dirname $0)"
+
+HELP="Usage: $(basename $0) [OPTION]...
+
+Options (all options can be omitted, but when present they must appear in the
+following order):
+--help prints this help and exits.
+--container CONTAINER_NAME the name to assign to the container. Defaults to
+  talkbuchet-selenium.
+--selenium-image SELENIUM_IMAGE the name of the Selenium image to use. If not
+  given a Chrome image will be used by default.
+--vnc-port PORT_NUMBER the port used to map the VNC server in the host. Defaults
+  to 5900.
+--web-vnc-port PORT_NUMBER the port used to map the web VNC server in the host.
+  Defaults to 7900.
+--dev-shm-size SIZE the size to assign to /dev/shm in the Docker container.
+  Defaults to 2g"
+if [ "$1" = "--help" ]; then
+	echo "$HELP"
+
+	exit 0
+fi
+
+CONTAINER="talkbuchet-selenium"
+if [ "$1" = "--container" ]; then
+	CONTAINER="$2"
+
+	shift 2
+fi
+
+CUSTOM_CONTAINER_OPTIONS=false
+
+SELENIUM_IMAGE="selenium/standalone-chrome:101.0-20220427"
+if [ "$1" = "--selenium-image" ]; then
+	SELENIUM_IMAGE="$2"
+	CUSTOM_CONTAINER_OPTIONS=true
+
+	shift 2
+fi
+
+VNC_PORT="5900"
+if [ "$1" = "--vnc-port" ]; then
+	VNC_PORT="$2"
+	CUSTOM_CONTAINER_OPTIONS=true
+
+	shift 2
+fi
+
+WEB_VNC_PORT="7900"
+if [ "$1" = "--web-vnc-port" ]; then
+	WEB_VNC_PORT="$2"
+	CUSTOM_CONTAINER_OPTIONS=true
+
+	shift 2
+fi
+
+# 2g is the default value recommended in the documentation of the Docker images
+# for Selenium:
+# https://github.com/SeleniumHQ/docker-selenium#--shm-size2g
+DEV_SHM_SIZE="2g"
+if [ "$1" = "--dev-shm-size" ]; then
+	DEV_SHM_SIZE="$2"
+	CUSTOM_CONTAINER_OPTIONS=true
+
+	shift 2
+fi
+
+if [ -n "$1" ]; then
+	echo "Invalid option (or at invalid position): $1
+
+$HELP"
+
+	exit 1
+fi
+
+setOperatingSystemAbstractionVariables
+
+# If the container is not found a new one is prepared. Otherwise the existing
+# container is used.
+#
+# The name filter must be specified as "^/XXX$" to get an exact match; using
+# just "XXX" would match every name that contained "XXX".
+if [ -z "$(docker ps --all --quiet --filter name="^/$CONTAINER$")" ]; then
+	echo "Creating Selenium container"
+	docker run --detach --name=$CONTAINER --publish $VNC_PORT:5900 --publish $WEB_VNC_PORT:7900 --shm-size=$DEV_SHM_SIZE $DOCKER_OPTIONS $SELENIUM_IMAGE
+
+	echo "Installing required Python modules"
+	docker exec --user root $CONTAINER bash -c "apt-get update && apt-get install --assume-yes python3-pip && pip install selenium websocket-client"
+
+	echo "Copying Talkbuchet to the container"
+	docker cp Talkbuchet.js $CONTAINER:/tmp/
+	docker cp Talkbuchet-cli.py $CONTAINER:/tmp/
+elif $CUSTOM_CONTAINER_OPTIONS; then
+	echo "WARNING: Using existing container, custom container options ignored"
+fi
+
+# Start existing container if it is stopped.
+if [ -n "$(docker ps --all --quiet --filter status=exited --filter name="^/$CONTAINER$")" ]; then
+	echo "Starting Selenium container"
+	docker start $CONTAINER
+fi
+
+echo "Starting Talkbuchet CLI"
+docker exec --tty --interactive --workdir /tmp $CONTAINER python3 -i /tmp/Talkbuchet-cli.py

--- a/docs/Talkbuchet.js
+++ b/docs/Talkbuchet.js
@@ -447,13 +447,11 @@ class Peer {
 			}
 		})
 
-		const connectionTimeout = 5
-
 		setTimeout(() => {
 			if (!this.connected) {
-				this.connectedPromiseReject('Peer has not connected in ' + connectionTimeout + ' seconds')
+				this.connectedPromiseReject('Peer has not connected in ' + connectionWarningTimeout + ' seconds')
 			}
-		}, connectionTimeout * 1000)
+		}, connectionWarningTimeout)
 
 		return this.connectedPromise
 	}

--- a/docs/Talkbuchet.js
+++ b/docs/Talkbuchet.js
@@ -865,6 +865,16 @@ async function initSubscribers() {
 	listenToSubscriberConnectionChanges()
 }
 
+// Expose publishers to CLI.
+const getPublishers = function() {
+	return publishers
+}
+
+// Expose subscribers to CLI.
+const getSubscribers = function() {
+	return subscribers
+}
+
 const closeConnections = function() {
 	subscribers.forEach(subscriber => {
 		subscriber.peerConnection.close()
@@ -1089,6 +1099,11 @@ const siege = async function() {
 
 	await initPublishers()
 	await initSubscribers()
+}
+
+// Expose virtual participant to CLI.
+const getVirtualParticipant = function() {
+	return virtualParticipant
 }
 
 const startVirtualParticipant = async function() {

--- a/docs/Talkbuchet.js
+++ b/docs/Talkbuchet.js
@@ -296,6 +296,10 @@ class Signaling extends EventTarget {
 			const error = event.detail
 
 			console.warn(error)
+
+			if (error.code === 'not_allowed') {
+				console.info('Is "allowsubscribeany = true" set in the signaling server configuration?')
+			}
 		})
 	}
 

--- a/docs/Talkbuchet.js
+++ b/docs/Talkbuchet.js
@@ -26,9 +26,12 @@
  * browser. A Python script (Talkbuchet-cli.py) is provided to launch a web
  * browser, load Talkbuchet and control it from a command line interface (which
  * requires Selenium and certain Python packages to be available in the system).
+ * A Bash script (Talkbuchet-run.sh) is provided to set up a Docker container
+ * with Selenium, a web browser and all the needed Python dependencies for
+ * Talkbuchet-cli.py.
  *
- * Please refer to the documentation in Talkbuchet-cli.py for information on how
- * to control Talkbuchet.
+ * Please refer to the documentation in Talkbuchet-cli.py and Talkbuchet-run.sh
+ * for information on how to control Talkbuchet and easily run it.
  *
  * A High Performance Backend (HPB) server must be configured in Nextcloud Talk
  * to use Talkbuchet.

--- a/docs/Talkbuchet.js
+++ b/docs/Talkbuchet.js
@@ -283,13 +283,6 @@ class Signaling extends EventTarget {
 
 			this.sessionId = sessionId
 			resolveSessionId(sessionId)
-
-			if (!user) {
-				// If the current user is a guest the room needs to be joined,
-				// as guests are kicked out if they just open a session in the
-				// signaling server.
-				this.joinRoom()
-			}
 		})
 
 		this.addEventListener('error', event => {

--- a/docs/Talkbuchet.js
+++ b/docs/Talkbuchet.js
@@ -20,11 +20,27 @@
  */
 
 /**
- * HOW TO SETUP:
+ * Talkbuchet is the helper tool for load/stress testing of Nextcloud Talk.
+ *
+ * Talkbuchet is a JavaScript script (Talkbuchet.js), and it is run using a web
+ * browser. A Python script (Talkbuchet-cli.py) is provided to launch a web
+ * browser, load Talkbuchet and control it from a command line interface (which
+ * requires Selenium and certain Python packages to be available in the system).
+ *
+ * Please refer to the documentation in Talkbuchet-cli.py for information on how
+ * to control Talkbuchet.
+ *
+ * A High Performance Backend (HPB) server must be configured in Nextcloud Talk
+ * to use Talkbuchet.
+ *
+ * HOW TO SETUP (without using the CLI):
  * -----------------------------------------------------------------------------
  * - In the browser, log in the Nextcloud server (with the same user as in this
  *   script).
  * - Copy and paste the full script in the console of the browser.
+ *
+ * HOW TO RUN:
+ * -----------------------------------------------------------------------------
  * - Set the user and appToken (a user must be used; guests do not work;
  *   generate an apptoken at index.php/settings/user/security) by calling
  *   "setCredentials(user, appToken)" in the console.
@@ -36,9 +52,6 @@
  *   regular call with N participants you would have N publishers and N-1
  *   subscribers) by calling "setPublishersAndSubscribersCount(publishersCount,
  *   subscribersPerPublisherCount)" in the console.
- *
- * HOW TO RUN:
- * -----------------------------------------------------------------------------
  * - Once all the needed parameters are set execute "siege()" in the console.
  * - To run it again execute "siege()" again in the console; if any parameter
  *   needs to be changed it is recommended to first stop the previous siege by

--- a/docs/Talkbuchet.js
+++ b/docs/Talkbuchet.js
@@ -682,7 +682,7 @@ const closeConnections = function() {
 }
 
 const setAudioEnabled = function(enabled) {
-	if (!stream.getAudioTracks().length) {
+	if (!stream || !stream.getAudioTracks().length) {
 		console.error('Audio was not initialized')
 
 		return
@@ -693,7 +693,7 @@ const setAudioEnabled = function(enabled) {
 }
 
 const setVideoEnabled = function(enabled) {
-	if (!stream.getVideoTracks().length) {
+	if (!stream || !stream.getVideoTracks().length) {
 		console.error('Video was not initialized')
 
 		return
@@ -704,7 +704,7 @@ const setVideoEnabled = function(enabled) {
 }
 
 const setSentAudioStreamEnabled = function(enabled) {
-	if (!stream.getAudioTracks().length) {
+	if (!stream || !stream.getAudioTracks().length) {
 		console.error('Audio was not initialized')
 
 		return
@@ -723,7 +723,7 @@ const setSentAudioStreamEnabled = function(enabled) {
 }
 
 const setSentVideoStreamEnabled = function(enabled) {
-	if (!stream.getVideoTracks().length) {
+	if (!stream || !stream.getVideoTracks().length) {
 		console.error('Video was not initialized')
 
 		return

--- a/docs/Talkbuchet.js
+++ b/docs/Talkbuchet.js
@@ -757,8 +757,10 @@ const setSentVideoStreamEnabled = function(enabled) {
 const checkPublishersConnections = function() {
 	const iceConnectionStateCount = {}
 
-	Object.values(publishers).forEach(publisher => {
-		console.info(publisher.peerConnection.iceConnectionState)
+	Object.keys(publishers).forEach(publisherSessionId => {
+		publisher = publishers[publisherSessionId]
+
+		console.info(publisherSessionId + ': ' + publisher.peerConnection.iceConnectionState)
 
 		if (iceConnectionStateCount[publisher.peerConnection.iceConnectionState] === undefined) {
 			iceConnectionStateCount[publisher.peerConnection.iceConnectionState] = 1
@@ -777,8 +779,11 @@ const checkPublishersConnections = function() {
 const checkSubscribersConnections = function() {
 	const iceConnectionStateCount = {}
 
+	i = 0
+
 	subscribers.forEach(subscriber => {
-		console.info(subscriber.peerConnection.iceConnectionState)
+		console.info(i + ': ' + subscriber.peerConnection.iceConnectionState)
+		i++
 
 		if (iceConnectionStateCount[subscriber.peerConnection.iceConnectionState] === undefined) {
 			iceConnectionStateCount[subscriber.peerConnection.iceConnectionState] = 1

--- a/docs/Talkbuchet.js
+++ b/docs/Talkbuchet.js
@@ -588,6 +588,10 @@ async function initPublishers() {
 
 		try {
 			await publisher.connect()
+
+			if ((i + 1) % 5 === 0 && (i + 1) < publishersCount) {
+				console.info('Publisher started (' + (i + 1) + '/' + publishersCount + ')')
+			}
 		} catch (exception) {
 			console.warn('Publisher ' + i + ' error: ' + exception)
 		}
@@ -650,6 +654,10 @@ async function initSubscribers() {
 	for (let i = 0; i < subscribers.length; i++) {
 		try {
 			await subscribers[i].connect()
+
+			if ((i + 1) % 5 === 0 && (i + 1) < subscribers.length) {
+				console.info('Subscriber started (' + (i + 1) + '/' + subscribers.length + ')')
+			}
 		} catch (exception) {
 			console.warn('Subscriber ' + i + ' error: ' + exception)
 		}

--- a/docs/Talkbuchet.js
+++ b/docs/Talkbuchet.js
@@ -807,6 +807,8 @@ const startMedia = async function(audio, video) {
 		stream.getTracks().forEach(track => {
 			track.stop()
 		})
+
+		stream = null
 	}
 
 	if (audio !== undefined) {

--- a/docs/Talkbuchet.js
+++ b/docs/Talkbuchet.js
@@ -799,6 +799,42 @@ const checkSubscribersConnections = function() {
 	console.info('  - Failed: ' + (iceConnectionStateCount['failed'] ?? 0))
 }
 
+const printPublisherStats = async function(publisherSessionId, stringify = false) {
+	if (!(publisherSessionId in publishers)) {
+		console.error('Invalid publisher session ID')
+
+		return
+	}
+
+	stats = await publishers[publisherSessionId].peerConnection.getStats()
+
+	for (stat of stats.values()) {
+		if (stringify) {
+			console.info(JSON.stringify(stat))
+		} else {
+			console.info(stat)
+		}
+	}
+}
+
+const printSubscriberStats = async function(index, stringify = false) {
+	if (!(index in subscribers)) {
+		console.error('Index out of range')
+
+		return
+	}
+
+	stats = await subscribers[index].peerConnection.getStats()
+
+	for (stat of stats.values()) {
+		if (stringify) {
+			console.info(JSON.stringify(stat))
+		} else {
+			console.info(stat)
+		}
+	}
+}
+
 const setCredentials = function(userToSet, appTokenToSet) {
 	user = userToSet
 	appToken = appTokenToSet

--- a/docs/Talkbuchet.js
+++ b/docs/Talkbuchet.js
@@ -192,6 +192,11 @@
  * would be able to add a much higher number of virtual participants than of
  * real participants.
  *
+ * However, note that each web browser session can execute a single virtual
+ * participant. Due to this it is recommended to use Talkbuchet CLI instead to
+ * easily start several web browser sessions, each one with its own virtual
+ * participant, and control the virtual participants from the CLI.
+ *
  * HOW TO RUN:
  * -----------------------------------------------------------------------------
  * - Set the user and appToken (generate an apptoken at

--- a/docs/Talkbuchet.js
+++ b/docs/Talkbuchet.js
@@ -395,6 +395,10 @@ class Signaling extends EventTarget {
 			method: 'POST',
 		}
 
+		if (user) {
+			fetchOptions.headers['Authorization'] = 'Basic ' + btoa(user + ':' + appToken)
+		}
+
 		const joinRoomResponse = await fetch(joinRoomUrl, fetchOptions)
 		const joinRoomResult = await joinRoomResponse.json()
 		const nextcloudSessionId = joinRoomResult.ocs.data.sessionId


### PR DESCRIPTION
Talkbuchet is a JavaScript script meant to be loaded and run in a browser. However, until now that required manually copying and pasting the script in a browser console. This pull request adds a Python script that uses Selenium to launch a new browser, load Talkbuchet in it and control it through the Python script.

The CLI requires Selenium and some Python packages to be available in the system, so to simplify using it a helper Bash script is provided to run Talkbuchet CLI in a Docker container with all the needed dependencies.

In the end this pull request ended growing much much more than initially planned. A virtual participant mode was also added to Talkbuchet in addition to the main siege mode; while the siege mode can be used for load tests of the HPB server the virtual participant mode can be used for load tests of the clients.

Finally, another additional mode was added only to Talbuchet CLI to add real participants to a conversation and, optionally, a call. Unlike the other two modes this one is mainly for development and not suitable for load tests (due to the resources needed to run several real participants).

Pending:
- [X] Add documentation
- [X] Try to make it work also with Firefox
- [X] Add Bash script to run Talkbuchet in a Docker container
- [X] Check if a headless browser can handle a higher number of connections; if it does add an option to use it
