### PR TITLE
Fix message options when submitting from the advanced input

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -96,7 +96,7 @@
 						:placeholder-text="placeholderText"
 						:aria-label="placeholderText"
 						@update:contentEditable="contentEditableToParsed"
-						@submit="handleSubmit"
+						@submit="handleSubmit({ silent: false })"
 						@files-pasted="handlePastedFiles" />
 				</div>
 


### PR DESCRIPTION
Follow up to #7392

`handleSubmit` was called from an event, so the `options` were the event itself; this did not fail, as the options were defined, but they were useless anyway. Now the options are explicitly set.