### PR TITLE
follow-up(ChatView) - align scroll button position with mobile clients

### DIFF
--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -58,7 +58,7 @@
 				:style="`bottom: ${scrollButtonOffset}px`"
 				@click="smoothScrollToBottom">
 				<template #icon>
-					<ChevronDown :size="20" />
+					<ChevronDoubleDown :size="20" />
 				</template>
 			</NcButton>
 		</transition>
@@ -66,7 +66,7 @@
 </template>
 
 <script>
-import ChevronDown from 'vue-material-design-icons/ChevronDown.vue'
+import ChevronDoubleDown from 'vue-material-design-icons/ChevronDoubleDown.vue'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 
@@ -82,7 +82,7 @@ export default {
 
 	components: {
 		NcButton,
-		ChevronDown,
+		ChevronDoubleDown,
 		MessagesList,
 		NewMessage,
 	},
@@ -138,8 +138,8 @@ export default {
 			immediate: true,
 			handler() {
 				this.$nextTick(() => {
-					// overlap NewMessage component by 8px, set its min-height: 69px as a fallback
-					this.scrollButtonOffset = (this.$refs.newMessage?.$el?.clientHeight ?? 69) - 8
+					// offset from NewMessage component by 8px, with its min-height: 69px as a fallback
+					this.scrollButtonOffset = (this.$refs.newMessage?.$el?.clientHeight ?? 69) + 8
 				})
 			},
 		},

--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -41,27 +41,48 @@
 		<MessagesList role="region"
 			:aria-label="t('spreed', 'Conversation messages')"
 			:token="token"
+			:is-chat-scrolled-to-bottom.sync="isChatScrolledToBottom"
 			:is-visible="isVisible" />
 		<NewMessage v-if="containerId"
+			ref="newMessage"
 			role="region"
 			:token="token"
 			:container="containerId"
 			has-typing-indicator
 			:aria-label="t('spreed', 'Post message')" />
+		<transition name="fade">
+			<NcButton v-show="!isChatScrolledToBottom"
+				type="secondary"
+				:aria-label="t('spreed', 'Scroll to bottom')"
+				class="scroll-to-bottom"
+				:style="`bottom: ${scrollButtonOffset}px`"
+				@click="smoothScrollToBottom">
+				<template #icon>
+					<ChevronDown :size="20" />
+				</template>
+			</NcButton>
+		</transition>
 	</div>
 </template>
 
 <script>
+import ChevronDown from 'vue-material-design-icons/ChevronDown.vue'
+
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+
 import MessagesList from './MessagesList/MessagesList.vue'
 import NewMessage from './NewMessage/NewMessage.vue'
 
 import { CONVERSATION } from '../constants.js'
+import { EventBus } from '../services/EventBus.js'
 
 export default {
 
 	name: 'ChatView',
 
 	components: {
+		NcButton,
+		ChevronDown,
 		MessagesList,
 		NewMessage,
 	},
@@ -75,6 +96,8 @@ export default {
 
 	data() {
 		return {
+			isChatScrolledToBottom: true,
+			scrollButtonOffset: undefined,
 			isDraggingOver: false,
 			containerId: undefined,
 		}
@@ -104,7 +127,24 @@ export default {
 		token() {
 			return this.$store.getters.getToken()
 		},
+
+		typingParticipants() {
+			return this.$store.getters.participantsListTyping(this.token)
+		},
 	},
+
+	watch: {
+		typingParticipants: {
+			immediate: true,
+			handler() {
+				this.$nextTick(() => {
+					// overlap NewMessage component by 8px, set its min-height: 69px as a fallback
+					this.scrollButtonOffset = (this.$refs.newMessage?.$el?.clientHeight ?? 69) - 8
+				})
+			},
+		},
+	},
+
 	mounted() {
 		// Postpone render of NewMessage until application is mounted
 		this.containerId = this.$store.getters.getMainContainerSelector()
@@ -141,6 +181,10 @@ export default {
 			const uploadId = new Date().getTime()
 			// Uploads and shares the files
 			this.$store.dispatch('initialiseUpload', { files, token: this.token, uploadId })
+		},
+
+		smoothScrollToBottom() {
+			EventBus.$emit('smooth-scroll-chat-to-bottom')
 		},
 	},
 
@@ -181,6 +225,11 @@ export default {
 		height: 48px;
 		margin-bottom: 16px;
 	}
+}
+
+.scroll-to-bottom {
+	position: absolute !important;
+	right: 24px;
 }
 
 .slide {


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up from #9826 (cc @dijeth )
* Scroll button was moved to the parent component level
* Its position updated based on NewMessage component's height (which is updated if someone is typing)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2023-06-26 11-50-23](https://github.com/nextcloud/spreed/assets/93392545/c9844752-9c25-4cf7-8b8a-3cc3e7d69e1c) | ![image](https://github.com/nextcloud/spreed/assets/93392545/e43b1d9f-3f4e-4553-885c-3575df5d84f3)
![Screenshot from 2023-06-26 11-50-29](https://github.com/nextcloud/spreed/assets/93392545/0ce67b15-d9b3-4fff-84ae-52ea3f2b6ef6) | ![image](https://github.com/nextcloud/spreed/assets/93392545/aa0dd147-e083-4648-80b9-47ec1524bd24)



### 🚧 Tasks

- [ ] Visual check / Testing
- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
