### PR TITLE
Use PHP8's constructor property promotion

### DIFF
--- a/lib/Middleware/InjectionMiddleware.php
+++ b/lib/Middleware/InjectionMiddleware.php
@@ -57,27 +57,15 @@ use OCP\IRequest;
 use OCP\Security\Bruteforce\IThrottler;
 
 class InjectionMiddleware extends Middleware {
-	protected IRequest $request;
-	protected ParticipantService $participantService;
-	protected TalkSession $talkSession;
-	protected Manager $manager;
-	protected IThrottler $throttler;
-	protected ?string $userId;
 
 	public function __construct(
-		IRequest $request,
-		ParticipantService $participantService,
-		TalkSession $talkSession,
-		Manager $manager,
-		IThrottler $throttler,
-		?string $userId,
+		protected IRequest $request,
+		protected ParticipantService $participantService,
+		protected TalkSession $talkSession,
+		protected Manager $manager,
+		protected IThrottler $throttler,
+		protected ?string $userId,
 	) {
-		$this->request = $request;
-		$this->participantService = $participantService;
-		$this->talkSession = $talkSession;
-		$this->manager = $manager;
-		$this->throttler = $throttler;
-		$this->userId = $userId;
 	}
 
 	/**

--- a/lib/Migration/CacheUserDisplayNames.php
+++ b/lib/Migration/CacheUserDisplayNames.php
@@ -31,15 +31,11 @@ use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
 class CacheUserDisplayNames implements IRepairStep {
-	protected IDBConnection $connection;
-	protected IUserManager $userManager;
 
 	public function __construct(
-		IDBConnection $connection,
-		IUserManager $userManager,
+		protected IDBConnection $connection,
+		protected IUserManager $userManager,
 	) {
-		$this->connection = $connection;
-		$this->userManager = $userManager;
 	}
 
 	public function getName(): string {

--- a/lib/Migration/ClearResourceAccessCache.php
+++ b/lib/Migration/ClearResourceAccessCache.php
@@ -34,18 +34,11 @@ use OCP\Migration\IRepairStep;
 class ClearResourceAccessCache implements IRepairStep {
 	protected const INVALIDATIONS = 1;
 
-	protected IConfig $config;
-	protected IManager $manager;
-	protected ConversationProvider $provider;
-
 	public function __construct(
-		IConfig $config,
-		IManager $manager,
-		ConversationProvider $provider,
+		protected IConfig $config,
+		protected IManager $manager,
+		protected ConversationProvider $provider,
 	) {
-		$this->config = $config;
-		$this->manager = $manager;
-		$this->provider = $provider;
 	}
 
 	public function getName(): string {

--- a/lib/Migration/CreateHelpCommand.php
+++ b/lib/Migration/CreateHelpCommand.php
@@ -33,10 +33,10 @@ use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
 class CreateHelpCommand implements IRepairStep {
-	protected CommandService $service;
 
-	public function __construct(CommandService $service) {
-		$this->service = $service;
+	public function __construct(
+		protected CommandService $service,
+	) {
 	}
 
 	public function getName(): string {

--- a/lib/Migration/FixNamespaceInDatabaseTables.php
+++ b/lib/Migration/FixNamespaceInDatabaseTables.php
@@ -28,10 +28,10 @@ use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
 class FixNamespaceInDatabaseTables implements IRepairStep {
-	protected IDBConnection $connection;
 
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 	}
 
 	public function getName(): string {

--- a/lib/Migration/Version10000Date20201015134000.php
+++ b/lib/Migration/Version10000Date20201015134000.php
@@ -43,15 +43,11 @@ use OCP\Migration\SimpleMigrationStep;
  * email addresses, etc the sessions had to be decoupled from the participants
  */
 class Version10000Date20201015134000 extends SimpleMigrationStep {
-	protected IDBConnection $connection;
-	protected ITimeFactory $timeFactory;
 
 	public function __construct(
-		IDBConnection $connection,
-		ITimeFactory $timeFactory,
+		protected IDBConnection $connection,
+		protected ITimeFactory $timeFactory,
 	) {
-		$this->connection = $connection;
-		$this->timeFactory = $timeFactory;
 	}
 
 	/**

--- a/lib/Migration/Version11000Date20200922161218.php
+++ b/lib/Migration/Version11000Date20200922161218.php
@@ -34,10 +34,10 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version11000Date20200922161218 extends SimpleMigrationStep {
-	protected IDBConnection $connection;
 
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 	}
 
 	/**

--- a/lib/Migration/Version14000Date20220217115327.php
+++ b/lib/Migration/Version14000Date20220217115327.php
@@ -30,10 +30,10 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version14000Date20220217115327 extends SimpleMigrationStep {
-	protected IConfig $config;
 
-	public function __construct(IConfig $config) {
-		$this->config = $config;
+	public function __construct(
+		protected IConfig $config,
+	) {
 	}
 
 	/**

--- a/lib/Migration/Version14000Date20220330141647.php
+++ b/lib/Migration/Version14000Date20220330141647.php
@@ -35,10 +35,10 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version14000Date20220330141647 extends SimpleMigrationStep {
-	protected IDBConnection $connection;
 
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 	}
 
 	/**

--- a/lib/Migration/Version15000Date20220427183026.php
+++ b/lib/Migration/Version15000Date20220427183026.php
@@ -33,10 +33,10 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version15000Date20220427183026 extends SimpleMigrationStep {
-	protected IDBConnection $connection;
 
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 	}
 
 	/**

--- a/lib/Migration/Version2000Date20171026140256.php
+++ b/lib/Migration/Version2000Date20171026140256.php
@@ -32,20 +32,12 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version2000Date20171026140256 extends SimpleMigrationStep {
-	protected IDBConnection $connection;
-
-	protected IConfig $config;
-
-	protected IGroupManager $groupManager;
 
 	public function __construct(
-		IDBConnection $connection,
-		IConfig $config,
-		IGroupManager $groupManager,
+		protected IDBConnection $connection,
+		protected IConfig $config,
+		protected IGroupManager $groupManager,
 	) {
-		$this->connection = $connection;
-		$this->config = $config;
-		$this->groupManager = $groupManager;
 	}
 
 	/**

--- a/lib/Migration/Version2000Date20171026140257.php
+++ b/lib/Migration/Version2000Date20171026140257.php
@@ -32,23 +32,15 @@ use OCP\Migration\SimpleMigrationStep;
 use OCP\Security\ISecureRandom;
 
 class Version2000Date20171026140257 extends SimpleMigrationStep {
-	protected IDBConnection $connection;
-
-	protected IConfig $config;
-
-	protected ISecureRandom $secureRandom;
 
 	/** @var string[] */
 	protected array $tokens;
 
 	public function __construct(
-		IDBConnection $connection,
-		IConfig $config,
-		ISecureRandom $secureRandom,
+		protected IDBConnection $connection,
+		protected IConfig $config,
+		protected ISecureRandom $secureRandom,
 	) {
-		$this->connection = $connection;
-		$this->config = $config;
-		$this->secureRandom = $secureRandom;
 		$this->tokens = [];
 	}
 

--- a/lib/Migration/Version2001Date20170707115443.php
+++ b/lib/Migration/Version2001Date20170707115443.php
@@ -36,16 +36,11 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version2001Date20170707115443 extends SimpleMigrationStep {
-	protected IDBConnection $db;
-
-	protected IConfig $config;
 
 	public function __construct(
-		IDBConnection $db,
-		IConfig $config,
+		protected IDBConnection $db,
+		protected IConfig $config,
 	) {
-		$this->db = $db;
-		$this->config = $config;
 	}
 
 	/**

--- a/lib/Migration/Version2001Date20170929092606.php
+++ b/lib/Migration/Version2001Date20170929092606.php
@@ -29,10 +29,10 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version2001Date20170929092606 extends SimpleMigrationStep {
-	protected IConfig $config;
 
-	public function __construct(IConfig $config) {
-		$this->config = $config;
+	public function __construct(
+		protected IConfig $config,
+	) {
 	}
 
 	/**

--- a/lib/Migration/Version2001Date20171026134605.php
+++ b/lib/Migration/Version2001Date20171026134605.php
@@ -36,16 +36,11 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version2001Date20171026134605 extends SimpleMigrationStep {
-	protected IDBConnection $connection;
-
-	protected IConfig $config;
 
 	public function __construct(
-		IDBConnection $connection,
-		IConfig $config,
+		protected IDBConnection $connection,
+		protected IConfig $config,
 	) {
-		$this->connection = $connection;
-		$this->config = $config;
 	}
 
 	/**

--- a/lib/Migration/Version2001Date20180103144447.php
+++ b/lib/Migration/Version2001Date20180103144447.php
@@ -33,16 +33,11 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version2001Date20180103144447 extends SimpleMigrationStep {
-	protected IDBConnection $connection;
-
-	protected IConfig $config;
 
 	public function __construct(
-		IDBConnection $connection,
-		IConfig $config,
+		protected IDBConnection $connection,
+		protected IConfig $config,
 	) {
-		$this->connection = $connection;
-		$this->config = $config;
 	}
 
 

--- a/lib/Migration/Version3003Date20180718112436.php
+++ b/lib/Migration/Version3003Date20180718112436.php
@@ -32,10 +32,10 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version3003Date20180718112436 extends SimpleMigrationStep {
-	protected IDBConnection $connection;
 
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 	}
 
 	/**

--- a/lib/Migration/Version3003Date20180718133519.php
+++ b/lib/Migration/Version3003Date20180718133519.php
@@ -29,10 +29,10 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version3003Date20180718133519 extends SimpleMigrationStep {
-	protected IDBConnection $connection;
 
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 	}
 
 	/**

--- a/lib/Migration/Version7000Date20190724121136.php
+++ b/lib/Migration/Version7000Date20190724121136.php
@@ -33,10 +33,10 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version7000Date20190724121136 extends SimpleMigrationStep {
-	protected IDBConnection $connection;
 
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 	}
 
 	/**

--- a/lib/Migration/Version7000Date20190724121137.php
+++ b/lib/Migration/Version7000Date20190724121137.php
@@ -34,10 +34,10 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version7000Date20190724121137 extends SimpleMigrationStep {
-	protected IDBConnection $connection;
 
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 	}
 
 	/**


### PR DESCRIPTION
### Summary

This PR is a continuation of the previous PRs regarding refactoring and using PHP8's constructor property promotion:
#9912

I'm splitting the refactoring and the changes into a few PRs to make reviewing the changes easier.

### ☑️ Resolves

* Using PHP8's constructor property promotion in the following namespaces:
- `/lib/Middleware`
- `/lib/Migration`

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
