### PR TITLE
Always scroll chat when in a call

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -75,6 +75,7 @@ import MessagesGroup from './MessagesGroup/MessagesGroup.vue'
 import Axios from '@nextcloud/axios'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import isInLobby from '../../mixins/isInLobby.js'
+import isInCall from '../../mixins/isInCall.js'
 import {
 	ATTENDEE,
 	CHAT,
@@ -102,6 +103,7 @@ export default {
 
 	mixins: [
 		isInLobby,
+		isInCall,
 	],
 
 	props: {
@@ -909,7 +911,7 @@ export default {
 		 */
 		smoothScrollToBottom() {
 			this.$nextTick(function() {
-				if (this.isWindowVisible && document.hasFocus()) {
+				if (this.isWindowVisible && (document.hasFocus() || this.isInCall)) {
 					// scrollTo is used when the user is watching
 					this.scroller.scrollTo({
 						top: this.scroller.scrollHeight,


### PR DESCRIPTION
Fixes #7690 

Before:
When in a call, but the window itself was not focused, the chat wouldn't scroll.

After:
When in a call, the chat will be scrolled when the window is visible (independent of being focused).

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
