### PR TITLE
Removed parent property when forwarding a message, this property is a…

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Forwarder.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Forwarder.vue
@@ -131,6 +131,10 @@ export default {
 			// Overwrite the selected conversation token
 			messageToBeForwarded.token = token
 
+			if (messageToBeForwarded.parent) {
+				delete messageToBeForwarded.parent
+			}
+
 			if (messageToBeForwarded.message === '{object}' && messageToBeForwarded.messageParameters.object) {
 				const richObject = messageToBeForwarded.messageParameters.object
 				try {


### PR DESCRIPTION
When forwarding a message that was replied to, it was returning error

I investigated in depth and the failure was occurring due to the replyTo property being filled in at the time of sending the request.

In this pull request I just tried on the frontend to remove the parent property so that the replyTo value is not filled in when sending the request

Fix #7310 