### PR TITLE
Adjust logs during calls

### DIFF
--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -513,7 +513,7 @@ Peer.prototype.selectSimulcastStream = function(substream, temporal) {
 		return
 	}
 
-	console.debug('Changing simulcast stream', this, substream, temporal)
+	console.debug('Changing simulcast stream', this.id, this, substream, temporal)
 	this.send('selectStream', {
 		substream,
 		temporal,

--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -510,7 +510,6 @@ Peer.prototype.handleAnswer = function(answer) {
 
 Peer.prototype.selectSimulcastStream = function(substream, temporal) {
 	if (this.substream === substream && this.temporal === temporal) {
-		console.debug('Simulcast stream not changed', this, substream, temporal)
 		return
 	}
 

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -186,7 +186,7 @@ function checkStartPublishOwnPeer(signaling) {
 		}
 
 		if (currentSessionId !== signaling.getSessionId()) {
-			console.debug('No answer received for own peer but current session id changed, not sending offer again')
+			console.debug('No answer received for own peer but current session id changed, not sending offer again', currentSessionId, signaling.getSessionId())
 
 			clearInterval(delayedConnectionToPeer[currentSessionId])
 			delete delayedConnectionToPeer[currentSessionId]
@@ -194,7 +194,7 @@ function checkStartPublishOwnPeer(signaling) {
 			return
 		}
 
-		console.debug('No answer received for own peer, sending offer again')
+		console.debug('No answer received for own peer, sending offer again', currentSessionId)
 		createPeer()
 	}, 10000)
 }
@@ -372,7 +372,7 @@ function usersChanged(signaling, newUsers, disconnectedSessionIds) {
 				clearInterval(delayedConnectionToPeer[user.sessionId])
 
 				delayedConnectionToPeer[user.sessionId] = setInterval(function() {
-					console.debug('No offer received for new peer, request offer again')
+					console.debug('No offer received for new peer, request offer again', sessionId)
 
 					signaling.requestOffer(user, 'video')
 				}, 10000)
@@ -380,7 +380,7 @@ function usersChanged(signaling, newUsers, disconnectedSessionIds) {
 				// To avoid overloading the user joining a room (who previously called
 				// all the other participants), we decide who calls who by comparing
 				// the session ids of the users: "larger" ids call "smaller" ones.
-				console.debug('Starting call with', user)
+				console.debug('Starting call with', user, sessionId)
 				createPeer()
 			} else if (!useMcu && userHasStreams(selfInCall) && userHasStreams(user) && sessionId > currentSessionId) {
 				// If the remote peer is not aware that it was disconnected
@@ -398,11 +398,11 @@ function usersChanged(signaling, newUsers, disconnectedSessionIds) {
 						peer.end()
 					})
 
-					console.debug('No offer nor answer received, sending offer again')
+					console.debug('No offer nor answer received, sending offer again', sessionId)
 					createPeer()
 				}, 10000)
 			} else {
-				console.debug('User has no streams, not sending another offer')
+				console.debug('User has no streams, not sending another offer', sessionId)
 			}
 		}
 
@@ -1575,10 +1575,10 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 			} else if (data.type === 'speaking' || data.type === 'stoppedSpeaking') {
 				// Valid known messages, but handled elsewhere
 			} else {
-				console.debug('Unknown message type %s from %s datachannel', data.type, label, data)
+				console.debug('Unknown message type %s from %s datachannel', data.type, label, data, peer.id, peer)
 			}
 		} else {
-			console.debug('Unknown message from %s datachannel', label, data)
+			console.debug('Unknown message from %s datachannel', label, data, peer.id, peer)
 		}
 	})
 

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -748,7 +748,7 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 					if (peer.pc.localDescription.type === 'offer'
 							&& peer.pc.signalingState === 'stable') {
 						spreedPeerConnectionTable[peer.id]++
-						console.debug('ICE restart after disconnect.', peer)
+						console.debug('ICE restart after disconnect.', peer.id, peer)
 						peer.icerestart()
 					}
 				}
@@ -778,25 +778,25 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 				if (peer.pc.localDescription.type === 'offer'
 						&& peer.pc.signalingState === 'stable') {
 					spreedPeerConnectionTable[peer.id]++
-					console.debug('ICE restart after failure.', peer)
+					console.debug('ICE restart after failure.', peer.id, peer)
 					peer.icerestart()
 				}
 			} else {
-				console.error('ICE failed after 5 tries.', peer)
+				console.error('ICE failed after 5 tries.', peer.id, peer)
 
 				peer.emit('extendedIceConnectionStateChange', 'failed-no-restart')
 			}
 		} else {
 			// This handles ICE failures of a receiver peer; ICE failures of
 			// the sender peer are handled in the "iceFailed" event.
-			console.debug('Request offer again', peer)
+			console.debug('Request offer again', peer.id, peer)
 
 			signaling.requestOffer(peer.id, 'video')
 
 			clearInterval(delayedConnectionToPeer[peer.id])
 
 			delayedConnectionToPeer[peer.id] = setInterval(function() {
-				console.debug('No offer received, request offer again', peer)
+				console.debug('No offer received, request offer again', peer.id, peer)
 
 				signaling.requestOffer(peer.id, 'video')
 			}, 10000)
@@ -815,27 +815,27 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 
 			switch (peer.pc.iceConnectionState) {
 			case 'checking':
-				console.debug('Connecting to peer...', peer)
+				console.debug('Connecting to peer...', peer.id, peer)
 
 				break
 			case 'connected':
 			case 'completed': // on caller side
-				console.debug('Connection established.', peer)
+				console.debug('Connection established.', peer.id, peer)
 
 				handleIceConnectionStateConnected(peer)
 				break
 			case 'disconnected':
-				console.debug('Disconnected.', peer)
+				console.debug('Disconnected.', peer.id, peer)
 
 				handleIceConnectionStateDisconnected(peer)
 				break
 			case 'failed':
-				console.debug('Connection failed.', peer)
+				console.debug('Connection failed.', peer.id, peer)
 
 				handleIceConnectionStateFailed(peer)
 				break
 			case 'closed':
-				console.debug('Connection closed.', peer)
+				console.debug('Connection closed.', peer.id, peer)
 
 				break
 			}
@@ -884,16 +884,16 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 
 			switch (peer.pc.iceConnectionState) {
 			case 'checking':
-				console.debug('Connecting own peer...', peer)
+				console.debug('Connecting own peer...', peer.id, peer)
 
 				break
 			case 'connected':
 			case 'completed':
-				console.debug('Connection established (own peer).', peer)
+				console.debug('Connection established (own peer).', peer.id, peer)
 
 				break
 			case 'disconnected':
-				console.debug('Disconnected (own peer).', peer)
+				console.debug('Disconnected (own peer).', peer.id, peer)
 
 				setTimeout(function() {
 					if (peer.pc.iceConnectionState !== 'disconnected') {
@@ -904,11 +904,11 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 				}, 5000)
 				break
 			case 'failed':
-				console.debug('Connection failed (own peer).', peer)
+				console.debug('Connection failed (own peer).', peer.id, peer)
 
 				break
 			case 'closed':
-				console.debug('Connection closed (own peer).', peer)
+				console.debug('Connection closed (own peer).', peer.id, peer)
 
 				break
 			}
@@ -967,7 +967,7 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 				clearInterval(delayedConnectionToPeer[peer.id])
 
 				delayedConnectionToPeer[peer.id] = setInterval(function() {
-					console.debug('No offer received, request offer again' + update ? '(update)' : '', peer)
+					console.debug('No offer received, request offer again' + update ? '(update)' : '', peer.id, peer)
 
 					signaling.requestOffer(peer.id, 'video', update ? peer.sid : undefined)
 				}, 10000)
@@ -1159,7 +1159,7 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 	})
 
 	webrtc.on('createdPeer', function(peer) {
-		console.debug('Peer created', peer)
+		console.debug('Peer created', peer.id, peer)
 
 		if (peer.id !== signaling.getSessionId() && !peer.sharemyscreen) {
 			// In some strange cases a Peer can be added before its


### PR DESCRIPTION
This pull request adjusts the logs during calls to be more useful, specially when exported to a text file to be analysed later.

## How to test (scenario 1)

- Start a call
- Join the call with another speaking participant

### Result with this pull request

No `Simulcast stream not changed` messages are printed

### Result without this pull request

`Simulcast stream not changed` messages are shown when the other participant starts and stops speaking (and in large calls those messages flood the logs)



## How to test (scenario 2)

- Start a call
- Join the call with other two participants
- Export the browser console of the original participant to a text file
- Try to find out which call event belongs to which peer

### Result with this pull request

The messages can be differentiated from the peer id

### Result without this pull request

:shrug:
