### PR TITLE
Use PHP8's constructor property promotion

### DIFF
--- a/lib/Files/Listener.php
+++ b/lib/Files/Listener.php
@@ -53,21 +53,13 @@ use OCP\Server;
  * events.
  */
 class Listener {
-	protected Util $util;
-	protected ParticipantService $participantService;
-	protected IUserManager $userManager;
-	protected TalkSession $talkSession;
 
 	public function __construct(
-		Util $util,
-		ParticipantService $participantService,
-		IUserManager $userManager,
-		TalkSession $talkSession,
+		protected Util $util,
+		protected ParticipantService $participantService,
+		protected IUserManager $userManager,
+		protected TalkSession $talkSession,
 	) {
-		$this->util = $util;
-		$this->participantService = $participantService;
-		$this->userManager = $userManager;
-		$this->talkSession = $talkSession;
 	}
 
 	public static function register(IEventDispatcher $dispatcher): void {

--- a/lib/Files/TemplateLoader.php
+++ b/lib/Files/TemplateLoader.php
@@ -49,27 +49,20 @@ use OCP\Util;
 class TemplateLoader implements IEventListener {
 	use TInitialState;
 
-	private IAppManager $appManager;
-	private IRootFolder $rootFolder;
-	private IUserSession $userSession;
-
 	public function __construct(
 		IInitialState $initialState,
 		ICacheFactory $memcacheFactory,
 		Config $talkConfig,
 		IConfig $serverConfig,
-		IAppManager $appManager,
-		IRootFolder $rootFolder,
-		IUserSession $userSession,
+		private IAppManager $appManager,
+		private IRootFolder $rootFolder,
+		private IUserSession $userSession,
 		IGroupManager $groupManager,
 	) {
 		$this->initialState = $initialState;
 		$this->memcacheFactory = $memcacheFactory;
 		$this->talkConfig = $talkConfig;
 		$this->serverConfig = $serverConfig;
-		$this->appManager = $appManager;
-		$this->rootFolder = $rootFolder;
-		$this->userSession = $userSession;
 		$this->groupManager = $groupManager;
 	}
 

--- a/lib/Files/Util.php
+++ b/lib/Files/Util.php
@@ -35,25 +35,17 @@ use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager as IShareManager;
 
 class Util {
-	private IRootFolder $rootFolder;
-	private ISession $session;
-	private IShareManager $shareManager;
-	private IUserMountCache $userMountCache;
 	/** @var array[] */
 	private array $accessLists = [];
 	/** @var bool[] */
 	private array $publicAccessLists = [];
 
 	public function __construct(
-		IRootFolder $rootFolder,
-		ISession $session,
-		IShareManager $shareManager,
-		IUserMountCache $userMountCache,
+		private IRootFolder $rootFolder,
+		private ISession $session,
+		private IShareManager $shareManager,
+		private IUserMountCache $userMountCache,
 	) {
-		$this->rootFolder = $rootFolder;
-		$this->session = $session;
-		$this->shareManager = $shareManager;
-		$this->userMountCache = $userMountCache;
 	}
 
 	public function getUsersWithAccessFile(string $fileId): array {

--- a/lib/Flow/Operation.php
+++ b/lib/Flow/Operation.php
@@ -54,27 +54,14 @@ class Operation implements IOperation {
 		'ROOM_MENTION' => 3,
 	];
 
-	protected IL10N $l;
-	protected IURLGenerator $urlGenerator;
-	protected TalkManager $talkManager;
-	protected ParticipantService $participantService;
-	protected IUserSession $session;
-	protected ChatManager $chatManager;
-
 	public function __construct(
-		IL10N $l,
-		IURLGenerator $urlGenerator,
-		TalkManager $talkManager,
-		ParticipantService $participantService,
-		IUserSession $session,
-		ChatManager $chatManager,
+		protected IL10N $l,
+		protected IURLGenerator $urlGenerator,
+		protected TalkManager $talkManager,
+		protected ParticipantService $participantService,
+		protected IUserSession $session,
+		protected ChatManager $chatManager,
 	) {
-		$this->l = $l;
-		$this->urlGenerator = $urlGenerator;
-		$this->talkManager = $talkManager;
-		$this->participantService = $participantService;
-		$this->session = $session;
-		$this->chatManager = $chatManager;
 	}
 
 	public function getDisplayName(): string {

--- a/lib/Flow/RegisterOperationsListener.php
+++ b/lib/Flow/RegisterOperationsListener.php
@@ -32,10 +32,10 @@ use OCP\WorkflowEngine\Events\RegisterOperationsEvent;
  * @template-implements IEventListener<Event>
  */
 class RegisterOperationsListener implements IEventListener {
-	private Operation $operation;
 
-	public function __construct(Operation $operation) {
-		$this->operation = $operation;
+	public function __construct(
+		private Operation $operation,
+	) {
 	}
 
 	public function handle(Event $event): void {

--- a/lib/Listener/AMembershipListener.php
+++ b/lib/Listener/AMembershipListener.php
@@ -43,21 +43,13 @@ use Psr\Log\LoggerInterface;
  * @template-implements IEventListener<Event>
  */
 abstract class AMembershipListener implements IEventListener {
-	protected Manager $manager;
-	protected IAppManager $appManager;
-	protected IGroupManager $groupManager;
-	protected ParticipantService $participantService;
 
 	public function __construct(
-		Manager $manager,
-		IAppManager $appManager,
-		IGroupManager $groupManager,
-		ParticipantService $participantService,
+		protected Manager $manager,
+		protected IAppManager $appManager,
+		protected IGroupManager $groupManager,
+		protected ParticipantService $participantService,
 	) {
-		$this->manager = $manager;
-		$this->appManager = $appManager;
-		$this->groupManager = $groupManager;
-		$this->participantService = $participantService;
 	}
 
 	protected function removeFromRoomsUnlessStillLinked(array $rooms, IUser $user): void {

--- a/lib/Listener/BeforeUserLoggedOutListener.php
+++ b/lib/Listener/BeforeUserLoggedOutListener.php
@@ -38,18 +38,12 @@ use OCP\User\Events\BeforeUserLoggedOutEvent;
  * @template-implements IEventListener<Event>
  */
 class BeforeUserLoggedOutListener implements IEventListener {
-	private Manager $manager;
-	private ParticipantService $participantService;
-	private TalkSession $talkSession;
 
 	public function __construct(
-		Manager $manager,
-		ParticipantService $participantService,
-		TalkSession $talkSession,
+		private Manager $manager,
+		private ParticipantService $participantService,
+		private TalkSession $talkSession,
 	) {
-		$this->manager = $manager;
-		$this->participantService = $participantService;
-		$this->talkSession = $talkSession;
 	}
 
 	public function handle(Event $event): void {

--- a/lib/Listener/CSPListener.php
+++ b/lib/Listener/CSPListener.php
@@ -35,10 +35,10 @@ use OCP\Security\CSP\AddContentSecurityPolicyEvent;
  * @template-implements IEventListener<Event>
  */
 class CSPListener implements IEventListener {
-	private Config $config;
 
-	public function __construct(Config $config) {
-		$this->config = $config;
+	public function __construct(
+		private Config $config,
+	) {
 	}
 
 	public function handle(Event $event): void {

--- a/lib/Listener/CircleDeletedListener.php
+++ b/lib/Listener/CircleDeletedListener.php
@@ -35,15 +35,11 @@ use OCP\EventDispatcher\IEventListener;
  * @template-implements IEventListener<Event>
  */
 class CircleDeletedListener implements IEventListener {
-	private Manager $manager;
-	private ParticipantService $participantService;
 
 	public function __construct(
-		Manager $manager,
-		ParticipantService $participantService,
+		private Manager $manager,
+		private ParticipantService $participantService,
 	) {
-		$this->manager = $manager;
-		$this->participantService = $participantService;
 	}
 
 	public function handle(Event $event): void {

--- a/lib/Listener/CircleMembershipListener.php
+++ b/lib/Listener/CircleMembershipListener.php
@@ -43,16 +43,14 @@ use OCP\IUserManager;
  * @template-implements IEventListener<Event>
  */
 class CircleMembershipListener extends AMembershipListener {
-	private ISession $session;
-	private IUserManager $userManager;
 
 	public function __construct(
 		Manager $manager,
 		IAppManager $appManager,
 		IGroupManager $groupManager,
 		ParticipantService $participantService,
-		IUserManager $userManager,
-		ISession $session,
+		private IUserManager $userManager,
+		private ISession $session,
 	) {
 		parent::__construct(
 			$manager,
@@ -60,8 +58,6 @@ class CircleMembershipListener extends AMembershipListener {
 			$groupManager,
 			$participantService
 		);
-		$this->userManager = $userManager;
-		$this->session = $session;
 	}
 
 	public function handle(Event $event): void {

--- a/lib/Listener/DisplayNameListener.php
+++ b/lib/Listener/DisplayNameListener.php
@@ -35,15 +35,11 @@ use OCP\User\Events\UserChangedEvent;
  * @template-implements IEventListener<Event>
  */
 class DisplayNameListener implements IEventListener {
-	private ParticipantService $participantService;
-	private PollService $pollService;
 
 	public function __construct(
-		ParticipantService $participantService,
-		PollService $pollService,
+		private ParticipantService $participantService,
+		private PollService $pollService,
 	) {
-		$this->participantService = $participantService;
-		$this->pollService = $pollService;
 	}
 
 	public function handle(Event $event): void {

--- a/lib/Listener/GroupDeletedListener.php
+++ b/lib/Listener/GroupDeletedListener.php
@@ -36,18 +36,12 @@ use OCP\IConfig;
  * @template-implements IEventListener<Event>
  */
 class GroupDeletedListener implements IEventListener {
-	private IConfig $config;
-	private Manager $manager;
-	private ParticipantService $participantService;
 
 	public function __construct(
-		IConfig $config,
-		Manager $manager,
-		ParticipantService $participantService,
+		private IConfig $config,
+		private Manager $manager,
+		private ParticipantService $participantService,
 	) {
-		$this->config = $config;
-		$this->manager = $manager;
-		$this->participantService = $participantService;
 	}
 
 	public function handle(Event $event): void {

--- a/lib/Listener/RestrictStartingCalls.php
+++ b/lib/Listener/RestrictStartingCalls.php
@@ -37,16 +37,11 @@ use OCP\Server;
  * @template-implements IEventListener<Event>
  */
 class RestrictStartingCalls {
-	protected IConfig $config;
-
-	protected ParticipantService $participantService;
 
 	public function __construct(
-		IConfig $config,
-		ParticipantService $participantService,
+		protected IConfig $config,
+		protected ParticipantService $participantService,
 	) {
-		$this->config = $config;
-		$this->participantService = $participantService;
 	}
 
 	public static function register(IEventDispatcher $dispatcher): void {

--- a/lib/Listener/UserDeletedListener.php
+++ b/lib/Listener/UserDeletedListener.php
@@ -34,15 +34,11 @@ use OCP\User\Events\UserDeletedEvent;
  * @template-implements IEventListener<Event>
  */
 class UserDeletedListener implements IEventListener {
-	private Manager $manager;
-	private PollService $pollService;
 
 	public function __construct(
-		Manager $manager,
-		PollService $pollService,
+		private Manager $manager,
+		private PollService $pollService,
 	) {
-		$this->manager = $manager;
-		$this->pollService = $pollService;
 	}
 
 	public function handle(Event $event): void {

--- a/lib/Maps/MapsPluginLoader.php
+++ b/lib/Maps/MapsPluginLoader.php
@@ -36,18 +36,12 @@ use OCP\Util;
  * @template-implements IEventListener<Event>
  */
 class MapsPluginLoader implements IEventListener {
-	protected IRequest $request;
-	protected Config $talkConfig;
-	protected IUserSession $userSession;
 
 	public function __construct(
-		IRequest $request,
-		Config $talkConfig,
-		IUserSession $userSession,
+		protected IRequest $request,
+		protected Config $talkConfig,
+		protected IUserSession $userSession,
 	) {
-		$this->request = $request;
-		$this->talkConfig = $talkConfig;
-		$this->userSession = $userSession;
 	}
 
 	public function handle(Event $event): void {


### PR DESCRIPTION
### Summary

This PR is a continuation of the previous PRs regarding refactoring and using PHP8's constructor property promotion:
#9908

I'm splitting the refactoring and the changes into a few PRs to make reviewing the changes easier.

### ☑️ Resolves

* Using PHP8's constructor property promotion in the following namespaces:
- `/lib/Files`
- `/lib/Flow`
- `/lib/Listener`
- `/lib/Maps`

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
