### PR TITLE
Only request reactions once

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -657,7 +657,8 @@ export default {
 
 		async getReactions() {
 			if (this.detailedReactionsLoading) {
-				// FIXME not sure how to await the other execution
+				// A parallel request is already doing this
+				return
 			}
 
 			try {


### PR DESCRIPTION
Saw multiple request for the same summary being triggered when hovering emojis in the company call and all requests made the same response and where triggered basically in the same millisecond