### PR TITLE
feat(MessageGroup) - group system messages

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
@@ -541,6 +541,7 @@ describe('Message.vue', () => {
 
 		test('renders author if first message', async () => {
 			messageProps.isFirstMessage = true
+			messageProps.showAuthor = true
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -38,7 +38,9 @@ the main body of the message as well as a quote.
 		@animationend="isHighlighted = false"
 		@mouseover="handleMouseover"
 		@mouseleave="handleMouseleave">
-		<div :class="{'normal-message-body': !isSystemMessage && !isDeletedMessage, 'system' : isSystemMessage}"
+		<div :class="{'normal-message-body': !isSystemMessage && !isDeletedMessage,
+			'system' : isSystemMessage,
+			'combined-system': isCombinedSystemMessage}"
 			class="message-body">
 			<div v-if="isFirstMessage && showAuthor"
 				class="message-body__author"
@@ -184,6 +186,7 @@ the main body of the message as well as a quote.
 		<div class="message-body__scroll">
 			<MessageButtonsBar v-if="showMessageButtonsBar"
 				ref="messageButtonsBar"
+				class="message-buttons-bar"
 				:is-translation-available="isTranslationAvailable"
 				:is-action-menu-open.sync="isActionMenuOpen"
 				:is-emoji-picker-open.sync="isEmojiPickerOpen"
@@ -201,6 +204,18 @@ the main body of the message as well as a quote.
 				:sent-icon-tooltip="sentIconTooltip"
 				@show-translate-dialog="isTranslateDialogOpen = true"
 				@delete="handleDelete" />
+			<div v-else-if="showCombinedSystemMessageToggle"
+				class="message-buttons-bar">
+				<NcButton type="tertiary"
+					:aria-label="t('spreed', 'Show or collapse system messages')"
+					:title="t('spreed', 'Show or collapse system messages')"
+					@click="toggleCombinedSystemMessage">
+					<template #icon>
+						<UnfoldMore v-if="isCombinedSystemMessageCollapsed" />
+						<UnfoldLess v-else />
+					</template>
+				</NcButton>
+			</div>
 		</div>
 
 		<MessageTranslateDialog v-if="isTranslateDialogOpen"
@@ -225,6 +240,8 @@ import Check from 'vue-material-design-icons/Check.vue'
 import CheckAll from 'vue-material-design-icons/CheckAll.vue'
 import EmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
 import Reload from 'vue-material-design-icons/Reload.vue'
+import UnfoldLess from 'vue-material-design-icons/UnfoldLessHorizontal.vue'
+import UnfoldMore from 'vue-material-design-icons/UnfoldMoreHorizontal.vue'
 
 import { getCapabilities } from '@nextcloud/capabilities'
 import { showError, showSuccess, showWarning, TOAST_DEFAULT_TIMEOUT } from '@nextcloud/dialogs'
@@ -276,6 +293,8 @@ export default {
 		CheckAll,
 		EmoticonOutline,
 		Reload,
+		UnfoldLess,
+		UnfoldMore,
 	},
 
 	mixins: [
@@ -380,6 +399,20 @@ export default {
 			required: true,
 		},
 		/**
+		 * Specifies if the message is a combined system message.
+		 */
+		isCombinedSystemMessage: {
+			type: Boolean,
+			default: false,
+		},
+		/**
+		 * Specifies whether the combined system message is collapsed.
+		 */
+		isCombinedSystemMessageCollapsed: {
+			type: Boolean,
+			default: undefined,
+		},
+		/**
 		 * The type of the message.
 		 */
 		messageType: {
@@ -425,6 +458,8 @@ export default {
 			default: () => { return [] },
 		},
 	},
+
+	emits: ['toggle-combined-system-message'],
 
 	setup() {
 		const isInCall = useIsInCall()
@@ -611,6 +646,11 @@ export default {
 			return !this.isSystemMessage && !this.isDeletedMessage && !this.isTemporary
 				&& (this.isHovered || this.isActionMenuOpen || this.isEmojiPickerOpen || this.isFollowUpEmojiPickerOpen
 					|| this.isReactionsMenuOpen || this.isForwarderOpen || this.isTranslateDialogOpen)
+		},
+
+		showCombinedSystemMessageToggle() {
+			return this.isSystemMessage && !this.isDeletedMessage && !this.isTemporary
+				&& this.isCombinedSystemMessage && (this.isHovered || !this.isCombinedSystemMessageCollapsed)
 		},
 
 		isTemporaryUpload() {
@@ -851,6 +891,10 @@ export default {
 
 			return displayName
 		},
+
+		toggleCombinedSystemMessage() {
+			this.$emit('toggle-combined-system-message')
+		},
 	},
 }
 </script>
@@ -858,16 +902,17 @@ export default {
 <style lang="scss" scoped>
 @import '../../../../assets/variables';
 
-.message:hover .normal-message-body {
-	border-radius: 8px;
-	background-color: var(--color-background-hover);
-}
-
 .message {
 	position: relative;
 
 	&__last {
 		margin-bottom: 12px;
+	}
+
+	&:hover .normal-message-body,
+	&:hover .combined-system {
+		border-radius: 8px;
+		background-color: var(--color-background-hover);
 	}
 }
 
@@ -1023,6 +1068,22 @@ export default {
 
 .reaction-details {
 	padding: 8px;
+}
+
+.message-buttons-bar {
+	display: flex;
+	right: 14px;
+	top: 8px;
+	position: sticky;
+	background-color: var(--color-main-background);
+	border-radius: calc(var(--default-clickable-area) / 2);
+	box-shadow: 0 0 4px 0 var(--color-box-shadow);
+	height: 44px;
+	z-index: 1;
+
+	& h6 {
+		margin-left: auto;
+	}
 }
 
 .message-body__main__text--markdown {

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -341,7 +341,7 @@ export default {
 		 */
 		showAuthor: {
 			type: Boolean,
-			default: true,
+			default: false,
 		},
 		/**
 		 * Specifies if the message is temporary in order to display the spinner instead
@@ -349,14 +349,14 @@ export default {
 		 */
 		isTemporary: {
 			type: Boolean,
-			required: true,
+			default: false,
 		},
 		/**
 		 * Specifies if the message is the first of a group of same-author messages.
 		 */
 		isFirstMessage: {
 			type: Boolean,
-			required: true,
+			default: false,
 		},
 		/**
 		 * Specifies if the message can be replied to.

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -21,8 +21,7 @@
 
 <template>
 	<!-- Message Actions -->
-	<div v-click-outside="handleClickOutside"
-		class="message-buttons-bar">
+	<div v-click-outside="handleClickOutside">
 		<template v-if="!isReactionsMenuOpen">
 			<NcButton v-if="canReact"
 				type="tertiary"
@@ -578,24 +577,3 @@ export default {
 	},
 }
 </script>
-
-<style lang="scss" scoped>
-@import '../../../../../assets/variables';
-
-.message-buttons-bar {
-	display: flex;
-	right: 14px;
-	top: 8px;
-	position: sticky;
-	background-color: var(--color-main-background);
-	border-radius: calc(var(--default-clickable-area) / 2);
-	box-shadow: 0 0 4px 0 var(--color-box-shadow);
-	height: 44px;
-	z-index: 1;
-
-	& h6 {
-		margin-left: auto;
-	}
-}
-
-</style>

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.spec.js
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.spec.js
@@ -3,6 +3,7 @@ import { cloneDeep } from 'lodash'
 import Vuex from 'vuex'
 
 import MessagesGroup from './MessagesGroup.vue'
+import MessagesSystemGroup from './MessagesSystemGroup.vue'
 
 import { ATTENDEE } from '../../../constants.js'
 import storeConfig from '../../../store/storeConfig.js'
@@ -123,7 +124,33 @@ describe('MessagesGroup.vue', () => {
 	})
 
 	test('renders grouped system messages', () => {
-		const wrapper = shallowMount(MessagesGroup, {
+		const MESSAGES = [{
+			id: 100,
+			token: TOKEN,
+			actorId: 'actor-1',
+			actorDisplayName: 'actor one',
+			actorType: ATTENDEE.ACTOR_TYPE.USERS,
+			message: 'Actor entered the scene',
+			messageType: 'comment',
+			messageParameters: {},
+			systemMessage: 'call_started',
+			timestamp: 100,
+			isReplyable: false,
+		}, {
+			id: 110,
+			token: TOKEN,
+			actorId: 'actor-1',
+			actorDisplayName: 'actor one',
+			actorType: ATTENDEE.ACTOR_TYPE.USERS,
+			message: 'Actor left the scene',
+			messageType: 'comment',
+			messageParameters: {},
+			systemMessage: 'call_stopped',
+			timestamp: 200,
+			isReplyable: false,
+		}]
+
+		const wrapper = shallowMount(MessagesSystemGroup, {
 			localVue,
 			store,
 			propsData: {
@@ -132,31 +159,7 @@ describe('MessagesGroup.vue', () => {
 				dateSeparator: '<date separator>',
 				previousMessageId: 90,
 				nextMessageId: 200,
-				messages: [{
-					id: 100,
-					token: TOKEN,
-					actorId: 'actor-1',
-					actorDisplayName: 'actor one',
-					actorType: ATTENDEE.ACTOR_TYPE.USERS,
-					message: 'Actor entered the scene',
-					messageType: 'comment',
-					messageParameters: {},
-					systemMessage: 'call_started',
-					timestamp: 100,
-					isReplyable: false,
-				}, {
-					id: 110,
-					token: TOKEN,
-					actorId: 'actor-1',
-					actorDisplayName: 'actor one',
-					actorType: ATTENDEE.ACTOR_TYPE.USERS,
-					message: 'Actor left the scene',
-					messageType: 'comment',
-					messageParameters: {},
-					systemMessage: 'call_stopped',
-					timestamp: 200,
-					isReplyable: false,
-				}],
+				messages: MESSAGES,
 			},
 		})
 
@@ -169,24 +172,24 @@ describe('MessagesGroup.vue', () => {
 		const messagesEl = wrapper.findAllComponents({ name: 'Message' })
 		// TODO: date separator
 		let message = messagesEl.at(0)
-		expect(message.attributes('id')).toBe('100')
-		expect(message.attributes('message')).toBe('Actor entered the scene')
-		expect(message.attributes('actorid')).toBe('actor-1')
-		expect(message.attributes('actordisplayname')).toBe('actor one')
-		expect(message.attributes('previousmessageid')).toBe('90')
-		expect(message.attributes('nextmessageid')).toBe('110')
-		expect(message.attributes('isfirstmessage')).toBe('true')
-		expect(message.attributes('showauthor')).not.toBeDefined()
+		expect(message.props('id')).toBe(MESSAGES[0].id)
+		expect(message.props('message')).toBe(MESSAGES[0].message)
+		expect(message.props('actorid')).toBe(MESSAGES[0].actorid)
+		expect(message.props('actordisplayname')).toBe(MESSAGES[0].actordisplayname)
+		expect(message.props('previousmessageid')).toBe(MESSAGES[0].previousmessageid)
+		expect(message.props('nextmessageid')).toBe(MESSAGES[0].nextmessageid)
+		expect(message.props('isfirstmessage')).toBe(MESSAGES[0].isfirstmessage)
+		expect(message.props('showauthor')).not.toBeDefined()
 
 		message = messagesEl.at(1)
-		expect(message.attributes('id')).toBe('110')
-		expect(message.attributes('message')).toBe('Actor left the scene')
-		expect(message.attributes('actorid')).toBe('actor-1')
-		expect(message.attributes('actordisplayname')).toBe('actor one')
-		expect(message.attributes('previousmessageid')).toBe('100')
-		expect(message.attributes('nextmessageid')).toBe('200')
-		expect(message.attributes('isfirstmessage')).not.toBeDefined()
-		expect(message.attributes('showauthor')).not.toBeDefined()
+		expect(message.props('id')).toBe(MESSAGES[1].id)
+		expect(message.props('message')).toBe(MESSAGES[1].message)
+		expect(message.props('actorid')).toBe(MESSAGES[1].actorid)
+		expect(message.props('actordisplayname')).toBe(MESSAGES[1].actordisplayname)
+		expect(message.props('previousmessageid')).toBe(MESSAGES[1].previousmessageid)
+		expect(message.props('nextmessageid')).toBe(MESSAGES[1].nextmessageid)
+		expect(message.props('isfirstmessage')).not.toBeDefined()
+		expect(message.props('showauthor')).not.toBeDefined()
 	})
 
 	test('renders guest display name', () => {

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -27,9 +27,8 @@
 				role="heading"
 				aria-level="3">{{ dateSeparator }}</span>
 		</div>
-		<div class="wrapper"
-			:class="{'wrapper--system': isSystemMessage}">
-			<div v-if="!isSystemMessage" class="messages__avatar">
+		<div class="wrapper">
+			<div class="messages__avatar">
 				<AuthorAvatar :author-type="actorType"
 					:author-id="actorId"
 					:display-name="actorDisplayName" />
@@ -40,13 +39,13 @@
 					ref="message"
 					v-bind="message"
 					:is-first-message="index === 0"
+					:is-temporary="message.timestamp === 0"
 					:next-message-id="(messages[index + 1] && messages[index + 1].id) || nextMessageId"
 					:previous-message-id="(index > 0 && messages[index - 1].id) || previousMessageId"
 					:actor-type="actorType"
 					:actor-id="actorId"
 					:actor-display-name="actorDisplayName"
-					:show-author="!isSystemMessage"
-					:is-temporary="message.timestamp === 0" />
+					show-author />
 			</ul>
 		</div>
 	</div>
@@ -138,14 +137,6 @@ export default {
 
 			return displayName
 		},
-		/**
-		 * Whether the given message is a system message
-		 *
-		 * @return {boolean}
-		 */
-		isSystemMessage() {
-			return this.messages[0].systemMessage.length !== 0
-		},
 	},
 
 	methods: {
@@ -188,9 +179,6 @@ export default {
 	display: flex;
 	margin: auto;
 	padding: 0;
-	&--system {
-		padding-left: $clickable-area + 8px;
-	}
 	&:focus {
 		background-color: rgba(47, 47, 47, 0.068);
 	}

--- a/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
@@ -236,11 +236,11 @@ export default {
 			for (const message of messages) {
 				const groupingType = this.messagesShouldBeGrouped(message, lastMessage)
 				if (!groupingType || forceNextGroup) {
-					groups.push({ messages: [message], type: '', collapsed: true })
+					groups.push({ id: message.id, messages: [message], type: '', collapsed: this.groupIsCollapsed[message.id] ?? true })
 					forceNextGroup = false
 				} else {
 					if (groupingType === 'call_reconnected') {
-						groups.push({ messages: [groups.at(-1).messages.pop()], type: '', collapsed: true })
+						groups.push({ id: message.id, messages: [groups.at(-1).messages.pop()], type: '', collapsed: this.groupIsCollapsed[message.id] ?? true })
 						forceNextGroup = true
 					}
 					groups.at(-1).messages.push(message)
@@ -248,6 +248,12 @@ export default {
 				}
 				lastMessage = message
 			}
+
+			groups.forEach(group => {
+				if (this.groupIsCollapsed[group.id] === undefined) {
+					this.groupIsCollapsed[group.id] = true
+				}
+			})
 			return groups
 		},
 
@@ -529,6 +535,7 @@ export default {
 
 		toggleCollapsed(messages) {
 			this.$set(messages, 'collapsed', !messages.collapsed)
+			this.groupIsCollapsed[messages.id] = !this.groupIsCollapsed[messages.id]
 		},
 
 		getNextMessageId(message) {
@@ -605,9 +612,8 @@ export default {
 		position: relative;
 		& &__toggle {
 			position: absolute;
-			top: 50%;
+			top: -6px;
 			right: 0;
-			transform: translateY(-50%);
 		}
 	}
 	&--collapsed {

--- a/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
@@ -70,6 +70,22 @@ import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 
 import Message from './Message/Message.vue'
 
+// List only sortable messages with order, in which they should be sorted
+const MESSAGES = {
+	user_added: 1,
+	user_removed: 1,
+	moderator_promoted: 11,
+	guest_moderator_promoted: 11,
+	moderator_demoted: 11,
+	guest_moderator_demoted: 11,
+	call_started: 20,
+	recording_started: 21,
+	call_joined: 22,
+	call_left: 22,
+	call_ended: 23,
+	call_ended_everyone: 23,
+}
+
 export default {
 	name: 'MessagesSystemGroup',
 
@@ -126,9 +142,10 @@ export default {
 
 	watch: {
 		messages: {
+			deep: true,
 			immediate: true,
 			handler(value) {
-				this.messagesGroupedBySystemMessage = this.groupMessages(value)
+				this.messagesGroupedBySystemMessage = this.groupMessages(this.sortMessages(value))
 			},
 		},
 	},
@@ -198,6 +215,18 @@ export default {
 			}
 
 			return ''
+		},
+
+		sortMessages(messages) {
+			return messages.slice().sort((message1, message2) => {
+				// Don't sort messages if they're not intended to be sorted
+				if (!MESSAGES[message1.systemMessage] || !MESSAGES[message2.systemMessage]) {
+					return 0
+				}
+
+				// Don't sort related system messages (call join - call left) between each other
+				return MESSAGES[message1.systemMessage] - MESSAGES[message2.systemMessage]
+			})
 		},
 
 		groupMessages(messages) {

--- a/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
@@ -34,17 +34,11 @@
 				<ul v-if="messagesCollapsed.messages?.length > 1"
 					class="messages messages--header">
 					<Message v-bind="createCombinedSystemMessage(messagesCollapsed)"
+						is-combined-system-message
+						:is-combined-system-message-collapsed="messagesCollapsed.collapsed"
 						:next-message-id="getNextMessageId(messagesCollapsed.messages.at(-1))"
-						:previous-message-id="getPrevMessageId(messagesCollapsed.messages.at(0))" />
-					<NcButton type="tertiary"
-						class="messages--header__toggle"
-						:aria-label="t('spreed', 'Show or collapse system messages')"
-						@click="toggleCollapsed(messagesCollapsed)">
-						<template #icon>
-							<UnfoldMore v-if="messagesCollapsed.collapsed" />
-							<UnfoldLess v-else />
-						</template>
-					</NcButton>
+						:previous-message-id="getPrevMessageId(messagesCollapsed.messages.at(0))"
+						@toggle-combined-system-message="toggleCollapsed(messagesCollapsed)" />
 				</ul>
 				<ul v-show="messagesCollapsed.messages?.length === 1 || !messagesCollapsed.collapsed"
 					class="messages"
@@ -61,11 +55,6 @@
 </template>
 
 <script>
-import UnfoldLess from 'vue-material-design-icons/UnfoldLessHorizontal.vue'
-import UnfoldMore from 'vue-material-design-icons/UnfoldMoreHorizontal.vue'
-
-import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-
 import Message from './Message/Message.vue'
 
 import { useCombinedSystemMessage } from '../../../composables/useCombinedSystemMessage.js'
@@ -91,10 +80,8 @@ export default {
 
 	components: {
 		Message,
-		NcButton,
-		UnfoldLess,
-		UnfoldMore,
 	},
+
 	inheritAttrs: false,
 
 	props: {
@@ -341,12 +328,6 @@ export default {
 	min-width: 0;
 
 	&--header {
-		position: relative;
-		& &__toggle {
-			position: absolute;
-			top: -6px;
-			right: 0;
-		}
 	}
 	&--collapsed {
 		border-radius: var(--border-radius-large);

--- a/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
@@ -185,6 +185,18 @@ export default {
 				return 'call_left'
 			}
 
+			// Group users promoted one by one
+			if ((message1.systemMessage === 'moderator_promoted' || message1.systemMessage === 'guest_moderator_promoted')
+				&& (message2.systemMessage === 'moderator_promoted' || message2.systemMessage === 'guest_moderator_promoted')) {
+				return 'moderator_promoted'
+			}
+
+			// Group users demoted one by one
+			if ((message1.systemMessage === 'moderator_demoted' || message1.systemMessage === 'guest_moderator_demoted')
+				&& (message2.systemMessage === 'moderator_demoted' || message2.systemMessage === 'guest_moderator_demoted')) {
+				return 'moderator_demoted'
+			}
+
 			return ''
 		},
 
@@ -373,6 +385,112 @@ export default {
 						combinedMessage.message = n('spreed',
 							'{user0}, {user1} and %n more participant left the call',
 							'{user0}, {user1} and %n more participants left the call', usersCounter - 2)
+					}
+				}
+			}
+
+			// Handle cases when actor promoted several users to moderators
+			if (type === 'moderator_promoted') {
+				const selfIsActor = combinedMessage.actorId === this.$store.getters.getActorId()
+					&& combinedMessage.actorType === this.$store.getters.getActorType()
+				messages.forEach(message => {
+					if (this.checkIfSelfIsUser(message)) {
+						selfIsUser = true
+					} else {
+						combinedMessage.messageParameters[`user${referenceIndex}`] = message.messageParameters.user
+						referenceIndex++
+					}
+					usersCounter++
+				})
+
+				if (selfIsActor) {
+					if (usersCounter === 2) {
+						combinedMessage.message = t('spreed', 'You promoted {user0} and {user1} to moderators')
+					} else {
+						combinedMessage.message = n('spreed',
+							'You promoted {user0}, {user1} and %n more participant to moderators',
+							'You promoted {user0}, {user1} and %n more participants to moderators', usersCounter - 2)
+					}
+				} else if (selfIsUser) {
+					if (usersCounter === 2) {
+						combinedMessage.message = actorIsAdministrator
+							? t('spreed', 'An administrator promoted you and {user0} to moderators')
+							: t('spreed', '{actor} promoted you and {user0} to moderators')
+					} else {
+						combinedMessage.message = actorIsAdministrator
+							? n('spreed',
+								'An administrator promoted you, {user0} and %n more participant to moderators',
+								'An administrator promoted you, {user0} and %n more participants to moderators', usersCounter - 2)
+							: n('spreed',
+								'{actor} promoted you, {user0} and %n more participant to moderators',
+								'{actor} promoted you, {user0} and %n more participants to moderators', usersCounter - 2)
+					}
+				} else {
+					if (usersCounter === 2) {
+						combinedMessage.message = actorIsAdministrator
+							? t('spreed', 'An administrator promoted {user0} and {user1} to moderators')
+							: t('spreed', '{actor} promoted {user0} and {user1} to moderators')
+					} else {
+						combinedMessage.message = actorIsAdministrator
+							? n('spreed',
+								'An administrator promoted {user0}, {user1} and %n more participant to moderators',
+								'An administrator promoted {user0}, {user1} and %n more participants to moderators', usersCounter - 2)
+							: n('spreed',
+								'{actor} promoted {user0}, {user1} and %n more participant to moderators',
+								'{actor} promoted {user0}, {user1} and %n more participants to moderators', usersCounter - 2)
+					}
+				}
+			}
+
+			// Handle cases when actor demoted several users from moderators
+			if (type === 'moderator_demoted') {
+				const selfIsActor = combinedMessage.actorId === this.$store.getters.getActorId()
+					&& combinedMessage.actorType === this.$store.getters.getActorType()
+				messages.forEach(message => {
+					if (this.checkIfSelfIsUser(message)) {
+						selfIsUser = true
+					} else {
+						combinedMessage.messageParameters[`user${referenceIndex}`] = message.messageParameters.user
+						referenceIndex++
+					}
+					usersCounter++
+				})
+
+				if (selfIsActor) {
+					if (usersCounter === 2) {
+						combinedMessage.message = t('spreed', 'You demoted {user0} and {user1} from moderators')
+					} else {
+						combinedMessage.message = n('spreed',
+							'You demoted {user0}, {user1} and %n more participant from moderators',
+							'You demoted {user0}, {user1} and %n more participants from moderators', usersCounter - 2)
+					}
+				} else if (selfIsUser) {
+					if (usersCounter === 2) {
+						combinedMessage.message = actorIsAdministrator
+							? t('spreed', 'An administrator demoted you and {user0} from moderators')
+							: t('spreed', '{actor} demoted you and {user0} from moderators')
+					} else {
+						combinedMessage.message = actorIsAdministrator
+							? n('spreed',
+								'An administrator demoted you, {user0} and %n more participant from moderators',
+								'An administrator demoted you, {user0} and %n more participants from moderators', usersCounter - 2)
+							: n('spreed',
+								'{actor} demoted you, {user0} and %n more participant from moderators',
+								'{actor} demoted you, {user0} and %n more participants from moderators', usersCounter - 2)
+					}
+				} else {
+					if (usersCounter === 2) {
+						combinedMessage.message = actorIsAdministrator
+							? t('spreed', 'An administrator demoted {user0} and {user1} from moderators')
+							: t('spreed', '{actor} demoted {user0} and {user1} from moderators')
+					} else {
+						combinedMessage.message = actorIsAdministrator
+							? n('spreed',
+								'An administrator demoted {user0}, {user1} and %n more participant from moderators',
+								'An administrator demoted {user0}, {user1} and %n more participants from moderators', usersCounter - 2)
+							: n('spreed',
+								'{actor} demoted {user0}, {user1} and %n more participant from moderators',
+								'{actor} demoted {user0}, {user1} and %n more participants from moderators', usersCounter - 2)
 					}
 				}
 			}

--- a/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
@@ -1,0 +1,213 @@
+<!--
+  - @copyright Copyright (c) 2023 Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @author Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+	<div class="message-group">
+		<div v-if="dateSeparator"
+			class="message-group__date-header">
+			<span class="date"
+				role="heading"
+				aria-level="3">{{ dateSeparator }}</span>
+		</div>
+		<div class="wrapper"
+			:class="{'wrapper--system': isSystemMessage}">
+			<div v-if="!isSystemMessage" class="messages__avatar">
+				<AuthorAvatar :author-type="actorType"
+					:author-id="actorId"
+					:display-name="actorDisplayName" />
+			</div>
+			<ul class="messages">
+				<Message v-for="(message, index) of messages"
+					:key="message.id"
+					v-bind="message"
+					:is-first-message="index === 0"
+					:next-message-id="(messages[index + 1] && messages[index + 1].id) || nextMessageId"
+					:previous-message-id="(index > 0 && messages[index - 1].id) || previousMessageId"
+					:actor-type="actorType"
+					:actor-id="actorId"
+					:actor-display-name="actorDisplayName"
+					:show-author="!isSystemMessage"
+					:is-temporary="message.timestamp === 0" />
+			</ul>
+		</div>
+	</div>
+</template>
+
+<script>
+import AuthorAvatar from './AuthorAvatar.vue'
+import Message from './Message/Message.vue'
+
+import { ATTENDEE } from '../../../constants.js'
+
+export default {
+	name: 'MessagesSystemGroup',
+
+	components: {
+		AuthorAvatar,
+		Message,
+	},
+	inheritAttrs: false,
+
+	props: {
+		/**
+		 * The conversation token.
+		 */
+		token: {
+			type: String,
+			required: true,
+		},
+		/**
+		 * The messages object.
+		 */
+		messages: {
+			type: Array,
+			required: true,
+		},
+		/**
+		 * The message date separator.
+		 */
+		dateSeparator: {
+			type: String,
+			required: true,
+		},
+
+		previousMessageId: {
+			type: [String, Number],
+			default: 0,
+		},
+
+		nextMessageId: {
+			type: [String, Number],
+			default: 0,
+		},
+	},
+
+	expose: ['highlightMessage'],
+
+	computed: {
+		/**
+		 * The message actor type.
+		 *
+		 * @return {string}
+		 */
+		actorType() {
+			return this.messages[0].actorType
+		},
+		/**
+		 * The message actor id.
+		 *
+		 * @return {string}
+		 */
+		actorId() {
+			return this.messages[0].actorId
+		},
+		/**
+		 * The message actor display name.
+		 *
+		 * @return {string}
+		 */
+		actorDisplayName() {
+			const displayName = this.messages[0].actorDisplayName.trim()
+
+			if (this.actorType === ATTENDEE.ACTOR_TYPE.GUESTS) {
+				return this.$store.getters.getGuestName(this.token, this.actorId)
+			}
+
+			if (displayName === '') {
+				return t('spreed', 'Deleted user')
+			}
+
+			return displayName
+		},
+		/**
+		 * Whether the given message is a system message
+		 *
+		 * @return {boolean}
+		 */
+		isSystemMessage() {
+			return this.messages[0].systemMessage.length !== 0
+		},
+	},
+
+	methods: {
+		highlightMessage(messageId) {
+			for (const message of this.$refs.message) {
+				if (message.id === messageId) {
+					message.highlightMessage()
+					break
+				}
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+@import '../../../assets/variables';
+
+.message-group {
+	&__date-header {
+		display: block;
+		text-align: center;
+		padding-top: 20px;
+		position: relative;
+		margin: 20px 0;
+		.date {
+			margin-right: $clickable-area * 2;
+			content: attr(data-date);
+			padding: 4px 12px;
+			left: 50%;
+			color: var(--color-text-maxcontrast);
+			background-color: var(--color-background-dark);
+			border-radius: var(--border-radius-pill);
+		}
+	}
+}
+
+.wrapper {
+	max-width: $messages-list-max-width;
+	display: flex;
+	margin: auto;
+	padding: 0;
+	&--system {
+		padding-left: $clickable-area + 8px;
+	}
+	&:focus {
+		background-color: rgba(47, 47, 47, 0.068);
+	}
+}
+
+.messages {
+	flex: auto;
+	display: flex;
+	padding: 8px 0 8px 0;
+	flex-direction: column;
+	width: 100%;
+	min-width: 0;
+	&__avatar {
+		position: sticky;
+		top: 0;
+		height: 52px;
+		width: 52px;
+		padding: 18px 10px 10px 10px;
+	}
+}
+</style>

--- a/src/components/MessagesList/MessagesList.spec.js
+++ b/src/components/MessagesList/MessagesList.spec.js
@@ -270,7 +270,7 @@ describe('MessagesList.vue', () => {
 				},
 			})
 
-			const groups = wrapper.findAllComponents({ name: 'MessagesGroup' })
+			const groups = wrapper.findAllComponents({ ref: 'messagesGroup' })
 
 			expect(groups.exists()).toBe(true)
 
@@ -298,7 +298,7 @@ describe('MessagesList.vue', () => {
 				},
 			})
 
-			const groups = wrapper.findAllComponents({ name: 'MessagesGroup' })
+			const groups = wrapper.findAllComponents({ ref: 'messagesGroup' })
 
 			expect(groups.exists()).toBe(true)
 

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -33,7 +33,8 @@ get the messagesList array and loop through the list to generate the messages.
 		:class="{'scroller--chatScrolledToBottom': isChatScrolledToBottom}"
 		@scroll="debounceHandleScroll">
 		<div v-if="displayMessagesLoader" class="scroller__loading icon-loading" />
-		<MessagesGroup v-for="item of messagesGroupedByAuthor"
+		<component :is="messagesGroupComponent(item)"
+			v-for="item of messagesGroupedByAuthor"
 			:key="item.id"
 			ref="messagesGroup"
 			v-bind="item.messages"
@@ -72,6 +73,7 @@ import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 
 import LoadingPlaceholder from '../LoadingPlaceholder.vue'
 import MessagesGroup from './MessagesGroup/MessagesGroup.vue'
+import MessagesSystemGroup from './MessagesGroup/MessagesSystemGroup.vue'
 
 import { useIsInCall } from '../../composables/useIsInCall.js'
 import { ATTENDEE, CHAT } from '../../constants.js'
@@ -82,7 +84,6 @@ export default {
 	name: 'MessagesList',
 	components: {
 		LoadingPlaceholder,
-		MessagesGroup,
 		Message,
 		NcEmptyContent,
 	},
@@ -324,6 +325,7 @@ export default {
 						dateSeparator: this.generateDateSeparator(message, lastMessage),
 						previousMessageId: groups.at(-1)?.messages.at(-1).id ?? 0,
 						nextMessageId: 0,
+						isSystemMessagesGroup: message.systemMessage.length !== 0,
 					})
 				} else {
 					groups.at(-1).messages.push(message)
@@ -1121,6 +1123,10 @@ export default {
 
 		onWindowFocus() {
 			this.refreshReadMarkerPosition()
+		},
+
+		messagesGroupComponent(group) {
+			return group.isSystemMessagesGroup ? MessagesSystemGroup : MessagesGroup
 		},
 	},
 }

--- a/src/composables/useCombinedSystemMessage.js
+++ b/src/composables/useCombinedSystemMessage.js
@@ -1,0 +1,319 @@
+/*
+ * @copyright Copyright (c) 2023 Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @author Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cloneDeep from 'lodash/cloneDeep.js'
+
+import { useStore } from './useStore.js'
+
+/**
+ * Create combined system message from the passed object
+ *
+ */
+export function useCombinedSystemMessage() {
+	const store = useStore()
+
+	/**
+	 *
+	 * @param {object} message message to check for
+	 * @return {boolean}
+	 */
+	function checkIfSelfIsActor(message) {
+		return message.actorId === store.getters.getActorId()
+			&& message.actorType === store.getters.getActorType()
+	}
+
+	/**
+	 *
+	 * @param {object} message message to check for
+	 * @return {boolean}
+	 */
+	function checkIfSelfIsOneOfActors(message) {
+		return message.messageParameters.actor.id === store.getters.getActorId()
+			&& message.messageParameters.actor.type + 's' === store.getters.getActorType()
+	}
+
+	/**
+	 *
+	 * @param {object} message message to check for
+	 * @return {boolean}
+	 */
+	function checkIfSelfIsOneOfUsers(message) {
+		return message.messageParameters.user.id === store.getters.getActorId()
+			&& message.messageParameters.user.type + 's' === store.getters.getActorType()
+	}
+
+	/**
+	 *
+	 * @param {object} group object representing the group of system messages
+	 * @param {number} group.id id of the group
+	 * @param {Array} group.messages array of grouped messages
+	 * @param {string} group.type combination type
+	 * @param {boolean} group.collapsed collapsed state
+	 * @return {object}
+	 */
+	function createCombinedSystemMessage({ id, messages, type, collapsed }) {
+		const combinedMessage = cloneDeep(messages[0])
+
+		// Handle cases when users reconnected to the call
+		if (type === 'call_reconnected') {
+			if (checkIfSelfIsOneOfActors(combinedMessage)) {
+				combinedMessage.message = t('spreed', 'You reconnected to the call')
+			} else {
+				combinedMessage.message = t('spreed', '{actor} reconnected to the call')
+			}
+
+			return combinedMessage
+		}
+
+		// clear messageParameters to be filled later
+		const actor = messages[0].messageParameters.actor
+		combinedMessage.messageParameters = { actor }
+		const actorIsAdministrator = actor.id === 'guest/cli' && actor.type === 'guest'
+
+		// usersCounter should be equal at least 2, as we're using method only for groups
+		let usersCounter = 0
+		let selfIsUser = false
+		let referenceIndex = 0
+
+		// Handle cases when actor added users to conversation (when populate on creation, for example)
+		if (type === 'user_added') {
+			messages.forEach(message => {
+				if (checkIfSelfIsOneOfUsers(message)) {
+					selfIsUser = true
+				} else {
+					combinedMessage.messageParameters[`user${referenceIndex}`] = message.messageParameters.user
+					referenceIndex++
+				}
+				usersCounter++
+			})
+
+			if (checkIfSelfIsActor(combinedMessage)) {
+				if (usersCounter === 2) {
+					combinedMessage.message = t('spreed', 'You added {user0} and {user1}')
+				} else {
+					combinedMessage.message = n('spreed',
+						'You added {user0}, {user1} and %n more participant',
+						'You added {user0}, {user1} and %n more participants', usersCounter - 2)
+				}
+			} else if (selfIsUser) {
+				if (usersCounter === 2) {
+					combinedMessage.message = actorIsAdministrator
+						? t('spreed', 'An administrator added you and {user0}')
+						: t('spreed', '{actor} added you and {user0}')
+				} else {
+					combinedMessage.message = actorIsAdministrator
+						? n('spreed',
+							'An administrator added you, {user0} and %n more participant',
+							'An administrator added you, {user0} and %n more participants', usersCounter - 2)
+						: n('spreed',
+							'{actor} added you, {user0} and %n more participant',
+							'{actor} added you, {user0} and %n more participants', usersCounter - 2)
+				}
+			} else {
+				if (usersCounter === 2) {
+					combinedMessage.message = actorIsAdministrator
+						? t('spreed', 'An administrator added {user0} and {user1}')
+						: t('spreed', '{actor} added {user0} and {user1}')
+				} else {
+					combinedMessage.message = actorIsAdministrator
+						? n('spreed',
+							'An administrator added {user0}, {user1} and %n more participant',
+							'An administrator added {user0}, {user1} and %n more participants', usersCounter - 2)
+						: n('spreed',
+							'{actor} added {user0}, {user1} and %n more participant',
+							'{actor} added {user0}, {user1} and %n more participants', usersCounter - 2)
+				}
+			}
+		}
+
+		// Handle cases when users joined or left the call
+		if (type === 'call_joined' || type === 'call_left') {
+			const storedUniqueUsers = []
+
+			messages.forEach(message => {
+				const actorReference = `${message.messageParameters.actor.id}_${message.messageParameters.actor.type}`
+				if (storedUniqueUsers.includes(actorReference)) {
+					return
+				}
+				if (checkIfSelfIsOneOfActors(message)) {
+					selfIsUser = true
+				} else {
+					combinedMessage.messageParameters[`user${referenceIndex}`] = message.messageParameters.actor
+					storedUniqueUsers.push(actorReference)
+					referenceIndex++
+				}
+				usersCounter++
+			})
+
+			if (usersCounter === 1) {
+				combinedMessage.message = messages[0].message
+				return combinedMessage
+			}
+
+			if (type === 'call_joined') {
+				if (selfIsUser) {
+					if (usersCounter === 2) {
+						combinedMessage.message = t('spreed', 'You and {user0} joined the call')
+					} else {
+						combinedMessage.message = n('spreed',
+							'You, {user0} and %n more participant joined the call',
+							'You, {user0} and %n more participants joined the call', usersCounter - 2)
+					}
+				} else {
+					if (usersCounter === 2) {
+						combinedMessage.message = t('spreed', '{user0} and {user1} joined the call')
+					} else {
+						combinedMessage.message = n('spreed',
+							'{user0}, {user1} and %n more participant joined the call',
+							'{user0}, {user1} and %n more participants joined the call', usersCounter - 2)
+					}
+				}
+			} else if (type === 'call_left') {
+				if (selfIsUser) {
+					if (usersCounter === 2) {
+						combinedMessage.message = t('spreed', 'You and {user0} left the call')
+					} else {
+						combinedMessage.message = n('spreed',
+							'You, {user0} and %n more participant left the call',
+							'You, {user0} and %n more participants left the call', usersCounter - 2)
+					}
+				} else {
+					if (usersCounter === 2) {
+						combinedMessage.message = t('spreed', '{user0} and {user1} left the call')
+					} else {
+						combinedMessage.message = n('spreed',
+							'{user0}, {user1} and %n more participant left the call',
+							'{user0}, {user1} and %n more participants left the call', usersCounter - 2)
+					}
+				}
+			}
+
+		}
+
+		// Handle cases when actor promoted several users to moderators
+		if (type === 'moderator_promoted') {
+			messages.forEach(message => {
+				if (checkIfSelfIsOneOfUsers(message)) {
+					selfIsUser = true
+				} else {
+					combinedMessage.messageParameters[`user${referenceIndex}`] = message.messageParameters.user
+					referenceIndex++
+				}
+				usersCounter++
+			})
+
+			if (checkIfSelfIsActor(combinedMessage)) {
+				if (usersCounter === 2) {
+					combinedMessage.message = t('spreed', 'You promoted {user0} and {user1} to moderators')
+				} else {
+					combinedMessage.message = n('spreed',
+						'You promoted {user0}, {user1} and %n more participant to moderators',
+						'You promoted {user0}, {user1} and %n more participants to moderators', usersCounter - 2)
+				}
+			} else if (selfIsUser) {
+				if (usersCounter === 2) {
+					combinedMessage.message = actorIsAdministrator
+						? t('spreed', 'An administrator promoted you and {user0} to moderators')
+						: t('spreed', '{actor} promoted you and {user0} to moderators')
+				} else {
+					combinedMessage.message = actorIsAdministrator
+						? n('spreed',
+							'An administrator promoted you, {user0} and %n more participant to moderators',
+							'An administrator promoted you, {user0} and %n more participants to moderators', usersCounter - 2)
+						: n('spreed',
+							'{actor} promoted you, {user0} and %n more participant to moderators',
+							'{actor} promoted you, {user0} and %n more participants to moderators', usersCounter - 2)
+				}
+			} else {
+				if (usersCounter === 2) {
+					combinedMessage.message = actorIsAdministrator
+						? t('spreed', 'An administrator promoted {user0} and {user1} to moderators')
+						: t('spreed', '{actor} promoted {user0} and {user1} to moderators')
+				} else {
+					combinedMessage.message = actorIsAdministrator
+						? n('spreed',
+							'An administrator promoted {user0}, {user1} and %n more participant to moderators',
+							'An administrator promoted {user0}, {user1} and %n more participants to moderators', usersCounter - 2)
+						: n('spreed',
+							'{actor} promoted {user0}, {user1} and %n more participant to moderators',
+							'{actor} promoted {user0}, {user1} and %n more participants to moderators', usersCounter - 2)
+				}
+			}
+		}
+
+		// Handle cases when actor demoted several users from moderators
+		if (type === 'moderator_demoted') {
+			messages.forEach(message => {
+				if (checkIfSelfIsOneOfUsers(message)) {
+					selfIsUser = true
+				} else {
+					combinedMessage.messageParameters[`user${referenceIndex}`] = message.messageParameters.user
+					referenceIndex++
+				}
+				usersCounter++
+			})
+
+			if (checkIfSelfIsActor(combinedMessage)) {
+				if (usersCounter === 2) {
+					combinedMessage.message = t('spreed', 'You demoted {user0} and {user1} from moderators')
+				} else {
+					combinedMessage.message = n('spreed',
+						'You demoted {user0}, {user1} and %n more participant from moderators',
+						'You demoted {user0}, {user1} and %n more participants from moderators', usersCounter - 2)
+				}
+			} else if (selfIsUser) {
+				if (usersCounter === 2) {
+					combinedMessage.message = actorIsAdministrator
+						? t('spreed', 'An administrator demoted you and {user0} from moderators')
+						: t('spreed', '{actor} demoted you and {user0} from moderators')
+				} else {
+					combinedMessage.message = actorIsAdministrator
+						? n('spreed',
+							'An administrator demoted you, {user0} and %n more participant from moderators',
+							'An administrator demoted you, {user0} and %n more participants from moderators', usersCounter - 2)
+						: n('spreed',
+							'{actor} demoted you, {user0} and %n more participant from moderators',
+							'{actor} demoted you, {user0} and %n more participants from moderators', usersCounter - 2)
+				}
+			} else {
+				if (usersCounter === 2) {
+					combinedMessage.message = actorIsAdministrator
+						? t('spreed', 'An administrator demoted {user0} and {user1} from moderators')
+						: t('spreed', '{actor} demoted {user0} and {user1} from moderators')
+				} else {
+					combinedMessage.message = actorIsAdministrator
+						? n('spreed',
+							'An administrator demoted {user0}, {user1} and %n more participant from moderators',
+							'An administrator demoted {user0}, {user1} and %n more participants from moderators', usersCounter - 2)
+						: n('spreed',
+							'{actor} demoted {user0}, {user1} and %n more participant from moderators',
+							'{actor} demoted {user0}, {user1} and %n more participants from moderators', usersCounter - 2)
+				}
+			}
+		}
+
+		return combinedMessage
+	}
+
+	return {
+		createCombinedSystemMessage,
+	}
+}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9678
* New component and util for handling groups of system messages added
* Combine messages for following actions:
  * participants being added to the conversations
  * participants promoted to / demoted from moderators
  * participants joined / left the call
  * participant reconnected to the call
* Light sort of messages within one group:
  `user added/removed` => `moderator promoted/demoted` => `call started` => `recording started` => `call joined/left` => `call ended`

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2023-08-03 12-52-48](https://github.com/nextcloud/spreed/assets/93392545/8333cc6d-17e6-4a5d-9f1a-d87e6453ac30) | ![image](https://github.com/nextcloud/spreed/assets/93392545/b5572ef0-6cb2-475c-949a-b23866c1c228) 

### 🚧 Tasks

- [ ] Design: appearance of header and collapsed messages, toggle button, animation
- [ ] RFC: re-sorting system messages within one MessagesSystemGroup: define a list of system messages being sorted, and theirs order (sorting of related messages brings weird results , like `call_left` and `call_joined` in various combinations, so they're not sorted between each other)
- [ ] Follow-up - test coverage
- [ ] Follow-up - messages re-rendering

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
