### PR TITLE
Fully translate aria-labels for predefined backgrounds

### DIFF
--- a/src/components/MediaSettings/VideoBackgroundEditor.vue
+++ b/src/components/MediaSettings/VideoBackgroundEditor.vue
@@ -55,6 +55,7 @@
 			<button v-for="path in predefinedBackgroundsURLs"
 				:key="path"
 				:aria-label="ariaLabelForPredefinedBackground(path)"
+				:title="ariaLabelForPredefinedBackground(path)"
 				class="background-editor__element"
 				:class="{'background-editor__element--selected': selectedBackground === path}"
 				:style="{
@@ -96,6 +97,16 @@ import { findUniquePath } from '../../utils/fileUpload.js'
 
 const canUploadBackgrounds = getCapabilities()?.spreed?.config?.call?.['can-upload-background']
 const predefinedBackgrounds = getCapabilities()?.spreed?.config?.call?.['predefined-backgrounds']
+const predefinedBackgroundLabels = {
+	'1_office': t('spreed', 'Select virtual office background'),
+	'2_home': t('spreed', 'Select virtual home background'),
+	'3_abstract': t('spreed', 'Select virtual abstract background'),
+	'4_beach': t('spreed', 'Select virtual beach background'),
+	'5_park': t('spreed', 'Select virtual park background'),
+	'6_theater': t('spreed', 'Select virtual theater background'),
+	'7_library': t('spreed', 'Select virtual library background'),
+	'8_space_station': t('spreed', 'Select virtual space station background'),
+}
 
 let picker
 
@@ -263,12 +274,9 @@ export default {
 		},
 
 		ariaLabelForPredefinedBackground(path) {
-			const removeFolders = (name) => name.includes('/') ? name.slice(name.lastIndexOf('/') + 1) : name
-			const removePositionNumber = (name) => name.includes('_') ? name.slice(name.indexOf('_') + 1) : name
-			const removeFileType = (name) => name.includes('.') ? name.slice(0, name.lastIndexOf('.')) : name
-			return t('spreed', 'Select virtual {atmosphere} background', {
-				atmosphere: removeFileType(removePositionNumber(removeFolders(path))).replaceAll('_', ' '),
-			})
+			const fileName = path.split('/').pop().split('.').shift()
+
+			return predefinedBackgroundLabels[fileName]
 		},
 	},
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9610
* Instead of translating `Select virtual {{unknown}} background'` and eight single-word strings like `abstract` or `beach`, translators now need to translate eight meaningful strings (which could take up to 3-5 minutes with Transifex autocompletion)
* Method of extracting filename without extension should work as before, according to JS prototypes behavior:
  * `String.split(substr)` always returns an array, even if `substr` isn't found;
  * `Array.pop()` and `Array.shift()` return last / first element of array, and the only existing element from 1-length array.

### 🖼️ Screenshots

| 🏡 After |
|---|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/7dfd9569-b837-43cf-b496-c4cab94ad032) |
| ![image](https://github.com/nextcloud/spreed/assets/93392545/da34442a-f8c6-4534-9d99-9bf5e7696a7c) |



### 🚧 Tasks

- [ ] Code review
- [ ] Visual check

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
