### PR TITLE
Fix inconsistent state when leaving a call fails

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -338,8 +338,14 @@ Signaling.Base.prototype.leaveCall = function(token, keepToken, all = false) {
 				}
 			}.bind(this))
 			.catch(function() {
+				this._trigger('leaveCall', [token, keepToken])
 				reject(new Error())
-			})
+				// We left the current call.
+				if (!keepToken && token === this.currentCallToken) {
+					this.currentCallToken = null
+					this.currentCallFlags = null
+				}
+			}.bind(this))
 	})
 }
 

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -52,7 +52,7 @@ let ownScreenPeer = null
 let selfInCall = PARTICIPANT.CALL_FLAG.DISCONNECTED
 // Special variable to know when the local user explicitly joined and left the
 // call; this is needed to know when the user was kicked out from the call by a
-// moderator.
+// moderator and discard signaling events if received when not in the call.
 let localUserInCall = false
 const delayedConnectionToPeer = []
 let callParticipantCollection = null
@@ -531,12 +531,20 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 	localCallParticipantModel = _localCallParticipantModel
 
 	signaling.on('usersLeft', function(users) {
+		if (!localUserInCall) {
+			return
+		}
+
 		users.forEach(function(user) {
 			delete usersInCallMapping[user]
 		})
 		usersChanged(signaling, [], users)
 	})
 	signaling.on('usersChanged', function(users) {
+		if (!localUserInCall) {
+			return
+		}
+
 		users.forEach(function(user) {
 			const sessionId = user.sessionId || user.sessionid
 			usersInCallMapping[sessionId] = user
@@ -544,11 +552,19 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 		usersInCallChanged(signaling, usersInCallMapping)
 	})
 	signaling.on('allUsersChangedInCallToDisconnected', function() {
+		if (!localUserInCall) {
+			return
+		}
+
 		// "End meeting for all" was used, we don't have a user list but everyone disconnects from the call
 		usersInCallMapping = {}
 		usersInCallChanged(signaling, usersInCallMapping)
 	})
 	signaling.on('participantFlagsChanged', function(event) {
+		if (!localUserInCall) {
+			return
+		}
+
 		/**
 		 * event {
 		 *   roomid: "1609407087",
@@ -567,6 +583,10 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 		}
 	})
 	signaling.on('usersInRoom', function(users) {
+		if (!localUserInCall) {
+			return
+		}
+
 		usersInCallMapping = {}
 		users.forEach(function(user) {
 			const sessionId = user.sessionId || user.sessionid
@@ -623,6 +643,14 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 	})
 
 	signaling.on('message', function(message) {
+		if (!localUserInCall) {
+			console.debug('Message received when not in the call, ignore', message.type, message)
+
+			message.type = 'message-to-ignore'
+
+			return
+		}
+
 		if (message.type === 'answer' && message.roomType === 'video' && delayedConnectionToPeer[message.from]) {
 			clearInterval(delayedConnectionToPeer[message.from])
 			delete delayedConnectionToPeer[message.from]
@@ -650,12 +678,6 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 		if (message.roomType === 'video' && delayedConnectionToPeer[message.from]) {
 			clearInterval(delayedConnectionToPeer[message.from])
 			delete delayedConnectionToPeer[message.from]
-		}
-
-		if (!selfInCall) {
-			console.debug('Offer received when not in the call, ignore')
-
-			message.type = 'offer-to-ignore'
 		}
 
 		// MCU screen offers do not include the "broadcaster" property,

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -926,7 +926,6 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 
 		usersChanged(signaling, [], previousUsersInRoom)
 		usersInCallMapping = {}
-		previousUsersInRoom = []
 
 		// Reconnects with a new session id will trigger "usersChanged"
 		// with the users in the room and that will re-establish the
@@ -1710,7 +1709,6 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 
 		usersChanged(signaling, [], previousUsersInRoom)
 		usersInCallMapping = {}
-		previousUsersInRoom = []
 	})
 
 	return webrtc

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -604,12 +604,20 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 		// stopped, as the current own session is not passed along with the
 		// sessions of the other participants as "disconnected" to
 		// "usersChanged" when a call is left.
-		// The peer, on the other hand, is automatically ended by "leaveCall"
-		// below.
+		// The peer, on the other hand, is ended by the calls below.
 		if (ownPeer && delayedConnectionToPeer[ownPeer.id]) {
 			clearInterval(delayedConnectionToPeer[ownPeer.id])
 			delete delayedConnectionToPeer[ownPeer.id]
 		}
+
+		// Besides stopping the media "leaveCall" would end the peers, but it
+		// does not stop the timers for pending connections, removes models or
+		// clears the call data, so this needs to be explicitly done here
+		// instead.
+		selfInCall = PARTICIPANT.CALL_FLAG.DISCONNECTED
+
+		usersChanged(signaling, [], previousUsersInRoom)
+		usersInCallMapping = {}
 
 		webrtc.leaveCall()
 	})


### PR DESCRIPTION
When a call is left a request to leave the call is sent to the server and then the UI changes to the _not-in-a-call_ state. Even if the request sent to the server fails (which sometimes happens with flaky connections) [the layout is changed](https://github.com/nextcloud/spreed/blob/a22b31b3cb94b57ea1b65a489d9d900e91852957/src/store/participantsStore.js#L415-L424) ([failures are ignored in the service](https://github.com/nextcloud/spreed/blob/a22b31b3cb94b57ea1b65a489d9d900e91852957/src/services/callsService.js#L61-L67)). However, if the request sent to the server fails the call was not left from the WebRTC side, because the `leaveCall` event was triggered only on success. Due to this the UI implied that the call was left, but the RTCPeerConnections were all still active.

This pull request unifies the behaviour to always locally leave the call (both in the UI and the WebRTC side), even if the request sent to the server failed, as forcing the user to stay in the call until it was possible to properly leave it did not seem like a good approach. If the request to leave fails then that participant will still appear as in the call for the rest of participants, but now the connections will be ended and not restarted (unless the participant joins the call again).

Except otherwise noted, the scenarios below can be tested with or without HPB.

## How to test (scenario 1)

- Force a failure when leaving the call by adding `return new DataResponse([], Http::STATUS_NOT_FOUND);` to the beginning of [CallController::leaveCall](https://github.com/nextcloud/spreed/blob/10c5c13040dfe175b58c64a8238cd29910bc96e5/lib/Controller/CallController.php#L190)
- Create a public conversation
- Start a call
- In a private window, open the conversation
- Join the call
- In the original window, leave the call

### Result with this pull request

The participant from the private window can not be heard in the original window; the participant from the original window can not be heard nor seen in the private window

### Result without this pull request

The participant from the private window can still be heard in the original window; the participant from the original window can be heard and seen in the private window



## How to test (scenario 2)

- Force a failure when leaving the call by adding `return new DataResponse([], Http::STATUS_NOT_FOUND);` to the beginning of [CallController::leaveCall](https://github.com/nextcloud/spreed/blob/10c5c13040dfe175b58c64a8238cd29910bc96e5/lib/Controller/CallController.php#L190)
- Create a public conversation
- Start a call
- Leave the call
- In a private window, open the conversation
- Start a call again

### Result with this pull request

The participant from the private window can not be heard in the original window; the participant from the original window can not be heard nor seen in the private window

### Result without this pull request

The participant from the private window can be heard in the original window; the participant from the original window can be heard and seen in the private window



## How to test (scenario 3)

- Force a failure when leaving the call by adding `return new DataResponse([], Http::STATUS_NOT_FOUND);` to the beginning of [CallController::leaveCall](https://github.com/nextcloud/spreed/blob/10c5c13040dfe175b58c64a8238cd29910bc96e5/lib/Controller/CallController.php#L190)
- Create a public conversation
- Start a call
- In a private window, open the conversation
- Join the call
- In the original window, leave the call
- Join the call again

### Result with this pull request

The participant from the private window can be heard and seen in the original window

Note that, without HPB, in some rare cases the connection may be established yet nothing is visible; I have not been able to fix that (and it could even be a bug in the RTCPeerConnection implementation of the browser, as in my experience ICE restarts are not very reliable), so [something for later](https://github.com/nextcloud/spreed/issues/7800).

### Result with only first commit

The participant from the private window appears in the original window, but no connection is tried to be established and therefore can not be heard nor seen



## How to test (scenario 4)

- Do not setup the HPB (also happens with HPB, but it is easier to force it without HPB)
- Prevent offers from being sent by wrapping [`$this->messages->addMessage($message...`](https://github.com/nextcloud/spreed/blob/91d3bd8df8a5288c2abb3badde00c248d974dae8/lib/Controller/SignalingController.php#L291) with `if ($decodedMessage['type'] !== 'offer') { ... }`
- Force a failure when leaving the call by adding `return new DataResponse([], Http::STATUS_NOT_FOUND);` to the beginning of [CallController::leaveCall](https://github.com/nextcloud/spreed/blob/10c5c13040dfe175b58c64a8238cd29910bc96e5/lib/Controller/CallController.php#L190)
- Create a public conversation
- Start a call
- In a private window, open the conversation
- Join the call
- Open the browser console of both windows and look for _No offer nor answer received, sending offer again_
- In the window where the offers are being sent again, leave the call

### Result with this pull request

Offers are no longer sent to try to establish a connection

### Result without this pull request

New offers are sent again and again to try to establish a connection
