### PR TITLE
Import missing variables for fade transition

### DIFF
--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -182,6 +182,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '../../assets/variables';
+
 .signaling-warning label {
 	margin: 0;
 }

--- a/src/components/AdminSettings/StunServers.vue
+++ b/src/components/AdminSettings/StunServers.vue
@@ -151,6 +151,8 @@ export default {
 </script>
 
 <style lang="scss">
+@import '../../assets/variables';
+
 .stun-server {
 	h2 {
 		height: 44px;

--- a/src/components/AdminSettings/TurnServers.vue
+++ b/src/components/AdminSettings/TurnServers.vue
@@ -168,6 +168,8 @@ export default {
 </script>
 
 <style lang="scss">
+@import '../../assets/variables';
+
 .turn-server {
 	h2 {
 		height: 44px;

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -70,6 +70,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '../assets/variables';
 
 .main-view {
 	height: 100%;


### PR DESCRIPTION
The `fade` class for transitions is defined in the `variables` asset, so it needs to be imported wherever the transition is used.

Note that this causes the asset to be imported several times when two or more different components that import it are used in the same parent component, although that should not be a problem (and hopefully the bundler is smart enough to import it just once, but I have not checked).

This should not be related to https://github.com/nextcloud/spreed/pull/7704. I have not checked if it happens in previous versions, though, as it is not a big issue.