### PR TITLE
Add signaling messages for reactions in calls

### DIFF
--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -93,6 +93,7 @@ export default function CallParticipantModel(options) {
 	this._handleChannelMessageBound = this._handleChannelMessage.bind(this)
 	this._handleRaisedHandBound = this._handleRaisedHand.bind(this)
 	this._handleRemoteVideoBlockedBound = this._handleRemoteVideoBlocked.bind(this)
+	this._handleReactionBound = this._handleReaction.bind(this)
 
 	this._webRtc.on('peerStreamAdded', this._handlePeerStreamAddedBound)
 	this._webRtc.on('peerStreamRemoved', this._handlePeerStreamRemovedBound)
@@ -101,6 +102,7 @@ export default function CallParticipantModel(options) {
 	this._webRtc.on('unmute', this._handleUnmuteBound)
 	this._webRtc.on('channelMessage', this._handleChannelMessageBound)
 	this._webRtc.on('raisedHand', this._handleRaisedHandBound)
+	this._webRtc.on('reaction', this._handleReactionBound)
 }
 
 CallParticipantModel.prototype = {
@@ -119,6 +121,7 @@ CallParticipantModel.prototype = {
 		this._webRtc.off('unmute', this._handleUnmuteBound)
 		this._webRtc.off('channelMessage', this._handleChannelMessageBound)
 		this._webRtc.off('raisedHand', this._handleRaisedHandBound)
+		this._webRtc.off('reaction', this._handleReactionBound)
 	},
 
 	get(key) {
@@ -433,6 +436,15 @@ CallParticipantModel.prototype = {
 
 		// Use same quality for simulcast and temporal layer.
 		this.get('screenPeer').selectSimulcastStream(simulcastScreenQuality, simulcastScreenQuality)
+	},
+
+	_handleReaction(data) {
+		// A reaction could be sent even if there is no Peer object.
+		if (this.get('peerId') !== data.id) {
+			return
+		}
+
+		this._trigger('reaction', [data.reaction])
 	},
 
 }

--- a/src/utils/webrtc/models/LocalCallParticipantModel.js
+++ b/src/utils/webrtc/models/LocalCallParticipantModel.js
@@ -162,6 +162,16 @@ LocalCallParticipantModel.prototype = {
 		}
 	},
 
+	sendReaction(reaction) {
+		if (!this._webRtc) {
+			throw new Error('WebRtc not initialized yet')
+		}
+
+		this._webRtc.sendToAll('reaction', {
+			reaction,
+		})
+	},
+
 }
 
 EmitterMixin.apply(LocalCallParticipantModel.prototype)

--- a/src/utils/webrtc/simplewebrtc/simplewebrtc.js
+++ b/src/utils/webrtc/simplewebrtc/simplewebrtc.js
@@ -118,6 +118,10 @@ function SimpleWebRTC(opts) {
 			// "nickChanged" can be received from a participant without a Peer
 			// object if that participant is not sending audio nor video.
 			self.emit('nick', { id: message.from, name: message.payload.name })
+		} else if (message.type === 'reaction') {
+			// "reaction" can be received from a participant without a Peer
+			// object if that participant is not sending audio nor video.
+			self.emit('reaction', { id: message.from, reaction: message.payload.reaction })
 		} else if (message.type === 'raiseHand') {
 			// "raisedHand" can be received from a participant without a Peer
 			// object if that participant is not sending audio nor video.


### PR DESCRIPTION
Fixes #9267

The signaling messages used for reactions are similar to the ones used for raised hands. It is just a generic signaling message of type _message_ which includes a _reaction_ field. The value of that field is a string with the reaction.

There is no validation of the reactions. It is expected that clients just send the appropriate reactions, most likely a single emoji character. Nevertheless, it would be possible to send any string as reaction, for example, _LOL_. Please, do not do that :-P

The signaling messages work both with the external signaling server and the internal signaling server.

Besides the signaling message this pull request also shows the reactions sent by remote participants. It is just some old code I had lying around, so it does NOT follow in any way the agreed design. Please adjust it as needed :-)

### How to use from Vue components
- Received reactions can be shown by listening to the `reaction` event emitted by the `CallParticipantModel`. Please refer to the example code included in the pull request. This will probably need to be moved to `CallView` to be able to show reactions for any participant, no matter if that participant is currently visible or not (right now, for simplicity, the code was just added to `VideoView`, so reactions are shown directly on the participants that sent them).
- Reactions can be sent by calling `LocalCallParticipantModel.sendReaction(reaction)`. Note that this is slightly different than [raised hands](https://github.com/nextcloud/spreed/blob/09d0d6ada5dde88806ff7977cc5824860bf9a9f0/src/components/CallView/shared/LocalMediaControls.vue#L706), as `toggleHandRaised` is part of `LocalMediaModel` instead (but it should be part of `LocalCallParticipantModel` :shrug:).

### How to test
- Start a call
- In a private window, join the call
- Open the browser console
- Execute `document.querySelector('#localVideoContainer').__vue__.localCallParticipantModel.sendReaction('👍')`
- Check the reaction in the other window

### 🚧 Tasks

- [X] There is no rate limit for reactions. As far as I know it is not currently possible to rate limit specific messages in the external signaling server, so it would require an explicit implementation (and same for the internal signaling server). Alternatively (and possibly better, at least for now) the rate limit could be implemented directly in the clients, so the UI does not allow to send too many reactions, and if too many reactions are received some of them are just ignored. - A rate limit will be used in the UI
- [X] Is a capability needed? Even if the signaling message is a generic one, and therefore it could be sent or received on any version, would it be necessary to add a capability to show or hide the UI to send reactions in the mobile apps? - Capability will be added in a follow up
- [X] Fix sending signaling messages when there is more than one connection for the same participant (video and screen share) - Done in #9334 

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
