### PR TITLE
feat(avatar): Allow to select an emoji + color as avatar

### DIFF
--- a/appinfo/routes/routesAvatarController.php
+++ b/appinfo/routes/routesAvatarController.php
@@ -32,6 +32,8 @@ return [
 	'ocs' => [
 		/** @see \OCA\Talk\Controller\AvatarController::uploadAvatar() */
 		['name' => 'Avatar#uploadAvatar', 'url' => '/api/{apiVersion}/room/{token}/avatar', 'verb' => 'POST', 'requirements' => $requirements],
+		/** @see \OCA\Talk\Controller\AvatarController::emojiAvatar() */
+		['name' => 'Avatar#emojiAvatar', 'url' => '/api/{apiVersion}/room/{token}/avatar/emoji', 'verb' => 'POST', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\AvatarController::getAvatar() */
 		['name' => 'Avatar#getAvatar', 'url' => '/api/{apiVersion}/room/{token}/avatar', 'verb' => 'GET', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\AvatarController::getAvatarDark() */

--- a/docs/avatar.md
+++ b/docs/avatar.md
@@ -20,7 +20,34 @@
         + `403 Forbidden` When the current user is not a moderator, owner or guest moderator
         + `404 Not Found` When the conversation could not be found for the participant
 
-    - Data: See array definition in `Get user´s conversations`
+    - Data:
+        + `200 OK`: See array definition in `Get user´s conversations`
+        + `400 Bad Request`: Array with a `message` field contain the error in user language
+
+## Set emoji as avatar
+
+* Required capability: `avatar`
+* Method: `POST`
+* Endpoint: `/room/{token}/avatar/emoji`
+* Data:
+
+| field   | type        | Description                                                                                                                                |
+|---------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| `emoji` | string      | A single emoji being used as avatar (can contain properties like gender, skin color, age, job, etc.)                                       |
+| `color` | string/null | HEX color code (6 times 0-9A-F) without the leading `#` character (omit to fallback to the default bright/dark mode icon background color) |
+
+* Response:
+    - Status code:
+        + `200 OK`
+        + `400 Bad Request` When the conversation is a one-to-one conversation
+        + `400 Bad Request` When the emoji is not a single emoji
+        + `400 Bad Request` When color was provided but is not matching the expected pattern
+        + `403 Forbidden` When the current user is not a moderator, owner or guest moderator
+        + `404 Not Found` When the conversation could not be found for the participant
+
+    - Data:
+        + `200 OK`: See array definition in `Get user´s conversations`
+        + `400 Bad Request`: Array with a `message` field contain the error in user language
 
 ## Delete conversations avatar
 

--- a/tests/integration/features/conversation/avatar.feature
+++ b/tests/integration/features/conversation/avatar.feature
@@ -104,7 +104,8 @@ Feature: conversation/avatar
       | roomType | 3 |
       | roomName | public room |
     Then user "participant1" sets emoji "👋🚀" with color "123456" as avatar of room "room" with 400 (v1)
-    Then user "participant1" sets emoji "👋" with color "1234567" as avatar of room "room" with 400 (v1)
+    And user "participant1" sets emoji "👋" with color "1234567" as avatar of room "room" with 400 (v1)
+    And user "participant1" sets emoji "👋" with color "GGGGGG" as avatar of room "room" with 400 (v1)
     And user "participant1" gets room "room" with 200 (v4)
       | avatarVersion | NOT_EMPTY |
       | isCustomAvatar | 0 |

--- a/tests/integration/features/conversation/avatar.feature
+++ b/tests/integration/features/conversation/avatar.feature
@@ -61,6 +61,10 @@ Feature: conversation/avatar
     And user "participant1" gets room "one2one" with 200 (v4)
       | avatarVersion | NOT_EMPTY |
       | isCustomAvatar | 0 |
+    Then user "participant1" sets emoji "👋" with color "123456" as avatar of room "one2one" with 400 (v1)
+    And user "participant1" gets room "one2one" with 200 (v4)
+      | avatarVersion | NOT_EMPTY |
+      | isCustomAvatar | 0 |
 
   Scenario: Conversation that the name start with emoji dont need to have custom avatar
     Given user "participant1" creates room "room1" (v4)
@@ -94,3 +98,27 @@ Feature: conversation/avatar
     Then user "participant1" sees the following shared other in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message  | messageParameters |
       | public room | users     | participant1 | participant1-displayname | {object} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"object":{"name":"Another room","call-type":"group","type":"call","id":"R4nd0mT0k3n","icon-url":"{VALIDATE_ICON_URL_PATTERN}"}} |
+
+  Scenario: User sets emoji as avatar
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | public room |
+    Then user "participant1" sets emoji "👋🚀" with color "123456" as avatar of room "room" with 400 (v1)
+    Then user "participant1" sets emoji "👋" with color "1234567" as avatar of room "room" with 400 (v1)
+    And user "participant1" gets room "room" with 200 (v4)
+      | avatarVersion | NOT_EMPTY |
+      | isCustomAvatar | 0 |
+    Then user "participant1" sets emoji "👩🏽‍🚀" with color "123456" as avatar of room "room" with 200 (v1)
+    And user "participant1" gets room "room" with 200 (v4)
+      | avatarVersion | NOT_EMPTY |
+      | isCustomAvatar | 1 |
+    And the room "room" has an svg as avatar with 200
+    And the avatar svg of room "room" contains the string "👩🏽‍🚀"
+    And the avatar svg of room "room" contains the string "123456"
+    Then user "participant1" sets emoji "🍏" with color "null" as avatar of room "room" with 200 (v1)
+    And the avatar svg of room "room" contains the string "🍏"
+    And the avatar svg of room "room" contains the string "DBDBDB"
+    And the avatar svg of room "room" not contains the string "3B3B3B"
+    And the dark avatar svg of room "room" contains the string "🍏"
+    And the dark avatar svg of room "room" not contains the string "DBDBDB"
+    And the dark avatar svg of room "room" contains the string "3B3B3B"


### PR DESCRIPTION
Ref #8444 

### 🚧 Tasks

- [x] Allow picking emoji and color
- [x] Fallback to dark/bright mode if no color is given
- [x] Document API
- [x] Write integration test

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
