### PR TITLE
Make sure to initialise the in call flag with the default we use later…

### DIFF
--- a/lib/Service/SessionService.php
+++ b/lib/Service/SessionService.php
@@ -26,6 +26,7 @@ namespace OCA\Talk\Service;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\Session;
 use OCA\Talk\Model\SessionMapper;
+use OCA\Talk\Participant;
 use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -92,6 +93,7 @@ class SessionService {
 	public function createSessionForAttendee(Attendee $attendee, string $forceSessionId = ''): Session {
 		$session = new Session();
 		$session->setAttendeeId($attendee->getId());
+		$session->setInCall(Participant::FLAG_DISCONNECTED);
 
 		if ($forceSessionId !== '') {
 			$session->setSessionId($forceSessionId);


### PR DESCRIPTION
Fix #8356 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
