### PR TITLE
feat(NewMessageUploadEditor): multiple files sharing support 🖼️+🖼️

### DIFF
--- a/src/services/filesSharingServices.js
+++ b/src/services/filesSharingServices.js
@@ -24,7 +24,7 @@ import { showError } from '@nextcloud/dialogs'
 import { generateOcsUrl } from '@nextcloud/router'
 
 /**
- * Appends a file as a message to the messagelist.
+ * Appends a file as a message to the message list.
  *
  * @param {string} path The file path from the user's root directory
  * @param {string} token The conversation's token
@@ -55,6 +55,36 @@ const shareFile = async function(path, token, referenceId, metadata) {
 	}
 }
 
+/**
+ * Appends a multiple files as a message to the message list.
+ *
+ * @param {string} token The conversation's token
+ * @param {Array<string>} shareIds a list of ids we're getting in shareFile() response
+ * @param {string} caption a text message attached to the files
+ * @param {string} actorDisplayName The display name of the actor
+ * @param {string} referenceId An optional reference id to recognize the message later
+ */
+const shareMultipleFiles = async function(token, shareIds, caption, actorDisplayName, referenceId) {
+	try {
+		return axios.post(generateOcsUrl('apps/spreed/api/v1/chat/{token}/share-files', { token }),
+			{
+				shareIds,
+				caption,
+				actorDisplayName,
+				referenceId,
+			})
+	} catch (error) {
+		// FIXME: errors should be handled by called instead
+		if (error?.response?.data?.ocs?.meta?.message) {
+			console.error('Error while sharing files: ' + error.response.data.ocs.meta.message)
+			showError(error.response.data.ocs.meta.message)
+		} else {
+			console.error('Error while sharing files: Unknown error')
+			showError(t('spreed', 'Error while sharing files'))
+		}
+	}
+}
+
 const getFileTemplates = async () => {
 	return await axios.get(generateOcsUrl('apps/files/api/v1/templates'))
 }
@@ -77,6 +107,7 @@ const createNewFile = async function(filePath, templatePath, templateType) {
 
 export {
 	shareFile,
+	shareMultipleFiles,
 	getFileTemplates,
 	createNewFile,
 }

--- a/src/services/filesSharingServices.spec.js
+++ b/src/services/filesSharingServices.spec.js
@@ -1,7 +1,7 @@
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 
-import { shareFile } from './filesSharingServices.js'
+import { shareFile, shareMultipleFiles } from './filesSharingServices.js'
 
 jest.mock('@nextcloud/axios', () => ({
 	post: jest.fn(),
@@ -23,6 +23,20 @@ describe('filesSharingServices', () => {
 				shareWith: 'XXTOKENXX',
 				path: 'path/to/file',
 				referenceId: 'the-reference-id',
+			}
+		)
+	})
+
+	test('shareMultipleFiles calls the spreed API endpoint', () => {
+		shareMultipleFiles('XXTOKENXX', ['1', '2', '3'], 'text caption', 'Display name', 'long_hash_string')
+
+		expect(axios.post).toHaveBeenCalledWith(
+			generateOcsUrl('apps/spreed/api/v1/chat/XXTOKENXX/share-files'),
+			{
+				shareIds: ['1', '2', '3'],
+				caption: 'text caption',
+				actorDisplayName: 'Display name',
+				referenceId: 'long_hash_string',
 			}
 		)
 	})

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -31,6 +31,7 @@ import { EventBus } from '../services/EventBus.js'
 import {
 	getFileTemplates,
 	shareFile,
+	// shareMultipleFiles,
 } from '../services/filesSharingServices.js'
 import { setAttachmentFolder } from '../services/settingsService.js'
 import { useChatExtrasStore } from '../stores/chatExtras.js'
@@ -310,6 +311,9 @@ const actions = {
 
 		EventBus.$emit('upload-start')
 
+		// Check for quantity of files to upload
+		// const isMultipleFilesUpload = getters.getUploadsArray(uploadId).length !== 1
+
 		// Tag previously indexed files and add temporary messages to the MessagesList
 		// If caption is provided, attach to the last temporary message
 		const lastIndex = getters.getInitialisedUploads(uploadId).at(-1).at(0)
@@ -395,6 +399,9 @@ const actions = {
 			if (temporaryMessage.parent) {
 				Object.assign(rawMetadata, { replyTo: temporaryMessage.parent.id })
 			}
+			// if (isMultipleFilesUpload) {
+			// 	Object.assign(rawMetadata, { noMessage: isMultipleFilesUpload })
+			// }
 			const metadata = JSON.stringify(rawMetadata)
 
 			const { token, id, referenceId } = temporaryMessage
@@ -402,6 +409,9 @@ const actions = {
 				dispatch('markFileAsSharing', { uploadId, index })
 				await shareFile(path, token, referenceId, metadata)
 				dispatch('markFileAsShared', { uploadId, index })
+
+				// return share id of file returned from the server
+				// return response.data.ocs.data.id
 			} catch (error) {
 				if (error?.response?.status === 403) {
 					showError(t('spreed', 'You are not allowed to share files'))
@@ -445,6 +455,10 @@ const actions = {
 			// Share all files in parallel
 			await Promise.all(shares.map(share => performShare(share)))
 		}
+
+		// if (isMultipleFilesUpload) {
+		// 	await shareMultipleFiles(temporaryMessage.token, shareIds, caption, temporaryMessage.actorDisplayName, temporaryMessage.referenceId)
+		// }
 
 		EventBus.$emit('upload-finished')
 	},


### PR DESCRIPTION
### ☑️ Resolves

* Support sending and receiving a group of shared files in a single message
* Fix #…


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| B          | A        |

### 🚧 Tasks

- [ ] Mobile clients support:
  - As per backend setup, if message with file share contains a caption, it will replace the default message text (`{file}`). So we need to manually add references to the message text (see Message.vue)
  - When multiple files are loaded, they'll get indexed references - `file-1`, `file-2` (and `file-missing-3` for files deleted afterwards)
  - When sending multiple files, we still need to upload it via `apps/files_sharing/api/v1/shares` one by one, but metadata object should contain 'noMessage: true' to nont generate a separate message for each file. Instead, we're sending a new request to `apps/spreed/api/v1/chat/{token}/share-files` with caption and share ids of all the uploaded files
- [x] Autotests
- [ ] Capabilities
- [ ] Silent sending - check if possible
- [ ] User bubbles - don't render for prefilled messages
- [ ] Manual testing
- [ ] Visual check
- [ ] Code review

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required