### PR TITLE
Use PHP8's constructor property promotion

### DIFF
--- a/lib/Settings/Admin/AdminSettings.php
+++ b/lib/Settings/Admin/AdminSettings.php
@@ -44,39 +44,21 @@ use OCP\Settings\ISettings;
 use OCP\Util;
 
 class AdminSettings implements ISettings {
-	private Config $talkConfig;
-	private IConfig $serverConfig;
-	private CommandService $commandService;
-	private IInitialState $initialState;
-	private ICacheFactory $memcacheFactory;
-	private IGroupManager $groupManager;
-	private MatterbridgeManager $bridgeManager;
 	private ?IUser $currentUser = null;
-	private IL10N $l10n;
-	private IFactory $l10nFactory;
 
 	public function __construct(
-		Config $talkConfig,
-		IConfig $serverConfig,
-		CommandService $commandService,
-		IInitialState $initialState,
-		ICacheFactory $memcacheFactory,
-		IGroupManager $groupManager,
-		MatterbridgeManager $bridgeManager,
+		private Config $talkConfig,
+		private IConfig $serverConfig,
+		private CommandService $commandService,
+		private IInitialState $initialState,
+		private ICacheFactory $memcacheFactory,
+		private IGroupManager $groupManager,
+		private MatterbridgeManager $bridgeManager,
 		IUserSession $userSession,
-		IL10N $l10n,
-		IFactory $l10nFactory,
+		private IL10N $l10n,
+		private IFactory $l10nFactory,
 	) {
-		$this->talkConfig = $talkConfig;
-		$this->serverConfig = $serverConfig;
-		$this->commandService = $commandService;
-		$this->initialState = $initialState;
-		$this->memcacheFactory = $memcacheFactory;
-		$this->groupManager = $groupManager;
-		$this->bridgeManager = $bridgeManager;
 		$this->currentUser = $userSession->getUser();
-		$this->l10n = $l10n;
-		$this->l10nFactory = $l10nFactory;
 	}
 
 	/**

--- a/lib/Settings/Admin/Section.php
+++ b/lib/Settings/Admin/Section.php
@@ -28,16 +28,11 @@ use OCP\IURLGenerator;
 use OCP\Settings\IIconSection;
 
 class Section implements IIconSection {
-	private IL10N $l;
-
-	private IURLGenerator $url;
 
 	public function __construct(
-		IURLGenerator $url,
-		IL10N $l,
+		private IURLGenerator $url,
+		private IL10N $l,
 	) {
-		$this->url = $url;
-		$this->l = $l;
 	}
 
 	/**

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -30,10 +30,10 @@ use OCP\IConfig;
 use OCP\Settings\ISettings;
 
 class Personal implements ISettings {
-	private IConfig $config;
 
-	public function __construct(IConfig $config) {
-		$this->config = $config;
+	public function __construct(
+		private IConfig $config,
+	) {
 	}
 
 	/**

--- a/lib/Share/Helper/DeletedShareAPIController.php
+++ b/lib/Share/Helper/DeletedShareAPIController.php
@@ -36,15 +36,11 @@ use OCP\Share\IShare;
  * perform actions or checks specific to room shares.
  */
 class DeletedShareAPIController {
-	private string $userId;
-	private Manager $manager;
 
 	public function __construct(
-		string $UserId,
-		Manager $manager,
+		private string $userId,
+		private Manager $manager,
 	) {
-		$this->userId = $UserId;
-		$this->manager = $manager;
 	}
 
 	/**

--- a/lib/Share/Helper/ShareAPIController.php
+++ b/lib/Share/Helper/ShareAPIController.php
@@ -42,27 +42,15 @@ use OCP\Share\IShare;
  * actions or checks specific to room shares.
  */
 class ShareAPIController {
-	protected string $userId;
-	protected Manager $manager;
-	protected ParticipantService $participantService;
-	protected ITimeFactory $timeFactory;
-	protected IL10N $l;
-	protected IURLGenerator $urlGenerator;
 
 	public function __construct(
-		string $UserId,
-		Manager $manager,
-		ParticipantService $participantService,
-		ITimeFactory $timeFactory,
-		IL10N $l10n,
-		IURLGenerator $urlGenerator,
+		protected string $userId,
+		protected Manager $manager,
+		protected ParticipantService $participantService,
+		protected ITimeFactory $timeFactory,
+		protected IL10N $l,
+		protected IURLGenerator $urlGenerator,
 	) {
-		$this->userId = $UserId;
-		$this->manager = $manager;
-		$this->participantService = $participantService;
-		$this->timeFactory = $timeFactory;
-		$this->l = $l10n;
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**

--- a/lib/Share/Listener.php
+++ b/lib/Share/Listener.php
@@ -50,10 +50,9 @@ class Listener {
 		$listener->overwriteMountPoint($event);
 	}
 
-	protected Config $config;
-
-	public function __construct(Config $config) {
-		$this->config = $config;
+	public function __construct(
+		protected Config $config,
+	) {
 	}
 
 	public function overwriteShareTarget(GenericEvent $event): void {

--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -75,38 +75,19 @@ class RoomShareProvider implements IShareProvider {
 
 	public const EVENT_SHARE_FILE_AGAIN = self::class . '::shareFileAgain';
 
-	private IDBConnection $dbConnection;
-	private ISecureRandom $secureRandom;
-	private IShareManager $shareManager;
-	private IEventDispatcher $dispatcher;
-	private Manager $manager;
-	private ParticipantService $participantService;
-	protected ITimeFactory $timeFactory;
-	private IL10N $l;
-	private IMimeTypeLoader $mimeTypeLoader;
-
 	private CappedMemoryCache $sharesByIdCache;
 
 	public function __construct(
-		IDBConnection $connection,
-		ISecureRandom $secureRandom,
-		IShareManager $shareManager,
-		IEventDispatcher $dispatcher,
-		Manager $manager,
-		ParticipantService $participantService,
-		ITimeFactory $timeFactory,
-		IL10N $l,
-		IMimeTypeLoader $mimeTypeLoader,
+		private IDBConnection $dbConnection,
+		private ISecureRandom $secureRandom,
+		private IShareManager $shareManager,
+		private IEventDispatcher $dispatcher,
+		private Manager $manager,
+		private ParticipantService $participantService,
+		protected ITimeFactory $timeFactory,
+		private IL10N $l,
+		private IMimeTypeLoader $mimeTypeLoader,
 	) {
-		$this->dbConnection = $connection;
-		$this->secureRandom = $secureRandom;
-		$this->shareManager = $shareManager;
-		$this->dispatcher = $dispatcher;
-		$this->manager = $manager;
-		$this->participantService = $participantService;
-		$this->timeFactory = $timeFactory;
-		$this->l = $l;
-		$this->mimeTypeLoader = $mimeTypeLoader;
 		$this->sharesByIdCache = new CappedMemoryCache();
 	}
 

--- a/lib/Signaling/BackendNotifier.php
+++ b/lib/Signaling/BackendNotifier.php
@@ -39,30 +39,16 @@ use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
 class BackendNotifier {
-	private Config $config;
-	private LoggerInterface $logger;
-	private IClientService $clientService;
-	private ISecureRandom $secureRandom;
-	private Manager $signalingManager;
-	private ParticipantService $participantService;
-	private IURLGenerator $urlGenerator;
 
 	public function __construct(
-		Config $config,
-		LoggerInterface $logger,
-		IClientService $clientService,
-		ISecureRandom $secureRandom,
-		Manager $signalingManager,
-		ParticipantService $participantService,
-		IURLGenerator $urlGenerator,
+		private Config $config,
+		private LoggerInterface $logger,
+		private IClientService $clientService,
+		private ISecureRandom $secureRandom,
+		private Manager $signalingManager,
+		private ParticipantService $participantService,
+		private IURLGenerator $urlGenerator,
 	) {
-		$this->config = $config;
-		$this->logger = $logger;
-		$this->clientService = $clientService;
-		$this->secureRandom = $secureRandom;
-		$this->signalingManager = $signalingManager;
-		$this->participantService = $participantService;
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**

--- a/lib/Signaling/Manager.php
+++ b/lib/Signaling/Manager.php
@@ -34,20 +34,14 @@ use OCP\IConfig;
 class Manager {
 	public const FEATURE_HEADER = 'X-Spreed-Signaling-Features';
 
-	protected IConfig $serverConfig;
-	protected Config $talkConfig;
-	protected RoomService $roomService;
 	protected ICache $cache;
 
 	public function __construct(
-		IConfig $serverConfig,
-		Config $talkConfig,
-		RoomService $roomService,
+		protected IConfig $serverConfig,
+		protected Config $talkConfig,
+		protected RoomService $roomService,
 		ICacheFactory $cacheFactory,
 	) {
-		$this->serverConfig = $serverConfig;
-		$this->talkConfig = $talkConfig;
-		$this->roomService = $roomService;
 		$this->cache = $cacheFactory->createDistributed('hpb_servers');
 	}
 

--- a/lib/Signaling/Messages.php
+++ b/lib/Signaling/Messages.php
@@ -34,20 +34,11 @@ use OCP\IDBConnection;
 class Messages {
 	use TTransactional;
 
-	protected IDBConnection $db;
-
-	protected ParticipantService $participantService;
-
-	protected ITimeFactory $timeFactory;
-
 	public function __construct(
-		IDBConnection $db,
-		ParticipantService $participantService,
-		ITimeFactory $timeFactory,
+		protected IDBConnection $db,
+		protected ParticipantService $participantService,
+		protected ITimeFactory $timeFactory,
 	) {
-		$this->db = $db;
-		$this->participantService = $participantService;
-		$this->timeFactory = $timeFactory;
 	}
 
 	/**

--- a/lib/Status/Listener.php
+++ b/lib/Status/Listener.php
@@ -37,10 +37,10 @@ use OCP\UserStatus\IManager;
 use OCP\UserStatus\IUserStatus;
 
 class Listener {
-	public IManager $statusManager;
 
-	public function __construct(IManager $statusManager) {
-		$this->statusManager = $statusManager;
+	public function __construct(
+		public IManager $statusManager,
+	) {
 	}
 
 	public static function register(IEventDispatcher $dispatcher): void {


### PR DESCRIPTION
### Summary

This PR is a continuation of the previous PRs regarding refactoring and using PHP8's constructor property promotion:
#9942

I'm splitting the refactoring and the changes into a few PRs to make reviewing the changes easier.

### ☑️ Resolves

* Using PHP8's constructor property promotion in the following namespaces:
- `/lib/Settings`
- `/lib/Share`
- `/lib/Signaling`
- `/lib/Status`
- `/lib/Vendor`

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
