### PR TITLE
Support "Silent call" on API

### DIFF
--- a/docs/call.md
+++ b/docs/call.md
@@ -38,6 +38,7 @@
     field | type | Description
     ---|---|---
     `flags` | int | Flags what streams are provided by the participant (see [Constants - Participant in-call flag](constants.md#participant-in-call-flag))
+	`silent` | bool | Disable start call notifications for group/public calls
 
 * Response:
     - Status code:

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -98,4 +98,5 @@ title: Capabilities
 * `silent-send` - Whether the chat API allows to send chat messages without triggering notifications
 * `sip-support-nopin` - Whether SIP can be configured to not require a custom attendee PIN
 * `send-call-notification` - When the API allows to resend call notifications for individual users that did not join yet
+* `silent-call` - Allow to start calls without sending notification
 * `config => call => enabled` - Whether calling is enabled on the instance or not

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -104,6 +104,7 @@ class Capabilities implements IPublicCapability {
 				'rich-object-delete',
 				'chat-permission',
 				'silent-send',
+				'silent-call',
 				'send-call-notification',
 			],
 			'config' => [

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -111,7 +111,7 @@ class CallController extends AEnvironmentAwareController {
 	 * @param int|null $forcePermissions
 	 * @return DataResponse
 	 */
-	public function joinCall(?int $flags = null, ?int $forcePermissions = null): DataResponse {
+	public function joinCall(?int $flags = null, ?int $forcePermissions = null, bool $silent = false): DataResponse {
 		$this->participantService->ensureOneToOneRoomIsFilled($this->room);
 
 		$session = $this->participant->getSession();
@@ -128,7 +128,7 @@ class CallController extends AEnvironmentAwareController {
 			$this->roomService->setPermissions($this->room, 'call', Attendee::PERMISSIONS_MODIFY_SET, $forcePermissions, true);
 		}
 
-		$this->participantService->changeInCall($this->room, $this->participant, $flags);
+		$this->participantService->changeInCall($this->room, $this->participant, $flags, false, $silent);
 
 		return new DataResponse();
 	}

--- a/lib/Events/SilentModifyParticipantEvent.php
+++ b/lib/Events/SilentModifyParticipantEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Vitor Mattos <vitor@php.rio>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Events;
+
+class SilentModifyParticipantEvent extends ModifyParticipantEvent {
+}

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -43,6 +43,7 @@ use OCA\Talk\Events\RemoveParticipantEvent;
 use OCA\Talk\Events\RemoveUserEvent;
 use OCA\Talk\Events\RoomEvent;
 use OCA\Talk\Events\SendCallNotificationEvent;
+use OCA\Talk\Events\SilentModifyParticipantEvent;
 use OCA\Talk\Exceptions\ForbiddenException;
 use OCA\Talk\Exceptions\InvalidPasswordException;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
@@ -947,7 +948,7 @@ class ParticipantService {
 		$this->dispatcher->dispatch(Room::EVENT_AFTER_END_CALL_FOR_EVERYONE, $event);
 	}
 
-	public function changeInCall(Room $room, Participant $participant, int $flags, bool $endCallForEveryone = false): void {
+	public function changeInCall(Room $room, Participant $participant, int $flags, bool $endCallForEveryone = false, bool $silent = false): void {
 		$session = $participant->getSession();
 		if (!$session instanceof Session) {
 			return;
@@ -962,7 +963,11 @@ class ParticipantService {
 		}
 
 		if ($flags !== Participant::FLAG_DISCONNECTED) {
-			$event = new ModifyParticipantEvent($room, $participant, 'inCall', $flags, $session->getInCall());
+			if ($silent) {
+				$event = new SilentModifyParticipantEvent($room, $participant, 'inCall', $flags, $session->getInCall(), $silent);
+			} else {
+				$event = new ModifyParticipantEvent($room, $participant, 'inCall', $flags, $session->getInCall(), $silent);
+			}
 			$this->dispatcher->dispatch(Room::EVENT_BEFORE_SESSION_JOIN_CALL, $event);
 		} else {
 			if ($endCallForEveryone) {

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1342,6 +1342,22 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" pings (user|guest) "([^"]*)" to join call "([^"]*)" with (\d+) \((v4)\)$/
+	 *
+	 * @param string $user
+	 * @param string $actorType
+	 * @param string $actorId
+	 * @param string $identifier
+	 * @param int $statusCode
+	 * @param string $apiVersion
+	 */
+	public function userPingsAttendeeInRoomTo(string $user, string $actorType, string $actorId, string $identifier, int $statusCode, string $apiVersion): void {
+		$this->setCurrentUser($user);
+		$this->sendRequest('POST', '/apps/spreed/api/' . $apiVersion . '/call/' . self::$identifierToToken[$identifier] . '/ring/' . self::$userToAttendeeId[$actorType . 's'][$actorId]);
+		$this->assertStatusCode($this->response, $statusCode);
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" leaves call "([^"]*)" with (\d+) \((v4)\)$/
 	 *
 	 * @param string $user

--- a/tests/integration/features/callapi/notifications.feature
+++ b/tests/integration/features/callapi/notifications.feature
@@ -1,0 +1,68 @@
+Feature: chat/notifications
+
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+
+  Scenario: Normal call notification
+    When user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    Given user "participant1" joins room "room" with 200 (v4)
+    Given user "participant2" joins room "room" with 200 (v4)
+    Given user "participant1" joins call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id | subject                          |
+      | spreed | call        | room      | A group call has started in room |
+    Given user "participant2" joins call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app | object_type | object_id | subject |
+
+  Scenario: Missed call notification
+    When user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    Given user "participant1" joins room "room" with 200 (v4)
+    Given user "participant2" joins room "room" with 200 (v4)
+    Given user "participant1" joins call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id | subject                          |
+      | spreed | call        | room      | A group call has started in room |
+    Given user "participant1" leaves call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id | subject                          |
+      | spreed | call        | room      | You missed a group call in room |
+
+  Scenario: Silent call does not trigger notifications
+    When user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    Given user "participant1" joins room "room" with 200 (v4)
+    Given user "participant2" joins room "room" with 200 (v4)
+    Given user "participant1" joins call "room" with 200 (v4)
+      | silent | true |
+    Then user "participant2" has the following notifications
+      | app | object_type | object_id | subject |
+    Given user "participant1" leaves call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app | object_type | object_id | subject |
+
+  Scenario: Silent call with dedicated ping does trigger notifications
+    When user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    Given user "participant1" joins room "room" with 200 (v4)
+    Given user "participant2" joins room "room" with 200 (v4)
+    Given user "participant1" loads attendees attendee ids in room "room" (v4)
+    Given user "participant1" joins call "room" with 200 (v4)
+      | silent | true |
+    Then user "participant2" has the following notifications
+      | app | object_type | object_id | subject |
+    Given user "participant1" pings user "participant2" to join call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id | subject                          |
+      | spreed | call        | room      | A group call has started in room |

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -108,6 +108,7 @@ class CapabilitiesTest extends TestCase {
 			'rich-object-delete',
 			'chat-permission',
 			'silent-send',
+			'silent-call',
 			'send-call-notification',
 			'reactions',
 		];


### PR DESCRIPTION
Related with #3950

- [x] Implement changes on API to accept boolean `silent` flag
- [x] Implement capability `silent-call`
- [x] Document api changes
- [x] Should add an integration test in features/callapi/ checking the notifications, like we did for https://github.com/nextcloud/spreed/pull/7331