### PR TITLE
fix(CI): Disable rate limiting protection

### DIFF
--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -68,6 +68,8 @@ echo '# Optimizing configuration'
 echo '#'
 # Disable bruteforce protection because the integration tests do trigger them
 ${ROOT_DIR}/occ config:system:set auth.bruteforce.protection.enabled --value false --type bool
+# Disable rate limit protection because the integration tests do trigger them
+${ROOT_DIR}/occ config:system:set ratelimit.protection.enabled --value false --type bool
 # Allow local remote urls otherwise we can not share
 ${ROOT_DIR}/occ config:system:set allow_local_remote_servers --value true --type bool
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix red CI on integration tests
* Close #9233 

### 🚧 Tasks

- [x] https://github.com/nextcloud/server/pull/37542

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
