### PR TITLE
fix(open-conversations): Add options for open conversations to be usa…

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
@@ -541,7 +541,7 @@ describe('Conversation.vue', () => {
 
 			expect(clearLastReadMessageAction).toHaveBeenCalledWith(expect.anything(), { token: item.token })
 		})
-		test('does not show actions for search result', () => {
+		test('does not show all actions for search result (open conversations)', () => {
 			const wrapper = shallowMount(Conversation, {
 				localVue,
 				store: new Vuex.Store(testStoreConfig),
@@ -558,7 +558,15 @@ describe('Conversation.vue', () => {
 			expect(el.exists()).toBe(true)
 
 			const actionButtons = wrapper.findAllComponents(NcActionButton)
-			expect(actionButtons.exists()).toBe(false)
+			expect(actionButtons.exists()).toBe(true)
+
+			// Join conversation and Copy link actions are intended
+			expect(findNcActionButton(el, 'Join conversation').exists()).toBe(true)
+			expect(findNcActionButton(el, 'Copy link').exists()).toBe(true)
+
+			// But not default conversation actions
+			expect(findNcActionButton(el, 'Add to favorites').exists()).toBe(false)
+			expect(findNcActionButton(el, 'Remove from favorites').exists()).toBe(false)
 		})
 	})
 })

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -94,7 +94,7 @@
 			</NcActionButton>
 		</template>
 		<template v-else-if="item.token" slot="actions">
-			<NcActionButton @click.stop.prevent="onClick">
+			<NcActionButton close-after-click @click="onClick">
 				<template #icon>
 					<ArrowRight :size="16" />
 				</template>

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -93,6 +93,18 @@
 				{{ t('spreed', 'Delete conversation') }}
 			</NcActionButton>
 		</template>
+		<template v-else-if="item.token" slot="actions">
+			<NcActionButton @click.stop.prevent="onClick">
+				<template #icon>
+					<ArrowRight :size="16" />
+				</template>
+				{{ t('spreed', 'Join conversation') }}
+			</NcActionButton>
+			<NcActionButton icon="icon-clippy"
+				@click.stop.prevent="handleCopyLink">
+				{{ t('spreed', 'Copy link') }}
+			</NcActionButton>
+		</template>
 	</NcListItem>
 </template>
 
@@ -100,6 +112,7 @@
 
 import { isNavigationFailure, NavigationFailureType } from 'vue-router'
 
+import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import Cog from 'vue-material-design-icons/Cog.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
 import ExitToApp from 'vue-material-design-icons/ExitToApp.vue'
@@ -121,6 +134,7 @@ export default {
 	name: 'Conversation',
 
 	components: {
+		ArrowRight,
 		Cog,
 		ConversationIcon,
 		Delete,


### PR DESCRIPTION
…ble in desktop client

### ☑️ Resolves

* Open conversation URLs can not be copied without joining in the desktop client
* This now allows "redirecting" people to the correct chat by being able to give them a link to the room

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://user-images.githubusercontent.com/213943/231728694-1e0dde38-1fbd-4b56-a9b8-99a3db17919b.png) | ![grafik](https://user-images.githubusercontent.com/213943/231728627-c0fa07df-f158-4439-87e5-636885d74a73.png)

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
