### PR TITLE
Fix category selection in reactions emoji picker

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -115,7 +115,7 @@
 					<span>❤️</span>
 				</template>
 			</Button>
-			<EmojiPicker :container="`#message_${id}`"
+			<EmojiPicker :container="`#message_${id} .message-buttons-bar`"
 				@select="handleReactionClick"
 				@after-show="onEmojiPickerOpen"
 				@after-hide="onEmojiPickerClose">


### PR DESCRIPTION
Before clicking a category was "outside" of the message button bar
and therefor closed the reactions popover.

Signed-off-by: Joas Schilling <coding@schilljs.com>