### PR TITLE
refactor: replace `indexOf` with `includes`

### DIFF
--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -293,10 +293,10 @@ export default {
 			const types = candidates.map((cand) => cand.type)
 
 			this.testing = false
-			if (types.indexOf('relay') === -1) {
-				this.testingError = true
-			} else {
+			if (types.includes('relay')) {
 				this.testingSuccess = true
+			} else {
+				this.testingError = true
 			}
 
 			setTimeout(() => {

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -214,8 +214,8 @@ export default {
 			if (this.searchText !== '') {
 				const lowerSearchText = this.searchText.toLowerCase()
 				conversations = conversations.filter(conversation =>
-					conversation.displayName.toLowerCase().indexOf(lowerSearchText) !== -1
-					|| conversation.name.toLowerCase().indexOf(lowerSearchText) !== -1
+					conversation.displayName.toLowerCase().includes(lowerSearchText)
+					|| conversation.name.toLowerCase().includes(lowerSearchText)
 				)
 			}
 

--- a/src/components/MediaDevicesSelector.vue
+++ b/src/components/MediaDevicesSelector.vue
@@ -59,7 +59,7 @@ export default {
 	props: {
 		kind: {
 			validator(value) {
-				return ['audioinput', 'videoinput'].indexOf(value) !== -1
+				return ['audioinput', 'videoinput'].includes(value)
 			},
 			required: true,
 		},

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -668,7 +668,7 @@ export default {
 
 	methods: {
 		userHasReacted(reaction) {
-			return this.reactionsSelf && this.reactionsSelf.indexOf(reaction) !== -1
+			return this.reactionsSelf && this.reactionsSelf.includes(reaction)
 		},
 
 		lastReadMessageVisibilityChanged(isVisible) {

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -541,7 +541,7 @@ export default {
 
 		// Making sure that the click is outside the MessageButtonsBar
 		handleClickOutside(event) {
-			if (event.composedPath().indexOf(this.$el) !== -1) {
+			if (event.composedPath().includes(this.$el)) {
 				return
 			}
 			this.closeReactionsMenu()

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
@@ -351,7 +351,7 @@ export default {
 		},
 
 		currentUserIsModerator() {
-			return [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR].indexOf(this.participantType) !== -1
+			return [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR].includes(this.participantType)
 		},
 
 		canEndPoll() {

--- a/src/components/NewMessageForm/TemplatePreview.vue
+++ b/src/components/NewMessageForm/TemplatePreview.vue
@@ -125,7 +125,7 @@ export default {
 		 * @return {string}
 		 */
 		nameWithoutExt() {
-			return this.basename.indexOf('.') > -1 ? this.basename.split('.').slice(0, -1).join('.') : this.basename
+			return this.basename.includes('.') ? this.basename.split('.').slice(0, -1).join('.') : this.basename
 		},
 
 		id() {

--- a/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
+++ b/src/components/RightSidebar/Participants/CurrentParticipants/CurrentParticipants.vue
@@ -76,9 +76,9 @@ export default {
 			if (this.searchText !== '') {
 				const lowerSearchText = this.searchText.toLowerCase()
 				participants = participants.filter(participant => {
-					return participant.displayName.toLowerCase().indexOf(lowerSearchText) !== -1
+					return participant.displayName.toLowerCase().includes(lowerSearchText)
 						|| (participant.actorType !== 'guests'
-							&& participant.actorId.toLowerCase().indexOf(lowerSearchText) !== -1)
+							&& participant.actorId.toLowerCase().includes(lowerSearchText))
 				})
 			}
 
@@ -98,7 +98,7 @@ export default {
 
 		currentParticipantIsModerator() {
 			const moderatorTypes = [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR]
-			return this.currentParticipant && moderatorTypes.indexOf(this.currentParticipant.participantType) !== -1
+			return this.currentParticipant && moderatorTypes.includes(this.currentParticipant.participantType)
 		},
 	},
 
@@ -215,8 +215,8 @@ export default {
 			}
 
 			const moderatorTypes = [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR]
-			const moderator1 = moderatorTypes.indexOf(participant1.participantType) !== -1
-			const moderator2 = moderatorTypes.indexOf(participant2.participantType) !== -1
+			const moderator1 = moderatorTypes.includes(participant1.participantType)
+			const moderator2 = moderatorTypes.includes(participant2.participantType)
 
 			if (moderator1 !== moderator2) {
 				return moderator1 ? -1 : 1

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.spec.js
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.spec.js
@@ -702,7 +702,7 @@ describe('Participant.vue', () => {
 				const wrapper = mountParticipant(participant)
 				let actionTexts = wrapper.findAllComponents(NcActionText)
 				actionTexts = actionTexts.filter((actionText) => {
-					return actionText.props('title').indexOf('PIN') >= 0
+					return actionText.props('title').includes('PIN')
 				})
 
 				expect(actionTexts.exists()).toBe(true)
@@ -727,7 +727,7 @@ describe('Participant.vue', () => {
 				const wrapper = mountParticipant(participant)
 				let actionTexts = wrapper.findAllComponents(NcActionText)
 				actionTexts = actionTexts.filter((actionText) => {
-					return actionText.props('title').indexOf('PIN') >= 0
+					return actionText.props('title').includes('PIN')
 				})
 
 				expect(actionTexts.exists()).toBe(false)
@@ -739,7 +739,7 @@ describe('Participant.vue', () => {
 				const wrapper = mountParticipant(participant)
 				let actionTexts = wrapper.findAllComponents(NcActionText)
 				actionTexts = actionTexts.filter((actionText) => {
-					return actionText.props('title').indexOf('PIN') >= 0
+					return actionText.props('title').includes('PIN')
 				})
 
 				expect(actionTexts.exists()).toBe(false)

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -513,7 +513,7 @@ export default {
 		},
 
 		isSelf() {
-			return this.sessionIds.length && this.sessionIds.indexOf(this.currentParticipant.sessionId) >= 0
+			return this.sessionIds.length && this.sessionIds.includes(this.currentParticipant.sessionId)
 		},
 
 		selfIsModerator() {
@@ -530,7 +530,7 @@ export default {
 		},
 
 		isGuest() {
-			return [PARTICIPANT.TYPE.GUEST, PARTICIPANT.TYPE.GUEST_MODERATOR].indexOf(this.participantType) !== -1
+			return [PARTICIPANT.TYPE.GUEST, PARTICIPANT.TYPE.GUEST_MODERATOR].includes(this.participantType)
 		},
 
 		isGroup() {
@@ -551,7 +551,7 @@ export default {
 
 		showModeratorLabel() {
 			return this.isModerator
-				&& [CONVERSATION.TYPE.ONE_TO_ONE, CONVERSATION.TYPE.ONE_TO_ONE_FORMER, CONVERSATION.TYPE.CHANGELOG].indexOf(this.conversation.type) === -1
+				&& ![CONVERSATION.TYPE.ONE_TO_ONE, CONVERSATION.TYPE.ONE_TO_ONE_FORMER, CONVERSATION.TYPE.CHANGELOG].includes(this.conversation.type)
 		},
 
 		canBeModerated() {
@@ -563,7 +563,7 @@ export default {
 
 		canBeDemoted() {
 			return this.canBeModerated
-				&& [PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR].indexOf(this.participantType) !== -1
+				&& [PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR].includes(this.participantType)
 		},
 
 		canBePromoted() {
@@ -635,7 +635,7 @@ export default {
 		},
 
 		participantTypeIsModerator(participantType) {
-			return [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR].indexOf(participantType) !== -1
+			return [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR].includes(participantType)
 		},
 
 		async promoteToModerator() {

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/ParticipantPermissionsEditor/ParticipantPermissionsEditor.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/ParticipantPermissionsEditor/ParticipantPermissionsEditor.vue
@@ -76,7 +76,7 @@ export default {
 		 * Whether the participant is a guest or not.
 		 */
 		isGuest() {
-			return [PARTICIPANT.TYPE.GUEST, PARTICIPANT.TYPE.GUEST_MODERATOR].indexOf(this.participant.participantType) !== -1
+			return [PARTICIPANT.TYPE.GUEST, PARTICIPANT.TYPE.GUEST_MODERATOR].includes(this.participant.participantType)
 		},
 
 		/**

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -274,7 +274,7 @@ export default {
 
 	methods: {
 		isParticipantTypeModerator(participantType) {
-			return [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR].indexOf(participantType) !== -1
+			return [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR].includes(participantType)
 		},
 
 		/**

--- a/src/mixins/devices.js
+++ b/src/mixins/devices.js
@@ -386,7 +386,7 @@ export const devices = {
 			// insecure contexts; in older browser versions it is, but getting
 			// the user media fails with "NotAllowedError".
 			const isInsecureContext = 'isSecureContext' in window && !window.isSecureContext
-			const isInsecureContextAccordingToErrorMessage = this.audioStreamError.message && this.audioStreamError.message.indexOf('Only secure origins') !== -1
+			const isInsecureContextAccordingToErrorMessage = this.audioStreamError.message && this.audioStreamError.message.includes('Only secure origins')
 			if ((this.audioStreamError.name === 'NotSupportedError' && isInsecureContext)
 				|| (this.audioStreamError.name === 'NotAllowedError' && isInsecureContextAccordingToErrorMessage)) {
 				return t('spreed', 'Access to microphone is only possible with HTTPS')
@@ -412,7 +412,7 @@ export const devices = {
 			// insecure contexts; in older browser versions it is, but getting
 			// the user media fails with "NotAllowedError".
 			const isInsecureContext = 'isSecureContext' in window && !window.isSecureContext
-			const isInsecureContextAccordingToErrorMessage = this.videoStreamError.message && this.videoStreamError.message.indexOf('Only secure origins') !== -1
+			const isInsecureContextAccordingToErrorMessage = this.videoStreamError.message && this.videoStreamError.message.includes('Only secure origins')
 			if ((this.videoStreamError.name === 'NotSupportedError' && isInsecureContext)
 				|| (this.videoStreamError.name === 'NotAllowedError' && isInsecureContextAccordingToErrorMessage)) {
 				return t('spreed', 'Access to camera is only possible with HTTPS')

--- a/src/utils/media/pipeline/TrackToStream.spec.js
+++ b/src/utils/media/pipeline/TrackToStream.spec.js
@@ -51,8 +51,7 @@ describe('TrackToStream', () => {
 			this._tracks = []
 
 			this.addTrack = jest.fn((track) => {
-				const index = this._tracks.indexOf(track)
-				if (index >= 0) {
+				if (this._tracks.includes(track)) {
 					console.error('Tried to add again track already added to stream')
 					return
 				}

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -66,9 +66,7 @@ let sendCurrentStateWithRepetitionTimeout = null
  * @param {Array} b Object to find all items in
  */
 function arrayDiff(a, b) {
-	return a.filter(function(i) {
-		return b.indexOf(i) < 0
-	})
+	return a.filter(i => !b.includes(i))
 }
 
 /**
@@ -290,8 +288,8 @@ function usersChanged(signaling, newUsers, disconnectedSessionIds) {
 
 		// TODO(fancycode): Adjust property name of internal PHP backend to be all lowercase.
 		const sessionId = user.sessionId || user.sessionid
-		if (!sessionId || sessionId === currentSessionId || previousUsersInRoom.indexOf(sessionId) !== -1) {
-			if (sessionId === currentSessionId && previousUsersInRoom.indexOf(sessionId) !== -1) {
+		if (!sessionId || sessionId === currentSessionId || previousUsersInRoom.includes(sessionId)) {
+			if (sessionId === currentSessionId && previousUsersInRoom.includes(sessionId)) {
 				Sounds.playJoin(true, newUsers.length === 1)
 			}
 			return
@@ -1562,7 +1560,7 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 		if ((error.name === 'NotSupportedError'
 				&& webrtc.capabilities.supportRTCPeerConnection)
 			|| (error.name === 'NotAllowedError'
-				&& error.message && error.message.indexOf('Only secure origins') !== -1)) {
+				&& error.message && error.message.includes('Only secure origins'))) {
 			message = t('spreed', 'Access to microphone & camera is only possible with HTTPS')
 			message += ': ' + t('spreed', 'Please move your setup to HTTPS')
 		} else if (error.name === 'NotAllowedError') {


### PR DESCRIPTION
Hello :wave:, first-time contributor here.

This PR replaces the use of `.indexOf` with `.includes` for cases where the method is used to check if an array contains a particular element. This results in improved code readability and better adherence to modern JavaScript best practices.

The replaced code snippets include:

1. `.indexOf(...) === -1`
2. `.indexOf(...) !== -1`
3. `.indexOf(...) > -1`
4. `.indexOf(...) >= 0`