### PR TITLE
Revert "[stable25] Bump @nextcloud/vue to 7.0.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"@nextcloud/moment": "^1.2.1",
 				"@nextcloud/paths": "^2.1.0",
 				"@nextcloud/router": "^2.0.0",
-				"@nextcloud/vue": "^7.0.1",
+				"@nextcloud/vue": "^7.0.0",
 				"@nextcloud/vue-dashboard": "^2.0.1",
 				"@nextcloud/vue-richtext": "^2.0.3",
 				"attachmediastream": "^2.1.0",
@@ -3265,18 +3265,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
-		"node_modules/@nextcloud/focus-trap": {
-			"version": "0.1.0-beta",
-			"resolved": "https://registry.npmjs.org/@nextcloud/focus-trap/-/focus-trap-0.1.0-beta.tgz",
-			"integrity": "sha512-c6mrUrvDGRVkYfUGAJl7o2lxA/iIMF46XgBdCGCnCJFISFqHoWYGQoG6adc6w2IL7uhGka+lzy38szz+WUYpkA==",
-			"dependencies": {
-				"focus-trap": "^7.0.0"
-			},
-			"engines": {
-				"node": "^16.0.0",
-				"npm": "^7.0.0 || ^8.0.0"
-			}
-		},
 		"node_modules/@nextcloud/initial-state": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.0.0.tgz",
@@ -3402,9 +3390,9 @@
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.1.tgz",
-			"integrity": "sha512-VwukKyu2ytFLYVrLHKN+waC4xuZaaFdns5+bKX8PzYfqjhjMDbjaZubCb4VkCISsaNqfcnJiE6Rkxtw4mwI8Pw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.0.tgz",
+			"integrity": "sha512-x+JAWCdL30qpxx4u4Ggdlg+l33f8ajX/qP5mZ3o4fshSDSZnz+d8kvnPoQXC6zRcdvNKzpgzCFe80I+G0q/QRQ==",
 			"dependencies": {
 				"@nextcloud/auth": "^2.0.0",
 				"@nextcloud/axios": "^2.0.0",
@@ -3413,7 +3401,6 @@
 				"@nextcloud/capabilities": "^1.0.4",
 				"@nextcloud/dialogs": "^3.1.4",
 				"@nextcloud/event-bus": "^3.0.0",
-				"@nextcloud/focus-trap": "^0.1.0-beta",
 				"@nextcloud/initial-state": "^2.0.0",
 				"@nextcloud/l10n": "^1.6.0",
 				"@nextcloud/logger": "^2.2.1",
@@ -3422,6 +3409,7 @@
 				"emoji-mart-vue-fast": "^11.1.1",
 				"escape-html": "^1.0.3",
 				"floating-vue": "^1.0.0-beta.18",
+				"focus-trap": "^7.0.0",
 				"hammerjs": "^2.0.8",
 				"linkify-string": "^4.0.0",
 				"md5": "^2.3.0",
@@ -24162,14 +24150,6 @@
 				}
 			}
 		},
-		"@nextcloud/focus-trap": {
-			"version": "0.1.0-beta",
-			"resolved": "https://registry.npmjs.org/@nextcloud/focus-trap/-/focus-trap-0.1.0-beta.tgz",
-			"integrity": "sha512-c6mrUrvDGRVkYfUGAJl7o2lxA/iIMF46XgBdCGCnCJFISFqHoWYGQoG6adc6w2IL7uhGka+lzy38szz+WUYpkA==",
-			"requires": {
-				"focus-trap": "^7.0.0"
-			}
-		},
 		"@nextcloud/initial-state": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.0.0.tgz",
@@ -24280,9 +24260,9 @@
 			}
 		},
 		"@nextcloud/vue": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.1.tgz",
-			"integrity": "sha512-VwukKyu2ytFLYVrLHKN+waC4xuZaaFdns5+bKX8PzYfqjhjMDbjaZubCb4VkCISsaNqfcnJiE6Rkxtw4mwI8Pw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.0.tgz",
+			"integrity": "sha512-x+JAWCdL30qpxx4u4Ggdlg+l33f8ajX/qP5mZ3o4fshSDSZnz+d8kvnPoQXC6zRcdvNKzpgzCFe80I+G0q/QRQ==",
 			"requires": {
 				"@nextcloud/auth": "^2.0.0",
 				"@nextcloud/axios": "^2.0.0",
@@ -24291,7 +24271,6 @@
 				"@nextcloud/capabilities": "^1.0.4",
 				"@nextcloud/dialogs": "^3.1.4",
 				"@nextcloud/event-bus": "^3.0.0",
-				"@nextcloud/focus-trap": "^0.1.0-beta",
 				"@nextcloud/initial-state": "^2.0.0",
 				"@nextcloud/l10n": "^1.6.0",
 				"@nextcloud/logger": "^2.2.1",
@@ -24300,6 +24279,7 @@
 				"emoji-mart-vue-fast": "^11.1.1",
 				"escape-html": "^1.0.3",
 				"floating-vue": "^1.0.0-beta.18",
+				"focus-trap": "^7.0.0",
 				"hammerjs": "^2.0.8",
 				"linkify-string": "^4.0.0",
 				"md5": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@nextcloud/moment": "^1.2.1",
 		"@nextcloud/paths": "^2.1.0",
 		"@nextcloud/router": "^2.0.0",
-		"@nextcloud/vue": "^7.0.1",
+		"@nextcloud/vue": "^7.0.0",
 		"@nextcloud/vue-dashboard": "^2.0.1",
 		"@nextcloud/vue-richtext": "^2.0.3",
 		"attachmediastream": "^2.1.0",


### PR DESCRIPTION
Reverts nextcloud/spreed#8211

Following #8214 due to the performance regression downgrading to 7.0.0 again for todays release