### PR TITLE
Fix `PollVotersDetails` style

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/PollVotersDetails.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/PollVotersDetails.vue
@@ -20,10 +20,10 @@
 -->
 
 <template>
-	<NcPopover trigger="hover">
+	<NcPopover class="poll-voters-details" trigger="hover">
 		<template #trigger>
 			<NcButton type="tertiary-no-background"
-				class="poll-voters-details">
+				class="poll-voters-details__button">
 				<template #icon>
 					<AvatarWrapperSmall v-for="(item, index) in details.slice(0, 8)"
 						:id="item.actorId"
@@ -102,8 +102,8 @@ export default {
 .poll-voters-details {
 	margin-right: 8px;
 
-	&,
-	& :deep(.button-vue__icon) {
+	& &__button,
+	&__button :deep(.button-vue__icon) {
 		min-height: auto;
 		height: auto;
 		min-width: auto;


### PR DESCRIPTION
Regression from #8764 

Missed during the development of previous solution, that NcButton styles could override current, and noticed it just now...

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2023-03-10 14-02-55](https://user-images.githubusercontent.com/93392545/224336198-e50e6034-2288-4e5a-add3-5d23d73b01d8.png) | ![image](https://user-images.githubusercontent.com/93392545/224336358-c79195db-7a0e-4788-8063-975721b5bb03.png)
