### PR TITLE
Fix mentions of groups and guests as well as users with spaces

### DIFF
--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -859,12 +859,6 @@ export default {
 			const possibleMentions = response.data.ocs.data
 
 			possibleMentions.forEach(possibleMention => {
-				// Wrap mention ids with spaces in quotes.
-				if (possibleMention.id.indexOf(' ') !== -1
-					|| possibleMention.id.indexOf('/') !== -1) {
-					possibleMention.id = '"' + possibleMention.id + '"'
-				}
-
 				// Set icon for candidate mentions that are not for users.
 				if (possibleMention.source === 'calls') {
 					possibleMention.icon = 'icon-user-forced-white'


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9389 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://user-images.githubusercontent.com/213943/235493230-d109bebf-dc1d-4022-8edb-a01047ab74db.png) | ![Bildschirmfoto vom 2023-05-01 18-56-17](https://user-images.githubusercontent.com/213943/235493250-908ec7ac-c063-4792-85dc-cc32addba84a.png)


### 🚧 Tasks

- [x] Mention a user with a space
- [x] Mention a group with a space
- [x] Mention a group without a space
- [x] Mention a user without a space

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
