### PR TITLE
fix(chat): Prevent empty chat messages

### DIFF
--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -214,6 +214,10 @@ class ChatController extends AEnvironmentAwareController {
 	#[RequirePermission(permission: RequirePermission::CHAT)]
 	#[RequireReadWriteConversation]
 	public function sendMessage(string $message, string $actorDisplayName = '', string $referenceId = '', int $replyTo = 0, bool $silent = false): DataResponse {
+		if (trim($message) === '') {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
 		[$actorType, $actorId] = $this->getActorInfo($actorDisplayName);
 		if (!$actorId) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);

--- a/src/components/NewMessageForm/NewMessageForm.vue
+++ b/src/components/NewMessageForm/NewMessageForm.vue
@@ -439,7 +439,7 @@ export default {
 		},
 
 		hasText() {
-			return this.text !== ''
+			return this.text.trim() !== ''
 		},
 
 		containerElement() {
@@ -592,12 +592,15 @@ export default {
 				}
 			}
 
-			if (this.text !== '') {
+			if (this.hasText) {
 				// FIXME: remove after issue is resolved: https://github.com/nextcloud/nextcloud-vue/issues/3264
 				const temp = document.createElement('textarea')
 				temp.innerHTML = this.text
 				this.text = temp.value
-				const temporaryMessage = await this.$store.dispatch('createTemporaryMessage', { text: this.text, token: this.token })
+				const temporaryMessage = await this.$store.dispatch('createTemporaryMessage', {
+					text: this.text.trim(),
+					token: this.token,
+				})
 				// FIXME: move "addTemporaryMessage" into "postNewMessage" as it's a pre-requisite anyway ?
 				if (!this.broadcast) {
 					await this.$store.dispatch('addTemporaryMessage', temporaryMessage)

--- a/tests/integration/features/chat/group.feature
+++ b/tests/integration/features/chat/group.feature
@@ -59,6 +59,7 @@ Feature: chat/group
       | invite   | attendees1 |
     When user "participant1" sends message "Message 1" to room "group room" with 201
     And user "participant2" sends message "Message 2" to room "group room" with 201
+    And user "participant2" sends message "" to room "group room" with 400
     Then user "participant1" sees the following messages in room "group room" with 200
       | room       | actorType | actorId      | actorDisplayName         | message   | messageParameters |
       | group room | users     | participant2 | participant2-displayname | Message 2 | []                |


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9507

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
With only new lines the submit button is active | With only new lines the submit button is inactive
![Bildschirmfoto vom 2023-05-10 07-17-54](https://github.com/nextcloud/spreed/assets/213943/561461b9-896c-4156-b1cb-3389e113d8a7) | ![Bildschirmfoto vom 2023-05-10 07-17-35](https://github.com/nextcloud/spreed/assets/213943/c96d763a-9ec5-4ccb-b078-5dfb0bdfd472)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
