### PR TITLE
Fix colors in GitHub Actions Jest tests output

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -42,4 +42,4 @@ jobs:
         run: npm ci
 
       - name: Run jest
-        run: npm run test:coverage
+        run: npm run test:coverage -- --colors


### PR DESCRIPTION
In GitHub Actions Jest output doesn't have colors. It can be fixed with [--colors](https://jestjs.io/docs/cli#--colors)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://user-images.githubusercontent.com/25978914/221288246-efbb9f16-75f7-4d50-a3ff-6ead07a9ecac.png) | ![image](https://user-images.githubusercontent.com/25978914/221290234-d4fef5c4-5dcd-43a9-934e-5258bbcab2a3.png)
![image](https://user-images.githubusercontent.com/25978914/221290774-ebeffbb4-9c9e-42b3-884a-955b44b387f7.png) | ![image](https://user-images.githubusercontent.com/25978914/221290363-969f9a63-d227-4be4-a4c7-31a23969fb3f.png)



### 🚧 TODO

- [x] Fix colors

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
