### PR TITLE
Fix redirect url in session error handling for desktop

### DIFF
--- a/src/mixins/sessionIssueHandler.js
+++ b/src/mixins/sessionIssueHandler.js
@@ -56,8 +56,8 @@ const sessionIssueHandler = {
 					window.location = generateUrl(url)
 				})
 			} else {
-				// TODO: DESKTOP: to not hard-code the address?
-				window.location = `/talk_window/#${url}`
+				window.location.hash = `#${url}`
+				window.location.reload()
 			}
 		},
 


### PR DESCRIPTION
### 💁 Description

The URL in the session error handling redirect was not correct on the Desktop. 

Previously it redirected by an absolute URL. But it worked only on the dev server on the `http://` protocol. An absolute path is not correct for the `file://` protocol on the production build. It causes a black screen after receiving any signaling session error.

The new solution updates only hash (Hash routing is used on desktop) and reloads the page.

**NO CHANGES FOR WEB**

### ☑️ Resolves

* Fix (likely): https://github.com/nextcloud/talk-desktop/issues/73

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
