### PR TITLE
Don't throw/error when the recording was stopped in parallel

### DIFF
--- a/docs/recording.md
+++ b/docs/recording.md
@@ -33,7 +33,6 @@
     - Status code:
         + `200 OK`
         + `400 Bad Request` Message: `config`. Need to enable the config `recording`.
-        + `400 Bad Request` Message: `recording`. Recording has already been stopped.
         + `400 Bad Request` Message: `call`. Call is not activated.
         + `403 Forbidden` When the user is not a moderator/owner.
         + `412 Precondition Failed` When the lobby is active and the user is not a moderator.

--- a/lib/Service/RecordingService.php
+++ b/lib/Service/RecordingService.php
@@ -68,7 +68,7 @@ class RecordingService {
 
 	public function stop(Room $room): void {
 		if ($room->getCallRecording() === Room::RECORDING_NONE) {
-			throw new InvalidArgumentException('recording');
+			return;
 		}
 		$this->roomService->setCallRecording($room);
 	}

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -369,6 +369,8 @@ class RoomService {
 	/**
 	 * @param Room $room
 	 * @param integer $status 0 none|1 video|2 audio
+	 * @throws \InvalidArgumentException When the status is invalid, not Room::RECORDING_*
+	 * @throws \InvalidArgumentException When trying to start
 	 */
 	public function setCallRecording(Room $room, int $status = Room::RECORDING_NONE): void {
 		if (!$this->config->isRecordingEnabled() && $status !== Room::RECORDING_NONE) {

--- a/tests/integration/features/callapi/recording.feature
+++ b/tests/integration/features/callapi/recording.feature
@@ -59,14 +59,12 @@ Feature: callapi/recording
     Then user "participant1" starts "audio" recording in room "room1" with 400 (v1)
     And the response error matches with "recording"
     When user "participant1" stops recording in room "room1" with 200 (v1)
-    Then user "participant1" stops recording in room "room1" with 400 (v1)
-    And the response error matches with "recording"
+    Then user "participant1" stops recording in room "room1" with 200 (v1)
     When user "participant1" starts "video" recording in room "room1" with 200 (v1)
     Then user "participant1" starts "video" recording in room "room1" with 400 (v1)
     And the response error matches with "recording"
     When user "participant1" stops recording in room "room1" with 200 (v1)
-    Then user "participant1" stops recording in room "room1" with 400 (v1)
-    And the response error matches with "recording"
+    Then user "participant1" stops recording in room "room1" with 200 (v1)
 
   Scenario: Get error when try to start recording with invalid status
     When the following "spreed" app config is set


### PR DESCRIPTION
Allow multiple calls in parallel to stop call recordings

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
