### PR TITLE
fix(CI): Force enable 3rdparty apps in integration tests

### DIFF
--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -54,9 +54,9 @@ ${ROOT_DIR}/occ app:getpath notifications || (cd ../../../ && git clone --depth 
 ${ROOT_DIR}/occ app:getpath guests || (cd ../../../ && git clone --depth 1 --branch ${GUESTS_BRANCH} https://github.com/nextcloud/guests)
 
 ${ROOT_DIR}/occ app:enable spreed || exit 1
-${ROOT_DIR}/occ app:enable spreedcheats || exit 1
-${ROOT_DIR}/occ app:enable notifications || exit 1
-${ROOT_DIR}/occ app:enable guests || exit 1
+${ROOT_DIR}/occ app:enable --force spreedcheats || exit 1
+${ROOT_DIR}/occ app:enable --force notifications || exit 1
+${ROOT_DIR}/occ app:enable --force guests || exit 1
 
 ${ROOT_DIR}/occ app:list | grep spreed
 ${ROOT_DIR}/occ app:list | grep notifications


### PR DESCRIPTION
### ☑️ Resolves

* Fix integration tests after guests app removed 27 support from master: https://github.com/nextcloud/guests/pull/1009#discussion_r1154097978

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
