### PR TITLE
fix(docs): Document end call for everyone parameter

### DIFF
--- a/docs/call.md
+++ b/docs/call.md
@@ -99,6 +99,12 @@
 
 * Method: `DELETE`
 * Endpoint: `/call/{token}`
+* Data:
+
+| field | type | Description                                                                 |
+|-------|------|-----------------------------------------------------------------------------|
+| `all` | bool | If sent as a moderator, end the meeting and all participants leave the call |
+
 
 * Response:
     - Status code:


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9527 
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
