### PR TITLE
fix(conversations): Notify participants about conversation changes so…

### DIFF
--- a/lib/Signaling/Listener.php
+++ b/lib/Signaling/Listener.php
@@ -81,6 +81,9 @@ class Listener {
 		$dispatcher->addListener(Room::EVENT_AFTER_LISTABLE_SET, [self::class, 'notifyAfterRoomSettingsChanged']);
 		$dispatcher->addListener(Room::EVENT_AFTER_LOBBY_STATE_SET, [self::class, 'notifyAfterRoomSettingsChanged']);
 		$dispatcher->addListener(Room::EVENT_AFTER_SIP_ENABLED_SET, [self::class, 'notifyAfterRoomSettingsChanged']);
+		$dispatcher->addListener(Room::EVENT_AFTER_SET_CALL_RECORDING, [self::class, 'notifyAfterRoomSettingsChanged']);
+		$dispatcher->addListener(Room::EVENT_AFTER_SET_BREAKOUT_ROOM_MODE, [self::class, 'notifyAfterRoomSettingsChanged']);
+		$dispatcher->addListener(Room::EVENT_AFTER_SET_BREAKOUT_ROOM_STATUS, [self::class, 'notifyAfterRoomSettingsChanged']);
 		// TODO remove handler with "roomModified" in favour of handler with
 		// "participantsModified" once the clients no longer expect a
 		// "roomModified" message for participant type changes.


### PR DESCRIPTION
### 🚧 TODO

- [x] Trigger refresh of conversation list when recording is started/stopped
- [x] Trigger refresh when breakout rooms are setup/removed
- [x] Trigger refresh when breakout rooms are started/stopped

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
