### PR TITLE
Quote again when retrying to send a failed message

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -580,6 +580,26 @@ export default {
 				if (temporaryMessage) {
 					this.text = temporaryMessage.message || this.text
 					this.parsedText = temporaryMessage.message || this.parsedText
+
+					// Restore the parent/quote message
+					if (temporaryMessage.parent) {
+						const temporaryParent = this.$store.getters.message(this.token, temporaryMessage.parent)
+
+						this.$store.dispatch('addMessageToBeReplied', {
+							id: temporaryParent.id,
+							actorId: temporaryParent.actorId,
+							actorType: temporaryParent.actorType,
+							actorDisplayName: temporaryParent.actorDisplayName,
+							timestamp: temporaryParent.timestamp,
+							systemMessage: temporaryParent.systemMessage,
+							messageType: temporaryParent.messageType,
+							message: temporaryParent.message,
+							messageParameters: temporaryParent.messageParameters,
+							token: temporaryParent.token,
+							previousMessageId: temporaryParent.previousMessageId,
+						})
+					}
+
 					this.$store.dispatch('removeTemporaryMessageFromStore', temporaryMessage)
 				}
 			}


### PR DESCRIPTION
Fix #7904 

Steps:
1. Post a message
2. Apply the following patch
```diff
diff --git a/lib/Controller/ChatController.php b/lib/Controller/ChatController.php
index 3608f5959..39b1f5935 100644
--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -221,6 +221,8 @@ class ChatController extends AEnvironmentAwareController {
                        if (!$parentMessage->isReplyable()) {
                                return new DataResponse([], Http::STATUS_BAD_REQUEST);
                        }
+
+                       return new DataResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
                }
 
                $this->participantService->ensureOneToOneRoomIsFilled($this->room);
```
4. Quote the previous message
5. Wait until the message failed
6. Click on the resend option 💥 Quote is missing
