### PR TITLE
Fix invalid current conversation after conversation remove

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -609,6 +609,9 @@ export default {
 			}
 			if (from.name === 'conversation') {
 				this.$store.dispatch('leaveConversation', { token: from.params.token })
+				if (to.name !== 'conversation') {
+					this.$store.dispatch('updateToken', '')
+				}
 			}
 			if (to.name === 'conversation') {
 				this.$store.dispatch('joinConversation', { token: to.params.token })


### PR DESCRIPTION
### ☑️ Resolves

Regression of: #9068

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
After removing a conversation it is still considered current | After removing a conversation no is considered current
![image](https://user-images.githubusercontent.com/25978914/230175054-2352e5aa-47e9-469d-85ae-cfe55c2d77f6.png) | ![image](https://user-images.githubusercontent.com/25978914/230176199-05104eb9-a12c-4844-b8fe-f979a845f9eb.png)


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
