### PR TITLE
Fix new-conversation padding

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -514,7 +514,7 @@ export default {
 
 .new-conversation {
 	display: flex;
-	padding: 6px 0 6px 10px;
+	padding: 8px 0 8px 12px;
 	align-items: center;
 	&--scrolled-down {
 		border-bottom: 1px solid var(--color-placeholder-dark);


### PR DESCRIPTION
Signed-off-by: Marco <marcoambrosini@icloud.com>

before:
<img width="352" alt="Screenshot 2022-09-22 at 08 49 21" src="https://user-images.githubusercontent.com/26852655/191678220-dcd87e75-5555-46f9-85a2-54231578d96d.png">

After: 
<img width="352" alt="Screenshot 2022-09-22 at 08 49 15" src="https://user-images.githubusercontent.com/26852655/191678256-ed4e1fd6-9ac5-4d5a-a018-68777c68e08a.png">
