### PR TITLE
fix(chat): Fix call summary with only numeric user ids

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -900,9 +900,10 @@ class SystemMessage {
 	protected function parseCall(string $message, array $parameters, array $params): array {
 		if ($message === 'call_ended_everyone') {
 			if ($params['actor']['type'] === 'user') {
-				$flipped = array_flip($parameters['users']);
-				unset($flipped[$params['actor']['id']]);
-				$parameters['users'] = array_flip($flipped);
+				$entry = array_keys($parameters['users'], $params['actor']['id'], true);
+				foreach ($entry as $i) {
+					unset($parameters['users'][$i]);
+				}
 			} else {
 				$parameters['guests']--;
 			}

--- a/tests/php/Chat/Parser/SystemMessageTest.php
+++ b/tests/php/Chat/Parser/SystemMessageTest.php
@@ -1355,6 +1355,15 @@ class SystemMessageTest extends TestCase {
 					['user1' => ['data' => 'user2'], 'user2' => ['data' => 'user3'], 'user3' => ['data' => 'user4'], 'user4' => ['data' => 'user5']],
 				],
 			],
+			'numeric users only' => [
+				'call_ended_everyone',
+				['users' => ['123', '234', '345', '456', '576', '678'], 'guests' => 2, 'duration' => 42],
+				['type' => 'user', 'id' => '123', 'name' => '123'],
+				[
+					'{actor} ended the call with {user1}, {user2}, {user3}, {user4} and 3 others (Duration "duration")',
+					['user1' => ['data' => '234'], 'user2' => ['data' => '345'], 'user3' => ['data' => '456'], 'user4' => ['data' => '576']],
+				],
+			],
 		];
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9493 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
