### PR TITLE
Add a step "production-setup" to produce a release package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,9 @@ version+=master
 
 all: dev-setup build-production
 
-dev-setup: clean-dev composer-install-dev npm-init
+dev-setup: clean-dev npm-init build-dev
+
+production-setup: clean-dev npm-init build-production
 
 release: appstore create-tag
 


### PR DESCRIPTION
Currently the release manual says:
```
make dev-setup build-js-production
```

But that does not install composer deps with no-dev mode and does not build the class loader. So I'm adding an explicit step that does all the steps the release action is doing

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
