### PR TITLE
add var hint

### DIFF
--- a/lib/Chat/Command/Listener.php
+++ b/lib/Chat/Command/Listener.php
@@ -49,6 +49,9 @@ class Listener {
 		$message = $event->getComment();
 		$participant = $event->getParticipant();
 
+		/**
+		 * @var Listener $listener
+		 */
 		$listener = Server::get(self::class);
 
 		if (strpos($message->getMessage(), '//') === 0) {


### PR DESCRIPTION
- let's tools like IDEs better deduct the classses and methods used

Background story: I was looking where the executor's `exec` was being used, but my IDE was clueless.

