### PR TITLE
Adjust typing indicator behaviour

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -398,7 +398,7 @@ export default {
 					this.typingTimeout = setTimeout(() => {
 						this.resetTypingIndicator()
 					}, 5000)
-					this.$store.dispatch('setTyping', { typing: true })
+					this.$store.dispatch('sendTypingSignal', { typing: true })
 				}
 
 			}
@@ -436,7 +436,7 @@ export default {
 			if (this.typingTimeout) {
 				clearTimeout(this.typingTimeout)
 			}
-			this.$store.dispatch('setTyping', { typing: false })
+			this.$store.dispatch('sendTypingSignal', { typing: false })
 		},
 
 		handleUploadStart() {

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -380,6 +380,11 @@ export default {
 		},
 
 		text(newValue) {
+			// Do nothing if join a conversation with pre-filled input
+			if (this.text === this.$store.getters.currentMessageInput(this.token) || this.text === '') {
+				return
+			}
+
 			this.$store.dispatch('setCurrentMessageInput', { token: this.token, text: newValue })
 
 			// Enable signal sending, only if indicator for this input is on
@@ -401,7 +406,7 @@ export default {
 
 		token(token) {
 			if (token) {
-				this.text = this.$store.getters.currentMessageInput(token) || ''
+				this.text = this.$store.getters.currentMessageInput(token)
 			} else {
 				this.text = ''
 			}
@@ -413,7 +418,7 @@ export default {
 		EventBus.$on('focus-chat-input', this.focusInput)
 		EventBus.$on('upload-start', this.handleUploadStart)
 		EventBus.$on('retry-message', this.handleRetryMessage)
-		this.text = this.$store.getters.currentMessageInput(this.token) || ''
+		this.text = this.$store.getters.currentMessageInput(this.token)
 
 		if (!this.$store.getters.areFileTemplatesInitialised) {
 			this.$store.dispatch('getFileTemplates')

--- a/src/components/NewMessage/NewMessageTypingIndicator.vue
+++ b/src/components/NewMessage/NewMessageTypingIndicator.vue
@@ -143,7 +143,7 @@ export default {
 <style lang="scss" scoped>
 .indicator {
 	position: absolute;
-	top: 4px;
+	bottom: calc(100% - 2em);
 	left: 0;
 	width: 100%;
 	padding-right: 12px;

--- a/src/components/NewMessage/NewMessageTypingIndicator.vue
+++ b/src/components/NewMessage/NewMessageTypingIndicator.vue
@@ -69,10 +69,7 @@ export default {
 		},
 
 		typingParticipants() {
-			return this.$store.getters.participantsListTyping(this.token).filter(participant => {
-				return participant.actorType !== this.$store.getters.getActorType()
-					|| participant.actorId !== this.$store.getters.getActorId()
-			})
+			return this.$store.getters.participantsListTyping(this.token)
 		},
 
 		visibleParticipants() {

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -99,6 +99,23 @@ const getters = {
 	},
 
 	/**
+	 * Gets the array of external session ids.
+	 *
+	 * @param {object} state - the state object.
+	 * @param {object} getters - the getters object.
+	 * @param {object} rootState - the rootState object.
+	 * @param {object} rootGetters - the rootGetters object.
+	 * @return {Array} the typing session IDs array.
+	 */
+	actorIsTyping: (state, getters, rootState, rootGetters) => () => {
+		if (!state.typing[rootGetters.getToken()]) {
+			return false
+		}
+
+		return Object.keys(state.typing[rootGetters.getToken()]).some(sessionId => rootGetters.getSessionId() === sessionId)
+	},
+
+	/**
 	 * Gets the participants array filtered to include only those that are
 	 * currently typing.
 	 *

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -105,9 +105,9 @@ const getters = {
 	 * @param {object} getters - the getters object.
 	 * @param {object} rootState - the rootState object.
 	 * @param {object} rootGetters - the rootGetters object.
-	 * @return {Array} the typing session IDs array.
+	 * @return {boolean} the typing status of actor.
 	 */
-	actorIsTyping: (state, getters, rootState, rootGetters) => () => {
+	actorIsTyping: (state, getters, rootState, rootGetters) => {
 		if (!state.typing[rootGetters.getToken()]) {
 			return false
 		}
@@ -121,17 +121,20 @@ const getters = {
 	 *
 	 * @param {object} state - the state object.
 	 * @param {object} getters - the getters object.
-	 * @return {Array} the participants array (if there are participants in the
-	 * store).
+	 * @param {object} rootState - the rootState object.
+	 * @param {object} rootGetters - the rootGetters object.
+	 * @return {Array} the participants array (for registered users only).
 	 */
-	participantsListTyping: (state, getters) => (token) => {
+	participantsListTyping: (state, getters, rootState, rootGetters) => (token) => {
 		if (!getters.externalTypingSignals(token).length) {
 			return []
 		}
 
-		// Check if participant's sessionId matches with any of sessionIds from signaling
 		return getters.participantsList(token).filter(attendee => {
+			// Check if participant's sessionId matches with any of sessionIds from signaling...
 			return getters.externalTypingSignals(token).some((sessionId) => attendee.sessionIds.includes(sessionId))
+				// ... and it's not the participant with same actorType and actorId as yourself
+				&& (attendee.actorType !== rootGetters.getActorType() || attendee.actorId !== rootGetters.getActorId())
 		})
 	},
 

--- a/src/store/quoteReplyStore.js
+++ b/src/store/quoteReplyStore.js
@@ -39,9 +39,7 @@ const getters = {
 	},
 
 	currentMessageInput: (state) => (token) => {
-		if (state.currentMessageInput[token]) {
-			return state.currentMessageInput[token]
-		}
+		return state.currentMessageInput[token] ?? ''
 	},
 }
 

--- a/src/utils/SignalingTypingHandler.js
+++ b/src/utils/SignalingTypingHandler.js
@@ -37,8 +37,6 @@ export default function SignalingTypingHandler(store) {
 	this._signaling = null
 	this._signalingParticipantList = new SignalingParticipantList()
 
-	this._typing = false
-
 	this._handleMessageBound = this._handleMessage.bind(this)
 	this._handleParticipantsJoinedBound = this._handleParticipantsJoined.bind(this)
 	this._handleParticipantsLeftBound = this._handleParticipantsLeft.bind(this)
@@ -92,8 +90,6 @@ SignalingTypingHandler.prototype = {
 			return
 		}
 
-		this._typing = typing
-
 		const currentNextcloudSessionId = this._store.getters.getSessionId()
 
 		for (const participant of this._signalingParticipantList.getParticipants()) {
@@ -132,7 +128,7 @@ SignalingTypingHandler.prototype = {
 	},
 
 	_handleParticipantsJoined(SignalingParticipantList, participants) {
-		if (!this._typing) {
+		if (!this._store.getters.actorIsTyping()) {
 			return
 		}
 

--- a/src/utils/SignalingTypingHandler.js
+++ b/src/utils/SignalingTypingHandler.js
@@ -128,7 +128,7 @@ SignalingTypingHandler.prototype = {
 	},
 
 	_handleParticipantsJoined(SignalingParticipantList, participants) {
-		if (!this._store.getters.actorIsTyping()) {
+		if (!this._store.getters.actorIsTyping) {
 			return
 		}
 

--- a/src/utils/SignalingTypingHandler.js
+++ b/src/utils/SignalingTypingHandler.js
@@ -107,7 +107,7 @@ SignalingTypingHandler.prototype = {
 			})
 		}
 
-		this._store.commit('setTyping', {
+		this._store.dispatch('setTyping', {
 			token: this._store.getters.getToken(),
 			sessionId: this._store.getters.getSessionId(),
 			typing,
@@ -124,7 +124,7 @@ SignalingTypingHandler.prototype = {
 			return
 		}
 
-		this._store.commit('setTyping', {
+		this._store.dispatch('setTyping', {
 			token: this._store.getters.getToken(),
 			sessionId: participant.nextcloudSessionId,
 			typing: data.type === 'startedTyping',
@@ -146,7 +146,7 @@ SignalingTypingHandler.prototype = {
 
 	_handleParticipantsLeft(SignalingParticipantList, participants) {
 		for (const participant of participants) {
-			this._store.commit('setTyping', {
+			this._store.dispatch('setTyping', {
 				token: this._store.getters.getToken(),
 				sessionId: participant.nextcloudSessionId,
 				typing: false,

--- a/src/utils/SignalingTypingHandler.spec.js
+++ b/src/utils/SignalingTypingHandler.spec.js
@@ -79,10 +79,6 @@ describe('SignalingTypingHandler', () => {
 		signalingSessionId: 'guest2SignalingSessionId',
 	}
 
-	const expectedLocalParticipant = {
-		sessionIds: ['localNextcloudSessionId'],
-		attendeeId: 'localAttendeeId',
-	}
 	const expectedUser1Participant = {
 		sessionIds: ['user1NextcloudSessionId'],
 		attendeeId: 'user1AttendeeId',
@@ -157,9 +153,7 @@ describe('SignalingTypingHandler', () => {
 
 			signalingTypingHandler.setTyping(true)
 
-			expect(store.getters.participantsListTyping('theToken')).toEqual([
-				expectedLocalParticipant,
-			])
+			expect(store.getters.participantsListTyping('theToken')).toEqual([])
 			expect(signaling.emit).toHaveBeenCalledTimes(0)
 		})
 
@@ -179,9 +173,7 @@ describe('SignalingTypingHandler', () => {
 
 			signalingTypingHandler.setTyping(true)
 
-			expect(store.getters.participantsListTyping('theToken')).toEqual([
-				expectedLocalParticipant,
-			])
+			expect(store.getters.participantsListTyping('theToken')).toEqual([])
 			expect(signaling.emit).toHaveBeenCalledTimes(1)
 			expect(signaling.emit).toHaveBeenCalledWith('message', { type: 'startedTyping', to: 'user1SignalingSessionId' })
 		})
@@ -204,9 +196,7 @@ describe('SignalingTypingHandler', () => {
 
 			signalingTypingHandler.setTyping(true)
 
-			expect(store.getters.participantsListTyping('theToken')).toEqual([
-				expectedLocalParticipant,
-			])
+			expect(store.getters.participantsListTyping('theToken')).toEqual([])
 			expect(signaling.emit).toHaveBeenCalledTimes(2)
 			expect(signaling.emit).toHaveBeenNthCalledWith(1, 'message', { type: 'startedTyping', to: 'user1SignalingSessionId' })
 			expect(signaling.emit).toHaveBeenNthCalledWith(2, 'message', { type: 'startedTyping', to: 'guest1SignalingSessionId' })
@@ -509,9 +499,7 @@ describe('SignalingTypingHandler', () => {
 			user1ParticipantInSignalingParticipantList,
 		]])
 
-		expect(store.getters.participantsListTyping('theToken')).toEqual([
-			expectedLocalParticipant,
-		])
+		expect(store.getters.participantsListTyping('theToken')).toEqual([])
 		expect(signaling.emit).toHaveBeenCalledTimes(2)
 		expect(signaling.emit).toHaveBeenNthCalledWith(1, 'message', { type: 'startedTyping', to: 'guest1SignalingSessionId' })
 		expect(signaling.emit).toHaveBeenNthCalledWith(2, 'message', { type: 'startedTyping', to: 'user1SignalingSessionId' })


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9589 
* Fix #9604
* Fix #9615
* Fix #9624

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/cb816ce0-d300-4425-96dc-33e2a3bc1a96) | ![image](https://github.com/nextcloud/spreed/assets/93392545/abe2da2c-51de-41f9-9723-0533fe0c15e9)

---

After the first key stroke, we send first `true` signal start to watching after input value, if it was changed within intervals:
* 0-10s: if something else was typed, after 10s from the start we send another `true` signal;
* 10-20s: if still typing, after 20s from the start we send another`true` signal;
* ... and repeat for each 10s interval.

In that case, first possible `true` signal will be received in 0s + delay after actor started typing;
consequent signals will come every 10s + delay.

---

`false` signal will be received:
* after actor sent message: in 0s + delay;
`false` signal will be set locally by client:
* after actor left chat: in 0s;
* after actor stopped typing (input value wasn't changed in 10s interval): in 15-24s;

As typing person
  - [x] Send "Typing" every 10 sec when there was a change - done with interval
  - [x] Stop on leave room - already done on receiving end
  - [x] Stop on send message - the only stop-signal to be sent

As receiver
  - [x] Hide user from indicator after not receive "Typing" in the last 15 sec - done with store
  - [x] Group sessions by actor type + actor id - should work as-is
  - [x] Ignore self - done with store, adjusted in tests

---

### 🚧 Tasks

- [ ] Code review
- [ ] Behaviour check

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
