### PR TITLE
Fix chat endpoints with empty reactions in XML format

### DIFF
--- a/lib/Controller/AEnvironmentAwareController.php
+++ b/lib/Controller/AEnvironmentAwareController.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Controller;
 
+use OC\AppFramework\Http\Dispatcher;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCP\AppFramework\OCSController;
@@ -58,5 +59,26 @@ abstract class AEnvironmentAwareController extends OCSController {
 
 	public function getParticipant(): ?Participant {
 		return $this->participant;
+	}
+
+	/**
+	 * Following the logic of {@see Dispatcher::executeController}
+	 * @return string Either 'json' or 'xml'
+	 */
+	public function getResponseFormat(): string {
+		// get format from the url format or request format parameter
+		$format = $this->request->getParam('format');
+
+		// if none is given try the first Accept header
+		if ($format === null) {
+			$headers = $this->request->getHeader('Accept');
+			/**
+			 * Default value of
+			 * @see OCSController::buildResponse()
+			 */
+			$format = $this->getResponderByHTTPHeader($headers, 'xml');
+		}
+
+		return $format;
 	}
 }

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -168,9 +168,9 @@ class ChatController extends AEnvironmentAwareController {
 
 		$this->participantService->updateLastReadMessage($this->participant, (int) $comment->getId());
 
-		$data = $chatMessage->toArray();
+		$data = $chatMessage->toArray($this->getResponseFormat());
 		if ($parentMessage instanceof Message) {
-			$data['parent'] = $parentMessage->toArray();
+			$data['parent'] = $parentMessage->toArray($this->getResponseFormat());
 		}
 
 		$response = new DataResponse($data, Http::STATUS_CREATED);
@@ -481,7 +481,7 @@ class ChatController extends AEnvironmentAwareController {
 				$parentIds[$id] = $comment->getParentId();
 			}
 
-			$messages[] = $message->toArray();
+			$messages[] = $message->toArray($this->getResponseFormat());
 			$commentIdToIndex[$id] = $i;
 			$i++;
 		}
@@ -517,7 +517,7 @@ class ChatController extends AEnvironmentAwareController {
 					$this->messageParser->parseMessage($message);
 
 					if ($message->getVisibility()) {
-						$loadedParents[$parentId] = $message->toArray();
+						$loadedParents[$parentId] = $message->toArray($this->getResponseFormat());
 						$messages[$commentKey]['parent'] = $loadedParents[$parentId];
 						continue;
 					}
@@ -667,8 +667,8 @@ class ChatController extends AEnvironmentAwareController {
 		$message = $this->messageParser->createMessage($this->room, $this->participant, $comment, $this->l);
 		$this->messageParser->parseMessage($message);
 
-		$data = $systemMessage->toArray();
-		$data['parent'] = $message->toArray();
+		$data = $systemMessage->toArray($this->getResponseFormat());
+		$data['parent'] = $message->toArray($this->getResponseFormat());
 
 		$bridge = $this->matterbridgeManager->getBridgeOfRoom($this->room);
 
@@ -704,7 +704,7 @@ class ChatController extends AEnvironmentAwareController {
 		$this->messageParser->parseMessage($systemMessage);
 
 
-		$data = $systemMessage->toArray();
+		$data = $systemMessage->toArray($this->getResponseFormat());
 
 		$bridge = $this->matterbridgeManager->getBridgeOfRoom($this->room);
 
@@ -797,7 +797,7 @@ class ChatController extends AEnvironmentAwareController {
 				continue;
 			}
 
-			$messages[(int) $comment->getId()] = $message->toArray();
+			$messages[(int) $comment->getId()] = $message->toArray($this->getResponseFormat());
 		}
 
 		$messagesByType = [];
@@ -853,7 +853,7 @@ class ChatController extends AEnvironmentAwareController {
 				continue;
 			}
 
-			$messages[(int) $comment->getId()] = $message->toArray();
+			$messages[(int) $comment->getId()] = $message->toArray($this->getResponseFormat());
 		}
 
 		return $messages;

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -624,7 +624,7 @@ class RoomController extends AEnvironmentAwareController {
 			return [];
 		}
 
-		return $message->toArray();
+		return $message->toArray($this->getResponseFormat());
 	}
 
 	/**

--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -168,11 +168,11 @@ class Message {
 			\in_array($this->getActorType(), [Attendee::ACTOR_USERS, Attendee::ACTOR_GUESTS]);
 	}
 
-	public function toArray(): array {
+	public function toArray(string $format): array {
 		$expireDate = $this->getComment()->getExpireDate();
 
 		$reactions = $this->getComment()->getReactions();
-		if (empty($reactions)) {
+		if ($format === 'json' && empty($reactions)) {
 			// Cheating here to make sure the reactions array is always a
 			// JSON object on the API, even when there is no reaction at all.
 			$reactions = new \StdClass();


### PR DESCRIPTION
Fix #7952 

Check result of both curl commands before and after:

```sh
# json
curl -k -u admin:admin \
    'https://nextcloud25.local/ocs/v2.php/apps/spreed/api/v1/chat/7d85h4a9?setReadMarker=0&lookIntoFuture=0&lastKnownMessageId=201&includeLastKnown=1' \
    -H 'OCS-APIRequest: true' \
    -H 'Accept: application/json, text/plain, */*' \
    | jq .


# xml
curl -k -u admin:admin \
    'https://nextcloud25.local/ocs/v2.php/apps/spreed/api/v1/chat/7d85h4a9?setReadMarker=0&lookIntoFuture=0&lastKnownMessageId=201&includeLastKnown=1' \
    -H 'OCS-APIRequest: true'
```

(Adjust domain and token and make sure the json one still returns an empty object for reactions