### PR TITLE
Add changelog 12.2.8, 13.0.10, 14.0.6 and 15.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,66 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 15.0.1 – 2022-11-03
+### Changed
+- Take the device pixel ratio into account when calculating minimum grid size (should see more videos now on High DPI settings like MacOS and most 4k setup)
+  [#8246](https://github.com/nextcloud/spreed/pull/8246)
+
+### Fixed
+- Show the number of casted votes to the question raiser and moderators on the voting screen
+  [#8273](https://github.com/nextcloud/spreed/pull/8273)
+- Hide talk dashboard when user can not use the Talk app
+  [#8236](https://github.com/nextcloud/spreed/pull/8236)
+- Hide talk sidebar integration when user can not use the Talk app
+  [#8240](https://github.com/nextcloud/spreed/pull/8240)
+- Show other participant's name when waiting in a one-to-one call
+  [#8228](https://github.com/nextcloud/spreed/pull/8228)
+
+## 14.0.6 – 2022-11-03
+### Changed
+- Take the device pixel ratio into account when calculating minimum grid size (should see more videos now on High DPI settings like MacOS and most 4k setup)
+  [#8247](https://github.com/nextcloud/spreed/pull/8247)
+
+### Fixed
+- Fix XML API endpoint for chats with empty reactions result
+  [#8110](https://github.com/nextcloud/spreed/pull/8110)
+- Hide talk dashboard when user can not use the Talk app
+  [#8237](https://github.com/nextcloud/spreed/pull/8237)
+- Hide talk sidebar integration when user can not use the Talk app
+  [#8241](https://github.com/nextcloud/spreed/pull/8241)
+- Fix participant sessions not sent to the HPB
+  [#8099](https://github.com/nextcloud/spreed/pull/8099)
+- Don't search in lobbied conversations
+  [#8116](https://github.com/nextcloud/spreed/pull/8116)
+- Fix an issue with detecting Safari on iOS version
+  [#8135](https://github.com/nextcloud/spreed/pull/8135)
+
+## 13.0.10 – 2022-11-03
+### Changed
+- Take the device pixel ratio into account when calculating minimum grid size (should see more videos now on High DPI settings like MacOS and most 4k setup)
+  [#8248](https://github.com/nextcloud/spreed/pull/8248)
+
+### Fixed
+- Hide talk dashboard when user can not use the Talk app
+  [#8238](https://github.com/nextcloud/spreed/pull/8238)
+- Hide talk sidebar integration when user can not use the Talk app
+  [#8242](https://github.com/nextcloud/spreed/pull/8242)
+- Fix participant sessions not sent to the HPB
+  [#8100](https://github.com/nextcloud/spreed/pull/8100)
+- Don't search in lobbied conversations
+  [#8117](https://github.com/nextcloud/spreed/pull/8117)
+- Fix an issue with detecting Safari on iOS version
+  [#8136](https://github.com/nextcloud/spreed/pull/8136)
+
+## 12.2.8 – 2022-11-03
+### Fixed
+- Fix participant sessions not sent to the HPB
+  [#8114](https://github.com/nextcloud/spreed/pull/8114)
+- Fix guest names in search results
+  [#7591](https://github.com/nextcloud/spreed/pull/7591)
+- Fix an issue with detecting Safari on iOS version
+  [#8277](https://github.com/nextcloud/spreed/pull/8277)
+
 ## 15.0.0 – 2022-10-18
 ### Added
 - 🌏 Show link previews for chat messages with links


### PR DESCRIPTION
## 15.0.1 – 2022-11-03
### 🛠️ Changed
- Take the device pixel ratio into account when calculating minimum grid size (should see more videos now on High DPI settings like MacOS and most 4k setup)  [#8246](https://github.com/nextcloud/spreed/pull/8246)

### 🐞 Fixed
- Show the number of casted votes to the question raiser and moderators on the voting screen  [#8273](https://github.com/nextcloud/spreed/pull/8273)
- Hide talk dashboard when user can not use the Talk app  [#8236](https://github.com/nextcloud/spreed/pull/8236)
- Hide talk sidebar integration when user can not use the Talk app  [#8240](https://github.com/nextcloud/spreed/pull/8240)
- Show other participant's name when waiting in a one-to-one call  [#8228](https://github.com/nextcloud/spreed/pull/8228)

## 14.0.6 – 2022-11-03
### 🛠️ Changed
- Take the device pixel ratio into account when calculating minimum grid size (should see more videos now on High DPI settings like MacOS and most 4k setup)  [#8247](https://github.com/nextcloud/spreed/pull/8247)

### 🐞 Fixed
- Fix XML API endpoint for chats with empty reactions result  [#8110](https://github.com/nextcloud/spreed/pull/8110)
- Hide talk dashboard when user can not use the Talk app  [#8237](https://github.com/nextcloud/spreed/pull/8237)
- Hide talk sidebar integration when user can not use the Talk app  [#8241](https://github.com/nextcloud/spreed/pull/8241)
- Fix participant sessions not sent to the HPB  [#8099](https://github.com/nextcloud/spreed/pull/8099)
- Don't search in lobbied conversations  [#8116](https://github.com/nextcloud/spreed/pull/8116)
- Fix an issue with detecting Safari on iOS version  [#8135](https://github.com/nextcloud/spreed/pull/8135)

## 13.0.10 – 2022-11-03
### 🛠️ Changed
- Take the device pixel ratio into account when calculating minimum grid size (should see more videos now on High DPI settings like MacOS and most 4k setup)  [#8248](https://github.com/nextcloud/spreed/pull/8248)

### 🐞 Fixed
- Hide talk dashboard when user can not use the Talk app  [#8238](https://github.com/nextcloud/spreed/pull/8238)
- Hide talk sidebar integration when user can not use the Talk app  [#8242](https://github.com/nextcloud/spreed/pull/8242)
- Fix participant sessions not sent to the HPB  [#8100](https://github.com/nextcloud/spreed/pull/8100)
- Don't search in lobbied conversations  [#8117](https://github.com/nextcloud/spreed/pull/8117)
- Fix an issue with detecting Safari on iOS version  [#8136](https://github.com/nextcloud/spreed/pull/8136)

## 12.2.8 – 2022-11-03
### 🐞 Fixed
- Fix participant sessions not sent to the HPB  [#8114](https://github.com/nextcloud/spreed/pull/8114)
- Fix guest names in search results  [#7591](https://github.com/nextcloud/spreed/pull/7591)
- Fix an issue with detecting Safari on iOS version  [#8277](https://github.com/nextcloud/spreed/pull/8277)
