### PR TITLE
feat(API): Allow to block older clients

### DIFF
--- a/docs/global.md
+++ b/docs/global.md
@@ -1,0 +1,42 @@
+# Global API status and headers
+
+## Maintenance mode
+
+Server is in maintenance mode, when the header is not available it could be a missing execution of a database upgrade or any other general server failure.
+
+* Response:
+    - Status code:
+        + `503 Service Unavailable`
+
+    - Header:
+
+| field                          | type | Description |
+|--------------------------------|------|-------------|
+| `X-Nextcloud-Maintenance-Mode` | int  | Value `1`   |
+
+
+## Rate limit
+
+The remote address sent too many requests targeting the same endpoint, see the [Nextcloud Developer manual](https://docs.nextcloud.com//server/stable/developer_manual/basics/controllers.html#rate-limiting) for more information.
+
+* Response:
+    - Status code:
+       + `429 Too Many Requests`
+
+## Brute force protection
+
+The remote address sent too many requests targeting the same action, see the [Nextcloud Developer manual](https://docs.nextcloud.com//server/stable/developer_manual/basics/controllers.html#brute-force-protection) for more information.
+
+* Response:
+    - Status code:
+       + `429 Too Many Requests`
+
+## Outdated client
+
+From time to time it is unavoidable to break compatibility. In such cases we try to be as helpful for the users as possible and instead of behaving unexpected, a dedicated error response is returned and the clients should handle it properly and show a message that the client is outdated and needs to be upgraded in order to continue using this server.
+
+* Response:
+    - Status code:
+       + `426 Upgrade Required`
+    - Body:
+       + `ocs.meta.message` contains the minimum required version of the used client

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@
 
 ## API documentation
 
+* [Global API status and headers](global.md)
 * [Conversation management](conversation.md)
 * [Conversation avatar management](avatar.md)
 * [Participant management](participant.md)

--- a/lib/Middleware/Exceptions/UnsupportedClientVersionException.php
+++ b/lib/Middleware/Exceptions/UnsupportedClientVersionException.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023, Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Middleware\Exceptions;
+
+use OCP\AppFramework\Http;
+
+class UnsupportedClientVersionException extends \Exception {
+	public function __construct(
+		protected string $version,
+	) {
+		parent::__construct('Unsupported client version', Http::STATUS_UPGRADE_REQUIRED);
+	}
+
+	public function getMinVersion(): string {
+		return $this->version;
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
       - 'Capabilities': 'capabilities.md'
       - 'PHP events': 'events.md'
   - 'API documentation':
+      - 'Global API status and headers': 'global.md'
       - 'Conversations management': 'conversation.md'
       - 'Conversation avatars management': 'avatar.md'
       - 'Participants management': 'participant.md'

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -3452,6 +3452,20 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^client "([^"]*)" requests room list with (\d+) \((v4)\)$/
+	 *
+	 * @param string $userAgent
+	 * @param int $statusCode
+	 * @param string $apiVersion
+	 */
+	public function getRoomListWithSpecificUserAgent(string $userAgent, int $statusCode, string $apiVersion): void {
+		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/room', null, [
+			'USER_AGENT' => $userAgent,
+		]);
+		$this->assertStatusCode($this->response, $statusCode);
+	}
+
+	/**
 	 * @Then the response error matches with :error
 	 */
 	public function assertResponseErrorMatchesWith(string $error): void {

--- a/tests/integration/features/integration/outdated-client.feature
+++ b/tests/integration/features/integration/outdated-client.feature
@@ -1,0 +1,24 @@
+Feature: integration/outdated-client
+  Background:
+    Given user "participant1" exists
+
+  Scenario: Check if outdated clients correctly receive a 426 error
+    Given as user "participant1"
+    # Android
+    When client "Mozilla/5.0 (Android) Nextcloud-Talk v14.1.1" requests room list with 426 (v4)
+    Then last response body contains "15.0.0"
+    When client "Mozilla/5.0 (Android) Nextcloud-Talk v17.0.0" requests room list with 200 (v4)
+    # iOS
+    When client "Mozilla/5.0 (iOS) Nextcloud-Talk v14.1.1" requests room list with 426 (v4)
+    Then last response body contains "15.0.0"
+    When client "Mozilla/5.0 (iOS) Nextcloud-Talk v17.0.0" requests room list with 200 (v4)
+    # Desktop
+    When client "Mozilla/5.0 (Linux) Nextcloud-Talk v0.3.2" requests room list with 426 (v4)
+    Then last response body contains "0.6.0"
+    When client "Mozilla/5.0 (Linux) Nextcloud-Talk v0.6.0" requests room list with 200 (v4)
+    When client "Mozilla/5.0 (Mac) Nextcloud-Talk v0.3.2" requests room list with 426 (v4)
+    Then last response body contains "0.6.0"
+    When client "Mozilla/5.0 (Mac) Nextcloud-Talk v0.6.0" requests room list with 200 (v4)
+    When client "Mozilla/5.0 (Windows) Nextcloud-Talk v0.3.2" requests room list with 426 (v4)
+    Then last response body contains "0.6.0"
+    When client "Mozilla/5.0 (Windows) Nextcloud-Talk v0.6.0" requests room list with 200 (v4)


### PR DESCRIPTION
### ☑️ Resolves

* API throws an exception and returns with a `426 Upgrade Required` status code


### 🚧 Tasks

- [x] Raise iOS issue https://github.com/nextcloud/talk-ios/issues/1254
- [x] Raise Android issue https://github.com/nextcloud/talk-android/issues/3061
- [x] Raise Desktop issue (or fix in web frontend) https://github.com/nextcloud/talk-desktop/issues/209

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
