### PR TITLE
Remove expired message and when there are too many from the Vue store

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -254,6 +254,11 @@ export default {
 				this.removeExpiredMessagesFromStore()
 			},
 		},
+
+		token(newToken, oldToken) {
+			// Expire older messages when navigating to another conversation
+			this.$store.dispatch('easeMessageList', { token: oldToken })
+		},
 	},
 
 	mounted() {

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -129,6 +129,8 @@ export default {
 			loadingOldMessages: false,
 
 			destroying: false,
+
+			expirationInterval: null,
 		}
 	},
 
@@ -247,6 +249,9 @@ export default {
 					this.$store.dispatch('cancelLookForNewMessages', { requestId: oldValue })
 				}
 				this.handleStartGettingMessagesPreconditions()
+
+				// Remove expired messages when joining a room
+				this.removeExpiredMessagesFromStore()
 			},
 		},
 	},
@@ -261,6 +266,13 @@ export default {
 		subscribe('networkOffline', this.handleNetworkOffline)
 		subscribe('networkOnline', this.handleNetworkOnline)
 		window.addEventListener('focus', this.onWindowFocus)
+
+		/**
+		 * Every 30 seconds we remove expired messages from the store
+		 */
+		this.expirationInterval = window.setInterval(() => {
+			this.removeExpiredMessagesFromStore()
+		}, 30000)
 	},
 
 	beforeDestroy() {
@@ -275,9 +287,20 @@ export default {
 
 		unsubscribe('networkOffline', this.handleNetworkOffline)
 		unsubscribe('networkOnline', this.handleNetworkOnline)
+
+		if (this.expirationInterval) {
+			clearInterval(this.expirationInterval)
+			this.expirationInterval = null
+		}
 	},
 
 	methods: {
+		removeExpiredMessagesFromStore() {
+			this.$store.dispatch('removeExpiredMessages', {
+				token: this.token,
+			})
+		},
+
 		/**
 		 * Compare two messages to decide if they should be grouped
 		 *

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -382,6 +382,21 @@ const mutations = {
 			}
 		}
 	},
+
+	removeExpiredMessages(state, { token }) {
+		if (!state.messages[token]) {
+			return
+		}
+
+		const timestamp = (new Date()) / 1000
+		const messageIds = Object.keys(state.messages[token])
+		messageIds.forEach((messageId) => {
+			if (state.messages[token][messageId].expirationTimestamp
+				&& timestamp > state.messages[token][messageId].expirationTimestamp) {
+				Vue.delete(state.messages[token], messageId)
+			}
+		})
+	},
 }
 
 const actions = {
@@ -1078,6 +1093,10 @@ const actions = {
 			console.error(error)
 			showError(t('spreed', 'Failed to remove reaction'))
 		}
+	},
+
+	async removeExpiredMessages(context, { token }) {
+		context.commit('removeExpiredMessages', { token })
 	},
 }
 

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -397,6 +397,28 @@ const mutations = {
 			}
 		})
 	},
+
+	easeMessageList(state, { token }) {
+		if (!state.messages[token]) {
+			return
+		}
+
+		const messageIds = Object.keys(state.messages[token])
+		if (messageIds.length < 300) {
+			return
+		}
+
+		const messagesToRemove = messageIds.sort().reverse().slice(199)
+		const newFirstKnown = messagesToRemove.shift()
+
+		messagesToRemove.forEach((messageId) => {
+			Vue.delete(state.messages[token], messageId)
+		})
+
+		if (state.firstKnown[token] && messagesToRemove.includes(state.firstKnown[token])) {
+			Vue.set(state.firstKnown, token, newFirstKnown)
+		}
+	},
 }
 
 const actions = {
@@ -1097,6 +1119,10 @@ const actions = {
 
 	async removeExpiredMessages(context, { token }) {
 		context.commit('removeExpiredMessages', { token })
+	},
+
+	async easeMessageList(context, { token }) {
+		context.commit('easeMessageList', { token })
 	},
 }
 


### PR DESCRIPTION
Fix #7826 
Fix #7546 

Patch for testing:
```diff
diff --git a/lib/Model/Message.php b/lib/Model/Message.php
index d888d0133..5e8202961 100644
--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -192,7 +192,7 @@ class Message {
                        'isReplyable' => $this->isReplyable(),
                        'referenceId' => (string) $this->getComment()->getReferenceId(),
                        'reactions' => $reactions,
-                       'expirationTimestamp' => $expireDate ? $expireDate->getTimestamp() : 0,
+                       'expirationTimestamp' => time() + 5, //$expireDate ? $expireDate->getTimestamp() : 0,
                ];
 
                if ($this->getMessageType() === ChatManager::VERB_MESSAGE_DELETED) {
diff --git a/src/components/MessagesList/MessagesList.vue b/src/components/MessagesList/MessagesList.vue
index 0bd7b689d..293fa616c 100644
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -272,7 +272,7 @@ export default {
                 */
                this.expirationInterval = window.setInterval(() => {
                        this.removeExpiredMessagesFromStore()
-               }, 30000)
+               }, 3000) // FIXME }, 30000)
        },
 
        beforeDestroy() {
```

Remaining issue for a follow up:
- When all messages are "Expired" the chat shows the loading animation instead of an empty content message. But that also needs cross verification with the mobile apps, so it's good to manage it additionally. => #7919 
