### PR TITLE
📊 Simple polls API

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>15.0.0-dev.3</version>
+	<version>15.0.0-dev.4</version>
 	<licence>agpl</licence>
 
 	<author>Aleksandra Lazarević</author>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -35,6 +35,7 @@ return array_merge_recursive(
 	include(__DIR__ . '/routes/routesMatterbridgeController.php'),
 	include(__DIR__ . '/routes/routesMatterbridgeSettingsController.php'),
 	include(__DIR__ . '/routes/routesPageController.php'),
+	include(__DIR__ . '/routes/routesPollController.php'),
 	include(__DIR__ . '/routes/routesPublicShareAuthController.php'),
 	include(__DIR__ . '/routes/routesReactionController.php'),
 	include(__DIR__ . '/routes/routesRoomController.php'),

--- a/appinfo/routes/routesPollController.php
+++ b/appinfo/routes/routesPollController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2016 Lukas Reschke <lukas@statuscode.ch>
+ *
+ * @author Lukas Reschke <lukas@statuscode.ch>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+$requirements = [
+	'apiVersion' => 'v1',
+	'token' => '^[a-z0-9]{4,30}$',
+];
+
+$requirementsWithPollId = [
+	'apiVersion' => 'v1',
+	'token' => '^[a-z0-9]{4,30}$',
+	'pollId' => '^[0-9]+$',
+];
+
+return [
+	'ocs' => [
+		/** @see \OCA\Talk\Controller\PollController::createPoll() */
+		['name' => 'Poll#createPoll', 'url' => '/api/{apiVersion}/poll/{token}', 'verb' => 'POST', 'requirements' => $requirements],
+	],
+];

--- a/appinfo/routes/routesPollController.php
+++ b/appinfo/routes/routesPollController.php
@@ -40,6 +40,8 @@ return [
 		['name' => 'Poll#createPoll', 'url' => '/api/{apiVersion}/poll/{token}', 'verb' => 'POST', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\PollController::showPoll() */
 		['name' => 'Poll#showPoll', 'url' => '/api/{apiVersion}/poll/{token}/{pollId}', 'verb' => 'GET', 'requirements' => $requirementsWithPollId],
+		/** @see \OCA\Talk\Controller\PollController::votePoll() */
+		['name' => 'Poll#votePoll', 'url' => '/api/{apiVersion}/poll/{token}/{pollId}', 'verb' => 'POST', 'requirements' => $requirementsWithPollId],
 		/** @see \OCA\Talk\Controller\PollController::closePoll() */
 		['name' => 'Poll#closePoll', 'url' => '/api/{apiVersion}/poll/{token}/{pollId}', 'verb' => 'DELETE', 'requirements' => $requirementsWithPollId],
 	],

--- a/appinfo/routes/routesPollController.php
+++ b/appinfo/routes/routesPollController.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 /**
- * @copyright Copyright (c) 2016 Lukas Reschke <lukas@statuscode.ch>
+ * @copyright Copyright (c) 2022 Joas Schilling <coding@schilljs.com>
  *
- * @author Lukas Reschke <lukas@statuscode.ch>
+ * @author Joas Schilling <coding@schilljs.com>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -38,5 +38,9 @@ return [
 	'ocs' => [
 		/** @see \OCA\Talk\Controller\PollController::createPoll() */
 		['name' => 'Poll#createPoll', 'url' => '/api/{apiVersion}/poll/{token}', 'verb' => 'POST', 'requirements' => $requirements],
+		/** @see \OCA\Talk\Controller\PollController::showPoll() */
+		['name' => 'Poll#showPoll', 'url' => '/api/{apiVersion}/poll/{token}/{pollId}', 'verb' => 'GET', 'requirements' => $requirementsWithPollId],
+		/** @see \OCA\Talk\Controller\PollController::closePoll() */
+		['name' => 'Poll#closePoll', 'url' => '/api/{apiVersion}/poll/{token}/{pollId}', 'verb' => 'DELETE', 'requirements' => $requirementsWithPollId],
 	],
 ];

--- a/docs/constants.md
+++ b/docs/constants.md
@@ -99,6 +99,16 @@ title: Constants
 * `other` - Shared objects not falling into any other category
 * `voice` - Voice messages
 
+## Poll
+
+### Poll status
+* `0` - Open: Participants can cast votes
+* `1` - Closed: Participants can no longer cast votes and the result is displayed
+
+### Poll mode
+* `0` - Public: Participants can see the result immediately and also who voted for which option
+* `1` - Hidden: The result is hidden until the poll is closed and then only the number of votes for each option are displayed
+
 ## Signaling modes
 * `internal` - No external signaling server is used
 * `external` - A single external signaling server is used

--- a/docs/poll.md
+++ b/docs/poll.md
@@ -1,0 +1,102 @@
+# Poll API
+
+Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
+
+## Create a poll in a conversation
+
+* Method: `POST`
+* Endpoint: `/poll/{token}`
+* Data:
+
+| field        | type         | Description                                                                                                                                                                                                                    |
+|--------------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `question`   | string       | The question of the poll                                                                                                                                                                                                       |
+| `options`    | string[]     | Array of strings with the voting options                                                                                                                                                                                       |
+| `resultMode` | int          | The result and voting mode of the poll, `0` means participants can immediatelly see the result and who voted for which option. `1` means the result is hidden until the poll is closed and then only the summary is published. |
+| `maxVotes`   | int          | Maximum amount of options a participant can vote for                                                                                                                                                                           |
+
+* Response:
+    - Status code:
+        + `201 Created`
+        + `400 Bad Request` When the question or the options were too long
+        + `403 Forbidden` When the conversation is read-only
+        + `403 Forbidden` When the actor does not have chat permissions
+        + `404 Not Found` When the conversation could not be found for the participant
+        + `412 Precondition Failed` When the lobby is active and the user is not a moderator
+
+    - Data:
+
+        See [Poll data](#poll-data)
+
+## Get state or result of a poll
+
+* Method: `GET`
+* Endpoint: `/poll/{token}/{pollId}`
+
+* Response:
+    - Status code:
+        + `201 Created`
+        + `400 Bad Request` In case of any other error
+        + `404 Not Found` When the conversation could not be found for the participant
+        + `404 Not Found` When the poll id could not be found in the conversation
+        + `412 Precondition Failed` When the lobby is active and the user is not a moderator
+
+    - Data:
+
+      See [Poll data](#poll-data)
+
+## Vote on a poll
+
+* Method: `POST`
+* Endpoint: `/poll/{token}/{pollId}`
+* Data:
+
+| field        | type  | Description                                      |
+|--------------|-------|--------------------------------------------------|
+| `optionIds`  | int[] | The option IDs the participant wants to vote for |
+
+
+* Response:
+    - Status code:
+        + `201 Created`
+        + `400 Bad Request` When an option id is invalid
+        + `400 Bad Request` When too many options were voted
+        + `404 Not Found` When the conversation could not be found for the participant
+        + `404 Not Found` When the poll id could not be found in the conversation
+        + `412 Precondition Failed` When the lobby is active and the user is not a moderator
+
+    - Data:
+
+      See [Poll data](#poll-data)
+
+## Close a poll
+
+* Method: `DELETE`
+* Endpoint: `/poll/{token}/{pollId}`
+
+* Response:
+    - Status code:
+        + `200 OK`
+        + `403 Forbidden` When the participant is not the author of the poll or a moderator
+        + `404 Not Found` When the conversation could not be found for the participant
+        + `404 Not Found` When the poll id could not be found in the conversation
+        + `412 Precondition Failed` When the lobby is active and the user is not a moderator
+
+    - Data:
+
+      See [Poll data](#poll-data)
+
+## Poll data
+
+| field              | type     | Description                                                                                   |
+|--------------------|----------|-----------------------------------------------------------------------------------------------|
+| `id`               | int      | ID of the poll                                                                                |
+| `question`         | string   | The question of the poll                                                                      |
+| `options`          | string[] | The options participants can vote for                                                         |
+| `actorType`        | string   | Actor type of the poll author (see [Constants - Attendee types](constants.md#attendee-types)) |
+| `actorId`          | string   | Actor ID identifying the poll author                                                          |
+| `actorDisplayName` | string   | Display name of the poll author                                                               |
+| `status`           | int      | Status of the poll (see [Constants - Poll status](constants.md#poll-status))                  |
+| `resultMode`       | int      | Result mode of the poll (see [Constants - Poll mode](constants.md#poll-mode))                 |
+| `maxVotes`         | int      | Maximum amount of options a user can vote for, `0` means unlimited                            |
+| `voted`            | int[]    | Array of option ids the participant voted for                                                 |

--- a/docs/poll.md
+++ b/docs/poll.md
@@ -88,15 +88,16 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 
 ## Poll data
 
-| field              | type     | Description                                                                                   |
-|--------------------|----------|-----------------------------------------------------------------------------------------------|
-| `id`               | int      | ID of the poll                                                                                |
-| `question`         | string   | The question of the poll                                                                      |
-| `options`          | string[] | The options participants can vote for                                                         |
-| `actorType`        | string   | Actor type of the poll author (see [Constants - Attendee types](constants.md#attendee-types)) |
-| `actorId`          | string   | Actor ID identifying the poll author                                                          |
-| `actorDisplayName` | string   | Display name of the poll author                                                               |
-| `status`           | int      | Status of the poll (see [Constants - Poll status](constants.md#poll-status))                  |
-| `resultMode`       | int      | Result mode of the poll (see [Constants - Poll mode](constants.md#poll-mode))                 |
-| `maxVotes`         | int      | Maximum amount of options a user can vote for, `0` means unlimited                            |
-| `voted`            | int[]    | Array of option ids the participant voted for                                                 |
+| field              | type     | Description                                                                                     |
+|--------------------|----------|-------------------------------------------------------------------------------------------------|
+| `id`               | int      | ID of the poll                                                                                  |
+| `question`         | string   | The question of the poll                                                                        |
+| `options`          | string[] | The options participants can vote for                                                           |
+| `votes`            | int[]    | Map with optionId => number of votes (empty if the resultMode is hidden and the statue is open) |
+| `actorType`        | string   | Actor type of the poll author (see [Constants - Attendee types](constants.md#attendee-types))   |
+| `actorId`          | string   | Actor ID identifying the poll author                                                            |
+| `actorDisplayName` | string   | Display name of the poll author                                                                 |
+| `status`           | int      | Status of the poll (see [Constants - Poll status](constants.md#poll-status))                    |
+| `resultMode`       | int      | Result mode of the poll (see [Constants - Poll mode](constants.md#poll-mode))                   |
+| `maxVotes`         | int      | Maximum amount of options a user can vote for, `0` means unlimited                              |
+| `votedSelf`        | int[]    | Array of option ids the participant voted for                                                   |

--- a/docs/poll.md
+++ b/docs/poll.md
@@ -88,16 +88,27 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
 
 ## Poll data
 
-| field              | type     | Description                                                                                     |
-|--------------------|----------|-------------------------------------------------------------------------------------------------|
-| `id`               | int      | ID of the poll                                                                                  |
-| `question`         | string   | The question of the poll                                                                        |
-| `options`          | string[] | The options participants can vote for                                                           |
-| `votes`            | int[]    | Map with optionId => number of votes (empty if the resultMode is hidden and the statue is open) |
-| `actorType`        | string   | Actor type of the poll author (see [Constants - Attendee types](constants.md#attendee-types))   |
-| `actorId`          | string   | Actor ID identifying the poll author                                                            |
-| `actorDisplayName` | string   | Display name of the poll author                                                                 |
-| `status`           | int      | Status of the poll (see [Constants - Poll status](constants.md#poll-status))                    |
-| `resultMode`       | int      | Result mode of the poll (see [Constants - Poll mode](constants.md#poll-mode))                   |
-| `maxVotes`         | int      | Maximum amount of options a user can vote for, `0` means unlimited                              |
-| `votedSelf`        | int[]    | Array of option ids the participant voted for                                                   |
+| field              | type     | Description                                                                                                      |
+|--------------------|----------|------------------------------------------------------------------------------------------------------------------|
+| `id`               | int      | ID of the poll                                                                                                   |
+| `question`         | string   | The question of the poll                                                                                         |
+| `options`          | string[] | The options participants can vote for                                                                            |
+| `votes`            | int[]    | Map with optionId => number of votes (only available for when the actor voted on public poll or the poll is closed) |
+| `actorType`        | string   | Actor type of the poll author (see [Constants - Attendee types](constants.md#attendee-types))                    |
+| `actorId`          | string   | Actor ID identifying the poll author                                                                             |
+| `actorDisplayName` | string   | Display name of the poll author                                                                                  |
+| `status`           | int      | Status of the poll (see [Constants - Poll status](constants.md#poll-status))                                     |
+| `resultMode`       | int      | Result mode of the poll (see [Constants - Poll mode](constants.md#poll-mode))                                    |
+| `maxVotes`         | int      | Maximum amount of options a user can vote for, `0` means unlimited                                               |
+| `votedSelf`        | int[]    | Array of option ids the participant voted for                                                                    |
+| `numVoters`        | int      | The number of unique voters that (only available for when the actor voted on public poll or the poll is closed)  |
+| `details`          | array[]  | Detailed list who voted for which option (only available for public closed polls), see [Details](#details) below |
+
+### Details
+
+| field            | type   | Description                                                                                                  |
+|------------------|--------|--------------------------------------------------------------------------------------------------------------|
+| actorType        | string | The actor type of the participant that voted (see [Constants - Attendee types](constants.md#attendee-types)) |
+| actorId          | string | The actor id of the participant that voted                                                                   |
+| actorDisplayName | string | The display name of the participant that voted                                                               |
+| optionId         | int    | The option that was voted for                                                                                |

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -33,6 +33,7 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\AttachmentService;
 use OCA\Talk\Service\ParticipantService;
+use OCA\Talk\Service\PollService;
 use OCA\Talk\Share\RoomShareProvider;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\IComment;
@@ -85,6 +86,7 @@ class ChatManager {
 	private IManager $shareManager;
 	private RoomShareProvider $shareProvider;
 	private ParticipantService $participantService;
+	private PollService $pollService;
 	private Notifier $notifier;
 	protected ITimeFactory $timeFactory;
 	protected ICache $cache;
@@ -98,6 +100,7 @@ class ChatManager {
 								IManager $shareManager,
 								RoomShareProvider $shareProvider,
 								ParticipantService $participantService,
+								PollService $pollService,
 								Notifier $notifier,
 								ICacheFactory $cacheFactory,
 								ITimeFactory $timeFactory,
@@ -109,6 +112,7 @@ class ChatManager {
 		$this->shareManager = $shareManager;
 		$this->shareProvider = $shareProvider;
 		$this->participantService = $participantService;
+		$this->pollService = $pollService;
 		$this->notifier = $notifier;
 		$this->cache = $cacheFactory->createDistributed('talk/lastmsgid');
 		$this->unreadCountCache = $cacheFactory->createDistributed('talk/unreadcount');
@@ -621,6 +625,8 @@ class ChatManager {
 		$this->notifier->removePendingNotificationsForRoom($chat);
 
 		$this->attachmentService->deleteAttachmentsForRoom($chat);
+
+		$this->pollService->deleteByRoomId($chat->getId());
 	}
 
 	/**

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -461,6 +461,18 @@ class SystemMessage {
 			if ($currentUserIsActor) {
 				$parsedMessage = $this->l->t('You cleared the history of the conversation');
 			}
+		} elseif ($message === 'poll_closed') {
+			$parsedParameters['poll'] = $parameters['poll'];
+			$parsedMessage = $this->l->t('{actor} closed the poll {poll}');
+			if ($currentUserIsActor) {
+				$parsedMessage = $this->l->t('You closed the poll {poll}');
+			}
+		} elseif ($message === 'poll_voted') {
+			$parsedParameters['poll'] = $parameters['poll'];
+			$parsedMessage = $this->l->t('{actor} voted on the poll {poll}');
+			if ($currentUserIsActor) {
+				$parsedMessage = $this->l->t('You voted on the poll {poll}');
+			}
 		} else {
 			throw new \OutOfBoundsException('Unknown subject');
 		}

--- a/lib/Controller/PollController.php
+++ b/lib/Controller/PollController.php
@@ -155,6 +155,10 @@ class PollController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
+		if ($poll->getStatus() === Poll::STATUS_CLOSED) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
 		try {
 			$votedSelf = $this->pollService->votePoll($this->participant, $poll, $optionIds);
 		} catch (\RuntimeException $e) {

--- a/lib/Controller/PollController.php
+++ b/lib/Controller/PollController.php
@@ -31,6 +31,7 @@ use OCA\Talk\Exceptions\WrongPermissionsException;
 use OCA\Talk\Model\Poll;
 use OCA\Talk\Model\Vote;
 use OCA\Talk\Service\PollService;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -77,12 +78,14 @@ class PollController extends AEnvironmentAwareController {
 				$this->room->getId(),
 				$attendee->getActorType(),
 				$attendee->getActorId(),
+				$attendee->getDisplayName(),
 				$question,
 				$options,
 				$resultMode,
 				$maxVotes
 			);
 		} catch (\Exception $e) {
+			$this->logger->error('Error creating poll', ['exception' => $e]);
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
@@ -119,7 +122,7 @@ class PollController extends AEnvironmentAwareController {
 	public function showPoll(int $pollId): DataResponse {
 		try {
 			$poll = $this->pollService->getPoll($this->room->getId(), $pollId);
-		} catch (\Exception $e) {
+		} catch (DoesNotExistException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 

--- a/lib/Controller/PollController.php
+++ b/lib/Controller/PollController.php
@@ -198,6 +198,7 @@ class PollController extends AEnvironmentAwareController {
 
 		if ($poll->getResultMode() === Poll::MODE_HIDDEN && $poll->getStatus() === Poll::STATUS_OPEN) {
 			$data['votes'] = [];
+			$data['numVoters'] = 0;
 		} elseif (!empty($detailedVotes)) {
 			$data['details'] = array_map(static fn (Vote $vote) => $vote->asArray(), $detailedVotes);
 		}

--- a/lib/Controller/PollController.php
+++ b/lib/Controller/PollController.php
@@ -152,19 +152,11 @@ class PollController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
-		if ($poll->getMaxVotes() !== Poll::MAX_VOTES_UNLIMITED
-			&& $poll->getMaxVotes() < count($optionIds)) {
+		try {
+			$votedSelf = $this->pollService->votePoll($this->participant, $poll, $optionIds);
+		} catch (\RuntimeException $e) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
-
-		$maxOptionId = max(array_keys(json_decode($poll->getOptions(), true, 512, JSON_THROW_ON_ERROR)));
-		$maxVotedId = max($optionIds);
-		$minVotedId = min($optionIds);
-		if ($minVotedId < 0 || $maxVotedId > $maxOptionId) {
-			return new DataResponse([], Http::STATUS_BAD_REQUEST);
-		}
-
-		$votedSelf = $this->pollService->votePoll($this->participant, $poll, $optionIds);
 
 		return new DataResponse($this->renderPoll($poll, $votedSelf));
 	}

--- a/lib/Controller/PollController.php
+++ b/lib/Controller/PollController.php
@@ -199,7 +199,11 @@ class PollController extends AEnvironmentAwareController {
 		$data = $poll->asArray();
 		unset($data['roomId']);
 
-		$data['voted'] = array_map(static fn (Vote $vote) => $vote->getOptionId(), $votes);
+		if ($poll->getResultMode() === Poll::MODE_HIDDEN && $poll->getStatus() === Poll::STATUS_OPEN) {
+			$data['votes'] = [];
+		}
+
+		$data['votedSelf'] = array_map(static fn (Vote $vote) => $vote->getOptionId(), $votes);
 
 		return $data;
 	}

--- a/lib/Controller/PollController.php
+++ b/lib/Controller/PollController.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2016 Lukas Reschke <lukas@statuscode.ch>
+ * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Lukas Reschke <lukas@statuscode.ch>
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Controller;
+
+use OCA\Talk\Chat\ChatManager;
+use OCA\Talk\Service\PollService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Comments\MessageTooLongException;
+use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+
+class PollController extends AEnvironmentAwareController {
+	protected ChatManager $chatManager;
+	protected PollService $pollService;
+	protected ITimeFactory $timeFactory;
+	protected LoggerInterface $logger;
+
+	public function __construct(string $appName,
+								IRequest $request,
+								ChatManager $chatManager,
+								PollService $pollService,
+								ITimeFactory $timeFactory,
+								LoggerInterface $logger) {
+		parent::__construct($appName, $request);
+		$this->pollService = $pollService;
+		$this->chatManager = $chatManager;
+		$this->timeFactory = $timeFactory;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @PublicPage
+	 * @RequireParticipant
+	 * @RequireReadWriteConversation
+	 * @RequirePermissions(permissions=chat)
+	 * @RequireModeratorOrNoLobby
+	 *
+	 * @param string $question
+	 * @param array $options
+	 * @param int $resultMode
+	 * @param int $maxVotes
+	 * @return DataResponse
+	 */
+	public function createPoll(string $question, array $options, int $resultMode, int $maxVotes): DataResponse {
+		$attendee = $this->participant->getAttendee();
+		try {
+			$poll = $this->pollService->createPoll(
+				$this->room->getId(),
+				$attendee->getActorType(),
+				$attendee->getActorId(),
+				$question,
+				$options,
+				$resultMode,
+				$maxVotes
+			);
+		} catch (\Exception $e) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
+		$message = json_encode([
+			'message' => 'object_shared',
+			'parameters' => [
+				'objectType' => 'highlight', // FIXME 'talk-poll',
+				'objectId' => $poll->getId(),
+				'metaData' => [
+					'type' => 'highlight', // FIXME 'talk-poll',
+					'id' => $poll->getId(),
+					'name' => $question,
+				]
+			],
+		], JSON_THROW_ON_ERROR);
+
+		try {
+			$this->chatManager->addSystemMessage($this->room, $attendee->getActorType(), $attendee->getActorId(), $message, $this->timeFactory->getDateTime(), true);
+		} catch (\Exception $e) {
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+		}
+
+		return new DataResponse($poll->asArray());
+	}
+}

--- a/lib/GuestManager.php
+++ b/lib/GuestManager.php
@@ -27,6 +27,7 @@ use OCA\Talk\Events\AddEmailEvent;
 use OCA\Talk\Events\ModifyParticipantEvent;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Service\ParticipantService;
+use OCA\Talk\Service\PollService;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IL10N;
@@ -42,19 +43,13 @@ class GuestManager {
 	public const EVENT_AFTER_NAME_UPDATE = self::class . '::updateName';
 
 	protected Config $talkConfig;
-
 	protected IMailer $mailer;
-
 	protected Defaults $defaults;
-
 	protected IUserSession $userSession;
-
-	private ParticipantService $participantService;
-
+	protected ParticipantService $participantService;
+	protected PollService $pollService;
 	protected IURLGenerator $url;
-
 	protected IL10N $l;
-
 	protected IEventDispatcher $dispatcher;
 
 	public function __construct(Config $talkConfig,
@@ -62,6 +57,7 @@ class GuestManager {
 								Defaults $defaults,
 								IUserSession $userSession,
 								ParticipantService $participantService,
+								PollService $pollService,
 								IURLGenerator $url,
 								IL10N $l,
 								IEventDispatcher $dispatcher) {
@@ -70,6 +66,7 @@ class GuestManager {
 		$this->defaults = $defaults;
 		$this->userSession = $userSession;
 		$this->participantService = $participantService;
+		$this->pollService = $pollService;
 		$this->url = $url;
 		$this->l = $l;
 		$this->dispatcher = $dispatcher;
@@ -84,6 +81,12 @@ class GuestManager {
 		$attendee = $participant->getAttendee();
 		if ($attendee->getDisplayName() !== $displayName) {
 			$this->participantService->updateDisplayNameForActor(
+				$attendee->getActorType(),
+				$attendee->getActorId(),
+				$displayName
+			);
+
+			$this->pollService->updateDisplayNameForActor(
 				$attendee->getActorType(),
 				$attendee->getActorId(),
 				$displayName

--- a/lib/Listener/UserDisplayNameListener.php
+++ b/lib/Listener/UserDisplayNameListener.php
@@ -25,15 +25,19 @@ namespace OCA\Talk\Listener;
 
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Service\ParticipantService;
+use OCA\Talk\Service\PollService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\User\Events\UserChangedEvent;
 
 class UserDisplayNameListener implements IEventListener {
 	private ParticipantService $participantService;
+	private PollService $pollService;
 
-	public function __construct(ParticipantService $participantService) {
+	public function __construct(ParticipantService $participantService,
+								PollService $pollService) {
 		$this->participantService = $participantService;
+		$this->pollService = $pollService;
 	}
 
 	public function handle(Event $event): void {
@@ -48,6 +52,12 @@ class UserDisplayNameListener implements IEventListener {
 		}
 
 		$this->participantService->updateDisplayNameForActor(
+			Attendee::ACTOR_USERS,
+			$event->getUser()->getUID(),
+			(string) $event->getValue()
+		);
+
+		$this->pollService->updateDisplayNameForActor(
 			Attendee::ACTOR_USERS,
 			$event->getUser()->getUID(),
 			(string) $event->getValue()

--- a/lib/Migration/Version15000Date20220503121308.php
+++ b/lib/Migration/Version15000Date20220503121308.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version15000Date20220503121308 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('talk_polls')) {
+			$table = $schema->createTable('talk_polls');
+
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 20,
+			]);
+			$table->addColumn('room_id', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 20,
+			]);
+			$table->addColumn('question', Types::TEXT, [
+				'notnull' => false,
+				'length' => null,
+			]);
+			$table->addColumn('options', Types::TEXT, [
+				'notnull' => false,
+				'length' => null,
+			]);
+			$table->addColumn('actor_type', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('actor_id', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('status', Types::SMALLINT, [
+				'notnull' => false,
+				'default' => 0,
+			]);
+			$table->addColumn('result_mode', Types::SMALLINT, [
+				'notnull' => false,
+				'default' => 0,
+			]);
+			$table->addColumn('max_votes', Types::INTEGER, [
+				'notnull' => true,
+				'default' => 0,
+			]);
+
+			$table->setPrimaryKey(['id']);
+			$table->addIndex(['room_id'], 'talk_poll_room');
+		}
+
+		if (!$schema->hasTable('talk_poll_votes')) {
+			$table = $schema->createTable('talk_poll_votes');
+
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 20,
+			]);
+			$table->addColumn('poll_id', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 20,
+			]);
+			$table->addColumn('room_id', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 20,
+			]);
+			$table->addColumn('actor_type', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('actor_id', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('option_id', Types::INTEGER, [
+				'notnull' => true,
+				'length' => 6,
+				'default' => 1,
+			]);
+
+			$table->setPrimaryKey(['id']);
+			$table->addIndex(['poll_id', 'actor_type', 'actor_id'], 'talk_poll_vote');
+			$table->addIndex(['room_id'], 'talk_vote_room');
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version15000Date20220503121308.php
+++ b/lib/Migration/Version15000Date20220503121308.php
@@ -67,6 +67,11 @@ class Version15000Date20220503121308 extends SimpleMigrationStep {
 				'notnull' => false,
 				'length' => null,
 			]);
+			$table->addColumn('num_voters', Types::BIGINT, [
+				'notnull' => false,
+				'length' => 20,
+				'default' => 0,
+			]);
 			$table->addColumn('actor_type', Types::STRING, [
 				'notnull' => true,
 				'length' => 64,

--- a/lib/Migration/Version15000Date20220503121308.php
+++ b/lib/Migration/Version15000Date20220503121308.php
@@ -71,6 +71,10 @@ class Version15000Date20220503121308 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 64,
 			]);
+			$table->addColumn('display_name', Types::STRING, [
+				'notnull' => false,
+				'length' => 255,
+			]);
 			$table->addColumn('status', Types::SMALLINT, [
 				'notnull' => false,
 				'default' => 0,
@@ -111,6 +115,10 @@ class Version15000Date20220503121308 extends SimpleMigrationStep {
 			$table->addColumn('actor_id', Types::STRING, [
 				'notnull' => true,
 				'length' => 64,
+			]);
+			$table->addColumn('display_name', Types::STRING, [
+				'notnull' => false,
+				'length' => 255,
 			]);
 			$table->addColumn('option_id', Types::INTEGER, [
 				'notnull' => true,

--- a/lib/Migration/Version15000Date20220503121308.php
+++ b/lib/Migration/Version15000Date20220503121308.php
@@ -63,6 +63,10 @@ class Version15000Date20220503121308 extends SimpleMigrationStep {
 				'notnull' => false,
 				'length' => null,
 			]);
+			$table->addColumn('votes', Types::TEXT, [
+				'notnull' => false,
+				'length' => null,
+			]);
 			$table->addColumn('actor_type', Types::STRING, [
 				'notnull' => true,
 				'length' => 64,

--- a/lib/Model/Poll.php
+++ b/lib/Model/Poll.php
@@ -35,6 +35,8 @@ use OCP\AppFramework\Db\Entity;
  * @method string getQuestion()
  * @method void setOptions(string $options)
  * @method string getOptions()
+ * @method void setVotes(string $votes)
+ * @method string getVotes()
  * @method void setActorType(string $actorType)
  * @method string getActorType()
  * @method void setActorId(string $actorId)
@@ -58,6 +60,7 @@ class Poll extends Entity {
 	protected int $roomId = 0;
 	protected string $question = '';
 	protected string $options = '';
+	protected string $votes = '';
 	protected string $actorType = '';
 	protected string $actorId = '';
 	protected ?string $displayName = null;
@@ -69,6 +72,7 @@ class Poll extends Entity {
 		$this->addType('roomId', 'int');
 		$this->addType('question', 'string');
 		$this->addType('options', 'string');
+		$this->addType('votes', 'string');
 		$this->addType('actorType', 'string');
 		$this->addType('actorId', 'string');
 		$this->addType('displayName', 'string');
@@ -85,7 +89,8 @@ class Poll extends Entity {
 			'id' => $this->getId(),
 			// 'roomId' => $this->getRoomId(),
 			'question' => $this->getQuestion(),
-			'options' => $this->getOptions(),
+			'options' => json_decode($this->getOptions(), true, 512, JSON_THROW_ON_ERROR),
+			'votes' => json_decode($this->getVotes(), true, 512, JSON_THROW_ON_ERROR),
 			'actorType' => $this->getActorType(),
 			'actorId' => $this->getActorId(),
 			'actorDisplayName' => $this->getDisplayName(),

--- a/lib/Model/Poll.php
+++ b/lib/Model/Poll.php
@@ -37,6 +37,8 @@ use OCP\AppFramework\Db\Entity;
  * @method string getOptions()
  * @method void setVotes(string $votes)
  * @method string getVotes()
+ * @method void setNumVoters(int $numVoters)
+ * @method int getNumVoters()
  * @method void setActorType(string $actorType)
  * @method string getActorType()
  * @method void setActorId(string $actorId)
@@ -61,6 +63,7 @@ class Poll extends Entity {
 	protected string $question = '';
 	protected string $options = '';
 	protected string $votes = '';
+	protected int $numVoters = 0;
 	protected string $actorType = '';
 	protected string $actorId = '';
 	protected ?string $displayName = null;
@@ -73,6 +76,7 @@ class Poll extends Entity {
 		$this->addType('question', 'string');
 		$this->addType('options', 'string');
 		$this->addType('votes', 'string');
+		$this->addType('numVoters', 'int');
 		$this->addType('actorType', 'string');
 		$this->addType('actorId', 'string');
 		$this->addType('displayName', 'string');
@@ -91,6 +95,7 @@ class Poll extends Entity {
 			'question' => $this->getQuestion(),
 			'options' => json_decode($this->getOptions(), true, 512, JSON_THROW_ON_ERROR),
 			'votes' => json_decode($this->getVotes(), true, 512, JSON_THROW_ON_ERROR),
+			'numVoters' => $this->getNumVoters(),
 			'actorType' => $this->getActorType(),
 			'actorId' => $this->getActorId(),
 			'actorDisplayName' => $this->getDisplayName(),

--- a/lib/Model/Poll.php
+++ b/lib/Model/Poll.php
@@ -91,6 +91,7 @@ class Poll extends Entity {
 	public function asArray(): array {
 		return [
 			'id' => $this->getId(),
+			// The room id is not needed on the API level but only internally for optimising database queries
 			// 'roomId' => $this->getRoomId(),
 			'question' => $this->getQuestion(),
 			'options' => json_decode($this->getOptions(), true, 512, JSON_THROW_ON_ERROR),

--- a/lib/Model/Poll.php
+++ b/lib/Model/Poll.php
@@ -79,7 +79,7 @@ class Poll extends Entity {
 	public function asArray(): array {
 		return [
 			'id' => $this->getId(),
-			'roomId' => $this->getRoomId(),
+			// 'roomId' => $this->getRoomId(),
 			'question' => $this->getQuestion(),
 			'options' => $this->getOptions(),
 			'actorType' => $this->getActorType(),

--- a/lib/Model/Poll.php
+++ b/lib/Model/Poll.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Model;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method void setRoomId(int $roomId)
+ * @method int getRoomId()
+ * @method void setQuestion(string $question)
+ * @method string getQuestion()
+ * @method void setOptions(string $options)
+ * @method string getOptions()
+ * @method void setActorType(string $actorType)
+ * @method string getActorType()
+ * @method void setActorId(string $actorId)
+ * @method string getActorId()
+ * @method void setStatus(int $status)
+ * @method int getStatus()
+ * @method void setResultMode(int $resultMode)
+ * @method int getResultMode()
+ * @method void setMaxVotes(int $maxVotes)
+ * @method int getMaxVotes()
+ */
+class Poll extends Entity {
+	public const STATUS_OPEN = 0;
+	public const STATUS_CLOSED = 1;
+	public const MODE_PUBLIC = 0;
+	public const MODE_HIDDEN = 1;
+	public const MAX_VOTES_UNLIMITED = 0;
+
+	protected int $roomId = 0;
+	protected string $question = '';
+	protected string $options = '';
+	protected string $actorType = '';
+	protected string $actorId = '';
+	protected int $status = self::STATUS_OPEN;
+	protected int $resultMode = self::MODE_PUBLIC;
+	protected int $maxVotes = self::MAX_VOTES_UNLIMITED;
+
+	public function __construct() {
+		$this->addType('roomId', 'int');
+		$this->addType('question', 'string');
+		$this->addType('options', 'string');
+		$this->addType('actorType', 'string');
+		$this->addType('actorId', 'string');
+		$this->addType('status', 'int');
+		$this->addType('resultMode', 'int');
+		$this->addType('maxVotes', 'int');
+	}
+
+	/**
+	 * @return array
+	 */
+	public function asArray(): array {
+		return [
+			'id' => $this->getId(),
+			'roomId' => $this->getRoomId(),
+			'question' => $this->getQuestion(),
+			'options' => $this->getOptions(),
+			'actorType' => $this->getActorType(),
+			'actorId' => $this->getActorId(),
+			'status' => $this->getStatus(),
+			'resultMode' => $this->getResultMode(),
+			'maxVotes' => $this->getMaxVotes(),
+		];
+	}
+}

--- a/lib/Model/Poll.php
+++ b/lib/Model/Poll.php
@@ -39,6 +39,8 @@ use OCP\AppFramework\Db\Entity;
  * @method string getActorType()
  * @method void setActorId(string $actorId)
  * @method string getActorId()
+ * @method void setDisplayName(string $displayName)
+ * @method string getDisplayName()
  * @method void setStatus(int $status)
  * @method int getStatus()
  * @method void setResultMode(int $resultMode)
@@ -58,6 +60,7 @@ class Poll extends Entity {
 	protected string $options = '';
 	protected string $actorType = '';
 	protected string $actorId = '';
+	protected ?string $displayName = null;
 	protected int $status = self::STATUS_OPEN;
 	protected int $resultMode = self::MODE_PUBLIC;
 	protected int $maxVotes = self::MAX_VOTES_UNLIMITED;
@@ -68,6 +71,7 @@ class Poll extends Entity {
 		$this->addType('options', 'string');
 		$this->addType('actorType', 'string');
 		$this->addType('actorId', 'string');
+		$this->addType('displayName', 'string');
 		$this->addType('status', 'int');
 		$this->addType('resultMode', 'int');
 		$this->addType('maxVotes', 'int');
@@ -84,6 +88,7 @@ class Poll extends Entity {
 			'options' => $this->getOptions(),
 			'actorType' => $this->getActorType(),
 			'actorId' => $this->getActorId(),
+			'actorDisplayName' => $this->getDisplayName(),
 			'status' => $this->getStatus(),
 			'resultMode' => $this->getResultMode(),
 			'maxVotes' => $this->getMaxVotes(),

--- a/lib/Model/PollMapper.php
+++ b/lib/Model/PollMapper.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Model;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\IDBConnection;
+
+class PollMapper extends QBMapper {
+
+	/**
+	 * @param IDBConnection $db
+	 */
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'talk_polls', Poll::class);
+	}
+}

--- a/lib/Model/PollMapper.php
+++ b/lib/Model/PollMapper.php
@@ -53,9 +53,18 @@ class PollMapper extends QBMapper {
 		$query = $this->db->getQueryBuilder();
 
 		$query->select('*')
-			->from('talk_polls')
+			->from($this->getTableName())
 			->where($query->expr()->eq('id', $query->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)));
 
 		return $this->findEntity($query);
+	}
+
+	public function deleteByRoomId(int $roomId): void {
+		$query = $this->db->getQueryBuilder();
+
+		$query->delete($this->getTableName())
+			->where($query->expr()->eq('room_id', $query->createNamedParameter($roomId, IQueryBuilder::PARAM_INT)));
+
+		$query->executeStatement();
 	}
 }

--- a/lib/Model/PollMapper.php
+++ b/lib/Model/PollMapper.php
@@ -26,7 +26,11 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Model;
 
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
 class PollMapper extends QBMapper {
@@ -36,5 +40,22 @@ class PollMapper extends QBMapper {
 	 */
 	public function __construct(IDBConnection $db) {
 		parent::__construct($db, 'talk_polls', Poll::class);
+	}
+
+	/**
+	 * @param int $pollId
+	 * @return Poll
+	 * @throws DoesNotExistException
+	 * @throws MultipleObjectsReturnedException
+	 * @throws Exception
+	 */
+	public function getByPollId(int $pollId): Poll {
+		$query = $this->db->getQueryBuilder();
+
+		$query->select('*')
+			->from('talk_polls')
+			->where($query->expr()->eq('id', $query->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)));
+
+		return $this->findEntity($query);
 	}
 }

--- a/lib/Model/Vote.php
+++ b/lib/Model/Vote.php
@@ -41,11 +41,11 @@ use OCP\AppFramework\Db\Entity;
  * @method int getOptionId()
  */
 class Vote extends Entity {
-	protected int $pollId;
-	protected int $roomId;
-	protected string $actorType;
-	protected string $actorId;
-	protected int $optionId;
+	protected int $pollId = 0;
+	protected int $roomId = 0;
+	protected string $actorType = '';
+	protected string $actorId = '';
+	protected int $optionId = 0;
 
 	public function __construct() {
 		$this->addType('pollId', 'int');

--- a/lib/Model/Vote.php
+++ b/lib/Model/Vote.php
@@ -64,7 +64,8 @@ class Vote extends Entity {
 	 */
 	public function asArray(): array {
 		return [
-			'id' => $this->getId(),
+			// The ids are not needed on the API level but only internally for optimising database queries
+			// 'id' => $this->getId(),
 			// 'pollId' => $this->getPollId(),
 			// 'roomId' => $this->getRoomId(),
 			'actorType' => $this->getActorType(),

--- a/lib/Model/Vote.php
+++ b/lib/Model/Vote.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Model;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method void setPollId(int $pollId)
+ * @method int getPollId()
+ * @method void setRoomId(int $roomId)
+ * @method int getRoomId()
+ * @method void setActorType(string $actorType)
+ * @method string getActorType()
+ * @method void setActorId(string $actorId)
+ * @method string getActorId()
+ * @method void setOptionId(int $optionId)
+ * @method int getOptionId()
+ */
+class Vote extends Entity {
+	protected int $pollId;
+	protected int $roomId;
+	protected string $actorType;
+	protected string $actorId;
+	protected int $optionId;
+
+	public function __construct() {
+		$this->addType('pollId', 'int');
+		$this->addType('roomId', 'int');
+		$this->addType('actorType', 'string');
+		$this->addType('actorId', 'string');
+		$this->addType('optionId', 'int');
+	}
+
+	/**
+	 * @return array
+	 */
+	public function asArray(): array {
+		return [
+			'id' => $this->getId(),
+			'pollId' => $this->getPollId(),
+			// 'roomId' => $this->getRoomId(),
+			'actorType' => $this->getActorType(),
+			'actorId' => $this->getActorId(),
+			'optionId' => $this->getOptionId(),
+		];
+	}
+}

--- a/lib/Model/Vote.php
+++ b/lib/Model/Vote.php
@@ -37,6 +37,8 @@ use OCP\AppFramework\Db\Entity;
  * @method string getActorType()
  * @method void setActorId(string $actorId)
  * @method string getActorId()
+ * @method void setDisplayName(string $displayName)
+ * @method string getDisplayName()
  * @method void setOptionId(int $optionId)
  * @method int getOptionId()
  */
@@ -45,6 +47,7 @@ class Vote extends Entity {
 	protected int $roomId = 0;
 	protected string $actorType = '';
 	protected string $actorId = '';
+	protected ?string $displayName = null;
 	protected int $optionId = 0;
 
 	public function __construct() {
@@ -52,6 +55,7 @@ class Vote extends Entity {
 		$this->addType('roomId', 'int');
 		$this->addType('actorType', 'string');
 		$this->addType('actorId', 'string');
+		$this->addType('displayName', 'string');
 		$this->addType('optionId', 'int');
 	}
 
@@ -65,6 +69,7 @@ class Vote extends Entity {
 			// 'roomId' => $this->getRoomId(),
 			'actorType' => $this->getActorType(),
 			'actorId' => $this->getActorId(),
+			'actorDisplayName' => $this->getDisplayName(),
 			'optionId' => $this->getOptionId(),
 		];
 	}

--- a/lib/Model/Vote.php
+++ b/lib/Model/Vote.php
@@ -65,7 +65,7 @@ class Vote extends Entity {
 	public function asArray(): array {
 		return [
 			'id' => $this->getId(),
-			'pollId' => $this->getPollId(),
+			// 'pollId' => $this->getPollId(),
 			// 'roomId' => $this->getRoomId(),
 			'actorType' => $this->getActorType(),
 			'actorId' => $this->getActorId(),

--- a/lib/Model/VoteMapper.php
+++ b/lib/Model/VoteMapper.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Model;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\IDBConnection;
+
+class VoteMapper extends QBMapper {
+
+	/**
+	 * @param IDBConnection $db
+	 */
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'talk_poll_votes', Vote::class);
+	}
+
+	/**
+	 * @param int $pollId
+	 * @return Vote[]
+	 */
+	public function findByPollId(int $pollId): array {
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->eq('poll_id', $query->createNamedParameter($pollId)));
+
+		return $this->findEntities($query);
+	}
+
+	/**
+	 * @param int $pollId
+	 * @param string $actorType
+	 * @param string $actorId
+	 * @return Vote[]
+	 */
+	public function findByPollIdForActor(int $pollId, string $actorType, string $actorId): array {
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->eq('poll_id', $query->createNamedParameter($pollId)))
+			->andWhere($query->expr()->eq('actor_type', $query->createNamedParameter($actorType)))
+			->andWhere($query->expr()->eq('actor_id', $query->createNamedParameter($actorId)));
+
+		return $this->findEntities($query);
+	}
+}

--- a/lib/Model/VoteMapper.php
+++ b/lib/Model/VoteMapper.php
@@ -77,4 +77,15 @@ class VoteMapper extends QBMapper {
 
 		$query->executeStatement();
 	}
+
+	public function deleteVotesByActor(int $pollId, string $actorType, string $actorId): void {
+		$query = $this->db->getQueryBuilder();
+
+		$query->delete($this->getTableName())
+			->where($query->expr()->eq('poll_id', $query->createNamedParameter($pollId)))
+			->andWhere($query->expr()->eq('actor_type', $query->createNamedParameter($actorType)))
+			->andWhere($query->expr()->eq('actor_id', $query->createNamedParameter($actorId)));
+
+		$query->executeStatement();
+	}
 }

--- a/lib/Model/VoteMapper.php
+++ b/lib/Model/VoteMapper.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Model;
 
 use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
 class VoteMapper extends QBMapper {
@@ -66,5 +67,14 @@ class VoteMapper extends QBMapper {
 			->andWhere($query->expr()->eq('actor_id', $query->createNamedParameter($actorId)));
 
 		return $this->findEntities($query);
+	}
+
+	public function deleteByRoomId(int $roomId): void {
+		$query = $this->db->getQueryBuilder();
+
+		$query->delete($this->getTableName())
+			->where($query->expr()->eq('room_id', $query->createNamedParameter($roomId, IQueryBuilder::PARAM_INT)));
+
+		$query->executeStatement();
 	}
 }

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Service;
+
+use OCA\Talk\Model\Poll;
+use OCA\Talk\Model\PollMapper;
+use OCA\Talk\Model\VoteMapper;
+
+class PollService {
+	protected PollMapper $pollMapper;
+	protected VoteMapper $voteMapper;
+
+	public function __construct(PollMapper $pollMapper,
+								VoteMapper $voteMapper) {
+		$this->pollMapper = $pollMapper;
+		$this->voteMapper = $voteMapper;
+	}
+
+	public function createPoll(int $roomId, string $actorType, string $actorId, string $question, array $options, int $resultMode, int $maxVotes): Poll {
+		$poll = new Poll();
+		$poll->setRoomId($roomId);
+		$poll->setActorType($actorType);
+		$poll->setActorId($actorId);
+		$poll->setQuestion($question);
+		$poll->setOptions(json_encode($options));
+		$poll->setResultMode($resultMode);
+		$poll->setMaxVotes($maxVotes);
+
+		$this->pollMapper->insert($poll);
+
+		return $poll;
+	}
+}

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -235,6 +235,7 @@ class PollService {
 		$subQuery = $this->connection->getQueryBuilder();
 		$subQuery->select('actor_type', 'actor_id')
 			->from('talk_poll_votes')
+			->where($subQuery->expr()->eq('poll_id', $subQuery->createNamedParameter($pollId)))
 			->groupBy('actor_type', 'actor_id');
 
 		$votersQuery = $this->connection->getQueryBuilder();

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -92,7 +92,7 @@ class PollService {
 		if (!$participant->hasModeratorPermissions()
 		 && ($poll->getActorType() !== $participant->getAttendee()->getActorType()
 		 || $poll->getActorId() !== $participant->getAttendee()->getActorId())) {
-			// Only moderators and the author of the poll can close it
+			// Only moderators and the author of the poll can update it
 			throw new WrongPermissionsException();
 		}
 

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -93,4 +93,9 @@ class PollService {
 
 		$this->pollMapper->update($poll);
 	}
+
+	public function deleteByRoomId(int $roomId): void {
+		$this->voteMapper->deleteByRoomId($roomId);
+		$this->pollMapper->deleteByRoomId($roomId);
+	}
 }

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -113,6 +113,14 @@ class PollService {
 	}
 
 	/**
+	 * @param Poll $poll
+	 * @return Vote[]
+	 */
+	public function getVotes(Poll $poll): array {
+		return $this->voteMapper->findByPollId($poll->getId());
+	}
+
+	/**
 	 * @param Participant $participant
 	 * @param Poll $poll
 	 * @param int[] $optionIds Options the user voted for

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
       - 'Call management': 'call.md'
       - 'Chat management': 'chat.md'
       - 'Reaction management': 'reaction.md'
+      - 'Poll management': 'poll.md'
       - 'Webinar management': 'webinar.md'
       - 'Settings': 'settings.md'
       - 'Integration by other apps': 'integration.md'

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1554,22 +1554,19 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" sees (poll details|poll) "([^"]*)" in room "([^"]*)" with (\d+)(?: \((v1)\))?$/
+	 * @Then /^user "([^"]*)" sees poll "([^"]*)" in room "([^"]*)" with (\d+)(?: \((v1)\))?$/
 	 *
 	 * @param string $user
-	 * @param string $details
 	 * @param string $question
 	 * @param string $identifier
 	 * @param string $statusCode
 	 * @param string $apiVersion
 	 * @param ?TableNode $formData
 	 */
-	public function userSeesPollInRoom($user, $details, $question, $identifier, $statusCode, $apiVersion = 'v1', TableNode $formData = null) {
+	public function userSeesPollInRoom($user, $question, $identifier, $statusCode, $apiVersion = 'v1', TableNode $formData = null) {
 		$this->setCurrentUser($user);
 
-		$query = $details === 'poll details' ? '?details=1' : '';
-
-		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/poll/' . self::$identifierToToken[$identifier] . '/' . self::$questionToPollId[$question] . $query);
+		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/poll/' . self::$identifierToToken[$identifier] . '/' . self::$questionToPollId[$question]);
 		$this->assertStatusCode($this->response, $statusCode);
 
 		$expected = $this->preparePollExpectedData($formData->getRowsHash());
@@ -1671,6 +1668,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		if (isset($expected['details'])) {
 			$expected['details'] = json_decode($expected['details'], true);
 		}
+		$expected['numVoters'] = (int) $expected['numVoters'];
 		$expected['options'] = json_decode($expected['options'], true);
 
 		$result = preg_match('/POLL_ID\(([^)]+)\)/', $expected['id'], $matches);

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1563,7 +1563,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	 * @param string $apiVersion
 	 * @param ?TableNode $formData
 	 */
-	public function userSeesPollInRoom($user, $question, $identifier, $statusCode, $apiVersion = 'v1', TableNode $formData = null) {
+	public function userSeesPollInRoom(string $user, string $question, string $identifier, string $statusCode, string $apiVersion = 'v1', TableNode $formData = null): void {
 		$this->setCurrentUser($user);
 
 		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/poll/' . self::$identifierToToken[$identifier] . '/' . self::$questionToPollId[$question]);
@@ -1584,7 +1584,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	 * @param string $apiVersion
 	 * @param ?TableNode $formData
 	 */
-	public function userClosesPollInRoom($user, $question, $identifier, $statusCode, $apiVersion = 'v1', TableNode $formData = null) {
+	public function userClosesPollInRoom(string $user, string $question, string $identifier, string $statusCode, string $apiVersion = 'v1', TableNode $formData = null): void {
 		$this->setCurrentUser($user);
 		$this->sendRequest('DELETE', '/apps/spreed/api/' . $apiVersion . '/poll/' . self::$identifierToToken[$identifier] . '/' . self::$questionToPollId[$question]);
 		$this->assertStatusCode($this->response, $statusCode);
@@ -1609,7 +1609,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	 * @param string $apiVersion
 	 * @param ?TableNode $formData
 	 */
-	public function userVotesPollInRoom($user, $options, $question, $identifier, $statusCode, $apiVersion = 'v1', TableNode $formData = null) {
+	public function userVotesPollInRoom(string $user, string $options, string $question, string $identifier, string $statusCode, string $apiVersion = 'v1', TableNode $formData = null): void {
 		$data = [
 			'optionIds' => json_decode($options, true),
 		];

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1543,6 +1543,10 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		);
 		$this->assertStatusCode($this->response, $statusCode);
 
+		if ($statusCode !== '201') {
+			return;
+		}
+
 		$response = $this->getDataFromResponse($this->response);
 		if (isset($response['id'])) {
 			self::$questionToPollId[$data['question']] = $response['id'];
@@ -1585,6 +1589,10 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->sendRequest('DELETE', '/apps/spreed/api/' . $apiVersion . '/poll/' . self::$identifierToToken[$identifier] . '/' . self::$questionToPollId[$question]);
 		$this->assertStatusCode($this->response, $statusCode);
 
+		if ($statusCode !== '200') {
+			return;
+		}
+
 		$expected = $this->preparePollExpectedData($formData->getRowsHash());
 		$response = $this->getDataFromResponse($this->response);
 
@@ -1613,6 +1621,10 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			$data
 		);
 		$this->assertStatusCode($this->response, $statusCode);
+
+		if ($statusCode !== '200' && $statusCode !== '201') {
+			return;
+		}
 
 		$expected = $this->preparePollExpectedData($formData->getRowsHash());
 		$response = $this->getDataFromResponse($this->response);

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1647,11 +1647,14 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			$expected['status'] = 1;
 		}
 
-		if ($expected['voted'] === 'not voted') {
-			$expected['voted'] = [];
+		if ($expected['votedSelf'] === 'not voted') {
+			$expected['votedSelf'] = [];
 		} else {
-			$expected['voted'] = json_decode($expected['voted'], true);
+			$expected['votedSelf'] = json_decode($expected['votedSelf'], true);
 		}
+
+		$expected['votes'] = isset($expected['votes']) ? json_decode($expected['votes'], true) : [];
+		$expected['options'] = json_decode($expected['options'], true);
 
 		$result = preg_match('/POLL_ID\(([^)]+)\)/', $expected['id'], $matches);
 		if ($result) {

--- a/tests/integration/features/chat/poll.feature
+++ b/tests/integration/features/chat/poll.feature
@@ -1,0 +1,16 @@
+Feature: chat/poll
+  Background:
+    Given user "participant1" exists
+
+  Scenario: create a public poll without max votes limit
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" creates a poll in room "room" with 200
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | room | users     | participant1 | participant1-displayname | {object}  | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"object":{"type":"highlight","id":POLL_ID(What is the question?),"name":"What is the question?"}} |

--- a/tests/integration/features/chat/poll.feature
+++ b/tests/integration/features/chat/poll.feature
@@ -23,6 +23,17 @@ Feature: chat/poll
       | actorType  | users |
       | actorId    | participant1 |
       | status     | open |
+      | voted      | not voted |
+    Then user "participant1" votes for options "[1]" on poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | status     | open |
+      | voted      | [1] |
     Then user "participant1" closes poll "What is the question?" in room "room" with 200
       | id         | POLL_ID(What is the question?) |
       | question   | What is the question? |
@@ -32,3 +43,4 @@ Feature: chat/poll
       | actorType  | users |
       | actorId    | participant1 |
       | status     | closed |
+      | voted      | [1] |

--- a/tests/integration/features/chat/poll.feature
+++ b/tests/integration/features/chat/poll.feature
@@ -6,7 +6,7 @@ Feature: chat/poll
     Given user "participant1" creates room "room" (v4)
       | roomType | 2 |
       | roomName | room |
-    When user "participant1" creates a poll in room "room" with 200
+    When user "participant1" creates a poll in room "room" with 201
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
       | resultMode | public |

--- a/tests/integration/features/chat/poll.feature
+++ b/tests/integration/features/chat/poll.feature
@@ -23,6 +23,7 @@ Feature: chat/poll
       | maxVotes   | unlimited |
       | actorType  | users |
       | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
       | status     | open |
       | voted      | not voted |
     Then user "participant1" votes for options "[1]" on poll "What is the question?" in room "room" with 200
@@ -33,6 +34,7 @@ Feature: chat/poll
       | maxVotes   | unlimited |
       | actorType  | users |
       | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
       | status     | open |
       | voted      | [1] |
     Then user "participant1" closes poll "What is the question?" in room "room" with 200
@@ -43,6 +45,7 @@ Feature: chat/poll
       | maxVotes   | unlimited |
       | actorType  | users |
       | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
       | status     | closed |
       | voted      | [1] |
 
@@ -63,6 +66,7 @@ Feature: chat/poll
       | maxVotes   | unlimited |
       | actorType  | users |
       | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
       | status     | open |
       | voted      | [1] |
     Then user "participant1" votes for options "[0]" on poll "What is the question?" in room "room" with 200
@@ -73,6 +77,7 @@ Feature: chat/poll
       | maxVotes   | unlimited |
       | actorType  | users |
       | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
       | status     | open |
       | voted      | [0] |
 
@@ -116,6 +121,7 @@ Feature: chat/poll
       | maxVotes   | unlimited |
       | actorType  | users |
       | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
       | status     | open |
       | voted      | [0,1] |
 
@@ -140,6 +146,7 @@ Feature: chat/poll
       | maxVotes   | unlimited |
       | actorType  | users |
       | actorId    | participant2 |
+      | actorDisplayName    | participant2-displayname |
       | status     | closed |
       | voted      | not voted |
 
@@ -174,6 +181,7 @@ Feature: chat/poll
       | maxVotes   | unlimited |
       | actorType  | users |
       | actorId    | participant2 |
+      | actorDisplayName    | participant2-displayname |
       | status     | closed |
       | voted      | not voted |
 

--- a/tests/integration/features/chat/poll.feature
+++ b/tests/integration/features/chat/poll.feature
@@ -145,6 +145,17 @@ Feature: chat/poll
       | status     | open |
       | votedSelf  | [0,1] |
 
+  Scenario: Participants can not vote for the same option multiple times
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" creates a poll in room "room" with 201
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+    Then user "participant1" votes for options "[1,1]" on poll "What is the question?" in room "room" with 400
+
   Scenario: Non-moderators can also create polls and close it themselves
     Given user "participant1" creates room "room" (v4)
       | roomType | 2 |

--- a/tests/integration/features/chat/poll.feature
+++ b/tests/integration/features/chat/poll.feature
@@ -1,8 +1,9 @@
 Feature: chat/poll
   Background:
     Given user "participant1" exists
+    Given user "participant2" exists
 
-  Scenario: create a public poll without max votes limit
+  Scenario: Create a public poll without max votes limit
     Given user "participant1" creates room "room" (v4)
       | roomType | 2 |
       | roomName | room |
@@ -13,7 +14,7 @@ Feature: chat/poll
       | maxVotes   | unlimited |
     Then user "participant1" sees the following messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | message   | messageParameters |
-      | room | users     | participant1 | participant1-displayname | {object}  | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"object":{"type":"highlight","id":POLL_ID(What is the question?),"name":"What is the question?"}} |
+      | room | users     | participant1 | participant1-displayname | {object}  | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"object":{"type":"talk-poll","id":POLL_ID(What is the question?),"name":"What is the question?"}} |
     Then user "participant1" sees poll "What is the question?" in room "room" with 200
       | id         | POLL_ID(What is the question?) |
       | question   | What is the question? |
@@ -44,3 +45,146 @@ Feature: chat/poll
       | actorId    | participant1 |
       | status     | closed |
       | voted      | [1] |
+
+  Scenario: Participants can update their votes
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" creates a poll in room "room" with 201
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+    Then user "participant1" votes for options "[1]" on poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | status     | open |
+      | voted      | [1] |
+    Then user "participant1" votes for options "[0]" on poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | status     | open |
+      | voted      | [0] |
+
+  Scenario: Participants can only vote for valid options
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" creates a poll in room "room" with 201
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+    Then user "participant1" votes for options "[-1]" on poll "What is the question?" in room "room" with 400
+    Then user "participant1" votes for options "[2]" on poll "What is the question?" in room "room" with 400
+
+  Scenario: Participants can not exceed the maxVotes
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" creates a poll in room "room" with 201
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | 1 |
+    Then user "participant1" votes for options "[0,1]" on poll "What is the question?" in room "room" with 400
+
+  Scenario: Participants can vote for multiple options
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" creates a poll in room "room" with 201
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+    Then user "participant1" votes for options "[0,1]" on poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | status     | open |
+      | voted      | [0,1] |
+
+  Scenario: Non-moderators can also create polls and close it themselves
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    When user "participant2" creates a poll in room "room" with 201
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | room | users     | participant2 | participant2-displayname | {object}  | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname"},"object":{"type":"talk-poll","id":POLL_ID(What is the question?),"name":"What is the question?"}} |
+    Then user "participant2" closes poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant2 |
+      | status     | closed |
+      | voted      | not voted |
+
+  Scenario: Non-moderators can note create polls without chat permission
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    # Removing chat permission only
+    Then user "participant1" sets permissions for "participant2" in room "room" to "CSJLAVP" with 200 (v4)
+    When user "participant2" creates a poll in room "room" with 403
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+
+  Scenario: Moderators can close polls of others
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    When user "participant2" creates a poll in room "room" with 201
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+    Then user "participant1" closes poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant2 |
+      | status     | closed |
+      | voted      | not voted |
+
+  Scenario: Non-moderators can not close polls of others
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    When user "participant1" creates a poll in room "room" with 201
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+    Then user "participant2" closes poll "What is the question?" in room "room" with 403

--- a/tests/integration/features/chat/poll.feature
+++ b/tests/integration/features/chat/poll.feature
@@ -97,7 +97,7 @@ Feature: chat/poll
       | votedSelf  | not voted |
       | details    | [{"actorType":"users","actorId":"participant1","actorDisplayName":"participant1-displayname","optionId":1}] |
 
-  Scenario: Participants can update their votes
+  Scenario: Participants can update their votes but only while open
     Given user "participant1" creates room "room" (v4)
       | roomType | 2 |
       | roomName | room |
@@ -132,6 +132,21 @@ Feature: chat/poll
       | actorDisplayName    | participant1-displayname |
       | status     | open |
       | votedSelf  | [1] |
+    Then user "participant1" closes poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | {"1":1}   |
+      | numVoters  | 1    |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
+      | status     | closed |
+      | votedSelf  | [1] |
+      | details    | [{"actorType":"users","actorId":"participant1","actorDisplayName":"participant1-displayname","optionId":1}] |
+    Then user "participant1" votes for options "[0]" on poll "What is the question?" in room "room" with 400
 
   Scenario: Participants can only vote for valid options
     Given user "participant1" creates room "room" (v4)

--- a/tests/integration/features/chat/poll.feature
+++ b/tests/integration/features/chat/poll.feature
@@ -14,3 +14,21 @@ Feature: chat/poll
     Then user "participant1" sees the following messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | message   | messageParameters |
       | room | users     | participant1 | participant1-displayname | {object}  | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"object":{"type":"highlight","id":POLL_ID(What is the question?),"name":"What is the question?"}} |
+    Then user "participant1" sees poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | status     | open |
+    Then user "participant1" closes poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | status     | closed |

--- a/tests/integration/features/chat/poll.feature
+++ b/tests/integration/features/chat/poll.feature
@@ -468,3 +468,58 @@ Feature: chat/poll
       | actorDisplayName    | participant1-displayname |
       | status     | closed |
       | votedSelf  | not voted |
+
+  Scenario: Number of voters and votes are restricted to the very same poll
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    When user "participant1" creates a poll in room "room" with 201
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+    Then user "participant1" votes for options "[0]" on poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | {"0":1} |
+      | numVoters  | 1 |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
+      | status     | open |
+      | votedSelf  | [0] |
+    When user "participant2" creates a poll in room "room" with 201
+      | question   | Another one ... |
+      | options    | ["... bites the dust!","... bites de_dust!"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+    Then user "participant2" votes for options "[1]" on poll "Another one ..." in room "room" with 200
+      | id         | POLL_ID(Another one ...) |
+      | question   | Another one ... |
+      | options    | ["... bites the dust!","... bites de_dust!"] |
+      | votes      | {"1":1} |
+      | numVoters  | 1 |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant2 |
+      | actorDisplayName    | participant2-displayname |
+      | status     | open |
+      | votedSelf  | [1] |
+    Then user "participant2" sees poll "Another one ..." in room "room" with 200
+      | id         | POLL_ID(Another one ...) |
+      | question   | Another one ... |
+      | options    | ["... bites the dust!","... bites de_dust!"] |
+      | votes      | {"1":1} |
+      | numVoters  | 1 |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant2 |
+      | actorDisplayName    | participant2-displayname |
+      | status     | open |
+      | votedSelf  | [1] |

--- a/tests/integration/features/chat/poll.feature
+++ b/tests/integration/features/chat/poll.feature
@@ -7,6 +7,7 @@ Feature: chat/poll
     Given user "participant1" creates room "room" (v4)
       | roomType | 2 |
       | roomName | room |
+    When user "participant1" adds user "participant2" to room "room" with 200 (v4)
     When user "participant1" creates a poll in room "room" with 201
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
@@ -39,6 +40,19 @@ Feature: chat/poll
       | actorDisplayName    | participant1-displayname |
       | status     | open |
       | votedSelf  | [1] |
+    Then user "participant2" sees poll details "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | {"1":1}   |
+      | details    | [{"actorType":"users","actorId":"participant1","actorDisplayName":"participant1-displayname","optionId":1}]   |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
+      | status     | open |
+      | votedSelf  | not voted |
     Then user "participant1" closes poll "What is the question?" in room "room" with 200
       | id         | POLL_ID(What is the question?) |
       | question   | What is the question? |
@@ -204,3 +218,65 @@ Feature: chat/poll
       | resultMode | public |
       | maxVotes   | unlimited |
     Then user "participant2" closes poll "What is the question?" in room "room" with 403
+
+  Scenario: Votes and details are not accessible in hidden result mode
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    When user "participant1" creates a poll in room "room" with 201
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | hidden |
+      | maxVotes   | unlimited |
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | room | users     | participant1 | participant1-displayname | {object}  | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"object":{"type":"talk-poll","id":POLL_ID(What is the question?),"name":"What is the question?"}} |
+    Then user "participant2" votes for options "[1]" on poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | []   |
+      | resultMode | hidden |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
+      | status     | open |
+      | votedSelf  | [1] |
+    Then user "participant1" sees poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | []   |
+      | resultMode | hidden |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
+      | status     | open |
+      | votedSelf  | not voted |
+    Then user "participant1" sees poll details "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | []   |
+      | resultMode | hidden |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
+      | status     | open |
+      | votedSelf  | not voted |
+    Then user "participant1" closes poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | {"1":1}   |
+      | resultMode | hidden |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
+      | status     | closed |
+      | votedSelf  | not voted |

--- a/tests/integration/features/chat/poll.feature
+++ b/tests/integration/features/chat/poll.feature
@@ -34,7 +34,7 @@ Feature: chat/poll
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
       | votes      | {"1":1}   |
-      | numVoters  | 1    |
+      | numVoters  | 1 |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
@@ -42,13 +42,25 @@ Feature: chat/poll
       | actorDisplayName    | participant1-displayname |
       | status     | open |
       | votedSelf  | [1] |
-    Then user "participant2" sees poll details "What is the question?" in room "room" with 200
+    Then user "participant1" sees poll "What is the question?" in room "room" with 200
       | id         | POLL_ID(What is the question?) |
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
       | votes      | {"1":1}   |
-      | numVoters  | 1    |
-      | details    | [{"actorType":"users","actorId":"participant1","actorDisplayName":"participant1-displayname","optionId":1}]   |
+      | numVoters  | 1 |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
+      | status     | open |
+      | votedSelf  | [1] |
+    Then user "participant2" sees poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | [] |
+      | numVoters  | 0 |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
@@ -69,6 +81,21 @@ Feature: chat/poll
       | actorDisplayName    | participant1-displayname |
       | status     | closed |
       | votedSelf  | [1] |
+      | details    | [{"actorType":"users","actorId":"participant1","actorDisplayName":"participant1-displayname","optionId":1}] |
+    Then user "participant2" sees poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | {"1":1}   |
+      | numVoters  | 1 |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
+      | status     | closed |
+      | votedSelf  | not voted |
+      | details    | [{"actorType":"users","actorId":"participant1","actorDisplayName":"participant1-displayname","optionId":1}] |
 
   Scenario: Participants can update their votes
     Given user "participant1" creates room "room" (v4)
@@ -189,6 +216,7 @@ Feature: chat/poll
       | actorDisplayName    | participant2-displayname |
       | status     | closed |
       | votedSelf  | not voted |
+      | details    | {} |
 
   Scenario: Non-moderators can note create polls without chat permission
     Given user "participant1" creates room "room" (v4)
@@ -226,6 +254,7 @@ Feature: chat/poll
       | actorDisplayName    | participant2-displayname |
       | status     | closed |
       | votedSelf  | not voted |
+      | details    | {} |
 
   Scenario: Non-moderators can not close polls of others
     Given user "participant1" creates room "room" (v4)
@@ -278,7 +307,7 @@ Feature: chat/poll
       | actorDisplayName    | participant1-displayname |
       | status     | open |
       | votedSelf  | not voted |
-    Then user "participant1" sees poll details "What is the question?" in room "room" with 200
+    Then user "participant2" sees poll "What is the question?" in room "room" with 200
       | id         | POLL_ID(What is the question?) |
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
@@ -290,7 +319,7 @@ Feature: chat/poll
       | actorId    | participant1 |
       | actorDisplayName    | participant1-displayname |
       | status     | open |
-      | votedSelf  | not voted |
+      | votedSelf  | [1] |
     Then user "participant1" closes poll "What is the question?" in room "room" with 200
       | id         | POLL_ID(What is the question?) |
       | question   | What is the question? |

--- a/tests/integration/features/chat/poll.feature
+++ b/tests/integration/features/chat/poll.feature
@@ -256,6 +256,126 @@ Feature: chat/poll
       | votedSelf  | not voted |
       | details    | {} |
 
+  Scenario: There are system messages for opening, voting and closing on public polls
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    When user "participant1" creates a poll in room "room" with 201
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+    Then user "participant1" votes for options "[0]" on poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | {"0":1} |
+      | numVoters  | 1 |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
+      | status     | open |
+      | votedSelf  | [0] |
+    Then user "participant2" votes for options "[1]" on poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | {"0":1,"1":1} |
+      | numVoters  | 2 |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
+      | status     | open |
+      | votedSelf  | [1] |
+    Then user "participant1" closes poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | {"0":1,"1":1} |
+      | numVoters  | 2 |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
+      | status     | closed |
+      | votedSelf  | [0] |
+      | details    | [{"actorType":"users","actorId":"participant1","actorDisplayName":"participant1-displayname","optionId":0},{"actorType":"users","actorId":"participant2","actorDisplayName":"participant2-displayname","optionId":1}] |
+    Then user "participant1" sees the following system messages in room "room" with 200 (v1)
+      | room | actorType | actorId      | actorDisplayName         | systemMessage        |
+      | room | users     | participant1 | participant1-displayname | poll_closed          |
+      | room | users     | participant2 | participant2-displayname | poll_voted           |
+      | room | users     | participant1 | participant1-displayname | poll_voted           |
+      | room | users     | participant1 | participant1-displayname | user_added           |
+      | room | users     | participant1 | participant1-displayname | conversation_created |
+    Then user "participant1" sees the following messages in room "room" with 200 (v1)
+      | room | actorType | actorId      | actorDisplayName         | message  | messageParameters |
+      | room | users     | participant1 | participant1-displayname | {object} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"object":{"type":"talk-poll","id":POLL_ID(What is the question?),"name":"What is the question?"}} |
+
+
+  Scenario: There are only system messages for opening and closing on hidden polls
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    When user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    When user "participant1" creates a poll in room "room" with 201
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | hidden |
+      | maxVotes   | unlimited |
+    Then user "participant1" votes for options "[0]" on poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | [] |
+      | numVoters  | 0 |
+      | resultMode | hidden |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
+      | status     | open |
+      | votedSelf  | [0] |
+    Then user "participant2" votes for options "[1]" on poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | [] |
+      | numVoters  | 0 |
+      | resultMode | hidden |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
+      | status     | open |
+      | votedSelf  | [1] |
+    Then user "participant1" closes poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | {"0":1,"1":1} |
+      | numVoters  | 2 |
+      | resultMode | hidden |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
+      | status     | closed |
+      | votedSelf  | [0] |
+    Then user "participant1" sees the following system messages in room "room" with 200 (v1)
+      | room | actorType | actorId      | actorDisplayName         | systemMessage        |
+      | room | users     | participant1 | participant1-displayname | poll_closed          |
+      | room | users     | participant1 | participant1-displayname | user_added           |
+      | room | users     | participant1 | participant1-displayname | conversation_created |
+    Then user "participant1" sees the following messages in room "room" with 200 (v1)
+      | room | actorType | actorId      | actorDisplayName         | message  | messageParameters |
+      | room | users     | participant1 | participant1-displayname | {object} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"object":{"type":"talk-poll","id":POLL_ID(What is the question?),"name":"What is the question?"}} |
+
   Scenario: Non-moderators can not close polls of others
     Given user "participant1" creates room "room" (v4)
       | roomType | 2 |

--- a/tests/integration/features/chat/poll.feature
+++ b/tests/integration/features/chat/poll.feature
@@ -21,6 +21,7 @@ Feature: chat/poll
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
       | votes      | []   |
+      | numVoters  | 0    |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
@@ -33,6 +34,7 @@ Feature: chat/poll
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
       | votes      | {"1":1}   |
+      | numVoters  | 1    |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
@@ -45,6 +47,7 @@ Feature: chat/poll
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
       | votes      | {"1":1}   |
+      | numVoters  | 1    |
       | details    | [{"actorType":"users","actorId":"participant1","actorDisplayName":"participant1-displayname","optionId":1}]   |
       | resultMode | public |
       | maxVotes   | unlimited |
@@ -58,6 +61,7 @@ Feature: chat/poll
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
       | votes      | {"1":1}   |
+      | numVoters  | 1    |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
@@ -80,6 +84,7 @@ Feature: chat/poll
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
       | votes      | {"0":1}   |
+      | numVoters  | 1    |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
@@ -92,6 +97,7 @@ Feature: chat/poll
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
       | votes      | {"1":1}   |
+      | numVoters  | 1    |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
@@ -137,6 +143,7 @@ Feature: chat/poll
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
       | votes      | {"0":1,"1":1} |
+      | numVoters  | 1    |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
@@ -174,6 +181,7 @@ Feature: chat/poll
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
       | votes      | [] |
+      | numVoters  | 0 |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
@@ -210,6 +218,7 @@ Feature: chat/poll
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
       | votes      | [] |
+      | numVoters  | 0 |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
@@ -248,6 +257,7 @@ Feature: chat/poll
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
       | votes      | []   |
+      | numVoters  | 0 |
       | resultMode | hidden |
       | maxVotes   | unlimited |
       | actorType  | users |
@@ -260,6 +270,7 @@ Feature: chat/poll
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
       | votes      | []   |
+      | numVoters  | 0 |
       | resultMode | hidden |
       | maxVotes   | unlimited |
       | actorType  | users |
@@ -272,6 +283,7 @@ Feature: chat/poll
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
       | votes      | []   |
+      | numVoters  | 0 |
       | resultMode | hidden |
       | maxVotes   | unlimited |
       | actorType  | users |
@@ -284,6 +296,7 @@ Feature: chat/poll
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
       | votes      | {"1":1}   |
+      | numVoters  | 1 |
       | resultMode | hidden |
       | maxVotes   | unlimited |
       | actorType  | users |

--- a/tests/integration/features/chat/poll.feature
+++ b/tests/integration/features/chat/poll.feature
@@ -19,35 +19,38 @@ Feature: chat/poll
       | id         | POLL_ID(What is the question?) |
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | []   |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
       | actorId    | participant1 |
       | actorDisplayName    | participant1-displayname |
       | status     | open |
-      | voted      | not voted |
+      | votedSelf  | not voted |
     Then user "participant1" votes for options "[1]" on poll "What is the question?" in room "room" with 200
       | id         | POLL_ID(What is the question?) |
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | {"1":1}   |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
       | actorId    | participant1 |
       | actorDisplayName    | participant1-displayname |
       | status     | open |
-      | voted      | [1] |
+      | votedSelf  | [1] |
     Then user "participant1" closes poll "What is the question?" in room "room" with 200
       | id         | POLL_ID(What is the question?) |
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | {"1":1}   |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
       | actorId    | participant1 |
       | actorDisplayName    | participant1-displayname |
       | status     | closed |
-      | voted      | [1] |
+      | votedSelf  | [1] |
 
   Scenario: Participants can update their votes
     Given user "participant1" creates room "room" (v4)
@@ -58,28 +61,30 @@ Feature: chat/poll
       | options    | ["Where are you?","How much is the fish?"] |
       | resultMode | public |
       | maxVotes   | unlimited |
-    Then user "participant1" votes for options "[1]" on poll "What is the question?" in room "room" with 200
-      | id         | POLL_ID(What is the question?) |
-      | question   | What is the question? |
-      | options    | ["Where are you?","How much is the fish?"] |
-      | resultMode | public |
-      | maxVotes   | unlimited |
-      | actorType  | users |
-      | actorId    | participant1 |
-      | actorDisplayName    | participant1-displayname |
-      | status     | open |
-      | voted      | [1] |
     Then user "participant1" votes for options "[0]" on poll "What is the question?" in room "room" with 200
       | id         | POLL_ID(What is the question?) |
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | {"0":1}   |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
       | actorId    | participant1 |
       | actorDisplayName    | participant1-displayname |
       | status     | open |
-      | voted      | [0] |
+      | votedSelf  | [0] |
+    Then user "participant1" votes for options "[1]" on poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | {"1":1}   |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant1 |
+      | actorDisplayName    | participant1-displayname |
+      | status     | open |
+      | votedSelf  | [1] |
 
   Scenario: Participants can only vote for valid options
     Given user "participant1" creates room "room" (v4)
@@ -117,13 +122,14 @@ Feature: chat/poll
       | id         | POLL_ID(What is the question?) |
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | {"0":1,"1":1} |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
       | actorId    | participant1 |
       | actorDisplayName    | participant1-displayname |
       | status     | open |
-      | voted      | [0,1] |
+      | votedSelf  | [0,1] |
 
   Scenario: Non-moderators can also create polls and close it themselves
     Given user "participant1" creates room "room" (v4)
@@ -142,13 +148,14 @@ Feature: chat/poll
       | id         | POLL_ID(What is the question?) |
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | [] |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
       | actorId    | participant2 |
       | actorDisplayName    | participant2-displayname |
       | status     | closed |
-      | voted      | not voted |
+      | votedSelf  | not voted |
 
   Scenario: Non-moderators can note create polls without chat permission
     Given user "participant1" creates room "room" (v4)
@@ -177,13 +184,14 @@ Feature: chat/poll
       | id         | POLL_ID(What is the question?) |
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | [] |
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | users |
       | actorId    | participant2 |
       | actorDisplayName    | participant2-displayname |
       | status     | closed |
-      | voted      | not voted |
+      | votedSelf  | not voted |
 
   Scenario: Non-moderators can not close polls of others
     Given user "participant1" creates room "room" (v4)

--- a/tests/integration/spreedcheats/lib/Controller/ApiController.php
+++ b/tests/integration/spreedcheats/lib/Controller/ApiController.php
@@ -75,6 +75,12 @@ class ApiController extends OCSController {
 		$delete->delete('talk_rooms')->executeStatement();
 
 		$delete = $this->db->getQueryBuilder();
+		$delete->delete('talk_polls')->executeStatement();
+
+		$delete = $this->db->getQueryBuilder();
+		$delete->delete('talk_polls')->executeStatement();
+
+		$delete = $this->db->getQueryBuilder();
 		$delete->delete('talk_sessions')->executeStatement();
 
 		$delete = $this->db->getQueryBuilder();

--- a/tests/integration/spreedcheats/lib/Controller/ApiController.php
+++ b/tests/integration/spreedcheats/lib/Controller/ApiController.php
@@ -78,7 +78,7 @@ class ApiController extends OCSController {
 		$delete->delete('talk_polls')->executeStatement();
 
 		$delete = $this->db->getQueryBuilder();
-		$delete->delete('talk_polls')->executeStatement();
+		$delete->delete('talk_poll_votes')->executeStatement();
 
 		$delete = $this->db->getQueryBuilder();
 		$delete->delete('talk_sessions')->executeStatement();

--- a/tests/php/Chat/ChatManagerTest.php
+++ b/tests/php/Chat/ChatManagerTest.php
@@ -33,6 +33,7 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\AttachmentService;
 use OCA\Talk\Service\ParticipantService;
+use OCA\Talk\Service\PollService;
 use OCA\Talk\Share\RoomShareProvider;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\IComment;
@@ -64,6 +65,8 @@ class ChatManagerTest extends TestCase {
 	protected $shareProvider;
 	/** @var ParticipantService|MockObject */
 	protected $participantService;
+	/** @var PollService|MockObject */
+	protected $pollService;
 	/** @var Notifier|MockObject */
 	protected $notifier;
 	/** @var ITimeFactory|MockObject */
@@ -81,6 +84,7 @@ class ChatManagerTest extends TestCase {
 		$this->shareManager = $this->createMock(IManager::class);
 		$this->shareProvider = $this->createMock(RoomShareProvider::class);
 		$this->participantService = $this->createMock(ParticipantService::class);
+		$this->pollService = $this->createMock(PollService::class);
 		$this->notifier = $this->createMock(Notifier::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->attachmentService = $this->createMock(AttachmentService::class);
@@ -94,6 +98,7 @@ class ChatManagerTest extends TestCase {
 			$this->shareManager,
 			$this->shareProvider,
 			$this->participantService,
+			$this->pollService,
 			$this->notifier,
 			$cacheFactory,
 			$this->timeFactory,
@@ -118,6 +123,7 @@ class ChatManagerTest extends TestCase {
 					$this->shareManager,
 					$this->shareProvider,
 					$this->participantService,
+					$this->pollService,
 					$this->notifier,
 					$cacheFactory,
 					$this->timeFactory,
@@ -135,6 +141,7 @@ class ChatManagerTest extends TestCase {
 			$this->shareManager,
 			$this->shareProvider,
 			$this->participantService,
+			$this->pollService,
 			$this->notifier,
 			$cacheFactory,
 			$this->timeFactory,


### PR DESCRIPTION
- [x] `talk-poll` ROS https://github.com/nextcloud/server/pull/32336
- [x] Add docs
- [x] Create polls
- [x] Get result / state
    - [x] Return self state
    - [x] Missing display name of author
- [x] Vote
    - [x] Add room_id to votes for easier deleting
- [x] Close polls
- [x] Closing should have a visible system message
- [x] Voting should have a neutral system message (hidden?) to make clients update the poll state if it's a public poll
- [ ] Add new media tab => https://github.com/nextcloud/spreed/issues/7480
- [ ] Add capability for mobile clients => https://github.com/nextcloud/spreed/issues/7480

API for #7355 