### PR TITLE
Fix reaction buttons due to remove CSS variable

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -138,8 +138,8 @@ the main body of the message as well as a quote.
 					trigger="hover">
 					<NcButton v-if="simpleReactions[reaction]!== 0"
 						slot="trigger"
+						:type="userHasReacted(reaction) ? 'primary' : 'secondary'"
 						class="reaction-button"
-						:class="{'reaction-button__has-reacted': userHasReacted(reaction)}"
 						@click="handleReactionClick(reaction)">
 						{{ reaction }} {{ simpleReactions[reaction] }}
 					</NcButton>
@@ -977,15 +977,10 @@ export default {
 
 	margin: 2px;
 	height: 26px;
-	background-color: var(--color-main-background) !important;
-	margin-right: 8px !important;
+	padding: 0 6px !important;
 
 	&__emoji {
 		margin: 0 4px 0 0;
-	}
-
-	&__has-reacted {
-		background-color: var(--color-primary-element-lighter) !important;
 	}
 }
 


### PR DESCRIPTION
Fix #7913 

(I tried tertiary but that has no background as the hover is already on the full message, so I think those 2 are the best)
Before | After
---|---
Unclear what you selected, not enough contrast on hover, etc. | Primary = You, Secondary = Others 
![Bildschirmfoto vom 2022-09-20 17-03-29](https://user-images.githubusercontent.com/213943/191294136-1513529b-f2e2-4f43-a496-f92390a8c6e7.png) | ![Bildschirmfoto vom 2022-09-20 16-59-14](https://user-images.githubusercontent.com/213943/191294148-6bd88d7b-cb50-4de7-ad5c-9987ab472812.png)

