### PR TITLE
Fix tooltip appearance for long names in ConversationList

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
 				"@vue/vue2-jest": "^29.2.1",
 				"babel-loader-exclude-node-modules-except": "^1.2.1",
 				"babel-plugin-add-module-exports": "^1.0.4",
+				"flush-promises": "^1.0.2",
 				"jest": "^29.2.2",
 				"jest-environment-jsdom": "^29.3.1",
 				"jest-localstorage-mock": "^2.4.26",
@@ -8601,6 +8602,12 @@
 			"peerDependencies": {
 				"vue": "^2.6.10"
 			}
+		},
+		"node_modules/flush-promises": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/flush-promises/-/flush-promises-1.0.2.tgz",
+			"integrity": "sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==",
+			"dev": true
 		},
 		"node_modules/focus-trap": {
 			"version": "7.1.0",
@@ -26768,6 +26775,12 @@
 				"@floating-ui/dom": "^0.1.10",
 				"vue-resize": "^1.0.0"
 			}
+		},
+		"flush-promises": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/flush-promises/-/flush-promises-1.0.2.tgz",
+			"integrity": "sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==",
+			"dev": true
 		},
 		"focus-trap": {
 			"version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
 		"@vue/vue2-jest": "^29.2.1",
 		"babel-loader-exclude-node-modules-except": "^1.2.1",
 		"babel-plugin-add-module-exports": "^1.0.4",
+		"flush-promises": "^1.0.2",
 		"jest": "^29.2.2",
 		"jest-environment-jsdom": "^29.3.1",
 		"jest-localstorage-mock": "^2.4.26",

--- a/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
@@ -9,6 +9,9 @@ import { showSuccess, showError } from '@nextcloud/dialogs'
 
 import Conversation from './Conversation.vue'
 
+// Update after migration to @vue/test-utils v2.0.0
+import flushPromises from 'flush-promises'
+
 jest.mock('@nextcloud/dialogs', () => ({
 	showSuccess: jest.fn(),
 	showError: jest.fn(),
@@ -367,7 +370,8 @@ describe('Conversation.vue', () => {
 				const action = shallowMountAndGetAction('Leave conversation')
 				expect(action.exists()).toBe(true)
 
-				await action.find('button').trigger('click')
+				action.find('button').trigger('click')
+				await flushPromises()
 
 				expect(actionHandler).toHaveBeenCalledWith(expect.anything(), { token: TOKEN })
 				expect(showError).toHaveBeenCalledWith(expect.stringContaining('promote'))

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -20,7 +20,8 @@
 -->
 
 <template>
-	<NcListItem :title="item.displayName"
+	<NcListItem ref="listItem"
+		:title="item.displayName"
 		:class="{'unread-mention-conversation': item.unreadMention}"
 		:anchor-id="`conversation_${item.token}`"
 		:actions-aria-label="t('spreed', 'Conversation actions')"
@@ -303,11 +304,20 @@ export default {
 		},
 	},
 
-	mounted() {
-		const titleSpan = document.getElementById(`conversation_${this.item.token}`)?.querySelector('.line-one__title')
-		if (!titleSpan) return
+	// TODO: move the implementation to @nextcloud-vue/NcListItem
+	watch: {
+		'item.displayName': {
+			immediate: true,
+			handler(value) {
+				this.$nextTick().then(() => {
+					const titleSpan = this.$refs.listItem?.$el?.querySelector('.line-one__title')
 
-		if (titleSpan.offsetWidth < titleSpan.scrollWidth) titleSpan.setAttribute('title', this.item.displayName)
+					if (titleSpan && titleSpan.offsetWidth < titleSpan.scrollWidth) {
+						titleSpan.setAttribute('title', value)
+					}
+				})
+			},
+		},
 	},
 
 	methods: {

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -302,6 +302,13 @@ export default {
 			}
 		},
 	},
+
+	mounted() {
+		const titleSpan = document.getElementById(`conversation_${this.item.token}`).querySelector('.line-one__title')
+
+		if (titleSpan.offsetWidth < titleSpan.scrollWidth) titleSpan.setAttribute('title', this.item.displayName)
+	},
+
 	methods: {
 		async copyLinkToConversation() {
 			try {

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -304,7 +304,8 @@ export default {
 	},
 
 	mounted() {
-		const titleSpan = document.getElementById(`conversation_${this.item.token}`).querySelector('.line-one__title')
+		const titleSpan = document.getElementById(`conversation_${this.item.token}`)?.querySelector('.line-one__title')
+		if (!titleSpan) return
 
 		if (titleSpan.offsetWidth < titleSpan.scrollWidth) titleSpan.setAttribute('title', this.item.displayName)
 	},


### PR DESCRIPTION
Signed-off-by: Maksim Sukharev <antreesy.web@gmail.com>

Fix #7254 

Due to using the NcListItem component with title locked for modifications, we don't have opportunities to add `v-tooltip` here.
So, HTML-attribute `title` was applied for long names to show tooltip via native browser tools, when name is ellipsed.

*!IMPORTANT*
Current realisation works only if name is ellipsed initially (action button appears on hover and crops name even more) 

### 🖼️ Screenshots
![image](https://user-images.githubusercontent.com/93392545/214914351-9ca30e36-6c0d-4476-90b6-b0610adaa260.png)


### 🚧 TODO

- [ ] Cross-browser testing (working on Google)  
- [ ] Design review
- [ ] Code review

### 🏁 Checklist
- [X] 📘 API documentation in `docs/` has been updated or is not required
- [X] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [X] 🔖 Capability is added or not needed 
