### PR TITLE
chore(deps): Bump @nextcloud/vue to v7.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"@nextcloud/moment": "^1.2.1",
 				"@nextcloud/paths": "^2.1.0",
 				"@nextcloud/router": "^2.1.1",
-				"@nextcloud/vue": "^7.10.0",
+				"@nextcloud/vue": "^7.11.1",
 				"attachmediastream": "^2.1.0",
 				"color.js": "^1.2.0",
 				"crypto-js": "^4.1.1",
@@ -2953,9 +2953,9 @@
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.10.0.tgz",
-			"integrity": "sha512-RYh3luZgyXftewE97fVhI779l7FFWqKSa8OCa7xdNnKtOoS9o6AxFG6yOI9IWkifA3F9WYalRBJle6lffaMi/g==",
+			"version": "7.11.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.11.1.tgz",
+			"integrity": "sha512-+nP+6c2h1Vq2tIeQMmauojnnSNM6vCQTH44QvQjpU4fJrpongIL6NndH2goH7rzMnXS7QAfJYbuj1WT5qFAbBA==",
 			"dependencies": {
 				"@floating-ui/dom": "^1.1.0",
 				"@nextcloud/auth": "^2.0.0",
@@ -2971,7 +2971,7 @@
 				"@nextcloud/router": "^2.0.0",
 				"@nextcloud/vue-select": "^3.21.2",
 				"@skjnldsv/sanitize-svg": "^1.0.2",
-				"@vueuse/components": "^9.13.0",
+				"@vueuse/components": "^10.0.2",
 				"clone": "^2.1.2",
 				"debounce": "1.2.1",
 				"emoji-mart-vue-fast": "^12.0.1",
@@ -3744,9 +3744,9 @@
 			"integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
 		},
 		"node_modules/@types/web-bluetooth": {
-			"version": "0.0.16",
-			"resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.16.tgz",
-			"integrity": "sha512-oh8q2Zc32S6gd/j50GowEjKLoOVOwHP/bWVjKJInBwQqdOYMdPrf1oVlelTlyfFK3CKxL1uahMDAr+vy8T7yMQ=="
+			"version": "0.0.17",
+			"resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.17.tgz",
+			"integrity": "sha512-4p9vcSmxAayx72yn70joFoL44c9MO/0+iVEBIQXe3v2h2SiAsEIo/G5v6ObFWvNKRFjbrVadNf9LqEEZeQPzdA=="
 		},
 		"node_modules/@types/ws": {
 			"version": "8.5.4",
@@ -4238,19 +4238,19 @@
 			}
 		},
 		"node_modules/@vueuse/components": {
-			"version": "9.13.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/components/-/components-9.13.0.tgz",
-			"integrity": "sha512-UJ8PjQ4SGb2rsVIy9vhEc6aCu+3+2cc+xEfGNX8/M1NKIuL2Vo6c2Kc2fYFaRzWZkP8HWXu+IcwvnAzL44IEFA==",
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/@vueuse/components/-/components-10.1.2.tgz",
+			"integrity": "sha512-HlYFYCg3twMhnQgPS4/muz8XIYKViFVKnpL0Xtw5+9ib2gtWvu1Qu7hj6kDMDtOIw1CnNRsUbMLiNI+LXkxSSQ==",
 			"dependencies": {
-				"@vueuse/core": "9.13.0",
-				"@vueuse/shared": "9.13.0",
-				"vue-demi": "*"
+				"@vueuse/core": "10.1.2",
+				"@vueuse/shared": "10.1.2",
+				"vue-demi": ">=0.14.0"
 			}
 		},
 		"node_modules/@vueuse/components/node_modules/vue-demi": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-			"integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.0.tgz",
+			"integrity": "sha512-gt58r2ogsNQeVoQ3EhoUAvUsH9xviydl0dWJj7dabBC/2L4uBId7ujtCwDRD0JhkGsV1i0CtfLAeyYKBht9oWg==",
 			"hasInstallScript": true,
 			"bin": {
 				"vue-demi-fix": "bin/vue-demi-fix.js",
@@ -4273,23 +4273,23 @@
 			}
 		},
 		"node_modules/@vueuse/core": {
-			"version": "9.13.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-9.13.0.tgz",
-			"integrity": "sha512-pujnclbeHWxxPRqXWmdkKV5OX4Wk4YeK7wusHqRwU0Q7EFusHoqNA/aPhB6KCh9hEqJkLAJo7bb0Lh9b+OIVzw==",
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.1.2.tgz",
+			"integrity": "sha512-roNn8WuerI56A5uiTyF/TEYX0Y+VKlhZAF94unUfdhbDUI+NfwQMn4FUnUscIRUhv3344qvAghopU4bzLPNFlA==",
 			"dependencies": {
-				"@types/web-bluetooth": "^0.0.16",
-				"@vueuse/metadata": "9.13.0",
-				"@vueuse/shared": "9.13.0",
-				"vue-demi": "*"
+				"@types/web-bluetooth": "^0.0.17",
+				"@vueuse/metadata": "10.1.2",
+				"@vueuse/shared": "10.1.2",
+				"vue-demi": ">=0.14.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/@vueuse/core/node_modules/vue-demi": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-			"integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.0.tgz",
+			"integrity": "sha512-gt58r2ogsNQeVoQ3EhoUAvUsH9xviydl0dWJj7dabBC/2L4uBId7ujtCwDRD0JhkGsV1i0CtfLAeyYKBht9oWg==",
 			"hasInstallScript": true,
 			"bin": {
 				"vue-demi-fix": "bin/vue-demi-fix.js",
@@ -4312,28 +4312,28 @@
 			}
 		},
 		"node_modules/@vueuse/metadata": {
-			"version": "9.13.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-9.13.0.tgz",
-			"integrity": "sha512-gdU7TKNAUVlXXLbaF+ZCfte8BjRJQWPCa2J55+7/h+yDtzw3vOoGQDRXzI6pyKyo6bXFT5/QoPE4hAknExjRLQ==",
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.1.2.tgz",
+			"integrity": "sha512-3mc5BqN9aU2SqBeBuWE7ne4OtXHoHKggNgxZR2K+zIW4YLsy6xoZ4/9vErQs6tvoKDX6QAqm3lvsrv0mczAwIQ==",
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/@vueuse/shared": {
-			"version": "9.13.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-9.13.0.tgz",
-			"integrity": "sha512-UrnhU+Cnufu4S6JLCPZnkWh0WwZGUp72ktOF2DFptMlOs3TOdVv8xJN53zhHGARmVOsz5KqOls09+J1NR6sBKw==",
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.1.2.tgz",
+			"integrity": "sha512-1uoUTPBlgyscK9v6ScGeVYDDzlPSFXBlxuK7SfrDGyUTBiznb3mNceqhwvZHjtDRELZEN79V5uWPTF1VDV8svA==",
 			"dependencies": {
-				"vue-demi": "*"
+				"vue-demi": ">=0.14.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/@vueuse/shared/node_modules/vue-demi": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-			"integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.0.tgz",
+			"integrity": "sha512-gt58r2ogsNQeVoQ3EhoUAvUsH9xviydl0dWJj7dabBC/2L4uBId7ujtCwDRD0JhkGsV1i0CtfLAeyYKBht9oWg==",
 			"hasInstallScript": true,
 			"bin": {
 				"vue-demi-fix": "bin/vue-demi-fix.js",
@@ -20538,9 +20538,9 @@
 			}
 		},
 		"@nextcloud/vue": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.10.0.tgz",
-			"integrity": "sha512-RYh3luZgyXftewE97fVhI779l7FFWqKSa8OCa7xdNnKtOoS9o6AxFG6yOI9IWkifA3F9WYalRBJle6lffaMi/g==",
+			"version": "7.11.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.11.1.tgz",
+			"integrity": "sha512-+nP+6c2h1Vq2tIeQMmauojnnSNM6vCQTH44QvQjpU4fJrpongIL6NndH2goH7rzMnXS7QAfJYbuj1WT5qFAbBA==",
 			"requires": {
 				"@floating-ui/dom": "^1.1.0",
 				"@nextcloud/auth": "^2.0.0",
@@ -20556,7 +20556,7 @@
 				"@nextcloud/router": "^2.0.0",
 				"@nextcloud/vue-select": "^3.21.2",
 				"@skjnldsv/sanitize-svg": "^1.0.2",
-				"@vueuse/components": "^9.13.0",
+				"@vueuse/components": "^10.0.2",
 				"clone": "^2.1.2",
 				"debounce": "1.2.1",
 				"emoji-mart-vue-fast": "^12.0.1",
@@ -21230,9 +21230,9 @@
 			"integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
 		},
 		"@types/web-bluetooth": {
-			"version": "0.0.16",
-			"resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.16.tgz",
-			"integrity": "sha512-oh8q2Zc32S6gd/j50GowEjKLoOVOwHP/bWVjKJInBwQqdOYMdPrf1oVlelTlyfFK3CKxL1uahMDAr+vy8T7yMQ=="
+			"version": "0.0.17",
+			"resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.17.tgz",
+			"integrity": "sha512-4p9vcSmxAayx72yn70joFoL44c9MO/0+iVEBIQXe3v2h2SiAsEIo/G5v6ObFWvNKRFjbrVadNf9LqEEZeQPzdA=="
 		},
 		"@types/ws": {
 			"version": "8.5.4",
@@ -21562,59 +21562,59 @@
 			}
 		},
 		"@vueuse/components": {
-			"version": "9.13.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/components/-/components-9.13.0.tgz",
-			"integrity": "sha512-UJ8PjQ4SGb2rsVIy9vhEc6aCu+3+2cc+xEfGNX8/M1NKIuL2Vo6c2Kc2fYFaRzWZkP8HWXu+IcwvnAzL44IEFA==",
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/@vueuse/components/-/components-10.1.2.tgz",
+			"integrity": "sha512-HlYFYCg3twMhnQgPS4/muz8XIYKViFVKnpL0Xtw5+9ib2gtWvu1Qu7hj6kDMDtOIw1CnNRsUbMLiNI+LXkxSSQ==",
 			"requires": {
-				"@vueuse/core": "9.13.0",
-				"@vueuse/shared": "9.13.0",
-				"vue-demi": "*"
+				"@vueuse/core": "10.1.2",
+				"@vueuse/shared": "10.1.2",
+				"vue-demi": ">=0.14.0"
 			},
 			"dependencies": {
 				"vue-demi": {
-					"version": "0.13.11",
-					"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-					"integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+					"version": "0.14.0",
+					"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.0.tgz",
+					"integrity": "sha512-gt58r2ogsNQeVoQ3EhoUAvUsH9xviydl0dWJj7dabBC/2L4uBId7ujtCwDRD0JhkGsV1i0CtfLAeyYKBht9oWg==",
 					"requires": {}
 				}
 			}
 		},
 		"@vueuse/core": {
-			"version": "9.13.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-9.13.0.tgz",
-			"integrity": "sha512-pujnclbeHWxxPRqXWmdkKV5OX4Wk4YeK7wusHqRwU0Q7EFusHoqNA/aPhB6KCh9hEqJkLAJo7bb0Lh9b+OIVzw==",
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.1.2.tgz",
+			"integrity": "sha512-roNn8WuerI56A5uiTyF/TEYX0Y+VKlhZAF94unUfdhbDUI+NfwQMn4FUnUscIRUhv3344qvAghopU4bzLPNFlA==",
 			"requires": {
-				"@types/web-bluetooth": "^0.0.16",
-				"@vueuse/metadata": "9.13.0",
-				"@vueuse/shared": "9.13.0",
-				"vue-demi": "*"
+				"@types/web-bluetooth": "^0.0.17",
+				"@vueuse/metadata": "10.1.2",
+				"@vueuse/shared": "10.1.2",
+				"vue-demi": ">=0.14.0"
 			},
 			"dependencies": {
 				"vue-demi": {
-					"version": "0.13.11",
-					"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-					"integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+					"version": "0.14.0",
+					"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.0.tgz",
+					"integrity": "sha512-gt58r2ogsNQeVoQ3EhoUAvUsH9xviydl0dWJj7dabBC/2L4uBId7ujtCwDRD0JhkGsV1i0CtfLAeyYKBht9oWg==",
 					"requires": {}
 				}
 			}
 		},
 		"@vueuse/metadata": {
-			"version": "9.13.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-9.13.0.tgz",
-			"integrity": "sha512-gdU7TKNAUVlXXLbaF+ZCfte8BjRJQWPCa2J55+7/h+yDtzw3vOoGQDRXzI6pyKyo6bXFT5/QoPE4hAknExjRLQ=="
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.1.2.tgz",
+			"integrity": "sha512-3mc5BqN9aU2SqBeBuWE7ne4OtXHoHKggNgxZR2K+zIW4YLsy6xoZ4/9vErQs6tvoKDX6QAqm3lvsrv0mczAwIQ=="
 		},
 		"@vueuse/shared": {
-			"version": "9.13.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-9.13.0.tgz",
-			"integrity": "sha512-UrnhU+Cnufu4S6JLCPZnkWh0WwZGUp72ktOF2DFptMlOs3TOdVv8xJN53zhHGARmVOsz5KqOls09+J1NR6sBKw==",
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.1.2.tgz",
+			"integrity": "sha512-1uoUTPBlgyscK9v6ScGeVYDDzlPSFXBlxuK7SfrDGyUTBiznb3mNceqhwvZHjtDRELZEN79V5uWPTF1VDV8svA==",
 			"requires": {
-				"vue-demi": "*"
+				"vue-demi": ">=0.14.0"
 			},
 			"dependencies": {
 				"vue-demi": {
-					"version": "0.13.11",
-					"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-					"integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+					"version": "0.14.0",
+					"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.0.tgz",
+					"integrity": "sha512-gt58r2ogsNQeVoQ3EhoUAvUsH9xviydl0dWJj7dabBC/2L4uBId7ujtCwDRD0JhkGsV1i0CtfLAeyYKBht9oWg==",
 					"requires": {}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"@nextcloud/moment": "^1.2.1",
 		"@nextcloud/paths": "^2.1.0",
 		"@nextcloud/router": "^2.1.1",
-		"@nextcloud/vue": "^7.10.0",
+		"@nextcloud/vue": "^7.11.1",
 		"attachmediastream": "^2.1.0",
 		"color.js": "^1.2.0",
 		"crypto-js": "^4.1.1",


### PR DESCRIPTION
Smoke tested for:
* fix(NcAvatar): Use correct prop to track "open" aka. "shown" state
* feat(NcRichContenteditable): Support iconUrl on mention bubbles 
* NcAppSidebarTabs: fix activating the tab being added 

Note: looks awful :vomiting_face: 
![image](https://user-images.githubusercontent.com/93392545/236146924-420cd4a0-3265-4f6b-8144-dc35527325dd.png)

