### PR TITLE
Add schemes to turn OCC commands

### DIFF
--- a/lib/Command/Turn/Add.php
+++ b/lib/Command/Turn/Add.php
@@ -45,6 +45,10 @@ class Add extends Base {
 			->setName('talk:turn:add')
 			->setDescription('Add a TURN server.')
 			->addArgument(
+				'schemes',
+				InputArgument::REQUIRED,
+				'Schemes, can be turn or turns or turn,turns.'
+			)->addArgument(
 				'server',
 				InputArgument::REQUIRED,
 				'A domain name, ex. turn.nextcloud.com'
@@ -66,11 +70,16 @@ class Add extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$schemes = $input->getArgument('schemes');
 		$server = $input->getArgument('server');
 		$protocols = $input->getArgument('protocols');
 		$secret = $input->getOption('secret');
 		$generate = $input->getOption('generate-secret');
 
+		if (!in_array($schemes, ['turn', 'turns', 'turn,turns'])) {
+			$output->writeln('<error>Not allowed schemes, must be turn or turns or turn,turns.</error>');
+			return 1;
+		}
 		if (!in_array($protocols, ['tcp', 'udp', 'udp,tcp'])) {
 			$output->writeln('<error>Not allowed protocols, must be udp or tcp or udp,tcp.</error>');
 			return 1;
@@ -107,6 +116,7 @@ class Add extends Base {
 		}
 
 		$servers[] = [
+			'schemes' => $schemes,
 			'server' => $server,
 			'secret' => $secret, // @todo: check the order
 			'protocols' => $protocols,

--- a/lib/Command/Turn/Add.php
+++ b/lib/Command/Turn/Add.php
@@ -71,7 +71,7 @@ class Add extends Base {
 		$secret = $input->getOption('secret');
 		$generate = $input->getOption('generate-secret');
 
-		if (! in_array($protocols, ['tcp', 'udp', 'udp,tcp'])) {
+		if (!in_array($protocols, ['tcp', 'udp', 'udp,tcp'])) {
 			$output->writeln('<error>Not allowed protocols, must be udp or tcp or udp,tcp.</error>');
 			return 1;
 		}

--- a/lib/Command/Turn/Delete.php
+++ b/lib/Command/Turn/Delete.php
@@ -44,6 +44,10 @@ class Delete extends Base {
 			->setName('talk:turn:delete')
 			->setDescription('Remove an existing TURN server.')
 			->addArgument(
+				'schemes',
+				InputArgument::REQUIRED,
+				'Schemes, can be turn or turns or turn,turns'
+			)->addArgument(
 				'server',
 				InputArgument::REQUIRED,
 				'A domain name, ex. turn.nextcloud.com'
@@ -55,6 +59,7 @@ class Delete extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$schemes = $input->getArgument('schemes');
 		$server = $input->getArgument('server');
 		$protocols = $input->getArgument('protocols');
 
@@ -66,9 +71,9 @@ class Delete extends Base {
 		}
 
 		$count = count($servers);
-		// remove all occurrences which math $server and $protocols
-		$servers = array_filter($servers, function ($s) use ($server, $protocols) {
-			return $s['server'] !== $server || $s['protocols'] !== $protocols;
+		// remove all occurrences which match $schemes, $server and $protocols
+		$servers = array_filter($servers, function ($s) use ($schemes, $server, $protocols) {
+			return $s['schemes'] !== $schemes || $s['server'] !== $server || $s['protocols'] !== $protocols;
 		});
 		$servers = array_values($servers); // reindex
 

--- a/tests/php/Command/Turn/AddTest.php
+++ b/tests/php/Command/Turn/AddTest.php
@@ -56,7 +56,9 @@ class AddTest extends TestCase {
 	public function testServerEmptyString() {
 		$this->input->method('getArgument')
 			->willReturnCallback(function ($arg) {
-				if ($arg === 'server') {
+				if ($arg === 'schemes') {
+					return 'turn,turns';
+				} elseif ($arg === 'server') {
 					return '';
 				} elseif ($arg === 'protocols') {
 					return 'udp,tcp';
@@ -84,7 +86,9 @@ class AddTest extends TestCase {
 	public function testSecretEmpty() {
 		$this->input->method('getArgument')
 			->willReturnCallback(function ($arg) {
-				if ($arg === 'server') {
+				if ($arg === 'schemes') {
+					return 'turn,turns';
+				} elseif ($arg === 'server') {
 					return 'turn.test.com';
 				} elseif ($arg === 'protocols') {
 					return 'udp,tcp';
@@ -112,7 +116,9 @@ class AddTest extends TestCase {
 	public function testGenerateSecret() {
 		$this->input->method('getArgument')
 			->willReturnCallback(function ($arg) {
-				if ($arg === 'server') {
+				if ($arg === 'schemes') {
+					return 'turn,turns';
+				} elseif ($arg === 'server') {
 					return 'turn.test.com';
 				} elseif ($arg === 'protocols') {
 					return 'udp,tcp';
@@ -146,6 +152,7 @@ class AddTest extends TestCase {
 				$this->equalTo('turn_servers'),
 				$this->equalTo(json_encode([
 					[
+						'schemes' => 'turn,turns',
 						'server' => 'turn.test.com',
 						'secret' => 'my-generaeted-test-secret',
 						'protocols' => 'udp,tcp'
@@ -162,7 +169,9 @@ class AddTest extends TestCase {
 	public function testSecretAndGenerateSecretOptions() {
 		$this->input->method('getArgument')
 			->willReturnCallback(function ($arg) {
-				if ($arg === 'server') {
+				if ($arg === 'schemes') {
+					return 'turn,turns';
+				} elseif ($arg === 'server') {
 					return 'turn.test.com';
 				} elseif ($arg === 'protocols') {
 					return 'udp,tcp';
@@ -187,10 +196,42 @@ class AddTest extends TestCase {
 		$this->invokePrivate($this->command, 'execute', [$this->input, $this->output]);
 	}
 
+	public function testInvalidSchemesString() {
+		$this->input->method('getArgument')
+			->willReturnCallback(function ($arg) {
+				if ($arg === 'schemes') {
+					return 'invalid-scheme';
+				} elseif ($arg === 'server') {
+					return 'turn.test.com';
+				} elseif ($arg === 'protocols') {
+					return 'udp,tcp';
+				}
+				throw new \Exception();
+			});
+		$this->input->method('getOption')
+			->willReturnCallback(function ($arg) {
+				if ($arg === 'secret') {
+					return 'my-test-secret';
+				} elseif ($arg === 'generate-secret') {
+					return false;
+				}
+				throw new \Exception();
+			});
+		$this->output->expects($this->once())
+			->method('writeln')
+			->with($this->equalTo('<error>Not allowed schemes, must be turn or turns or turn,turns.</error>'));
+		$this->config->expects($this->never())
+			->method('setAppValue');
+
+		$this->invokePrivate($this->command, 'execute', [$this->input, $this->output]);
+	}
+
 	public function testInvalidProtocolsString() {
 		$this->input->method('getArgument')
 			->willReturnCallback(function ($arg) {
-				if ($arg === 'server') {
+				if ($arg === 'schemes') {
+					return 'turn,turns';
+				} elseif ($arg === 'server') {
 					return 'turn.test.com';
 				} elseif ($arg === 'protocols') {
 					return 'invalid-protocol';
@@ -218,7 +259,9 @@ class AddTest extends TestCase {
 	public function testAddServerToEmptyList() {
 		$this->input->method('getArgument')
 			->willReturnCallback(function ($arg) {
-				if ($arg === 'server') {
+				if ($arg === 'schemes') {
+					return 'turn,turns';
+				} elseif ($arg === 'server') {
 					return 'turn.test.com';
 				} elseif ($arg === 'protocols') {
 					return 'udp,tcp';
@@ -244,6 +287,7 @@ class AddTest extends TestCase {
 				$this->equalTo('turn_servers'),
 				$this->equalTo(json_encode([
 					[
+						'schemes' => 'turn,turns',
 						'server' => 'turn.test.com',
 						'secret' => 'my-test-secret',
 						'protocols' => 'udp,tcp'
@@ -260,7 +304,9 @@ class AddTest extends TestCase {
 	public function testAddServerToNonEmptyList() {
 		$this->input->method('getArgument')
 			->willReturnCallback(function ($arg) {
-				if ($arg === 'server') {
+				if ($arg === 'schemes') {
+					return 'turn,turns';
+				} elseif ($arg === 'server') {
 					return 'turn2.test.com';
 				} elseif ($arg === 'protocols') {
 					return 'udp,tcp';
@@ -297,6 +343,7 @@ class AddTest extends TestCase {
 						'protocols' => 'udp,tcp'
 					],
 					[
+						'schemes' => 'turn,turns',
 						'server' => 'turn2.test.com',
 						'secret' => 'my-test-secret-2',
 						'protocols' => 'udp,tcp'
@@ -313,7 +360,9 @@ class AddTest extends TestCase {
 	public function testServerSanitization() {
 		$this->input->method('getArgument')
 			->willReturnCallback(function ($arg) {
-				if ($arg === 'server') {
+				if ($arg === 'schemes') {
+					return 'turn,turns';
+				} elseif ($arg === 'server') {
 					return 'https://turn.test.com';
 				} elseif ($arg === 'protocols') {
 					return 'udp,tcp';
@@ -339,6 +388,7 @@ class AddTest extends TestCase {
 				$this->equalTo('turn_servers'),
 				$this->equalTo(json_encode([
 					[
+						'schemes' => 'turn,turns',
 						'server' => 'turn.test.com',
 						'secret' => 'my-test-secret',
 						'protocols' => 'udp,tcp'


### PR DESCRIPTION
Although it was possible to add TURN servers with OCC commands they had no scheme set, so in practice they always used "turn". If a different scheme had to be set that had to be done afterwards from the UI.

On the other hand, as no scheme could be set when deleting a TURN server all TURN servers matching the server and protocols were deleted regardless of their scheme.

Not sure if it is worth a backport or not, so feel free to call backportbot.