### PR TITLE
Fix broken styles for navigation buttons in call

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -37,7 +37,7 @@
 		</NcButton>
 		<transition :name="isStripe ? 'slide-down' : ''">
 			<div v-if="!isStripe || stripeOpen" class="wrapper" :style="wrapperStyle">
-				<div :class="{'stripe-wrapper': isStripe, 'wrapper': !isStripe}">
+				<div :class="[isStripe ? 'stripe-wrapper' : 'grid-wrapper']">
 					<NcButton v-if="hasPreviousPage && gridWidth > 0"
 						type="tertiary-no-background"
 						class="grid-navigation grid-navigation__previous"
@@ -870,7 +870,6 @@ export default {
 	position: relative;
 	bottom: 0;
 	left: 0;
-	flex: 1 0 auto;
 }
 
 .grid {
@@ -889,6 +888,12 @@ export default {
 .empty-call-view {
 	position: relative;
 	padding: 16px;
+}
+
+.grid-wrapper {
+	width: 100%;
+	position: relative;
+	flex: 1 0 auto;
 }
 
 .stripe-wrapper {
@@ -956,7 +961,6 @@ export default {
 }
 
 .grid-navigation {
-	position: absolute;
 	z-index: 2;
 	background-color: rgba(0, 0, 0, 0.5);
 
@@ -965,7 +969,8 @@ export default {
 		background-color: rgba(0, 0, 0, 0.8) !important;
 	}
 
-	.wrapper & {
+	.grid-wrapper & {
+		position: absolute;
 		top: calc(50% - var(--default-clickable-area) / 2);
 		&__previous {
 			left: -4px;
@@ -976,6 +981,7 @@ export default {
 	}
 
 	.stripe-wrapper & {
+		position: absolute;
 		top: 16px;
 		&__previous {
 			left: 8px;
@@ -1011,7 +1017,7 @@ export default {
 }
 
 .stripe--collapse {
-	position: absolute;
+	position: absolute !important;
 	top: calc(-1 * var(--default-clickable-area));
 	right: 0;
 	z-index: 2;


### PR DESCRIPTION
### ☑️ Resolves

* Fix overriding of `position: absolute` for navigation buttons with base styles

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2023-04-11 16-27-09](https://user-images.githubusercontent.com/93392545/231386788-a68f17df-eeed-4e1e-8073-7550b4bf3857.png) | ![Screenshot from 2023-04-11 16-27-16](https://user-images.githubusercontent.com/93392545/231386782-1de6dff1-3871-4bca-8fdb-7db08205f081.png)
![Screenshot from 2023-04-11 16-26-25](https://user-images.githubusercontent.com/93392545/231386794-22348d75-8dc5-4e4b-b181-77b267af5ad1.png) | ![Screenshot from 2023-04-11 16-26-30](https://user-images.githubusercontent.com/93392545/231386793-96d45dba-667d-4a83-a8df-dfcb48928433.png)

### 🚧 Tasks

- [ ] Code review
- [ ] Visual check

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
