### PR TITLE
Fix forwarding the menu-container for avatars

### DIFF
--- a/src/components/AvatarWrapper/AvatarWrapper.vue
+++ b/src/components/AvatarWrapper/AvatarWrapper.vue
@@ -99,7 +99,7 @@ export default {
 		},
 
 		menuContainer: {
-			type: Object,
+			type: String,
 			default: undefined,
 		},
 	},


### PR DESCRIPTION
Followup to #7598 

I mixed up container (string) and boundaries-element (object)
https://github.com/nextcloud/nextcloud-vue/blame/master/src/components/Actions/Actions.vue#L338-L341

Currently there is a lot of error spam when participants are shown