### PR TITLE
Change notification object type for call recordings to allow better handling in mobile clients

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -297,7 +297,7 @@ class Notifier implements INotifier {
 		return $temp;
 	}
 
-	private function parseStoredRecording(
+	protected function parseStoredRecording(
 		INotification $notification,
 		Room $room,
 		Participant $participant,

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -308,10 +308,13 @@ class Notifier implements INotifier {
 			$userFolder = $this->rootFolder->getUserFolder($notification->getUser());
 			/** @var \OCP\Files\File[] */
 			$files = $userFolder->getById($parameters['objectId']);
+			/** @var \OCP\Files\File $file */
 			$file = array_shift($files);
+			$path = $userFolder->getRelativePath($file->getPath());
 		} catch (\Throwable $th) {
 			throw new AlreadyProcessedException();
 		}
+
 		$shareAction = $notification->createAction()
 			->setParsedLabel($l->t('Share to chat'))
 			->setPrimary(true)
@@ -343,13 +346,20 @@ class Notifier implements INotifier {
 
 		$notification
 			->setRichSubject(
-				$l->t('Recording for the call in {call} was uploaded.'),
+				$l->t('Recording for the call in {call} was uploaded to {file}.'),
 				[
 					'call' => [
 						'type' => 'call',
 						'id' => $room->getId(),
 						'name' => $room->getDisplayName($participant->getAttendee()->getActorId()),
 						'call-type' => $this->getRoomType($room),
+					],
+					'file' => [
+						'type' => 'file',
+						'id' => $file->getId(),
+						'name' => $file->getName(),
+						'path' => $path,
+						'link' => $this->url->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileid' => $file->getId()]),
 					],
 				])
 			->addParsedAction($shareAction)

--- a/lib/Service/RecordingService.php
+++ b/lib/Service/RecordingService.php
@@ -179,7 +179,7 @@ class RecordingService {
 		$notification
 			->setApp('spreed')
 			->setDateTime($this->timeFactory->getDateTime())
-			->setObject('chat', $room->getToken())
+			->setObject('recording', $room->getToken())
 			->setUser($attendee->getActorId())
 			->setSubject('record_file_stored', [
 				'objectId' => $file->getId(),
@@ -190,7 +190,7 @@ class RecordingService {
 	public function notificationDismiss(Room $room, Participant $participant, int $timestamp): void {
 		$notification = $this->notificationManager->createNotification();
 		$notification->setApp('spreed')
-			->setObject('chat', $room->getToken())
+			->setObject('recording', $room->getToken())
 			->setSubject('record_file_stored')
 			->setDateTime($this->timeFactory->getDateTime('@' . $timestamp))
 			->setUser($participant->getAttendee()->getActorId());

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2752,7 +2752,10 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 				}
 			}
 			if (isset($expectedNotification['subject'])) {
-				$data['subject'] = str_replace($notification['object_id'], '{{TOKEN}}', (string) $notification['subject']);
+				$data['subject'] = (string) $notification['subject'];
+				if (str_contains($expectedNotification['subject'], '{{TOKEN}}')) {
+					$data['subject'] = str_replace($notification['object_id'], '{{TOKEN}}', $data['subject']);
+				}
 			}
 			if (isset($expectedNotification['object_type'])) {
 				$data['object_type'] = (string) $notification['object_type'];

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2752,7 +2752,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 				}
 			}
 			if (isset($expectedNotification['subject'])) {
-				$data['subject'] = (string) $notification['subject'];
+				$data['subject'] = str_replace($notification['object_id'], '{{TOKEN}}', (string) $notification['subject']);
 			}
 			if (isset($expectedNotification['object_type'])) {
 				$data['object_type'] = (string) $notification['object_type'];

--- a/tests/integration/features/callapi/recording.feature
+++ b/tests/integration/features/callapi/recording.feature
@@ -202,8 +202,8 @@ Feature: callapi/recording
     And user "participant1" joins room "room1" with 200 (v4)
     When user "participant1" store recording file "/img/join_call.ogg" in room "room1" with 200 (v1)
     Then user "participant1" has the following notifications
-      | app    | object_type | object_id | subject                                        |
-      | spreed | recording   | room1     | Recording for the call in room1 was uploaded.  |
+      | app    | object_type | object_id | subject                                                            |
+      | spreed | recording   | room1     | Recording for the call in room1 was uploaded to /Talk/Recording/{{TOKEN}}/join_call.ogg. |
     And user "participant1" is participant of the following unordered rooms (v4)
       | type | name  | callRecording |
       | 2    | room1 | 0             |

--- a/tests/integration/features/callapi/recording.feature
+++ b/tests/integration/features/callapi/recording.feature
@@ -203,7 +203,7 @@ Feature: callapi/recording
     When user "participant1" store recording file "/img/join_call.ogg" in room "room1" with 200 (v1)
     Then user "participant1" has the following notifications
       | app    | object_type | object_id | subject                                        |
-      | spreed | chat        | room1     | Recording for the call in room1 was uploaded.  |
+      | spreed | recording   | room1     | Recording for the call in room1 was uploaded.  |
     And user "participant1" is participant of the following unordered rooms (v4)
       | type | name  | callRecording |
       | 2    | room1 | 0             |


### PR DESCRIPTION
Fix  #8759

### Todo
- [x] Change notification object type so that notifications are distinguishable
- [x] Add subject parameter with the file

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
