### PR TITLE
Make conversation name and description selectable

### DIFF
--- a/src/components/ConversationSettings/EditableTextField.vue
+++ b/src/components/ConversationSettings/EditableTextField.vue
@@ -300,6 +300,7 @@ export default {
 		border-color: transparent;
 		opacity: 1;
 		border-radius: 0;
+		user-select: text;
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9136 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/56f6deaa-6743-41bc-9ebd-1018c965a931) | ![image](https://github.com/nextcloud/spreed/assets/93392545/1af0977e-aa0a-4e66-b21c-5220882f31c8)



### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is noxt required
- [x] 🔖 Capability is added or not needed 
