### PR TITLE
fix(permissions): Fix the permissions editor claiming custom permissions are used, when all boxes are ticked

### DIFF
--- a/src/components/ConversationSettings/ConversationPermissionsSettings.vue
+++ b/src/components/ConversationSettings/ConversationPermissionsSettings.vue
@@ -221,6 +221,7 @@ export default {
 		getPermissionRadioValue(value) {
 			switch (value) {
 			case PERMISSIONS.MAX_DEFAULT:
+			case PERMISSIONS.MAX_CUSTOM:
 				return 'all'
 			case PERMISSIONS.CALL_JOIN:
 				return 'restricted'

--- a/src/components/ConversationSettings/ConversationPermissionsSettings.vue
+++ b/src/components/ConversationSettings/ConversationPermissionsSettings.vue
@@ -224,6 +224,7 @@ export default {
 			case PERMISSIONS.MAX_CUSTOM:
 				return 'all'
 			case PERMISSIONS.CALL_JOIN:
+			case PERMISSIONS.CALL_JOIN | PERMISSIONS.CUSTOM:
 				return 'restricted'
 
 			default:

--- a/src/components/PermissionsEditor/PermissionsEditor.vue
+++ b/src/components/PermissionsEditor/PermissionsEditor.vue
@@ -178,6 +178,7 @@ export default {
 		 */
 		formPermissions() {
 			return (this.callStart ? PERMISSIONS.CALL_START : 0)
+			| PERMISSIONS.CALL_JOIN // Currently not handled, just adding it, so that manually selecting all checkboxes goes to the "All" permissions state
 			| (this.lobbyIgnore ? PERMISSIONS.LOBBY_IGNORE : 0)
 			| (this.chatMessagesAndReactions ? PERMISSIONS.CHAT : 0)
 			| (this.publishAudio ? PERMISSIONS.PUBLISH_AUDIO : 0)

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/ParticipantPermissionsEditor/ParticipantPermissionsEditor.spec.js
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/ParticipantPermissionsEditor/ParticipantPermissionsEditor.spec.js
@@ -131,6 +131,7 @@ describe('ParticipantPermissionsEditor.vue', () => {
 				expect.anything(),
 				expect.objectContaining({
 					permissions: PARTICIPANT.PERMISSIONS.CALL_START
+						| PARTICIPANT.PERMISSIONS.CALL_JOIN
 						| PARTICIPANT.PERMISSIONS.LOBBY_IGNORE
 						| PARTICIPANT.PERMISSIONS.PUBLISH_AUDIO
 						| PARTICIPANT.PERMISSIONS.PUBLISH_VIDEO
@@ -153,6 +154,7 @@ describe('ParticipantPermissionsEditor.vue', () => {
 				expect.anything(),
 				expect.objectContaining({
 					permissions: PARTICIPANT.PERMISSIONS.CALL_START
+						| PARTICIPANT.PERMISSIONS.CALL_JOIN
 						| PARTICIPANT.PERMISSIONS.PUBLISH_VIDEO
 						| PARTICIPANT.PERMISSIONS.CUSTOM,
 				})


### PR DESCRIPTION
Fix #8924 

### Steps (before)

1. Create a conversation
2. Open settings permissions section: 🗒️ (expected) **Advanced** 👀 (actual) **Advanced**
3. Go to advanced 
4. Grant "Skip lobby"
5. "Update permissions"
6. Settings: 🗒️ (expected) **All permissions** 👀 (actual) **Advanced**


### Steps (after)

1. Create a conversation
2. Open settings permissions section: 🗒️ (expected) **Advanced** 👀 (actual) **Advanced**
3. Go to advanced 
4. Grant "Skip lobby"
5. "Update permissions"
6. Settings: 🗒️ (expected) **All permissions** 👀 (actual) **All permissions**



### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
