### PR TITLE
Empty iceServers.urls handling fix

### DIFF
--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -1,5 +1,6 @@
 <!--
  - @copyright Copyright (c) 2019 Joas Schilling <coding@schilljs.com>
+ - @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  -
  - @author Joas Schilling <coding@schilljs.com>
  -
@@ -234,11 +235,19 @@ export default {
 			}
 
 			// Create a PeerConnection with no streams, but force a m=audio line.
-			const config = {
-				iceServers: [
-					iceServer,
-				],
-				iceTransportPolicy: 'relay',
+			// Only items with non-empty urls may occur in iceServers according to WebRTC spec.
+			if (urls.length) {
+				const config = {
+					iceServers: [
+						iceServer,
+					],
+					iceTransportPolicy: 'relay',
+				}
+			} else {
+				const config = {
+					iceServers: [],
+					iceTransportPolicy: 'relay',
+				}
 			}
 			const offerOptions = {
 				offerToReceiveAudio: 1,

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -1,6 +1,5 @@
 <!--
  - @copyright Copyright (c) 2019 Joas Schilling <coding@schilljs.com>
- - @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  -
  - @author Joas Schilling <coding@schilljs.com>
  -
@@ -235,19 +234,11 @@ export default {
 			}
 
 			// Create a PeerConnection with no streams, but force a m=audio line.
-			// Only items with non-empty urls may occur in iceServers according to WebRTC spec.
-			if (urls.length) {
-				const config = {
-					iceServers: [
-						iceServer,
-					],
-					iceTransportPolicy: 'relay',
-				}
-			} else {
-				const config = {
-					iceServers: [],
-					iceTransportPolicy: 'relay',
-				}
+			const config = {
+				iceServers: [
+					iceServer,
+				],
+				iceTransportPolicy: 'relay',
 			}
 			const offerOptions = {
 				offerToReceiveAudio: 1,

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -167,12 +167,26 @@ function SimpleWebRTC(opts) {
 
 	connection.on('stunservers', function(args) {
 		// resets/overrides the config
-		self.webrtc.config.peerConnectionConfig.iceServers = args
+		// Only items with non-empty urls may occur in iceServers according to WebRTC spec.
+		var stunServers = []
+		for (const stunServer of args) {
+			if (stunServer.urls && stunServer.urls.length) {
+				stunServers.push(stunServer)
+			}
+		}
+		self.webrtc.config.peerConnectionConfig.iceServers = stunServers
 		self.emit('stunservers', args)
 	})
 	connection.on('turnservers', function(args) {
 		// appends to the config
-		self.webrtc.config.peerConnectionConfig.iceServers = self.webrtc.config.peerConnectionConfig.iceServers.concat(args)
+		// Only items with non-empty urls may occur in iceServers according to WebRTC spec.
+		var turnServers = []
+		for (const turnServer of args) {
+			if (turnServer.urls && turnServer.urls.length) {
+				turnServers.push(turnServer)
+			}
+		}
+		self.webrtc.config.peerConnectionConfig.iceServers = self.webrtc.config.peerConnectionConfig.iceServers.concat(turnServers)
 		self.emit('turnservers', args)
 	})
 


### PR DESCRIPTION
According to https://www.w3.org/TR/webrtc/#set-the-configuration browser should throw SyntaxError when starting call with `iceServers` defined with empty `urls`.

Talk may call `RTCPeerConnection` with empty `iceServers[0].urls` when no STUN nor TURN servers are configured (tested with HPB) what makes Firefox to throw errors like

`RTCPeerConnection constructor passed invalid RTCConfiguration - urls is empty SyntaxError`.

With this fix Talk will ignore items with empty `urls` when populating `iceServers` array.

Author-Change-Id: IB#1125985
Signed-off-by: Pawel Boguslawski <pawel.boguslawski@ib.pl>