### PR TITLE
Fix dark/light theme in `LoadingPlaceholder` and refactor dark theme detection

### DIFF
--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -65,6 +65,7 @@ import { generateOcsUrl } from '@nextcloud/router'
 import NcAvatar from '@nextcloud/vue/dist/Components/NcAvatar.js'
 
 import { CONVERSATION } from '../constants.js'
+import { isDarkTheme } from '../utils/isDarkTheme.js'
 
 const supportsAvatar = getCapabilities()?.spreed?.features?.includes('avatar')
 
@@ -220,9 +221,7 @@ export default {
 				return undefined
 			}
 
-			const darkTheme = window.getComputedStyle(document.body)
-				.getPropertyValue('--background-invert-if-dark') === 'invert(100%)'
-			const avatarEndpoint = 'apps/spreed/api/v1/room/{token}/avatar' + (darkTheme ? '/dark' : '')
+			const avatarEndpoint = 'apps/spreed/api/v1/room/{token}/avatar' + (isDarkTheme ? '/dark' : '')
 
 			return generateOcsUrl(avatarEndpoint + '?v={avatarVersion}', {
 				token: this.item.token,

--- a/src/components/LoadingPlaceholder.vue
+++ b/src/components/LoadingPlaceholder.vue
@@ -36,8 +36,8 @@ each other by animating the opacities.
 			<svg :key="'gradient' + suffix" :class="'placeholder-gradient placeholder-gradient' + suffix">
 				<defs>
 					<linearGradient :id="'placeholder-gradient' + suffix">
-						<stop offset="0%" :stop-color="(gradientIndex == 0) ? light : dark" />
-						<stop offset="100%" :stop-color="(gradientIndex == 0) ? dark : light" />
+						<stop offset="0%" :stop-color="(gradientIndex === 0) ? colorPlaceholderLight : colorPlaceholderDark" />
+						<stop offset="100%" :stop-color="(gradientIndex === 0) ? colorPlaceholderDark : colorPlaceholderLight" />
 					</linearGradient>
 				</defs>
 			</svg>
@@ -69,6 +69,10 @@ each other by animating the opacities.
 </template>
 
 <script>
+const bodyStyles = window.getComputedStyle(document.body)
+const colorPlaceholderDark = bodyStyles.getPropertyValue('--color-placeholder-dark')
+const colorPlaceholderLight = bodyStyles.getPropertyValue('--color-placeholder-light')
+
 export default {
 	name: 'LoadingPlaceholder',
 
@@ -83,10 +87,10 @@ export default {
 		},
 	},
 
-	data() {
+	setup() {
 		return {
-			light: null,
-			dark: null,
+			colorPlaceholderDark,
+			colorPlaceholderLight,
 		}
 	},
 
@@ -99,12 +103,6 @@ export default {
 			}
 			return data
 		},
-	},
-
-	mounted() {
-		const styles = getComputedStyle(document.documentElement)
-		this.dark = styles.getPropertyValue('--color-placeholder-dark')
-		this.light = styles.getPropertyValue('--color-placeholder-light')
 	},
 }
 </script>

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
@@ -47,6 +47,8 @@ import { generateOcsUrl } from '@nextcloud/router'
 
 import NcUserBubble from '@nextcloud/vue/dist/Components/NcUserBubble.js'
 
+import { isDarkTheme } from '../../../../../utils/isDarkTheme.js'
+
 export default {
 	name: 'Mention',
 
@@ -97,7 +99,7 @@ export default {
 				&& loadState('spreed', 'user_group_ids', []).includes(this.id)
 		},
 		avatarUrl() {
-			return generateOcsUrl('apps/spreed/api/v1/room/{token}/avatar' + (this.darkTheme ? '/dark' : ''), {
+			return generateOcsUrl('apps/spreed/api/v1/room/{token}/avatar' + (isDarkTheme ? '/dark' : ''), {
 				token: this.id,
 			})
 		},

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
@@ -96,10 +96,6 @@ export default {
 			return this.isGroupMention
 				&& loadState('spreed', 'user_group_ids', []).includes(this.id)
 		},
-		isDarkTheme() {
-			return window.getComputedStyle(document.body)
-				.getPropertyValue('--background-invert-if-dark') === 'invert(100%)'
-		},
 		avatarUrl() {
 			return generateOcsUrl('apps/spreed/api/v1/room/{token}/avatar' + (this.darkTheme ? '/dark' : ''), {
 				token: this.id,

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -186,6 +186,7 @@ import { EventBus } from '../../services/EventBus.js'
 import { shareFile } from '../../services/filesSharingServices.js'
 import { searchPossibleMentions } from '../../services/mentionsService.js'
 import { fetchClipboardContent } from '../../utils/clipboard.js'
+import { isDarkTheme } from '../../utils/isDarkTheme.js'
 
 const picker = getFilePickerBuilder(t('spreed', 'File to share'))
 	.setMultiSelect(false)
@@ -724,9 +725,7 @@ export default {
 				// Set icon for candidate mentions that are not for users.
 				if (possibleMention.source === 'calls') {
 					possibleMention.icon = 'icon-user-forced-white'
-					const darkTheme = window.getComputedStyle(document.body)
-						.getPropertyValue('--background-invert-if-dark') === 'invert(100%)'
-					possibleMention.iconUrl = generateOcsUrl('apps/spreed/api/v1/room/{token}/avatar' + (darkTheme ? '/dark' : ''), {
+					possibleMention.iconUrl = generateOcsUrl('apps/spreed/api/v1/room/{token}/avatar' + (isDarkTheme ? '/dark' : ''), {
 						token: this.token,
 					})
 					possibleMention.subline = t('spreed', 'Everyone')

--- a/src/utils/isDarkTheme.js
+++ b/src/utils/isDarkTheme.js
@@ -1,0 +1,41 @@
+/*
+ * @copyright Copyright (c) 2023 Grigorii Shartsev <me@shgk.me>
+ *
+ * @author Grigorii Shartsev <me@shgk.me>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Check if dark theme is used
+ *
+ * @return {boolean}
+ */
+function checkIfDarkTheme() {
+	// Nextcloud uses --background-invert-if-dark for dark theme filters in CSS
+	// Values:
+	// - 'invert(100%)' for dark theme
+	// - 'no' for light theme
+	return window.getComputedStyle(document.body).getPropertyValue('--background-invert-if-dark') === 'invert(100%)'
+}
+
+/**
+ * Is Dark Theme enabled
+ * We do not support dark/light theme update without reload the page, so the value can be computed once
+ *
+ * @type {boolean}
+ */
+export const isDarkTheme = checkIfDarkTheme()


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9720
* Fix https://github.com/nextcloud/talk-desktop/issues/45

### 🖼️ Screenshots

🏚️ Before LoadingPlaceholder | 🏡 After LoadingPlaceholder
---|---
Default on 🌑 Dark system |
![image](https://github.com/nextcloud/spreed/assets/25978914/1122c212-e0e7-4359-a35c-46c7d776f8a6) | ![image](https://github.com/nextcloud/spreed/assets/25978914/09330845-b2f8-45e4-ab95-1549a56c8369)
🌑 Dark theme with 🌑 Dark system |
![image](https://github.com/nextcloud/spreed/assets/25978914/f28c9ed9-c1d4-443c-9b2a-9d067d3b88a1) | ![image](https://github.com/nextcloud/spreed/assets/25978914/9f97d489-5aae-4f6c-9724-6ad736d6ffe1)
🌕 Light theme with 🌑 Dark system |
![image](https://github.com/nextcloud/spreed/assets/25978914/ee7350e8-e59a-4f5a-a7ae-2b81c5bf5c5f) | ![image](https://github.com/nextcloud/spreed/assets/25978914/424ba5f0-beba-4df9-869f-cb9280191efd) 
Default on 🌕 Light system  |
![image](https://github.com/nextcloud/spreed/assets/25978914/5efcfdde-cbac-4eab-bf7f-2d439ac449a6) | ![image](https://github.com/nextcloud/spreed/assets/25978914/1bd19cbf-a02d-4ea6-a3ba-37ba2d91a9b4)
🌕 Light theme with 🌕 Light system |
![image](https://github.com/nextcloud/spreed/assets/25978914/039b323d-4174-4499-9c37-29bc5689348d) | ![image](https://github.com/nextcloud/spreed/assets/25978914/2f1539fa-849f-41fa-b0e3-64b12b7c9d11)
🌑 Dark theme with 🌕 Light system |
![image](https://github.com/nextcloud/spreed/assets/25978914/8eab2e9b-257f-4718-b204-f74837dbe579) | ![image](https://github.com/nextcloud/spreed/assets/25978914/64e44730-c6b0-42ef-9142-5dd1395f9807)

### 🚧 Tasks

### Fix dark/light theme in `LoadingPlaceholder`

In Nextcloud we have CSS variables for themes:
1. `:root` - default values based on system `preferred-color-scheme`
2. On `<body>` - set by current theme if not "System default theme" is used in settings. These styles override defaults.

The `LoadingPlaceholder` used variables from `documentElement` (`:root`) instead of `body`. It caused a problem when the system-preferred theme was not equal to the selected in Nextcloud settings.

- [x] Use styles from `body` instead of `documentElement` in `LoadingPlaceholder`
- [x] Move styles getting from instance's `mounted` to component's ES module
  - Render the component right away with the styles instead of useless re-render after mount.
  - Do not get the value from DOM API for each instance, get only once.

### Refactor dark theme detection

- [x] Add `isDarkTheme` util

In some components, we checked if a dark theme is enabled by this line:
```js
const isDarkTheme = window.getComputedStyle(document.body)
  .getPropertyValue('--background-invert-if-dark') === 'invert(100%)'
```

Problems:
- Duplication
- It is evaluated for each instance again using DOM API to get the same value

New `isDarkTheme` util checks if the dark theme is enabled only once and then exports the result.

It assumes that the dark/light theme is not been changing without page reload. But this case didn't fully work early anyway...

No changes after the refactoring

![image](https://github.com/nextcloud/spreed/assets/25978914/11c681f4-738d-4bb0-a5d4-4d5d6dcce067) | ![image](https://github.com/nextcloud/spreed/assets/25978914/a018d6c4-a8f0-4c65-aa14-f8b06625f684)
---|---

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
