### PR TITLE
Improve parse system message when message expiration is enabled

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -459,7 +459,8 @@ class SystemMessage {
 		} elseif ($message === 'message_expiration_enabled') {
 			$weeks = $parameters['seconds'] > (86400 * 7) ? (int) round($parameters['seconds'] / (86400 * 7)) : 0;
 			$days = $parameters['seconds'] > 86400 ? (int) round($parameters['seconds'] / 86400) : 0;
-			$hours = $parameters['seconds']  ? (int) round($parameters['seconds'] / 3600) : 0;
+			$hours = $parameters['seconds'] > 3600 ? (int) round($parameters['seconds'] / 3600) : 0;
+			$minutes = $parameters['seconds'] > 60 ? (int) round($parameters['seconds'] / 60) : 0;
 
 			$parsedParameters['seconds'] = $parameters['seconds'];
 			if ($currentUserIsActor) {
@@ -467,16 +468,24 @@ class SystemMessage {
 					$parsedMessage = $this->l->n('You set the message expiration to %n week', 'You set the message expiration to %n weeks', $weeks);
 				} elseif ($days > 0) {
 					$parsedMessage = $this->l->n('You set the message expiration to %n day', 'You set the message expiration to %n days', $days);
-				} else {
+				} elseif ($hours > 0) {
 					$parsedMessage = $this->l->n('You set the message expiration to %n hour', 'You set the message expiration to %n hours', $hours);
+				} elseif ($minutes > 0) {
+					$parsedMessage = $this->l->n('You set the message expiration to %n minute', 'You set the message expiration to %n minutes', $hours);
+				} else {
+					$parsedMessage = $this->l->n('You set the message expiration to %n second', 'You set the message expiration to %n seconds', $hours);
 				}
 			} else {
 				if ($weeks > 0) {
 					$parsedMessage = $this->l->n('{actor} set the message expiration to %n week', '{actor} set the message expiration to %n weeks', $weeks);
 				} elseif ($days > 0) {
 					$parsedMessage = $this->l->n('{actor} set the message expiration to %n day', '{actor} set the message expiration to %n days', $days);
-				} else {
+				} elseif ($hours > 0) {
 					$parsedMessage = $this->l->n('{actor} set the message expiration to %n hour', '{actor} set the message expiration to %n hours', $hours);
+				} elseif ($minutes > 0) {
+					$parsedMessage = $this->l->n('{actor} set the message expiration to %n minute', '{actor} set the message expiration to %n minutes', $hours);
+				} else {
+					$parsedMessage = $this->l->n('{actor} set the message expiration to %n second', '{actor} set the message expiration to %n seconds', $hours);
 				}
 			}
 		} elseif ($message === 'message_expiration_disabled') {


### PR DESCRIPTION
**Problem**: Running tests directly by API, I defined the expiration time to 3 seconds and received the message "`You set the message expiration to 0 hour`".

**Solution**: Implemented minutes and seconds in response messages.

**PS**: For now, the messages are expired using a cron job process that run in usually for each 5 minutes. Expire in X seconds only will work if the cron runs less than a minute or manually triggered.

Related with #7508