### PR TITLE
Change icon for 'Leave conversation'

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -97,28 +97,30 @@
 
 <script>
 import { showError, showSuccess } from '@nextcloud/dialogs'
+import { generateUrl } from '@nextcloud/router'
+import { emit } from '@nextcloud/event-bus'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
+import NcListItem from '@nextcloud/vue/dist/Components/NcListItem.js'
+
 import Cog from 'vue-material-design-icons/Cog.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
 import ExitToApp from 'vue-material-design-icons/ExitToApp.vue'
 import EyeOutline from 'vue-material-design-icons/EyeOutline.vue'
 import Star from 'vue-material-design-icons/Star.vue'
+
 import ConversationIcon from './../../ConversationIcon.vue'
-import { generateUrl } from '@nextcloud/router'
-import { emit } from '@nextcloud/event-bus'
 import { CONVERSATION, PARTICIPANT, ATTENDEE } from '../../../constants.js'
-import NcListItem from '@nextcloud/vue/dist/Components/NcListItem.js'
 
 export default {
 	name: 'Conversation',
 	components: {
-		NcActionButton,
-		NcListItem,
-		ConversationIcon,
 		Cog,
+		ConversationIcon,
 		Delete,
 		ExitToApp,
 		EyeOutline,
+		NcActionButton,
+		NcListItem,
 		Star,
 	},
 	props: {

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -76,8 +76,10 @@
 			</NcActionButton>
 			<NcActionButton v-if="canLeaveConversation"
 				:close-after-click="true"
-				:icon="iconLeaveConversation"
 				@click.prevent.exact="leaveConversation">
+				<template #icon>
+					<ExitToApp :size="16" />
+				</template>
 				{{ t('spreed', 'Leave conversation') }}
 			</NcActionButton>
 			<NcActionButton v-if="canDeleteConversation"
@@ -98,6 +100,7 @@ import { showError, showSuccess } from '@nextcloud/dialogs'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import Cog from 'vue-material-design-icons/Cog.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
+import ExitToApp from 'vue-material-design-icons/ExitToApp.vue'
 import EyeOutline from 'vue-material-design-icons/EyeOutline.vue'
 import Star from 'vue-material-design-icons/Star.vue'
 import ConversationIcon from './../../ConversationIcon.vue'
@@ -114,6 +117,7 @@ export default {
 		ConversationIcon,
 		Cog,
 		Delete,
+		ExitToApp,
 		EyeOutline,
 		Star,
 	},
@@ -188,13 +192,6 @@ export default {
 
 		canLeaveConversation() {
 			return this.item.canLeaveConversation
-		},
-
-		iconLeaveConversation() {
-			if (this.canDeleteConversation) {
-				return 'icon-close'
-			}
-			return 'icon-delete'
 		},
 
 		conversationInformation() {


### PR DESCRIPTION
Fix #8464

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
Moderator | - 
![image](https://user-images.githubusercontent.com/93392545/214283963-493ac4a9-464a-4487-bf9c-268f32ffbf54.png) ![image](https://user-images.githubusercontent.com/93392545/214284296-e59595e1-9809-4c88-b429-c79aa860c899.png) | ![image](https://user-images.githubusercontent.com/93392545/214283659-413e2309-8d1a-4856-bb3b-6a3f54c1f088.png) ![image](https://user-images.githubusercontent.com/93392545/214283382-2247f2cb-a1be-407c-84d9-68b7840c0f56.png)
User | - 
![image](https://user-images.githubusercontent.com/93392545/214284050-dd3019bc-17c7-45d5-bb09-06688a4c6c31.png) ![image](https://user-images.githubusercontent.com/93392545/214284201-fb749819-fd8a-49e3-b021-cfa91b46fa02.png) | ![image](https://user-images.githubusercontent.com/93392545/214283519-7b7cc94e-7b3a-43f9-b62f-ba812a1750f0.png) ![image](https://user-images.githubusercontent.com/93392545/214283198-7c6c8654-844e-4dfa-af66-7402ab501882.png)



### 🚧 TODO

### 🏁 Checklist

- [X] 📘 API documentation in `docs/` has been updated or is not required
- [X] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [X] 🔖 Capability is added or not needed 