### PR TITLE
Use PHP8's constructor property promotion

### DIFF
--- a/lib/Deck/DeckPluginLoader.php
+++ b/lib/Deck/DeckPluginLoader.php
@@ -33,10 +33,10 @@ use OCP\Util;
  * @template-implements IEventListener<Event>
  */
 class DeckPluginLoader implements IEventListener {
-	private IRequest $request;
 
-	public function __construct(IRequest $request) {
-		$this->request = $request;
+	public function __construct(
+		private IRequest $request,
+	) {
 	}
 
 	public function handle(Event $event): void {

--- a/lib/Events/AddEmailEvent.php
+++ b/lib/Events/AddEmailEvent.php
@@ -26,15 +26,12 @@ namespace OCA\Talk\Events;
 use OCA\Talk\Room;
 
 class AddEmailEvent extends RoomEvent {
-	protected string $email;
-
 
 	public function __construct(
 		Room $room,
-		string $email,
+		protected string $email,
 	) {
 		parent::__construct($room);
-		$this->email = $email;
 	}
 
 	/**

--- a/lib/Events/AddParticipantsEvent.php
+++ b/lib/Events/AddParticipantsEvent.php
@@ -27,20 +27,15 @@ use OCA\Talk\Room;
 use OCP\Comments\IComment;
 
 class AddParticipantsEvent extends RoomEvent {
-	protected array $participants;
-
-	protected bool $skipLastMessageUpdate;
 
 	protected ?IComment $lastMessage = null;
 
 	public function __construct(
 		Room $room,
-		array $participants,
-		bool $skipLastMessageUpdate = false,
+		protected array $participants,
+		protected bool $skipLastMessageUpdate = false,
 	) {
 		parent::__construct($room);
-		$this->participants = $participants;
-		$this->skipLastMessageUpdate = $skipLastMessageUpdate;
 	}
 
 	/**

--- a/lib/Events/AlreadySharedEvent.php
+++ b/lib/Events/AlreadySharedEvent.php
@@ -29,9 +29,9 @@ namespace OCA\Talk\Events;
 use OCP\EventDispatcher\Event;
 
 class AlreadySharedEvent extends Event {
-	private $subject;
-	public function __construct($subject = null) {
-		$this->subject = $subject;
+	public function __construct(
+		private $subject = null,
+	) {
 	}
 
 	/**

--- a/lib/Events/AttendeesEvent.php
+++ b/lib/Events/AttendeesEvent.php
@@ -27,15 +27,11 @@ use OCA\Talk\Model\Attendee;
 use OCA\Talk\Room;
 
 class AttendeesEvent extends RoomEvent {
-	/** @var Attendee[] */
-	protected array $attendees;
-
 	public function __construct(
 		Room $room,
-		array $attendees,
+		protected array $attendees,
 	) {
 		parent::__construct($room);
-		$this->attendees = $attendees;
 	}
 
 	/**

--- a/lib/Events/ChatEvent.php
+++ b/lib/Events/ChatEvent.php
@@ -27,18 +27,12 @@ use OCA\Talk\Room;
 use OCP\Comments\IComment;
 
 class ChatEvent extends RoomEvent {
-	protected IComment $comment;
-
-	protected bool $skipLastActivityUpdate;
-
 	public function __construct(
 		Room $room,
-		IComment $comment,
-		bool $skipLastActivityUpdate = false,
+		protected IComment $comment,
+		protected bool $skipLastActivityUpdate = false,
 	) {
 		parent::__construct($room);
-		$this->comment = $comment;
-		$this->skipLastActivityUpdate = $skipLastActivityUpdate;
 	}
 
 	public function getComment(): IComment {

--- a/lib/Events/ChatMessageEvent.php
+++ b/lib/Events/ChatMessageEvent.php
@@ -26,12 +26,10 @@ namespace OCA\Talk\Events;
 use OCA\Talk\Model\Message;
 
 class ChatMessageEvent extends ChatEvent {
-	protected Message $message;
-
-
-	public function __construct(Message $message) {
+	public function __construct(
+		protected Message $message,
+	) {
 		parent::__construct($message->getRoom(), $message->getComment());
-		$this->message = $message;
 	}
 
 	public function getMessage(): Message {

--- a/lib/Events/ChatParticipantEvent.php
+++ b/lib/Events/ChatParticipantEvent.php
@@ -28,18 +28,13 @@ use OCA\Talk\Room;
 use OCP\Comments\IComment;
 
 class ChatParticipantEvent extends ChatEvent {
-	protected Participant $participant;
-	protected bool $silent;
-
 	public function __construct(
 		Room $room,
 		IComment $message,
-		Participant $participant,
-		bool $silent,
+		protected Participant $participant,
+		protected bool $silent,
 	) {
 		parent::__construct($room, $message);
-		$this->participant = $participant;
-		$this->silent = $silent;
 	}
 
 	public function getParticipant(): Participant {

--- a/lib/Events/CommandEvent.php
+++ b/lib/Events/CommandEvent.php
@@ -28,20 +28,15 @@ use OCA\Talk\Room;
 use OCP\Comments\IComment;
 
 class CommandEvent extends ChatEvent {
-	protected Command $command;
-	protected string $arguments;
 	protected string $output = '';
-
 
 	public function __construct(
 		Room $room,
 		IComment $message,
-		Command $command,
-		string $arguments,
+		protected Command $command,
+		protected string $arguments,
 	) {
 		parent::__construct($room, $message);
-		$this->command = $command;
-		$this->arguments = $arguments;
 	}
 
 	public function getCommand(): Command {

--- a/lib/Events/CreateRoomTokenEvent.php
+++ b/lib/Events/CreateRoomTokenEvent.php
@@ -26,18 +26,13 @@ namespace OCA\Talk\Events;
 use OCP\EventDispatcher\Event;
 
 class CreateRoomTokenEvent extends Event {
-	protected int $entropy;
-	protected string $chars;
 	protected string $token;
 
-
 	public function __construct(
-		int $entropy,
-		string $chars,
+		protected int $entropy,
+		protected string $chars,
 	) {
 		parent::__construct();
-		$this->entropy = $entropy;
-		$this->chars = $chars;
 		$this->token = '';
 	}
 

--- a/lib/Events/GetTurnServersEvent.php
+++ b/lib/Events/GetTurnServersEvent.php
@@ -26,11 +26,11 @@ namespace OCA\Talk\Events;
 use OCP\EventDispatcher\Event;
 
 class GetTurnServersEvent extends Event {
-	protected array $servers;
 
-	public function __construct(array $servers) {
+	public function __construct(
+		protected array $servers
+	) {
 		parent::__construct();
-		$this->servers = $servers;
 	}
 
 	public function getServers(): array {

--- a/lib/Events/JoinRoomGuestEvent.php
+++ b/lib/Events/JoinRoomGuestEvent.php
@@ -27,19 +27,15 @@ use OCA\Talk\Room;
 
 class JoinRoomGuestEvent extends RoomEvent {
 	protected bool $cancelJoin;
-	protected string $password;
-	protected bool $passedPasswordProtection;
 
 
 	public function __construct(
 		Room $room,
-		string $password,
-		bool $passedPasswordProtection,
+		protected string $password,
+		protected bool $passedPasswordProtection,
 	) {
 		parent::__construct($room);
 		$this->cancelJoin = false;
-		$this->password = $password;
-		$this->passedPasswordProtection = $passedPasswordProtection;
 	}
 
 	public function setCancelJoin(bool $cancelJoin): void {

--- a/lib/Events/JoinRoomUserEvent.php
+++ b/lib/Events/JoinRoomUserEvent.php
@@ -27,23 +27,17 @@ use OCA\Talk\Room;
 use OCP\IUser;
 
 class JoinRoomUserEvent extends RoomEvent {
-	protected IUser $user;
 	protected bool $cancelJoin;
-	protected string $password;
-	protected bool $passedPasswordProtection;
 
 
 	public function __construct(
 		Room $room,
-		IUser $user,
-		string $password,
-		bool $passedPasswordProtection,
+		protected IUser $user,
+		protected string $password,
+		protected bool $passedPasswordProtection,
 	) {
 		parent::__construct($room);
 		$this->cancelJoin = false;
-		$this->user = $user;
-		$this->password = $password;
-		$this->passedPasswordProtection = $passedPasswordProtection;
 	}
 
 	public function setCancelJoin(bool $cancelJoin): void {

--- a/lib/Events/ModifyLobbyEvent.php
+++ b/lib/Events/ModifyLobbyEvent.php
@@ -26,20 +26,16 @@ namespace OCA\Talk\Events;
 use OCA\Talk\Room;
 
 class ModifyLobbyEvent extends ModifyRoomEvent {
-	protected ?\DateTime $lobbyTimer;
-	protected bool $timerReached;
 
 	public function __construct(
 		Room $room,
 		string $parameter,
 		int $newValue,
 		int $oldValue,
-		?\DateTime $lobbyTimer,
-		bool $timerReached,
+		protected ?\DateTime $lobbyTimer,
+		protected bool $timerReached,
 	) {
 		parent::__construct($room, $parameter, $newValue, $oldValue);
-		$this->lobbyTimer = $lobbyTimer;
-		$this->timerReached = $timerReached;
 	}
 
 	/**

--- a/lib/Events/ModifyParticipantEvent.php
+++ b/lib/Events/ModifyParticipantEvent.php
@@ -27,24 +27,15 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 
 class ModifyParticipantEvent extends ParticipantEvent {
-	protected string $parameter;
-	/** @var int|string|bool */
-	protected $newValue;
-	/** @var int|string|bool|null */
-	protected $oldValue;
-
 
 	public function __construct(
 		Room $room,
 		Participant $participant,
-		string $parameter,
-		$newValue,
-		$oldValue = null,
+		protected string $parameter,
+		protected $newValue,
+		protected $oldValue = null,
 	) {
 		parent::__construct($room, $participant);
-		$this->parameter = $parameter;
-		$this->newValue = $newValue;
-		$this->oldValue = $oldValue;
 	}
 
 	/**

--- a/lib/Events/ModifyRoomEvent.php
+++ b/lib/Events/ModifyRoomEvent.php
@@ -27,26 +27,15 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 
 class ModifyRoomEvent extends RoomEvent {
-	protected string $parameter;
-	/** @var int|string|bool */
-	protected $newValue;
-	/** @var int|string|bool|null */
-	protected $oldValue;
-	protected ?Participant $actor;
-
 
 	public function __construct(
 		Room $room,
-		string $parameter,
-		$newValue,
-		$oldValue = null,
-		?Participant $actor = null,
+		protected string $parameter,
+		protected $newValue,
+		protected $oldValue = null,
+		protected ?Participant $actor = null,
 	) {
 		parent::__construct($room);
-		$this->parameter = $parameter;
-		$this->newValue = $newValue;
-		$this->oldValue = $oldValue;
-		$this->actor = $actor;
 	}
 
 	public function getParameter(): string {

--- a/lib/Events/ParticipantEvent.php
+++ b/lib/Events/ParticipantEvent.php
@@ -27,15 +27,13 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 
 class ParticipantEvent extends RoomEvent {
-	protected Participant $participant;
 
 
 	public function __construct(
 		Room $room,
-		Participant $participant,
+		protected Participant $participant,
 	) {
 		parent::__construct($room);
-		$this->participant = $participant;
 	}
 
 	public function getParticipant(): Participant {

--- a/lib/Events/RemoveParticipantEvent.php
+++ b/lib/Events/RemoveParticipantEvent.php
@@ -28,20 +28,14 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 
 class RemoveParticipantEvent extends ParticipantEvent {
-	protected string $reason;
-
-	/** @var Session[] */
-	protected array $sessions;
 
 	public function __construct(
 		Room $room,
 		Participant $participant,
-		string $reason,
-		array $sessions = [],
+		protected string $reason,
+		protected array $sessions = [],
 	) {
 		parent::__construct($room, $participant);
-		$this->reason = $reason;
-		$this->sessions = $sessions;
 	}
 
 	public function getReason(): string {

--- a/lib/Events/RemoveUserEvent.php
+++ b/lib/Events/RemoveUserEvent.php
@@ -28,17 +28,15 @@ use OCA\Talk\Room;
 use OCP\IUser;
 
 class RemoveUserEvent extends RemoveParticipantEvent {
-	protected IUser $user;
 
 	public function __construct(
 		Room $room,
 		Participant $participant,
-		IUser $user,
+		protected IUser $user,
 		string $reason,
 		array $sessions = [],
 	) {
 		parent::__construct($room, $participant, $reason, $sessions);
-		$this->user = $user;
 	}
 
 	public function getUser(): IUser {

--- a/lib/Events/RoomEvent.php
+++ b/lib/Events/RoomEvent.php
@@ -27,12 +27,12 @@ use OCA\Talk\Room;
 use OCP\EventDispatcher\Event;
 
 class RoomEvent extends Event {
-	protected Room $room;
 
 
-	public function __construct(Room $room) {
+	public function __construct(
+		protected Room $room,
+	) {
 		parent::__construct();
-		$this->room = $room;
 	}
 
 	/**

--- a/lib/Events/SendCallNotificationEvent.php
+++ b/lib/Events/SendCallNotificationEvent.php
@@ -27,17 +27,13 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 
 class SendCallNotificationEvent extends RoomEvent {
-	protected Participant $actor;
-	protected Participant $target;
 
 	public function __construct(
 		Room $room,
-		Participant $actor,
-		Participant $target,
+		protected Participant $actor,
+		protected Participant $target,
 	) {
 		parent::__construct($room);
-		$this->actor = $actor;
-		$this->target = $target;
 	}
 
 	public function getActor(): Participant {

--- a/lib/Events/SignalingEvent.php
+++ b/lib/Events/SignalingEvent.php
@@ -27,17 +27,15 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 
 class SignalingEvent extends ParticipantEvent {
-	protected string $action;
 	/** @var mixed */
 	protected $session;
 
 	public function __construct(
 		Room $room,
 		Participant $participant,
-		string $action,
+		protected string $action,
 	) {
 		parent::__construct($room, $participant);
-		$this->action = $action;
 		$this->session = '';
 	}
 

--- a/lib/Events/SignalingRoomPropertiesEvent.php
+++ b/lib/Events/SignalingRoomPropertiesEvent.php
@@ -26,17 +26,13 @@ namespace OCA\Talk\Events;
 use OCA\Talk\Room;
 
 class SignalingRoomPropertiesEvent extends RoomEvent {
-	protected ?string $userId;
-	protected array $properties;
 
 	public function __construct(
 		Room $room,
-		?string $userId,
-		array $properties,
+		protected ?string $userId,
+		protected array $properties,
 	) {
 		parent::__construct($room);
-		$this->userId = $userId;
-		$this->properties = $properties;
 	}
 
 	public function getUserId(): ?string {

--- a/lib/Events/UserEvent.php
+++ b/lib/Events/UserEvent.php
@@ -26,12 +26,12 @@ namespace OCA\Talk\Events;
 use OCP\EventDispatcher\Event;
 
 class UserEvent extends Event {
-	protected string $userId;
 
 
-	public function __construct(string $userId) {
+	public function __construct(
+		protected string $userId,
+	) {
 		parent::__construct();
-		$this->userId = $userId;
 	}
 
 	public function getUserId(): string {

--- a/lib/Events/VerifyRoomPasswordEvent.php
+++ b/lib/Events/VerifyRoomPasswordEvent.php
@@ -26,17 +26,15 @@ namespace OCA\Talk\Events;
 use OCA\Talk\Room;
 
 class VerifyRoomPasswordEvent extends RoomEvent {
-	protected string $password;
 	protected ?bool $isPasswordValid = null;
 	protected string $redirectUrl = '';
 
 
 	public function __construct(
 		Room $room,
-		string $password,
+		protected string $password,
 	) {
 		parent::__construct($room);
-		$this->password = $password;
 	}
 
 	public function getPassword(): string {

--- a/lib/Federation/CloudFederationProviderTalk.php
+++ b/lib/Federation/CloudFederationProviderTalk.php
@@ -55,53 +55,21 @@ use OCP\Share\Exceptions\ShareNotFound;
 use Psr\Log\LoggerInterface;
 
 class CloudFederationProviderTalk implements ICloudFederationProvider {
-	private IUserManager $userManager;
-
-	private AddressHandler $addressHandler;
-
-	private FederationManager $federationManager;
-
-	private Config $config;
-
-	private INotificationManager $notificationManager;
-
-	private IURLGenerator $urlGenerator;
-
-	private ParticipantService $participantService;
-
-	private AttendeeMapper $attendeeMapper;
-
-	private Manager $manager;
-	private ISession $session;
-	private IEventDispatcher $dispatcher;
-	private LoggerInterface $logger;
 
 	public function __construct(
-		IUserManager $userManager,
-		AddressHandler $addressHandler,
-		FederationManager $federationManager,
-		Config $config,
-		INotificationManager $notificationManager,
-		IURLGenerator $urlGenerator,
-		ParticipantService $participantService,
-		AttendeeMapper $attendeeMapper,
-		Manager $manager,
-		ISession $session,
-		IEventDispatcher $dispatcher,
-		LoggerInterface $logger,
+		private IUserManager $userManager,
+		private AddressHandler $addressHandler,
+		private FederationManager $federationManager,
+		private Config $config,
+		private INotificationManager $notificationManager,
+		private IURLGenerator $urlGenerator,
+		private ParticipantService $participantService,
+		private AttendeeMapper $attendeeMapper,
+		private Manager $manager,
+		private ISession $session,
+		private IEventDispatcher $dispatcher,
+		private LoggerInterface $logger,
 	) {
-		$this->userManager = $userManager;
-		$this->addressHandler = $addressHandler;
-		$this->federationManager = $federationManager;
-		$this->config = $config;
-		$this->notificationManager = $notificationManager;
-		$this->urlGenerator = $urlGenerator;
-		$this->participantService = $participantService;
-		$this->attendeeMapper = $attendeeMapper;
-		$this->manager = $manager;
-		$this->session = $session;
-		$this->dispatcher = $dispatcher;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/Federation/FederationManager.php
+++ b/lib/Federation/FederationManager.php
@@ -53,28 +53,13 @@ class FederationManager {
 	public const TALK_PROTOCOL_NAME = 'nctalk';
 	public const TOKEN_LENGTH = 15;
 
-	private IConfig $config;
-
-	private Manager $manager;
-
-	private ParticipantService $participantService;
-
-	private InvitationMapper $invitationMapper;
-
-	private Notifications $notifications;
-
 	public function __construct(
-		IConfig $config,
-		Manager $manager,
-		ParticipantService $participantService,
-		InvitationMapper $invitationMapper,
-		Notifications $notifications,
+		private IConfig $config,
+		private Manager $manager,
+		private ParticipantService $participantService,
+		private InvitationMapper $invitationMapper,
+		private Notifications $notifications,
 	) {
-		$this->config = $config;
-		$this->manager = $manager;
-		$this->participantService = $participantService;
-		$this->invitationMapper = $invitationMapper;
-		$this->notifications = $notifications;
 	}
 
 	/**

--- a/lib/Federation/Notifications.php
+++ b/lib/Federation/Notifications.php
@@ -42,33 +42,15 @@ use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 class Notifications {
-	private ICloudFederationFactory $cloudFederationFactory;
-
-	private LoggerInterface $logger;
-
-	private ICloudFederationProviderManager $federationProviderManager;
-
-	private IJobList $jobList;
-
-	private IUserManager $userManager;
-
-	/** @var AddressHandler */
-	private $addressHandler;
 
 	public function __construct(
-		ICloudFederationFactory $cloudFederationFactory,
-		AddressHandler $addressHandler,
-		LoggerInterface $logger,
-		ICloudFederationProviderManager $federationProviderManager,
-		IJobList $jobList,
-		IUserManager $userManager,
+		private ICloudFederationFactory $cloudFederationFactory,
+		private AddressHandler $addressHandler,
+		private LoggerInterface $logger,
+		private ICloudFederationProviderManager $federationProviderManager,
+		private IJobList $jobList,
+		private IUserManager $userManager,
 	) {
-		$this->cloudFederationFactory = $cloudFederationFactory;
-		$this->logger = $logger;
-		$this->federationProviderManager = $federationProviderManager;
-		$this->jobList = $jobList;
-		$this->userManager = $userManager;
-		$this->addressHandler = $addressHandler;
 	}
 
 	/**


### PR DESCRIPTION
### Summary

This PR is a continuation of the previous PRs regarding refactoring and using PHP8's constructor property promotion:
#9904
#9906 
#9907 

I'm splitting the refactoring and the changes into a few PRs to make reviewing the changes easier.
### ☑️ Resolves

* Using PHP8's constructor property promotion in the following namespaces:
- `/lib/Deck`
- `/lib/Events`
- `/lib/Federation`



### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
