### PR TITLE
Add missing user agent and double slashes cleanup

### DIFF
--- a/recording/src/nextcloud/talk/recording/BackendNotifier.py
+++ b/recording/src/nextcloud/talk/recording/BackendNotifier.py
@@ -99,7 +99,7 @@ def backendRequest(backend, data):
         'OCS-ApiRequest': 'true',
         'Talk-Recording-Random': random,
         'Talk-Recording-Checksum': checksum,
-        'User-Agent': 'Mozilla/5.0 (Recording) Nextcloud-Talk v' + recording.__version__,
+        'User-Agent': recording.USER_AGENT,
     }
 
     backendRequest = Request(url, data, headers)
@@ -209,6 +209,7 @@ def uploadRecording(backend, token, fileName, owner):
         'OCS-ApiRequest': 'true',
         'Talk-Recording-Random': random,
         'Talk-Recording-Checksum': checksum,
+        'User-Agent': recording.USER_AGENT,
     }
 
     uploadRequest = Request(url, data, headers)

--- a/recording/src/nextcloud/talk/recording/BackendNotifier.py
+++ b/recording/src/nextcloud/talk/recording/BackendNotifier.py
@@ -188,7 +188,7 @@ def uploadRecording(backend, token, fileName, owner):
 
     logger.info(f"Upload recording {fileName} to {backend} in {token} as {owner}")
 
-    url = backend + '/ocs/v2.php/apps/spreed/api/v1/recording/' + token + '/store'
+    url = backend.rstrip('/') + '/ocs/v2.php/apps/spreed/api/v1/recording/' + token + '/store'
 
     fileContents = None
     with open(fileName, 'rb') as file:

--- a/recording/src/nextcloud/talk/recording/__init__.py
+++ b/recording/src/nextcloud/talk/recording/__init__.py
@@ -1,5 +1,6 @@
 #
 # @copyright Copyright (c) 2023, Daniel Calviño Sánchez (danxuliu@gmail.com)
+# @copyright Copyright (c) 2023, Elmer Miroslav Mosher Golovin (miroslav@mishamosher.com)
 #
 # @license GNU AGPL version 3 or any later version
 #

--- a/recording/src/nextcloud/talk/recording/__init__.py
+++ b/recording/src/nextcloud/talk/recording/__init__.py
@@ -21,3 +21,5 @@ __version__ = 0.1
 
 RECORDING_STATUS_AUDIO_AND_VIDEO = 1
 RECORDING_STATUS_AUDIO_ONLY = 2
+
+USER_AGENT = f'Mozilla/5.0 (Recording) Nextcloud-Talk v{__version__}'


### PR DESCRIPTION
A follow up of [#9175](https://github.com/nextcloud/spreed/pull/9175), as there was a missing `User-Agent`.

Also, clean up the double slashes for `uploadRecording`.