### PR TITLE
Replace deprecated oc_defaults with OC.theme

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -393,7 +393,7 @@ export default {
 		},
 
 		shareFromNextcloudLabel() {
-			return t('spreed', 'Share from {nextcloud}', { nextcloud: window.oc_defaults.productName })
+			return t('spreed', 'Share from {nextcloud}', { nextcloud: OC.theme.productName })
 		},
 
 		fileTemplateOptions() {


### PR DESCRIPTION
Replace deprecated `oc_defaults` with `OC.theme` for `productName` in the "Share from Nextcloud" button on the new message form.

Fixes warning: `oc_defaults is deprecated: use OC.theme instead, this will be removed in Nextcloud 20`.

It doesn't affect UI or tests.