### PR TITLE
removed duplicate link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ If you have suggestions or problems, please [open an issue](https://github.com/n
 
 * **[👤 User system requirements](https://nextcloud-talk.readthedocs.io/en/latest/user-requirements/)**
 * **[📖 User documentation](https://docs.nextcloud.com/server/latest/user_manual/en/talk/index.html)**
-* **[📖 User documentation](https://docs.nextcloud.com/server/latest/user_manual/en/talk/index.html)**
 * **[💻 Server system requirements](https://nextcloud-talk.readthedocs.io/en/latest/system-requirements/)**
 * **[⚙️ API documentation](https://nextcloud-talk.readthedocs.io/en/latest/#talk-api)**
 


### PR DESCRIPTION
The user documentation link was written twice: 
in file `README.md:32`

* **[📖 User documentation](https://docs.nextcloud.com/server/latest/user_manual/en/talk/index.html)**

### ☑️ Resolves

removed the duplicate user documentation link

### 🏁 Checklist

- ✅ ⛑️ Tests (unit and/or integration) are included or not required
- ✅ 📘 API documentation in `docs/` has been updated or is not required
- ✅ 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- ✅ 🔖 Capability is added or not needed 
