### PR TITLE
Prevent the navigation bar from floating

### DIFF
--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -100,43 +100,43 @@
 						:success="success"
 						:is-public="isPublic" />
 				</div>
-				<!-- Navigation: different buttons with different actions and
+			</div>
+			<!-- Navigation: different buttons with different actions and
 				placement are rendered depending on the current page -->
-				<div class="navigation">
-					<!-- First page -->
-					<NcButton v-if="page===0 && isPublic"
-						:disabled="disabled"
-						type="tertiary"
-						@click="handleCreateConversation">
-						{{ t('spreed', 'Create conversation') }}
-					</NcButton>
-					<NcButton v-if="page===0"
-						type="primary"
-						:disabled="disabled"
-						class="navigation__button-right"
-						@click="handleSetConversationName">
-						{{ t('spreed', 'Add participants') }}
-					</NcButton>
-					<!-- Second page -->
-					<NcButton v-if="page===1"
-						type="tertiary"
-						@click="handleClickBack">
-						{{ t('spreed', 'Back') }}
-					</NcButton>
-					<NcButton v-if="page===1"
-						type="primary"
-						class="navigation__button-right"
-						@click="handleCreateConversation">
-						{{ t('spreed', 'Create conversation') }}
-					</NcButton>
-					<!-- Third page -->
-					<NcButton v-if="page===2 && (error || isPublic)"
-						type="primary"
-						class="navigation__button-right"
-						@click="closeModal">
-						{{ t('spreed', 'Close') }}
-					</NcButton>
-				</div>
+			<div class="navigation">
+				<!-- First page -->
+				<NcButton v-if="page===0 && isPublic"
+					:disabled="disabled"
+					type="tertiary"
+					@click="handleCreateConversation">
+					{{ t('spreed', 'Create conversation') }}
+				</NcButton>
+				<NcButton v-if="page===0"
+					type="primary"
+					:disabled="disabled"
+					class="navigation__button-right"
+					@click="handleSetConversationName">
+					{{ t('spreed', 'Add participants') }}
+				</NcButton>
+				<!-- Second page -->
+				<NcButton v-if="page===1"
+					type="tertiary"
+					@click="handleClickBack">
+					{{ t('spreed', 'Back') }}
+				</NcButton>
+				<NcButton v-if="page===1"
+					type="primary"
+					class="navigation__button-right"
+					@click="handleCreateConversation">
+					{{ t('spreed', 'Create conversation') }}
+				</NcButton>
+				<!-- Third page -->
+				<NcButton v-if="page===2 && (error || isPublic)"
+					type="primary"
+					class="navigation__button-right"
+					@click="closeModal">
+					{{ t('spreed', 'Close') }}
+				</NcButton>
 			</div>
 		</NcModal>
 	</div>
@@ -456,6 +456,7 @@ export default {
 	the margin applied to the content is added to the total modal width,
 	so here we subtract it to the width and height of the content.
 	*/
+	height: auto;
 	padding: 20px;
 	display: flex;
 	flex-direction: column;
@@ -496,15 +497,26 @@ it back */
 	height: 900px;
 }
 
+:deep(){
+	.modal-wrapper--normal{
+		.modal-container {
+			height: max-content;
+		}
+	}
+}
+
 .navigation {
+	position: sticky;
+    bottom: 0;
 	display: flex;
 	justify-content: space-between;
 	flex: 0 0 40px;
-	height: 50px;
 	background-color: var(--color-main-background);
-	box-shadow: 0 -10px 5px var(--color-main-background);
+	box-shadow:0 -2px 5px var(--color-background-darker);
 	z-index: 1;
-	width: 100%;
+	width: 600px;
+	padding: 10px;
+	height: auto;
 
 	&__button-right {
 		margin-left: auto;

--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -452,10 +452,6 @@ export default {
 }
 
 .new-group-conversation {
-	/** This next 2 rules are pretty hacky, with the modal component somehow
-	the margin applied to the content is added to the total modal width,
-	so here we subtract it to the width and height of the content.
-	*/
 	height: auto;
 	padding: 20px;
 	display: flex;
@@ -464,11 +460,6 @@ export default {
 	position: relative;
 
 	&__content {
-		/**
-		 * Top: 30px line height header + 12px margin
-		 * Bottom: 44px buttons + 12 px margin
-		 * Total: 98px
-		 */
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;
@@ -496,19 +487,19 @@ it back */
 }
 
 :deep(.modal-wrapper .modal-container) {
-			height: max-content;
+	height: max-content;
 }
 
 .navigation {
 	position: sticky;
-    bottom: -1px;
+	bottom: -1px;
 	display: flex;
 	justify-content: space-between;
 	flex: 0 0 40px;
 	background-color: var(--color-main-background);
 	box-shadow: 0 -10px 5px var(--color-main-background);
 	z-index: 1;
-	padding: 10px 20px;
+	padding: 0 20px 20px;
 
 	&__button-right {
 		margin-left: auto;

--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -462,7 +462,6 @@ export default {
 	flex-direction: column;
 	justify-content: space-between;
 	position: relative;
-	gap: 10px;
 
 	&__content {
 		/**
@@ -470,7 +469,6 @@ export default {
 		 * Bottom: 44px buttons + 12 px margin
 		 * Total: 98px
 		 */
-		height: calc(100% - 98px);
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;
@@ -497,26 +495,20 @@ it back */
 	height: 900px;
 }
 
-:deep(){
-	.modal-wrapper--normal{
-		.modal-container {
+:deep(.modal-wrapper .modal-container) {
 			height: max-content;
-		}
-	}
 }
 
 .navigation {
 	position: sticky;
-    bottom: 0;
+    bottom: -1px;
 	display: flex;
 	justify-content: space-between;
 	flex: 0 0 40px;
 	background-color: var(--color-main-background);
-	box-shadow:0 -2px 5px var(--color-background-darker);
+	box-shadow: 0 -10px 5px var(--color-main-background);
 	z-index: 1;
-	width: 600px;
-	padding: 10px;
-	height: auto;
+	padding: 10px 20px;
 
 	&__button-right {
 		margin-left: auto;

--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -456,12 +456,12 @@ export default {
 	the margin applied to the content is added to the total modal width,
 	so here we subtract it to the width and height of the content.
 	*/
-	height: 100%;
 	padding: 20px;
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
 	position: relative;
+	gap: 10px;
 
 	&__content {
 		/**


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9761 
The navigation bar is used to float over the content. Now it is fixed at the bottom.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/84044328/24463e9a-91a5-41f6-b189-fa2cb99235dd)| ![image](https://github.com/nextcloud/spreed/assets/84044328/67e41a1a-13b0-441a-a226-5e7c908666ed)
### 🚧 Tasks

- [ ] visual check
- [ ] code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
