### PR TITLE
Small consistency dialogTitle fix

### DIFF
--- a/src/components/BreakoutRoomsEditor/SendMessageDialog.vue
+++ b/src/components/BreakoutRoomsEditor/SendMessageDialog.vue
@@ -82,7 +82,7 @@ export default {
 	computed: {
 		dialogTitle() {
 			return this.broadcast
-				? t('spreed', 'Send message to all breakout rooms')
+				? t('spreed', 'Send a message to all breakout rooms')
 				: t('spreed', 'Send a message to "{roomName}"', { roomName: this.displayName })
 		},
 	},


### PR DESCRIPTION
Also helps translation disambiguation between 'a' and 'the'.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
