### PR TITLE
Bump @nextcloud/event-bus from 3.0.1 to 3.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3586,9 +3586,9 @@
 			}
 		},
 		"node_modules/@nextcloud/event-bus": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.0.1.tgz",
-			"integrity": "sha512-0YvijvmmBN9bWmcGd9O0oFL+yd2PI4pq8h5J81gxrRmjU7UlCzh79zQJ/JaVA3uzZwY4e3hf+yFp589nvB3P1g==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.0.2.tgz",
+			"integrity": "sha512-svXCZa4UkoZKsBiGzTi0cVcbPFUOhCm7pMKjGumRwBvHywX+8by478IQ8Grw75PFHxajMJZ0KrOTTM8WnzzEAw==",
 			"dependencies": {
 				"semver": "^7.3.7"
 			},
@@ -31215,9 +31215,9 @@
 			}
 		},
 		"@nextcloud/event-bus": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.0.1.tgz",
-			"integrity": "sha512-0YvijvmmBN9bWmcGd9O0oFL+yd2PI4pq8h5J81gxrRmjU7UlCzh79zQJ/JaVA3uzZwY4e3hf+yFp589nvB3P1g==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.0.2.tgz",
+			"integrity": "sha512-svXCZa4UkoZKsBiGzTi0cVcbPFUOhCm7pMKjGumRwBvHywX+8by478IQ8Grw75PFHxajMJZ0KrOTTM8WnzzEAw==",
 			"requires": {
 				"semver": "^7.3.7"
 			},


### PR DESCRIPTION
Fixes the `ReferenceError: exports is not defined` error introduced in [3.0.1](https://github.com/nextcloud/spreed/pull/7854).
