### PR TITLE
 feat(recording): Add a shorter subject for the call recording notification

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -345,8 +345,9 @@ class Notifier implements INotifier {
 			);
 
 		$notification
-			->setRichSubject(
-				$l->t('Recording for the call in {call} was uploaded to {file}.'),
+			->setRichSubject($l->t('Call recording now available'))
+			->setRichMessage(
+				$l->t('The recording for the call in {call} was uploaded to {file}.'),
 				[
 					'call' => [
 						'type' => 'call',

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -22,7 +22,7 @@
 import Vue from 'vue'
 
 import { getCurrentUser } from '@nextcloud/auth'
-import { showInfo, showSuccess } from '@nextcloud/dialogs'
+import { showInfo, showSuccess, TOAST_PERMANENT_TIMEOUT } from '@nextcloud/dialogs'
 
 import {
 	CALL,
@@ -704,7 +704,9 @@ const actions = {
 			|| previousCallRecordingStatus === CALL.RECORDING.VIDEO_STARTING) {
 			showInfo(t('spreed', 'Call recording stopped while starting.'))
 		} else {
-			showInfo(t('spreed', 'Call recording stopped. You will be notified once the recording is available.'))
+			showInfo(t('spreed', 'Call recording stopped. You will be notified once the recording is available.'), {
+				timeout: TOAST_PERMANENT_TIMEOUT,
+			})
 		}
 		context.commit('setCallRecording', { token, callRecording: CALL.RECORDING.OFF })
 	},

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2754,8 +2754,11 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			}
 			if (isset($expectedNotification['subject'])) {
 				$data['subject'] = (string) $notification['subject'];
-				if (str_contains($expectedNotification['subject'], '{{TOKEN}}')) {
-					$data['subject'] = str_replace($notification['object_id'], '{{TOKEN}}', $data['subject']);
+			}
+			if (isset($expectedNotification['message'])) {
+				$data['message'] = (string) $notification['message'];
+				if (str_contains($expectedNotification['message'], '{{TOKEN}}')) {
+					$data['message'] = str_replace($notification['object_id'], '{{TOKEN}}', $data['message']);
 				}
 			}
 			if (isset($expectedNotification['object_type'])) {

--- a/tests/integration/features/callapi/recording.feature
+++ b/tests/integration/features/callapi/recording.feature
@@ -402,8 +402,8 @@ Feature: callapi/recording
     And user "participant1" joins room "room1" with 200 (v4)
     When user "participant1" store recording file "/img/join_call.ogg" in room "room1" with 200 (v1)
     Then user "participant1" has the following notifications
-      | app    | object_type | object_id | subject                                                            |
-      | spreed | recording   | room1     | Recording for the call in room1 was uploaded to /Talk/Recording/{{TOKEN}}/join_call.ogg. |
+      | app    | object_type | object_id | subject                      | message                                                                                      |
+      | spreed | recording   | room1     | Call recording now available | The recording for the call in room1 was uploaded to /Talk/Recording/{{TOKEN}}/join_call.ogg. |
     And user "participant1" is participant of the following unordered rooms (v4)
       | type | name  | callRecording |
       | 2    | room1 | 0             |


### PR DESCRIPTION
Fix #8835

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Bildschirmfoto vom 2023-02-24 07-12-36](https://user-images.githubusercontent.com/213943/221105678-19afd67a-e4a9-4460-b128-a6c9c1e32ce6.png) | ![Bildschirmfoto vom 2023-02-24 07-12-19](https://user-images.githubusercontent.com/213943/221105676-73d8798e-f9c6-4838-aa9a-1c33adfd9315.png)

### 🚧 TODO

- [x] Add a shorter subject to the notification which survives the pushing
- [x] Make the toast about the post-processing show infinite

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
