### PR TITLE
Fix leaving call when switching to another conversation

### DIFF
--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -185,6 +185,15 @@ export default {
 				return
 			}
 
+			// TODO: move to store under a special action ?
+
+			// Remove the conversation to ensure that the old data is not used
+			// before fetching it again if this conversation is joined again.
+			await this.$store.dispatch('deleteConversation', this.token)
+			// Remove the participant to ensure that it will be set again fresh
+			// if this conversation is joined again.
+			await this.$store.dispatch('purgeParticipantsStore', this.token)
+
 			await this.$store.dispatch('joinConversation', { token: this.token })
 
 			// The current participant (which is automatically set when fetching
@@ -218,15 +227,6 @@ export default {
 			EventBus.$off('should-refresh-conversations', OCA.Talk.fetchCurrentConversationWrapper)
 			EventBus.$off('signaling-participant-list-changed', OCA.Talk.fetchCurrentConversationWrapper)
 			window.clearInterval(OCA.Talk.fetchCurrentConversationIntervalId)
-
-			// TODO: move to store under a special action ?
-
-			// Remove the conversation to ensure that the old data is not used
-			// before fetching it again if this conversation is joined again.
-			this.$store.dispatch('deleteConversation', this.token)
-			// Remove the participant to ensure that it will be set again fresh
-			// if this conversation is joined again.
-			this.$store.dispatch('purgeParticipantsStore', this.token)
 
 			this.$store.dispatch('leaveConversation', { token: this.token })
 

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -553,6 +553,13 @@ const actions = {
 	 * @param {string} data.token - conversation token.
 	 */
 	async leaveConversation(context, { token }) {
+		if (context.getters.isInCall(token)) {
+			await context.dispatch('leaveCall', {
+				token,
+				participantIdentifier: context.getters.getParticipantIdentifier(),
+			})
+		}
+
 		await leaveConversation(token)
 	},
 


### PR DESCRIPTION
## How to test (scenario 1)

- Open Talk
- Open a conversation
- Start a call
- Open the left navigation bar
- Change to another conversation (when asked by the modal, leave the call)
- Change again to the original conversation

### Result with this pull request

The call view is not shown

### Result without this pull request

The call view is automatically shown again, but the call is not actually joined


## How to test (scenario 2)

- Open Files
- Share a file
- Open the _Chat_ tab for that file
- Join the conversation
- Start a call
- Open the details for another file
- Open the details again of the original file
- Join again the conversation

### Result with this pull request

The call view is not shown

### Result without this pull request

The call view is automatically shown again, but the call is not actually joined
