### PR TITLE
Make "End call for everyone" always available for moderators

### DIFF
--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -63,9 +63,9 @@
 			</NcActionButton>
 			<NcActionButton @click="leaveCall(true)">
 				<template #icon>
-					<VideoOff :size="20" />
+					<VideoBoxOff :size="20" />
 				</template>
-				{{ t('spreed', 'End meeting for all') }}
+				{{ t('spreed', 'End call for everyone') }}
 			</NcActionButton>
 		</NcActions>
 	</div>
@@ -83,6 +83,7 @@ import { loadState } from '@nextcloud/initial-state'
 import BrowserStorage from '../../services/BrowserStorage.js'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
+import VideoBoxOff from 'vue-material-design-icons/VideoBoxOff.vue'
 import VideoIcon from 'vue-material-design-icons/Video.vue'
 import VideoOff from 'vue-material-design-icons/VideoOff.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
@@ -97,6 +98,7 @@ export default {
 	components: {
 		NcActions,
 		NcActionButton,
+		VideoBoxOff,
 		VideoIcon,
 		VideoOff,
 		NcButton,
@@ -157,13 +159,9 @@ export default {
 		},
 
 		canEndForAll() {
-			return ((this.conversation.callPermissions !== PARTICIPANT.PERMISSIONS.DEFAULT
-					&& (this.conversation.callPermissions & PARTICIPANT.PERMISSIONS.CALL_START) === 0)
-				|| (this.conversation.defaultPermissions !== PARTICIPANT.PERMISSIONS.DEFAULT
-					&& (this.conversation.defaultPermissions & PARTICIPANT.PERMISSIONS.CALL_START) === 0))
-			 && (this.participantType === PARTICIPANT.TYPE.OWNER
+			return this.participantType === PARTICIPANT.TYPE.OWNER
 				|| this.participantType === PARTICIPANT.TYPE.MODERATOR
-				|| this.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR)
+				|| this.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR
 		},
 
 		hasCall() {


### PR DESCRIPTION
Fix #7518 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Bildschirmfoto vom 2023-02-17 10-03-30](https://user-images.githubusercontent.com/213943/219606041-6669fe14-e847-4f47-9eae-c606f866d2c6.png) | ![Bildschirmfoto vom 2023-02-17 10-26-52](https://user-images.githubusercontent.com/213943/219606067-4c9b0452-0e2a-46bf-8910-ce84d9d94c78.png)
![Bildschirmfoto vom 2023-02-17 10-04-13](https://user-images.githubusercontent.com/213943/219606055-a91a1e73-e84c-4931-8521-734ed10f7f85.png) | ![Bildschirmfoto vom 2023-02-17 10-26-52](https://user-images.githubusercontent.com/213943/219606067-4c9b0452-0e2a-46bf-8910-ce84d9d94c78.png)


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
