### PR TITLE
Fix message forwarding

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -174,6 +174,7 @@ the main body of the message as well as a quote.
 			:is-action-menu-open.sync="isActionMenuOpen"
 			:is-emoji-picker-open.sync="isEmojiPickerOpen"
 			:is-reactions-menu-open.sync="isReactionsMenuOpen"
+			:is-forwarder-open.sync="isForwarderOpen"
 			:message-api-data="messageApiData"
 			:message-object="messageObject"
 			:is-last-read="isLastReadMessage"
@@ -400,6 +401,7 @@ export default {
 			isActionMenuOpen: false,
 			isEmojiPickerOpen: false,
 			isReactionsMenuOpen: false,
+			isForwarderOpen: false,
 			detailedReactionsLoading: false,
 		}
 	},
@@ -566,7 +568,7 @@ export default {
 		},
 
 		showMessageButtonsBar() {
-			return !this.isSystemMessage && !this.isTemporary && (this.isHovered || this.isActionMenuOpen || this.isEmojiPickerOpen || this.isReactionsMenuOpen)
+			return !this.isSystemMessage && !this.isTemporary && (this.isHovered || this.isActionMenuOpen || this.isEmojiPickerOpen || this.isReactionsMenuOpen || this.isForwarderOpen)
 		},
 
 		isTemporaryUpload() {

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/Forwarder.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/Forwarder.vue
@@ -118,7 +118,7 @@ export default {
 		},
 
 		selectedConversationName() {
-			return this.$store.getters?.conversation(this.selectedConversationToken).name
+			return this.$store.getters?.conversation(this.selectedConversationToken).displayName
 		},
 
 		/**

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -72,9 +72,10 @@
 				</NcActionLink>
 				<NcActionButton v-if="!isCurrentGuest && !isFileShare && !isDeletedMessage"
 					:close-after-click="true"
-					@click.stop="showForwarder = true">
-					<Share slot="icon"
-						:size="16" />
+					@click.stop="openForwarder">
+					<template #icon>
+						<Share :size="16" />
+					</template>
 					{{ t('spreed', 'Forward message') }}
 				</NcActionButton>
 				<NcActionSeparator v-if="messageActions.length > 0" />
@@ -131,9 +132,9 @@
 				</NcButton>
 			</NcEmojiPicker>
 		</template>
-		<Forwarder v-if="showForwarder"
+		<Forwarder v-if="isForwarderOpen"
 			:message-object="messageObject"
-			@close="showForwarder = false" />
+			@close="closeForwarder" />
 	</div>
 </template>
 
@@ -294,6 +295,11 @@ export default {
 			required: true,
 		},
 
+		isForwarderOpen: {
+			type: Boolean,
+			required: true,
+		},
+
 		canReact: {
 			type: Boolean,
 			required: true,
@@ -308,13 +314,6 @@ export default {
 			type: Boolean,
 			required: true,
 		},
-	},
-
-	data() {
-		return {
-			// Shows/hides the message forwarder component
-			showForwarder: false,
-		}
 	},
 
 	computed: {
@@ -472,6 +471,14 @@ export default {
 
 		openReactionsMenu() {
 			this.$emit('update:isReactionsMenuOpen', true)
+		},
+
+		openForwarder() {
+			this.$emit('update:isForwarderOpen', true)
+		},
+
+		closeForwarder() {
+			this.$emit('update:isForwarderOpen', false)
 		},
 
 		// Making sure that the click is outside the MessageButtonsBar


### PR DESCRIPTION
Fix #7845 

- [x] Forwarder did not appear
- [x] One-to-one conversations showed the user id in the confirmation dialog

UI still looks weird but gets fixed in the Vue lib:
* https://github.com/nextcloud/nextcloud-vue/pull/3253