### PR TITLE
Add configuration options for FFmpeg

### DIFF
--- a/recording/server.conf.in
+++ b/recording/server.conf.in
@@ -102,7 +102,7 @@
 
 # The options given to FFmpeg to encode the video output. The options given here
 # fully override the default options for the video output.
-#outputvideo = -c:v libvpx -deadline:v realtime
+#outputvideo = -c:v libvpx -deadline:v realtime -crf 10 -b:v 1M
 
 # The extension of the file for audio only recordings.
 #extensionaudio = .ogg

--- a/recording/server.conf.in
+++ b/recording/server.conf.in
@@ -102,7 +102,7 @@
 
 # The options given to FFmpeg to encode the video output. The options given here
 # fully override the default options for the video output.
-#outputvideo = -c:v libvpx -quality:v realtime
+#outputvideo = -c:v libvpx -deadline:v realtime
 
 # The extension of the file for audio only recordings.
 #extensionaudio = .ogg

--- a/recording/server.conf.in
+++ b/recording/server.conf.in
@@ -94,3 +94,18 @@
 # This must be the same value as configured in the signaling server
 # configuration file.
 #internalsecret = the-shared-secret-for-internal-clients
+
+[ffmpeg]
+# The options given to FFmpeg to encode the audio output. The options given here
+# fully override the default options for the audio output.
+#outputaudio = -c:a libopus
+
+# The options given to FFmpeg to encode the video output. The options given here
+# fully override the default options for the video output.
+#outputvideo = -c:v libvpx -quality:v realtime
+
+# The extension of the file for audio only recordings.
+#extensionaudio = .ogg
+
+# The extension of the file for audio and video recordings.
+#extensionvideo = .webm

--- a/recording/src/nextcloud/talk/recording/Config.py
+++ b/recording/src/nextcloud/talk/recording/Config.py
@@ -216,9 +216,9 @@ class Config:
         """
         Returns the options given to FFmpeg to encode the video output.
 
-        Defaults to ['-c:v', 'libvpx', '-quality:v', 'realtime'].
+        Defaults to ['-c:v', 'libvpx', '-deadline:v', 'realtime'].
         """
-        return self._configParser.get('ffmpeg', 'outputvideo', fallback='-c:v libvpx -quality:v realtime').split()
+        return self._configParser.get('ffmpeg', 'outputvideo', fallback='-c:v libvpx -deadline:v realtime').split()
 
     def getFfmpegExtensionAudio(self):
         """

--- a/recording/src/nextcloud/talk/recording/Config.py
+++ b/recording/src/nextcloud/talk/recording/Config.py
@@ -216,9 +216,9 @@ class Config:
         """
         Returns the options given to FFmpeg to encode the video output.
 
-        Defaults to ['-c:v', 'libvpx', '-deadline:v', 'realtime'].
+        Defaults to ['-c:v', 'libvpx', '-deadline:v', 'realtime', '-crf', '10', '-b:v', '1M'].
         """
-        return self._configParser.get('ffmpeg', 'outputvideo', fallback='-c:v libvpx -deadline:v realtime').split()
+        return self._configParser.get('ffmpeg', 'outputvideo', fallback='-c:v libvpx -deadline:v realtime -crf 10 -b:v 1M').split()
 
     def getFfmpegExtensionAudio(self):
         """

--- a/recording/src/nextcloud/talk/recording/Config.py
+++ b/recording/src/nextcloud/talk/recording/Config.py
@@ -204,4 +204,36 @@ class Config:
 
         return self._configParser.get('signaling', 'internalsecret', fallback=None)
 
+    def getFfmpegOutputAudio(self):
+        """
+        Returns the options given to FFmpeg to encode the audio output.
+
+        Defaults to ['-c:a', 'libopus'].
+        """
+        return self._configParser.get('ffmpeg', 'outputaudio', fallback='-c:a libopus').split()
+
+    def getFfmpegOutputVideo(self):
+        """
+        Returns the options given to FFmpeg to encode the video output.
+
+        Defaults to ['-c:v', 'libvpx', '-quality:v', 'realtime'].
+        """
+        return self._configParser.get('ffmpeg', 'outputvideo', fallback='-c:v libvpx -quality:v realtime').split()
+
+    def getFfmpegExtensionAudio(self):
+        """
+        Returns the extension of the output file for audio recordings.
+
+        Defaults to ".ogg".
+        """
+        return self._configParser.get('ffmpeg', 'extensionaudio', fallback='.ogg')
+
+    def getFfmpegExtensionVideo(self):
+        """
+        Returns the extension of the output file for video recordings.
+
+        Defaults to ".webm".
+        """
+        return self._configParser.get('ffmpeg', 'extensionvideo', fallback='.webm')
+
 config = Config()

--- a/recording/src/nextcloud/talk/recording/Service.py
+++ b/recording/src/nextcloud/talk/recording/Service.py
@@ -54,12 +54,12 @@ def getRecorderArgs(status, displayId, audioSinkIndex, width, height, extensionl
     ffmpegCommon = ['ffmpeg', '-loglevel', 'level+warning', '-n']
     ffmpegInputAudio = ['-f', 'pulse', '-i', audioSinkIndex]
     ffmpegInputVideo = ['-f', 'x11grab', '-draw_mouse', '0', '-video_size', f'{width}x{height}', '-i', displayId]
-    ffmpegOutputAudio = ['-c:a', 'libopus']
-    ffmpegOutputVideo = ['-c:v', 'libvpx', '-quality:v', 'realtime']
+    ffmpegOutputAudio = config.getFfmpegOutputAudio()
+    ffmpegOutputVideo = config.getFfmpegOutputVideo()
 
-    extension = '.ogg'
+    extension = config.getFfmpegExtensionAudio()
     if status == RECORDING_STATUS_AUDIO_AND_VIDEO:
-        extension = '.webm'
+        extension = config.getFfmpegExtensionVideo()
 
     outputFileName = extensionlessOutputFileName + extension
 


### PR DESCRIPTION
Besides making the encoders and the extension configurable this also increases the default quality for videos and serves as the basis to add a benchmark tool.

In the future it could be better to make it configurable as well by backend, given that each backend can use different resolutions and thus might not require the same quality, but for now this should be enough.
