### PR TITLE
Add messageId to richObject in ReferenceProvider

### DIFF
--- a/lib/Collaboration/Reference/TalkReferenceProvider.php
+++ b/lib/Collaboration/Reference/TalkReferenceProvider.php
@@ -177,6 +177,7 @@ class TalkReferenceProvider extends ADiscoverableReferenceProvider implements IS
 		$roomName = $room->getDisplayName($this->userId);
 		$title = $roomName;
 		$description = '';
+		$messageId = null;
 
 		if ($participant instanceof Participant
 			|| $this->roomManager->isRoomListableByUser($room, $this->userId)) {
@@ -190,7 +191,8 @@ class TalkReferenceProvider extends ADiscoverableReferenceProvider implements IS
 		 * Description is the plain text chat message
 		 */
 		if ($participant && !empty($referenceMatch['message'])) {
-			$comment = $this->chatManager->getComment($room, (string) $referenceMatch['message']);
+			$messageId = (string) $referenceMatch['message'];
+			$comment = $this->chatManager->getComment($room, $messageId);
 			$message = $this->messageParser->createMessage($room, $participant, $comment, $this->l);
 			$this->messageParser->parseMessage($message);
 
@@ -233,12 +235,18 @@ class TalkReferenceProvider extends ADiscoverableReferenceProvider implements IS
 		$reference->setUrl($this->urlGenerator->linkToRouteAbsolute('spreed.Page.showCall', ['token' => $room->getToken()]));
 		$reference->setImageUrl($this->avatarService->getAvatarUrl($room));
 
-		$reference->setRichObject('call', [
+		$referenceData = [
 			'id' => $room->getToken(),
 			'name' => $roomName,
 			'link' => $reference->getUrl(),
 			'call-type' => $this->getRoomType($room),
-		]);
+		];
+
+		if ($messageId) {
+			$referenceData['message-id'] = $messageId;
+		}
+
+		$reference->setRichObject('call', $referenceData);
 	}
 
 	/**


### PR DESCRIPTION
This adds the messageId to the richObject provided by the reference provider in case a link to a message is provided.

Server PR for definition: https://github.com/nextcloud/server/pull/38102

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
