### PR TITLE
Fix console error '[vuex] duplicate getter key: reactionsLoaded' in jest

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
@@ -864,8 +864,8 @@ describe('Message.vue', () => {
 			const userHasReactedGetter = jest.fn().mockReturnValue(() => false)
 			const reactionsLoadedGetter = jest.fn().mockReturnValue(() => true)
 			testStoreConfig.modules.messagesStore.actions.addReactionToMessage = addReactionToMessageAction
-			testStoreConfig.modules.messagesStore.getters.userHasReacted = userHasReactedGetter
-			testStoreConfig.modules.messagesStore.getters.reactionsLoaded = reactionsLoadedGetter
+			testStoreConfig.modules.reactionsStore.getters.userHasReacted = userHasReactedGetter
+			testStoreConfig.modules.reactionsStore.getters.reactionsLoaded = reactionsLoadedGetter
 
 			store = new Store(testStoreConfig)
 
@@ -907,8 +907,8 @@ describe('Message.vue', () => {
 			const userHasReactedGetter = jest.fn().mockReturnValue(() => true)
 			const reactionsLoadedGetter = jest.fn().mockReturnValue(() => true)
 			testStoreConfig.modules.messagesStore.actions.removeReactionFromMessage = removeReactionFromMessageAction
-			testStoreConfig.modules.messagesStore.getters.userHasReacted = userHasReactedGetter
-			testStoreConfig.modules.messagesStore.getters.reactionsLoaded = reactionsLoadedGetter
+			testStoreConfig.modules.reactionsStore.getters.userHasReacted = userHasReactedGetter
+			testStoreConfig.modules.reactionsStore.getters.reactionsLoaded = reactionsLoadedGetter
 
 			store = new Store(testStoreConfig)
 


### PR DESCRIPTION
```
console.error
      [vuex] duplicate getter key: reactionsLoaded

      915 | 			testStoreConfig.modules.messagesStore.getters.reactionsLoaded = reactionsLoadedGetter
      916 |
    > 917 | 			store = new Store(testStoreConfig)
          | 			        ^
      918 |
      919 | 			const messagePropsWithReactions = Object.assign({}, messageProps)
      920 | 			messagePropsWithReactions.reactions = { '❤️': 1 }

      at registerGetter (node_modules/vuex/dist/vuex.common.js:878:15)
      at node_modules/vuex/dist/vuex.common.js:751:5
      at node_modules/vuex/dist/vuex.common.js:125:52
          at Array.forEach (<anonymous>)
      at forEachValue (node_modules/vuex/dist/vuex.common.js:125:20)
      at Module.forEachGetter (node_modules/vuex/dist/vuex.common.js:200:5)
      at installModule (node_modules/vuex/dist/vuex.common.js:749:10)
      at node_modules/vuex/dist/vuex.common.js:755:5
      at node_modules/vuex/dist/vuex.common.js:125:52
          at Array.forEach (<anonymous>)
      at forEachValue (node_modules/vuex/dist/vuex.common.js:125:20)
      at Module.forEachChild (node_modules/vuex/dist/vuex.common.js:195:3)
      at installModule (node_modules/vuex/dist/vuex.common.js:754:10)
      at new Store (node_modules/vuex/dist/vuex.common.js:422:3)
      at _callee10$ (src/components/MessagesList/MessagesGroup/Message/Message.spec.js:917:12)
      at tryCatch (src/components/MessagesList/MessagesGroup/Message/Message.spec.js:51:2404)
      at Generator._invoke (src/components/MessagesList/MessagesGroup/Message/Message.spec.js:51:1964)
      at Generator.next (src/components/MessagesList/MessagesGroup/Message/Message.spec.js:51:3255)
      at asyncGeneratorStep (src/components/MessagesList/MessagesGroup/Message/Message.spec.js:53:103)
      at _next (src/components/MessagesList/MessagesGroup/Message/Message.spec.js:55:194)
      at src/components/MessagesList/MessagesGroup/Message/Message.spec.js:55:364
      at Object.<anonymous> (src/components/MessagesList/MessagesGroup/Message/Message.spec.js:55:97)

    console.error
      [vuex] duplicate getter key: userHasReacted

      915 | 			testStoreConfig.modules.messagesStore.getters.reactionsLoaded = reactionsLoadedGetter
      916 |
    > 917 | 			store = new Store(testStoreConfig)
          | 			        ^
      918 |
      919 | 			const messagePropsWithReactions = Object.assign({}, messageProps)
      920 | 			messagePropsWithReactions.reactions = { '❤️': 1 }

      at registerGetter (node_modules/vuex/dist/vuex.common.js:878:15)
      at node_modules/vuex/dist/vuex.common.js:751:5
      at node_modules/vuex/dist/vuex.common.js:125:52
          at Array.forEach (<anonymous>)
      at forEachValue (node_modules/vuex/dist/vuex.common.js:125:20)
      at Module.forEachGetter (node_modules/vuex/dist/vuex.common.js:200:5)
      at installModule (node_modules/vuex/dist/vuex.common.js:749:10)
      at node_modules/vuex/dist/vuex.common.js:755:5
      at node_modules/vuex/dist/vuex.common.js:125:52
          at Array.forEach (<anonymous>)
      at forEachValue (node_modules/vuex/dist/vuex.common.js:125:20)
      at Module.forEachChild (node_modules/vuex/dist/vuex.common.js:195:3)
      at installModule (node_modules/vuex/dist/vuex.common.js:754:10)
      at new Store (node_modules/vuex/dist/vuex.common.js:422:3)
      at _callee10$ (src/components/MessagesList/MessagesGroup/Message/Message.spec.js:917:12)
      at tryCatch (src/components/MessagesList/MessagesGroup/Message/Message.spec.js:51:2404)
      at Generator._invoke (src/components/MessagesList/MessagesGroup/Message/Message.spec.js:51:1964)
      at Generator.next (src/components/MessagesList/MessagesGroup/Message/Message.spec.js:51:3255)
      at asyncGeneratorStep (src/components/MessagesList/MessagesGroup/Message/Message.spec.js:53:103)
      at _next (src/components/MessagesList/MessagesGroup/Message/Message.spec.js:55:194)
      at src/components/MessagesList/MessagesGroup/Message/Message.spec.js:55:364
      at Object.<anonymous> (src/components/MessagesList/MessagesGroup/Message/Message.spec.js:55:97)
```