### PR TITLE
Use PHP8's constructor property promotion

### DIFF
--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -30,17 +30,6 @@ use OCP\Comments\IComment;
 use OCP\IL10N;
 
 class Message {
-	/** @var Room */
-	protected $room;
-
-	/** @var IComment */
-	protected $comment;
-
-	/** @var IL10N */
-	protected $l;
-
-	/** @var Participant */
-	protected $participant;
 
 	/** @var bool */
 	protected $visible = true;
@@ -66,14 +55,12 @@ class Message {
 	/** @var string */
 	protected $actorDisplayName = '';
 
-	public function __construct(Room $room,
-		Participant $participant,
-		IComment $comment,
-		IL10N $l) {
-		$this->room = $room;
-		$this->participant = $participant;
-		$this->comment = $comment;
-		$this->l = $l;
+	public function __construct(
+		protected Room $room,
+		protected Participant $participant,
+		protected IComment $comment,
+		protected IL10N $l,
+	) {
 	}
 
 	/*

--- a/lib/Notification/Listener.php
+++ b/lib/Notification/Listener.php
@@ -47,32 +47,18 @@ use Psr\Log\LoggerInterface;
  * @template-implements IEventListener<Event>
  */
 class Listener implements IEventListener {
-	protected IDBConnection $connection;
-	protected IManager $notificationManager;
-	protected ParticipantService $participantsService;
-	protected IEventDispatcher $dispatcher;
-	protected IUserSession $userSession;
-	protected ITimeFactory $timeFactory;
-	protected LoggerInterface $logger;
 
 	protected bool $shouldSendCallNotification = false;
 
 	public function __construct(
-		IDBConnection $connection,
-		IManager $notificationManager,
-		ParticipantService $participantsService,
-		IEventDispatcher $dispatcher,
-		IUserSession $userSession,
-		ITimeFactory $timeFactory,
-		LoggerInterface $logger,
+		protected IDBConnection $connection,
+		protected IManager $notificationManager,
+		protected ParticipantService $participantsService,
+		protected IEventDispatcher $dispatcher,
+		protected IUserSession $userSession,
+		protected ITimeFactory $timeFactory,
+		protected LoggerInterface $logger,
 	) {
-		$this->connection = $connection;
-		$this->notificationManager = $notificationManager;
-		$this->participantsService = $participantsService;
-		$this->dispatcher = $dispatcher;
-		$this->userSession = $userSession;
-		$this->timeFactory = $timeFactory;
-		$this->logger = $logger;
 	}
 
 	public static function register(IEventDispatcher $dispatcher): void {

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -40,7 +40,6 @@ use OCA\Talk\Service\AvatarService;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Webinary;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
 use OCP\Files\IRootFolder;
 use OCP\HintException;

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -40,6 +40,7 @@ use OCA\Talk\Service\AvatarService;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Webinary;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
 use OCP\Files\IRootFolder;
 use OCP\HintException;
@@ -65,6 +66,7 @@ class Notifier implements INotifier {
 	protected array $rooms = [];
 	/** @var Participant[][] */
 	protected array $participants = [];
+	protected ICommentsManager $commentManager;
 
 	public function __construct(
 		protected IFactory $lFactory,
@@ -78,7 +80,7 @@ class Notifier implements INotifier {
 		protected ParticipantService $participantService,
 		protected AvatarService $avatarService,
 		protected INotificationManager $notificationManager,
-		protected CommentsManager $commentManager,
+		CommentsManager $commentManager,
 		protected MessageParser $messageParser,
 		protected IURLGenerator $urlGenerator,
 		protected IRootFolder $rootFolder,
@@ -86,6 +88,7 @@ class Notifier implements INotifier {
 		protected Definitions $definitions,
 		protected AddressHandler $addressHandler,
 	) {
+		$this->commentManager = $commentManager;
 	}
 
 	/**

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -61,24 +61,6 @@ use OCP\Share\IManager as IShareManager;
 use OCP\Share\IShare;
 
 class Notifier implements INotifier {
-	protected IFactory $lFactory;
-	protected IURLGenerator $url;
-	protected Config $config;
-	protected IUserManager $userManager;
-	protected IGroupManager $groupManager;
-	protected GuestManager $guestManager;
-	private IShareManager $shareManager;
-	protected Manager $manager;
-	protected ParticipantService $participantService;
-	protected AvatarService $avatarService;
-	protected INotificationManager $notificationManager;
-	protected ICommentsManager $commentManager;
-	protected MessageParser $messageParser;
-	protected IURLGenerator $urlGenerator;
-	protected IRootFolder $rootFolder;
-	protected ITimeFactory $timeFactory;
-	protected Definitions $definitions;
-	protected AddressHandler $addressHandler;
 
 	/** @var Room[] */
 	protected array $rooms = [];
@@ -86,43 +68,25 @@ class Notifier implements INotifier {
 	protected array $participants = [];
 
 	public function __construct(
-		IFactory $lFactory,
-		IURLGenerator $url,
-		Config $config,
-		IUserManager $userManager,
-		IGroupManager $groupManager,
-		GuestManager $guestManager,
-		IShareManager $shareManager,
-		Manager $manager,
-		ParticipantService $participantService,
-		AvatarService $avatarService,
-		INotificationManager $notificationManager,
-		CommentsManager $commentManager,
-		MessageParser $messageParser,
-		IURLGenerator $urlGenerator,
-		IRootFolder $rootFolder,
-		ITimeFactory $timeFactory,
-		Definitions $definitions,
-		AddressHandler $addressHandler,
+		protected IFactory $lFactory,
+		protected IURLGenerator $url,
+		protected Config $config,
+		protected IUserManager $userManager,
+		protected IGroupManager $groupManager,
+		protected GuestManager $guestManager,
+		private IShareManager $shareManager,
+		protected Manager $manager,
+		protected ParticipantService $participantService,
+		protected AvatarService $avatarService,
+		protected INotificationManager $notificationManager,
+		protected CommentsManager $commentManager,
+		protected MessageParser $messageParser,
+		protected IURLGenerator $urlGenerator,
+		protected IRootFolder $rootFolder,
+		protected ITimeFactory $timeFactory,
+		protected Definitions $definitions,
+		protected AddressHandler $addressHandler,
 	) {
-		$this->lFactory = $lFactory;
-		$this->url = $url;
-		$this->config = $config;
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
-		$this->guestManager = $guestManager;
-		$this->shareManager = $shareManager;
-		$this->manager = $manager;
-		$this->participantService = $participantService;
-		$this->avatarService = $avatarService;
-		$this->notificationManager = $notificationManager;
-		$this->commentManager = $commentManager;
-		$this->messageParser = $messageParser;
-		$this->urlGenerator = $urlGenerator;
-		$this->rootFolder = $rootFolder;
-		$this->timeFactory = $timeFactory;
-		$this->definitions = $definitions;
-		$this->addressHandler = $addressHandler;
 	}
 
 	/**

--- a/lib/OCP/Conversation.php
+++ b/lib/OCP/Conversation.php
@@ -31,15 +31,11 @@ use OCP\IURLGenerator;
 use OCP\Talk\IConversation;
 
 class Conversation implements IConversation {
-	protected IURLGenerator $url;
-	protected Room $room;
 
 	public function __construct(
-		IURLGenerator $url,
-		Room $room,
+		protected IURLGenerator $url,
+		protected Room $room,
 	) {
-		$this->url = $url;
-		$this->room = $room;
 	}
 
 	public function getId(): string {

--- a/lib/OCP/TalkBackend.php
+++ b/lib/OCP/TalkBackend.php
@@ -38,21 +38,13 @@ use OCP\Talk\IConversationOptions;
 use OCP\Talk\ITalkBackend;
 
 class TalkBackend implements ITalkBackend {
-	protected Manager $manager;
-	protected ParticipantService $participantService;
-	protected RoomService $roomService;
-	protected IURLGenerator $url;
 
 	public function __construct(
-		Manager $manager,
-		ParticipantService $participantService,
-		RoomService $roomService,
-		IURLGenerator $url,
+		protected Manager $manager,
+		protected ParticipantService $participantService,
+		protected RoomService $roomService,
+		protected IURLGenerator $url,
 	) {
-		$this->manager = $manager;
-		$this->participantService = $participantService;
-		$this->roomService = $roomService;
-		$this->url = $url;
 	}
 
 	public function createConversation(string $name, array $moderators, IConversationOptions $options): IConversation {

--- a/lib/Profile/TalkAction.php
+++ b/lib/Profile/TalkAction.php
@@ -37,25 +37,12 @@ use OCP\Profile\ILinkAction;
 class TalkAction implements ILinkAction {
 	private ?IUser $targetUser = null;
 
-	private Config $config;
-
-	private IL10N $l;
-
-	/** @var IUrlGenerator */
-	private $urlGenerator;
-
-	private IUserSession $userSession;
-
 	public function __construct(
-		Config $config,
-		IL10N $l,
-		IURLGenerator $urlGenerator,
-		IUserSession $userSession,
+		private Config $config,
+		private IL10N $l,
+		private IURLGenerator $urlGenerator,
+		private IUserSession $userSession,
 	) {
-		$this->config = $config;
-		$this->l = $l;
-		$this->urlGenerator = $urlGenerator;
-		$this->userSession = $userSession;
 	}
 
 	public function preload(IUser $targetUser): void {

--- a/lib/Recording/BackendNotifier.php
+++ b/lib/Recording/BackendNotifier.php
@@ -38,24 +38,14 @@ use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
 class BackendNotifier {
-	private Config $config;
-	private LoggerInterface $logger;
-	private IClientService $clientService;
-	private ISecureRandom $secureRandom;
-	private IURLGenerator $urlGenerator;
 
 	public function __construct(
-		Config $config,
-		LoggerInterface $logger,
-		IClientService $clientService,
-		ISecureRandom $secureRandom,
-		IURLGenerator $urlGenerator,
+		private Config $config,
+		private LoggerInterface $logger,
+		private IClientService $clientService,
+		private ISecureRandom $secureRandom,
+		private IURLGenerator $urlGenerator,
 	) {
-		$this->config = $config;
-		$this->logger = $logger;
-		$this->clientService = $clientService;
-		$this->secureRandom = $secureRandom;
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**

--- a/lib/Search/ConversationSearch.php
+++ b/lib/Search/ConversationSearch.php
@@ -38,21 +38,13 @@ use OCP\Search\SearchResult;
 use OCP\Search\SearchResultEntry;
 
 class ConversationSearch implements IProvider {
-	protected AvatarService $avatarService;
-	protected Manager $manager;
-	protected IURLGenerator $url;
-	protected IL10N $l;
 
 	public function __construct(
-		AvatarService $avatarService,
-		Manager $manager,
-		IURLGenerator $url,
-		IL10N $l,
+		protected AvatarService $avatarService,
+		protected Manager $manager,
+		protected IURLGenerator $url,
+		protected IL10N $l,
 	) {
-		$this->avatarService = $avatarService;
-		$this->manager = $manager;
-		$this->url = $url;
-		$this->l = $l;
 	}
 
 	/**

--- a/lib/Search/MessageSearch.php
+++ b/lib/Search/MessageSearch.php
@@ -44,30 +44,16 @@ use OCP\Search\SearchResult;
 use OCP\Search\SearchResultEntry;
 
 class MessageSearch implements IProvider {
-	protected RoomManager $roomManager;
-	protected ParticipantService $participantService;
-	protected ChatManager $chatManager;
-	protected MessageParser $messageParser;
-	protected ITimeFactory $timeFactory;
-	protected IURLGenerator $url;
-	protected IL10N $l;
 
 	public function __construct(
-		RoomManager $roomManager,
-		ParticipantService $participantService,
-		ChatManager $chatManager,
-		MessageParser $messageParser,
-		ITimeFactory $timeFactory,
-		IURLGenerator $url,
-		IL10N $l,
+		protected RoomManager $roomManager,
+		protected ParticipantService $participantService,
+		protected ChatManager $chatManager,
+		protected MessageParser $messageParser,
+		protected ITimeFactory $timeFactory,
+		protected IURLGenerator $url,
+		protected IL10N $l,
 	) {
-		$this->roomManager = $roomManager;
-		$this->participantService = $participantService;
-		$this->chatManager = $chatManager;
-		$this->messageParser = $messageParser;
-		$this->timeFactory = $timeFactory;
-		$this->url = $url;
-		$this->l = $l;
 	}
 
 	/**

--- a/lib/Service/AttachmentService.php
+++ b/lib/Service/AttachmentService.php
@@ -32,10 +32,10 @@ use OCA\Talk\Room;
 use OCP\Comments\IComment;
 
 class AttachmentService {
-	public AttachmentMapper $attachmentMapper;
 
-	public function __construct(AttachmentMapper $attachmentMapper) {
-		$this->attachmentMapper = $attachmentMapper;
+	public function __construct(
+		public AttachmentMapper $attachmentMapper,
+	) {
 	}
 
 	public function createAttachmentEntry(Room $room, IComment $comment, string $messageType, array $parameters): void {

--- a/lib/Service/CertificateService.php
+++ b/lib/Service/CertificateService.php
@@ -29,10 +29,10 @@ namespace OCA\Talk\Service;
 use Psr\Log\LoggerInterface;
 
 class CertificateService {
-	private LoggerInterface $logger;
 
-	public function __construct(LoggerInterface $logger) {
-		$this->logger = $logger;
+	public function __construct(
+		private LoggerInterface $logger,
+	) {
 	}
 
 	/**

--- a/lib/Service/CommandService.php
+++ b/lib/Service/CommandService.php
@@ -29,16 +29,11 @@ use OCA\Talk\Model\CommandMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 
 class CommandService {
-	protected CommandMapper $mapper;
-
-	protected ShellExecutor $shellExecutor;
 
 	public function __construct(
-		CommandMapper $mapper,
-		ShellExecutor $shellExecutor,
+		protected CommandMapper $mapper,
+		protected ShellExecutor $shellExecutor,
 	) {
-		$this->mapper = $mapper;
-		$this->shellExecutor = $shellExecutor;
 	}
 
 	/**

--- a/lib/Service/HostedSignalingServerService.php
+++ b/lib/Service/HostedSignalingServerService.php
@@ -38,26 +38,16 @@ use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
 class HostedSignalingServerService {
-	private IConfig $config;
 	/** @var mixed */
 	private $apiServerUrl;
-	private IClientService $clientService;
-	private LoggerInterface $logger;
-	private IL10N $l10n;
-	private ISecureRandom $secureRandom;
 
 	public function __construct(
-		IConfig $config,
-		IClientService $clientService,
-		LoggerInterface $logger,
-		IL10N $l10n,
-		ISecureRandom $secureRandom,
+		private IConfig $config,
+		private IClientService $clientService,
+		private LoggerInterface $logger,
+		private IL10N $l10n,
+		private ISecureRandom $secureRandom,
 	) {
-		$this->config = $config;
-		$this->clientService = $clientService;
-		$this->logger = $logger;
-		$this->l10n = $l10n;
-		$this->secureRandom = $secureRandom;
 
 		$this->apiServerUrl = $this->config->getSystemValue('talk_hardcoded_hpb_service', 'https://api.spreed.cloud');
 	}

--- a/lib/Service/MembershipService.php
+++ b/lib/Service/MembershipService.php
@@ -36,18 +36,12 @@ use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class MembershipService {
-	protected IAppManager $appManager;
-	protected IGroupManager $groupManager;
-	protected AttendeeMapper $attendeeMapper;
 
 	public function __construct(
-		IAppManager $appManager,
-		IGroupManager $groupManager,
-		AttendeeMapper $attendeeMapper,
+		protected IAppManager $appManager,
+		protected IGroupManager $groupManager,
+		protected AttendeeMapper $attendeeMapper,
 	) {
-		$this->appManager = $appManager;
-		$this->groupManager = $groupManager;
-		$this->attendeeMapper = $attendeeMapper;
 	}
 
 	/**

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -77,54 +77,26 @@ use OCP\Security\ISecureRandom;
 use OCP\Server;
 
 class ParticipantService {
-	protected IConfig $serverConfig;
-	protected Config $talkConfig;
-	protected AttendeeMapper $attendeeMapper;
-	protected SessionMapper $sessionMapper;
-	protected SessionService $sessionService;
-	private ISecureRandom $secureRandom;
-	protected IDBConnection $connection;
-	private IEventDispatcher $dispatcher;
-	private IUserManager $userManager;
-	private IGroupManager $groupManager;
-	private MembershipService $membershipService;
-	private Notifications $notifications;
-	private ITimeFactory $timeFactory;
-	private ICacheFactory $cacheFactory;
 
 	protected array $userCache;
 	protected array $sessionCache;
 
 	public function __construct(
-		IConfig $serverConfig,
-		Config $talkConfig,
-		AttendeeMapper $attendeeMapper,
-		SessionMapper $sessionMapper,
-		SessionService $sessionService,
-		ISecureRandom $secureRandom,
-		IDBConnection $connection,
-		IEventDispatcher $dispatcher,
-		IUserManager $userManager,
-		IGroupManager $groupManager,
-		MembershipService $membershipService,
-		Notifications $notifications,
-		ITimeFactory $timeFactory,
-		ICacheFactory $cacheFactory,
+		protected IConfig $serverConfig,
+		protected Config $talkConfig,
+		protected AttendeeMapper $attendeeMapper,
+		protected SessionMapper $sessionMapper,
+		protected SessionService $sessionService,
+		private ISecureRandom $secureRandom,
+		protected IDBConnection $connection,
+		private IEventDispatcher $dispatcher,
+		private IUserManager $userManager,
+		private IGroupManager $groupManager,
+		private MembershipService $membershipService,
+		private Notifications $notifications,
+		private ITimeFactory $timeFactory,
+		private ICacheFactory $cacheFactory,
 	) {
-		$this->serverConfig = $serverConfig;
-		$this->talkConfig = $talkConfig;
-		$this->attendeeMapper = $attendeeMapper;
-		$this->sessionMapper = $sessionMapper;
-		$this->sessionService = $sessionService;
-		$this->secureRandom = $secureRandom;
-		$this->connection = $connection;
-		$this->dispatcher = $dispatcher;
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
-		$this->membershipService = $membershipService;
-		$this->timeFactory = $timeFactory;
-		$this->cacheFactory = $cacheFactory;
-		$this->notifications = $notifications;
 	}
 
 	public function updateParticipantType(Room $room, Participant $participant, int $participantType): void {

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -37,18 +37,12 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
 class PollService {
-	protected IDBConnection $connection;
-	protected PollMapper $pollMapper;
-	protected VoteMapper $voteMapper;
 
 	public function __construct(
-		IDBConnection $connection,
-		PollMapper $pollMapper,
-		VoteMapper $voteMapper,
+		protected IDBConnection $connection,
+		protected PollMapper $pollMapper,
+		protected VoteMapper $voteMapper,
 	) {
-		$this->connection = $connection;
-		$this->pollMapper = $pollMapper;
-		$this->voteMapper = $voteMapper;
 	}
 
 	public function createPoll(int $roomId, string $actorType, string $actorId, string $displayName, string $question, array $options, int $resultMode, int $maxVotes): Poll {

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -50,36 +50,18 @@ use OCP\Security\IHasher;
 use OCP\Share\IManager as IShareManager;
 
 class RoomService {
-	protected Manager $manager;
-	protected ParticipantService $participantService;
-	protected IDBConnection $db;
-	protected ITimeFactory $timeFactory;
-	protected IShareManager $shareManager;
-	protected Config $config;
-	protected IHasher $hasher;
-	protected IEventDispatcher $dispatcher;
-	protected IJobList $jobList;
 
 	public function __construct(
-		Manager $manager,
-		ParticipantService $participantService,
-		IDBConnection $db,
-		ITimeFactory $timeFactory,
-		IShareManager $shareManager,
-		Config $config,
-		IHasher $hasher,
-		IEventDispatcher $dispatcher,
-		IJobList $jobList,
+		protected Manager $manager,
+		protected ParticipantService $participantService,
+		protected IDBConnection $db,
+		protected ITimeFactory $timeFactory,
+		protected IShareManager $shareManager,
+		protected Config $config,
+		protected IHasher $hasher,
+		protected IEventDispatcher $dispatcher,
+		protected IJobList $jobList,
 	) {
-		$this->manager = $manager;
-		$this->participantService = $participantService;
-		$this->db = $db;
-		$this->timeFactory = $timeFactory;
-		$this->shareManager = $shareManager;
-		$this->config = $config;
-		$this->hasher = $hasher;
-		$this->dispatcher = $dispatcher;
-		$this->jobList = $jobList;
 	}
 
 	/**

--- a/lib/Service/SessionService.php
+++ b/lib/Service/SessionService.php
@@ -33,18 +33,12 @@ use OCP\IDBConnection;
 use OCP\Security\ISecureRandom;
 
 class SessionService {
-	protected SessionMapper $sessionMapper;
-	protected IDBConnection $connection;
-	protected ISecureRandom $secureRandom;
 
 	public function __construct(
-		SessionMapper $sessionMapper,
-		IDBConnection $connection,
-		ISecureRandom $secureRandom,
+		protected SessionMapper $sessionMapper,
+		protected IDBConnection $connection,
+		protected ISecureRandom $secureRandom,
 	) {
-		$this->sessionMapper = $sessionMapper;
-		$this->connection = $connection;
-		$this->secureRandom = $secureRandom;
 	}
 
 	/**


### PR DESCRIPTION
### Summary

This PR is a continuation of the previous PRs regarding refactoring and using PHP8's constructor property promotion:
#9913

I'm splitting the refactoring and the changes into a few PRs to make reviewing the changes easier.

### ☑️ Resolves

* Using PHP8's constructor property promotion in the following namespaces:
- `/lib/Model`
- `/lib/OCP`
- `/lib/Notification`
- `/lib/Profile`
- `/lib/Recording`
- `/lib/Search`
- `/lib/Service`

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
