### PR TITLE
Raise exception if the Nextcloud server responded with an HTTP error

### DIFF
--- a/recording/src/nextcloud/talk/recording/BackendNotifier.py
+++ b/recording/src/nextcloud/talk/recording/BackendNotifier.py
@@ -68,7 +68,8 @@ def doRequest(backend, request, retries=3):
     try:
         session = Session()
         preparedRequest = session.prepare_request(request)
-        session.send(preparedRequest, verify=not backendSkipVerify)
+        response = session.send(preparedRequest, verify=not backendSkipVerify)
+        response.raise_for_status()
     except Exception as exception:
         if retries > 1:
             logger.exception(f"Failed to send message to backend, {retries} retries left!")


### PR DESCRIPTION
Follow up to #9253 (specifically, https://github.com/nextcloud/spreed/pull/9253/commits/d166a8b994dc393532fa7ea9bde87aacecd6ca57#diff-9dcf622fec2ddba84dbc38fbb90bad7f1d4b7893d4ce299d6cfcc846275df193L71-R71)

By default `urlopen` from `urllib3` raises an exception if the response is an HTTP error. However, `session.send` from `requests` does not, so [it must be explicitly checked](https://requests.readthedocs.io/en/latest/api/#requests.Response.raise_for_status). Otherwise if the Nextcloud server returns an error the recording server would not abort the current operation as expected, leading to confusion and head-scratching :-)
