### PR TITLE
Create a data-channel when testing the turn setup

### DIFF
--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -99,6 +99,7 @@
 import Base64 from 'crypto-js/enc-base64.js'
 import hmacSHA1 from 'crypto-js/hmac-sha1.js'
 import debounce from 'debounce'
+import webrtcSupport from 'webrtcsupport'
 
 import AlertCircle from 'vue-material-design-icons/AlertCircle.vue'
 import Check from 'vue-material-design-icons/Check.vue'
@@ -256,6 +257,12 @@ export default {
 			}.bind(this), 10000)
 			pc.onicecandidate = this.iceCallback.bind(this, pc, candidates, timeout)
 			pc.onicegatheringstatechange = this.gatheringStateChange.bind(this, pc, candidates, timeout)
+
+			// This test will always fail without a data channel on Safari
+			if (webrtcSupport.supportDataChannel) {
+				pc.createDataChannel('status')
+			}
+
 			pc.createOffer(
 				offerOptions
 			).then(


### PR DESCRIPTION
### ☑️ Resolves

* Fix #5563

Without creating a data channel Safari does not even try to create a connection to the turn server. With this PR a connection to the turn server is create successfully and candidates are returned. Tested this with Safari 16.3, Mobile Safari on iOS 16.4.1 and Chrome 112 using:
* `only turn:`
* `UDP & TCP`

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://user-images.githubusercontent.com/1580193/234716565-96628068-4bdd-4353-96a1-fcd9b3d9babe.png) | <img width="240" alt="image" src="https://user-images.githubusercontent.com/1580193/234716686-03607ca3-bd13-4448-a2e8-e71acf49aa97.png">

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
