### PR TITLE
Сorrect hover styles for buttons in TopBar during a call

### DIFF
--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -403,7 +403,7 @@ export default {
 		:deep(.action-item__menutoggle:hover),
 		:deep(.action-item--single:hover),
 		:deep(.buttons-bar button:hover) {
-			background-color: rgba(0, 0, 0, 0.2) !important;
+			background-color: rgba(0, 0, 0, 0.2);
 		}
 	}
 

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -398,6 +398,13 @@ export default {
 		& * {
 			color: #fff;
 		}
+
+		:deep(.action-item--open .action-item__menutoggle),
+		:deep(.action-item__menutoggle:hover),
+		:deep(.action-item--single:hover),
+		:deep(.buttons-bar button:hover) {
+			background-color: rgba(0, 0, 0, 0.2) !important;
+		}
 	}
 
 	&__button {


### PR DESCRIPTION
Signed-off-by: Maksim Sukharev <antreesy.web@gmail.com>

Fix #8019 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
Light / Dark themes difference | New appearance
![image](https://user-images.githubusercontent.com/93392545/215795270-1b641548-b6b3-49ad-9ced-79377beb47d6.png) ![image](https://user-images.githubusercontent.com/93392545/215795404-e3a66608-c9c9-4db3-ade6-3ebb1e0cc915.png) | ![image](https://user-images.githubusercontent.com/93392545/215795940-7a889eb0-d0a6-4eaa-a29d-75add0ec5e68.png) ![image](https://user-images.githubusercontent.com/93392545/215796176-c7af31db-90c1-48e9-bb25-ccfda0b5ca10.png)

to clarify changes:
```
	:deep(.action-item--open .action-item__menutoggle),
	:deep(.action-item__menutoggle:hover),
	:deep(.action-item--single:hover),
```
for NcActions elements (with open menu and on hover) - Screensharing, Conversation Settings, Chat

```
	:deep(.buttons-bar button:hover) {
```
for other buttons in LocalMediaControls - Microphone, Camera, etc

hover `background-color: rgba(0, 0, 0, 0.2)` was copied from left sidebar toggle button.
Changes are scoped inside `.top-bar.in-call` selector

### 🚧 TODO

- [ ] Code review (tested only in 1:1 calls, maybe some specific buttons were skipped)

### 🏁 Checklist

- [X] 📘 API documentation in `docs/` has been updated or is not required
- [X] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [X] 🔖 Capability is added or not needed 
