### PR TITLE
fix(chat): Update own read marker before triggering events when posting

### DIFF
--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -179,8 +179,6 @@ class ChatController extends AEnvironmentAwareController {
 			return $response;
 		}
 
-		$this->participantService->updateLastReadMessage($this->participant, (int) $comment->getId());
-
 		$data = $chatMessage->toArray($this->getResponseFormat());
 		if ($parentMessage instanceof Message) {
 			$data['parent'] = $parentMessage->toArray($this->getResponseFormat());

--- a/tests/integration/features/chat-2/unread-messages.feature
+++ b/tests/integration/features/chat-2/unread-messages.feature
@@ -109,12 +109,12 @@ Feature: chat-2/unread-messages
       | roomName | room |
     And user "participant1" adds user "participant2" to room "group room" with 200 (v4)
     When user "participant1" shares "welcome.txt" with room "group room"
-    # Unread counter for sender is not cleared in this case, as it is not
+    # Unread counter for sender is cleared in this case, as it is not
     # possible to know whether the file was shared from Talk, which could clear
     # the counter, or from the Files app, which should not clear it.
     Then user "participant1" is participant of room "group room" (v4)
       | unreadMessages |
-      | 1              |
+      | 0              |
     And user "participant2" is participant of room "group room" (v4)
       | unreadMessages |
       | 1              |


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9206 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required - Due to the nature of race condition, automated testing is not really possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
