### PR TITLE
Reserve space for the last message's buttons bar

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -32,6 +32,7 @@ the main body of the message as well as a quote.
 		:data-next-message-id="nextMessageId"
 		:data-previous-message-id="previousMessageId"
 		class="message"
+		:class="{'message__last': isLastMessage}"
 		tabindex="0"
 		@mouseover="handleMouseover"
 		@mouseleave="handleMouseleave">
@@ -419,13 +420,13 @@ export default {
 	},
 
 	computed: {
-		isLastReadMessage() {
-			if (!this.nextMessageId || this.id === this.conversation?.lastMessage?.id) {
-				// never display indicator on the very last message
-				return false
-			}
+		isLastMessage() {
+			// never displayed for the very last message
+			return !this.nextMessageId || this.id === this.conversation?.lastMessage?.id
+		},
 
-			return this.id === this.$store.getters.getVisualLastReadMessageId(this.token)
+		isLastReadMessage() {
+			return !this.isLastMessage && this.id === this.$store.getters.getVisualLastReadMessageId(this.token)
 		},
 
 		messageObject() {
@@ -841,6 +842,10 @@ export default {
 
 .message {
 	position: relative;
+
+	&__last {
+		margin-bottom: 12px;
+	}
 }
 
 .message-body {
@@ -917,7 +922,7 @@ export default {
 		right: 0;
 		width: fit-content;
 		height: 100%;
-		padding-top: 8px;
+		padding: 8px 8px 0 0;
 	}
 
 	&__reactions {


### PR DESCRIPTION
Fix #9016

Added a gap under the last message
Also set a right padding for buttons bar (to avoid cropping in sidebar chat and for the better look)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
See issue | ![image](https://user-images.githubusercontent.com/93392545/224552112-d52aca2c-870d-4f9d-be73-0c1127621a6e.png)



### 🚧 TODO

- [ ] Visual check

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
