### PR TITLE
fix(Grid) - finetune columns calculations

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -405,12 +405,15 @@ export default {
 
 		// Max number of columns possible
 		columnsMax() {
-			if (Math.floor(this.gridWidth / this.dpiAwareMinWidth) < 1) {
-				// Return at least 1 column
-				return 1
-			} else {
-				return Math.floor(this.gridWidth / this.dpiAwareMinWidth)
-			}
+			// Max amount of columns that fits on screen, including gaps and paddings (8px)
+			const calculatedApproxColumnsMax = Math.floor((this.gridWidth - 8 * this.columns) / this.dpiAwareMinWidth)
+			// Max amount of columns that fits on screen (with one more gap, as if we try to fit one more column)
+			const calculatedHypotheticalColumnsMax = Math.floor((this.gridWidth - 8 * (this.columns + 1)) / this.dpiAwareMinWidth)
+			// If we about to change current columns amount, check if one more column could fit the screen
+			// This helps to avoid flickering, when resize within 8px from minimal gridWidth for current amount of columns
+			const calculatedColumnsMax = calculatedApproxColumnsMax === this.columns ? calculatedApproxColumnsMax : calculatedHypotheticalColumnsMax
+			// Return at least 1 column
+			return calculatedColumnsMax <= 1 ? 1 : calculatedColumnsMax
 		},
 
 		// Max number of rows possible
@@ -675,7 +678,7 @@ export default {
 			// currently if the user is not on the 'first page', upon resize the
 			// current position in the videos array is lost (first element
 			// in the grid goes back to be first video)
-			debounce(this.makeGrid(), 200)
+				debounce(this.makeGrid(), 200)
 		},
 
 		// Find the right size if the grid in rows and columns (we already know
@@ -894,12 +897,14 @@ export default {
 
 .grid-wrapper {
 	width: 100%;
+	min-width: 0;
 	position: relative;
 	flex: 1 0 auto;
 }
 
 .stripe-wrapper {
 	width: 100%;
+	min-width: 0;
 	position: relative;
 }
 

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -678,7 +678,7 @@ export default {
 			// currently if the user is not on the 'first page', upon resize the
 			// current position in the videos array is lost (first element
 			// in the grid goes back to be first video)
-				debounce(this.makeGrid(), 200)
+			debounce(this.makeGrid(), 200)
 		},
 
 		// Find the right size if the grid in rows and columns (we already know
@@ -832,7 +832,9 @@ export default {
 				clearTimeout(this.showVideoOverlayTimer)
 			}
 			this.showVideoOverlay = true
-			this.showVideoOverlayTimer = setTimeout(() => { this.showVideoOverlay = false }, 5000)
+			this.showVideoOverlayTimer = setTimeout(() => {
+				this.showVideoOverlay = false
+			}, 5000)
 		},
 
 		handleClickVideo(event, peerId) {
@@ -913,6 +915,7 @@ export default {
 		border: 1px solid #00FF41;
 		color: #00FF41;
 	}
+
 	position: relative;
 
 	&--self {
@@ -924,7 +927,7 @@ export default {
 		object-fit: cover;
 		height: 100%;
 		width: 100%;
-		border-radius: calc(var(--default-clickable-area)/2);
+		border-radius: calc(var(--default-clickable-area) / 2);
 	}
 
 	.wrapper {
@@ -951,11 +954,12 @@ export default {
 	left: 20px;
 	bottom: 50%;
 	padding: 20px;
-	background: rgba(0,0,0,0.8);
+	background: rgba(0, 0, 0, 0.8);
 	border: 1px solid #00FF41;
 	width: 212px;
 	font-size: 12px;
 	z-index: 999999999999999;
+
 	& p {
 		text-overflow: ellipsis;
 		overflow: hidden;
@@ -971,9 +975,11 @@ export default {
 	.grid-wrapper & {
 		position: absolute;
 		top: calc(50% - var(--default-clickable-area) / 2);
+
 		&__previous {
 			left: 8px;
 		}
+
 		&__next {
 			right: 8px;
 		}
@@ -982,9 +988,11 @@ export default {
 	.stripe-wrapper & {
 		position: absolute;
 		top: 16px;
+
 		&__previous {
 			left: 8px;
 		}
+
 		&__next {
 			right: 16px;
 		}
@@ -1000,6 +1008,7 @@ export default {
 	height: 44px;
 	padding: 0 22px;
 	border-radius: 22px;
+
 	&__dot {
 		width: 8px;
 		height: 8px;


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9203 
* Stripe wrapper min-width was set to auto, which prevent it from shrinking => as a result, LocalVideo goes out of screen borders
* After fixing that, noticed that columnsMax calculation doesn't consider gaps between video frames => videos also overflowing screen

### 🖼️ Screenshots

:warning: To switch call to the devMode, pass boolean prop `dev-mode` to Grid.vue 
🏚️ Before | 🏡 After
---|---
![Screenshot from 2023-06-20 15-09-16](https://github.com/nextcloud/spreed/assets/93392545/26fa7eb0-2bf7-434a-ba4f-92f9dc608999) | ![Screenshot from 2023-06-20 15-10-17](https://github.com/nextcloud/spreed/assets/93392545/490d1caf-508a-4690-8785-0ee7a7a44a1f)
![Screenshot from 2023-06-20 15-08-57](https://github.com/nextcloud/spreed/assets/93392545/16101ff1-4d04-4a5f-ac3f-4b4b73a9085a) | ![Screenshot from 2023-06-20 15-10-37](https://github.com/nextcloud/spreed/assets/93392545/776a4901-06bb-419a-aca0-a21ba3edd8ea)

### 🚧 Tasks

- [ ] Code review
- [ ] Visual check

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
