### PR TITLE
Fix signaling messages sent to all participants

### DIFF
--- a/src/utils/webrtc/simplewebrtc/webrtc.js
+++ b/src/utils/webrtc/simplewebrtc/webrtc.js
@@ -120,10 +120,6 @@ WebRTC.prototype.getPeers = function(sessionId, type) {
 
 // sends message to all
 WebRTC.prototype.sendToAll = function(message, payload) {
-	this.peers.forEach(function(peer) {
-		peer.send(message, payload)
-	})
-
 	this.emit('sendToAll', message, payload)
 }
 

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -1613,27 +1613,18 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 	})
 
 	webrtc.on('sendToAll', function(messageType, payload) {
-		const sessionIdsForParticipantsWithPeers = {}
-		webrtc.webrtc.peers.forEach(peer => {
-			sessionIdsForParticipantsWithPeers[peer.id] = peer
-		})
-
-		// "webrtc.sendToAll" only sends the signaling message to participants
-		// for which there is a Peer object. Therefore the message needs to be
-		// explicitly sent here too to participants without audio and video.
 		for (const sessionId in usersInCallMapping) {
-			if (sessionIdsForParticipantsWithPeers[sessionId]) {
-				continue
-			} else if (!usersInCallMapping[sessionId].inCall) {
+			if (!usersInCallMapping[sessionId].inCall) {
 				continue
 			} else if (sessionId === signaling.getSessionId()) {
 				continue
 			}
 
-			// "roomType" is not really relevant without a peer, but it is
-			// nevertheless expected in the message. As the signaling messages
-			// currently sent to all participants are related to video peers
-			// "video" is used as the room type.
+			// "roomType" is not really relevant without a peer or when
+			// referring to the whole participant, but it is nevertheless
+			// expected in the message. As most of the signaling messages
+			// currently sent to all participants are related to audio/video
+			// state "video" is used as the room type.
 			const message = {
 				to: sessionId,
 				roomType: 'video',


### PR DESCRIPTION
When a signaling message was sent to all the participants in the call it was first sent to all the peers and, then, to all the participants that had no peer. Due to this the signaling message was sent to screen peers and, when the HPB was used, to the own peer used to send media to the HPB.

Now those messages only take into account the participants, independently of the peers related to them, and a single message is sent for each participant (always with `video` as `roomType`, as `roomType` is always expected in the messages). This prevents, for example, duplicated messages to be received by a participant sending audio/video and sharing the screen.

Note that the `sid` parameter is no longer sent in the messages. Nevertheless, this parameter is specific to identify the session of a connection, and it is not relevant in the messages sent to all the participants, so this is not a problem. Moreover, when the HPB is used its value was useless anyway, as it referred to the connection between the sender and the HPB, which is unrelated to the receiver connection.

This fix affects the following message types: `mute`, `unmute`, `nickChanged`, `raiseHand` and `control` (for `forceMute`). Nevertheless, this should have no effect in the mobile apps, and also be backwards compatible if backported to previous versions:
- the Android app does not share the screen, so it never received a signaling message sent to a screen peer by other participants. The `sid` parameter is not taken into account in those messages, only in WebRTC messages like _offer_ or _answer_.
- the iOS app ~~can share the screen, but~~ does not share the screen either, and according to @Ivansss there is no problem if the signaling message is no longer sent to the screen peer but only to the participant itself with `roomType: video`. In @Ivansss we trust :-P Same for the `sid` parameter.

## How to test

- If using the HPB, add `'debug' => true,` to _config.php_ in Nexcloud server
- If not using the HPB, add `console.debug('Sending', data)` to [`sendCallMessage()`](https://github.com/nextcloud/spreed/blob/f9d955d1536ad02c8ba43100f41869840769cdef/src/utils/signaling.js#L455) and `console.debug('Received', message)` to [`_startPullingMessages`](https://github.com/nextcloud/spreed/blob/f9d955d1536ad02c8ba43100f41869840769cdef/src/utils/signaling.js#L493)
- Start a call with audio and/or video
- In a private window, join the call with audio and/or video
- Share the screen
- Open the browser console in both windows
- Wait ~30 seconds until no more initial status messages are sent
- Raise the hand as the participant that is not sharing the screen

### Result with this pull request

In the window where the hand was raised one signaling message was sent, and in the other window one signaling message was received

### Result without this pull request

In the window where the hand was raised three signaling messages were sent (to the own video peer, the receiver video peer and the receiver screen peer), and in the other window two signaling messages were received (with room types _video_ and _screen_ and _sid_ parameters that are only relevant in the connections established in the other window)
