### PR TITLE
Update iOS requirements

### DIFF
--- a/docs/system-requirements.md
+++ b/docs/system-requirements.md
@@ -55,4 +55,4 @@ A TURN server running on **port 443** (or 80) is required in almost all scenario
 # Mobile apps
 
 * Android: 5 or later
-* iOS: 10 or later
+* iOS: 12 or later


### PR DESCRIPTION
Since https://github.com/nextcloud/talk-ios/pull/736 talk-ios targets iOS 12 as minimum iOS version.