### PR TITLE
Fix reactions endpoints not accessible by guests

### DIFF
--- a/lib/Controller/ReactionController.php
+++ b/lib/Controller/ReactionController.php
@@ -45,7 +45,7 @@ class ReactionController extends AEnvironmentAwareController {
 	}
 
 	/**
-	 * @NoAdminRequired
+	 * @PublicPage
 	 * @RequireParticipant
 	 * @RequireReadWriteConversation
 	 * @RequireModeratorOrNoLobby
@@ -75,7 +75,7 @@ class ReactionController extends AEnvironmentAwareController {
 	}
 
 	/**
-	 * @NoAdminRequired
+	 * @PublicPage
 	 * @RequireParticipant
 	 * @RequireReadWriteConversation
 	 * @RequireModeratorOrNoLobby
@@ -103,7 +103,7 @@ class ReactionController extends AEnvironmentAwareController {
 	}
 
 	/**
-	 * @NoAdminRequired
+	 * @PublicPage
 	 * @RequireParticipant
 	 * @RequireReadWriteConversation
 	 * @RequireModeratorOrNoLobby

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -190,6 +190,7 @@ import EmojiPicker from '@nextcloud/vue/dist/Components/EmojiPicker'
 import EmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
 import Popover from '@nextcloud/vue/dist/Components/Popover'
 import { showError, showSuccess, showWarning, TOAST_DEFAULT_TIMEOUT } from '@nextcloud/dialogs'
+import { ATTENDEE } from '../../../../constants'
 
 export default {
 	name: 'Message',
@@ -738,11 +739,25 @@ export default {
 					&& list[item].actorId === this.$store.getters.getActorId()) {
 					summary.unshift(t('spreed', 'You'))
 				} else {
-					summary.push(list[item].actorDisplayName)
+					summary.push(this.getDisplayNameForReaction(list[item]))
 				}
 			}
 
 			return summary.join(', ')
+		},
+
+		getDisplayNameForReaction(reaction) {
+			const displayName = reaction.actorDisplayName.trim()
+
+			if (reaction.actorType === ATTENDEE.ACTOR_TYPE.GUESTS) {
+				return this.$store.getters.getGuestNameWithGuestSuffix(this.token, reaction.actorId)
+			}
+
+			if (displayName === '') {
+				return t('spreed', 'Deleted user')
+			}
+
+			return displayName
 		},
 	},
 }

--- a/src/store/guestNameStore.js
+++ b/src/store/guestNameStore.js
@@ -39,6 +39,14 @@ const getters = {
 		}
 		return t('spreed', 'Guest')
 	},
+
+	getGuestNameWithGuestSuffix: (state, getters) => (token, actorId) => {
+		const displayName = getters.getGuestName(token, actorId)
+		if (displayName === t('spreed', 'Guest')) {
+			return displayName
+		}
+		return t('spreed', '{guest} (guest)', { guest: displayName })
+	},
 }
 
 const mutations = {

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2300,6 +2300,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$result = array_map(static function ($reaction, $list) use ($expected): array {
 			$list = array_map(function ($reaction) {
 				unset($reaction['timestamp']);
+				$reaction['actorId'] = ($reaction['actorType'] === 'guests') ? self::$sessionIdToUser[$reaction['actorId']] : (string) $reaction['actorId'];
 				return $reaction;
 			}, $list);
 			Assert::assertArrayHasKey($reaction, $expected, 'Not expected reaction: ' . $reaction);

--- a/tests/integration/features/reaction/react.feature
+++ b/tests/integration/features/reaction/react.feature
@@ -25,11 +25,14 @@ Feature: reaction/react
       | users     | participant1 | participant1-displayname | 👍       |
       | users     | participant2 | participant2-displayname | 👍       |
     And user "participant1" react with "🚀" on message "Message 1" to room "room" with 201
+    Then user "guest" joins room "room" with 200 (v4)
+    And user "guest" react with "👤" on message "Message 1" to room "room" with 201
     Then user "participant1" sees the following messages in room "room" with 200
-      | room | actorType | actorId      | actorDisplayName         | message   | messageParameters | reactions       | reactionsSelf |
-      | room | users     | participant1 | participant1-displayname | Message 1 | []                | {"👍":2,"🚀":1} | ["👍","🚀"]   |
+      | room | actorType | actorId      | actorDisplayName         | message   | messageParameters | reactions              | reactionsSelf |
+      | room | users     | participant1 | participant1-displayname | Message 1 | []                | {"👍":2,"👤":1,"🚀":1} | ["👍","🚀"]   |
     Then user "participant1" sees the following system messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | systemMessage |
+      | room | guests    | guest        |                          | reaction |
       | room | users     | participant1 | participant1-displayname | reaction |
       | room | users     | participant1 | participant1-displayname | reaction |
       | room | users     | participant2 | participant2-displayname | reaction |
@@ -66,17 +69,24 @@ Feature: reaction/react
     And user "participant2" react with "👍" on message "Message 1" to room "room" with 201
       | actorType | actorId      | actorDisplayName         | reaction |
       | users     | participant2 | participant2-displayname | 👍       |
+    Then user "guest" joins room "room" with 200 (v4)
+    And user "guest" react with "👤" on message "Message 1" to room "room" with 201
     Then user "participant1" sees the following messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | message   | messageParameters | reactions |
-      | room | users     | participant1 | participant1-displayname | Message 1 | []                | {"👍":1}  |
+      | room | users     | participant1 | participant1-displayname | Message 1 | []                | {"👤":1,"👍":1}  |
     And user "participant2" delete react with "👍" on message "Message 1" to room "room" with 200
+      | actorType | actorId      | actorDisplayName         | reaction |
+      | guests    | guest        |                          | 👤       |
+    And user "guest" delete react with "👤" on message "Message 1" to room "room" with 200
       | actorType | actorId      | actorDisplayName         | reaction |
     Then user "participant1" sees the following messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | message   | messageParameters | reactions |
       | room | users     | participant1 | participant1-displayname | Message 1 | []                | []        |
     Then user "participant1" sees the following system messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | systemMessage |
+      | room | guests    | guest        |                          | reaction_revoked |
       | room | users     | participant2 | participant2-displayname | reaction_revoked |
+      | room | guests    | guest        |                          | reaction_deleted |
       | room | users     | participant2 | participant2-displayname | reaction_deleted |
       | room | users     | participant1 | participant1-displayname | user_added |
       | room | users     | participant1 | participant1-displayname | conversation_created |


### PR DESCRIPTION
Pending:
- [x] Add integration tests
- [x] The WebUI should show a name placeholder in the list of "reacters" if a guest has no name