### PR TITLE
Fix permissions returned by getSharesInFolder

### DIFF
--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -546,7 +546,11 @@ class RoomShareProvider implements IShareProvider {
 	 */
 	public function getSharesInFolder($userId, Folder $node, $reshares, $shallow = true): array {
 		$qb = $this->dbConnection->getQueryBuilder();
-		$qb->select('*')
+		$qb->select('s.*',
+			'f.fileid', 'f.path', 'f.permissions AS f_permissions', 'f.storage', 'f.path_hash',
+			'f.parent AS f_parent', 'f.name', 'f.mimetype', 'f.mimepart', 'f.size', 'f.mtime', 'f.storage_mtime',
+			'f.encrypted', 'f.unencrypted_size', 'f.etag', 'f.checksum'
+		)
 			->from('share', 's')
 			->andWhere($qb->expr()->orX(
 				$qb->expr()->eq('s.item_type', $qb->createNamedParameter('file')),


### PR DESCRIPTION
When working on https://github.com/nextcloud/server/pull/34918, I have noticed that after applying changes proposed in that PR, incorrect permissions are returned for room shares.

This seems to be caused by the fact that the database query issued in **RoomShareProvider::getSharesInFolder** returnes two columns named `permissions` - one from the `oc_shares` table and a second one from `oc_filecache`. Which column is then used by the PHP code probably depends on the database driver used and maybe some random factors. In my case (MariaDB) the wrong column was consistently used.

In this PR I propose to change the SELECT part of the query to match other methods in the class - **getSharesByIds** and **getSharedWith**.

This change also means that the node data will be stored in the cache: https://github.com/nextcloud/spreed/blob/master/lib/Share/RoomShareProvider.php#L313, but I do not know what side effects this might introduce.