### PR TITLE
Prevent calling of duplicate paste event

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -339,6 +339,7 @@ export default {
 			// Check empty template by default
 			checked: -1,
 			userData: {},
+			clipboardTimeStamp: null,
 		}
 	},
 
@@ -684,6 +685,12 @@ export default {
 		 */
 		async handlePastedFiles(e) {
 			e.preventDefault()
+			// Prevent a new call of this.handleFiles if already called
+			if (this.clipboardTimeStamp === e.timeStamp) {
+				return
+			}
+
+			this.clipboardTimeStamp = e.timeStamp
 			const content = fetchClipboardContent(e)
 			if (content.kind === 'file') {
 				this.handleFiles(content.files, true)


### PR DESCRIPTION
Fix #9004 
### 🖼️ Screenshots
See responses amount from `fileUploadStore.js`

🏚️ Before | 🏡 After
---|---
![image](https://user-images.githubusercontent.com/93392545/224086603-d8cde0b8-90ba-46a4-8568-7fe78371d076.png) | ![image](https://user-images.githubusercontent.com/93392545/224086221-e99afd8a-bedf-48ff-8497-1a55e7dc3ab4.png)

### 🚧 TODO

- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
