### PR TITLE
Add fallback if label for background fileName doesn't exist

### DIFF
--- a/src/components/MediaSettings/VideoBackgroundEditor.vue
+++ b/src/components/MediaSettings/VideoBackgroundEditor.vue
@@ -277,6 +277,7 @@ export default {
 			const fileName = path.split('/').pop().split('.').shift()
 
 			return predefinedBackgroundLabels[fileName]
+				?? t('spreed', 'Select virtual background from file {fileName}', { fileName })
 		},
 	},
 }


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up for #9710 

### 🖼️ Screenshots

🏡 After (if name isn't presented)
![Screenshot from 2023-06-07 12-21-25](https://github.com/nextcloud/spreed/assets/93392545/2cef34f1-437c-4800-9c51-e4533d4e5574)

