### PR TITLE
Fix squeezed user mentions in NcRichcontenteditable

### DIFF
--- a/src/components/BreakoutRoomsEditor/SendMessageDialog.vue
+++ b/src/components/BreakoutRoomsEditor/SendMessageDialog.vue
@@ -30,7 +30,7 @@
 				role="region"
 				:token="token"
 				:breakout-room="true"
-				:container-id="modalContainerId"
+				:container="modalContainerId"
 				:aria-label="t('spreed', 'Post message')"
 				:broadcast="broadcast"
 				@sent="handleMessageSent"

--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -42,8 +42,10 @@
 			:aria-label="t('spreed', 'Conversation messages')"
 			:token="token"
 			:is-visible="isVisible" />
-		<NewMessageForm role="region"
+		<NewMessageForm v-if="containerId"
+			role="region"
 			:token="token"
+			:container="containerId"
 			:aria-label="t('spreed', 'Post message')" />
 	</div>
 </template>
@@ -73,6 +75,7 @@ export default {
 	data() {
 		return {
 			isDraggingOver: false,
+			containerId: undefined,
 		}
 	},
 
@@ -100,6 +103,10 @@ export default {
 		token() {
 			return this.$store.getters.getToken()
 		},
+	},
+	mounted() {
+		// Postpone render of NewMessageForm until application is mounted
+		this.containerId = this.$store.getters.getMainContainerSelector()
 	},
 
 	methods: {

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -308,12 +308,12 @@ export default {
 		},
 
 		/**
-		 * When this component is used to send message to a breakout room we
-		 * pass an id of modal containing component to render properly.
+		 * Selector for popovers and pickers to be rendered inside container properly.
+		 * Container must be mounted before passing its ID as a prop
 		 */
-		containerId: {
+		container: {
 			type: String,
-			default: null,
+			required: true,
 		},
 
 		/**
@@ -409,14 +409,8 @@ export default {
 			return this.text !== ''
 		},
 
-		container() {
-			return this.containerId ?? this.$store.getters.getMainContainerSelector()
-		},
-
 		containerElement() {
-			// TODO can't find DOM element by #content-vue. undefined is passed
-			//  for NcRichContenteditable to use 'document.body' by default
-			return document.querySelector(this.container) ?? undefined
+			return document.querySelector(this.container)
 		},
 
 		isOneToOne() {
@@ -928,6 +922,20 @@ export default {
 	},
 }
 </script>
+
+<style lang="scss">
+// Enforce NcAutoCompleteResult to have proper box-sizing
+.tribute-container {
+	position: absolute;
+	box-sizing: content-box !important;
+
+	& *,
+	& *::before,
+	& *::after {
+		box-sizing: inherit !important;
+	}
+}
+</style>
 
 <style lang="scss" scoped>
 @import '../../assets/variables';


### PR DESCRIPTION
### ☑️ Resolves

* Fix container reference, passing to subcomponents in `NewMessageForm` (without changes, document.body by default)
* Prevents tribute to appear in `#content-vue` (which resolves this flickering)

![image](https://user-images.githubusercontent.com/93392545/230459080-f3ce6fc1-50f3-4500-bb87-178feb42bb95.png)

* As a result, tribute doesn't inherit `box-sizing: border-box` from `NcContent` and looks normal

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2023-04-06 14-30-17](https://user-images.githubusercontent.com/93392545/230380723-0ab1ef69-45bf-4435-974c-172b865da62f.png) | ![Screenshot from 2023-04-06 14-30-31](https://user-images.githubusercontent.com/93392545/230380716-39170708-dab1-4ae2-a296-518b55365f75.png)



### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
