### PR TITLE
Fix missing bottom+right frame when following in a 2 person call

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -39,6 +39,7 @@
 							:show-talking-highlight="false"
 							:is-grid="true"
 							:is-big="true"
+							:is-one-to-one="isOneToOne"
 							:fit-video="true" />
 					</template>
 				</div>


### PR DESCRIPTION
Fix #7879 

### Steps

1. Start a group call
2. Join with a second user
3. Switch to grid view
4. Click on the other participant
5. Check your frame
6. Unfollow
7. Check the frame again

Before | After
---|---
![Bildschirmfoto vom 2022-09-15 09-51-30](https://user-images.githubusercontent.com/213943/190347207-f8e1bac9-c843-41a9-8739-e6a8e5130946.png) | ![Bildschirmfoto vom 2022-09-15 09-50-58](https://user-images.githubusercontent.com/213943/190347190-2fd51543-908c-47df-9449-271e182e3305.png)
![Bildschirmfoto vom 2022-09-15 09-51-36](https://user-images.githubusercontent.com/213943/190347394-f3e9aba6-9e02-4343-aca6-b3a7bfec68b3.png) | ![Bildschirmfoto vom 2022-09-15 09-51-03](https://user-images.githubusercontent.com/213943/190347324-f2726f58-35d9-45bb-bb8f-448bf1a37c08.png)



