### PR TITLE
Fix missing modals and popovers in Fullscreen mode

### DIFF
--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
@@ -21,7 +21,7 @@
 
 <template>
 	<NcModal v-bind="$attrs"
-		:container="$store.getters.getMainContainerSelector()"
+		:container="container"
 		:class="{'modal-mask__participants-step': isEditingParticipants}"
 		v-on="$listeners">
 		<div class="breakout-rooms-editor"
@@ -113,6 +113,10 @@ export default {
 	},
 
 	computed: {
+		container() {
+			return this.$store.getters.getMainContainerSelector()
+		},
+
 		modalTitle() {
 			return this.isEditingParticipants
 				? t('spreed', 'Assign participants to rooms')

--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
@@ -70,6 +70,7 @@
 			</NcButton>
 			<NcActions v-if="hasSelected"
 				type="primary"
+				:container="container"
 				:menu-title="t('spreed', 'Assign')">
 				<NcActionButton v-for="(item, index) in assignments"
 					:key="index"
@@ -145,6 +146,10 @@ export default {
 	},
 
 	computed: {
+		container() {
+			return this.$store.getters.getMainContainerSelector()
+		},
+
 		participants() {
 			return this.$store.getters.participantsList(this.token).filter(participant => {
 				return (participant.participantType === PARTICIPANT.TYPE.USER

--- a/src/components/BreakoutRoomsEditor/SendMessageDialog.vue
+++ b/src/components/BreakoutRoomsEditor/SendMessageDialog.vue
@@ -20,7 +20,9 @@
 -->
 
 <template>
-	<NcModal ref="modal" v-on="$listeners">
+	<NcModal ref="modal"
+		:container="container"
+		v-on="$listeners">
 		<div class="send-message-dialog">
 			<h2 class="send-message-dialog__title">
 				{{ dialogTitle }}
@@ -89,6 +91,10 @@ export default {
 	},
 
 	computed: {
+		container() {
+			return this.$store.getters.getMainContainerSelector()
+		},
+
 		dialogTitle() {
 			return this.broadcast
 				? t('spreed', 'Send a message to all breakout rooms')

--- a/src/components/ConversationSettings/Matterbridge/BridgePart.vue
+++ b/src/components/ConversationSettings/Matterbridge/BridgePart.vue
@@ -28,7 +28,8 @@
 			<span>
 				{{ type.name }}
 			</span>
-			<NcActions :force-menu="false">
+			<NcActions :container="container"
+				:force-menu="false">
 				<NcActionButton v-if="editable"
 					:icon="editing ? 'icon-checkmark' : 'icon-rename'"
 					@click="onEditClick">
@@ -36,6 +37,7 @@
 				</NcActionButton>
 			</NcActions>
 			<NcActions class="actions"
+				:container="container"
 				:force-menu="true"
 				placement="bottom">
 				<NcActionLink icon="icon-info"
@@ -114,6 +116,10 @@ export default {
 		},
 		type: {
 			type: Object,
+			required: true,
+		},
+		container: {
+			type: String,
 			required: true,
 		},
 		editing: {

--- a/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
+++ b/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
@@ -86,6 +86,7 @@
 						:type="types[part.type]"
 						:editing="part.editing"
 						:editable="!enabled"
+						:container="container"
 						@edit-clicked="onEditClicked(i)"
 						@delete-part="onDelete(i)" />
 				</li>

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/Forwarder.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/Forwarder.vue
@@ -48,6 +48,7 @@
 		the possibility to directly route to the conversation to which the
 		message has been forwarded -->
 		<NcModal v-else
+			:container="container"
 			@close="handleClose">
 			<NcEmptyContent :description="t('spreed', 'The message has been forwarded to {selectedConversationName}', { selectedConversationName })">
 				<template #icon>

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
@@ -50,7 +50,7 @@
 		<!-- voting and results dialog -->
 		<NcModal v-if="vote !== undefined && showModal"
 			size="small"
-			:container="$store.getters.getMainContainerSelector()"
+			:container="container"
 			@close="dismissModal">
 			<div class="poll__modal">
 				<!-- First screen, displayed while voting-->
@@ -226,6 +226,9 @@ export default {
 	},
 
 	computed: {
+		container() {
+			return this.$store.getters.getMainContainerSelector()
+		},
 
 		poll() {
 			return this.$store.getters.getPoll(this.token, this.id)

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -137,6 +137,7 @@
 				<!-- Send buttons -->
 				<template v-else>
 					<NcActions v-if="!broadcast"
+						:container="container"
 						:force-menu="true">
 						<!-- Silent send -->
 						<NcActionButton :close-after-click="true"

--- a/src/components/NewMessageForm/SimplePollsEditor/SimplePollsEditor.vue
+++ b/src/components/NewMessageForm/SimplePollsEditor/SimplePollsEditor.vue
@@ -22,7 +22,7 @@
 
 <template>
 	<NcModal size="small"
-		:container="$store.getters.getMainContainerSelector()"
+		:container="container"
 		v-on="$listeners">
 		<div class="simple-polls-editor">
 			<h2>{{ t('spreed', 'Create new poll') }}</h2>
@@ -117,6 +117,12 @@ export default {
 		}
 	},
 
+	computed: {
+		container() {
+			return this.$store.getters.getMainContainerSelector()
+		},
+	},
+
 	methods: {
 		// Remove a previously added option
 		deleteOption(index) {
@@ -166,7 +172,6 @@ export default {
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
-	align-items: left;
 
 	&__caption {
 		padding: 16px 0 4px 0;

--- a/src/components/PermissionsEditor/PermissionsEditor.vue
+++ b/src/components/PermissionsEditor/PermissionsEditor.vue
@@ -21,7 +21,7 @@
 
 <template>
 	<NcModal size="small"
-		:container="$store.getters.getMainContainerSelector()"
+		:container="container"
 		v-on="$listeners">
 		<div class="wrapper">
 			<template v-if="!loading">
@@ -146,6 +146,10 @@ export default {
 	},
 
 	computed: {
+		container() {
+			return this.$store.getters.getMainContainerSelector()
+		},
+
 		modalTitle() {
 			if (this.displayName) {
 				return t('spreed', 'In this conversation <strong>{user}</strong> can:', {

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomItem.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomItem.vue
@@ -44,7 +44,9 @@
 				<NcButton v-if="showJoinButton" @click="joinRoom">
 					{{ t('spreed', 'Join') }}
 				</NcButton>
-				<NcActions v-if="canModerate" :force-menu="true">
+				<NcActions v-if="canModerate"
+					:container="container"
+					:force-menu="true">
 					<NcActionButton v-if="showAssistanceButton"
 						@click="dismissRequestAssistance">
 						<template #icon>
@@ -144,6 +146,10 @@ export default {
 	},
 
 	computed: {
+		container() {
+			return this.$store.getters.getMainContainerSelector()
+		},
+
 		participantType() {
 			return this.breakoutRoom.participantType
 		},

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
@@ -83,6 +83,7 @@
 
 		<!-- Participants editor -->
 		<NcModal v-if="showParticipantsEditor"
+			:container="container"
 			@close="closeParticipantsEditor">
 			<div class="breakout-rooms-actions__editor">
 				<h2> {{ manageBreakoutRoomsTitle }} </h2>
@@ -189,6 +190,10 @@ export default {
 
 		isInBreakoutRoom() {
 			return this.mainToken !== this.$store.getters.getToken()
+		},
+
+		container() {
+			return this.$store.getters.getMainContainerSelector()
 		},
 
 		manageBreakoutRoomsTitle() {

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
@@ -61,7 +61,9 @@
 				</template>
 				{{ backToBreakoutRoomLabel }}
 			</NcButton>
-			<NcActions v-if="canModerate" class="right">
+			<NcActions v-if="canModerate"
+				class="right"
+				:container="container">
 				<NcActionButton v-if="canModerate && isInBreakoutRoom"
 					:title="sendMessageLabel"
 					:aria-label="sendMessageLabel"

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -51,6 +51,7 @@
 		<NcActions v-else-if="showLeaveCallButton && (canEndForAll || isBreakoutRoom)"
 			:disabled="loading"
 			:menu-title="leaveCallCombinedLabel"
+			:container="container"
 			type="error">
 			<template #icon>
 				<VideoOff v-if="!isBreakoutRoom" :size="20" />
@@ -159,7 +160,9 @@ export default {
 		isNextcloudTalkHashDirty() {
 			return this.$store.getters.isNextcloudTalkHashDirty
 		},
-
+		container() {
+			return this.$store.getters.getMainContainerSelector()
+		},
 		conversation() {
 			return this.$store.getters.conversation(this.token) || this.$store.getters.dummyConversation
 		},


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9299 

### 🖼️ Screenshots

See issue above
🏚️ Before | 🏡 After
---|---
Modals and popovers without `container` prop were rendered outside of `<div #content-vue>` and missing at Fullscreen | `container` props / computed properties are unified and added to every `NcModal` and `NcActions`

### 🚧 Tasks

- [ ] All `NcModal` and `NcActions` in Talk should have `container` prop to be visible (in future)
- [ ] DeviceChecker => MediaSettings is untouched to avoid conflicts.
  * @marcoambrosini please fix it also for #9276 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
