### PR TITLE
fix(MessagesList) - scroll sticky list to bottom, if reaction was added

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -671,6 +671,11 @@ export default {
 		showJoinCallButton() {
 			EventBus.$emit('scroll-chat-to-bottom')
 		},
+
+		// Scroll list to the bottom if reaction to the message was added, as it expands the list
+		simpleReactions() {
+			EventBus.$emit('scroll-chat-to-bottom-if-sticky')
+		},
 	},
 
 	mounted() {

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -282,6 +282,7 @@ export default {
 		this.scrollToBottom()
 		EventBus.$on('scroll-chat-to-bottom', this.handleScrollChatToBottomEvent)
 		EventBus.$on('smooth-scroll-chat-to-bottom', this.smoothScrollToBottom)
+		EventBus.$on('scroll-chat-to-bottom-if-sticky', this.scrollToBottomIfSticky)
 		EventBus.$on('focus-message', this.focusMessage)
 		EventBus.$on('route-change', this.onRouteChange)
 		subscribe('networkOffline', this.handleNetworkOffline)
@@ -300,6 +301,7 @@ export default {
 		window.removeEventListener('focus', this.onWindowFocus)
 		EventBus.$off('scroll-chat-to-bottom', this.handleScrollChatToBottomEvent)
 		EventBus.$off('smooth-scroll-chat-to-bottom', this.smoothScrollToBottom)
+		EventBus.$on('scroll-chat-to-bottom-if-sticky', this.scrollToBottomIfSticky)
 		EventBus.$off('focus-message', this.focusMessage)
 		EventBus.$off('route-change', this.onRouteChange)
 
@@ -886,6 +888,15 @@ export default {
 		 */
 		handleScrollChatToBottomEvent(options) {
 			if ((options && options.force) || this.isChatScrolledToBottom) {
+				this.scrollToBottom()
+			}
+		},
+
+		/**
+		 * Scrolls to the bottom of the list (to show reaction to the last message).
+		 */
+		scrollToBottomIfSticky() {
+			if (this.isSticky) {
 				this.scrollToBottom()
 			}
 		},


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9129 

### 🖼️ Screenshots

https://github.com/nextcloud/spreed/assets/93392545/22a53289-c90a-4cea-b3ec-ac0fd1c67368

### 🚧 Tasks

- [ ] Visual check
- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
