### PR TITLE
fix(settings): Fix recording server check for blocked admins

### DIFF
--- a/lib/Middleware/CanUseTalkMiddleware.php
+++ b/lib/Middleware/CanUseTalkMiddleware.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Middleware;
 
 use OCA\Talk\Config;
+use OCA\Talk\Controller\RecordingController;
 use OCA\Talk\Controller\SignalingController;
 use OCA\Talk\Exceptions\ForbiddenException;
 use OCA\Talk\Middleware\Attribute\RequireCallEnabled;
@@ -66,7 +67,8 @@ class CanUseTalkMiddleware extends Middleware {
 		$user = $this->userSession->getUser();
 		if ($user instanceof IUser && $this->talkConfig->isDisabledForUser($user)) {
 			if ($methodName === 'getWelcomeMessage'
-				&& $controller instanceof SignalingController
+				&& ($controller instanceof SignalingController
+					|| $controller instanceof RecordingController)
 				&& $this->groupManager->isAdmin($user->getUID())) {
 				return;
 			}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9416 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/nextcloud/spreed/assets/213943/37486dab-1ca5-49a0-ba1c-bca014bfb39d) | ![grafik](https://github.com/nextcloud/spreed/assets/213943/cb55d244-7ecc-4840-9964-8b2899eac5b4)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
