### PR TITLE
fix(frontend): Fix empty action separator for group participants

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -180,7 +180,7 @@
 			</template>
 
 			<!-- Remove -->
-			<NcActionSeparator v-if="canBeModerated" />
+			<NcActionSeparator v-if="canBeModerated && showPermissionsOptions" />
 			<NcActionButton v-if="canBeModerated"
 				icon="icon-delete"
 				:close-after-click="true"


### PR DESCRIPTION
Fix #8934 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://user-images.githubusercontent.com/213943/223164104-29ef2702-61a6-4f69-bf7a-2a1c50e89726.png) | ![Bildschirmfoto vom 2023-03-06 16-59-26](https://user-images.githubusercontent.com/213943/223164071-e61ff2a3-a32d-4d2c-86fe-0d9685737286.png)


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
