### PR TITLE
Don't keep the session open when joining/leaving a room to reduce the…

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1342,7 +1342,6 @@ class RoomController extends AEnvironmentAwareController {
 
 	/**
 	 * @PublicPage
-	 * @UseSession
 	 * @BruteForceProtection(action=talkRoomPassword)
 	 *
 	 * @param string $token
@@ -1483,7 +1482,6 @@ class RoomController extends AEnvironmentAwareController {
 
 	/**
 	 * @PublicPage
-	 * @UseSession
 	 *
 	 * @param string $token
 	 * @return DataResponse

--- a/lib/TalkSession.php
+++ b/lib/TalkSession.php
@@ -92,43 +92,32 @@ class TalkSession {
 
 	protected function getValue(string $key, string $token): ?string {
 		$values = $this->getValues($key);
-
-		if (!isset($values[$token])) {
-			return null;
-		}
-		return $values[$token];
+		return $values[$token] ?? null;
 	}
 
 	protected function setValue(string $key, string $token, string $value): void {
-		$values = $this->session->get($key);
-		if ($values === null) {
-			$values = [];
-		} else {
-			$values = json_decode($values, true);
-			if ($values === null) {
-				$values = [];
-			}
-		}
+		$reopened = $this->session->reopen();
 
-
+		$values = $this->getValues($key);
 		$values[$token] = $value;
 		$this->session->set($key, json_encode($values));
+
+
+		if ($reopened) {
+			$this->session->close();
+		}
 	}
 
 	protected function removeValue(string $key, string $token): void {
-		$values = $this->session->get($key);
-		if ($values === null) {
-			$values = [];
-		} else {
-			$values = json_decode($values, true);
-			if ($values === null) {
-				$values = [];
-			} else {
-				unset($values[$token]);
-			}
-		}
+		$reopened = $this->session->reopen();
 
+		$values = $this->getValues($key);
+		unset($values[$token]);
 		$this->session->set($key, json_encode($values));
+
+		if ($reopened) {
+			$this->session->close();
+		}
 	}
 
 	public function renewSessionId(): void {


### PR DESCRIPTION
… chance of dirty reads

Improves the rate of "Session not found 404 redirect" ( #4670 ) from ~50% to ~10% for me.

The problem is the joining and leaving of the room, not actually the signaling code that is later on failing to find the session:

Current case:
```
join before["8bitgnry"]1667396997.431
join after["8bitgnry","deorokdx"]1667396997.4842

leave before["8bitgnry"]1667396997.4895
leave after[]1667396997.5102

signaling[]1667396997.7326
```

I also observed working room-changes which did the opposite order:
```
leave before["8bitgnry"]1667397317.6301
leave after[]1667397317.6513

join before["8bitgnry"]1667397317.6525
join after["8bitgnry","deorokdx"]1667397317.7005 
```

So it could happen that the session string for the old room was "restored"