### PR TITLE
fix(settings): Fix missing recording settings when upload limit is INF

### DIFF
--- a/lib/Settings/Admin/AdminSettings.php
+++ b/lib/Settings/Admin/AdminSettings.php
@@ -474,10 +474,11 @@ class AdminSettings implements ISettings {
 	}
 
 	protected function initRecording(): void {
+		$uploadLimit = Util::uploadLimit();
 		$this->initialState->provideInitialState('recording_servers', [
 			'servers' => $this->talkConfig->getRecordingServers(),
 			'secret' => $this->talkConfig->getRecordingSecret(),
-			'uploadLimit' => Util::uploadLimit(),
+			'uploadLimit' => is_infinite($uploadLimit) ? 0 : $uploadLimit,
 		]);
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9181 
* API upstream proposal in https://github.com/nextcloud/server/pull/37572

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://user-images.githubusercontent.com/213943/229737883-d731c641-efa5-4223-9d3b-5abbbf6d989a.png)<br>![grafik](https://user-images.githubusercontent.com/213943/229737967-d516f8a0-906b-4a65-96e9-5ff21b6b4af9.png) | ![grafik](https://user-images.githubusercontent.com/213943/229738052-cd4fa417-868a-4ba5-a446-bf4086068fba.png)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
