### PR TITLE
Fix documentation about capability and update wording

### DIFF
--- a/docs/chat.md
+++ b/docs/chat.md
@@ -24,7 +24,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`: since Nextcloud 13
 | `setReadMarker`           | int  | `1` to automatically set the read timer after fetching the messages, use `0` when your client calls `Mark chat as read` manually. (Default: `1`)                                                                                        |
 | `includeLastKnown`        | int  | `1` to include the last known message as well (Default: `0`)                                                                                                                                                                            |
 | `noStatusUpdate`          | int  | Whether the "online" user status of the current user should be "kept-alive" (`1`) or not (`0`) (defaults to `0`)                                                                                                                        |
-| `markNotificationsAsRead` | int  | `0` to not mark notifications as read (Default: `1`, only available with `chat-read-status` capability)                                                                                                                                 |
+| `markNotificationsAsRead` | int  | `0` to not mark notifications as read (Default: `1`, only available with `chat-keep-notifications` capability)                                                                                                                          |
 
 * Response:
     - Status code:

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -23,7 +23,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`: since Nextcloud 13
 | `timeout`                 | int  | `$lookIntoFuture = 1` only, Number of seconds to wait for new messages (30 by default, 60 at most)                                                                                                                                      |
 | `setReadMarker`           | int  | `1` to automatically set the read timer after fetching the messages, use `0` when your client calls `Mark chat as read` manually. (Default: `1`)                                                                                        |
 | `includeLastKnown`        | int  | `1` to include the last known message as well (Default: `0`)                                                                                                                                                                            |
-| `noStatusUpdate`          | int  | Whether the "online" user status of the current user should be "kept-alive" (`1`) or not (`0`) (defaults to `0`)                                                                                                                        |
+| `noStatusUpdate`          | int  | When the user status should not be automatically set to online set to 1 (default 0)                                                                                                                                                     |
 | `markNotificationsAsRead` | int  | `0` to not mark notifications as read (Default: `1`, only available with `chat-keep-notifications` capability)                                                                                                                          |
 
 * Response:

--- a/docs/conversation.md
+++ b/docs/conversation.md
@@ -29,7 +29,7 @@
 
 | field            | type | Description                                                                                                                                                                     |
 |------------------|------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `noStatusUpdate` | int  | Whether the "online" user status of the current user should be "kept-alive" (`1`) or not (`0`) (defaults to `0`)                                                                |
+| `noStatusUpdate` | int  | When the user status should not be automatically set to online set to 1 (default 0)                                                                                             |
 | `includeStatus`  | bool | Whether the user status information of all one-to-one conversations should be loaded (default false)                                                                            |
 | `modifiedSince`  | int  | **Use with care as per note above.** When provided only conversations with a newer `lastActivity` (and one-to-one conversations when `includeStatus` is provided) are returned. |
 


### PR DESCRIPTION
### ☑️ Resolves

Fixes https://github.com/nextcloud/spreed/pull/9066#discussion_r1143267669

`chat-keep-notifications` is the correct capability needed for the `markNotificationsAsRead` parameter.
Also I updated the wording for `noStatusUpdate` parameter, to be inline with the PHP annotation, which I think makes more sense.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
