### PR TITLE
Release 16.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,50 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 16.0.4 – 2023-05-25
+### Added
+- Allow to mark conversations unread in the sidebar
+  [#9366](https://github.com/nextcloud/spreed/issues/9366)
+
+### Changed
+- Make self-joined users persistent members when assigning permissions
+  [#9434](https://github.com/nextcloud/spreed/issues/9434)
+- Update dependencies
+
+### Fixed
+- Special characters are HTML encoded when selecting an Emoji from the picker
+  [#9545](https://github.com/nextcloud/spreed/issues/9545)
+- Fix missing "New message" form on share and files app integration
+  [#9532](https://github.com/nextcloud/spreed/issues/9532)
+- Fix diverging user status between top bar and conversation list
+  [#9419](https://github.com/nextcloud/spreed/issues/9419)
+- Fix call summary when a user has a full numeric user ID
+  [#9502](https://github.com/nextcloud/spreed/issues/9502)
+- Fix mentions of groups with spaces in the ID and guests
+  [#9420](https://github.com/nextcloud/spreed/issues/9420)
+- Prevent sending empty chat messages
+  [#9515](https://github.com/nextcloud/spreed/issues/9515)
+
+## 15.0.6 – 2023-05-25
+### Changed
+- Allow Brave browser without unsupported warning
+  [#9167](https://github.com/nextcloud/spreed/issues/9167)
+- Update dependencies
+
+### Fixed
+- Fix call summary when a user has a full numeric user ID
+  [#9504](https://github.com/nextcloud/spreed/issues/9504)
+
+## 14.0.11 – 2023-05-25
+### Changed
+- Allow Brave browser without unsupported warning
+  [#9172](https://github.com/nextcloud/spreed/issues/9172)
+- Update dependencies
+
+### Fixed
+- Fix call summary when a user has a full numeric user ID
+  [#9503](https://github.com/nextcloud/spreed/issues/9503)
+
 ## 16.0.3 – 2023-04-20
 ### Added
 - feat: Add missing "New in Talk 16" section

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>16.0.3</version>
+	<version>16.0.4</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk",
-	"version": "16.0.3",
+	"version": "16.0.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk",
-			"version": "16.0.3",
+			"version": "16.0.4",
 			"license": "agpl",
 			"dependencies": {
 				"@nextcloud/auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "talk",
-	"version": "16.0.3",
+	"version": "16.0.4",
 	"private": true,
 	"description": "",
 	"author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 16.0.4 – 2023-05-25
### Added
- Allow to mark conversations unread in the sidebar [#9366](https://github.com/nextcloud/spreed/issues/9366)

### Changed
- Make self-joined users persistent members when assigning permissions [#9434](https://github.com/nextcloud/spreed/issues/9434)
- Update dependencies

### Fixed
- Special characters are HTML encoded when selecting an Emoji from the picker [#9545](https://github.com/nextcloud/spreed/issues/9545)
- Fix missing "New message" form on share and files app integration [#9532](https://github.com/nextcloud/spreed/issues/9532)
- Fix diverging user status between top bar and conversation list [#9419](https://github.com/nextcloud/spreed/issues/9419)
- Fix call summary when a user has a full numeric user ID [#9502](https://github.com/nextcloud/spreed/issues/9502)
- Fix mentions of groups with spaces in the ID and guests [#9420](https://github.com/nextcloud/spreed/issues/9420)
- Prevent sending empty chat messages [#9515](https://github.com/nextcloud/spreed/issues/9515)