### PR TITLE
Apply title to reaction button

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -28,6 +28,7 @@
 			<NcButton v-if="canReact"
 				type="tertiary"
 				:aria-label="t('spreed', 'Add a reaction to this message')"
+				:title="t('spreed', 'Add a reaction to this message')"
 				@click="openReactionsMenu">
 				<template #icon>
 					<EmoticonOutline :size="20" />


### PR DESCRIPTION
Signed-off-by: Maksim Sukharev <antreesy.web@gmail.com>

Fix #8363 

Native title attribute was added with same text as for aria-label

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
See issue | ![Screenshot from 2023-02-13 11-18-19](https://user-images.githubusercontent.com/93392545/218434011-aae5c3a5-6caf-46eb-b0fc-d3b8eba0cfeb.png)



### 🚧 TODO

- [ ] Approve text

### 🏁 Checklist

- [X] 📘 API documentation in `docs/` has been updated or is not required
- [X] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [X] 🔖 Capability is added or not needed 
