### PR TITLE
[stable24] Fix notifications when lobby is active

### DIFF
--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -32,6 +32,7 @@ use OCA\Talk\Model\Session;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
+use OCA\Talk\Webinary;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\IComment;
 use OCP\IConfig;
@@ -437,6 +438,13 @@ class Notifier {
 
 				$participant = $room->getParticipant($userId, false);
 				$attendee = $participant->getAttendee();
+			} else {
+				$participant = new Participant($room, $attendee, null);
+			}
+
+			if ($room->getLobbyState() !== Webinary::LOBBY_NONE &&
+				!($participant->getPermissions() & Attendee::PERMISSIONS_LOBBY_IGNORE)) {
+				return false;
 			}
 
 			$notificationLevel = $attendee->getNotificationLevel();

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -36,6 +36,7 @@ use OCA\Talk\Model\Attendee;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
+use OCA\Talk\Webinary;
 use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
 use OCP\HintException;
@@ -242,6 +243,13 @@ class Notifier implements INotifier {
 			return $this->parseInvitation($notification, $room, $l);
 		}
 		if ($subject === 'call') {
+			if ($room->getLobbyState() !== Webinary::LOBBY_NONE &&
+				$participant instanceof Participant &&
+				!($participant->getPermissions() & Attendee::PERMISSIONS_LOBBY_IGNORE)) {
+				// User is blocked by the lobby, remove notification
+				throw new AlreadyProcessedException();
+			}
+
 			if ($room->getObjectType() === 'share:password') {
 				return $this->parsePasswordRequest($notification, $room, $l);
 			}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -256,6 +256,13 @@ class Notifier implements INotifier {
 			return $this->parseCall($notification, $room, $l);
 		}
 		if ($subject === 'reply' || $subject === 'mention' || $subject === 'chat' || $subject === 'reaction') {
+			if ($room->getLobbyState() !== Webinary::LOBBY_NONE &&
+				$participant instanceof Participant &&
+				!($participant->getPermissions() & Attendee::PERMISSIONS_LOBBY_IGNORE)) {
+				// User is blocked by the lobby, remove notification
+				throw new AlreadyProcessedException();
+			}
+
 			return $this->parseChatMessage($notification, $room, $participant, $l);
 		}
 

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1308,6 +1308,28 @@ class ParticipantService {
 			->andWhere($query->expr()->eq('a.notification_calls', $query->createNamedParameter(Participant::NOTIFY_CALLS_ON)))
 			->andWhere($query->expr()->isNull('s.in_call'));
 
+		if ($room->getLobbyState() !== Webinary::LOBBY_NONE) {
+			// Filter out non-moderators and users without lobby permissions
+			$query->andWhere(
+				$query->expr()->orX(
+					$query->expr()->in('a.participant_type', $query->createNamedParameter(
+						[Participant::MODERATOR, Participant::OWNER],
+						IQueryBuilder::PARAM_INT_ARRAY
+					)),
+					$query->expr()->eq(
+						$query->expr()->castColumn(
+							$query->expr()->bitwiseAnd(
+								'permissions',
+								Attendee::PERMISSIONS_LOBBY_IGNORE
+							),
+							IQueryBuilder::PARAM_INT
+						),
+						$query->createNamedParameter(Attendee::PERMISSIONS_LOBBY_IGNORE, IQueryBuilder::PARAM_INT)
+					)
+				)
+			);
+		}
+
 		$userIds = [];
 		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {

--- a/tests/integration/features/callapi/notifications.feature
+++ b/tests/integration/features/callapi/notifications.feature
@@ -1,0 +1,92 @@
+Feature: chat/notifications
+
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+
+  Scenario: Normal call notification
+    When user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    Given user "participant1" joins room "room" with 200 (v4)
+    Given user "participant2" joins room "room" with 200 (v4)
+    Given user "participant1" joins call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id | subject                          |
+      | spreed | call        | room      | A group call has started in room |
+    Given user "participant2" joins call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app | object_type | object_id | subject |
+
+  Scenario: Missed call notification
+    When user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    Given user "participant1" joins room "room" with 200 (v4)
+    Given user "participant2" joins room "room" with 200 (v4)
+    Given user "participant1" joins call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id | subject                          |
+      | spreed | call        | room      | A group call has started in room |
+    Given user "participant1" leaves call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id | subject                          |
+      | spreed | call        | room      | You missed a group call in room |
+
+  Scenario: Lobby: No call notification sent for users that are blocked by the lobby
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    And user "participant1" joins room "room" with 200 (v4)
+    And user "participant2" joins room "room" with 200 (v4)
+    And user "participant1" sets lobby state for room "room" to "non moderators" with 200 (v4)
+    When user "participant1" joins call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app | object_type | object_id | subject |
+
+  Scenario: Lobby: Call notification sent to users with ignore lobby permissions
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    And user "participant1" joins room "room" with 200 (v4)
+    And user "participant2" joins room "room" with 200 (v4)
+    And user "participant1" sets permissions for "participant2" in room "room" to "L" with 200 (v4)
+    And user "participant1" sets lobby state for room "room" to "non moderators" with 200 (v4)
+    When user "participant1" joins call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id | subject                          |
+      | spreed | call        | room      | A group call has started in room |
+
+  Scenario: Lobby: Call notification sent to moderators
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    And user "participant1" joins room "room" with 200 (v4)
+    And user "participant2" joins room "room" with 200 (v4)
+    And user "participant1" promotes "participant2" in room "room" with 200 (v4)
+    And user "participant1" sets lobby state for room "room" to "non moderators" with 200 (v4)
+    When user "participant1" joins call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id | subject                          |
+      | spreed | call        | room      | A group call has started in room |
+
+  Scenario: Lobby: Call notification wiped if lobby enabled afterwards
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    And user "participant1" joins room "room" with 200 (v4)
+    And user "participant2" joins room "room" with 200 (v4)
+    When user "participant1" joins call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id | subject                          |
+      | spreed | call        | room      | A group call has started in room |
+    And user "participant1" sets lobby state for room "room" to "non moderators" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app | object_type | object_id | subject |
+

--- a/tests/integration/features/chat/notifications.feature
+++ b/tests/integration/features/chat/notifications.feature
@@ -283,3 +283,84 @@ Feature: chat/notifications
     And user "participant1" react with "🚀" on message "Message 1" to room "room" with 201
     Then user "participant2" has the following notifications
       | app | object_type | object_id | subject |
+
+  Scenario: Lobby: No notifications while being blocked by the lobby
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    # Join and leave to clear the invite notification
+    And user "participant2" joins room "room" with 200 (v4)
+    And user "participant2" leaves room "room" with 200 (v4)
+    And user "participant2" sends message "Message 1" to room "room" with 201
+    And user "participant2" sets notifications to all for room "room" (v4)
+    And user "participant1" sets lobby state for room "room" to "non moderators" with 200 (v4)
+    When user "participant1" sends message "Hi @all bye" to room "room" with 201
+    And user "participant1" react with "🚀" on message "Message 1" to room "room" with 201
+    When user "participant1" sends message "Hi @participant2" to room "room" with 201
+    Then user "participant2" has the following notifications
+      | app | object_type | object_id | subject |
+
+  Scenario: Lobby: Notifications for users that ignore the lobby
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    # Join and leave to clear the invite notification
+    And user "participant2" joins room "room" with 200 (v4)
+    And user "participant2" leaves room "room" with 200 (v4)
+    And user "participant2" sends message "Message 1" to room "room" with 201
+    And user "participant2" sets notifications to all for room "room" (v4)
+    And user "participant1" sets lobby state for room "room" to "non moderators" with 200 (v4)
+    And user "participant1" sets permissions for "participant2" in room "room" to "L" with 200 (v4)
+    And user "participant1" sends message "Hi @all bye" to room "room" with 201
+    And user "participant1" react with "🚀" on message "Message 1" to room "room" with 201
+    When user "participant1" sends message "Hi @participant2" to room "room" with 201
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id                 | subject                                                                       |
+      | spreed | chat        | room/Hi @participant2     | participant1-displayname mentioned you in conversation room                   |
+      | spreed | chat        | room/Message 1            | participant1-displayname reacted with 🚀 to your message in conversation room |
+      | spreed | chat        | room/Hi @all bye          | participant1-displayname mentioned you in conversation room                   |
+
+  Scenario: Lobby: Notifications for moderators
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    # Join and leave to clear the invite notification
+    And user "participant2" joins room "room" with 200 (v4)
+    And user "participant2" leaves room "room" with 200 (v4)
+    And user "participant2" sends message "Message 1" to room "room" with 201
+    And user "participant2" sets notifications to all for room "room" (v4)
+    And user "participant1" sets lobby state for room "room" to "non moderators" with 200 (v4)
+    And user "participant1" promotes "participant2" in room "room" with 200 (v4)
+    And user "participant1" sends message "Hi @all bye" to room "room" with 201
+    And user "participant1" react with "🚀" on message "Message 1" to room "room" with 201
+    When user "participant1" sends message "Hi @participant2" to room "room" with 201
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id                 | subject                                                                       |
+      | spreed | chat        | room/Hi @participant2     | participant1-displayname mentioned you in conversation room                   |
+      | spreed | chat        | room/Message 1            | participant1-displayname reacted with 🚀 to your message in conversation room |
+      | spreed | chat        | room/Hi @all bye          | participant1-displayname mentioned you in conversation room                   |
+
+  Scenario: Lobby: Wipe notifications when being blocked by the lobby
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    # Join and leave to clear the invite notification
+    And user "participant2" joins room "room" with 200 (v4)
+    And user "participant2" leaves room "room" with 200 (v4)
+    And user "participant2" sends message "Message 1" to room "room" with 201
+    And user "participant2" sets notifications to all for room "room" (v4)
+    And user "participant1" sends message "Hi @all bye" to room "room" with 201
+    And user "participant1" react with "🚀" on message "Message 1" to room "room" with 201
+    And user "participant1" sends message "Hi @participant2" to room "room" with 201
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id                 | subject                                                                       |
+      | spreed | chat        | room/Hi @participant2     | participant1-displayname mentioned you in conversation room                   |
+      | spreed | chat        | room/Message 1            | participant1-displayname reacted with 🚀 to your message in conversation room |
+      | spreed | chat        | room/Hi @all bye          | participant1-displayname mentioned you in conversation room                   |
+    When user "participant1" sets lobby state for room "room" to "non moderators" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app | object_type | object_id | subject |


### PR DESCRIPTION
Backport of #7788 

Auto backport failed because the callapi/notifications.feature file was only introduced with silent call which is not in 24