### PR TITLE
Fix console error 'Missing required prop: "isForwarderOpen"' in jest

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
@@ -52,6 +52,7 @@ describe('MessageButtonsBar.vue', () => {
 			canReact: true,
 			isReactionsMenuOpen: false,
 			isLastRead: false,
+			isForwarderOpen: false,
 			timestamp: new Date('2020-05-07 09:23:00').getTime() / 1000,
 			token: TOKEN,
 			systemMessage: '',


### PR DESCRIPTION
```
 PASS  src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
  ● Console

    console.error
      [Vue warn]: Missing required prop: "isForwarderOpen"
      
      found in
      
      ---> <MessageButtonsBar>
             <Root>

      86 | 				store = new Store(testStoreConfig)
      87 |
    > 88 | 				const wrapper = shallowMount(MessageButtonsBar, {
         | 				                ^
      89 | 					localVue,
      90 | 					store,
      91 | 					stubs: {

      at warn (node_modules/vue/dist/vue.runtime.common.dev.js:4516:21)
      at assertProp (node_modules/vue/dist/vue.runtime.common.dev.js:5034:9)
      at validateProp (node_modules/vue/dist/vue.runtime.common.dev.js:4994:9)
      at initProps$1 (node_modules/vue/dist/vue.runtime.common.dev.js:5285:23)
      at initState (node_modules/vue/dist/vue.runtime.common.dev.js:5254:9)
      at VueComponent.Vue._init (node_modules/vue/dist/vue.runtime.common.dev.js:5571:9)
      at new VueComponent (node_modules/vue/dist/vue.runtime.common.dev.js:5706:18)
      at createComponentInstanceForVnode (node_modules/vue/dist/vue.runtime.common.dev.js:4458:12)
      at init (node_modules/vue/dist/vue.runtime.common.dev.js:4320:54)
      at createComponent (node_modules/vue/dist/vue.runtime.common.dev.js:6445:17)
      at createElm (node_modules/vue/dist/vue.runtime.common.dev.js:6399:13)
      at VueComponent.patch [as __patch__] (node_modules/vue/dist/vue.runtime.common.dev.js:6947:13)
      at VueComponent.Vue._update (node_modules/vue/dist/vue.runtime.common.dev.js:3687:25)
      at VueComponent.updateComponent (node_modules/vue/dist/vue.runtime.common.dev.js:3797:16)
      at Watcher.get (node_modules/vue/dist/vue.runtime.common.dev.js:3369:33)
      at new Watcher (node_modules/vue/dist/vue.runtime.common.dev.js:3359:51)
      at mountComponent (node_modules/vue/dist/vue.runtime.common.dev.js:3814:5)
      at VueComponent.Object.<anonymous>.Vue.$mount (node_modules/vue/dist/vue.runtime.common.dev.js:8643:12)
      at mount (node_modules/@vue/test-utils/dist/vue-test-utils.js:14057:21)
      at shallowMount (node_modules/@vue/test-utils/dist/vue-test-utils.js:14083:10)
      at _callee$ (src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js:88:21)
      at tryCatch (src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js:29:2404)
      at Generator._invoke (src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js:29:1964)
      at Generator.next (src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js:29:3255)
      at asyncGeneratorStep (src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js:31:103)
      at _next (src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js:33:194)
      at src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js:33:364
      at Object.<anonymous> (src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js:33:97)
```

Regression from #7915 