### PR TITLE
Handle invalid browser versions more gracefully and fix Safari iPadOS…

### DIFF
--- a/src/mixins/browserCheck.js
+++ b/src/mixins/browserCheck.js
@@ -37,9 +37,12 @@ const browserCheck = {
 		},
 	},
 	computed: {
+		parser() {
+			return new UAParser()
+		},
+
 		browser() {
-			const parser = new UAParser()
-			return parser.getBrowser()
+			return this.parser.getBrowser()
 		},
 
 		isFirefox() {
@@ -61,8 +64,28 @@ const browserCheck = {
 			return this.browser.name === 'IE' || this.browser.name === 'IEMobile'
 		},
 
+		browserVersion() {
+			if (this.browser.version) {
+				return this.browser.version
+			}
+
+			if (this.browser.name === 'Safari') {
+				// Workaround for https://github.com/faisalman/ua-parser-js/issues/599
+				const match = this.parser.getUA().match(' Version/([0-9.,]+) ')
+				if (match) {
+					return match[1]
+				}
+			}
+
+			return undefined
+		},
+
 		majorVersion() {
-			return parseInt(this.browser.version.split('.')[0], 10)
+			if (this.browserVersion) {
+				return parseInt(this.browserVersion.split('.')[0], 10)
+			}
+
+			return 0
 		},
 
 		isFullySupported() {


### PR DESCRIPTION
… 15.7

Workaround for:
* https://github.com/faisalman/ua-parser-js/issues/599
* https://github.com/faisalman/ua-parser-js/issues/594
* https://github.com/faisalman/ua-parser-js/issues/595

Fix #8008 

## Steps

insert the following as first argument to the UAParser() call of:
https://github.com/nextcloud/spreed/blob/47e98d86d617925253f69f4a5a7ad67d63fd4d79/src/mixins/browserCheck.js#L41

```
Mozilla/5.0 (iPhone; CPU iPhone OS 15_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6,2 Mobile/15E148 Safari/604.1
```