### PR TITLE
fix/9446/add-empty-call-view-to-viewer-overlay

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -22,13 +22,13 @@
 
 <template>
 	<div id="call-container">
-		<EmptyCallView v-if="!remoteParticipantsCount && !screenSharingActive && !isGrid"
-			:is-sidebar="isSidebar" />
-
-		<ViewerOverlayCallView v-else-if="isViewerOverlay && promotedParticipantModel"
+		<ViewerOverlayCallView v-if="isViewerOverlay"
 			:token="token"
 			:model="promotedParticipantModel"
-			:shared-data="sharedDatas[promotedParticipantModel.attributes.peerId]" />
+			:shared-data="promotedParticipantModel && sharedDatas[promotedParticipantModel.attributes.peerId]" />
+
+		<EmptyCallView v-if="!remoteParticipantsCount && !screenSharingActive && !isGrid"
+			:is-sidebar="isSidebar" />
 
 		<div v-else-if="!isViewerOverlay" id="videos">
 			<template v-if="!isGrid">

--- a/src/components/CallView/shared/EmptyCallView.vue
+++ b/src/components/CallView/shared/EmptyCallView.vue
@@ -19,19 +19,23 @@
   -->
 
 <template>
-	<div class="empty-call-view" :class="{'empty-call-view--sidebar': isSidebar}">
+	<div class="empty-call-view"
+		:class="{
+			'empty-call-view--sidebar': isSidebar,
+			'empty-call-view--small': isSmall
+		}">
 		<div class="icon" :class="iconClass" />
-		<h2>
-			{{ title }}
-		</h2>
-		<p v-if="message" class="emptycontent-additional">
-			{{ message }}
-		</p>
-		<NcButton v-if="showLink"
-			type="primary"
-			@click.stop.prevent="handleCopyLink">
-			{{ t('spreed', 'Copy link') }}
-		</NcButton>
+		<h2>{{ title }}</h2>
+		<template v-if="!isSmall">
+			<p v-if="message" class="emptycontent-additional">
+				{{ message }}
+			</p>
+			<NcButton v-if="showLink"
+				type="primary"
+				@click.stop.prevent="handleCopyLink">
+				{{ t('spreed', 'Copy link') }}
+			</NcButton>
+		</template>
 	</div>
 </template>
 
@@ -56,6 +60,11 @@ export default {
 		},
 
 		isSidebar: {
+			type: Boolean,
+			default: false,
+		},
+
+		isSmall: {
 			type: Boolean,
 			default: false,
 		},
@@ -208,6 +217,25 @@ export default {
 			transform: scale(0.7);
 			margin-top: 0;
 			margin-bottom: 0;
+		}
+	}
+
+	&--small {
+		border-radius: calc(var(--default-clickable-area) / 2);
+		background-color: rgba(34, 34, 34, 0.8); /* Copy from the call view */
+		padding: 8px;
+
+		h2 {
+			font-size: 1rem;
+			font-weight: normal;
+		}
+
+		.icon {
+			transform: none;
+			margin-bottom: 0;
+			background-size: 32px;
+			height: 32px;
+			width: 32px;
 		}
 	}
 }

--- a/src/components/CallView/shared/VideoVue.vue
+++ b/src/components/CallView/shared/VideoVue.vue
@@ -82,7 +82,7 @@
 			class="connection-message">
 			{{ connectionMessage }}
 		</div>
-		<slot name="bottom-bar">
+		<slot v-if="!hideBottomBar" name="bottom-bar">
 			<VideoBottomBar v-bind="$props"
 				:has-shadow="hasVideo"
 				:participant-name="participantName" />
@@ -173,6 +173,11 @@ export default {
 		},
 
 		unSelectable: {
+			type: Boolean,
+			default: false,
+		},
+
+		hideBottomBar: {
 			type: Boolean,
 			default: false,
 		},

--- a/src/components/CallView/shared/ViewerOverlayCallView.vue
+++ b/src/components/CallView/shared/ViewerOverlayCallView.vue
@@ -20,7 +20,8 @@
 <template>
 	<div ref="ghost" class="viewer-overlay-ghost">
 		<Portal>
-			<div class="viewer-overlay"
+			<!-- Add .app-talk to use Talk icon classes outside of #content-vue -->
+			<div class="viewer-overlay app-talk"
 				:style="{
 					right: position.right + 'px',
 					bottom: position.bottom + 'px'
@@ -41,7 +42,10 @@
 				</div>
 
 				<Transition name="slide-down">
-					<div v-show="!isCollapsed" class="viewer-overlay__video-container">
+					<div v-show="!isCollapsed"
+						class="viewer-overlay__video-container"
+						tabindex="0"
+						@click="maximize">
 						<div class="video-overlay__top-bar">
 							<NcButton type="secondary"
 								class="viewer-overlay__button"
@@ -53,6 +57,20 @@
 							</NcButton>
 						</div>
 
+						<VideoVue v-if="model"
+							class="viewer-overlay__video"
+							:token="token"
+							:model="model"
+							:shared-data="sharedData"
+							is-grid
+							un-selectable
+							hide-bottom-bar
+							@click-video="maximize">
+							<template #bottom-bar />
+						</VideoVue>
+
+						<EmptyCallView v-else is-small />
+
 						<LocalVideo v-if="localModel.attributes.videoEnabled"
 							class="viewer-overlay__local-video"
 							:token="token"
@@ -62,28 +80,18 @@
 							is-small
 							un-selectable />
 
-						<VideoVue class="viewer-overlay__video"
-							:token="token"
-							:model="model"
-							:shared-data="sharedData"
-							is-grid
-							un-selectable
-							@click-video="maximize">
-							<template #bottom-bar>
-								<div class="viewer-overlay__bottom-bar">
-									<LocalAudioControlButton class="viewer-overlay__button"
-										:conversation="conversation"
-										:model="localModel"
-										nc-button-type="secondary"
-										disable-keyboard-shortcuts />
-									<LocalVideoControlButton class="viewer-overlay__button"
-										:conversation="conversation"
-										:model="localModel"
-										nc-button-type="secondary"
-										disable-keyboard-shortcuts />
-								</div>
-							</template>
-						</VideoVue>
+						<div class="viewer-overlay__bottom-bar">
+							<LocalAudioControlButton class="viewer-overlay__button"
+								:conversation="conversation"
+								:model="localModel"
+								nc-button-type="secondary"
+								disable-keyboard-shortcuts />
+							<LocalVideoControlButton class="viewer-overlay__button"
+								:conversation="conversation"
+								:model="localModel"
+								nc-button-type="secondary"
+								disable-keyboard-shortcuts />
+						</div>
 					</div>
 				</Transition>
 			</div>
@@ -100,6 +108,7 @@ import ChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 
 import { NcButton, Tooltip } from '@nextcloud/vue'
 
+import EmptyCallView from './EmptyCallView.vue'
 import LocalAudioControlButton from './LocalAudioControlButton.vue'
 import LocalVideo from './LocalVideo.vue'
 import LocalVideoControlButton from './LocalVideoControlButton.vue'
@@ -111,6 +120,7 @@ export default {
 	name: 'ViewerOverlayCallView',
 
 	components: {
+		EmptyCallView,
 		LocalAudioControlButton,
 		LocalVideoControlButton,
 		Portal,
@@ -134,12 +144,14 @@ export default {
 
 		model: {
 			type: Object,
-			required: true,
+			required: false,
+			default: null,
 		},
 
 		sharedData: {
 			type: Object,
-			required: true,
+			required: false,
+			default: null,
 		},
 
 		localModel: {
@@ -203,10 +215,10 @@ export default {
 @import "../../../assets/variables";
 
 .viewer-overlay-ghost {
-  position: absolute;
-  bottom: 8px;
-  right: 8px;
-  left: 0;
+	position: absolute;
+	bottom: 8px;
+	right: 8px;
+	left: 0;
 }
 
 .viewer-overlay {
@@ -222,11 +234,15 @@ export default {
 	z-index: 11000;
 }
 
+.viewer-overlay * {
+	box-sizing: border-box;
+}
+
 .viewer-overlay__collapse {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  z-index: 100;
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	z-index: 100;
 }
 
 .viewer-overlay__button {
@@ -239,22 +255,22 @@ export default {
 }
 
 .video-overlay__top-bar {
-  position: absolute;
-  top: 8px;
-  left: 8px;
-  z-index: 100;
+	position: absolute;
+	top: 8px;
+	left: 8px;
+	z-index: 100;
 }
 
 .viewer-overlay__bottom-bar {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  padding: 0 12px 8px 12px;
-  z-index: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	position: absolute;
+	bottom: 0;
+	width: 100%;
+	padding: 0 12px 8px 12px;
+	z-index: 1;
 }
 
 .viewer-overlay__video-container {
@@ -268,12 +284,12 @@ export default {
 }
 
 .viewer-overlay__local-video {
-  position: absolute;
-  bottom: 8px;
-  right: 8px;
-  width: 25%;
-  height: 25%;
-  overflow: hidden;
+	position: absolute;
+	bottom: 8px;
+	right: 8px;
+	width: 25%;
+	height: 25%;
+	overflow: hidden;
 }
 
 .viewer-overlay__video {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9446

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://user-images.githubusercontent.com/25978914/236475766-21b008e6-2ea0-4313-83a5-faca83c47537.png) | ![image](https://user-images.githubusercontent.com/25978914/236475530-44b6dd0b-a7a2-431e-bc12-d7df1257216a.png)

Gif with the smallest size

![EmptyCallViewOnOverlay](https://user-images.githubusercontent.com/25978914/236475619-cf34cc1f-12d1-4b34-af59-fbd4c5961235.gif)

Fullscreen on light theme

![image](https://user-images.githubusercontent.com/25978914/236480984-118edde5-f65a-4c3c-923f-3729282cc517.png)

### 🚧 Tasks

- [x] Add EmptyCallView to ViewerOverlayCallView

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
