### PR TITLE
Send signaling messages when starting and stopping breakout rooms

### DIFF
--- a/lib/Service/BreakoutRoomService.php
+++ b/lib/Service/BreakoutRoomService.php
@@ -432,6 +432,8 @@ class BreakoutRoomService {
 			throw new \InvalidArgumentException('mode');
 		}
 
+		$this->roomService->setBreakoutRoomStatus($parent, BreakoutRoom::STATUS_STOPPED);
+
 		$breakoutRooms = $this->manager->getMultipleRoomsByObject(BreakoutRoom::PARENT_OBJECT_TYPE, $parent->getToken());
 		foreach ($breakoutRooms as $breakoutRoom) {
 			$this->roomService->setLobby($breakoutRoom, Webinary::LOBBY_NON_MODERATORS, null);
@@ -440,8 +442,6 @@ class BreakoutRoomService {
 				$this->roomService->setBreakoutRoomStatus($breakoutRoom, BreakoutRoom::STATUS_ASSISTANCE_RESET);
 			}
 		}
-
-		$this->roomService->setBreakoutRoomStatus($parent, BreakoutRoom::STATUS_STOPPED);
 
 		return $breakoutRooms;
 	}

--- a/lib/Signaling/BackendNotifier.php
+++ b/lib/Signaling/BackendNotifier.php
@@ -281,6 +281,33 @@ class BackendNotifier {
 	}
 
 	/**
+	 * The given participants should switch to the given room.
+	 *
+	 * @param Room $room
+	 * @param string $switchToRoomToken
+	 * @param string[] $sessionIds
+	 * @throws \Exception
+	 */
+	public function switchToRoom(Room $room, string $switchToRoomToken, array $sessionIds): void {
+		$start = microtime(true);
+		$this->backendRequest($room, [
+			'type' => 'switchto',
+			'switchto' => [
+				'roomid' => $switchToRoomToken,
+				'sessions' => $sessionIds,
+			],
+		]);
+		$duration = microtime(true) - $start;
+		$this->logger->debug('Switch to room: {token} {roomid} {sessions} ({duration})', [
+			'token' => $room->getToken(),
+			'roomid' => $switchToRoomToken,
+			'sessions' => print_r($sessionIds, true),
+			'duration' => sprintf('%.2f', $duration),
+			'app' => 'spreed-hpb',
+		]);
+	}
+
+	/**
 	 * The participant list of the given room has been modified.
 	 *
 	 * @param Room $room

--- a/lib/Signaling/Listener.php
+++ b/lib/Signaling/Listener.php
@@ -361,7 +361,9 @@ class Listener {
 				}
 			}
 
-			$notifier->switchToRoom($room, $breakoutRoom->getToken(), $sessionIds);
+			if (!empty($sessionIds)) {
+				$notifier->switchToRoom($room, $breakoutRoom->getToken(), $sessionIds);
+			}
 		}
 	}
 
@@ -401,7 +403,9 @@ class Listener {
 				}
 			}
 
-			$notifier->switchToRoom($breakoutRoom, $room->getToken(), $sessionIds);
+			if (!empty($sessionIds)) {
+				$notifier->switchToRoom($breakoutRoom, $room->getToken(), $sessionIds);
+			}
 		}
 	}
 

--- a/lib/Signaling/Manager.php
+++ b/lib/Signaling/Manager.php
@@ -55,7 +55,8 @@ class Manager {
 		$features = array_map('trim', $features);
 		return in_array('audio-video-permissions', $features, true)
 			&& in_array('incall-all', $features, true)
-			&& in_array('hello-v2', $features, true);
+			&& in_array('hello-v2', $features, true)
+			&& in_array('switchto', $features, true);
 	}
 
 	public function getSignalingServerLinkForConversation(?Room $room): string {

--- a/src/App.vue
+++ b/src/App.vue
@@ -267,9 +267,29 @@ export default {
 			if (this.isInCall) {
 				this.$store.dispatch('setForceCallView', true)
 
+				const enableAudio = !localStorage.getItem('audioDisabled_' + this.token)
+				const enableVideo = !localStorage.getItem('videoDisabled_' + this.token)
+				const enableVirtualBackground = !!localStorage.getItem('virtualBackgroundEnabled_' + this.token)
+
 				EventBus.$once('joined-conversation', async ({ token }) => {
 					if (params.token !== token) {
 						return
+					}
+
+					if (enableAudio) {
+						localStorage.removeItem('audioDisabled_' + token)
+					} else {
+						localStorage.setItem('audioDisabled_' + token, 'true')
+					}
+					if (enableVideo) {
+						localStorage.removeItem('videoDisabled_' + token)
+					} else {
+						localStorage.setItem('videoDisabled_' + token, 'true')
+					}
+					if (enableVirtualBackground) {
+						localStorage.setItem('virtualBackgroundEnabled_' + token, 'true')
+					} else {
+						localStorage.removeItem('virtualBackgroundEnabled_' + token)
 					}
 
 					const conversation = this.$store.getters.conversation(token)

--- a/src/App.vue
+++ b/src/App.vue
@@ -65,7 +65,7 @@ import UploadEditor from './components/UploadEditor.vue'
 import SettingsDialog from './components/SettingsDialog/SettingsDialog.vue'
 import ConversationSettingsDialog from './components/ConversationSettings/ConversationSettingsDialog.vue'
 import '@nextcloud/dialogs/styles/toast.scss'
-import { CONVERSATION } from './constants.js'
+import { CONVERSATION, PARTICIPANT } from './constants.js'
 import DeviceChecker from './components/DeviceChecker/DeviceChecker.vue'
 import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
 
@@ -261,6 +261,38 @@ export default {
 					leaveConversationSync(this.token)
 				}
 			}
+		})
+
+		EventBus.$on('switch-to-conversation', (params) => {
+			if (this.isInCall) {
+				this.$store.dispatch('setForceCallView', true)
+
+				EventBus.$once('joined-conversation', async ({ token }) => {
+					if (params.token !== token) {
+						return
+					}
+
+					const conversation = this.$store.getters.conversation(token)
+
+					let flags = PARTICIPANT.CALL_FLAG.IN_CALL
+					if (conversation.permissions & PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO) {
+						flags |= PARTICIPANT.CALL_FLAG.WITH_AUDIO
+					}
+					if (conversation.permissions & PARTICIPANT.PERMISSIONS.PUBLISH_VIDEO) {
+						flags |= PARTICIPANT.CALL_FLAG.WITH_VIDEO
+					}
+
+					await this.$store.dispatch('joinCall', {
+						token: params.token,
+						participantIdentifier: this.$store.getters.getParticipantIdentifier(),
+						flags,
+					})
+
+					this.$store.dispatch('setForceCallView', false)
+				})
+			}
+
+			this.$router.push({ name: 'conversation', params: { token: params.token, skipLeaveWarning: true } })
 		})
 
 		EventBus.$on('conversations-received', (params) => {

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -260,14 +260,14 @@ export default {
 			}
 		}, 30000)
 
-		EventBus.$on('should-refresh-conversations', this.debounceFetchConversations)
+		EventBus.$on('should-refresh-conversations', this.handleShouldRefreshConversations)
 		EventBus.$once('conversations-received', this.handleUnreadMention)
 
 		this.mountArrowNavigation()
 	},
 
 	beforeDestroy() {
-		EventBus.$off('should-refresh-conversations', this.debounceFetchConversations)
+		EventBus.$off('should-refresh-conversations', this.handleShouldRefreshConversations)
 		EventBus.$off('conversations-received', this.handleUnreadMention)
 
 		this.cancelSearchPossibleConversations()
@@ -437,6 +437,14 @@ export default {
 			}
 
 			return conversation2.lastActivity - conversation1.lastActivity
+		},
+
+		async handleShouldRefreshConversations(token, properties) {
+			if (token && properties) {
+				await this.$store.dispatch('setConversationProperties', { token, properties })
+			}
+
+			this.debounceFetchConversations()
 		},
 
 		debounceFetchConversations: debounce(function() {

--- a/src/mixins/isInCall.js
+++ b/src/mixins/isInCall.js
@@ -35,8 +35,9 @@ export default {
 
 	computed: {
 		isInCall() {
-			return this.sessionStorageJoinedConversation === this.$store.getters.getToken()
-				&& this.$store.getters.isInCall(this.$store.getters.getToken())
+			return this.$store.getters.forceCallView
+				|| (this.sessionStorageJoinedConversation === this.$store.getters.getToken()
+					&& this.$store.getters.isInCall(this.$store.getters.getToken()))
 		},
 	},
 

--- a/src/store/callViewStore.js
+++ b/src/store/callViewStore.js
@@ -27,6 +27,7 @@ import {
 } from '../constants.js'
 
 const state = {
+	forceCallView: false,
 	isGrid: false,
 	isStripeOpen: true,
 	lastIsGrid: null,
@@ -39,6 +40,7 @@ const state = {
 }
 
 const getters = {
+	forceCallView: (state) => state.forceCallView,
 	isGrid: (state) => state.isGrid,
 	isStripeOpen: (state) => state.isStripeOpen,
 	lastIsGrid: (state) => state.lastIsGrid,
@@ -65,6 +67,9 @@ const getters = {
 
 const mutations = {
 
+	setForceCallView(state, value) {
+		state.forceCallView = value
+	},
 	isGrid(state, value) {
 		state.isGrid = value
 	},
@@ -108,6 +113,10 @@ const mutations = {
 }
 
 const actions = {
+	setForceCallView(context, value) {
+		context.commit('setForceCallView', value)
+	},
+
 	selectedVideoPeerId(context, value) {
 		context.commit('selectedVideoPeerId', value)
 	},

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -407,6 +407,17 @@ const actions = {
 		commit('addConversation', conversation)
 	},
 
+	async setConversationProperties({ commit, getters }, { token, properties }) {
+		let conversation = Object.assign({}, getters.conversations[token])
+		if (!conversation) {
+			return
+		}
+
+		conversation = Object.assign(conversation, properties)
+
+		commit('addConversation', conversation)
+	},
+
 	async markConversationRead({ commit, getters }, token) {
 		const conversation = Object.assign({}, getters.conversations[token])
 		if (!conversation) {

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -1026,7 +1026,7 @@ Signaling.Standalone.prototype.helloResponseReceived = function(data) {
 		}
 	}
 
-	if (!this.hasFeature('audio-video-permissions') || !this.hasFeature('incall-all')) {
+	if (!this.hasFeature('audio-video-permissions') || !this.hasFeature('incall-all') || !this.hasFeature('switchto')) {
 		showError(
 			t('spreed', 'The configured signaling server needs to be updated to be compatible with this version of Talk. Please contact your administrator.'),
 			{

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -1275,6 +1275,11 @@ Signaling.Standalone.prototype.processRoomEvent = function(data) {
 			this._trigger('participantListChanged')
 		}
 		break
+	case 'switchto':
+		EventBus.$emit('switch-to-conversation', {
+			token: data.event.switchto.roomid,
+		})
+		break
 	case 'message':
 		this.processRoomMessageEvent(data.event.message.data)
 		break

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -1311,6 +1311,33 @@ Signaling.Standalone.prototype.processRoomListEvent = function(data) {
 				// Participant list in another room changed, we don't really care
 			}
 			break
+		} else {
+			// Some keys do not exactly match those in the room data, so they
+			// are normalized before emitting the event.
+			const properties = data.event.update.properties
+			const normalizedProperties = {}
+
+			Object.keys(properties).forEach(key => {
+				if (key === 'active-since') {
+					return
+				}
+
+				let normalizedKey = key
+				if (key === 'lobby-state') {
+					normalizedKey = 'lobbyState'
+				} else if (key === 'lobby-timer') {
+					normalizedKey = 'lobbyTimer'
+				} else if (key === 'read-only') {
+					normalizedKey = 'readOnly'
+				} else if (key === 'sip-enabled') {
+					normalizedKey = 'sipEnabled'
+				}
+
+				normalizedProperties[normalizedKey] = properties[key]
+			})
+
+			EventBus.$emit('should-refresh-conversations', data.event.update.roomid, normalizedProperties)
+			break
 		}
 		// eslint-disable-next-line no-fallthrough
 	case 'disinvite':

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -211,6 +211,9 @@ class BackendNotifierTest extends TestCase {
 		$expectedUrl = $this->baseUrl . '/api/v1/room/' . $room->getToken();
 
 		$requests = $this->controller->getRequests();
+		$requests = array_filter($requests, function ($request) use ($expectedUrl) {
+			return $request['url'] === $expectedUrl;
+		});
 		$bodies = array_map(function ($request) use ($expectedUrl) {
 			return json_decode($this->validateBackendRequest($expectedUrl, $request), true);
 		}, $requests);

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -208,9 +208,11 @@ class BackendNotifierTest extends TestCase {
 	}
 
 	private function assertMessageWasSent(Room $room, array $message): void {
+		$expectedUrl = $this->baseUrl . '/api/v1/room/' . $room->getToken();
+
 		$requests = $this->controller->getRequests();
-		$bodies = array_map(function ($request) use ($room) {
-			return json_decode($this->validateBackendRequest($this->baseUrl . '/api/v1/room/' . $room->getToken(), $request), true);
+		$bodies = array_map(function ($request) use ($expectedUrl) {
+			return json_decode($this->validateBackendRequest($expectedUrl, $request), true);
 		}, $requests);
 
 		$bodies = array_filter($bodies, function (array $body) use ($message) {

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -23,15 +23,18 @@
 namespace OCA\Talk\Tests\php\Signaling;
 
 use OCA\Talk\AppInfo\Application;
+use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Config;
 use OCA\Talk\Events\SignalingRoomPropertiesEvent;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\AttendeeMapper;
+use OCA\Talk\Model\BreakoutRoom;
 use OCA\Talk\Model\SessionMapper;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
+use OCA\Talk\Service\BreakoutRoomService;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\RoomService;
 use OCA\Talk\Signaling\BackendNotifier;
@@ -47,6 +50,7 @@ use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\Notification\IManager as INotificationManager;
 use OCP\Security\IHasher;
 use OCP\Security\ISecureRandom;
 use OCP\Share\IManager;
@@ -91,6 +95,7 @@ class BackendNotifierTest extends TestCase {
 
 	private ?Manager $manager = null;
 	private ?RoomService $roomService = null;
+	private ?BreakoutRoomService $breakoutRoomService = null;
 
 	private ?string $userId = null;
 	private ?string $signalingSecret = null;
@@ -166,6 +171,24 @@ class BackendNotifierTest extends TestCase {
 			$this->createMock(IHasher::class),
 			$this->dispatcher,
 			$this->jobList
+		);
+
+		$l = $this->createMock(IL10N::class);
+		$l->expects($this->any())
+			->method('t')
+			->willReturnCallback(function ($text, $parameters = []) {
+				return vsprintf($text, $parameters);
+			});
+
+		$this->breakoutRoomService = new BreakoutRoomService(
+			$this->config,
+			$this->manager,
+			$this->roomService,
+			$this->participantService,
+			$this->createMock(ChatManager::class),
+			$this->createMock(INotificationManager::class),
+			$this->dispatcher,
+			$l
 		);
 	}
 
@@ -257,6 +280,11 @@ class BackendNotifierTest extends TestCase {
 					<=>
 					[$b['userId'] ?? '', $b['participantType'], $b['sessionId'], $b['lastPing']]
 				;
+			});
+		}
+		if ($message['type'] === 'switchto') {
+			usort($message['switchto']['sessions'], static function ($a, $b) {
+				return $a <=> $b;
 			});
 		}
 		return $message;
@@ -1156,6 +1184,232 @@ class BackendNotifierTest extends TestCase {
 						'participantType' => Participant::GUEST,
 						'participantPermissions' => Attendee::PERMISSIONS_CUSTOM,
 					],
+				],
+			],
+		]);
+	}
+
+	public function testBreakoutRoomStart() {
+		$room = $this->manager->createRoom(Room::TYPE_GROUP);
+		$this->participantService->addUsers($room, [
+			[
+				'actorType' => 'users',
+				'actorId' => 'userId1',
+			],
+			[
+				'actorType' => 'users',
+				'actorId' => 'userId2',
+			],
+			[
+				'actorType' => 'users',
+				'actorId' => 'userId3',
+			],
+			[
+				'actorType' => 'users',
+				'actorId' => 'userIdModerator1',
+			],
+		]);
+
+		/** @var IUser|MockObject $user1 */
+		$user1 = $this->createMock(IUser::class);
+		$user1->expects($this->any())
+			->method('getUID')
+			->willReturn('userId1');
+
+		/** @var IUser|MockObject $user2 */
+		$user2 = $this->createMock(IUser::class);
+		$user2->expects($this->any())
+			->method('getUID')
+			->willReturn('userId2');
+
+		/** @var IUser|MockObject $user3 */
+		$user3 = $this->createMock(IUser::class);
+		$user3->expects($this->any())
+			->method('getUID')
+			->willReturn('userId3');
+
+		/** @var IUser|MockObject $userModerator1 */
+		$userModerator1 = $this->createMock(IUser::class);
+		$userModerator1->expects($this->any())
+			->method('getUID')
+			->willReturn('userIdModerator1');
+
+		$roomService = $this->createMock(RoomService::class);
+		$roomService->method('verifyPassword')
+			->willReturn(['result' => true, 'url' => '']);
+
+		$participant1 = $this->participantService->joinRoom($roomService, $room, $user1, '');
+		$sessionId1 = $participant1->getSession()->getSessionId();
+		$participant1 = $this->participantService->getParticipantBySession($room, $sessionId1);
+
+		$participant2 = $this->participantService->joinRoom($roomService, $room, $user2, '');
+		$sessionId2 = $participant2->getSession()->getSessionId();
+		$participant2 = $this->participantService->getParticipantBySession($room, $sessionId2);
+
+		$participant3 = $this->participantService->joinRoom($roomService, $room, $user3, '');
+		$sessionId3 = $participant3->getSession()->getSessionId();
+		$participant3 = $this->participantService->getParticipantBySession($room, $sessionId3);
+
+		$participant3b = $this->participantService->joinRoom($roomService, $room, $user3, '');
+		$sessionId3b = $participant3b->getSession()->getSessionId();
+		$participant3b = $this->participantService->getParticipantBySession($room, $sessionId3b);
+
+		$participantModerator1 = $this->participantService->joinRoom($roomService, $room, $userModerator1, '');
+		$sessionIdModerator1 = $participantModerator1->getSession()->getSessionId();
+		$participantModerator1 = $this->participantService->getParticipantBySession($room, $sessionIdModerator1);
+
+		$this->participantService->updateParticipantType($room, $participantModerator1, Participant::MODERATOR);
+
+		$attendeeMap = [];
+		$attendeeMap[$participant1->getSession()->getAttendeeId()] = 0;
+		$attendeeMap[$participant2->getSession()->getAttendeeId()] = 1;
+		$attendeeMap[$participant3->getSession()->getAttendeeId()] = 0;
+		$attendeeMap[$participantModerator1->getSession()->getAttendeeId()] = 0;
+
+		$breakoutRooms = $this->breakoutRoomService->setupBreakoutRooms($room, BreakoutRoom::MODE_MANUAL, 2, json_encode($attendeeMap));
+
+		$this->controller->clearRequests();
+
+		$this->breakoutRoomService->startBreakoutRooms($room);
+
+		$this->assertMessageWasSent($room, [
+			'type' => 'switchto',
+			'switchto' => [
+				'roomid' => $breakoutRooms[0]->getToken(),
+				'sessions' => [
+					$sessionId1,
+					$sessionId3,
+					$sessionId3b,
+				],
+			],
+		]);
+
+		$this->assertMessageWasSent($room, [
+			'type' => 'switchto',
+			'switchto' => [
+				'roomid' => $breakoutRooms[1]->getToken(),
+				'sessions' => [
+					$sessionId2,
+				],
+			],
+		]);
+	}
+
+	public function testBreakoutRoomStop() {
+		$room = $this->manager->createRoom(Room::TYPE_GROUP);
+		$this->participantService->addUsers($room, [
+			[
+				'actorType' => 'users',
+				'actorId' => 'userId1',
+			],
+			[
+				'actorType' => 'users',
+				'actorId' => 'userId2',
+			],
+			[
+				'actorType' => 'users',
+				'actorId' => 'userId3',
+			],
+			[
+				'actorType' => 'users',
+				'actorId' => 'userIdModerator1',
+			],
+		]);
+
+		/** @var IUser|MockObject $user1 */
+		$user1 = $this->createMock(IUser::class);
+		$user1->expects($this->any())
+			->method('getUID')
+			->willReturn('userId1');
+
+		/** @var IUser|MockObject $user2 */
+		$user2 = $this->createMock(IUser::class);
+		$user2->expects($this->any())
+			->method('getUID')
+			->willReturn('userId2');
+
+		/** @var IUser|MockObject $user3 */
+		$user3 = $this->createMock(IUser::class);
+		$user3->expects($this->any())
+			->method('getUID')
+			->willReturn('userId3');
+
+		/** @var IUser|MockObject $userModerator1 */
+		$userModerator1 = $this->createMock(IUser::class);
+		$userModerator1->expects($this->any())
+			->method('getUID')
+			->willReturn('userIdModerator1');
+
+		$roomService = $this->createMock(RoomService::class);
+		$roomService->method('verifyPassword')
+			->willReturn(['result' => true, 'url' => '']);
+
+		$participant1 = $this->participantService->joinRoom($roomService, $room, $user1, '');
+		$sessionId1 = $participant1->getSession()->getSessionId();
+		$participant1 = $this->participantService->getParticipantBySession($room, $sessionId1);
+
+		$participant2 = $this->participantService->joinRoom($roomService, $room, $user2, '');
+		$sessionId2 = $participant2->getSession()->getSessionId();
+		$participant2 = $this->participantService->getParticipantBySession($room, $sessionId2);
+
+		$participant3 = $this->participantService->joinRoom($roomService, $room, $user3, '');
+		$sessionId3 = $participant3->getSession()->getSessionId();
+		$participant3 = $this->participantService->getParticipantBySession($room, $sessionId3);
+
+		$participantModerator1 = $this->participantService->joinRoom($roomService, $room, $userModerator1, '');
+		$sessionIdModerator1 = $participantModerator1->getSession()->getSessionId();
+		$participantModerator1 = $this->participantService->getParticipantBySession($room, $sessionIdModerator1);
+
+		$this->participantService->updateParticipantType($room, $participantModerator1, Participant::MODERATOR);
+
+		$attendeeMap = [];
+		$attendeeMap[$participant1->getSession()->getAttendeeId()] = 0;
+		$attendeeMap[$participant2->getSession()->getAttendeeId()] = 1;
+		$attendeeMap[$participant3->getSession()->getAttendeeId()] = 0;
+		$attendeeMap[$participantModerator1->getSession()->getAttendeeId()] = 0;
+
+		$breakoutRooms = $this->breakoutRoomService->setupBreakoutRooms($room, BreakoutRoom::MODE_MANUAL, 2, json_encode($attendeeMap));
+
+		$this->breakoutRoomService->startBreakoutRooms($room);
+
+		$participant1 = $this->participantService->joinRoom($roomService, $breakoutRooms[0], $user1, '');
+		$sessionId1 = $participant1->getSession()->getSessionId();
+
+		$participant2 = $this->participantService->joinRoom($roomService, $breakoutRooms[1], $user2, '');
+		$sessionId2 = $participant2->getSession()->getSessionId();
+
+		$participant3 = $this->participantService->joinRoom($roomService, $breakoutRooms[0], $user3, '');
+		$sessionId3 = $participant3->getSession()->getSessionId();
+
+		$participant3b = $this->participantService->joinRoom($roomService, $breakoutRooms[0], $user3, '');
+		$sessionId3b = $participant3b->getSession()->getSessionId();
+
+		$participantModerator1 = $this->participantService->joinRoom($roomService, $breakoutRooms[0], $userModerator1, '');
+		$sessionIdModerator1 = $participantModerator1->getSession()->getSessionId();
+
+		$this->controller->clearRequests();
+
+		$this->breakoutRoomService->stopBreakoutRooms($room);
+
+		$this->assertMessageWasSent($breakoutRooms[0], [
+			'type' => 'switchto',
+			'switchto' => [
+				'roomid' => $room->getToken(),
+				'sessions' => [
+					$sessionId1,
+					$sessionId3,
+					$sessionId3b,
+					$sessionIdModerator1,
+				],
+			],
+		]);
+
+		$this->assertMessageWasSent($breakoutRooms[1], [
+			'type' => 'switchto',
+			'switchto' => [
+				'roomid' => $room->getToken(),
+				'sessions' => [
+					$sessionId2,
 				],
 			],
 		]);


### PR DESCRIPTION
- [x] Requires https://github.com/nextcloud/spreed/pull/8519

When the breakout room status changes a generic `room` message is sent to all the active sessions in either the parent or the breakout rooms (depending on whether they are being started or stopped) with the token of the room that they have to switch to.

### 🚧 TODO

- [X] ~~Another possibility would have been to send a `roomModified` message including the breakout room status and then let each client figure which room they need to switch to. This could lead to a potential issue with guests in the future, as if the client has to figure the target room it would need to check all the conversation data to find the room, but guests can only get the data for the room they are in and that is it. However that could be simply fixable by also including the token of the assigned breakout room for the participant in the parent room data, so maybe it is better to let the clients figure where to switch to.~~ The explicit message will be kept, as it could be used in other scenarios
- [X] Currently the session IDs are indexed by the token of the room that they have to switch to. An alternative would be to use each session as a key and the token of the room to switch to as the value; the benefit would be that this would make possible to send additional information, like the permissions that the participant will have in the target room. The drawback would be that the messages will be bigger, as the room token (and a label like _token:_) would be repeated for each session.
- [X] Adjust to format in https://github.com/strukturag/nextcloud-spreed-signaling/pull/409
- [X] Avoid showing the lobby screen for a moment when starting the breakout rooms - As a `roomlist` update event is sent when the lobby is modified and that event contains the up to date value of some properties, like the lobby state, the conversation data is now updated from the data in the event (besides still fetching again the conversation data from the server like before)
- [X] Keep the same media state (audio and video enabled or disabled) as before when joining the call after switching the conversation
- [ ] Look for possible race conditions when handling the message in the clients

### 🏁 Checklist

- [X] ⛑️ Tests (unit and/or integration) are included
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
