### PR TITLE
Remove poll data when deleting the message

### DIFF
--- a/lib/Model/PollMapper.php
+++ b/lib/Model/PollMapper.php
@@ -66,4 +66,13 @@ class PollMapper extends QBMapper {
 
 		$query->executeStatement();
 	}
+
+	public function deleteByPollId(int $pollId): void {
+		$query = $this->db->getQueryBuilder();
+
+		$query->delete($this->getTableName())
+			->where($query->expr()->eq('id', $query->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)));
+
+		$query->executeStatement();
+	}
 }

--- a/lib/Model/VoteMapper.php
+++ b/lib/Model/VoteMapper.php
@@ -77,6 +77,15 @@ class VoteMapper extends QBMapper {
 		$query->executeStatement();
 	}
 
+	public function deleteByPollId(int $pollId): void {
+		$query = $this->db->getQueryBuilder();
+
+		$query->delete($this->getTableName())
+			->where($query->expr()->eq('poll_id', $query->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)));
+
+		$query->executeStatement();
+	}
+
 	public function deleteVotesByActor(int $pollId, string $actorType, string $actorId): void {
 		$query = $this->db->getQueryBuilder();
 

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -318,6 +318,11 @@ class PollService {
 		$this->pollMapper->deleteByRoomId($roomId);
 	}
 
+	public function deleteByPollId(int $pollId): void {
+		$this->voteMapper->deleteByPollId($pollId);
+		$this->pollMapper->deleteByPollId($pollId);
+	}
+
 	public function updateDisplayNameForActor(string $actorType, string $actorId, string $displayName): void {
 		$update = $this->connection->getQueryBuilder();
 		$update->update('talk_polls')

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1614,9 +1614,11 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/poll/' . self::$identifierToToken[$identifier] . '/' . self::$questionToPollId[$question]);
 		$this->assertStatusCode($this->response, $statusCode);
 
-		$expected = $this->preparePollExpectedData($formData->getRowsHash());
-		$response = $this->getDataFromResponse($this->response);
-		$this->assertPollEquals($expected, $response);
+		if ($statusCode === '200' || $formData instanceof TableNode) {
+			$expected = $this->preparePollExpectedData($formData->getRowsHash());
+			$response = $this->getDataFromResponse($this->response);
+			$this->assertPollEquals($expected, $response);
+		}
 	}
 
 	/**

--- a/tests/integration/features/chat-2/poll.feature
+++ b/tests/integration/features/chat-2/poll.feature
@@ -652,3 +652,66 @@ Feature: chat-2/poll
       | status     | closed |
       | votedSelf  | [] |
       | details    | [{"actorType":"deleted_users","actorId":"deleted_users","actorDisplayName":"","optionId":0}] |
+
+  Scenario: Deleting the poll message removes all details
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    And user "participant2" creates a poll in room "room" with 201
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+    And user "participant1" sees the following messages in room "room" with 200 (v1)
+      | room | actorType | actorId      | actorDisplayName         | message  | messageParameters |
+      | room | users     | participant2 | participant2-displayname | {object} | "IGNORE"          |
+    And user "participant1" deletes message "{object}" from room "room" with 200 (v1)
+    And user "participant1" votes for options "[1]" on poll "What is the question?" in room "room" with 404
+    And user "participant2" votes for options "[0]" on poll "What is the question?" in room "room" with 404
+    And user "participant1" closes poll "What is the question?" in room "room" with 404
+    And user "participant2" closes poll "What is the question?" in room "room" with 404
+    Then user "participant1" sees poll "What is the question?" in room "room" with 404
+    Then user "participant2" sees poll "What is the question?" in room "room" with 404
+    And user "participant1" sees the following messages in room "room" with 200 (v1)
+      | room | actorType | actorId      | actorDisplayName         | message                | messageParameters |
+      | room | users     | participant2 | participant2-displayname | Message deleted by you | "IGNORE"          |
+
+  Scenario: Deleting a closed poll message removes also the close message
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    And user "participant2" creates a poll in room "room" with 201
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+    And user "participant1" sees the following messages in room "room" with 200 (v1)
+      | room | actorType | actorId      | actorDisplayName         | message  | messageParameters |
+      | room | users     | participant2 | participant2-displayname | {object} | "IGNORE"          |
+    And user "participant2" closes poll "What is the question?" in room "room" with 200
+      | id         | POLL_ID(What is the question?) |
+      | question   | What is the question? |
+      | options    | ["Where are you?","How much is the fish?"] |
+      | votes      | [] |
+      | numVoters  | 0 |
+      | resultMode | public |
+      | maxVotes   | unlimited |
+      | actorType  | users |
+      | actorId    | participant2 |
+      | actorDisplayName    | participant2-displayname |
+      | status     | closed |
+      | votedSelf  | [] |
+      | details    | [] |
+    And user "participant1" deletes message "{object}" from room "room" with 200 (v1)
+    And user "participant1" votes for options "[1]" on poll "What is the question?" in room "room" with 404
+    And user "participant2" votes for options "[0]" on poll "What is the question?" in room "room" with 404
+    And user "participant1" closes poll "What is the question?" in room "room" with 404
+    And user "participant2" closes poll "What is the question?" in room "room" with 404
+    Then user "participant1" sees poll "What is the question?" in room "room" with 404
+    Then user "participant2" sees poll "What is the question?" in room "room" with 404
+    And user "participant1" sees the following messages in room "room" with 200 (v1)
+      | room | actorType | actorId      | actorDisplayName         | message                | messageParameters |
+      | room | users     | participant2 | participant2-displayname | Message deleted by you | "IGNORE"          |
+      | room | users     | participant2 | participant2-displayname | Message deleted by you | "IGNORE"          |


### PR DESCRIPTION
Fix #8342 

### 🚧 Todo list

- [x] Remove all data
- [x] Make sure the "Create" message is neutralized
- [x] Make sure the "Close" message is neutralized
- [x] UI "Show result" button on deleted polls is not removed and title of the poll is still leaked in the "result message"

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
