### PR TITLE
Send system message when change room avatar

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -133,12 +133,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "1f55e0826beda2248274a5130e7c4c59f2895b60"
+                "reference": "e7787ed0c7aabea48d78effd992cf4aae5514169"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/1f55e0826beda2248274a5130e7c4c59f2895b60",
-                "reference": "1f55e0826beda2248274a5130e7c4c59f2895b60",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e7787ed0c7aabea48d78effd992cf4aae5514169",
+                "reference": "e7787ed0c7aabea48d78effd992cf4aae5514169",
                 "shasum": ""
             },
             "require": {
@@ -169,7 +169,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2022-12-10T00:34:18+00:00"
+            "time": "2022-12-14T00:37:01+00:00"
         },
         {
             "name": "psr/container",

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -397,5 +397,5 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 * `video_recording_stopped` - {actor} stopped a video recording
 * `audio_recording_started` - {actor} started an audio recording
 * `audio_recording_stopped` - {actor} stopped an audio recording
-* `set_room_avatar` - {actor} set the conversation avatar
-* `delete_room_avatar` - {actor} deleted the conversation avatar
+* `avatar_set` - {actor} set the conversation avatar
+* `avatar_removed` - {actor} removed the conversation avatar

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -397,3 +397,5 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 * `video_recording_stopped` - {actor} stopped a video recording
 * `audio_recording_started` - {actor} started an audio recording
 * `audio_recording_stopped` - {actor} stopped an audio recording
+* `set_room_avatar` - {actor} set the conversation avatar
+* `delete_room_avatar` - {actor} deleted the conversation avatar

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -507,15 +507,15 @@ class SystemMessage {
 			if ($currentUserIsActor) {
 				$parsedMessage = $this->l->t('You cleared the history of the conversation');
 			}
-		} elseif ($message === 'set_room_avatar') {
+		} elseif ($message === 'avatar_set') {
 			$parsedMessage = $this->l->t('{actor} set the conversation avatar');
 			if ($currentUserIsActor) {
 				$parsedMessage = $this->l->t('You set the conversation avatar');
 			}
-		} elseif ($message === 'delete_room_avatar') {
-			$parsedMessage = $this->l->t('{actor} deleted the conversation avatar');
+		} elseif ($message === 'avatar_removed') {
+			$parsedMessage = $this->l->t('{actor} removed the conversation avatar');
 			if ($currentUserIsActor) {
-				$parsedMessage = $this->l->t('You deleted the conversation avatar');
+				$parsedMessage = $this->l->t('You removed the conversation avatar');
 			}
 		} elseif ($message === 'poll_closed') {
 			$parsedParameters['poll'] = $parameters['poll'];

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -507,6 +507,16 @@ class SystemMessage {
 			if ($currentUserIsActor) {
 				$parsedMessage = $this->l->t('You cleared the history of the conversation');
 			}
+		} elseif ($message === 'set_room_avatar') {
+			$parsedMessage = $this->l->t('{actor} set the conversation avatar');
+			if ($currentUserIsActor) {
+				$parsedMessage = $this->l->t('You set the conversation avatar');
+			}
+		} elseif ($message === 'delete_room_avatar') {
+			$parsedMessage = $this->l->t('{actor} deleted the conversation avatar');
+			if ($currentUserIsActor) {
+				$parsedMessage = $this->l->t('You deleted the conversation avatar');
+			}
 		} elseif ($message === 'poll_closed') {
 			$parsedParameters['poll'] = $parameters['poll'];
 			$parsedParameters['poll']['id'] = (string) $parsedParameters['poll']['id'];

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -101,6 +101,7 @@ class Listener implements IEventListener {
 		$dispatcher->addListener(RoomShareProvider::EVENT_SHARE_FILE_AGAIN, self::class . '::fixMimeTypeOfVoiceMessage');
 		$dispatcher->addListener(Room::EVENT_AFTER_SET_MESSAGE_EXPIRATION, self::class . '::afterSetMessageExpiration');
 		$dispatcher->addListener(Room::EVENT_AFTER_SET_CALL_RECORDING, self::class . '::setCallRecording');
+		$dispatcher->addListener(Room::EVENT_AFTER_AVATAR_SET, self::class . '::avatarChanged');
 	}
 
 	public static function sendSystemMessageAboutBeginOfCall(ModifyParticipantEvent $event): void {
@@ -520,5 +521,16 @@ class Listener implements IEventListener {
 		$isAudioStatus = $newValue === Room::RECORDING_AUDIO
 			|| $oldValue === Room::RECORDING_AUDIO;
 		return $isAudioStatus ? 'audio_' : '';
+	}
+
+	public static function avatarChanged(ModifyRoomEvent $event): void {
+		if ($event->getNewValue()) {
+			$message = 'set_room_avatar';
+		} else {
+			$message = 'delete_room_avatar';
+		}
+
+		$listener = Server::get(self::class);
+		$listener->sendSystemMessage($event->getRoom(), $message);
 	}
 }

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -525,9 +525,9 @@ class Listener implements IEventListener {
 
 	public static function avatarChanged(ModifyRoomEvent $event): void {
 		if ($event->getNewValue()) {
-			$message = 'set_room_avatar';
+			$message = 'avatar_set';
 		} else {
-			$message = 'delete_room_avatar';
+			$message = 'avatar_removed';
 		}
 
 		$listener = Server::get(self::class);

--- a/tests/integration/features/conversation/avatar.feature
+++ b/tests/integration/features/conversation/avatar.feature
@@ -19,13 +19,13 @@ Feature: conversation/avatar
     Then the room "room2" has an avatar with 200
     And user "participant1" sees the following system messages in room "room2" with 200
       | room  | actorType     | actorId      | systemMessage        | message                         |
-      | room2 | users         | participant1 | set_room_avatar      | You set the conversation avatar |
+      | room2 | users         | participant1 | avatar_set           | You set the conversation avatar |
       | room2 | users         | participant1 | conversation_created | You created the conversation    |
     And user "participant1" delete the avatar of room "room2" with 200
     And user "participant1" sees the following system messages in room "room2" with 200
       | room  | actorType     | actorId      | systemMessage        | message                             |
-      | room2 | users         | participant1 | delete_room_avatar   | You deleted the conversation avatar |
-      | room2 | users         | participant1 | set_room_avatar      | You set the conversation avatar     |
+      | room2 | users         | participant1 | avatar_removed       | You removed the conversation avatar |
+      | room2 | users         | participant1 | avatar_set           | You set the conversation avatar     |
       | room2 | users         | participant1 | conversation_created | You created the conversation        |
 
   Scenario: Get avatar of conversation without custom avatar (fallback)

--- a/tests/integration/features/conversation/avatar.feature
+++ b/tests/integration/features/conversation/avatar.feature
@@ -15,9 +15,18 @@ Feature: conversation/avatar
     Given user "participant1" creates room "room2" (v4)
       | roomType | 3 |
       | roomName | room2 |
-    And user "participant1" uploads file "/img/favicon.png" as avatar of room "room2" with 200
+    When user "participant1" uploads file "/img/favicon.png" as avatar of room "room2" with 200
     Then the room "room2" has an avatar with 200
+    And user "participant1" sees the following system messages in room "room2" with 200
+      | room  | actorType     | actorId      | systemMessage        | message                         |
+      | room2 | users         | participant1 | set_room_avatar      | You set the conversation avatar |
+      | room2 | users         | participant1 | conversation_created | You created the conversation    |
     And user "participant1" delete the avatar of room "room2" with 200
+    And user "participant1" sees the following system messages in room "room2" with 200
+      | room  | actorType     | actorId      | systemMessage        | message                             |
+      | room2 | users         | participant1 | delete_room_avatar   | You deleted the conversation avatar |
+      | room2 | users         | participant1 | set_room_avatar      | You set the conversation avatar     |
+      | room2 | users         | participant1 | conversation_created | You created the conversation        |
 
   Scenario: Get avatar of conversation without custom avatar (fallback)
     Given user "participant1" creates room "room3" (v4)


### PR DESCRIPTION
Close: #8443

### 🚧 TODO

- [x] send system message "You set the conversation avatar" when add or change the room avatar
- [x] send system message "You deleted the conversation avatar" when delete the room avatar

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
