### PR TITLE
do not focus input on mobile

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -880,6 +880,9 @@ export default {
 		},
 
 		focusInput() {
+			if (this.isMobile()) {
+				return
+			}
 			this.$nextTick().then(() => {
 				this.$refs.richContenteditable.$refs.contenteditable.focus()
 			})
@@ -895,6 +898,10 @@ export default {
 			if (!this.isTributePickerActive) {
 				this.blurInput()
 			}
+		},
+
+		isMobile() {
+			return /Android|iPhone|iPad|iPod/i.test(navigator.userAgent)
 		},
 	},
 }


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/spreed/pull/8058

Regression of https://github.com/nextcloud/spreed/pull/4333

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [ ] 🔖 Capability is added or not needed 

<details>
<summary>For my own testing</summary>

```
docker run -it \
--name nextcloud-easy-test \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.24.128 \
--volume="nextcloud_easy_test_npm_cache_volume:/var/www/.npm" \
-e TALK_BRANCH=fix/noid/mobile-focus \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>