### PR TITLE
Use PHP8's constructor property promotion

### DIFF
--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -44,38 +44,17 @@ use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class Listener {
-	protected IManager $activityManager;
-
-	protected IUserSession $userSession;
-
-	protected ChatManager $chatManager;
-
-	protected ParticipantService $participantService;
-	protected RoomService $roomService;
-	protected RecordingService $recordingService;
-
-	protected LoggerInterface $logger;
-
-	protected ITimeFactory $timeFactory;
 
 	public function __construct(
-		IManager $activityManager,
-		IUserSession $userSession,
-		ChatManager $chatManager,
-		ParticipantService $participantService,
-		RoomService $roomService,
-		RecordingService $recordingService,
-		LoggerInterface $logger,
-		ITimeFactory $timeFactory,
+		protected IManager $activityManager,
+		protected IUserSession $userSession,
+		protected ChatManager $chatManager,
+		protected ParticipantService $participantService,
+		protected RoomService $roomService,
+		protected RecordingService $recordingService,
+		protected LoggerInterface $logger,
+		protected ITimeFactory $timeFactory,
 	) {
-		$this->activityManager = $activityManager;
-		$this->userSession = $userSession;
-		$this->chatManager = $chatManager;
-		$this->participantService = $participantService;
-		$this->roomService = $roomService;
-		$this->recordingService = $recordingService;
-		$this->logger = $logger;
-		$this->timeFactory = $timeFactory;
 	}
 
 	public static function register(IEventDispatcher $dispatcher): void {

--- a/lib/Activity/Provider/Base.php
+++ b/lib/Activity/Provider/Base.php
@@ -37,30 +37,16 @@ use OCP\IUserManager;
 use OCP\L10N\IFactory;
 
 abstract class Base implements IProvider {
-	protected IFactory $languageFactory;
-	protected IURLGenerator $url;
-	protected Config $config;
-	protected IManager $activityManager;
-	protected AvatarService $avatarService;
-	protected IUserManager $userManager;
-	protected Manager $manager;
 
 	public function __construct(
-		IFactory $languageFactory,
-		IURLGenerator $url,
-		Config $config,
-		IManager $activityManager,
-		IUserManager $userManager,
-		AvatarService $avatarService,
-		Manager $manager,
+		protected IFactory $languageFactory,
+		protected IURLGenerator $url,
+		protected Config $config,
+		protected IManager $activityManager,
+		protected IUserManager $userManager,
+		protected AvatarService $avatarService,
+		protected Manager $manager,
 	) {
-		$this->languageFactory = $languageFactory;
-		$this->url = $url;
-		$this->config = $config;
-		$this->activityManager = $activityManager;
-		$this->userManager = $userManager;
-		$this->avatarService = $avatarService;
-		$this->manager = $manager;
 	}
 
 	/**

--- a/lib/Activity/Setting.php
+++ b/lib/Activity/Setting.php
@@ -27,10 +27,10 @@ use OCP\Activity\ActivitySettings;
 use OCP\IL10N;
 
 class Setting extends ActivitySettings {
-	protected IL10N $l;
 
-	public function __construct(IL10N $l) {
-		$this->l = $l;
+	public function __construct(
+		protected IL10N $l,
+	) {
 	}
 
 	/**

--- a/lib/BackgroundJob/CheckHostedSignalingServer.php
+++ b/lib/BackgroundJob/CheckHostedSignalingServer.php
@@ -39,21 +39,15 @@ use OCP\Notification\IManager;
 use Psr\Log\LoggerInterface;
 
 class CheckHostedSignalingServer extends TimedJob {
-	private HostedSignalingServerService $hostedSignalingServerService;
-	private IConfig $config;
-	private IManager $notificationManager;
-	private IGroupManager $groupManager;
-	private IURLGenerator $urlGenerator;
-	private LoggerInterface $logger;
 
 	public function __construct(
 		ITimeFactory $timeFactory,
-		HostedSignalingServerService $hostedSignalingServerService,
-		IConfig $config,
-		IManager $notificationManager,
-		IGroupManager $groupManager,
-		IURLGenerator $urlGenerator,
-		LoggerInterface $logger,
+		private HostedSignalingServerService $hostedSignalingServerService,
+		private IConfig $config,
+		private IManager $notificationManager,
+		private IGroupManager $groupManager,
+		private IURLGenerator $urlGenerator,
+		private LoggerInterface $logger,
 	) {
 		parent::__construct($timeFactory);
 
@@ -61,12 +55,6 @@ class CheckHostedSignalingServer extends TimedJob {
 		$this->setInterval(3600);
 		$this->setTimeSensitivity(IJob::TIME_SENSITIVE);
 
-		$this->hostedSignalingServerService = $hostedSignalingServerService;
-		$this->config = $config;
-		$this->notificationManager = $notificationManager;
-		$this->groupManager = $groupManager;
-		$this->urlGenerator = $urlGenerator;
-		$this->logger = $logger;
 	}
 
 	protected function run($argument): void {

--- a/lib/BackgroundJob/CheckMatterbridges.php
+++ b/lib/BackgroundJob/CheckMatterbridges.php
@@ -36,17 +36,12 @@ use Psr\Log\LoggerInterface;
  * @package OCA\Talk\BackgroundJob
  */
 class CheckMatterbridges extends TimedJob {
-	protected IConfig $serverConfig;
-
-	protected MatterbridgeManager $bridgeManager;
-
-	protected LoggerInterface $logger;
 
 	public function __construct(
 		ITimeFactory $time,
-		IConfig $serverConfig,
-		MatterbridgeManager $bridgeManager,
-		LoggerInterface $logger,
+		protected IConfig $serverConfig,
+		protected MatterbridgeManager $bridgeManager,
+		protected LoggerInterface $logger,
 	) {
 		parent::__construct($time);
 
@@ -54,9 +49,6 @@ class CheckMatterbridges extends TimedJob {
 		$this->setInterval(60 * 15);
 		$this->setTimeSensitivity(IJob::TIME_SENSITIVE);
 
-		$this->serverConfig = $serverConfig;
-		$this->bridgeManager = $bridgeManager;
-		$this->logger = $logger;
 	}
 
 	protected function run($argument): void {

--- a/lib/BackgroundJob/CheckReferenceIdColumn.php
+++ b/lib/BackgroundJob/CheckReferenceIdColumn.php
@@ -38,20 +38,22 @@ use OCP\IDBConnection;
  * @package OCA\Talk\BackgroundJob
  */
 class CheckReferenceIdColumn extends TimedJob {
-	protected IJobList $jobList;
-	protected IConfig $serverConfig;
 	/** @var IDBConnection|ConnectionAdapter */
 	protected $connection;
 
+	/**
+	 * @param ITimeFactory $timeFactory
+	 * @param IJobList $jobList
+	 * @param IConfig $serverConfig
+	 * @param IDBConnection $connection
+	 */
 	public function __construct(
 		ITimeFactory $timeFactory,
-		IJobList $jobList,
-		IConfig $serverConfig,
+		protected IJobList $jobList,
+		protected IConfig $serverConfig,
 		IDBConnection $connection,
 	) {
 		parent::__construct($timeFactory);
-		$this->jobList = $jobList;
-		$this->serverConfig = $serverConfig;
 		$this->connection = $connection;
 
 		// Every hour

--- a/lib/BackgroundJob/ExpireChatMessages.php
+++ b/lib/BackgroundJob/ExpireChatMessages.php
@@ -31,14 +31,12 @@ use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;
 
 class ExpireChatMessages extends TimedJob {
-	private ChatManager $chatManager;
 
 	public function __construct(
 		ITimeFactory $timeFactory,
-		ChatManager $chatManager,
+		private ChatManager $chatManager,
 	) {
 		parent::__construct($timeFactory);
-		$this->chatManager = $chatManager;
 
 		// Every 5 minutes
 		$this->setInterval(5 * 60);

--- a/lib/BackgroundJob/ExpireSignalingMessage.php
+++ b/lib/BackgroundJob/ExpireSignalingMessage.php
@@ -34,11 +34,10 @@ use OCP\BackgroundJob\TimedJob;
  * @package OCA\Talk\BackgroundJob
  */
 class ExpireSignalingMessage extends TimedJob {
-	protected Messages $messages;
 
 	public function __construct(
 		ITimeFactory $timeFactory,
-		Messages $messages,
+		protected Messages $messages,
 	) {
 		parent::__construct($timeFactory);
 
@@ -46,7 +45,6 @@ class ExpireSignalingMessage extends TimedJob {
 		$this->setInterval(60 * 5);
 		$this->setTimeSensitivity(IJob::TIME_SENSITIVE);
 
-		$this->messages = $messages;
 	}
 
 	protected function run($argument): void {

--- a/lib/BackgroundJob/RemoveEmptyRooms.php
+++ b/lib/BackgroundJob/RemoveEmptyRooms.php
@@ -39,21 +39,16 @@ use Psr\Log\LoggerInterface;
  * @package OCA\Talk\BackgroundJob
  */
 class RemoveEmptyRooms extends TimedJob {
-	protected Manager $manager;
-	protected RoomService $roomService;
-	protected ParticipantService $participantService;
-	protected LoggerInterface $logger;
-	protected IUserMountCache $userMountCache;
 
 	protected int $numDeletedRooms = 0;
 
 	public function __construct(
 		ITimeFactory $timeFactory,
-		Manager $manager,
-		RoomService $roomService,
-		ParticipantService $participantService,
-		LoggerInterface $logger,
-		IUserMountCache $userMountCache,
+		protected Manager $manager,
+		protected RoomService $roomService,
+		protected ParticipantService $participantService,
+		protected LoggerInterface $logger,
+		protected IUserMountCache $userMountCache,
 	) {
 		parent::__construct($timeFactory);
 
@@ -61,11 +56,6 @@ class RemoveEmptyRooms extends TimedJob {
 		$this->setInterval(60 * 5);
 		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
 
-		$this->manager = $manager;
-		$this->roomService = $roomService;
-		$this->participantService = $participantService;
-		$this->logger = $logger;
-		$this->userMountCache = $userMountCache;
 	}
 
 	protected function run($argument): void {

--- a/lib/BackgroundJob/ResetAssignedSignalingServer.php
+++ b/lib/BackgroundJob/ResetAssignedSignalingServer.php
@@ -31,12 +31,16 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 
 class ResetAssignedSignalingServer extends TimedJob {
-	protected Manager $manager;
 	protected ICache $cache;
 
+	/**
+	 * @param ITimeFactory $time
+	 * @param Manager $manager
+	 * @param ICacheFactory $cacheFactory
+	 */
 	public function __construct(
 		ITimeFactory $time,
-		Manager $manager,
+		protected Manager $manager,
 		ICacheFactory $cacheFactory,
 	) {
 		parent::__construct($time);
@@ -45,7 +49,6 @@ class ResetAssignedSignalingServer extends TimedJob {
 		$this->setInterval(60 * 5);
 		$this->setTimeSensitivity(IJob::TIME_SENSITIVE);
 
-		$this->manager = $manager;
 		$this->cache = $cacheFactory->createDistributed('hpb_servers');
 	}
 

--- a/lib/BackgroundJob/RetryJob.php
+++ b/lib/BackgroundJob/RetryJob.php
@@ -45,18 +45,16 @@ use OCP\ILogger;
  * @package OCA\Talk\BackgroundJob
  */
 class RetryJob extends Job {
-	private Notifications $notifications;
 
 	/** @var int max number of attempts to send the request */
 	private int $maxTry = 20;
 
 
 	public function __construct(
-		Notifications $notifications,
+		private Notifications $notifications,
 		ITimeFactory $timeFactory,
 	) {
 		parent::__construct($timeFactory);
-		$this->notifications = $notifications;
 	}
 
 	/**

--- a/lib/Chat/AutoComplete/SearchPlugin.php
+++ b/lib/Chat/AutoComplete/SearchPlugin.php
@@ -38,35 +38,19 @@ use OCP\IL10N;
 use OCP\IUserManager;
 
 class SearchPlugin implements ISearchPlugin {
-	protected IUserManager $userManager;
-	protected IGroupManager $groupManager;
-	protected GuestManager $guestManager;
-	protected TalkSession $talkSession;
-	protected ParticipantService $participantService;
-	protected Util $util;
-	protected ?string $userId;
-	protected IL10N $l;
 
 	protected ?Room $room = null;
 
 	public function __construct(
-		IUserManager $userManager,
-		IGroupManager $groupManager,
-		GuestManager $guestManager,
-		TalkSession $talkSession,
-		ParticipantService $participantService,
-		Util $util,
-		?string $userId,
-		IL10N $l,
+		protected IUserManager $userManager,
+		protected IGroupManager $groupManager,
+		protected GuestManager $guestManager,
+		protected TalkSession $talkSession,
+		protected ParticipantService $participantService,
+		protected Util $util,
+		protected ?string $userId,
+		protected IL10N $l,
 	) {
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
-		$this->guestManager = $guestManager;
-		$this->talkSession = $talkSession;
-		$this->participantService = $participantService;
-		$this->util = $util;
-		$this->userId = $userId;
-		$this->l = $l;
 	}
 
 	public function setContext(array $context): void {

--- a/lib/Chat/Changelog/Listener.php
+++ b/lib/Chat/Changelog/Listener.php
@@ -33,10 +33,9 @@ class Listener {
 		$dispatcher->addListener(RoomController::EVENT_BEFORE_ROOMS_GET, [self::class, 'updateChangelog'], -100);
 	}
 
-	protected Manager $manager;
-
-	public function __construct(Manager $manager) {
-		$this->manager = $manager;
+	public function __construct(
+		protected Manager $manager,
+	) {
 	}
 
 	public static function updateChangelog(UserEvent $event): void {

--- a/lib/Chat/Changelog/Manager.php
+++ b/lib/Chat/Changelog/Manager.php
@@ -31,27 +31,15 @@ use OCP\IDBConnection;
 use OCP\IL10N;
 
 class Manager {
-	protected IConfig $config;
-	protected IDBConnection $connection;
-	protected RoomManager $roomManager;
-	protected ChatManager $chatManager;
-	protected ITimeFactory $timeFactory;
-	protected IL10N $l;
 
 	public function __construct(
-		IConfig $config,
-		IDBConnection $connection,
-		RoomManager $roomManager,
-		ChatManager $chatManager,
-		ITimeFactory $timeFactory,
-		IL10N $l,
+		protected IConfig $config,
+		protected IDBConnection $connection,
+		protected RoomManager $roomManager,
+		protected ChatManager $chatManager,
+		protected ITimeFactory $timeFactory,
+		protected IL10N $l,
 	) {
-		$this->config = $config;
-		$this->connection = $connection;
-		$this->roomManager = $roomManager;
-		$this->chatManager = $chatManager;
-		$this->timeFactory = $timeFactory;
-		$this->l = $l;
 	}
 
 	public function getChangelogForUser(string $userId): int {

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -83,53 +83,27 @@ class ChatManager {
 	public const VERB_REACTION = 'reaction';
 	public const VERB_REACTION_DELETED = 'reaction_deleted';
 
-	private CommentsManager $commentsManager;
-	private IEventDispatcher $dispatcher;
-	private IDBConnection $connection;
-	private INotificationManager $notificationManager;
-	private IManager $shareManager;
-	private RoomShareProvider $shareProvider;
-	private ParticipantService $participantService;
-	private RoomService $roomService;
-	private PollService $pollService;
-	private Notifier $notifier;
-	protected ITimeFactory $timeFactory;
 	protected ICache $cache;
 	protected ICache $unreadCountCache;
-	protected AttachmentService $attachmentService;
-	protected IReferenceManager $referenceManager;
 
 	public function __construct(
-		CommentsManager $commentsManager,
-		IEventDispatcher $dispatcher,
-		IDBConnection $connection,
-		INotificationManager $notificationManager,
-		IManager $shareManager,
-		RoomShareProvider $shareProvider,
-		ParticipantService $participantService,
-		RoomService $roomService,
-		PollService $pollService,
-		Notifier $notifier,
+		private CommentsManager $commentsManager,
+		private IEventDispatcher $dispatcher,
+		private IDBConnection $connection,
+		private INotificationManager $notificationManager,
+		private IManager $shareManager,
+		private RoomShareProvider $shareProvider,
+		private ParticipantService $participantService,
+		private RoomService $roomService,
+		private PollService $pollService,
+		private Notifier $notifier,
 		ICacheFactory $cacheFactory,
-		ITimeFactory $timeFactory,
-		AttachmentService $attachmentService,
-		IReferenceManager $referenceManager,
+		protected ITimeFactory $timeFactory,
+		protected AttachmentService $attachmentService,
+		protected IReferenceManager $referenceManager,
 	) {
-		$this->commentsManager = $commentsManager;
-		$this->dispatcher = $dispatcher;
-		$this->connection = $connection;
-		$this->notificationManager = $notificationManager;
-		$this->shareManager = $shareManager;
-		$this->shareProvider = $shareProvider;
-		$this->participantService = $participantService;
-		$this->roomService = $roomService;
-		$this->pollService = $pollService;
-		$this->notifier = $notifier;
 		$this->cache = $cacheFactory->createDistributed('talk/lastmsgid');
 		$this->unreadCountCache = $cacheFactory->createDistributed('talk/unreadcount');
-		$this->timeFactory = $timeFactory;
-		$this->attachmentService = $attachmentService;
-		$this->referenceManager = $referenceManager;
 	}
 
 	/**

--- a/lib/Chat/Command/Executor.php
+++ b/lib/Chat/Command/Executor.php
@@ -44,28 +44,13 @@ class Executor {
 	public const PLACEHOLDER_ARGUMENTS = '{ARGUMENTS}';
 	public const PLACEHOLDER_ARGUMENTS_DOUBLEQUOTE_ESCAPED = '{ARGUMENTS_DOUBLEQUOTE_ESCAPED}';
 
-	protected IEventDispatcher $dispatcher;
-
-	protected ShellExecutor $shellExecutor;
-
-	protected CommandService $commandService;
-
-	protected LoggerInterface $logger;
-
-	protected IL10N $l;
-
 	public function __construct(
-		IEventDispatcher $dispatcher,
-		ShellExecutor $shellExecutor,
-		CommandService $commandService,
-		LoggerInterface $logger,
-		IL10N $l,
+		protected IEventDispatcher $dispatcher,
+		protected ShellExecutor $shellExecutor,
+		protected CommandService $commandService,
+		protected LoggerInterface $logger,
+		protected IL10N $l,
 	) {
-		$this->dispatcher = $dispatcher;
-		$this->shellExecutor = $shellExecutor;
-		$this->commandService = $commandService;
-		$this->logger = $logger;
-		$this->l = $l;
 	}
 
 	public function isCommandAvailableForParticipant(Command $command, Participant $participant): bool {

--- a/lib/Chat/Command/Listener.php
+++ b/lib/Chat/Command/Listener.php
@@ -32,15 +32,11 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Server;
 
 class Listener {
-	protected CommandService $commandService;
-	protected Executor $executor;
 
 	public function __construct(
-		CommandService $commandService,
-		Executor $executor,
+		protected CommandService $commandService,
+		protected Executor $executor,
 	) {
-		$this->commandService = $commandService;
-		$this->executor = $executor;
 	}
 
 	public static function register(IEventDispatcher $dispatcher): void {

--- a/lib/Chat/MessageParser.php
+++ b/lib/Chat/MessageParser.php
@@ -43,20 +43,13 @@ use OCP\IUserManager;
 class MessageParser {
 	public const EVENT_MESSAGE_PARSE = self::class . '::parseMessage';
 
-	protected IEventDispatcher $dispatcher;
-	protected IUserManager $userManager;
-	protected ParticipantService $participantService;
-
 	protected array $guestNames = [];
 
 	public function __construct(
-		IEventDispatcher $dispatcher,
-		IUserManager $userManager,
-		ParticipantService $participantService,
+		protected IEventDispatcher $dispatcher,
+		protected IUserManager $userManager,
+		protected ParticipantService $participantService,
 	) {
-		$this->dispatcher = $dispatcher;
-		$this->participantService = $participantService;
-		$this->userManager = $userManager;
 	}
 
 	public function createMessage(Room $room, Participant $participant, IComment $comment, IL10N $l): Message {

--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -50,33 +50,17 @@ use OCP\Notification\INotification;
  * prepares the notifications for display.
  */
 class Notifier {
-	private INotificationManager $notificationManager;
-	private IUserManager $userManager;
-	private IGroupManager $groupManager;
-	private ParticipantService $participantService;
-	private Manager $manager;
-	private IConfig $config;
-	private ITimeFactory $timeFactory;
-	private Util $util;
 
 	public function __construct(
-		INotificationManager $notificationManager,
-		IUserManager $userManager,
-		IGroupManager $groupManager,
-		ParticipantService $participantService,
-		Manager $manager,
-		IConfig $config,
-		ITimeFactory $timeFactory,
-		Util $util,
+		private INotificationManager $notificationManager,
+		private IUserManager $userManager,
+		private IGroupManager $groupManager,
+		private ParticipantService $participantService,
+		private Manager $manager,
+		private IConfig $config,
+		private ITimeFactory $timeFactory,
+		private Util $util,
 	) {
-		$this->notificationManager = $notificationManager;
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
-		$this->participantService = $participantService;
-		$this->manager = $manager;
-		$this->config = $config;
-		$this->timeFactory = $timeFactory;
-		$this->util = $util;
 	}
 
 	/**

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -51,16 +51,6 @@ use OCP\Share\Exceptions\ShareNotFound;
 use Sabre\VObject\Reader;
 
 class SystemMessage {
-	protected IUserManager $userManager;
-	protected IGroupManager $groupManager;
-	protected GuestManager $guestManager;
-	protected ParticipantService $participantService;
-	protected IPreviewManager $previewManager;
-	protected RoomShareProvider $shareProvider;
-	protected PhotoCache $photoCache;
-	protected IRootFolder $rootFolder;
-	protected ICloudIdManager $cloudIdManager;
-	protected IURLGenerator $url;
 	protected ?IL10N $l = null;
 
 	/**
@@ -77,27 +67,17 @@ class SystemMessage {
 	protected array $guestNames = [];
 
 	public function __construct(
-		IUserManager $userManager,
-		IGroupManager $groupManager,
-		GuestManager $guestManager,
-		ParticipantService $participantService,
-		IPreviewManager $previewManager,
-		RoomShareProvider $shareProvider,
-		PhotoCache $photoCache,
-		IRootFolder $rootFolder,
-		ICloudIdManager $cloudIdManager,
-		IURLGenerator $url,
+		protected IUserManager $userManager,
+		protected IGroupManager $groupManager,
+		protected GuestManager $guestManager,
+		protected ParticipantService $participantService,
+		protected IPreviewManager $previewManager,
+		protected RoomShareProvider $shareProvider,
+		protected PhotoCache $photoCache,
+		protected IRootFolder $rootFolder,
+		protected ICloudIdManager $cloudIdManager,
+		protected IURLGenerator $url,
 	) {
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
-		$this->guestManager = $guestManager;
-		$this->participantService = $participantService;
-		$this->previewManager = $previewManager;
-		$this->shareProvider = $shareProvider;
-		$this->photoCache = $photoCache;
-		$this->rootFolder = $rootFolder;
-		$this->cloudIdManager = $cloudIdManager;
-		$this->url = $url;
 	}
 
 	/**

--- a/lib/Chat/Parser/UserMention.php
+++ b/lib/Chat/Parser/UserMention.php
@@ -41,35 +41,16 @@ use OCP\IUserManager;
  * Helper class to get a rich message from a plain text message.
  */
 class UserMention {
-	/**
-	 * Do NOT inject OCA\Talk\Chat\CommentsManager here
-	 * otherwise the display name resolvers are lost
-	 * and mentions are not replaced anymore.
-	 */
-	protected ICommentsManager $commentsManager;
-	protected IUserManager $userManager;
-	protected IGroupManager $groupManager;
-	protected GuestManager $guestManager;
-	protected ParticipantService $participantService;
-	protected AvatarService $avatarService;
-	protected IL10N $l;
 
 	public function __construct(
-		ICommentsManager $commentsManager,
-		IUserManager $userManager,
-		IGroupManager $groupManager,
-		GuestManager $guestManager,
-		AvatarService $avatarService,
-		ParticipantService $participantService,
-		IL10N $l,
+		protected ICommentsManager $commentsManager,
+		protected IUserManager $userManager,
+		protected IGroupManager $groupManager,
+		protected GuestManager $guestManager,
+		protected AvatarService $avatarService,
+		protected ParticipantService $participantService,
+		protected IL10N $l,
 	) {
-		$this->commentsManager = $commentsManager;
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
-		$this->guestManager = $guestManager;
-		$this->participantService = $participantService;
-		$this->avatarService = $avatarService;
-		$this->l = $l;
 	}
 
 	/**

--- a/lib/Chat/ReactionManager.php
+++ b/lib/Chat/ReactionManager.php
@@ -36,27 +36,15 @@ use OCP\Comments\NotFoundException;
 use OCP\IL10N;
 
 class ReactionManager {
-	private ChatManager $chatManager;
-	private CommentsManager $commentsManager;
-	private IL10N $l;
-	private MessageParser $messageParser;
-	private Notifier $notifier;
-	protected ITimeFactory $timeFactory;
 
 	public function __construct(
-		ChatManager $chatManager,
-		CommentsManager $commentsManager,
-		IL10N $l,
-		MessageParser $messageParser,
-		Notifier $notifier,
-		ITimeFactory $timeFactory,
+		private ChatManager $chatManager,
+		private CommentsManager $commentsManager,
+		private IL10N $l,
+		private MessageParser $messageParser,
+		private Notifier $notifier,
+		protected ITimeFactory $timeFactory,
 	) {
-		$this->chatManager = $chatManager;
-		$this->commentsManager = $commentsManager;
-		$this->l = $l;
-		$this->messageParser = $messageParser;
-		$this->notifier = $notifier;
-		$this->timeFactory = $timeFactory;
 	}
 
 	/**

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -61,27 +61,15 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * @template-implements IEventListener<Event>
  */
 class Listener implements IEventListener {
-	protected IRequest $request;
-	protected ChatManager $chatManager;
-	protected TalkSession $talkSession;
-	protected ISession $session;
-	protected IUserSession $userSession;
-	protected ITimeFactory $timeFactory;
 
 	public function __construct(
-		IRequest $request,
-		ChatManager $chatManager,
-		TalkSession $talkSession,
-		ISession $session,
-		IUserSession $userSession,
-		ITimeFactory $timeFactory,
+		protected IRequest $request,
+		protected ChatManager $chatManager,
+		protected TalkSession $talkSession,
+		protected ISession $session,
+		protected IUserSession $userSession,
+		protected ITimeFactory $timeFactory,
 	) {
-		$this->request = $request;
-		$this->chatManager = $chatManager;
-		$this->talkSession = $talkSession;
-		$this->session = $session;
-		$this->userSession = $userSession;
-		$this->timeFactory = $timeFactory;
 	}
 
 	public static function register(IEventDispatcher $dispatcher): void {


### PR DESCRIPTION
### ☑️ Resolves

* Using PHP8's constructor property promotion in the following namespaces:
- `/lib/Activity`
- `/lib/BackgroundJob`
- `/lib/Chat`



### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
