### PR TITLE
fix(chat): Conversation avatar for mention chips

### DIFF
--- a/css/icons.css
+++ b/css/icons.css
@@ -71,10 +71,12 @@
  * .app-Talk rules above.
  * "forced-white" needs to be included in the class name as the Avatar does
  * not accept several classes. */
+.mention-bubble__icon.icon-group-forced-white,
 .tribute-container .icon-group-forced-white {
 	background-image: url(../img/icon-contacts-white.svg);
 }
 
+.mention-bubble__icon.icon-user-forced-white,
 .tribute-container .icon-user-forced-white {
 	background-image: url(../img/icon-user-white.svg)
 }

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -519,7 +519,7 @@ export default {
 			Object.keys(this.messageParameters).forEach(function(p) {
 				const type = this.messageParameters[p].type
 				const mimetype = this.messageParameters[p].mimetype
-				if (type === 'user' || type === 'call' || type === 'guest' || type === 'group') {
+				if (type === 'user' || type === 'call' || type === 'guest' || type === 'user-group' || type === 'group') {
 					richParameters[p] = {
 						component: Mention,
 						props: this.messageParameters[p],

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
@@ -23,7 +23,7 @@
 	<div class="mention">
 		<NcUserBubble v-if="isMentionToAll"
 			:display-name="name"
-			:avatar-image="'icon-group-forced-white'"
+			:avatar-image="avatarUrl"
 			:primary="true" />
 		<NcUserBubble v-else-if="isGroupMention"
 			:display-name="name"
@@ -40,6 +40,8 @@
 </template>
 
 <script>
+
+import { generateOcsUrl } from '@nextcloud/router'
 
 import NcUserBubble from '@nextcloud/vue/dist/Components/NcUserBubble.js'
 
@@ -87,6 +89,15 @@ export default {
 		isCurrentUser() {
 			return this.$store.getters.getActorType() === 'users'
 				&& this.id === this.$store.getters.getUserId()
+		},
+		isDarkTheme() {
+			return window.getComputedStyle(document.body)
+				.getPropertyValue('--background-invert-if-dark') === 'invert(100%)'
+		},
+		avatarUrl() {
+			return generateOcsUrl('apps/spreed/api/v1/room/{token}/avatar' + (this.darkTheme ? '/dark' : ''), {
+				token: this.id,
+			})
 		},
 	},
 }

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
@@ -72,7 +72,7 @@ export default {
 			return this.type === 'call'
 		},
 		isGroupMention() {
-			return this.type === 'group'
+			return this.type === 'user-group' || this.type === 'group'
 		},
 		isMentionToGuest() {
 			return this.type === 'guest'


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9188 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
Groups show in bold | Groups show as mention
At-all shows group icon | At-all shows conversation avatar
Chat input shows no icon | Chat inpt shows avatar or group icon
![grafik](https://user-images.githubusercontent.com/213943/234569872-9838c2b6-9da7-4869-83b6-783fa329ccfd.png) | ![Bildschirmfoto vom 2023-04-26 14-00-04](https://user-images.githubusercontent.com/213943/234569890-85c3a5bf-7beb-4492-8ca3-6c641e40804f.png)


### 🚧 Tasks

- Helpful addition: https://github.com/nextcloud/nextcloud-vue/pull/4007

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
