### PR TITLE
Fix console error 'TypeError: unreadMentions.forEach is not a function in jest

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -480,14 +480,16 @@ export default {
 		handleUnreadMention() {
 			this.unreadNum = 0
 			const unreadMentions = document.getElementsByClassName('unread-mention-conversation')
-			unreadMentions.forEach(x => {
-				if (this.elementIsBelowViewpoint(this.$refs.scroller, x)) {
-					if (this.unreadNum === 0) {
-						this.firstUnreadPos = x.offsetTop
+			if (unreadMentions.length) {
+				unreadMentions.forEach(x => {
+					if (this.elementIsBelowViewpoint(this.$refs.scroller, x)) {
+						if (this.unreadNum === 0) {
+							this.firstUnreadPos = x.offsetTop
+						}
+						this.unreadNum += 1
 					}
-					this.unreadNum += 1
-				}
-			})
+				})
+			}
 		},
 		debounceHandleScroll: debounce(function() {
 			this.handleScroll()


### PR DESCRIPTION
```
PASS  src/components/LeftSidebar/LeftSidebar.spec.js (6.678 s)
  ● Console

    console.error
      [Vue warn]: Error in event handler for "conversations-received": "TypeError: unreadMentions.forEach is not a function"
      
      (found in <Root>)

      344 |
      345 | 		async fetchListedConversations() {
    > 346 | 			try {
          | 			          ^
      347 | 				this.listedConversationsLoading = true
      348 |
      349 | 				// FIXME: move to conversationsStore

      at warn (node_modules/vue/dist/vue.runtime.common.dev.js:4516:21)
      at logError (node_modules/vue/dist/vue.runtime.common.dev.js:2917:9)
      at globalHandleError (node_modules/vue/dist/vue.runtime.common.dev.js:2913:5)
      at handleError (node_modules/vue/dist/vue.runtime.common.dev.js:2880:9)
      at invokeWithErrorHandling (node_modules/vue/dist/vue.runtime.common.dev.js:2896:9)
      at Vue.$emit (node_modules/vue/dist/vue.runtime.common.dev.js:3638:17)
      at $emit (src/components/LeftSidebar/LeftSidebar.vue:346:14)
      at tryCatch (src/components/LeftSidebar/LeftSidebar.vue:48:2404)
      at Generator._invoke (src/components/LeftSidebar/LeftSidebar.vue:48:1964)
      at Generator.next (src/components/LeftSidebar/LeftSidebar.vue:48:3255)
      at asyncGeneratorStep (src/components/LeftSidebar/LeftSidebar.vue:50:103)
      at _next (src/components/LeftSidebar/LeftSidebar.vue:52:194)

    console.error
      TypeError: unreadMentions.forEach is not a function
          at VueComponent.forEach (/home/nickv/Nextcloud/25/server/appsbabies/spreed/src/components/LeftSidebar/LeftSidebar.vue:369:20)
          at Vue.on (/home/nickv/Nextcloud/25/server/appsbabies/spreed/node_modules/vue/dist/vue.runtime.common.dev.js:3579:16)
          at invokeWithErrorHandling (/home/nickv/Nextcloud/25/server/appsbabies/spreed/node_modules/vue/dist/vue.runtime.common.dev.js:2889:30)
          at Vue.$emit (/home/nickv/Nextcloud/25/server/appsbabies/spreed/node_modules/vue/dist/vue.runtime.common.dev.js:3638:17)
          at $emit (/home/nickv/Nextcloud/25/server/appsbabies/spreed/src/components/LeftSidebar/LeftSidebar.vue:346:14)
          at tryCatch (/home/nickv/Nextcloud/25/server/appsbabies/spreed/src/components/LeftSidebar/LeftSidebar.vue:48:2404)
          at Generator._invoke (/home/nickv/Nextcloud/25/server/appsbabies/spreed/src/components/LeftSidebar/LeftSidebar.vue:48:1964)
          at Generator.next (/home/nickv/Nextcloud/25/server/appsbabies/spreed/src/components/LeftSidebar/LeftSidebar.vue:48:3255)
          at asyncGeneratorStep (/home/nickv/Nextcloud/25/server/appsbabies/spreed/src/components/LeftSidebar/LeftSidebar.vue:50:103)
          at _next (/home/nickv/Nextcloud/25/server/appsbabies/spreed/src/components/LeftSidebar/LeftSidebar.vue:52:194)
          at processTicksAndRejections (node:internal/process/task_queues:96:5)

      344 |
      345 | 		async fetchListedConversations() {
    > 346 | 			try {
          | 			          ^
      347 | 				this.listedConversationsLoading = true
      348 |
      349 | 				// FIXME: move to conversationsStore

      at logError (node_modules/vue/dist/vue.runtime.common.dev.js:2921:17)
      at globalHandleError (node_modules/vue/dist/vue.runtime.common.dev.js:2913:5)
      at handleError (node_modules/vue/dist/vue.runtime.common.dev.js:2880:9)
      at invokeWithErrorHandling (node_modules/vue/dist/vue.runtime.common.dev.js:2896:9)
      at Vue.$emit (node_modules/vue/dist/vue.runtime.common.dev.js:3638:17)
      at $emit (src/components/LeftSidebar/LeftSidebar.vue:346:14)
      at tryCatch (src/components/LeftSidebar/LeftSidebar.vue:48:2404)
      at Generator._invoke (src/components/LeftSidebar/LeftSidebar.vue:48:1964)
      at Generator.next (src/components/LeftSidebar/LeftSidebar.vue:48:3255)
      at asyncGeneratorStep (src/components/LeftSidebar/LeftSidebar.vue:50:103)
      at _next (src/components/LeftSidebar/LeftSidebar.vue:52:194)
```