### PR TITLE
Disconnect received videos by toggling the video directly in Janus

### DIFF
--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -886,6 +886,19 @@ Peer.prototype.setRemoteVideoBlocked = function(remoteVideoBlocked) {
 		return
 	}
 
+	// If the HPB is used the remote video can be blocked through a standard
+	// WebRTC renegotiation or by toggling the video directly in Janus. The last
+	// one is preferred, as it requires less signaling messages to be exchanged
+	// and, besides that, the browser starts to decode the video faster once
+	// enabled again.
+	if (this.receiverOnly && this.parent.config.connection.hasFeature('update-sdp')) {
+		this.send('selectStream', {
+			video: !remoteVideoBlocked,
+		})
+
+		return
+	}
+
 	this._remoteVideoShouldBeBlocked = remoteVideoBlocked
 
 	// The "negotiationneeded" event is emitted if needed based on the direction


### PR DESCRIPTION
Follow up to #6862 
Requires https://github.com/strukturag/nextcloud-spreed-signaling/pull/239 (v0.5.0)

Originally the HPB required a renegotiation to block the received videos. However, besides the standard WebRTC way, Janus also supports directly toggling on and off the video without any renegotiation. This is now exposed by the signaling server through the `selectStream` message, so the video is now blocked using that approach instead.

The previous code to block the video using a renegotiation is still kept, though, as it could be used without HPB once all the clients support renegotiations.

Pending:
- [X] Explicitly block the video after a renegotiation? After a renegotiation the video needs to be explicitly blocked again, although currently no renegotiations (requesting an offer again with the same sid) should be triggered on the HPB subscribers (it was done only to block the video before doing that with the Janus specific approach) - Not needed, see [comment below](https://github.com/nextcloud/spreed/pull/7237#issuecomment-1232795655)

## How to test

In the test below, in Firefox it can be verified that the video is stopped and resumed again opening `about:webrtc` and checking the video stats in the receiver connection; for easier checking it is recommended to join the call without audio nor video in the private window so there is only one sender and one receiver connection.

- Setup the HPB
- Start a call with audio and video
- In a private window, join the call
- Open the browser console to check the messages
- Disable and enable the received video

### Result with this pull request

No offers are requested (there are no new _Request offer from_ messages when the video is disabled and enabled); the video immediately resumes after enabling it again

### Result without this pull request

Offers are requested to renegotiate the existing connection and disable the video; the video may take a few seconds to resume once it is enabled again
