### PR TITLE
Load history and first set of new messages with 1 API request

### DIFF
--- a/appinfo/routes/routesChatController.php
+++ b/appinfo/routes/routesChatController.php
@@ -44,6 +44,8 @@ return [
 		['name' => 'Chat#clearHistory', 'url' => '/api/{apiVersion}/chat/{token}', 'verb' => 'DELETE', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\ChatController::deleteMessage() */
 		['name' => 'Chat#deleteMessage', 'url' => '/api/{apiVersion}/chat/{token}/{messageId}', 'verb' => 'DELETE', 'requirements' => $requirementsWithMessageId],
+		/** @see \OCA\Talk\Controller\ChatController::getMessageContext() */
+		['name' => 'Chat#getMessageContext', 'url' => '/api/{apiVersion}/chat/{token}/{messageId}/context', 'verb' => 'GET', 'requirements' => $requirementsWithMessageId],
 		/** @see \OCA\Talk\Controller\ChatController::setReadMarker() */
 		['name' => 'Chat#setReadMarker', 'url' => '/api/{apiVersion}/chat/{token}/read', 'verb' => 'POST', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\ChatController::markUnread() */

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -110,5 +110,6 @@ title: Capabilities
 * `breakout-rooms-v1` - Whether breakout-rooms API v1 is available
 * `avatar` - Avatar of conversation
 * `recording-v1` - Call recording is available.
+* `chat-get-context` - Whether the message context API endpoint is available
 * `config => call => breakout-rooms` - Whether breakout rooms are enabled on this instance
 * `config => call => recording` - Whether calls can be recorded (requires the High-performance backend server)

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -73,6 +73,37 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`: since Nextcloud 13
 
     Full message array as shown above, but `parent` will never be set for a parent message.
 
+## Get context of a message
+
+!!! note
+
+    Due to the structure of the `lastMessage.reactions` array the response is not valid in XML.
+    It is therefor recommended to use `format=json` or send the `Accept: application/json` header,
+    to receive a JSON response.
+
+* Required capability: `chat-get-context`
+* Method: `GET`
+* Endpoint: `/chat/{token}/{messageId}/context`
+* Data:
+
+| field                | type | Description                                                                         |
+|----------------------|------|-------------------------------------------------------------------------------------|
+| `limit`              | int  | Number of chat messages to receive into each direction (50 by default, 100 at most) |
+
+* Response:
+	- Status code:
+		+ `200 OK`
+		+ `404 Not Found` When the conversation could not be found for the participant
+		+ `412 Precondition Failed` When the lobby is active and the user is not a moderator
+
+	- Header:
+
+| field                     | type | Description                                                                                                                                                                                                                                        |
+|---------------------------|------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `X-Chat-Last-Given`       | int  | Offset (lastKnownMessageId) for the next page when getting more history.                                                                                                                                                                           |
+| `X-Chat-Last-Common-Read` | int  | ID of the last message read by every user that has read privacy set to public. When the user themself has it set to private the value the header is not set (only available with `chat-read-status` capability and when lastCommonReadId was sent) |
+
+    - Data: See array definition in `Receive chat messages of a conversation`
 
 ## Sending a new chat message
 

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -128,6 +128,7 @@ class Capabilities implements IPublicCapability {
 				'chat' => [
 					'max-length' => ChatManager::MAX_CHAT_LENGTH,
 					'read-privacy' => Participant::PRIVACY_PUBLIC,
+					//'legacy' => true, // Temporary A-B switch to opt-out of the new context loading
 				],
 				'conversations' => [
 					'can-create' => $user instanceof IUser && !$this->talkConfig->isNotAllowedToCreateConversations($user)

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -115,6 +115,7 @@ class Capabilities implements IPublicCapability {
 				'breakout-rooms-v1',
 				'recording-v1',
 				'avatar',
+				'chat-get-context',
 			],
 			'config' => [
 				'attachments' => [

--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -306,6 +306,8 @@ class RoomFormatter {
 					&& $currentParticipant->hasModeratorPermissions(false)
 					&& $this->talkConfig->canUserEnableSIP($currentUser);
 			}
+		} else {
+			$roomData['lastReadMessage'] = $attendee->getLastReadMessage();
 		}
 
 		// FIXME This should not be done, but currently all the clients use it to get the avatar of the user …

--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -75,12 +75,7 @@ export default {
 	data() {
 		return {
 			isDraggingOver: false,
-			/**
-			 * Initialised as true as when we open a new conversation we're scrolling to
-			 * the bottom for now. In the future when we'll open the conversation close
-			 * to the scroll position of the last read message, we will need to change this.
-			 */
-			isChatScrolledToBottom: true,
+			isChatScrolledToBottom: false,
 		}
 	},
 

--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -55,6 +55,7 @@
 import MessagesList from './MessagesList/MessagesList.vue'
 import NewMessageForm from './NewMessageForm/NewMessageForm.vue'
 import { CONVERSATION } from '../constants.js'
+import { getCapabilities } from '@nextcloud/capabilities'
 
 export default {
 
@@ -75,7 +76,7 @@ export default {
 	data() {
 		return {
 			isDraggingOver: false,
-			isChatScrolledToBottom: false,
+			isChatScrolledToBottom: getCapabilities()?.spreed?.config?.chat?.legacy || false,
 		}
 	},
 

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -510,8 +510,24 @@ export default {
 					}
 				}
 
+				let hasScrolled = false
+				// if lookForNewMessages will long poll instead of returning existing messages,
+				// scroll right away to avoid delays
+				if (!this.$store.getters.hasMoreMessagesToLoad(this.token)) {
+					hasScrolled = true
+					this.$nextTick(() => {
+						this.scrollToFocussedMessage()
+					})
+				}
+
 				// get new messages
 				await this.lookForNewMessages()
+
+				// don't scroll if lookForNewMessages was polling as we don't want
+				// to scroll back to the read marker after receiving new messages later
+				if (!hasScrolled) {
+					this.scrollToFocussedMessage()
+				}
 			} else {
 				this.$store.dispatch('cancelLookForNewMessages', { requestId: this.chatIdentifier })
 			}

--- a/src/services/messagesService.js
+++ b/src/services/messagesService.js
@@ -69,6 +69,25 @@ const lookForNewMessages = async ({ token, lastKnownMessageId }, options) => {
 }
 
 /**
+ * Get the context of a message
+ *
+ * Loads some messages from before and after the given one.
+ *
+ * @param {object} data the wrapping object;
+ * @param {string} data.token the conversation token;
+ * @param {number} data.messageId last known message id;
+ * @param {number} data.limit Number of messages to load (default: 50)
+ * @param {object} options options;
+ */
+const getMessageContext = async function({ token, messageId, limit }, options) {
+	return axios.get(generateOcsUrl('apps/spreed/api/v1/chat/{token}/{messageId}/context', { token, messageId }), Object.assign(options, {
+		params: {
+			limit: limit || 50,
+		},
+	}))
+}
+
+/**
  * Posts a new message to the server.
  *
  * @param {object} param0 The message object that is destructured
@@ -158,6 +177,7 @@ const getReactionsDetails = async function(token, messageId) {
 export {
 	fetchMessages,
 	lookForNewMessages,
+	getMessageContext,
 	postNewMessage,
 	deleteMessage,
 	postRichObjectToConversation,

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -221,6 +221,23 @@ const getters = {
 		return null
 	},
 
+	getFirstDisplayableMessageIdBeforeReadMarker: (state, getters) => (token, readMessageId) => {
+		if (!state.messages[token]) {
+			return null
+		}
+
+		const displayableMessages = getters.messagesList(token).filter(message => {
+			return message.id < readMessageId
+				&& !('' + message.id).startsWith('temp-')
+		})
+
+		if (displayableMessages.length) {
+			return displayableMessages.pop().id
+		}
+
+		return null
+	},
+
 	isSendingMessages: (state) => {
 		// the cancel handler only exists when a message is being sent
 		return Object.keys(state.cancelPostNewMessage).length !== 0

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -906,10 +906,6 @@ const actions = {
 			})
 		}
 
-		// TODO: Verify guests comment
-		// For guests, we also need to set the last known message id
-		// after the first grab of the history, otherwise they start loading
-		// the full history with fetchMessages().
 		if (newestKnownMessageId
 			&& !context.getters.getLastKnownMessageId(token)) {
 			context.dispatch('setLastKnownMessageId', {

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -872,13 +872,13 @@ const actions = {
 
 		let newestKnownMessageId = 0
 
-		// if ('x-chat-last-common-read' in response.headers) {
-		// const lastCommonReadMessage = parseInt(response.headers['x-chat-last-common-read'], 10)
-		// context.dispatch('updateLastCommonReadMessage', {
-		// token,
-		// lastCommonReadMessage,
-		// })
-		// }
+		if ('x-chat-last-common-read' in response.headers) {
+			const lastCommonReadMessage = parseInt(response.headers['x-chat-last-common-read'], 10)
+			context.dispatch('updateLastCommonReadMessage', {
+				token,
+				lastCommonReadMessage,
+			})
+		}
 
 		// Process each messages and adds it to the store
 		response.data.ocs.data.forEach(message => {

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -450,12 +450,12 @@ Feature: conversation/breakout-rooms
     When user "participant2" switches in room "class room" to breakout room "Room 1" with 400 (v1)
     And user "participant1" starts breakout rooms in room "class room" with 200 (v1)
     When user "participant2" switches in room "class room" to breakout room "Room 1" with 200 (v1)
-    Then user "participant2" is participant of the following rooms (v4)
+    Then user "participant2" is participant of the following unordered rooms (v4)
       | type | name       |
       | 2    | class room |
       | 2    | Room 1     |
     When user "participant2" switches in room "class room" to breakout room "Room 2" with 200 (v1)
-    Then user "participant2" is participant of the following rooms (v4)
+    Then user "participant2" is participant of the following unordered rooms (v4)
       | type | name       |
       | 2    | class room |
       | 2    | Room 2     |

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -124,6 +124,7 @@ class CapabilitiesTest extends TestCase {
 			'breakout-rooms-v1',
 			'recording-v1',
 			'avatar',
+			'chat-get-context',
 			'message-expiration',
 			'reactions',
 		];


### PR DESCRIPTION
Ref #8710 

### 🚧 TODO

- [x] Add endpoint to get the message context
  - [ ] Integration tests
- [x] Use for first load of messages when entering a chat
- [x] Revert not setting the read marker
- [ ] JS/Frontend Test
  - [x] Check guests behaviour
  - [x] Check self-joined users behaviour
  - [x] Check revisiting a check room
  - [x] Check behaviour with more than 100 unread messages (context end)
  - [x] Check behaviour with more than 300 unread messages (first future end)

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
