### PR TITLE
Allow to mark conversation as unread

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
@@ -530,10 +530,22 @@ describe('Conversation.vue', () => {
 
 			expect(toggleFavoriteAction).toHaveBeenCalledWith(expect.anything(), item)
 		})
+		test('marks conversation as unread', async () => {
+			const markConversationUnreadAction = jest.fn().mockResolvedValueOnce()
+			testStoreConfig.modules.conversationsStore.actions.markConversationUnread = markConversationUnreadAction
+
+			const action = shallowMountAndGetAction('Mark as unread')
+			expect(action.exists()).toBe(true)
+
+			await action.find('button').trigger('click')
+
+			expect(markConversationUnreadAction).toHaveBeenCalledWith(expect.anything(), { token: item.token })
+		})
 		test('marks conversation as read', async () => {
 			const clearLastReadMessageAction = jest.fn().mockResolvedValueOnce()
 			testStoreConfig.modules.conversationsStore.actions.clearLastReadMessage = clearLastReadMessageAction
 
+			item.unreadMessages = 1
 			const action = shallowMountAndGetAction('Mark as read')
 			expect(action.exists()).toBe(true)
 

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -62,12 +62,21 @@
 				@click.stop.prevent="handleCopyLink">
 				{{ t('spreed', 'Copy link') }}
 			</NcActionButton>
-			<NcActionButton :close-after-click="true"
+			<NcActionButton v-if="item.unreadMessages"
+				:close-after-click="true"
 				@click.prevent.exact="markConversationAsRead">
 				<template #icon>
 					<EyeOutline :size="16" />
 				</template>
 				{{ t('spreed', 'Mark as read') }}
+			</NcActionButton>
+			<NcActionButton v-else
+				:close-after-click="true"
+				@click.prevent.exact="markConversationAsUnread">
+				<template #icon>
+					<EyeOffOutline :size="16" />
+				</template>
+				{{ t('spreed', 'Mark as unread') }}
 			</NcActionButton>
 			<NcActionButton :close-after-click="true"
 				@click.prevent.exact="showConversationSettings">
@@ -116,6 +125,7 @@ import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import Cog from 'vue-material-design-icons/Cog.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
 import ExitToApp from 'vue-material-design-icons/ExitToApp.vue'
+import EyeOffOutline from 'vue-material-design-icons/EyeOffOutline.vue'
 import EyeOutline from 'vue-material-design-icons/EyeOutline.vue'
 import Star from 'vue-material-design-icons/Star.vue'
 
@@ -134,14 +144,16 @@ export default {
 	name: 'Conversation',
 
 	components: {
-		ArrowRight,
-		Cog,
 		ConversationIcon,
-		Delete,
-		ExitToApp,
-		EyeOutline,
 		NcActionButton,
 		NcListItem,
+		// Icons
+		ArrowRight,
+		Cog,
+		Delete,
+		ExitToApp,
+		EyeOffOutline,
+		EyeOutline,
 		Star,
 	},
 
@@ -348,6 +360,10 @@ export default {
 
 		markConversationAsRead() {
 			this.$store.dispatch('clearLastReadMessage', { token: this.item.token })
+		},
+
+		markConversationAsUnread() {
+			this.$store.dispatch('markConversationUnread', { token: this.item.token })
 		},
 
 		showConversationSettings() {

--- a/src/services/conversationsService.js
+++ b/src/services/conversationsService.js
@@ -207,6 +207,20 @@ const clearConversationHistory = async function(token) {
 }
 
 /**
+ * Set conversation as unread
+ *
+ * @param {string} token The token of the conversation to be set as unread
+ */
+const setConversationUnread = async function(token) {
+	try {
+		const response = axios.delete(generateOcsUrl('apps/spreed/api/v1/chat/{token}/read', { token }))
+		return response
+	} catch (error) {
+		console.debug('Error while setting the conversation as unread: ', error)
+	}
+}
+
+/**
  * Add a conversation to the favorites
  *
  * @param {string} token The token of the conversation to be favorites
@@ -441,6 +455,7 @@ export {
 	setConversationName,
 	setConversationDescription,
 	clearConversationHistory,
+	setConversationUnread,
 	setConversationPermissions,
 	setCallPermissions,
 	setMessageExpiration,

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -46,6 +46,7 @@ import {
 	setConversationDescription,
 	deleteConversation,
 	clearConversationHistory,
+	setConversationUnread,
 	setNotificationLevel,
 	setNotificationCalls,
 	setConversationPermissions,
@@ -129,7 +130,7 @@ const mutations = {
 		Vue.delete(state.conversations, token)
 	},
 	/**
-	 * Resets the store to it's original state
+	 * Resets the store to its original state
 	 *
 	 * @param {object} state current store state;
 	 */
@@ -428,15 +429,25 @@ const actions = {
 	},
 
 	async markConversationRead({ commit, getters }, token) {
-		const conversation = Object.assign({}, getters.conversations[token])
-		if (!conversation) {
+		if (!getters.conversations[token]) {
 			return
 		}
 
-		conversation.unreadMessages = 0
-		conversation.unreadMention = false
+		commit('updateUnreadMessages', { token, unreadMessages: 0, unreadMention: false })
+	},
 
-		commit('addConversation', conversation)
+	async markConversationUnread({ commit, dispatch, getters }, { token }) {
+		if (!getters.conversations[token]) {
+			return
+		}
+
+		try {
+			await setConversationUnread(token)
+			commit('updateUnreadMessages', { token, unreadMessages: 1 })
+			await dispatch('fetchConversation', { token })
+		} catch (error) {
+			console.debug('Error while marking conversation as unread: ', error)
+		}
 	},
 
 	async updateLastCommonReadMessage({ commit, getters }, { token, lastCommonReadMessage }) {

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -124,7 +124,7 @@ const mutations = {
 	 * Deletes a conversation from the store.
 	 *
 	 * @param {object} state current store state;
-	 * @param {object} token the token of the conversation to delete;
+	 * @param {string} token the token of the conversation to delete;
 	 */
 	deleteConversation(state, token) {
 		Vue.delete(state.conversations, token)
@@ -201,7 +201,7 @@ const mutations = {
 
 const actions = {
 	/**
-	 * Add a conversation to the store and index the displayname.
+	 * Add a conversation to the store and index the displayName.
 	 *
 	 * @param {object} context default store context;
 	 * @param {object} conversation the conversation;
@@ -214,8 +214,8 @@ const actions = {
 			displayName: context.getters.getDisplayName(),
 		}
 
-		// Fallback to getCurrentUser() only if if has not been set yet (as
-		// getCurrentUser() needs to be overriden in public share pages as it
+		// Fallback to getCurrentUser() only if it has not been set yet (as
+		// getCurrentUser() needs to be overridden in public share pages as it
 		// always returns an anonymous user).
 		if (!currentUser.uid) {
 			currentUser = getCurrentUser()
@@ -253,7 +253,7 @@ const actions = {
 	 *
 	 * @param {object} context default store context;
 	 * @param {object} data the wrapping object;
-	 * @param {object} data.token the token of the conversation to be deleted;
+	 * @param {string} data.token the token of the conversation to be deleted;
 	 */
 	async deleteConversationFromServer(context, { token }) {
 		await deleteConversation(token)
@@ -266,7 +266,7 @@ const actions = {
 	 *
 	 * @param {object} context default store context;
 	 * @param {object} data the wrapping object;
-	 * @param {object} data.token the token of the conversation whose history is
+	 * @param {string} data.token the token of the conversation whose history is
 	 * to be cleared;
 	 */
 	async clearConversationHistory(context, { token }) {
@@ -282,7 +282,7 @@ const actions = {
 	},
 
 	/**
-	 * Resets the store to it's original state.
+	 * Resets the store to its original state.
 	 *
 	 * @param {object} context default store context;
 	 */
@@ -292,11 +292,11 @@ const actions = {
 	},
 
 	async toggleGuests({ commit, getters }, { token, allowGuests }) {
-		const conversation = Object.assign({}, getters.conversations[token])
-		if (!conversation) {
+		if (!getters.conversations[token]) {
 			return
 		}
 
+		const conversation = Object.assign({}, getters.conversations[token])
 		if (allowGuests) {
 			await makePublic(token)
 			conversation.type = CONVERSATION.TYPE.PUBLIC
@@ -309,8 +309,7 @@ const actions = {
 	},
 
 	async toggleFavorite({ commit, getters }, { token, isFavorite }) {
-		const conversation = Object.assign({}, getters.conversations[token])
-		if (!conversation) {
+		if (!getters.conversations[token]) {
 			return
 		}
 
@@ -320,17 +319,18 @@ const actions = {
 		} else {
 			await addToFavorites(token)
 		}
-		conversation.isFavorite = !isFavorite
+
+		const conversation = Object.assign({}, getters.conversations[token], { isFavorite: !isFavorite })
 
 		commit('addConversation', conversation)
 	},
 
 	async toggleLobby({ commit, getters }, { token, enableLobby }) {
-		const conversation = Object.assign({}, getters.conversations[token])
-		if (!conversation) {
+		if (!getters.conversations[token]) {
 			return
 		}
 
+		const conversation = Object.assign({}, getters.conversations[token])
 		if (enableLobby) {
 			await changeLobbyState(token, WEBINAR.LOBBY.NON_MODERATORS)
 			conversation.lobbyState = WEBINAR.LOBBY.NON_MODERATORS
@@ -343,13 +343,13 @@ const actions = {
 	},
 
 	async setConversationName({ commit, getters }, { token, name }) {
-		const conversation = Object.assign({}, getters.conversations[token])
-		if (!conversation) {
+		if (!getters.conversations[token]) {
 			return
 		}
 
 		await setConversationName(token, name)
-		conversation.displayName = name
+
+		const conversation = Object.assign({}, getters.conversations[token], { displayName: name })
 
 		commit('addConversation', conversation)
 	},
@@ -369,61 +369,60 @@ const actions = {
 	},
 
 	async setReadOnlyState({ commit, getters }, { token, readOnly }) {
-		const conversation = Object.assign({}, getters.conversations[token])
-		if (!conversation) {
+		if (!getters.conversations[token]) {
 			return
 		}
 
 		await changeReadOnlyState(token, readOnly)
-		conversation.readOnly = readOnly
+
+		const conversation = Object.assign({}, getters.conversations[token], { readOnly })
 
 		commit('addConversation', conversation)
 	},
 
 	async setListable({ commit, getters }, { token, listable }) {
-		const conversation = Object.assign({}, getters.conversations[token])
-		if (!conversation) {
+		if (!getters.conversations[token]) {
 			return
 		}
 
 		await changeListable(token, listable)
-		conversation.listable = listable
+
+		const conversation = Object.assign({}, getters.conversations[token], { listable })
 
 		commit('addConversation', conversation)
 	},
 
 	async setLobbyTimer({ commit, getters }, { token, timestamp }) {
-		const conversation = Object.assign({}, getters.conversations[token])
-		if (!conversation) {
+		if (!getters.conversations[token]) {
 			return
 		}
 
+		const conversation = Object.assign({}, getters.conversations[token], { lobbyTimer: timestamp })
+
 		// The backend requires the state and timestamp to be set together.
 		await changeLobbyState(token, conversation.lobbyState, timestamp)
-		conversation.lobbyTimer = timestamp
 
 		commit('addConversation', conversation)
 	},
 
 	async setSIPEnabled({ commit, getters }, { token, state }) {
-		const conversation = Object.assign({}, getters.conversations[token])
-		if (!conversation) {
+		if (!getters.conversations[token]) {
 			return
 		}
 
 		await setSIPEnabled(token, state)
-		conversation.sipEnabled = state
+
+		const conversation = Object.assign({}, getters.conversations[token], { sipEnabled: state })
 
 		commit('addConversation', conversation)
 	},
 
 	async setConversationProperties({ commit, getters }, { token, properties }) {
-		let conversation = Object.assign({}, getters.conversations[token])
-		if (!conversation) {
+		if (!getters.conversations[token]) {
 			return
 		}
 
-		conversation = Object.assign(conversation, properties)
+		const conversation = Object.assign({}, getters.conversations[token], properties)
 
 		commit('addConversation', conversation)
 	},
@@ -441,40 +440,36 @@ const actions = {
 			return
 		}
 
-		try {
-			await setConversationUnread(token)
-			commit('updateUnreadMessages', { token, unreadMessages: 1 })
-			await dispatch('fetchConversation', { token })
-		} catch (error) {
-			console.debug('Error while marking conversation as unread: ', error)
-		}
+		await setConversationUnread(token)
+		commit('updateUnreadMessages', { token, unreadMessages: 1 })
+		await dispatch('fetchConversation', { token })
 	},
 
 	async updateLastCommonReadMessage({ commit, getters }, { token, lastCommonReadMessage }) {
-		const conversation = Object.assign({}, getters.conversations[token])
-		if (!conversation) {
+		if (!getters.conversations[token]) {
 			return
 		}
 
-		conversation.lastCommonReadMessage = lastCommonReadMessage
+		const conversation = Object.assign({}, getters.conversations[token], { lastCommonReadMessage })
 
 		commit('addConversation', conversation)
 	},
 
 	async updateConversationLastActive({ commit, getters }, token) {
-		const conversation = Object.assign({}, getters.conversations[token])
-		if (!conversation) {
+		if (!getters.conversations[token]) {
 			return
 		}
 
-		conversation.lastActivity = (new Date().getTime()) / 1000
+		const conversation = Object.assign({}, getters.conversations[token], {
+			lastActivity: (new Date().getTime()) / 1000,
+		})
 
 		commit('addConversation', conversation)
 	},
 
 	async updateConversationLastMessage({ commit }, { token, lastMessage }) {
 		/**
-		 * Only use the last message as lastmessage when:
+		 * Only use the last message as lastMessage when:
 		 * 1. It's not a command reply
 		 * 2. It's not a temporary message starting with "/" which is a user posting a command
 		 * 3. It's not a reaction or deletion of a reaction
@@ -496,12 +491,13 @@ const actions = {
 
 	async updateConversationLastMessageFromNotification({ getters, commit }, { notification }) {
 		const [token, messageId] = notification.objectId.split('/')
-		const conversation = { ...getters.conversation(token) }
 
-		if (!conversation) {
+		if (!getters.conversations[token]) {
 			// Conversation not loaded yet, skipping
 			return
 		}
+
+		const conversation = Object.assign({}, getters.conversations[token])
 
 		const actor = notification.subjectRichParameters.user || notification.subjectRichParameters.guest || {
 			type: 'guest',
@@ -560,29 +556,32 @@ const actions = {
 
 	async updateCallStateFromNotification({ getters, commit }, { notification }) {
 		const token = notification.objectId
-		const conversation = { ...getters.conversation(token) }
 
-		if (!conversation) {
+		if (!getters.conversations[token]) {
 			// Conversation not loaded yet, skipping
 			return
 		}
 
-		conversation.hasCall = true
-		conversation.callFlag = PARTICIPANT.CALL_FLAG.WITH_VIDEO
-		conversation.activeSince = (new Date(notification.datetime)).getTime() / 1000
-		conversation.lastActivity = conversation.activeSince
-		conversation.callStartTime = conversation.activeSince
+		const activeSince = (new Date(notification.datetime)).getTime() / 1000
+
+		const conversation = Object.assign({}, getters.conversations[token], {
+			hasCall: true,
+			callFlag: PARTICIPANT.CALL_FLAG.WITH_VIDEO,
+			activeSince,
+			lastActivity: activeSince,
+			callStartTime: activeSince,
+		})
 
 		// Inaccurate but best effort from here on:
 		const lastMessage = {
 			token,
-			id: 'temp' + conversation.activeSince,
+			id: 'temp' + activeSince,
 			actorType: 'guests',
 			actorId: 'unknown',
 			actorDisplayName: t('spreed', 'Guest'),
 			message: notification.subjectRich,
 			messageParameters: notification.subjectRichParameters,
-			timestamp: conversation.activeSince,
+			timestamp: activeSince,
 			messageType: 'system',
 			systemMessage: 'call_started',
 			expirationTimestamp: 0,


### PR DESCRIPTION
### ☑️ Resolves

* Fix #6808 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
`Mark as read` is shown for all conversation | Different buttons for read and unread conversations
![image](https://user-images.githubusercontent.com/93392545/233635223-e75dbf10-74dc-423e-9d8c-4b97c086088c.png) | ![image](https://user-images.githubusercontent.com/93392545/233638056-d8aef9f1-571f-428c-9ea8-08e49ec0a3c9.png)



### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x]  🔖 Capability is added or not needed 
