### PR TITLE
Introduce a "former one-to-one" conversation type

### DIFF
--- a/docs/constants.md
+++ b/docs/constants.md
@@ -9,6 +9,7 @@ title: Constants
 * `2` Group
 * `3` Public
 * `4` Changelog
+* `5` Former "One to one" (When a user is deleted from the server or removed from all their conversations, `1` "One to one" rooms are converted to this type)
 
 ### Read-only states
 * `0` Read-write

--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -137,7 +137,7 @@ class Listener {
 		$message = 'call_ended';
 		if ($endForEveryone) {
 			$message = 'call_ended_everyone';
-		} elseif ($room->getType() === Room::TYPE_ONE_TO_ONE && \count($userIds) === 1) {
+		} elseif (($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) && \count($userIds) === 1) {
 			$message = 'call_missed';
 		}
 

--- a/lib/Activity/Provider/Base.php
+++ b/lib/Activity/Provider/Base.php
@@ -113,6 +113,7 @@ abstract class Base implements IProvider {
 	protected function getRoom(Room $room, string $userId): array {
 		switch ($room->getType()) {
 			case Room::TYPE_ONE_TO_ONE:
+			case Room::TYPE_ONE_TO_ONE_FORMER:
 				$stringType = 'one2one';
 				break;
 			case Room::TYPE_GROUP:

--- a/lib/Chat/Parser/UserMention.php
+++ b/lib/Chat/Parser/UserMention.php
@@ -172,6 +172,7 @@ class UserMention {
 	protected function getRoomType(Room $room): string {
 		switch ($room->getType()) {
 			case Room::TYPE_ONE_TO_ONE:
+			case Room::TYPE_ONE_TO_ONE_FORMER:
 				return 'one2one';
 			case Room::TYPE_GROUP:
 				return 'group';

--- a/lib/Collaboration/Reference/TalkReferenceProvider.php
+++ b/lib/Collaboration/Reference/TalkReferenceProvider.php
@@ -202,7 +202,7 @@ class TalkReferenceProvider implements IReferenceProvider {
 			$description = str_replace($placeholders, $replacements, $message->getMessage());
 
 			$titleLine = $this->l->t('Message of {user} in {conversation}');
-			if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+			if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 				$titleLine = $this->l->t('Message of {user}');
 			}
 
@@ -264,6 +264,7 @@ class TalkReferenceProvider implements IReferenceProvider {
 	protected function getRoomType(Room $room): string {
 		switch ($room->getType()) {
 			case Room::TYPE_ONE_TO_ONE:
+			case Room::TYPE_ONE_TO_ONE_FORMER:
 				return 'one2one';
 			case Room::TYPE_GROUP:
 				return 'group';

--- a/lib/Collaboration/Resources/ConversationProvider.php
+++ b/lib/Collaboration/Resources/ConversationProvider.php
@@ -118,6 +118,7 @@ class ConversationProvider implements IProvider {
 	protected function getRoomType(Room $room): string {
 		switch ($room->getType()) {
 			case Room::TYPE_ONE_TO_ONE:
+			case Room::TYPE_ONE_TO_ONE_FORMER:
 				return 'one2one';
 			case Room::TYPE_GROUP:
 				return 'group';

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -645,7 +645,8 @@ class ChatController extends AEnvironmentAwareController {
 		$isOwnMessage = $isOwnMessage || ($message->getActorType() === Attendee::ACTOR_BRIDGED && $attendee->getActorId() === MatterbridgeManager::BRIDGE_BOT_USERID);
 		if (!$isOwnMessage
 			&& (!$this->participant->hasModeratorPermissions(false)
-				|| $this->room->getType() === Room::TYPE_ONE_TO_ONE)) {
+				|| $this->room->getType() === Room::TYPE_ONE_TO_ONE
+				|| $this->room->getType() === Room::TYPE_ONE_TO_ONE_FORMER)) {
 			// Actor is not a moderator or not the owner of the message
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
@@ -702,7 +703,8 @@ class ChatController extends AEnvironmentAwareController {
 	public function clearHistory(): DataResponse {
 		$attendee = $this->participant->getAttendee();
 		if (!$this->participant->hasModeratorPermissions(false)
-				|| $this->room->getType() === Room::TYPE_ONE_TO_ONE) {
+				|| $this->room->getType() === Room::TYPE_ONE_TO_ONE
+				|| $this->room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			// Actor is not a moderator or not the owner of the message
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}

--- a/lib/Controller/PollController.php
+++ b/lib/Controller/PollController.php
@@ -77,7 +77,8 @@ class PollController extends AEnvironmentAwareController {
 	 * @return DataResponse
 	 */
 	public function createPoll(string $question, array $options, int $resultMode, int $maxVotes): DataResponse {
-		if ($this->room->getType() === Room::TYPE_ONE_TO_ONE) {
+		if ($this->room->getType() === Room::TYPE_ONE_TO_ONE
+			|| $this->room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -524,7 +524,7 @@ class RoomController extends AEnvironmentAwareController {
 		if ($roomData['notificationLevel'] === Participant::NOTIFY_DEFAULT) {
 			if ($currentParticipant->isGuest()) {
 				$roomData['notificationLevel'] = Participant::NOTIFY_NEVER;
-			} elseif ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+			} elseif ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 				$roomData['notificationLevel'] = Participant::NOTIFY_ALWAYS;
 			} else {
 				$adminSetting = (int) $this->config->getAppValue('spreed', 'default_group_notification', (string) Participant::NOTIFY_DEFAULT);
@@ -574,6 +574,7 @@ class RoomController extends AEnvironmentAwareController {
 				$roomData['lastReadMessage'] = $lastReadMessage;
 
 				$roomData['canDeleteConversation'] = $room->getType() !== Room::TYPE_ONE_TO_ONE
+					&& $room->getType() !== Room::TYPE_ONE_TO_ONE_FORMER
 					&& $currentParticipant->hasModeratorPermissions(false);
 				$roomData['canLeaveConversation'] = true;
 				$roomData['canEnableSIP'] =
@@ -920,7 +921,7 @@ class RoomController extends AEnvironmentAwareController {
 	 * @return DataResponse
 	 */
 	public function renameRoom(string $roomName): DataResponse {
-		if ($this->room->getType() === Room::TYPE_ONE_TO_ONE) {
+		if ($this->room->getType() === Room::TYPE_ONE_TO_ONE || $this->room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
@@ -942,7 +943,7 @@ class RoomController extends AEnvironmentAwareController {
 	 * @return DataResponse
 	 */
 	public function setDescription(string $description): DataResponse {
-		if ($this->room->getType() === Room::TYPE_ONE_TO_ONE) {
+		if ($this->room->getType() === Room::TYPE_ONE_TO_ONE || $this->room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
@@ -962,7 +963,7 @@ class RoomController extends AEnvironmentAwareController {
 	 * @return DataResponse
 	 */
 	public function deleteRoom(): DataResponse {
-		if ($this->room->getType() === Room::TYPE_ONE_TO_ONE) {
+		if ($this->room->getType() === Room::TYPE_ONE_TO_ONE || $this->room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
@@ -1118,7 +1119,9 @@ class RoomController extends AEnvironmentAwareController {
 	 * @return DataResponse
 	 */
 	public function addParticipantToRoom(string $newParticipant, string $source = 'users'): DataResponse {
-		if ($this->room->getType() === Room::TYPE_ONE_TO_ONE || $this->room->getObjectType() === 'share:password') {
+		if ($this->room->getType() === Room::TYPE_ONE_TO_ONE
+			|| $this->room->getType() === Room::TYPE_ONE_TO_ONE_FORMER
+			|| $this->room->getObjectType() === 'share:password') {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
@@ -1269,7 +1272,7 @@ class RoomController extends AEnvironmentAwareController {
 	}
 
 	protected function removeSelfFromRoomLogic(Room $room, Participant $participant): DataResponse {
-		if ($room->getType() !== Room::TYPE_ONE_TO_ONE) {
+		if ($room->getType() !== Room::TYPE_ONE_TO_ONE && $room->getType() !== Room::TYPE_ONE_TO_ONE_FORMER) {
 			if ($participant->hasModeratorPermissions(false)
 				&& $this->participantService->getNumberOfUsers($room) > 1
 				&& $this->participantService->getNumberOfModerators($room) === 1) {
@@ -1318,7 +1321,7 @@ class RoomController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
-		if ($this->room->getType() === Room::TYPE_ONE_TO_ONE) {
+		if ($this->room->getType() === Room::TYPE_ONE_TO_ONE || $this->room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 

--- a/lib/Dashboard/TalkWidget.php
+++ b/lib/Dashboard/TalkWidget.php
@@ -164,7 +164,11 @@ class TalkWidget implements IAPIWidget, IIconWidget, IButtonWidget, IOptionWidge
 			$attendee = $participant->getAttendee();
 			return $room->getCallFlag() !== Participant::FLAG_DISCONNECTED
 				|| $attendee->getLastMentionMessage() > $attendee->getLastReadMessage()
-				|| ($room->getType() === Room::TYPE_ONE_TO_ONE && $room->getLastMessage() && $room->getLastMessage()->getId() > $attendee->getLastReadMessage());
+				|| (
+					($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER)
+					&& $room->getLastMessage()
+					&& $room->getLastMessage()->getId() > $attendee->getLastReadMessage()
+				);
 		});
 
 		uasort($rooms, [$this, 'sortRooms']);

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -432,12 +432,13 @@ class Manager {
 
 		$leftRooms = $this->getLeftOneToOneRoomsForUser($user->getUID());
 		foreach ($leftRooms as $room) {
-			// We are changing the room type and name so a potential follow up
+			// We are changing the room type and name so a potential follow-up
 			// user with the same user-id can not reopen the one-to-one conversation.
 			/** @var RoomService $roomService */
 			$roomService = Server::get(RoomService::class);
-			$roomService->setType($room, Room::TYPE_GROUP, true);
+			$roomService->setType($room, Room::TYPE_ONE_TO_ONE_FORMER, true);
 			$roomService->setName($room, $user->getDisplayName(), '');
+			$roomService->setReadOnly($room, Room::READ_ONLY);
 		}
 	}
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -503,7 +503,7 @@ class Notifier implements INotifier {
 				'id' => $message->getComment()->getId(),
 				'name' => $shortenMessage,
 			];
-			if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+			if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 				$subject = "{user}\n{message}";
 			} elseif ($richSubjectUser) {
 				$subject = $l->t('{user} in {call}') . "\n{message}";
@@ -518,7 +518,7 @@ class Notifier implements INotifier {
 				}
 			}
 		} elseif ($notification->getSubject() === 'chat') {
-			if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+			if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 				$subject = $l->t('{user} sent you a private message');
 			} elseif ($richSubjectUser) {
 				$subject = $l->t('{user} sent a message in conversation {call}');
@@ -533,7 +533,7 @@ class Notifier implements INotifier {
 				}
 			}
 		} elseif ($notification->getSubject() === 'reply') {
-			if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+			if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 				$subject = $l->t('{user} replied to your private message');
 			} elseif ($richSubjectUser) {
 				$subject = $l->t('{user} replied to your message in conversation {call}');
@@ -554,7 +554,7 @@ class Notifier implements INotifier {
 				'name' => $subjectParameters['reaction'],
 			];
 
-			if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+			if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 				$subject = $l->t('{user} reacted with {reaction} to your private message');
 			} elseif ($richSubjectUser) {
 				$subject = $l->t('{user} reacted with {reaction} to your message in conversation {call}');
@@ -568,7 +568,7 @@ class Notifier implements INotifier {
 					$subject = $l->t('A guest reacted with {reaction} to your message in conversation {call}');
 				}
 			}
-		} elseif ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+		} elseif ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			$subject = $l->t('{user} mentioned you in a private conversation');
 		} elseif ($richSubjectUser) {
 			$subject = $l->t('{user} mentioned you in conversation {call}');
@@ -628,6 +628,7 @@ class Notifier implements INotifier {
 	protected function getRoomType(Room $room): string {
 		switch ($room->getType()) {
 			case Room::TYPE_ONE_TO_ONE:
+			case Room::TYPE_ONE_TO_ONE_FORMER:
 				return 'one2one';
 			case Room::TYPE_GROUP:
 				return 'group';
@@ -660,7 +661,7 @@ class Notifier implements INotifier {
 		}
 
 		$roomName = $room->getDisplayName($notification->getUser());
-		if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+		if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			$subject = $l->t('{user} invited you to a private conversation');
 			if ($this->participantService->hasActiveSessionsInCall($room)) {
 				$notification = $this->addActionButton($notification, $l->t('Join call'));
@@ -731,7 +732,7 @@ class Notifier implements INotifier {
 		}
 
 		$roomName = $room->getDisplayName($notification->getUser());
-		if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+		if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			$parameters = $notification->getSubjectParameters();
 			$calleeId = $parameters['callee'];
 			$userDisplayName = $this->userManager->getDisplayName($calleeId);

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -54,6 +54,7 @@ class Room {
 	public const TYPE_GROUP = 2;
 	public const TYPE_PUBLIC = 3;
 	public const TYPE_CHANGELOG = 4;
+	public const TYPE_ONE_TO_ONE_FORMER = 5;
 
 	public const RECORDING_NONE = 0;
 	public const RECORDING_VIDEO = 1;

--- a/lib/Search/ConversationSearch.php
+++ b/lib/Search/ConversationSearch.php
@@ -100,7 +100,7 @@ class ConversationSearch implements IProvider {
 				continue;
 			}
 
-			if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+			if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 				$otherUserId = str_replace(
 					json_encode($user->getUID()),
 					'',

--- a/lib/Search/MessageSearch.php
+++ b/lib/Search/MessageSearch.php
@@ -217,7 +217,7 @@ class MessageSearch implements IProvider {
 		}
 
 		$subline = $this->getSublineTemplate();
-		if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+		if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			$subline = '{user}';
 		}
 

--- a/lib/Service/AvatarService.php
+++ b/lib/Service/AvatarService.php
@@ -69,7 +69,7 @@ class AvatarService {
 	}
 
 	public function setAvatarFromRequest(Room $room, ?array $file): void {
-		if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+		if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			throw new InvalidArgumentException($this->l->t('One to one rooms always need to show the other users avatar'));
 		}
 
@@ -97,7 +97,7 @@ class AvatarService {
 	}
 
 	public function setAvatar(Room $room, \OC_Image $image): void {
-		if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+		if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			throw new InvalidArgumentException($this->l->t('One to one rooms always need to show the other users avatar'));
 		}
 		$image->fixOrientation();
@@ -166,7 +166,7 @@ class AvatarService {
 		}
 		// Fallback
 		if (!isset($file)) {
-			if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+			if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 				$users = json_decode($room->getName(), true);
 				foreach ($users as $participantId) {
 					if ($user instanceof IUser && $participantId !== $user->getUID()) {

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -201,7 +201,7 @@ class ParticipantService {
 	 * @throws ForbiddenException
 	 */
 	public function updatePermissions(Room $room, Participant $participant, string $method, int $newPermissions): bool {
-		if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+		if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			return false;
 		}
 

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -182,7 +182,7 @@ class RoomService {
 	}
 
 	public function setPermissions(Room $room, string $level, string $method, int $permissions, bool $resetCustomPermissions): bool {
-		if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+		if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			return false;
 		}
 
@@ -347,7 +347,7 @@ class RoomService {
 	}
 
 	public function setAvatar(Room $room, string $avatar): bool {
-		if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
+		if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			return false;
 		}
 
@@ -412,7 +412,15 @@ class RoomService {
 			return false;
 		}
 
-		if (!in_array($newType, [Room::TYPE_GROUP, Room::TYPE_PUBLIC], true)) {
+		if ($room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
+			return false;
+		}
+
+		if (!in_array($newType, [Room::TYPE_GROUP, Room::TYPE_PUBLIC, Room::TYPE_ONE_TO_ONE_FORMER], true)) {
+			return false;
+		}
+
+		if ($newType === Room::TYPE_ONE_TO_ONE_FORMER && $room->getType() !== Room::TYPE_ONE_TO_ONE) {
 			return false;
 		}
 
@@ -466,7 +474,10 @@ class RoomService {
 		}
 
 		if (!in_array($room->getType(), [Room::TYPE_GROUP, Room::TYPE_PUBLIC, Room::TYPE_CHANGELOG], true)) {
-			return false;
+			if ($newState !== Room::READ_ONLY || $room->getType() !== Room::TYPE_ONE_TO_ONE_FORMER) {
+				// Allowed for the automated conversation of one-to-one chats to read only former
+				return false;
+			}
 		}
 
 		if (!in_array($newState, [Room::READ_ONLY, Room::READ_WRITE], true)) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -197,6 +197,7 @@ export default {
 		 */
 		isOneToOne() {
 			return this.currentConversation?.type === CONVERSATION.TYPE.ONE_TO_ONE
+				|| this.currentConversation?.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER
 		},
 
 		disableKeyboardShortcuts() {

--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -116,6 +116,8 @@ export default {
 				return 'icon-mail'
 			} else if (this.item.type === CONVERSATION.TYPE.CHANGELOG) {
 				return 'icon-changelog'
+			} else if (this.item.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER) {
+				return 'icon-user'
 			} else if (this.item.type === CONVERSATION.TYPE.GROUP) {
 				return 'icon-contacts'
 			} else if (this.item.type === CONVERSATION.TYPE.PUBLIC) {
@@ -169,6 +171,7 @@ $icon-size: 44px;
 
 		&.icon-public,
 		&.icon-contacts,
+		&.icon-user,
 		&.icon-password,
 		&.icon-file,
 		&.icon-mail {

--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -179,6 +179,7 @@ export default {
 			return (this.participantType === PARTICIPANT.TYPE.OWNER
 				|| this.participantType === PARTICIPANT.TYPE.MODERATOR)
 				&& this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE
+				&& this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE_FORMER
 		},
 
 		canDeleteConversation() {
@@ -196,6 +197,7 @@ export default {
 		showDescription() {
 			if (this.canFullModerate) {
 				return this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE
+					&& this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE_FORMER
 			} else {
 				return this.description !== ''
 			}

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -151,7 +151,9 @@ export default {
 	computed: {
 
 		counterType() {
-			if (this.item.unreadMentionDirect || (this.item.unreadMessages !== 0 && this.item.type === CONVERSATION.TYPE.ONE_TO_ONE)) {
+			if (this.item.unreadMentionDirect || (this.item.unreadMessages !== 0 && (
+				this.item.type === CONVERSATION.TYPE.ONE_TO_ONE || this.item.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER
+			))) {
 				return 'highlighted'
 			} else if (this.item.unreadMention) {
 				return 'outlined'
@@ -220,6 +222,7 @@ export default {
 			}
 
 			if (this.item.type === CONVERSATION.TYPE.ONE_TO_ONE
+				|| this.item.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER
 				|| this.item.type === CONVERSATION.TYPE.CHANGELOG) {
 				return this.simpleLastChatMessage
 			}

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -344,6 +344,7 @@ export default {
 				&& !this.isDeleting
 				&& (this.isMyMsg
 					|| (this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE
+						&& this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE_FORMER
 						&& (this.participant.participantType === PARTICIPANT.TYPE.OWNER
 							|| this.participant.participantType === PARTICIPANT.TYPE.MODERATOR)))
 		},

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -382,6 +382,7 @@ export default {
 
 		isOneToOne() {
 			return this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE
+				|| this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER
 		},
 
 		silentSendInfo() {

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -549,7 +549,7 @@ export default {
 
 		showModeratorLabel() {
 			return this.isModerator
-				&& [CONVERSATION.TYPE.ONE_TO_ONE, CONVERSATION.TYPE.CHANGELOG].indexOf(this.conversation.type) === -1
+				&& [CONVERSATION.TYPE.ONE_TO_ONE, CONVERSATION.TYPE.ONE_TO_ONE_FORMER, CONVERSATION.TYPE.CHANGELOG].indexOf(this.conversation.type) === -1
 		},
 
 		canBeModerated() {

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -250,6 +250,7 @@ export default {
 
 		isOneToOne() {
 			return this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE
+				|| this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER
 		},
 
 		participantsText() {
@@ -269,7 +270,8 @@ export default {
 			}
 
 			if (newConversation.token !== oldConversation.token) {
-				if (newConversation.type === CONVERSATION.TYPE.ONE_TO_ONE) {
+				if (newConversation.type === CONVERSATION.TYPE.ONE_TO_ONE
+					|| newConversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER) {
 					this.activeTab = 'shared-items'
 				} else {
 					this.activeTab = 'participants'
@@ -281,7 +283,8 @@ export default {
 			if (chatInSidebar) {
 				this.activeTab = 'chat'
 			} else if (this.activeTab === 'chat') {
-				if (this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE) {
+				if (this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE
+					|| this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER) {
 					this.activeTab = 'shared-items'
 				} else {
 					this.activeTab = 'participants'

--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -299,6 +299,7 @@ export default {
 
 		isOneToOneConversation() {
 			return this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE
+				|| this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER
 		},
 
 		toggleVirtualBackgroundButtonLabel() {

--- a/src/constants.js
+++ b/src/constants.js
@@ -60,6 +60,7 @@ export const CONVERSATION = {
 		GROUP: 2,
 		PUBLIC: 3,
 		CHANGELOG: 4,
+		ONE_TO_ONE_FORMER: 5,
 	},
 
 	BREAKOUT_ROOM_MODE: {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -187,7 +187,7 @@ export default {
 				const importantRooms = rooms.filter((conversation) => {
 					return conversation.hasCall
 						|| conversation.unreadMention
-						|| (conversation.unreadMessages > 0 && conversation.type === CONVERSATION.TYPE.ONE_TO_ONE)
+						|| (conversation.unreadMessages > 0 && (conversation.type === CONVERSATION.TYPE.ONE_TO_ONE || conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER))
 				})
 
 				if (importantRooms.length) {

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -150,7 +150,9 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		self::$identifierToToken = [];
 		self::$identifierToId = [];
 		self::$tokenToIdentifier = [];
-		self::$sessionIdToUser = [];
+		self::$sessionIdToUser = [
+			'cli' => 'cli',
+		];
 		self::$userToSessionId = [];
 		self::$userToAttendeeId = [];
 		self::$textToMessageId = [];

--- a/tests/integration/features/command/user-remove.feature
+++ b/tests/integration/features/command/user-remove.feature
@@ -12,14 +12,18 @@ Feature: command/user-remove
       | roomType | 3 |
       | roomName | room |
     And user "participant1" adds user "participant2" to room "room2" with 200 (v4)
+    And user "participant1" is participant of the following unordered rooms (v4)
+      | id    | name         | type | participantType | readOnly |
+      | room1 | participant2 | 1    | 1               | 0        |
+      | room2 | room         | 3    | 1               | 0        |
     And invoking occ with "talk:user:remove --user participant2"
     And the command output contains the text "Users successfully removed from all rooms"
     Then the command was successful
     And user "participant2" is participant of the following rooms (v4)
     And user "participant1" is participant of the following unordered rooms (v4)
-      | id    | name                     | type | participantType |
-      | room1 | participant2-displayname | 2    | 1               |
-      | room2 | room                     | 3    | 1               |
+      | id    | name                     | type | participantType | readOnly |
+      | room1 | participant2-displayname | 5    | 1               | 1        |
+      | room2 | room                     | 3    | 1               | 0        |
     And user "participant1" sees the following attendees in room "room1" with 200 (v4)
       | actorType  | actorId      | participantType |
       | users      | participant1 | 1               |
@@ -41,9 +45,10 @@ Feature: command/user-remove
     And user "participant2" is participant of the following rooms (v4)
     And user "participant1" is participant of the following rooms (v4)
       | id   | name                     | type | participantType |
-      | room | participant2-displayname | 2    | 1               |
+      | room | participant2-displayname | 5    | 1               |
     Then user "participant1" sees the following system messages in room "room" with 200
       | room | actorType     | actorId      | systemMessage        | message                      | messageParameters |
+      | room | guests        | cli          | read_only            | An administrator locked the conversation | {"actor":{"type":"guest","id":"guest\/cli","name":"Guest"}} |
       | room | users         | participant1 | call_tried           | You tried to call {user}     | {"user":{"type":"highlight","id":"deleted_user","name":"participant2-displayname"}} |
       | room | users         | participant1 | call_left            | You left the call            | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
       | room | users         | participant1 | call_started         | You started a call           | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |

--- a/tests/integration/features/command/user-transfer-ownership.feature
+++ b/tests/integration/features/command/user-transfer-ownership.feature
@@ -4,9 +4,13 @@ Feature: command/user-remove
     Given user "participant1" exists
     Given user "participant2" exists
     Given user "participant3" exists
+    Given user "participant4" exists
 
   Scenario: Only transfer when moderator permissions
     Given user "participant1" creates room "one-to-one" (v4)
+      | roomType | 1 |
+      | invite   | participant2 |
+    Given user "participant4" creates room "one-to-one former" (v4)
       | roomType | 1 |
       | invite   | participant2 |
     Given user "participant1" creates room "user" (v4)
@@ -25,12 +29,14 @@ Feature: command/user-remove
       | roomType | 3 |
       | roomName | self-joined |
     And user "participant2" joins room "self-joined" with 200 (v4)
+    And invoking occ with "talk:user:remove --user participant4"
     And invoking occ with "talk:user:transfer-ownership participant2 participant3"
     And the command output contains the text "Added or promoted user participant3 in 2 rooms."
     Then the command was successful
     And user "participant2" is participant of the following unordered rooms (v4)
       | id          | name         | type | participantType |
       | one-to-one  | participant1 | 1    | 1               |
+      | one-to-one former | participant4-displayname | 5 | 1 |
       | user        | user         | 3    | 3               |
       | moderator   | moderator    | 2    | 2               |
       | owner       | owner        | 2    | 1               |
@@ -44,6 +50,9 @@ Feature: command/user-remove
     Given user "participant1" creates room "one-to-one" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant4" creates room "one-to-one former" (v4)
+      | roomType | 1 |
+      | invite   | participant2 |
     Given user "participant1" creates room "user" (v4)
       | roomType | 3 |
       | roomName | user |
@@ -60,12 +69,14 @@ Feature: command/user-remove
       | roomType | 3 |
       | roomName | self-joined |
     And user "participant2" joins room "self-joined" with 200 (v4)
+    And invoking occ with "talk:user:remove --user participant4"
     And invoking occ with "talk:user:transfer-ownership --include-non-moderator participant2 participant3"
     And the command output contains the text "Added or promoted user participant3 in 3 rooms."
     Then the command was successful
     And user "participant2" is participant of the following unordered rooms (v4)
       | id          | name         | type | participantType |
       | one-to-one  | participant1 | 1    | 1               |
+      | one-to-one former | participant4-displayname | 5 | 1 |
       | user        | user         | 3    | 3               |
       | moderator   | moderator    | 2    | 2               |
       | owner       | owner        | 2    | 1               |
@@ -80,6 +91,9 @@ Feature: command/user-remove
     Given user "participant1" creates room "one-to-one" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant4" creates room "one-to-one former" (v4)
+      | roomType | 1 |
+      | invite   | participant2 |
     Given user "participant1" creates room "user" (v4)
       | roomType | 3 |
       | roomName | user |
@@ -96,12 +110,14 @@ Feature: command/user-remove
       | roomType | 3 |
       | roomName | self-joined |
     And user "participant2" joins room "self-joined" with 200 (v4)
+    And invoking occ with "talk:user:remove --user participant4"
     And invoking occ with "talk:user:transfer-ownership --remove-source-user participant2 participant3"
     And the command output contains the text "Added or promoted user participant3 in 2 rooms."
     Then the command was successful
     And user "participant2" is participant of the following unordered rooms (v4)
       | id          | name         | type | participantType |
       | one-to-one  | participant1 | 1    | 1               |
+      | one-to-one former | participant4-displayname | 5 | 1 |
       | user        | user         | 3    | 3               |
       | self-joined | self-joined  | 3    | 5               |
     And user "participant3" is participant of the following unordered rooms (v4)

--- a/tests/integration/features/conversation/delete-user.feature
+++ b/tests/integration/features/conversation/delete-user.feature
@@ -12,27 +12,33 @@ Feature: conversation/delete-user
       | roomType | 1 |
       | invite   | participant2 |
     And user "participant2" sends message "Message 1" to room "one-to-one room" with 201
+    Then user "participant1" is participant of the following rooms (v4)
+      | name         | type     | readOnly |
+      | participant2 | 1        | 0        |
     When user "participant2" is deleted
     Then user "participant1" sees the following messages in room "one-to-one room" with 200
       | room            | actorType     | actorId       | actorDisplayName | message   | messageParameters |
       | one-to-one room | deleted_users | deleted_users |                  | Message 1 | []                |
     Then user "participant1" is participant of the following rooms (v4)
-      | name                     | type     |
-      | participant2-displayname | 2        |
+      | name                     | type     | readOnly |
+      | participant2-displayname | 5        | 1        |
 
   Scenario: delete user who left a one-to-one room
     Given user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
     And user "participant2" sends message "Message 1" to room "one-to-one room" with 201
+    Then user "participant1" is participant of the following rooms (v4)
+      | name         | type     | readOnly |
+      | participant2 | 1        | 0        |
     When user "participant2" leaves room "one-to-one room" with 200 (v4)
     When user "participant2" is deleted
     Then user "participant1" sees the following messages in room "one-to-one room" with 200
       | room            | actorType     | actorId       | actorDisplayName | message   | messageParameters |
       | one-to-one room | deleted_users | deleted_users |                  | Message 1 | []                |
     Then user "participant1" is participant of the following rooms (v4)
-      | name                     | type     |
-      | participant2-displayname | 2        |
+      | name                     | type     | readOnly |
+      | participant2-displayname | 5        | 1        |
 
   Scenario: delete user who is in a group room
     Given user "participant1" creates room "group room" (v4)

--- a/tests/php/Service/RoomServiceTest.php
+++ b/tests/php/Service/RoomServiceTest.php
@@ -219,7 +219,8 @@ class RoomServiceTest extends TestCase {
 		return [
 			[Room::TYPE_ONE_TO_ONE],
 			[Room::TYPE_UNKNOWN],
-			[5],
+			[Room::TYPE_ONE_TO_ONE_FORMER],
+			[6],
 		];
 	}
 


### PR DESCRIPTION
### 🚧 TODO

- [x] Introduce new type "former one-to-one"
- [x] Automatically "read-only" them
- [x] Single person icon as conversation image

### 🖼️ Screenshot
 
![grafik](https://user-images.githubusercontent.com/213943/214605616-41fc8087-952c-42cb-abe0-d81bbb53bca3.png)


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
