### PR TITLE
fix(NewMessageNewFileDialog) - fix creation of file from Blank template

### DIFF
--- a/src/components/NewMessage/NewMessageNewFileDialog.vue
+++ b/src/components/NewMessage/NewMessageNewFileDialog.vue
@@ -210,17 +210,13 @@ export default {
 
 			let fileData
 			try {
-				let response
-				if (this.selectedTemplate.fileid === -1) {
-					// Don't send template information for Blank
-					response = await createNewFile(filePath)
-				} else {
-					response = await createNewFile(
+				const response = this.selectedTemplate.fileid === -1
+					? await createNewFile(filePath)
+					: await createNewFile(
 						filePath,
 						this.selectedTemplate?.filename,
 						this.selectedTemplate?.templateType,
 					)
-				}
 				fileData = response.data.ocs.data
 			} catch (error) {
 				console.error('Error while creating file', error)

--- a/src/components/NewMessage/NewMessageNewFileDialog.vue
+++ b/src/components/NewMessage/NewMessageNewFileDialog.vue
@@ -210,11 +210,17 @@ export default {
 
 			let fileData
 			try {
-				const response = await createNewFile(
-					filePath,
-					this.selectedTemplate?.filename,
-					this.selectedTemplate?.templateType,
-				)
+				let response
+				if (this.selectedTemplate.fileid === -1) {
+					// Don't send template information for Blank
+					response = await createNewFile(filePath)
+				} else {
+					response = await createNewFile(
+						filePath,
+						this.selectedTemplate?.filename,
+						this.selectedTemplate?.templateType,
+					)
+				}
 				fileData = response.data.ocs.data
 			} catch (error) {
 				console.error('Error while creating file', error)

--- a/src/services/filesSharingServices.js
+++ b/src/services/filesSharingServices.js
@@ -63,8 +63,8 @@ const getFileTemplates = async () => {
  * Share a text file to a conversation
  *
  * @param {string} filePath The new file destination path
- * @param {string} templatePath The template source path
- * @param {string} templateType The template type e.g 'user'
+ * @param {string} [templatePath] The template source path
+ * @param {string} [templateType] The template type e.g 'user'
  * @return { object } the file object
  */
 const createNewFile = async function(filePath, templatePath, templateType) {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9779
* Regression from https://github.com/nextcloud/spreed/commit/5ae4c8207f03887ecfd6fec5f6510a1d66689888 - joining of empty template with others into one array
* `this.selectedTemplate?.filename` checks for the path to file, for example, `Templates/Filename.md`. With `/Blank` file, we receive a search error, but file will still be created in `Talk` folder

To reproduce:
1) in Files, click "+" => "Set Templates folder" (could be wrong with button title)
2) Add some templates [from there](https://github.com/nextcloud/example-files/tree/master)
3) in Talk, click :paperclip: => "New text file"
4) Try to create a file with Blank or any of the existing templates
![image](https://github.com/nextcloud/spreed/assets/93392545/bd189280-2210-47df-8ef1-6cd330604a45)
5) Everything should work
5.1) Or use only steps 3-4, template is Blank by default

### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
