### PR TITLE
Improve spacing left sidebar

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
@@ -126,6 +126,9 @@ export default {
 // Override vue overflow rules for <ul> elements within app-navigation
 .conversations {
 	overflow: visible !important;
-	margin-top: 4px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	padding: 0 !important;
 }
 </style>

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -511,7 +511,7 @@ export default {
 
 @import '../../assets/variables';
 .scroller {
-	padding: 0 4px 0 6px;
+	padding: 0 !important;
 }
 
 .new-conversation {


### PR DESCRIPTION
Remove too much padding in the conversation list and add spacing between entries. Now everything is padding and gap is 4px.

After:

![image](https://user-images.githubusercontent.com/23653902/192542664-243ede3e-6c91-4302-84d3-b8f31cdab40c.png)
