### PR TITLE
feat(avatar): Use the first emoji of room names as avatar emoji

### DIFF
--- a/tests/php/Service/AvatarServiceTest.php
+++ b/tests/php/Service/AvatarServiceTest.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Tests\php\Service;
 
+use OC\EmojiHelper;
 use OCA\Talk\Room;
 use OCA\Talk\Service\AvatarService;
 use OCA\Talk\Service\RoomService;
@@ -61,13 +62,15 @@ class AvatarServiceTest extends TestCase {
 		$this->random = $this->createMock(ISecureRandom::class);
 		$this->roomService = $this->createMock(RoomService::class);
 		$this->avatarManager = $this->createMock(IAvatarManager::class);
+		$this->emojiHelper = \OCP\Server::get(EmojiHelper::class);
 		$this->service = new AvatarService(
 			$this->appData,
 			$this->l,
 			$this->url,
 			$this->random,
 			$this->roomService,
-			$this->avatarManager
+			$this->avatarManager,
+			$this->emojiHelper,
 		);
 	}
 
@@ -90,5 +93,20 @@ class AvatarServiceTest extends TestCase {
 			['1', '1'],
 			['1.png', '1'],
 		];
+	}
+
+	public function dataGetFirstCombinedEmoji(): array {
+		return [
+			['👋 Hello', '👋'],
+			['Only leading emojis 🚀', ''],
+			['👩🏽‍💻👩🏻‍💻👨🏿‍💻 Only one, but with all attributes', '👩🏽‍💻'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetFirstCombinedEmoji
+	 */
+	public function testGetFirstCombinedEmoji(string $roomName, string $avatarEmoji): void {
+		$this->assertSame($avatarEmoji, self::invokePrivate($this->service, 'getFirstCombinedEmoji', [$roomName]));
 	}
 }

--- a/tests/php/Service/AvatarServiceTest.php
+++ b/tests/php/Service/AvatarServiceTest.php
@@ -35,6 +35,7 @@ use OCP\IAvatarManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Security\ISecureRandom;
+use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -52,6 +53,8 @@ class AvatarServiceTest extends TestCase {
 	private $roomService;
 	/** @var IAvatarManager|MockObject */
 	private $avatarManager;
+	/** @var EmojiHelper|MockObject */
+	private $emojiHelper;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -62,7 +65,7 @@ class AvatarServiceTest extends TestCase {
 		$this->random = $this->createMock(ISecureRandom::class);
 		$this->roomService = $this->createMock(RoomService::class);
 		$this->avatarManager = $this->createMock(IAvatarManager::class);
-		$this->emojiHelper = \OCP\Server::get(EmojiHelper::class);
+		$this->emojiHelper = Server::get(EmojiHelper::class);
 		$this->service = new AvatarService(
 			$this->appData,
 			$this->l,


### PR DESCRIPTION
### ☑️ Resolves

* Fix #8444 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://user-images.githubusercontent.com/213943/235696814-c54c8b16-8e39-4e7c-ba5c-b7aac1dcad6a.png) | ![image](https://user-images.githubusercontent.com/213943/235714058-f3463f7f-deee-4f02-97f0-8a827ba0702c.png)


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
