### PR TITLE
Move all API version requirements to the same format

### DIFF
--- a/appinfo/routes/routesCallController.php
+++ b/appinfo/routes/routesCallController.php
@@ -24,8 +24,8 @@ declare(strict_types=1);
  */
 
 $requirements = [
-	'apiVersion' => 'v(4)',
-	'token' => '^[a-z0-9]{4,30}$',
+	'apiVersion' => 'v4',
+	'token' => '[a-z0-9]{4,30}',
 ];
 
 return [

--- a/appinfo/routes/routesChatController.php
+++ b/appinfo/routes/routesChatController.php
@@ -25,13 +25,13 @@ declare(strict_types=1);
 
 $requirements = [
 	'apiVersion' => 'v1',
-	'token' => '^[a-z0-9]{4,30}$',
+	'token' => '[a-z0-9]{4,30}',
 ];
 
 $requirementsWithMessageId = [
 	'apiVersion' => 'v1',
-	'token' => '^[a-z0-9]{4,30}$',
-	'messageId' => '^[0-9]+$',
+	'token' => '[a-z0-9]{4,30}',
+	'messageId' => '[0-9]+',
 ];
 
 return [

--- a/appinfo/routes/routesCommandController.php
+++ b/appinfo/routes/routesCommandController.php
@@ -23,11 +23,13 @@ declare(strict_types=1);
  *
  */
 
+$requirements = [
+	'apiVersion' => 'v1',
+];
+
 return [
 	'ocs' => [
 		/** @see \OCA\Talk\Controller\CommandController::index() */
-		['name' => 'Command#index', 'url' => '/api/{apiVersion}/command', 'verb' => 'GET', 'requirements' => [
-			'apiVersion' => 'v1',
-		]],
+		['name' => 'Command#index', 'url' => '/api/{apiVersion}/command', 'verb' => 'GET', 'requirements' => $requirements],
 	],
 ];

--- a/appinfo/routes/routesFilesIntegrationController.php
+++ b/appinfo/routes/routesFilesIntegrationController.php
@@ -23,17 +23,20 @@ declare(strict_types=1);
  *
  */
 
+$requirementsFile = [
+	'apiVersion' => 'v1',
+	'fileId' => '.+',
+];
+$requirementsShare = [
+	'apiVersion' => 'v1',
+	'shareToken' => '.+',
+];
+
 return [
 	'ocs' => [
 		/** @see \OCA\Talk\Controller\FilesIntegrationController::getRoomByFileId() */
-		['name' => 'FilesIntegration#getRoomByFileId', 'url' => '/api/{apiVersion}/file/{fileId}', 'verb' => 'GET', 'requirements' => [
-			'apiVersion' => 'v1',
-			'fileId' => '.+'
-		]],
+		['name' => 'FilesIntegration#getRoomByFileId', 'url' => '/api/{apiVersion}/file/{fileId}', 'verb' => 'GET', 'requirements' => $requirementsFile],
 		/** @see \OCA\Talk\Controller\FilesIntegrationController::getRoomByShareToken() */
-		['name' => 'FilesIntegration#getRoomByShareToken', 'url' => '/api/{apiVersion}/publicshare/{shareToken}', 'verb' => 'GET', 'requirements' => [
-			'apiVersion' => 'v1',
-			'shareToken' => '.+',
-		]],
+		['name' => 'FilesIntegration#getRoomByShareToken', 'url' => '/api/{apiVersion}/publicshare/{shareToken}', 'verb' => 'GET', 'requirements' => $requirementsShare],
 	],
 ];

--- a/appinfo/routes/routesGuestController.php
+++ b/appinfo/routes/routesGuestController.php
@@ -23,12 +23,14 @@ declare(strict_types=1);
  *
  */
 
+$requirements = [
+	'apiVersion' => 'v1',
+	'token' => '[a-z0-9]{4,30}',
+];
+
 return [
 	'ocs' => [
 		/** @see \OCA\Talk\Controller\GuestController::setDisplayName() */
-		['name' => 'Guest#setDisplayName', 'url' => '/api/{apiVersion}/guest/{token}/name', 'verb' => 'POST', 'requirements' => [
-			'apiVersion' => 'v1',
-			'token' => '^[a-z0-9]{4,30}$',
-		]],
+		['name' => 'Guest#setDisplayName', 'url' => '/api/{apiVersion}/guest/{token}/name', 'verb' => 'POST', 'requirements' => $requirements],
 	],
 ];

--- a/appinfo/routes/routesMatterbridgeController.php
+++ b/appinfo/routes/routesMatterbridgeController.php
@@ -25,7 +25,7 @@ declare(strict_types=1);
 
 $requirements = [
 	'apiVersion' => 'v1',
-	'token' => '^[a-z0-9]{4,30}$',
+	'token' => '[a-z0-9]{4,30}',
 ];
 
 return [

--- a/appinfo/routes/routesPageController.php
+++ b/appinfo/routes/routesPageController.php
@@ -23,6 +23,10 @@ declare(strict_types=1);
  *
  */
 
+$requirements = [
+	'token' => '[a-z0-9]{4,30}',
+];
+
 return [
 	'routes' => [
 		/** @see \OCA\Talk\Controller\PageController::index() */
@@ -32,8 +36,8 @@ return [
 		/** @see \OCA\Talk\Controller\PageController::duplicateSession() */
 		['name' => 'Page#duplicateSession', 'url' => '/duplicate-session', 'verb' => 'GET'],
 		/** @see \OCA\Talk\Controller\PageController::showCall() */
-		['name' => 'Page#showCall', 'url' => '/call/{token}', 'root' => '', 'verb' => 'GET'],
+		['name' => 'Page#showCall', 'url' => '/call/{token}', 'root' => '', 'verb' => 'GET', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\PageController::authenticatePassword() */
-		['name' => 'Page#authenticatePassword', 'url' => '/call/{token}', 'root' => '', 'verb' => 'POST'],
+		['name' => 'Page#authenticatePassword', 'url' => '/call/{token}', 'root' => '', 'verb' => 'POST', 'requirements' => $requirements],
 	],
 ];

--- a/appinfo/routes/routesPollController.php
+++ b/appinfo/routes/routesPollController.php
@@ -25,13 +25,13 @@ declare(strict_types=1);
 
 $requirements = [
 	'apiVersion' => 'v1',
-	'token' => '^[a-z0-9]{4,30}$',
+	'token' => '[a-z0-9]{4,30}',
 ];
 
 $requirementsWithPollId = [
 	'apiVersion' => 'v1',
-	'token' => '^[a-z0-9]{4,30}$',
-	'pollId' => '^[0-9]+$',
+	'token' => '[a-z0-9]{4,30}',
+	'pollId' => '\d+',
 ];
 
 return [

--- a/appinfo/routes/routesPublicShareAuthController.php
+++ b/appinfo/routes/routesPublicShareAuthController.php
@@ -23,9 +23,13 @@ declare(strict_types=1);
  *
  */
 
+$requirements = [
+	'apiVersion' => 'v1',
+];
+
 return [
 	'ocs' => [
 		/** @see \OCA\Talk\Controller\PublicShareAuthController::createRoom() */
-		['name' => 'PublicShareAuth#createRoom', 'url' => '/api/{apiVersion}/publicshareauth', 'verb' => 'POST', 'requirements' => ['apiVersion' => 'v1'],],
+		['name' => 'PublicShareAuth#createRoom', 'url' => '/api/{apiVersion}/publicshareauth', 'verb' => 'POST', 'requirements' => $requirements],
 	],
 ];

--- a/appinfo/routes/routesReactionController.php
+++ b/appinfo/routes/routesReactionController.php
@@ -23,22 +23,19 @@ declare(strict_types=1);
  *
  */
 
+$requirements = [
+	'apiVersion' => 'v1',
+	'token' => '[a-z0-9]{4,30}',
+	'messageId' => '[0-9]+',
+];
+
 return [
 	'ocs' => [
 		/** @see \OCA\Talk\Controller\ReactionController::react() */
-		['name' => 'Reaction#react', 'url' => '/api/{apiVersion}/reaction/{token}/{messageId}', 'verb' => 'POST', 'requirements' => [
-			'apiVersion' => 'v1',
-			'token' => '^[a-z0-9]{4,30}$',
-		]],
+		['name' => 'Reaction#react', 'url' => '/api/{apiVersion}/reaction/{token}/{messageId}', 'verb' => 'POST', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\ReactionController::delete() */
-		['name' => 'Reaction#delete', 'url' => '/api/{apiVersion}/reaction/{token}/{messageId}', 'verb' => 'DELETE', 'requirements' => [
-			'apiVersion' => 'v1',
-			'token' => '^[a-z0-9]{4,30}$',
-		]],
+		['name' => 'Reaction#delete', 'url' => '/api/{apiVersion}/reaction/{token}/{messageId}', 'verb' => 'DELETE', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\ReactionController::getReactions() */
-		['name' => 'Reaction#getReactions', 'url' => '/api/{apiVersion}/reaction/{token}/{messageId}', 'verb' => 'GET', 'requirements' => [
-			'apiVersion' => 'v1',
-			'token' => '^[a-z0-9]{4,30}$',
-		]],
+		['name' => 'Reaction#getReactions', 'url' => '/api/{apiVersion}/reaction/{token}/{messageId}', 'verb' => 'GET', 'requirements' => $requirements],
 	],
 ];

--- a/appinfo/routes/routesRoomController.php
+++ b/appinfo/routes/routesRoomController.php
@@ -24,12 +24,12 @@ declare(strict_types=1);
  */
 
 $requirements = [
-	'apiVersion' => 'v(4)',
+	'apiVersion' => 'v4',
 ];
 
 $requirementsWithToken = [
-	'apiVersion' => 'v(4)',
-	'token' => '^[a-z0-9]{4,30}$',
+	'apiVersion' => 'v4',
+	'token' => '[a-z0-9]{4,30}',
 ];
 
 return [
@@ -60,7 +60,7 @@ return [
 		['name' => 'Room#setPassword', 'url' => '/api/{apiVersion}/room/{token}/password', 'verb' => 'PUT', 'requirements' => $requirementsWithToken],
 		/** @see \OCA\Talk\Controller\RoomController::setPermissions() */
 		['name' => 'Room#setPermissions', 'url' => '/api/{apiVersion}/room/{token}/permissions/{mode}', 'verb' => 'PUT', 'requirements' => array_merge($requirementsWithToken, [
-			'mode' => '^(call|default)$',
+			'mode' => '(call|default)',
 		])],
 		/** @see \OCA\Talk\Controller\RoomController::getParticipants() */
 		['name' => 'Room#getParticipants', 'url' => '/api/{apiVersion}/room/{token}/participants', 'verb' => 'GET', 'requirements' => $requirementsWithToken],
@@ -90,7 +90,7 @@ return [
 		['name' => 'Room#removeFromFavorites', 'url' => '/api/{apiVersion}/room/{token}/favorite', 'verb' => 'DELETE', 'requirements' => $requirementsWithToken],
 		/** @see \OCA\Talk\Controller\RoomController::getParticipantByDialInPin() */
 		['name' => 'Room#getParticipantByDialInPin', 'url' => '/api/{apiVersion}/room/{token}/pin/{pin}', 'verb' => 'GET', 'requirements' => array_merge($requirementsWithToken, [
-			'pin' => '^\d{7,32}$',
+			'pin' => '\d{7,32}',
 		])],
 		/** @see \OCA\Talk\Controller\RoomController::createGuestByDialIn() */
 		['name' => 'Room#createGuestByDialIn', 'url' => '/api/{apiVersion}/room/{token}/open-dial-in', 'verb' => 'POST', 'requirements' => $requirementsWithToken],

--- a/appinfo/routes/routesSignalingController.php
+++ b/appinfo/routes/routesSignalingController.php
@@ -24,13 +24,13 @@ declare(strict_types=1);
  */
 
 $requirements = [
-	'apiVersion' => 'v(3)',
+	'apiVersion' => 'v3',
 ];
 
 
 $requirementsWithToken = [
-	'apiVersion' => 'v(3)',
-	'token' => '^[a-z0-9]{4,30}$',
+	'apiVersion' => 'v3',
+	'token' => '[a-z0-9]{4,30}',
 ];
 
 return [
@@ -39,7 +39,7 @@ return [
 		['name' => 'Signaling#getSettings', 'url' => '/api/{apiVersion}/signaling/settings', 'verb' => 'GET', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\SignalingController::getWelcomeMessage() */
 		['name' => 'Signaling#getWelcomeMessage', 'url' => '/api/{apiVersion}/signaling/welcome/{serverId}', 'verb' => 'GET', 'requirements' => array_merge($requirements, [
-			'serverId' => '^\d+$',
+			'serverId' => '\d+',
 		])],
 		/** @see \OCA\Talk\Controller\SignalingController::backend() */
 		['name' => 'Signaling#backend', 'url' => '/api/{apiVersion}/signaling/backend', 'verb' => 'POST', 'requirements' => $requirements],


### PR DESCRIPTION
This allows better parsing for OpenAPI specs later

Fix #8354 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
