### PR TITLE
fix(reactions): Fix reacting to people that left

### DIFF
--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -283,7 +283,12 @@ class Notifier {
 			return;
 		}
 
-		$participant = $this->participantService->getParticipant($chat, $comment->getActorId(), false);
+		try {
+			$participant = $this->participantService->getParticipant($chat, $comment->getActorId(), false);
+		} catch (ParticipantNotFoundException $e) {
+			return;
+		}
+
 		$notificationLevel = $participant->getAttendee()->getNotificationLevel();
 		if ($notificationLevel === Participant::NOTIFY_DEFAULT) {
 			if ($chat->getType() === Room::TYPE_ONE_TO_ONE) {

--- a/tests/integration/features/chat-2/reaction.feature
+++ b/tests/integration/features/chat-2/reaction.feature
@@ -84,6 +84,23 @@ Feature: chat-2/reaction
       | room | users     | participant1 | participant1-displayname | user_added |
       | room | users     | participant1 | participant1-displayname | conversation_created |
 
+  Scenario: React to message does not fail when the author left the conversation
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    And user "participant2" sends message "Message 1" to room "room" with 201
+    And user "participant2" removes themselves from room "room" with 200 (v4)
+    And user "participant1" react with "👍" on message "Message 1" to room "room" with 201
+      | actorType | actorId      | actorDisplayName         | reaction |
+      | users     | participant1 | participant1-displayname | 👍       |
+    Then user "participant1" sees the following system messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | systemMessage |
+      | room | users     | participant1 | participant1-displayname | reaction |
+      | room | users     | participant2 | participant2-displayname | user_removed |
+      | room | users     | participant1 | participant1-displayname | user_added |
+      | room | users     | participant1 | participant1-displayname | conversation_created |
+
   Scenario: Delete reaction to message with success
     Given user "participant1" creates room "room" (v4)
       | roomType | 3 |


### PR DESCRIPTION
Fix #8881 

Integration test before
> ![image](https://user-images.githubusercontent.com/213943/221824985-8dbfe7f9-d728-453a-a3fc-9a4efc9ead7c.png)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
