### PR TITLE
🖖 Breakout rooms 🛠️ API - Part 4

### DIFF
--- a/appinfo/routes/routesBreakoutRoomController.php
+++ b/appinfo/routes/routesBreakoutRoomController.php
@@ -36,6 +36,8 @@ return [
 		['name' => 'BreakoutRoom#removeBreakoutRooms', 'url' => '/api/{apiVersion}/breakout-rooms/{token}', 'verb' => 'DELETE', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\BreakoutRoomController::broadcastChatMessage() */
 		['name' => 'BreakoutRoom#broadcastChatMessage', 'url' => '/api/{apiVersion}/breakout-rooms/{token}/broadcast', 'verb' => 'POST', 'requirements' => $requirements],
+		/** @see \OCA\Talk\Controller\BreakoutRoomController::applyAttendeeMap() */
+		['name' => 'BreakoutRoom#applyAttendeeMap', 'url' => '/api/{apiVersion}/breakout-rooms/{token}/attendees', 'verb' => 'POST', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\BreakoutRoomController::requestAssistance() */
 		['name' => 'BreakoutRoom#requestAssistance', 'url' => '/api/{apiVersion}/breakout-rooms/{token}/request-assistance', 'verb' => 'POST', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\BreakoutRoomController::resetRequestForAssistance() */

--- a/docs/breakout-rooms.md
+++ b/docs/breakout-rooms.md
@@ -17,22 +17,22 @@ Group and public conversations can be used to host breakout rooms.
 * Endpoint: `/breakout-rooms/{token}`
 * Data:
 
-| field         | type   | Description                                                                                          |
-|---------------|--------|------------------------------------------------------------------------------------------------------|
-| `mode`        | int    | Participant assignment mode (see [constants list](constants.md#breakout-room-modes))                 |
-| `amount`      | int    | Number of breakout rooms to create (Minimum `1`, maximum `20`)                                       |
-| `attendeeMap` | string | A json encoded Map of attendeeId => room number (0 based) (Only considered when the mode is "manual" |
+| field         | type   | Description                                                                                           |
+|---------------|--------|-------------------------------------------------------------------------------------------------------|
+| `mode`        | int    | Participant assignment mode (see [constants list](constants.md#breakout-room-modes))                  |
+| `amount`      | int    | Number of breakout rooms to create (Minimum `1`, maximum `20`)                                        |
+| `attendeeMap` | string | A json encoded Map of attendeeId => room number (0 based) (Only considered when the mode is "manual") |
 
 * Response:
     - Status code:
         + `200 OK`
-        + `400 Bad Request` When breakout rooms are disabled on the server
-        + `400 Bad Request` When breakout rooms are already configured
-        + `400 Bad Request` When the conversation is not a group conversation
-        + `400 Bad Request` When the conversation is a breakout room itself
-        + `400 Bad Request` When the mode is invalid
-        + `400 Bad Request` When the amount is below the minimum or above the maximum
-        + `400 Bad Request` When the attendee map contains an invalid room number or moderator
+        + `400 Bad Request` Error `config`: When breakout rooms are disabled on the server
+        + `400 Bad Request` Error `mode`: When breakout rooms are already configured
+        + `400 Bad Request` Error `room`: When the conversation is not a group conversation
+        + `400 Bad Request` Error `room`: When the conversation is a breakout room itself
+        + `400 Bad Request` Error `mode`: When the mode is invalid
+        + `400 Bad Request` Error `amount`: When the amount is below the minimum or above the maximum
+        + `400 Bad Request` Error `attendeeMap`: When the attendee map contains an invalid room number or moderator
         + `403 Forbidden` When the current user is not a moderator/owner
         + `404 Not Found` When the conversation could not be found for the participant
 
@@ -57,7 +57,7 @@ Group and public conversations can be used to host breakout rooms.
 * Response:
 	- Status code:
 		+ `200 OK`
-		+ `400 Bad Request` When breakout rooms are not configured
+		+ `400 Bad Request` Error `mode`: When breakout rooms are not configured
 		+ `403 Forbidden` When the current user is not a moderator/owner
 		+ `404 Not Found` When the conversation could not be found for the participant
 
@@ -70,7 +70,7 @@ Group and public conversations can be used to host breakout rooms.
 * Response:
 	- Status code:
 		+ `200 OK`
-		+ `400 Bad Request` When breakout rooms are not configured
+		+ `400 Bad Request` Error `mode`: When breakout rooms are not configured
 		+ `403 Forbidden` When the current user is not a moderator/owner
 		+ `404 Not Found` When the conversation could not be found for the participant
 
@@ -89,28 +89,28 @@ Group and public conversations can be used to host breakout rooms.
 * Response:
 	- Status code:
 		+ `201 Created`
-		+ `400 Bad Request` When the room does not have breakout rooms configured
+		+ `400 Bad Request` Error `mode`: When the room does not have breakout rooms configured
 		+ `403 Forbidden` When the participant is not a moderator
 		+ `404 Not Found` When the conversation could not be found for the participant
 		+ `413 Payload Too Large` When the message was longer than the allowed limit of 32000 characters (check the `spreed => config => chat => max-length` capability for the limit)
 
-## Configure breakout rooms
+## Reorganize attendees
 
 * Required capability: `breakout-rooms-v1`
 * Method: `POST`
 * Endpoint: `/breakout-rooms/{token}/attendees`
 * Data:
 
-| field         | type   | Description                                                                                          |
-|---------------|--------|------------------------------------------------------------------------------------------------------|
-| `attendeeMap` | string | A json encoded Map of attendeeId => room number (0 based) (Only considered when the mode is "manual" |
+| field         | type   | Description                                                                                           |
+|---------------|--------|-------------------------------------------------------------------------------------------------------|
+| `attendeeMap` | string | A json encoded Map of attendeeId => room number (0 based) (Only considered when the mode is "manual") |
 
 * Response:
 	- Status code:
 		+ `200 OK`
-		+ `400 Bad Request` When breakout rooms are disabled on the server
-		+ `400 Bad Request` When breakout rooms are not configured
-		+ `400 Bad Request` When the attendee map contains an invalid room number or moderator
+		+ `400 Bad Request` Error `config`: When breakout rooms are disabled on the server
+		+ `400 Bad Request` Error `mode`: When breakout rooms are not configured
+		+ `400 Bad Request` Error `attendeeMap`: When the attendee map contains an invalid room number or moderator
 		+ `403 Forbidden` When the current user is not a moderator/owner
 		+ `404 Not Found` When the conversation could not be found for the participant
 
@@ -124,7 +124,7 @@ This endpoint allows participants to raise their hand (token is the breakout roo
 * Response:
 	- Status code:
 		+ `200 OK`
-		+ `400 Bad Request` When the room is not a breakout room or breakout rooms are not started
+		+ `400 Bad Request` Error `room`: When the room is not a breakout room or breakout rooms are not started
 		+ `404 Not Found` When the conversation could not be found for the participant
 
 ## Reset request for assistance
@@ -135,7 +135,7 @@ This endpoint allows participants to raise their hand (token is the breakout roo
 * Response:
 	- Status code:
 		+ `200 OK`
-		+ `400 Bad Request` When the room does not have breakout rooms configured
+		+ `400 Bad Request` Error `room`: When the room does not have breakout rooms configured
 		+ `404 Not Found` When the conversation could not be found for the participant
 
 ## List all breakout rooms
@@ -159,7 +159,8 @@ This endpoint allows participants to raise their hand (token is the breakout roo
 * Response:
 	- Status code:
 		+ `200 OK`
-		+ `400 Bad Request` When the participant is a moderator in the conversation
-		+ `400 Bad Request` When breakout rooms are not configured in `free` mode
-		+ `400 Bad Request` When breakout rooms are not started
+		+ `400 Bad Request` Error `moderator`: When the participant is a moderator in the conversation
+		+ `400 Bad Request` Error `mode`: When breakout rooms are not configured in `free` mode
+		+ `400 Bad Request` Error `status`: When breakout rooms are not started
+		+ `400 Bad Request` Error `target`: When the target room is not breakout room of the parent
 		+ `404 Not Found` When the conversation could not be found for the participant

--- a/docs/breakout-rooms.md
+++ b/docs/breakout-rooms.md
@@ -32,7 +32,7 @@ Group and public conversations can be used to host breakout rooms.
         + `400 Bad Request` When the conversation is a breakout room itself
         + `400 Bad Request` When the mode is invalid
         + `400 Bad Request` When the amount is below the minimum or above the maximum
-        + `400 Bad Request` When the attendee map contains an invalid room number
+        + `400 Bad Request` When the attendee map contains an invalid room number or moderator
         + `403 Forbidden` When the current user is not a moderator/owner
         + `404 Not Found` When the conversation could not be found for the participant
 
@@ -93,6 +93,26 @@ Group and public conversations can be used to host breakout rooms.
 		+ `403 Forbidden` When the participant is not a moderator
 		+ `404 Not Found` When the conversation could not be found for the participant
 		+ `413 Payload Too Large` When the message was longer than the allowed limit of 32000 characters (check the `spreed => config => chat => max-length` capability for the limit)
+
+## Configure breakout rooms
+
+* Required capability: `breakout-rooms-v1`
+* Method: `POST`
+* Endpoint: `/breakout-rooms/{token}/attendees`
+* Data:
+
+| field         | type   | Description                                                                                          |
+|---------------|--------|------------------------------------------------------------------------------------------------------|
+| `attendeeMap` | string | A json encoded Map of attendeeId => room number (0 based) (Only considered when the mode is "manual" |
+
+* Response:
+	- Status code:
+		+ `200 OK`
+		+ `400 Bad Request` When breakout rooms are disabled on the server
+		+ `400 Bad Request` When breakout rooms are not configured
+		+ `400 Bad Request` When the attendee map contains an invalid room number or moderator
+		+ `403 Forbidden` When the current user is not a moderator/owner
+		+ `404 Not Found` When the conversation could not be found for the participant
 
 ## Request assistance
 

--- a/docs/conversation.md
+++ b/docs/conversation.md
@@ -96,16 +96,20 @@
 
 ## Creating a new conversation
 
+*Note:* Creating a conversation as a child breakout room, will automatically set the lobby when breakout rooms are not started and will always overwrite the room type with the parent room type. Also moderators of the parent conversation will be automatically added as moderators.
+
 * Method: `POST`
 * Endpoint: `/room`
 * Data:
 
-| field      | type   | Description                                                                                                                                                          |
-|------------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `roomType` | int    | See [constants list](constants.md#conversation-types)                                                                                                                |
-| `invite`   | string | user id (`roomType = 1`), group id (`roomType = 2` - optional), circle id (`roomType = 2`, `source = 'circles'`], only available with `circles-support` capability)) |
-| `source`   | string | The source for the invite, only supported on `roomType = 2` for `groups` and `circles` (only available with `circles-support` capability)                            |
-| `roomName` | string | Conversation name up to 255 characters (Not available for `roomType = 1`)                                                                                            |
+| field        | type   | Description                                                                                                                                                           |
+|--------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `roomType`   | int    | See [constants list](constants.md#conversation-types)                                                                                                                 |
+| `invite`     | string | user id (`roomType = 1`), group id (`roomType = 2` - optional), circle id (`roomType = 2`, `source = 'circles'`], only available with `circles-support` capability))  |
+| `source`     | string | The source for the invite, only supported on `roomType = 2` for `groups` and `circles` (only available with `circles-support` capability)                             |
+| `roomName`   | string | Conversation name up to 255 characters (Not available for `roomType = 1`)                                                                                             |
+| `objectType` | string | Type of an object this room references, currently only allowed value is `room` to indicate the parent of a breakout room                                              |
+| `objectId`   | string | Id of an object this room references, room token is used for the parent of a breakout room                                                                            |
 
 * Response:
     - Status code:

--- a/docs/conversation.md
+++ b/docs/conversation.md
@@ -161,7 +161,7 @@
 
 ## Get breakout rooms
 
-Get all (for moderators and in case of "free selection) or the assigned breakout room
+Get all (for moderators and in case of "free selection") or the assigned breakout room
 
 * Required capability: `breakout-rooms-v1`
 * Method: `GET`

--- a/docs/conversation.md
+++ b/docs/conversation.md
@@ -193,6 +193,8 @@ Get all (for moderators and in case of "free selection) or the assigned breakout
 
 ## Delete a conversation
 
+*Note:* Deleting a conversation that is the parent of breakout rooms, will also delete them.
+
 * Method: `DELETE`
 * Endpoint: `/room/{token}`
 

--- a/docs/participant.md
+++ b/docs/participant.md
@@ -44,6 +44,12 @@
 
 ## Add a participant to a conversation
 
+*Note:* Adding a participant to a breakout room will automatically add them to the parent room as well.
+
+*Note:* Only source users can be added directly to a breakout room.
+
+*Note:* Adding a participant to a breakout room, that is already a participant in another breakout room of the same parent will remove them from there.
+
 * Method: `POST`
 * Endpoint: `/room/{token}/participants`
 * Data:

--- a/lib/Controller/BreakoutRoomController.php
+++ b/lib/Controller/BreakoutRoomController.php
@@ -88,6 +88,19 @@ class BreakoutRoomController extends AEnvironmentAwareController {
 
 	/**
 	 * @NoAdminRequired
+	 * @RequireLoggedInModeratorParticipant
+	 */
+	public function applyAttendeeMap(string $attendeeMap): DataResponse {
+		try {
+			$this->breakoutRoomService->applyAttendeeMap($this->room, $attendeeMap);
+		} catch (InvalidArgumentException $e) {
+			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+		}
+		return new DataResponse([], Http::STATUS_OK);
+	}
+
+	/**
+	 * @NoAdminRequired
 	 * @RequireLoggedInParticipant
 	 *
 	 * @return DataResponse

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1740,6 +1740,11 @@ class RoomController extends AEnvironmentAwareController {
 			}
 		}
 
+		if ($this->room->getObjectType() === BreakoutRoom::PARENT_OBJECT_TYPE) {
+			// Do not allow manual changing the lobby in breakout rooms
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
 		if (!$this->roomService->setLobby($this->room, $state, $timerDateTime)) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -657,7 +657,7 @@ class RoomController extends AEnvironmentAwareController {
 	 * @param string $source
 	 * @return DataResponse
 	 */
-	public function createRoom(int $roomType, string $invite = '', string $roomName = '', string $source = ''): DataResponse {
+	public function createRoom(int $roomType, string $invite = '', string $roomName = '', string $source = '', string $objectType = '', string $objectId = ''): DataResponse {
 		if ($roomType !== Room::TYPE_ONE_TO_ONE) {
 			/** @var IUser $user */
 			$user = $this->userManager->get($this->userId);
@@ -672,7 +672,7 @@ class RoomController extends AEnvironmentAwareController {
 				return $this->createOneToOneRoom($invite);
 			case Room::TYPE_GROUP:
 				if ($invite === '') {
-					return $this->createEmptyRoom($roomName, false);
+					return $this->createEmptyRoom($roomName, false, $objectType, $objectId);
 				}
 				if ($source === 'circles') {
 					return $this->createCircleRoom($invite);
@@ -795,27 +795,63 @@ class RoomController extends AEnvironmentAwareController {
 
 	/**
 	 * @NoAdminRequired
-	 *
-	 * @param string $roomName
-	 * @param bool $public
-	 * @return DataResponse
 	 */
-	protected function createEmptyRoom(string $roomName, bool $public = true): DataResponse {
+	protected function createEmptyRoom(string $roomName, bool $public = true, string $objectType = '', string $objectId = ''): DataResponse {
 		$currentUser = $this->userManager->get($this->userId);
 		if (!$currentUser instanceof IUser) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
 		$roomType = $public ? Room::TYPE_PUBLIC : Room::TYPE_GROUP;
+		/** @var Room|null $parentRoom */
+		$parentRoom = null;
+
+		if ($objectType === BreakoutRoom::PARENT_OBJECT_TYPE) {
+			try {
+				$parentRoom = $this->manager->getRoomForUserByToken($objectId, $this->userId);
+				$parentRoomParticipant = $this->participantService->getParticipant($parentRoom, $this->userId);
+
+				if (!$parentRoomParticipant->hasModeratorPermissions()) {
+					return new DataResponse(['error' => 'permissions'], Http::STATUS_BAD_REQUEST);
+				}
+				if ($parentRoom->getBreakoutRoomMode() === BreakoutRoom::MODE_NOT_CONFIGURED) {
+					return new DataResponse(['error' => 'mode'], Http::STATUS_BAD_REQUEST);
+				}
+
+				// Overwriting the type with the parent type.
+				$roomType = $parentRoom->getType();
+			} catch (RoomNotFoundException $e) {
+				return new DataResponse(['error' => 'room'], Http::STATUS_BAD_REQUEST);
+			} catch (ParticipantNotFoundException $e) {
+				return new DataResponse(['error' => 'permissions'], Http::STATUS_BAD_REQUEST);
+			}
+		}
 
 		// Create the room
 		try {
-			$room = $this->roomService->createConversation($roomType, $roomName, $currentUser);
+			$room = $this->roomService->createConversation($roomType, $roomName, $currentUser, $objectType, $objectId);
 		} catch (InvalidArgumentException $e) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
-		return new DataResponse($this->formatRoom($room, $this->participantService->getParticipant($room, $currentUser->getUID(), false)), Http::STATUS_CREATED);
+		$currentParticipant = $this->participantService->getParticipant($room, $currentUser->getUID(), false);
+		if ($objectType === BreakoutRoom::PARENT_OBJECT_TYPE) {
+			// Enforce the lobby state when breakout rooms are disabled
+			if ($parentRoom instanceof Room && $parentRoom->getBreakoutRoomStatus() === BreakoutRoom::STATUS_STOPPED) {
+				$this->roomService->setLobby($room, Webinary::LOBBY_NON_MODERATORS, null, false, false);
+			}
+
+			$participants = $this->participantService->getParticipantsForRoom($parentRoom);
+			$moderators = array_filter($participants, static function (Participant $participant) use ($currentParticipant) {
+				return $participant->hasModeratorPermissions()
+					&& $participant->getAttendee()->getId() !== $currentParticipant->getAttendee()->getId();
+			});
+			if (!empty($moderators)) {
+				$this->breakoutRoomService->addModeratorsToBreakoutRooms([$room], $moderators);
+			}
+		}
+
+		return new DataResponse($this->formatRoom($room, $currentParticipant), Http::STATUS_CREATED);
 	}
 
 	/**

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -825,6 +825,8 @@ class RoomController extends AEnvironmentAwareController {
 			} catch (ParticipantNotFoundException $e) {
 				return new DataResponse(['error' => 'permissions'], Http::STATUS_BAD_REQUEST);
 			}
+		} elseif ($objectType !== '') {
+			return new DataResponse(['error' => 'object'], Http::STATUS_BAD_REQUEST);
 		}
 
 		// Create the room

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -388,7 +388,7 @@ class Manager {
 			if ($this->participantService->getNumberOfUsers($room) === 1) {
 				Server::get(RoomService::class)->deleteRoom($room);
 			} else {
-				$this->participantService->removeUser($room, $user, Room::PARTICIPANT_REMOVED);
+				$this->participantService->removeUser($room, $user, Room::PARTICIPANT_REMOVED_ALL);
 			}
 		}
 

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -94,6 +94,7 @@ class Room {
 	public const START_CALL_NOONE = 3;
 
 	public const PARTICIPANT_REMOVED = 'remove';
+	public const PARTICIPANT_REMOVED_ALL = 'remove_all';
 	public const PARTICIPANT_LEFT = 'leave';
 
 	public const EVENT_AFTER_ROOM_CREATE = self::class . '::createdRoom';

--- a/lib/Service/BreakoutRoomService.php
+++ b/lib/Service/BreakoutRoomService.php
@@ -204,7 +204,7 @@ class BreakoutRoomService {
 	/**
 	 * @param Room $parent
 	 * @param string $attendeeMap
-	 * @throws InvalidArgumentException When the map was invalid
+	 * @throws InvalidArgumentException When the map was invalid, breakout rooms are disabled or not configured for this conversation
 	 */
 	public function applyAttendeeMap(Room $parent, string $attendeeMap): void {
 		if (!$this->config->isBreakoutRoomsEnabled()) {

--- a/lib/Service/BreakoutRoomService.php
+++ b/lib/Service/BreakoutRoomService.php
@@ -171,7 +171,7 @@ class BreakoutRoomService {
 	 * @param Room[] $rooms
 	 * @param Participant[] $moderators
 	 */
-	protected function addModeratorsToBreakoutRooms(array $rooms, array $moderators): void {
+	public function addModeratorsToBreakoutRooms(array $rooms, array $moderators): void {
 		$moderatorsToAdd = [];
 		foreach ($moderators as $moderator) {
 			$attendee = $moderator->getAttendee();

--- a/lib/Service/BreakoutRoomService.php
+++ b/lib/Service/BreakoutRoomService.php
@@ -438,4 +438,33 @@ class BreakoutRoomService {
 		}
 		return $breakoutRooms;
 	}
+
+	/**
+	 * @param Room $parent
+	 * @param string $actorType
+	 * @param string $actorId
+	 * @return void
+	 * @throws InvalidArgumentException When being used for a moderator
+	 */
+	public function removeAttendeeFromBreakoutRoom(Room $parent, string $actorType, string $actorId): void {
+		$breakoutRooms = $this->manager->getMultipleRoomsByObject(BreakoutRoom::PARENT_OBJECT_TYPE, $parent->getToken());
+
+		foreach ($breakoutRooms as $breakoutRoom) {
+			try {
+				$participant = $this->participantService->getParticipantByActor(
+					$breakoutRoom,
+					$actorType,
+					$actorId
+				);
+
+				if ($participant->hasModeratorPermissions()) {
+					throw new \InvalidArgumentException('moderator');
+				}
+
+				$this->participantService->removeAttendee($breakoutRoom, $participant, Room::PARTICIPANT_REMOVED);
+			} catch (ParticipantNotFoundException $e) {
+				// Skip this room
+			}
+		}
+	}
 }

--- a/lib/Service/BreakoutRoomService.php
+++ b/lib/Service/BreakoutRoomService.php
@@ -543,10 +543,11 @@ class BreakoutRoomService {
 	 * @param Room $parent
 	 * @param string $actorType
 	 * @param string $actorId
+	 * @param bool $throwOnModerator
 	 * @return void
 	 * @throws InvalidArgumentException When being used for a moderator
 	 */
-	public function removeAttendeeFromBreakoutRoom(Room $parent, string $actorType, string $actorId): void {
+	public function removeAttendeeFromBreakoutRoom(Room $parent, string $actorType, string $actorId, bool $throwOnModerator = true): void {
 		$breakoutRooms = $this->manager->getMultipleRoomsByObject(BreakoutRoom::PARENT_OBJECT_TYPE, $parent->getToken());
 
 		foreach ($breakoutRooms as $breakoutRoom) {
@@ -557,7 +558,7 @@ class BreakoutRoomService {
 					$actorId
 				);
 
-				if ($participant->hasModeratorPermissions()) {
+				if ($throwOnModerator && $participant->hasModeratorPermissions()) {
 					throw new \InvalidArgumentException('moderator');
 				}
 

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -931,7 +931,7 @@ class ParticipantService {
 		$attendee = $participant->getAttendee();
 		$sessions = $this->sessionService->getAllSessionsForAttendee($attendee);
 
-		if ($room->getBreakoutRoomMode() !== BreakoutRoom::MODE_NOT_CONFIGURED) {
+		if ($reason !== Room::PARTICIPANT_REMOVED_ALL && $room->getBreakoutRoomMode() !== BreakoutRoom::MODE_NOT_CONFIGURED) {
 			/** @var BreakoutRoomService $breakoutRoomService */
 			$breakoutRoomService = Server::get(BreakoutRoomService::class);
 			$breakoutRoomService->removeAttendeeFromBreakoutRoom(
@@ -940,6 +940,8 @@ class ParticipantService {
 				$attendee->getActorId(),
 				false
 			);
+		} elseif ($reason === Room::PARTICIPANT_REMOVED_ALL) {
+			$reason = Room::PARTICIPANT_REMOVED;
 		}
 
 		$event = new RemoveUserEvent($room, $participant, $user, $reason, $sessions);

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -787,6 +787,17 @@ class ParticipantService {
 
 		$sessions = $this->sessionService->getAllSessionsForAttendee($participant->getAttendee());
 
+		if ($room->getBreakoutRoomMode() !== BreakoutRoom::MODE_NOT_CONFIGURED) {
+			/** @var BreakoutRoomService $breakoutRoomService */
+			$breakoutRoomService = Server::get(BreakoutRoomService::class);
+			$breakoutRoomService->removeAttendeeFromBreakoutRoom(
+				$room,
+				$participant->getAttendee()->getActorType(),
+				$participant->getAttendee()->getActorId(),
+				false
+			);
+		}
+
 		if ($isUser) {
 			$user = $this->userManager->get($participant->getAttendee()->getActorId());
 			$event = new RemoveUserEvent($room, $participant, $user, $reason, $sessions);
@@ -919,6 +930,17 @@ class ParticipantService {
 
 		$attendee = $participant->getAttendee();
 		$sessions = $this->sessionService->getAllSessionsForAttendee($attendee);
+
+		if ($room->getBreakoutRoomMode() !== BreakoutRoom::MODE_NOT_CONFIGURED) {
+			/** @var BreakoutRoomService $breakoutRoomService */
+			$breakoutRoomService = Server::get(BreakoutRoomService::class);
+			$breakoutRoomService->removeAttendeeFromBreakoutRoom(
+				$room,
+				$attendee->getActorType(),
+				$attendee->getActorId(),
+				false
+			);
+		}
 
 		$event = new RemoveUserEvent($room, $participant, $user, $reason, $sessions);
 		$this->dispatcher->dispatch(Room::EVENT_BEFORE_USER_REMOVE, $event);

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -794,14 +794,23 @@ class RoomService {
 	public function deleteRoom(Room $room): void {
 		$event = new RoomEvent($room);
 		$this->dispatcher->dispatch(Room::EVENT_BEFORE_ROOM_DELETE, $event);
-		$delete = $this->db->getQueryBuilder();
+
+		// Delete all breakout rooms when deleting a parent room
+		if ($room->getBreakoutRoomMode() !== BreakoutRoom::MODE_NOT_CONFIGURED) {
+			$breakoutRooms = $this->manager->getMultipleRoomsByObject(BreakoutRoom::PARENT_OBJECT_TYPE, $room->getToken());
+			foreach ($breakoutRooms as $breakoutRoom) {
+				$this->deleteRoom($breakoutRoom);
+			}
+		}
 
 		// Delete attendees
+		$delete = $this->db->getQueryBuilder();
 		$delete->delete('talk_attendees')
 			->where($delete->expr()->eq('room_id', $delete->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)));
 		$delete->executeStatement();
 
 		// Delete room
+		$delete = $this->db->getQueryBuilder();
 		$delete->delete('talk_rooms')
 			->where($delete->expr()->eq('id', $delete->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)));
 		$delete->executeStatement();

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -435,6 +435,14 @@ class RoomService {
 			return false;
 		}
 
+		if ($room->getBreakoutRoomMode() !== BreakoutRoom::MODE_NOT_CONFIGURED) {
+			return false;
+		}
+
+		if ($room->getObjectType() === BreakoutRoom::PARENT_OBJECT_TYPE) {
+			return false;
+		}
+
 		$oldType = $room->getType();
 
 		$event = new ModifyRoomEvent($room, 'type', $newType, $oldType);
@@ -514,6 +522,10 @@ class RoomService {
 		}
 
 		if (!in_array($room->getType(), [Room::TYPE_GROUP, Room::TYPE_PUBLIC], true)) {
+			return false;
+		}
+
+		if ($room->getObjectType() === BreakoutRoom::PARENT_OBJECT_TYPE) {
 			return false;
 		}
 

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2420,6 +2420,32 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" moves participants into different breakout rooms for "([^"]*)" with (\d+) \((v1)\)$/
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 * @param int $status
+	 * @param string $apiVersion
+	 * @param TableNode|null $formData
+	 */
+	public function userMovesParticipantsInsideBreakoutRooms(string $user, string $identifier, int $status, string $apiVersion, TableNode $formData = null): void {
+		$data = [];
+		if ($formData instanceof TableNode) {
+			$mapArray = [];
+			foreach ($formData->getRowsHash() as $attendee => $roomNumber) {
+				[$type, $id] = explode('::', $attendee);
+				$attendeeId = $this->getAttendeeId($type, $id, $identifier);
+				$mapArray[$attendeeId] = (int) $roomNumber;
+			}
+			$data['attendeeMap'] = json_encode($mapArray, JSON_THROW_ON_ERROR);
+		}
+
+		$this->setCurrentUser($user);
+		$this->sendRequest('POST', '/apps/spreed/api/' . $apiVersion . '/breakout-rooms/' . self::$identifierToToken[$identifier] . '/attendees', $data);
+		$this->assertStatusCode($this->response, $status);
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" broadcasts message "([^"]*)" to room "([^"]*)" with (\d+)(?: \((v1)\))?$/
 	 *
 	 * @param string $user

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -789,8 +789,20 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	 * @param TableNode|null $formData
 	 */
 	public function userCreatesRoomWith(string $user, string $identifier, int $statusCode, string $apiVersion = 'v1', TableNode $formData = null): void {
+		$body = $formData->getRowsHash();
+
+		if (isset($body['objectType'], $body['objectId']) && $body['objectType'] === 'room') {
+			$result = preg_match('/ROOM\(([^)]+)\)/', $body['objectId'], $matches);
+			if ($result && isset(self::$identifierToToken[$matches[1]])) {
+				$body['objectId'] = self::$identifierToToken[$matches[1]];
+			} elseif ($result) {
+				throw new \InvalidArgumentException('Could not find parent room');
+			}
+		}
+
+
 		$this->setCurrentUser($user);
-		$this->sendRequest('POST', '/apps/spreed/api/' . $apiVersion . '/room', $formData);
+		$this->sendRequest('POST', '/apps/spreed/api/' . $apiVersion . '/room', $body);
 		$this->assertStatusCode($this->response, $statusCode);
 
 		$response = $this->getDataFromResponse($this->response);
@@ -2367,12 +2379,12 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	 * @param string $user
 	 * @param int $amount
 	 * @param string $modeString
-	 * @param string $roomName
+	 * @param string $identifier
 	 * @param int $status
 	 * @param string $apiVersion
 	 * @param TableNode|null $formData
 	 */
-	public function userCreatesBreakoutRooms(string $user, int $amount, string $modeString, string $roomName, int $status, string $apiVersion, TableNode $formData = null): void {
+	public function userCreatesBreakoutRooms(string $user, int $amount, string $modeString, string $identifier, int $status, string $apiVersion, TableNode $formData = null): void {
 		switch ($modeString) {
 			case 'automatic':
 				$mode = 1;
@@ -2396,14 +2408,14 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			$mapArray = [];
 			foreach ($formData->getRowsHash() as $attendee => $roomNumber) {
 				[$type, $id] = explode('::', $attendee);
-				$attendeeId = $this->getAttendeeId($type, $id, $roomName);
+				$attendeeId = $this->getAttendeeId($type, $id, $identifier);
 				$mapArray[$attendeeId] = (int) $roomNumber;
 			}
 			$data['attendeeMap'] = json_encode($mapArray, JSON_THROW_ON_ERROR);
 		}
 
 		$this->setCurrentUser($user);
-		$this->sendRequest('POST', '/apps/spreed/api/' . $apiVersion . '/breakout-rooms/' . self::$identifierToToken[$roomName], $data);
+		$this->sendRequest('POST', '/apps/spreed/api/' . $apiVersion . '/breakout-rooms/' . self::$identifierToToken[$identifier], $data);
 		$this->assertStatusCode($this->response, $status);
 	}
 

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -4,6 +4,7 @@ Feature: conversation/breakout-rooms
     Given user "participant2" exists
     Given user "participant3" exists
     Given user "participant4" exists
+    Given group "group1" exists
 
   Scenario: Teacher creates manual breakout rooms
     Given user "participant1" creates room "class room" (v4)
@@ -625,3 +626,72 @@ Feature: conversation/breakout-rooms
       | 2    | Room 2     | 0          | 0                | 0                  |
       | 2    | Room 3     | 0          | 0                | 0                  |
       | 2    | Room 4     | 0          | 0                | 0                  |
+
+  Scenario: Adding a user directly to a breakout room adds them to the parent as well
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    And user "participant1" creates 2 automatic breakout rooms for "class room" with 200 (v1)
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 1                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+    When user "participant1" adds user "participant2" to room "Room 2" with 200 (v4)
+    Then user "participant1" sees the following attendees in room "class room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+      | users      | participant2 | 3               |
+    And user "participant1" sees the following attendees in room "Room 2" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+      | users      | participant2 | 3               |
+    And user "participant2" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 1                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+
+  Scenario: Adding a user directly to a breakout room adds them to the parent as well
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    And user "participant1" creates 2 automatic breakout rooms for "class room" with 200 (v1)
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 1                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+    When user "participant1" adds user "participant2" to room "Room 2" with 200 (v4)
+    Then user "participant1" sees the following attendees in room "class room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+      | users      | participant2 | 3               |
+    And user "participant1" sees the following attendees in room "Room 2" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+      | users      | participant2 | 3               |
+    And user "participant2" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 1                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+
+  Scenario: Only users with normal level can be moved between breakout rooms
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    When user "participant1" adds user "participant2" to room "class room" with 200 (v4)
+    Then user "participant1" sees the following attendees in room "class room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+      | users      | participant2 | 3               |
+    And user "participant1" promotes "participant2" in room "class room" with 200 (v4)
+    And user "participant1" creates 2 automatic breakout rooms for "class room" with 200 (v1)
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 1                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+    # Can not "move" moderators
+    When user "participant1" adds user "participant2" to room "Room 2" with 400 (v4)
+    # Can not "add" groups
+    When user "participant1" adds group "group1" to room "Room 2" with 400 (v4)

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -791,3 +791,23 @@ Feature: conversation/breakout-rooms
       | type | name       |
       | 2    | class room |
       | 2    | Room 2     |
+
+  Scenario: Can not change lobby status, allow or disallow guests in breakout rooms directly
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    And user "participant1" sees the following attendees in room "class room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+    And user "participant1" creates 2 automatic breakout rooms for "class room" with 200 (v1)
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 1                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+    # Can not disable lobby
+    Then user "participant1" sets lobby state for room "Room 1" to "no lobby" with 400 (v4)
+    # Can not enable listing
+    And user "participant1" allows listing room "Room 1" for "all" with 400 (v4)
+    # Can not allow guests
+    And user "participant1" makes room "Room 1" public with 400 (v4)

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -701,3 +701,56 @@ Feature: conversation/breakout-rooms
     When user "participant1" adds user "participant2" to room "Room 2" with 400 (v4)
     # Can not "add" groups
     When user "participant1" adds group "group1" to room "Room 2" with 400 (v4)
+
+  Scenario: Teacher applies a new attendee map
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
+    And user "participant1" adds user "participant3" to room "class room" with 200 (v4)
+    And user "participant1" adds user "participant4" to room "class room" with 200 (v4)
+    And user "participant1" sees the following attendees in room "class room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+      | users      | participant2 | 3               |
+      | users      | participant3 | 3               |
+      | users      | participant4 | 3               |
+    And user "participant1" promotes "participant2" in room "class room" with 200 (v4)
+    And user "participant1" sees the following attendees in room "class room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+      | users      | participant2 | 2               |
+      | users      | participant3 | 3               |
+      | users      | participant4 | 3               |
+    When user "participant1" creates 3 manual breakout rooms for "class room" with 200 (v1)
+      | users::participant3 | 0 |
+      | users::participant4 | 1 |
+    Then user "participant3" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 1     |
+    Then user "participant4" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 2     |
+    When user "participant1" moves participants into different breakout rooms for "class room" with 400 (v1)
+      | users::participant2 | 0 |
+      | users::participant3 | 2 |
+      | users::participant4 | 1 |
+    When user "participant1" moves participants into different breakout rooms for "class room" with 400 (v1)
+      | users::participant3 | -2 |
+      | users::participant4 | 1 |
+    When user "participant1" moves participants into different breakout rooms for "class room" with 400 (v1)
+      | users::participant3 | 3 |
+      | users::participant4 | 1 |
+    When user "participant1" moves participants into different breakout rooms for "class room" with 200 (v1)
+      | users::participant3 | 2 |
+      | users::participant4 | 1 |
+    Then user "participant3" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 3     |
+    Then user "participant4" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 2     |

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -516,3 +516,67 @@ Feature: conversation/breakout-rooms
     When user "participant1" deletes room "class room" with 200 (v4)
     And user "participant1" is participant of the following rooms (v4)
     And user "participant2" is participant of the following rooms (v4)
+
+  Scenario: Create an additional breakout room on the fly
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
+    And user "participant1" promotes "participant2" in room "class room" with 200 (v4)
+    And user "participant1" sees the following attendees in room "class room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+      | users      | participant2 | 2               |
+    And user "participant1" creates 2 automatic breakout rooms for "class room" with 200 (v1)
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 1                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+    And user "participant2" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 1                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+    # Can not nest
+    Given user "participant1" creates room "Room 3" with 400 (v4)
+      | roomType   | 2 |
+      | roomName   | Room 3 |
+      | objectType | room |
+      | objectId   | ROOM(Room 2) |
+    Given user "participant1" creates room "Room 3" with 201 (v4)
+      | roomType   | 2 |
+      | roomName   | Room 3 |
+      | objectType | room |
+      | objectId   | ROOM(class room) |
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 1                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+      | 2    | Room 3     | 1          | 0                | 0                  |
+    And user "participant2" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 1                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+      | 2    | Room 3     | 1          | 0                | 0                  |
+    And user "participant1" starts breakout rooms in room "class room" with 200 (v1)
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 1                | 1                  |
+      | 2    | Room 1     | 0          | 0                | 0                  |
+      | 2    | Room 2     | 0          | 0                | 0                  |
+      | 2    | Room 3     | 0          | 0                | 0                  |
+    Given user "participant1" creates room "Room 3" with 201 (v4)
+      | roomType   | 2 |
+      | roomName   | Room 4 |
+      | objectType | room |
+      | objectId   | ROOM(class room) |
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 1                | 1                  |
+      | 2    | Room 1     | 0          | 0                | 0                  |
+      | 2    | Room 2     | 0          | 0                | 0                  |
+      | 2    | Room 3     | 0          | 0                | 0                  |
+      | 2    | Room 4     | 0          | 0                | 0                  |

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -584,12 +584,18 @@ Feature: conversation/breakout-rooms
       | 2    | class room | 0          | 1                | 0                  |
       | 2    | Room 1     | 1          | 0                | 0                  |
       | 2    | Room 2     | 1          | 0                | 0                  |
-    # Can not nest
+    # Can not nest breakout rooms
     Given user "participant1" creates room "Room 3" with 400 (v4)
       | roomType   | 2 |
       | roomName   | Room 3 |
       | objectType | room |
       | objectId   | ROOM(Room 2) |
+    # Can not create room for other object types
+    Given user "participant1" creates room "Room 3" with 400 (v4)
+      | roomType   | 2 |
+      | roomName   | Room 3 |
+      | objectType | files |
+      | objectId   | ROOM(class room) |
     Given user "participant1" creates room "Room 3" with 201 (v4)
       | roomType   | 2 |
       | roomName   | Room 3 |

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -492,3 +492,27 @@ Feature: conversation/breakout-rooms
       | 2    | Room 1     |
     And user "participant1" starts breakout rooms in room "class room" with 200 (v1)
     When user "participant2" switches in room "class room" to breakout room "Room 1" with 400 (v1)
+
+  Scenario: Deleting the parent also deletes all breakout rooms
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
+    And user "participant1" sees the following attendees in room "class room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+      | users      | participant2 | 3               |
+    And user "participant1" creates 2 automatic breakout rooms for "class room" with 200 (v1)
+      | users::participant2 | 0 |
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 1                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+    And user "participant2" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 1     |
+    When user "participant1" deletes room "class room" with 200 (v4)
+    And user "participant1" is participant of the following rooms (v4)
+    And user "participant2" is participant of the following rooms (v4)

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -681,6 +681,43 @@ Feature: conversation/breakout-rooms
       | 2    | class room | 0          | 1                | 0                  |
       | 2    | Room 2     | 1          | 0                | 0                  |
 
+  Scenario: Removing a user from the parent also removes them from the breakout room
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    When user "participant1" adds user "participant2" to room "class room" with 200 (v4)
+    When user "participant1" adds user "participant3" to room "class room" with 200 (v4)
+    When user "participant1" adds user "participant4" to room "class room" with 200 (v4)
+    Then user "participant1" sees the following attendees in room "class room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+      | users      | participant2 | 3               |
+      | users      | participant3 | 3               |
+      | users      | participant4 | 3               |
+    And user "participant1" promotes "participant2" in room "class room" with 200 (v4)
+    When user "participant1" creates 2 manual breakout rooms for "class room" with 200 (v1)
+      | users::participant3 | 0 |
+      | users::participant4 | 1 |
+    And user "participant2" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 2                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+    And user "participant3" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 2                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+    And user "participant4" is participant of the following rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 2                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+    When user "participant1" removes user "participant2" from room "class room" with 200 (v4)
+    And user "participant1" removes user "participant3" from room "class room" with 200 (v4)
+    And user "participant4" removes themselves from room "class room" with 200 (v4)
+    Then user "participant2" is participant of the following rooms (v4)
+    And user "participant3" is participant of the following rooms (v4)
+    And user "participant4" is participant of the following rooms (v4)
+
   Scenario: Only users with normal level can be moved between breakout rooms
     Given user "participant1" creates room "class room" (v4)
       | roomType | 2 |

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -517,6 +517,51 @@ Feature: conversation/breakout-rooms
     And user "participant1" is participant of the following rooms (v4)
     And user "participant2" is participant of the following rooms (v4)
 
+  Scenario: Deleting a single breakout room unassigned the students from the mapping
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
+    And user "participant1" adds user "participant3" to room "class room" with 200 (v4)
+    And user "participant1" adds user "participant4" to room "class room" with 200 (v4)
+    And user "participant1" sees the following attendees in room "class room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+      | users      | participant2 | 3               |
+      | users      | participant3 | 3               |
+      | users      | participant4 | 3               |
+    And user "participant1" creates 3 manual breakout rooms for "class room" with 200 (v1)
+      | users::participant2 | 0 |
+      | users::participant3 | 1 |
+      | users::participant4 | 2 |
+    And user "participant1" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 1     |
+      | 2    | Room 2     |
+      | 2    | Room 3     |
+    And user "participant2" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 1     |
+    And user "participant3" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 2     |
+    And user "participant4" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 3     |
+    When user "participant1" deletes room "Room 2" with 200 (v4)
+    Then user "participant1" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 1     |
+      | 2    | Room 3     |
+    And user "participant3" is participant of the following rooms (v4)
+      | type | name       |
+      | 2    | class room |
+
   Scenario: Create an additional breakout room on the fly
     Given user "participant1" creates room "class room" (v4)
       | roomType | 2 |

--- a/tests/php/Service/BreakoutRoomServiceTest.php
+++ b/tests/php/Service/BreakoutRoomServiceTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023, Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Tests\php\Service;
+
+use OCA\Talk\Chat\ChatManager;
+use OCA\Talk\Config;
+use OCA\Talk\Manager;
+use OCA\Talk\Service\BreakoutRoomService;
+use OCA\Talk\Service\ParticipantService;
+use OCA\Talk\Service\RoomService;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IL10N;
+use OCP\Notification\IManager as INotificationManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class BreakoutRoomServiceTest extends TestCase {
+	private BreakoutRoomService $service;
+
+	/** @var Config|MockObject */
+	private $config;
+	/** @var Manager|MockObject */
+	private $manager;
+	/** @var RoomService|MockObject */
+	private $roomService;
+	/** @var ParticipantService|MockObject */
+	private $participantService;
+	/** @var ChatManager|MockObject */
+	private $chatManager;
+	/** @var IEventDispatcher|MockObject */
+	private $dispatcher;
+	/** @var IL10N|MockObject */
+	private $l;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(Config::class);
+		$this->manager = $this->createMock(Manager::class);
+		$this->roomService = $this->createMock(RoomService::class);
+		$this->participantService = $this->createMock(ParticipantService::class);
+		$this->chatManager = $this->createMock(ChatManager::class);
+		$this->notificationManager = $this->createMock(INotificationManager::class);
+		$this->dispatcher = $this->createMock(IEventDispatcher::class);
+		$this->l = $this->createMock(IL10N::class);
+		$this->service = new BreakoutRoomService(
+			$this->config,
+			$this->manager,
+			$this->roomService,
+			$this->participantService,
+			$this->chatManager,
+			$this->notificationManager,
+			$this->dispatcher,
+			$this->l
+		);
+	}
+	public function dataParseAttendeeMap(): array {
+		return [
+			'Empty string means no map' => ['', 3, [], false],
+			'Empty array means no map' => ['[]', 3, [], false],
+			'OK' => [json_encode([1 => 1, 13 => 0, 42 => 2]), 3, [1 => 1, 13 => 0, 42 => 2], false],
+			'Not an array' => ['"hello"', 3, null, true],
+			'Room above max' => [json_encode([1 => 0, 13 => 1, 42 => 2]), 2, null, true],
+			'Room below min' => [json_encode([1 => 0, 13 => -1, 42 => 2]), 3, null, true],
+			'Room not int' => [json_encode([1 => 0, 13 => 'foo', 42 => 2]), 3, null, true],
+			'Room null' => [json_encode([1 => 0, 13 => null, 42 => 2]), 3, null, true],
+			'Attendee not int' => [json_encode([1 => 0, 'foo' => 1, 42 => 2]), 3, null, true],
+			'Attendee negative' => [json_encode([1 => 0, -13 => 1, 42 => 2]), 3, null, true],
+			'Attendee zero' => [json_encode([1 => 0, 0 => 1, 42 => 2]), 3, null, true],
+		];
+	}
+
+	/**
+	 * @dataProvider dataParseAttendeeMap
+	 */
+	public function testParseAttendeeMap(string $json, int $max, ?array $expected, bool $throws): void {
+		if ($throws) {
+			$this->expectException(\InvalidArgumentException::class);
+		}
+
+		$actual = self::invokePrivate($this->service, 'parseAttendeeMap', [$json, $max]);
+		$this->assertEquals($expected, $actual);
+	}
+}


### PR DESCRIPTION
Ref #8338

### 🚧 TODO

- [x] Delete breakout rooms when the parent room is being deleted
- [x] Allow to create breakout rooms by providing objectType + objectId
  - [x] Lobby state is correctly set
  - [x] Moderators are added and promoted
- [x] Should prevent direct deletion of individual rooms when they are breakout rooms (as it breaks the mapping)?
  - [x] Allow this and use it as mechanism to manually rearrange the breakout room situation
- [x] When a user is added directly to a breakout room, we should add them to the parent room too or prevent adding
  - [x] Allow this and remove from other breakout rooms and use it as mechanism to manually rearrange the breakout room situation
- [x] ~~Moderators should be able to move single participants between breakout rooms~~ See above point
- [x] Moderators should be able to provide the map afterwards again
- [x] Remove participants from breakout rooms when removed from parent
- [x] Prevent changes directly on breakout rooms
  - [x] Guests allow/disallow
  - [x] Lobby

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
