### PR TITLE
Revert @nextcloud/vue changes to sidebar scrolling

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -347,6 +347,10 @@ export default {
 	flex-direction: column;
 }
 
+::v-deep .app-sidebar-tabs {
+	min-height: 0;
+}
+
 .app-sidebar-tabs__content #tab-chat {
 	/* Remove padding to maximize the space for the chat view. */
 	padding: 0;


### PR DESCRIPTION
Since @nextcloud/vue 7.1.0-beta.0 the tabs in the right sidebar expand to the full height of its contents, which causes the sidebar to be fully scrollable, rather than scrollable only in the tab contents, which breaks the chat when shown in the sidebar.

Until a better fix is found for now the changes in the sidebar CSS from @nextcloud/vue that causes that are reverted specifically for Talk.