### PR TITLE
Breakout room fixes

### DIFF
--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomItem.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomItem.vue
@@ -38,7 +38,7 @@
 			</NcButton>
 			{{ roomName }}
 			<div class="breakout-room-item__actions">
-				<NcButton @click="joinRoom">
+				<NcButton v-if="showJoinButton" @click="joinRoom">
 					{{ t('spreed', 'Join') }}
 				</NcButton>
 				<NcActions :force-menu="true">
@@ -117,6 +117,10 @@ export default {
 			type: Object,
 			required: true,
 		},
+		mainConversation: {
+			type: Object,
+			required: true,
+		},
 	},
 
 	data() {
@@ -138,6 +142,10 @@ export default {
 
 		roomToken() {
 			return this.breakoutRoom.token
+		},
+
+		showJoinButton() {
+			return this.roomToken !== this.$store.getters.getToken()
 		},
 
 		roomParticipants() {
@@ -187,10 +195,12 @@ export default {
 				})
 			} else {
 				try {
-					await this.$store.dispatch('switchToBreakoutRoomAction', {
-						token: this.$store.getters.parentRoomToken(this.roomToken),
-						target: this.roomToken,
-					})
+					if (this.mainConversation.breakoutRoomMode === CONVERSATION.BREAKOUT_ROOM_MODE.FREE) {
+						await this.$store.dispatch('switchToBreakoutRoomAction', {
+							token: this.$store.getters.parentRoomToken(this.roomToken),
+							target: this.roomToken,
+						})
+					}
 					EventBus.$emit('switch-to-conversation', {
 						token: this.roomToken,
 					})

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomItem.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomItem.vue
@@ -41,7 +41,7 @@
 				<NcButton v-if="showJoinButton" @click="joinRoom">
 					{{ t('spreed', 'Join') }}
 				</NcButton>
-				<NcActions :force-menu="true">
+				<NcActions v-if="canModerate" :force-menu="true">
 					<NcActionButton v-if="showAssistanceButton"
 						@click="dismissRequestAssistance">
 						<template #icon>

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
@@ -50,7 +50,7 @@
 				</template>
 				{{ backToMainRoomLabel }}
 			</NcButton>
-			<NcButton v-else-if="!isInBreakoutRoom && !canModerate"
+			<NcButton v-else-if="!canModerate"
 				:title="backToBreakoutRoomLabel"
 				:aria-label="backToBreakoutRoomLabel"
 				:wide="true"

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
@@ -4,7 +4,7 @@
 	<div v-if="canModerate || isInBreakoutRoom" class="breakout-rooms-actions">
 		<div class="breakout-rooms-actions__row">
 			<NcButton v-if="breakoutRoomsNotStarted && canModerate"
-				:title="startLabel"
+				:title="startLabelTitle"
 				:aria-label="startLabel"
 				type="primary"
 				:wide="true"
@@ -50,6 +50,17 @@
 				</template>
 				{{ backToMainRoomLabel }}
 			</NcButton>
+			<NcButton v-else-if="!isInBreakoutRoom && !canModerate"
+				:title="backToBreakoutRoomLabel"
+				:aria-label="backToBreakoutRoomLabel"
+				:wide="true"
+				type="secondary"
+				@click="switchToBreakoutRoom">
+				<template #icon>
+					<ArrowRight :size="20" />
+				</template>
+				{{ backToBreakoutRoomLabel }}
+			</NcButton>
 			<NcActions v-if="canModerate" class="right">
 				<NcActionButton v-if="canModerate && isInBreakoutRoom"
 					:title="sendMessageLabel"
@@ -93,6 +104,7 @@
 
 <script>
 import ArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
+import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import Check from 'vue-material-design-icons/Check.vue'
 import Cog from 'vue-material-design-icons/Cog.vue'
 import Play from 'vue-material-design-icons/Play.vue'
@@ -127,6 +139,7 @@ export default {
 		Cog,
 		Check,
 		ArrowLeft,
+		ArrowRight,
 		Send,
 	},
 
@@ -186,12 +199,23 @@ export default {
 			return t('spreed', 'Back to main room')
 		},
 
+		backToBreakoutRoomLabel() {
+			return t('spreed', 'Back to your room')
+		},
+
 		sendMessageLabel() {
 			return t('spreed', 'Message all rooms')
 		},
 
 		startLabel() {
 			return t('spreed', 'Start session')
+		},
+
+		startLabelTitle() {
+			if (this.isInCall) {
+				return this.startLabel
+			}
+			return t('spreed', 'Start a call before you start a breakout room session')
 		},
 
 		stopLabel() {
@@ -225,6 +249,12 @@ export default {
 		},
 
 		async switchToParentRoom() {
+			EventBus.$emit('switch-to-conversation', {
+				token: this.mainToken,
+			})
+		},
+
+		async switchToBreakoutRoom() {
 			EventBus.$emit('switch-to-conversation', {
 				token: this.mainToken,
 			})

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsTab.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsTab.vue
@@ -27,21 +27,30 @@
 			:breakout-rooms="breakoutRooms"
 			:breakout-rooms-configured="breakoutRoomsConfigured" />
 		<!-- Breakout rooms list -->
-		<ul v-if="breakoutRooms">
+		<ul v-if="showBreakoutRoomsList">
 			<template v-for="breakoutRoom in breakoutRooms">
 				<BreakoutRoomItem :key="breakoutRoom.token"
 					:breakout-room="breakoutRoom" />
 			</template>
 		</ul>
+		<NcEmptyContent v-else :title="t('spreed', 'Breakout rooms are not started')">
+			<template #icon>
+				<DotsCircle :size="20" />
+			</template>
+		</NcEmptyContent>
 	</div>
 </template>
 
 <script>
+import DotsCircle from 'vue-material-design-icons/DotsCircle.vue'
+
+import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
+
 import BreakoutRoomItem from './BreakoutRoomItem.vue'
 import BreakoutRoomsActions from './BreakoutRoomsActions.vue'
 
 // Constants
-import { CONVERSATION } from '../../../constants.js'
+import { CONVERSATION, PARTICIPANT } from '../../../constants.js'
 
 export default {
 	name: 'BreakoutRoomsTab',
@@ -50,6 +59,10 @@ export default {
 		// Components
 		BreakoutRoomItem,
 		BreakoutRoomsActions,
+		NcEmptyContent,
+
+		// Icons
+		DotsCircle,
 	},
 
 	props: {
@@ -76,6 +89,19 @@ export default {
 	},
 
 	computed: {
+		canFullModerate() {
+			return this.mainConversation.participantType === PARTICIPANT.TYPE.OWNER || this.mainConversation.participantType === PARTICIPANT.TYPE.MODERATOR
+		},
+
+		canModerate() {
+			return !this.isOneToOne && (this.canFullModerate || this.mainConversation.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR)
+		},
+
+		showBreakoutRoomsList() {
+			return this.breakoutRoomsConfigured
+				&& (this.canModerate || this.mainConversation.breakoutRoomStatus === CONVERSATION.BREAKOUT_ROOM_STATUS.STARTED)
+		},
+
 		breakoutRooms() {
 			return this.$store.getters.breakoutRooms(this.mainToken)
 		},
@@ -83,7 +109,6 @@ export default {
 		breakoutRoomsConfigured() {
 			return this.mainConversation.breakoutRoomMode !== CONVERSATION.BREAKOUT_ROOM_MODE.NOT_CONFIGURED
 		},
-
 	},
 
 	watch: {

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsTab.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsTab.vue
@@ -30,7 +30,8 @@
 		<ul v-if="showBreakoutRoomsList">
 			<template v-for="breakoutRoom in breakoutRooms">
 				<BreakoutRoomItem :key="breakoutRoom.token"
-					:breakout-room="breakoutRoom" />
+					:breakout-room="breakoutRoom"
+					:main-conversation="mainConversation" />
 			</template>
 		</ul>
 		<NcEmptyContent v-else :title="t('spreed', 'Breakout rooms are not started')">

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsTab.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsTab.vue
@@ -22,8 +22,8 @@
 <template>
 	<div class="breakout-rooms">
 		<!-- Actions -->
-		<BreakoutRoomsActions :token="token"
-			:conversation="conversation"
+		<BreakoutRoomsActions :main-token="mainToken"
+			:main-conversation="mainConversation"
 			:breakout-rooms="breakoutRooms"
 			:breakout-rooms-configured="breakoutRoomsConfigured" />
 		<!-- Breakout rooms list -->
@@ -53,12 +53,12 @@ export default {
 	},
 
 	props: {
-		token: {
+		mainToken: {
 			type: String,
 			required: true,
 		},
 
-		conversation: {
+		mainConversation: {
 			type: Object,
 			required: true,
 		},
@@ -77,11 +77,11 @@ export default {
 
 	computed: {
 		breakoutRooms() {
-			return this.$store.getters.breakoutRooms(this.token)
+			return this.$store.getters.breakoutRooms(this.mainToken)
 		},
 
 		breakoutRoomsConfigured() {
-			return this.conversation.breakoutRoomMode !== CONVERSATION.BREAKOUT_ROOM_MODE.NOT_CONFIGURED
+			return this.mainConversation.breakoutRoomMode !== CONVERSATION.BREAKOUT_ROOM_MODE.NOT_CONFIGURED
 		},
 
 	},
@@ -118,7 +118,7 @@ export default {
 		getBreakoutRooms() {
 			if (this.breakoutRoomsConfigured) {
 				this.$store.dispatch('getBreakoutRoomsAction', {
-					token: this.token,
+					token: this.mainToken,
 				})
 			}
 		},
@@ -126,7 +126,7 @@ export default {
 		getParticipants() {
 			if (this.breakoutRoomsConfigured) {
 				this.$store.dispatch('getBreakoutRoomsParticipantsAction', {
-					token: this.token,
+					token: this.mainToken,
 				})
 			}
 		},

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -67,8 +67,8 @@
 			<template slot="icon">
 				<DotsCircle :size="20" />
 			</template>
-			<BreakoutRoomsTab :token="token"
-				:conversation="conversation"
+			<BreakoutRoomsTab :main-token="mainConversationToken"
+				:main-conversation="mainConversation"
 				:is-active="activeTab === 'breakout-rooms'" />
 		</NcAppSidebarTab>
 		<NcAppSidebarTab v-if="!getUserId || showSIPSettings"
@@ -188,6 +188,17 @@ export default {
 
 		conversation() {
 			return this.$store.getters.conversation(this.token) || this.$store.getters.dummyConversation
+		},
+
+		mainConversationToken() {
+			if (this.conversation.objectType === 'room') {
+				return this.conversation.objectId
+			}
+			return this.token
+		},
+
+		mainConversation() {
+			return this.$store.getters.conversation(this.mainConversationToken) || this.$store.getters.dummyConversation
 		},
 
 		getUserId() {


### PR DESCRIPTION
### 🖼️ Screenshots

#### Parent tab as a moderator not knowing what to do
🏚️ Before | 🏡 After
---|---
![grafik](https://user-images.githubusercontent.com/213943/223092094-4f85b3be-163f-4789-9290-ed2186747a9a.png) | ![Bildschirmfoto vom 2023-03-06 11-56-12](https://user-images.githubusercontent.com/213943/223091800-1884302e-842a-4385-b7e7-7fb009cb8b7f.png)

#### Parent tab as a participant when BR are not started
🏚️ Before | 🏡 After
---|---
![grafik](https://user-images.githubusercontent.com/213943/223092398-1998a38f-1a34-4548-9390-f82c9f3ec86a.png) | ![Bildschirmfoto vom 2023-03-06 11-53-33](https://user-images.githubusercontent.com/213943/223091795-fccf0a75-b0cd-49be-a191-fe520247a1e7.png)

#### Parent tab as a participant when BR are started

Aka. late comer, page reloaded, browser crashed, etc.

🏚️ Before | 🏡 After
---|---
![grafik](https://user-images.githubusercontent.com/213943/223092695-5792b1e8-ca9f-47d2-9a3f-a59454968643.png) | ![grafik](https://user-images.githubusercontent.com/213943/223093251-e3005238-614a-4024-9499-0f8150402664.png)


#### BR tab as a participant when BR are started
🏚️ Before | 🏡 After
---|---
![grafik](https://user-images.githubusercontent.com/213943/223092552-ccc0dfe3-3947-4bbe-941b-4cf7476919d9.png) | ![grafik](https://user-images.githubusercontent.com/213943/223093285-9f6f19f2-5480-4e23-86fd-29fc17a99f34.png)

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
