### PR TITLE
Fix endless offer requests with the SIP bridge

### DIFF
--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -561,6 +561,9 @@ Peer.prototype.sendDirectly = function(channel, messageType, payload) {
 	}
 	this.logger.log('sending via datachannel', channel, messageType, message)
 	const dc = this.getDataChannel(channel)
+	if (!dc) {
+		return false
+	}
 	if (dc.readyState !== 'open') {
 		if (!Object.prototype.hasOwnProperty.call(this.pendingDCMessages, channel)) {
 			this.pendingDCMessages[channel] = []
@@ -597,6 +600,9 @@ Peer.prototype._observeDataChannel = function(channel) {
 Peer.prototype.getDataChannel = function(name, opts) {
 	if (!webrtcSupport.supportDataChannel) {
 		return this.emit('error', new Error('createDataChannel not supported'))
+	}
+	if (!this.enableDataChannels) {
+		return null
 	}
 	let channel = this.channels[name]
 	opts || (opts = {})
@@ -635,9 +641,7 @@ Peer.prototype.start = function() {
 	// a) create a datachannel a priori
 	// b) do a renegotiation later to add the SCTP m-line
 	// Let's do (a) first...
-	if (this.enableDataChannels) {
-		this.getDataChannel('simplewebrtc')
-	}
+	this.getDataChannel('simplewebrtc')
 
 	this.offer(this.receiveMedia)
 }

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -693,8 +693,11 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 	const sendDataChannelToAll = function(channel, message, payload) {
 		// If running with MCU, the message must be sent through the
 		// publishing peer and will be distributed by the MCU to subscribers.
-		if (ownPeer && signaling.hasFeature && signaling.hasFeature('mcu')) {
-			ownPeer.sendDirectly(channel, message, payload)
+		if (signaling.hasFeature && signaling.hasFeature('mcu')) {
+			if (ownPeer) {
+				ownPeer.sendDirectly(channel, message, payload)
+			}
+
 			return
 		}
 		webrtc.sendDirectlyToAll(channel, message, payload)

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -1172,6 +1172,15 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 			} else {
 				callParticipantModel.setScreenPeer(peer)
 			}
+
+			// The SIP bridge publisher does not have data channels, so they
+			// need to be explicitly disabled in the subscriber. Otherwise it
+			// would try to open them, which would cause an endless loop of
+			// renegotiations, as after a negotiation the data channels will
+			// still not be opened, which will trigger a negotiation again.
+			if (callParticipantModel.get('internal')) {
+				peer.enableDataChannels = false
+			}
 		}
 
 		if (peer.type === 'video') {
@@ -1185,10 +1194,10 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 
 			setHandlerForNegotiationNeeded(peer)
 
-			// Make sure required data channels exist for all peers. This
-			// is required for peers that get created by SimpleWebRTC from
-			// received "Offer" messages. Otherwise the "channelMessage"
-			// will not be called.
+			// Make sure required data channels exist for all peers (that have
+			// not disabled them). This is required for peers that get created
+			// by SimpleWebRTC from received "Offer" messages. Otherwise the
+			// "channelMessage" will not be called.
 			peer.getDataChannel('status')
 		}
 	})


### PR DESCRIPTION
Follow up to #6862

Since https://github.com/nextcloud/spreed/commit/48a74da64eac1a593116694f8c6ca299058f6304 offers are requested again and again in an endless loop for the peer of the SIP bridge. If [the block that requests an offer when a negotiation is needed for a subscriber](https://github.com/nextcloud/spreed/blob/48a74da64eac1a593116694f8c6ca299058f6304/src/utils/webrtc/webrtc.js#L935-L968) is moved into [the if condition that checks that the ICE connection state is not `new` nor `checking`](https://github.com/nextcloud/spreed/blob/48a74da64eac1a593116694f8c6ca299058f6304/src/utils/webrtc/webrtc.js#L970-L973) then only the original offer is requested and that is it.

My guess is that this is caused by the lack of data channels in the SIP bridge (but as mentioned it is just a guess, I do not know if the SIP bridge has data channels or not, and I can not test it either). If a publisher does not have data channels then Janus will not open data channels for its subscribers. However, when a subscriber is created [the `status` data channel was always tried to be opened](https://github.com/nextcloud/spreed/blob/48a74da64eac1a593116694f8c6ca299058f6304/src/utils/webrtc/webrtc.js#L1185-L1189). As the offer sent by Janus for the SIP bridge subscriber does not have data channels [opening them will trigger a `negotiationneeded` event](https://github.com/w3c/webrtc-pc/blob/3a9bd42b46c5a3b39affc75c33ef96191e2efb27/webrtc.html#L13013-L13015). This will [cause a new offer to be requested](https://github.com/nextcloud/spreed/blob/48a74da64eac1a593116694f8c6ca299058f6304/src/utils/webrtc/webrtc.js#L957), but that offer will still not have data channels, so `negotiationneeded` will be triggered again, another offer will be requested, the offer will not have data channels... and so on.

Then, why does it work when moving the block inside the if condition? In that case opening the data channel will still trigger the `negotiationneeded` event. However, as it is done even [before the offer was set](https://github.com/nextcloud/spreed/blob/7e75c34ff5e69029ddfc5c36dface7a28b9a2527/src/utils/webrtc/simplewebrtc/simplewebrtc.js#L102-L104) the ICE connection state will be `new`, so it will not enter the if condition. That is, the subscriber is left forever in the `negotiationneeded` state, and as there are no further offers received for that subscriber the endless loop does not occur.

Due to all that this pull request prevents the SIP bridge subscriber from creating data channels. It also fixes another minor bug found while investigating that (trying to send data channels messages through the subscribers if there is no publisher peer).

@fancycode Could you test this pull request and confirm (or deny :-) ) my suspicions? Thanks!
