### PR TITLE
Do not show Talk sidebar if Talk is disabled for the user

### DIFF
--- a/lib/Files/TemplateLoader.php
+++ b/lib/Files/TemplateLoader.php
@@ -88,11 +88,15 @@ class TemplateLoader implements IEventListener {
 			return;
 		}
 
+		$user = $this->userSession->getUser();
+		if ($user instanceof IUser && $this->talkConfig->isDisabledForUser($user)) {
+			return;
+		}
+
 		Util::addStyle(Application::APP_ID, 'At');
 		Util::addStyle(Application::APP_ID, 'icons');
 		Util::addScript(Application::APP_ID, 'talk-files-sidebar');
 
-		$user = $this->userSession->getUser();
 		if ($user instanceof IUser) {
 			$this->publishInitialStateForUser($user, $this->rootFolder, $this->appManager);
 		} else {

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -55,6 +55,7 @@
 <script>
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import PreventUnload from 'vue-prevent-unload'
+import { showError } from '@nextcloud/dialogs'
 import { loadState } from '@nextcloud/initial-state'
 import CallView from './components/CallView/CallView.vue'
 import ChatView from './components/ChatView.vue'
@@ -154,9 +155,19 @@ export default {
 
 			this.joiningConversation = true
 
-			await this.getPublicShareConversationData()
+			try {
+				await this.getPublicShareConversationData()
 
-			await this.$store.dispatch('joinConversation', { token: this.token })
+				await this.$store.dispatch('joinConversation', { token: this.token })
+			} catch (exception) {
+				this.joiningConversation = false
+
+				showError(t('spreed', 'Error occurred when joining the conversation'))
+
+				console.error(exception)
+
+				return
+			}
 
 			// No need to wait for it, but fetching the conversation needs to be
 			// done once the user has joined the conversation (otherwise only


### PR DESCRIPTION
Pending:
- [x] Do not show Talk sidebar in public share page if Talk is disabled for the user? The problem is that the same approach used for the Files app does not seem to work in this case, probably because [the user is in incognito mode](https://github.com/nextcloud/server/blob/54031e370ac05b127d4bc799de99ce1b643adcbb/apps/files_sharing/lib/Controller/ShareController.php#L353) when loading the public share page (although not in other requests, for example when joining the conversation).
  I have not checked if there is some way to know the actual user from the `TemplateLoader`, but if not then at least an error should be shown when failing to join the conversation in the public share page (which should be shown nevertheless if there is an error independently of this issue, so maybe it would be the way to go).

## How to test (scenario 1)

- Open Talk settings
- Restrict Talk to be used only by certain group
- Log in as a user not in that group
- Open the Files app
- Open the sidebar for a file

### Result with this pull request

The `Chat` tab is not shown in the sidebar

### Result without this pull request

The `Chat` tab is shown in the sidebar



## How to test (scenario 2)

- Open Talk settings
- Restrict Talk to be used only by certain group
- Log in as a user not in that group
- Open the Files app
- Share a file by link
- Open the link in another tab in the same window
- Join the conversation

### Result with this pull request

The button is restored and an error is shown

### Result without this pull request

The button is kept disabled and with a loading spinner forever, and no error is shown to the user