### PR TITLE
Fix literal value passed as reactive property

### DIFF
--- a/src/components/ConversationSettings/LinkShareSettings.vue
+++ b/src/components/ConversationSettings/LinkShareSettings.vue
@@ -73,7 +73,7 @@
 					<Button id="link_share_settings_link_password_submit"
 						:aria-label="t('spreed', 'Save password')"
 						:disabled="isSaving"
-						:native-type="submit">
+						native-type="submit">
 						<template #icon>
 							<ArrowRight />
 						</template>


### PR DESCRIPTION
```
[Vue warn]: Property or method "submit" is not defined on the instance but referenced during render. Make sure that this property is reactive, either in the data option, or for class-based components, by initializing the property. See: https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties.

found in

---> <LinkShareSettings> at src/components/ConversationSettings/LinkShareSettings.vue
       <AppSettingsSection>
         <Modal>
           <AppSettingsDialog>
             <ConversationSettingsDialog> at src/components/ConversationSettings/ConversationSettingsDialog.vue
               <Content>
                 <App> at src/App.vue
                   <Root>
```