### PR TITLE
Set status to none when recording not found

### DIFF
--- a/lib/Service/RecordingService.php
+++ b/lib/Service/RecordingService.php
@@ -112,7 +112,7 @@ class RecordingService {
 			// If the recording to be stopped is not known to the recording
 			// server it will never notify that the recording was stopped, so
 			// the status needs to be explicitly changed here.
-			$this->roomService->setCallRecording($room, Room::RECORDING_FAILED);
+			$this->roomService->setCallRecording($room, Room::RECORDING_NONE);
 		}
 	}
 


### PR DESCRIPTION
When is short the interval between start and stop request, isn't possible to store the stop request because the start didn't finished as well. Because this was changed error status "recording failed" to stauts equal to none (no recording).

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
