### PR TITLE
Improve performance in share handling

### DIFF
--- a/appinfo/routes/routesChatController.php
+++ b/appinfo/routes/routesChatController.php
@@ -52,6 +52,8 @@ return [
 		['name' => 'Chat#markUnread', 'url' => '/api/{apiVersion}/chat/{token}/read', 'verb' => 'DELETE', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\ChatController::mentions() */
 		['name' => 'Chat#mentions', 'url' => '/api/{apiVersion}/chat/{token}/mentions', 'verb' => 'GET', 'requirements' => $requirements],
+		/** @see \OCA\Talk\Controller\ChatController::prepareUploadingFile() */
+		['name' => 'Chat#prepareUploadingFile', 'url' => '/api/{apiVersion}/chat/{token}/upload-prepare', 'verb' => 'POST', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\ChatController::shareObjectToChat() */
 		['name' => 'Chat#shareObjectToChat', 'url' => '/api/{apiVersion}/chat/{token}/share', 'verb' => 'POST', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\ChatController::getObjectsSharedInRoomOverview() */

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -388,6 +388,9 @@ class Listener implements IEventListener {
 		if ($request->getParam('_route') === 'ocs.spreed.Recording.shareToChat') {
 			return;
 		}
+		if ($request->getParam('_route') === 'ocs.spreed.Chat.prepareUploadingFile') {
+			return;
+		}
 		$room = $manager->getRoomByToken($share->getSharedWith());
 		$metaData = Server::get(IRequest::class)->getParam('talkMetaData') ?? '';
 		$metaData = json_decode($metaData, true);

--- a/lib/Share/Helper/AttachmentFolder.php
+++ b/lib/Share/Helper/AttachmentFolder.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Share\Helper;
+
+use OCA\Talk\Config;
+use OCA\Talk\Model\Attendee;
+use OCA\Talk\Model\AttendeeMapper;
+use OCA\Talk\Participant;
+use OCA\Talk\Room;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\IConfig;
+use Psr\Log\LoggerInterface;
+
+class AttachmentFolder {
+	public function __construct(
+		protected IRootFolder $rootFolder,
+		protected IConfig $serverConfig,
+		protected Config $talkConfig,
+		protected AttendeeMapper $attendeeMapper,
+		protected LoggerInterface $logger,
+	) {
+	}
+
+	protected function prepareSharingFile(Room $room, Participant $participant, string $fileName): array {
+		$attendee = $participant->getAttendee();
+		if ($attendee->getActorType() !== Attendee::ACTOR_USERS) {
+			throw new \InvalidArgumentException('participant');
+		}
+
+		$userId = $attendee->getActorId();
+		$userFolder = $this->rootFolder->getUserFolder($userId);
+
+		$conversationFolderId = 0; // $attendee->getAttachmentFolderId();
+		if ($conversationFolderId !== 0) {
+			try {
+				$conversationFolder = $userFolder->getById($conversationFolderId);
+			} catch (NotFoundException $e) {
+			}
+		}
+
+		if (!$conversationFolder instanceof Folder) {
+			$talkFolder = $this->ensureTalkFolderExists($userFolder, $userId);
+			$conversationFolder = $this->createConversationFolderExists($talkFolder, $room, $attendee);
+		}
+
+		// FIXME when root or talk folder is used, we need to tell the clients that the individual file still needs sharing
+
+
+//			$freeSpace = $attachmentFolder->getFreeSpace();
+	}
+
+	protected function ensureTalkFolderExists(Folder $userFolder, string $userId): Folder {
+		$attachmentFolderName = $this->talkConfig->getAttachmentFolder($userId);
+		try {
+			try {
+				$attachmentFolder = $userFolder->get($attachmentFolderName);
+			} catch (NotFoundException $e) {
+				$attachmentFolder = $userFolder->newFolder($attachmentFolderName);
+			}
+
+			return $attachmentFolder;
+		} catch (NotPermittedException $e) {
+			$this->serverConfig->setUserValue($userId, 'spreed', 'attachment_folder', '/');
+			return $userFolder;
+		}
+	}
+
+	protected function createConversationFolderExists(Folder $talkFolder, Room $room, Attendee $attendee): Folder {
+		try {
+			for ($i = 0; $i < 10_000; $i++) {
+				$folderName = $i === 0 ? $room->getToken() : $room->getToken() . ' (' . $i . ')';
+				try {
+					$talkFolder->get($folderName);
+				} catch (NotFoundException $e) {
+					$folder = $talkFolder->newFolder($folderName);
+//					$attendee->setAttachmentFolderId($attachmentFolder->getId());
+					$this->attendeeMapper->update($attendee);
+					return $folder;
+				}
+			}
+
+			$this->logger->warning('More than 10k attempts to find a free folder name for conversation ' . $room->getToken() . ' as user ' . $attendee->getActorId() . ' failed, giving up and saving to Talk/ folder.');
+		} catch (NotPermittedException $e) {
+		}
+
+		return $talkFolder;
+	}
+}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9667 

### 🚧 Tasks

- [x] Add endpoint to create a folder that is shared with a room
- [ ] Add option/endpoint to trigger the share system-message individually
- [ ] Opt-out when expiration is on as the shares can otherwise not expire

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
