### PR TITLE
perf(autoloader): Force own autoloader

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -21,9 +21,14 @@ local Pipeline(test_set, database, services) = {
 			},
 			commands: [
 				"bash tests/drone-run-integration-tests.sh || exit 0",
+				"composer --version",
+				"composer self-update --2",
 				"wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh",
 				"bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST",
 				"cd ../server",
+				"cd apps/$APP_NAME",
+				"composer install --no-dev",
+				"cd ../..",
 				"./occ app:enable $APP_NAME",
 				"git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications apps/notifications",
 				"./occ app:enable notifications"
@@ -32,11 +37,7 @@ local Pipeline(test_set, database, services) = {
 					"git clone --depth 1 -b $GUESTS_BRANCH https://github.com/nextcloud/guests apps/guests"
 				] else []
 			) + [
-				"cd apps/$APP_NAME",
-				"composer --version",
-				"composer self-update --2",
-				"composer install",
-				"cd tests/integration/",
+				"cd apps/$APP_NAME/tests/integration/",
 				"bash run.sh features/"+test_set
 			]
 		}

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,18 +7,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/callapi
   environment:
     APP_NAME: spreed
@@ -43,18 +44,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/chat
   environment:
     APP_NAME: spreed
@@ -79,18 +81,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/chat-2
   environment:
     APP_NAME: spreed
@@ -115,18 +118,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/command
   environment:
     APP_NAME: spreed
@@ -151,19 +155,20 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
   - git clone --depth 1 -b $GUESTS_BRANCH https://github.com/nextcloud/guests apps/guests
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/conversation
   environment:
     APP_NAME: spreed
@@ -188,19 +193,20 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
   - git clone --depth 1 -b $GUESTS_BRANCH https://github.com/nextcloud/guests apps/guests
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/conversation-2
   environment:
     APP_NAME: spreed
@@ -225,18 +231,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/federation
   environment:
     APP_NAME: spreed
@@ -261,18 +268,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/integration
   environment:
     APP_NAME: spreed
@@ -297,18 +305,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/sharing
   environment:
     APP_NAME: spreed
@@ -333,18 +342,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/sharing-2
   environment:
     APP_NAME: spreed
@@ -383,18 +393,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/callapi
   environment:
     APP_NAME: spreed
@@ -433,18 +444,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/chat
   environment:
     APP_NAME: spreed
@@ -483,18 +495,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/chat-2
   environment:
     APP_NAME: spreed
@@ -533,18 +546,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/command
   environment:
     APP_NAME: spreed
@@ -583,19 +597,20 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
   - git clone --depth 1 -b $GUESTS_BRANCH https://github.com/nextcloud/guests apps/guests
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/conversation
   environment:
     APP_NAME: spreed
@@ -634,19 +649,20 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
   - git clone --depth 1 -b $GUESTS_BRANCH https://github.com/nextcloud/guests apps/guests
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/conversation-2
   environment:
     APP_NAME: spreed
@@ -685,18 +701,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/federation
   environment:
     APP_NAME: spreed
@@ -735,18 +752,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/integration
   environment:
     APP_NAME: spreed
@@ -785,18 +803,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/sharing
   environment:
     APP_NAME: spreed
@@ -835,18 +854,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/sharing-2
   environment:
     APP_NAME: spreed
@@ -880,18 +900,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/callapi
   environment:
     APP_NAME: spreed
@@ -926,18 +947,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/chat
   environment:
     APP_NAME: spreed
@@ -972,18 +994,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/chat-2
   environment:
     APP_NAME: spreed
@@ -1018,18 +1041,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/command
   environment:
     APP_NAME: spreed
@@ -1064,19 +1088,20 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
   - git clone --depth 1 -b $GUESTS_BRANCH https://github.com/nextcloud/guests apps/guests
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/conversation
   environment:
     APP_NAME: spreed
@@ -1111,19 +1136,20 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
   - git clone --depth 1 -b $GUESTS_BRANCH https://github.com/nextcloud/guests apps/guests
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/conversation-2
   environment:
     APP_NAME: spreed
@@ -1158,18 +1184,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/federation
   environment:
     APP_NAME: spreed
@@ -1204,18 +1231,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/integration
   environment:
     APP_NAME: spreed
@@ -1250,18 +1278,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/sharing
   environment:
     APP_NAME: spreed
@@ -1296,18 +1325,19 @@ services:
 steps:
 - commands:
   - bash tests/drone-run-integration-tests.sh || exit 0
+  - composer --version
+  - composer self-update --2
   - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DATABASEHOST
   - cd ../server
+  - cd apps/$APP_NAME
+  - composer install --no-dev
+  - cd ../..
   - ./occ app:enable $APP_NAME
   - git clone --depth 1 -b $NOTIFICATIONS_BRANCH https://github.com/nextcloud/notifications
     apps/notifications
   - ./occ app:enable notifications
-  - cd apps/$APP_NAME
-  - composer --version
-  - composer self-update --2
-  - composer install
-  - cd tests/integration/
+  - cd apps/$APP_NAME/tests/integration/
   - bash run.sh features/sharing-2
   environment:
     APP_NAME: spreed

--- a/composer/autoload.php
+++ b/composer/autoload.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
And don't register any generic PSR-4 nor PSR-0 loader in server.

https://github.com/nextcloud/server/blob/473c546b5c562e19ba8f9d3aef9cd64d2458cda7/lib/private/legacy/OC_App.php#L284-L290

## Benchmarks

### Blackfire comparison graph on IO wait
![Bildschirmfoto vom 2023-01-20 13-51-25](https://user-images.githubusercontent.com/1374172/213699316-93317237-e9d3-4b08-9a39-c8e8b8656abe.png)

### Blackfire recommendations before
![Bildschirmfoto vom 2023-01-20 13-53-14](https://user-images.githubusercontent.com/1374172/213699445-3fb78d0f-89e3-4010-ad5a-7469d8ff5057.png)

### Blackfire recommendations after
![Bildschirmfoto vom 2023-01-20 13-50-49](https://user-images.githubusercontent.com/1374172/213699323-d65c0f87-7b28-46b7-ad49-8b422c23a272.png)


### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
:sloth:  | :snail: 

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
