### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -1,8 +1,13 @@
 name: Dependabot auto approve
 on: pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   auto-merge:
+    permissions:
+      pull-requests: write  # for hmarr/auto-approve-action to approve PRs
     runs-on: ubuntu-latest
     steps:
       # Default github action approve

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -7,6 +7,9 @@ on:
       - master
       - stable*
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-info-xml.yml
+++ b/.github/workflows/lint-info-xml.yml
@@ -12,6 +12,9 @@ on:
       - master
       - stable*
 
+permissions:
+  contents: read
+
 jobs:
   xml-linters:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-php-cs.yml
+++ b/.github/workflows/lint-php-cs.yml
@@ -12,6 +12,9 @@ on:
       - master
       - stable*
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -12,6 +12,9 @@ on:
       - master
       - stable*
 
+permissions:
+  contents: read
+
 jobs:
   php-lint:
     runs-on: ubuntu-latest
@@ -35,6 +38,8 @@ jobs:
         run: composer run lint
 
   summary:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     needs: php-lint
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,6 +17,9 @@ on:
 env:
   APP_NAME: spreed
 
+permissions:
+  contents: read
+
 jobs:
   php:
     runs-on: ubuntu-latest

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -7,6 +7,9 @@ on:
       - master
       - stable*
 
+permissions:
+  contents: read
+
 jobs:
   static-psalm-analysis:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
