### PR TITLE
fix(a11y): Add aria-label to button with only numeric label

### DIFF
--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -61,7 +61,8 @@
 
 		<!-- Participants counter -->
 		<NcButton v-if="isInCall && !isOneToOneConversation && isModeratorOrUser"
-			v-tooltip="t('spreed', 'Participants in call')"
+			:title="participantsInCallAriaLabel"
+			:aria-label="participantsInCallAriaLabel"
 			class="top-bar__button dark-hover"
 			type="tertiary"
 			@click="openSidebar('participants')">
@@ -288,6 +289,10 @@ export default {
 
 		participantsInCall() {
 			return this.$store.getters.participantsInCall(this.token) || ''
+		},
+
+		participantsInCallAriaLabel() {
+			return n('spreed', '%n participant in call', '%n participants in call', this.$store.getters.participantsInCall(this.token))
 		},
 	},
 

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -374,11 +374,6 @@ export default {
 		openConversationSettings() {
 			emit('show-conversation-settings', { token: this.token })
 		},
-
-		// TODO: implement real method
-		stopRecording() {
-			console.debug('stop recording')
-		},
 	},
 }
 </script>


### PR DESCRIPTION
Before there is a plain text button with only a numeric value on it without any further clue for screenreader users.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Bildschirmfoto vom 2023-03-07 06-45-55](https://user-images.githubusercontent.com/213943/223331949-82be6b36-794e-4138-9bf9-0faa1d158577.png) | ![grafik](https://user-images.githubusercontent.com/213943/223331845-c360319c-f8ac-48dd-8816-ea7c59c43ccf.png)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
