### PR TITLE
Allow the HPB to group session pinging across rooms

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -99,3 +99,4 @@ title: Capabilities
 * `sip-support-nopin` - Whether SIP can be configured to not require a custom attendee PIN
 * `send-call-notification` - When the API allows to resend call notifications for individual users that did not join yet
 * `config => call => enabled` - Whether calling is enabled on the instance or not
+* `config => signaling => session-ping-limit` - Number of sessions the HPB is allowed to ping in the same request

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -119,7 +119,10 @@ class Capabilities implements IPublicCapability {
 				],
 				'conversations' => [],
 				'previews' => [
-					'max-gif-size' => (int)$this->serverConfig->getAppValue('spreed', 'max-gif-size', '3145728')
+					'max-gif-size' => (int)$this->serverConfig->getAppValue('spreed', 'max-gif-size', '3145728'),
+				],
+				'signaling' => [
+					'session-ping-limit' => max(0, (int)$this->serverConfig->getAppValue('spreed', 'session-ping-limit', '200')),
 				],
 			],
 		];

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -729,22 +729,6 @@ class SignalingController extends OCSController {
 	}
 
 	private function backendPing(array $request): DataResponse {
-		try {
-			$room = $this->manager->getRoomByToken($request['roomid']);
-		} catch (RoomNotFoundException $e) {
-			$this->logger->debug('Tried to ping non existing room {token}', [
-				'token' => $request['roomid'],
-				'app' => 'spreed-hpb',
-			]);
-			return new DataResponse([
-				'type' => 'error',
-				'error' => [
-					'code' => 'no_such_room',
-					'message' => 'No such room.',
-				],
-			]);
-		}
-
 		$pingSessionIds = [];
 		$now = $this->timeFactory->getTime();
 		foreach ($request['entries'] as $entry) {
@@ -760,12 +744,11 @@ class SignalingController extends OCSController {
 			'type' => 'room',
 			'room' => [
 				'version' => '1.0',
-				'roomid' => $room->getToken(),
 			],
 		];
 		$this->logger->debug('Pinged {numSessions} sessions in room {token}', [
 			'numSessions' => count($pingSessionIds),
-			'token' => $request['roomid'],
+			'token' => $request['roomid'] ?? 'N/A',
 			'app' => 'spreed-hpb',
 		]);
 		return new DataResponse($response);

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -746,9 +746,9 @@ class SignalingController extends OCSController {
 				'version' => '1.0',
 			],
 		];
-		$this->logger->debug('Pinged {numSessions} sessions in room {token}', [
+		$this->logger->debug('Pinged {numSessions} sessions {token}', [
 			'numSessions' => count($pingSessionIds),
-			'token' => $request['roomid'] ?? 'N/A',
+			'token' => !empty($request['roomid']) ? ('in room ' . $request['roomid']) : '',
 			'app' => 'spreed-hpb',
 		]);
 		return new DataResponse($response);

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -134,6 +134,7 @@ class CapabilitiesTest extends TestCase {
 				['spreed', 'has_reference_id', 'no', 'no'],
 				['spreed', 'max-gif-size', '3145728', '200000'],
 				['spreed', 'start_calls', Room::START_CALL_EVERYONE, Room::START_CALL_EVERYONE],
+				['spreed', 'session-ping-limit', '200', '200'],
 			]);
 
 		$this->assertInstanceOf(IPublicCapability::class, $capabilities);
@@ -156,6 +157,9 @@ class CapabilitiesTest extends TestCase {
 					],
 					'previews' => [
 						'max-gif-size' => 200000,
+					],
+					'signaling' => [
+						'session-ping-limit' => 200,
 					],
 				],
 			],
@@ -217,6 +221,7 @@ class CapabilitiesTest extends TestCase {
 				['spreed', 'has_reference_id', 'no', 'yes'],
 				['spreed', 'max-gif-size', '3145728', '200000'],
 				['spreed', 'start_calls', Room::START_CALL_EVERYONE, Room::START_CALL_NOONE],
+				['spreed', 'session-ping-limit', '200', '50'],
 			]);
 
 		$this->assertInstanceOf(IPublicCapability::class, $capabilities);
@@ -245,6 +250,9 @@ class CapabilitiesTest extends TestCase {
 					],
 					'previews' => [
 						'max-gif-size' => 200000,
+					],
+					'signaling' => [
+						'session-ping-limit' => 50,
 					],
 				],
 			],

--- a/tests/php/Controller/SignalingControllerTest.php
+++ b/tests/php/Controller/SignalingControllerTest.php
@@ -869,45 +869,8 @@ class SignalingControllerTest extends TestCase {
 		], $result->getData());
 	}
 
-	public function testBackendPingUnknownRoom() {
-		$roomToken = 'the-room';
-		$room = $this->createMock(Room::class);
-		$this->manager->expects($this->once())
-			->method('getRoomByToken')
-			->with($roomToken)
-			->willThrowException(new RoomNotFoundException());
-
-		$result = $this->performBackendRequest([
-			'type' => 'ping',
-			'ping' => [
-				'roomid' => $roomToken,
-				'entries' => [
-					[
-						'userid' => $this->userId,
-					],
-				],
-			],
-		]);
-		$this->assertSame([
-			'type' => 'error',
-			'error' => [
-				'code' => 'no_such_room',
-				'message' => 'No such room.',
-			],
-		], $result->getData());
-	}
-
 	public function testBackendPingUser() {
-		$roomToken = 'the-room';
 		$sessionId = 'the-session';
-		$room = $this->createMock(Room::class);
-		$this->manager->expects($this->once())
-			->method('getRoomByToken')
-			->with($roomToken)
-			->willReturn($room);
-		$room->expects($this->once())
-			->method('getToken')
-			->willReturn($roomToken);
 
 		$this->timeFactory->method('getTime')
 			->willReturn(123456);
@@ -918,7 +881,6 @@ class SignalingControllerTest extends TestCase {
 		$result = $this->performBackendRequest([
 			'type' => 'ping',
 			'ping' => [
-				'roomid' => $roomToken,
 				'entries' => [
 					[
 						'userid' => $this->userId,
@@ -931,22 +893,12 @@ class SignalingControllerTest extends TestCase {
 			'type' => 'room',
 			'room' => [
 				'version' => '1.0',
-				'roomid' => $roomToken,
 			],
 		], $result->getData());
 	}
 
 	public function testBackendPingAnonymous() {
-		$roomToken = 'the-room';
 		$sessionId = 'the-session';
-		$room = $this->createMock(Room::class);
-		$this->manager->expects($this->once())
-			->method('getRoomByToken')
-			->with($roomToken)
-			->willReturn($room);
-		$room->expects($this->once())
-			->method('getToken')
-			->willReturn($roomToken);
 
 		$this->timeFactory->method('getTime')
 			->willReturn(1234567);
@@ -957,7 +909,6 @@ class SignalingControllerTest extends TestCase {
 		$result = $this->performBackendRequest([
 			'type' => 'ping',
 			'ping' => [
-				'roomid' => $roomToken,
 				'entries' => [
 					[
 						'userid' => '',
@@ -970,22 +921,12 @@ class SignalingControllerTest extends TestCase {
 			'type' => 'room',
 			'room' => [
 				'version' => '1.0',
-				'roomid' => $roomToken,
 			],
 		], $result->getData());
 	}
 
 	public function testBackendPingMixedAndInactive() {
-		$roomToken = 'the-room';
 		$sessionId = 'the-session';
-		$room = $this->createMock(Room::class);
-		$this->manager->expects($this->once())
-			->method('getRoomByToken')
-			->with($roomToken)
-			->willReturn($room);
-		$room->expects($this->once())
-			->method('getToken')
-			->willReturn($roomToken);
 
 		$this->timeFactory->method('getTime')
 			->willReturn(234567);
@@ -996,7 +937,6 @@ class SignalingControllerTest extends TestCase {
 		$result = $this->performBackendRequest([
 			'type' => 'ping',
 			'ping' => [
-				'roomid' => $roomToken,
 				'entries' => [
 					[
 						'userid' => '',
@@ -1017,7 +957,6 @@ class SignalingControllerTest extends TestCase {
 			'type' => 'room',
 			'room' => [
 				'version' => '1.0',
-				'roomid' => $roomToken,
 			],
 		], $result->getData());
 	}


### PR DESCRIPTION
- [x] Requires https://github.com/strukturag/nextcloud-spreed-signaling/issues/246

Default enabled with 200 sessions per request:
```
occ config:app:set spreed "session-ping-limit" --value="200"
```

Fix #7335 