### PR TITLE
fix(recording): Don't create confusing system message about recording if actor ended the call

### DIFF
--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -153,7 +153,7 @@ class Listener {
 		}
 
 		if ($room->getCallRecording() !== Room::RECORDING_NONE && $room->getCallRecording() !== Room::RECORDING_FAILED) {
-			$this->recordingService->stop($room, $actor);
+			$this->recordingService->stop($room);
 		}
 		if ($actor instanceof Participant) {
 			$actorId = $actor->getAttendee()->getActorId();

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -514,12 +514,19 @@ class Listener implements IEventListener {
 			return;
 		}
 
+		$actor = $event->getActor();
+		if ($recordingHasStopped && $actor === null) {
+			// No actor means the recording was stopped by the end of the call.
+			// So we are not generating a system message
+			return;
+		}
+
 		$prefix = self::getCallRecordingPrefix($event);
 		$suffix = self::getCallRecordingSuffix($event);
 		$systemMessage = $prefix . 'recording_' . $suffix;
 
 		$listener = Server::get(self::class);
-		$listener->sendSystemMessage($event->getRoom(), $systemMessage, [], $event->getActor());
+		$listener->sendSystemMessage($event->getRoom(), $systemMessage, [], $actor);
 	}
 
 	private static function getCallRecordingSuffix(ModifyRoomEvent $event): string {

--- a/psalm.xml
+++ b/psalm.xml
@@ -52,6 +52,7 @@
 				<referencedClass name="Doctrine\DBAL\Schema\SchemaException" />
 				<referencedClass name="Doctrine\DBAL\Schema\Table" />
 				<referencedClass name="OC\DB\ConnectionAdapter" />
+				<referencedClass name="OC\User\NoUserException" />
 				<referencedClass name="OCA\Circles\CirclesManager" />
 				<referencedClass name="OCA\Circles\Model\Member" />
 				<referencedClass name="OCA\DAV\CardDAV\PhotoCache" />

--- a/tests/integration/features/callapi/recording.feature
+++ b/tests/integration/features/callapi/recording.feature
@@ -85,6 +85,65 @@ Feature: callapi/recording
       | type | name  | callRecording |
       | 2    | room1 | 0             |
 
+  Scenario: No system message should be shown when the call was just ended for everyone
+    Given recording server is started
+    And user "participant1" creates room "room1" (v4)
+      | roomType | 2 |
+      | roomName | room1 |
+    And user "participant1" joins room "room1" with 200 (v4)
+    And user "participant1" joins call "room1" with 200 (v4)
+    When user "participant1" starts "video" recording in room "room1" with 200 (v1)
+    And recording server received the following requests
+      | token | data                                                         |
+      | room1 | {"type":"start","start":{"status":1,"owner":"participant1","actor":{"type":"users","id":"participant1"}}} |
+    And recording server sent started request for "video" recording in room "room1" as "participant1" with 200
+    Then user "participant1" sees the following system messages in room "room1" with 200 (v1)
+      | room  | actorType | actorId      | actorDisplayName         | systemMessage        |
+      | room1 | users     | participant1 | participant1-displayname | recording_started    |
+      | room1 | users     | participant1 | participant1-displayname | call_started         |
+      | room1 | users     | participant1 | participant1-displayname | conversation_created |
+    And user "participant1" ends call "room1" with 200 (v4)
+    And recording server received the following requests
+      | token | data             |
+      | room1 | {"type":"stop","stop":[]} |
+    And recording server sent stopped request for recording in room "room1" with 200
+    Then user "participant1" sees the following system messages in room "room1" with 200 (v1)
+      | room  | actorType | actorId      | actorDisplayName         | systemMessage        |
+      | room1 | users     | participant1 | participant1-displayname | call_ended_everyone  |
+      | room1 | users     | participant1 | participant1-displayname | recording_started    |
+      | room1 | users     | participant1 | participant1-displayname | call_started         |
+      | room1 | users     | participant1 | participant1-displayname | conversation_created |
+
+  Scenario: No system message should be shown when the call was ended by the last one leaving
+    Given recording server is started
+    And user "participant1" creates room "room1" (v4)
+      | roomType | 2 |
+      | roomName | room1 |
+    And user "participant1" joins room "room1" with 200 (v4)
+    And user "participant1" joins call "room1" with 200 (v4)
+    When user "participant1" starts "video" recording in room "room1" with 200 (v1)
+    And recording server received the following requests
+      | token | data                                                         |
+      | room1 | {"type":"start","start":{"status":1,"owner":"participant1","actor":{"type":"users","id":"participant1"}}} |
+    And recording server sent started request for "video" recording in room "room1" as "participant1" with 200
+    Then user "participant1" sees the following system messages in room "room1" with 200 (v1)
+      | room  | actorType | actorId      | actorDisplayName         | systemMessage        |
+      | room1 | users     | participant1 | participant1-displayname | recording_started    |
+      | room1 | users     | participant1 | participant1-displayname | call_started         |
+      | room1 | users     | participant1 | participant1-displayname | conversation_created |
+    And user "participant1" leaves call "room1" with 200 (v4)
+    And recording server received the following requests
+      | token | data             |
+      | room1 | {"type":"stop","stop":[]} |
+    And recording server sent stopped request for recording in room "room1" with 200
+    Then user "participant1" sees the following system messages in room "room1" with 200 (v1)
+      | room  | actorType | actorId      | actorDisplayName         | systemMessage        |
+      | room1 | users     | participant1 | participant1-displayname | call_ended           |
+      | room1 | users     | participant1 | participant1-displayname | call_left            |
+      | room1 | users     | participant1 | participant1-displayname | recording_started    |
+      | room1 | users     | participant1 | participant1-displayname | call_started         |
+      | room1 | users     | participant1 | participant1-displayname | conversation_created |
+
   Scenario: Recording failed to start
     Given recording server is started
     And user "participant1" creates room "room1" (v4)
@@ -417,7 +476,7 @@ Feature: callapi/recording
     When user "participant1" ends call "room1" with 200 (v4)
     Then recording server received the following requests
       | token | data             |
-      | room1 | {"type":"stop","stop":{"actor":{"type":"users","id":"participant1"}}} |
+      | room1 | {"type":"stop","stop":[]} |
     And user "participant1" is participant of the following unordered rooms (v4)
       | type | name  | callRecording |
       | 2    | room1 | 2             |
@@ -426,7 +485,7 @@ Feature: callapi/recording
       | type | name  | callRecording |
       | 2    | room1 | 0             |
 
-  Scenario: Stop recording automatically when the last participant go out
+  Scenario: Stop recording automatically when the last participant leaves the call
     Given recording server is started
     And user "participant1" creates room "room1" (v4)
       | roomType | 2 |
@@ -441,7 +500,7 @@ Feature: callapi/recording
     And user "participant1" is participant of the following unordered rooms (v4)
       | type | name  | callRecording |
       | 2    | room1 | 2             |
-    When user "participant1" leaves room "room1" with 200 (v4)
+    When user "participant1" leaves call "room1" with 200 (v4)
     Then recording server received the following requests
       | token | data             |
       | room1 | {"type":"stop","stop":[]} |

--- a/tests/php/Chat/SystemMessage/ListenerTest.php
+++ b/tests/php/Chat/SystemMessage/ListenerTest.php
@@ -424,7 +424,7 @@ class ListenerTest extends TestCase {
 				Room::RECORDING_VIDEO,
 				null,
 				null,
-				['message' => 'recording_stopped', 'parameters' => []],
+				null,
 			],
 			[
 				Room::RECORDING_NONE,
@@ -452,7 +452,7 @@ class ListenerTest extends TestCase {
 				Room::RECORDING_AUDIO,
 				null,
 				null,
-				['message' => 'audio_recording_stopped', 'parameters' => []],
+				null,
 			],
 			[
 				Room::RECORDING_NONE,
@@ -555,7 +555,7 @@ class ListenerTest extends TestCase {
 	 * @param int $oldStatus
 	 * @param string|null $actorType
 	 * @param string|null $actorId
-	 * @param array $expectedMessage
+	 * @param array|null $expectedMessage
 	 */
 	public function testAfterCallRecordingSet(int $newStatus, int $oldStatus, ?string $actorType, ?string $actorId, ?array $expectedMessage): void {
 		$this->mockLoggedInUser('logged_in_user');
@@ -594,7 +594,7 @@ class ListenerTest extends TestCase {
 					json_encode($expectedMessage),
 					$this->dummyTime,
 					false,
-					SELF::DUMMY_REFERENCE_ID,
+					self::DUMMY_REFERENCE_ID,
 					null,
 					false
 				);


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9294


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
