### PR TITLE
fix(chats): Don't mark conversation unread when receiving a reaction …

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -498,6 +498,11 @@ export default {
 			}
 
 			if (event.notification.objectType === 'chat') {
+				if (event.notification.subjectRichParameters?.reaction) {
+					// Ignore reaction notifications in case of one-to-one and always-notify
+					return
+				}
+
 				this.$store.dispatch('updateConversationLastMessageFromNotification', {
 					notification: event.notification,
 				})


### PR DESCRIPTION
…notification

### ☑️ Resolves

* Fix #9134 

### Steps

1. User 1: Write a message in Talk room
2. User 1: Open talk homepage
3. User 2: React to the message from 1.
4. User 1: Between the time the notifications refresh and the conversation list refreshes, see the chat as unread with counter "(1)" and subline being "User 2:" + your chat message

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
