### PR TITLE
Avoid out-of-memory errors when uploading a recording

### DIFF
--- a/recording/pyproject.toml
+++ b/recording/pyproject.toml
@@ -9,8 +9,8 @@ dependencies = [
     "flask",
     "pulsectl",
     "pyvirtualdisplay>=2.0",
+    "requests-toolbelt",
     "selenium>=4.6.0",
-    "urllib3",
     "websocket-client",
 ]
 dynamic = ["version"]

--- a/recording/src/nextcloud/talk/recording/BackendNotifier.py
+++ b/recording/src/nextcloud/talk/recording/BackendNotifier.py
@@ -190,15 +190,11 @@ def uploadRecording(backend, token, fileName, owner):
 
     url = backend.rstrip('/') + '/ocs/v2.php/apps/spreed/api/v1/recording/' + token + '/store'
 
-    fileContents = None
-    with open(fileName, 'rb') as file:
-        fileContents = file.read()
-
     # Plain values become arguments, while tuples become files; the body used to
     # calculate the checksum is empty.
     data = {
         'owner': owner,
-        'file': (os.path.basename(fileName), fileContents),
+        'file': (os.path.basename(fileName), open(fileName, 'rb')),
     }
 
     multipartEncoder = MultipartEncoder(data)

--- a/tests/php/Service/RecordingServiceTest.php
+++ b/tests/php/Service/RecordingServiceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2022, Vitor Mattos <vitor@php.rio>
+ * @copyright Copyright (c) 2023, Elmer Miroslav Mosher Golovin (miroslav@mishamosher.com)
  *
  * @author Vitor Mattos <vitor@php.rio>
  *
@@ -119,34 +120,35 @@ class RecordingServiceTest extends TestCase {
 	}
 
 	/** @dataProvider dataValidateFileFormat */
-	public function testValidateFileFormat(string $fileName, string $content, string $exceptionMessage):void {
+	public function testValidateFileFormat(string $fileName, string $fileRealPath, string $exceptionMessage): void {
 		if ($exceptionMessage) {
 			$this->expectExceptionMessage($exceptionMessage);
 		} else {
 			$this->expectNotToPerformAssertions();
 		}
-		$this->recordingService->validateFileFormat($fileName, $content);
+		$this->recordingService->validateFileFormat($fileName, $fileRealPath);
 	}
 
 	public function dataValidateFileFormat(): array {
 		return [
+			# file_invalid_path
+			['', '', 'file_invalid_path'],
 			# file_mimetype
-			['', '', 'file_mimetype'],
-			['', file_get_contents(__DIR__ . '/../../../img/app.svg'), 'file_mimetype'],
-			['name.ogg', file_get_contents(__DIR__ . '/../../../img/app.svg'), 'file_mimetype'],
+			['', realpath(__DIR__ . '/../../../img/app.svg'), 'file_mimetype'],
+			['name.ogg', realpath(__DIR__ . '/../../../img/app.svg'), 'file_mimetype'],
 			# file_extension
-			['', file_get_contents(__DIR__ . '/../../../img/join_call.ogg'), 'file_extension'],
-			['name', file_get_contents(__DIR__ . '/../../../img/join_call.ogg'), 'file_extension'],
-			['name.mp3', file_get_contents(__DIR__ . '/../../../img/join_call.ogg'), 'file_extension'],
+			['', realpath(__DIR__ . '/../../../img/join_call.ogg'), 'file_extension'],
+			['name', realpath(__DIR__ . '/../../../img/join_call.ogg'), 'file_extension'],
+			['name.mp3', realpath(__DIR__ . '/../../../img/join_call.ogg'), 'file_extension'],
 			# Success
-			['name.ogg', file_get_contents(__DIR__ . '/../../../img/join_call.ogg'), ''],
+			['name.ogg', realpath(__DIR__ . '/../../../img/join_call.ogg'), ''],
 		];
 	}
 
 	/**
-	 * @dataProvider dataGetContentFromFileArray
+	 * @dataProvider dataGetResourceFromFileArray
 	 */
-	public function testGetContentFromFileArray(array $file, $expected, string $exceptionMessage): void {
+	public function testGetResourceFromFileArray(array $file, $expected, string $exceptionMessage): void {
 		if ($exceptionMessage) {
 			$this->expectExceptionMessage($exceptionMessage);
 		}
@@ -158,12 +160,11 @@ class RecordingServiceTest extends TestCase {
 		]);
 		$participant = new Participant($room, $attendee, null);
 
-		$actual = $this->recordingService->getContentFromFileArray($file, $room, $participant);
+		$actual = stream_get_contents($this->recordingService->getResourceFromFileArray($file, $room, $participant));
 		$this->assertEquals($expected, $actual);
-		$this->assertFileDoesNotExist($file['tmp_name']);
 	}
 
-	public function dataGetContentFromFileArray(): array {
+	public function dataGetResourceFromFileArray(): array {
 		$fileWithContent = tempnam(sys_get_temp_dir(), 'txt');
 		file_put_contents($fileWithContent, 'bla');
 		return [


### PR DESCRIPTION
Currently, the recording server (and the backend server) loads the entirety of the recording file into RAM, which is far from optimal.

This PR changes such behavior and uses a streaming POST request instead.

# For reviewers:

I've noted that `newFile($fileName, $content)` ([source code](https://github.com/nextcloud/server/blob/215aef3cbdc1963be1bb6bca5218ee0a4b7f1665/lib/public/Files/Folder.php#L113)) accepts `string|resource|null`, and `resource` is used in this case.

In my tests it performs a *copy* (and not a simple file rename), which temporarily wastes storage space in my current implementation.

I'm unsure how to force it to perform a file rename instead, or even if the current implementation (copy) is the desired solution so that compatibility with streaming-based file storage is not affected.