### PR TITLE
Align search field with rest of the page

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -516,7 +516,7 @@ export default {
 
 .new-conversation {
 	display: flex;
-	padding: 8px 0 8px 12px;
+	padding: 4px 4px 4px 8px;
 	align-items: center;
 	&--scrolled-down {
 		border-bottom: 1px solid var(--color-placeholder-dark);


### PR DESCRIPTION
And add some right padding

Before:

![image](https://user-images.githubusercontent.com/23653902/192538934-04ebf23d-4f73-41e7-a2e6-7bf008dfbd48.png)


After:

![image](https://user-images.githubusercontent.com/23653902/192538720-ee2f5664-54ff-4d1e-98aa-8d347c30915a.png)
