### PR TITLE
Show voters count on voting screen for moderators

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
@@ -62,6 +62,11 @@
 							{{ pollName }}
 						</h2>
 					</div>
+					<div class="poll__summary">
+						<template v-if="currentUserIsPollCreator || currentUserIsModerator || pollIsPublic">
+							{{ n('spreed', 'Poll results • %n vote', 'Poll results • %n votes', votersNumber) }}
+						</template>
+					</div>
 
 					<!-- options -->
 					<div class="poll__modal-options">


### PR DESCRIPTION
Fix #8267 

Currently using this string because it's translated already and we want to release today.

Will make a follow up to be backported after the release to remove the "Poll results" bit as its the voting screen not the result screen?