### PR TITLE
Enable helper app with force

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -25,8 +25,7 @@ local Pipeline(test_set, database, services) = {
 				"bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST",
 				"cd ../server",
 				"./occ app:enable $APP_NAME",
-				"git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications apps/notifications",
-				"./occ app:enable notifications"
+				"git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications apps/notifications"
 			] + (
 				if test_set == "conversation" || test_set == "conversation-2" then [
 					"git clone --depth 1 -b $GUESTS_BRANCH https://github.com/nextcloud/guests apps/guests"

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/callapi
@@ -46,7 +45,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/chat
@@ -79,7 +77,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/command
@@ -112,7 +109,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - git clone --depth 1 -b $GUESTS_BRANCH https://github.com/nextcloud/guests apps/guests
   - cd apps/$APP_NAME
   - cd tests/integration/
@@ -146,7 +142,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - git clone --depth 1 -b $GUESTS_BRANCH https://github.com/nextcloud/guests apps/guests
   - cd apps/$APP_NAME
   - cd tests/integration/
@@ -180,7 +175,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/federation
@@ -213,7 +207,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/reaction
@@ -246,7 +239,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/sharing
@@ -279,7 +271,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/sharing-2
@@ -326,7 +317,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/callapi
@@ -374,7 +364,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/chat
@@ -422,7 +411,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/command
@@ -470,7 +458,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - git clone --depth 1 -b $GUESTS_BRANCH https://github.com/nextcloud/guests apps/guests
   - cd apps/$APP_NAME
   - cd tests/integration/
@@ -519,7 +506,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - git clone --depth 1 -b $GUESTS_BRANCH https://github.com/nextcloud/guests apps/guests
   - cd apps/$APP_NAME
   - cd tests/integration/
@@ -568,7 +554,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/federation
@@ -616,7 +601,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/reaction
@@ -664,7 +648,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/sharing
@@ -712,7 +695,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/sharing-2
@@ -755,7 +737,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/callapi
@@ -797,7 +778,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/chat
@@ -839,7 +819,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/command
@@ -881,7 +860,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - git clone --depth 1 -b $GUESTS_BRANCH https://github.com/nextcloud/guests apps/guests
   - cd apps/$APP_NAME
   - cd tests/integration/
@@ -924,7 +902,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - git clone --depth 1 -b $GUESTS_BRANCH https://github.com/nextcloud/guests apps/guests
   - cd apps/$APP_NAME
   - cd tests/integration/
@@ -967,7 +944,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/federation
@@ -1009,7 +985,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/reaction
@@ -1051,7 +1026,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/sharing
@@ -1093,7 +1067,6 @@ steps:
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
-  - ./occ app:enable notifications
   - cd apps/$APP_NAME
   - cd tests/integration/
   - bash run.sh features/sharing-2

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -45,9 +45,9 @@ ${ROOT_DIR}/occ app:getpath notifications || (cd ../../../ && git clone --depth 
 ${ROOT_DIR}/occ app:getpath guests || (cd ../../../ && git clone --depth 1 --branch ${GUESTS_BRANCH} https://github.com/nextcloud/guests)
 
 ${ROOT_DIR}/occ app:enable spreed || exit 1
-${ROOT_DIR}/occ app:enable spreedcheats || exit 1
-${ROOT_DIR}/occ app:enable notifications || exit 1
-${ROOT_DIR}/occ app:enable guests || exit 1
+${ROOT_DIR}/occ app:enable --force spreedcheats || exit 1
+${ROOT_DIR}/occ app:enable --force notifications || exit 1
+${ROOT_DIR}/occ app:enable --force guests || exit 1
 
 ${ROOT_DIR}/occ app:list | grep spreed
 ${ROOT_DIR}/occ app:list | grep notifications


### PR DESCRIPTION
This allows to not bump the version in the helper app anymore.
Will save me a roundtrip of CI every time we branch off as I always forget it.

Also notifications and guests server requirement are of no interest to us and instead of having troubles during the transition period with red CI we just force enable them too.
