### PR TITLE
Use DisplayNameCache

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -242,12 +242,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ChristophWurst/nextcloud_composer.git",
-                "reference": "577103cb24552d134a6338014fe665cabfd9c2c8"
+                "reference": "433f70a9ddfece0233927997ae5ff38070fc1fcc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_composer/zipball/577103cb24552d134a6338014fe665cabfd9c2c8",
-                "reference": "577103cb24552d134a6338014fe665cabfd9c2c8",
+                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_composer/zipball/433f70a9ddfece0233927997ae5ff38070fc1fcc",
+                "reference": "433f70a9ddfece0233927997ae5ff38070fc1fcc",
                 "shasum": ""
             },
             "require": {
@@ -278,7 +278,7 @@
                 "issues": "https://github.com/ChristophWurst/nextcloud_composer/issues",
                 "source": "https://github.com/ChristophWurst/nextcloud_composer/tree/master"
             },
-            "time": "2022-08-09T02:21:50+00:00"
+            "time": "2022-08-17T02:31:52+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",

--- a/lib/Chat/MessageParser.php
+++ b/lib/Chat/MessageParser.php
@@ -34,7 +34,6 @@ use OCA\Talk\Room;
 use OCP\Comments\IComment;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IL10N;
-use OCP\IUser;
 use OCP\IUserManager;
 
 /**
@@ -79,7 +78,7 @@ class MessageParser {
 		$actorId = $comment->getActorId();
 		$displayName = '';
 		if ($comment->getActorType() === Attendee::ACTOR_USERS) {
-			$displayName = $this->userManager->getDisplayName($comment->getActorId());
+			$displayName = $this->userManager->getDisplayName($comment->getActorId()) ?? $comment->getActorId();
 		} elseif ($comment->getActorType() === Attendee::ACTOR_BRIDGED) {
 			$displayName = $comment->getActorId();
 			$actorId = MatterbridgeManager::BRIDGE_BOT_USERID;

--- a/lib/Chat/MessageParser.php
+++ b/lib/Chat/MessageParser.php
@@ -79,8 +79,8 @@ class MessageParser {
 		$actorId = $comment->getActorId();
 		$displayName = '';
 		if ($comment->getActorType() === Attendee::ACTOR_USERS) {
-			$user = $this->userManager->get($comment->getActorId());
-			$displayName = $user instanceof IUser ? $user->getDisplayName() : $comment->getActorId();
+			$displayNameCache = \OCP\Server::get(\OC\User\DisplayNameCache::class);
+			$displayName = $displayNameCache->getDisplayName($comment->getActorId());
 		} elseif ($comment->getActorType() === Attendee::ACTOR_BRIDGED) {
 			$displayName = $comment->getActorId();
 			$actorId = MatterbridgeManager::BRIDGE_BOT_USERID;

--- a/lib/Chat/MessageParser.php
+++ b/lib/Chat/MessageParser.php
@@ -79,8 +79,7 @@ class MessageParser {
 		$actorId = $comment->getActorId();
 		$displayName = '';
 		if ($comment->getActorType() === Attendee::ACTOR_USERS) {
-			$displayNameCache = \OCP\Server::get(\OC\User\DisplayNameCache::class);
-			$displayName = $displayNameCache->getDisplayName($comment->getActorId());
+			$displayName = $this->userManager->getDisplayName($comment->getActorId());
 		} elseif ($comment->getActorType() === Attendee::ACTOR_BRIDGED) {
 			$displayName = $comment->getActorId();
 			$actorId = MatterbridgeManager::BRIDGE_BOT_USERID;

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -44,7 +44,6 @@ use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IPreview as IPreviewManager;
 use OCP\IURLGenerator;
-use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Server;
 use OCP\Share\Exceptions\ShareNotFound;
@@ -698,9 +697,9 @@ class SystemMessage {
 	}
 
 	protected function getDisplayName(string $uid): string {
-		$user = $this->userManager->get($uid);
-		if ($user instanceof IUser) {
-			return $user->getDisplayName();
+		$userName = $this->userManager->getDisplayName($uid);
+		if ($userName !== null) {
+			return $userName;
 		}
 
 		throw new ParticipantNotFoundException();

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -988,10 +988,9 @@ class Manager {
 			$otherParticipant = '';
 			$userIsParticipant = false;
 
-			$displayNameCache = \OCP\Server::get(\OC\User\DisplayNameCache::class);
 			foreach ($users as $participantId) {
 				if ($participantId !== $userId) {
-					$otherParticipant = $displayNameCache->getDisplayName($participantId);
+					$otherParticipant = $this->userManager->getDisplayName($participantId);
 				} else {
 					$userIsParticipant = true;
 				}

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -990,7 +990,7 @@ class Manager {
 
 			foreach ($users as $participantId) {
 				if ($participantId !== $userId) {
-					$otherParticipant = $this->userManager->getDisplayName($participantId);
+					$otherParticipant = $this->userManager->getDisplayName($participantId) ?? $participantId;
 				} else {
 					$userIsParticipant = true;
 				}

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -988,10 +988,10 @@ class Manager {
 			$otherParticipant = '';
 			$userIsParticipant = false;
 
+			$displayNameCache = \OCP\Server::get(\OC\User\DisplayNameCache::class);
 			foreach ($users as $participantId) {
 				if ($participantId !== $userId) {
-					$user = $this->userManager->get($participantId);
-					$otherParticipant = $user instanceof IUser ? $user->getDisplayName() : $participantId;
+					$otherParticipant = $displayNameCache->getDisplayName($participantId);
 				} else {
 					$userIsParticipant = true;
 				}

--- a/tests/php/Chat/Parser/SystemMessageTest.php
+++ b/tests/php/Chat/Parser/SystemMessageTest.php
@@ -44,7 +44,6 @@ use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IPreview as IPreviewManager;
 use OCP\IURLGenerator;
-use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IShare;

--- a/tests/php/Chat/Parser/SystemMessageTest.php
+++ b/tests/php/Chat/Parser/SystemMessageTest.php
@@ -948,17 +948,13 @@ class SystemMessageTest extends TestCase {
 		$parser = $this->getParser();
 
 		if ($validUser) {
-			$user = $this->createMock(IUser::class);
-			$user->expects($this->once())
-				->method('getDisplayName')
-				->willReturn($name);
 			$this->userManager->expects($this->once())
-				->method('get')
+				->method('getDisplayName')
 				->with($uid)
-				->willReturn($user);
+				->willReturn($name);
 		} else {
 			$this->userManager->expects($this->once())
-				->method('get')
+				->method('getDisplayName')
 				->with($uid)
 				->willReturn(null);
 			$this->expectException(ParticipantNotFoundException::class);


### PR DESCRIPTION
Reduce query by 1/3 when fetching the list of rooms on the production
instance.

TODO:
- [x] Use dependency injections
- [x] Adapt tests
- [x] Make DisplayNameCache part of OCP https://github.com/nextcloud/server/pull/32461