### PR TITLE
Reduce number of queries required to read shares

### DIFF
--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -312,8 +312,10 @@ class ChatController extends AEnvironmentAwareController {
 	/*
 	 * Gather share IDs from the comments and preload share definitions
 	 * to avoid separate database query for each individual share.
+	 *
+	 * @param IComment[] $comments
 	 */
-	protected function preloadShares(array $comments) {
+	protected function preloadShares(array $comments): void {
 		// Scan messages for share IDs
 		$shareIds = [];
 		foreach ($comments as $comment) {

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -437,20 +437,23 @@ class ChatController extends AEnvironmentAwareController {
 		}
 
 		// Quickly scan messages for share IDs
-		$share_ids = [];
+		$shareIds = [];
 		foreach ($comments as $comment) {
 			$verb = $comment->getVerb();
-			$message = $comment->getMessage();
 			if ($verb === 'object_shared') {
+				$message = $comment->getMessage();
 				$data = json_decode($message, true);
-				$parameters = $data['parameters'];
-				$share_ids[] = $parameters['share'];
+				if (isset($data['parameters']['share'])) {
+					$shareIds[] = $data['parameters']['share'];
+				}
 			}
 		}
 		// Ignore the result for now. Retrieved Share objects will be cached by
 		// the RoomShareProvider and returned from the cache to
 		// the MessageParser without additional database queries.
-		$this->shareProvider->getSharesByIds($share_ids);
+		if (!empty($shareIds)) {
+			$this->shareProvider->getSharesByIds($shareIds);
+		}
 
 		$i = 0;
 		$messages = $commentIdToIndex = $parentIds = [];

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -678,7 +678,7 @@ class RoomShareProvider implements IShareProvider {
 	 *
 	 * @param int[] $id
 	 * @param string|null $recipientId
-	 * @return IShare[]
+	 * @return (IShare|false)[]
 	 */
 	public function getSharesByIds(array $ids, ?string $recipientId = null): array {
 		$qb = $this->dbConnection->getQueryBuilder();
@@ -710,13 +710,13 @@ class RoomShareProvider implements IShareProvider {
 			$id = $data['id'];
 			if ($this->isAccessibleResult($data)) {
 				$share = $this->createShareObject($data);
+				$shares[] = $share;
 			} else {
 				$share = false;
 			}
 			if ($recipientId === null && !isset($this->sharesByIdCache[$id])) {
 				$this->sharesByIdCache[$id] = $share;
 			}
-			$shares[] = $share;
 		}
 		$cursor->closeCursor();
 

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Share;
 
-use OCP\Cache\CappedMemoryCache;
 use OC\Files\Cache\Cache;
 use OCA\Talk\Events\AlreadySharedEvent;
 use OCA\Talk\Events\RoomEvent;
@@ -39,6 +38,7 @@ use OCA\Talk\Model\Attendee;
 use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Cache\CappedMemoryCache;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Folder;

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -112,7 +112,7 @@ class RoomShareProvider implements IShareProvider {
 	/*
 	 * Clean sharesByIdCache
 	 */
-	private function cleanSharesByIdCache() {
+	private function cleanSharesByIdCache(): void {
 		$this->sharesByIdCache = new CappedMemoryCache();
 	}
 
@@ -675,7 +675,7 @@ class RoomShareProvider implements IShareProvider {
 	 *
 	 * Not part of IShareProvider API, but needed by OCA\Talk\Controller\ChatController.
 	 *
-	 * @param int[] $id
+	 * @param int[] $ids
 	 * @param string|null $recipientId
 	 * @return IShare[]
 	 */

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -109,6 +109,13 @@ class RoomShareProvider implements IShareProvider {
 		$this->sharesByIdCache = new CappedMemoryCache();
 	}
 
+	/*
+	 * Clean sharesByIdCache
+	 */
+	private function cleanSharesByIdCache() {
+		$this->sharesByIdCache = new CappedMemoryCache();
+	}
+
 	public static function register(IEventDispatcher $dispatcher): void {
 		$listener = static function (RoomEvent $event): void {
 			$room = $event->getRoom();
@@ -318,6 +325,8 @@ class RoomShareProvider implements IShareProvider {
 	 * @return IShare The share object
 	 */
 	public function update(IShare $share): IShare {
+		$this->cleanSharesByIdCache();
+
 		$update = $this->dbConnection->getQueryBuilder();
 		$update->update('share')
 			->where($update->expr()->eq('id', $update->createNamedParameter($share->getId())))
@@ -361,6 +370,8 @@ class RoomShareProvider implements IShareProvider {
 	 * @param IShare $share
 	 */
 	public function delete(IShare $share): void {
+		$this->cleanSharesByIdCache();
+
 		$delete = $this->dbConnection->getQueryBuilder();
 		$delete->delete('share')
 			->where($delete->expr()->eq('id', $delete->createNamedParameter($share->getId())));
@@ -380,6 +391,8 @@ class RoomShareProvider implements IShareProvider {
 	 * @param string $recipient UserId of the recipient
 	 */
 	public function deleteFromSelf(IShare $share, $recipient): void {
+		$this->cleanSharesByIdCache();
+
 		// Check if there is a userroom share
 		$qb = $this->dbConnection->getQueryBuilder();
 		$stmt = $qb->select(['id', 'permissions'])
@@ -432,6 +445,8 @@ class RoomShareProvider implements IShareProvider {
 	 * @throws GenericShareException In case the share could not be restored
 	 */
 	public function restore(IShare $share, string $recipient): IShare {
+		$this->cleanSharesByIdCache();
+
 		$qb = $this->dbConnection->getQueryBuilder();
 		$qb->select('permissions')
 			->from('share')
@@ -472,6 +487,8 @@ class RoomShareProvider implements IShareProvider {
 	 * @return IShare
 	 */
 	public function move(IShare $share, $recipient): IShare {
+		$this->cleanSharesByIdCache();
+
 		// Check if there is a userroom share
 		$qb = $this->dbConnection->getQueryBuilder();
 		$stmt = $qb->select('id')
@@ -1110,6 +1127,8 @@ class RoomShareProvider implements IShareProvider {
 	 * @param string|null $user
 	 */
 	public function deleteInRoom(string $roomToken, string $user = null): void {
+		$this->cleanSharesByIdCache();
+
 		//First delete all custom room shares for the original shares to be removed
 		$qb = $this->dbConnection->getQueryBuilder();
 		$qb->select('id')

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Share;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OC\Files\Cache\Cache;
 use OCA\Talk\Events\AlreadySharedEvent;
 use OCA\Talk\Events\RoomEvent;
@@ -84,7 +84,7 @@ class RoomShareProvider implements IShareProvider {
 	private IL10N $l;
 	private IMimeTypeLoader $mimeTypeLoader;
 
-	private $sharesByIdCache;
+	private CappedMemoryCache $sharesByIdCache;
 
 	public function __construct(
 			IDBConnection $connection,
@@ -684,7 +684,7 @@ class RoomShareProvider implements IShareProvider {
 	 * @return IShare[]
 	 * @throws ShareNotFound
 	 */
-	public function getSharesByIds($ids, $recipientId = null): array {
+	public function getSharesByIds(array $ids, ?string $recipientId = null): array {
 
 		$qb = $this->dbConnection->getQueryBuilder();
 		$qb->select('s.*',

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -662,9 +662,8 @@ class RoomShareProvider implements IShareProvider {
 			$share = $shares[0];
 		}
 
+		// Shares referring to deleted files are stored as 'false' in the cache.
 		if ($share === false) {
-			// Shares referring to deleted files are stored as 'false',
-			// both in the cache and in the array returned from getSharesByIds.
 			throw new ShareNotFound();
 		}
 

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -652,7 +652,6 @@ class RoomShareProvider implements IShareProvider {
 	 * @throws ShareNotFound
 	 */
 	public function getShareById($id, $recipientId = null): IShare {
-
 		if (($recipientId === null) && isset($this->sharesByIdCache[$id])) {
 			$share = $this->sharesByIdCache[$id];
 		} else {
@@ -682,7 +681,6 @@ class RoomShareProvider implements IShareProvider {
 	 * @return IShare[]
 	 */
 	public function getSharesByIds(array $ids, ?string $recipientId = null): array {
-
 		$qb = $this->dbConnection->getQueryBuilder();
 		$qb->select('s.*',
 			'f.fileid', 'f.path', 'f.permissions AS f_permissions', 'f.storage', 'f.path_hash',
@@ -700,9 +698,9 @@ class RoomShareProvider implements IShareProvider {
 
 		/*
 		 * Keep retrieved shares in sharesByIdCache.
-		 * 
+		 *
 		 * Fill the cache only when $recipientId === null.
-		 * 
+		 *
 		 * For inaccessible shares use 'false' instead of the IShare object.
 		 * (This is required to avoid additional queries in getShareById when
 		 * the share refers to a deleted file.)

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -678,7 +678,7 @@ class RoomShareProvider implements IShareProvider {
 	 *
 	 * @param int[] $id
 	 * @param string|null $recipientId
-	 * @return (IShare|false)[]
+	 * @return IShare[]
 	 */
 	public function getSharesByIds(array $ids, ?string $recipientId = null): array {
 		$qb = $this->dbConnection->getQueryBuilder();

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -37,6 +37,7 @@ use OCA\Talk\Room;
 use OCA\Talk\Service\AttachmentService;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\SessionService;
+use OCA\Talk\Share\RoomShareProvider;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
@@ -76,6 +77,8 @@ class ChatControllerTest extends TestCase {
 	protected $guestManager;
 	/** @var MessageParser|MockObject */
 	protected $messageParser;
+	/** @var RoomShareProvider|MockObject */
+	protected $roomShareProvider;
 	/** @var IManager|MockObject */
 	protected $autoCompleteManager;
 	/** @var IUserStatusManager|MockObject */
@@ -118,6 +121,7 @@ class ChatControllerTest extends TestCase {
 		$this->attachmentService = $this->createMock(AttachmentService::class);
 		$this->guestManager = $this->createMock(GuestManager::class);
 		$this->messageParser = $this->createMock(MessageParser::class);
+		$this->roomShareProvider = $this->createMock(RoomShareProvider::class);
 		$this->autoCompleteManager = $this->createMock(IManager::class);
 		$this->statusManager = $this->createMock(IUserStatusManager::class);
 		$this->matterbridgeManager = $this->createMock(MatterbridgeManager::class);
@@ -155,6 +159,7 @@ class ChatControllerTest extends TestCase {
 			$this->attachmentService,
 			$this->guestManager,
 			$this->messageParser,
+			$this->roomShareProvider,
 			$this->autoCompleteManager,
 			$this->statusManager,
 			$this->matterbridgeManager,


### PR DESCRIPTION
When diagnosing [slow loading of chat messages](https://github.com/nextcloud/talk-android/issues/2228) in the Talk Android app, I have noticed that information about files (usually images) shared in the chat is read using a separate query for each file.

This is an initial proof-of-concept that reduces it to a single query.

Instead of executing a separate query in **RoomShareProvider::getShareById** for each share, we gather all share ids and execute a single query in a new method **RoomShareProvider::getSharesByIds**.

While performance improvements in the development environment are difficult to notice, on my family "production" environment this gives around 15% improvement of the **ChatController::receiveMessages** execution time (**280 ms** down from **330 ms**).

This code is certainly **not** production-ready and requires refactoring/clean-up. However I would like to get some feedback, if this looks like a reasonable way to go forward.

Trying to read info about all shared items together also seems to be a pre-requisite to eventually optimize **SystemMessage::getFileFromShare**. Currently additional 3-4 database queries are performed for each shared file (by the Files app if I understand correctly).

Thoughts?