### PR TITLE
fix(chat): Ignore whitespace for "emoji only" check

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -499,9 +499,10 @@ export default {
 			let match
 			let emojiStrings = ''
 			let emojiCount = 0
+			const trimmedMessage = this.message.trim()
 
 			// eslint-disable-next-line no-cond-assign
-			while (match = regex.exec(this.message)) {
+			while (match = regex.exec(trimmedMessage)) {
 				if (emojiCount > 2) {
 					return false
 				}
@@ -510,7 +511,7 @@ export default {
 				emojiCount++
 			}
 
-			return emojiStrings === this.message
+			return emojiStrings === trimmedMessage
 		},
 
 		richParameters() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9258 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://user-images.githubusercontent.com/213943/230155191-9f786d5b-8e09-4b3f-ac85-a93635c2b35b.png) | ![Bildschirmfoto vom 2023-04-05 19-13-18](https://user-images.githubusercontent.com/213943/230155220-dbe1ac65-9fe4-45f6-8c26-6faa60dfac17.png)


### 🚧 Tasks

Patch that allows better testing as the temporary message is shown for longer:

```diff
diff --git a/lib/Controller/ChatController.php b/lib/Controller/ChatController.php
index 09f0b9dd4..6b07a04f9 100644
--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -206,6 +206,7 @@ class ChatController extends AEnvironmentAwareController {
         *         found".
         */
        public function sendMessage(string $message, string $actorDisplayName = '', string $referenceId = '', int $replyTo = 0, bool $silent = false): DataResponse {
+               sleep(5);
                [$actorType, $actorId] = $this->getActorInfo($actorDisplayName);
                if (!$actorId) {
                        return new DataResponse([], Http::STATUS_NOT_FOUND);
```

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
