### PR TITLE
`RightSidebar` improvements and bug fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -28,7 +28,7 @@
 		<NcAppContent>
 			<router-view />
 		</NcAppContent>
-		<RightSidebar :show-chat-in-sidebar="isInCall" />
+		<RightSidebar :is-in-call="isInCall" />
 		<PreventUnload :when="warnLeaving || isSendingMessages" />
 		<DeviceChecker :initialize-on-mounted="false" />
 		<UploadEditor />
@@ -65,12 +65,8 @@ import talkHashCheck from './mixins/talkHashCheck.js'
 import Router from './router/router.js'
 import BrowserStorage from './services/BrowserStorage.js'
 import { EventBus } from './services/EventBus.js'
-import {
-	leaveConversationSync,
-} from './services/participantsService.js'
-import {
-	signalingKill,
-} from './utils/webrtc/index.js'
+import { leaveConversationSync } from './services/participantsService.js'
+import { signalingKill } from './utils/webrtc/index.js'
 
 // Styles
 import '@nextcloud/dialogs/dist/index.css'

--- a/src/components/BreakoutRoomsEditor/SendMessageDialog.vue
+++ b/src/components/BreakoutRoomsEditor/SendMessageDialog.vue
@@ -26,6 +26,7 @@
 				{{ dialogTitle }}
 			</h2>
 			<NewMessageForm v-if="modalContainerId"
+				ref="messageForm"
 				role="region"
 				:token="token"
 				:breakout-room="true"
@@ -98,6 +99,9 @@ export default {
 	mounted() {
 		// Postpone render of NewMessageForm until modal container is mounted
 		this.modalContainerId = `#modal-description-${this.$refs.modal.randId}`
+		this.$nextTick(() => {
+			this.$refs.messageForm.focusInput()
+		})
 	},
 
 	methods: {

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -562,7 +562,7 @@ export default {
 				// Also remove the message to be replied for this conversation
 				await this.$store.dispatch('removeMessageToBeReplied', this.token)
 
-				this.breakoutRoom
+				this.broadcast
 					? await this.broadcastMessage(temporaryMessage, options)
 					: await this.postMessage(temporaryMessage, options)
 			}

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -287,17 +287,28 @@ export default {
 			}
 		},
 
-		showChatInSidebar(chatInSidebar) {
-			if (chatInSidebar) {
-				this.activeTab = 'chat'
-			} else if (this.activeTab === 'chat') {
+		showChatInSidebar(newValue) {
+			// Waiting for chat tab to mount / destroy
+			this.$nextTick(() => {
+				if (newValue) {
+				// Set 'chat' tab as active, and switch to it if sidebar is open
+					this.activeTab = 'chat'
+					return
+				}
+
+				// If 'chat' tab wasn't active, leave it as is
+				if (this.activeTab !== 'chat') {
+					return
+				}
+
+				// In other case switch to other tabs
 				if (this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE
 					|| this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER) {
 					this.activeTab = 'shared-items'
 				} else {
 					this.activeTab = 'participants'
 				}
-			}
+			})
 		},
 
 		token() {

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -201,7 +201,7 @@ export default {
 
 		canSearchParticipants() {
 			return (this.conversation.type === CONVERSATION.TYPE.GROUP
-					|| (this.conversation.type === CONVERSATION.TYPE.PUBLIC && this.conversation.objectType !== 'share:password'))
+				|| (this.conversation.type === CONVERSATION.TYPE.PUBLIC && this.conversation.objectType !== 'share:password'))
 		},
 
 		isSearching() {
@@ -277,13 +277,26 @@ export default {
 				this.conversationName = this.conversation.displayName
 			}
 
-			if (newConversation.token !== oldConversation.token) {
-				if (newConversation.type === CONVERSATION.TYPE.ONE_TO_ONE
-					|| newConversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER) {
-					this.activeTab = 'shared-items'
-				} else {
-					this.activeTab = 'participants'
-				}
+			if (newConversation.token === oldConversation.token) {
+				return
+			}
+
+			if (newConversation.type === CONVERSATION.TYPE.ONE_TO_ONE
+				|| newConversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER) {
+				this.activeTab = 'shared-items'
+				return
+			}
+
+			// Remain on "breakout-rooms" tab, when switching back to main room
+			if (this.breakoutRoomsConfigured && this.activeTab === 'breakout-rooms') {
+				return
+			}
+
+			// In other case switch to other tabs
+			if (this.showChatInSidebar) {
+				this.activeTab = 'chat'
+			} else {
+				this.activeTab = 'participants'
 			}
 		},
 

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -32,7 +32,7 @@
 		<template slot="description">
 			<LobbyStatus v-if="canFullModerate && hasLobbyEnabled" :token="token" />
 		</template>
-		<NcAppSidebarTab v-if="showChatInSidebar"
+		<NcAppSidebarTab v-if="isInCall"
 			id="chat"
 			:order="1"
 			:name="t('spreed', 'Chat')">
@@ -129,22 +129,23 @@ import BrowserStorage from '../../services/BrowserStorage.js'
 export default {
 	name: 'RightSidebar',
 	components: {
+		BreakoutRoomsTab,
+		ChatView,
+		LobbyStatus,
 		NcAppSidebar,
 		NcAppSidebarTab,
-		SharedItemsTab,
-		ChatView,
+		NcButton,
 		ParticipantsTab,
 		SetGuestUsername,
+		SharedItemsTab,
 		SipSettings,
-		LobbyStatus,
-		NcButton,
+		// Icons
 		AccountMultiple,
 		CogIcon,
+		DotsCircle,
 		FolderMultipleImage,
 		InformationOutline,
 		Message,
-		DotsCircle,
-		BreakoutRoomsTab,
 	},
 
 	mixins: [
@@ -152,7 +153,7 @@ export default {
 	],
 
 	props: {
-		showChatInSidebar: {
+		isInCall: {
 			type: Boolean,
 			required: true,
 		},
@@ -261,8 +262,7 @@ export default {
 		},
 
 		showBreakoutRoomsTab() {
-			return this.getUserId
-				&& !this.isOneToOne
+			return this.getUserId && !this.isOneToOne
 				&& (this.breakoutRoomsConfigured || this.conversation.breakoutRoomMode === CONVERSATION.BREAKOUT_ROOM_MODE.FREE || this.conversation.objectType === 'room')
 		},
 
@@ -281,8 +281,7 @@ export default {
 				return
 			}
 
-			if (newConversation.type === CONVERSATION.TYPE.ONE_TO_ONE
-				|| newConversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER) {
+			if (this.isOneToOne) {
 				this.activeTab = 'shared-items'
 				return
 			}
@@ -293,18 +292,18 @@ export default {
 			}
 
 			// In other case switch to other tabs
-			if (this.showChatInSidebar) {
+			if (this.isInCall) {
 				this.activeTab = 'chat'
 			} else {
 				this.activeTab = 'participants'
 			}
 		},
 
-		showChatInSidebar(newValue) {
+		isInCall(newValue) {
 			// Waiting for chat tab to mount / destroy
 			this.$nextTick(() => {
 				if (newValue) {
-				// Set 'chat' tab as active, and switch to it if sidebar is open
+					// Set 'chat' tab as active, and switch to it if sidebar is open
 					this.activeTab = 'chat'
 					return
 				}
@@ -315,8 +314,7 @@ export default {
 				}
 
 				// In other case switch to other tabs
-				if (this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE
-					|| this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER) {
+				if (this.isOneToOne) {
 					this.activeTab = 'shared-items'
 				} else {
 					this.activeTab = 'participants'


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9183 

### 🖼️ Screenshots

https://user-images.githubusercontent.com/93392545/228841793-86d419d8-4100-4e5d-ac81-96befe7d3d7e.mp4




### 🚧 Tasks

- [x] Fix issue: check if message is a broadcast or for specific room;

Other fixes:
- [x] Autofocus on input when messaging to breakout rooms;
- [x] Fix intended tab behavior (open chat tab when joining the call);
- [x] Moderator remains on `breakout rooms` tab when goes back to main room;
- [x] Refactoring;

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
