### PR TITLE
Add missing aria label to buttons to show conversation actions

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -23,6 +23,7 @@
 	<ListItem :title="item.displayName"
 		:class="{'unread-mention-conversation': item.unreadMention}"
 		:anchor-id="`conversation_${item.token}`"
+		:actions-aria-label="t('spreed', 'Conversation actions')"
 		:active="isActive"
 		:to="to"
 		:bold="!!item.unreadMessages"


### PR DESCRIPTION
[The default aria label for actions is _Actions_](https://github.com/nextcloud/nextcloud-vue/blob/9d29c3cf8327e47bf921dfa5081ae578611699a8/src/components/Actions/Actions.vue#L461-L467), but the default value is overriden to an empty string [when used in a list item](https://github.com/nextcloud/nextcloud-vue/blob/e499b4e9b018f8ef6a5d2a05b3d02a6670e5ce4b/src/components/ListItem/ListItem.vue#L362-L368), so it needs to be explicitly set.

Fixes the console warning `You need to fill either the text or the ariaLabel props in the button component.` referred to the actions buttons. I have done it in Talk rather than in Nextcloud vue as having an empty aria label for list items seems to be an explicit decision, probably because the text would need to change depending on the list item context (_Conversation actions_, _Mail actions_ and so on).

I have noticed that the same aria label [is used in the top bar](https://github.com/nextcloud/spreed/blob/47e98d86d617925253f69f4a5a7ad67d63fd4d79/src/components/TopBar/TopBar.vue#L75). I guess that it is not a problem if they are not unique, but I do not know.
