### PR TITLE
Fix messagebuttonsbar position for last read messages

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -154,6 +154,7 @@ the main body of the message as well as a quote.
 			:is-reactions-menu-open.sync="isReactionsMenuOpen"
 			:message-api-data="messageApiData"
 			:message-object="messageObject"
+			:is-last-read="isLastReadMessage"
 			:can-react="canReact"
 			v-bind="$props"
 			:previous-message-id="previousMessageId"

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -22,7 +22,8 @@
 <template>
 	<!-- Message Actions -->
 	<div v-click-outside="handleClickOutside"
-		class="message-buttons-bar">
+		class="message-buttons-bar"
+		:class="{ 'message-buttons-bar--last-read' : isLastRead }">
 		<template v-if="!isReactionsMenuOpen">
 			<Button v-if="canReact"
 				type="tertiary"
@@ -297,6 +298,16 @@ export default {
 			type: Boolean,
 			required: true,
 		},
+
+		/**
+		 * If the MessageButtonsBar belongs to the last read message, we need
+		 * to raise it to compensate for the shift in position brought by the
+		 * last read marker that's added to the message component.
+		 */
+		isLastRead: {
+			type: Boolean,
+			required: true,
+		},
 	},
 
 	data() {
@@ -489,9 +500,14 @@ export default {
 	background-color: var(--color-main-background);
 	border-radius: calc($clickable-area / 2);
 	box-shadow: 0 0 4px 0 var(--color-box-shadow);
+	height: 44px;
 
 	& h6 {
 		margin-left: auto;
+	}
+
+	&--last-read {
+		bottom: 36px;
 	}
 }
 


### PR DESCRIPTION
If the MessageButtonsBar belongs to the last read message, we need
to raise it to compensate for the shift in position brought by the
last read marker that's added to the message component.

fixes #7219 

Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>