### PR TITLE
Fix icon size type

### DIFF
--- a/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
+++ b/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
@@ -71,7 +71,7 @@
 						:aria-label="t('spreed', 'Show Matterbridge log')"
 						@click="showLogContent">
 						<template #icon>
-							<Message size="20" />
+							<Message :size="20" />
 						</template>
 					</ButtonVue>
 					<Modal v-if="logModal"

--- a/src/components/LeftSidebar/NewGroupConversation/SetContacts/ContactSelectionBubble/ContactSelectionBubble.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/SetContacts/ContactSelectionBubble/ContactSelectionBubble.vue
@@ -35,7 +35,7 @@
 			:aria-label="removeLabel"
 			@click="removeParticipantFromSelection(participant)">
 			<template #icon>
-				<Close size="16" />
+				<Close :size="16" />
 			</template>
 		</ButtonVue>
 	</div>


### PR DESCRIPTION
```
[Vue warn]: Invalid prop: type check failed for prop "size". Expected Number with value 16, got String with value "16".

found in

---> <CloseIcon> at node_modules/vue-material-design-icons/Close.vue
       <ButtonVue>
         <ContactSelectionBubble> at src/components/LeftSidebar/NewGroupConversation/SetContacts/ContactSelectionBubble/ContactSelectionBubble.vue
           <TransitionGroup>
             <SetContacts> at src/components/LeftSidebar/NewGroupConversation/SetContacts/SetContacts.vue
               <Modal>
                 <NewGroupConversation> at src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
                   <AppNavigation>
                     <LeftSidebar> at src/components/LeftSidebar/LeftSidebar.vue
                       <Content>
                         <App> at src/App.vue
                           <Root>
```

**I have not tested the Matterbridge icon**, but I guess it has the same problem.
