### PR TITLE
Improve MessageButtonsBar positionioning and message info visibility

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
@@ -626,12 +626,6 @@ describe('Message.vue', () => {
 			await wrapper.find('.message').trigger('mouseover')
 			expect(wrapper.findComponent(MessageButtonsBar).exists()).toBe(true)
 
-			// position of MessageButtonsBar is calculated correctly, to be in visible area
-			expect(wrapper.vm.getButtonsBarPositionStyle()).toBeUndefined()
-
-			injected.scrollerBoundingClientRect.bottom = -100
-			expect(wrapper.vm.getButtonsBarPositionStyle()).toBeTruthy()
-
 			// actions are present and rendered when the MessageButtonsBar is rendered
 			const actions = wrapper.findAllComponents({ name: 'NcActions' })
 			expect(actions.length).toBe(2)

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -173,21 +173,27 @@ the main body of the message as well as a quote.
 		</div>
 
 		<!-- Message actions -->
-		<MessageButtonsBar v-if="showMessageButtonsBar"
-			ref="messageButtonsBar"
-			:is-action-menu-open.sync="isActionMenuOpen"
-			:is-emoji-picker-open.sync="isEmojiPickerOpen"
-			:is-reactions-menu-open.sync="isReactionsMenuOpen"
-			:is-forwarder-open.sync="isForwarderOpen"
-			:message-api-data="messageApiData"
-			:message-object="messageObject"
-			:is-last-read="isLastReadMessage"
-			:can-react="canReact"
-			v-bind="$props"
-			:previous-message-id="previousMessageId"
-			:participant="participant"
-			:style="messageButtonsBarStyle"
-			@delete="handleDelete" />
+		<div class="message-body__scroll">
+			<MessageButtonsBar v-if="showMessageButtonsBar"
+				ref="messageButtonsBar"
+				:is-action-menu-open.sync="isActionMenuOpen"
+				:is-emoji-picker-open.sync="isEmojiPickerOpen"
+				:is-reactions-menu-open.sync="isReactionsMenuOpen"
+				:is-forwarder-open.sync="isForwarderOpen"
+				:message-api-data="messageApiData"
+				:message-object="messageObject"
+				:is-last-read="isLastReadMessage"
+				:can-react="canReact"
+				v-bind="$props"
+				:previous-message-id="previousMessageId"
+				:participant="participant"
+				:show-common-read-icon="showCommonReadIcon"
+				:common-read-icon-tooltip="commonReadIconTooltip"
+				:show-sent-icon="showSentIcon"
+				:sent-icon-tooltip="sentIconTooltip"
+				@delete="handleDelete" />
+		</div>
+
 		<div v-if="isLastReadMessage"
 			v-observe-visibility="lastReadMessageVisibilityChanged">
 			<div class="new-message-marker">
@@ -208,11 +214,11 @@ import Reload from 'vue-material-design-icons/Reload.vue'
 
 import { showError, showSuccess, showWarning, TOAST_DEFAULT_TIMEOUT } from '@nextcloud/dialogs'
 import moment from '@nextcloud/moment'
-import NcRichText from '@nextcloud/vue/dist/Components/NcRichText.js'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcEmojiPicker from '@nextcloud/vue/dist/Components/NcEmojiPicker.js'
 import NcPopover from '@nextcloud/vue/dist/Components/NcPopover.js'
+import NcRichText from '@nextcloud/vue/dist/Components/NcRichText.js'
 
 import Quote from '../../../Quote.vue'
 import CallButton from '../../../TopBar/CallButton.vue'
@@ -237,19 +243,20 @@ export default {
 	name: 'Message',
 
 	components: {
-		NcButton,
 		CallButton,
-		Quote,
+		MessageButtonsBar,
+		NcButton,
+		NcEmojiPicker,
+		NcPopover,
 		NcRichText,
+		Poll,
+		Quote,
+		// Icons
 		AlertCircle,
 		Check,
 		CheckAll,
-		Reload,
-		MessageButtonsBar,
-		NcEmojiPicker,
 		EmoticonOutline,
-		NcPopover,
-		Poll,
+		Reload,
 	},
 
 	mixins: [
@@ -414,7 +421,6 @@ export default {
 			isReactionsMenuOpen: false,
 			isForwarderOpen: false,
 			detailedReactionsLoading: false,
-			messageButtonsBarStyle: undefined,
 		}
 	},
 
@@ -913,6 +919,16 @@ export default {
 			padding: 0 8px 0 8px;
 		}
 	}
+
+	&__scroll {
+		position: absolute;
+		top: 0;
+		right: 0;
+		width: fit-content;
+		height: 100%;
+		padding-top: 8px;
+	}
+
 	&__reactions {
 		display: flex;
 		flex-wrap: wrap;

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -82,7 +82,7 @@ the main body of the message as well as a quote.
 						:autolink="true"
 						:reference-limit="1" />
 				</div>
-				<div v-if="!isDeletedMessage" ref="messageInfo" class="message-body__main__right">
+				<div v-if="!isDeletedMessage" class="message-body__main__right">
 					<span :title="messageDate"
 						class="date"
 						:style="{'visibility': hasDate ? 'visible' : 'hidden'}"
@@ -645,11 +645,6 @@ export default {
 		detailedReactionsLoaded() {
 			return this.$store.getters.reactionsLoaded(this.token, this.id)
 		},
-
-		messageButtonsBarHeight() {
-			return parseInt(getComputedStyle(this.$refs.message)
-				.getPropertyValue('--default-clickable-area'), 10) || 0
-		},
 	},
 
 	watch: {
@@ -702,7 +697,6 @@ export default {
 		handleMouseover() {
 			if (!this.isHovered) {
 				this.isHovered = true
-				this.messageButtonsBarStyle = this.getButtonsBarPositionStyle()
 			}
 		},
 
@@ -835,18 +829,6 @@ export default {
 			}
 
 			return displayName
-		},
-
-		getButtonsBarPositionStyle() {
-			if (!this.showMessageButtonsBar) {
-				return
-			}
-
-			// Check if the bottom of messageButtonsBar is outside visible area (36px offset from message bottom)
-			const messageButtonsBarBottom = this.$refs.message.getBoundingClientRect().bottom + this.messageButtonsBarHeight - 8
-			if (this.scrollerBoundingClientRect.bottom < messageButtonsBarBottom) {
-				return `bottom: calc(100% - ${this.$refs.messageInfo.offsetTop}px)`
-			}
 		},
 	},
 }

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -48,6 +48,23 @@
 				:boundaries-element="containerElement"
 				@open="onMenuOpen"
 				@close="onMenuClose">
+				<NcActionButton>
+					<template #icon>
+						<span v-if="showCommonReadIcon"
+							:title="commonReadIconTooltip"
+							:aria-label="commonReadIconTooltip">
+							<CheckAll :size="16" />
+						</span>
+						<span v-else-if="showSentIcon"
+							:title="sentIconTooltip"
+							:aria-label="sentIconTooltip">
+							<Check :size="16" />
+						</span>
+						<ClockOutline v-else :size="16" />
+					</template>
+					{{ messageDateTime }}
+				</NcActionButton>
+				<NcActionSeparator />
 				<NcActionButton v-if="isPrivateReplyable"
 					icon="icon-user"
 					:close-after-click="true"
@@ -142,6 +159,9 @@ import { frequently, EmojiIndex as EmojiIndexFactory } from 'emoji-mart-vue-fast
 import data from 'emoji-mart-vue-fast/data/all.json'
 
 import ArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
+import Check from 'vue-material-design-icons/Check.vue'
+import CheckAll from 'vue-material-design-icons/CheckAll.vue'
+import ClockOutline from 'vue-material-design-icons/ClockOutline.vue'
 import EmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
 import EyeOffOutline from 'vue-material-design-icons/EyeOffOutline.vue'
 import File from 'vue-material-design-icons/File.vue'
@@ -149,10 +169,7 @@ import Plus from 'vue-material-design-icons/Plus.vue'
 import Reply from 'vue-material-design-icons/Reply.vue'
 import Share from 'vue-material-design-icons/Share.vue'
 
-import {
-	showError,
-	showSuccess,
-} from '@nextcloud/dialogs'
+import { showError, showSuccess } from '@nextcloud/dialogs'
 import moment from '@nextcloud/moment'
 import { generateUrl } from '@nextcloud/router'
 
@@ -176,20 +193,24 @@ export default {
 	name: 'MessageButtonsBar',
 
 	components: {
-		NcActions,
+		Forwarder,
 		NcActionButton,
 		NcActionLink,
+		NcActionSeparator,
+		NcActions,
+		NcButton,
+		NcEmojiPicker,
+		// Icons
+		ArrowLeft,
+		Check,
+		CheckAll,
+		ClockOutline,
+		EmoticonOutline,
 		EyeOffOutline,
 		File,
-		Share,
-		NcActionSeparator,
-		Forwarder,
-		NcButton,
-		EmoticonOutline,
-		ArrowLeft,
 		Plus,
 		Reply,
-		NcEmojiPicker,
+		Share,
 	},
 	props: {
 		token: {
@@ -313,6 +334,25 @@ export default {
 			type: Boolean,
 			required: true,
 		},
+		/**
+		 * Message read information
+		 */
+		showCommonReadIcon: {
+			type: Boolean,
+			required: true,
+		},
+		showSentIcon: {
+			type: Boolean,
+			required: true,
+		},
+		commonReadIconTooltip: {
+			type: String,
+			required: true,
+		},
+		sentIconTooltip: {
+			type: String,
+			required: true,
+		},
 
 		/**
 		 * If the MessageButtonsBar belongs to the last read message, we need
@@ -407,6 +447,10 @@ export default {
 				&& !this.isFileShare
 				&& !this.isDeletedMessage
 				&& !this.isPollMessage
+		},
+
+		messageDateTime() {
+			return moment(this.timestamp * 1000).format('lll')
 		},
 	},
 
@@ -539,8 +583,8 @@ export default {
 .message-buttons-bar {
 	display: flex;
 	right: 14px;
-	bottom: calc(8px - var(--default-clickable-area)); // 36px offset
-	position: absolute;
+	top: 8px;
+	position: sticky;
 	background-color: var(--color-main-background);
 	border-radius: calc(var(--default-clickable-area) / 2);
 	box-shadow: 0 0 4px 0 var(--color-box-shadow);


### PR DESCRIPTION
Fix #8885 

### 🖼️ Screenshots

Sticky behaviour:

https://user-images.githubusercontent.com/93392545/223789949-7dc30ea9-f5f4-43be-b7f5-1cccb818a413.mp4

Message info:
![image](https://user-images.githubusercontent.com/93392545/224024711-d4ced139-40d3-4321-a24c-dd275a661231.png)


### 🚧 TODO

- [ ] Visual check
- [ ] Code review

### 🏁 Checklist

- [X] ⛑️ Tests (unit and/or integration) are included
- [X] 📘 API documentation in `docs/` has been updated or is not required
- [X] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [X] 🔖 Capability is added or not needed 
