### PR TITLE
follow-up (Poll) - change description for open polls

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
@@ -323,14 +323,14 @@ export default {
 			}
 
 			if (this.selfIsOwnerOrModerator || (this.isPollPublic && this.selfHasVoted)) {
-				return n('spreed', 'Poll • %n vote', 'Poll • %n votes', this.numVoters)
+				return n('spreed', 'Open poll • %n vote', 'Open poll • %n votes', this.numVoters)
 			}
 
 			if (!this.isPollPublic && this.selfHasVoted) {
-				return t('spreed', 'Poll • You voted already')
+				return t('spreed', 'Open poll • You voted already')
 			}
 
-			return t('spreed', 'Poll')
+			return t('spreed', 'Open poll')
 		},
 
 		canEndPoll() {
@@ -339,7 +339,7 @@ export default {
 
 		pollFooterText() {
 			if (this.isPollOpen) {
-				return this.selfHasVoted ? t('spreed', 'Poll • You voted already') : t('spreed', 'Poll • Click to vote')
+				return this.selfHasVoted ? t('spreed', 'Open poll • You voted already') : t('spreed', 'Open poll • Click to vote')
 			} else if (this.isPollClosed) {
 				return t('spreed', 'Poll • Ended')
 			}


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #9815 

### 🖼️ Screenshots

🏡 After (Message view, voting) | 🏡 After (results)
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/9c0ef38d-99f2-41b1-b237-74bf1cc4b579) ![image](https://github.com/nextcloud/spreed/assets/93392545/d4ee62af-97d9-4e24-9a13-b4adcf995bb6) | ![image](https://github.com/nextcloud/spreed/assets/93392545/a713f8d4-53bf-43d7-b91d-ec9d4eb08f70) 
![image](https://github.com/nextcloud/spreed/assets/93392545/3f47b2c9-69ac-4b0c-b1f4-f479a3f8b199) | ![image](https://github.com/nextcloud/spreed/assets/93392545/97600baf-b1e2-45c5-8938-639f09e1e6a2)


### 🚧 Tasks

- [ ] Visual check

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
