### PR TITLE
Remove unused property

### DIFF
--- a/lib/Service/AvatarService.php
+++ b/lib/Service/AvatarService.php
@@ -35,7 +35,6 @@ use OCP\Files\SimpleFS\InMemoryFile;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\IAvatarManager;
-use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
@@ -44,7 +43,6 @@ use OCP\Security\ISecureRandom;
 class AvatarService {
 	private IAppData $appData;
 	private IL10N $l;
-	private IConfig $config;
 	private IURLGenerator $url;
 	private ISecureRandom $random;
 	private RoomService $roomService;
@@ -53,7 +51,6 @@ class AvatarService {
 	public function __construct(
 		IAppData $appData,
 		IL10N $l,
-		IConfig $config,
 		IURLGenerator $url,
 		ISecureRandom $random,
 		RoomService $roomService,
@@ -61,7 +58,6 @@ class AvatarService {
 	) {
 		$this->appData = $appData;
 		$this->l = $l;
-		$this->config = $config;
 		$this->url = $url;
 		$this->random = $random;
 		$this->roomService = $roomService;

--- a/tests/php/Service/AvatarServiceTest.php
+++ b/tests/php/Service/AvatarServiceTest.php
@@ -31,7 +31,6 @@ use OCA\Talk\Service\AvatarService;
 use OCA\Talk\Service\RoomService;
 use OCP\Files\IAppData;
 use OCP\IAvatarManager;
-use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Security\ISecureRandom;
@@ -44,8 +43,6 @@ class AvatarServiceTest extends TestCase {
 	private $appData;
 	/** @var IL10N|MockObject */
 	private $l;
-	/** @var IConfig|MockObject */
-	private $config;
 	/** @var IURLGenerator|MockObject */
 	private $url;
 	/** @var ISecureRandom|MockObject */
@@ -60,7 +57,6 @@ class AvatarServiceTest extends TestCase {
 
 		$this->appData = $this->createMock(IAppData::class);
 		$this->l = $this->createMock(IL10N::class);
-		$this->config = $this->createMock(IConfig::class);
 		$this->url = $this->createMock(IURLGenerator::class);
 		$this->random = $this->createMock(ISecureRandom::class);
 		$this->roomService = $this->createMock(RoomService::class);
@@ -68,7 +64,6 @@ class AvatarServiceTest extends TestCase {
 		$this->service = new AvatarService(
 			$this->appData,
 			$this->l,
-			$this->config,
 			$this->url,
 			$this->random,
 			$this->roomService,


### PR DESCRIPTION
The property config isn't used at this class

### 🚧 TODO

- [ ] Close https://github.com/nextcloud/spreed/issues/9112

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
