### PR TITLE
User agent for recording backend requests

### DIFF
--- a/recording/src/nextcloud/talk/recording/BackendNotifier.py
+++ b/recording/src/nextcloud/talk/recording/BackendNotifier.py
@@ -28,6 +28,7 @@ import json
 import logging
 import os
 import ssl
+from nextcloud.talk import recording
 from secrets import token_urlsafe
 from urllib.request import Request, urlopen
 from urllib3 import encode_multipart_formdata
@@ -98,6 +99,7 @@ def backendRequest(backend, data):
         'OCS-ApiRequest': 'true',
         'Talk-Recording-Random': random,
         'Talk-Recording-Checksum': checksum,
+        'User-Agent': 'Mozilla/5.0 (Recording) Nextcloud-Talk v' + recording.__version__,
     }
 
     backendRequest = Request(url, data, headers)


### PR DESCRIPTION
When Cloudflare or similar is used for the main/frontend site, it stops the Recording Server requests from ever reaching the server, due to the `User-Agent` reported by the recording server, `Python-urllib/X.Y` ([urllib.request.Request](https://docs.python.org/3/library/urllib.request.html#urllib.request.Request)).

This PR adds a user-configurable setting for such `User-Agent`.