### PR TITLE
Only show permission options for real users

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -143,7 +143,7 @@
 			</ActionButton>
 
 			<!-- Permissions -->
-			<template v-if="selfIsModerator && !isModerator">
+			<template v-if="showPermissionsOptions">
 				<ActionSeparator />
 				<ActionButton v-if="hasNonDefaultPermissions"
 					:close-after-click="true"
@@ -525,6 +525,14 @@ export default {
 
 		isModerator() {
 			return this.participantTypeIsModerator(this.participantType)
+		},
+
+		showPermissionsOptions() {
+			return this.selfIsModerator
+				&& !this.isModerator
+				&& (this.participant.actorType === ATTENDEE.ACTOR_TYPE.USERS
+					|| this.participant.actorType === ATTENDEE.ACTOR_TYPE.GUESTS
+					|| this.participant.actorType === ATTENDEE.ACTOR_TYPE.EMAILS)
 		},
 
 		showModeratorLabel() {


### PR DESCRIPTION
1. Add a group to a conversation
2. Open the options menu
3. See permissions things which do not have an effect 😕 
