### PR TITLE
Improve emojipicker placement

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -122,6 +122,8 @@
 				</template>
 			</NcButton>
 			<NcEmojiPicker :container="`#message_${id} .message-buttons-bar`"
+				:boundary="containerElement"
+				placement="auto"
 				@select="handleReactionClick"
 				@after-show="onEmojiPickerOpen"
 				@after-hide="onEmojiPickerClose">


### PR DESCRIPTION
Improves the placement a bit, but possibly we should have a tripped down emoji-picker for smaller screeens?

<img width="917" alt="Screenshot 2022-09-23 at 12 49 14" src="https://user-images.githubusercontent.com/26852655/191952420-0828d4ed-8007-44f0-90b8-252fa169c1ca.png">


Signed-off-by: Marco <marcoambrosini@icloud.com>