### PR TITLE
Cache display name of owner as well

### DIFF
--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -151,6 +151,7 @@ class RoomService {
 			$this->participantService->addUsers($room, [[
 				'actorType' => Attendee::ACTOR_USERS,
 				'actorId' => $owner->getUID(),
+				'displayName' => $owner->getDisplayName(),
 				'participantType' => Participant::OWNER,
 			]], null);
 		}

--- a/tests/php/Service/RoomServiceTest.php
+++ b/tests/php/Service/RoomServiceTest.php
@@ -268,12 +268,15 @@ class RoomServiceTest extends TestCase {
 			$owner = $this->createMock(IUser::class);
 			$owner->method('getUID')
 				->willReturn($ownerId);
+			$owner->method('getDisplayName')
+				->willReturn($ownerId . '-display');
 
 			$this->participantService->expects($this->once())
 				->method('addUsers')
 				->with($room, [[
 					'actorType' => 'users',
 					'actorId' => $ownerId,
+					'displayName' => $ownerId . '-display',
 					'participantType' => Participant::OWNER,
 				]]);
 		} else {


### PR DESCRIPTION
Forgotten step from https://github.com/nextcloud/spreed/commit/383ca5fd4c0fa9ddfd0f1c023b9b25ec1f67727e

Noticed while writing integration tests for https://github.com/nextcloud/spreed/pull/7306