### PR TITLE
Add background job to check TURN certificate

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -63,6 +63,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 		<job>OCA\Talk\BackgroundJob\CheckHostedSignalingServer</job>
 		<job>OCA\Talk\BackgroundJob\CheckMatterbridges</job>
 		<job>OCA\Talk\BackgroundJob\ExpireChatMessages</job>
+		<job>OCA\Talk\BackgroundJob\CheckTurnCertificate</job>
 	</background-jobs>
 
 	<repair-steps>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -28,6 +28,7 @@ return array_merge_recursive(
 	include(__DIR__ . '/routes/routesAvatarController.php'),
 	include(__DIR__ . '/routes/routesBreakoutRoomController.php'),
 	include(__DIR__ . '/routes/routesCallController.php'),
+	include(__DIR__ . '/routes/routesCertificateController.php'),
 	include(__DIR__ . '/routes/routesChatController.php'),
 	include(__DIR__ . '/routes/routesCommandController.php'),
 	include(__DIR__ . '/routes/routesFederationController.php'),

--- a/appinfo/routes/routesCertificateController.php
+++ b/appinfo/routes/routesCertificateController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023 Marcel Müller <marcel.mueller@nextcloud.com>
+ *
+ * @author Marcel Müller <marcel.mueller@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+$requirements = [
+	'apiVersion' => 'v1',
+];
+
+return [
+	'ocs' => [
+		/** @see \OCA\Talk\Controller\CertificateController::getCertificateExpiration() */
+		['name' => 'Certificate#getCertificateExpiration', 'url' => '/api/{apiVersion}/certificate/expiration', 'verb' => 'GET', 'requirements' => $requirements],
+	],
+];

--- a/lib/BackgroundJob/CheckCertificates.php
+++ b/lib/BackgroundJob/CheckCertificates.php
@@ -26,8 +26,8 @@ declare(strict_types=1);
 namespace OCA\Talk\BackgroundJob;
 
 use OCA\Talk\AppInfo\Application;
-use OCA\Talk\Service\CertificateService;
 use OCA\Talk\Config;
+use OCA\Talk\Service\CertificateService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;

--- a/lib/BackgroundJob/CheckCertificates.php
+++ b/lib/BackgroundJob/CheckCertificates.php
@@ -135,13 +135,17 @@ class CheckCertificates extends TimedJob {
 		$signalingServers = $this->talkConfig->getSignalingServers();
 
 		foreach ($signalingServers as $signalingServer) {
-			$this->checkServerCertificate($signalingServer['server']);
+			if ((bool) $signalingServer['verify']) {
+				$this->checkServerCertificate($signalingServer['server']);
+			}
 		}
 
 		$recordingServers = $this->talkConfig->getRecordingServers();
 
 		foreach ($recordingServers as $recordingServer) {
-			$this->checkServerCertificate($recordingServer['server']);
+			if ((bool) $recordingServer['verify']) {
+				$this->checkServerCertificate($recordingServer['server']);
+			}
 		}
 	}
 }

--- a/lib/BackgroundJob/CheckTurnCertificate.php
+++ b/lib/BackgroundJob/CheckTurnCertificate.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023 Marcel Müller <marcel.mueller@nextcloud.com>
+ *
+ * @author Marcel Müller <marcel.mueller@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\BackgroundJob;
+
+use OCA\Talk\AppInfo\Application;
+use OCA\Talk\Config;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\TimedJob;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\Notification\IManager;
+use Psr\Log\LoggerInterface;
+
+class CheckTurnCertificate extends TimedJob {
+	private Config $talkConfig;
+	private ITimeFactory $timeFactory;
+	private IGroupManager $groupManager;
+	private IManager $notificationManager;
+	private LoggerInterface $logger;
+
+	public function __construct(
+		ITimeFactory $timeFactory,
+		Config $talkConfig,
+		IGroupManager $groupManager,
+		IManager $notificationManager,
+		LoggerInterface $logger,
+	) {
+		parent::__construct($timeFactory);
+		$this->talkConfig = $talkConfig;
+		$this->timeFactory = $timeFactory;
+		$this->groupManager = $groupManager;
+		$this->notificationManager = $notificationManager;
+		$this->logger = $logger;
+
+		// Run once a week
+		$this->setInterval(60 * 60 * 24 * 7);
+		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+	}
+
+	/*
+	 * @return string[]
+	 */
+	private function getUsersToNotify(): array {
+		$users = [];
+
+		$groupToNotify = $this->groupManager->get('admin');
+		if ($groupToNotify instanceof IGroup) {
+			foreach ($groupToNotify->getUsers() as $user) {
+				$users[] = $user->getUID();
+			}
+		}
+
+		return $users;
+	}
+
+	/**
+	 * Create a notification and inform admins about the certificate which is about to expire
+	 *
+	 * @param string $turnHost The host which was checked
+	 * @param int $days Number of days until the certificate expires
+	 */
+	private function createNotifications(string $turnHost, int $days): void {
+		$notification = $this->notificationManager->createNotification();
+
+		try {
+			$notification->setApp(Application::APP_ID)
+				->setDateTime(new \DateTime())
+				->setObject('turn_certificate_expiration', $turnHost);
+
+			$notification->setSubject('turn_certificate_expiration', [
+				'host' => $turnHost,
+				'days_to_expire' => $days,
+			]);
+
+			foreach ($this->getUsersToNotify() as $uid) {
+				$notification->setUser($uid);
+				$this->notificationManager->notify($notification);
+			}
+		} catch (\InvalidArgumentException $e) {
+			return;
+		}
+	}
+
+	/**
+	 * Check the certificate of the specified TURN host
+	 *
+	 * @param string $turnHost The TURN host to check the certificate
+	 */
+	private function checkTurnServerCertificate(string $turnHost): void {
+		// We need to disable verification here to also get an expired certificate
+		$streamContext = stream_context_create([
+			'ssl' => [
+				'capture_peer_cert' => true,
+				'verify_peer' => false,
+				'verify_peer_name' => false,
+				'allow_self_signed' => true,
+			],
+		]);
+
+		$this->logger->debug('Checking certificate of ' . $turnHost);
+
+		// In case no port was specified, use port 443 for the check
+		if (!str_contains($turnHost, ':')) {
+			$turnHost .= ':443';
+		}
+
+		$streamClient = stream_socket_client('ssl://' . $turnHost, $errorNumber, $errorString, 30, STREAM_CLIENT_CONNECT, $streamContext);
+
+		if ($errorNumber !== 0) {
+			// Unable to connect or invalid server address
+			$this->logger->debug('Unable to check certificate of ' . $turnHost);
+			return;
+		}
+
+		$streamCertificate = stream_context_get_params($streamClient);
+		$certificateInfo = openssl_x509_parse($streamCertificate['options']['ssl']['peer_certificate']);
+		$certificateValidTo = $this->timeFactory->getDateTime('@' . $certificateInfo['validTo_time_t']);
+
+		$now = $this->timeFactory->getDateTime();
+		$diff = $now->diff($certificateValidTo);
+		$days = $diff->days;
+
+		// $days will always be positive -> invert it, when the end date of the certificate is in the past
+		if ($diff->invert) {
+			$days *= -1;
+		}
+
+		if ($days < 10) {
+			$this->logger->warning('Certificate of ' . $turnHost . ' expires in less than ' . $days . ' days');
+
+			$this->createNotifications($turnHost, $days);
+		} else {
+			$this->logger->debug('Certificate of ' . $turnHost . ' is valid for ' . $days . ' days');
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function run($argument): void {
+		$turnServers = $this->talkConfig->getTurnServers(false);
+
+		foreach ($turnServers as $turnServer) {
+			// Only check server which support the 'turns' protocol
+			if (!str_contains($turnServer['schemes'], 'turns')) {
+				continue;
+			}
+
+			$this->checkTurnServerCertificate($turnServer['server']);
+		}
+	}
+}

--- a/lib/Controller/CertificateController.php
+++ b/lib/Controller/CertificateController.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Marcel Müller <marcel.mueller@nextcloud.com>
+ *
+ * @author Marcel Müller <marcel.mueller@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Controller;
+
+use OCA\Talk\Service\CertificateService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
+use OCP\IRequest;
+use OCP\IL10N;
+use Psr\Log\LoggerInterface;
+
+class CertificateController extends OCSController {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		protected CertificateService $certificateService,
+		protected IL10N $l,
+		protected LoggerInterface $logger,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	public function getCertificateExpiration(string $host): DataResponse {
+		try {
+			$expirationInDays = $this->certificateService->getCertificateExpirationInDays($host);
+
+			return new DataResponse([
+				'expiration_in_days' => $expirationInDays,
+			]);
+		} catch (\Exception $e) {
+			$this->logger->error('Failed get certificate expiration', [
+				'exception' => $e,
+			]);
+
+			return new DataResponse(['message' => $this->l->t('An error occurred. Please contact your administrator.')], Http::STATUS_BAD_REQUEST);
+		}
+	}
+}

--- a/lib/Controller/CertificateController.php
+++ b/lib/Controller/CertificateController.php
@@ -30,8 +30,8 @@ use OCA\Talk\Service\CertificateService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
-use OCP\IRequest;
 use OCP\IL10N;
+use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
 class CertificateController extends OCSController {

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -239,6 +239,10 @@ class Notifier implements INotifier {
 			return $this->parseRemoteInvitationMessage($notification, $l);
 		}
 
+		if ($notification->getObjectType() === 'turn_certificate_expiration') {
+			return $this->parseTurnCertificateExpiration($notification, $l);
+		}
+
 		try {
 			$room = $this->getRoom($notification->getObjectId(), $userId);
 		} catch (RoomNotFoundException $e) {
@@ -1029,5 +1033,28 @@ class Notifier implements INotifier {
 			->setParsedSubject($subject)
 			->setIcon($notification->getIcon())
 			->addParsedAction($action);
+	}
+
+	protected function parseTurnCertificateExpiration(INotification $notification, IL10N $l): INotification {
+		$subjectParameters = $notification->getSubjectParameters();
+
+		$host = $subjectParameters['host'];
+		$daysToExpire = $subjectParameters['days_to_expire'];
+
+		if ($daysToExpire > 0) {
+			$subject = $l->t('The certificate of {host} expires in {days} days');
+		} else {
+			$subject = $l->t('The certificate of {host} expired');
+		}
+
+		$subject = str_replace(
+			['{host}', '{days}'],
+			[$host, $daysToExpire],
+			$subject
+		);
+
+		$notification->setParsedSubject($subject);
+
+		return $notification;
 	}
 }

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -239,8 +239,8 @@ class Notifier implements INotifier {
 			return $this->parseRemoteInvitationMessage($notification, $l);
 		}
 
-		if ($notification->getObjectType() === 'turn_certificate_expiration') {
-			return $this->parseTurnCertificateExpiration($notification, $l);
+		if ($notification->getObjectType() === 'certificate_expiration') {
+			return $this->parseCertificateExpiration($notification, $l);
 		}
 
 		try {
@@ -1035,7 +1035,7 @@ class Notifier implements INotifier {
 			->addParsedAction($action);
 	}
 
-	protected function parseTurnCertificateExpiration(INotification $notification, IL10N $l): INotification {
+	protected function parseCertificateExpiration(INotification $notification, IL10N $l): INotification {
 		$subjectParameters = $notification->getSubjectParameters();
 
 		$host = $subjectParameters['host'];

--- a/lib/Service/CertificateService.php
+++ b/lib/Service/CertificateService.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Marcel Müller <marcel.mueller@nextcloud.com>
+ *
+ * @author Marcel Müller <marcel.mueller@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Service;
+
+use Psr\Log\LoggerInterface;
+
+class CertificateService {
+	private LoggerInterface $logger;
+
+	public function __construct(LoggerInterface $logger) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Parse a url and only returns the host and optionally the port
+	 *
+	 * @param string $host The url to parse (e.g. 'https://hostname:port/directory')
+	 * @return string|null null if the url has a non-tls scheme, otherwise the host and optionally the port (e.g. 'hostname:port')
+	 */
+	public function getParsedTlsHost(string $host): ?string {
+		$parsedUrl = parse_url($host);
+
+		// parse_url failed, $host is a seriously malformed URL
+		if ($parsedUrl === false) {
+			return null;
+		}
+
+		if (isset($parsedUrl['scheme'])) {
+			$scheme = strtolower($parsedUrl['scheme']);
+
+			// When we have a scheme specified which is different than https/wss, there's no tls host
+			if ($scheme !== 'https' && $scheme !== 'wss') {
+				return null;
+			}
+		}
+
+		// When we are unable to retrieve a host from the URL, just return the original host
+		if (!isset($parsedUrl['host'])) {
+			return $host;
+		}
+
+		$parsedHost = $parsedUrl['host'];
+
+		if (isset($parsedUrl['port'])) {
+			$parsedHost .= ':' . $parsedUrl['port'];
+		}
+
+		return $parsedHost;
+	}
+
+	/**
+	 * Retrieve the hosts certificate expiration in days
+	 *
+	 * @param string $host The host to check the certificate of without scheme
+	 * @return int|null Days until the certificate expires (negative when it's already expired)
+	 */
+	public function getCertificateExpirationInDays(string $host): ?int {
+		$parsedHost = $this->getParsedTlsHost($host);
+
+		if ($parsedHost === null) {
+			// Unable to parse the specified host
+			$this->logger->debug('Ignoring certificate check of non-tls host ' . $host);
+			return null;
+		}
+
+		// We need to disable verification here to also get an expired certificate
+		$streamContext = stream_context_create([
+			'ssl' => [
+				'capture_peer_cert' => true,
+				'verify_peer' => false,
+				'verify_peer_name' => false,
+				'allow_self_signed' => true,
+			],
+		]);
+
+		// In case no port was specified, use port 443 for the check
+		if (!str_contains($parsedHost, ':')) {
+			$parsedHost .= ':443';
+		}
+
+		$this->logger->debug('Checking certificate of ' . $parsedHost);
+
+		$streamClient = stream_socket_client('ssl://' . $parsedHost, $errorNumber, $errorString, 30, STREAM_CLIENT_CONNECT, $streamContext);
+
+		if ($streamClient === false || $errorNumber !== 0) {
+			// Unable to connect or invalid server address
+			$this->logger->debug('Unable to check certificate of ' . $parsedHost);
+			return null;
+		}
+
+		$streamCertificate = stream_context_get_params($streamClient);
+		$certificateInfo = openssl_x509_parse($streamCertificate['options']['ssl']['peer_certificate']);
+		$certificateValidTo = new \DateTime('@' . $certificateInfo['validTo_time_t']);
+
+		$now = new \DateTime();
+		$diff = $now->diff($certificateValidTo);
+		$days = $diff->days;
+
+		// $days will always be positive -> invert it, when the end date of the certificate is in the past
+		if ($diff->invert) {
+			$days *= -1;
+		}
+
+		return $days;
+	}
+}

--- a/lib/Service/CertificateService.php
+++ b/lib/Service/CertificateService.php
@@ -120,6 +120,10 @@ class CertificateService {
 		$diff = $now->diff($certificateValidTo);
 		$days = $diff->days;
 
+		if ($days === false) {
+			return null;
+		}
+
 		// $days will always be positive -> invert it, when the end date of the certificate is in the past
 		if ($diff->invert) {
 			$days *= -1;

--- a/src/components/AdminSettings/RecordingServer.vue
+++ b/src/components/AdminSettings/RecordingServer.vue
@@ -164,9 +164,9 @@ export default {
 				this.versionFound = response.data.ocs.data.version
 			} catch (exception) {
 				this.checked = true
-				let data = exception.response.data.ocs.data
-				let error = data.error
-				
+				const data = exception.response.data.ocs.data
+				const error = data.error
+
 				if (error === 'CAN_NOT_CONNECT') {
 					this.errorMessage = t('spreed', 'Error: Cannot connect to server')
 				} else if (error === 'JSON_INVALID') {

--- a/src/components/AdminSettings/RecordingServer.vue
+++ b/src/components/AdminSettings/RecordingServer.vue
@@ -164,12 +164,17 @@ export default {
 				this.versionFound = response.data.ocs.data.version
 			} catch (exception) {
 				this.checked = true
-				if (exception.response.data.ocs.data.error === 'CAN_NOT_CONNECT') {
+				let data = exception.response.data.ocs.data
+				let error = data.error
+				
+				if (error === 'CAN_NOT_CONNECT') {
 					this.errorMessage = t('spreed', 'Error: Cannot connect to server')
-				} else if (exception.response.data.ocs.data.error === 'JSON_INVALID') {
+				} else if (error === 'JSON_INVALID') {
 					this.errorMessage = t('spreed', 'Error: Server did not respond with proper JSON')
-				} else if (exception.response.data.ocs.data.error) {
-					this.errorMessage = t('spreed', 'Error: Server responded with: {error}', exception.response.data.ocs.data)
+				} else if (error === 'CERTIFICATE_EXPIRED') {
+					this.errorMessage = t('spreed', 'Error: Certificate expired')
+				} else if (error) {
+					this.errorMessage = t('spreed', 'Error: Server responded with: {error}', data)
 				} else {
 					this.errorMessage = t('spreed', 'Error: Unknown error occurred')
 				}

--- a/src/components/AdminSettings/SignalingServer.vue
+++ b/src/components/AdminSettings/SignalingServer.vue
@@ -163,8 +163,8 @@ export default {
 				this.versionFound = response.data.ocs.data.version
 			} catch (exception) {
 				this.checked = true
-				let data = exception.response.data.ocs.data
-				let error = data.error
+				const data = exception.response.data.ocs.data
+				const error = data.error
 
 				if (error === 'CAN_NOT_CONNECT') {
 					this.errorMessage = t('spreed', 'Error: Cannot connect to server')

--- a/src/components/AdminSettings/SignalingServer.vue
+++ b/src/components/AdminSettings/SignalingServer.vue
@@ -163,17 +163,22 @@ export default {
 				this.versionFound = response.data.ocs.data.version
 			} catch (exception) {
 				this.checked = true
-				if (exception.response.data.ocs.data.error === 'CAN_NOT_CONNECT') {
+				let data = exception.response.data.ocs.data
+				let error = data.error
+
+				if (error === 'CAN_NOT_CONNECT') {
 					this.errorMessage = t('spreed', 'Error: Cannot connect to server')
-				} else if (exception.response.data.ocs.data.error === 'JSON_INVALID') {
+				} else if (error === 'JSON_INVALID') {
 					this.errorMessage = t('spreed', 'Error: Server did not respond with proper JSON')
-				} else if (exception.response.data.ocs.data.error === 'UPDATE_REQUIRED') {
-					this.versionFound = exception.response.data.ocs.data.version || t('spreed', 'Could not get version')
+				} else if (error === 'CERTIFICATE_EXPIRED') {
+					this.errorMessage = t('spreed', 'Error: Certificate expired')
+				} else if (error === 'UPDATE_REQUIRED') {
+					this.versionFound = data.version || t('spreed', 'Could not get version')
 					this.errorMessage = t('spreed', 'Error: Running version: {version}; Server needs to be updated to be compatible with this version of Talk', {
 						version: this.versionFound,
 					})
-				} else if (exception.response.data.ocs.data.error) {
-					this.errorMessage = t('spreed', 'Error: Server responded with: {error}', exception.response.data.ocs.data)
+				} else if (error) {
+					this.errorMessage = t('spreed', 'Error: Server responded with: {error}', data)
 				} else {
 					this.errorMessage = t('spreed', 'Error: Unknown error occurred')
 				}

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -106,6 +106,7 @@ import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import CategoryMonitoring from '../missingMaterialDesignIcons/CategoryMonitoring.vue'
+import { isCertificateValid } from '../../services/certificateService.js'
 
 export default {
 	name: 'TurnServer',
@@ -289,7 +290,14 @@ export default {
 
 		iceCallback(pc, candidates, timeout, e) {
 			if (e.candidate) {
-				candidates.push(this.parseCandidate(e.candidate.candidate))
+				let parseCandidate = this.parseCandidate(e.candidate.candidate)
+				candidates.push(parseCandidate)
+
+				// We received a relay candidate, no need to wait any longer
+				if (parseCandidate.type.includes('relay')) {
+					pc.close()
+					this.notifyTurnResult(candidates, timeout)
+				}
 			} else if (!('onicegatheringstatechange' in RTCPeerConnection.prototype)) {
 				pc.close()
 				this.notifyTurnResult(candidates, timeout)
@@ -301,10 +309,21 @@ export default {
 
 			const types = candidates.map((cand) => cand.type)
 
-			this.testing = false
 			if (types.includes('relay')) {
-				this.testingSuccess = true
+				if (!this.schemes.includes('turns')) {
+					// No 'turns' is used and we received relay candidates -> TURN is working
+					this.testing = false
+					this.testingSuccess = true
+				} else {
+					// We received relay candidates, but since 'turns' is used, we check the certificate additionally
+					isCertificateValid(this.server).then((isValid) => {
+						this.testing = false
+						this.testingSuccess = isValid
+						this.testingError = !isValid
+					});
+				}
 			} else {
+				this.testing = false
 				this.testingError = true
 			}
 

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -106,6 +106,7 @@ import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import CategoryMonitoring from '../missingMaterialDesignIcons/CategoryMonitoring.vue'
+
 import { isCertificateValid } from '../../services/certificateService.js'
 
 export default {
@@ -290,7 +291,7 @@ export default {
 
 		iceCallback(pc, candidates, timeout, e) {
 			if (e.candidate) {
-				let parseCandidate = this.parseCandidate(e.candidate.candidate)
+				const parseCandidate = this.parseCandidate(e.candidate.candidate)
 				candidates.push(parseCandidate)
 
 				// We received a relay candidate, no need to wait any longer
@@ -320,7 +321,7 @@ export default {
 						this.testing = false
 						this.testingSuccess = isValid
 						this.testingError = !isValid
-					});
+					})
 				}
 			} else {
 				this.testing = false

--- a/src/services/certificateService.js
+++ b/src/services/certificateService.js
@@ -26,11 +26,11 @@ import { generateOcsUrl } from '@nextcloud/router'
  * Retrieves the certificate expiration of the specified host
  *
  * @param {string} host The host to check the certificate
- * @return {int|null} Null if unable to retrieve the certificates expiration, otherwise the expiration in days (negative if already expired)
+ * @return {number|null} Null if unable to retrieve the certificates expiration, otherwise the expiration in days (negative if already expired)
  */
 const getCertificateExpiration = async (host) => {
 	try {
-		let response = await axios.get(generateOcsUrl('apps/spreed/api/v1/certificate/expiration'), {
+		const response = await axios.get(generateOcsUrl('apps/spreed/api/v1/certificate/expiration'), {
 			params: {
 				host,
 			},
@@ -39,7 +39,7 @@ const getCertificateExpiration = async (host) => {
 		return response.data.ocs.data.expiration_in_days
 	} catch (error) {
 		console.error(error)
-	}	
+	}
 
 	return null
 }
@@ -50,8 +50,8 @@ const getCertificateExpiration = async (host) => {
  * @param {string} host The host to check the certificate
  * @return {boolean} true if the certificate is valid, false otherwise
  */
-const isCertificateValid = async(host) => {
-	let expiration = await getCertificateExpiration(host)
+const isCertificateValid = async (host) => {
+	const expiration = await getCertificateExpiration(host)
 
 	if (expiration == null) {
 		console.warn('Unable to check certificate of', host)
@@ -60,7 +60,7 @@ const isCertificateValid = async(host) => {
 	} else {
 		console.info('Certificate of', host, 'is valid for', expiration, 'days')
 	}
-	
+
 	return expiration > 0
 }
 

--- a/src/services/certificateService.js
+++ b/src/services/certificateService.js
@@ -1,0 +1,70 @@
+/**
+ * @copyright Copyright (c) 2023 Marcel Müller <marcel.mueller@nextcloud.com>
+ *
+ * @author Marcel Müller <marcel.mueller@nextcloud.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+
+/**
+ * Retrieves the certificate expiration of the specified host
+ *
+ * @param {string} host The host to check the certificate
+ * @return {int|null} Null if unable to retrieve the certificates expiration, otherwise the expiration in days (negative if already expired)
+ */
+const getCertificateExpiration = async (host) => {
+	try {
+		let response = await axios.get(generateOcsUrl('apps/spreed/api/v1/certificate/expiration'), {
+			params: {
+				host,
+			},
+		})
+
+		return response.data.ocs.data.expiration_in_days
+	} catch (error) {
+		console.error(error)
+	}	
+
+	return null
+}
+
+/**
+ * Checks if the certificate of a host is valid
+ *
+ * @param {string} host The host to check the certificate
+ * @return {boolean} true if the certificate is valid, false otherwise
+ */
+const isCertificateValid = async(host) => {
+	let expiration = await getCertificateExpiration(host)
+
+	if (expiration == null) {
+		console.warn('Unable to check certificate of', host)
+	} else if (expiration < 0) {
+		console.error('Certificate of', host, 'expired')
+	} else {
+		console.info('Certificate of', host, 'is valid for', expiration, 'days')
+	}
+	
+	return expiration > 0
+}
+
+export {
+	getCertificateExpiration,
+	isCertificateValid,
+}

--- a/tests/php/Controller/SignalingControllerTest.php
+++ b/tests/php/Controller/SignalingControllerTest.php
@@ -34,6 +34,7 @@ use OCA\Talk\Model\AttendeeMapper;
 use OCA\Talk\Model\SessionMapper;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
+use OCA\Talk\Service\CertificateService;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\RoomService;
 use OCA\Talk\Service\SessionService;
@@ -82,6 +83,8 @@ class SignalingControllerTest extends TestCase {
 	private $signalingManager;
 	/** @var Manager|MockObject */
 	protected $manager;
+	/** @var CertificateService|MockObject */
+	protected $certificateService;
 	/** @var ParticipantService|MockObject */
 	protected $participantService;
 	/** @var SessionService|MockObject */
@@ -127,6 +130,7 @@ class SignalingControllerTest extends TestCase {
 		$this->dbConnection = \OC::$server->getDatabaseConnection();
 		$this->signalingManager = $this->createMock(\OCA\Talk\Signaling\Manager::class);
 		$this->manager = $this->createMock(Manager::class);
+		$this->certificateService = $this->createMock(CertificateService::class);
 		$this->participantService = $this->createMock(ParticipantService::class);
 		$this->sessionService = $this->createMock(SessionService::class);
 		$this->messages = $this->createMock(Messages::class);
@@ -146,6 +150,7 @@ class SignalingControllerTest extends TestCase {
 			$this->signalingManager,
 			$this->session,
 			$this->manager,
+			$this->certificateService,
 			$this->participantService,
 			$this->sessionService,
 			$this->dbConnection,

--- a/tests/php/Service/CertificateServiceTest.php
+++ b/tests/php/Service/CertificateServiceTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023 Marcel Müller <marcel.mueller@nextcloud.com>
+ *
+ * @author Marcel Müller <marcel.mueller@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Tests\php\Service;
+
+use OCA\Talk\Service\CertificateService;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class CertificateServiceTest extends TestCase {
+	protected CertificateService $service;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$this->service = new CertificateService($logger);
+	}
+
+	public function testGetParsedTlsHost() {
+		$actual = $this->service->getParsedTlsHost("domain.com");
+		$this->assertEquals($actual, "domain.com");
+
+		$actual = $this->service->getParsedTlsHost("subdomain.domain.com");
+		$this->assertEquals($actual, "subdomain.domain.com");
+
+		$actual = $this->service->getParsedTlsHost("https://domain.com");
+		$this->assertEquals($actual, "domain.com");
+
+		$actual = $this->service->getParsedTlsHost("https://domain.com:1234");
+		$this->assertEquals($actual, "domain.com:1234");
+
+		$actual = $this->service->getParsedTlsHost("https://domain.com:1234/path/1/");
+		$this->assertEquals($actual, "domain.com:1234");
+
+		$actual = $this->service->getParsedTlsHost("http://domain.com:1234/path/1/");
+		$this->assertNull($actual);
+	}
+}


### PR DESCRIPTION
Fixes #9606 

This PR adds a background job which checks the certificate of the TURN server (if `turns:` is used) and sends a notification to admins when the certificate is about to expire (less than 10 days).
Adding a test for this is a bit above my head - not sure how this can be done.


### 🚧 Tasks

- [ ] Add test?
- [ ] Allow to specify a different group to be notified? (Like it is done at [updatenotification](https://github.com/nextcloud/server/blob/fa23698c23a7ef9380f13c4fe439ff3aa6a9b9b0/apps/updatenotification/lib/Notification/BackgroundJob.php#L228-L237))

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
