### PR TITLE
Populate icon-url on call rich objects

### DIFF
--- a/lib/Chat/Parser/UserMention.php
+++ b/lib/Chat/Parser/UserMention.php
@@ -29,6 +29,7 @@ use OCA\Talk\GuestManager;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\Message;
 use OCA\Talk\Room;
+use OCA\Talk\Service\AvatarService;
 use OCA\Talk\Service\ParticipantService;
 use OCP\Comments\ICommentsManager;
 use OCP\IGroup;
@@ -50,12 +51,14 @@ class UserMention {
 	protected IGroupManager $groupManager;
 	protected GuestManager $guestManager;
 	protected ParticipantService $participantService;
+	protected AvatarService $avatarService;
 	protected IL10N $l;
 
 	public function __construct(ICommentsManager $commentsManager,
 								IUserManager $userManager,
 								IGroupManager $groupManager,
 								GuestManager $guestManager,
+								AvatarService $avatarService,
 								ParticipantService $participantService,
 								IL10N $l) {
 		$this->commentsManager = $commentsManager;
@@ -63,6 +66,7 @@ class UserMention {
 		$this->groupManager = $groupManager;
 		$this->guestManager = $guestManager;
 		$this->participantService = $participantService;
+		$this->avatarService = $avatarService;
 		$this->l = $l;
 	}
 
@@ -138,7 +142,7 @@ class UserMention {
 					'id' => $chatMessage->getRoom()->getToken(),
 					'name' => $chatMessage->getRoom()->getDisplayName($userId),
 					'call-type' => $this->getRoomType($chatMessage->getRoom()),
-					'icon-url' => $chatMessage->getRoom()->getAvatar(),
+					'icon-url' => $this->avatarService->getAvatarUrl($chatMessage->getRoom()),
 				];
 			} elseif ($mention['type'] === 'guest') {
 				try {

--- a/lib/Chat/Parser/UserMention.php
+++ b/lib/Chat/Parser/UserMention.php
@@ -138,6 +138,7 @@ class UserMention {
 					'id' => $chatMessage->getRoom()->getToken(),
 					'name' => $chatMessage->getRoom()->getDisplayName($userId),
 					'call-type' => $this->getRoomType($chatMessage->getRoom()),
+					'icon-url' => $chatMessage->getRoom()->getAvatar(),
 				];
 			} elseif ($mention['type'] === 'guest') {
 				try {

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -38,6 +38,7 @@ use OCA\Talk\Model\Session;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\AttachmentService;
+use OCA\Talk\Service\AvatarService;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\SessionService;
 use OCA\Talk\Share\RoomShareProvider;
@@ -71,6 +72,7 @@ class ChatController extends AEnvironmentAwareController {
 	private ParticipantService $participantService;
 	private SessionService $sessionService;
 	protected AttachmentService $attachmentService;
+	protected avatarService $avatarService;
 	private GuestManager $guestManager;
 	/** @var string[] */
 	protected array $guestNames;
@@ -97,6 +99,7 @@ class ChatController extends AEnvironmentAwareController {
 								ParticipantService $participantService,
 								SessionService $sessionService,
 								AttachmentService $attachmentService,
+								avatarService $avatarService,
 								GuestManager $guestManager,
 								MessageParser $messageParser,
 								RoomShareProvider $shareProvider,
@@ -120,6 +123,7 @@ class ChatController extends AEnvironmentAwareController {
 		$this->participantService = $participantService;
 		$this->sessionService = $sessionService;
 		$this->attachmentService = $attachmentService;
+		$this->avatarService = $avatarService;
 		$this->guestManager = $guestManager;
 		$this->messageParser = $messageParser;
 		$this->shareProvider = $shareProvider;
@@ -270,7 +274,7 @@ class ChatController extends AEnvironmentAwareController {
 		}
 		$data['type'] = $objectType;
 		$data['id'] = $objectId;
-		$data['icon-url'] = $this->room->getAvatar();
+		$data['icon-url'] = $this->avatarService->getAvatarUrl($this->room);
 
 		if (isset($data['link']) && !$this->trustedDomainHelper->isTrustedUrl($data['link'])) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -270,6 +270,7 @@ class ChatController extends AEnvironmentAwareController {
 		}
 		$data['type'] = $objectType;
 		$data['id'] = $objectId;
+		$data['icon-url'] = $this->room->getAvatar();
 
 		if (isset($data['link']) && !$this->trustedDomainHelper->isTrustedUrl($data['link'])) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -36,6 +36,7 @@ use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
+use OCA\Talk\Service\AvatarService;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Webinary;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -69,6 +70,7 @@ class Notifier implements INotifier {
 	private IShareManager $shareManager;
 	protected Manager $manager;
 	protected ParticipantService $participantService;
+	protected AvatarService $avatarService;
 	protected INotificationManager $notificationManager;
 	protected ICommentsManager $commentManager;
 	protected MessageParser $messageParser;
@@ -92,6 +94,7 @@ class Notifier implements INotifier {
 								IShareManager $shareManager,
 								Manager $manager,
 								ParticipantService $participantService,
+								AvatarService $avatarService,
 								INotificationManager $notificationManager,
 								CommentsManager $commentManager,
 								MessageParser $messageParser,
@@ -109,6 +112,7 @@ class Notifier implements INotifier {
 		$this->shareManager = $shareManager;
 		$this->manager = $manager;
 		$this->participantService = $participantService;
+		$this->avatarService = $avatarService;
 		$this->notificationManager = $notificationManager;
 		$this->commentManager = $commentManager;
 		$this->messageParser = $messageParser;
@@ -322,7 +326,7 @@ class Notifier implements INotifier {
 						'id' => $room->getId(),
 						'name' => $room->getDisplayName($participant->getAttendee()->getActorId()),
 						'call-type' => $this->getRoomType($room),
-						'icon-url' => $room->getAvatar(),
+						'icon-url' => $this->avatarService->getAvatarUrl($room),
 					],
 				]
 			);
@@ -386,7 +390,7 @@ class Notifier implements INotifier {
 						'id' => $room->getId(),
 						'name' => $room->getDisplayName($participant->getAttendee()->getActorId()),
 						'call-type' => $this->getRoomType($room),
-						'icon-url' => $room->getAvatar(),
+						'icon-url' => $this->avatarService->getAvatarUrl($room),
 					],
 					'file' => [
 						'type' => 'file',
@@ -483,7 +487,7 @@ class Notifier implements INotifier {
 			'id' => $room->getId(),
 			'name' => $room->getDisplayName($notification->getUser()),
 			'call-type' => $this->getRoomType($room),
-			'icon-url' => $room->getAvatar(),
+			'icon-url' => $this->avatarService->getAvatarUrl($room),
 		];
 
 		$messageParameters = $notification->getMessageParameters();
@@ -780,7 +784,7 @@ class Notifier implements INotifier {
 							'id' => $room->getId(),
 							'name' => $roomName,
 							'call-type' => $this->getRoomType($room),
-							'icon-url' => $room->getAvatar(),
+							'icon-url' => $this->avatarService->getAvatarUrl($room),
 						],
 					]
 				);
@@ -806,7 +810,7 @@ class Notifier implements INotifier {
 							'id' => $room->getId(),
 							'name' => $roomName,
 							'call-type' => $this->getRoomType($room),
-							'icon-url' => $room->getAvatar(),
+							'icon-url' => $this->avatarService->getAvatarUrl($room),
 						],
 					]
 				);
@@ -858,7 +862,7 @@ class Notifier implements INotifier {
 								'id' => $room->getId(),
 								'name' => $roomName,
 								'call-type' => $this->getRoomType($room),
-								'icon-url' => $room->getAvatar(),
+								'icon-url' => $this->avatarService->getAvatarUrl($room),
 							],
 						]
 					);
@@ -883,7 +887,7 @@ class Notifier implements INotifier {
 							'id' => $room->getId(),
 							'name' => $roomName,
 							'call-type' => $this->getRoomType($room),
-							'icon-url' => $room->getAvatar(),
+							'icon-url' => $this->avatarService->getAvatarUrl($room),
 						],
 					]
 				);

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -322,6 +322,7 @@ class Notifier implements INotifier {
 						'id' => $room->getId(),
 						'name' => $room->getDisplayName($participant->getAttendee()->getActorId()),
 						'call-type' => $this->getRoomType($room),
+						'icon-url' => $room->getAvatar(),
 					],
 				]
 			);
@@ -385,6 +386,7 @@ class Notifier implements INotifier {
 						'id' => $room->getId(),
 						'name' => $room->getDisplayName($participant->getAttendee()->getActorId()),
 						'call-type' => $this->getRoomType($room),
+						'icon-url' => $room->getAvatar(),
 					],
 					'file' => [
 						'type' => 'file',
@@ -481,6 +483,7 @@ class Notifier implements INotifier {
 			'id' => $room->getId(),
 			'name' => $room->getDisplayName($notification->getUser()),
 			'call-type' => $this->getRoomType($room),
+			'icon-url' => $room->getAvatar(),
 		];
 
 		$messageParameters = $notification->getMessageParameters();
@@ -777,6 +780,7 @@ class Notifier implements INotifier {
 							'id' => $room->getId(),
 							'name' => $roomName,
 							'call-type' => $this->getRoomType($room),
+							'icon-url' => $room->getAvatar(),
 						],
 					]
 				);
@@ -802,6 +806,7 @@ class Notifier implements INotifier {
 							'id' => $room->getId(),
 							'name' => $roomName,
 							'call-type' => $this->getRoomType($room),
+							'icon-url' => $room->getAvatar(),
 						],
 					]
 				);
@@ -853,6 +858,7 @@ class Notifier implements INotifier {
 								'id' => $room->getId(),
 								'name' => $roomName,
 								'call-type' => $this->getRoomType($room),
+								'icon-url' => $room->getAvatar(),
 							],
 						]
 					);
@@ -877,6 +883,7 @@ class Notifier implements INotifier {
 							'id' => $room->getId(),
 							'name' => $roomName,
 							'call-type' => $this->getRoomType($room),
+							'icon-url' => $room->getAvatar(),
 						],
 					]
 				);

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2230,7 +2230,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			if (isset($messages[$i]['messageParameters']['object']['icon-url'])) {
 				$result = preg_match('/"\{VALIDATE_ICON_URL_PATTERN\}"/', $expected[$i]['messageParameters'], $matches);
 				if ($result) {
-					Assert::assertMatchesRegularExpression('/avatar\?v=\w+/', $messages[$i]['messageParameters']['object']['icon-url']);
+					Assert::assertMatchesRegularExpression('/avatar(\?v=\w+)?/', $messages[$i]['messageParameters']['object']['icon-url']);
 					$expected[$i]['messageParameters'] = str_replace($matches[0], json_encode($messages[$i]['messageParameters']['object']['icon-url']), $expected[$i]['messageParameters']);
 				}
 			}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2227,6 +2227,13 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			if ($result) {
 				$expected[$i]['messageParameters'] = str_replace($matches[0], '"' . self::$questionToPollId[$matches[1]] . '"', $expected[$i]['messageParameters']);
 			}
+			if (isset($messages[$i]['messageParameters']['object']['icon-url'])) {
+				$result = preg_match('/"\{VALIDATE_ICON_URL_PATTERN\}"/', $expected[$i]['messageParameters'], $matches);
+				if ($result) {
+					Assert::assertMatchesRegularExpression('/avatar\?v=\w+/', $messages[$i]['messageParameters']['object']['icon-url']);
+					$expected[$i]['messageParameters'] = str_replace($matches[0], json_encode($messages[$i]['messageParameters']['object']['icon-url']), $expected[$i]['messageParameters']);
+				}
+			}
 		}
 
 		Assert::assertEquals($expected, array_map(function ($message) use ($includeParents, $includeReferenceId, $includeReactions, $includeReactionsSelf) {

--- a/tests/integration/features/chat-2/rich-object-share.feature
+++ b/tests/integration/features/chat-2/rich-object-share.feature
@@ -67,7 +67,7 @@ Feature: chat-2/rich-object-share
     When user "participant1" shares rich-object "call" "R4nd0mT0k3n" '{"name":"Another room","call-type":"group"}' to room "public room" with 201 (v1)
     Then user "participant1" sees the following shared other in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message  | messageParameters |
-      | public room | users     | participant1 | participant1-displayname | {object} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"object":{"name":"Another room","call-type":"group","type":"call","id":"R4nd0mT0k3n"}} |
+      | public room | users     | participant1 | participant1-displayname | {object} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"object":{"name":"Another room","call-type":"group","type":"call","id":"R4nd0mT0k3n","icon-url":""}} |
     When user "participant1" shares "welcome.txt" with room "public room" with OCS 100
     Then user "participant1" sees the following shared file in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message  | messageParameters |

--- a/tests/integration/features/chat-2/rich-object-share.feature
+++ b/tests/integration/features/chat-2/rich-object-share.feature
@@ -64,10 +64,11 @@ Feature: chat-2/rich-object-share
     Given user "participant1" creates room "public room" (v4)
       | roomType | 3 |
       | roomName | room |
+    And user "participant1" uploads file "/img/favicon.png" as avatar of room "public room" with 200
     When user "participant1" shares rich-object "call" "R4nd0mT0k3n" '{"name":"Another room","call-type":"group"}' to room "public room" with 201 (v1)
     Then user "participant1" sees the following shared other in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message  | messageParameters |
-      | public room | users     | participant1 | participant1-displayname | {object} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"object":{"name":"Another room","call-type":"group","type":"call","id":"R4nd0mT0k3n","icon-url":""}} |
+      | public room | users     | participant1 | participant1-displayname | {object} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"object":{"name":"Another room","call-type":"group","type":"call","id":"R4nd0mT0k3n","icon-url":"{VALIDATE_ICON_URL_PATTERN}"}} |
     When user "participant1" shares "welcome.txt" with room "public room" with OCS 100
     Then user "participant1" sees the following shared file in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message  | messageParameters |

--- a/tests/integration/features/chat-2/rich-object-share.feature
+++ b/tests/integration/features/chat-2/rich-object-share.feature
@@ -64,7 +64,6 @@ Feature: chat-2/rich-object-share
     Given user "participant1" creates room "public room" (v4)
       | roomType | 3 |
       | roomName | room |
-    And user "participant1" uploads file "/img/favicon.png" as avatar of room "public room" with 200
     When user "participant1" shares rich-object "call" "R4nd0mT0k3n" '{"name":"Another room","call-type":"group"}' to room "public room" with 201 (v1)
     Then user "participant1" sees the following shared other in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message  | messageParameters |

--- a/tests/integration/features/chat-2/rich-object-share.feature
+++ b/tests/integration/features/chat-2/rich-object-share.feature
@@ -10,7 +10,7 @@ Feature: chat-2/rich-object-share
     When user "participant1" shares rich-object "call" "R4nd0mT0k3n" '{"name":"Another room","call-type":"group"}' to room "public room" with 201 (v1)
     Then user "participant1" sees the following messages in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message  | messageParameters |
-      | public room | users     | participant1 | participant1-displayname | {object} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"object":{"name":"Another room","call-type":"group","type":"call","id":"R4nd0mT0k3n"}} |
+      | public room | users     | participant1 | participant1-displayname | {object} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"object":{"name":"Another room","call-type":"group","type":"call","id":"R4nd0mT0k3n","icon-url":"{VALIDATE_ICON_URL_PATTERN}"}} |
 
   Scenario: Can not share without chat permission
     Given user "participant1" creates room "public room" (v4)
@@ -44,7 +44,7 @@ Feature: chat-2/rich-object-share
     And user "participant2" deletes message "shared::call::R4nd0mT0k3n" from room "public room" with 403
     Then user "participant1" sees the following messages in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message                  | messageParameters |
-      | public room | users     | participant2 | participant2-displayname | {object} | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname"},"object":{"name":"Another room","call-type":"group","type":"call","id":"R4nd0mT0k3n"}} |
+      | public room | users     | participant2 | participant2-displayname | {object} | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname"},"object":{"name":"Another room","call-type":"group","type":"call","id":"R4nd0mT0k3n","icon-url":"{VALIDATE_ICON_URL_PATTERN}"}} |
 
   Scenario: Share an invalid rich object to a chat
     Given user "participant1" creates room "public room" (v4)

--- a/tests/integration/features/conversation/avatar.feature
+++ b/tests/integration/features/conversation/avatar.feature
@@ -45,3 +45,13 @@ Feature: conversation/avatar
       | roomType | 1 |
       | invite   | participant2 |
     Then user "participant1" uploads file "/img/favicon.png" as avatar of room "one2one" with 400
+
+  Scenario: User should receive the room avatar when see a rich object at media tab
+    Given user "participant1" creates room "public room" (v4)
+      | roomType | 3 |
+      | roomName | public room |
+    And user "participant1" uploads file "/img/favicon.png" as avatar of room "public room" with 200
+    When user "participant1" shares rich-object "call" "R4nd0mT0k3n" '{"name":"Another room","call-type":"group"}' to room "public room" with 201 (v1)
+    Then user "participant1" sees the following shared other in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message  | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | {object} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"object":{"name":"Another room","call-type":"group","type":"call","id":"R4nd0mT0k3n","icon-url":"{VALIDATE_ICON_URL_PATTERN}"}} |

--- a/tests/php/Chat/Parser/UserMentionTest.php
+++ b/tests/php/Chat/Parser/UserMentionTest.php
@@ -439,6 +439,7 @@ class UserMentionTest extends TestCase {
 				'id' => 'token',
 				'name' => 'name',
 				'call-type' => 'group',
+				'icon-url' => '',
 			]
 		];
 

--- a/tests/php/Chat/Parser/UserMentionTest.php
+++ b/tests/php/Chat/Parser/UserMentionTest.php
@@ -31,6 +31,7 @@ use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\Message;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
+use OCA\Talk\Service\AvatarService;
 use OCA\Talk\Service\ParticipantService;
 use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
@@ -49,6 +50,8 @@ class UserMentionTest extends TestCase {
 	protected $groupManager;
 	/** @var GuestManager|MockObject */
 	protected $guestManager;
+	/** @var AvatarService|MockObject */
+	protected $avatarService;
 	/** @var ParticipantService|MockObject */
 	protected $participantService;
 	/** @var IL10N|MockObject */
@@ -63,6 +66,7 @@ class UserMentionTest extends TestCase {
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->guestManager = $this->createMock(GuestManager::class);
+		$this->avatarService = $this->createMock(AvatarService::class);
 		$this->participantService = $this->createMock(ParticipantService::class);
 		$this->l = $this->createMock(IL10N::class);
 
@@ -71,6 +75,7 @@ class UserMentionTest extends TestCase {
 			$this->userManager,
 			$this->groupManager,
 			$this->guestManager,
+			$this->avatarService,
 			$this->participantService,
 			$this->l);
 	}

--- a/tests/php/Chat/Parser/UserMentionTest.php
+++ b/tests/php/Chat/Parser/UserMentionTest.php
@@ -436,6 +436,10 @@ class UserMentionTest extends TestCase {
 		$chatMessage = new Message($room, $participant, $comment, $l);
 		$chatMessage->setMessage('Mention to @all', []);
 
+		$this->avatarService->method('getAvatarUrl')
+			->with($room)
+			->willReturn('getAvatarUrl');
+
 		$this->parser->parseMessage($chatMessage);
 
 		$expectedMessageParameters = [
@@ -444,7 +448,7 @@ class UserMentionTest extends TestCase {
 				'id' => 'token',
 				'name' => 'name',
 				'call-type' => 'group',
-				'icon-url' => '',
+				'icon-url' => 'getAvatarUrl',
 			]
 		];
 

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -35,6 +35,7 @@ use OCA\Talk\Model\Message;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\AttachmentService;
+use OCA\Talk\Service\AvatarService;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\SessionService;
 use OCA\Talk\Share\RoomShareProvider;
@@ -73,6 +74,8 @@ class ChatControllerTest extends TestCase {
 	protected $sessionService;
 	/** @var AttachmentService|MockObject */
 	protected $attachmentService;
+	/** @var AvatarService|MockObject */
+	protected $avatarService;
 	/** @var GuestManager|MockObject */
 	protected $guestManager;
 	/** @var MessageParser|MockObject */
@@ -119,6 +122,7 @@ class ChatControllerTest extends TestCase {
 		$this->participantService = $this->createMock(ParticipantService::class);
 		$this->sessionService = $this->createMock(SessionService::class);
 		$this->attachmentService = $this->createMock(AttachmentService::class);
+		$this->avatarService = $this->createMock(AvatarService::class);
 		$this->guestManager = $this->createMock(GuestManager::class);
 		$this->messageParser = $this->createMock(MessageParser::class);
 		$this->roomShareProvider = $this->createMock(RoomShareProvider::class);
@@ -157,6 +161,7 @@ class ChatControllerTest extends TestCase {
 			$this->participantService,
 			$this->sessionService,
 			$this->attachmentService,
+			$this->avatarService,
 			$this->guestManager,
 			$this->messageParser,
 			$this->roomShareProvider,

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -637,6 +637,7 @@ class ChatControllerTest extends TestCase {
 			'call-type' => 'one2one',
 			'type' => 'call',
 			'id' => 'R4nd0mToken',
+			'icon-url' => '',
 		];
 
 		$date = new \DateTime();
@@ -659,6 +660,7 @@ class ChatControllerTest extends TestCase {
 							'call-type' => 'one2one',
 							'type' => 'call',
 							'id' => 'R4nd0mToken',
+							'icon-url' => '',
 						],
 					],
 				]),

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -638,6 +638,10 @@ class ChatControllerTest extends TestCase {
 	public function testShareObjectToChatByUser() {
 		$participant = $this->createMock(Participant::class);
 
+		$this->avatarService->method('getAvatarUrl')
+			->with($this->room)
+			->willReturn('getAvatarUrl');
+
 		$richData = [
 			'call-type' => 'one2one',
 			'type' => 'call',
@@ -665,7 +669,7 @@ class ChatControllerTest extends TestCase {
 							'call-type' => 'one2one',
 							'type' => 'call',
 							'id' => 'R4nd0mToken',
-							'icon-url' => '',
+							'icon-url' => 'getAvatarUrl',
 						],
 					],
 				]),

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -208,7 +208,8 @@ class NotifierTest extends TestCase {
 					'type' => 'call',
 					'id' => 1234,
 					'name' => $displayName,
-					'call-type' => 'one2one'
+					'call-type' => 'one2one',
+					'icon-url' => '',
 				],
 			])
 			->willReturnSelf();
@@ -322,7 +323,8 @@ class NotifierTest extends TestCase {
 					'type' => 'call',
 					'id' => 1234,
 					'name' => $displayName,
-					'call-type' => 'one2one'
+					'call-type' => 'one2one',
+					'icon-url' => '',
 				],
 			])
 			->willReturnSelf();
@@ -431,6 +433,7 @@ class NotifierTest extends TestCase {
 						'id' => $roomId,
 						'name' => $name,
 						'call-type' => 'group',
+						'icon-url' => '',
 					],
 				])
 				->willReturnSelf();
@@ -448,6 +451,7 @@ class NotifierTest extends TestCase {
 						'id' => $roomId,
 						'name' => $name,
 						'call-type' => 'public',
+						'icon-url' => '',
 					],
 				])
 				->willReturnSelf();
@@ -482,7 +486,7 @@ class NotifierTest extends TestCase {
 					'{user} mentioned you in a private conversation',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Test user', 'call-type' => 'one2one'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Test user', 'call-type' => 'one2one', 'icon-url' => ''],
 					],
 				],
 			],
@@ -493,7 +497,7 @@ class NotifierTest extends TestCase {
 					'{user} mentioned you in conversation {call}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => ''],
 					],
 				],
 			],
@@ -503,7 +507,7 @@ class NotifierTest extends TestCase {
 				[
 					'A deleted user mentioned you in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => ''],
 					],
 				],
 				$deletedUser = true,
@@ -515,7 +519,7 @@ class NotifierTest extends TestCase {
 					'{user} mentioned you in conversation {call}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 					],
 				],
 			],
@@ -525,7 +529,7 @@ class NotifierTest extends TestCase {
 				[
 					'A deleted user mentioned you in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 					],
 				],
 				$deletedUser = true,
@@ -536,7 +540,7 @@ class NotifierTest extends TestCase {
 				[
 					'A guest mentioned you in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 					],
 				],
 				$deletedUser = false, $guestName = null,
@@ -547,7 +551,7 @@ class NotifierTest extends TestCase {
 				[
 					'{guest} (guest) mentioned you in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 						'guest' => ['type' => 'guest', 'id' => 'random-hash', 'name' => 'MyNameIs'],
 					]
 				],
@@ -559,7 +563,7 @@ class NotifierTest extends TestCase {
 				[
 					'A guest mentioned you in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 					],
 				],
 				$deletedUser = false, $guestName = '',
@@ -573,7 +577,7 @@ class NotifierTest extends TestCase {
 					'{user} sent you a private message',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Test user', 'call-type' => 'one2one'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Test user', 'call-type' => 'one2one', 'icon-url' => ''],
 					],
 				],
 			],
@@ -584,7 +588,7 @@ class NotifierTest extends TestCase {
 					'{user} sent a message in conversation {call}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => ''],
 					],
 				],
 			],
@@ -594,7 +598,7 @@ class NotifierTest extends TestCase {
 				[
 					'A deleted user sent a message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => ''],
 					],
 				],
 				$deletedUser = true,
@@ -606,7 +610,7 @@ class NotifierTest extends TestCase {
 					'{user} sent a message in conversation {call}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 					]
 				],
 			],
@@ -616,7 +620,7 @@ class NotifierTest extends TestCase {
 				[
 					'A deleted user sent a message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 					],
 				],
 				$deletedUser = true
@@ -626,7 +630,7 @@ class NotifierTest extends TestCase {
 				'A guest sent a message in conversation Room name',
 				['A guest sent a message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 					],
 				],
 				$deletedUser = false, $guestName = null,
@@ -637,7 +641,7 @@ class NotifierTest extends TestCase {
 				[
 					'{guest} (guest) sent a message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 						'guest' => ['type' => 'guest', 'id' => 'random-hash', 'name' => 'MyNameIs'],
 					],
 				],
@@ -649,7 +653,7 @@ class NotifierTest extends TestCase {
 				[
 					'A guest sent a message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 					],
 				],
 				$deletedUser = false, $guestName = '',
@@ -663,7 +667,7 @@ class NotifierTest extends TestCase {
 					'{user} replied to your private message',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Test user', 'call-type' => 'one2one'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Test user', 'call-type' => 'one2one', 'icon-url' => ''],
 					],
 				],
 			],
@@ -674,7 +678,7 @@ class NotifierTest extends TestCase {
 					'{user} replied to your message in conversation {call}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => ''],
 					],
 				],
 			],
@@ -684,7 +688,7 @@ class NotifierTest extends TestCase {
 				[
 					'A deleted user replied to your message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => ''],
 					],
 				],
 				$deletedUser = true,
@@ -696,7 +700,7 @@ class NotifierTest extends TestCase {
 					'{user} replied to your message in conversation {call}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 					]
 				],
 			],
@@ -706,7 +710,7 @@ class NotifierTest extends TestCase {
 				[
 					'A deleted user replied to your message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 					],
 				],
 				$deletedUser = true
@@ -716,7 +720,7 @@ class NotifierTest extends TestCase {
 				'A guest replied to your message in conversation Room name',
 				['A guest replied to your message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 					],
 				],
 				$deletedUser = false, $guestName = null,
@@ -727,7 +731,7 @@ class NotifierTest extends TestCase {
 				[
 					'{guest} (guest) replied to your message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 						'guest' => ['type' => 'guest', 'id' => 'random-hash', 'name' => 'MyNameIs'],
 					],
 				],
@@ -739,7 +743,7 @@ class NotifierTest extends TestCase {
 				[
 					'A guest replied to your message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 					],
 				],
 				$deletedUser = false, $guestName = '',
@@ -753,7 +757,7 @@ class NotifierTest extends TestCase {
 					'{user}' . "\n" . '{message}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Test user', 'call-type' => 'one2one'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Test user', 'call-type' => 'one2one', 'icon-url' => ''],
 						'message' => ['type' => 'highlight', 'id' => '123456789', 'name' => 'Hi @Administrator'],
 					],
 				],
@@ -766,7 +770,7 @@ class NotifierTest extends TestCase {
 					'{user} in {call}' . "\n" . '{message}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => ''],
 						'message' => ['type' => 'highlight', 'id' => '123456789', 'name' => 'Hi @Administrator'],
 					],
 				],
@@ -778,7 +782,7 @@ class NotifierTest extends TestCase {
 				[
 					'Deleted user in {call}' . "\n" . '{message}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => ''],
 						'message' => ['type' => 'highlight', 'id' => '123456789', 'name' => 'Hi @Administrator'],
 					],
 				],
@@ -791,7 +795,7 @@ class NotifierTest extends TestCase {
 					'{user} in {call}' . "\n" . '{message}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 						'message' => ['type' => 'highlight', 'id' => '123456789', 'name' => 'Hi @Administrator'],
 					],
 				],
@@ -803,7 +807,7 @@ class NotifierTest extends TestCase {
 				[
 					'Deleted user in {call}' . "\n" . '{message}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 						'message' => ['type' => 'highlight', 'id' => '123456789', 'name' => 'Hi @Administrator'],
 					],
 				],
@@ -815,7 +819,7 @@ class NotifierTest extends TestCase {
 				[
 					'Guest in {call}' . "\n" . '{message}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 						'message' => ['type' => 'highlight', 'id' => '123456789', 'name' => 'Hi @Administrator'],
 					],
 				],
@@ -827,7 +831,7 @@ class NotifierTest extends TestCase {
 				[
 					'{guest} (guest) in {call}' . "\n" . '{message}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 						'guest' => ['type' => 'guest', 'id' => 'random-hash', 'name' => 'MyNameIs'],
 						'message' => ['type' => 'highlight', 'id' => '123456789', 'name' => 'Hi @Administrator'],
 					],
@@ -840,7 +844,7 @@ class NotifierTest extends TestCase {
 				[
 					'Guest in {call}' . "\n" . '{message}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public'],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
 						'message' => ['type' => 'highlight', 'id' => '123456789', 'name' => 'Hi @Administrator'],
 					],
 				],

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -424,6 +424,10 @@ class NotifierTest extends TestCase {
 			->method('getId')
 			->willReturn($roomId);
 
+		$this->avatarService->method('getAvatarUrl')
+			->with($room)
+			->willReturn('getAvatarUrl');
+
 		if ($type === Room::TYPE_GROUP) {
 			$n->expects($this->once())
 				->method('setRichSubject')
@@ -438,7 +442,7 @@ class NotifierTest extends TestCase {
 						'id' => $roomId,
 						'name' => $name,
 						'call-type' => 'group',
-						'icon-url' => '',
+						'icon-url' => 'getAvatarUrl',
 					],
 				])
 				->willReturnSelf();
@@ -456,7 +460,7 @@ class NotifierTest extends TestCase {
 						'id' => $roomId,
 						'name' => $name,
 						'call-type' => 'public',
-						'icon-url' => '',
+						'icon-url' => 'getAvatarUrl',
 					],
 				])
 				->willReturnSelf();
@@ -491,7 +495,7 @@ class NotifierTest extends TestCase {
 					'{user} mentioned you in a private conversation',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Test user', 'call-type' => 'one2one', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Test user', 'call-type' => 'one2one', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 			],
@@ -502,7 +506,7 @@ class NotifierTest extends TestCase {
 					'{user} mentioned you in conversation {call}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 			],
@@ -512,7 +516,7 @@ class NotifierTest extends TestCase {
 				[
 					'A deleted user mentioned you in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 				$deletedUser = true,
@@ -524,7 +528,7 @@ class NotifierTest extends TestCase {
 					'{user} mentioned you in conversation {call}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 			],
@@ -534,7 +538,7 @@ class NotifierTest extends TestCase {
 				[
 					'A deleted user mentioned you in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 				$deletedUser = true,
@@ -545,7 +549,7 @@ class NotifierTest extends TestCase {
 				[
 					'A guest mentioned you in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 				$deletedUser = false, $guestName = null,
@@ -556,7 +560,7 @@ class NotifierTest extends TestCase {
 				[
 					'{guest} (guest) mentioned you in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 						'guest' => ['type' => 'guest', 'id' => 'random-hash', 'name' => 'MyNameIs'],
 					]
 				],
@@ -568,7 +572,7 @@ class NotifierTest extends TestCase {
 				[
 					'A guest mentioned you in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 				$deletedUser = false, $guestName = '',
@@ -582,7 +586,7 @@ class NotifierTest extends TestCase {
 					'{user} sent you a private message',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Test user', 'call-type' => 'one2one', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Test user', 'call-type' => 'one2one', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 			],
@@ -593,7 +597,7 @@ class NotifierTest extends TestCase {
 					'{user} sent a message in conversation {call}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 			],
@@ -603,7 +607,7 @@ class NotifierTest extends TestCase {
 				[
 					'A deleted user sent a message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 				$deletedUser = true,
@@ -615,7 +619,7 @@ class NotifierTest extends TestCase {
 					'{user} sent a message in conversation {call}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 					]
 				],
 			],
@@ -625,7 +629,7 @@ class NotifierTest extends TestCase {
 				[
 					'A deleted user sent a message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 				$deletedUser = true
@@ -635,7 +639,7 @@ class NotifierTest extends TestCase {
 				'A guest sent a message in conversation Room name',
 				['A guest sent a message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 				$deletedUser = false, $guestName = null,
@@ -646,7 +650,7 @@ class NotifierTest extends TestCase {
 				[
 					'{guest} (guest) sent a message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 						'guest' => ['type' => 'guest', 'id' => 'random-hash', 'name' => 'MyNameIs'],
 					],
 				],
@@ -658,7 +662,7 @@ class NotifierTest extends TestCase {
 				[
 					'A guest sent a message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 				$deletedUser = false, $guestName = '',
@@ -672,7 +676,7 @@ class NotifierTest extends TestCase {
 					'{user} replied to your private message',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Test user', 'call-type' => 'one2one', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Test user', 'call-type' => 'one2one', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 			],
@@ -683,7 +687,7 @@ class NotifierTest extends TestCase {
 					'{user} replied to your message in conversation {call}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 			],
@@ -693,7 +697,7 @@ class NotifierTest extends TestCase {
 				[
 					'A deleted user replied to your message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 				$deletedUser = true,
@@ -705,7 +709,7 @@ class NotifierTest extends TestCase {
 					'{user} replied to your message in conversation {call}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 					]
 				],
 			],
@@ -715,7 +719,7 @@ class NotifierTest extends TestCase {
 				[
 					'A deleted user replied to your message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 				$deletedUser = true
@@ -725,7 +729,7 @@ class NotifierTest extends TestCase {
 				'A guest replied to your message in conversation Room name',
 				['A guest replied to your message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 				$deletedUser = false, $guestName = null,
@@ -736,7 +740,7 @@ class NotifierTest extends TestCase {
 				[
 					'{guest} (guest) replied to your message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 						'guest' => ['type' => 'guest', 'id' => 'random-hash', 'name' => 'MyNameIs'],
 					],
 				],
@@ -748,7 +752,7 @@ class NotifierTest extends TestCase {
 				[
 					'A guest replied to your message in conversation {call}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 					],
 				],
 				$deletedUser = false, $guestName = '',
@@ -762,7 +766,7 @@ class NotifierTest extends TestCase {
 					'{user}' . "\n" . '{message}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Test user', 'call-type' => 'one2one', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Test user', 'call-type' => 'one2one', 'icon-url' => 'getAvatarUrl'],
 						'message' => ['type' => 'highlight', 'id' => '123456789', 'name' => 'Hi @Administrator'],
 					],
 				],
@@ -775,7 +779,7 @@ class NotifierTest extends TestCase {
 					'{user} in {call}' . "\n" . '{message}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => 'getAvatarUrl'],
 						'message' => ['type' => 'highlight', 'id' => '123456789', 'name' => 'Hi @Administrator'],
 					],
 				],
@@ -787,7 +791,7 @@ class NotifierTest extends TestCase {
 				[
 					'Deleted user in {call}' . "\n" . '{message}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'group', 'icon-url' => 'getAvatarUrl'],
 						'message' => ['type' => 'highlight', 'id' => '123456789', 'name' => 'Hi @Administrator'],
 					],
 				],
@@ -800,7 +804,7 @@ class NotifierTest extends TestCase {
 					'{user} in {call}' . "\n" . '{message}',
 					[
 						'user' => ['type' => 'user', 'id' => 'testUser', 'name' => 'Test user'],
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 						'message' => ['type' => 'highlight', 'id' => '123456789', 'name' => 'Hi @Administrator'],
 					],
 				],
@@ -812,7 +816,7 @@ class NotifierTest extends TestCase {
 				[
 					'Deleted user in {call}' . "\n" . '{message}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 						'message' => ['type' => 'highlight', 'id' => '123456789', 'name' => 'Hi @Administrator'],
 					],
 				],
@@ -824,7 +828,7 @@ class NotifierTest extends TestCase {
 				[
 					'Guest in {call}' . "\n" . '{message}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 						'message' => ['type' => 'highlight', 'id' => '123456789', 'name' => 'Hi @Administrator'],
 					],
 				],
@@ -836,7 +840,7 @@ class NotifierTest extends TestCase {
 				[
 					'{guest} (guest) in {call}' . "\n" . '{message}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 						'guest' => ['type' => 'guest', 'id' => 'random-hash', 'name' => 'MyNameIs'],
 						'message' => ['type' => 'highlight', 'id' => '123456789', 'name' => 'Hi @Administrator'],
 					],
@@ -849,7 +853,7 @@ class NotifierTest extends TestCase {
 				[
 					'Guest in {call}' . "\n" . '{message}',
 					[
-						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => ''],
+						'call' => ['type' => 'call', 'id' => 1234, 'name' => 'Room name', 'call-type' => 'public', 'icon-url' => 'getAvatarUrl'],
 						'message' => ['type' => 'highlight', 'id' => '123456789', 'name' => 'Hi @Administrator'],
 					],
 				],
@@ -894,6 +898,10 @@ class NotifierTest extends TestCase {
 			->method('getDisplayName')
 			->with('recipient')
 			->willReturn($roomName);
+
+		$this->avatarService->method('getAvatarUrl')
+			->with($room)
+			->willReturn('getAvatarUrl');
 
 		$participant = $this->createMock(Participant::class);
 		$this->participantService->expects($this->once())

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -34,6 +34,7 @@ use OCA\Talk\Model\Message;
 use OCA\Talk\Notification\Notifier;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
+use OCA\Talk\Service\AvatarService;
 use OCA\Talk\Service\ParticipantService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\IComment;
@@ -71,6 +72,8 @@ class NotifierTest extends TestCase {
 	protected $manager;
 	/** @var ParticipantService|MockObject */
 	protected $participantService;
+	/** @var AvatarService|MockObject */
+	protected $avatarService;
 	/** @var INotificationManager|MockObject */
 	protected $notificationManager;
 	/** @var CommentsManager|MockObject */
@@ -101,6 +104,7 @@ class NotifierTest extends TestCase {
 		$this->shareManager = $this->createMock(IShareManager::class);
 		$this->manager = $this->createMock(Manager::class);
 		$this->participantService = $this->createMock(ParticipantService::class);
+		$this->avatarService = $this->createMock(AvatarService::class);
 		$this->notificationManager = $this->createMock(INotificationManager::class);
 		$this->commentsManager = $this->createMock(CommentsManager::class);
 		$this->messageParser = $this->createMock(MessageParser::class);
@@ -120,6 +124,7 @@ class NotifierTest extends TestCase {
 			$this->shareManager,
 			$this->manager,
 			$this->participantService,
+			$this->avatarService,
 			$this->notificationManager,
 			$this->commentsManager,
 			$this->messageParser,


### PR DESCRIPTION
https://github.com/nextcloud/spreed/pull/8333 introduced an optional `icon-url` for the call objects in rich messages.

Fix #8389

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
