### PR TITLE
Add app version to capabilities

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -31,21 +31,25 @@ use OCP\Comments\ICommentsManager;
 use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\App\IAppManager;
 
 class Capabilities implements IPublicCapability {
 	protected IConfig $serverConfig;
 	protected Config $talkConfig;
 	protected ICommentsManager $commentsManager;
 	protected IUserSession $userSession;
+	private IAppManager $appManager;
 
 	public function __construct(IConfig $serverConfig,
 								Config $talkConfig,
 								ICommentsManager $commentsManager,
-								IUserSession $userSession) {
+								IUserSession $userSession,
+								IAppManager $appManager) {
 		$this->serverConfig = $serverConfig;
 		$this->talkConfig = $talkConfig;
 		$this->commentsManager = $commentsManager;
 		$this->userSession = $userSession;
+		$this->appManager = $appManager;
 	}
 
 	public function getCapabilities(): array {
@@ -127,6 +131,7 @@ class Capabilities implements IPublicCapability {
 					'session-ping-limit' => max(0, (int)$this->serverConfig->getAppValue('spreed', 'session-ping-limit', '200')),
 				],
 			],
+			'version' => $this->appManager->getAppVersion('spreed'),
 		];
 
 		if ($this->commentsManager->supportReactions()) {

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -34,6 +34,7 @@ use OCP\Capabilities\IPublicCapability;
 use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\App\IAppManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -47,6 +48,8 @@ class CapabilitiesTest extends TestCase {
 	protected $commentsManager;
 	/** @var IUserSession|MockObject */
 	protected $userSession;
+	/** @var IAppManager|MockObject */
+	protected $appManager;
 	protected ?array $baseFeatures = null;
 
 	public function setUp(): void {
@@ -55,9 +58,16 @@ class CapabilitiesTest extends TestCase {
 		$this->talkConfig = $this->createMock(Config::class);
 		$this->commentsManager = $this->createMock(CommentsManager::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		
 		$this->commentsManager->expects($this->any())
 			->method('supportReactions')
 			->willReturn(true);
+
+		$this->appManager->expects($this->any())
+			->method('getAppVersion')
+			->with('spreed')
+			->willReturn('1.2.3');
 
 		$this->baseFeatures = [
 			'audio',
@@ -120,7 +130,8 @@ class CapabilitiesTest extends TestCase {
 			$this->serverConfig,
 			$this->talkConfig,
 			$this->commentsManager,
-			$this->userSession
+			$this->userSession,
+			$this->appManager
 		);
 
 		$this->userSession->expects($this->once())
@@ -164,6 +175,7 @@ class CapabilitiesTest extends TestCase {
 						'session-ping-limit' => 200,
 					],
 				],
+				'version' => '1.2.3',
 			],
 		], $capabilities->getCapabilities());
 	}
@@ -186,7 +198,8 @@ class CapabilitiesTest extends TestCase {
 			$this->serverConfig,
 			$this->talkConfig,
 			$this->commentsManager,
-			$this->userSession
+			$this->userSession,
+			$this->appManager
 		);
 
 		$user = $this->createMock(IUser::class);
@@ -257,6 +270,7 @@ class CapabilitiesTest extends TestCase {
 						'session-ping-limit' => 50,
 					],
 				],
+				'version' => '1.2.3',
 			],
 		], $data);
 
@@ -281,7 +295,8 @@ class CapabilitiesTest extends TestCase {
 			$this->serverConfig,
 			$this->talkConfig,
 			$this->commentsManager,
-			$this->userSession
+			$this->userSession,
+			$this->appManager
 		);
 
 		$user = $this->createMock(IUser::class);


### PR DESCRIPTION
To make troubleshooting problems with Talk iOS easier I've submitted a PR which adds some troubleshooting infos to talk-ios, see https://github.com/nextcloud/talk-ios/pull/829
For this it would be really helpful to also show the version of the server version, but currently this version is not exposed. This PR adds the version as part of the capabilities. 