### PR TITLE
Fix avatar size to be a legal value

### DIFF
--- a/lib/Search/ConversationSearch.php
+++ b/lib/Search/ConversationSearch.php
@@ -121,7 +121,7 @@ class ConversationSearch implements IProvider {
 					if ($participantId !== $user->getUID()) {
 						$icon = $this->url->linkToRouteAbsolute('core.avatar.getAvatar', [
 							'userId' => $participantId,
-							'size' => 128,
+							'size' => 512,
 						]);
 					}
 				}

--- a/lib/Search/MessageSearch.php
+++ b/lib/Search/MessageSearch.php
@@ -191,7 +191,7 @@ class MessageSearch implements IProvider {
 		if ($message->getActorType() === Attendee::ACTOR_USERS) {
 			$iconUrl = $this->url->linkToRouteAbsolute('core.avatar.getAvatar', [
 				'userId' => $message->getActorId(),
-				'size' => 64,
+				'size' => 512,
 			]);
 		}
 


### PR DESCRIPTION
And since it's better for iOS to be bigger,
we also bump the Message result icon size
so it looks sharp on high DPI devices

---

Tested with Android and web and it looks normal.
The 128px avatar returned a 512 already since 24