### PR TITLE
Show `Guest` to self when guest reacts in call with no name

### DIFF
--- a/src/components/CallView/shared/ReactionToaster.vue
+++ b/src/components/CallView/shared/ReactionToaster.vue
@@ -138,7 +138,7 @@ export default {
 				id: model.attributes.peerId,
 				reaction,
 				name: isLocalModel
-					? this.$store.getters.getDisplayName()
+					? this.$store.getters.getDisplayName() || this.$store.getters.getGuestName()
 					: this.getParticipantName(model),
 				seed: Math.random(),
 			})


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9772
* Registered users always have a display name (as far as i know), so if it's empty, it's probably a guest. We could then look if guestName is set in the store, and if it's empty, return `t('spreed', 'Guest')`

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/e110f957-1c74-4b2e-9354-064e13fe5344) | ![image](https://github.com/nextcloud/spreed/assets/93392545/f35a7455-183f-4dd2-b675-74953d6deb32)



### 🚧 Tasks

- [ ] Visual check

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
