### PR TITLE
Ensure that the reactions array is always a JSON object

### DIFF
--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -172,6 +172,13 @@ class Message {
 	public function toArray(): array {
 		$expireDate = $this->getComment()->getExpireDate();
 
+		$reactions = $this->getComment()->getReactions();
+		if (empty($reactions)) {
+			// Cheating here to make sure the reactions array is always a
+			// JSON object on the API, even when there is no reaction at all.
+			$reactions = new \StdClass();
+		}
+
 		$data = [
 			'id' => (int) $this->getComment()->getId(),
 			'token' => $this->getRoom()->getToken(),
@@ -185,7 +192,7 @@ class Message {
 			'messageType' => $this->getMessageType(),
 			'isReplyable' => $this->isReplyable(),
 			'referenceId' => (string) $this->getComment()->getReferenceId(),
-			'reactions' => $this->getComment()->getReactions(),
+			'reactions' => $reactions,
 			'expirationTimestamp' => $expireDate ? $expireDate->getTimestamp() : 0,
 		];
 


### PR DESCRIPTION
Fix #7751 

- [x] Confirmation from @mahibi that it does not break Android
- [x] Confirmation from @Ivansss that it does not break iOS