### PR TITLE
Adjust user agent for recording server to not match with desktop client

### DIFF
--- a/recording/src/nextcloud/talk/recording/__init__.py
+++ b/recording/src/nextcloud/talk/recording/__init__.py
@@ -23,4 +23,4 @@ __version__ = 0.1
 RECORDING_STATUS_AUDIO_AND_VIDEO = 1
 RECORDING_STATUS_AUDIO_ONLY = 2
 
-USER_AGENT = f'Mozilla/5.0 (Recording) Nextcloud-Talk v{__version__}'
+USER_AGENT = f'Nextcloud-Talk-Recording/{__version__}'


### PR DESCRIPTION
Follow up to #9632

The recording server ~~uses~~ used [`Mozilla/5.0 (Recording) Nextcloud-Talk vXXX` as its user agent](https://github.com/nextcloud/spreed/blob/82fdadf29511587611072b0a761bc354144a0bf7/recording/src/nextcloud/talk/recording/__init__.py#L26), which wrongly matched with the regular expression for the desktop client.

Moreover, as the recording server version is lower than the minimum allowed desktop client version the recording server requests were blocked by the Nextcloud server.

~~[The regular expression provided by the Nextcloud server](https://github.com/nextcloud/server/blob/3ecd85f817a0508618e122cf77efe1834a948ebe/lib/public/IRequest.php#L80-L83) would need to be updated as well; it is used in [the inital check](https://github.com/nextcloud/spreed/blob/67c22f97d7d9a10fe085f7bc65ee4f0c23c9e652/lib/Middleware/CanUseTalkMiddleware.php#L84-L90), although the final check that throws the exception if needed uses [the local regular expression](https://github.com/nextcloud/spreed/blob/67c22f97d7d9a10fe085f7bc65ee4f0c23c9e652/lib/Middleware/CanUseTalkMiddleware.php#L156), but [as far as I understand](https://github.com/nextcloud/server/pull/38561) in the future the regular expression from the server will be used also there.~~

~~Alternatively, rather than modifying the regular expressions the user agent from the recording server could be changed to something that does not match the desktop client (for example, `Mozilla/5.0 Nextcloud-Talk-Recording vXXX`).~~

Due to all that the user agent of the recording server is now set to `Nextcloud-Talk-Recording/XXX`, [similar to what is used by other libraries and net tools, like curl](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent#library_and_net_tool_ua_strings).