### PR TITLE
Fix `NcRichContenteditable` styles overriding in `NewMessageForm`

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -921,9 +921,10 @@ export default {
 			position: relative;
 		}
 
-		&__richContenteditable {
+		// Override NcRichContenteditable styles
+		& &__richContenteditable {
 			border: 1px solid var(--color-border-dark);
-			border-radius: calc($clickable-area / 2);
+			border-radius: calc(var(--default-clickable-area) / 2);
 			padding: 8px 16px 8px 44px;
 			max-height: 180px;
 			&:hover,


### PR DESCRIPTION
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://user-images.githubusercontent.com/25978914/220374235-487339c5-a8a8-4523-978a-61e35edc024b.png) | ![image](https://user-images.githubusercontent.com/25978914/220373981-ad94ea62-c96d-40bb-b9bd-69da2d2f03c6.png)


### 🚧 TODO

Style overriding in https://github.com/nextcloud/spreed/pull/4333 worked on local tests but actually depends on building order and other apps. For example, `NcRichContenteditable` may be loaded on the page several times. Another instance may be loaded after the Talk.

~~Adding `!import` makes styles independent of order and duplications.~~
Increase specificity by combinator.

- [x] Fix `NcRichContenteditable` styles overriding in `NewMessageForm`

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
