### PR TITLE
Adjust public share authentication page to layout changes in NC25

### DIFF
--- a/css/publicshareauth.css
+++ b/css/publicshareauth.css
@@ -33,6 +33,8 @@ body.talk-sidebar-enabled #body-login {
 
 /* #body-login should be used to override the #content rules set in server. */
 #body-login #content {
+	position: relative;
+
 	flex-grow: 1;
 
 	flex-direction: column;


### PR DESCRIPTION
Fixes #7852

The content now has a fixed position to be always centered in the page. However, in order to add the Talk sidebar the content in the public share authentication page needs to be "pushed" to the left when the sidebar is added, so the content position needs to have a relative position instead (which also keeps the same appearance of the fixed position when the Talk sidebar is not shown yet).
