### PR TITLE
Set local video in Stripe to 4:3 aspect-ratio

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -882,12 +882,8 @@ export default {
 	padding: 16px;
 }
 
-.local-video-stripe {
-	width: 300px;
-}
-
 .stripe-wrapper {
-	width: calc(100% - 300px);
+	width: 100%;
 	position: relative;
 }
 

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -72,11 +72,7 @@ import attachMediaStream from 'attachmediastream'
 import Hex from 'crypto-js/enc-hex.js'
 import SHA1 from 'crypto-js/sha1.js'
 
-import {
-	showError,
-	showInfo,
-	TOAST_PERMANENT_TIMEOUT,
-} from '@nextcloud/dialogs'
+import { showError, showInfo, TOAST_PERMANENT_TIMEOUT } from '@nextcloud/dialogs'
 
 import NcAvatar from '@nextcloud/vue/dist/Components/NcAvatar.js'
 
@@ -160,7 +156,7 @@ export default {
 		},
 
 		videoWrapperStyle() {
-			if (!this.containerAspectRatio || !this.videoAspectRatio) {
+			if (!this.containerAspectRatio || !this.videoAspectRatio || !this.isBig) {
 				return
 			}
 			return (this.containerAspectRatio > this.videoAspectRatio)
@@ -371,13 +367,16 @@ export default {
 }
 
 .video-container-stripe:not(.local-video--sidebar) {
-	position:relative;
-	flex: 0 0 300px;
+	// aspect-ratio is set according to the maximum video resolution after applying constraints (720*540)
+	--aspect-ratio: 1.33333;
+	--stripe-height: 242px;
+	position: relative;
+	flex: 0 0 calc(var(--aspect-ratio) * var(--stripe-height));
 	overflow: hidden;
 	display: flex;
 	flex-direction: column;
 	margin-top: auto;
-	height: 242px !important;
+	height: var(--stripe-height) !important;
 }
 
 .video-container-big {


### PR DESCRIPTION
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://user-images.githubusercontent.com/93392545/220951997-2a86576b-b282-475c-870c-e9ddb28e795b.png)| ![image](https://user-images.githubusercontent.com/93392545/220952217-29ec94bd-d6d5-4090-b5fd-c2995787c060.png)

As mentioned in corellated issue #8815 :

>... Even if the camera supports a higher resolution [in calls the resolution is requested to be 720x540](https://github.com/nextcloud/spreed/blob/de32c67ee0b1abf7f0f819ca03e577f951f6f9e7/src/utils/webrtc/VideoConstrainer.js#L187-L194). This is a default value chosen for performance reasons, both for CPU load when encoding the video and for network bandwidth when sending it.

Maximum capable video resolution is fixed at 4:3. This PR adjusts width and height of local video frame in stripe to fit in desired resolution and avoid its cropping

### 🚧 TODO

- [X] Remove video width lock at 300px
- [X] Set aspect-ratio to mentioned resolution at 4:3
- [ ] Code review 

### 🏁 Checklist

- [X] 📘 API documentation in `docs/` has been updated or is not required
- [X] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [X] 🔖 Capability is added or not needed 
