### PR TITLE
Query in sqlite returning wrong result.

### DIFF
--- a/lib/Command/Monitor/Calls.php
+++ b/lib/Command/Monitor/Calls.php
@@ -59,7 +59,7 @@ class Calls extends Base {
 		$query->select('r.token', $query->func()->count('*', 'num_attendees'))
 			->from('talk_attendees', 'a')
 			->leftJoin('a', 'talk_rooms', 'r', $query->expr()->eq('a.room_id', 'r.id'))
-			->where($query->expr()->in('a.id', $query->createFunction('(' . $subQuery->getSQL() . ')')))
+			->where($query->expr()->in('a.id', $query->createFunction($subQuery->getSQL())))
 			->groupBy('r.token');
 
 		$data = [];


### PR DESCRIPTION
The function `in` already put the parenthesis, duplicated parenthesis return wrong result with sqlite.

close #8186