### PR TITLE
Release 17.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 17.0.0-rc.1 – 2023-05-17
+### Changed
+- Update dependencies
+
+### Fixed
+- Fix virtual background image being stretched instead of cropped
+  [#9549](https://github.com/nextcloud/spreed/issues/9549)
+
 ## 17.0.0-beta.3 – 2023-05-12
 ### Added
 - Allow translating chat messages

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>17.0.0-beta.3</version>
+	<version>17.0.0-rc.1</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk",
-	"version": "17.0.0-beta.3",
+	"version": "17.0.0-rc.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk",
-			"version": "17.0.0-beta.3",
+			"version": "17.0.0-rc.1",
 			"license": "agpl",
 			"dependencies": {
 				"@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "talk",
-	"version": "17.0.0-beta.3",
+	"version": "17.0.0-rc.1",
 	"private": true,
 	"description": "",
 	"author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 17.0.0-rc.1 – 2023-05-17
### Changed
- Update dependencies

### Fixed
- Fix virtual background image being stretched instead of cropped [#9549](https://github.com/nextcloud/spreed/issues/9549)
