### PR TITLE
Fix leaving room as a self joined user with several sessions

### DIFF
--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -775,17 +775,8 @@ class ParticipantService {
 		if ($participant->getAttendee()->getParticipantType() === Participant::USER_SELF_JOINED
 			&& empty($this->sessionMapper->findByAttendeeId($participant->getAttendee()->getId()))) {
 			$user = $this->userManager->get($participant->getAttendee()->getActorId());
-			$reason = Room::PARTICIPANT_LEFT;
 
-			$event = new RemoveUserEvent($room, $participant, $user, $reason, [$session]);
-			$this->dispatcher->dispatch(Room::EVENT_BEFORE_USER_REMOVE, $event);
-
-			$this->attendeeMapper->delete($participant->getAttendee());
-
-			$attendeeEvent = new AttendeesRemovedEvent($room, [$participant->getAttendee()]);
-			$this->dispatcher->dispatchTyped($attendeeEvent);
-
-			$this->dispatcher->dispatch(Room::EVENT_AFTER_USER_REMOVE, $event);
+			$this->removeUser($room, $user, Room::PARTICIPANT_LEFT);
 		}
 
 		$this->dispatcher->dispatch(Room::EVENT_AFTER_ROOM_DISCONNECT, $event);

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -772,14 +772,14 @@ class ParticipantService {
 			$this->sessionMapper->deleteByAttendeeId($participant->getAttendee()->getId());
 		}
 
+		$this->dispatcher->dispatch(Room::EVENT_AFTER_ROOM_DISCONNECT, $event);
+
 		if ($participant->getAttendee()->getParticipantType() === Participant::USER_SELF_JOINED
 			&& empty($this->sessionMapper->findByAttendeeId($participant->getAttendee()->getId()))) {
 			$user = $this->userManager->get($participant->getAttendee()->getActorId());
 
 			$this->removeUser($room, $user, Room::PARTICIPANT_LEFT);
 		}
-
-		$this->dispatcher->dispatch(Room::EVENT_AFTER_ROOM_DISCONNECT, $event);
 	}
 
 	public function removeAttendee(Room $room, Participant $participant, string $reason, bool $attendeeEventIsTriggeredAlready = false): void {

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -774,10 +774,18 @@ class ParticipantService {
 
 		if ($participant->getAttendee()->getParticipantType() === Participant::USER_SELF_JOINED
 			&& empty($this->sessionMapper->findByAttendeeId($participant->getAttendee()->getId()))) {
+			$user = $this->userManager->get($participant->getAttendee()->getActorId());
+			$reason = Room::PARTICIPANT_LEFT;
+
+			$event = new RemoveUserEvent($room, $participant, $user, $reason, [$session]);
+			$this->dispatcher->dispatch(Room::EVENT_BEFORE_USER_REMOVE, $event);
+
 			$this->attendeeMapper->delete($participant->getAttendee());
 
 			$attendeeEvent = new AttendeesRemovedEvent($room, [$participant->getAttendee()]);
 			$this->dispatcher->dispatchTyped($attendeeEvent);
+
+			$this->dispatcher->dispatch(Room::EVENT_AFTER_USER_REMOVE, $event);
 		}
 
 		$this->dispatcher->dispatch(Room::EVENT_AFTER_ROOM_DISCONNECT, $event);

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -772,7 +772,8 @@ class ParticipantService {
 			$this->sessionMapper->deleteByAttendeeId($participant->getAttendee()->getId());
 		}
 
-		if ($participant->getAttendee()->getParticipantType() === Participant::USER_SELF_JOINED) {
+		if ($participant->getAttendee()->getParticipantType() === Participant::USER_SELF_JOINED
+			&& empty($this->sessionMapper->findByAttendeeId($participant->getAttendee()->getId()))) {
 			$this->attendeeMapper->delete($participant->getAttendee());
 
 			$attendeeEvent = new AttendeesRemovedEvent($room, [$participant->getAttendee()]);

--- a/lib/Signaling/Listener.php
+++ b/lib/Signaling/Listener.php
@@ -253,17 +253,14 @@ class Listener {
 		if ($event->getParticipant()->getSession()) {
 			// If a previous duplicated session is being removed it must be
 			// notified to the external signaling server. Otherwise only for
-			// guests and self-joined users disconnecting is "leaving" and
-			// therefor should trigger a disinvite.
+			// guests disconnecting is "leaving" and therefor should trigger a
+			// disinvite.
 			$attendeeParticipantType = $event->getParticipant()->getAttendee()->getParticipantType();
 			if ($event instanceof DuplicatedParticipantEvent
 				|| $attendeeParticipantType === Participant::GUEST
 				|| $attendeeParticipantType === Participant::GUEST_MODERATOR) {
 				$sessionIds[] = $event->getParticipant()->getSession()->getSessionId();
 				$notifier->roomSessionsRemoved($event->getRoom(), $sessionIds);
-			}
-			if ($attendeeParticipantType === Participant::USER_SELF_JOINED) {
-				$notifier->roomsDisinvited($event->getRoom(), [$event->getParticipant()->getAttendee()->getActorId()]);
 			}
 		}
 	}

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -91,6 +91,8 @@ class BackendNotifierTest extends TestCase {
 	private $signalingManager;
 	/** @var IURLGenerator|MockObject */
 	private $urlGenerator;
+	/** @var IUserManager|MockObject */
+	private $userManager;
 	private ?\OCA\Talk\Tests\php\Signaling\CustomBackendNotifier $controller = null;
 
 	private ?Manager $manager = null;
@@ -115,7 +117,7 @@ class BackendNotifierTest extends TestCase {
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$groupManager = $this->createMock(IGroupManager::class);
-		$userManager = $this->createMock(IUserManager::class);
+		$this->userManager = $this->createMock(IUserManager::class);
 		$config = \OC::$server->getConfig();
 		$this->signalingSecret = 'the-signaling-secret';
 		$this->baseUrl = 'https://localhost/signaling';
@@ -135,7 +137,7 @@ class BackendNotifierTest extends TestCase {
 			->willReturn(['server' => $this->baseUrl]);
 
 		$this->dispatcher = \OC::$server->get(IEventDispatcher::class);
-		$this->config = new Config($config, $this->secureRandom, $groupManager, $userManager, $this->urlGenerator, $this->timeFactory, $this->dispatcher);
+		$this->config = new Config($config, $this->secureRandom, $groupManager, $this->userManager, $this->urlGenerator, $this->timeFactory, $this->dispatcher);
 		$this->recreateBackendNotifier();
 
 		$this->overwriteService(BackendNotifier::class, $this->controller);

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -27,6 +27,7 @@ use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Config;
 use OCA\Talk\Events\SignalingRoomPropertiesEvent;
+use OCA\Talk\Federation\Notifications;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\AttendeeMapper;
@@ -35,8 +36,10 @@ use OCA\Talk\Model\SessionMapper;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\BreakoutRoomService;
+use OCA\Talk\Service\MembershipService;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\RoomService;
+use OCA\Talk\Service\SessionService;
 use OCA\Talk\Signaling\BackendNotifier;
 use OCA\Talk\TalkSession;
 use OCA\Talk\Webinary;
@@ -45,6 +48,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Http\Client\IClientService;
+use OCP\ICacheFactory;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -130,7 +134,6 @@ class BackendNotifierTest extends TestCase {
 			],
 		]));
 
-		$this->participantService = \OC::$server->get(ParticipantService::class);
 		$this->signalingManager = $this->createMock(\OCA\Talk\Signaling\Manager::class);
 		$this->signalingManager->expects($this->any())
 			->method('getSignalingServerForConversation')
@@ -138,11 +141,29 @@ class BackendNotifierTest extends TestCase {
 
 		$this->dispatcher = \OC::$server->get(IEventDispatcher::class);
 		$this->config = new Config($config, $this->secureRandom, $groupManager, $this->userManager, $this->urlGenerator, $this->timeFactory, $this->dispatcher);
+
+		$dbConnection = \OC::$server->getDatabaseConnection();
+		$this->participantService = new ParticipantService(
+			$config,
+			$this->config,
+			\OC::$server->get(AttendeeMapper::class),
+			\OC::$server->get(SessionMapper::class),
+			\OC::$server->get(SessionService::class),
+			$this->secureRandom,
+			$dbConnection,
+			$this->dispatcher,
+			$this->userManager,
+			$groupManager,
+			\OC::$server->get(MembershipService::class),
+			\OC::$server->get(Notifications::class),
+			$this->timeFactory,
+			\OC::$server->get(ICacheFactory::class)
+		);
+
 		$this->recreateBackendNotifier();
 
 		$this->overwriteService(BackendNotifier::class, $this->controller);
 
-		$dbConnection = \OC::$server->getDatabaseConnection();
 		$this->manager = new Manager(
 			$dbConnection,
 			$config,
@@ -492,6 +513,12 @@ class BackendNotifierTest extends TestCase {
 		$room = $this->manager->createRoom(Room::TYPE_PUBLIC);
 		$participant = $this->participantService->joinRoom($roomService, $room, $testUser, '');
 		$this->controller->clearRequests();
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with($this->userId)
+			->willReturn($testUser);
+
 		$this->participantService->leaveRoomAsSession($room, $participant);
 
 		$this->assertMessageWasSent($room, [


### PR DESCRIPTION
Fixes #8626

Self-joined users are just temporary participants and they need to be removed when they leave a conversation. However, this needs to be done once they have no more sessions in that conversation; otherwise the remaining sessions would be kicked out from the conversation as soon as one leaves it.

Moreover, if the external signaling server is used, when a participant is disinvited it is expected that the client leaves the conversation if still in it. Therefore, self-joined users should not be disinvited when
they disconnect from a conversation, as they can still have other sessions in it.

To ensure that self-joined users will be disinvited when their last session leaves the conversation now a USER_REMOVE event is explicitly triggered when that last session leaves and the user is, in fact, removed from the conversation.

Note that this does not cause the system message about the participant leaving to be sent, as [it is explicitly guarded against self-joined users leaving the conversation](https://github.com/nextcloud/spreed/blob/b71fc1d3d9c99502db1e9b514c4d219592cccae3/lib/Chat/SystemMessage/Listener.php#L305-L309). However, this change will cause other handlers to be called now, like [those to invalidate resources](https://github.com/nextcloud/spreed/blob/de8b51e6060a0a97ff8d2ae1176f0838fd93982c/lib/Collaboration/Reference/ReferenceInvalidationListener.php#L43), but it is very likely that they should have been called and that this change is actually a fix too in that regard.

It would be great to add integration tests to explicitly check this, but I do not if it is possible to simulate different sessions for the same participant in the integration tests.
