### PR TITLE
Remove next function call

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -341,7 +341,7 @@ export default {
 			}
 		})
 
-		Router.afterEach((to, from, next) => {
+		Router.afterEach((to) => {
 			/**
 			 * Change the page title only after the route was changed
 			 */
@@ -352,8 +352,6 @@ export default {
 			} else if (to.name === 'notfound') {
 				this.setPageTitle('')
 			}
-
-			next()
 		})
 
 		if (getCurrentUser()) {


### PR DESCRIPTION
the next() function is not available in the afterEach router
guard
https://router.vuejs.org/guide/advaiced/navigation-guards.html#global-after-hooks

Signed-off-by: Marco Ambrosini <marcoambrosini@icloud.com>
<img width="695" alt="Screenshot 2022-08-05 at 09 43 54" src="https://user-images.githubusercontent.com/26852655/183028616-47a9ccc9-a733-483a-a265-c424264b05a6.png">

