### PR TITLE
Use tertiary-no-background for emoji picker

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -68,7 +68,7 @@
 							@select="addEmoji">
 							<Button :disabled="disabled"
 								:aria-label="t('spreed', 'Add emoji')"
-								type="tertiary"
+								type="tertiary-no-background"
 								:aria-haspopup="true">
 								<EmoticonOutline :size="16"
 									decorative


### PR DESCRIPTION
Fix #7098 

Before | After
---|---
![Bildschirmfoto von 2022-04-06 11-27-16](https://user-images.githubusercontent.com/213943/161943815-261b349c-655c-4918-92ec-de25529a322f.png) | ![Bildschirmfoto von 2022-04-08 08-50-27](https://user-images.githubusercontent.com/213943/162380599-4ecae794-0195-4f97-93b0-3f8576447659.png)
 