### PR TITLE
Correct MessageButtonsBar position (relative to message itself) on screen

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -871,6 +871,7 @@ export default {
 	&__main {
 		display: flex;
 		justify-content: space-between;
+		align-items: flex-start;
 		min-width: 100%;
 		&__text {
 			flex: 0 1 600px;

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -82,15 +82,15 @@ the main body of the message as well as a quote.
 						:autolink="true"
 						:reference-limit="1" />
 				</div>
-				<div v-if="!isDeletedMessage" class="message-body__main__right">
-					<span v-tooltip.auto="messageDate"
+				<div v-if="!isDeletedMessage" ref="messageInfo" class="message-body__main__right">
+					<span :title="messageDate"
 						class="date"
 						:style="{'visibility': hasDate ? 'visible' : 'hidden'}"
 						:class="{'date--self': showSentIcon}">{{ messageTime }}</span>
 
 					<!-- Message delivery status indicators -->
 					<div v-if="sendingFailure"
-						v-tooltip.auto="sendingErrorIconTooltip"
+						:title="sendingErrorIconTooltip"
 						class="message-status sending-failed"
 						:class="{'retry-option': sendingErrorCanRetry}"
 						:aria-label="sendingErrorIconTooltip"
@@ -110,17 +110,17 @@ the main body of the message as well as a quote.
 							:size="16" />
 					</div>
 					<div v-else-if="isTemporary && !isTemporaryUpload || isDeleting"
-						v-tooltip.auto="loadingIconTooltip"
+						:title="loadingIconTooltip"
 						class="icon-loading-small message-status"
 						:aria-label="loadingIconTooltip" />
 					<div v-else-if="showCommonReadIcon"
-						v-tooltip.auto="commonReadIconTooltip"
+						:title="commonReadIconTooltip"
 						class="message-status"
 						:aria-label="commonReadIconTooltip">
 						<CheckAll :size="16" />
 					</div>
 					<div v-else-if="showSentIcon"
-						v-tooltip.auto="sentIconTooltip"
+						:title="sentIconTooltip"
 						class="message-status"
 						:aria-label="sentIconTooltip">
 						<Check :size="16" />
@@ -198,7 +198,6 @@ the main body of the message as well as a quote.
 
 <script>
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 import CallButton from '../../../TopBar/CallButton.vue'
 import DeckCard from './MessagePart/DeckCard.vue'
 import DefaultParameter from './MessagePart/DefaultParameter.vue'
@@ -227,10 +226,6 @@ import Poll from './MessagePart/Poll.vue'
 
 export default {
 	name: 'Message',
-
-	directives: {
-		tooltip: Tooltip,
-	},
 
 	components: {
 		NcButton,
@@ -396,8 +391,6 @@ export default {
 	data() {
 		return {
 			isHovered: false,
-			// Is tall enough for both actions and date upon hovering
-			isTallEnough: false,
 			showReloadButton: false,
 			isDeleting: false,
 			// whether the message was seen, only used if this was marked as last read message
@@ -542,8 +535,8 @@ export default {
 					// Add the token to the component props
 					props.token = this.token
 					// The word 'name' is reserved in for the component name in
-					// vue instances so we cannot pass that into the component
-					// as a prop. Therefore we rename it into pollName
+					// Vue instances, so we cannot pass that into the component
+					// as a prop, therefore we rename it into pollName
 					props.pollName = this.messageParameters[p].name
 					richParameters[p] = {
 						component: Poll,
@@ -566,16 +559,11 @@ export default {
 
 		// Determines whether the date has to be displayed or not
 		hasDate() {
-			if (this.isTemporary || this.isDeleting || this.sendingFailure) {
-				// Never on temporary or failed messages
-				return false
-			}
-
-			return this.isSystemMessage || !this.isHovered || this.isTallEnough
+			return (!this.isTemporary && !this.isDeleting && !this.sendingFailure)
 		},
 
 		showMessageButtonsBar() {
-			return !this.isSystemMessage && !this.isTemporary && (this.isHovered || this.isActionMenuOpen || this.isEmojiPickerOpen || this.isFollowUpEmojiPickerOpen || this.isReactionsMenuOpen || this.isForwarderOpen)
+			return !this.isSystemMessage && !this.isDeletedMessage && !this.isTemporary && (this.isHovered || this.isActionMenuOpen || this.isEmojiPickerOpen || this.isFollowUpEmojiPickerOpen || this.isReactionsMenuOpen || this.isForwarderOpen)
 		},
 
 		isTemporaryUpload() {
@@ -654,11 +642,7 @@ export default {
 	},
 
 	mounted() {
-		if (this.$refs.messageMain.clientHeight > 56) {
-			this.isTallEnough = true
-		}
-
-		// define a function so it can be triggered directly on the DOM element
+		// define a function, so it can be triggered directly on the DOM element
 		// which can be found with document.getElementById()
 		this.$refs.message.highlightAnimation = () => {
 			this.highlightAnimation()
@@ -687,8 +671,7 @@ export default {
 			this.$refs.message.classList.add('highlight-animation')
 		},
 		highlightAnimationStop() {
-			// when the animation ended, remove the class so we can trigger it
-			// again another time
+			// when the animation ended, remove the class, so we can trigger it again another time
 			this.$refs.message.classList.remove('highlight-animation')
 		},
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -534,12 +534,13 @@ export default {
 .message-buttons-bar {
 	display: flex;
 	right: 14px;
-	bottom: -4px;
+	bottom: calc(8px - var(--default-clickable-area)); // 36px offset
 	position: absolute;
 	background-color: var(--color-main-background);
-	border-radius: calc($clickable-area / 2);
+	border-radius: calc(var(--default-clickable-area) / 2);
 	box-shadow: 0 0 4px 0 var(--color-box-shadow);
 	height: 44px;
+	z-index: 1;
 
 	& h6 {
 		margin-left: auto;

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -89,6 +89,7 @@ import uniqueId from 'lodash/uniqueId.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import { getCapabilities } from '@nextcloud/capabilities'
+import { computed } from 'vue'
 
 export default {
 	name: 'MessagesList',
@@ -105,6 +106,12 @@ export default {
 		isInLobby,
 		isInCall,
 	],
+
+	provide() {
+		return {
+			scrollerBoundingClientRect: computed(() => this.$refs.scroller.getBoundingClientRect()),
+		}
+	},
 
 	props: {
 		/**


### PR DESCRIPTION
Signed-off-by: Maksim Sukharev <antreesy.web@gmail.com>

Fix #8463

### 🖼️ Screenshots
:derelict_house:  Before (covers date and check marker, fall outside of visible area): | -
-- | --
![image](https://user-images.githubusercontent.com/93392545/217843071-e91b830a-533e-442c-a9e9-78a6017c3936.png)

🏡 After
One- and two-line text messages: | In case buttons bar will be rendered outside of scroll area:
-- | --
![image](https://user-images.githubusercontent.com/93392545/217301520-110e74f9-1fa7-40fc-9866-4e9d79ba0a37.png) | ![image](https://user-images.githubusercontent.com/93392545/217302491-82884eb0-bc5b-4300-a9b2-a24146552bcc.png)


### 🚧 TODO

- [X] Make date visible in right sidebar
- [X] Fix tooltip appearance for date to the left
- [ ] Visual check (both Main Chat and Call Chat in sidebar)
- [ ] Code-review

### 🏁 Checklist

- [X] 📘 API documentation in `docs/` has been updated or is not required
- [X] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [X] 🔖 Capability is added or not needed 
