### PR TITLE
fix(LeftSidebar): fix scroll with new created conversations

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -41,7 +41,7 @@
 						:title="t('spreed', 'Conversations')" />
 					<Conversation v-for="item of conversationsList"
 						:key="item.id"
-						ref="conversations"
+						:ref="`conversation-${item.token}`"
 						:item="item" />
 					<template v-if="!initialisedConversations">
 						<LoadingPlaceholder type="conversations" />
@@ -548,7 +548,12 @@ export default {
 
 		scrollToConversation(token) {
 			this.$nextTick(() => {
-				const conversation = this.$refs.conversations[this.conversationsList.findIndex(item => item.token === token)].$el
+				// In Vue 2 ref on v-for is always an array and its order is not guaranteed to match the order of v-for source
+				// See https://github.com/vuejs/vue/issues/4952#issuecomment-280661367
+				// Fixed in Vue 3
+				// Temp solution - use unique ref name for each v-for element. The value is still array but with one element
+				// TODO: Vue3: remove [0] here or use object for template refs
+				const conversation = this.$refs[`conversation-${token}`]?.[0].$el
 				if (!conversation) {
 					return
 				}


### PR DESCRIPTION
### ☑️ Resolves

During the discussion of https://github.com/nextcloud/spreed/pull/9706 I missed that in Vue 2 `ref` on `v-for` is always an array and its order is **not guaranteed to match** the order of the `v-for` source. It has initial order in `$refs` and always puts new nodes in the end.

See Evan's comment: https://github.com/vuejs/vue/issues/4952#issuecomment-280661367

It caused a problem with scrolling with newly created conversations (and with reordered ones).

**Step to reproduce:** create 10 new chats, do not reload the page
**Expected:** it scrolls to the newly created chat after the creation or after joining
**Actual:** it scrolls to the first chat because the new chat has index 0 in the data but the last index in the `$refs`.


### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![before](https://github.com/nextcloud/spreed/assets/25978914/a34f72a4-87b9-4876-ad3f-e7f1b5217c61) | ![after](https://github.com/nextcloud/spreed/assets/25978914/3ad33f7e-ac9c-49e4-8439-002af070d5be)


### 🚧 Tasks

Use an unique ref name for each conversation node in the list.

Vue still creates an array for such refs (because they are still used with `v-for`), so we need to take `[0]` element.

An alternative solution is to use DOM API with query selectors here, but it is less Vue-way and requires depending on things that are not a public API of the component. Also, this solution won't be dirty after the migration to Vue 3.


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required (not possible to test in Jest)
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
