### PR TITLE
Fix(webserver): Remove uncertain warning to not alert on working setups

### DIFF
--- a/lib/Settings/Admin/AdminSettings.php
+++ b/lib/Settings/Admin/AdminSettings.php
@@ -509,7 +509,7 @@ class AdminSettings implements ISettings {
 
 		$output = [];
 		try {
-			@exec('apachectl -M | grep mpm', $output, $returnCode);
+			@exec('apachectl -V | grep MPM', $output, $returnCode);
 		} catch (\Throwable $e) {
 			return 'unknown';
 		}
@@ -523,11 +523,11 @@ class AdminSettings implements ISettings {
 
 		if ($usingFPM) {
 			// Needs to use mpm_event
-			return strpos($apacheModule, 'mpm_event') !== false ? '' : 'invalid';
+			return strpos($apacheModule, 'event') !== false ? '' : 'invalid';
 		}
 
 		// Needs to use mpm_prefork
-		return strpos($apacheModule, 'mpm_prefork') !== false ? '' : 'invalid';
+		return strpos($apacheModule, 'prefork') !== false ? '' : 'invalid';
 	}
 
 	/**

--- a/src/components/AdminSettings/WebServerSetupChecks.vue
+++ b/src/components/AdminSettings/WebServerSetupChecks.vue
@@ -120,9 +120,10 @@ export default {
 			if (this.apachePHPConfiguration === 'invalid') {
 				return t('spreed', 'It seems that the PHP and Apache configuration is not compatible. Please note that PHP can only be used with the MPM_PREFORK module and PHP-FPM can only be used with the MPM_EVENT module.')
 			}
-			if (this.apachePHPConfiguration === 'unknown') {
-				return t('spreed', 'Could not detect the PHP and Apache configuration because exec is disabled or apachectl is not working as expected. Please note that PHP can only be used with the MPM_PREFORK module and PHP-FPM can only be used with the MPM_EVENT module.')
-			}
+			// Disabling this for now as there were too many false catches (VMs, AIO, nginx, permissions issue, …)
+			// if (this.apachePHPConfiguration === 'unknown') {
+			// return t('spreed', 'Could not detect the PHP and Apache configuration because exec is disabled or apachectl is not working as expected. Please note that PHP can only be used with the MPM_PREFORK module and PHP-FPM can only be used with the MPM_EVENT module.')
+			// }
 			return ''
 		},
 


### PR DESCRIPTION
Fix #8436 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
