### PR TITLE
Reactions in video calls

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -120,6 +120,10 @@
 				:shared-datas="sharedDatas"
 				@select-video="handleSelectVideo"
 				@click-local-video="handleClickLocalVideo" />
+
+			<ReactionToaster :token="token"
+				:call-participant-models="callParticipantModels" />
+
 			<!-- Local video if sidebar -->
 			<LocalVideo v-if="isSidebar && !showLocalVideo"
 				ref="localVideo"
@@ -148,6 +152,7 @@ import { loadState } from '@nextcloud/initial-state'
 import Grid from './Grid/Grid.vue'
 import EmptyCallView from './shared/EmptyCallView.vue'
 import LocalVideo from './shared/LocalVideo.vue'
+import ReactionToaster from './shared/ReactionToaster.vue'
 import Screen from './shared/Screen.vue'
 import VideoVue from './shared/VideoVue.vue'
 
@@ -161,11 +166,12 @@ export default {
 	name: 'CallView',
 
 	components: {
-		Grid,
 		EmptyCallView,
-		VideoVue,
+		Grid,
 		LocalVideo,
+		ReactionToaster,
 		Screen,
+		VideoVue,
 	},
 
 	props: {

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -121,7 +121,9 @@
 				@select-video="handleSelectVideo"
 				@click-local-video="handleClickLocalVideo" />
 
-			<ReactionToaster :token="token"
+			<ReactionToaster v-if="supportedReactions?.length"
+				:token="token"
+				:supported-reactions="supportedReactions"
 				:call-participant-models="callParticipantModels" />
 
 			<!-- Local video if sidebar -->
@@ -145,6 +147,7 @@
 <script>
 import debounce from 'debounce'
 
+import { getCapabilities } from '@nextcloud/capabilities'
 import { showMessage } from '@nextcloud/dialogs'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { loadState } from '@nextcloud/initial-state'
@@ -342,6 +345,10 @@ export default {
 			}
 
 			return null
+		},
+
+		supportedReactions() {
+			return getCapabilities()?.spreed?.config?.call?.['supported-reactions']
 		},
 	},
 	watch: {

--- a/src/components/CallView/shared/ReactionToaster.vue
+++ b/src/components/CallView/shared/ReactionToaster.vue
@@ -54,6 +54,16 @@ export default {
 			type: String,
 			required: true,
 		},
+
+		/**
+		 * Supported reactions
+		 */
+		supportedReactions: {
+			type: Array,
+			validator: (prop) => prop.every(e => typeof e === 'string'),
+			required: true,
+		},
+
 		callParticipantModels: {
 			type: Array,
 			required: true,
@@ -110,6 +120,11 @@ export default {
 		},
 
 		handleReaction(model, reaction) {
+			// prevent receiving anything rather than defined reactions in capabilities
+			if (!this.supportedReactions.includes(reaction)) {
+				return
+			}
+
 			this.reactionsQueue.push({
 				reaction,
 				name: this.getParticipantName(model),

--- a/src/components/CallView/shared/ReactionToaster.vue
+++ b/src/components/CallView/shared/ReactionToaster.vue
@@ -1,0 +1,228 @@
+<!--
+  - @copyright Copyright (c) 2023 Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @author Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+	<transition-group name="toast" class="toaster" tag="ul">
+		<li v-for="toast in toasts"
+			:key="toast.seed"
+			class="toast"
+			:style="styled(toast.name, toast.seed)">
+			<span class="toast__reaction">
+				{{ toast.reaction }}
+			</span>
+			<span class="toast__name">
+				{{ toast.name }}
+			</span>
+		</li>
+	</transition-group>
+</template>
+
+<script>
+import Hex from 'crypto-js/enc-hex.js'
+import SHA1 from 'crypto-js/sha1.js'
+
+import { subscribe, unsubscribe } from '@nextcloud/event-bus'
+
+import usernameToColor from '@nextcloud/vue/dist/Functions/usernameToColor.js'
+
+export default {
+	name: 'ReactionToaster',
+
+	props: {
+		/**
+		 * The conversation token
+		 */
+		token: {
+			type: String,
+			required: true,
+		},
+		callParticipantModels: {
+			type: Array,
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			registeredModels: {},
+			reactionsQueue: [],
+			intervalId: null,
+			animationLength: 2000,
+			toasts: [],
+		}
+	},
+
+	computed: {
+		participants() {
+			return this.$store.getters.participantsList(this.token)
+		},
+	},
+
+	watch: {
+		callParticipantModels(models) {
+			// subscribe connected models for reaction signals
+			const addedModels = models.filter(model => !this.registeredModels[model.attributes.peerId])
+			addedModels.forEach(addedModel => {
+				this.registeredModels[addedModel.attributes.peerId] = addedModel
+				this.registeredModels[addedModel.attributes.peerId].on('reaction', this.handleReaction)
+			})
+
+			// unsubscribe disconnected models
+			const removedModels = Object.keys(this.registeredModels).filter(registeredModelId => !models.find(model => model.attributes.peerId === registeredModelId))
+			removedModels.forEach(removedModel => {
+				this.registeredModels[removedModel].off('reaction', this.handleReaction)
+				delete this.registeredModels[removedModel]
+			})
+		},
+	},
+
+	mounted() {
+		this.intervalId = setInterval(this.processReactionsQueue, this.animationLength / 4)
+		subscribe('send-reaction', this.handleOwnReaction)
+	},
+
+	beforeDestroy() {
+		clearInterval(this.intervalId)
+		unsubscribe('send-reaction', this.handleOwnReaction)
+	},
+
+	methods: {
+		handleOwnReaction({ model, reaction }) {
+			this.handleReaction(model, reaction)
+		},
+
+		handleReaction(model, reaction) {
+			this.reactionsQueue.push({
+				reaction,
+				name: this.getParticipantName(model),
+				seed: Math.random(),
+			})
+		},
+
+		processReactionsQueue() {
+			if (this.reactionsQueue.length > 0) {
+				// Move reactions from queue to visible array
+				this.toasts.push(this.reactionsQueue.shift())
+
+				// Delete reactions from array after animation ends
+				setTimeout(() => {
+					this.toasts.shift()
+				}, this.animationLength)
+			}
+		},
+
+		getParticipantName(model) {
+			const { name, peerId } = model.attributes
+			if (name) {
+				return name
+			}
+
+			const participant = this.participants.find(participant => participant.sessionIds.includes(peerId))
+			if (participant?.displayName) {
+				return participant.displayName
+			}
+
+			return this.$store.getters.getGuestName(this.token, Hex.stringify(SHA1(peerId)))
+		},
+
+		styled(name, seed) {
+			const color = usernameToColor(name)
+
+			return {
+				'--background-color': `rgb(${color.r}, ${color.g}, ${color.b})`,
+				'--animation-length': `${this.animationLength + 300}ms`,
+				'--horizontal-offset': `${10 + 20 * seed}%`,
+				'--vertical-offset': 30 + 5 * seed,
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.toaster {
+	position: absolute;
+	bottom: 20px;
+	left: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+	width: 100%;
+	z-index: 1;
+}
+
+.toast {
+	position: absolute;
+	bottom: 0;
+	left: var(--horizontal-offset, 0);
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	animation: toast-floating var(--animation-length) linear;
+
+	&__reaction {
+		font-size: 250%;
+		line-height: 100%;
+
+		@media only screen and (max-width: 1920px) {
+			& {
+				font-size: 150%;
+			}
+		}
+	}
+
+	&__name {
+		padding: 8px 12px;
+		border-radius: 6px;
+		line-height: 100%;
+		white-space: nowrap;
+		color: #ffffff;
+		background-color: var(--background-color);
+		box-shadow: 1px 1px 4px var(--color-box-shadow);
+	}
+}
+
+@keyframes toast-floating {
+	0% {
+		transform: translateY(0);
+		opacity: 1;
+	}
+	50% {
+		transform: translateY(calc(-0.5 * var(--vertical-offset) * 1vh));
+		opacity: 1;
+	}
+	100% {
+		transform: translateY(calc(-1 * var(--vertical-offset) * 1vh));
+		opacity: 0;
+	}
+}
+
+.toast-move,
+.toast-enter-active,
+.toast-leave-active {
+	transition: opacity 0.3s linear;
+}
+
+.toast-enter-from,
+.toast-leave-to {
+	opacity: 0;
+}
+</style>

--- a/src/components/TopBar/ReactionMenu.vue
+++ b/src/components/TopBar/ReactionMenu.vue
@@ -31,7 +31,7 @@
 
 		<NcActionButtonGroup class="reaction__group"
 			:style="{'--reactions-in-single-row': reactionsInSingleRow}">
-			<NcActionButton v-for="(reaction, index) in reactions"
+			<NcActionButton v-for="(reaction, index) in supportedReactions"
 				:key="index"
 				:aria-label="t('spreed', 'React with {reaction}', { reaction })"
 				class="reaction__button"
@@ -88,7 +88,7 @@ export default {
 		/**
 		 * Supported reactions
 		 */
-		reactions: {
+		supportedReactions: {
 			type: Array,
 			validator: (prop) => prop.every(e => typeof e === 'string'),
 			required: true,
@@ -109,7 +109,7 @@ export default {
 		},
 
 		reactionsInSingleRow() {
-			return Math.ceil(this.reactions.length / 2)
+			return Math.ceil(this.supportedReactions.length / 2)
 		},
 	},
 

--- a/src/components/TopBar/ReactionMenu.vue
+++ b/src/components/TopBar/ReactionMenu.vue
@@ -1,0 +1,176 @@
+<!--
+  - @copyright Copyright (c) 2023 Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @author Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+	<NcActions v-tooltip="t('spreed', 'Send a reaction')"
+		:aria-label="t('spreed', 'Send a reaction')"
+		:container="container"
+		class="reaction">
+		<template #icon>
+			<EmoticonOutline :size="20"
+				fill-color="#ffffff" />
+		</template>
+
+		<NcActionButtonGroup class="reaction__group"
+			:style="{'--reactions-in-single-row': reactionsInSingleRow}">
+			<NcActionButton v-for="(reaction, index) in reactions"
+				:key="index"
+				:aria-label="t('spreed', 'React with {reaction}', { reaction })"
+				class="reaction__button"
+				@click="throttledSendReaction(reaction)">
+				<template #icon>
+					{{ reaction }}
+				</template>
+			</NcActionButton>
+		</NcActionButtonGroup>
+
+		<!-- TODO for development purposes, remove before release -->
+		<NcActionButton @click="spamReaction">
+			{{ spammer ? 'Stop spamming' : 'Spam reactions' }}
+		</NcActionButton>
+	</NcActions>
+</template>
+
+<script>
+import EmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
+
+import { emit } from '@nextcloud/event-bus'
+
+import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
+import NcActionButtonGroup from '@nextcloud/vue/dist/Components/NcActionButtonGroup.js'
+import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
+
+export default {
+	name: 'ReactionMenu',
+
+	components: {
+		NcActions,
+		NcActionButton,
+		NcActionButtonGroup,
+		EmoticonOutline,
+	},
+
+	props: {
+		/**
+		 * The conversation token
+		 */
+		token: {
+			type: String,
+			required: true,
+		},
+
+		/**
+		 * Signalling participant model
+		 */
+		localCallParticipantModel: {
+			type: Object,
+			required: true,
+		},
+
+		/**
+		 * Supported reactions
+		 */
+		reactions: {
+			type: Array,
+			validator: (prop) => prop.every(e => typeof e === 'string'),
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			throttleTimer: null,
+			// TODO for development purposes, remove before release
+			spammer: null,
+		}
+	},
+
+	computed: {
+		container() {
+			return this.$store.getters.getMainContainerSelector()
+		},
+
+		reactionsInSingleRow() {
+			return Math.ceil(this.reactions.length / 2)
+		},
+	},
+
+	methods: {
+		throttledSendReaction(reaction) {
+			if (this.throttleTimer) {
+				return
+			}
+
+			this.sendReaction(reaction)
+			this.throttleTimer = setTimeout(() => {
+				this.throttleTimer = null
+			}, 2000)
+		},
+
+		sendReaction(reaction) {
+			// send reaction to other participants
+			this.localCallParticipantModel.sendReaction(reaction)
+
+			// show reaction to yourself
+			emit('send-reaction', {
+				model: this.localCallParticipantModel,
+				reaction,
+			})
+		},
+
+		// TODO for development purposes, remove before release
+		spamReaction() {
+			if (this.spammer) {
+				clearInterval(this.spammer)
+				this.spammer = null
+				return
+			}
+
+			this.spammer = setInterval(() => {
+				const reactionRand = this.reactions[Math.floor(Math.random() * 10)]
+				this.localCallParticipantModel.sendReaction(reactionRand)
+
+				// show reaction to yourself
+				emit('send-reaction', {
+					model: this.localCallParticipantModel,
+					reaction: reactionRand,
+				})
+			}, 1000)
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.reaction {
+	&__group {
+		:deep(.nc-button-group-content) {
+			flex-wrap: wrap;
+			justify-content: flex-start;
+			width: calc(var(--reactions-in-single-row) * var(--default-clickable-area))
+		}
+	}
+
+	&__button {
+		flex: 0 0 calc(100% / var(--reactions-in-single-row)) !important;
+	}
+}
+</style>

--- a/src/components/TopBar/ReactionMenu.vue
+++ b/src/components/TopBar/ReactionMenu.vue
@@ -41,11 +41,6 @@
 				</template>
 			</NcActionButton>
 		</NcActionButtonGroup>
-
-		<!-- TODO for development purposes, remove before release -->
-		<NcActionButton @click="spamReaction">
-			{{ spammer ? 'Stop spamming' : 'Spam reactions' }}
-		</NcActionButton>
 	</NcActions>
 </template>
 
@@ -98,8 +93,6 @@ export default {
 	data() {
 		return {
 			throttleTimer: null,
-			// TODO for development purposes, remove before release
-			spammer: null,
 		}
 	},
 
@@ -134,26 +127,6 @@ export default {
 				model: this.localCallParticipantModel,
 				reaction,
 			})
-		},
-
-		// TODO for development purposes, remove before release
-		spamReaction() {
-			if (this.spammer) {
-				clearInterval(this.spammer)
-				this.spammer = null
-				return
-			}
-
-			this.spammer = setInterval(() => {
-				const reactionRand = this.reactions[Math.floor(Math.random() * 10)]
-				this.localCallParticipantModel.sendReaction(reactionRand)
-
-				// show reaction to yourself
-				emit('send-reaction', {
-					model: this.localCallParticipantModel,
-					reaction: reactionRand,
-				})
-			}, 1000)
 		},
 	},
 }

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -78,7 +78,7 @@
 		<ReactionMenu v-if="hasReactionSupport"
 			class="top-bar__button dark-hover"
 			:token="token"
-			:reactions="reactions"
+			:supported-reactions="supportedReactions"
 			:local-call-participant-model="localCallParticipantModel" />
 
 		<!-- Local media controls -->
@@ -305,12 +305,12 @@ export default {
 			return IS_DESKTOP
 		},
 
-		reactions() {
+		supportedReactions() {
 			return getCapabilities()?.spreed?.config?.call?.['supported-reactions']
 		},
 
 		hasReactionSupport() {
-			return this.isInCall && this.reactions?.length > 0
+			return this.isInCall && this.supportedReactions?.length > 0
 		},
 	},
 

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -74,6 +74,13 @@
 			{{ participantsInCall }}
 		</NcButton>
 
+		<!-- Reactions menu -->
+		<ReactionMenu v-if="hasReactionSupport"
+			class="top-bar__button dark-hover"
+			:token="token"
+			:reactions="reactions"
+			:local-call-participant-model="localCallParticipantModel" />
+
 		<!-- Local media controls -->
 		<LocalMediaControls v-if="isInCall"
 			class="local-media-controls dark-hover"
@@ -137,6 +144,7 @@ import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
 import MenuIcon from 'vue-material-design-icons/Menu.vue'
 import MessageText from 'vue-material-design-icons/MessageText.vue'
 
+import { getCapabilities } from '@nextcloud/capabilities'
 import { showMessage } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 
@@ -150,6 +158,7 @@ import LocalMediaControls from '../CallView/shared/LocalMediaControls.vue'
 import ConversationIcon from '../ConversationIcon.vue'
 import CallButton from './CallButton.vue'
 import CallTime from './CallTime.vue'
+import ReactionMenu from './ReactionMenu.vue'
 import TopBarMenu from './TopBarMenu.vue'
 
 import { CONVERSATION } from '../../constants.js'
@@ -175,6 +184,7 @@ export default {
 		NcButton,
 		NcCounterBubble,
 		TopBarMenu,
+		ReactionMenu,
 		// Icons
 		AccountMultiple,
 		MenuIcon,
@@ -293,6 +303,14 @@ export default {
 			// NcAvatarMenu doesn't work on Desktop
 			// See: https://github.com/nextcloud/talk-desktop/issues/34
 			return IS_DESKTOP
+		},
+
+		reactions() {
+			return getCapabilities()?.spreed?.config?.call?.['supported-reactions']
+		},
+
+		hasReactionSupport() {
+			return this.isInCall && this.reactions?.length > 0
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Overview in #9249
* Close #9266

### 🖼️ Screenshots

**Reacting** - user's click is throttled to 1 reaction / 2 seconds. Horizontal and vertical offset are randomized to make it look more "natural"
One reaction | Spamming with reactions
-- | --
![image](https://user-images.githubusercontent.com/93392545/233116759-de3568d2-186d-4c92-9840-43196f2cf0ce.png) | ![image](https://user-images.githubusercontent.com/93392545/233117120-a118ce04-43bf-40af-aca4-0cfdb39cad77.png)

---
**Overlapping** - reactions source is located around 10-30% of call container width from the left, and each reaction flows up and dissapears at around 30-35% of screen height.
Speaker view | Screensharing
--- | ---
![image](https://user-images.githubusercontent.com/93392545/233118900-765b93c6-e367-4faa-b90f-5bf7d0278364.png) | ![image](https://user-images.githubusercontent.com/93392545/233118954-8fce8499-207c-4714-816a-676539f6cdbe.png)

**Screen capture**

[reactions.webm](https://user-images.githubusercontent.com/93392545/233122383-ca5c4f14-8a7c-4166-96d7-95b9f685d62b.webm)

### 🚧 Tasks
Ongoing tasks:
- [ ] The available reactions are: ❤️ 🎉 👏🏽 👍🏽 👎🏽 😂 🤩 🤔 😮 😢 (to be discussed)
- [ ] Code review
- [ ] Animation behavior confirmation


API tasks:
- [x] Emoji is sent as signaling message
- [x] When a signaling message is received, the emoji is shown
- [x] Get supported reactions from capabilities

Visual tasks:
- [x] The emojis reactions are accessible from a menu in the TopBar. Menu doesn't close on click.
- [x] Received (and self) reaction appears at the bottom of the screen and floats to the top with a sender name next to it and fades away.
- [x] The color of the name tag could be the avatar color
- [x] For small screens, size of emoji is 24px. For bigger screens: 44px (starting from 1920px)
- [x] The total time taken for the emoji to float to the top and disappear is 2000ms 
- [x] The total height travelled by the emoji depends on the screen. It can vary by 10% to look more natural. Generally it should disappear before it reaches the mid point of the screen to not be too distracting. (30-35% of screen height)
- [x] The emoji should start fading while it reaches the top. However, it doesn't look right if it starts fading right from the start. So from 0% to 50% of the animation, only the position would change and opacity remains constant. For 50% to 100% of the animation, the position would change as well as the opacity would change from 1 to 0. Transition is linear.
- [x]  One person can react maximum once per 2 seconds.
- [x] If many people are reacting simultaneously, the number of reactions shown on screen must be limited to avoid overcrowding the screen.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
