### PR TITLE
Allow to abort emoji and user autocompletion

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -123,7 +123,7 @@
 						:placeholder="placeholderText"
 						:aria-label="placeholderText"
 						@shortkey="focusInput"
-						@keydown.esc.prevent="blurInput"
+						@keydown.esc="blurInput"
 						@paste="handlePastedFiles"
 						@submit="handleSubmit({ silent: false })" />
 				</div>
@@ -883,8 +883,19 @@ export default {
 			})
 		},
 
-		blurInput() {
-			document.activeElement.blur()
+		/**
+		 * Escape was used inside the chat input
+		 *
+		 * Unfocus it when there is no message, otherwise this is used to abort
+		 * autocompletion of emojis and users.
+		 *
+		 * @param {Event} event Key down event
+		 */
+		blurInput(event) {
+			if (this.text.trim() === '') {
+				document.activeElement.blur()
+				event.stopPropagation()
+			}
 		},
 	},
 }


### PR DESCRIPTION
Fix #8849 


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
