### PR TITLE
Fix media settings in files sidebar

### DIFF
--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -22,7 +22,6 @@
 <template>
 	<NcModal v-if="modal"
 		class="talk-modal"
-		:container="container"
 		@close="closeModal">
 		<div class="media-settings">
 			<h2 class="media-settings__title">
@@ -616,4 +615,5 @@ export default {
 	display: flex !important;
 	max-width: 500px !important;
 }
+
 </style>


### PR DESCRIPTION
When starting a call from the files sidebar and while editing a file, the media settings was not display because it was covered by the file dialog. Increasing the z-index of the media settings dialog didn't fix the issue (it's unclear to me why not). Removing the container of the media settings dialog and thereby assigning the default body as container fixes the issue.

### ☑️ Resolves

* Fix #8709 

### 🖼️ Screenshots

<img width="822" alt="Screenshot 2023-06-16 at 13 45 12" src="https://github.com/nextcloud/spreed/assets/26852655/303b7673-692e-47c8-a4a6-888b0a225413">
