### PR TITLE
Only render emoji picker on hover

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
@@ -839,6 +839,23 @@ describe('Message.vue', () => {
 			expect(reactionButtons.wrappers[1].text()).toBe('👍  7')
 		})
 
+		test('no emoji picker is mounted when the bottom bar is not shown', () => {
+			store = new Store(testStoreConfig)
+
+			const wrapper = shallowMount(Message, {
+				localVue,
+				store,
+				propsData: messageProps,
+				stubs: {
+					EmojiPicker,
+				},
+			})
+
+			const emojiPicker = wrapper.findComponent(EmojiPicker)
+
+			expect(emojiPicker.vm).toBeUndefined()
+		})
+
 		test('dispatches store action upon picking an emoji from the emojipicker', () => {
 			const addReactionToMessageAction = jest.fn()
 			const userHasReactedGetter = jest.fn().mockReturnValue(() => false)
@@ -856,10 +873,17 @@ describe('Message.vue', () => {
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
-				propsData: messageProps,
+				propsData: messagePropsWithReactions,
 				stubs: {
 					EmojiPicker,
 				},
+				mixins: [{
+					computed: {
+						showMessageButtonsBar: () => {
+							return true
+						},
+					},
+				}],
 			})
 
 			const emojiPicker = wrapper.findComponent(EmojiPicker)

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -136,7 +136,7 @@ the main body of the message as well as a quote.
 				</Popover>
 
 				<!-- More reactions picker -->
-				<EmojiPicker v-if="canReact"
+				<EmojiPicker v-if="canReact && showMessageButtonsBar"
 					:per-line="5"
 					:container="`#message_${id}`"
 					@select="handleReactionClick">
@@ -144,6 +144,10 @@ the main body of the message as well as a quote.
 						<EmoticonOutline :size="15" />
 					</button>
 				</EmojiPicker>
+				<button v-else-if="canReact"
+					class="reaction-button">
+					<EmoticonOutline :size="15" />
+				</button>
 			</div>
 		</div>
 


### PR DESCRIPTION
Fix #7319 


### Steps
1. Open two tabs with 2 users and send chat message `/spam 200 messages` in both
2. Close the tabs
3. Remove the div around the picker (to save you from having to react to all messages)
https://github.com/nextcloud/spreed/blob/e6e005760174417fd820aeb91180b9931635e9c8/src/components/MessagesList/MessagesGroup/Message/Message.vue#L118-L136
and
https://github.com/nextcloud/spreed/blob/e6e005760174417fd820aeb91180b9931635e9c8/src/components/MessagesList/MessagesGroup/Message/Message.vue#L147
5. Open Talk in a new tab
6. Load the chat
7. Wait until it loaded and observe 1.5GB ram being used
8. Scroll up and load the second page
9. Wait long again and see 1.5 GB more being used
10. Close the tab and see 3 GB ram being freed
11. Change to this patch
12. Remove again the change from 3.
13. Load the chat again in a new tab and see no significant memory consumption and also much more loading speed
14. Same with page 2 of the chat
15. Closing the tab also doesn't free 3 GB again