### PR TITLE
Make participants counter always-on during the call

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -47,7 +47,7 @@
 			</template>
 			<ChatView :is-visible="opened" />
 		</NcAppSidebarTab>
-		<NcAppSidebarTab v-if="getUserId && !isOneToOne"
+		<NcAppSidebarTab v-if="(getUserId || isModeratorOrUser) && !isOneToOne"
 			id="participants"
 			ref="participantsTab"
 			:order="2"
@@ -311,6 +311,14 @@ export default {
 			console.debug('Sidebar slots changed, re rendering')
 			this.$forceUpdate()
 		},
+
+		// Switch tab for guest if he is demoted from moderators
+		isModeratorOrUser(newValue) {
+			if (!newValue) {
+				this.activeTab = 'chat'
+			}
+		},
+
 	},
 
 	mounted() {

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -309,15 +309,11 @@ export default {
 				this.notifyUnreadMessages(null)
 			}
 		},
+	},
 
-		// Starts and stops the getParticipantsMixin logic
-		isOneToOneConversation(newValue) {
-			if (newValue) {
-				this.initialiseGetParticipantsMixin()
-			} else {
-				this.stopGetParticipantsMixin()
-			}
-		},
+	beforeMount() {
+		// Initialises the get participants mixin for participants counter
+		this.initialiseGetParticipantsMixin()
 	},
 
 	mounted() {
@@ -335,6 +331,8 @@ export default {
 		document.removeEventListener('MSFullscreenChange', this.fullScreenChanged, false)
 		document.removeEventListener('webkitfullscreenchange', this.fullScreenChanged, false)
 		document.body.classList.remove('has-topbar')
+
+		this.stopGetParticipantsMixin()
 	},
 
 	methods: {

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -107,20 +107,19 @@
 					{{ unreadMessagesCounter }}
 				</NcCounterBubble>
 			</div>
-
-			<!-- participants button -->
-			<NcButton v-if="isInCall && !isOneToOneConversation"
-				class="top-bar__button"
-				close-after-click="true"
-				type="tertiary"
-				@click="openSidebar('participants')">
-				<template #icon>
-					<AccountMultiple :size="20"
-						fill-color="#ffffff" />
-				</template>
-				{{ participantsInCall }}
-			</NcButton>
 		</template>
+
+		<!-- participants button -->
+		<NcButton v-if="isInCall && !isOneToOneConversation"
+			class="top-bar__button"
+			type="tertiary"
+			@click="openSidebar('participants')">
+			<template #icon>
+				<AccountMultiple :size="20"
+					fill-color="#ffffff" />
+			</template>
+			{{ participantsInCall }}
+		</NcButton>
 	</div>
 </template>
 
@@ -278,7 +277,7 @@ export default {
 		},
 
 		participantsInCall() {
-			return this.$store.getters.participantsInCall(this.token) ? this.$store.getters.participantsInCall(this.token) : ''
+			return this.$store.getters.participantsInCall(this.token) || ''
 		},
 	},
 
@@ -399,6 +398,7 @@ export default {
 			color: #fff;
 		}
 
+		& button.top-bar__button:hover,
 		:deep(.action-item--open .action-item__menutoggle),
 		:deep(.action-item__menutoggle:hover),
 		:deep(.action-item--single:hover),
@@ -429,6 +429,7 @@ export default {
 			top: 24px;
 			right: 2px;
 			pointer-events: none;
+			color: var(--color-primary-element);
 		}
 	}
 }

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -59,7 +59,7 @@
 			:start="conversation.callStartTime" />
 
 		<!-- Participants counter -->
-		<NcButton v-if="isInCall && !isOneToOneConversation"
+		<NcButton v-if="isInCall && !isOneToOneConversation && isModeratorOrUser"
 			v-tooltip="t('spreed', 'Participants in call')"
 			class="top-bar__button"
 			type="tertiary"
@@ -308,6 +308,13 @@ export default {
 			if (!newValue) {
 				// discard notification if the call ends
 				this.notifyUnreadMessages(null)
+			}
+		},
+
+		isModeratorOrUser(newValue) {
+			if (newValue) {
+				// fetch participants immediately when becomes available
+				this.cancelableGetParticipants()
 			}
 		},
 	},

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -111,6 +111,7 @@
 
 		<!-- participants button -->
 		<NcButton v-if="isInCall && !isOneToOneConversation"
+			v-tooltip="t('spreed', 'Participants in call')"
 			class="top-bar__button"
 			type="tertiary"
 			@click="openSidebar('participants')">

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -58,6 +58,19 @@
 		<CallTime v-if="isInCall"
 			:start="conversation.callStartTime" />
 
+		<!-- Participants counter -->
+		<NcButton v-if="isInCall && !isOneToOneConversation"
+			v-tooltip="t('spreed', 'Participants in call')"
+			class="top-bar__button"
+			type="tertiary"
+			@click="openSidebar('participants')">
+			<template #icon>
+				<AccountMultiple :size="20"
+					fill-color="#ffffff" />
+			</template>
+			{{ participantsInCall }}
+		</NcButton>
+
 		<!-- Local media controls -->
 		<LocalMediaControls v-if="isInCall"
 			class="local-media-controls"
@@ -108,19 +121,6 @@
 				</NcCounterBubble>
 			</div>
 		</template>
-
-		<!-- participants button -->
-		<NcButton v-if="isInCall && !isOneToOneConversation"
-			v-tooltip="t('spreed', 'Participants in call')"
-			class="top-bar__button"
-			type="tertiary"
-			@click="openSidebar('participants')">
-			<template #icon>
-				<AccountMultiple :size="20"
-					fill-color="#ffffff" />
-			</template>
-			{{ participantsInCall }}
-		</NcButton>
 	</div>
 </template>
 

--- a/src/mixins/getParticipants.js
+++ b/src/mixins/getParticipants.js
@@ -85,14 +85,16 @@ const getParticipants = {
 		},
 
 		debounceUpdateParticipants() {
-			if (!this.$store.getters.windowIsVisible()
-				|| !this.$store.getters.getSidebarStatus
-				|| !this.isActive) {
-				this.debounceSlowUpdateParticipants()
+			if (!this.isActive) {
 				return
 			}
 
-			this.debounceFastUpdateParticipants()
+			if (this.$store.getters.windowIsVisible()) {
+				this.debounceFastUpdateParticipants()
+			} else {
+				this.debounceSlowUpdateParticipants()
+			}
+
 		},
 
 		debounceSlowUpdateParticipants: debounce(function() {

--- a/src/mixins/getParticipants.js
+++ b/src/mixins/getParticipants.js
@@ -110,7 +110,7 @@ const getParticipants = {
 		}, 3000),
 
 		async cancelableGetParticipants() {
-			if (this.token === '' || this.isInLobby) {
+			if (this.token === '' || this.isInLobby || !this.isModeratorOrUser) {
 				return
 			}
 

--- a/src/mixins/isInLobby.js
+++ b/src/mixins/isInLobby.js
@@ -38,6 +38,13 @@ export default {
 					|| this.conversation.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR)
 		},
 
+		isModeratorOrUser() {
+			// Check isDummyConversation, because the participant type by default is USER
+			return this.conversation && !this.conversation.isDummyConversation && (this.isModerator
+				|| this.conversation.participantType === PARTICIPANT.TYPE.USER
+				|| this.conversation.participantType === PARTICIPANT.TYPE.USER_SELF_JOINED)
+		},
+
 		isInLobby() {
 			return this.conversation
 				&& this.conversation.lobbyState === WEBINAR.LOBBY.NON_MODERATORS


### PR DESCRIPTION
Signed-off-by: Maksim Sukharev <antreesy.web@gmail.com>
Fix #8407 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
See mentioned issue | ![image](https://user-images.githubusercontent.com/93392545/219093353-63511eaa-1dcd-44ac-88a9-c598737f8206.png)


### 🚧 TODO

- [X] Show button when right sidebar is open
- [X] Correct hover effect (as per #8671)
- [ ] Fix: button counter react to attendees number change slowly when sidebar is closed
- [ ] Code review
- [ ] Visual check

### 🏁 Checklist

- [X] 📘 API documentation in `docs/` has been updated or is not required
- [X] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [X] 🔖 Capability is added or not needed 
