### PR TITLE
Add headline to conversation list for screenreaders

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -37,7 +37,7 @@
 				<ul ref="scroller"
 					class="scroller"
 					@scroll="debounceHandleScroll">
-					<AppNavigationCaption v-if="isSearching"
+					<AppNavigationCaption :class="{'hidden-visually': !isSearching}"
 						:title="t('spreed', 'Conversations')" />
 					<li role="presentation">
 						<ConversationsList ref="conversationsList"


### PR DESCRIPTION
Fix #7103 

Or is this not needed anymore as the AppNavigation already has `Conversation list` as aria label and there is only the search box in between? @jancborchardt any clue?