### PR TITLE
Fix using signaling settings while being refetched

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -141,6 +141,20 @@ Signaling.Base.prototype._trigger = function(ev, args) {
 	EventBus.$emit('signaling-' + kebabCase(ev), args)
 }
 
+Signaling.Base.prototype.setSettings = function(settings) {
+	if (!settings) {
+		// Signaling object is expected to always have a settings object
+		return
+	}
+
+	this.settings = settings
+
+	if (this._pendingUpdateSettingsPromise) {
+		this._pendingUpdateSettingsPromise.resolve()
+		delete this._pendingUpdateSettingsPromise
+	}
+}
+
 Signaling.Base.prototype.isNoMcuWarningEnabled = function() {
 	return !this.settings.hideWarning
 }
@@ -652,6 +666,19 @@ Signaling.Standalone.prototype.connect = function() {
 				timeout: TOAST_PERMANENT_TIMEOUT,
 			})
 		}, 2000)
+	}
+
+	if (this._pendingUpdateSettingsPromise) {
+		console.info('Deferring establishing signaling connection until signaling settings are updated')
+
+		this._pendingUpdateSettingsPromise.then(() => {
+			// "reconnect()" is called instead of "connect()", even if that
+			// slightly delays the connection, as "reconnect()" prevents
+			// duplicated connection requests.
+			this.reconnect()
+		})
+
+		return
 	}
 
 	console.debug('Connecting to ' + this.url + ' for ' + this.settings.token)
@@ -1422,6 +1449,17 @@ Signaling.Standalone.prototype.processRoomParticipantsEvent = function(data) {
 
 Signaling.Standalone.prototype.processErrorTokenExpired = function() {
 	console.info('The signaling token is expired, need to update settings')
+
+	if (!this._pendingUpdateSettingsPromise) {
+		let pendingUpdateSettingsPromiseResolve
+		this._pendingUpdateSettingsPromise = new Promise((resolve, reject) => {
+			// The Promise executor is run even before the Promise constructor has
+			// finished, so "this._pendingUpdateSettingsPromise" is not available
+			// yet.
+			pendingUpdateSettingsPromiseResolve = resolve
+		})
+		this._pendingUpdateSettingsPromise.resolve = pendingUpdateSettingsPromiseResolve
+	}
 
 	this._trigger('updateSettings')
 }

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -772,8 +772,7 @@ Signaling.Standalone.prototype.connect = function() {
 				console.error('An error occurred processing the signaling message, please ask your server administrator to check the log file')
 				break
 			case 'token_expired':
-				console.info('The signaling token is expired, need to update settings')
-				this._trigger('updateSettings')
+				this.processErrorTokenExpired()
 				break
 			default:
 				console.error('Ignore unknown error', data)
@@ -1419,6 +1418,12 @@ Signaling.Standalone.prototype.processRoomParticipantsEvent = function(data) {
 		console.error('Unknown room participant event', data)
 		break
 	}
+}
+
+Signaling.Standalone.prototype.processErrorTokenExpired = function() {
+	console.info('The signaling token is expired, need to update settings')
+
+	this._trigger('updateSettings')
 }
 
 Signaling.Standalone.prototype.requestOffer = function(sessionid, roomType, sid = undefined) {

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -134,7 +134,7 @@ async function connectSignaling(token) {
 		signaling.on('updateSettings', async function() {
 			const settings = await getSignalingSettings(token)
 			console.debug('Received updated settings', settings)
-			signaling.settings = settings
+			signaling.setSettings(settings)
 		})
 
 		signalingTypingHandler?.setSignaling(signaling)


### PR DESCRIPTION
Follow up to #7472

When the external signaling server returns the error `token_expired` the signaling settings [are fetched again](https://github.com/nextcloud/spreed/blob/650d0dd4d4f423b7a7c4e03e0d3a7cd972ecb81e/src/utils/webrtc/index.js#L134-L135). However, if there are further requests and `token_expired` is returned again [the previous fetch is canceled](https://github.com/nextcloud/spreed/blob/650d0dd4d4f423b7a7c4e03e0d3a7cd972ecb81e/src/utils/webrtc/index.js#L86) and a new one started instead, which caused the settings to be temporary set to `null`. The signaling settings are expected to always be an object, so setting them to `null` could cause an error if they were used during that time (for example, during a reconnection, which caused the signaling object to "hang" and not do any further connection attempt).

Preventing the settings to be nullified is only half of the story, though; `token_expired` can be thrown when trying to connect, and errors thrown when trying to connect [cause a reconnection attempt](https://github.com/nextcloud/spreed/blob/f9d955d1536ad02c8ba43100f41869840769cdef/src/utils/signaling.js#L1013). This could end in a reconnection loop, as each `token_expired` error would cause another fetch of the settings, cancelling the previous fetch and thus preventing the settings to be updated, and as the previous settings would be still used any connection attempt would end again in another `token_expired` error.

To solve all that now any connection attempt done after receiving a `token_expired` error is deferred until the signaling settings were updated.

Note that the previous signaling settings are kept to ensure that a signaling object is always available, even if outdated. However, any usage of the outdated signaling settings is expected to cause a `token_expired` error to be thrown; [right now that only happens during connections](https://github.com/strukturag/nextcloud-spreed-signaling/blob/e9140178f92d3e11c6ec809677c25d54a2faa634/hub.go#L1011), so only that code needs to wait for the settings to be fetched again.

## How to test

- Add `sleep(5);` to [`SignalingController::getSettings()`](https://github.com/nextcloud/spreed/blob/0c494e386ffd4c367af509a5d186f22b7ebfe612/lib/Controller/SignalingController.php#L121) to delay getting the signaling settings
- Add a helper to expose the signaling object, for example, in [_src/utils/webrtc/index.js_](https://github.com/nextcloud/spreed/blob/650d0dd4d4f423b7a7c4e03e0d3a7cd972ecb81e/src/utils/webrtc/index.js#L60):
```
window.getSignaling = function() {
	return signaling
}
```
- Rebuild the code
- Setup the HPB
- Open a conversation in Talk
- Wait more than [one minute](https://github.com/nextcloud/spreed/blob/8a850b6192e0f84353ab7104ae4b4b719f24f0e2/lib/Config.php#L543) to ensure that the authentication token received in the signaling settings [has expired](https://github.com/strukturag/nextcloud-spreed-signaling/blob/e9140178f92d3e11c6ec809677c25d54a2faa634/hub.go#L1086-L1088)
- In the browser console, run `getSignaling().forceReconnect(true)`

### Result with this pull request

The first reconnection attempt fails with `token_expired`, and then the connection with the signaling server is established again once the signaling settings were updated

### Result without this pull request

The first and second reconnection attempts fail with `token_expired`, and `this.settings is null` is thrown in the third and last attempt, as it was done while fetching the settings again for the second time, which cancelled the first fetching and caused the settings to be set to null
