### PR TITLE
Release 17.0.0 beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 17.0.0-beta.2 – 2023-05-09
+### Added
+- Typing indicators frontend and settings
+  [#9455](https://github.com/nextcloud/spreed/issues/9455)
+  [#9431](https://github.com/nextcloud/spreed/issues/9431)
+
+### Changed
+- Update several dependencies
+
+### Fixed
+- Show empty call view on viewer overlay
+  [#9460](https://github.com/nextcloud/spreed/issues/9460)
+- Fix avatar handling when interacting with non-supporting backends
+  [#9492](https://github.com/nextcloud/spreed/issues/9492)
+
 ## 17.0.0-beta.1 – 2023-05-04
 ### Added
 - Conversations can now have an avatar or emoji as icon

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>17.0.0-beta.1</version>
+	<version>17.0.0-beta.2</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk",
-	"version": "17.0.0-beta.1",
+	"version": "17.0.0-beta.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk",
-			"version": "17.0.0-beta.1",
+			"version": "17.0.0-beta.2",
 			"license": "agpl",
 			"dependencies": {
 				"@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "talk",
-	"version": "17.0.0-beta.1",
+	"version": "17.0.0-beta.2",
 	"private": true,
 	"description": "",
 	"author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
### Added
- Typing indicators frontend and settings [#9455](https://github.com/nextcloud/spreed/issues/9455) [#9431](https://github.com/nextcloud/spreed/issues/9431)

### Changed
- Update several dependencies

### Fixed
- Show empty call view on viewer overlay [#9460](https://github.com/nextcloud/spreed/issues/9460)
- Fix avatar handling when interacting with non-supporting backends [#9492](https://github.com/nextcloud/spreed/issues/9492)


---

### Still waiting for

- [x] #9460 
- [x] #9344 