### PR TITLE
Release 17.0.0 rc.2

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -15,7 +15,7 @@ local Pipeline(test_set, database, services) = {
 			environment: {
 				APP_NAME: "spreed",
 				CORE_BRANCH: "stable27",
-				GUESTS_BRANCH: "stable27",
+				GUESTS_BRANCH: "master",
 				NOTIFICATIONS_BRANCH: "stable27",
 				DATABASEHOST: database
 			},

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: sqlite
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-callapi
@@ -62,7 +62,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: sqlite
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-chat
@@ -99,7 +99,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: sqlite
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-chat-2
@@ -136,7 +136,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: sqlite
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-command
@@ -174,7 +174,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: sqlite
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-conversation
@@ -212,7 +212,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: sqlite
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-conversation-2
@@ -249,7 +249,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: sqlite
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-federation
@@ -286,7 +286,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: sqlite
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-integration
@@ -323,7 +323,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: sqlite
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-sharing
@@ -360,7 +360,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: sqlite
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-sharing-2
@@ -411,7 +411,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: mysql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-callapi
@@ -462,7 +462,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: mysql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-chat
@@ -513,7 +513,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: mysql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-chat-2
@@ -564,7 +564,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: mysql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-command
@@ -616,7 +616,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: mysql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-conversation
@@ -668,7 +668,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: mysql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-conversation-2
@@ -719,7 +719,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: mysql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-federation
@@ -770,7 +770,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: mysql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-integration
@@ -821,7 +821,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: mysql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-sharing
@@ -872,7 +872,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: mysql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-sharing-2
@@ -918,7 +918,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: pgsql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-callapi
@@ -965,7 +965,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: pgsql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-chat
@@ -1012,7 +1012,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: pgsql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-chat-2
@@ -1059,7 +1059,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: pgsql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-command
@@ -1107,7 +1107,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: pgsql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-conversation
@@ -1155,7 +1155,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: pgsql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-conversation-2
@@ -1202,7 +1202,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: pgsql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-federation
@@ -1249,7 +1249,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: pgsql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-integration
@@ -1296,7 +1296,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: pgsql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-sharing
@@ -1343,7 +1343,7 @@ steps:
     APP_NAME: spreed
     CORE_BRANCH: stable27
     DATABASEHOST: pgsql
-    GUESTS_BRANCH: stable27
+    GUESTS_BRANCH: master
     NOTIFICATIONS_BRANCH: stable27
   image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
   name: integration-sharing-2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ All notable changes to this project will be documented in this file.
   [#9617](https://github.com/nextcloud/spreed/issues/9617)
 - fix(CallView): Fix Fullscreen mode support in ViewerOverlay
   [#9613](https://github.com/nextcloud/spreed/issues/9613)
+  [#9618](https://github.com/nextcloud/spreed/issues/9618)
 - fix(CallView): fix no local video on empty call in not grid mode
   [#9584](https://github.com/nextcloud/spreed/issues/9584)
+- fix(chat): Update own read marker before triggering events when posting
+  [#9612](https://github.com/nextcloud/spreed/issues/9612)
 - fix(chat): Don't send startTyping signaling message for each keystroke
   [#9614](https://github.com/nextcloud/spreed/issues/9614)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,65 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 17.0.0-rc.2 – 2023-05-25
+### Fixed
+- fix(reactions): Fix own call reactions when the high-performance backend is used
+  [#9586](https://github.com/nextcloud/spreed/issues/9586)
+- fix(mediasettings): Hide virtual background options when not supported
+  [#9611](https://github.com/nextcloud/spreed/issues/9611)
+- fix(mediasettings): Fix broken aria-label
+  [#9617](https://github.com/nextcloud/spreed/issues/9617)
+- fix(CallView): Fix Fullscreen mode support in ViewerOverlay
+  [#9613](https://github.com/nextcloud/spreed/issues/9613)
+- fix(CallView): fix no local video on empty call in not grid mode
+  [#9584](https://github.com/nextcloud/spreed/issues/9584)
+- fix(chat): Don't send startTyping signaling message for each keystroke
+  [#9614](https://github.com/nextcloud/spreed/issues/9614)
+
+## 16.0.4 – 2023-05-25
+### Added
+- Allow to mark conversations unread in the sidebar
+  [#9366](https://github.com/nextcloud/spreed/issues/9366)
+
+### Changed
+- Make self-joined users persistent members when assigning permissions
+  [#9434](https://github.com/nextcloud/spreed/issues/9434)
+- Update dependencies
+
+### Fixed
+- Special characters are HTML encoded when selecting an Emoji from the picker
+  [#9545](https://github.com/nextcloud/spreed/issues/9545)
+- Fix missing "New message" form on share and files app integration
+  [#9532](https://github.com/nextcloud/spreed/issues/9532)
+- Fix diverging user status between top bar and conversation list
+  [#9419](https://github.com/nextcloud/spreed/issues/9419)
+- Fix call summary when a user has a full numeric user ID
+  [#9502](https://github.com/nextcloud/spreed/issues/9502)
+- Fix mentions of groups with spaces in the ID and guests
+  [#9420](https://github.com/nextcloud/spreed/issues/9420)
+- Prevent sending empty chat messages
+  [#9515](https://github.com/nextcloud/spreed/issues/9515)
+
+## 15.0.6 – 2023-05-25
+### Changed
+- Allow Brave browser without unsupported warning
+  [#9167](https://github.com/nextcloud/spreed/issues/9167)
+- Update dependencies
+
+### Fixed
+- Fix call summary when a user has a full numeric user ID
+  [#9504](https://github.com/nextcloud/spreed/issues/9504)
+
+## 14.0.11 – 2023-05-25
+### Changed
+- Allow Brave browser without unsupported warning
+  [#9172](https://github.com/nextcloud/spreed/issues/9172)
+- Update dependencies
+
+### Fixed
+- Fix call summary when a user has a full numeric user ID
+  [#9503](https://github.com/nextcloud/spreed/issues/9503)
+
 ## 17.0.0-rc.1 – 2023-05-17
 ### Changed
 - Update dependencies

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>17.0.0-rc.1</version>
+	<version>17.0.0-rc.2</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk",
-	"version": "17.0.0-rc.1",
+	"version": "17.0.0-rc.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk",
-			"version": "17.0.0-rc.1",
+			"version": "17.0.0-rc.2",
 			"license": "agpl",
 			"dependencies": {
 				"@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "talk",
-	"version": "17.0.0-rc.1",
+	"version": "17.0.0-rc.2",
 	"private": true,
 	"description": "",
 	"author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 17.0.0-rc.2 – 2023-05-25
### Fixed
- fix(reactions): Fix own call reactions when the high-performance backend is used [#9586](https://github.com/nextcloud/spreed/issues/9586)
- fix(mediasettings): Hide virtual background options when not supported [#9611](https://github.com/nextcloud/spreed/issues/9611)
- fix(mediasettings): Fix broken aria-label [#9617](https://github.com/nextcloud/spreed/issues/9617)
- fix(CallView): Fix Fullscreen mode support in ViewerOverlay [#9613](https://github.com/nextcloud/spreed/issues/9613) [#9618](https://github.com/nextcloud/spreed/issues/9618)
- fix(CallView): fix no local video on empty call in not grid mode [#9584](https://github.com/nextcloud/spreed/issues/9584)
- fix(chat): Update own read marker before triggering events when posting [#9612](https://github.com/nextcloud/spreed/issues/9612)
- fix(chat): Don't send startTyping signaling message for each keystroke [#9614](https://github.com/nextcloud/spreed/issues/9614)
