### PR TITLE
Fix uploading video backgrounds from Files

### DIFF
--- a/src/components/MediaSettings/VideoBackgroundEditor.vue
+++ b/src/components/MediaSettings/VideoBackgroundEditor.vue
@@ -174,22 +174,22 @@ export default {
 		const relativeBackgroundsFolderPath = this.$store.getters.getAttachmentFolder() + '/Backgrounds'
 		const absoluteBackgroundsFolderPath = userRoot + relativeBackgroundsFolderPath
 
-		// Create the backgrounds folder if it doesn't exist
-		if (await client.exists(absoluteBackgroundsFolderPath) === false) {
-			try {
+		try {
+			// Create the backgrounds folder if it doesn't exist
+			if (await client.exists(absoluteBackgroundsFolderPath) === false) {
 				await client.createDirectory(absoluteBackgroundsFolderPath)
-
-				// Create picker
-				picker = getFilePickerBuilder(t('spreed', 'File to share'))
-					.setMultiSelect(false)
-					.setModal(true)
-					.startAt(relativeBackgroundsFolderPath)
-					.setType(1)
-					.allowDirectories(false)
-					.build()
-			} catch (error) {
-				console.debug(error)
 			}
+
+			// Create picker
+			picker = getFilePickerBuilder(t('spreed', 'File to share'))
+				.setMultiSelect(false)
+				.setModal(true)
+				.startAt(relativeBackgroundsFolderPath)
+				.setType(1)
+				.allowDirectories(false)
+				.build()
+		} catch (error) {
+			console.debug(error)
 		}
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9783 
* Regression from #9347 
* method skipped picker initialization, if directory for background was already created

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/ba9c1798-853a-4cd2-b894-8fba7f318023) | ![image](https://github.com/nextcloud/spreed/assets/93392545/b5f2db6b-1b45-49a6-bd37-d579165edc8b)



### 🚧 Tasks

- [ ] Visual check
- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
