### PR TITLE
Use PHP8's match expression instead of switch

### DIFF
--- a/lib/Activity/Provider/Base.php
+++ b/lib/Activity/Provider/Base.php
@@ -106,19 +106,11 @@ abstract class Base implements IProvider {
 	}
 
 	protected function getRoom(Room $room, string $userId): array {
-		switch ($room->getType()) {
-			case Room::TYPE_ONE_TO_ONE:
-			case Room::TYPE_ONE_TO_ONE_FORMER:
-				$stringType = 'one2one';
-				break;
-			case Room::TYPE_GROUP:
-				$stringType = 'group';
-				break;
-			case Room::TYPE_PUBLIC:
-			default:
-				$stringType = 'public';
-				break;
-		}
+		$stringType = match ($room->getType()) {
+			Room::TYPE_ONE_TO_ONE, Room::TYPE_ONE_TO_ONE_FORMER => 'one2one',
+			Room::TYPE_GROUP => 'group',
+			default => 'public',
+		};
 
 		return [
 			'type' => 'call',

--- a/lib/Chat/Parser/UserMention.php
+++ b/lib/Chat/Parser/UserMention.php
@@ -202,16 +202,11 @@ class UserMention {
 	 * @throws \InvalidArgumentException
 	 */
 	protected function getRoomType(Room $room): string {
-		switch ($room->getType()) {
-			case Room::TYPE_ONE_TO_ONE:
-			case Room::TYPE_ONE_TO_ONE_FORMER:
-				return 'one2one';
-			case Room::TYPE_GROUP:
-				return 'group';
-			case Room::TYPE_PUBLIC:
-				return 'public';
-			default:
-				throw new \InvalidArgumentException('Unknown room type');
-		}
+		return match ($room->getType()) {
+			Room::TYPE_ONE_TO_ONE, Room::TYPE_ONE_TO_ONE_FORMER => 'one2one',
+			Room::TYPE_GROUP => 'group',
+			Room::TYPE_PUBLIC => 'public',
+			default => throw new \InvalidArgumentException('Unknown room type'),
+		};
 	}
 }

--- a/lib/Collaboration/Reference/TalkReferenceProvider.php
+++ b/lib/Collaboration/Reference/TalkReferenceProvider.php
@@ -274,17 +274,12 @@ class TalkReferenceProvider extends ADiscoverableReferenceProvider implements IS
 	}
 
 	protected function getRoomType(Room $room): string {
-		switch ($room->getType()) {
-			case Room::TYPE_ONE_TO_ONE:
-			case Room::TYPE_ONE_TO_ONE_FORMER:
-				return 'one2one';
-			case Room::TYPE_GROUP:
-				return 'group';
-			case Room::TYPE_PUBLIC:
-				return 'public';
-			default:
-				return 'unknown';
-		}
+		return match ($room->getType()) {
+			Room::TYPE_ONE_TO_ONE, Room::TYPE_ONE_TO_ONE_FORMER => 'one2one',
+			Room::TYPE_GROUP => 'group',
+			Room::TYPE_PUBLIC => 'public',
+			default => 'unknown',
+		};
 	}
 
 	/**

--- a/lib/Collaboration/Resources/ConversationProvider.php
+++ b/lib/Collaboration/Resources/ConversationProvider.php
@@ -118,16 +118,11 @@ class ConversationProvider implements IProvider {
 	 * @throws \InvalidArgumentException
 	 */
 	protected function getRoomType(Room $room): string {
-		switch ($room->getType()) {
-			case Room::TYPE_ONE_TO_ONE:
-			case Room::TYPE_ONE_TO_ONE_FORMER:
-				return 'one2one';
-			case Room::TYPE_GROUP:
-				return 'group';
-			case Room::TYPE_PUBLIC:
-				return 'public';
-			default:
-				throw new \InvalidArgumentException('Unknown room type');
-		}
+		return match ($room->getType()) {
+			Room::TYPE_ONE_TO_ONE, Room::TYPE_ONE_TO_ONE_FORMER => 'one2one',
+			Room::TYPE_GROUP => 'group',
+			Room::TYPE_PUBLIC => 'public',
+			default => throw new \InvalidArgumentException('Unknown room type'),
+		};
 	}
 }

--- a/lib/Command/Room/Add.php
+++ b/lib/Command/Room/Add.php
@@ -89,23 +89,19 @@ class Add extends Base {
 	}
 
 	public function completeOptionValues($optionName, CompletionContext $context) {
-		switch ($optionName) {
-			case 'user':
-				return $this->completeUserValues($context);
+		return match ($optionName) {
+			'user' => $this->completeUserValues($context),
+			'group' => $this->completeGroupValues($context),
+			default => parent::completeOptionValues($optionName, $context),
+		};
 
-			case 'group':
-				return $this->completeGroupValues($context);
-		}
-
-		return parent::completeOptionValues($optionName, $context);
 	}
 
 	public function completeArgumentValues($argumentName, CompletionContext $context) {
-		switch ($argumentName) {
-			case 'token':
-				return $this->completeTokenValues($context);
-		}
+		return match ($argumentName) {
+			'token' => $this->completeTokenValues($context),
+			default => parent::completeArgumentValues($argumentName, $context),
+		};
 
-		return parent::completeArgumentValues($argumentName, $context);
 	}
 }

--- a/lib/Command/Room/Create.php
+++ b/lib/Command/Room/Create.php
@@ -168,26 +168,18 @@ class Create extends Base {
 	}
 
 	public function completeOptionValues($optionName, CompletionContext $context) {
-		switch ($optionName) {
-			case 'user':
-				return $this->completeUserValues($context);
+		return match ($optionName) {
+			'user' => $this->completeUserValues($context),
+			'group' => $this->completeGroupValues($context),
+			'owner', 'moderator' => $this->completeParticipantValues($context),
+			'readonly' => [(string)Room::READ_ONLY, (string)Room::READ_WRITE],
+			'listable' => [
+				(string)Room::LISTABLE_ALL,
+				(string)Room::LISTABLE_USERS,
+				(string)Room::LISTABLE_NONE,
+			],
+			default => parent::completeOptionValues($optionName, $context),
+		};
 
-			case 'group':
-				return $this->completeGroupValues($context);
-
-			case 'owner':
-			case 'moderator':
-				return $this->completeParticipantValues($context);
-			case 'readonly':
-				return [(string)Room::READ_ONLY, (string)Room::READ_WRITE];
-			case 'listable':
-				return [
-					(string)Room::LISTABLE_ALL,
-					(string)Room::LISTABLE_USERS,
-					(string)Room::LISTABLE_NONE,
-				];
-		}
-
-		return parent::completeOptionValues($optionName, $context);
 	}
 }

--- a/lib/Command/Room/Delete.php
+++ b/lib/Command/Room/Delete.php
@@ -69,11 +69,10 @@ class Delete extends Base {
 	}
 
 	public function completeArgumentValues($argumentName, CompletionContext $context) {
-		switch ($argumentName) {
-			case 'token':
-				return $this->completeTokenValues($context);
-		}
+		return match ($argumentName) {
+			'token' => $this->completeTokenValues($context),
+			default => parent::completeArgumentValues($argumentName, $context),
+		};
 
-		return parent::completeArgumentValues($argumentName, $context);
 	}
 }

--- a/lib/Command/Room/Demote.php
+++ b/lib/Command/Room/Demote.php
@@ -80,14 +80,11 @@ class Demote extends Base {
 	}
 
 	public function completeArgumentValues($argumentName, CompletionContext $context) {
-		switch ($argumentName) {
-			case 'token':
-				return $this->completeTokenValues($context);
+		return match ($argumentName) {
+			'token' => $this->completeTokenValues($context),
+			'participant' => $this->completeParticipantValues($context),
+			default => parent::completeArgumentValues($argumentName, $context),
+		};
 
-			case 'participant':
-				return $this->completeParticipantValues($context);
-		}
-
-		return parent::completeArgumentValues($argumentName, $context);
 	}
 }

--- a/lib/Command/Room/Promote.php
+++ b/lib/Command/Room/Promote.php
@@ -80,14 +80,11 @@ class Promote extends Base {
 	}
 
 	public function completeArgumentValues($argumentName, CompletionContext $context) {
-		switch ($argumentName) {
-			case 'token':
-				return $this->completeTokenValues($context);
+		return match ($argumentName) {
+			'token' => $this->completeTokenValues($context),
+			'participant' => $this->completeParticipantValues($context),
+			default => parent::completeArgumentValues($argumentName, $context),
+		};
 
-			case 'participant':
-				return $this->completeParticipantValues($context);
-		}
-
-		return parent::completeArgumentValues($argumentName, $context);
 	}
 }

--- a/lib/Command/Room/Remove.php
+++ b/lib/Command/Room/Remove.php
@@ -80,14 +80,11 @@ class Remove extends Base {
 	}
 
 	public function completeArgumentValues($argumentName, CompletionContext $context) {
-		switch ($argumentName) {
-			case 'token':
-				return $this->completeTokenValues($context);
+		return match ($argumentName) {
+			'token' => $this->completeTokenValues($context),
+			'participant' => $this->completeParticipantValues($context),
+			default => parent::completeArgumentValues($argumentName, $context),
+		};
 
-			case 'participant':
-				return $this->completeParticipantValues($context);
-		}
-
-		return parent::completeArgumentValues($argumentName, $context);
 	}
 }

--- a/lib/Command/Room/Update.php
+++ b/lib/Command/Room/Update.php
@@ -178,30 +178,24 @@ class Update extends Base {
 	}
 
 	public function completeOptionValues($optionName, CompletionContext $context) {
-		switch ($optionName) {
-			case 'public':
-			case 'readonly':
-				return [(string)Room::READ_ONLY, (string)Room::READ_WRITE];
-			case 'listable':
-				return [
-					(string)Room::LISTABLE_ALL,
-					(string)Room::LISTABLE_USERS,
-					(string)Room::LISTABLE_NONE,
-				];
+		return match ($optionName) {
+			'public', 'readonly' => [(string)Room::READ_ONLY, (string)Room::READ_WRITE],
+			'listable' => [
+				(string)Room::LISTABLE_ALL,
+				(string)Room::LISTABLE_USERS,
+				(string)Room::LISTABLE_NONE,
+			],
+			'owner' => $this->completeParticipantValues($context),
+			default => parent::completeOptionValues($optionName, $context),
+		};
 
-			case 'owner':
-				return $this->completeParticipantValues($context);
-		}
-
-		return parent::completeOptionValues($optionName, $context);
 	}
 
 	public function completeArgumentValues($argumentName, CompletionContext $context) {
-		switch ($argumentName) {
-			case 'token':
-				return $this->completeTokenValues($context);
-		}
+		return match ($argumentName) {
+			'token' => $this->completeTokenValues($context),
+			default => parent::completeArgumentValues($argumentName, $context),
+		};
 
-		return parent::completeArgumentValues($argumentName, $context);
 	}
 }

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -435,14 +435,11 @@ class Config {
 	 * @return string
 	 */
 	public function getSignalingTicket(int $version, ?string $userId): string {
-		switch ($version) {
-			case self::SIGNALING_TICKET_V1:
-				return $this->getSignalingTicketV1($userId);
-			case self::SIGNALING_TICKET_V2:
-				return $this->getSignalingTicketV2($userId);
-			default:
-				return $this->getSignalingTicketV1($userId);
-		}
+		return match ($version) {
+			self::SIGNALING_TICKET_V1 => $this->getSignalingTicketV1($userId),
+			self::SIGNALING_TICKET_V2 => $this->getSignalingTicketV2($userId),
+			default => $this->getSignalingTicketV1($userId),
+		};
 	}
 
 	/**

--- a/lib/Controller/RecordingController.php
+++ b/lib/Controller/RecordingController.php
@@ -156,22 +156,18 @@ class RecordingController extends AEnvironmentAwareController {
 		}
 
 		$message = json_decode($json, true);
-		switch ($message['type'] ?? '') {
-			case 'started':
-				return $this->backendStarted($message['started']);
-			case 'stopped':
-				return $this->backendStopped($message['stopped']);
-			case 'failed':
-				return $this->backendFailed($message['failed']);
-			default:
-				return new DataResponse([
-					'type' => 'error',
-					'error' => [
-						'code' => 'unknown_type',
-						'message' => 'The given type ' . json_encode($message) . ' is not supported.',
-					],
-				], Http::STATUS_BAD_REQUEST);
-		}
+		return match ($message['type'] ?? '') {
+			'started' => $this->backendStarted($message['started']),
+			'stopped' => $this->backendStopped($message['stopped']),
+			'failed' => $this->backendFailed($message['failed']),
+			default => new DataResponse([
+				'type' => 'error',
+				'error' => [
+					'code' => 'unknown_type',
+					'message' => 'The given type ' . json_encode($message) . ' is not supported.',
+				],
+			], Http::STATUS_BAD_REQUEST),
+		};
 	}
 
 	private function backendStarted(array $started): DataResponse {

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -525,25 +525,18 @@ class SignalingController extends OCSController {
 		}
 
 		$message = json_decode($json, true);
-		switch ($message['type'] ?? '') {
-			case 'auth':
-				// Query authentication information about a user.
-				return $this->backendAuth($message['auth']);
-			case 'room':
-				// Query information about a room.
-				return $this->backendRoom($message['room']);
-			case 'ping':
-				// Ping sessions connected to a room.
-				return $this->backendPing($message['ping']);
-			default:
-				return new DataResponse([
-					'type' => 'error',
-					'error' => [
-						'code' => 'unknown_type',
-						'message' => 'The given type ' . json_encode($message) . ' is not supported.',
-					],
-				]);
-		}
+		return match ($message['type'] ?? '') {
+			'auth' => $this->backendAuth($message['auth']),
+			'room' => $this->backendRoom($message['room']),
+			'ping' => $this->backendPing($message['ping']),
+			default => new DataResponse([
+				'type' => 'error',
+				'error' => [
+					'code' => 'unknown_type',
+					'message' => 'The given type ' . json_encode($message) . ' is not supported.',
+				],
+			]),
+		};
 	}
 
 	private function backendAuth(array $auth): DataResponse {

--- a/lib/Federation/CloudFederationProviderTalk.php
+++ b/lib/Federation/CloudFederationProviderTalk.php
@@ -176,21 +176,15 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 		if (!is_numeric($providerId)) {
 			throw new BadRequestException(['providerId']);
 		}
-		switch ($notificationType) {
-			case 'SHARE_ACCEPTED':
-				return $this->shareAccepted((int) $providerId, $notification);
-			case 'SHARE_DECLINED':
-				return $this->shareDeclined((int) $providerId, $notification);
-			case 'SHARE_UNSHARED':
-				return $this->shareUnshared((int) $providerId, $notification);
-			case 'REQUEST_RESHARE':
-				return []; // TODO: Implement
-			case 'RESHARE_UNDO':
-				return []; // TODO: Implement
-			case 'RESHARE_CHANGE_PERMISSION':
-				return []; // TODO: Implement
-		}
-		return [];
+		return match ($notificationType) {
+			'SHARE_ACCEPTED' => $this->shareAccepted((int)$providerId, $notification),
+			'SHARE_DECLINED' => $this->shareDeclined((int)$providerId, $notification),
+			'SHARE_UNSHARED' => $this->shareUnshared((int)$providerId, $notification),
+			'REQUEST_RESHARE' => [],
+			'RESHARE_UNDO' => [],
+			'RESHARE_CHANGE_PERMISSION' => [],
+			default => [],
+		};
 		// TODO: Implement notificationReceived() method.
 	}
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -744,17 +744,12 @@ class Notifier implements INotifier {
 	 * @throws \InvalidArgumentException
 	 */
 	protected function getRoomType(Room $room): string {
-		switch ($room->getType()) {
-			case Room::TYPE_ONE_TO_ONE:
-			case Room::TYPE_ONE_TO_ONE_FORMER:
-				return 'one2one';
-			case Room::TYPE_GROUP:
-				return 'group';
-			case Room::TYPE_PUBLIC:
-				return 'public';
-			default:
-				throw new \InvalidArgumentException('Unknown room type');
-		}
+		return match ($room->getType()) {
+			Room::TYPE_ONE_TO_ONE, Room::TYPE_ONE_TO_ONE_FORMER => 'one2one',
+			Room::TYPE_GROUP => 'group',
+			Room::TYPE_PUBLIC => 'public',
+			default => throw new \InvalidArgumentException('Unknown room type'),
+		};
 	}
 
 	/**


### PR DESCRIPTION
### ☑️ Resolves

* Using PHP8's `match` expression instead of `switch`

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
