### PR TITLE
🖖 Breakout rooms 🛠️ API - Part 3

### DIFF
--- a/appinfo/routes/routesBreakoutRoomController.php
+++ b/appinfo/routes/routesBreakoutRoomController.php
@@ -44,5 +44,7 @@ return [
 		['name' => 'BreakoutRoom#startBreakoutRooms', 'url' => '/api/{apiVersion}/breakout-rooms/{token}/rooms', 'verb' => 'POST', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\BreakoutRoomController::stopBreakoutRooms() */
 		['name' => 'BreakoutRoom#stopBreakoutRooms', 'url' => '/api/{apiVersion}/breakout-rooms/{token}/rooms', 'verb' => 'DELETE', 'requirements' => $requirements],
+		/** @see \OCA\Talk\Controller\BreakoutRoomController::switchBreakoutRoom() */
+		['name' => 'BreakoutRoom#switchBreakoutRoom', 'url' => '/api/{apiVersion}/breakout-rooms/{token}/switch', 'verb' => 'POST', 'requirements' => $requirements],
 	],
 ];

--- a/appinfo/routes/routesBreakoutRoomController.php
+++ b/appinfo/routes/routesBreakoutRoomController.php
@@ -36,6 +36,10 @@ return [
 		['name' => 'BreakoutRoom#removeBreakoutRooms', 'url' => '/api/{apiVersion}/breakout-rooms/{token}', 'verb' => 'DELETE', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\BreakoutRoomController::broadcastChatMessage() */
 		['name' => 'BreakoutRoom#broadcastChatMessage', 'url' => '/api/{apiVersion}/breakout-rooms/{token}/broadcast', 'verb' => 'POST', 'requirements' => $requirements],
+		/** @see \OCA\Talk\Controller\BreakoutRoomController::requestAssistance() */
+		['name' => 'BreakoutRoom#requestAssistance', 'url' => '/api/{apiVersion}/breakout-rooms/{token}/request-assistance', 'verb' => 'POST', 'requirements' => $requirements],
+		/** @see \OCA\Talk\Controller\BreakoutRoomController::resetRequestForAssistance() */
+		['name' => 'BreakoutRoom#resetRequestForAssistance', 'url' => '/api/{apiVersion}/breakout-rooms/{token}/request-assistance', 'verb' => 'DELETE', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\BreakoutRoomController::startBreakoutRooms() */
 		['name' => 'BreakoutRoom#startBreakoutRooms', 'url' => '/api/{apiVersion}/breakout-rooms/{token}/rooms', 'verb' => 'POST', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\BreakoutRoomController::stopBreakoutRooms() */

--- a/appinfo/routes/routesRoomController.php
+++ b/appinfo/routes/routesRoomController.php
@@ -42,6 +42,8 @@ return [
 		['name' => 'Room#createRoom', 'url' => '/api/{apiVersion}/room', 'verb' => 'POST', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\RoomController::getSingleRoom() */
 		['name' => 'Room#getSingleRoom', 'url' => '/api/{apiVersion}/room/{token}', 'verb' => 'GET', 'requirements' => $requirementsWithToken],
+		/** @see \OCA\Talk\Controller\RoomController::getBreakoutRooms() */
+		['name' => 'Room#getBreakoutRooms', 'url' => '/api/{apiVersion}/room/{token}/breakout-rooms', 'verb' => 'GET', 'requirements' => $requirementsWithToken],
 		/** @see \OCA\Talk\Controller\RoomController::renameRoom() */
 		['name' => 'Room#renameRoom', 'url' => '/api/{apiVersion}/room/{token}', 'verb' => 'PUT', 'requirements' => $requirementsWithToken],
 		/** @see \OCA\Talk\Controller\RoomController::deleteRoom() */

--- a/docs/breakout-rooms.md
+++ b/docs/breakout-rooms.md
@@ -93,3 +93,27 @@ Group and public conversations can be used to host breakout rooms.
 		+ `403 Forbidden` When the participant is not a moderator
 		+ `404 Not Found` When the conversation could not be found for the participant
 		+ `413 Payload Too Large` When the message was longer than the allowed limit of 32000 characters (check the `spreed => config => chat => max-length` capability for the limit)
+
+## Request assistance
+
+This endpoint allows participants to raise their hand (token is the breakout room) and moderators will see it in any of the breakout rooms as well as the parent room.
+
+* Required capability: `breakout-rooms-v1`
+* Method: `POST`
+* Endpoint: `/breakout-rooms/{token}/request-assistance`
+* Response:
+	- Status code:
+		+ `200 OK`
+		+ `400 Bad Request` When the room is not a breakout room or breakout rooms are not started
+		+ `404 Not Found` When the conversation could not be found for the participant
+
+## Reset request for assistance
+
+* Required capability: `breakout-rooms-v1`
+* Method: `DELETE`
+* Endpoint: `/breakout-rooms/{token}/request-assistance`
+* Response:
+	- Status code:
+		+ `200 OK`
+		+ `400 Bad Request` When the room does not have breakout rooms configured
+		+ `404 Not Found` When the conversation could not be found for the participant

--- a/docs/breakout-rooms.md
+++ b/docs/breakout-rooms.md
@@ -28,7 +28,7 @@ Group and public conversations can be used to host breakout rooms.
         + `200 OK`
         + `400 Bad Request` When breakout rooms are disabled on the server
         + `400 Bad Request` When breakout rooms are already configured
-        + `400 Bad Request` When the conversation is not a group or public conversation
+        + `400 Bad Request` When the conversation is not a group conversation
         + `400 Bad Request` When the conversation is a breakout room itself
         + `400 Bad Request` When the mode is invalid
         + `400 Bad Request` When the amount is below the minimum or above the maximum
@@ -117,3 +117,7 @@ This endpoint allows participants to raise their hand (token is the breakout roo
 		+ `200 OK`
 		+ `400 Bad Request` When the room does not have breakout rooms configured
 		+ `404 Not Found` When the conversation could not be found for the participant
+
+## List all breakout rooms
+
+See [conversation API](conversation.md#get-breakout-rooms))

--- a/docs/breakout-rooms.md
+++ b/docs/breakout-rooms.md
@@ -121,3 +121,25 @@ This endpoint allows participants to raise their hand (token is the breakout roo
 ## List all breakout rooms
 
 See [conversation API](conversation.md#get-breakout-rooms))
+
+## Switch to a different breakout room (as non moderator)
+
+This endpoint allows participants to raise their hand (token is the breakout room) and moderators will see it in any of the breakout rooms as well as the parent room.
+
+* Required capability: `breakout-rooms-v1`
+* Method: `POST`
+* Endpoint: `/breakout-rooms/{token}/switch`
+* Data:
+
+| field    | type   | Description                                                                   |
+|----------|--------|-------------------------------------------------------------------------------|
+| `token`  | string | (In the URL) Conversation token of the parent room hosting the breakout rooms |
+| `target` | string | Conversation token of the target breakout room                                |
+
+* Response:
+	- Status code:
+		+ `200 OK`
+		+ `400 Bad Request` When the participant is a moderator in the conversation
+		+ `400 Bad Request` When breakout rooms are not configured in `free` mode
+		+ `400 Bad Request` When breakout rooms are not started
+		+ `404 Not Found` When the conversation could not be found for the participant

--- a/docs/conversation.md
+++ b/docs/conversation.md
@@ -153,6 +153,24 @@
 
     - Data: See array definition in `Get user´s conversations`
 
+## Get breakout rooms
+
+Get all (for moderators and in case of "free selection) or the assigned breakout room
+
+* Required capability: `breakout-rooms-v1`
+* Method: `GET`
+* Endpoint: `/room/{token}/breakout-rooms`
+
+* Response:
+    - Status code:
+        + `200 OK`
+        + `400 Bad Request` When the conversation does not have breakout rooms configured
+        + `400 Bad Request` When the breakout rooms are not started and the participant is not a moderator
+        + `401 Unauthorized` When the user is not logged in
+        + `404 Not Found` When the conversation could not be found for the participant
+
+    - Data: See array definition in `Get user´s conversations`
+
 ## Rename a conversation
 
 * Method: `PUT`

--- a/lib/Controller/BreakoutRoomController.php
+++ b/lib/Controller/BreakoutRoomController.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Controller;
 
 use InvalidArgumentException;
+use OCA\Talk\Model\BreakoutRoom;
 use OCA\Talk\Service\BreakoutRoomService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
@@ -84,6 +85,38 @@ class BreakoutRoomController extends AEnvironmentAwareController {
 			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}
 		return new DataResponse([], Http::STATUS_CREATED);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @RequireLoggedInParticipant
+	 *
+	 * @return DataResponse
+	 */
+	public function requestAssistance(): DataResponse {
+		try {
+			$this->breakoutRoomService->setBreakoutRoomAssistanceRequest($this->room, BreakoutRoom::STATUS_ASSISTANCE_REQUESTED);
+		} catch (InvalidArgumentException $e) {
+			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+		}
+
+		return new DataResponse();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @RequireLoggedInParticipant
+	 *
+	 * @return DataResponse
+	 */
+	public function resetRequestForAssistance(): DataResponse {
+		try {
+			$this->breakoutRoomService->setBreakoutRoomAssistanceRequest($this->room, BreakoutRoom::STATUS_ASSISTANCE_RESET);
+		} catch (InvalidArgumentException $e) {
+			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+		}
+
+		return new DataResponse();
 	}
 
 	/**

--- a/lib/Controller/BreakoutRoomController.php
+++ b/lib/Controller/BreakoutRoomController.php
@@ -95,7 +95,7 @@ class BreakoutRoomController extends AEnvironmentAwareController {
 	 */
 	public function requestAssistance(): DataResponse {
 		try {
-			$this->breakoutRoomService->setBreakoutRoomAssistanceRequest($this->room, BreakoutRoom::STATUS_ASSISTANCE_REQUESTED);
+			$this->breakoutRoomService->requestAssistance($this->room);
 		} catch (InvalidArgumentException $e) {
 			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}
@@ -111,7 +111,7 @@ class BreakoutRoomController extends AEnvironmentAwareController {
 	 */
 	public function resetRequestForAssistance(): DataResponse {
 		try {
-			$this->breakoutRoomService->setBreakoutRoomAssistanceRequest($this->room, BreakoutRoom::STATUS_ASSISTANCE_RESET);
+			$this->breakoutRoomService->resetRequestForAssistance($this->room);
 		} catch (InvalidArgumentException $e) {
 			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}

--- a/lib/Controller/BreakoutRoomController.php
+++ b/lib/Controller/BreakoutRoomController.php
@@ -26,7 +26,6 @@ declare(strict_types=1);
 namespace OCA\Talk\Controller;
 
 use InvalidArgumentException;
-use OCA\Talk\Model\BreakoutRoom;
 use OCA\Talk\Service\BreakoutRoomService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
@@ -140,6 +139,20 @@ class BreakoutRoomController extends AEnvironmentAwareController {
 	public function stopBreakoutRooms(): DataResponse {
 		try {
 			$this->breakoutRoomService->stopBreakoutRooms($this->room);
+		} catch (InvalidArgumentException $e) {
+			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+		}
+
+		return new DataResponse();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @RequireLoggedInParticipant
+	 */
+	public function switchBreakoutRoom(string $target): DataResponse {
+		try {
+			$this->breakoutRoomService->switchBreakoutRoom($this->room, $this->participant, $target);
 		} catch (InvalidArgumentException $e) {
 			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -236,11 +236,9 @@ class RoomController extends AEnvironmentAwareController {
 		foreach ($rooms as $room) {
 			try {
 				$return[] = $this->formatRoom($room, $this->participantService->getParticipant($room, $this->userId), $statuses);
-			} catch (RoomNotFoundException $e) {
 			} catch (ParticipantNotFoundException $e) {
 				// for example in case the room was deleted concurrently,
-				// the user is not a participant any more
-			} catch (\RuntimeException $e) {
+				// the user is not a participant anymore
 			}
 		}
 
@@ -260,11 +258,7 @@ class RoomController extends AEnvironmentAwareController {
 
 		$return = [];
 		foreach ($rooms as $room) {
-			try {
-				$return[] = $this->formatRoom($room, null);
-			} catch (RoomNotFoundException $e) {
-			} catch (\RuntimeException $e) {
-			}
+			$return[] = $this->formatRoom($room, null);
 		}
 
 		return new DataResponse($return, Http::STATUS_OK);
@@ -294,10 +288,7 @@ class RoomController extends AEnvironmentAwareController {
 				$participant = null;
 			}
 
-			try {
-				$return[] = $this->formatRoom($room, $participant, null, false, true);
-			} catch (\RuntimeException $e) {
-			}
+			$return[] = $this->formatRoom($room, $participant, null, false, true);
 		}
 
 
@@ -389,28 +380,10 @@ class RoomController extends AEnvironmentAwareController {
 		throw new UnauthorizedException('Invalid HMAC provided');
 	}
 
-	/**
-	 * @param Room $room
-	 * @param Participant|null $currentParticipant
-	 * @param array|null $statuses
-	 * @param bool $isSIPBridgeRequest
-	 * @param bool $isListingBreakoutRooms
-	 * @return array
-	 * @throws RoomNotFoundException
-	 */
 	protected function formatRoom(Room $room, ?Participant $currentParticipant, ?array $statuses = null, bool $isSIPBridgeRequest = false, bool $isListingBreakoutRooms = false): array {
 		return $this->formatRoomV4($room, $currentParticipant, $statuses, $isSIPBridgeRequest, $isListingBreakoutRooms);
 	}
 
-	/**
-	 * @param Room $room
-	 * @param Participant|null $currentParticipant
-	 * @param array|null $statuses
-	 * @param bool $isSIPBridgeRequest
-	 * @param bool $isListingBreakoutRooms
-	 * @return array
-	 * @throws RoomNotFoundException
-	 */
 	protected function formatRoomV4(Room $room, ?Participant $currentParticipant, ?array $statuses, bool $isSIPBridgeRequest, bool $isListingBreakoutRooms): array {
 		$roomData = [
 			'id' => $room->getId(),

--- a/lib/Model/BreakoutRoom.php
+++ b/lib/Model/BreakoutRoom.php
@@ -33,6 +33,8 @@ class BreakoutRoom {
 
 	public const STATUS_STOPPED = 0;
 	public const STATUS_STARTED = 1;
+	public const STATUS_ASSISTANCE_RESET = 0;
+	public const STATUS_ASSISTANCE_REQUESTED = 2;
 
 	public const MINIMUM_ROOM_AMOUNT = 1;
 	public const MAXIMUM_ROOM_AMOUNT = 20;

--- a/lib/Service/BreakoutRoomService.php
+++ b/lib/Service/BreakoutRoomService.php
@@ -277,7 +277,15 @@ class BreakoutRoomService {
 		}
 	}
 
-	public function setBreakoutRoomAssistanceRequest(Room $breakoutRoom, int $status): void {
+	public function requestAssistance(Room $breakoutRoom): void {
+		$this->setAssistanceRequest($breakoutRoom, BreakoutRoom::STATUS_ASSISTANCE_REQUESTED);
+	}
+
+	public function resetRequestForAssistance(Room $breakoutRoom): void {
+		$this->setAssistanceRequest($breakoutRoom, BreakoutRoom::STATUS_ASSISTANCE_RESET);
+	}
+
+	protected function setAssistanceRequest(Room $breakoutRoom, int $status): void {
 		if ($breakoutRoom->getObjectType() !== BreakoutRoom::PARENT_OBJECT_TYPE) {
 			throw new \InvalidArgumentException('room');
 		}
@@ -319,6 +327,10 @@ class BreakoutRoomService {
 		$breakoutRooms = $this->manager->getMultipleRoomsByObject(BreakoutRoom::PARENT_OBJECT_TYPE, $parent->getToken());
 		foreach ($breakoutRooms as $breakoutRoom) {
 			$this->roomService->setLobby($breakoutRoom, Webinary::LOBBY_NON_MODERATORS, null);
+
+			if ($breakoutRoom->getBreakoutRoomStatus() === BreakoutRoom::STATUS_ASSISTANCE_REQUESTED) {
+				$this->roomService->setBreakoutRoomStatus($breakoutRoom, BreakoutRoom::STATUS_ASSISTANCE_RESET);
+			}
 		}
 
 		$this->roomService->setBreakoutRoomStatus($parent, BreakoutRoom::STATUS_STOPPED);
@@ -357,9 +369,8 @@ class BreakoutRoomService {
 					// Skip this room
 				}
 			}
-		} else {
-			$rooms = $breakoutRooms;
+			return $rooms;
 		}
-		return $rooms;
+		return $breakoutRooms;
 	}
 }

--- a/lib/Service/BreakoutRoomService.php
+++ b/lib/Service/BreakoutRoomService.php
@@ -353,7 +353,7 @@ class BreakoutRoomService {
 						$participant->getAttendee()->getActorId()
 					);
 					$rooms[] = $breakoutRoom;
-				} catch (ParticipantNotFoundException $e){
+				} catch (ParticipantNotFoundException $e) {
 					// Skip this room
 				}
 			}

--- a/lib/Service/BreakoutRoomService.php
+++ b/lib/Service/BreakoutRoomService.php
@@ -277,6 +277,25 @@ class BreakoutRoomService {
 		}
 	}
 
+	public function setBreakoutRoomAssistanceRequest(Room $breakoutRoom, int $status): void {
+		if ($breakoutRoom->getObjectType() !== BreakoutRoom::PARENT_OBJECT_TYPE) {
+			throw new \InvalidArgumentException('room');
+		}
+
+		if ($breakoutRoom->getLobbyState() !== Webinary::LOBBY_NONE) {
+			throw new \InvalidArgumentException('room');
+		}
+
+		if (!in_array($status, [
+			BreakoutRoom::STATUS_ASSISTANCE_RESET,
+			BreakoutRoom::STATUS_ASSISTANCE_REQUESTED,
+		], true)) {
+			throw new \InvalidArgumentException('status');
+		}
+
+		$this->roomService->setBreakoutRoomStatus($breakoutRoom, $status);
+	}
+
 	public function startBreakoutRooms(Room $parent): void {
 		if ($parent->getBreakoutRoomMode() === BreakoutRoom::MODE_NOT_CONFIGURED) {
 			throw new \InvalidArgumentException('mode');

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -633,6 +633,8 @@ class RoomService {
 		if (!in_array($status, [
 			BreakoutRoom::STATUS_STOPPED,
 			BreakoutRoom::STATUS_STARTED,
+			BreakoutRoom::STATUS_ASSISTANCE_RESET,
+			BreakoutRoom::STATUS_ASSISTANCE_REQUESTED,
 		], true)) {
 			return false;
 		}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2383,6 +2383,25 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" (requests assistance|cancels request for assistance) in room "([^"]*)" with (\d+)(?: \((v1)\))?$/
+	 *
+	 * @param string $user
+	 * @param string $requestCancel
+	 * @param string $identifier
+	 * @param string $statusCode
+	 * @param string $apiVersion
+	 */
+	public function userRequestsOrCancelsAssistanceInBreakoutRooms(string $user, string $requestCancel, string $identifier, string $statusCode, string $apiVersion = 'v1') {
+		$this->setCurrentUser($user);
+		$this->sendRequest(
+			$requestCancel === 'requests assistance' ? 'POST' : 'DELETE',
+			'/apps/spreed/api/' . $apiVersion . '/breakout-rooms/' . self::$identifierToToken[$identifier] . '/request-assistance'
+		);
+
+		$this->assertStatusCode($this->response, $statusCode);
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" sets setting "([^"]*)" to "([^"]*)" with (\d+)(?: \((v1)\))?$/
 	 *
 	 * @param string $user

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2416,6 +2416,28 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" switches in room "([^"]*)" to breakout room "([^"]*)" with (\d+)(?: \((v1)\))?$/
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 * @param string $target
+	 * @param string $statusCode
+	 * @param string $apiVersion
+	 */
+	public function userSwitchesBreakoutRoom(string $user, string $identifier, string $target, string $statusCode, string $apiVersion = 'v1') {
+		$this->setCurrentUser($user);
+		$this->sendRequest(
+			'POST',
+			'/apps/spreed/api/' . $apiVersion . '/breakout-rooms/' . self::$identifierToToken[$identifier] . '/switch',
+			[
+				'target' => self::$identifierToToken[$target],
+			]
+		);
+
+		$this->assertStatusCode($this->response, $statusCode);
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" (requests assistance|cancels request for assistance) in room "([^"]*)" with (\d+)(?: \((v1)\))?$/
 	 *
 	 * @param string $user

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -283,6 +283,39 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" sees the following breakout rooms for room "([^"]*)" with (\d+) \((v4)\)$/
+	 *
+	 * @param string $user
+	 * @param string $apiVersion
+	 * @param int $status
+	 * @param TableNode|null $formData
+	 */
+	public function userListsBreakoutRooms(string $user, string $identifier, int $status, string $apiVersion, TableNode $formData = null): void {
+		$token = self::$identifierToToken[$identifier];
+
+		$this->setCurrentUser($user);
+		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/room/' . $token . '/breakout-rooms');
+		$this->assertStatusCode($this->response, $status);
+
+		if ($status !== 200) {
+			return;
+		}
+
+		$rooms = $this->getDataFromResponse($this->response);
+
+		$rooms = array_filter($rooms, function ($room) {
+			return $room['type'] !== 4;
+		});
+
+		if ($formData === null) {
+			Assert::assertEmpty($rooms);
+			return;
+		}
+
+		$this->assertRooms($rooms, $formData);
+	}
+
+	/**
 	 * @param array $rooms
 	 * @param TableNode $formData
 	 */

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -311,3 +311,43 @@ Feature: conversation/breakout-rooms
       | Room 3 | users     | participant1 | participant1-displayname | breakout_rooms_stopped |
       | Room 3 | users     | participant1 | participant1-displayname | breakout_rooms_started |
       | Room 3 | users     | participant1 | participant1-displayname | conversation_created   |
+
+  Scenario: Request assistance and cancel it
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 3 |
+      | roomName | class room |
+    And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
+    And user "participant1" sees the following attendees in room "class room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+      | users      | participant2 | 3               |
+    When user "participant1" creates 1 automatic breakout rooms for "class room" with 200 (v1)
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 3    | class room | 0          | 1                | 0                  |
+      | 3    | Room 1     | 1          | 0                | 0                  |
+    And user "participant1" starts breakout rooms in room "class room" with 200 (v1)
+    And user "participant2" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 3    | class room | 0          | 1                | 1                  |
+      | 3    | Room 1     | 0          | 0                | 0                  |
+    And user "participant2" requests assistance in room "Room 1" with 200 (v1)
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 3    | class room | 0          | 1                | 1                  |
+      | 3    | Room 1     | 0          | 0                | 2                  |
+    And user "participant2" cancels request for assistance in room "Room 1" with 200 (v1)
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 3    | class room | 0          | 1                | 1                  |
+      | 3    | Room 1     | 0          | 0                | 0                  |
+    And user "participant2" requests assistance in room "Room 1" with 200 (v1)
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 3    | class room | 0          | 1                | 1                  |
+      | 3    | Room 1     | 0          | 0                | 2                  |
+    And user "participant1" cancels request for assistance in room "Room 1" with 200 (v1)
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 3    | class room | 0          | 1                | 1                  |
+      | 3    | Room 1     | 0          | 0                | 0                  |

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -367,8 +367,8 @@ Feature: conversation/breakout-rooms
     Then user "participant2" sees the following breakout rooms for room "class room" with 400 (v4)
     Then user "participant1" sees the following breakout rooms for room "class room" with 200 (v4)
       | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
-      | 2    | Room 1     | 0          | 0                | 0                  |
-      | 2    | Room 2     | 0          | 0                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
     And user "participant1" starts breakout rooms in room "class room" with 200 (v1)
     Then user "participant2" sees the following breakout rooms for room "class room" with 200 (v4)
       | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -7,7 +7,7 @@ Feature: conversation/breakout-rooms
 
   Scenario: Teacher creates manual breakout rooms
     Given user "participant1" creates room "class room" (v4)
-      | roomType | 3 |
+      | roomType | 2 |
       | roomName | class room |
     And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
     And user "participant1" adds user "participant3" to room "class room" with 200 (v4)
@@ -24,26 +24,26 @@ Feature: conversation/breakout-rooms
       | users::participant4 | 2 |
     Then user "participant1" is participant of the following rooms (v4)
       | type | name       |
-      | 3    | class room |
-      | 3    | Room 1     |
-      | 3    | Room 2     |
-      | 3    | Room 3     |
+      | 2    | class room |
+      | 2    | Room 1     |
+      | 2    | Room 2     |
+      | 2    | Room 3     |
     Then user "participant2" is participant of the following rooms (v4)
       | type | name       |
-      | 3    | class room |
-      | 3    | Room 1     |
+      | 2    | class room |
+      | 2    | Room 1     |
     Then user "participant3" is participant of the following rooms (v4)
       | type | name       |
-      | 3    | class room |
-      | 3    | Room 2     |
+      | 2    | class room |
+      | 2    | Room 2     |
     Then user "participant4" is participant of the following rooms (v4)
       | type | name       |
-      | 3    | class room |
-      | 3    | Room 3     |
+      | 2    | class room |
+      | 2    | Room 3     |
 
   Scenario: Teacher creates automatic breakout rooms
     Given user "participant1" creates room "class room" (v4)
-      | roomType | 3 |
+      | roomType | 2 |
       | roomName | class room |
     And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
     And user "participant1" adds user "participant3" to room "class room" with 200 (v4)
@@ -57,10 +57,10 @@ Feature: conversation/breakout-rooms
     When user "participant1" creates 3 automatic breakout rooms for "class room" with 200 (v1)
     Then user "participant1" is participant of the following rooms (v4)
       | type | name       |
-      | 3    | class room |
-      | 3    | Room 1     |
-      | 3    | Room 2     |
-      | 3    | Room 3     |
+      | 2    | class room |
+      | 2    | Room 1     |
+      | 2    | Room 2     |
+      | 2    | Room 3     |
     And user "participant1" sees the following attendees in room "Room 1" with 200 (v4)
       | actorType  | actorId           | participantType |
       | users      | participant1      | 1               |
@@ -75,20 +75,20 @@ Feature: conversation/breakout-rooms
       | users      | /^participant\d$/ | 3               |
     Then user "participant2" is participant of the following rooms (v4)
       | type | name        |
-      | 3    | class room  |
-      | 3    | /^Room \d$/ |
+      | 2    | class room  |
+      | 2    | /^Room \d$/ |
     Then user "participant3" is participant of the following rooms (v4)
       | type | name        |
-      | 3    | class room  |
-      | 3    | /^Room \d$/ |
+      | 2    | class room  |
+      | 2    | /^Room \d$/ |
     Then user "participant4" is participant of the following rooms (v4)
       | type | name        |
-      | 3    | class room  |
-      | 3    | /^Room \d$/ |
+      | 2    | class room  |
+      | 2    | /^Room \d$/ |
 
   Scenario: Co-teachers are promoted and removed in all breakout rooms
     Given user "participant1" creates room "class room" (v4)
-      | roomType | 3 |
+      | roomType | 2 |
       | roomName | class room |
     And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
     And user "participant1" sees the following attendees in room "class room" with 200 (v4)
@@ -99,21 +99,21 @@ Feature: conversation/breakout-rooms
       | users::participant2 | 0 |
     And user "participant1" is participant of the following rooms (v4)
       | type | name       |
-      | 3    | class room |
-      | 3    | Room 1     |
-      | 3    | Room 2     |
-      | 3    | Room 3     |
+      | 2    | class room |
+      | 2    | Room 1     |
+      | 2    | Room 2     |
+      | 2    | Room 3     |
     And user "participant2" is participant of the following rooms (v4)
       | type | name       |
-      | 3    | class room |
-      | 3    | Room 1     |
+      | 2    | class room |
+      | 2    | Room 1     |
     When user "participant1" promotes "participant2" in room "class room" with 200 (v4)
     Then user "participant2" is participant of the following rooms (v4)
       | type | name       |
-      | 3    | class room |
-      | 3    | Room 1     |
-      | 3    | Room 2     |
-      | 3    | Room 3     |
+      | 2    | class room |
+      | 2    | Room 1     |
+      | 2    | Room 2     |
+      | 2    | Room 3     |
     And user "participant1" sees the following attendees in room "Room 1" with 200 (v4)
       | actorType  | actorId      | participantType |
       | users      | participant1 | 1               |
@@ -129,7 +129,7 @@ Feature: conversation/breakout-rooms
     When user "participant1" demotes "participant2" in room "class room" with 200 (v4)
     Then user "participant2" is participant of the following rooms (v4)
       | type | name       |
-      | 3    | class room |
+      | 2    | class room |
     And user "participant1" sees the following attendees in room "Room 1" with 200 (v4)
       | actorType  | actorId      | participantType |
       | users      | participant1 | 1               |
@@ -142,15 +142,15 @@ Feature: conversation/breakout-rooms
 
   Scenario: Can not nest breakout rooms
     When user "participant1" creates room "class room" (v4)
-      | roomType | 3 |
+      | roomType | 2 |
       | roomName | class room |
     And user "participant1" creates 3 manual breakout rooms for "class room" with 200 (v1)
     And user "participant1" is participant of the following rooms (v4)
       | type | name       |
-      | 3    | class room |
-      | 3    | Room 1     |
-      | 3    | Room 2     |
-      | 3    | Room 3     |
+      | 2    | class room |
+      | 2    | Room 1     |
+      | 2    | Room 2     |
+      | 2    | Room 3     |
     And user "participant1" creates 3 manual breakout rooms for "Room 1" with 400 (v1)
 
   Scenario: Can not create breakout rooms in one-to-one
@@ -161,19 +161,19 @@ Feature: conversation/breakout-rooms
 
   Scenario: Can not create more than 20 breakout rooms
     When user "participant1" creates room "class room" (v4)
-      | roomType | 3 |
+      | roomType | 2 |
       | roomName | class room |
     And user "participant1" creates 21 manual breakout rooms for "class room" with 400 (v1)
 
   Scenario: Can not create less than 1 breakout rooms
     When user "participant1" creates room "class room" (v4)
-      | roomType | 3 |
+      | roomType | 2 |
       | roomName | class room |
     And user "participant1" creates 0 manual breakout rooms for "class room" with 400 (v1)
 
   Scenario: Invalid breakout room number in attendee map (low)
     Given user "participant1" creates room "class room" (v4)
-      | roomType | 3 |
+      | roomType | 2 |
       | roomName | class room |
     And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
     And user "participant1" sees the following attendees in room "class room" with 200 (v4)
@@ -185,7 +185,7 @@ Feature: conversation/breakout-rooms
 
   Scenario: Invalid breakout room number in attendee map (high)
     Given user "participant1" creates room "class room" (v4)
-      | roomType | 3 |
+      | roomType | 2 |
       | roomName | class room |
     And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
     And user "participant1" sees the following attendees in room "class room" with 200 (v4)
@@ -197,7 +197,7 @@ Feature: conversation/breakout-rooms
 
   Scenario: Breakout rooms are disabled
     Given user "participant1" creates room "class room" (v4)
-      | roomType | 3 |
+      | roomType | 2 |
       | roomName | class room |
     And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
     And user "participant1" sees the following attendees in room "class room" with 200 (v4)
@@ -211,7 +211,7 @@ Feature: conversation/breakout-rooms
 
   Scenario: Broadcast chat message to all breakout room
     Given user "participant1" creates room "class room" (v4)
-      | roomType | 3 |
+      | roomType | 2 |
       | roomName | class room |
     And user "participant1" sees the following attendees in room "class room" with 200 (v4)
       | actorType  | actorId      | participantType |
@@ -219,10 +219,10 @@ Feature: conversation/breakout-rooms
     When user "participant1" creates 3 manual breakout rooms for "class room" with 200 (v1)
     And user "participant1" is participant of the following rooms (v4)
       | type | name       |
-      | 3    | class room |
-      | 3    | Room 1     |
-      | 3    | Room 2     |
-      | 3    | Room 3     |
+      | 2    | class room |
+      | 2    | Room 1     |
+      | 2    | Room 2     |
+      | 2    | Room 3     |
     And user "participant1" broadcasts message "Hello rooms 1-3" to room "class room" with 201 (v1)
     Then user "participant1" sees the following messages in room "Room 1" with 200
       | room   | actorType | actorId      | actorDisplayName         | message         | messageParameters |
@@ -236,20 +236,20 @@ Feature: conversation/breakout-rooms
 
   Scenario: Can not broadcast chat message in a non-breakout room
     Given user "participant1" creates room "room" (v4)
-      | roomType | 3 |
+      | roomType | 2 |
       | roomName | class room |
     And user "participant1" broadcasts message "Does not work" to room "room" with 400 (v1)
 
   Scenario: Can not start in a non-breakout room
     Given user "participant1" creates room "room" (v4)
-      | roomType | 3 |
+      | roomType | 2 |
       | roomName | room |
     And user "participant1" starts breakout rooms in room "room" with 400 (v1)
     And user "participant1" stops breakout rooms in room "room" with 400 (v1)
 
   Scenario: Moderator starts and stops breakout rooms
     Given user "participant1" creates room "class room" (v4)
-      | roomType | 3 |
+      | roomType | 2 |
       | roomName | class room |
     And user "participant1" sees the following attendees in room "class room" with 200 (v4)
       | actorType  | actorId      | participantType |
@@ -257,10 +257,10 @@ Feature: conversation/breakout-rooms
     When user "participant1" creates 3 manual breakout rooms for "class room" with 200 (v1)
     And user "participant1" is participant of the following rooms (v4)
       | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
-      | 3    | class room | 0          | 2                | 0                  |
-      | 3    | Room 1     | 1          | 0                | 0                  |
-      | 3    | Room 2     | 1          | 0                | 0                  |
-      | 3    | Room 3     | 1          | 0                | 0                  |
+      | 2    | class room | 0          | 2                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+      | 2    | Room 3     | 1          | 0                | 0                  |
     Then user "participant1" sees the following system messages in room "Room 1" with 200
       | room   | actorType | actorId      | actorDisplayName         | systemMessage          |
       | Room 1 | users     | participant1 | participant1-displayname | conversation_created   |
@@ -273,10 +273,10 @@ Feature: conversation/breakout-rooms
     And user "participant1" starts breakout rooms in room "class room" with 200 (v1)
     And user "participant1" is participant of the following rooms (v4)
       | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
-      | 3    | class room | 0          | 2                | 1                  |
-      | 3    | Room 1     | 0          | 0                | 0                  |
-      | 3    | Room 2     | 0          | 0                | 0                  |
-      | 3    | Room 3     | 0          | 0                | 0                  |
+      | 2    | class room | 0          | 2                | 1                  |
+      | 2    | Room 1     | 0          | 0                | 0                  |
+      | 2    | Room 2     | 0          | 0                | 0                  |
+      | 2    | Room 3     | 0          | 0                | 0                  |
     Then user "participant1" sees the following system messages in room "Room 1" with 200
       | room   | actorType | actorId      | actorDisplayName         | systemMessage          |
       | Room 1 | users     | participant1 | participant1-displayname | breakout_rooms_started |
@@ -292,10 +292,10 @@ Feature: conversation/breakout-rooms
     And user "participant1" stops breakout rooms in room "class room" with 200 (v1)
     And user "participant1" is participant of the following rooms (v4)
       | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
-      | 3    | class room | 0          | 2                | 0                  |
-      | 3    | Room 1     | 1          | 0                | 0                  |
-      | 3    | Room 2     | 1          | 0                | 0                  |
-      | 3    | Room 3     | 1          | 0                | 0                  |
+      | 2    | class room | 0          | 2                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+      | 2    | Room 3     | 1          | 0                | 0                  |
     Then user "participant1" sees the following system messages in room "Room 1" with 200
       | room   | actorType | actorId      | actorDisplayName         | systemMessage          |
       | Room 1 | users     | participant1 | participant1-displayname | breakout_rooms_stopped |
@@ -314,7 +314,7 @@ Feature: conversation/breakout-rooms
 
   Scenario: Request assistance and cancel it
     Given user "participant1" creates room "class room" (v4)
-      | roomType | 3 |
+      | roomType | 2 |
       | roomName | class room |
     And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
     And user "participant1" sees the following attendees in room "class room" with 200 (v4)
@@ -324,30 +324,85 @@ Feature: conversation/breakout-rooms
     When user "participant1" creates 1 automatic breakout rooms for "class room" with 200 (v1)
     And user "participant1" is participant of the following rooms (v4)
       | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
-      | 3    | class room | 0          | 1                | 0                  |
-      | 3    | Room 1     | 1          | 0                | 0                  |
+      | 2    | class room | 0          | 1                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
     And user "participant1" starts breakout rooms in room "class room" with 200 (v1)
     And user "participant2" is participant of the following rooms (v4)
       | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
-      | 3    | class room | 0          | 1                | 1                  |
-      | 3    | Room 1     | 0          | 0                | 0                  |
+      | 2    | class room | 0          | 1                | 1                  |
+      | 2    | Room 1     | 0          | 0                | 0                  |
     And user "participant2" requests assistance in room "Room 1" with 200 (v1)
     And user "participant1" is participant of the following rooms (v4)
       | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
-      | 3    | class room | 0          | 1                | 1                  |
-      | 3    | Room 1     | 0          | 0                | 2                  |
+      | 2    | class room | 0          | 1                | 1                  |
+      | 2    | Room 1     | 0          | 0                | 2                  |
     And user "participant2" cancels request for assistance in room "Room 1" with 200 (v1)
     And user "participant1" is participant of the following rooms (v4)
       | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
-      | 3    | class room | 0          | 1                | 1                  |
-      | 3    | Room 1     | 0          | 0                | 0                  |
+      | 2    | class room | 0          | 1                | 1                  |
+      | 2    | Room 1     | 0          | 0                | 0                  |
     And user "participant2" requests assistance in room "Room 1" with 200 (v1)
     And user "participant1" is participant of the following rooms (v4)
       | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
-      | 3    | class room | 0          | 1                | 1                  |
-      | 3    | Room 1     | 0          | 0                | 2                  |
+      | 2    | class room | 0          | 1                | 1                  |
+      | 2    | Room 1     | 0          | 0                | 2                  |
     And user "participant1" cancels request for assistance in room "Room 1" with 200 (v1)
     And user "participant1" is participant of the following rooms (v4)
       | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
-      | 3    | class room | 0          | 1                | 1                  |
-      | 3    | Room 1     | 0          | 0                | 0                  |
+      | 2    | class room | 0          | 1                | 1                  |
+      | 2    | Room 1     | 0          | 0                | 0                  |
+
+  Scenario: Teacher creates free breakout rooms
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    And user "participant1" creates 2 free breakout rooms for "class room" with 200 (v1)
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 3                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+    Then user "participant2" sees the following breakout rooms for room "class room" with 404 (v4)
+    And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
+    Then user "participant2" sees the following breakout rooms for room "class room" with 400 (v4)
+    Then user "participant1" sees the following breakout rooms for room "class room" with 200 (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | Room 1     | 0          | 0                | 0                  |
+      | 2    | Room 2     | 0          | 0                | 0                  |
+    And user "participant1" starts breakout rooms in room "class room" with 200 (v1)
+    Then user "participant2" sees the following breakout rooms for room "class room" with 200 (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | Room 1     | 0          | 0                | 0                  |
+      | 2    | Room 2     | 0          | 0                | 0                  |
+
+  Scenario: Student can only get their own breakout room when non-free
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
+    And user "participant1" sees the following attendees in room "class room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+      | users      | participant2 | 3               |
+    When user "participant1" creates 3 manual breakout rooms for "class room" with 200 (v1)
+      | users::participant2 | 0 |
+    Then user "participant1" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 1     |
+      | 2    | Room 2     |
+      | 2    | Room 3     |
+    Then user "participant2" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 1     |
+    Then user "participant1" sees the following breakout rooms for room "class room" with 200 (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+      | 2    | Room 3     | 1          | 0                | 0                  |
+    Then user "participant2" sees the following breakout rooms for room "class room" with 400 (v4)
+    And user "participant1" starts breakout rooms in room "class room" with 200 (v1)
+    Then user "participant2" sees the following breakout rooms for room "class room" with 200 (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | Room 1     | 0          | 0                | 0                  |

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -406,3 +406,89 @@ Feature: conversation/breakout-rooms
     Then user "participant2" sees the following breakout rooms for room "class room" with 200 (v4)
       | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
       | 2    | Room 1     | 0          | 0                | 0                  |
+
+  Scenario: Teachers can not "switch" breakout rooms as they are in all of them
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    And user "participant1" creates 2 free breakout rooms for "class room" with 200 (v1)
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 3                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+    And user "participant1" starts breakout rooms in room "class room" with 200 (v1)
+    When user "participant1" switches in room "class room" to breakout room "Room 1" with 400 (v1)
+
+  Scenario: Student switching breakout room in free selection
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    And user "participant1" creates 2 free breakout rooms for "class room" with 200 (v1)
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 3                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+    And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
+    Then user "participant2" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+    When user "participant2" switches in room "class room" to breakout room "Room 1" with 400 (v1)
+    And user "participant1" starts breakout rooms in room "class room" with 200 (v1)
+    When user "participant2" switches in room "class room" to breakout room "Room 1" with 200 (v1)
+    Then user "participant2" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 1     |
+    When user "participant2" switches in room "class room" to breakout room "Room 2" with 200 (v1)
+    Then user "participant2" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 2     |
+
+  Scenario: Student can not switch on manual breakout rooms
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
+    And user "participant1" sees the following attendees in room "class room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+      | users      | participant2 | 3               |
+    And user "participant1" creates 2 manual breakout rooms for "class room" with 200 (v1)
+      | users::participant2 | 0 |
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 2                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+    Then user "participant2" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 1     |
+    And user "participant1" starts breakout rooms in room "class room" with 200 (v1)
+    When user "participant2" switches in room "class room" to breakout room "Room 1" with 400 (v1)
+
+  Scenario: Student can not switch on automatic breakout rooms
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
+    And user "participant1" sees the following attendees in room "class room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+      | users      | participant2 | 3               |
+    And user "participant1" creates 2 automatic breakout rooms for "class room" with 200 (v1)
+      | users::participant2 | 0 |
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 1                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+    Then user "participant2" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 1     |
+    And user "participant1" starts breakout rooms in room "class room" with 200 (v1)
+    When user "participant2" switches in room "class room" to breakout room "Room 1" with 400 (v1)


### PR DESCRIPTION
Fix #8338

### 🚧 TODO

- [x] Based on #8370 
- [x] Create API for participants to "raise hand" across the rooms
  - [x] Integration tests
  - [x] API Documentation
- [x] Create API for participants to abort/reset assistance request
  - [x] Integration tests
  - [x] API Documentation
- [x] Configuring breakout rooms before the call
  - [x] Free distribution (?)
    - [x] Expose the list of potential breakout rooms (⚠️ listed convos would expose to everyone on the instance)
    - [x] Integration tests
    - [x] API Documentation
- [x] Allow students to switch between breakout rooms in case of free distribution
  - [x] Integration tests
  - [x] API Documentation

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
