### PR TITLE
Fix stylelint

### DIFF
--- a/src/components/RightSidebar/SharedItems/SharedItems.vue
+++ b/src/components/RightSidebar/SharedItems/SharedItems.vue
@@ -136,16 +136,15 @@ export default {
 	}
 
 	&__other {
-
 		width: 100%;
 		margin-left: 8px;
+
 		a {
 			text-decoration: underline;
 			&:after {
-			content: " ↗";
+				content: " ↗";
+			}
 		}
-		}
-
 	}
 }
 </style>

--- a/src/components/RightSidebar/SharedItems/SharedItems.vue
+++ b/src/components/RightSidebar/SharedItems/SharedItems.vue
@@ -142,7 +142,7 @@ export default {
 		a {
 			text-decoration: underline;
 			&:after {
-				content: " ↗";
+				content: ' ↗';
 			}
 		}
 	}


### PR DESCRIPTION
```
ERROR in src/components/RightSidebar/SharedItems/SharedItems.vue
 140:3   ✖  Unexpected empty line before declaration  declaration-empty-line-before
 145:4   ✖  Expected indentation of 4 tabs            indentation
 145:13  ✖  Expected single quotes                    string-quotes
 146:3   ✖  Expected indentation of 3 tabs            indentation
```

Signed-off-by: Joas Schilling <coding@schilljs.com>