### PR TITLE
Fullscreen - use Material Design icons

### DIFF
--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -79,10 +79,13 @@
 		</NcActionButton>
 
 		<!-- Fullscreen -->
-		<NcActionButton :icon="iconFullscreen"
-			:aria-label="t('spreed', 'Toggle fullscreen')"
+		<NcActionButton :aria-label="t('spreed', 'Toggle fullscreen')"
 			:close-after-click="true"
 			@click="toggleFullscreen">
+			<template #icon>
+				<Fullscreen v-if="!isFullscreen" :size="20" />
+				<FullscreenExit v-else :size="20" />
+			</template>
 			{{ labelFullscreen }}
 		</NcActionButton>
 
@@ -147,6 +150,8 @@
 import Cog from 'vue-material-design-icons/Cog.vue'
 import DotsCircle from 'vue-material-design-icons/DotsCircle.vue'
 import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
+import Fullscreen from 'vue-material-design-icons/Fullscreen.vue'
+import FullscreenExit from 'vue-material-design-icons/FullscreenExit.vue'
 import HandBackLeft from 'vue-material-design-icons/HandBackLeft.vue'
 import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff.vue'
 import RecordCircle from 'vue-material-design-icons/RecordCircle.vue'
@@ -182,6 +187,8 @@ export default {
 		PromotedView,
 		Cog,
 		DotsHorizontal,
+		Fullscreen,
+		FullscreenExit,
 		GridView,
 		HandBackLeft,
 		VideoIcon,


### PR DESCRIPTION
### ☑️ Resolves

* Align icons with **Viewer** (https://github.com/nextcloud/viewer/pull/1588#issuecomment-1510802067)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![obraz](https://user-images.githubusercontent.com/8277636/236621909-e25e334b-ef70-4986-a07b-f337d87984a5.png) | ![obraz](https://user-images.githubusercontent.com/8277636/236621753-0b9d4b2c-3f37-4351-a4ad-2aac4bbc9aff.png)
![obraz](https://user-images.githubusercontent.com/8277636/236621926-37f61494-4660-409a-a877-dcf190a0c7a7.png) | ![obraz](https://user-images.githubusercontent.com/8277636/236621785-7209ff21-be00-405a-90b2-da58baca931c.png)

### 🚧 Tasks

- [x] Use Material Design icons
- [ ] Adjust spelling

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
