### PR TITLE
Show index page instead of hard redirect to 404 on chat delete after signaling error

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsList.vue
@@ -114,6 +114,9 @@ export default {
 			}
 			if (from.name === 'conversation') {
 				this.$store.dispatch('leaveConversation', { token: from.params.token })
+				if (to.name !== 'conversation') {
+					this.$store.dispatch('updateToken', '')
+				}
 			}
 			if (to.name === 'conversation') {
 				this.$store.dispatch('joinConversation', { token: to.params.token })

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -443,6 +443,7 @@ Signaling.Internal.prototype._joinRoomSuccess = function(token, sessionId) {
 
 Signaling.Internal.prototype._doLeaveRoom = function(token) {
 	this._joinCallAgainOnceDisconnected = false
+	this.pullMessagesRequest?.('canceled')
 }
 
 Signaling.Internal.prototype.sendCallMessage = function(data) {


### PR DESCRIPTION
### A problem

1. Open a chat
2. Delete the opened chat

#### Expected behavior

Chat is not open.

#### Actual behavior

After successful deleting, a web-page received a signaling error and redirect to `not-found` with a page reload.

### 🖼️ Screenshots

#### 🏚️ Before

https://user-images.githubusercontent.com/25978914/224779100-903fbd0f-1d17-4305-9c77-e7dbc2d27a73.mp4

#### 🏡 After

https://user-images.githubusercontent.com/25978914/224779367-0b1f534f-8ac5-4877-a4c3-16eef4210c0a.mp4

### 🚧 TODO

- [x] leave room after successful deletion
- [x] Stop waiting for new messages from removed chat
- [x] Push navigation to the root page

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
