### PR TITLE
Use the color-primary-element* variables

### DIFF
--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -165,7 +165,7 @@ export default {
 	left: 10%;
 	width: 80%;
 	height: 80%;
-	background: var(--color-primary-light);
+	background: var(--color-primary-element-light);
 	z-index: 11;
 	display: flex;
 	box-shadow: 0 0 36px var(--color-box-shadow);

--- a/src/components/ConversationSettings/NotificationsSettings.vue
+++ b/src/components/ConversationSettings/NotificationsSettings.vue
@@ -165,7 +165,7 @@ export default {
 		background-color: var(--color-background-hover);
 	}
 	&--active{
-		background-color: var(--color-primary-light) !important;
+		background-color: var(--color-primary-element-light) !important;
 	}
 	&__icon {
 		display: flex;

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -468,6 +468,6 @@ export default {
 }
 
 .forced-active {
-	background-color: var(--color-primary-light) !important //Overrides gray hover feedback;
+	background-color: var(--color-primary-element-light) !important //Overrides gray hover feedback;
 }
 </style>

--- a/src/components/LeftSidebar/NewGroupConversation/SetContacts/ContactSelectionBubble/ContactSelectionBubble.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/SetContacts/ContactSelectionBubble/ContactSelectionBubble.vue
@@ -93,7 +93,7 @@ $bubble-height: 24px;
 	display: flex;
 	align-items: center;
 	margin: 4px;
-	background-color: var(--color-primary-light);
+	background-color: var(--color-primary-element-light);
 	border-radius: $bubble-height;
 	height: $bubble-height;
 	&__avatar {

--- a/src/components/MediaSettings/VideoBackgroundEditor.vue
+++ b/src/components/MediaSettings/VideoBackgroundEditor.vue
@@ -292,7 +292,7 @@ export default {
 		flex: 1 0 108px;
 
 		&--selected {
-			box-shadow: inset 0 0 0 var(--default-grid-baseline) var(--color-primary);
+			box-shadow: inset 0 0 0 var(--default-grid-baseline) var(--color-primary-element);
 		}
 	 }
 }

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -880,7 +880,7 @@ export default {
 			}
 
 			&.call-started {
-				background-color: var(--color-primary-light);
+				background-color: var(--color-primary-element-light);
 				padding: 10px;
 				border-radius: var(--border-radius-large);
 				text-align: center;
@@ -906,7 +906,7 @@ export default {
 			}
 
 			&--quote {
-				border-left: 4px solid var(--color-primary);
+				border-left: 4px solid var(--color-primary-element);
 				padding: 4px 0 0 8px;
 			}
 		}

--- a/src/components/NewMessageForm/TemplatePreview.vue
+++ b/src/components/NewMessageForm/TemplatePreview.vue
@@ -203,7 +203,7 @@ export default {
 		border-radius: var(--border-radius-large);
 
 		input:checked + label > & {
-			border-color: var(--color-primary);
+			border-color: var(--color-primary-element);
 		}
 
 		&--failed {

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -262,7 +262,7 @@ export default {
 	max-width: $messages-list-max-width - $message-utils-width;
 
 	&.quote-own-message {
-		border-left: 4px solid var(--color-primary);
+		border-left: 4px solid var(--color-primary-element);
 	}
 
 	&__main {

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -730,7 +730,7 @@ export default {
 
 <style lang="scss" scoped>
 .selected {
-	background-color: var(--color-primary-light);
+	background-color: var(--color-primary-element-light);
 	border-radius: 5px;
 }
 

--- a/src/components/RightSidebar/SharedItems/SharedItemsBrowser/SharedItemsBrowser.vue
+++ b/src/components/RightSidebar/SharedItems/SharedItemsBrowser/SharedItemsBrowser.vue
@@ -176,7 +176,7 @@ export default {
 :deep(.button-vue) {
 	border-radius: var(--border-radius-large);
 	&.active {
-		background-color: var(--color-primary-light);
+		background-color: var(--color-primary-element-light);
 	}
 }
 </style>

--- a/src/views/RoomSelector.vue
+++ b/src/views/RoomSelector.vue
@@ -233,7 +233,7 @@ li {
 	}
 
 	&.selected {
-		background-color: var(--color-primary-light);
+		background-color: var(--color-primary-element-light);
 		border-radius: var(--border-radius-pill);
 	}
 


### PR DESCRIPTION
Explanation: the color-primary variables are not to be used in components because the introduce problems with high-contrast primary colors. Fix this by using the primary-element variables instead.