### PR TITLE
Fix leaving room in one session causing call to be partially left in another session

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1390,7 +1390,7 @@ class RoomController extends AEnvironmentAwareController {
 				$this->participantService->changeInCall($room, $previousParticipant, Participant::FLAG_DISCONNECTED);
 			}
 
-			$this->participantService->leaveRoomAsSession($room, $previousParticipant);
+			$this->participantService->leaveRoomAsSession($room, $previousParticipant, true);
 		}
 
 		$user = $this->userManager->get($this->userId);

--- a/lib/Events/DuplicatedParticipantEvent.php
+++ b/lib/Events/DuplicatedParticipantEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Events;
+
+use OCA\Talk\Participant;
+use OCA\Talk\Room;
+
+class DuplicatedParticipantEvent extends ParticipantEvent {
+	public function __construct(Room $room,
+								Participant $participant) {
+		parent::__construct($room, $participant);
+	}
+}

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -698,17 +698,12 @@ class ParticipantService {
 
 		$session = $participant->getSession();
 		if ($session instanceof Session) {
-			$dispatchLeaveCallEvents = $session->getInCall() !== Participant::FLAG_DISCONNECTED;
-			if ($dispatchLeaveCallEvents) {
-				$event = new ModifyParticipantEvent($room, $participant, 'inCall', Participant::FLAG_DISCONNECTED, $session->getInCall());
-				$this->dispatcher->dispatch(Room::EVENT_BEFORE_SESSION_LEAVE_CALL, $event);
+			$isInCall = $session->getInCall() !== Participant::FLAG_DISCONNECTED;
+			if ($isInCall) {
+				$this->changeInCall($room, $participant, Participant::FLAG_DISCONNECTED);
 			}
 
 			$this->sessionMapper->delete($session);
-
-			if ($dispatchLeaveCallEvents) {
-				$this->dispatcher->dispatch(Room::EVENT_AFTER_SESSION_LEAVE_CALL, $event);
-			}
 		} else {
 			$this->sessionMapper->deleteByAttendeeId($participant->getAttendee()->getId());
 		}

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -33,6 +33,7 @@ use OCA\Talk\Events\AddParticipantsEvent;
 use OCA\Talk\Events\AttendeesAddedEvent;
 use OCA\Talk\Events\AttendeesRemovedEvent;
 use OCA\Talk\Events\ChatEvent;
+use OCA\Talk\Events\DuplicatedParticipantEvent;
 use OCA\Talk\Events\EndCallForEveryoneEvent;
 use OCA\Talk\Events\JoinRoomGuestEvent;
 use OCA\Talk\Events\JoinRoomUserEvent;
@@ -692,8 +693,12 @@ class ParticipantService {
 		}
 	}
 
-	public function leaveRoomAsSession(Room $room, Participant $participant): void {
-		$event = new ParticipantEvent($room, $participant);
+	public function leaveRoomAsSession(Room $room, Participant $participant, bool $duplicatedParticipant = false): void {
+		if ($duplicatedParticipant) {
+			$event = new DuplicatedParticipantEvent($room, $participant);
+		} else {
+			$event = new ParticipantEvent($room, $participant);
+		}
 		$this->dispatcher->dispatch(Room::EVENT_BEFORE_ROOM_DISCONNECT, $event);
 
 		$session = $participant->getSession();

--- a/lib/Signaling/Listener.php
+++ b/lib/Signaling/Listener.php
@@ -27,6 +27,7 @@ use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Config;
 use OCA\Talk\Events\AddParticipantsEvent;
 use OCA\Talk\Events\ChatEvent;
+use OCA\Talk\Events\DuplicatedParticipantEvent;
 use OCA\Talk\Events\EndCallForEveryoneEvent;
 use OCA\Talk\Events\ModifyEveryoneEvent;
 use OCA\Talk\Events\ModifyParticipantEvent;
@@ -248,9 +249,13 @@ class Listener {
 
 		$sessionIds = [];
 		if ($event->getParticipant()->getSession()) {
-			// Only for guests and self-joined users disconnecting is "leaving" and therefor should trigger a disinvite
+			// If a previous duplicated session is being removed it must be
+			// notified to the external signaling server. Otherwise only for
+			// guests and self-joined users disconnecting is "leaving" and
+			// therefor should trigger a disinvite.
 			$attendeeParticipantType = $event->getParticipant()->getAttendee()->getParticipantType();
-			if ($attendeeParticipantType === Participant::GUEST
+			if ($event instanceof DuplicatedParticipantEvent
+				|| $attendeeParticipantType === Participant::GUEST
 				|| $attendeeParticipantType === Participant::GUEST_MODERATOR) {
 				$sessionIds[] = $event->getParticipant()->getSession()->getSessionId();
 				$notifier->roomSessionsRemoved($event->getRoom(), $sessionIds);

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -737,6 +737,49 @@ class BackendNotifierTest extends TestCase {
 		]);
 	}
 
+	public function testRoomInCallChangedWhenLeavingConversationWhileInCall() {
+		/** @var IUser|MockObject $testUser */
+		$testUser = $this->createMock(IUser::class);
+		$testUser->expects($this->any())
+			->method('getUID')
+			->willReturn($this->userId);
+
+		$roomService = $this->createMock(RoomService::class);
+		$roomService->method('verifyPassword')
+			->willReturn(['result' => true, 'url' => '']);
+
+		$room = $this->manager->createRoom(Room::TYPE_PUBLIC);
+		$this->participantService->addUsers($room, [[
+			'actorType' => 'users',
+			'actorId' => $this->userId,
+		]]);
+		$participant = $this->participantService->joinRoom($roomService, $room, $testUser, '');
+		$userSession = $participant->getSession()->getSessionId();
+		$this->participantService->changeInCall($room, $participant, Participant::FLAG_IN_CALL | Participant::FLAG_WITH_AUDIO | Participant::FLAG_WITH_VIDEO);
+		$this->controller->clearRequests();
+		$this->participantService->leaveRoomAsSession($room, $participant);
+
+		$this->assertMessageWasSent($room, [
+			'type' => 'incall',
+			'incall' => [
+				'incall' => 0,
+				'changed' => [
+					[
+						'inCall' => 0,
+						'lastPing' => 0,
+						'sessionId' => $userSession,
+						'nextcloudSessionId' => $userSession,
+						'participantType' => Participant::USER,
+						'participantPermissions' => (Attendee::PERMISSIONS_MAX_DEFAULT ^ Attendee::PERMISSIONS_LOBBY_IGNORE),
+						'userId' => $this->userId,
+					],
+				],
+				'users' => [
+				],
+			],
+		]);
+	}
+
 	public function testRoomPropertiesEvent(): void {
 		$listener = static function (SignalingRoomPropertiesEvent $event) {
 			$room = $event->getRoom();

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -352,6 +352,50 @@ class BackendNotifierTest extends TestCase {
 		$this->assertNoMessageOfTypeWasSent($room, 'disinvite');
 	}
 
+	public function testRoomDisinviteOnLeaveOfNormalUserWithDuplicatedSession() {
+		/** @var IUser|MockObject $testUser */
+		$testUser = $this->createMock(IUser::class);
+		$testUser->expects($this->any())
+			->method('getUID')
+			->willReturn($this->userId);
+
+		$roomService = $this->createMock(RoomService::class);
+		$roomService->method('verifyPassword')
+			->willReturn(['result' => true, 'url' => '']);
+
+		$room = $this->manager->createRoom(Room::TYPE_PUBLIC);
+		$this->participantService->addUsers($room, [[
+			'actorType' => 'users',
+			'actorId' => $this->userId,
+		]]);
+		$participant = $this->participantService->joinRoom($roomService, $room, $testUser, '');
+		$this->controller->clearRequests();
+		$this->participantService->leaveRoomAsSession($room, $participant, true);
+
+		$this->assertMessageWasSent($room, [
+			'type' => 'disinvite',
+			'disinvite' => [
+				'sessionids' => [
+					$participant->getSession()->getSessionId(),
+				],
+				'alluserids' => [
+					$this->userId,
+				],
+				'properties' => [
+					'name' => $room->getDisplayName(''),
+					'type' => $room->getType(),
+					'lobby-state' => Webinary::LOBBY_NONE,
+					'lobby-timer' => null,
+					'read-only' => Room::READ_WRITE,
+					'listable' => Room::LISTABLE_NONE,
+					'active-since' => null,
+					'sip-enabled' => 0,
+					'participant-list' => 'refresh',
+				],
+			],
+		]);
+	}
+
 	public function testRoomDisinviteOnLeaveOfSelfJoinedUser() {
 		/** @var IUser|MockObject $testUser */
 		$testUser = $this->createMock(IUser::class);


### PR DESCRIPTION
Fixes a regression introduced in #6707 (specifically, in 802d1d2f3e4af3e1a590fca7b6dc24c4115f30a4)

When the HPB is not used and the same conversation is joined in another tab [a conflict response is returned by the internal signaling server](https://github.com/nextcloud/spreed/blob/ba7394b51e4161ed803b0ec01f1057941f682410/lib/Controller/SignalingController.php#L367)* in the first tab, which causes [a `duplicate-session-detected` event to be triggered](https://github.com/nextcloud/spreed/blob/9e9197cc56fd8374c4916ba1fd029721cd1a5486/src/utils/signaling.js#L513-L518) and this in turn [causes a redirection to the `duplicate-session` page](https://github.com/nextcloud/spreed/blob/47e98d86d617925253f69f4a5a7ad67d63fd4d79/src/mixins/sessionIssueHandler.js#L58-L60).

*If a long polling request fails with an internal error, for example if SQLite is used and the database is locked due to concurrent access, when the next polling [gets again the session](https://github.com/nextcloud/spreed/blob/ba7394b51e4161ed803b0ec01f1057941f682410/lib/Controller/SignalingController.php#L301) it will already use the session set by the second tab, so [it will be the valid one and no conflict will be reported](https://github.com/nextcloud/spreed/blob/ba7394b51e4161ed803b0ec01f1057941f682410/lib/Controller/SignalingController.php#L350-L367). But an internal error should not happen during the long polling, so this is such a corner case that, unless there is an easy fix, it should be fine to ignore, at least for now.

However, if the HPB is used there is no conflict response; in the past a `disinvite` message was sent to the first session, which caused the UI to show a _Conversation does not exist_ page (it should have shown the duplicated session page, but I do not know if that ever worked). However, the `disinvite` message is no longer sent for registered users since 802d1d2f3e4af3e1a590fca7b6dc24c4115f30a4. Due to that when the same conversation is joined in another tab the UI in the original one is still active, so further actions in the first tab mess with the session in the second tab. For example, if the conversation is switched in the first tab while the second tab is in a call the participant will leave the call and stay in it at the same time. To solve that, the `disinvite` message is now sent again for regular users too, but only when removing a duplicated session.

But, if the session of the second tab leaves the conversation, why was the call still active? The problem is the order in which the events are handled. When the conversation is left an event to leave the call is triggered, but [the event is triggered once the conversation is left already](https://github.com/nextcloud/spreed/blob/10c5c13040dfe175b58c64a8238cd29910bc96e5/lib/Service/ParticipantService.php#L707-L711). When the event is handled [the session of the event is checked against the sessions in the conversation](https://github.com/nextcloud/spreed/blob/3c2c09eb93cd023fe3d5966be5d9d4398bf5cfe6/lib/Signaling/BackendNotifier.php#L377), but as the conversation was already left no session is found, so the message sent to the HPB is empty and therefore the HPB does not cause the call to be left.

To solve that now, when a conversation is left, if there is an active call it is first explicitly left and then the conversation is left. Note, however, that the RTCPeerConnections will be reconnected after some time, because the WebUI will try to leave the call but fail and, once the connection also fails, the handler to reconnect it will run despite no longer being in the call; that is fixed in #7799

The scenario 1 below can be tested only without the second commit, as the second commit fixes a precondition (being able to join the same conversation in another tab without leaving the conversation in the first tab). Nevertheless, even if the scenario 1 will no longer happen the first commit should still be applied.

## How to test (scenario 1)

- Setup the HPB
- Log in as a user
- Create a conversation
- Open the same conversation in another tab
- In that new tab, join the call
- In the original tab, change to another conversation (so you leave the other one, but note that closing the tab does not trigger the issue)

### Result with first commit of this pull request

The call is left in the second tab

Note that without #7799 the connections will be established again after some time (even if the UI still appears as not in the call)

### Result without this pull request

The call is not left in the second tab (although there is a chat message saying that you left the call)




## How to test (scenario 2)

- Setup the HPB
- Log in as a user
- Create a conversation
- Open the same conversation in another tab

### Result with this pull request

The conversation is left in the first tab

Note that no conflict warning is shown in the second tab because since #4374 this is done only when the previous session is in a call

### Result without this pull request

The conversation is not left in the first tab
