### PR TITLE
Add user setting for toggle typing privacy

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -119,4 +119,4 @@
 * `config => call => predefined-backgrounds` - List of predefined virtual backgrounds. The files are in Talks img/ folder, accessible via the normal image path methods. The list is cached for 5 minutes.
 * `config => call => can-upload-background` - Boolean flag whether the user can upload a custom virtual background (requires an account and non-zero quota). Uploads should be done to Talk/Backgrounds/ (respecting the user's attachment directory setting).
 * `config => call => supported-reactions` - A list of emojis supported as call reactions. If the list is absent or empty, clients should not show the emoji reaction option in calls.
-* `config => chat => typing-privacy` - User defined numeric value to enable 1 or dizable 0 the typing indicator to other users
+* `config => chat => typing-privacy` - User defined numeric value to enable 1 or disable 0 the typing indicator to other users

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -119,4 +119,4 @@
 * `config => call => predefined-backgrounds` - List of predefined virtual backgrounds. The files are in Talks img/ folder, accessible via the normal image path methods. The list is cached for 5 minutes.
 * `config => call => can-upload-background` - Boolean flag whether the user can upload a custom virtual background (requires an account and non-zero quota). Uploads should be done to Talk/Backgrounds/ (respecting the user's attachment directory setting).
 * `config => call => supported-reactions` - A list of emojis supported as call reactions. If the list is absent or empty, clients should not show the emoji reaction option in calls.
-* 
+* `config => chat => typing-privacy` - User defined numeric value to enable 1 or dizable 0 the typing indicator to other users

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -120,3 +120,4 @@
 * `config => call => can-upload-background` - Boolean flag whether the user can upload a custom virtual background (requires an account and non-zero quota). Uploads should be done to Talk/Backgrounds/ (respecting the user's attachment directory setting).
 * `config => call => supported-reactions` - A list of emojis supported as call reactions. If the list is absent or empty, clients should not show the emoji reaction option in calls.
 * `config => chat => typing-privacy` - User defined numeric value to enable 1 or disable 0 the typing indicator to other users
+* `typing-privacy` - Support toggle typing privacy

--- a/docs/constants.md
+++ b/docs/constants.md
@@ -76,6 +76,10 @@
 * `0` Read status is public
 * `1` Read status is private
 
+### Participant typing privacy
+* `0` Make visible the typing status
+* `1` Hide the typing status
+
 ### Attendee types
 * `users` - Logged-in users
 * `groups` - Groups

--- a/docs/constants.md
+++ b/docs/constants.md
@@ -77,8 +77,8 @@
 * `1` Read status is private
 
 ### Participant typing privacy
-* `0` Make visible the typing status
-* `1` Hide the typing status
+* `0` Typing status is public
+* `1` Typing status is private
 
 ### Attendee types
 * `users` - Logged-in users

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -21,10 +21,11 @@
 
 ## User settings
 
-| Key                   | Capability                        | Default                                         | Valid values                                                                                             |
-|-----------------------|-----------------------------------|-------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-| `attachment_folder`   | `config => attachments => folder` | Value of app config `default_attachment_folder` | Path owned by the user to store uploads and received shares. It is created if it does not exist.         |
-| `read_status_privacy` | `config => chat => read-privacy`  | `0`                                             | One of the read-status constants from the [constants list](constants.md#participant-read-status-privacy) |
+| Key                   | Capability                         | Default                                         | Valid values                                                                                             |
+|-----------------------|------------------------------------|-------------------------------------------------|----------------------------------------------------------------------------------------------------------|
+| `attachment_folder`   | `config => attachments => folder`  | Value of app config `default_attachment_folder` | Path owned by the user to store uploads and received shares. It is created if it does not exist.         |
+| `read_status_privacy` | `config => chat => read-privacy`   | `0`                                             | One of the read-status constants from the [constants list](constants.md#participant-read-status-privacy) |
+| `typing_privacy`      | `config => chat => typing-privacy` | `0`                                             | One of the typing privacy constants from the [constants list](constants.md#participant-typing-privacy)   |
 
 ## Set SIP settings
 

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -118,6 +118,7 @@ class Capabilities implements IPublicCapability {
 				'chat-get-context',
 				'single-conversation-status',
 				'chat-keep-notifications',
+				'typing-privacy',
 			],
 			'config' => [
 				'attachments' => [

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -160,7 +160,7 @@ class Capabilities implements IPublicCapability {
 		if ($user instanceof IUser) {
 			$capabilities['config']['attachments']['folder'] = $this->talkConfig->getAttachmentFolder($user->getUID());
 			$capabilities['config']['chat']['read-privacy'] = $this->talkConfig->getUserReadPrivacy($user->getUID());
-			$capabilities['config']['chat']['typing-privacy'] = $this->talkConfig->getTypingPrivacy($user->getUID());
+			$capabilities['config']['chat']['typing-privacy'] = $this->talkConfig->getUserTypingPrivacy($user->getUID());
 		}
 
 		$pubKey = $this->talkConfig->getSignalingTokenPublicKey();

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -134,6 +134,7 @@ class Capabilities implements IPublicCapability {
 					'read-privacy' => Participant::PRIVACY_PUBLIC,
 					// Transform the JsonSerializable language tuples to arrays
 					'translations' => json_decode(json_encode($this->translationManager->getLanguages()), true),
+					'typing-privacy' => Participant::PRIVACY_PUBLIC,
 				],
 				'conversations' => [
 					'can-create' => $user instanceof IUser && !$this->talkConfig->isNotAllowedToCreateConversations($user)
@@ -159,6 +160,7 @@ class Capabilities implements IPublicCapability {
 		if ($user instanceof IUser) {
 			$capabilities['config']['attachments']['folder'] = $this->talkConfig->getAttachmentFolder($user->getUID());
 			$capabilities['config']['chat']['read-privacy'] = $this->talkConfig->getUserReadPrivacy($user->getUID());
+			$capabilities['config']['chat']['typing-privacy'] = $this->talkConfig->getTypingPrivacy($user->getUID());
 		}
 
 		$pubKey = $this->talkConfig->getSignalingTokenPublicKey();

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -87,6 +87,14 @@ class Config {
 			(string) Participant::PRIVACY_PUBLIC);
 	}
 
+	public function getTypingPrivacy(string $userId): int {
+		return (int) $this->config->getUserValue(
+			$userId,
+			'spreed', 'typing_privacy',
+			(string) Participant::PRIVACY_PUBLIC);
+
+	}
+
 	/**
 	 * @return string[]
 	 */

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -87,7 +87,7 @@ class Config {
 			(string) Participant::PRIVACY_PUBLIC);
 	}
 
-	public function getTypingPrivacy(string $userId): int {
+	public function getUserTypingPrivacy(string $userId): int {
 		return (int) $this->config->getUserValue(
 			$userId,
 			'spreed', 'typing_privacy',

--- a/lib/Controller/AvatarController.php
+++ b/lib/Controller/AvatarController.php
@@ -27,7 +27,6 @@ declare(strict_types=1);
 namespace OCA\Talk\Controller;
 
 use InvalidArgumentException;
-use OCA\Mail\Service\Avatar\Avatar;
 use OCA\Talk\Middleware\Attribute\RequireModeratorParticipant;
 use OCA\Talk\Middleware\Attribute\RequireParticipant;
 use OCA\Talk\Service\AvatarService;

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -114,11 +114,7 @@ class SettingsController extends OCSController {
 			return false;
 		}
 
-		if ($setting === 'typing_privacy') {
-			return $value === '1' || $value === '0';
-		}
-
-		if ($setting === 'read_status_privacy') {
+		if ($setting === 'typing_privacy' || $setting === 'read_status_privacy') {
 			return (int) $value === Participant::PRIVACY_PUBLIC ||
 				(int) $value === Participant::PRIVACY_PRIVATE;
 		}

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -114,6 +114,10 @@ class SettingsController extends OCSController {
 			return false;
 		}
 
+		if ($setting === 'typing_privacy') {
+			return $value === '1' || $value === '0';
+		}
+
 		if ($setting === 'read_status_privacy') {
 			return (int) $value === Participant::PRIVACY_PUBLIC ||
 				(int) $value === Participant::PRIVACY_PRIVATE;

--- a/lib/TInitialState.php
+++ b/lib/TInitialState.php
@@ -122,6 +122,11 @@ trait TInitialState {
 		);
 
 		$this->initialState->provideInitialState(
+			'typing_privacy',
+			$this->talkConfig->getUserTypingPrivacy($user->getUID())
+		);
+
+		$this->initialState->provideInitialState(
 			'play_sounds',
 			$this->serverConfig->getUserValue($user->getUID(), 'spreed', 'play_sounds', 'yes') === 'yes'
 		);
@@ -188,6 +193,11 @@ trait TInitialState {
 		$this->initialState->provideInitialState(
 			'read_status_privacy',
 			Participant::PRIVACY_PUBLIC
+		);
+
+		$this->initialState->provideInitialState(
+			'typing_privacy',
+			'0'
 		);
 
 		$this->initialState->provideInitialState(

--- a/lib/TInitialState.php
+++ b/lib/TInitialState.php
@@ -197,7 +197,7 @@ trait TInitialState {
 
 		$this->initialState->provideInitialState(
 			'typing_privacy',
-			'0'
+			Participant::PRIVACY_PUBLIC
 		);
 
 		$this->initialState->provideInitialState(

--- a/tests/integration/features/chat-2/typing-privacy.feature
+++ b/tests/integration/features/chat-2/typing-privacy.feature
@@ -2,10 +2,10 @@ Feature: chat-2/typing-privacy
   Background:
     Given user "participant1" exists
   Scenario: User toggles the typing privacy
-    # Hide
+    # Private
     When user "participant1" sets setting "typing_privacy" to "1" with 200 (v1)
     Then user "participant1" has capability "spreed=>config=>chat=>typing-privacy" set to "1"
 
-    # Visible
+    # Public
     When user "participant1" sets setting "typing_privacy" to "0" with 200 (v1)
     Then user "participant1" has capability "spreed=>config=>chat=>typing-privacy" set to "0"

--- a/tests/integration/features/chat-2/typing-privacy.feature
+++ b/tests/integration/features/chat-2/typing-privacy.feature
@@ -1,0 +1,11 @@
+Feature: chat-2/typing-privacy
+  Background:
+    Given user "participant1" exists
+  Scenario: User toggles the typing privacy
+    # Hide
+    When user "participant1" sets setting "typing_privacy" to "1" with 200 (v1)
+    Then user "participant1" has capability "spreed=>config=>chat=>typing-privacy" set to "1"
+
+    # Visible
+    When user "participant1" sets setting "typing_privacy" to "0" with 200 (v1)
+    Then user "participant1" has capability "spreed=>config=>chat=>typing-privacy" set to "0"

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -136,6 +136,7 @@ class CapabilitiesTest extends TestCase {
 			'chat-get-context',
 			'single-conversation-status',
 			'chat-keep-notifications',
+			'typing-privacy',
 			'message-expiration',
 			'reactions',
 		];

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -202,6 +202,7 @@ class CapabilitiesTest extends TestCase {
 						'max-length' => 32000,
 						'read-privacy' => 0,
 						'translations' => [],
+						'typing-privacy' => 0,
 					],
 					'conversations' => [
 						'can-create' => false,
@@ -325,6 +326,7 @@ class CapabilitiesTest extends TestCase {
 						'max-length' => 32000,
 						'read-privacy' => $readPrivacy,
 						'translations' => [],
+						'typing-privacy' => 0,
 					],
 					'conversations' => [
 						'can-create' => $canCreate,


### PR DESCRIPTION
API side of #9248 to implement an user setting to toggle typing privacy

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
