### PR TITLE
Add container context for `NewMessageForm`

### DIFF
--- a/src/components/BreakoutRoomsEditor/SendMessageDialog.vue
+++ b/src/components/BreakoutRoomsEditor/SendMessageDialog.vue
@@ -20,14 +20,16 @@
 -->
 
 <template>
-	<NcModal v-on="$listeners">
+	<NcModal ref="modal" v-on="$listeners">
 		<div class="send-message-dialog">
 			<h2 class="send-message-dialog__title">
 				{{ dialogTitle }}
 			</h2>
-			<NewMessageForm role="region"
+			<NewMessageForm v-if="modalContainerId"
+				role="region"
 				:token="token"
 				:breakout-room="true"
+				:container-id="modalContainerId"
 				:aria-label="t('spreed', 'Post message')"
 				:broadcast="broadcast"
 				@sent="handleMessageSent"
@@ -79,12 +81,23 @@ export default {
 		},
 	},
 
+	data() {
+		return {
+			modalContainerId: null,
+		}
+	},
+
 	computed: {
 		dialogTitle() {
 			return this.broadcast
 				? t('spreed', 'Send a message to all breakout rooms')
 				: t('spreed', 'Send a message to "{roomName}"', { roomName: this.displayName })
 		},
+	},
+
+	mounted() {
+		// Postpone render of NewMessageForm until modal container is mounted
+		this.modalContainerId = `#modal-description-${this.$refs.modal.randId}`
 	},
 
 	methods: {
@@ -111,4 +124,10 @@ export default {
 		margin-bottom: 0;
 	}
 }
+
+:deep(.modal-container) {
+	// Fix visibility for popovers, like EmojiPicker
+	overflow: visible !important;
+}
+
 </style>

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -119,6 +119,7 @@
 						:auto-complete="autoComplete"
 						:disabled="disabled"
 						:user-data="userData"
+						:menu-container="containerElement"
 						:placeholder="placeholderText"
 						:aria-label="placeholderText"
 						@shortkey="focusInput"
@@ -169,7 +170,7 @@
 		<!-- Text file creation dialog -->
 		<NcModal v-if="showTextFileDialog !== false"
 			size="normal"
-			:container="$store.getters.getMainContainerSelector()"
+			:container="container"
 			class="templates-picker"
 			@close="dismissTextFileCreation">
 			<div class="new-text-file">
@@ -307,6 +308,15 @@ export default {
 		},
 
 		/**
+		 * When this component is used to send message to a breakout room we
+		 * pass an id of modal containing component to render properly.
+		 */
+		containerId: {
+			type: String,
+			default: null,
+		},
+
+		/**
 		 * Broadcast messages to all breakout rooms of a given conversation.
 		 */
 		broadcast: {
@@ -399,11 +409,13 @@ export default {
 		},
 
 		container() {
-			return this.$store.getters.getMainContainerSelector()
+			return this.containerId ?? this.$store.getters.getMainContainerSelector()
 		},
 
 		containerElement() {
-			return document.querySelector(this.container)
+			// TODO can't find DOM element by #content-vue. undefined is passed
+			//  for NcRichContenteditable to use 'document.body' by default
+			return document.querySelector(this.container) ?? undefined
 		},
 
 		isOneToOne() {


### PR DESCRIPTION
Fix #8915 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://user-images.githubusercontent.com/93392545/223481251-134e90f8-3531-4c7a-b2ac-756cb48a2302.png) | ![image](https://user-images.githubusercontent.com/93392545/223481469-6abf036e-3dcb-4bf4-a7fc-a0b906394362.png) ![image](https://user-images.githubusercontent.com/93392545/223481681-d87beeb2-4a24-418e-be50-1163d3684e9a.png)

### 🚧 TODO

- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
