### PR TITLE
[stable25] Сorrect hover styles for buttons in TopBar during a call

### DIFF
--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -538,7 +538,7 @@ export default {
 		:deep(.action-item__menutoggle:hover),
 		:deep(.action-item--single:hover),
 		:deep(.buttons-bar button:hover) {
-			background-color: rgba(0, 0, 0, 0.2) !important;
+			background-color: rgba(0, 0, 0, 0.2);
 		}
 	}
 

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -534,10 +534,10 @@ export default {
 		display: flex;
 		flex-wrap: wrap-reverse;
 
-		:deep(.action-item--open .action-item__menutoggle),
-		:deep(.action-item__menutoggle:hover),
-		:deep(.action-item--single:hover),
-		:deep(.buttons-bar button:hover) {
+		::v-deep .action-item--open .action-item__menutoggle,
+		::v-deep .action-item__menutoggle:hover,
+		::v-deep .action-item--single:hover,
+		::v-deep .buttons-bar button:hover {
 			background-color: rgba(0, 0, 0, 0.2);
 		}
 	}

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -533,6 +533,13 @@ export default {
 		background-color: transparent;
 		display: flex;
 		flex-wrap: wrap-reverse;
+
+		:deep(.action-item--open .action-item__menutoggle),
+		:deep(.action-item__menutoggle:hover),
+		:deep(.action-item--single:hover),
+		:deep(.buttons-bar button:hover) {
+			background-color: rgba(0, 0, 0, 0.2) !important;
+		}
 	}
 
 	&__buttons {


### PR DESCRIPTION
Manual backport of #8661 to `stable25` 

Somehow, `:deep(.selector)` isn't working in previous version, so it was changed to `::v-deep .selector`
Please also check it visually on running stable25 version

### 🚧 TODO

- [x] Code-review
- [x] Visual check

### 🏁 Checklist

- [X] 📘 API documentation in `docs/` has been updated or is not required
- [X] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [X] 🔖 Capability is added or not needed 
