### PR TITLE
Keep guest attendees with values

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -829,9 +829,18 @@ class RoomController extends AEnvironmentAwareController {
 					$result['statusClearAt'] = null;
 				}
 			} elseif ($participant->getAttendee()->getActorType() === Attendee::ACTOR_GUESTS) {
-				if ($result['lastPing'] <= $maxPingAge) {
-					$cleanGuests = true;
-					continue;
+				if ($participant->getAttendee()->getParticipantType() === Participant::GUEST
+					&& ($participant->getAttendee()->getPermissions() === Attendee::PERMISSIONS_DEFAULT
+						|| $participant->getAttendee()->getPermissions() === Attendee::PERMISSIONS_CUSTOM)) {
+					// Guests without an up-to-date session are filtered out. We
+					// only keep there attendees in the database, so that the
+					// comments show the display name. Only when they have
+					// non-default permissions we show them, so permissions can
+					// be reset or removed
+					if ($result['lastPing'] <= $maxPingAge) {
+						$cleanGuests = true;
+						continue;
+					}
 				}
 
 				$result['displayName'] = $participant->getAttendee()->getDisplayName();

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -995,6 +995,18 @@ class ParticipantService {
 		$attendees = [];
 		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
+			if ($row['display_name'] !== '' && $row['display_name'] !== null) {
+				// Keep guests with a non-empty display name, so we can still
+				// render the guest display name on chat messages.
+				continue;
+			}
+
+			if ($row['permissions'] !== Attendee::PERMISSIONS_DEFAULT
+				|| $row['participant_type'] === Participant::GUEST_MODERATOR) {
+				// Keep guests with non-default permissions in case they just reconnect
+				continue;
+			}
+
 			$attendeeIds[] = (int) $row['a_id'];
 			$attendees[] = $this->attendeeMapper->createAttendeeFromRow($row);
 		}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -130,6 +130,10 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			}
 		}
 
+		if (!isset(self::$userToAttendeeId[$room][$type][$id])) {
+			throw new \Exception('Attendee id unknown, please call userLoadsAttendeeIdsInRoom with a user that has access before');
+		}
+
 		return self::$userToAttendeeId[$room][$type][$id];
 	}
 
@@ -1051,6 +1055,10 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			// in chat messages is a hashed version instead.
 			self::$sessionIdToUser[sha1($response['sessionId'])] = $user;
 			self::$userToSessionId[$user] = $response['sessionId'];
+			if (!isset(self::$userToAttendeeId[$identifier][$response['actorType']])) {
+				self::$userToAttendeeId[$identifier][$response['actorType']] = [];
+			}
+			self::$userToAttendeeId[$identifier][$response['actorType']][$response['actorId']] = $response['attendeeId'];
 		}
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #8787
* Can't really write an integration test for this as we don't want to wait 90 seconds on the test

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
All guests without a session are deleted | Guests with display names a kept and hidden<br>Guests with permissions or moderator type are displayed<br>![image](https://user-images.githubusercontent.com/213943/235593277-d67430ef-fd8a-4838-a170-f665d9ab8815.png)


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
