### PR TITLE
Release 17.0.0 beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 17.0.0-beta.1 – 2023-05-04
+### Added
+- Conversations can now have an avatar or emoji as icon
+  [#927](https://github.com/nextcloud/spreed/issues/927)
+- Virtual backgrounds are now available in addition to the blurred background in video calls
+  [#9251](https://github.com/nextcloud/spreed/issues/9251)
+- Reactions are now available during calls
+  [#9249](https://github.com/nextcloud/spreed/issues/9249)
+- Typing indicators show which users are currently typing a message
+  [#9248](https://github.com/nextcloud/spreed/issues/9248)
+- Groups can now be mentioned in chats
+  [#6339](https://github.com/nextcloud/spreed/issues/6339)
+- Call recordings are automatically transcript if a transcription provider app is registered
+  [#9274](https://github.com/nextcloud/spreed/issues/9274)
+- Chat message can be translated if a translation provider app is registered
+  [#9273](https://github.com/nextcloud/spreed/issues/9273)
+
+### Changed
+- Update several dependencies
+
 ## 16.0.3 – 2023-04-20
 ### Added
 - feat: Add missing "New in Talk 16" section

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ All notable changes to this project will be documented in this file.
   [#9248](https://github.com/nextcloud/spreed/issues/9248)
 - Groups can now be mentioned in chats
   [#6339](https://github.com/nextcloud/spreed/issues/6339)
-- Call recordings are automatically transcript if a transcription provider app is registered
+- Call recordings are automatically transcribed if a transcription provider app is registered
   [#9274](https://github.com/nextcloud/spreed/issues/9274)
-- Chat message can be translated if a translation provider app is registered
+- Chat messages can be translated if a translation provider app is registered
   [#9273](https://github.com/nextcloud/spreed/issues/9273)
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ appstore:
 	--exclude=.github \
 	--exclude=.gitignore \
 	--exclude=jest.config.js \
+	--exclude=jest.global.setup.js \
 	--exclude=.l10nignore \
 	--exclude=mkdocs.yml \
 	--exclude=Makefile \
@@ -96,6 +97,7 @@ appstore:
 	--exclude=psalm.xml \
 	--exclude=README.md \
 	--exclude=/recording \
+	--exclude=/site \
 	--exclude=/src \
 	--exclude=.stylelintignore \
 	--exclude=stylelint.config.js \
@@ -105,6 +107,7 @@ appstore:
 	--exclude=vendor/bamarni \
 	--exclude=vendor/bin \
 	--exclude=vendor-bin \
+	--exclude=webpack.common.config.js \
 	--exclude=webpack.config.js \
 	$(project_dir)/  $(sign_dir)/$(app_name)
 	@if [ -f $(cert_dir)/$(app_name).key ]; then \

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>17.0.0-dev.1</version>
+	<version>17.0.0-beta.1</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/lib/Chat/Changelog/Manager.php
+++ b/lib/Chat/Changelog/Manager.php
@@ -131,6 +131,14 @@ class Manager {
 			$this->l->t('- Link various items using the new smart-picker by typing a "/"'),
 			$this->l->t('- Moderators can now create breakout rooms (requires the external signaling server)'),
 			$this->l->t('- Calls can now be recorded (requires the external signaling server)'),
+			$this->l->t('New in Talk %s', ['17']) . "\n"
+			. $this->l->t('- Conversations can now have an avatar or emoji as icon') . "\n"
+			. $this->l->t('- Virtual backgrounds are now available in addition to the blurred background in video calls') . "\n"
+			. $this->l->t('- Reactions are now available during calls') . "\n"
+			. $this->l->t('- Typing indicators show which users are currently typing a message') . "\n"
+			. $this->l->t('- Groups can now be mentioned in chats') . "\n"
+			. $this->l->t('- Call recordings are automatically transcript if a transcription provider app is registered') . "\n"
+			. $this->l->t('- Chat message can be translated if a translation provider app is registered'),
 		];
 	}
 }

--- a/lib/Chat/Changelog/Manager.php
+++ b/lib/Chat/Changelog/Manager.php
@@ -137,8 +137,8 @@ class Manager {
 			. $this->l->t('- Reactions are now available during calls') . "\n"
 			. $this->l->t('- Typing indicators show which users are currently typing a message') . "\n"
 			. $this->l->t('- Groups can now be mentioned in chats') . "\n"
-			. $this->l->t('- Call recordings are automatically transcript if a transcription provider app is registered') . "\n"
-			. $this->l->t('- Chat message can be translated if a translation provider app is registered'),
+			. $this->l->t('- Call recordings are automatically transcribed if a transcription provider app is registered') . "\n"
+			. $this->l->t('- Chat messages can be translated if a translation provider app is registered'),
 		];
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk",
-	"version": "17.0.0",
+	"version": "17.0.0-beta.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk",
-			"version": "17.0.0",
+			"version": "17.0.0-beta.1",
 			"license": "agpl",
 			"dependencies": {
 				"@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "talk",
-	"version": "17.0.0",
+	"version": "17.0.0-beta.1",
 	"private": true,
 	"description": "",
 	"author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 17.0.0-beta.1 – 2023-05-04
### Added
- Conversations can now have an avatar or emoji as icon [#927](https://github.com/nextcloud/spreed/issues/927)
- Virtual backgrounds are now available in addition to the blurred background in video calls [#9251](https://github.com/nextcloud/spreed/issues/9251)
- Reactions are now available during calls [#9249](https://github.com/nextcloud/spreed/issues/9249)
- Typing indicators show which users are currently typing a message [#9248](https://github.com/nextcloud/spreed/issues/9248)
- Groups can now be mentioned in chats [#6339](https://github.com/nextcloud/spreed/issues/6339)
- Call recordings are automatically transcript if a transcription provider app is registered [#9274](https://github.com/nextcloud/spreed/issues/9274)
- Chat message can be translated if a translation provider app is registered [#9273](https://github.com/nextcloud/spreed/issues/9273)

### Changed
- Update several dependencies