### PR TITLE
Fix message forwarding

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/Forwarder.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/Forwarder.vue
@@ -206,9 +206,6 @@ export default {
 		display: flex;
 		justify-content: space-between;
 		padding: 12px;
-		button {
-			height: 44px;
-		}
 	}
 }
 

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -976,7 +976,7 @@ const actions = {
 	 * @param {object} data.messageToBeForwarded the message object;
 	 */
 	async forwardMessage(context, { messageToBeForwarded }) {
-		const response = await postNewMessage(messageToBeForwarded)
+		const response = await postNewMessage(messageToBeForwarded, { silent: false })
 		return response
 	},
 


### PR DESCRIPTION
```
Error while forwarding message TypeError: options is undefined
    _callee3$ messagesService.js:144
    tryCatch runtime.js:63
    invoke runtime.js:294
    defineIteratorMethods runtime.js:119
    asyncGeneratorStep messagesService.js:1
    _next messagesService.js:3
    _asyncToGenerator messagesService.js:3
    _asyncToGenerator messagesService.js:3
    postNewMessage messagesService.js:156
    _callee7$ messagesStore.js:1220
    tryCatch runtime.js:63
    invoke runtime.js:294
```