### PR TITLE
Release 14.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 14.0.11 – 2023-05-25
+### Changed
+- Allow Brave browser without unsupported warning
+  [#9172](https://github.com/nextcloud/spreed/issues/9172)
+- Update dependencies
+
+### Fixed
+- Fix call summary when a user has a full numeric user ID
+  [#9503](https://github.com/nextcloud/spreed/issues/9503)
+
 ## 14.0.10 – 2023-03-24
 ### Fixed
 - fix(calls): Fix RemoteVideoBlocker still active after removing its associated model

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>14.0.10</version>
+	<version>14.0.11</version>
 	<licence>agpl</licence>
 
 	<author>Aleksandra Lazarević</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk",
-	"version": "14.0.0",
+	"version": "14.0.11",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk",
-			"version": "14.0.0",
+			"version": "14.0.11",
 			"license": "agpl",
 			"dependencies": {
 				"@juliushaertl/vue-richtext": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "talk",
-	"version": "14.0.0",
+	"version": "14.0.11",
 	"private": true,
 	"description": "",
 	"author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 14.0.11 – 2023-05-25
### Changed
- Allow Brave browser without unsupported warning  [#9172](https://github.com/nextcloud/spreed/issues/9172)
- Update dependencies

### Fixed
- Fix call summary when a user has a full numeric user ID  [#9503](https://github.com/nextcloud/spreed/issues/9503)