### PR TITLE
l10n: Changing name of store

### DIFF
--- a/src/components/AdminSettings/MatterbridgeIntegration.vue
+++ b/src/components/AdminSettings/MatterbridgeIntegration.vue
@@ -101,7 +101,7 @@ export default {
 			})
 		},
 		description() {
-			return t('spreed', 'You can install the Matterbridge to link Nextcloud Talk to some other services, visit their {linkstart1}GitHub page{linkend} for more details. Downloading and installing the app can take a while. In case it times out, please install it manually from the {linkstart2}App Store{linkend}.')
+			return t('spreed', 'You can install the Matterbridge to link Nextcloud Talk to some other services, visit their {linkstart1}GitHub page{linkend} for more details. Downloading and installing the app can take a while. In case it times out, please install it manually from the {linkstart2}Nextcloud App Store{linkend}.')
 				.replace('{linkstart1}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://github.com/42wim/matterbridge/wiki">')
 				.replace('{linkstart2}', '<a  target="_blank" rel="noreferrer nofollow" class="external" href="https://apps.nextcloud.com/apps/talk_matterbridge">')
 				.replace(/{linkend}/g, ' ↗</a>')


### PR DESCRIPTION
Change of the name of the Nextcloud store.
Comment: https://github.com/nextcloud/spreed/pull/7387#discussion_r875572208.

Signed-off-by: Valdnet <47037905+Valdnet@users.noreply.github.com>