### PR TITLE
Release/17.0.0 rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 17.0.0-rc.3 – 2023-06-02
+### Fixed
+
+- fix(MediaSettings): Fix guests being prompted with login window when blurring background
+  [#9620](https://github.com/nextcloud/spreed/issues/9620)
+- fix(TypingIndicator): Actors are only unique by type and id
+  [#9625](https://github.com/nextcloud/spreed/pull/9625)
+
 ## 17.0.0-rc.2 – 2023-05-25
 ### Fixed
 - fix(reactions): Fix own call reactions when the high-performance backend is used

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>17.0.0-rc.2</version>
+	<version>17.0.0-rc.3</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk",
-	"version": "17.0.0-rc.2",
+	"version": "17.0.0-rc.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk",
-			"version": "17.0.0-rc.2",
+			"version": "17.0.0-rc.3",
 			"license": "agpl",
 			"dependencies": {
 				"@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "talk",
-	"version": "17.0.0-rc.2",
+	"version": "17.0.0-rc.3",
 	"private": true,
 	"description": "",
 	"author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 17.0.0-rc.3 – 2023-06-02
### Fixed

- fix(MediaSettings): Fix guests being prompted with login window when blurring background [#9620](https://github.com/nextcloud/spreed/issues/9620)
- fix(TypingIndicator): Actors are only unique by type and id [#9625](https://github.com/nextcloud/spreed/pull/9625)