### PR TITLE
Fix bottom stripe of speaker view with high DPI

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -351,6 +351,12 @@ export default {
 		},
 
 		dpiFactor() {
+			if (this.isStripe) {
+				// On the stripe we only ever want 1 row, so we ignore the DPR
+				// as the height of the grid is the height of the video elements then.
+				return 1.0
+			}
+
 			const devicePixelRatio = window.devicePixelRatio
 
 			// Some sanity check to not screw up the math.


### PR DESCRIPTION
Fix #8314 

Before with 2.0 device pixel ratio | After with 2.0 device pixel ratio
---|---
![Bildschirmfoto vom 2022-11-09 07-18-52](https://user-images.githubusercontent.com/213943/200754207-cc3c3329-0c29-4563-bce9-89d04b55bb11.png) | ![Bildschirmfoto vom 2022-11-09 07-13-37](https://user-images.githubusercontent.com/213943/200754203-2225bd19-e7b6-4869-89d6-e7270b4ba1b7.png)
