### PR TITLE
Fix "Invalid argument supplied for foreach() at SystemMessage.php#720"

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -716,6 +716,21 @@ class SystemMessage {
 			];
 		}
 
+		if ($room->getType() !== Room::TYPE_ONE_TO_ONE) {
+			// Can happen if a user was remove from a one-to-one room.
+			return [
+				$this->l->t('You tried to call {user}'),
+				[
+					'user' => [
+						'type' => 'highlight',
+						'id' => 'deleted_user',
+						'name' => $room->getName(),
+					],
+				],
+				'call_tried',
+			];
+		}
+
 		$participants = json_decode($room->getName(), true);
 		$other = '';
 		foreach ($participants as $participant) {
@@ -723,6 +738,7 @@ class SystemMessage {
 				$other = $participant;
 			}
 		}
+
 		return [
 			$this->l->t('You tried to call {user}'),
 			[

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1760,16 +1760,31 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			return;
 		}
 
-		Assert::assertCount(count($formData->getHash()), $messages, 'Message count does not match');
-		Assert::assertEquals($formData->getHash(), array_map(function ($message) {
-			return [
+		$expected = $formData->getHash();
+
+		Assert::assertCount(count($expected), $messages, 'Message count does not match');
+		Assert::assertEquals($expected, array_map(function ($message, $expected) {
+			$data = [
 				'room' => self::$tokenToIdentifier[$message['token']],
 				'actorType' => (string) $message['actorType'],
-				'actorId' => ($message['actorType'] === 'guests')? self::$sessionIdToUser[$message['actorId']]: (string) $message['actorId'],
-				'actorDisplayName' => (string) $message['actorDisplayName'],
+				'actorId' => ($message['actorType'] === 'guests') ? self::$sessionIdToUser[$message['actorId']]: (string) $message['actorId'],
 				'systemMessage' => (string) $message['systemMessage'],
 			];
-		}, $messages));
+
+			if (isset($expected['actorDisplayName'])) {
+				$data['actorDisplayName'] = $message['actorDisplayName'];
+			}
+
+			if (isset($expected['message'])) {
+				$data['message'] = $message['message'];
+			}
+
+			if (isset($expected['messageParameters'])) {
+				$data['messageParameters'] = json_encode($message['messageParameters']);
+			}
+
+			return $data;
+		}, $messages, $expected));
 	}
 
 	/**

--- a/tests/integration/features/command/user-remove.feature
+++ b/tests/integration/features/command/user-remove.feature
@@ -26,3 +26,25 @@ Feature: User remove
     And user "participant1" sees the following attendees in room "room2" with 200 (v4)
       | actorType  | actorId      | participantType |
       | users      | participant1 | 1               |
+
+  Scenario: Remove a user after there was a missed call
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 1 |
+      | invite   | participant2 |
+    Then user "participant1" joins room "room" with 200 (v4)
+    Then user "participant1" joins call "room" with 200 (v4)
+    Then user "participant1" leaves call "room" with 200 (v4)
+    Then user "participant1" leaves room "room" with 200 (v4)
+    And invoking occ with "talk:user:remove --user participant2"
+    And the command output contains the text "Users successfully removed from all rooms"
+    Then the command was successful
+    And user "participant2" is participant of the following rooms (v4)
+    And user "participant1" is participant of the following rooms (v4)
+      | id   | name                     | type | participantType |
+      | room | participant2-displayname | 2    | 1               |
+    Then user "participant1" sees the following system messages in room "room" with 200
+      | room | actorType     | actorId      | systemMessage        | message                      | messageParameters |
+      | room | users         | participant1 | call_tried           | You tried to call {user}     | {"user":{"type":"highlight","id":"deleted_user","name":"participant2-displayname"}} |
+      | room | users         | participant1 | call_left            | You left the call            | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
+      | room | users         | participant1 | call_started         | You started a call           | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
+      | room | users         | participant1 | conversation_created | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |


### PR DESCRIPTION
This can happen if a user gets deleted from a one-to-one conversation

```
[PHP] Error: Error: Invalid argument supplied for foreach() at /var/www/html/apps/spreed/lib/Chat/Parser/SystemMessage.php#720 at <<closure>>

	0. /var/www/html/apps/spreed/lib/Chat/Parser/SystemMessage.php line 720
	OC\Log\ErrorHandler::onError()
	1. /var/www/html/apps/spreed/lib/Chat/Parser/SystemMessage.php line 169
	OCA\Talk\Chat\Parser\SystemMessage->parseMissedCall()
	2. /var/www/html/apps/spreed/lib/Chat/Parser/Listener.php line 74
	OCA\Talk\Chat\Parser\SystemMessage->parseMessage()
	3. /var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php line 251
	OCA\Talk\Chat\Parser\Listener::OCA\Talk\Chat\Parser\{closure}("*** sensitive parameters replaced ***")
	4. /var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php line 73
	Symfony\Component\EventDispatcher\EventDispatcher->callListeners()
	5. /var/www/html/lib/private/EventDispatcher/EventDispatcher.php line 88
	Symfony\Component\EventDispatcher\EventDispatcher->dispatch()
	6. /var/www/html/apps/spreed/lib/Chat/MessageParser.php line 73
	OC\EventDispatcher\EventDispatcher->dispatch()
	7. /var/www/html/apps/spreed/lib/Controller/RoomController.php line 606
	OCA\Talk\Chat\MessageParser->parseMessage()
	8. /var/www/html/apps/spreed/lib/Controller/RoomController.php line 590
	OCA\Talk\Controller\RoomController->formatLastMessage()
	9. /var/www/html/apps/spreed/lib/Controller/RoomController.php line 346
	OCA\Talk\Controller\RoomController->formatRoomV4()
	10. /var/www/html/apps/spreed/lib/Controller/RoomController.php line 223
	OCA\Talk\Controller\RoomController->formatRoom()
	11. /var/www/html/lib/private/AppFramework/Http/Dispatcher.php line 225
	OCA\Talk\Controller\RoomController->getRooms()
	12. /var/www/html/lib/private/AppFramework/Http/Dispatcher.php line 133
	OC\AppFramework\Http\Dispatcher->executeController()
	13. /var/www/html/lib/private/AppFramework/App.php line 172
	OC\AppFramework\Http\Dispatcher->dispatch()
	14. /var/www/html/lib/private/Route/Router.php line 298
	OC\AppFramework\App::main()
	15. /var/www/html/ocs/v1.php line 62
	OC\Route\Router->match()
	16. /var/www/html/ocs/v2.php line 23
	require_once("/var/www/html/ocs/v1.php")

	GET /ocs/v2.php/apps/spreed/api/v4/room?includeStatus=true
```
Spamed multiple times per minute on our instance after a user was removed with the `occ talk:user:remove` command.

- [x] Add integration test for this case
- [x] Check other system messages for similar cases
- [x] Check if handling is correct if a former "one-to-one" is turned into a "public" room or "group" room and others are added (should be blocked by demoting the second user?)