### PR TITLE
chore(Jest) - clear jest output

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.spec.js
+++ b/src/components/LeftSidebar/LeftSidebar.spec.js
@@ -282,14 +282,14 @@ describe('LeftSidebar.vue', () => {
 		 * @param {object} loadStateSettingsOverride Allows to override some properties
 		 */
 		async function testSearch(searchTerm, possibleResults, listedResults, loadStateSettingsOverride) {
-			searchPossibleConversations.mockResolvedValueOnce({
+			searchPossibleConversations.mockResolvedValue({
 				data: {
 					ocs: {
 						data: possibleResults,
 					},
 				},
 			})
-			searchListedConversations.mockResolvedValueOnce({
+			searchListedConversations.mockResolvedValue({
 				data: {
 					ocs: {
 						data: listedResults,

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
@@ -53,6 +53,7 @@ describe('MessageButtonsBar.vue', () => {
 			isTemporary: false,
 			isFirstMessage: true,
 			isReplyable: true,
+			isTranslationAvailable: false,
 			canReact: true,
 			isReactionsMenuOpen: false,
 			isLastRead: false,

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -79,6 +79,15 @@ global.OCP = {
 }
 global.IS_DESKTOP = false
 
+const originalConsoleError = console.error
+console.error = function(error) {
+	if (error?.message?.includes('Could not parse CSS stylesheet')) {
+		console.debug(error?.message)
+	} else {
+		originalConsoleError(error)
+	}
+}
+
 // Work around missing "URL.createObjectURL" (which is used in the code but not
 // relevant for the tests) in jsdom: https://github.com/jsdom/jsdom/issues/1721
 window.URL.createObjectURL = jest.fn()


### PR DESCRIPTION
### ☑️ Resolves

* Fix / supress Jest logging output:
  * Error searching for open conversations
  * [Vue warn]: Missing required prop
  * Error: Could not parse CSS stylesheet

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
~3,000 lines | ~750 lines

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
