### PR TITLE
Fix upgrade with Postgres and Oracle

### DIFF
--- a/lib/Migration/Version14000Date20220330141647.php
+++ b/lib/Migration/Version14000Date20220330141647.php
@@ -220,7 +220,7 @@ class Version14000Date20220330141647 extends SimpleMigrationStep {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('s.id', 'm.mimetype')
 			->from('share', 's')
-			->leftJoin('s', 'filecache', 'f', $query->expr()->eq('s.item_source', 'f.fileid'))
+			->leftJoin('s', 'filecache', 'f', $query->expr()->eq('s.file_source', 'f.fileid'))
 			->leftJoin('f', 'mimetypes', 'm', $query->expr()->eq('f.mimetype', 'm.id'))
 			->where($query->expr()->in('s.id', $query->createNamedParameter($shareIds, IQueryBuilder::PARAM_INT_ARRAY)));
 		$result = $query->executeQuery();


### PR DESCRIPTION
Error from Sermo:
```
Exception: Database error when running migration 14000Date20220330141647 for app spreed
An exception occurred while executing a query: SQLSTATE[42883]: Undefined function: 7 ERROR:  operator does not exist: character varying = bigint
LINE 1: ...LEFT JOIN "oc_filecache" "f" ON "s"."item_source" = "f"."fil...
                                                             ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
```