### PR TITLE
Send notification when get upload problem

### DIFF
--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -314,8 +314,16 @@ class Notifier {
 		// @todo this should be in the Notifications\Hooks
 		$notification->setApp('spreed');
 
-		$notification->setObject('chat', $chat->getToken());
-		$this->notificationManager->markProcessed($notification);
+		$objectTypes = [
+			'chat',
+			'recording',
+			'recording_information',
+			'remote_talk_share',
+		];
+		foreach ($objectTypes as $type) {
+			$notification->setObject($type, $chat->getToken());
+			$this->notificationManager->markProcessed($notification);
+		}
 
 		if (!$chatOnly) {
 			$notification->setObject('room', $chat->getToken());

--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -316,20 +316,19 @@ class Notifier {
 
 		$objectTypes = [
 			'chat',
-			'recording',
-			'recording_information',
-			'remote_talk_share',
 		];
+		if (!$chatOnly) {
+			$objectTypes = [
+				'call',
+				'chat',
+				'room',
+				'recording',
+				'recording_information',
+				'remote_talk_share',
+			];
+		}
 		foreach ($objectTypes as $type) {
 			$notification->setObject($type, $chat->getToken());
-			$this->notificationManager->markProcessed($notification);
-		}
-
-		if (!$chatOnly) {
-			$notification->setObject('room', $chat->getToken());
-			$this->notificationManager->markProcessed($notification);
-
-			$notification->setObject('call', $chat->getToken());
 			$this->notificationManager->markProcessed($notification);
 		}
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -258,6 +258,9 @@ class Notifier implements INotifier {
 		if ($subject === 'record_file_stored') {
 			return $this->parseStoredRecording($notification, $room, $participant, $l);
 		}
+		if ($subject === 'record_file_store_fail') {
+			return $this->parseStoredRecordingFail($notification, $room, $participant, $l);
+		}
 		if ($subject === 'invitation') {
 			return $this->parseInvitation($notification, $room, $l);
 		}
@@ -295,6 +298,27 @@ class Notifier implements INotifier {
 			$temp = mb_substr($temp, 0, -5);
 		}
 		return $temp;
+	}
+
+	protected function parseStoredRecordingFail(
+		INotification $notification,
+		Room $room,
+		Participant $participant,
+		IL10N $l
+	): INotification {
+		$notification
+			->setRichSubject(
+				$l->t('Fail to store recording of call {call}, reach out to the admin.'),
+				[
+					'call' => [
+						'type' => 'call',
+						'id' => $room->getId(),
+						'name' => $room->getDisplayName($participant->getAttendee()->getActorId()),
+						'call-type' => $this->getRoomType($room),
+					],
+				]
+			);
+		return $notification;
 	}
 
 	protected function parseStoredRecording(

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -308,7 +308,10 @@ class Notifier implements INotifier {
 	): INotification {
 		$notification
 			->setRichSubject(
-				$l->t('Failed to store recording of call {call}, reach out to the admin.'),
+				$l->t('Failed to upload call recording'),
+			)
+			->setRichMessage(
+				$l->t('The recording server failed to upload recording of call {call}. Please reach out to the adminstrators.'),
 				[
 					'call' => [
 						'type' => 'call',

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -308,7 +308,7 @@ class Notifier implements INotifier {
 	): INotification {
 		$notification
 			->setRichSubject(
-				$l->t('Fail to store recording of call {call}, reach out to the admin.'),
+				$l->t('Failed to store recording of call {call}, reach out to the admin.'),
 				[
 					'call' => [
 						'type' => 'call',

--- a/lib/Service/RecordingService.php
+++ b/lib/Service/RecordingService.php
@@ -148,7 +148,7 @@ class RecordingService {
 			$notification
 				->setApp('spreed')
 				->setDateTime($this->timeFactory->getDateTime())
-				->setObject('recording', $room->getToken())
+				->setObject('recording_information', $room->getToken())
 				->setUser($participant->getAttendee()->getActorId())
 				->setSubject('record_file_store_fail');
 			$this->notificationManager->notify($notification);

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -3247,18 +3247,35 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			'TALK_RECORDING_RANDOM' => $validRandom,
 			'TALK_RECORDING_CHECKSUM' => $validChecksum,
 		];
-		$options = [
-			'multipart' => [
-				[
-					'name' => 'file',
-					'contents' => $file !== 'invalid' ? fopen(__DIR__ . '/../../../..' . $file, 'r') : '',
-				],
-				[
-					'name' => 'owner',
-					'contents' => $user,
-				],
-			],
-		];
+		$options = ['multipart' => [['name' => 'owner', 'contents' => $user]]];
+		if ($file === 'invalid') {
+			// Create invalid content
+			$options['multipart'][] = [
+				'name' => 'file',
+				'contents' => '',
+			];
+		} elseif ($file === 'big') {
+			// More details about MAX_FILE_SIZE follow the link:
+			// https://www.php.net/manual/en/features.file-upload.post-method.php
+			$options['multipart'][] = [
+				'name' => 'MAX_FILE_SIZE',
+				'contents' => 1, // Limit the max file size to 1
+			];
+			// Create file with big content
+			$contents = tmpfile();
+			fwrite($contents, 'fake content'); // Bigger than 1
+			$options['multipart'][] = [
+				'name' => 'file',
+				'contents' => $contents,
+				'filename' => 'audio.ogg', // to get the mimetype by extension and do the upload
+			];
+		} else {
+			// Upload a file
+			$options['multipart'][] = [
+				'name' => 'file',
+				'contents' => fopen(__DIR__ . '/../../../..' . $file, 'r'),
+			];
+		}
 		$this->sendRequest(
 			'POST',
 			'/apps/spreed/api/' . $apiVersion . '/recording/' . self::$identifierToToken[$identifier] . '/store',

--- a/tests/integration/features/callapi/recording.feature
+++ b/tests/integration/features/callapi/recording.feature
@@ -393,8 +393,8 @@ Feature: callapi/recording
     And user "participant1" joins room "room1" with 200 (v4)
     When user "participant1" store recording file "big" in room "room1" with 400 (v1)
     Then user "participant1" has the following notifications
-      | app    | object_type | object_id | subject                                                          |
-      | spreed | recording   | room1     | Failed to store recording of call room1, reach out to the admin. |
+      | app    | object_type           | object_id | subject                                                          |
+      | spreed | recording_information | room1     | Failed to store recording of call room1, reach out to the admin. |
     And user "participant1" is participant of the following unordered rooms (v4)
       | type | name  | callRecording |
       | 2    | room1 | 0             |

--- a/tests/integration/features/callapi/recording.feature
+++ b/tests/integration/features/callapi/recording.feature
@@ -373,7 +373,7 @@ Feature: callapi/recording
       | type | name  | callRecording |
       | 2    | room1 | 0             |
 
-  Scenario: Store recording
+  Scenario: Store recording with success
     Given user "participant1" creates room "room1" (v4)
       | roomType | 2 |
       | roomName | room1 |
@@ -382,6 +382,19 @@ Feature: callapi/recording
     Then user "participant1" has the following notifications
       | app    | object_type | object_id | subject                      | message                                                                                      |
       | spreed | recording   | room1     | Call recording now available | The recording for the call in room1 was uploaded to /Talk/Recording/{{TOKEN}}/join_call.ogg. |
+    And user "participant1" is participant of the following unordered rooms (v4)
+      | type | name  | callRecording |
+      | 2    | room1 | 0             |
+
+  Scenario: Store recording with failure
+    Given user "participant1" creates room "room1" (v4)
+      | roomType | 2 |
+      | roomName | room1 |
+    And user "participant1" joins room "room1" with 200 (v4)
+    When user "participant1" store recording file "big" in room "room1" with 400 (v1)
+    Then user "participant1" has the following notifications
+      | app    | object_type | object_id | subject                                                        |
+      | spreed | recording   | room1     | Fail to store recording of call room1, reach out to the admin. |
     And user "participant1" is participant of the following unordered rooms (v4)
       | type | name  | callRecording |
       | 2    | room1 | 0             |

--- a/tests/integration/features/callapi/recording.feature
+++ b/tests/integration/features/callapi/recording.feature
@@ -393,8 +393,8 @@ Feature: callapi/recording
     And user "participant1" joins room "room1" with 200 (v4)
     When user "participant1" store recording file "big" in room "room1" with 400 (v1)
     Then user "participant1" has the following notifications
-      | app    | object_type           | object_id | subject                                                          |
-      | spreed | recording_information | room1     | Failed to store recording of call room1, reach out to the admin. |
+      | app    | object_type           | object_id | subject                         |
+      | spreed | recording_information | room1     | Failed to upload call recording |
     And user "participant1" is participant of the following unordered rooms (v4)
       | type | name  | callRecording |
       | 2    | room1 | 0             |

--- a/tests/integration/features/callapi/recording.feature
+++ b/tests/integration/features/callapi/recording.feature
@@ -393,8 +393,8 @@ Feature: callapi/recording
     And user "participant1" joins room "room1" with 200 (v4)
     When user "participant1" store recording file "big" in room "room1" with 400 (v1)
     Then user "participant1" has the following notifications
-      | app    | object_type | object_id | subject                                                        |
-      | spreed | recording   | room1     | Fail to store recording of call room1, reach out to the admin. |
+      | app    | object_type | object_id | subject                                                          |
+      | spreed | recording   | room1     | Failed to store recording of call room1, reach out to the admin. |
     And user "participant1" is participant of the following unordered rooms (v4)
       | type | name  | callRecording |
       | 2    | room1 | 0             |

--- a/tests/php/Chat/NotifierTest.php
+++ b/tests/php/Chat/NotifierTest.php
@@ -282,16 +282,12 @@ class NotifierTest extends TestCase {
 			->with('spreed')
 			->willReturnSelf();
 
-		$notification->expects($this->exactly(3))
+		$notification->expects($this->atLeastOnce())
 			->method('setObject')
-			->withConsecutive(
-				['chat', 'Token123'],
-				['room', 'Token123'],
-				['call', 'Token123']
-			)
+			->with($this->anything(), 'Token123')
 			->willReturnSelf();
 
-		$this->notificationManager->expects($this->exactly(3))
+		$this->notificationManager->expects($this->atLeastOnce())
 			->method('markProcessed')
 			->with($notification);
 
@@ -315,12 +311,12 @@ class NotifierTest extends TestCase {
 			->with('spreed')
 			->willReturnSelf();
 
-		$notification->expects($this->exactly(1))
+		$notification->expects($this->atLeastOnce())
 			->method('setObject')
-			->with('chat', 'Token123')
+			->with($this->anything(), 'Token123')
 			->willReturnSelf();
 
-		$this->notificationManager->expects($this->exactly(1))
+		$this->notificationManager->expects($this->atLeastOnce())
 			->method('markProcessed')
 			->with($notification);
 

--- a/tests/php/Service/RecordingServiceTest.php
+++ b/tests/php/Service/RecordingServiceTest.php
@@ -38,7 +38,10 @@ namespace OCA\Talk\Tests\php\Service;
 use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Config;
 use OCA\Talk\Manager;
+use OCA\Talk\Model\Attendee;
+use OCA\Talk\Participant;
 use OCA\Talk\Recording\BackendNotifier;
+use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\RecordingService;
 use OCA\Talk\Service\RoomService;
@@ -144,7 +147,14 @@ class RecordingServiceTest extends TestCase {
 			$this->expectExceptionMessage($exceptionMessage);
 		}
 
-		$actual = $this->recordingService->getContentFromFileArray($file);
+		$room = $this->createMock(Room::class);
+		$attendee = Attendee::fromRow([
+			'actor_type' => Attendee::ACTOR_USERS,
+			'actor_id' => 'participant1',
+		]);
+		$participant = new Participant($room, $attendee, null);
+
+		$actual = $this->recordingService->getContentFromFileArray($file, $room, $participant);
 		$this->assertEquals($expected, $actual);
 		$this->assertFileDoesNotExist($file['tmp_name']);
 	}
@@ -153,8 +163,8 @@ class RecordingServiceTest extends TestCase {
 		$fileWithContent = tempnam(sys_get_temp_dir(), 'txt');
 		file_put_contents($fileWithContent, 'bla');
 		return [
-			[['error' => 0, 'tmp_name' => ''], '', 'invalid_file'],
-			[['error' => 0, 'tmp_name' => 'a'], '', 'invalid_file'],
+			[['error' => 1, 'tmp_name' => ''], '', 'invalid_file'],
+			[['error' => 1, 'tmp_name' => 'a'], '', 'invalid_file'],
 			# Empty file
 			[['error' => 0, 'tmp_name' => tempnam(sys_get_temp_dir(), 'txt')], '', 'empty_file'],
 			# file with content


### PR DESCRIPTION
> PS: I couldn't reproduce the reported problem but I did changes to give a best error report and send the notification.

### Changes

* Notify as `error` when is an upload error
* Fix the error message to make more specific as the occurrence

### 🖼️ Screenshots

![Screenshot_20230224_165212](https://user-images.githubusercontent.com/1079143/221278701-7bfa05be-14d1-43e2-8e70-12081aefa25c.png)

### 🚧 TODO

- [ ] Close #8824

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
