### PR TITLE
Fixed crash when saving status without conversation selected

### DIFF
--- a/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
+++ b/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
@@ -110,18 +110,20 @@ export default {
 
 	methods: {
 		userStatusUpdated(state) {
-			this.$store.dispatch('updateUser', {
-				token: this.token,
-				participantIdentifier: {
-					actorType: 'users',
-					actorId: state.userId,
-				},
-				updatedData: {
-					status: state.status,
-					statusIcon: state.icon,
-					statusMessage: state.message,
-				},
-			})
+			if (this.token) {
+				this.$store.dispatch('updateUser', {
+					token: this.token,
+					participantIdentifier: {
+						actorType: 'users',
+						actorId: state.userId,
+					},
+					updatedData: {
+						status: state.status,
+						statusIcon: state.icon,
+						statusMessage: state.message,
+					},
+				})
+			}
 		},
 
 		/**


### PR DESCRIPTION
The failure is occurring due to when there is no token, it cannot find the participants.

Created validation for it to dispatch only when there is a token

Fix #7460 