### PR TITLE
Fix `Reply` and `Private reply` buttons show conditions

### DIFF
--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -156,10 +156,6 @@ class Message {
 	 * Specifies whether a message can be replied to
 	 */
 	public function isReplyable(): bool {
-		if ($this->getRoom()->getReadOnly() === Room::READ_ONLY) {
-			return false;
-		}
-
 		return $this->getMessageType() !== ChatManager::VERB_SYSTEM &&
 			$this->getMessageType() !== ChatManager::VERB_COMMAND &&
 			$this->getMessageType() !== ChatManager::VERB_MESSAGE_DELETED &&

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
@@ -139,7 +139,7 @@ describe('MessageButtonsBar.vue', () => {
 				})
 
 				const replyButton = findNcButton(wrapper, 'Reply')
-				expect(replyButton.isVisible()).toBe(false)
+				expect(replyButton.exists()).toBe(false)
 			})
 		})
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -33,7 +33,7 @@
 					<EmoticonOutline :size="20" />
 				</template>
 			</NcButton>
-			<NcButton v-show="isReplyable"
+			<NcButton v-if="isReplyable && !isConversationReadOnly"
 				type="tertiary"
 				:aria-label="t('spreed', 'Reply')"
 				:title="t('spreed', 'Reply')"


### PR DESCRIPTION
Fix #8447

![image](https://user-images.githubusercontent.com/93392545/224682115-38b5984d-6842-45df-9ea9-cd793854d289.png)
![image](https://user-images.githubusercontent.com/93392545/224683087-4021c755-022e-486f-8579-83e7e8278747.png)

### 🚧 TODO

- [ ] Code review
- [ ] Visual check

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
