### PR TITLE
Fix order of message of signaling server to be returned to client

### DIFF
--- a/lib/Signaling/Messages.php
+++ b/lib/Signaling/Messages.php
@@ -129,7 +129,8 @@ class Messages {
 		$query->select('*')
 			->from('talk_internalsignaling')
 			->where($query->expr()->eq('recipient', $query->createNamedParameter($sessionId)))
-			->andWhere($query->expr()->lte('timestamp', $query->createNamedParameter($time)));
+			->andWhere($query->expr()->lte('timestamp', $query->createNamedParameter($time)))
+			->orderBy('id', 'ASC');
 
 		$delete = $this->db->getQueryBuilder();
 		$delete->delete('talk_internalsignaling')


### PR DESCRIPTION
### 🚧 TODO

- [ ] Close https://github.com/nextcloud/spreed/issues/7863

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
