### PR TITLE
Fix toasts messages on Fullscreen mode

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -42,6 +42,7 @@ import debounce from 'debounce'
 import PreventUnload from 'vue-prevent-unload'
 
 import { getCurrentUser } from '@nextcloud/auth'
+import { setGlobalToastOptions } from '@nextcloud/dialogs'
 import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { generateUrl } from '@nextcloud/router'
 
@@ -254,6 +255,8 @@ export default {
 		document.addEventListener('visibilitychange', this.changeWindowVisibility)
 
 		this.onResize()
+
+		setGlobalToastOptions({ selector: this.$store.getters.getMainContainerSelector().slice(1) })
 
 		window.addEventListener('unload', () => {
 			console.info('Navigating away, leaving conversation')


### PR DESCRIPTION
### ☑️ Resolves

* Follow up from https://github.com/nextcloud/spreed/pull/9309#issuecomment-1510925486
* Requires https://github.com/nextcloud/nextcloud-dialogs/pull/803
* Set the global selector for toast messages, to render toast messages inside `#content-vue` (which fixes Fullscreen Mode)
* Tested on Webclient

### 🚧 Tasks

- [ ] Code review
- [ ] Visual check

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
