### PR TITLE
Fix the talk dashboard icon on dark mode

### DIFF
--- a/css/icons.css
+++ b/css/icons.css
@@ -79,3 +79,7 @@
 .app-files .app-sidebar__close.forced-white {
 	color: #ffffff;
 }
+
+.dashboard-talk-icon {
+	background-image: url(../img/app-dark.svg);
+}

--- a/lib/Dashboard/TalkWidget.php
+++ b/lib/Dashboard/TalkWidget.php
@@ -67,7 +67,7 @@ class TalkWidget implements IWidget {
 	 * @inheritDoc
 	 */
 	public function getIconClass(): string {
-		return 'icon-talk';
+		return 'dashboard-talk-icon';
 	}
 
 	/**


### PR DESCRIPTION
Before | After
---|---
![Bildschirmfoto vom 2022-08-16 10-01-04](https://user-images.githubusercontent.com/213943/184828776-0f4faa1c-3937-4a17-8576-109555017a25.png) | ![Bildschirmfoto vom 2022-08-16 09-59-55](https://user-images.githubusercontent.com/213943/184828772-cf41c9b4-e2df-43b0-a17b-5116a7b92a90.png)

The old icon is defined in server which toggles the icon based on the a11y theming, but the dashboard additionally has a `filter: var(--background-invert-if-dark)` so the icon was dark again.
