### PR TITLE
Use PHP8's constructor property promotion

### DIFF
--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -45,24 +45,16 @@ use OCP\IRequest;
 use OCP\IUserManager;
 
 class CallController extends AEnvironmentAwareController {
-	private ParticipantService $participantService;
-	private RoomService $roomService;
-	private IUserManager $userManager;
-	private ITimeFactory $timeFactory;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		ParticipantService $participantService,
-		RoomService $roomService,
-		IUserManager $userManager,
-		ITimeFactory $timeFactory,
+		private ParticipantService $participantService,
+		private RoomService $roomService,
+		private IUserManager $userManager,
+		private ITimeFactory $timeFactory,
 	) {
 		parent::__construct($appName, $request);
-		$this->participantService = $participantService;
-		$this->roomService = $roomService;
-		$this->userManager = $userManager;
-		$this->timeFactory = $timeFactory;
 	}
 
 	#[PublicPage]

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -71,81 +71,36 @@ use OCP\UserStatus\IManager as IUserStatusManager;
 use OCP\UserStatus\IUserStatus;
 
 class ChatController extends AEnvironmentAwareController {
-	private ?string $userId;
-	private IUserManager $userManager;
-	private IAppManager $appManager;
-	private ChatManager $chatManager;
-	private ReactionManager $reactionManager;
-	private ParticipantService $participantService;
-	private SessionService $sessionService;
-	protected AttachmentService $attachmentService;
-	protected avatarService $avatarService;
-	private GuestManager $guestManager;
 	/** @var string[] */
 	protected array $guestNames;
-	private MessageParser $messageParser;
-	protected RoomShareProvider $shareProvider;
-	private IManager $autoCompleteManager;
-	private IUserStatusManager $statusManager;
-	protected MatterbridgeManager $matterbridgeManager;
-	private SearchPlugin $searchPlugin;
-	private ISearchResult $searchResult;
-	protected ITimeFactory $timeFactory;
-	protected IEventDispatcher $eventDispatcher;
-	protected IValidator $richObjectValidator;
-	protected ITrustedDomainHelper $trustedDomainHelper;
-	private IL10N $l;
 
 	public function __construct(
 		string $appName,
-		?string $UserId,
+		private ?string $userId,
 		IRequest $request,
-		IUserManager $userManager,
-		IAppManager $appManager,
-		ChatManager $chatManager,
-		ReactionManager $reactionManager,
-		ParticipantService $participantService,
-		SessionService $sessionService,
-		AttachmentService $attachmentService,
-		avatarService $avatarService,
-		GuestManager $guestManager,
-		MessageParser $messageParser,
-		RoomShareProvider $shareProvider,
-		IManager $autoCompleteManager,
-		IUserStatusManager $statusManager,
-		MatterbridgeManager $matterbridgeManager,
-		SearchPlugin $searchPlugin,
-		ISearchResult $searchResult,
-		ITimeFactory $timeFactory,
-		IEventDispatcher $eventDispatcher,
-		IValidator $richObjectValidator,
-		ITrustedDomainHelper $trustedDomainHelper,
-		IL10N $l,
+		private IUserManager $userManager,
+		private IAppManager $appManager,
+		private ChatManager $chatManager,
+		private ReactionManager $reactionManager,
+		private ParticipantService $participantService,
+		private SessionService $sessionService,
+		protected AttachmentService $attachmentService,
+		protected avatarService $avatarService,
+		private GuestManager $guestManager,
+		private MessageParser $messageParser,
+		protected RoomShareProvider $shareProvider,
+		private IManager $autoCompleteManager,
+		private IUserStatusManager $statusManager,
+		protected MatterbridgeManager $matterbridgeManager,
+		private SearchPlugin $searchPlugin,
+		private ISearchResult $searchResult,
+		protected ITimeFactory $timeFactory,
+		protected IEventDispatcher $eventDispatcher,
+		protected IValidator $richObjectValidator,
+		protected ITrustedDomainHelper $trustedDomainHelper,
+		private IL10N $l,
 	) {
 		parent::__construct($appName, $request);
-
-		$this->userId = $UserId;
-		$this->userManager = $userManager;
-		$this->appManager = $appManager;
-		$this->chatManager = $chatManager;
-		$this->reactionManager = $reactionManager;
-		$this->participantService = $participantService;
-		$this->sessionService = $sessionService;
-		$this->attachmentService = $attachmentService;
-		$this->avatarService = $avatarService;
-		$this->guestManager = $guestManager;
-		$this->messageParser = $messageParser;
-		$this->shareProvider = $shareProvider;
-		$this->autoCompleteManager = $autoCompleteManager;
-		$this->statusManager = $statusManager;
-		$this->matterbridgeManager = $matterbridgeManager;
-		$this->searchPlugin = $searchPlugin;
-		$this->searchResult = $searchResult;
-		$this->timeFactory = $timeFactory;
-		$this->eventDispatcher = $eventDispatcher;
-		$this->richObjectValidator = $richObjectValidator;
-		$this->trustedDomainHelper = $trustedDomainHelper;
-		$this->l = $l;
 	}
 
 	protected function getActorInfo(string $actorDisplayName = ''): array {

--- a/lib/Controller/CommandController.php
+++ b/lib/Controller/CommandController.php
@@ -33,15 +33,13 @@ use OCP\AppFramework\OCSController;
 use OCP\IRequest;
 
 class CommandController extends OCSController {
-	protected CommandService $commandService;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		CommandService $commandService,
+		protected CommandService $commandService,
 	) {
 		parent::__construct($appName, $request);
-		$this->commandService = $commandService;
 	}
 
 	public function index(): DataResponse {

--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -41,22 +41,14 @@ use OCP\IUser;
 use OCP\IUserSession;
 
 class FederationController extends OCSController {
-	private FederationManager $federationManager;
-
-	private Manager $talkManager;
-
-	private IUserSession $userSession;
 
 	public function __construct(
 		IRequest $request,
-		FederationManager $federationManager,
-		Manager $talkManager,
-		IUserSession $userSession,
+		private FederationManager $federationManager,
+		private Manager $talkManager,
+		private IUserSession $userSession,
 	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->federationManager = $federationManager;
-		$this->talkManager = $talkManager;
-		$this->userSession = $userSession;
 	}
 
 	/**

--- a/lib/Controller/FilesIntegrationController.php
+++ b/lib/Controller/FilesIntegrationController.php
@@ -51,39 +51,21 @@ use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager as IShareManager;
 
 class FilesIntegrationController extends OCSController {
-	private Manager $manager;
-	private RoomService $roomService;
-	private IShareManager $shareManager;
-	private ISession $session;
-	private IUserSession $userSession;
-	private TalkSession $talkSession;
-	private Util $util;
-	private IConfig $config;
-	private IL10N $l;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		Manager $manager,
-		RoomService $roomService,
-		IShareManager $shareManager,
-		ISession $session,
-		IUserSession $userSession,
-		TalkSession $talkSession,
-		Util $util,
-		IConfig $config,
-		IL10N $l10n,
+		private Manager $manager,
+		private RoomService $roomService,
+		private IShareManager $shareManager,
+		private ISession $session,
+		private IUserSession $userSession,
+		private TalkSession $talkSession,
+		private Util $util,
+		private IConfig $config,
+		private IL10N $l,
 	) {
 		parent::__construct($appName, $request);
-		$this->manager = $manager;
-		$this->roomService = $roomService;
-		$this->shareManager = $shareManager;
-		$this->session = $session;
-		$this->userSession = $userSession;
-		$this->talkSession = $talkSession;
-		$this->util = $util;
-		$this->config = $config;
-		$this->l = $l10n;
 	}
 
 	/**

--- a/lib/Controller/GuestController.php
+++ b/lib/Controller/GuestController.php
@@ -33,16 +33,13 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
 
 class GuestController extends AEnvironmentAwareController {
-	private GuestManager $guestManager;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		GuestManager $guestManager,
+		private GuestManager $guestManager,
 	) {
 		parent::__construct($appName, $request);
-
-		$this->guestManager = $guestManager;
 	}
 
 	#[PublicPage]

--- a/lib/Controller/HostedSignalingServerController.php
+++ b/lib/Controller/HostedSignalingServerController.php
@@ -41,27 +41,17 @@ use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
 class HostedSignalingServerController extends OCSController {
-	protected IClientService $clientService;
-	protected IL10N $l10n;
-	protected IConfig $config;
-	protected LoggerInterface $logger;
-	private HostedSignalingServerService $hostedSignalingServerService;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		IClientService $clientService,
-		IL10N $l10n,
-		IConfig $config,
-		LoggerInterface $logger,
-		HostedSignalingServerService $hostedSignalingServerService,
+		protected IClientService $clientService,
+		protected IL10N $l10n,
+		protected IConfig $config,
+		protected LoggerInterface $logger,
+		private HostedSignalingServerService $hostedSignalingServerService,
 	) {
 		parent::__construct($appName, $request);
-		$this->clientService = $clientService;
-		$this->l10n = $l10n;
-		$this->config = $config;
-		$this->logger = $logger;
-		$this->hostedSignalingServerService = $hostedSignalingServerService;
 	}
 
 	#[PublicPage]

--- a/lib/Controller/MatterbridgeController.php
+++ b/lib/Controller/MatterbridgeController.php
@@ -35,21 +35,15 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
 
 class MatterbridgeController extends AEnvironmentAwareController {
-	protected ?string $userId;
-	protected Manager $manager;
-	protected MatterbridgeManager $bridgeManager;
 
 	public function __construct(
 		string $appName,
-		?string $UserId,
+		protected ?string $userId,
 		IRequest $request,
-		Manager $manager,
-		MatterbridgeManager $bridgeManager,
+		protected Manager $manager,
+		protected MatterbridgeManager $bridgeManager,
 	) {
 		parent::__construct($appName, $request);
-		$this->userId = $UserId;
-		$this->manager = $manager;
-		$this->bridgeManager = $bridgeManager;
 	}
 
 	/**

--- a/lib/Controller/MatterbridgeSettingsController.php
+++ b/lib/Controller/MatterbridgeSettingsController.php
@@ -34,15 +34,13 @@ use OCP\AppFramework\OCSController;
 use OCP\IRequest;
 
 class MatterbridgeSettingsController extends OCSController {
-	protected MatterbridgeManager $bridgeManager;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		MatterbridgeManager $bridgeManager,
+		protected MatterbridgeManager $bridgeManager,
 	) {
 		parent::__construct($appName, $request);
-		$this->bridgeManager = $bridgeManager;
 	}
 
 	/**

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -70,61 +70,32 @@ use Psr\Log\LoggerInterface;
 class PageController extends Controller {
 	use TInitialState;
 
-	private ?string $userId;
-	private IEventDispatcher $eventDispatcher;
-	private RoomController $api;
-	private TalkSession $talkSession;
-	private IUserSession $userSession;
-	private LoggerInterface $logger;
-	private Manager $manager;
-	private ParticipantService $participantService;
-	private RoomService $roomService;
-	private IURLGenerator $url;
-	private INotificationManager $notificationManager;
-	private IAppManager $appManager;
-	private IRootFolder $rootFolder;
-	private IThrottler $throttler;
-
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		IEventDispatcher $eventDispatcher,
-		RoomController $api,
-		TalkSession $session,
-		IUserSession $userSession,
-		?string $UserId,
-		LoggerInterface $logger,
-		Manager $manager,
-		ParticipantService $participantService,
-		RoomService $roomService,
-		IURLGenerator $url,
-		INotificationManager $notificationManager,
-		IAppManager $appManager,
+		private IEventDispatcher $eventDispatcher,
+		private RoomController $api,
+		private TalkSession $talkSession,
+		private IUserSession $userSession,
+		private ?string $userId,
+		private LoggerInterface $logger,
+		private Manager $manager,
+		private ParticipantService $participantService,
+		private RoomService $roomService,
+		private IURLGenerator $url,
+		private INotificationManager $notificationManager,
+		private IAppManager $appManager,
 		IInitialState $initialState,
 		ICacheFactory $memcacheFactory,
-		IRootFolder $rootFolder,
-		IThrottler $throttler,
+		private IRootFolder $rootFolder,
+		private IThrottler $throttler,
 		Config $talkConfig,
 		IConfig $serverConfig,
 		IGroupManager $groupManager,
 	) {
 		parent::__construct($appName, $request);
-		$this->eventDispatcher = $eventDispatcher;
-		$this->api = $api;
-		$this->talkSession = $session;
-		$this->userSession = $userSession;
-		$this->userId = $UserId;
-		$this->logger = $logger;
-		$this->manager = $manager;
-		$this->participantService = $participantService;
-		$this->roomService = $roomService;
-		$this->url = $url;
-		$this->notificationManager = $notificationManager;
-		$this->appManager = $appManager;
 		$this->initialState = $initialState;
 		$this->memcacheFactory = $memcacheFactory;
-		$this->rootFolder = $rootFolder;
-		$this->throttler = $throttler;
 		$this->talkConfig = $talkConfig;
 		$this->serverConfig = $serverConfig;
 		$this->groupManager = $groupManager;

--- a/lib/Controller/PollController.php
+++ b/lib/Controller/PollController.php
@@ -47,27 +47,17 @@ use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
 class PollController extends AEnvironmentAwareController {
-	protected ChatManager $chatManager;
-	protected PollService $pollService;
-	protected AttachmentService $attachmentService;
-	protected ITimeFactory $timeFactory;
-	protected LoggerInterface $logger;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		ChatManager $chatManager,
-		PollService $pollService,
-		AttachmentService $attachmentService,
-		ITimeFactory $timeFactory,
-		LoggerInterface $logger,
+		protected ChatManager $chatManager,
+		protected PollService $pollService,
+		protected AttachmentService $attachmentService,
+		protected ITimeFactory $timeFactory,
+		protected LoggerInterface $logger,
 	) {
 		parent::__construct($appName, $request);
-		$this->pollService = $pollService;
-		$this->attachmentService = $attachmentService;
-		$this->chatManager = $chatManager;
-		$this->timeFactory = $timeFactory;
-		$this->logger = $logger;
 	}
 
 	#[PublicPage]

--- a/lib/Controller/PublicShareAuthController.php
+++ b/lib/Controller/PublicShareAuthController.php
@@ -39,24 +39,16 @@ use OCP\Share\IManager as IShareManager;
 use OCP\Share\IShare;
 
 class PublicShareAuthController extends OCSController {
-	private IUserManager $userManager;
-	private IShareManager $shareManager;
-	private IUserSession $userSession;
-	private RoomService $roomService;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		IUserManager $userManager,
-		IShareManager $shareManager,
-		IUserSession $userSession,
-		RoomService $roomService,
+		private IUserManager $userManager,
+		private IShareManager $shareManager,
+		private IUserSession $userSession,
+		private RoomService $roomService,
 	) {
 		parent::__construct($appName, $request);
-		$this->userManager = $userManager;
-		$this->shareManager = $shareManager;
-		$this->userSession = $userSession;
-		$this->roomService = $roomService;
 	}
 
 	/**

--- a/lib/Controller/ReactionController.php
+++ b/lib/Controller/ReactionController.php
@@ -40,15 +40,13 @@ use OCP\Comments\NotFoundException;
 use OCP\IRequest;
 
 class ReactionController extends AEnvironmentAwareController {
-	private ReactionManager $reactionManager;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		ReactionManager $reactionManager,
+		private ReactionManager $reactionManager,
 	) {
 		parent::__construct($appName, $request);
-		$this->reactionManager = $reactionManager;
 	}
 
 	#[PublicPage]

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -82,77 +82,34 @@ use Psr\Log\LoggerInterface;
 class RoomController extends AEnvironmentAwareController {
 	public const EVENT_BEFORE_ROOMS_GET = self::class . '::preGetRooms';
 
-	protected ?string $userId;
-	protected IAppManager $appManager;
-	protected TalkSession $session;
-	protected IUserManager $userManager;
-	protected IGroupManager $groupManager;
-	protected Manager $manager;
-	protected ICloudIdManager $cloudIdManager;
-	protected RoomService $roomService;
-	protected BreakoutRoomService $breakoutRoomService;
-	protected ParticipantService $participantService;
-	protected SessionService $sessionService;
-	protected GuestManager $guestManager;
-	protected IUserStatusManager $statusManager;
-	protected IEventDispatcher $dispatcher;
-	protected ITimeFactory $timeFactory;
-	protected ChecksumVerificationService $checksumVerificationService;
-	protected RoomFormatter $roomFormatter;
-	protected IConfig $config;
-	protected Config $talkConfig;
-	protected IThrottler $throttler;
-	protected LoggerInterface $logger;
-
 	protected array $commonReadMessages = [];
 
 	public function __construct(
 		string $appName,
-		?string $UserId,
+		protected ?string $userId,
 		IRequest $request,
-		IAppManager $appManager,
-		TalkSession $session,
-		IUserManager $userManager,
-		IGroupManager $groupManager,
-		Manager $manager,
-		RoomService $roomService,
-		BreakoutRoomService $breakoutRoomService,
-		ParticipantService $participantService,
-		SessionService $sessionService,
-		GuestManager $guestManager,
-		IUserStatusManager $statusManager,
-		IEventDispatcher $dispatcher,
-		ITimeFactory $timeFactory,
-		ChecksumVerificationService $checksumVerificationService,
-		RoomFormatter $roomFormatter,
-		IConfig $config,
-		Config $talkConfig,
-		ICloudIdManager $cloudIdManager,
-		IThrottler $throttler,
-		LoggerInterface $logger,
+		protected IAppManager $appManager,
+		protected TalkSession $session,
+		protected IUserManager $userManager,
+		protected IGroupManager $groupManager,
+		protected Manager $manager,
+		protected RoomService $roomService,
+		protected BreakoutRoomService $breakoutRoomService,
+		protected ParticipantService $participantService,
+		protected SessionService $sessionService,
+		protected GuestManager $guestManager,
+		protected IUserStatusManager $statusManager,
+		protected IEventDispatcher $dispatcher,
+		protected ITimeFactory $timeFactory,
+		protected ChecksumVerificationService $checksumVerificationService,
+		protected RoomFormatter $roomFormatter,
+		protected IConfig $config,
+		protected Config $talkConfig,
+		protected ICloudIdManager $cloudIdManager,
+		protected IThrottler $throttler,
+		protected LoggerInterface $logger,
 	) {
 		parent::__construct($appName, $request);
-		$this->session = $session;
-		$this->appManager = $appManager;
-		$this->userId = $UserId;
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
-		$this->manager = $manager;
-		$this->roomService = $roomService;
-		$this->breakoutRoomService = $breakoutRoomService;
-		$this->participantService = $participantService;
-		$this->sessionService = $sessionService;
-		$this->guestManager = $guestManager;
-		$this->statusManager = $statusManager;
-		$this->dispatcher = $dispatcher;
-		$this->timeFactory = $timeFactory;
-		$this->checksumVerificationService = $checksumVerificationService;
-		$this->config = $config;
-		$this->talkConfig = $talkConfig;
-		$this->cloudIdManager = $cloudIdManager;
-		$this->throttler = $throttler;
-		$this->logger = $logger;
-		$this->roomFormatter = $roomFormatter;
 	}
 
 	protected function getTalkHashHeader(): array {

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -44,30 +44,18 @@ use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
 class SettingsController extends OCSController {
-	protected IRootFolder $rootFolder;
-	protected IConfig $config;
-	protected IGroupManager $groupManager;
-	protected ParticipantService $participantService;
-	protected LoggerInterface $logger;
-	protected ?string $userId;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		IRootFolder $rootFolder,
-		IConfig $config,
-		IGroupManager $groupManager,
-		ParticipantService $participantService,
-		LoggerInterface $logger,
-		?string $userId,
+		protected IRootFolder $rootFolder,
+		protected IConfig $config,
+		protected IGroupManager $groupManager,
+		protected ParticipantService $participantService,
+		protected LoggerInterface $logger,
+		protected ?string $userId,
 	) {
 		parent::__construct($appName, $request);
-		$this->rootFolder = $rootFolder;
-		$this->config = $config;
-		$this->groupManager = $groupManager;
-		$this->participantService = $participantService;
-		$this->logger = $logger;
-		$this->userId = $userId;
 	}
 
 	/**

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -62,56 +62,27 @@ class SignalingController extends OCSController {
 
 	public const EVENT_BACKEND_SIGNALING_ROOMS = self::class . '::signalingBackendRoom';
 
-	private Config $talkConfig;
-	private \OCA\Talk\Signaling\Manager $signalingManager;
-	private TalkSession $session;
-	private Manager $manager;
-	private ParticipantService $participantService;
-	private SessionService $sessionService;
-	private IDBConnection $dbConnection;
-	private Messages $messages;
-	private IUserManager $userManager;
-	private IEventDispatcher $dispatcher;
-	private ITimeFactory $timeFactory;
-	private IClientService $clientService;
-	private LoggerInterface $logger;
-	private ?string $userId;
-
 	public function __construct(
 		string $appName,
 		IRequest $request,
 		IConfig $serverConfig,
-		Config $talkConfig,
-		\OCA\Talk\Signaling\Manager $signalingManager,
-		TalkSession $session,
-		Manager $manager,
-		ParticipantService $participantService,
-		SessionService $sessionService,
-		IDBConnection $connection,
-		Messages $messages,
-		IUserManager $userManager,
-		IEventDispatcher $dispatcher,
-		ITimeFactory $timeFactory,
-		IClientService $clientService,
+		private Config $talkConfig,
+		private \OCA\Talk\Signaling\Manager $signalingManager,
+		private TalkSession $session,
+		private Manager $manager,
+		private ParticipantService $participantService,
+		private SessionService $sessionService,
+		private IDBConnection $dbConnection,
+		private Messages $messages,
+		private IUserManager $userManager,
+		private IEventDispatcher $dispatcher,
+		private ITimeFactory $timeFactory,
+		private IClientService $clientService,
 		IThrottler $throttler,
-		LoggerInterface $logger,
-		?string $UserId,
+		private LoggerInterface $logger,
+		private ?string $userId,
 	) {
 		parent::__construct($appName, $request);
-		$this->talkConfig = $talkConfig;
-		$this->signalingManager = $signalingManager;
-		$this->session = $session;
-		$this->dbConnection = $connection;
-		$this->manager = $manager;
-		$this->participantService = $participantService;
-		$this->sessionService = $sessionService;
-		$this->messages = $messages;
-		$this->userManager = $userManager;
-		$this->dispatcher = $dispatcher;
-		$this->timeFactory = $timeFactory;
-		$this->clientService = $clientService;
-		$this->logger = $logger;
-		$this->userId = $UserId;
 	}
 
 	/**

--- a/lib/Controller/TempAvatarController.php
+++ b/lib/Controller/TempAvatarController.php
@@ -37,24 +37,16 @@ use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
 class TempAvatarController extends OCSController {
-	private IAvatarManager $avatarManager;
-	private IL10N $l;
-	private LoggerInterface $logger;
-	private string $userId;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		IAvatarManager $avatarManager,
-		IL10N $l,
-		LoggerInterface $logger,
-		string $userId,
+		private IAvatarManager $avatarManager,
+		private IL10N $l,
+		private LoggerInterface $logger,
+		private string $userId,
 	) {
 		parent::__construct($appName, $request);
-		$this->avatarManager = $avatarManager;
-		$this->logger = $logger;
-		$this->l = $l;
-		$this->userId = $userId;
 	}
 
 	#[NoAdminRequired]

--- a/lib/Dashboard/TalkWidget.php
+++ b/lib/Dashboard/TalkWidget.php
@@ -50,36 +50,18 @@ use OCP\IUserSession;
 use OCP\Util;
 
 class TalkWidget implements IAPIWidget, IIconWidget, IButtonWidget, IOptionWidget, IConditionalWidget {
-	protected IUserSession $userSession;
-	protected Config $talkConfig;
-	protected IURLGenerator $url;
-	protected IL10N $l10n;
-	protected Manager $manager;
-	protected AvatarService $avatarService;
-	protected ParticipantService $participantService;
-	protected MessageParser $messageParser;
-	protected ITimeFactory $timeFactory;
 
 	public function __construct(
-		IUserSession $userSession,
-		Config $talkConfig,
-		IURLGenerator $url,
-		IL10N $l10n,
-		Manager $manager,
-		AvatarService $avatarService,
-		ParticipantService $participantService,
-		MessageParser $messageParser,
-		ITimeFactory $timeFactory,
+		protected IUserSession $userSession,
+		protected Config $talkConfig,
+		protected IURLGenerator $url,
+		protected IL10N $l10n,
+		protected Manager $manager,
+		protected AvatarService $avatarService,
+		protected ParticipantService $participantService,
+		protected MessageParser $messageParser,
+		protected ITimeFactory $timeFactory,
 	) {
-		$this->userSession = $userSession;
-		$this->talkConfig = $talkConfig;
-		$this->url = $url;
-		$this->l10n = $l10n;
-		$this->manager = $manager;
-		$this->avatarService = $avatarService;
-		$this->participantService = $participantService;
-		$this->messageParser = $messageParser;
-		$this->timeFactory = $timeFactory;
 	}
 
 	/**

--- a/lib/DataObjects/AccountId.php
+++ b/lib/DataObjects/AccountId.php
@@ -26,10 +26,10 @@ declare(strict_types=1);
 namespace OCA\Talk\DataObjects;
 
 class AccountId {
-	private string $accountId;
 
-	public function __construct(string $accountId) {
-		$this->accountId = $accountId;
+	public function __construct(
+		private string $accountId,
+	) {
 	}
 
 	public function get(): string {

--- a/lib/DataObjects/RegisterAccountData.php
+++ b/lib/DataObjects/RegisterAccountData.php
@@ -26,18 +26,14 @@ declare(strict_types=1);
 namespace OCA\Talk\DataObjects;
 
 class RegisterAccountData {
-	private string $url;
-	private string $name;
-	private string $email;
-	private string $language;
-	private string $country;
 
-	public function __construct(string $url, string $name, string $email, string $language, string $country) {
-		$this->url = $url;
-		$this->name = $name;
-		$this->email = $email;
-		$this->language = $language;
-		$this->country = $country;
+	public function __construct(
+		private string $url,
+		private string $name,
+		private string $email,
+		private string $language,
+		private string $country,
+	) {
 	}
 
 	public function getUrl(): string {


### PR DESCRIPTION
### Summary

This PR is a continuation of the previous PRs regarding refactoring and using PHP8's constructor property promotion:
#9904
#9906 

I'm splitting the refactoring and the changes into a few PRs to make reviewing the changes easier.
### ☑️ Resolves

* Using PHP8's constructor property promotion in the following namespaces:
- `/lib/Controller`
- `/lib/Dashboard`
- `/lib/DataObjects`



### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
