### PR TITLE
Set focus to native input in NcInputField

### DIFF
--- a/src/components/LeftSidebar/NewGroupConversation/SetConversationName/SetConversationName.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/SetConversationName/SetConversationName.vue
@@ -53,7 +53,7 @@ export default {
 		visibilityChanged(isVisible) {
 			if (isVisible) {
 				// Focus the input field of the current component.
-				this.$refs.conversationName.focus()
+				this.$refs.conversationName?.$refs.inputField?.$refs.input?.focus()
 			}
 		},
 		// Forward the keydown event to the parent


### PR DESCRIPTION
Fix #8842 

Previously we tried to call `focus()` method on NcTextField root DOM element, which is `div`. Fixed now

### 🚧 TODO

- [ ] Code review

### 🏁 Checklist

- [X] ⛑️ Tests (unit and/or integration) are included
- [X] 📘 API documentation in `docs/` has been updated or is not required
- [X] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [X] 🔖 Capability is added or not needed 