### PR TITLE
Fix Fullscreen mode support in ViewerOverlay

### DIFF
--- a/src/components/CallView/shared/ViewerOverlayCallView.vue
+++ b/src/components/CallView/shared/ViewerOverlayCallView.vue
@@ -19,7 +19,16 @@
 
 <template>
 	<div ref="ghost" class="viewer-overlay-ghost">
-		<Portal>
+		<!--
+			Viewer Overlay should be teleported to be to the top of DOM to be on top of the Viewer,
+			because by default Viewer is on top of an entire Talk (#content-vue).
+			In the fullscreen mode Viewer is manually moved to #content-vue which is top layer by Fullscreen API.
+			FIXME: this is not correct to use Portal/Teleport to move something inside the Vue app.
+			Alternative solutions could be:
+			- Use full version of the Portal library (doesn't solve the same problem with Viewer)
+			- Use a new child of #content-vue as Talk Vue app
+		-->
+		<Portal :selector="isFullscreen ? '#content-vue' : 'body'">
 			<!-- Add .app-talk to use Talk icon classes outside of #content-vue -->
 			<div class="viewer-overlay app-talk"
 				:style="{
@@ -181,6 +190,10 @@ export default {
 	computed: {
 		conversation() {
 			return this.$store.getters.conversation(this.token)
+		},
+
+		isFullscreen() {
+			return this.$store.getters.isFullscreen()
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9444

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/25978914/5a209875-2aff-4f71-875f-6cd4e38753cf) | ![image](https://github.com/nextcloud/spreed/assets/25978914/ce746c0e-f162-4f21-bc74-e455bf05d624)


### 🚧 Tasks

In the Fullscreen mode, Talk Vue app (`#content-vue`) is a [top layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer) element. It is not possible to display any other elements outside the Talk app on top of the top layer using CSS.

Both Viewer and ViewerOverlayCallView are rendered outside the Talk app and had this problem. With Viewer it is solved now by a `fixme` hack with manual moving a DOM element with Viewer to the Talk app.

This PR fixes this problem in a similar way, in a fullscreen mode `Teleport` is used to move the ViewerOverlay not to the body, but to the Talk app (`#content-vue`).

A do not like this solution. Formally this is not correct to use Portal/Teleport to move something **inside** the Vue app. It should only be used to teleport something **outside** the app and Vue app content should never be mutated directly without Vue and its Virtual DOM.

Alternative solutions could be:
1. Use the [full version of the Portal library](https://v2.portal-vue.linusb.org)
   - Requires adding a heavy library
   - Doesn't solve the same problem with Viewer anyway
2. Create and use a new child of `#content-vue` as Talk Vue app, so its parent could be in the Fullscreen allowing to render new elements there
   - Changes the Talk app layout by making `#content-vue` not a vue app or changes the Talk app server-side template. I'm afraid, it could break many things. I'd consider doing something like these in techdept later.

So I haven't found any better solution :( 

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
