### PR TITLE
Run PHPUnit on composer change

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -8,6 +8,9 @@ on:
       - 'lib/**'
       - 'templates/**'
       - 'tests/**'
+      - '.php-cs-fixer.dist.php'
+      - 'composer.json'
+      - 'composer.lock'
 
   push:
     branches:


### PR DESCRIPTION
E.g. https://github.com/nextcloud/spreed/pull/7682 didn't run it (kind of fine, but if the php dependency we use in no-dev is updated they should run)