### PR TITLE
Remove import of deleted `At.css`

### DIFF
--- a/lib/Files/TemplateLoader.php
+++ b/lib/Files/TemplateLoader.php
@@ -95,7 +95,6 @@ class TemplateLoader implements IEventListener {
 			return;
 		}
 
-		Util::addStyle(Application::APP_ID, 'At');
 		Util::addStyle(Application::APP_ID, 'icons');
 		if (strpos(\OC::$server->getRequest()->getPathInfo(), '/apps/maps') !== 0) {
 			Util::addScript(Application::APP_ID, 'talk-files-sidebar');

--- a/lib/PublicShare/TemplateLoader.php
+++ b/lib/PublicShare/TemplateLoader.php
@@ -81,7 +81,6 @@ class TemplateLoader implements IEventListener {
 			return;
 		}
 
-		Util::addStyle(Application::APP_ID, 'At');
 		Util::addStyle(Application::APP_ID, 'icons');
 		Util::addStyle(Application::APP_ID, 'publicshare');
 		Util::addScript(Application::APP_ID, 'talk-public-share-sidebar');

--- a/lib/PublicShareAuth/TemplateLoader.php
+++ b/lib/PublicShareAuth/TemplateLoader.php
@@ -76,7 +76,6 @@ class TemplateLoader implements IEventListener {
 			return;
 		}
 
-		Util::addStyle(Application::APP_ID, 'At');
 		Util::addStyle(Application::APP_ID, 'icons');
 		Util::addStyle(Application::APP_ID, 'publicshareauth');
 		Util::addScript(Application::APP_ID, 'talk-public-share-auth-sidebar');

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,7 +1,5 @@
 const stylelintConfig = require('@nextcloud/stylelint-config')
 
-stylelintConfig.ignoreFiles = ['css/At.scss']
-
 stylelintConfig.rules['at-rule-no-unknown'] = [
 	true, {
 		ignoreAtRules: ['include', 'mixin', 'use'],

--- a/templates/index.php
+++ b/templates/index.php
@@ -4,4 +4,3 @@ declare(strict_types=1);
 
 script('spreed', 'talk-main');
 style('spreed', 'icons');
-style('spreed', 'At');


### PR DESCRIPTION
Before replacing `AdvancedInput` with `NcRichcontenteditable` in https://github.com/nextcloud/spreed/pull/4333 edited styles from [`vue-at`](https://github.com/fritx/vue-at) were added globally. Not this library is not used, and there is no need for these global styles. But it was still included in templates.

### 🚧 TODO

- [x] Remove import of `At.css` from templates and template loaders
- [x] Also remove redundant config for not existing `At.scss`

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
