### PR TITLE
Show empty content only when there is nothing to show

### DIFF
--- a/src/components/RightSidebar/SharedItems/SharedItemsTab.vue
+++ b/src/components/RightSidebar/SharedItems/SharedItemsTab.vue
@@ -42,7 +42,8 @@
 		<NcRelatedResourcesPanel class="related-resources"
 			provider-id="talk"
 			:item-id="conversation.token"
-			@has-resources="value => hasRelatedResources = value" />
+			@has-resources="value => isRelatedResourcesVisible = value"
+			@has-error="value => isRelatedResourcesVisible = value" />
 		<template v-if="projectsEnabled">
 			<NcAppNavigationCaption :title="t('spreed', 'Projects')" />
 			<CollectionList v-if="getUserId && token"
@@ -51,7 +52,7 @@
 				:name="conversation.displayName"
 				:is-active="active" />
 		</template>
-		<NcEmptyContent v-else-if="!hasSharedItems && !hasRelatedResources"
+		<NcEmptyContent v-else-if="!hasSharedItems && !isRelatedResourcesVisible"
 			:title="t('spreed', 'No shared items')">
 			<template #icon>
 				<FolderMultipleImage :size="20" />
@@ -114,7 +115,7 @@ export default {
 			showSharedItemsBrowser: false,
 			browserActiveTab: '',
 			projectsEnabled: loadState('core', 'projects_enabled', false),
-			hasRelatedResources: false,
+			isRelatedResourcesVisible: false,
 		}
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

- For https://github.com/nextcloud/nextcloud-vue/issues/3838

Adapt to component changes requested by designers in https://github.com/nextcloud/nextcloud-vue/pull/3852

Now the panel is visible when there is an error in addition to when there are resources

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://user-images.githubusercontent.com/24800714/229940235-2015e34a-95b7-4b9e-bbfc-8973994f4fe3.png) | ![image](https://user-images.githubusercontent.com/24800714/229940255-60cd6f55-d17f-42c4-81b3-404b76409bec.png)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed