### PR TITLE
Use internal client of signaling server for recording

### DIFF
--- a/recording/server.conf.in
+++ b/recording/server.conf.in
@@ -65,3 +65,32 @@
 # Shared secret for requests from and to the backend servers. This must be the
 # same value as configured in the Nextcloud admin ui.
 #secret = the-shared-secret
+
+[signaling]
+# Common shared secret for authenticating as an internal client of signaling
+# servers if a specific secret is not set for a signaling server. This must be
+# the same value as configured in the signaling server configuration file.
+#internalsecret = the-shared-secret-for-internal-clients
+
+# Comma-separated list of signaling servers with specific internal secrets.
+#signalings = signaling-id, another-signaling
+
+# Signaling server configurations as defined in the "[signaling]" section above.
+# The section names must match the ids used in "signalings" above.
+#[signaling-id]
+# URL of the signaling server
+#url = https://signaling.domain.invalid
+
+# Shared secret for authenticating as an internal client of signaling servers.
+# This must be the same value as configured in the signaling server
+# configuration file.
+#internalsecret = the-shared-secret-for-internal-clients
+
+#[another-signaling]
+# URL of the signaling server
+#url = https://signaling.otherdomain.invalid
+
+# Shared secret for authenticating as an internal client of signaling servers.
+# This must be the same value as configured in the signaling server
+# configuration file.
+#internalsecret = the-shared-secret-for-internal-clients

--- a/recording/src/nextcloud/talk/recording/Participant.py
+++ b/recording/src/nextcloud/talk/recording/Participant.py
@@ -21,18 +21,23 @@
 Module to join a call with a browser.
 """
 
+import hashlib
+import hmac
 import json
 import logging
 import threading
 import websocket
 
 from datetime import datetime
+from secrets import token_urlsafe
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.service import Service as FirefoxService
 from selenium.webdriver.support.wait import WebDriverWait
 from shutil import disk_usage
 from time import sleep
+
+from .Config import config
 
 class BiDiLogsHelper:
     """
@@ -414,22 +419,56 @@ class Participant():
 
     def joinCall(self, token):
         """
-        Joins (or starts) the call in the room with the given token.
+        Joins the call in the room with the given token.
 
-        The participant will join as a guest.
+        The participant will join as an internal client of the signaling server.
 
         :param token: the token of the room to join.
         """
 
         self.seleniumHelper.driver.get(self.nextcloudUrl + '/index.php/call/' + token + '/recording')
 
-    def leaveCall(self):
-        """
-        Leaves the current call.
+        secret = config.getBackendSecret(self.nextcloudUrl)
+        if secret == None:
+            raise Exception(f"No configured backend secret for {self.nextcloudUrl}")
 
-        The call must have been joined first.
+        random = token_urlsafe(64)
+        hmacValue = hmac.new(secret.encode(), random.encode(), hashlib.sha256)
+
+        # If there are several signaling servers configured in Nextcloud the
+        # signaling settings can change between different calls, so they need to
+        # be got just once. The scripts are executed in their own scope, so
+        # values have to be stored in the window object to be able to use them
+        # later in another script.
+        settings = self.seleniumHelper.executeAsync(f'''
+            window.signalingSettings = await OCA.Talk.signalingGetSettingsForRecording('{token}', '{random}', '{hmacValue.hexdigest()}')
+            returnValue = window.signalingSettings
+        ''')
+
+        secret = config.getSignalingSecret(settings['server'])
+        if secret == None:
+            raise Exception(f"No configured signaling secret for {settings['server']}")
+
+        random = token_urlsafe(64)
+        hmacValue = hmac.new(secret.encode(), random.encode(), hashlib.sha256)
+
+        self.seleniumHelper.execute(f'''
+            OCA.Talk.signalingJoinCallForRecording(
+                '{token}',
+                window.signalingSettings,
+                {{
+                    random: '{random}',
+                    token: '{hmacValue.hexdigest()}',
+                    backend: '{self.nextcloudUrl}',
+                }}
+            )
+        ''')
+
+    def disconnect(self):
+        """
+        Disconnects from the signaling server.
         """
 
-        self.seleniumHelper.executeAsync('''
-            await OCA.Talk.SimpleWebRTC.connection.leaveCurrentCall()
+        self.seleniumHelper.execute('''
+            OCA.Talk.signalingKill()
         ''')

--- a/recording/src/nextcloud/talk/recording/Participant.py
+++ b/recording/src/nextcloud/talk/recording/Participant.py
@@ -284,6 +284,14 @@ class SeleniumHelper:
 
         If realtime logs are available logs are printed as soon as they are
         received. Otherwise they will be printed once the script has finished.
+
+        The value returned by the script will be in turn returned by this
+        function; the type will be respected and adjusted as needed (so a
+        JavaScript string is returned as a Python string, but a JavaScript
+        object is returned as a Python dict). If nothing is returned by the
+        script None will be returned.
+
+        :return: the value returned by the script, or None
         """
 
         # Real time logs are enabled while the command is being executed.
@@ -291,7 +299,7 @@ class SeleniumHelper:
             self.printLogs()
             self.bidiLogsHelper.setRealtimeLogsEnabled(True)
 
-        self.driver.execute_script(script)
+        result = self.driver.execute_script(script)
 
         if self.bidiLogsHelper:
             # Give it some time to receive the last real time logs before
@@ -301,6 +309,8 @@ class SeleniumHelper:
             self.bidiLogsHelper.setRealtimeLogsEnabled(False)
 
         self.printLogs()
+
+        return result
 
     def executeAsync(self, script):
         """
@@ -321,6 +331,17 @@ class SeleniumHelper:
 
         If realtime logs are available logs are printed as soon as they are
         received. Otherwise they will be printed once the script has finished.
+
+        The value returned by the script will be in turn returned by this
+        function; the type will be respected and adjusted as needed (so a
+        JavaScript string is returned as a Python string, but a JavaScript
+        object is returned as a Python dict). If nothing is returned by the
+        script None will be returned.
+
+        The returned value must be explicitly assigned to "returnValue" in the
+        script.
+
+        :return: the value returned by the script, or None
         """
 
         # Real time logs are enabled while the command is being executed.
@@ -335,14 +356,14 @@ class SeleniumHelper:
 
         # await is not valid in the root context in Firefox, so the script to be
         # executed needs to be wrapped in an async function.
-        script = '(async() => { ' + script  + ' })().catch(error => { console.error(error) {RETURN} })'
+        script = 'returnValue = undefined; (async() => { ' + script  + ' })().catch(error => { console.error(error) {RETURN} })'
 
         # Asynchronous scripts need to explicitly signal that they are finished
         # by invoking the callback injected as the last argument.
         # https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidexecute_async
-        script = script.replace('{RETURN}', '; arguments[arguments.length - 1]()')
+        script = script.replace('{RETURN}', '; arguments[arguments.length - 1](returnValue)')
 
-        self.driver.execute_async_script(script)
+        result = self.driver.execute_async_script(script)
 
         if self.bidiLogsHelper:
             # Give it some time to receive the last real time logs before
@@ -352,6 +373,8 @@ class SeleniumHelper:
             self.bidiLogsHelper.setRealtimeLogsEnabled(False)
 
         self.printLogs()
+
+        return result
 
 
 class Participant():

--- a/recording/src/nextcloud/talk/recording/Service.py
+++ b/recording/src/nextcloud/talk/recording/Service.py
@@ -284,11 +284,11 @@ class Service:
                 self._process = None
 
         if self._participant:
-            self._logger.debug("Leaving call")
+            self._logger.debug("Disconnecting from signaling server")
             try:
-                self._participant.leaveCall()
+                self._participant.disconnect()
             except:
-                self._logger.exception("Error when leaving call")
+                self._logger.exception("Error when disconnecting from signaling server")
             finally:
                 self._participant = None
 

--- a/src/Recording.vue
+++ b/src/Recording.vue
@@ -24,16 +24,6 @@
 
 <script>
 import {
-	PARTICIPANT,
-} from './constants.js'
-import {
-	joinCall,
-} from './services/callsService.js'
-import {
-	leaveConversationSync,
-} from './services/participantsService.js'
-import {
-	mediaDevicesManager,
 	signalingKill,
 } from './utils/webrtc/index.js'
 import CallView from './components/CallView/CallView.vue'
@@ -61,23 +51,16 @@ export default {
 			await this.$store.dispatch('updateToken', this.$route.params.token)
 
 			await this.$store.dispatch('setPlaySounds', false)
-
-			await this.$store.dispatch('joinConversation', { token: this.token })
-
-			mediaDevicesManager.set('audioInputId', null)
-			mediaDevicesManager.set('videoInputId', null)
-
-			await joinCall(this.token, PARTICIPANT.CALL_FLAG.IN_CALL, false)
 		}
 
+		// This should not be strictly needed, as the recording server is
+		// expected to clean up before leaving, but just in case.
 		window.addEventListener('unload', () => {
 			console.info('Navigating away, leaving conversation')
 			if (this.token) {
 				// We have to do this synchronously, because in unload and
 				// beforeunload Promises, async and await are prohibited.
 				signalingKill()
-
-				leaveConversationSync(this.token)
 			}
 		})
 	},

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -635,6 +635,14 @@ export default {
 		},
 
 		debounceFetchPeers: debounce(async function() {
+			// The recording participant does not have a Nextcloud session, so
+			// it can not fetch the peers. This should not be a problem, as all
+			// the needed data for the recording should be (eventually)
+			// available in the signaling data.
+			if (this.isRecording) {
+				return
+			}
+
 			const token = this.token
 			try {
 				const response = await fetchPeers(token)

--- a/src/mainRecording.js
+++ b/src/mainRecording.js
@@ -56,6 +56,12 @@ import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility
 // eslint-disable-next-line
 import 'leaflet-defaulticon-compatibility'
 
+import {
+	signalingGetSettingsForRecording,
+	signalingJoinCallForRecording,
+	signalingKill,
+} from './utils/webrtc/index.js'
+
 // CSP config for webpack dynamic chunk loading
 // eslint-disable-next-line
 __webpack_nonce__ = btoa(getRequestToken())
@@ -96,5 +102,10 @@ const instance = new Vue({
 
 // make the instance available to global components that might run on the same page
 OCA.Talk.instance = instance
+
+// Expose functions to be called by the recording server
+OCA.Talk.signalingGetSettingsForRecording = signalingGetSettingsForRecording
+OCA.Talk.signalingJoinCallForRecording = signalingJoinCallForRecording
+OCA.Talk.signalingKill = signalingKill
 
 export default instance

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -963,6 +963,10 @@ Signaling.Standalone.prototype.sendHello = function() {
 				},
 			},
 		}
+		if (this.settings.helloAuthParams.internal) {
+			msg.hello.auth.type = 'internal'
+			msg.hello.auth.params = this.settings.helloAuthParams.internal
+		}
 	}
 	this.doSend(msg, this.helloResponseReceived.bind(this))
 }
@@ -1026,7 +1030,7 @@ Signaling.Standalone.prototype.helloResponseReceived = function(data) {
 		}
 	}
 
-	if (!this.hasFeature('audio-video-permissions') || !this.hasFeature('incall-all') || !this.hasFeature('switchto')) {
+	if (!this.settings.helloAuthParams.internal && (!this.hasFeature('audio-video-permissions') || !this.hasFeature('incall-all') || !this.hasFeature('switchto'))) {
 		showError(
 			t('spreed', 'The configured signaling server needs to be updated to be compatible with this version of Talk. Please contact your administrator.'),
 			{
@@ -1045,7 +1049,7 @@ Signaling.Standalone.prototype.helloResponseReceived = function(data) {
 	}
 
 	this._trigger('connect')
-	if (!resumedSession && this.currentRoomToken && this.nextcloudSessionId) {
+	if (!resumedSession && this.currentRoomToken && (this.nextcloudSessionId || this.settings.helloAuthParams.internal)) {
 		this.joinRoom(this.currentRoomToken, this.nextcloudSessionId)
 	}
 }
@@ -1146,6 +1150,21 @@ Signaling.Standalone.prototype.joinCall = function(token, flags) {
 		this.pendingJoinCall.promise = promise
 
 		return this.pendingJoinCall.promise
+	}
+
+	// When using an internal client no request is done and joining the call
+	// just succeeds (the incall flags were already set when the room was
+	// joined).
+	if (this.settings.helloAuthParams.internal) {
+		return new Promise((resolve, reject) => {
+			this._trigger('beforeJoinCall', [token])
+
+			this.currentCallToken = token
+			this.currentCallFlags = flags
+			this._trigger('joinCall', [token])
+
+			resolve()
+		})
 	}
 
 	return Signaling.Base.prototype.joinCall.apply(this, arguments)

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -769,6 +769,7 @@ Signaling.Standalone.prototype.connect = function() {
 				break
 			default:
 				console.error('Ignore unknown error', data)
+				this._trigger('error', [data.error])
 				break
 			}
 			break

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -278,6 +278,21 @@ async function signalingJoinCallForRecording(token, settings, internalClientAuth
 
 	signaling = Signaling.createConnection(settings)
 
+	// The default call flags for internal clients include audio, so they must
+	// be downgraded to just "in call" to prevent other participants from trying
+	// to connect to the recording participant.
+	// This must be done before joining the room to ensure that other
+	// participants will see the correct flags from the beginning.
+	signaling.doSend({
+		type: 'internal',
+		internal: {
+			type: 'incall',
+			incall: {
+				incall: PARTICIPANT.CALL_FLAG.IN_CALL,
+			},
+		},
+	})
+
 	// No Nextcloud session ID is needed to join the room with an internal
 	// client.
 	await signaling.joinRoom(token)

--- a/tests/php/Controller/SignalingControllerTest.php
+++ b/tests/php/Controller/SignalingControllerTest.php
@@ -53,6 +53,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Security\IHasher;
 use OCP\Security\ISecureRandom;
+use OCP\Security\Bruteforce\IThrottler;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -98,6 +99,8 @@ class SignalingControllerTest extends TestCase {
 	private ?string $userId = null;
 	private ?ISecureRandom $secureRandom = null;
 	private ?IEventDispatcher $dispatcher = null;
+	/** @var IThrottler|MockObject */
+	private $throttler;
 	/** @var LoggerInterface|MockObject */
 	private $logger;
 
@@ -129,6 +132,7 @@ class SignalingControllerTest extends TestCase {
 		$this->messages = $this->createMock(Messages::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->clientService = $this->createMock(IClientService::class);
+		$this->throttler = $this->createMock(IThrottler::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->recreateSignalingController();
 	}
@@ -150,6 +154,7 @@ class SignalingControllerTest extends TestCase {
 			$this->dispatcher,
 			$this->timeFactory,
 			$this->clientService,
+			$this->throttler,
 			$this->logger,
 			$this->userId
 		);


### PR DESCRIPTION
Follow up to #8708
Requires #8725
Requires strukturag/nextcloud-spreed-signaling#421

[Internal clients are specific to the signaling server](https://github.com/strukturag/nextcloud-spreed-signaling/blob/69dfb0686fdcef5e77f0559aa9e9dd8ac734fcaa/docs/standalone-signaling-api-v1.md#client-type-internal) and do not have a counterpart Nextcloud user/session. Due to its special nature an internal client is able to join any call, so using an internal client makes possible to record calls other than public ones, which was a limitation of using a guest participant.

Besides that, this also fixes stopping a recording when the last participant leaves, as the recording participant was a regular participant and thus prevented the call from ending when the rest left.

Finally, the recording participant is no longer shown in the call for the rest of participants (although this might require a little change in the mobile apps to not show internal participants; this change should be done independently of the recording, though, to avoid showing other internal participants like the SIP bridge).

### How to test (without starting a recording)

- Start a call
- In a private window, open `{url of the call}/recording`
- In the browser console, execute (replacing the token of the conversation, secrets and server URL as needed):
```
signalingSettings = await OCA.Talk.signalingGetSettingsForRecording(
    'THE-TOKEN-OF-THE-CONVERSATION',
    '1234567890123456789012345678901234567890123',
    Array.from(new Uint8Array(await crypto.subtle.sign(
        'HMAC',
         await crypto.subtle.importKey(
            'raw',
            (new TextEncoder().encode('THE-SECRET-OF-THE-RECORDING-SERVER')).buffer,
            {
                name: 'HMAC',
                hash: { name: 'SHA-256', },
            },
            true,
            ['sign']
        ),
        new TextEncoder().encode('1234567890123456789012345678901234567890123')
    ))).map(b => b.toString(16).padStart(2, '0')).join('')
)

OCA.Talk.signalingJoinCallForRecording(
    'THE-TOKEN-OF-THE-CONVERSATION',
    signalingSettings,
    {
        random: '1234567890123456789012345678901234567890123',
        token: Array.from(new Uint8Array(await crypto.subtle.sign(
            'HMAC',
            await crypto.subtle.importKey(
                'raw',
                (new TextEncoder().encode('THE-INTERNAL-SECRET-OF-THE-SIGNALING-SERVER')).buffer,
                {
                    name: 'HMAC',
                    hash: { name: 'SHA-256', },
                },
                true,
                ['sign']
            ),
            new TextEncoder().encode('1234567890123456789012345678901234567890123')
        ))).map(b => b.toString(16).padStart(2, '0')).join(''),
        backend: 'THE-URL-OF-THE-NEXTCLOUD-SERVER',
    }
)

```

Note that there will be no sound, as the call is joined without any user interaction and therefore sounds are blocked. This is correctly handled when accessing the endpoint from the recording server.

### 🚧 TODO
- [X] Cleanup experimental code
- [X] Verify that [the signaling settings will not need to be updated](https://github.com/nextcloud/spreed/blob/e32afb6e5ebc8ec2097d980b4d82b40b02db4dd2/src/utils/webrtc/index.js#L104-L108) when authenticating as the internal client - It should not be needed, as the token only expires with version 2.0 of client type authentication, but not with internal type authentication (see `TokenExpired` in https://github.com/strukturag/nextcloud-spreed-signaling/blob/cbb6d9ca53b8c7ca416afeee3ae0074c7e39a24c/hub.go#L1016)
- [x] Make possible to get the signaling settings for a conversation without a user/session but with the recording secret (like in other endpoints used by the recording server), as getting the signaling settings without a specific token is a legacy behaviour.
- [x] Fix participants background. - As [explained below](https://github.com/nextcloud/spreed/pull/8756#issuecomment-1432692335) it will be probably fixed once the audio flag is removed for the internal client, although it might require some adjustments in the mobile clients.
- [x] Adjust to changes in https://github.com/strukturag/nextcloud-spreed-signaling/pull/421 to remove the audio flag for the internal client.
