### PR TITLE
fix(packaging): Exclude webpack.config.js from packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ appstore:
 	--exclude=vendor/bamarni \
 	--exclude=vendor/bin \
 	--exclude=vendor-bin \
-	--exclude=webpack.js \
+	--exclude=webpack.config.js \
 	$(project_dir)/  $(sign_dir)/$(app_name)
 	@if [ -f $(cert_dir)/$(app_name).key ]; then \
 		echo "Signing app files…"; \


### PR DESCRIPTION
From #8352

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
