### PR TITLE
[stable25] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -133,12 +133,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "91e61aba842365691d63a086dba68c3f3ccc3689"
+                "reference": "a4503a6e9a3fb5636930c4fa91319ae54f732936"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/91e61aba842365691d63a086dba68c3f3ccc3689",
-                "reference": "91e61aba842365691d63a086dba68c3f3ccc3689",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/a4503a6e9a3fb5636930c4fa91319ae54f732936",
+                "reference": "a4503a6e9a3fb5636930c4fa91319ae54f732936",
                 "shasum": ""
             },
             "require": {
@@ -168,7 +168,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable25"
             },
-            "time": "2023-04-13T00:33:11+00:00"
+            "time": "2023-05-05T00:32:38+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency