### PR TITLE
Release 17.0.0 beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 17.0.0-beta.3 – 2023-05-12
+### Added
+- Allow translating chat messages
+  [#9512](https://github.com/nextcloud/spreed/issues/9512)
+
+### Changed
+- Update several dependencies
+
+### Fixed
+- Media settings or not respected
+  [#9513](https://github.com/nextcloud/spreed/issues/9513)
+- Fix clearing guests over and over again on MySQL and Oracle
+  [#9517](https://github.com/nextcloud/spreed/issues/9517)
+- Prevent empty chat messages
+  [#9509](https://github.com/nextcloud/spreed/issues/9509)
+
 ## 17.0.0-beta.2 – 2023-05-09
 ### Added
 - Typing indicators frontend and settings

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk",
-	"version": "17.0.0-beta.2",
+	"version": "17.0.0-beta.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk",
-			"version": "17.0.0-beta.2",
+			"version": "17.0.0-beta.3",
 			"license": "agpl",
 			"dependencies": {
 				"@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "talk",
-	"version": "17.0.0-beta.2",
+	"version": "17.0.0-beta.3",
 	"private": true,
 	"description": "",
 	"author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 17.0.0-beta.3 – 2023-05-12
### Added
- Allow translating chat messages [#9512](https://github.com/nextcloud/spreed/issues/9512)

### Changed
- Update several dependencies

### Fixed
- Media settings or not respected [#9513](https://github.com/nextcloud/spreed/issues/9513)
- Fix clearing guests over and over again on MySQL and Oracle [#9517](https://github.com/nextcloud/spreed/issues/9517)
- Prevent empty chat messages [#9509](https://github.com/nextcloud/spreed/issues/9509)


---

## Todo

- [x] https://github.com/nextcloud/spreed/pull/9512
- [x] https://github.com/nextcloud/spreed/pull/9513
- [x] https://github.com/nextcloud/spreed/pull/9517
- [x] #9523 