### PR TITLE
Fix menu overlap

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -477,10 +477,9 @@ export default {
 	right: 14px;
 	bottom: -4px;
 	position: absolute;
-	z-index: 100000;
 	background-color: var(--color-main-background);
 	border-radius: calc($clickable-area / 2);
-	box-shadow: 0 0 4px 0px var(--color-box-shadow);
+	box-shadow: 0 0 4px 0 var(--color-box-shadow);
 
 	& h6 {
 		margin-left: auto;


### PR DESCRIPTION
Fix #7132 

Couldn't find a reason to keep the z-index, only when you hover the next message the hover-background will overlap the menu a little bit (see second screenshot row). But from my POV that's less important than the first case where it prevents you from using certain actions.

x | Before | After
---|---|---
Menu overlap | ![Bildschirmfoto von 2022-04-11 16-43-37](https://user-images.githubusercontent.com/213943/162765430-4fcae298-0d6d-4e52-aed3-3568d8c96a2b.png) | ![Bildschirmfoto von 2022-04-11 16-42-41](https://user-images.githubusercontent.com/213943/162765449-9a400265-5641-48ed-ae5e-db0b664f913d.png)
Hoverbackground overlap | ![Bildschirmfoto von 2022-04-11 16-43-49](https://user-images.githubusercontent.com/213943/162765465-809bb1ea-021e-473e-a9db-b6fa07dc9ddf.png) | ![Bildschirmfoto von 2022-04-11 16-42-28](https://user-images.githubusercontent.com/213943/162765475-dd5d7c21-db20-40fb-bcc5-4de7b1b473be.png)

