### PR TITLE
Only do classmap-authoritative on release

### DIFF
--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -83,7 +83,7 @@ jobs:
         if: steps.check_composer.outputs.files_exists == 'true'
         run: |
           cd ${{ env.APP_NAME }}
-          composer install --no-dev
+          composer install --no-dev --classmap-authoritative
 
       - name: Build ${{ env.APP_NAME }}
         # Skip if no package.json

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ composer-install-dev:
 	composer install
 
 composer-install-production:
-	composer install --no-dev
+	composer install --no-dev --classmap-authoritative
 
 build-js:
 	npm run dev

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
 			"bamarni/composer-bin-plugin": true
 		},
 		"autoloader-suffix": "Talk",
-		"classmap-authoritative": true,
 		"optimize-autoloader": true,
 		"platform": {
 			"php": "8.0"


### PR DESCRIPTION
Following https://github.com/nextcloud/mail/pull/8020/files

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
