### PR TITLE
Fix error when creating a conversation from search results

### DIFF
--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -285,7 +285,7 @@ export default {
 		showModalForItem(item) {
 			if (item) {
 				// Preload the conversation name from group selection
-				this.conversation.displayName = item.label
+				this.newConversation.displayName = item.label
 				this.$store.dispatch('updateSelectedParticipants', item)
 			}
 


### PR DESCRIPTION
### ☑️ Resolves

* Regression from #9465 

To test:
* have a user group (`admin` is default one)
* type group name in search field
* click on a search result -> create conversation modal should be opened

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/67acb14e-4775-4c7f-bde8-efc3e535c1d9) | ![image](https://github.com/nextcloud/spreed/assets/93392545/ebb94c25-ca1b-4d2f-9982-0d5ff38f60d3)


### 🚧 Tasks

- [ ] Test on browser

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
