### PR TITLE
Chore(deps): Bump emoji-mart-vue-fast from 12.0.5 to 15.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"color.js": "^1.2.0",
 				"crypto-js": "^4.1.1",
 				"debounce": "^1.2.1",
-				"emoji-mart-vue-fast": "^12.0.5",
+				"emoji-mart-vue-fast": "^15.0.0",
 				"emoji-regex": "^10.2.1",
 				"escape-html": "^1.0.3",
 				"extendable-media-recorder": "^7.1.18",
@@ -3060,6 +3060,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/emoji-mart-vue-fast": {
+			"version": "12.0.5",
+			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-12.0.5.tgz",
+			"integrity": "sha512-XFNwIk+ConSAjC4tmk//s6btlo3oQco7TBgP914Qytg/15jLa/0VrWNg271W2MTv+8N8BxYl2dDn3cZJxcreqw==",
+			"dependencies": {
+				"@babel/runtime": "^7.18.6",
+				"core-js": "^3.23.5"
+			},
+			"peerDependencies": {
+				"vue": ">2.0.0"
 			}
 		},
 		"node_modules/@nextcloud/vue/node_modules/linkify-string": {
@@ -7005,9 +7017,9 @@
 			}
 		},
 		"node_modules/emoji-mart-vue-fast": {
-			"version": "12.0.5",
-			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-12.0.5.tgz",
-			"integrity": "sha512-XFNwIk+ConSAjC4tmk//s6btlo3oQco7TBgP914Qytg/15jLa/0VrWNg271W2MTv+8N8BxYl2dDn3cZJxcreqw==",
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.0.tgz",
+			"integrity": "sha512-3BzkDrs60JyT00dLHMAxWKbpFhbyaW9C+q1AjtqGovSxTu8TC2mYAGsvTmXNYKm39IRRAS56v92TihOcB98IsQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.18.6",
 				"core-js": "^3.23.5"
@@ -20630,6 +20642,15 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
 					"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
 				},
+				"emoji-mart-vue-fast": {
+					"version": "12.0.5",
+					"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-12.0.5.tgz",
+					"integrity": "sha512-XFNwIk+ConSAjC4tmk//s6btlo3oQco7TBgP914Qytg/15jLa/0VrWNg271W2MTv+8N8BxYl2dDn3cZJxcreqw==",
+					"requires": {
+						"@babel/runtime": "^7.18.6",
+						"core-js": "^3.23.5"
+					}
+				},
 				"linkify-string": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/linkify-string/-/linkify-string-4.0.0.tgz",
@@ -23711,9 +23732,9 @@
 			"dev": true
 		},
 		"emoji-mart-vue-fast": {
-			"version": "12.0.5",
-			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-12.0.5.tgz",
-			"integrity": "sha512-XFNwIk+ConSAjC4tmk//s6btlo3oQco7TBgP914Qytg/15jLa/0VrWNg271W2MTv+8N8BxYl2dDn3cZJxcreqw==",
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.0.tgz",
+			"integrity": "sha512-3BzkDrs60JyT00dLHMAxWKbpFhbyaW9C+q1AjtqGovSxTu8TC2mYAGsvTmXNYKm39IRRAS56v92TihOcB98IsQ==",
 			"requires": {
 				"@babel/runtime": "^7.18.6",
 				"core-js": "^3.23.5"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"color.js": "^1.2.0",
 		"crypto-js": "^4.1.1",
 		"debounce": "^1.2.1",
-		"emoji-mart-vue-fast": "^12.0.5",
+		"emoji-mart-vue-fast": "^15.0.0",
 		"emoji-regex": "^10.2.1",
 		"escape-html": "^1.0.3",
 		"extendable-media-recorder": "^7.1.18",


### PR DESCRIPTION
Backport of #9806 