### PR TITLE
feat(virtual-background): Add capabilities for predefined virtual bac…

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -116,3 +116,5 @@
 ## 17
 * `avatar` - Avatar of conversation
 * `config => chat => translations` - List of translations tuples, JSON encoded sample `{"from":"de","fromLabel":"German","to":"en","toLabel":"English"}`. Those tuples should be provided as options when translating chat messages.
+* `config => call => predefined-backgrounds` - List of predefined virtual backgrounds. The files are in Talks img/ folder, accessible via the normal image path methods. The list is cached for 5 minutes.
+* `config => call => can-upload-background` - Boolean flag whether the user can upload a custom virtual background (requires an account and non-zero quota). Uploads should be done to Talk/Backgrounds/ (respecting the user's attachment directory setting).


### PR DESCRIPTION
…kgrounds and whether users can upload custom ones

### ☑️ Resolves

* Ref #9270 

### 🖼️ Screenshots

![grafik](https://user-images.githubusercontent.com/213943/232703241-aa903f9e-fafe-4028-abc4-952e98b4721d.png)


### 🚧 Tasks

- [x] Return the predefined backgrounds on the capabilities API
- [x] Expose whether the user can upload backgrounds

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
