### PR TITLE
Fix remote screen shares not shown in sidebar

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -43,7 +43,7 @@
 					</template>
 				</div>
 				<!-- Screens -->
-				<div v-else-if="!isSidebar && (showLocalScreen || showRemoteScreen || showSelectedScreen)" id="screens">
+				<div v-else-if="showLocalScreen || showRemoteScreen || showSelectedScreen" id="screens">
 					<!-- local screen -->
 					<Screen v-if="showLocalScreen"
 						:token="token"


### PR DESCRIPTION
Follow up to #3563

When the call view is shown in the sidebar there is no button to share the screen. However, other participants can nevertheless open the call from the main Talk UI and share their screen there, so remote screen shares should be shown even if local ones can not be started.

**Before:**
![Talk-Sidebar-Screenshare-Before](https://user-images.githubusercontent.com/26858233/184509529-df1063bb-b00c-488e-a847-2b3680519187.png)

**After:**
![Talk-Sidebar-Screenshare-After](https://user-images.githubusercontent.com/26858233/184509618-ebaa6e7b-9edf-4fa0-8918-852e3ae39a98.png)

