### PR TITLE
fix(deps): Bump @nextcloud/vue to 7.11.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"@nextcloud/moment": "^1.2.1",
 				"@nextcloud/paths": "^2.1.0",
 				"@nextcloud/router": "^2.1.1",
-				"@nextcloud/vue": "^7.11.4",
+				"@nextcloud/vue": "^7.11.6",
 				"attachmediastream": "^2.1.0",
 				"color.js": "^1.2.0",
 				"crypto-js": "^4.1.1",
@@ -2965,9 +2965,9 @@
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "7.11.4",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.11.4.tgz",
-			"integrity": "sha512-GDynE+HuC2eoSDg1oMSzl25Q6QDWycCYh6GkKFqTlTrWqsjAzINrcP8c/mVAbrJAkAuu8VYrQ8X3aTIuq7Vutw==",
+			"version": "7.11.6",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.11.6.tgz",
+			"integrity": "sha512-HqstdUdQYHMFx/xD36OElbE0DvXmGSnPI9/stvRDlTYV+aG2XNQPn57k5cXjsQe5LAFv0SXwXVTzKA6q5+wuoA==",
 			"dependencies": {
 				"@floating-ui/dom": "^1.1.0",
 				"@nextcloud/auth": "^2.0.0",
@@ -20558,9 +20558,9 @@
 			}
 		},
 		"@nextcloud/vue": {
-			"version": "7.11.4",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.11.4.tgz",
-			"integrity": "sha512-GDynE+HuC2eoSDg1oMSzl25Q6QDWycCYh6GkKFqTlTrWqsjAzINrcP8c/mVAbrJAkAuu8VYrQ8X3aTIuq7Vutw==",
+			"version": "7.11.6",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.11.6.tgz",
+			"integrity": "sha512-HqstdUdQYHMFx/xD36OElbE0DvXmGSnPI9/stvRDlTYV+aG2XNQPn57k5cXjsQe5LAFv0SXwXVTzKA6q5+wuoA==",
 			"requires": {
 				"@floating-ui/dom": "^1.1.0",
 				"@nextcloud/auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"@nextcloud/moment": "^1.2.1",
 		"@nextcloud/paths": "^2.1.0",
 		"@nextcloud/router": "^2.1.1",
-		"@nextcloud/vue": "^7.11.4",
+		"@nextcloud/vue": "^7.11.6",
 		"attachmediastream": "^2.1.0",
 		"color.js": "^1.2.0",
 		"crypto-js": "^4.1.1",


### PR DESCRIPTION
### ☑️ Resolves

* Ref https://github.com/nextcloud/nextcloud-vue/pull/4125

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Bildschirmfoto vom 2023-05-16 21-48-07](https://github.com/nextcloud/spreed/assets/213943/c32c8372-c032-419b-b80a-326e3c46294c) | ![Bildschirmfoto vom 2023-05-16 21-51-13](https://github.com/nextcloud/spreed/assets/213943/37c80105-844f-4550-8781-87f13c887a15)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
