### PR TITLE
Release 14.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 14.0.7 – 2022-12-01
+### Changed
+- Allow to disable the changelog conversation with an app config
+  [#8365](https://github.com/nextcloud/spreed/pull/8365)
+
+### Fixed
+- Fix in_call flag on the "Join room" API response
+  [#8372](https://github.com/nextcloud/spreed/pull/8372)
+- Fix bottom stripe of speaker view with high DPI
+  [#8320](https://github.com/nextcloud/spreed/pull/8320)
+
+## 13.0.11 – 2022-12-01
+### Changed
+- Allow to disable the changelog conversation with an app config
+  [#8366](https://github.com/nextcloud/spreed/pull/8366)
+
+### Fixed
+- Fix bottom stripe of speaker view with high DPI
+  [#8321](https://github.com/nextcloud/spreed/pull/8321)
+
 ## 14.0.6 – 2022-11-03
 ### Changed
 - Take the device pixel ratio into account when calculating minimum grid size (should see more videos now on High DPI settings like MacOS and most 4k setup)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>14.0.6</version>
+	<version>14.0.7</version>
 	<licence>agpl</licence>
 
 	<author>Aleksandra Lazarević</author>


### PR DESCRIPTION
## 14.0.7 – 2022-12-02
### 🔧 Changed
- Allow to disable the changelog conversation with an app config  [#8365](https://github.com/nextcloud/spreed/pull/8365)

### 🐞 Fixed
- Fix in_call flag on the "Join room" API response  [#8372](https://github.com/nextcloud/spreed/pull/8372)
- Fix bottom stripe of speaker view with high DPI  [#8320](https://github.com/nextcloud/spreed/pull/8320)