### PR TITLE
Add note about using modifiedSince with includeStatus set to true

### DIFF
--- a/docs/conversation.md
+++ b/docs/conversation.md
@@ -15,7 +15,7 @@
 
 !!! note
 
-    When `modifiedSince` is provided only conversations with a newer `lastActivity` are returned. If `includeStatus` is set to `true` this will also return all one-to-one conversations.
+    When `modifiedSince` is provided only conversations with a newer `lastActivity` are returned. If `includeStatus` is set to `true` all one-to-one conversations will be returned to make sure the latest user status is returned.
     Due to the nature of the data structure we can not return information that a conversation was deleted
     or the user removed from a conversation. Therefore it is recommended to do a full refresh:
     * Every 5 minutes

--- a/docs/conversation.md
+++ b/docs/conversation.md
@@ -15,7 +15,7 @@
 
 !!! note
 
-    When `modifiedSince` is provided only conversations with a newer `lastActivity` are returned.
+    When `modifiedSince` is provided only conversations with a newer `lastActivity` are returned. If `includeStatus` is set to `true` this will also return all one-to-one conversations.
     Due to the nature of the data structure we can not return information that a conversation was deleted
     or the user removed from a conversation. Therefore it is recommended to do a full refresh:
     * Every 5 minutes


### PR DESCRIPTION
### ☑️ Resolves

One to one conversations will always be returned when we use `modifiedSince` and also set `includeStatus` to `true` as implemented here:

https://github.com/nextcloud/spreed/blob/f112fb92cc641af27d0d0644940a658a974ba319/lib/Controller/RoomController.php#L202-L207

This should be added to the docs.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
