### PR TITLE
Fix trying to use "remoteVideoBlocker" with local screens

### DIFF
--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -220,7 +220,7 @@ export default {
 		},
 
 		showNameIndicator() {
-			return !this.model.attributes.videoAvailable || !this.sharedData.remoteVideoBlocker.isVideoEnabled() || this.showVideoOverlay || this.isSelected || this.isPromoted || this.isSpeaking
+			return !this.model.attributes.videoAvailable || (this.sharedData.remoteVideoBlocker && !this.sharedData.remoteVideoBlocker.isVideoEnabled()) || this.showVideoOverlay || this.isSelected || this.isPromoted || this.isSpeaking
 		},
 
 		boldenNameIndicator() {


### PR DESCRIPTION
Follow up to #6862
Fixes #7316

This fixes a regression introduced in 114b83dcdde32005ba25233cfe38b66d1d19823d

`remoteVideoBlocker` is set in the shared datas of all remote participants. However, `videoBottomBar` is used both for remote participants and for local screens, which do not have that attribute.

Other uses of `remoteVideoBlocker` should be safe, as they are implicitly guarded by checking `!isScreen` in the template.
