### PR TITLE
Focus chat input after quoting

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -497,10 +497,10 @@ export default {
 	},
 
 	mounted() {
+		EventBus.$on('focus-chat-input', this.focusInput)
 		EventBus.$on('upload-start', this.handleUploadStart)
 		EventBus.$on('retry-message', this.handleRetryMessage)
 		this.text = this.$store.getters.currentMessageInput(this.token) || ''
-		// this.startRecording()
 
 		if (!this.$store.getters.areFileTemplatesInitialised) {
 			this.$store.dispatch('getFileTemplates')
@@ -508,6 +508,7 @@ export default {
 	},
 
 	beforeDestroy() {
+		EventBus.$off('focus-chat-input', this.focusInput)
 		EventBus.$off('upload-start', this.handleUploadStart)
 		EventBus.$off('retry-message', this.handleRetryMessage)
 	},


### PR DESCRIPTION
Fix #8848 

Was there on the old advanced input:
https://github.com/nextcloud/spreed/blob/stable25/src/components/NewMessageForm/AdvancedInput/AdvancedInput.vue#L252

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://user-images.githubusercontent.com/213943/221524675-581474dd-a4d7-4034-bc28-a4c4084a92e4.png) | ![grafik](https://user-images.githubusercontent.com/213943/221524597-f6cc4612-be0b-4074-88e9-be857ea9244d.png)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
