### PR TITLE
Improve `Unread messages` counter reactivity

### DIFF
--- a/src/components/LobbyScreen.vue
+++ b/src/components/LobbyScreen.vue
@@ -49,6 +49,7 @@
 
 <script>
 import moment from '@nextcloud/moment'
+
 import NcRichText from '@nextcloud/vue/dist/Components/NcRichText.js'
 
 import Lobby from './missingMaterialDesignIcons/Lobby.vue'

--- a/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
@@ -46,6 +46,7 @@ describe('Message.vue', () => {
 	let conversationProps
 	let injected
 	let getActorTypeMock
+	const getVisualLastReadMessageIdMock = jest.fn()
 
 	beforeEach(() => {
 		localVue = createLocalVue()
@@ -80,6 +81,8 @@ describe('Message.vue', () => {
 			= jest.fn().mockReturnValue((token) => conversationProps)
 		testStoreConfig.modules.actorStore.getters.getActorId
 			= jest.fn().mockReturnValue(() => 'user-id-1')
+		testStoreConfig.modules.messagesStore.getters.getVisualLastReadMessageId
+			= jest.fn().mockReturnValue(getVisualLastReadMessageIdMock)
 		getActorTypeMock = jest.fn().mockReturnValue(() => ATTENDEE.ACTOR_TYPE.USERS)
 		testStoreConfig.modules.actorStore.getters.getActorType = getActorTypeMock
 
@@ -476,7 +479,7 @@ describe('Message.vue', () => {
 		})
 
 		test('displays unread message marker that marks the message seen when visible', () => {
-			messageProps.lastReadMessageId = 123
+			getVisualLastReadMessageIdMock.mockReturnValue(123)
 			messageProps.nextMessageId = 333
 			const observeVisibility = jest.fn()
 

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -182,7 +182,6 @@ the main body of the message as well as a quote.
 				:is-forwarder-open.sync="isForwarderOpen"
 				:message-api-data="messageApiData"
 				:message-object="messageObject"
-				:is-last-read="isLastReadMessage"
 				:can-react="canReact"
 				v-bind="$props"
 				:previous-message-id="previousMessageId"
@@ -390,11 +389,6 @@ export default {
 			default: 0,
 		},
 
-		lastReadMessageId: {
-			type: [String, Number],
-			default: 0,
-		},
-
 		reactions: {
 			type: [Array, Object],
 			default: () => { return {} },
@@ -426,15 +420,12 @@ export default {
 
 	computed: {
 		isLastReadMessage() {
-			if (!this.nextMessageId) {
+			if (!this.nextMessageId || this.id === this.conversation?.lastMessage?.id) {
 				// never display indicator on the very last message
 				return false
 			}
-			// note: not reading lastReadMessage from the conversation as we want to define it externally
-			// to have closer control on marker's visibility behavior
-			return this.id === this.lastReadMessageId
-				&& (!this.conversation.lastMessage
-				|| this.id !== this.conversation.lastMessage.id)
+
+			return this.id === this.$store.getters.getVisualLastReadMessageId(this.token)
 		},
 
 		messageObject() {

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -22,8 +22,7 @@
 <template>
 	<!-- Message Actions -->
 	<div v-click-outside="handleClickOutside"
-		class="message-buttons-bar"
-		:class="{ 'message-buttons-bar--last-read' : isLastRead }">
+		class="message-buttons-bar">
 		<template v-if="!isReactionsMenuOpen">
 			<NcButton v-if="canReact"
 				type="tertiary"
@@ -353,16 +352,6 @@ export default {
 			type: String,
 			required: true,
 		},
-
-		/**
-		 * If the MessageButtonsBar belongs to the last read message, we need
-		 * to raise it to compensate for the shift in position brought by the
-		 * last read marker that's added to the message component.
-		 */
-		isLastRead: {
-			type: Boolean,
-			required: true,
-		},
 	},
 
 	data() {
@@ -593,10 +582,6 @@ export default {
 
 	& h6 {
 		margin-left: auto;
-	}
-
-	&--last-read {
-		bottom: 36px;
 	}
 }
 

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.spec.js
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.spec.js
@@ -38,7 +38,6 @@ describe('MessagesGroup.vue', () => {
 				token: TOKEN,
 				previousMessageId: 90,
 				nextMessageId: 200,
-				lastReadMessageId: 110,
 				messages: [{
 					id: 100,
 					token: TOKEN,
@@ -97,7 +96,6 @@ describe('MessagesGroup.vue', () => {
 		expect(message.attributes('previousmessageid')).toBe('90')
 		expect(message.attributes('nextmessageid')).toBe('110')
 		expect(message.attributes('isfirstmessage')).toBe('true')
-		expect(message.attributes('lastreadmessageid')).toBe('110')
 		expect(message.attributes('showauthor')).toBe('true')
 		expect(message.attributes('istemporary')).not.toBeDefined()
 
@@ -109,7 +107,6 @@ describe('MessagesGroup.vue', () => {
 		expect(message.attributes('previousmessageid')).toBe('100')
 		expect(message.attributes('nextmessageid')).toBe('120')
 		expect(message.attributes('isfirstmessage')).not.toBeDefined()
-		expect(message.attributes('lastreadmessageid')).toBe('110')
 		expect(message.attributes('showauthor')).toBe('true')
 		expect(message.attributes('istemporary')).not.toBeDefined()
 
@@ -121,7 +118,6 @@ describe('MessagesGroup.vue', () => {
 		expect(message.attributes('previousmessageid')).toBe('110')
 		expect(message.attributes('nextmessageid')).toBe('200')
 		expect(message.attributes('isfirstmessage')).not.toBeDefined()
-		expect(message.attributes('lastreadmessageid')).toBe('110')
 		expect(message.attributes('showauthor')).toBe('true')
 		expect(message.attributes('istemporary')).toBe('true')
 	})
@@ -135,7 +131,6 @@ describe('MessagesGroup.vue', () => {
 				token: TOKEN,
 				previousMessageId: 90,
 				nextMessageId: 200,
-				lastReadMessageId: 110,
 				messages: [{
 					id: 100,
 					token: TOKEN,
@@ -181,7 +176,6 @@ describe('MessagesGroup.vue', () => {
 		expect(message.attributes('previousmessageid')).toBe('90')
 		expect(message.attributes('nextmessageid')).toBe('110')
 		expect(message.attributes('isfirstmessage')).toBe('true')
-		expect(message.attributes('lastreadmessageid')).toBe('110')
 		expect(message.attributes('showauthor')).not.toBeDefined()
 
 		message = messagesEl.at(1)
@@ -192,7 +186,6 @@ describe('MessagesGroup.vue', () => {
 		expect(message.attributes('previousmessageid')).toBe('100')
 		expect(message.attributes('nextmessageid')).toBe('200')
 		expect(message.attributes('isfirstmessage')).not.toBeDefined()
-		expect(message.attributes('lastreadmessageid')).toBe('110')
 		expect(message.attributes('showauthor')).not.toBeDefined()
 	})
 
@@ -206,7 +199,6 @@ describe('MessagesGroup.vue', () => {
 				token: TOKEN,
 				previousMessageId: 90,
 				nextMessageId: 200,
-				lastReadMessageId: 110,
 				messages: [{
 					id: 100,
 					token: TOKEN,
@@ -258,7 +250,7 @@ describe('MessagesGroup.vue', () => {
 		expect(getGuestNameMock).toHaveBeenCalledWith(TOKEN, 'actor-1')
 	})
 
-	test('renders guest display name', () => {
+	test('renders deleted guest display name', () => {
 		const wrapper = shallowMount(MessagesGroup, {
 			localVue,
 			store,
@@ -267,7 +259,6 @@ describe('MessagesGroup.vue', () => {
 				token: TOKEN,
 				previousMessageId: 90,
 				nextMessageId: 200,
-				lastReadMessageId: 110,
 				messages: [{
 					id: 100,
 					token: TOKEN,

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -41,7 +41,6 @@
 					:is-first-message="index === 0"
 					:next-message-id="(messages[index + 1] && messages[index + 1].id) || nextMessageId"
 					:previous-message-id="(index > 0 && messages[index - 1].id) || previousMessageId"
-					:last-read-message-id="lastReadMessageId"
 					:actor-type="actorType"
 					:actor-id="actorId"
 					:actor-display-name="actorDisplayName"
@@ -69,14 +68,6 @@ export default {
 
 	props: {
 		/**
-		 * The message id.
-		 */
-		// FIXME: looks unused
-		id: {
-			type: [String, Number],
-			required: true,
-		},
-		/**
 		 * The conversation token.
 		 */
 		token: {
@@ -97,12 +88,6 @@ export default {
 		},
 
 		nextMessageId: {
-			type: [String, Number],
-			default: 0,
-		},
-
-		// FIXME: read from messagesStore as this is the same value for all
-		lastReadMessageId: {
 			type: [String, Number],
 			default: 0,
 		},

--- a/src/components/MessagesList/MessagesList.spec.js
+++ b/src/components/MessagesList/MessagesList.spec.js
@@ -43,7 +43,6 @@ describe('MessagesList.vue', () => {
 
 	describe('message grouping', () => {
 		test('groups consecutive messages by author', () => {
-			getVisualLastReadMessageIdMock.mockReturnValue(110)
 			const messagesGroup1 = [{
 				id: 100,
 				token: TOKEN,
@@ -130,7 +129,6 @@ describe('MessagesList.vue', () => {
 			expect(group.props('messages')).toStrictEqual(messagesGroup1)
 			expect(group.props('previousMessageId')).toBe(0)
 			expect(group.props('nextMessageId')).toBe(200)
-			expect(group.props('lastReadMessageId')).toBe(110)
 			// using attributes to access v-bind props
 			expect(group.attributes('actorid')).toBe('alice')
 			expect(group.attributes('actortype')).toBe(ATTENDEE.ACTOR_TYPE.USERS)
@@ -139,7 +137,6 @@ describe('MessagesList.vue', () => {
 			expect(group.props('messages')).toStrictEqual(messagesGroup2)
 			expect(group.props('previousMessageId')).toBe(110)
 			expect(group.props('nextMessageId')).toBe(300)
-			expect(group.props('lastReadMessageId')).toBe(110)
 			expect(group.attributes('actorid')).toBe('bob')
 			expect(group.attributes('actortype')).toBe(ATTENDEE.ACTOR_TYPE.USERS)
 
@@ -147,12 +144,10 @@ describe('MessagesList.vue', () => {
 			expect(group.props('messages')).toStrictEqual(messagesGroup3)
 			expect(group.props('previousMessageId')).toBe(210)
 			expect(group.props('nextMessageId')).toBe(0)
-			expect(group.props('lastReadMessageId')).toBe(110)
 			expect(group.attributes('actorid')).toBe('alice')
 			expect(group.attributes('actortype')).toBe(ATTENDEE.ACTOR_TYPE.USERS)
 
 			expect(messagesListMock).toHaveBeenCalledWith(TOKEN)
-			expect(getVisualLastReadMessageIdMock).toHaveBeenCalledWith(TOKEN)
 
 			const placeholder = wrapper.findAllComponents({ name: 'LoadingPlaceholder' })
 			expect(placeholder.exists()).toBe(false)

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -41,7 +41,7 @@ get the messagesList array and loop through the list to generate the messages.
 			:key="item[0].id"
 			:style="{ height: item.height + 'px' }"
 			v-bind="item"
-			:last-read-message-id="visualLastReadMessageId"
+			:token="token"
 			:messages="item"
 			:next-message-id="(messagesGroupedByAuthor[index + 1] && messagesGroupedByAuthor[index + 1][0].id) || 0"
 			:previous-message-id="(index > 0 && messagesGroupedByAuthor[index - 1][messagesGroupedByAuthor[index - 1].length - 1].id) || 0" />

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -62,9 +62,8 @@ components.
 <script>
 import Close from 'vue-material-design-icons/Close.vue'
 
-import NcRichText from '@nextcloud/vue/dist/Components/NcRichText.js'
-
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcRichText from '@nextcloud/vue/dist/Components/NcRichText.js'
 
 import DefaultParameter from './MessagesList/MessagesGroup/Message/MessagePart/DefaultParameter.vue'
 import FilePreview from './MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue'

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -995,6 +995,8 @@ const actions = {
 		}
 
 		const conversation = context.getters.conversation(token)
+		const actorId = context.getters.getActorId()
+		const actorType = context.getters.getActorType()
 		let countNewMessages = 0
 		let hasNewMention = conversation.unreadMention
 		let lastMessage = null
@@ -1009,7 +1011,9 @@ const actions = {
 			context.dispatch('processMessage', message)
 			if (!lastMessage || message.id > lastMessage.id) {
 				if (!message.systemMessage) {
-					countNewMessages++
+					if (actorId !== message.actorId || actorType !== message.actorType) {
+						countNewMessages++
+					}
 
 					// parse mentions data to update "conversation.unreadMention",
 					// if needed

--- a/src/store/messagesStore.spec.js
+++ b/src/store/messagesStore.spec.js
@@ -561,7 +561,7 @@ describe('messagesStore', () => {
 			markConversationReadAction = jest.fn()
 			updateConversationLastReadMessageMock = jest.fn()
 			testStoreConfig.getters.conversations = conversationsMock
-			testStoreConfig.getters.getUserId = getUserIdMock
+			testStoreConfig.getters.getUserId = jest.fn().mockReturnValue(getUserIdMock)
 			testStoreConfig.actions.markConversationRead = markConversationReadAction
 			testStoreConfig.actions.updateConversationLastReadMessage = updateConversationLastReadMessageMock
 
@@ -579,7 +579,7 @@ describe('messagesStore', () => {
 		})
 
 		test('clears last read message', async () => {
-			getUserIdMock.mockReturnValue(() => 'user-1')
+			getUserIdMock.mockReturnValue('user-1')
 
 			store.dispatch('setVisualLastReadMessageId', { token: TOKEN, id: 100 })
 			await store.dispatch('clearLastReadMessage', {
@@ -600,7 +600,7 @@ describe('messagesStore', () => {
 		})
 
 		test('clears last read message and update visually', async () => {
-			getUserIdMock.mockReturnValue(() => 'user-1')
+			getUserIdMock.mockReturnValue('user-1')
 
 			store.dispatch('setVisualLastReadMessageId', { token: TOKEN, id: 100 })
 			await store.dispatch('clearLastReadMessage', {
@@ -621,7 +621,7 @@ describe('messagesStore', () => {
 		})
 
 		test('clears last read message for guests', async () => {
-			getUserIdMock.mockReturnValue(() => null)
+			getUserIdMock.mockReturnValue(null)
 
 			store.dispatch('setVisualLastReadMessageId', { token: TOKEN, id: 100 })
 			await store.dispatch('clearLastReadMessage', {
@@ -642,7 +642,7 @@ describe('messagesStore', () => {
 		})
 
 		test('updates last read message', async () => {
-			getUserIdMock.mockReturnValue(() => 'user-1')
+			getUserIdMock.mockReturnValue('user-1')
 
 			store.dispatch('setVisualLastReadMessageId', { token: TOKEN, id: 100 })
 			await store.dispatch('updateLastReadMessage', {
@@ -664,7 +664,7 @@ describe('messagesStore', () => {
 		})
 
 		test('updates last read message and update visually', async () => {
-			getUserIdMock.mockReturnValue(() => 'user-1')
+			getUserIdMock.mockReturnValue('user-1')
 
 			store.dispatch('setVisualLastReadMessageId', { token: TOKEN, id: 100 })
 			await store.dispatch('updateLastReadMessage', {
@@ -686,7 +686,7 @@ describe('messagesStore', () => {
 		})
 
 		test('updates last read message for guests', async () => {
-			getUserIdMock.mockReturnValue(() => null)
+			getUserIdMock.mockReturnValue(null)
 
 			store.dispatch('setVisualLastReadMessageId', { token: TOKEN, id: 100 })
 			await store.dispatch('updateLastReadMessage', {
@@ -879,16 +879,26 @@ describe('messagesStore', () => {
 		let forceGuestNameAction
 		let cancelFunctionMocks
 		let conversationMock
+		let getActorIdMock
+		let getActorTypeMock
+		let getUserIdMock
 
 		beforeEach(() => {
 			testStoreConfig = cloneDeep(messagesStore)
 
 			conversationMock = jest.fn()
+			getActorIdMock = jest.fn()
+			getActorTypeMock = jest.fn()
+			getUserIdMock = jest.fn()
+			testStoreConfig.getters.conversation = jest.fn().mockReturnValue(conversationMock)
+			testStoreConfig.getters.getActorId = jest.fn().mockReturnValue(getActorIdMock)
+			testStoreConfig.getters.getActorType = jest.fn().mockReturnValue(getActorTypeMock)
+			testStoreConfig.getters.getUserId = jest.fn().mockReturnValue(getUserIdMock)
+
 			updateConversationLastMessageAction = jest.fn()
 			updateLastCommonReadMessageAction = jest.fn()
 			updateUnreadMessagesMutation = jest.fn()
 			forceGuestNameAction = jest.fn()
-			testStoreConfig.getters.conversation = jest.fn().mockReturnValue(conversationMock)
 			testStoreConfig.actions.updateConversationLastMessage = updateConversationLastMessageAction
 			testStoreConfig.actions.updateLastCommonReadMessage = updateLastCommonReadMessageAction
 			testStoreConfig.actions.forceGuestName = forceGuestNameAction
@@ -1195,21 +1205,6 @@ describe('messagesStore', () => {
 			})
 
 			describe('updating unread mention flag', () => {
-				let getActorIdMock
-				let getActorTypeMock
-				let getUserIdMock
-
-				beforeEach(() => {
-					getActorIdMock = jest.fn()
-					getActorTypeMock = jest.fn()
-					getUserIdMock = jest.fn()
-					testStoreConfig.getters.getActorId = getActorIdMock
-					testStoreConfig.getters.getActorType = getActorTypeMock
-					testStoreConfig.getters.getUserId = getUserIdMock
-
-					store = new Vuex.Store(testStoreConfig)
-				})
-
 				/**
 				 * @param {object} messageParameters The rich-object-string parameters of the message
 				 * @param {boolean} expectedValue New state of the mention flag
@@ -1238,8 +1233,8 @@ describe('messagesStore', () => {
 				})
 
 				test('updates unread mention flag for guest mention', async () => {
-					getActorIdMock.mockReturnValue(() => 'me_as_guest')
-					getActorTypeMock.mockReturnValue(() => ATTENDEE.ACTOR_TYPE.GUESTS)
+					getActorIdMock.mockReturnValue('me_as_guest')
+					getActorTypeMock.mockReturnValue(ATTENDEE.ACTOR_TYPE.GUESTS)
 					await testMentionFlag({
 						'mention-0': {
 							type: 'user',
@@ -1253,8 +1248,8 @@ describe('messagesStore', () => {
 				})
 
 				test('does not update unread mention flag for a different guest mention', async () => {
-					getActorIdMock.mockReturnValue(() => 'me_as_guest')
-					getActorTypeMock.mockReturnValue(() => ATTENDEE.ACTOR_TYPE.GUESTS)
+					getActorIdMock.mockReturnValue('me_as_guest')
+					getActorTypeMock.mockReturnValue(ATTENDEE.ACTOR_TYPE.GUESTS)
 					await testMentionFlag({
 						'mention-1': {
 							type: 'guest',
@@ -1264,8 +1259,9 @@ describe('messagesStore', () => {
 				})
 
 				test('updates unread mention flag for user mention', async () => {
-					getUserIdMock.mockReturnValue(() => 'me_as_user')
-					getActorTypeMock.mockReturnValue(() => ATTENDEE.ACTOR_TYPE.USERS)
+					getUserIdMock.mockReturnValue('me_as_user')
+					getActorIdMock.mockReturnValue('me_as_user')
+					getActorTypeMock.mockReturnValue(ATTENDEE.ACTOR_TYPE.USERS)
 					await testMentionFlag({
 						'mention-0': {
 							type: 'user',
@@ -1279,8 +1275,8 @@ describe('messagesStore', () => {
 				})
 
 				test('does not update unread mention flag for another user mention', async () => {
-					getUserIdMock.mockReturnValue(() => 'me_as_user')
-					getActorTypeMock.mockReturnValue(() => ATTENDEE.ACTOR_TYPE.USERS)
+					getActorIdMock.mockReturnValue('me_as_user')
+					getActorTypeMock.mockReturnValue(ATTENDEE.ACTOR_TYPE.USERS)
 					await testMentionFlag({
 						'mention-1': {
 							type: 'user',


### PR DESCRIPTION
Fix #8862 

### 🚧 TODO

- [X] Get id of last read message directly from store and for Message only
- [X] Update last read counters when post new message
- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 