### PR TITLE
Correct position for local video in 1:1 call

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -698,7 +698,7 @@ export default {
 	-webkit-align-items: flex-end;
 	align-items: flex-end;
 	flex-direction: column;
-	padding: 1px 8px 8px 8px;
+	padding: 0 8px 8px 8px;
 }
 
 .video__promoted {

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -333,7 +333,7 @@ export default {
 	overflow: hidden;
 	display: flex;
 	flex-direction: column;
-	margin-top: 8px;
+	margin-top: auto;
 	height: 242px !important;
 }
 


### PR DESCRIPTION
Signed-off-by: Maksim Sukharev <antreesy.web@gmail.com>

Fix #8571

Removed top padding from video container

Also untied `margin-top` from fixed value for local video container
(Could be switched to `align-self: flex-end`, but this method has [less support](https://caniuse.com/?search=align-self%3A%20end) )

### 🖼️ Screenshots
![image](https://user-images.githubusercontent.com/93392545/215747462-423a093e-ac22-4c43-a097-5cd5fa3ff18f.png)

### 🚧 TODO

- [ ] Discuss for backport (could be safely backported to `stable24`, `stable25`)

### 🏁 Checklist

- [X] 📘 API documentation in `docs/` has been updated or is not required
- [X] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [X] 🔖 Capability is added or not needed 
