### PR TITLE
fix(packaging): Adjust the exclude list to package the composer autol…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,8 @@ appstore:
 	--exclude=.tx \
 	--exclude=tests \
 	--exclude=tsconfig.json \
-	--exclude=vendor \
+	--exclude=vendor/bamarni \
+	--exclude=vendor/bin \
 	--exclude=vendor-bin \
 	--exclude=webpack.js \
 	$(project_dir)/  $(sign_dir)/$(app_name)


### PR DESCRIPTION
…oader

From release todo:

- Create a test package and check if a new development file needs to be added to the packaging exclude list in `Makefile`
    ```sh
    make appstore
    ```

That showed composer/autoloader.php, but that linked to dead files

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
