### PR TITLE
added displayName to pending call message in 1on1 calls

### DIFF
--- a/src/components/CallView/shared/EmptyCallView.vue
+++ b/src/components/CallView/shared/EmptyCallView.vue
@@ -122,11 +122,10 @@ export default {
 			if (this.isConnecting) {
 				return t('spreed', 'Connecting …')
 			}
-			let callee = 'others'
 			if (this.isOneToOneConversation()) {
-				callee = this.getDisplayName()
+				return t('spreed', 'Waiting for {user} to join the call', { user: this.getDisplayName() })
 			}
-			return t('spreed', `Waiting for ${callee} to join the call …`)
+			return t('spreed', `Waiting for others to join the call …`)
 		},
 
 		message() {

--- a/src/components/CallView/shared/EmptyCallView.vue
+++ b/src/components/CallView/shared/EmptyCallView.vue
@@ -83,12 +83,20 @@ export default {
 			return this.conversation && this.conversation.type === CONVERSATION.TYPE.PUBLIC
 		},
 
+		isOneToOneConversation() {
+			return this.conversation && this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE
+		},
+
 		isPasswordRequestConversation() {
 			return this.conversation && this.conversation.objectType === 'share:password'
 		},
 
 		isFileConversation() {
 			return this.conversation && this.conversation.objectType === 'file'
+		},
+
+		getDisplayName() {
+			return this.conversation && this.conversation.displayName;
 		},
 
 		canInviteOthers() {
@@ -114,7 +122,11 @@ export default {
 			if (this.isConnecting) {
 				return t('spreed', 'Connecting …')
 			}
-			return t('spreed', 'Waiting for others to join the call …')
+			let callee = 'others'
+			if (this.isOneToOneConversation()) {
+				callee = this.getDisplayName()
+			}
+			return t('spreed', `Waiting for ${callee} to join the call …`)
 		},
 
 		message() {

--- a/src/components/CallView/shared/EmptyCallView.vue
+++ b/src/components/CallView/shared/EmptyCallView.vue
@@ -95,8 +95,8 @@ export default {
 			return this.conversation && this.conversation.objectType === 'file'
 		},
 
-		getDisplayName() {
-			return this.conversation && this.conversation.displayName;
+		conversationDisplayName() {
+			return this.conversation && this.conversation.displayName
 		},
 
 		canInviteOthers() {
@@ -122,10 +122,10 @@ export default {
 			if (this.isConnecting) {
 				return t('spreed', 'Connecting …')
 			}
-			if (this.isOneToOneConversation()) {
-				return t('spreed', 'Waiting for {user} to join the call', { user: this.getDisplayName() })
+			if (this.isOneToOneConversation) {
+				return t('spreed', 'Waiting for {user} to join the call', { user: this.conversationDisplayName })
 			}
-			return t('spreed', `Waiting for others to join the call …`)
+			return t('spreed', 'Waiting for others to join the call …')
 		},
 
 		message() {


### PR DESCRIPTION
When starting a call in a 1on1 conversation, the message is very generic: 
![image](https://user-images.githubusercontent.com/42038491/197335996-647f00a7-af73-40a1-aef4-8ada96bef698.png)

So, improving that to have callee's display name, simply "Waiting for [display name] to join the call …"