### PR TITLE
Close sidebar on mobile resolution immediately after changing the route

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -583,16 +583,16 @@ export default {
 			if (to.name === 'conversation') {
 				this.$store.dispatch('joinConversation', { token: to.params.token })
 			}
-		},
-
-		handleJoinedConversation({ token }) {
-			this.abortSearch()
-			this.scrollToConversation(token)
 			if (this.isMobile) {
 				emit('toggle-navigation', {
 					open: false,
 				})
 			}
+		},
+
+		handleJoinedConversation({ token }) {
+			this.abortSearch()
+			this.scrollToConversation(token)
 		},
 
 		iconData(item) {


### PR DESCRIPTION
### ☑️ Resolves

* Follow up for #9508 
* Previously we're waiting for server response to emit the event, that toggle sidebar. Now we do it after changing the route
  * Emitting the event comes from participantsStore async action `joinConversation`, which is called only on switching the conversations
  * Action is also called on App.vue `beforeMount()`, but sidebar toggling is also handling by App itself

### 🖼️ Screenshots

🏚️ Before

https://github.com/nextcloud/spreed/assets/93392545/1ad58e8c-0c1d-4692-a661-b4ae70d3ac10


 🏡 After

https://github.com/nextcloud/spreed/assets/93392545/81d287ec-9629-4e93-8b94-4436c88aff40



### 🚧 Tasks

- [ ] Visual check
- [ ] Code review
- [ ] Testing for all 'joined-conversation' emit cases

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
