### PR TITLE
Fix loading icon position in shared items tab

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -613,6 +613,11 @@ export default {
 		.name-container {
 			padding: 0 4px;
 		}
+
+		.loading {
+			width: 36px;
+			height: 36px;
+		}
 	}
 
 	&--shared-items-grid {
@@ -620,6 +625,7 @@ export default {
 		.preview {
 			width: 100%;
 			min-height: unset;
+			height: 100%;
 		}
 	}
 }


### PR DESCRIPTION


https://user-images.githubusercontent.com/26852655/166658495-d4691110-44ef-4133-89c7-ee29d2721885.mov



Signed-off-by: marco <marcoambrosini@pm.me>