### PR TITLE
fix(breakout-rooms): Fix breakout room option shown for public conver…

### DIFF
--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -357,7 +357,7 @@ export default {
 		},
 
 		canConfigureBreakoutRooms() {
-			if (!this.conversation.type === CONVERSATION.TYPE.GROUP || !this.canFullModerate) {
+			if (this.conversation.type !== CONVERSATION.TYPE.GROUP || !this.canFullModerate) {
 				return false
 			}
 


### PR DESCRIPTION
…sations

### ☑️ Resolves

* Issue #9128 
* Regression from boolean logic change in https://github.com/nextcloud/spreed/commit/ff1745b7bf316c574f0ec3341159136f68f348ed

![image](https://user-images.githubusercontent.com/213943/226851067-68dd1618-a041-467a-a8e4-e2f5f19a189f.png)


### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Bildschirmfoto vom 2023-03-22 09-55-09](https://user-images.githubusercontent.com/213943/226850894-9bf6c35e-62ba-48cc-820a-5350040fea03.png) | ![Bildschirmfoto vom 2023-03-22 09-55-18](https://user-images.githubusercontent.com/213943/226850901-23c36a73-2267-41ee-bf19-4ffe3e29011d.png)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
