### PR TITLE
Restrict available APIs for breakout rooms

### DIFF
--- a/docs/conversation.md
+++ b/docs/conversation.md
@@ -296,6 +296,7 @@ Get all (for moderators and in case of "free selection") or the assigned breakou
     - Status code:
         + `200 OK`
         + `400 Bad Request` When the password does not match the password policy. Show `ocs.data.message` to the user in this case
+        + `400 Bad Request` When the conversation is a breakout room
         + `403 Forbidden` When the current user is not a moderator or owner
         + `403 Forbidden` When the conversation is not a public conversation
         + `404 Not Found` When the conversation could not be found for the participant
@@ -321,6 +322,7 @@ Get all (for moderators and in case of "free selection") or the assigned breakou
         + `200 OK`
         + `400 Bad Request` When the conversation type does not support setting publishing permissions, e.g. one-to-one conversations
         + `400 Bad Request` When the mode is invalid
+        + `400 Bad Request` When the conversation is a breakout room
         + `403 Forbidden` When the current user is not a moderator, owner or guest moderator
         + `404 Not Found` When the conversation could not be found for the participant
 
@@ -399,6 +401,7 @@ Get all (for moderators and in case of "free selection") or the assigned breakou
     - Status code:
         + `200 OK`
         + `400 Bad Request` Invalid value
+        + `400 Bad Request` When the conversation is a breakout room
         + `403 Forbidden` When the current user is not a moderator, owner or guest moderator
         + `404 Not Found` When the conversation could not be found for the participant
 
@@ -417,6 +420,7 @@ Get all (for moderators and in case of "free selection") or the assigned breakou
     - Status code:
         + `200 OK`
         + `400 Bad Request` When the conversation type does not support making it listable (only group and public conversation)
+        + `400 Bad Request` When the conversation is a breakout room
         + `403 Forbidden` When the current user is not a moderator/owner or the conversation is not a public conversation
         + `404 Not Found` When the conversation could not be found for the participant
 

--- a/docs/webinar.md
+++ b/docs/webinar.md
@@ -50,6 +50,7 @@ Group and public conversations can be used to host webinars. Those online meetin
     - Status code:
         + `200 OK`
         + `400 Bad Request` When the state was invalid or the same
+        + `400 Bad Request` When the conversation is a breakout room
         + `401 Unauthorized` When the user can not enabled SIP
         + `403 Forbidden` When the current user is not a moderator/owner
         + `404 Not Found` When the conversation could not be found for the participant

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1196,7 +1196,9 @@ class RoomController extends AEnvironmentAwareController {
 		}
 
 		try {
-			$this->roomService->setPassword($this->room, $password);
+			if (!$this->roomService->setPassword($this->room, $password)) {
+				return new DataResponse([], Http::STATUS_BAD_REQUEST);
+			}
 		} catch (HintException $e) {
 			return new DataResponse([
 				'message' => $e->getHint(),
@@ -1613,7 +1615,13 @@ class RoomController extends AEnvironmentAwareController {
 		if ($seconds < 0) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
-		$this->roomService->setMessageExpiration($this->room, $seconds);
+
+		try {
+			$this->roomService->setMessageExpiration($this->room, $seconds);
+		} catch (\InvalidArgumentException $exception) {
+			return new DataResponse(['error' => $exception], Http::STATUS_BAD_REQUEST);
+		}
+
 		return new DataResponse();
 	}
 }

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -186,6 +186,11 @@ class RoomService {
 			return false;
 		}
 
+		if ($room->getObjectType() === BreakoutRoom::PARENT_OBJECT_TYPE) {
+			// Do not allow manual changing the permissions in breakout rooms
+			return false;
+		}
+
 		if ($level === 'default') {
 			$oldPermissions = $room->getDefaultPermissions();
 		} elseif ($level === 'call') {
@@ -241,6 +246,10 @@ class RoomService {
 		$oldSipEnabled = $room->getSIPEnabled();
 
 		if ($newSipEnabled === $oldSipEnabled) {
+			return false;
+		}
+
+		if ($room->getObjectType() === BreakoutRoom::PARENT_OBJECT_TYPE) {
 			return false;
 		}
 
@@ -608,6 +617,10 @@ class RoomService {
 			return false;
 		}
 
+		if ($room->getObjectType() === BreakoutRoom::PARENT_OBJECT_TYPE) {
+			return false;
+		}
+
 		if ($password !== '') {
 			$event = new ValidatePasswordPolicyEvent($password);
 			$this->dispatcher->dispatchTyped($event);
@@ -648,7 +661,14 @@ class RoomService {
 		];
 	}
 
+	/**
+	 * @throws \InvalidArgumentException When the room is a breakout room
+	 */
 	public function setMessageExpiration(Room $room, int $seconds): void {
+		if ($room->getObjectType() === BreakoutRoom::PARENT_OBJECT_TYPE) {
+			throw new \InvalidArgumentException('room');
+		}
+
 		$event = new ModifyRoomEvent($room, 'messageExpiration', $seconds);
 		$this->dispatcher->dispatch(Room::EVENT_BEFORE_SET_MESSAGE_EXPIRATION, $event);
 

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -332,6 +332,13 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$expected = $formData->getHash();
 		if ($shouldOrder) {
 			$sorter = static function (array $roomA, array $roomB): int {
+				if (str_starts_with($roomA['name'], '/')) {
+					return 1;
+				}
+				if (str_starts_with($roomB['name'], '/')) {
+					return -1;
+				}
+
 				$idA = $roomA['id'] ?? self::$identifierToId[$roomA['name']];
 				$idB = $roomB['id'] ?? self::$identifierToId[$roomB['name']];
 

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -820,7 +820,7 @@ Feature: conversation/breakout-rooms
       | 2    | class room |
       | 2    | Room 2     |
 
-  Scenario: Can not change lobby status, allow or disallow guests in breakout rooms directly
+  Scenario: Can not change various settings in breakout rooms directly
     Given user "participant1" creates room "class room" (v4)
       | roomType | 2 |
       | roomName | class room |
@@ -839,3 +839,7 @@ Feature: conversation/breakout-rooms
     And user "participant1" allows listing room "Room 1" for "all" with 400 (v4)
     # Can not allow guests
     And user "participant1" makes room "Room 1" public with 400 (v4)
+    # Can not set password - Currently 403 because it's not a public room, once they are supported as breakout rooms we need to check for 400 here.
+    And user "participant1" sets password "Test123!" for room "Room 1" with 403 (v4)
+    # Can not set message expiration
+    And user "participant1" set the message expiration to 3600 of room "Room 1" with 400 (v4)

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -96,15 +96,15 @@ Feature: conversation/breakout-rooms
       | actorType  | actorId           | participantType |
       | users      | participant1      | 1               |
       | users      | /^participant\d$/ | 3               |
-    Then user "participant2" is participant of the following rooms (v4)
+    Then user "participant2" is participant of the following unordered rooms (v4)
       | type | name        |
       | 2    | class room  |
       | 2    | /^Room \d$/ |
-    Then user "participant3" is participant of the following rooms (v4)
+    Then user "participant3" is participant of the following unordered rooms (v4)
       | type | name        |
       | 2    | class room  |
       | 2    | /^Room \d$/ |
-    Then user "participant4" is participant of the following rooms (v4)
+    Then user "participant4" is participant of the following unordered rooms (v4)
       | type | name        |
       | 2    | class room  |
       | 2    | /^Room \d$/ |


### PR DESCRIPTION
Fix #8794 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
