### PR TITLE
Remove the name that who started or stopped the call

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -533,22 +533,22 @@ class SystemMessage {
 				$parsedMessage = $this->l->t('You ended the poll {poll}');
 			}
 		} elseif ($message === 'recording_started') {
-			$parsedMessage = $this->l->t('{actor} started the video recording');
+			$parsedMessage = $this->l->t('Call recording started');
 			if ($currentUserIsActor) {
 				$parsedMessage = $this->l->t('You started the video recording');
 			}
 		} elseif ($message === 'recording_stopped') {
-			$parsedMessage = $this->l->t('{actor} stopped the video recording');
+			$parsedMessage = $this->l->t('Call recording stopped');
 			if ($currentUserIsActor) {
 				$parsedMessage = $this->l->t('You stopped the video recording');
 			}
 		} elseif ($message === 'audio_recording_started') {
-			$parsedMessage = $this->l->t('{actor} started the audio recording');
+			$parsedMessage = $this->l->t('Call recording started');
 			if ($currentUserIsActor) {
 				$parsedMessage = $this->l->t('You started the audio recording');
 			}
 		} elseif ($message === 'audio_recording_stopped') {
-			$parsedMessage = $this->l->t('{actor} stopped the audio recording');
+			$parsedMessage = $this->l->t('Call recording stopped');
 			if ($currentUserIsActor) {
 				$parsedMessage = $this->l->t('You stopped the audio recording');
 			}

--- a/tests/integration/features/callapi/recording.feature
+++ b/tests/integration/features/callapi/recording.feature
@@ -85,6 +85,76 @@ Feature: callapi/recording
       | type | name  | callRecording |
       | 2    | room1 | 0             |
 
+  Scenario: Non moderators need to receive the notification Start and stop audio recording
+    Given recording server is started
+    And user "participant1" creates room "room1" (v4)
+      | roomType | 2 |
+      | roomName | room1 |
+    And user "participant1" joins room "room1" with 200 (v4)
+    And user "participant1" joins call "room1" with 200 (v4)
+    And user "participant1" adds user "participant2" to room "room1" with 200 (v4)
+    And user "participant2" joins room "room1" with 200 (v4)
+    When user "participant1" starts "audio" recording in room "room1" with 200 (v1)
+    And recording server received the following requests
+      | token | data                                                         |
+      | room1 | {"type":"start","start":{"status":2,"owner":"participant1","actor":{"type":"users","id":"participant1"}}} |
+    And user "participant1" is participant of the following unordered rooms (v4)
+      | type | name  | callRecording |
+      | 2    | room1 | 4             |
+    And user "participant2" is participant of the following unordered rooms (v4)
+      | type | name  | callRecording |
+      | 2    | room1 | 4             |
+    And recording server sent started request for "audio" recording in room "room1" as "participant1" with 200
+    Then user "participant1" sees the following system messages in room "room1" with 200 (v1)
+      | room  | actorType | actorId      | actorDisplayName         | systemMessage           |
+      | room1 | users     | participant1 | participant1-displayname | audio_recording_started |
+      | room1 | users     | participant1 | participant1-displayname | user_added              |
+      | room1 | users     | participant1 | participant1-displayname | call_started            |
+      | room1 | users     | participant1 | participant1-displayname | conversation_created    |
+    Then user "participant2" sees the following system messages in room "room1" with 200 (v1)
+      | room  | actorType | actorId      | actorDisplayName         | systemMessage           |
+      | room1 | users     | participant1 | participant1-displayname | audio_recording_started |
+      | room1 | users     | participant1 | participant1-displayname | user_added              |
+      | room1 | users     | participant1 | participant1-displayname | call_started            |
+      | room1 | users     | participant1 | participant1-displayname | conversation_created    |
+    And user "participant1" is participant of the following unordered rooms (v4)
+      | type | name  | callRecording |
+      | 2    | room1 | 2             |
+    And user "participant2" is participant of the following unordered rooms (v4)
+      | type | name  | callRecording |
+      | 2    | room1 | 2             |
+    When user "participant1" stops recording in room "room1" with 200 (v1)
+    And recording server received the following requests
+      | token | data             |
+      | room1 | {"type":"stop","stop":{"actor":{"type":"users","id":"participant1"}}} |
+    And user "participant1" is participant of the following unordered rooms (v4)
+      | type | name  | callRecording |
+      | 2    | room1 | 2             |
+    And user "participant2" is participant of the following unordered rooms (v4)
+      | type | name  | callRecording |
+      | 2    | room1 | 2             |
+    And recording server sent stopped request for recording in room "room1" as "participant1" with 200
+    Then user "participant1" sees the following system messages in room "room1" with 200 (v1)
+      | room  | actorType | actorId      | actorDisplayName         | systemMessage           |
+      | room1 | users     | participant1 | participant1-displayname | audio_recording_stopped |
+      | room1 | users     | participant1 | participant1-displayname | audio_recording_started |
+      | room1 | users     | participant1 | participant1-displayname | user_added              |
+      | room1 | users     | participant1 | participant1-displayname | call_started            |
+      | room1 | users     | participant1 | participant1-displayname | conversation_created    |
+    Then user "participant2" sees the following system messages in room "room1" with 200 (v1)
+      | room  | actorType | actorId      | actorDisplayName         | systemMessage           |
+      | room1 | users     | participant1 | participant1-displayname | audio_recording_stopped |
+      | room1 | users     | participant1 | participant1-displayname | audio_recording_started |
+      | room1 | users     | participant1 | participant1-displayname | user_added              |
+      | room1 | users     | participant1 | participant1-displayname | call_started            |
+      | room1 | users     | participant1 | participant1-displayname | conversation_created    |
+    And user "participant1" is participant of the following unordered rooms (v4)
+      | type | name  | callRecording |
+      | 2    | room1 | 0             |
+    And user "participant2" is participant of the following unordered rooms (v4)
+      | type | name  | callRecording |
+      | 2    | room1 | 0             |
+
   Scenario: Recording failed to start
     Given recording server is started
     And user "participant1" creates room "room1" (v4)


### PR DESCRIPTION
To preserve the privacy of moderators, the name of who started or stopped the recording was removed from system message.

I added an integration test to check if all participants are receiving the system message when start|stop a recording.

### 🚧 TODO

- [ ] Close https://github.com/nextcloud/spreed/issues/8867

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
