### PR TITLE
Don't throw when breakout rooms are not started

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -717,7 +717,12 @@ class RoomController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		$breakoutRooms = $this->breakoutRoomService->getBreakoutRooms($this->room, $this->participant);
+		try {
+			$breakoutRooms = $this->breakoutRoomService->getBreakoutRooms($this->room, $this->participant);
+		} catch (InvalidArgumentException $e) {
+			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+		}
+
 		$breakoutRooms[] = $this->room;
 		$participants = $this->participantService->getSessionsAndParticipantsForRooms($breakoutRooms);
 

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -53,6 +53,16 @@ Feature: conversation/breakout-rooms
       | Room 2     | users      | participant3 | 3               |
       | Room 3     | users      | participant1 | 1               |
       | Room 3     | users      | participant4 | 3               |
+    And user "participant2" sees the following attendees in breakout rooms for room "class room" with 400 (v4)
+    And user "participant1" starts breakout rooms in room "class room" with 200 (v1)
+    And user "participant2" sees the following attendees in breakout rooms for room "class room" with 200 (v4)
+      | roomToken  | actorType  | actorId      | participantType |
+      | class room | users      | participant1 | 1               |
+      | class room | users      | participant2 | 3               |
+      | class room | users      | participant3 | 3               |
+      | class room | users      | participant4 | 3               |
+      | Room 1     | users      | participant1 | 1               |
+      | Room 1     | users      | participant2 | 3               |
 
   Scenario: Teacher creates automatic breakout rooms
     Given user "participant1" creates room "class room" (v4)


### PR DESCRIPTION
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
