### PR TITLE
Adjust navigation buttons offset for call in Grid view

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -967,10 +967,10 @@ export default {
 		position: absolute;
 		top: calc(50% - var(--default-clickable-area) / 2);
 		&__previous {
-			left: -4px;
+			left: 8px;
 		}
 		&__next {
-			right: -4px;
+			right: 8px;
 		}
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9767 
* As per discussion (and overall positive opinion on 8px offset), grid navigation buttons in call were adjusted

![image](https://github.com/nextcloud/spreed/assets/93392545/1055f374-087d-409d-9250-683751cb4be3)


### 🚧 Tasks

- [ ] Visual check

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
