### PR TITLE
Hide expired messages when do not run expire job

### DIFF
--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -466,6 +466,7 @@ class ChatController extends AEnvironmentAwareController {
 		$this->preloadShares($comments);
 
 		$i = 0;
+		$now = $this->timeFactory->getDateTime('now', new \DateTimeZone('UTC'));
 		$messages = $commentIdToIndex = $parentIds = [];
 		foreach ($comments as $comment) {
 			$id = (int) $comment->getId();
@@ -473,7 +474,7 @@ class ChatController extends AEnvironmentAwareController {
 			$this->messageParser->parseMessage($message);
 
 			$expireDate = $message->getComment()->getExpireDate();
-			if ($expireDate instanceof \DateTime && $expireDate < $this->timeFactory->getDateTime()) {
+			if ($expireDate instanceof \DateTime && $expireDate < $now) {
 				$message->setVisibility(false);
 			}
 

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -472,6 +472,11 @@ class ChatController extends AEnvironmentAwareController {
 			$message = $this->messageParser->createMessage($this->room, $this->participant, $comment, $this->l);
 			$this->messageParser->parseMessage($message);
 
+			$expireDate = $message->getComment()->getExpireDate();
+			if ($expireDate instanceof \DateTime && $expireDate < $this->timeFactory->getDateTime()) {
+				$message->setVisibility(false);
+			}
+
 			if (!$message->getVisibility()) {
 				$commentIdToIndex[$id] = null;
 				continue;

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -655,6 +655,12 @@ class RoomController extends AEnvironmentAwareController {
 			return [];
 		}
 
+		$now = $this->timeFactory->getDateTime();
+		$expireDate = $message->getComment()->getExpireDate();
+		if ($expireDate instanceof \DateTime && $expireDate < $now) {
+			return [];
+		}
+
 		return $message->toArray($this->getResponseFormat());
 	}
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -38,6 +38,7 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Webinary;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
 use OCP\HintException;
@@ -68,6 +69,7 @@ class Notifier implements INotifier {
 	protected INotificationManager $notificationManager;
 	protected ICommentsManager $commentManager;
 	protected MessageParser $messageParser;
+	protected ITimeFactory $timeFactory;
 	protected Definitions $definitions;
 	protected AddressHandler $addressHandler;
 
@@ -87,6 +89,7 @@ class Notifier implements INotifier {
 								INotificationManager $notificationManager,
 								CommentsManager $commentManager,
 								MessageParser $messageParser,
+								ITimeFactory $timeFactory,
 								Definitions $definitions,
 								AddressHandler $addressHandler) {
 		$this->lFactory = $lFactory;
@@ -100,6 +103,7 @@ class Notifier implements INotifier {
 		$this->notificationManager = $notificationManager;
 		$this->commentManager = $commentManager;
 		$this->messageParser = $messageParser;
+		$this->timeFactory = $timeFactory;
 		$this->definitions = $definitions;
 		$this->addressHandler = $addressHandler;
 	}
@@ -382,6 +386,12 @@ class Notifier implements INotifier {
 		$this->messageParser->parseMessage($message);
 
 		if (!$message->getVisibility()) {
+			throw new AlreadyProcessedException();
+		}
+
+		$now = $this->timeFactory->getDateTime();
+		$expireDate = $message->getComment()->getExpireDate();
+		if ($expireDate instanceof \DateTime && $expireDate < $now) {
 			throw new AlreadyProcessedException();
 		}
 

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2965,20 +2965,6 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		sleep($seconds);
 	}
 
-	/**
-	 * @When apply message expiration job manually
-	 */
-	public function applyMessageExpirationJob(): void {
-		$currentUser = $this->currentUser;
-		$this->setCurrentUser('admin');
-		$this->sendRequest('GET', '/apps/spreedcheats/get_message_expiration_job');
-		$response = $this->getDataFromResponse($this->response);
-		Assert::assertIsArray($response, 'Job not found');
-		Assert::assertArrayHasKey('id', $response, 'Job not found');
-		$this->runOcc(['background-job:execute', $response['id'], '--force-execute']);
-		$this->setCurrentUser($currentUser);
-	}
-
 	/*
 	 * Requests
 	 */

--- a/tests/integration/features/chat/message-expiration.feature
+++ b/tests/integration/features/chat/message-expiration.feature
@@ -15,11 +15,10 @@ Feature: chat/message-expiration
     And user "participant3" set the message expiration to 3 of room "room" with 404 (v4)
     And user "participant1" set the message expiration to 3 of room "room" with 200 (v4)
     And user "participant1" sends message "Message 2" to room "room" with 201
-    Then user "participant1" is participant of the following rooms (v4)
+    And user "participant1" is participant of the following rooms (v4)
       | id   | type | messageExpiration |
       | room | 3    | 3                 |
     And wait for 3 seconds
-    And apply message expiration job manually
     Then user "participant1" sees the following messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
       | room | users     | participant1 | participant1-displayname | Message 1   | []                |               |
@@ -34,7 +33,6 @@ Feature: chat/message-expiration
       | room  | actorType | actorId      | actorDisplayName         | message  | messageParameters |
       | room2 | users     | participant1 | participant1-displayname | {file}   | "IGNORE"          |
     And wait for 3 seconds
-    And apply message expiration job manually
     Then user "participant1" sees the following messages in room "room2" with 200
       | room | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
     And user "participant1" gets last share

--- a/tests/integration/spreedcheats/appinfo/routes.php
+++ b/tests/integration/spreedcheats/appinfo/routes.php
@@ -26,6 +26,5 @@ declare(strict_types=1);
 return [
 	'ocs' => [
 		['name' => 'Api#resetSpreed', 'url' => '/', 'verb' => 'DELETE'],
-		['name' => 'Api#getMessageExpirationJob', 'url' => '/get_message_expiration_job', 'verb' => 'GET'],
 	],
 ];

--- a/tests/integration/spreedcheats/lib/Controller/ApiController.php
+++ b/tests/integration/spreedcheats/lib/Controller/ApiController.php
@@ -25,8 +25,6 @@ declare(strict_types=1);
 
 namespace OCA\SpreedCheats\Controller;
 
-use OCA\Talk\BackgroundJob\ExpireChatMessages;
-use OCP\AppFramework\Http;
 use OCP\AppFramework\OCSController;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IDBConnection;

--- a/tests/integration/spreedcheats/lib/Controller/ApiController.php
+++ b/tests/integration/spreedcheats/lib/Controller/ApiController.php
@@ -103,24 +103,4 @@ class ApiController extends OCSController {
 
 		return new DataResponse();
 	}
-
-	/**
-	 * @NoCSRFRequired
-	 *
-	 * @return DataResponse
-	 */
-	public function getMessageExpirationJob(): DataResponse {
-		$query = $this->db->getQueryBuilder();
-		$query->select('id')
-			->from('jobs')
-			->where(
-				$query->expr()->eq('class', $query->createNamedParameter(ExpireChatMessages::class))
-			);
-		$result = $query->executeQuery();
-		$job = $result->fetchOne();
-		if ($job) {
-			return new DataResponse(['id' => (int) $job]);
-		}
-		return new DataResponse([], Http::STATUS_NOT_FOUND);
-	}
 }

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -35,6 +35,7 @@ use OCA\Talk\Notification\Notifier;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\IComment;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -72,6 +73,8 @@ class NotifierTest extends TestCase {
 	protected $commentsManager;
 	/** @var MessageParser|MockObject */
 	protected $messageParser;
+	/** @var ITimeFactory|MockObject */
+	protected $timeFactory;
 	/** @var Definitions|MockObject */
 	protected $definitions;
 	protected ?Notifier $notifier = null;
@@ -92,6 +95,7 @@ class NotifierTest extends TestCase {
 		$this->notificationManager = $this->createMock(INotificationManager::class);
 		$this->commentsManager = $this->createMock(CommentsManager::class);
 		$this->messageParser = $this->createMock(MessageParser::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->definitions = $this->createMock(Definitions::class);
 		$this->addressHandler = $this->createMock(AddressHandler::class);
 
@@ -107,6 +111,7 @@ class NotifierTest extends TestCase {
 			$this->notificationManager,
 			$this->commentsManager,
 			$this->messageParser,
+			$this->timeFactory,
 			$this->definitions,
 			$this->addressHandler
 		);


### PR DESCRIPTION
### 🚧 TODO

- [x] prevent display expired messages when don't run the job to do expire messages.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
