### PR TITLE
Prerelease 15.0.0 beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 15.0.0-beta.1 – 2022-08-12
+### Added
+- 🛂 Chat permission
+- 📊 Simple polls
+- 📴 "Silent call" for group/public calls
+- 🔔 Allow to re-notify a participant for a call
+- 🔕 "Silent send" for chat messages
+- 🔍 Search for messages in mobile apps
+- 📵 Allow to disable calling functionality
+- 📞 Allow SIP dial-in without individual user PINs
+
 ## 14.0.4 – 2022-08-11
 ### Added
 - Extend search result attributes for better handling in mobile clients

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ appstore:
 	--exclude=stylelint.config.js \
 	--exclude=.tx \
 	--exclude=tests \
+	--exclude=tsconfig.json \
 	--exclude=webpack.js \
 	$(project_dir)/  $(sign_dir)/$(app_name)
 	@if [ -f $(cert_dir)/$(app_name).key ]; then \

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,17 +16,15 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>15.0.0-dev.6</version>
+	<version>15.0.0-beta.1</version>
 	<licence>agpl</licence>
 
-	<author>Aleksandra Lazarević</author>
 	<author>Daniel Calviño Sánchez</author>
 	<author>Ivan Sein</author>
 	<author>Jan-Christoph Borchardt</author>
 	<author>Joas Schilling</author>
 	<author>Marcel Hibbe</author>
 	<author>Marco Ambrosini</author>
-	<author>Nikola Gladovic</author>
 	<author>Tim Krüger</author>
 	<author>Vitor Mattos</author>
 


### PR DESCRIPTION
### ✅ Added
- 🛂 Chat permission
- 📊 Simple polls
- 📴 "Silent call" for group/public calls
- 🔔 Allow to re-notify a participant for a call
- 🔕 "Silent send" for chat messages
- 🔍 Search for messages in mobile apps
- 📵 Allow to disable calling functionality
- 📞 Allow SIP dial-in without individual user PINs