### PR TITLE
Filter conversation list for unread / mentioned conversations only

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.spec.js
+++ b/src/components/LeftSidebar/LeftSidebar.spec.js
@@ -626,8 +626,8 @@ describe('LeftSidebar.vue', () => {
 				const ncModalComponent = wrapper.findComponent(NcModal)
 				expect(ncModalComponent.exists()).toBeTruthy()
 
-				const input = ncModalComponent.find('input[placeholder="Enter a name for this conversation"]')
-				expect(input.element.value).toBe(groupsResults[1].label)
+				const input = ncModalComponent.findComponent({name: 'NcTextField', ref: 'conversationName'})
+				expect(input.props('value')).toBe(groupsResults[1].label)
 
 				// nothing created yet
 				expect(createOneToOneConversationAction).not.toHaveBeenCalled()
@@ -648,9 +648,9 @@ describe('LeftSidebar.vue', () => {
 				await wrapper.vm.$nextTick()
 				const ncModalComponent = wrapper.findComponent(NcModal)
 				expect(ncModalComponent.exists()).toBeTruthy()
-
-				const input = ncModalComponent.find('input[placeholder="Enter a name for this conversation"]')
-				expect(input.element.value).toBe(circlesResults[1].label)
+				console.log(wrapper.html())
+				const input = ncModalComponent.findComponent({name: 'NcTextField', ref: 'conversationName'})
+				expect(input.props('value')).toBe(circlesResults[1].label)
 
 				// nothing created yet
 				expect(createOneToOneConversationAction).not.toHaveBeenCalled()

--- a/src/components/LeftSidebar/LeftSidebar.spec.js
+++ b/src/components/LeftSidebar/LeftSidebar.spec.js
@@ -13,7 +13,7 @@ import router from '../../__mocks__/router.js'
 import { searchPossibleConversations, searchListedConversations } from '../../services/conversationsService.js'
 import { EventBus } from '../../services/EventBus.js'
 import storeConfig from '../../store/storeConfig.js'
-import { findNcListItems } from '../../test-helpers.js'
+import { findNcListItems, findNcActionButton } from '../../test-helpers.js'
 
 jest.mock('@nextcloud/initial-state', () => ({
 	loadState: jest.fn(),
@@ -48,6 +48,7 @@ describe('LeftSidebar.vue', () => {
 				NcAvatar: true,
 				// to prevent complex dialog logic
 				NewGroupConversation: true,
+				NcActions: true,
 			},
 		})
 	}
@@ -701,14 +702,14 @@ describe('LeftSidebar.vue', () => {
 			loadStateSettings.start_conversations = true
 
 			const wrapper = mountComponent()
-			const buttonEl = wrapper.findComponent({ name: 'NewGroupConversation' })
+			const buttonEl = findNcActionButton(wrapper, 'Create a new conversation')
 			expect(buttonEl.exists()).toBeTruthy()
 		})
 		test('does not show new conversation button if user cannot start conversations', () => {
 			loadStateSettings.start_conversations = false
 
 			const wrapper = mountComponent()
-			const buttonEl = wrapper.findComponent({ name: 'NewGroupConversation' })
+			const buttonEl = findNcActionButton(wrapper, 'Create a new conversation')
 			expect(buttonEl.exists()).toBeFalsy()
 		})
 	})

--- a/src/components/LeftSidebar/LeftSidebar.spec.js
+++ b/src/components/LeftSidebar/LeftSidebar.spec.js
@@ -7,15 +7,13 @@ import Vuex from 'vuex'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { loadState } from '@nextcloud/initial-state'
 
-import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
-
 import LeftSidebar from './LeftSidebar.vue'
 
 import router from '../../__mocks__/router.js'
 import { searchPossibleConversations, searchListedConversations } from '../../services/conversationsService.js'
 import { EventBus } from '../../services/EventBus.js'
 import storeConfig from '../../store/storeConfig.js'
-import { findNcListItems, findNcActionButton } from '../../test-helpers.js'
+import { findNcListItems } from '../../test-helpers.js'
 
 jest.mock('@nextcloud/initial-state', () => ({
 	loadState: jest.fn(),
@@ -623,7 +621,7 @@ describe('LeftSidebar.vue', () => {
 				await resultsListItems.at(1).findAll('a').trigger('click')
 				// Wait for the component to render
 				await wrapper.vm.$nextTick()
-				const ncModalComponent = wrapper.findComponent(NcModal)
+				const ncModalComponent = wrapper.findComponent({ name: 'NcModal' })
 				expect(ncModalComponent.exists()).toBeTruthy()
 
 				const input = ncModalComponent.findComponent({ name: 'NcTextField', ref: 'conversationName' })
@@ -646,7 +644,7 @@ describe('LeftSidebar.vue', () => {
 
 				// Wait for the component to render
 				await wrapper.vm.$nextTick()
-				const ncModalComponent = wrapper.findComponent(NcModal)
+				const ncModalComponent = wrapper.findComponent({ name: 'NcModal' })
 				expect(ncModalComponent.exists()).toBeTruthy()
 				const input = ncModalComponent.findComponent({ name: 'NcTextField', ref: 'conversationName' })
 				expect(input.props('value')).toBe(circlesResults[1].label)
@@ -711,7 +709,7 @@ describe('LeftSidebar.vue', () => {
 			loadStateSettings.start_conversations = true
 
 			const wrapper = mountComponent()
-			const buttonEl = findNcActionButton(wrapper, 'Create a new conversation')
+			const buttonEl = wrapper.findComponent({ name: 'NewGroupConversation' })
 			expect(buttonEl.exists()).toBeTruthy()
 
 		})
@@ -719,7 +717,7 @@ describe('LeftSidebar.vue', () => {
 			loadStateSettings.start_conversations = false
 
 			const wrapper = mountComponent()
-			const buttonEl = findNcActionButton(wrapper, 'Create a new conversation')
+			const buttonEl = wrapper.findComponent({ name: 'NewGroupConversation' })
 			expect(buttonEl.exists()).toBeFalsy()
 		})
 	})

--- a/src/components/LeftSidebar/LeftSidebar.spec.js
+++ b/src/components/LeftSidebar/LeftSidebar.spec.js
@@ -626,7 +626,7 @@ describe('LeftSidebar.vue', () => {
 				const ncModalComponent = wrapper.findComponent(NcModal)
 				expect(ncModalComponent.exists()).toBeTruthy()
 
-				const input = ncModalComponent.findComponent({name: 'NcTextField', ref: 'conversationName'})
+				const input = ncModalComponent.findComponent({ name: 'NcTextField', ref: 'conversationName' })
 				expect(input.props('value')).toBe(groupsResults[1].label)
 
 				// nothing created yet
@@ -648,8 +648,7 @@ describe('LeftSidebar.vue', () => {
 				await wrapper.vm.$nextTick()
 				const ncModalComponent = wrapper.findComponent(NcModal)
 				expect(ncModalComponent.exists()).toBeTruthy()
-				console.log(wrapper.html())
-				const input = ncModalComponent.findComponent({name: 'NcTextField', ref: 'conversationName'})
+				const input = ncModalComponent.findComponent({ name: 'NcTextField', ref: 'conversationName' })
 				expect(input.props('value')).toBe(circlesResults[1].label)
 
 				// nothing created yet

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -37,7 +37,8 @@
 				@abort-search="abortSearch" />
 
 			<!-- Options -->
-			<div class="options">
+			<div class="options"
+				:class="{'options--hidden': isFocused}">
 				<NcActions ref="filterMainBtn"
 					class="filters-button">
 					<template #icon>
@@ -69,7 +70,7 @@
 						<template #icon>
 							<FilterRemoveIcon :size="20" />
 						</template>
-						{{ t('spreed','Clear filter :') }} {{ filterText }}
+						{{ t('spreed', 'Clear filters: {filterText}', { filterText: filterText }) }}
 					</NcActionButton>
 				</NcActions>
 
@@ -87,7 +88,6 @@
 					</NcActionButton>
 				</NcActions>
 			</div>
-
 			<!-- New Conversation -->
 			<NewGroupConversation ref="newGroupConversation"
 				:show-modal="isNewGroupConversationOpen"
@@ -297,7 +297,8 @@ export default {
 				conversations = conversations.filter(conversation => conversation.unreadMessages > 0)
 				break
 			case ('is:mentioned'):
-				conversations = conversations.filter(conversation => conversation.unreadMention)
+				conversations = conversations.filter(conversation => conversation.unreadMention || (conversation.unreadMessages > 0
+				 && (conversation.type === CONVERSATION.TYPE.ONE_TO_ONE || conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER)))
 				break
 			default:
 				if (this.searchText !== '') {
@@ -764,7 +765,6 @@ export default {
 }
 
 .conversations-search {
-	flex-grow: 1;
 	transition: all 0.3s ease;
 	width: 65%;
 	z-index: 2;
@@ -774,7 +774,7 @@ export default {
 		border-radius: var(--border-radius-pill);
 	}
 	&--expanded {
-		width: 95%;
+		width: 90%;
 	}
 
 	&--filter{
@@ -791,6 +791,10 @@ export default {
 	left : calc(65% + 10px);
 	display: flex;
 	gap: 0.25px;
+
+	&--hidden{
+		visibility: hidden;
+	}
 }
 
 .filterButton--Clear{

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -476,7 +476,6 @@ export default {
 			} else {
 				// For other types, show the modal directly
 				this.$refs.newGroupConversation.showModalForItem(item)
-				this.toggleNewGroupConversation(true)
 			}
 		},
 

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -24,6 +24,18 @@
 		<div class="new-conversation"
 			:class="{ 'new-conversation--scrolled-down': !isScrolledToTop }">
 
+			<SearchBox v-model="searchText"
+				class="conversations-search"
+				:class="{ 'conversations-search--expanded': isFocused }"
+				:is-searching="isSearching"
+				@blur="isFocused(false)"
+				@focus="isFocused(true)"
+				@focusCancel ="isFocused = false"
+				@input="debounceFetchSearchResults"
+				@submit="onInputEnter"
+				@keydown.enter.native="handleEnter"
+				@abort-search="abortSearch" />
+
 			<!-- Options -->
 			<div class="options">
 				<NcActions class ='filters-button'>
@@ -67,23 +79,11 @@
 					</NcActionButton>
 				</NcActions>
 			</div>
-
-			<SearchBox v-model="searchText"
-				class="conversations-search"
-				:class="{ 'conversations-search--expanded': isFocused }"
-				:is-searching="isSearching"
-				@focus="isFocused = true"
-				@focusCancel ="isFocused = false"
-				@input="debounceFetchSearchResults"
-				@submit="onInputEnter"
-				@keydown.enter.native="handleEnter"
-				@abort-search="abortSearch" />
 			
 			<!-- New Conversation -->
 			<NewGroupConversation ref="newGroupConversation"
 				:show-modal="isNewGroupConversationOpen"
-				@open-modal="toggleNewGroupConversation(true)"
-				@close-modal="toggleNewGroupConversation(false)" />
+				@update-modal="toggleNewGroupConversation" />
 		</div>
 
 		<template #list>
@@ -392,6 +392,9 @@ export default {
 	methods: {
 		getFocusableList() {
 			return this.$el.querySelectorAll('li.acli_wrapper .acli')
+		},
+		isFocused(value){
+			this.isFocused = value
 		},
 		focusCancel() {
 			return this.abortSearch()
@@ -742,22 +745,24 @@ export default {
 
 .conversations-search {
 	flex-grow: 1;
-	transition: all 0.7s ease;
+	transition: all 0.3s ease;
 	width: 65%;
+	z-index: 1;
 	position : absolute;
-	left: 8px; //padding
+	padding: 0 8px ;
 
 	:deep(.input-field__input) {
 		border-radius: var(--border-radius-pill);
 	}
 	&--expanded {
-		width: 95%;
+		width: 100%;
 	}
 }
 
 
 .options{
 	position: relative;
+	z-index: 2;
 	left : calc(65% + 7px);
 	display: flex;
 	gap: 0.5px;

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -23,42 +23,62 @@
 	<NcAppNavigation :aria-label="t('spreed', 'Conversation list')">
 		<div class="new-conversation"
 			:class="{ 'new-conversation--scrolled-down': !isScrolledToTop }">
+
+			<!-- Options -->
+			<div class="options">
+				<NcActions class ='filters-button'>
+					<template #icon>
+						<FilterIcon :size="15" />
+					</template>
+					<NcActionButton close-after-click
+						@click="insertValue(t('spreed','is:mentioned'))">
+						<template #icon>
+							<AtIcon :size="20" />
+						</template>
+						{{ t('spreed','Filter unread mentions') }}
+					</NcActionButton>
+
+					<NcActionButton close-after-click
+						@click="insertValue(t('spreed','is:unread'))">
+						<template #icon>
+							<MessageBadge :size="20" />
+						</template>
+						{{ t('spreed','Filter unread messages') }}
+					</NcActionButton>
+				</NcActions>
+
+				<NcActions >
+					<template #icon>
+						<PlusIcon :size="20" />
+					</template>
+					<NcActionButton v-if="canStartConversations"
+						close-after-click
+						@click="toggleNewGroupConversation(true)">
+						<template #icon>
+							<PlusIcon :size="20" />
+						</template>
+						{{ t('spreed','Create a new conversation') }}
+					</NcActionButton>
+					<NcActionButton close-after-click>
+						<template #icon>
+							<ListIcon :size="20" />
+						</template>
+						{{ t('spreed','List of open conversations') }}
+					</NcActionButton>
+				</NcActions>
+			</div>
+
 			<SearchBox v-model="searchText"
 				class="conversations-search"
+				:class="{ 'conversations-search--expanded': isFocused }"
 				:is-searching="isSearching"
+				@focus="isFocused = true"
+				@focusCancel ="isFocused = false"
 				@input="debounceFetchSearchResults"
 				@submit="onInputEnter"
 				@keydown.enter.native="handleEnter"
 				@abort-search="abortSearch" />
-
-			<!-- Options -->
-			<NcActions>
-				<NcActionButton v-if="canStartConversations"
-					close-after-click
-					@click="toggleNewGroupConversation(true)">
-					<template #icon>
-						<PlusIcon :size="20" />
-					</template>
-					{{ t('spreed','Create a new conversation') }}
-				</NcActionButton>
-
-				<NcActionButton close-after-click
-					@click="insertValue(t('spreed','is:mentioned'))">
-					<template #icon>
-						<AtIcon :size="20" />
-					</template>
-					{{ t('spreed','Filter unread mentions') }}
-				</NcActionButton>
-
-				<NcActionButton close-after-click
-					@click="insertValue(t('spreed','is:unread'))">
-					<template #icon>
-						<MessageBadge :size="20" />
-					</template>
-					{{ t('spreed','Filter unread messages') }}
-				</NcActionButton>
-			</NcActions>
-
+			
 			<!-- New Conversation -->
 			<NewGroupConversation ref="newGroupConversation"
 				:show-modal="isNewGroupConversationOpen"
@@ -169,6 +189,9 @@ import debounce from 'debounce'
 import AtIcon from 'vue-material-design-icons/At.vue'
 import MessageBadge from 'vue-material-design-icons/MessageBadge.vue'
 import PlusIcon from 'vue-material-design-icons/Plus.vue'
+import FilterIcon from 'vue-material-design-icons/Filter.vue'
+import ListIcon from 'vue-material-design-icons/FormatListBulleted.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
 
 import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
@@ -218,6 +241,8 @@ export default {
 		PlusIcon,
 		AtIcon,
 		MessageBadge,
+		FilterIcon,
+		ListIcon,
 	},
 
 	mixins: [
@@ -249,6 +274,7 @@ export default {
 			roomListModifiedBefore: 0,
 			forceFullRoomListRefreshAfterXLoops: 0,
 			isNewGroupConversationOpen: false,
+			isFocused: false
 		}
 	},
 
@@ -370,9 +396,7 @@ export default {
 		focusCancel() {
 			return this.abortSearch()
 		},
-		isFocused() {
-			return this.isSearching
-		},
+
 		scrollBottomUnread() {
 			this.preventFindingUnread = true
 			this.$refs.container.scrollTo({
@@ -718,10 +742,25 @@ export default {
 
 .conversations-search {
 	flex-grow: 1;
+	transition: all 0.7s ease;
+	width: 65%;
+	position : absolute;
+	left: 8px; //padding
 
 	:deep(.input-field__input) {
 		border-radius: var(--border-radius-pill);
 	}
+	&--expanded {
+		width: 95%;
+	}
+}
+
+
+.options{
+	position: relative;
+	left : calc(65% + 7px);
+	display: flex;
+	gap: 0.5px;
 }
 
 .settings-button {

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -26,7 +26,8 @@
 			<SearchBox ref="searchbox"
 				v-model="searchText"
 				class="conversations-search"
-				:class="{ 'conversations-search--expanded': isFocused }"
+				:class="{'conversations-search--expanded': isFocused,
+					'conversations-search--filter' : isFiltered }"
 				:is-searching="isSearching"
 				@blur="setIsFocused(false)"
 				@focus="setIsFocused(true)"
@@ -41,7 +42,7 @@
 					class="filters-button">
 					<template #icon>
 						<FilterIcon v-if="!isFiltered" :size="15" />
-						<UnFilterIcon v-else-if="isFiltered" :size="15" />
+						<FilterCheckIcon v-else-if="isFiltered" :size="15" />
 					</template>
 					<NcActionButton close-after-click
 						class="filterButton--Option"
@@ -59,6 +60,16 @@
 							<MessageBadge :size="20" />
 						</template>
 						{{ t('spreed','Filter unread messages') }}
+					</NcActionButton>
+
+					<NcActionButton v-if="isFiltered"
+						close-after-click
+						class="filterButton--Clear"
+						@click="clearFilter">
+						<template #icon>
+							<FilterRemoveIcon :size="20" />
+						</template>
+						{{ t('spreed','Clear filter :') }} {{ filterText }}
 					</NcActionButton>
 				</NcActions>
 
@@ -97,7 +108,7 @@
 					<template v-if="!initialisedConversations">
 						<LoadingPlaceholder type="conversations" />
 					</template>
-					<Hint v-else-if="searchText && !conversationsList.length"
+					<Hint v-else-if="(searchText && !conversationsList.length) || (!conversationsList.length && isFiltered)"
 						:hint="t('spreed', 'No matches')" />
 					<template v-if="isSearching">
 						<template v-if="!listedConversationsLoading && searchResultsListedConversations.length > 0">
@@ -185,7 +196,8 @@ import debounce from 'debounce'
 
 import AtIcon from 'vue-material-design-icons/At.vue'
 import FilterIcon from 'vue-material-design-icons/Filter.vue'
-import UnFilterIcon from 'vue-material-design-icons/FilterRemove.vue'
+import FilterCheckIcon from 'vue-material-design-icons/FilterCheck.vue'
+import FilterRemoveIcon from 'vue-material-design-icons/FilterRemove.vue'
 import MessageBadge from 'vue-material-design-icons/MessageBadge.vue'
 import PlusIcon from 'vue-material-design-icons/Plus.vue'
 
@@ -238,7 +250,8 @@ export default {
 		AtIcon,
 		MessageBadge,
 		FilterIcon,
-		UnFilterIcon,
+		FilterCheckIcon,
+		FilterRemoveIcon,
 	},
 
 	mixins: [
@@ -397,13 +410,14 @@ export default {
 		handleFilter(filter) {
 			this.isFiltered = true
 			this.filterText = filter
-			const divElement = document.querySelector('.filters-button')
 
-			divElement.addEventListener('click', function(event) {
-				this.filterText = ''
-				this.isFiltered = false
-			}.bind(this))
+		},
 
+		clearFilter() {
+			// clear the status filter
+			this.isFiltered = false
+			// clear the filter
+			this.filterText = ''
 		},
 
 		focusCancel() {
@@ -762,6 +776,13 @@ export default {
 	&--expanded {
 		width: 95%;
 	}
+
+	&--filter{
+		pointer-events: none;
+		:deep(.input-field__input) {
+		background-color: var(--color-background-dark);
+	}
+	}
 }
 
 .options{
@@ -770,6 +791,11 @@ export default {
 	left : calc(65% + 10px);
 	display: flex;
 	gap: 0.25px;
+}
+
+.filterButton--Clear{
+	font-style: italic;
+	background-color: var(--color-background-dark);
 }
 
 .settings-button {

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -33,20 +33,6 @@
 
 			<!-- Options -->
 			<NcActions>
-				<NcActionButton close-after-click
-					@click="insertValue(t('spreed','is:unread'))">
-					<template #icon>
-						<MessageBadge :size="20" />
-					</template>
-					{{ t('spreed','Filter unread messages') }}
-				</NcActionButton>
-				<NcActionButton close-after-click
-					@click="insertValue(t('spreed','is:mentioned'))">
-					<template #icon>
-						<AtIcon :size="20" />
-					</template>
-					{{ t('spreed','Filter unread mentions') }}
-				</NcActionButton>
 				<NcActionButton v-if="canStartConversations"
 					close-after-click
 					@click="toggleNewGroupConversation(true)">
@@ -55,10 +41,27 @@
 					</template>
 					{{ t('spreed','Create a new conversation') }}
 				</NcActionButton>
+
+				<NcActionButton close-after-click
+					@click="insertValue(t('spreed','is:mentioned'))">
+					<template #icon>
+						<AtIcon :size="20" />
+					</template>
+					{{ t('spreed','Filter unread mentions') }}
+				</NcActionButton>
+
+				<NcActionButton close-after-click
+					@click="insertValue(t('spreed','is:unread'))">
+					<template #icon>
+						<MessageBadge :size="20" />
+					</template>
+					{{ t('spreed','Filter unread messages') }}
+				</NcActionButton>
 			</NcActions>
 
 			<!-- New Conversation -->
-			<NewGroupConversation :show-modal="isNewGroupConversationOpen"
+			<NewGroupConversation ref="newGroupConversation"
+				:show-modal="isNewGroupConversationOpen"
 				@open-modal="toggleNewGroupConversation(true)"
 				@close-modal="toggleNewGroupConversation(false)" />
 		</div>
@@ -471,8 +474,9 @@ export default {
 					params: { token: conversation.token },
 				}).catch(err => console.debug(`Error while pushing the new conversation's route: ${err}`))
 			} else {
-				// For other types we start the conversation creation dialog
-				EventBus.$emit('new-group-conversation-dialog', item)
+				// For other types, show the modal directly
+				this.$refs.newGroupConversation.showModalForItem(item)
+				this.toggleNewGroupConversation(true)
 			}
 		},
 

--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -171,7 +171,6 @@ import {
 	createPrivateConversation,
 	setConversationPassword,
 } from '../../../services/conversationsService.js'
-import { EventBus } from '../../../services/EventBus.js'
 import { addParticipant } from '../../../services/participantsService.js'
 
 const NEW_CONVERSATION = {
@@ -267,14 +266,7 @@ export default {
 			}
 		},
 	},
-
-	mounted() {
-		EventBus.$on('new-group-conversation-dialog', this.showModalForItem)
-	},
-
-	destroyed() {
-		EventBus.$off('new-group-conversation-dialog', this.showModalForItem)
-	},
+	expose: ['showModalForItem'],
 
 	methods: {
 		showModal() {

--- a/src/components/LeftSidebar/SearchBox/SearchBox.vue
+++ b/src/components/LeftSidebar/SearchBox/SearchBox.vue
@@ -26,8 +26,7 @@
 			:label="placeholderText"
 			:show-trailing-button="isSearching"
 			trailing-button-icon="close"
-			@blur="isFocused(false)"
-			@focus="isFocused(true)"
+			v-on="$listeners"
 			@trailing-button-click="abortSearch"
 			@keypress.enter="handleSubmit">
 			<Magnify :size="16" />
@@ -105,19 +104,6 @@ export default {
 		EventBus.$off('route-change', this.focusInputIfRoot)
 	},
 	methods: {
-		isFocused(value){
-			if (value){
-				if (this.localValue != t('spreed','is:mentioned') & this.localValue != t('spreed','is:unread')){
-				this.$emit('focus')
-				}
-			}
-			else {
-				this.$emit('focusCancel')
-			}
-
-			
-		},
-
 		// Focus the input field of the searchbox component.
 		focusInput() {
 			this.$refs.searchConversations.$el.focus()

--- a/src/components/LeftSidebar/SearchBox/SearchBox.vue
+++ b/src/components/LeftSidebar/SearchBox/SearchBox.vue
@@ -53,7 +53,7 @@ export default {
 		 */
 		placeholderText: {
 			type: String,
-			default: t('spreed', 'Search...'),
+			default: t('spreed', 'Search…'),
 		},
 		/**
 		 * The value of the input field, when receiving it as a prop the localValue
@@ -72,7 +72,7 @@ export default {
 		},
 	},
 
-	emits: ['update:value', 'input', 'submit', 'abort-search', 'focus', 'focusCancel'],
+	emits: ['update:value', 'input', 'submit', 'abort-search'],
 
 	data() {
 		return {

--- a/src/components/LeftSidebar/SearchBox/SearchBox.vue
+++ b/src/components/LeftSidebar/SearchBox/SearchBox.vue
@@ -26,6 +26,8 @@
 			:label="placeholderText"
 			:show-trailing-button="isSearching"
 			trailing-button-icon="close"
+			@blur="isFocused(false)"
+			@focus="isFocused(true)"
 			@trailing-button-click="abortSearch"
 			@keypress.enter="handleSubmit">
 			<Magnify :size="16" />
@@ -52,7 +54,7 @@ export default {
 		 */
 		placeholderText: {
 			type: String,
-			default: t('spreed', 'Search conversations or users'),
+			default: t('spreed', 'Search...'),
 		},
 		/**
 		 * The value of the input field, when receiving it as a prop the localValue
@@ -71,7 +73,7 @@ export default {
 		},
 	},
 
-	emits: ['update:value', 'input', 'submit', 'abort-search'],
+	emits: ['update:value', 'input', 'submit', 'abort-search', 'focus', 'focusCancel'],
 
 	data() {
 		return {
@@ -103,6 +105,19 @@ export default {
 		EventBus.$off('route-change', this.focusInputIfRoot)
 	},
 	methods: {
+		isFocused(value){
+			if (value){
+				if (this.localValue != t('spreed','is:mentioned') & this.localValue != t('spreed','is:unread')){
+				this.$emit('focus')
+				}
+			}
+			else {
+				this.$emit('focusCancel')
+			}
+
+			
+		},
+
 		// Focus the input field of the searchbox component.
 		focusInput() {
 			this.$refs.searchConversations.$el.focus()

--- a/src/components/LeftSidebar/SearchBox/SearchBox.vue
+++ b/src/components/LeftSidebar/SearchBox/SearchBox.vue
@@ -25,7 +25,6 @@
 			:value="value"
 			:label="placeholderText"
 			:show-trailing-button="isSearching"
-			:disabled="disabled"
 			trailing-button-icon="close"
 			v-on="$listeners"
 			@update:value="updateValue"
@@ -68,10 +67,6 @@ export default {
 		 * If true, this component displays an 'x' button to abort the search
 		 */
 		isSearching: {
-			type: Boolean,
-			default: false,
-		},
-		disabled: {
 			type: Boolean,
 			default: false,
 		},

--- a/src/components/LeftSidebar/SearchBox/SearchBox.vue
+++ b/src/components/LeftSidebar/SearchBox/SearchBox.vue
@@ -22,12 +22,13 @@
 <template>
 	<form @submit.prevent="handleSubmit">
 		<NcTextField ref="searchConversations"
-			:value.sync="localValue"
+			:value="value"
 			:label="placeholderText"
 			:show-trailing-button="isSearching"
 			:disabled="disabled"
 			trailing-button-icon="close"
 			v-on="$listeners"
+			@update:value="updateValue"
 			@trailing-button-click="abortSearch"
 			@keypress.enter="handleSubmit">
 			<Magnify :size="16" />
@@ -57,8 +58,7 @@ export default {
 			default: t('spreed', 'Search …'),
 		},
 		/**
-		 * The value of the input field, when receiving it as a prop the localValue
-		 * is updated.
+		 * The value of the input field.
 		 */
 		value: {
 			type: String,
@@ -79,25 +79,12 @@ export default {
 
 	emits: ['update:value', 'input', 'submit', 'abort-search'],
 
-	data() {
-		return {
-			localValue: '',
-		}
-	},
 	computed: {
 		cancelSearchLabel() {
 			return t('spreed', 'Cancel search')
 		},
 	},
-	watch: {
-		localValue(localValue) {
-			this.$emit('update:value', localValue)
-			this.$emit('input', localValue)
-		},
-		value(value) {
-			this.localValue = value
-		},
-	},
+
 	mounted() {
 		this.focusInputIfRoot()
 		/**
@@ -109,6 +96,10 @@ export default {
 		EventBus.$off('route-change', this.focusInputIfRoot)
 	},
 	methods: {
+		updateValue(value) {
+			this.$emit('update:value', value)
+			this.$emit('input', value)
+		},
 		// Focus the input field of the searchbox component.
 		focusInput() {
 			this.$refs.searchConversations.$el.focus()

--- a/src/components/LeftSidebar/SearchBox/SearchBox.vue
+++ b/src/components/LeftSidebar/SearchBox/SearchBox.vue
@@ -25,6 +25,7 @@
 			:value.sync="localValue"
 			:label="placeholderText"
 			:show-trailing-button="isSearching"
+			:disabled="disabled"
 			trailing-button-icon="close"
 			v-on="$listeners"
 			@trailing-button-click="abortSearch"
@@ -53,7 +54,7 @@ export default {
 		 */
 		placeholderText: {
 			type: String,
-			default: t('spreed', 'Search…'),
+			default: t('spreed', 'Search …'),
 		},
 		/**
 		 * The value of the input field, when receiving it as a prop the localValue
@@ -67,6 +68,10 @@ export default {
 		 * If true, this component displays an 'x' button to abort the search
 		 */
 		isSearching: {
+			type: Boolean,
+			default: false,
+		},
+		disabled: {
 			type: Boolean,
 			default: false,
 		},

--- a/src/mixins/arrowNavigation.js
+++ b/src/mixins/arrowNavigation.js
@@ -43,7 +43,7 @@ const arrowNavigation = {
 		mountArrowNavigation() {
 			document.addEventListener('keydown', (event) => {
 				// https://www.w3.org/WAI/GL/wiki/Using_ARIA_menus
-				if (this.isFocused()) {
+				if (this.isSearching) {
 					// If arrow down, focus next result
 					if (event.key === 'ArrowDown') {
 						this.focusNext(event)


### PR DESCRIPTION
### ☑️ Resolves

* Fixes #9677 
* The search box gets expanded when it is focused on to cover the filter button. 
* During the textual search operation, no filter can be applied

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/84044328/b6e3b629-88cc-41a7-8899-46c3bd1072a0) | ![image](https://github.com/nextcloud/spreed/assets/84044328/c87bfb18-fe57-42db-b02c-024ca08eec15)



  Default View 
  ![image](https://github.com/nextcloud/spreed/assets/84044328/ee7a976f-dcfb-4e26-bebd-1a5696928f1d)

Focused on input or during the textual search 
![image](https://github.com/nextcloud/spreed/assets/84044328/ebb5e6e3-f992-4b85-b345-ec5fa9536442)





### 🚧 Tasks

- [ ] Visual review
- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
