### PR TITLE
Fix dashboard icon on dark mode again

### DIFF
--- a/css/icons.css
+++ b/css/icons.css
@@ -82,4 +82,5 @@
 
 .dashboard-talk-icon {
 	background-image: url(../img/app-dark.svg);
+	filter: var(--background-invert-if-dark);
 }


### PR DESCRIPTION
There was a generic filter in the past, but it was removed with https://github.com/nextcloud/server/commit/1d35a53991f356976d78b8053651737821502687

So now we apply the filter at our best knowledge

Fix #7878 

Before | After
---|---
![Bildschirmfoto vom 2022-09-13 10-02-58](https://user-images.githubusercontent.com/213943/189845768-c6527fc1-3606-46d0-b9c0-341be14b2d76.png) | ![Bildschirmfoto vom 2022-09-13 10-02-45](https://user-images.githubusercontent.com/213943/189845775-21ac58e5-c849-412a-a31c-1fd09ee5eb55.png)
