### PR TITLE
Fix message type of files shared from mobile clients

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -418,6 +418,8 @@ class SystemMessage {
 						$chatMessage->setMessageType('record-audio');
 					} elseif ($metaData['messageType'] === 'record-video') {
 						$chatMessage->setMessageType('record-video');
+					} else {
+						$chatMessage->setMessageType(ChatManager::VERB_MESSAGE);
 					}
 				} else {
 					$chatMessage->setMessageType(ChatManager::VERB_MESSAGE);

--- a/tests/integration/features/chat/file-share.feature
+++ b/tests/integration/features/chat/file-share.feature
@@ -12,6 +12,16 @@ Feature: chat/file-share
       | room        | actorType | actorId      | actorDisplayName         | message  | messageParameters |
       | public room | users     | participant1 | participant1-displayname | {file}   | "IGNORE"          |
 
+  Scenario: Share a file with meta data to a chat (like the mobile clients do)
+    Given user "participant1" creates room "public room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    When user "participant1" shares "welcome.txt" with room "public room"
+      | talkMetaData | {"mimetype":"text/plain","messageType":""} |
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message  | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | {file}   | "IGNORE"          |
+
   Scenario: Can not share a file without chat permission
     Given user "participant1" creates room "public room" (v4)
       | roomType | 3 |


### PR DESCRIPTION
Test fails before the patch:
> ![grafik](https://user-images.githubusercontent.com/213943/221491236-1991d42d-e256-4626-a68c-869f96b6e363.png)


Fix #8858 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
