### PR TITLE
Fix missing tooltip directive in DeviceChecker

### DIFF
--- a/src/components/DeviceChecker/DeviceChecker.vue
+++ b/src/components/DeviceChecker/DeviceChecker.vue
@@ -170,6 +170,7 @@
 
 <script>
 import Modal from '@nextcloud/vue/dist/Components/Modal.js'
+import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 import { devices } from '../../mixins/devices.js'
 import MediaDevicesSelector from '../MediaDevicesSelector.vue'
 import VideoBackground from '../CallView/shared/VideoBackground.vue'
@@ -196,6 +197,10 @@ import isInLobby from '../../mixins/isInLobby.js'
 
 export default {
 	name: 'DeviceChecker',
+
+	directives: {
+		Tooltip,
+	},
 
 	components: {
 		Modal,


### PR DESCRIPTION
Although the directive was missing the tooltips were still shown in the normal Talk UI; the tooltips were missing only when Talk was embedded in other apps, like the Files app.

## How to test

- Open the Files app
- Share a file
- Open the _Chat_ tab for that file
- Join the conversation
- Start a call

### Result with this pull request

The tooltips are shown on the buttons to enable/disable audio, video and background blur

### Result without this pull request

The tooltips are not shown on the buttons to enable/disable audio, video and background blur; an error is shown in the console about a missing tooltip directive
