### PR TITLE
Only register Maps plugin when allowed to use Talk

### DIFF
--- a/lib/Maps/MapsPluginLoader.php
+++ b/lib/Maps/MapsPluginLoader.php
@@ -23,21 +23,31 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Maps;
 
+use OCA\Talk\Config;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use OCP\Util;
 
 /**
  * @template-implements IEventListener<Event>
  */
 class MapsPluginLoader implements IEventListener {
-	/** @var IRequest */
-	private $request;
+	protected IRequest $request;
+	protected Config $talkConfig;
+	protected IUserSession $userSession;
 
-	public function __construct(IRequest $request) {
+	public function __construct(
+		IRequest $request,
+		Config $talkConfig,
+		IUserSession $userSession
+	) {
 		$this->request = $request;
+		$this->talkConfig = $talkConfig;
+		$this->userSession = $userSession;
 	}
 
 	public function handle(Event $event): void {
@@ -46,6 +56,11 @@ class MapsPluginLoader implements IEventListener {
 		}
 
 		if (!$event->isLoggedIn()) {
+			return;
+		}
+
+		$user = $this->userSession->getUser();
+		if ($user instanceof IUser && $this->talkConfig->isDisabledForUser($user)) {
 			return;
 		}
 


### PR DESCRIPTION
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Bildschirmfoto vom 2023-01-23 20-40-20](https://user-images.githubusercontent.com/213943/214134038-1519398d-8828-4e5b-8625-d72d9ed530c3.png) | ![Bildschirmfoto vom 2023-01-23 20-41-14](https://user-images.githubusercontent.com/213943/214134062-54a29314-9ca2-4774-bbd5-593a96d4c6c4.png)
Clicking results in 403 | No click, no error

### Steps

- Requires usage of stable25 as maps does not work in master yet
- Apply following patch to work around https://github.com/nextcloud/maps/issues/947
```diff
diff --git a/lib/Files/TemplateLoader.php b/lib/Files/TemplateLoader.php
index c129c1854..297a214ae 100644
--- a/lib/Files/TemplateLoader.php
+++ b/lib/Files/TemplateLoader.php
@@ -95,7 +95,9 @@ class TemplateLoader implements IEventListener {
 
 		Util::addStyle(Application::APP_ID, 'At');
 		Util::addStyle(Application::APP_ID, 'icons');
-		Util::addScript(Application::APP_ID, 'talk-files-sidebar');
+		if (strpos(\OC::$server->getRequest()->getPathInfo(), '/apps/maps') !== 0)
+			Util::addScript(Application::APP_ID, 'talk-files-sidebar');
+		}
 
 		if ($user instanceof IUser) {
 			$this->publishInitialStateForUser($user, $this->rootFolder, $this->appManager);
```

- Restrict usage of talk to a group you are not a member of
- Go to the maps app
- Rightclick


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
