### PR TITLE
Don't break the maps app with talks files sidebar

### DIFF
--- a/lib/Files/TemplateLoader.php
+++ b/lib/Files/TemplateLoader.php
@@ -97,7 +97,9 @@ class TemplateLoader implements IEventListener {
 
 		Util::addStyle(Application::APP_ID, 'At');
 		Util::addStyle(Application::APP_ID, 'icons');
-		Util::addScript(Application::APP_ID, 'talk-files-sidebar');
+		if (strpos(\OC::$server->getRequest()->getPathInfo(), '/apps/maps') !== 0) {
+			Util::addScript(Application::APP_ID, 'talk-files-sidebar');
+		}
 
 		if ($user instanceof IUser) {
 			$this->publishInitialStateForUser($user, $this->rootFolder, $this->appManager);


### PR DESCRIPTION
Fix https://github.com/nextcloud/maps/issues/947

Unsure why this happens at all, but for now it might be easier to just disable it.
This however means Talk chats of files are not visible in the files sidebar of Photos you watch on the Maps app, but that is better than Maps not rendering at all.

We could create a follow up to have a look where it breaks, unless @danxuliu already has a clue.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
