### PR TITLE
fix(UI): Only show breakout rooms option when it's usable

### DIFF
--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -369,10 +369,12 @@ export default {
 		},
 
 		canConfigureBreakoutRooms() {
-			const breakoutRoomsEnabled = getCapabilities()?.spreed?.config?.call?.['breakout-rooms'] || false
-			return this.canFullModerate
-				&& breakoutRoomsEnabled
-				&& this.conversation.type === CONVERSATION.TYPE.GROUP
+		  if (!this.conversation.type === CONVERSATION.TYPE.GROUP || !this.canFullModerate) {
+		    return false
+		  }
+		  
+			const breakoutRoomsEnabled = getCapabilities()?.spreed?.config?.call?.['breakout-rooms']
+			return !!breakoutRoomsEnabled
 		},
 
 		isStartingRecording() {

--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -144,7 +144,8 @@
 		</template>
 
 		<!-- Breakout rooms -->
-		<NcActionButton :close-after-click="true"
+		<NcActionButton v-if="canConfigureBreakoutRooms"
+			:close-after-click="true"
 			@click="$emit('open-breakout-rooms-editor')">
 			<template #icon>
 				<DotsCircle :size="20" />
@@ -365,6 +366,13 @@ export default {
 		canModerateRecording() {
 			const recordingEnabled = getCapabilities()?.spreed?.config?.call?.recording || false
 			return this.canFullModerate && recordingEnabled
+		},
+
+		canConfigureBreakoutRooms() {
+			const breakoutRoomsEnabled = getCapabilities()?.spreed?.config?.call?.['breakout-rooms'] || false
+			return this.canFullModerate
+				&& breakoutRoomsEnabled
+				&& this.conversation.type === CONVERSATION.TYPE.GROUP
 		},
 
 		isStartingRecording() {


### PR DESCRIPTION
Fix #8865 

### 🖼️ Screenshots

Type | 🏚️ Before | 🏡 After
---|---|---
Public | ![Bildschirmfoto vom 2023-02-27 15-57-28](https://user-images.githubusercontent.com/213943/221597966-1b44f06c-f009-4d62-952f-3f8f179f309f.png)| ![Bildschirmfoto vom 2023-02-27 15-55-55](https://user-images.githubusercontent.com/213943/221597605-e4877b12-931f-44f4-9fb7-0e0a34d436ee.png)
1-1 | ![Bildschirmfoto vom 2023-02-27 15-57-24](https://user-images.githubusercontent.com/213943/221597962-d850c021-3f30-434f-86c4-b537197ed5b2.png) | ![Bildschirmfoto vom 2023-02-27 15-55-59](https://user-images.githubusercontent.com/213943/221597609-3556db68-c02f-468c-8396-20b812cc1afb.png)
Group | ![Bildschirmfoto vom 2023-02-27 15-57-18](https://user-images.githubusercontent.com/213943/221597958-3eda834e-8666-43b4-b80b-34ad6a3574a0.png)| ![Bildschirmfoto vom 2023-02-27 15-56-05](https://user-images.githubusercontent.com/213943/221597614-6dd64cbd-15ac-4f95-8cfd-eff3bfe26112.png)

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
