### PR TITLE
fix(share): Directly return created share

### DIFF
--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -193,9 +193,10 @@ class RoomShareProvider implements IShareProvider {
 			$share->getExpirationDate()
 		);
 
-		$data = $this->getRawShare($shareId);
+		$share->setId((string) $shareId);
+		$share->setProviderId($this->identifier());
 
-		return $this->createShareObject($data);
+		return $share;
 	}
 
 	/**
@@ -242,33 +243,7 @@ class RoomShareProvider implements IShareProvider {
 		}
 
 		$insert->executeStatement();
-		$id = $insert->getLastInsertId();
-
-		return $id;
-	}
-
-	/**
-	 * Get database row of the given share
-	 *
-	 * @param int $id
-	 * @return array
-	 * @throws ShareNotFound
-	 */
-	private function getRawShare(int $id): array {
-		$qb = $this->dbConnection->getQueryBuilder();
-		$qb->select('*')
-			->from('share')
-			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
-
-		$cursor = $qb->executeQuery();
-		$data = $cursor->fetch();
-		$cursor->closeCursor();
-
-		if ($data === false) {
-			throw new ShareNotFound();
-		}
-
-		return $data;
+		return $insert->getLastInsertId();
 	}
 
 	/**


### PR DESCRIPTION
Avoid reading from the database after creating share and return it straight away. From what I can see it shouldn't change anything.

```
OCP\Share\Exceptions\ShareNotFound: Share not found
#9 /spreed/lib/Share/RoomShareProvider.php(268): OCA\Talk\Share\RoomShareProvider::getRawShare
#8 /spreed/lib/Share/RoomShareProvider.php(196): OCA\Talk\Share\RoomShareProvider::create
#7 /var/www/nc/nextcloud-25.0.1/lib/private/Share20/Manager.php(818): OC\Share20\Manager::createShare
#6 /files_sharing/lib/Controller/ShareAPIController.php(701): OCA\Files_Sharing\Controller\ShareAPIController::createShare
#5 /var/www/nc/nextcloud-25.0.1/lib/private/AppFramework/Http/Dispatcher.php(225): OC\AppFramework\Http\Dispatcher::executeController
```

Another possibility is #8742, feel free to close this one.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
