### PR TITLE
fix(dashboard): Hide breakout rooms from dashboard widgets

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -186,7 +186,9 @@ export default {
 			}
 
 			axios.get(generateOcsUrl('apps/spreed/api/v4/room')).then((response) => {
-				const rooms = response.data.ocs.data
+				const allRooms = response.data.ocs.data
+				// filter out breakout rooms
+				const rooms = allRooms.filter((conversation) => conversation.objectType !== 'room')
 				const importantRooms = rooms.filter((conversation) => {
 					return conversation.hasCall
 						|| conversation.unreadMention


### PR DESCRIPTION
Ref #8912 

This is not fixing the API, but the visual change should go in for the release today

Before | After
---|---
![Bildschirmfoto vom 2023-03-02 12-52-16](https://user-images.githubusercontent.com/213943/222421155-40c9cbbf-c0ad-4794-8bab-3bc6782a1197.png) | ![Bildschirmfoto vom 2023-03-02 12-52-04](https://user-images.githubusercontent.com/213943/222421161-4e9278f2-9f80-46e8-bded-cc2e13f3c39b.png)


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
