### PR TITLE
Correct Font weight for Subtitle

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -38,7 +38,8 @@
 				:disable-menu="true" />
 		</template>
 		<template #subtitle>
-			<strong v-if="item.unreadMessages">
+			<strong v-if="item.unreadMessages"
+				class="subtitle">
 				{{ conversationInformation }}
 			</strong>
 			<template v-else>
@@ -448,6 +449,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.subtitle {
+	font-weight: bold;
+}
 
 :deep(.action-text__title) {
 	margin-left: 12px;


### PR DESCRIPTION
### ☑️ Resolves

* Fix issue with bold weight for Firefox

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/84044328/5825b9dd-4f9d-4902-836c-5b25cabdd2a6)| ![image](https://github.com/nextcloud/spreed/assets/84044328/f71c53a9-6aca-4368-a734-3a1c002ee291)


### 🚧 Tasks

- [ ] Visual Check 
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
