### PR TITLE
Parse special symbols after NcRichContentEditable, like `<` and `>`

### DIFF
--- a/src/components/Description/Description.vue
+++ b/src/components/Description/Description.vue
@@ -23,7 +23,7 @@
 	<div ref="description"
 		:key="forceReRenderKey"
 		class="description">
-		<NcRichContentEditable ref="contenteditable"
+		<NcRichContenteditable ref="contenteditable"
 			:value.sync="descriptionText"
 			:auto-complete="()=>{}"
 			:maxlength="maxLength"
@@ -76,7 +76,7 @@ import Close from 'vue-material-design-icons/Close.vue'
 import Pencil from 'vue-material-design-icons/Pencil.vue'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import NcRichContentEditable from '@nextcloud/vue/dist/Components/NcRichContenteditable.js'
+import NcRichContenteditable from '@nextcloud/vue/dist/Components/NcRichContenteditable.js'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 export default {
@@ -85,7 +85,7 @@ export default {
 		Pencil,
 		Check,
 		Close,
-		NcRichContentEditable,
+		NcRichContenteditable,
 		NcButton,
 	},
 
@@ -213,11 +213,15 @@ export default {
 				return
 			}
 			// Remove leading/trailing whitespaces.
-			this.descriptionText = this.descriptionText.replace(/\r\n|\n|\r/gm, '\n').trim()
+			// FIXME: remove after issue is resolved: https://github.com/nextcloud/nextcloud-vue/issues/3264
+			const temp = document.createElement('textarea')
+			temp.innerHTML = this.descriptionText
+			this.descriptionText = temp.value.replace(/\r\n|\n|\r/gm, '\n').trim()
+
 			// Submit description
 			this.$emit('submit-description', this.descriptionText)
 			/**
-			 * Change the richcontenteditable key in order to trigger a re-render
+			 * Change the NcRichContenteditable key in order to trigger a re-render
 			 * without this all the trimmed new lines and whitespaces would
 			 * still be present in the contenteditable element.
 			 */
@@ -293,7 +297,7 @@ export default {
 	justify-content: center;
 }
 
-// Restyle richContentEditable component from our library.
+// Restyle NcRichContenteditable component from our library.
 ::v-deep .rich-contenteditable__input {
 	align-self: flex-start;
 	min-height: var(--default-line-height);

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -533,6 +533,10 @@ export default {
 			}
 
 			if (this.text !== '') {
+				// FIXME: remove after issue is resolved: https://github.com/nextcloud/nextcloud-vue/issues/3264
+				const temp = document.createElement('textarea')
+				temp.innerHTML = this.text
+				this.text = temp.value
 				const temporaryMessage = await this.$store.dispatch('createTemporaryMessage', { text: this.text, token: this.token })
 				// FIXME: move "addTemporaryMessage" into "postNewMessage" as it's a pre-requisite anyway ?
 				if (!this.broadcast) {


### PR DESCRIPTION
Fix #7309
Fix #8869 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
Conversation description | ---
![image](https://user-images.githubusercontent.com/93392545/223139586-03189013-8298-4ebd-a7d3-e0b2ea98d920.png) | ![image](https://user-images.githubusercontent.com/93392545/223138167-019d3dd4-e858-4280-af91-fce34d03acef.png)
Chat messages | ---
![image](https://user-images.githubusercontent.com/93392545/223139985-7398cdba-06ea-43d7-95f3-ffc9ccdea22f.png) | ![image](https://user-images.githubusercontent.com/93392545/223139861-0a49a6c5-c4df-4183-aec5-fce07d558fea.png)

### 🚧 TODO

- [X] Code review

### 🏁 Checklist

- [X] ⛑️ Tests (unit and/or integration) are included
- [X] 📘 API documentation in `docs/` has been updated or is not required
- [X] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [X] 🔖 Capability is added or not needed 
