### PR TITLE
Use PHP8's constructor property promotion

### DIFF
--- a/lib/Collaboration/Collaborators/Listener.php
+++ b/lib/Collaboration/Collaborators/Listener.php
@@ -41,31 +41,19 @@ use OCP\IUserManager;
 use OCP\Server;
 
 class Listener {
-	protected Manager $manager;
-	protected IUserManager $userManager;
-	protected ParticipantService $participantService;
-	protected Config $config;
-	protected TalkSession $talkSession;
 	/** @var string[] */
 	protected array $allowedGroupIds = [];
 	protected string $roomToken;
 	protected ?Room $room = null;
-	protected ?string $userId;
 
 	public function __construct(
-		Manager $manager,
-		IUserManager $userManager,
-		ParticipantService $participantService,
-		Config $config,
-		TalkSession $talkSession,
-		?string $userId,
+		protected Manager $manager,
+		protected IUserManager $userManager,
+		protected ParticipantService $participantService,
+		protected Config $config,
+		protected TalkSession $talkSession,
+		protected ?string $userId,
 	) {
-		$this->manager = $manager;
-		$this->userManager = $userManager;
-		$this->participantService = $participantService;
-		$this->talkSession = $talkSession;
-		$this->config = $config;
-		$this->userId = $userId;
 	}
 
 	public static function register(IEventDispatcher $dispatcher): void {

--- a/lib/Collaboration/Collaborators/RoomPlugin.php
+++ b/lib/Collaboration/Collaborators/RoomPlugin.php
@@ -36,18 +36,12 @@ use OCP\IUserSession;
 use OCP\Share\IShare;
 
 class RoomPlugin implements ISearchPlugin {
-	protected Manager $manager;
-	protected ParticipantService $participantService;
-	protected IUserSession $userSession;
 
 	public function __construct(
-		Manager $manager,
-		ParticipantService $participantService,
-		IUserSession $userSession,
+		protected Manager $manager,
+		protected ParticipantService $participantService,
+		protected IUserSession $userSession,
 	) {
-		$this->manager = $manager;
-		$this->participantService = $participantService;
-		$this->userSession = $userSession;
 	}
 
 	/**

--- a/lib/Collaboration/Reference/TalkReferenceProvider.php
+++ b/lib/Collaboration/Reference/TalkReferenceProvider.php
@@ -47,33 +47,17 @@ use OCP\IURLGenerator;
  * @psalm-type ReferenceMatch = array{token: string, message: int|null}
  */
 class TalkReferenceProvider extends ADiscoverableReferenceProvider implements ISearchableReferenceProvider {
-	protected IURLGenerator $urlGenerator;
-	protected Manager $roomManager;
-	protected ParticipantService $participantService;
-	protected ChatManager $chatManager;
-	protected AvatarService $avatarService;
-	protected MessageParser $messageParser;
-	protected IL10N $l;
-	protected ?string $userId;
 
 	public function __construct(
-		IURLGenerator $urlGenerator,
-		Manager $manager,
-		ParticipantService $participantService,
-		ChatManager $chatManager,
-		AvatarService $avatarService,
-		MessageParser $messageParser,
-		IL10N $l,
-		?string $userId,
+		protected IURLGenerator $urlGenerator,
+		protected Manager $manager,
+		protected ParticipantService $participantService,
+		protected ChatManager $chatManager,
+		protected AvatarService $avatarService,
+		protected MessageParser $messageParser,
+		protected IL10N $l,
+		protected ?string $userId,
 	) {
-		$this->urlGenerator = $urlGenerator;
-		$this->roomManager = $manager;
-		$this->participantService = $participantService;
-		$this->chatManager = $chatManager;
-		$this->avatarService = $avatarService;
-		$this->messageParser = $messageParser;
-		$this->l = $l;
-		$this->userId = $userId;
 	}
 
 

--- a/lib/Collaboration/Resources/ConversationProvider.php
+++ b/lib/Collaboration/Resources/ConversationProvider.php
@@ -38,24 +38,14 @@ use OCP\IUser;
 use OCP\IUserSession;
 
 class ConversationProvider implements IProvider {
-	protected Manager $manager;
-	protected ParticipantService $participantService;
-	protected AvatarService $avatarService;
-	protected IUserSession $userSession;
-	protected IURLGenerator $urlGenerator;
 
 	public function __construct(
-		Manager $manager,
-		AvatarService $avatarService,
-		ParticipantService $participantService,
-		IUserSession $userSession,
-		IURLGenerator $urlGenerator,
+		protected Manager $manager,
+		protected AvatarService $avatarService,
+		protected ParticipantService $participantService,
+		protected IUserSession $userSession,
+		protected IURLGenerator $urlGenerator,
 	) {
-		$this->manager = $manager;
-		$this->avatarService = $avatarService;
-		$this->participantService = $participantService;
-		$this->userSession = $userSession;
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	public function getResourceRichObject(IResource $resource): array {

--- a/lib/Command/Command/Add.php
+++ b/lib/Command/Command/Add.php
@@ -32,11 +32,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Add extends Base {
 	use TRenderCommand;
 
-	private CommandService $service;
-
-	public function __construct(CommandService $service) {
+	public function __construct(
+		private CommandService $service,
+	) {
 		parent::__construct();
-		$this->service = $service;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/Command/AddSamples.php
+++ b/lib/Command/Command/AddSamples.php
@@ -35,18 +35,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 class AddSamples extends Base {
 	use TRenderCommand;
 
-	private CommandService $service;
-	protected IAppManager $appManager;
-
 	protected array $commands = [];
 
 	public function __construct(
-		CommandService $service,
-		IAppManager $appManager,
+		private CommandService $service,
+		protected IAppManager $appManager,
 	) {
 		parent::__construct();
-		$this->service = $service;
-		$this->appManager = $appManager;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/Command/Delete.php
+++ b/lib/Command/Command/Delete.php
@@ -31,11 +31,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Delete extends Base {
-	private CommandService $service;
 
-	public function __construct(CommandService $service) {
+	public function __construct(
+		private CommandService $service,
+	) {
 		parent::__construct();
-		$this->service = $service;
 	}
 
 	protected function configure():void {

--- a/lib/Command/Command/ListCommand.php
+++ b/lib/Command/Command/ListCommand.php
@@ -32,11 +32,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ListCommand extends Base {
 	use TRenderCommand;
 
-	private CommandService $service;
-
-	public function __construct(CommandService $service) {
+	public function __construct(
+		private CommandService $service,
+	) {
 		parent::__construct();
-		$this->service = $service;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/Command/Update.php
+++ b/lib/Command/Command/Update.php
@@ -33,11 +33,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Update extends Base {
 	use TRenderCommand;
 
-	private CommandService $service;
-
-	public function __construct(CommandService $service) {
+	public function __construct(
+		private CommandService $service,
+	) {
 		parent::__construct();
-		$this->service = $service;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/Developer/UpdateDocs.php
+++ b/lib/Command/Developer/UpdateDocs.php
@@ -33,12 +33,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdateDocs extends Base {
-	private IConfig $config;
 	private IAppManager $appManager;
 
-	public function __construct(IConfig $config) {
-		$this->config = $config;
-
+	public function __construct(
+		private IConfig $config,
+	) {
 		parent::__construct();
 	}
 

--- a/lib/Command/Monitor/Calls.php
+++ b/lib/Command/Monitor/Calls.php
@@ -30,12 +30,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Calls extends Base {
-	protected IDBConnection $connection;
 
-	public function __construct(IDBConnection $connection) {
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 		parent::__construct();
-
-		$this->connection = $connection;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/Monitor/HasActiveCalls.php
+++ b/lib/Command/Monitor/HasActiveCalls.php
@@ -30,12 +30,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class HasActiveCalls extends Base {
-	protected IDBConnection $connection;
 
-	public function __construct(IDBConnection $connection) {
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 		parent::__construct();
-
-		$this->connection = $connection;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/Monitor/Room.php
+++ b/lib/Command/Monitor/Room.php
@@ -33,12 +33,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Room extends Base {
-	protected IDBConnection $connection;
 
-	public function __construct(IDBConnection $connection) {
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 		parent::__construct();
-
-		$this->connection = $connection;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/Room/TRoomCommand.php
+++ b/lib/Command/Room/TRoomCommand.php
@@ -45,35 +45,15 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputDefinition;
 
 trait TRoomCommand {
-	/** @var Manager */
-	protected $manager;
-
-	/** @var RoomService */
-	protected $roomService;
-
-	/** @var ParticipantService */
-	protected $participantService;
-
-	/** @var IUserManager */
-	protected $userManager;
-
-	/** @var IGroupManager */
-	protected $groupManager;
 
 	public function __construct(
-		Manager $manager,
-		RoomService $roomService,
-		ParticipantService $participantService,
-		IUserManager $userManager,
-		IGroupManager $groupManager,
+		protected Manager $manager,
+		protected RoomService $roomService,
+		protected ParticipantService $participantService,
+		protected IUserManager $userManager,
+		protected IGroupManager $groupManager,
 	) {
 		parent::__construct();
-
-		$this->manager = $manager;
-		$this->roomService = $roomService;
-		$this->participantService = $participantService;
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
 	}
 
 	/**

--- a/lib/Command/Signaling/Add.php
+++ b/lib/Command/Signaling/Add.php
@@ -33,11 +33,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Add extends Base {
-	private IConfig $config;
 
-	public function __construct(IConfig $config) {
+	public function __construct(
+		private IConfig $config,
+	) {
 		parent::__construct();
-		$this->config = $config;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/Signaling/Delete.php
+++ b/lib/Command/Signaling/Delete.php
@@ -32,11 +32,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Delete extends Base {
-	private IConfig $config;
 
-	public function __construct(IConfig $config) {
+	public function __construct(
+		private IConfig $config,
+	) {
 		parent::__construct();
-		$this->config = $config;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/Signaling/ListCommand.php
+++ b/lib/Command/Signaling/ListCommand.php
@@ -31,11 +31,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Base {
-	private IConfig $config;
 
-	public function __construct(IConfig $config) {
+	public function __construct(
+		private IConfig $config,
+	) {
 		parent::__construct();
-		$this->config = $config;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/Stun/Add.php
+++ b/lib/Command/Stun/Add.php
@@ -32,11 +32,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Add extends Base {
-	private IConfig $config;
 
-	public function __construct(IConfig $config) {
+	public function __construct(
+		private IConfig $config,
+	) {
 		parent::__construct();
-		$this->config = $config;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/Stun/Delete.php
+++ b/lib/Command/Stun/Delete.php
@@ -32,11 +32,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Delete extends Base {
-	private IConfig $config;
 
-	public function __construct(IConfig $config) {
+	public function __construct(
+		private IConfig $config,
+	) {
 		parent::__construct();
-		$this->config = $config;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/Stun/ListCommand.php
+++ b/lib/Command/Stun/ListCommand.php
@@ -31,11 +31,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Base {
-	private IConfig $config;
 
-	public function __construct(IConfig $config) {
+	public function __construct(
+		private IConfig $config,
+	) {
 		parent::__construct();
-		$this->config = $config;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/Turn/Add.php
+++ b/lib/Command/Turn/Add.php
@@ -33,11 +33,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Add extends Base {
-	private IConfig $config;
 
-	public function __construct(IConfig $config) {
+	public function __construct(
+		IConfig $config,
+	) {
 		parent::__construct();
-		$this->config = $config;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/Turn/Delete.php
+++ b/lib/Command/Turn/Delete.php
@@ -32,11 +32,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Delete extends Base {
-	private IConfig $config;
 
-	public function __construct(IConfig $config) {
+	public function __construct(
+		private IConfig $config,
+	) {
 		parent::__construct();
-		$this->config = $config;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/Turn/ListCommand.php
+++ b/lib/Command/Turn/ListCommand.php
@@ -31,11 +31,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Base {
-	private IConfig $config;
 
-	public function __construct(IConfig $config) {
+	public function __construct(
+		private IConfig $config,
+	) {
 		parent::__construct();
-		$this->config = $config;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/User/Remove.php
+++ b/lib/Command/User/Remove.php
@@ -33,16 +33,12 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Remove extends Base {
-	private IUserManager $userManager;
-	private Manager $manager;
 
 	public function __construct(
-		IUserManager $userManager,
-		Manager $manager,
+		private IUserManager $userManager,
+		private Manager $manager,
 	) {
 		parent::__construct();
-		$this->userManager = $userManager;
-		$this->manager = $manager;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/User/TransferOwnership.php
+++ b/lib/Command/User/TransferOwnership.php
@@ -41,19 +41,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class TransferOwnership extends Base {
 	private RoomService $roomService;
-	private ParticipantService $participantService;
-	private Manager $manager;
-	private IUserManager $userManager;
 
 	public function __construct(
-		ParticipantService $participantService,
-		Manager $manager,
-		IUserManager $userManager,
+		private ParticipantService $participantService,
+		private Manager $manager,
+		private IUserManager $userManager,
 	) {
 		parent::__construct();
-		$this->participantService = $participantService;
-		$this->manager = $manager;
-		$this->userManager = $userManager;
 	}
 
 	protected function configure(): void {

--- a/lib/ContactsMenu/Providers/CallProvider.php
+++ b/lib/ContactsMenu/Providers/CallProvider.php
@@ -36,24 +36,14 @@ use OCP\IUser;
 use OCP\IUserManager;
 
 class CallProvider implements IProvider {
-	private IActionFactory $actionFactory;
-	private IURLGenerator $urlGenerator;
-	private IUserManager $userManager;
-	private IL10N $l10n;
-	private Config $config;
 
 	public function __construct(
-		IActionFactory $actionFactory,
-		IURLGenerator $urlGenerator,
-		IL10N $l10n,
-		IUserManager $userManager,
-		Config $config,
+		private IActionFactory $actionFactory,
+		private IURLGenerator $urlGenerator,
+		private IL10N $l10n,
+		private IUserManager $userManager,
+		private Config $config,
 	) {
-		$this->actionFactory = $actionFactory;
-		$this->urlGenerator = $urlGenerator;
-		$this->userManager = $userManager;
-		$this->l10n = $l10n;
-		$this->config = $config;
 	}
 
 	public function process(IEntry $entry): void {


### PR DESCRIPTION
### ☑️ Resolves

* Using PHP8's constructor property promotion in the following namespaces:
- `/lib/Collaboration`
- `/lib/Command`
- `/lib/ContactsMenu`



### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
