### PR TITLE
Add an option for "Silent send" to the API

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -95,5 +95,6 @@ title: Capabilities
 
 ## 15
 * `chat-permission` - When permission 128 is required to post chat messages, reaction or share items to the conversation
+* `silent-send` - Whether the chat API allows to send chat messages without triggering notifications
 * `sip-support-nopin` - Whether SIP can be configured to not require a custom attendee PIN
 * `config => call => enabled` - Whether calling is enabled on the instance or not

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -79,6 +79,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`
     `actorDisplayName` | string | Guest display name (ignored for logged in users)
     `replyTo` | int | The message ID this message is a reply to (only allowed for messages from the same conversation and when the message type is not `system` or `command`)
     `referenceId` | string | A reference string to be able to identify the message again in a "get messages" request, should be a random sha256 (only available with `chat-reference-id` capability)
+    `slient` | bool | If sent silent the message will not create chat notifications even for mentions (only available with `silent-send` capability)
 
 * Response:
     - Status code:

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -103,6 +103,7 @@ class Capabilities implements IPublicCapability {
 				'rich-object-list-media',
 				'rich-object-delete',
 				'chat-permission',
+				'silent-send',
 			],
 			'config' => [
 				'attachments' => [

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -192,11 +192,12 @@ class ChatController extends AEnvironmentAwareController {
 	 * @param string $actorDisplayName for guests
 	 * @param string $referenceId for the message to be able to later identify it again
 	 * @param int $replyTo Parent id which this message is a reply to
+	 * @param bool $silent If sent silent the chat message will not create any notifications
 	 * @return DataResponse the status code is "201 Created" if successful, and
 	 *         "404 Not found" if the room or session for a guest user was not
 	 *         found".
 	 */
-	public function sendMessage(string $message, string $actorDisplayName = '', string $referenceId = '', int $replyTo = 0): DataResponse {
+	public function sendMessage(string $message, string $actorDisplayName = '', string $referenceId = '', int $replyTo = 0, bool $silent = false): DataResponse {
 		[$actorType, $actorId] = $this->getActorInfo($actorDisplayName);
 		if (!$actorId) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
@@ -222,7 +223,7 @@ class ChatController extends AEnvironmentAwareController {
 		$creationDateTime = $this->timeFactory->getDateTime('now', new \DateTimeZone('UTC'));
 
 		try {
-			$comment = $this->chatManager->sendMessage($this->room, $this->participant, $actorType, $actorId, $message, $creationDateTime, $parent, $referenceId);
+			$comment = $this->chatManager->sendMessage($this->room, $this->participant, $actorType, $actorId, $message, $creationDateTime, $parent, $referenceId, $silent);
 		} catch (MessageTooLongException $e) {
 			return new DataResponse([], Http::STATUS_REQUEST_ENTITY_TOO_LARGE);
 		} catch (\Exception $e) {

--- a/lib/Events/ChatParticipantEvent.php
+++ b/lib/Events/ChatParticipantEvent.php
@@ -29,14 +29,19 @@ use OCP\Comments\IComment;
 
 class ChatParticipantEvent extends ChatEvent {
 	protected Participant $participant;
+	protected bool $silent;
 
-
-	public function __construct(Room $room, IComment $message, Participant $participant) {
+	public function __construct(Room $room, IComment $message, Participant $participant, bool $silent) {
 		parent::__construct($room, $message);
 		$this->participant = $participant;
+		$this->silent = $silent;
 	}
 
 	public function getParticipant(): Participant {
 		return $this->participant;
+	}
+
+	public function isSilentMessage(): bool {
+		return $this->silent;
 	}
 }

--- a/lib/Flow/Operation.php
+++ b/lib/Flow/Operation.php
@@ -126,7 +126,8 @@ class Operation implements IOperation {
 					$this->prepareMention($mode, $participant) . $message,
 					new \DateTime(),
 					null,
-					''
+					'',
+					false
 				);
 			} catch (UnexpectedValueException $e) {
 				continue;

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1399,19 +1399,26 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" sends message "([^"]*)" to room "([^"]*)" with (\d+)(?: \((v1)\))?$/
+	 * @Then /^user "([^"]*)" (silent sends|sends) message "([^"]*)" to room "([^"]*)" with (\d+)(?: \((v1)\))?$/
 	 *
 	 * @param string $user
+	 * @param string $sendingMode
 	 * @param string $message
 	 * @param string $identifier
 	 * @param string $statusCode
 	 * @param string $apiVersion
 	 */
-	public function userSendsMessageToRoom($user, $message, $identifier, $statusCode, $apiVersion = 'v1') {
+	public function userSendsMessageToRoom(string $user, string $sendingMode, string $message, string $identifier, string $statusCode, string $apiVersion = 'v1') {
+		if ($sendingMode === 'silent sends') {
+			$body = new TableNode([['message', $message], ['silent', true]]);
+		} else {
+			$body = new TableNode([['message', $message]]);
+		}
+
 		$this->setCurrentUser($user);
 		$this->sendRequest(
 			'POST', '/apps/spreed/api/' . $apiVersion . '/chat/' . self::$identifierToToken[$identifier],
-			new TableNode([['message', $message]])
+			$body
 		);
 		$this->assertStatusCode($this->response, $statusCode);
 		sleep(1); // make sure Postgres manages the order of the messages

--- a/tests/integration/features/chat/notifications.feature
+++ b/tests/integration/features/chat/notifications.feature
@@ -25,6 +25,17 @@ Feature: chat/notifications
       | app    | object_type | object_id                 | subject                                             |
       | spreed | chat        | one-to-one room/Message 1 | participant1-displayname sent you a private message |
 
+  Scenario: Silent sent message when recipient is offline in the one-to-one
+    When user "participant1" creates room "one-to-one room" (v4)
+      | roomType | 1 |
+      | invite   | participant2 |
+    # Join and leave to clear the invite notification
+    Given user "participant2" joins room "one-to-one room" with 200 (v4)
+    Given user "participant2" leaves room "one-to-one room" with 200 (v4)
+    When user "participant1" silent sends message "Message 1" to room "one-to-one room" with 201
+    Then user "participant2" has the following notifications
+      | app | object_type | object_id | subject |
+
   Scenario: Normal message when recipient disabled notifications in the one-to-one
     When user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
@@ -152,6 +163,18 @@ Feature: chat/notifications
       | app    | object_type | object_id                 | subject                                                     |
       | spreed | chat        | room/Hi @participant2 bye | participant1-displayname mentioned you in conversation room |
 
+  Scenario: Silent mention when recipient is online in the group room
+    When user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    # Join and leave to clear the invite notification
+    Given user "participant2" joins room "room" with 200 (v4)
+    Given user "participant2" leaves room "room" with 200 (v4)
+    When user "participant1" silent sends message "Hi @participant2 bye" to room "room" with 201
+    Then user "participant2" has the following notifications
+      | app | object_type | object_id | subject |
+
   Scenario: Mention when recipient is offline in the group room
     When user "participant1" creates room "room" (v4)
       | roomType | 2 |
@@ -201,6 +224,18 @@ Feature: chat/notifications
     Then user "participant2" has the following notifications
       | app    | object_type | object_id        | subject                                                     |
       | spreed | chat        | room/Hi @all bye | participant1-displayname mentioned you in conversation room |
+
+  Scenario: Silent at-all when recipient is offline in the group room
+    When user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    # Join and leave to clear the invite notification
+    Given user "participant2" joins room "room" with 200 (v4)
+    Given user "participant2" leaves room "room" with 200 (v4)
+    When user "participant1" silent sends message "Hi @all bye" to room "room" with 201
+    Then user "participant2" has the following notifications
+      | app | object_type | object_id | subject |
 
   Scenario: At-all when recipient with disabled notifications in the group room
     When user "participant1" creates room "room" (v4)

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -107,6 +107,7 @@ class CapabilitiesTest extends TestCase {
 			'rich-object-list-media',
 			'rich-object-delete',
 			'chat-permission',
+			'silent-send',
 			'reactions',
 		];
 	}

--- a/tests/php/Chat/ChatManagerTest.php
+++ b/tests/php/Chat/ChatManagerTest.php
@@ -275,7 +275,7 @@ class ChatManagerTest extends TestCase {
 
 		$participant = $this->createMock(Participant::class);
 
-		$return = $this->chatManager->sendMessage($chat, $participant, 'users', $userId, $message, $creationDateTime, $replyTo, $referenceId);
+		$return = $this->chatManager->sendMessage($chat, $participant, 'users', $userId, $message, $creationDateTime, $replyTo, $referenceId, false);
 
 		$this->assertCommentEquals($commentExpected, $return);
 	}

--- a/tests/php/Chat/NotifierTest.php
+++ b/tests/php/Chat/NotifierTest.php
@@ -177,7 +177,7 @@ class NotifierTest extends TestCase {
 				'type' => Attendee::ACTOR_USERS,
 			];
 		}, $expectedReturn);
-		$actual = $notifier->notifyMentionedUsers($room, $comment, $alreadyNotifiedUsers);
+		$actual = $notifier->notifyMentionedUsers($room, $comment, $alreadyNotifiedUsers, false);
 
 		$this->assertEqualsCanonicalizing($expectedReturn, $actual);
 	}
@@ -341,7 +341,7 @@ class NotifierTest extends TestCase {
 		$this->assertCount(count($return), $actual);
 		foreach ($actual as $key => $value) {
 			$this->assertIsArray($value);
-			if (key_exists('attendee', $value)) {
+			if (array_key_exists('attendee', $value)) {
 				$this->assertInstanceOf(Attendee::class, $value['attendee']);
 				unset($value['attendee']);
 			}


### PR DESCRIPTION
Fix #6257 

- [ ] ~~Check if it would be possible to make the "silent" persistent so it could be displayed later on~~ => https://github.com/nextcloud/spreed/issues/6257#issuecomment-1125827646