### PR TITLE
Release/17.0.0 rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 17.0.0-rc.4 – 2023-06-09
+### Fixed
+
+- fix(chat): Fix dark/light theme in messages loading placeholder
+  [#9720](https://github.com/nextcloud/spreed/issues/9720)
+- fix(TypingIndicator): Signaling messages wrong when conversation is switched
+  [#9615](https://github.com/nextcloud/spreed/issues/9615)
+- fix(TypingIndicator): Typing indicator does not "expire"
+  [#9604](https://github.com/nextcloud/spreed/issues/9604)
+- fix(TypingIndicator): Typing indicator distorted on small sidebar during call when 3 or more people are typing
+  [#9589](https://github.com/nextcloud/spreed/issues/9589)
+- fix(mediasettings): Aria label keywords of virtual backgrounds are not translatable
+  [#9610](https://github.com/nextcloud/spreed/issues/9610)
+- fix(mediasettings): Conversation picture picker does not work well on mobile
+  [#9565](https://github.com/nextcloud/spreed/issues/9565)
+- fix(conversations): Do not scroll to conversations that are already visible in the conversations list
+  [#9582](https://github.com/nextcloud/spreed/issues/9582)
+- fix(conversations): Fix error when creating a conversation from search results
+  [#9709](https://github.com/nextcloud/spreed/pull/9709)
+
 ## 17.0.0-rc.3 – 2023-06-02
 ### Fixed
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>17.0.0-rc.3</version>
+	<version>17.0.0-rc.4</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk",
-	"version": "17.0.0-rc.3",
+	"version": "17.0.0-rc.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk",
-			"version": "17.0.0-rc.3",
+			"version": "17.0.0-rc.4",
 			"license": "agpl",
 			"dependencies": {
 				"@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "talk",
-	"version": "17.0.0-rc.3",
+	"version": "17.0.0-rc.4",
 	"private": true,
 	"description": "",
 	"author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 17.0.0-rc.4 – 2023-06-09
### Fixed

- fix(chat): Fix dark/light theme in messages loading placeholder
  [#9720](https://github.com/nextcloud/spreed/issues/9720)
- fix(TypingIndicator): Signaling messages wrong when conversation is switched
  [#9615](https://github.com/nextcloud/spreed/issues/9615)
- fix(TypingIndicator): Typing indicator does not "expire"
  [#9604](https://github.com/nextcloud/spreed/issues/9604)
- fix(TypingIndicator): Typing indicator distorted on small sidebar during call when 3 or more people are typing
  [#9589](https://github.com/nextcloud/spreed/issues/9589)
- fix(mediasettings): Aria label keywords of virtual backgrounds are not translatable
  [#9610](https://github.com/nextcloud/spreed/issues/9610)
- fix(mediasettings): Conversation picture picker does not work well on mobile
  [#9565](https://github.com/nextcloud/spreed/issues/9565)
- fix(conversations): Do not scroll to conversations that are already visible in the conversations list
  [#9582](https://github.com/nextcloud/spreed/issues/9582)
- fix(conversations): Fix error when creating a conversation from search results
  [#9709](https://github.com/nextcloud/spreed/pull/9709)