### PR TITLE
fix(changelog): Add missing "New in Talk 16"

### DIFF
--- a/lib/Chat/Changelog/Manager.php
+++ b/lib/Chat/Changelog/Manager.php
@@ -124,6 +124,11 @@ class Manager {
 			$this->l->t('- Configure an expiration time for chat messages'),
 			$this->l->t('- Start calls without notifying others in big conversations. You can send individual call notifications once the call has started.'),
 			$this->l->t('- Send chat messages without notifying the recipients in case it is not urgent'),
+			$this->l->t('New in Talk %s', ['16']),
+			$this->l->t('- Emojis can now be now be autocompleted by typing a :'),
+			$this->l->t('- Link various items using the new smart-picker by typing a /'),
+			$this->l->t('- Moderators can now create breakout rooms (Requires the external signaling server)'),
+			$this->l->t('- Calls can now be recorded (Requires the external signaling server)'),
 		];
 	}
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9106 

### 🖼️ Screenshots

![grafik](https://user-images.githubusercontent.com/213943/228499304-f21968c3-303a-4a6c-b87e-076f67ae4780.png)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
