### PR TITLE
Fix TypeError at `LeftSidebar`

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -33,7 +33,7 @@
 			<NewGroupConversation v-if="canStartConversations" />
 		</div>
 		<template #list>
-			<li class="left-sidebar__list">
+			<li ref="container" class="left-sidebar__list">
 				<ul ref="scroller"
 					class="scroller"
 					@scroll="debounceHandleScroll">
@@ -556,17 +556,15 @@ export default {
 		},
 		handleUnreadMention() {
 			this.unreadNum = 0
-			const unreadMentions = document.getElementsByClassName('unread-mention-conversation')
-			if (unreadMentions.length) {
-				unreadMentions.forEach(x => {
-					if (this.elementIsBelowViewpoint(this.$refs.container, x)) {
-						if (this.unreadNum === 0) {
-							this.firstUnreadPos = x.offsetTop
-						}
-						this.unreadNum += 1
+			const unreadMentions = document.querySelectorAll('.unread-mention-conversation')
+			unreadMentions.forEach(x => {
+				if (this.elementIsBelowViewpoint(this.$refs.container, x)) {
+					if (this.unreadNum === 0) {
+						this.firstUnreadPos = x.offsetTop
 					}
-				})
-			}
+					this.unreadNum += 1
+				}
+			})
 		},
 		debounceHandleScroll: debounce(function() {
 			this.handleScroll()


### PR DESCRIPTION
### ☑️ Resolves

* Perhaps a regression from #9068 
* Replace HTML Collection (doesn't have .forEach method) with iterable HTML NodeList (better at [performance](https://dev.to/wlytle/performance-tradeoffs-of-queryselector-and-queryselectorall-1074))
* Fix #9335 

Tested on Chrome, Talk-desktop

### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
