### PR TITLE
perf(PHP): Use static closures for registrations

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -198,7 +198,7 @@ class Application extends App implements IBootstrap {
 		/** @var IProviderManager $resourceManager */
 		$resourceManager = $server->get(IProviderManager::class);
 		$resourceManager->registerResourceProvider(ConversationProvider::class);
-		$server->getEventDispatcher()->addListener(LoadAdditionalScriptsEvent::class, function () {
+		$server->getEventDispatcher()->addListener(LoadAdditionalScriptsEvent::class, static function () {
 			Util::addScript(self::APP_ID, 'talk-collections');
 		});
 	}
@@ -212,7 +212,7 @@ class Application extends App implements IBootstrap {
 	}
 
 	protected function registerNavigationLink(IServerContainer $server): void {
-		$server->getNavigationManager()->add(function () use ($server) {
+		$server->getNavigationManager()->add(static function () use ($server) {
 			/** @var Config $config */
 			$config = $server->get(Config::class);
 			$user = $server->getUserSession()->getUser();


### PR DESCRIPTION
Micro performance optimization as it allows PHP to GC the surrounding class earlier when `$this` isn't bound to the closure.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
:right_anger_bubble:  | :left_speech_bubble: 


### 🚧 TODO

- [x] Do

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
