### PR TITLE
Hide bottom stripe in recordings

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -486,7 +486,7 @@ export default {
 		},
 
 		stripeOpen() {
-			return this.$store.getters.isStripeOpen
+			return this.$store.getters.isStripeOpen && !this.isRecording
 		},
 	},
 


### PR DESCRIPTION
This is specially important if the height of the recording is limited, due to the minimum fixed height of the stripe.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Recording-UI-Stripe-Before](https://user-images.githubusercontent.com/26858233/221210582-018b4c68-c4e7-4fe4-8aa4-821e7ec423bd.png) | ![Recording-UI-Stripe-After](https://user-images.githubusercontent.com/26858233/221210695-9322d57d-7547-488b-abdd-4f89d9cd424b.png)
