### PR TITLE
Configure tests for MessageButtonsBar appearance

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -214,6 +214,8 @@ import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcEmojiPicker from '@nextcloud/vue/dist/Components/NcEmojiPicker.js'
 import NcPopover from '@nextcloud/vue/dist/Components/NcPopover.js'
 
+import Quote from '../../../Quote.vue'
+import CallButton from '../../../TopBar/CallButton.vue'
 import MessageButtonsBar from './MessageButtonsBar/MessageButtonsBar.vue'
 import Contact from './MessagePart/Contact.vue'
 import DeckCard from './MessagePart/DeckCard.vue'
@@ -222,8 +224,6 @@ import FilePreview from './MessagePart/FilePreview.vue'
 import Location from './MessagePart/Location.vue'
 import Mention from './MessagePart/Mention.vue'
 import Poll from './MessagePart/Poll.vue'
-import Quote from '../../../Quote.vue'
-import CallButton from '../../../TopBar/CallButton.vue'
 
 import { ATTENDEE, CONVERSATION, PARTICIPANT } from '../../../../constants.js'
 import isInCall from '../../../../mixins/isInCall.js'
@@ -648,7 +648,7 @@ export default {
 
 		messageButtonsBarHeight() {
 			return parseInt(getComputedStyle(this.$refs.message)
-				.getPropertyValue('--default-clickable-area').match(/\d+/)[0]) // 44
+				.getPropertyValue('--default-clickable-area'), 10) || 0
 		},
 	},
 

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -79,11 +79,9 @@ global.OCP = {
 }
 
 // Work around missing "URL.createObjectURL" (which is used in the code but not
-// relevant for the tests) in jsdom:
-// https://github.com/jsdom/jsdom/issues/1721
-window.URL.createObjectURL = function() {
-	console.warn('URL.createObjectURL is not implemented in jsdom')
-}
+// relevant for the tests) in jsdom: https://github.com/jsdom/jsdom/issues/1721
+window.URL.createObjectURL = jest.fn()
+window.URL.revokeObjectURL = jest.fn()
 
 // TODO: use nextcloud-l10n lib once https://github.com/nextcloud/nextcloud-l10n/issues/271 is solved
 global.t = jest.fn().mockImplementation((app, text) => text)


### PR DESCRIPTION
### 🖼️ Screenshots

Clear warnings and fix some tests to correlate with MessageButtonsBar behavior (regression from #8716)

 🏚️ Before [(jest log)](https://github.com/nextcloud/spreed/actions/runs/4261312050/jobs/7415479683#step:7:1) | 🏡 After [(jest log)](https://github.com/nextcloud/spreed/actions/runs/4264954583/jobs/7423699597#step:7:1) 
--- | --- 
|![image](https://user-images.githubusercontent.com/93392545/221251736-fbaa86a7-ac56-4967-8780-e254894d6903.png) | - 
![image](https://user-images.githubusercontent.com/93392545/221251914-07d58300-5348-4bdb-8db3-6154f551b443.png) | - 


### 🚧 TODO

- [ ] Code review

### 🏁 Checklist

- [X] ⛑️ Tests (unit and/or integration) are included
- [X] 📘 API documentation in `docs/` has been updated or is not required
- [X] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [X] 🔖 Capability is added or not needed 
