### PR TITLE
Show empty content when all messages expired

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -50,7 +50,7 @@ get the messagesList array and loop through the list to generate the messages.
 		</template>
 		<NcEmptyContent v-else-if="showEmptyContent"
 			:title="t('spreed', 'No messages')"
-			:description="t('spreed', 'All messages have been expired or deleted. Restart the conversation!')">
+			:description="t('spreed', 'All messages have expired or have been deleted.')">
 			<template #icon>
 				<Message :size="64" />
 			</template>

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -44,10 +44,17 @@ get the messagesList array and loop through the list to generate the messages.
 			:messages="item"
 			:next-message-id="(messagesGroupedByAuthor[index + 1] && messagesGroupedByAuthor[index + 1][0].id) || 0"
 			:previous-message-id="(index > 0 && messagesGroupedByAuthor[index - 1][messagesGroupedByAuthor[index - 1].length - 1].id) || 0" />
-		<template v-if="!messagesGroupedByAuthor.length">
+		<template v-if="showLoadingAnimation">
 			<LoadingPlaceholder type="messages"
 				:count="15" />
 		</template>
+		<NcEmptyContent v-else-if="showEmptyContent"
+			:title="t('spreed', 'No messages')"
+			:description="t('spreed', 'All messages have been expired or deleted. Restart the conversation!')">
+			<template #icon>
+				<Message :size="64" />
+			</template>
+		</NcEmptyContent>
 		<transition name="fade">
 			<NcButton v-show="!isChatScrolledToBottom"
 				type="secondary"
@@ -73,8 +80,10 @@ import debounce from 'debounce'
 import { EventBus } from '../../services/EventBus.js'
 import LoadingPlaceholder from '../LoadingPlaceholder.vue'
 import ChevronDown from 'vue-material-design-icons/ChevronDown.vue'
+import Message from 'vue-material-design-icons/Message.vue'
 import uniqueId from 'lodash/uniqueId.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 
 export default {
 	name: 'MessagesList',
@@ -82,7 +91,9 @@ export default {
 		LoadingPlaceholder,
 		MessagesGroup,
 		ChevronDown,
+		Message,
 		NcButton,
+		NcEmptyContent,
 	},
 
 	mixins: [
@@ -189,6 +200,15 @@ export default {
 				}
 			}
 			return groups
+		},
+
+		showLoadingAnimation() {
+			return !this.$store.getters.isMessageListPopulated(this.token)
+				&& !this.messagesGroupedByAuthor.length
+		},
+
+		showEmptyContent() {
+			return !this.messagesGroupedByAuthor.length
 		},
 
 		/**

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -96,6 +96,15 @@ const state = {
 	visualLastReadMessageId: {},
 
 	/**
+	 * Loaded messages history parts of a conversation
+	 *
+	 * The messages list can still be empty due to message expiration,
+	 * but if we ever loaded the history, we need to show an empty content
+	 * instead of the loading animation
+	 */
+	loadedMessages: {},
+
+	/**
 	 * Stores the cancel function returned by `cancelableFetchMessages`,
 	 * which allows to cancel the previous request for old messages
 	 * when quickly switching to a new conversation.
@@ -130,6 +139,10 @@ const getters = {
 		}
 
 		return getters.getLastKnownMessageId(token) < conversation.lastMessage.id
+	},
+
+	isMessageListPopulated: (state) => (token) => {
+		return !!state.loadedMessages[token]
 	},
 
 	/**
@@ -365,6 +378,10 @@ const mutations = {
 		} else {
 			state.messages[token][messageId].reactionsSelf.push(reaction)
 		}
+	},
+
+	loadedMessagesOfConversation(state, { token }) {
+		Vue.set(state.loadedMessages, token, true)
 	},
 
 	// Decreases reaction count for a particular reaction on a message
@@ -760,6 +777,8 @@ const actions = {
 			})
 		}
 
+		context.commit('loadedMessagesOfConversation', { token })
+
 		return response
 	},
 
@@ -886,6 +905,8 @@ const actions = {
 				})
 			}
 		}
+
+		context.commit('loadedMessagesOfConversation', { token })
 
 		return response
 	},


### PR DESCRIPTION
Fix #7919 

Patch for testing:
```diff
diff --git a/lib/Model/Message.php b/lib/Model/Message.php
index d888d0133..5e8202961 100644
--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -192,7 +192,7 @@ class Message {
                        'isReplyable' => $this->isReplyable(),
                        'referenceId' => (string) $this->getComment()->getReferenceId(),
                        'reactions' => $reactions,
-                       'expirationTimestamp' => $expireDate ? $expireDate->getTimestamp() : 0,
+                       'expirationTimestamp' => time() + 5, //$expireDate ? $expireDate->getTimestamp() : 0,
                ];
 
                if ($this->getMessageType() === ChatManager::VERB_MESSAGE_DELETED) {
diff --git a/src/components/MessagesList/MessagesList.vue b/src/components/MessagesList/MessagesList.vue
index 0bd7b689d..293fa616c 100644
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -272,7 +272,7 @@ export default {
                 */
                this.expirationInterval = window.setInterval(() => {
                        this.removeExpiredMessagesFromStore()
-               }, 30000)
+               }, 3000) // FIXME }, 30000)
        },
 
        beforeDestroy() {
```

Before | After
---|---
![190152647-4923e598-f204-44e4-a3bd-4ebd64fa886b](https://user-images.githubusercontent.com/213943/191419131-6a510dfd-a790-4c10-993f-7e66a9f18616.png) | ![Bildschirmfoto vom 2022-09-21 07-07-35](https://user-images.githubusercontent.com/213943/191419139-e14811fc-037a-49ef-86d7-ce80b3fd81a8.png)
