### PR TITLE
Fix call view not visible when joining a call again in Files app

### DIFF
--- a/src/FilesSidebarCallViewApp.vue
+++ b/src/FilesSidebarCallViewApp.vue
@@ -145,12 +145,12 @@ export default {
 				return
 			}
 
-			const headerAction = document.querySelector('.app-sidebar-header__action')
-			if (!headerAction) {
+			const headerDescription = document.querySelector('.app-sidebar-header__description')
+			if (!headerDescription) {
 				return
 			}
 
-			if (this.$el.parentElement === headerAction) {
+			if (this.$el.parentElement === headerDescription) {
 				return
 			}
 
@@ -254,7 +254,7 @@ export default {
 
 		/**
 		 * Shows the sidebar header contents and moves the call view back to the
-		 * actions.
+		 * description.
 		 */
 		restoreSidebarHeaderContents() {
 			const header = document.querySelector('.app-sidebar-header')
@@ -272,9 +272,9 @@ export default {
 				}
 			}
 
-			const headerAction = document.querySelector('.app-sidebar-header__action')
-			if (headerAction) {
-				headerAction.appendChild(this.$el)
+			const headerDescription = document.querySelector('.app-sidebar-header__description')
+			if (headerDescription) {
+				headerDescription.appendChild(this.$el)
 			}
 		},
 	},


### PR DESCRIPTION
When a call is joined all the direct child elements of the header are hidden by adding a special CSS class, `hidden-by-call`, and then the call view is added to the header. When the call is left the `hidden-by-call` class is removed and the call view is moved back to [its original parent](https://github.com/nextcloud/spreed/blob/47e98d86d617925253f69f4a5a7ad67d63fd4d79/src/mainFilesSidebarLoader.js#L57). That parent was `.app-sidebar-header__action`, but in [nextcloud/vue 3.3.0 (Nextcloud 22) it was renamed to `app-sidebar-header__description`](https://github.com/nextcloud/nextcloud-vue/commit/7dec2b584b482699696a124c62e0fb3865984ba6).

As the expected parent did not exist the call view was not moved back and instead stayed as a direct child of the header, so when the call was joined again `hidden-by-call` was also added to the call view and therefore hid it like the other elements.

## How to test

- Open the Files app
- Share a file
- Open the _Chat_ tab
- Join the conversation
- Start a call
- Leave the call
- Start a call again

### Results with this pull request

The call view is visible.

### Results without this pull request

The call view is not visible.
