### PR TITLE
Revert "Revert @nextcloud/vue changes to sidebar scrolling"

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -347,10 +347,6 @@ export default {
 	flex-direction: column;
 }
 
-::v-deep .app-sidebar-tabs {
-	min-height: 0;
-}
-
 .app-sidebar-tabs__content #tab-chat {
 	/* Remove padding to maximize the space for the chat view. */
 	padding: 0;


### PR DESCRIPTION
Follow up to #8453 

This reverts commit da87a426aa3a06e247e6638b9c837884f46a0f39 from #8418
which is now not needed anymore as the upstream patch was reverted