### PR TITLE
fix(mediasettings): Hide virtual background options when not supported

### DIFF
--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -97,7 +97,8 @@
 					</template>
 					{{ t('spreed', 'Devices') }}
 				</NcButton>
-				<NcButton :type="showBackgroundEditor ? 'secondary' : 'tertiary'"
+				<NcButton v-if="isVirtualBackgroundAvailable"
+					:type="showBackgroundEditor ? 'secondary' : 'tertiary'"
 					@click="toggleTab('backgrounds')">
 					<template #icon>
 						<Creation :size="20" />
@@ -120,7 +121,6 @@
 
 			<!-- Background selection -->
 			<VideoBackgroundEditor v-if="showBackgroundEditor"
-				:virtual-background="virtualBackground"
 				:token="token"
 				@update-background="handleUpdateBackground" />
 
@@ -333,6 +333,11 @@ export default {
 		showBackgroundEditor() {
 			return this.tabContent === 'backgrounds'
 		},
+
+		isVirtualBackgroundAvailable() {
+			return this.virtualBackground.isAvailable()
+		},
+
 	},
 
 	watch: {

--- a/src/components/MediaSettings/VideoBackgroundEditor.vue
+++ b/src/components/MediaSettings/VideoBackgroundEditor.vue
@@ -32,7 +32,6 @@
 			}}
 		</button>
 		<button key="blur"
-			:disabled="!blurPreviewAvailable"
 			class="background-editor__element"
 			:class="{'background-editor__element--selected': selectedBackground === 'blur'}"
 			@click="handleSelectBackground('blur')">
@@ -116,11 +115,6 @@ export default {
 			type: String,
 			required: true,
 		},
-
-		virtualBackground: {
-			type: Object,
-			required: true,
-		},
 	},
 
 	emits: ['update-background'],
@@ -140,10 +134,6 @@ export default {
 	},
 
 	computed: {
-		blurPreviewAvailable() {
-			return this.virtualBackground.isAvailable()
-		},
-
 		isCustomBackground() {
 			return this.selectedBackground !== 'none'
 			    && this.selectedBackground !== 'blur'


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9597 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/nextcloud/spreed/assets/213943/f4029405-b94f-42d3-8550-84f53a9fc133) | ![Bildschirmfoto vom 2023-05-24 16-49-48](https://github.com/nextcloud/spreed/assets/213943/4ceb08bb-60a4-4c43-868a-e39f3f16f6df)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
