### PR TITLE
Only declare the actual changed session of a user as changed

### DIFF
--- a/lib/Signaling/Listener.php
+++ b/lib/Signaling/Listener.php
@@ -276,11 +276,8 @@ class Listener {
 		$notifier = Server::get(BackendNotifier::class);
 
 		$sessionIds = [];
-
-		$sessionService = Server::get(SessionService::class);
-		$sessions = $sessionService->getAllSessionsForAttendee($event->getParticipant()->getAttendee());
-		foreach ($sessions as $session) {
-			$sessionIds[] = $session->getSessionId();
+		if ($event->getParticipant()->getSession()) {
+			$sessionIds[] = $event->getParticipant()->getSession()->getSessionId();
 		}
 
 		if (!empty($sessionIds)) {


### PR DESCRIPTION
Before all sessions of a user where seen as changed, instead of
only the one session that actually was changed.
It is a regression from introducing multi-session support I assume.

It's what lead to the issue @danxuliu created while testing and producing #7367
All his sessions where with the same user so he ended up having 50+50 entries in the request, while it would be 1+99 as a limit otherwise.
So we still need to fix the issue, but at least it's not breaking at 50 participants but 99 now.