### PR TITLE
Make pagination buttons in call (grid, stripe views) visible on call view hover

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -963,14 +963,6 @@ export default {
 }
 
 .grid-navigation {
-	z-index: 2;
-	background-color: rgba(0, 0, 0, 0.5);
-
-	&:hover,
-	&:focus {
-		background-color: rgba(0, 0, 0, 0.8) !important;
-	}
-
 	.grid-wrapper & {
 		position: absolute;
 		top: calc(50% - var(--default-clickable-area) / 2);
@@ -1022,10 +1014,14 @@ export default {
 	position: absolute !important;
 	top: calc(-1 * var(--default-clickable-area));
 	right: 0;
+}
+
+.stripe--collapse,
+.grid-navigation {
 	z-index: 2;
 	opacity: .7;
 
-	.app-content:hover & {
+	#call-container:hover & {
 		background-color: rgba(0, 0, 0, 0.1) !important;
 
 		&:hover,


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9505

### 🖼️ Screenshots

🏚️ Before: see issue

🏡 After:
Without hover | With hover
---|---
![Screenshot from 2023-06-09 09-08-27](https://github.com/nextcloud/spreed/assets/93392545/b3c0911c-7a71-4349-87e6-79c764df16c0) | ![Screenshot from 2023-06-09 09-08-34](https://github.com/nextcloud/spreed/assets/93392545/8da69091-cd15-4011-a203-b21c6879be56)
![Screenshot from 2023-06-09 09-07-31](https://github.com/nextcloud/spreed/assets/93392545/ec90fa2b-cc7d-4cd1-82ac-6d8d64bbdd79) | ![Screenshot from 2023-06-09 09-07-34](https://github.com/nextcloud/spreed/assets/93392545/984f1f2d-459a-402e-939a-7ea09e48a6ff)



### 🚧 Tasks

- [ ] Visual check

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
