### PR TITLE
Fix RemoteVideoBlocker still active after removing its associated model

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -440,6 +440,8 @@ export default {
 			const removedModelIds = Object.keys(this.sharedDatas).filter(sharedDataId => models.find(model => model.attributes.peerId === sharedDataId) === undefined)
 
 			removedModelIds.forEach(removedModelId => {
+				this.sharedDatas[removedModelId].remoteVideoBlocker.destroy()
+
 				this.$delete(this.sharedDatas, removedModelId)
 
 				this.speakingUnwatchers[removedModelId]()

--- a/src/utils/webrtc/RemoteVideoBlocker.spec.js
+++ b/src/utils/webrtc/RemoteVideoBlocker.spec.js
@@ -333,4 +333,59 @@ describe('RemoteVideoBlocker', () => {
 			expect(remoteVideoBlocker.isVideoEnabled()).toBe(true)
 		})
 	})
+
+	describe('destroy', () => {
+		test('prevents the video from being blocked by default if not shown in some seconds', () => {
+			jest.advanceTimersByTime(4000)
+
+			expect(callParticipantModel.setVideoBlocked).toHaveBeenCalledTimes(0)
+
+			remoteVideoBlocker.destroy()
+
+			jest.advanceTimersByTime(1000)
+
+			expect(callParticipantModel.setVideoBlocked).toHaveBeenCalledTimes(0)
+		})
+
+		test('prevents the video from being blocked or unblocked if enabled or disabled', () => {
+			remoteVideoBlocker.increaseVisibleCounter()
+
+			remoteVideoBlocker.destroy()
+
+			remoteVideoBlocker.setVideoEnabled(false)
+			remoteVideoBlocker.setVideoEnabled(true)
+
+			expect(callParticipantModel.setVideoBlocked).toHaveBeenCalledTimes(0)
+		})
+
+		test('prevents the video from being blocked after some seconds if hidden before destroying', () => {
+			remoteVideoBlocker.increaseVisibleCounter()
+			remoteVideoBlocker.decreaseVisibleCounter()
+
+			jest.advanceTimersByTime(4000)
+
+			expect(callParticipantModel.setVideoBlocked).toHaveBeenCalledTimes(0)
+
+			remoteVideoBlocker.destroy()
+
+			jest.advanceTimersByTime(1000)
+
+			expect(callParticipantModel.setVideoBlocked).toHaveBeenCalledTimes(0)
+		})
+
+		test('prevents the video from being blocked after some seconds if hidden after destroying', () => {
+			remoteVideoBlocker.destroy()
+
+			remoteVideoBlocker.increaseVisibleCounter()
+			remoteVideoBlocker.decreaseVisibleCounter()
+
+			jest.advanceTimersByTime(4000)
+
+			expect(callParticipantModel.setVideoBlocked).toHaveBeenCalledTimes(0)
+
+			jest.advanceTimersByTime(1000)
+
+			expect(callParticipantModel.setVideoBlocked).toHaveBeenCalledTimes(0)
+		})
+	})
 })


### PR DESCRIPTION
## How to test (scenario 1)

- Setup the HPB
- Start a call with video enabled
- In a private window, join the call
- Open the browser console
- Leave the call

### Result with this pull request

No error is printed in the console

### Result without this pull request

`Ignore unknown error` (and, if expanded, `client_not_found - No MCU client found to send message to`) is printed (after 5 seconds) in the console



## How to test (scenario 2)

- Setup the HPB
- Start a call with video enabled
- In a private window, join the call
- Open the browser console
- Leave the call
- Quickly join the call again (before 5 seconds have elapsed)

### Result with this pull request

The remote video works as expected

### Result without this pull request

The remote video freezes
