### PR TITLE
🏷️ /call/ reference provider

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\AppInfo;
 
+use OCA\Talk\Collaboration\Reference\TalkReferenceProvider;
 use OCP\Util;
 use OCA\Circles\Events\AddingCircleMemberEvent;
 use OCA\Circles\Events\CircleDestroyedEvent;
@@ -144,6 +145,8 @@ class Application extends App implements IBootstrap {
 		$context->registerDashboardWidget(TalkWidget::class);
 
 		$context->registerProfileLinkAction(TalkAction::class);
+
+		$context->registerReferenceProvider(TalkReferenceProvider::class);
 
 		$context->registerTalkBackend(TalkBackend::class);
 	}

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\AppInfo;
 
+use OCA\Talk\Collaboration\Reference\ReferenceInvalidationListener;
 use OCA\Talk\Collaboration\Reference\TalkReferenceProvider;
 use OCP\Util;
 use OCA\Circles\Events\AddingCircleMemberEvent;
@@ -175,6 +176,7 @@ class Application extends App implements IBootstrap {
 		CommandListener::register($dispatcher);
 		CollaboratorsListener::register($dispatcher);
 		ResourceListener::register($dispatcher);
+		ReferenceInvalidationListener::register($dispatcher);
 		// Register only when Talk Updates are not disabled
 		if ($server->getConfig()->getAppValue('spreed', 'changelog', 'yes') === 'yes') {
 			ChangelogListener::register($dispatcher);

--- a/lib/Collaboration/Reference/ReferenceInvalidationListener.php
+++ b/lib/Collaboration/Reference/ReferenceInvalidationListener.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Collaboration\Reference;
+
+use OCA\Talk\Events\RoomEvent;
+use OCA\Talk\Room;
+use OCP\Collaboration\Reference\IReferenceManager;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Server;
+
+class ReferenceInvalidationListener {
+	public static function register(IEventDispatcher $dispatcher): void {
+		$listener = static function (RoomEvent $event): void {
+			$room = $event->getRoom();
+			$referenceManager = Server::get(IReferenceManager::class);
+
+			$referenceManager->invalidateCache($room->getToken());
+		};
+
+		$dispatcher->addListener(Room::EVENT_AFTER_ROOM_DELETE, $listener);
+		$dispatcher->addListener(Room::EVENT_AFTER_USERS_ADD, $listener);
+		$dispatcher->addListener(Room::EVENT_AFTER_USER_REMOVE, $listener);
+		$dispatcher->addListener(Room::EVENT_AFTER_DESCRIPTION_SET, $listener);
+		$dispatcher->addListener(Room::EVENT_AFTER_LISTABLE_SET, $listener);
+		$dispatcher->addListener(Room::EVENT_AFTER_LOBBY_STATE_SET, $listener);
+		$dispatcher->addListener(Room::EVENT_AFTER_NAME_SET, $listener);
+		$dispatcher->addListener(Room::EVENT_AFTER_PARTICIPANT_REMOVE, $listener);
+		$dispatcher->addListener(Room::EVENT_AFTER_PASSWORD_SET, $listener);
+		$dispatcher->addListener(Room::EVENT_AFTER_SET_MESSAGE_EXPIRATION, $listener);
+	}
+}

--- a/lib/Collaboration/Reference/TalkReferenceProvider.php
+++ b/lib/Collaboration/Reference/TalkReferenceProvider.php
@@ -255,19 +255,13 @@ class TalkReferenceProvider implements IReferenceProvider {
 
 	protected function getRoomIconUrl(Room $room, string $userId): string {
 		if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
-			$participants = json_decode($room->getName(), true);
-
-			foreach ($participants as $p) {
-				if ($p !== $userId) {
-					return $this->urlGenerator->linkToRouteAbsolute(
-						'core.avatar.getAvatar',
-						[
-							'userId' => $p,
-							'size' => 64,
-						]
-					);
-				}
-			}
+			return $this->urlGenerator->linkToRouteAbsolute(
+				'core.avatar.getAvatar',
+				[
+					'userId' => $room->getSecondParticipant($userId),
+					'size' => 64,
+				]
+			);
 		}
 
 		return $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('spreed', 'changelog.svg'));

--- a/lib/Collaboration/Reference/TalkReferenceProvider.php
+++ b/lib/Collaboration/Reference/TalkReferenceProvider.php
@@ -1,6 +1,7 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2022 Joas Schilling <coding@schilljs.com>
  *
@@ -22,28 +23,43 @@ declare(strict_types = 1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 namespace OCA\Talk\Collaboration\Reference;
 
+use OCA\Talk\Chat\ChatManager;
+use OCA\Talk\Chat\MessageParser;
+use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Exceptions\RoomNotFoundException;
 use OCA\Talk\Manager;
+use OCA\Talk\Model\Attendee;
 use OCA\Talk\Room;
 use OCP\Collaboration\Reference\IReference;
 use OCP\Collaboration\Reference\IReferenceProvider;
 use OCP\Collaboration\Reference\Reference;
+use OCP\IL10N;
 use OCP\IURLGenerator;
 
+/**
+ * @psalm-type ReferenceMatch = array{token: string, message: ?int}
+ */
 class TalkReferenceProvider implements IReferenceProvider {
-
 	protected IURLGenerator $urlGenerator;
-	protected Manager $manager;
+	protected Manager $roomManager;
+	protected ChatManager $chatManager;
+	protected MessageParser $messageParser;
+	protected IL10N $l;
 	protected ?string $userId;
 
 	public function __construct(IURLGenerator $urlGenerator,
 								Manager $manager,
+								ChatManager $chatManager,
+								MessageParser $messageParser,
+								IL10N $l,
 								?string $userId) {
 		$this->urlGenerator = $urlGenerator;
-		$this->manager = $manager;
+		$this->roomManager = $manager;
+		$this->chatManager = $chatManager;
+		$this->messageParser = $messageParser;
+		$this->l = $l;
 		$this->userId = $userId;
 	}
 
@@ -52,18 +68,54 @@ class TalkReferenceProvider implements IReferenceProvider {
 		return $this->getTalkAppLinkToken($referenceText) !== null;
 	}
 
-	private function getTalkAppLinkToken(string $referenceText): ?string {
+	/**
+	 * @param string $referenceText
+	 * @return array|null
+	 * @psalm-return ReferenceMatch|null
+	 */
+	private function getTalkAppLinkToken(string $referenceText): ?array {
 		$indexPhpUrl = $this->urlGenerator->getAbsoluteURL('/index.php/call/');
-		if (str_starts_with($referenceText, $indexPhpUrl)) {
-			return substr($referenceText, strlen($indexPhpUrl)) ?: null;
-		}
-
 		$rewriteUrl = $this->urlGenerator->getAbsoluteURL('/call/');
-		if (str_starts_with($referenceText, $rewriteUrl)) {
-			return substr($referenceText, strlen($rewriteUrl)) ?: null;
+
+		if (str_starts_with($referenceText, $indexPhpUrl)) {
+			$urlOfInterest = substr($referenceText, strlen($indexPhpUrl)) ?: null;
+		} elseif (str_starts_with($referenceText, $rewriteUrl)) {
+			$urlOfInterest = substr($referenceText, strlen($rewriteUrl)) ?: null;
+		} else {
+			return null;
 		}
 
-		return null;
+		$hashPosition = strpos($urlOfInterest, '#');
+		$queryPosition = strpos($urlOfInterest, '?');
+
+		if ($hashPosition === false && $queryPosition === false) {
+			return [
+				'token' => $urlOfInterest,
+				'message' => null,
+			];
+		}
+
+		if ($hashPosition !== false && $queryPosition !== false) {
+			$cutPosition = min($hashPosition, $queryPosition);
+		} elseif ($hashPosition !== false) {
+			$cutPosition = $hashPosition;
+		} else {
+			$cutPosition = $queryPosition;
+		}
+
+		$token = substr($urlOfInterest, 0, $cutPosition);
+		$messageId = null;
+		if ($hashPosition !== false) {
+			$afterHash = substr($urlOfInterest, $hashPosition + 1);
+			if (preg_match('/^message_(\d+)$/', $afterHash, $matches)) {
+				$messageId = $matches[1];
+			}
+		}
+
+		return [
+			'token' => $token,
+			'message' => $messageId,
+		];
 	}
 
 	/**
@@ -74,7 +126,7 @@ class TalkReferenceProvider implements IReferenceProvider {
 			$reference = new Reference($referenceText);
 			try {
 				$this->fetchReference($reference);
-			} catch (RoomNotFoundException $e) {
+			} catch (RoomNotFoundException|ParticipantNotFoundException $e) {
 				$reference->setRichObject('call', null);
 				$reference->setAccessible(false);
 			}
@@ -92,21 +144,82 @@ class TalkReferenceProvider implements IReferenceProvider {
 			throw new RoomNotFoundException();
 		}
 
-		$token = $this->getTalkAppLinkToken($reference->getId());
-		if ($token === null) {
+		$referenceMatch = $this->getTalkAppLinkToken($reference->getId());
+		if ($referenceMatch === null) {
 			throw new RoomNotFoundException();
 		}
 
-		$room = $this->manager->getRoomByToken($token, $this->userId);
+		$room = $this->roomManager->getRoomForUserByToken($referenceMatch['token'], $this->userId);
 
-		$reference->setTitle($room->getDisplayName($this->userId));
-		$reference->setDescription($room->getDescription());
+		/**
+		 * Default handling:
+		 * Title is the conversation name
+		 * Description the conversation description
+		 */
+		$roomName = $room->getDisplayName($this->userId);
+		$title = $roomName;
+		$description = $room->getDescription();
+
+		$participant = null;
+		if (!empty($referenceMatch['message'])) {
+			try {
+				$participant = $room->getParticipant($this->userId);
+			} catch (ParticipantNotFoundException $e) {
+			}
+		}
+
+		/**
+		 * If linking to a comment and the user is already a participant
+		 * Title is "Message of {user} in {conversation}"
+		 * Description is the plain text chat message
+		 */
+		if ($participant && !empty($referenceMatch['message'])) {
+			$comment = $this->chatManager->getComment($room, $referenceMatch['message']);
+			$message = $this->messageParser->createMessage($room, $participant, $comment, $this->l);
+			$this->messageParser->parseMessage($message);
+
+			$placeholders = $replacements = [];
+			foreach ($message->getMessageParameters() as $placeholder => $parameter) {
+				$placeholders[] = '{' . $placeholder . '}';
+				if ($parameter['type'] === 'user' || $parameter['type'] === 'guest') {
+					$replacements[] = '@' . $parameter['name'];
+				} else {
+					$replacements[] = $parameter['name'];
+				}
+			}
+			$description = str_replace($placeholders, $replacements, $message->getMessage());
+
+			$titleLine = $this->l->t('Message of {user} in {conversation}');
+			if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+				$titleLine = $this->l->t('Message of {user}');
+			}
+
+			$displayName = $message->getActorDisplayName();
+			if ($message->getActorType() === Attendee::ACTOR_GUESTS) {
+				if ($displayName === '') {
+					$displayName = $this->l->t('Guest');
+				} else {
+					$displayName = $this->l->t('%s (guest)', $displayName);
+				}
+			} elseif ($displayName === '') {
+				$titleLine = $this->l->t('Message of a deleted user in {conversation}');
+			}
+
+			$title = str_replace(
+				['{user}', '{conversation}'],
+				[$displayName, $title],
+				$titleLine
+			);
+		}
+
+		$reference->setTitle($title);
+		$reference->setDescription($description);
 		$reference->setUrl($this->urlGenerator->linkToRouteAbsolute('spreed.Page.showCall', ['token' => $room->getToken()]));
 		$reference->setImageUrl($this->getRoomIconUrl($room, $this->userId));
 
 		$reference->setRichObject('call', [
 			'id' => $room->getToken(),
-			'name' => $reference->getTitle(),
+			'name' => $roomName,
 			'link' => $reference->getUrl(),
 			'call-type' => $this->getRoomType($room),
 		]);
@@ -116,7 +229,12 @@ class TalkReferenceProvider implements IReferenceProvider {
 	 * @inheritDoc
 	 */
 	public function getCachePrefix(string $referenceId): string {
-		return $this->getTalkAppLinkToken($referenceId) ?? '';
+		$referenceMatch = $this->getTalkAppLinkToken($referenceId);
+		if ($referenceMatch === null) {
+			return '';
+		}
+
+		return $referenceMatch['token'] . '#' . ($referenceMatch['message'] ?? 0);
 	}
 
 	/**

--- a/lib/Collaboration/Reference/TalkReferenceProvider.php
+++ b/lib/Collaboration/Reference/TalkReferenceProvider.php
@@ -234,14 +234,19 @@ class TalkReferenceProvider implements IReferenceProvider {
 			return '';
 		}
 
-		return $referenceMatch['token'] . '#' . ($referenceMatch['message'] ?? 0);
+		return $referenceMatch['token'];
 	}
 
 	/**
 	 * @inheritDoc
 	 */
 	public function getCacheKey(string $referenceId): ?string {
-		return $this->userId ?? '';
+		$referenceMatch = $this->getTalkAppLinkToken($referenceId);
+		if ($referenceMatch === null) {
+			return '';
+		}
+
+		return ($this->userId ?? '') . '#' . ($referenceMatch['message'] ?? 0);
 	}
 
 	protected function getRoomIconUrl(Room $room, string $userId): string {

--- a/lib/Collaboration/Reference/TalkReferenceProvider.php
+++ b/lib/Collaboration/Reference/TalkReferenceProvider.php
@@ -40,7 +40,7 @@ use OCP\IL10N;
 use OCP\IURLGenerator;
 
 /**
- * @psalm-type ReferenceMatch = array{token: string, message: ?int}
+ * @psalm-type ReferenceMatch = array{token: string, message: int|null}
  */
 class TalkReferenceProvider implements IReferenceProvider {
 	protected IURLGenerator $urlGenerator;
@@ -79,9 +79,9 @@ class TalkReferenceProvider implements IReferenceProvider {
 		$rewriteUrl = $this->urlGenerator->getAbsoluteURL('/call/');
 
 		if (str_starts_with($referenceText, $indexPhpUrl)) {
-			$urlOfInterest = substr($referenceText, strlen($indexPhpUrl)) ?: null;
+			$urlOfInterest = substr($referenceText, strlen($indexPhpUrl));
 		} elseif (str_starts_with($referenceText, $rewriteUrl)) {
-			$urlOfInterest = substr($referenceText, strlen($rewriteUrl)) ?: null;
+			$urlOfInterest = substr($referenceText, strlen($rewriteUrl));
 		} else {
 			return null;
 		}
@@ -178,7 +178,7 @@ class TalkReferenceProvider implements IReferenceProvider {
 		 * Description is the plain text chat message
 		 */
 		if ($participant && !empty($referenceMatch['message'])) {
-			$comment = $this->chatManager->getComment($room, $referenceMatch['message']);
+			$comment = $this->chatManager->getComment($room, (string) $referenceMatch['message']);
 			$message = $this->messageParser->createMessage($room, $participant, $comment, $this->l);
 			$this->messageParser->parseMessage($message);
 

--- a/lib/Collaboration/Reference/TalkReferenceProvider.php
+++ b/lib/Collaboration/Reference/TalkReferenceProvider.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types = 1);
+/**
+ * @copyright Copyright (c) 2022 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+namespace OCA\Talk\Collaboration\Reference;
+
+use OCA\Talk\Exceptions\RoomNotFoundException;
+use OCA\Talk\Manager;
+use OCA\Talk\Room;
+use OCP\Collaboration\Reference\IReference;
+use OCP\Collaboration\Reference\IReferenceProvider;
+use OCP\Collaboration\Reference\Reference;
+use OCP\IURLGenerator;
+
+class TalkReferenceProvider implements IReferenceProvider {
+
+	protected IURLGenerator $urlGenerator;
+	protected Manager $manager;
+	protected ?string $userId;
+
+	public function __construct(IURLGenerator $urlGenerator,
+								Manager $manager,
+								?string $userId) {
+		$this->urlGenerator = $urlGenerator;
+		$this->manager = $manager;
+		$this->userId = $userId;
+	}
+
+
+	public function matchReference(string $referenceText): bool {
+		return $this->getTalkAppLinkToken($referenceText) !== null;
+	}
+
+	private function getTalkAppLinkToken(string $referenceText): ?string {
+		$indexPhpUrl = $this->urlGenerator->getAbsoluteURL('/index.php/call/');
+		if (str_starts_with($referenceText, $indexPhpUrl)) {
+			return substr($referenceText, strlen($indexPhpUrl)) ?: null;
+		}
+
+		$rewriteUrl = $this->urlGenerator->getAbsoluteURL('/call/');
+		if (str_starts_with($referenceText, $rewriteUrl)) {
+			return substr($referenceText, strlen($rewriteUrl)) ?: null;
+		}
+
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function resolveReference(string $referenceText): ?IReference {
+		if ($this->matchReference($referenceText)) {
+			$reference = new Reference($referenceText);
+			try {
+				$this->fetchReference($reference);
+			} catch (RoomNotFoundException $e) {
+				$reference->setRichObject('call', null);
+				$reference->setAccessible(false);
+			}
+			return $reference;
+		}
+
+		return null;
+	}
+
+	/**
+	 * @throws RoomNotFoundException
+	 */
+	private function fetchReference(Reference $reference): void {
+		if ($this->userId === null) {
+			throw new RoomNotFoundException();
+		}
+
+		$token = $this->getTalkAppLinkToken($reference->getId());
+		if ($token === null) {
+			throw new RoomNotFoundException();
+		}
+
+		$room = $this->manager->getRoomByToken($token, $this->userId);
+
+		$reference->setTitle($room->getDisplayName($this->userId));
+		$reference->setDescription($room->getDescription());
+		$reference->setUrl($this->urlGenerator->linkToRouteAbsolute('spreed.Page.showCall', ['token' => $room->getToken()]));
+		$reference->setImageUrl($this->getRoomIconUrl($room, $this->userId));
+
+		$reference->setRichObject('call', [
+			'id' => $room->getToken(),
+			'name' => $reference->getTitle(),
+			'link' => $reference->getUrl(),
+			'call-type' => $this->getRoomType($room),
+		]);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getCachePrefix(string $referenceId): string {
+		return $this->getTalkAppLinkToken($referenceId) ?? '';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getCacheKey(string $referenceId): ?string {
+		return $this->userId ?? '';
+	}
+
+	protected function getRoomIconUrl(Room $room, string $userId): string {
+		if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+			$participants = json_decode($room->getName(), true);
+
+			foreach ($participants as $p) {
+				if ($p !== $userId) {
+					return $this->urlGenerator->linkToRouteAbsolute(
+						'core.avatar.getAvatar',
+						[
+							'userId' => $p,
+							'size' => 64,
+						]
+					);
+				}
+			}
+		}
+
+		return $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('spreed', 'changelog.svg'));
+	}
+
+	protected function getRoomType(Room $room): string {
+		switch ($room->getType()) {
+			case Room::TYPE_ONE_TO_ONE:
+				return 'one2one';
+			case Room::TYPE_GROUP:
+				return 'group';
+			case Room::TYPE_PUBLIC:
+				return 'public';
+			default:
+				return 'unknown';
+		}
+	}
+}

--- a/lib/Collaboration/Reference/TalkReferenceProvider.php
+++ b/lib/Collaboration/Reference/TalkReferenceProvider.php
@@ -74,7 +74,7 @@ class TalkReferenceProvider implements IReferenceProvider {
 	 * @return array|null
 	 * @psalm-return ReferenceMatch|null
 	 */
-	private function getTalkAppLinkToken(string $referenceText): ?array {
+	protected function getTalkAppLinkToken(string $referenceText): ?array {
 		$indexPhpUrl = $this->urlGenerator->getAbsoluteURL('/index.php/call/');
 		$rewriteUrl = $this->urlGenerator->getAbsoluteURL('/call/');
 
@@ -109,7 +109,7 @@ class TalkReferenceProvider implements IReferenceProvider {
 		if ($hashPosition !== false) {
 			$afterHash = substr($urlOfInterest, $hashPosition + 1);
 			if (preg_match('/^message_(\d+)$/', $afterHash, $matches)) {
-				$messageId = $matches[1];
+				$messageId = (int) $matches[1];
 			}
 		}
 
@@ -140,7 +140,7 @@ class TalkReferenceProvider implements IReferenceProvider {
 	/**
 	 * @throws RoomNotFoundException
 	 */
-	private function fetchReference(Reference $reference): void {
+	protected function fetchReference(Reference $reference): void {
 		if ($this->userId === null) {
 			throw new RoomNotFoundException();
 		}

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -369,6 +369,21 @@ class Room {
 		return $this->name;
 	}
 
+	public function getSecondParticipant(string $userId): string {
+		if ($this->getType() !== self::TYPE_ONE_TO_ONE) {
+			throw new \InvalidArgumentException('Not a one-to-one room');
+		}
+		$participants = json_decode($this->getName(), true);
+
+		foreach ($participants as $uid) {
+			if ($uid !== $userId) {
+				return $uid;
+			}
+		}
+
+		return $this->getName();
+	}
+
 	public function getDisplayName(string $userId): string {
 		return $this->manager->resolveRoomDisplayName($this, $userId);
 	}

--- a/tests/php/Chat/ChatManagerTest.php
+++ b/tests/php/Chat/ChatManagerTest.php
@@ -27,7 +27,6 @@ namespace OCA\Talk\Tests\php\Chat;
 use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Chat\Notifier;
-use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\AttendeeMapper;
 use OCA\Talk\Participant;
@@ -37,6 +36,7 @@ use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\PollService;
 use OCA\Talk\Share\RoomShareProvider;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Collaboration\Reference\IReferenceManager;
 use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -61,8 +61,6 @@ class ChatManagerTest extends TestCase {
 	protected $notificationManager;
 	/** @var IManager|MockObject */
 	protected $shareManager;
-	/** @var Manager|MockObject */
-	protected $manager;
 	/** @var RoomShareProvider|MockObject */
 	protected $shareProvider;
 	/** @var ParticipantService|MockObject */
@@ -75,6 +73,8 @@ class ChatManagerTest extends TestCase {
 	protected $timeFactory;
 	/** @var AttachmentService|MockObject */
 	protected $attachmentService;
+	/** @var IReferenceManager|MockObject */
+	protected $referenceManager;
 	protected ?ChatManager $chatManager = null;
 
 	public function setUp(): void {
@@ -84,13 +84,13 @@ class ChatManagerTest extends TestCase {
 		$this->dispatcher = $this->createMock(IEventDispatcher::class);
 		$this->notificationManager = $this->createMock(INotificationManager::class);
 		$this->shareManager = $this->createMock(IManager::class);
-		$this->manager = $this->createMock(Manager::class);
 		$this->shareProvider = $this->createMock(RoomShareProvider::class);
 		$this->participantService = $this->createMock(ParticipantService::class);
 		$this->pollService = $this->createMock(PollService::class);
 		$this->notifier = $this->createMock(Notifier::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->attachmentService = $this->createMock(AttachmentService::class);
+		$this->referenceManager = $this->createMock(IReferenceManager::class);
 		$cacheFactory = $this->createMock(ICacheFactory::class);
 
 		$this->chatManager = new ChatManager(
@@ -99,14 +99,14 @@ class ChatManagerTest extends TestCase {
 			\OC::$server->getDatabaseConnection(),
 			$this->notificationManager,
 			$this->shareManager,
-			$this->manager,
 			$this->shareProvider,
 			$this->participantService,
 			$this->pollService,
 			$this->notifier,
 			$cacheFactory,
 			$this->timeFactory,
-			$this->attachmentService
+			$this->attachmentService,
+			$this->referenceManager
 		);
 	}
 
@@ -125,7 +125,6 @@ class ChatManagerTest extends TestCase {
 					\OC::$server->getDatabaseConnection(),
 					$this->notificationManager,
 					$this->shareManager,
-					$this->manager,
 					$this->shareProvider,
 					$this->participantService,
 					$this->pollService,
@@ -133,6 +132,7 @@ class ChatManagerTest extends TestCase {
 					$cacheFactory,
 					$this->timeFactory,
 					$this->attachmentService,
+					$this->referenceManager,
 				])
 				->onlyMethods($methods)
 				->getMock();
@@ -144,14 +144,14 @@ class ChatManagerTest extends TestCase {
 			\OC::$server->getDatabaseConnection(),
 			$this->notificationManager,
 			$this->shareManager,
-			$this->manager,
 			$this->shareProvider,
 			$this->participantService,
 			$this->pollService,
 			$this->notifier,
 			$cacheFactory,
 			$this->timeFactory,
-			$this->attachmentService
+			$this->attachmentService,
+			$this->referenceManager
 		);
 	}
 

--- a/tests/php/Collaboration/Reference/TalkReferenceProviderTest.php
+++ b/tests/php/Collaboration/Reference/TalkReferenceProviderTest.php
@@ -27,19 +27,9 @@ namespace OCA\Talk\Tests\php\Collaboration\Resources;
 use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Chat\MessageParser;
 use OCA\Talk\Collaboration\Reference\TalkReferenceProvider;
-use OCA\Talk\Collaboration\Resources\ConversationProvider;
-use OCA\Talk\Exceptions\ParticipantNotFoundException;
-use OCA\Talk\Exceptions\RoomNotFoundException;
 use OCA\Talk\Manager;
-use OCA\Talk\Model\Attendee;
-use OCA\Talk\Participant;
-use OCA\Talk\Room;
-use OCP\Collaboration\Resources\IResource;
-use OCP\Collaboration\Resources\ResourceException;
 use OCP\IL10N;
 use OCP\IURLGenerator;
-use OCP\IUser;
-use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -97,7 +87,7 @@ class TalkReferenceProviderTest extends TestCase {
 	public function testGetTalkAppLinkToken(string $reference, ?array $expected): void {
 		$this->urlGenerator->expects($this->any())
 			->method('getAbsoluteURL')
-			->willReturnCallback(static fn($url) => 'https://localhost' . $url);
+			->willReturnCallback(static fn ($url) => 'https://localhost' . $url);
 
 		$actual = self::invokePrivate($this->provider, 'getTalkAppLinkToken', [$reference]);
 		self::assertSame($expected, $actual);

--- a/tests/php/Collaboration/Reference/TalkReferenceProviderTest.php
+++ b/tests/php/Collaboration/Reference/TalkReferenceProviderTest.php
@@ -1,0 +1,105 @@
+<?php
+
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Tests\php\Collaboration\Resources;
+
+use OCA\Talk\Chat\ChatManager;
+use OCA\Talk\Chat\MessageParser;
+use OCA\Talk\Collaboration\Reference\TalkReferenceProvider;
+use OCA\Talk\Collaboration\Resources\ConversationProvider;
+use OCA\Talk\Exceptions\ParticipantNotFoundException;
+use OCA\Talk\Exceptions\RoomNotFoundException;
+use OCA\Talk\Manager;
+use OCA\Talk\Model\Attendee;
+use OCA\Talk\Participant;
+use OCA\Talk\Room;
+use OCP\Collaboration\Resources\IResource;
+use OCP\Collaboration\Resources\ResourceException;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class TalkReferenceProviderTest extends TestCase {
+	/** @var IURLGenerator|MockObject */
+	protected $urlGenerator;
+	/** @var Manager|MockObject */
+	protected $roomManager;
+	/** @var ChatManager|MockObject */
+	protected $chatManager;
+	/** @var MessageParser|MockObject */
+	protected $messageParser;
+	/** @var IL10N|MockObject */
+	protected $l;
+	protected ?TalkReferenceProvider $provider = null;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->roomManager = $this->createMock(Manager::class);
+		$this->chatManager = $this->createMock(ChatManager::class);
+		$this->messageParser = $this->createMock(MessageParser::class);
+		$this->l = $this->createMock(IL10N::class);
+
+		$this->provider = new TalkReferenceProvider(
+			$this->urlGenerator,
+			$this->roomManager,
+			$this->chatManager,
+			$this->messageParser,
+			$this->l,
+			'test'
+		);
+	}
+
+	public function dataGetTalkAppLinkToken(): array {
+		return [
+			['https://localhost/', null],
+			['https://localhost/call', null],
+			['https://localhost/call/abcdef', ['token' => 'abcdef', 'message' => null]],
+			['https://localhost/call/abcdef?query=1', ['token' => 'abcdef', 'message' => null]],
+			['https://localhost/call/abcdef#hash=1', ['token' => 'abcdef', 'message' => null]],
+			['https://localhost/call/abcdef#message_123', ['token' => 'abcdef', 'message' => 123]],
+			['https://localhost/call/abcdef?query=1#message_123', ['token' => 'abcdef', 'message' => 123]],
+			['https://localhost/call/abcdef?query=1#message_123bcd', ['token' => 'abcdef', 'message' => null]],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetTalkAppLinkToken
+	 * @param string $reference
+	 * @param array|null $expected
+	 * @return void
+	 */
+	public function testGetTalkAppLinkToken(string $reference, ?array $expected): void {
+		$this->urlGenerator->expects($this->any())
+			->method('getAbsoluteURL')
+			->willReturnCallback(static fn($url) => 'https://localhost' . $url);
+
+		$actual = self::invokePrivate($this->provider, 'getTalkAppLinkToken', [$reference]);
+		self::assertSame($expected, $actual);
+	}
+}


### PR DESCRIPTION
Fix #7988

### /call/…

* If the user is a participant
    * Title is the conversation name
    * Description the conversation description
* Open conversation joinable for the user
    * Title is the conversation name
    * Description the conversation description
* Public link (with and without password)
    * Title is the "Private conversation"
    * Description is empty

### /call/…#message_…

To get a closer preview the user needs to be a participant (open conversation or public link are not enough, in those cases the above information is shown)

* Title is "Message of {user} in {conversation}"
* Description is the plain text chat message

Participant | Stranger
---|---
![Bildschirmfoto vom 2022-09-23 14-47-20](https://user-images.githubusercontent.com/213943/191969909-28419148-7995-41e0-8530-6d39b73c22fd.png) | ![Bildschirmfoto vom 2022-09-23 14-47-47](https://user-images.githubusercontent.com/213943/191969915-adb538cb-bb00-446c-a4bd-442ccf844e38.png)
