### PR TITLE
feat(chat): Add capabilities for translation options

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -115,3 +115,4 @@
 
 ## 17
 * `avatar` - Avatar of conversation
+* `config => chat => translations` - List of translations tuples, JSON encoded sample `{"from":"de","fromLabel":"German","to":"en","toLabel":"English"}`. Those tuples should be provided as options when translating chat messages.

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -32,26 +32,18 @@ use OCP\Comments\ICommentsManager;
 use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\Translation\ITranslationManager;
 
 class Capabilities implements IPublicCapability {
-	protected IConfig $serverConfig;
-	protected Config $talkConfig;
-	protected ICommentsManager $commentsManager;
-	protected IUserSession $userSession;
-	private IAppManager $appManager;
 
 	public function __construct(
-		IConfig $serverConfig,
-		Config $talkConfig,
-		ICommentsManager $commentsManager,
-		IUserSession $userSession,
-		IAppManager $appManager,
+		protected IConfig $serverConfig,
+		protected Config $talkConfig,
+		protected ICommentsManager $commentsManager,
+		protected IUserSession $userSession,
+		protected IAppManager $appManager,
+		protected ITranslationManager $translationManager,
 	) {
-		$this->serverConfig = $serverConfig;
-		$this->talkConfig = $talkConfig;
-		$this->commentsManager = $commentsManager;
-		$this->userSession = $userSession;
-		$this->appManager = $appManager;
 	}
 
 	public function getCapabilities(): array {
@@ -134,6 +126,7 @@ class Capabilities implements IPublicCapability {
 					'max-length' => ChatManager::MAX_CHAT_LENGTH,
 					'read-privacy' => Participant::PRIVACY_PUBLIC,
 					//'legacy' => true, // Temporary A-B switch to opt-out of the new context loading
+					'translations' => $this->translationManager->getLanguages(),
 				],
 				'conversations' => [
 					'can-create' => $user instanceof IUser && !$this->talkConfig->isNotAllowedToCreateConversations($user)


### PR DESCRIPTION
### ☑️ Resolves

* Capability and it's docs for #9273 
* Actual API is missing documentation in server, will try to see if they are scheduled or in progress already

### 🖼️ Screenshots

![image](https://user-images.githubusercontent.com/213943/232460422-2947bb72-152b-4c78-b428-26553797dec7.png)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed
