### PR TITLE
Fix voting for option 0

### DIFF
--- a/lib/Migration/Version15000Date20220503121308.php
+++ b/lib/Migration/Version15000Date20220503121308.php
@@ -132,7 +132,6 @@ class Version15000Date20220503121308 extends SimpleMigrationStep {
 			$table->addColumn('option_id', Types::INTEGER, [
 				'notnull' => true,
 				'length' => 6,
-				'default' => 1,
 			]);
 
 			$table->setPrimaryKey(['id']);

--- a/lib/Model/Vote.php
+++ b/lib/Model/Vote.php
@@ -48,7 +48,7 @@ class Vote extends Entity {
 	protected string $actorType = '';
 	protected string $actorId = '';
 	protected ?string $displayName = null;
-	protected int $optionId = 0;
+	protected ?int $optionId = null;
 
 	public function __construct() {
 		$this->addType('pollId', 'int');


### PR DESCRIPTION
The problem is the entity had 0 as a default it would skip writing
it into the changeset of the query for the insert.
But the DB had a default of 1 so it would store a 1 afterwards in the db.

Having null as default on the Vote model fixes this, as then any number
is a change from the default, the mark-dirty happens and we add it to
the query.

The problem is integration tests always send integers due to the form body usage.
The `0` from the integration tests therefor hits the server as `'0'`, === does not match
and the mark dirty happens:
https://github.com/nextcloud/server/blob/1d30fb7852e61cf9a2fcd03e83fa193c6aa5c827/lib/public/AppFramework/Db/Entity.php#L106-L109
Therefor the option was always specified from integration tests and it set a 0.