### PR TITLE
Use PHP8's constructor property promotion

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -43,32 +43,17 @@ class Config {
 	public const SIGNALING_TICKET_V1 = 1;
 	public const SIGNALING_TICKET_V2 = 2;
 
-	protected IConfig $config;
-	protected ITimeFactory $timeFactory;
-	private IGroupManager $groupManager;
-	private IUserManager $userManager;
-	private IURLGenerator $urlGenerator;
-	private ISecureRandom $secureRandom;
-	private IEventDispatcher $dispatcher;
-
 	protected array $canEnableSIP = [];
 
 	public function __construct(
-		IConfig $config,
-		ISecureRandom $secureRandom,
-		IGroupManager $groupManager,
-		IUserManager $userManager,
-		IURLGenerator $urlGenerator,
-		ITimeFactory $timeFactory,
-		IEventDispatcher $dispatcher,
+		protected IConfig $config,
+		private ISecureRandom $secureRandom,
+		private IGroupManager $groupManager,
+		private IUserManager $userManager,
+		private IURLGenerator $urlGenerator,
+		protected ITimeFactory $timeFactory,
+		private IEventDispatcher $dispatcher,
 	) {
-		$this->config = $config;
-		$this->secureRandom = $secureRandom;
-		$this->groupManager = $groupManager;
-		$this->userManager = $userManager;
-		$this->urlGenerator = $urlGenerator;
-		$this->timeFactory = $timeFactory;
-		$this->dispatcher = $dispatcher;
 	}
 
 	/**

--- a/lib/GuestManager.php
+++ b/lib/GuestManager.php
@@ -42,36 +42,17 @@ class GuestManager {
 	public const EVENT_AFTER_EMAIL_INVITE = self::class . '::postInviteByEmail';
 	public const EVENT_AFTER_NAME_UPDATE = self::class . '::updateName';
 
-	protected Config $talkConfig;
-	protected IMailer $mailer;
-	protected Defaults $defaults;
-	protected IUserSession $userSession;
-	protected ParticipantService $participantService;
-	protected PollService $pollService;
-	protected IURLGenerator $url;
-	protected IL10N $l;
-	protected IEventDispatcher $dispatcher;
-
 	public function __construct(
-		Config $talkConfig,
-		IMailer $mailer,
-		Defaults $defaults,
-		IUserSession $userSession,
-		ParticipantService $participantService,
-		PollService $pollService,
-		IURLGenerator $url,
-		IL10N $l,
-		IEventDispatcher $dispatcher,
+		protected Config $talkConfig,
+		protected IMailer $mailer,
+		protected Defaults $defaults,
+		protected IUserSession $userSession,
+		protected ParticipantService $participantService,
+		protected PollService $pollService,
+		protected IURLGenerator $url,
+		protected IL10N $l,
+		protected IEventDispatcher $dispatcher,
 	) {
-		$this->talkConfig = $talkConfig;
-		$this->mailer = $mailer;
-		$this->defaults = $defaults;
-		$this->userSession = $userSession;
-		$this->participantService = $participantService;
-		$this->pollService = $pollService;
-		$this->url = $url;
-		$this->l = $l;
-		$this->dispatcher = $dispatcher;
 	}
 
 	/**

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -55,57 +55,27 @@ use OCP\Server;
 class Manager {
 	public const EVENT_TOKEN_GENERATE = self::class . '::generateNewToken';
 
-	protected IDBConnection $db;
-	protected IConfig $config;
-	protected Config $talkConfig;
-	protected IAppManager $appManager;
-	protected AttendeeMapper $attendeeMapper;
-	protected SessionMapper $sessionMapper;
-	protected ParticipantService $participantService;
-	protected ISecureRandom $secureRandom;
-	protected IUserManager $userManager;
-	protected IGroupManager $groupManager;
 	protected ICommentsManager $commentsManager;
-	protected TalkSession $talkSession;
-	protected IEventDispatcher $dispatcher;
-	protected ITimeFactory $timeFactory;
-	protected IHasher $hasher;
-	protected IL10N $l;
 
 	public function __construct(
-		IDBConnection $db,
-		IConfig $config,
-		Config $talkConfig,
-		IAppManager $appManager,
-		AttendeeMapper $attendeeMapper,
-		SessionMapper $sessionMapper,
-		ParticipantService $participantService,
-		ISecureRandom $secureRandom,
-		IUserManager $userManager,
-		IGroupManager $groupManager,
+		protected IDBConnection $db,
+		protected IConfig $config,
+		protected Config $talkConfig,
+		protected IAppManager $appManager,
+		protected AttendeeMapper $attendeeMapper,
+		protected SessionMapper $sessionMapper,
+		protected ParticipantService $participantService,
+		protected ISecureRandom $secureRandom,
+		protected IUserManager $userManager,
+		protected IGroupManager $groupManager,
 		CommentsManager $commentsManager,
-		TalkSession $talkSession,
-		IEventDispatcher $dispatcher,
-		ITimeFactory $timeFactory,
-		IHasher $hasher,
-		IL10N $l,
+		protected TalkSession $talkSession,
+		protected IEventDispatcher $dispatcher,
+		protected ITimeFactory $timeFactory,
+		protected IHasher $hasher,
+		protected IL10N $l,
 	) {
-		$this->db = $db;
-		$this->config = $config;
-		$this->talkConfig = $talkConfig;
-		$this->appManager = $appManager;
-		$this->attendeeMapper = $attendeeMapper;
-		$this->sessionMapper = $sessionMapper;
-		$this->participantService = $participantService;
-		$this->secureRandom = $secureRandom;
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
 		$this->commentsManager = $commentsManager;
-		$this->talkSession = $talkSession;
-		$this->dispatcher = $dispatcher;
-		$this->timeFactory = $timeFactory;
-		$this->hasher = $hasher;
-		$this->l = $l;
 	}
 
 	public function forAllRooms(callable $callback): void {

--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -46,45 +46,20 @@ use Psr\Log\LoggerInterface;
 class MatterbridgeManager {
 	public const BRIDGE_BOT_USERID = 'bridge-bot';
 
-	private IDBConnection $db;
-	private IConfig $config;
-	private IURLGenerator $urlGenerator;
-	private IUserManager $userManager;
-	private Manager $manager;
-	private ParticipantService $participantService;
-	private ChatManager $chatManager;
-	private IAuthTokenProvider $tokenProvider;
-	private ISecureRandom $random;
-	private IAvatarManager $avatarManager;
-	private LoggerInterface $logger;
-	private ITimeFactory $timeFactory;
-
 	public function __construct(
-		IDBConnection $db,
-		IConfig $config,
-		IURLGenerator $urlGenerator,
-		IUserManager $userManager,
-		Manager $manager,
-		ParticipantService $participantService,
-		ChatManager $chatManager,
-		IAuthTokenProvider $tokenProvider,
-		ISecureRandom $random,
-		IAvatarManager $avatarManager,
-		LoggerInterface $logger,
-		ITimeFactory $timeFactory,
+		private IDBConnection $db,
+		private IConfig $config,
+		private IURLGenerator $urlGenerator,
+		private IUserManager $userManager,
+		private Manager $manager,
+		private ParticipantService $participantService,
+		private ChatManager $chatManager,
+		private IAuthTokenProvider $tokenProvider,
+		private ISecureRandom $random,
+		private IAvatarManager $avatarManager,
+		private LoggerInterface $logger,
+		private ITimeFactory $timeFactory,
 	) {
-		$this->avatarManager = $avatarManager;
-		$this->db = $db;
-		$this->config = $config;
-		$this->urlGenerator = $urlGenerator;
-		$this->userManager = $userManager;
-		$this->manager = $manager;
-		$this->participantService = $participantService;
-		$this->chatManager = $chatManager;
-		$this->tokenProvider = $tokenProvider;
-		$this->random = $random;
-		$this->logger = $logger;
-		$this->timeFactory = $timeFactory;
 	}
 
 	/**

--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -45,7 +45,6 @@ use Psr\Log\LoggerInterface;
 
 class MatterbridgeManager {
 	public const BRIDGE_BOT_USERID = 'bridge-bot';
-	private IAuthTokenProvider $tokenProvider;
 
 	public function __construct(
 		private IDBConnection $db,
@@ -55,13 +54,12 @@ class MatterbridgeManager {
 		private Manager $manager,
 		private ParticipantService $participantService,
 		private ChatManager $chatManager,
-		IAuthTokenProvider $tokenProvider,
+		private IAuthTokenProvider $tokenProvider,
 		private ISecureRandom $random,
 		private IAvatarManager $avatarManager,
 		private LoggerInterface $logger,
 		private ITimeFactory $timeFactory,
 	) {
-		$this->tokenProvider = $tokenProvider;
 	}
 
 	/**

--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -45,6 +45,7 @@ use Psr\Log\LoggerInterface;
 
 class MatterbridgeManager {
 	public const BRIDGE_BOT_USERID = 'bridge-bot';
+	private IAuthTokenProvider $tokenProvider;
 
 	public function __construct(
 		private IDBConnection $db,
@@ -54,12 +55,13 @@ class MatterbridgeManager {
 		private Manager $manager,
 		private ParticipantService $participantService,
 		private ChatManager $chatManager,
-		private IAuthTokenProvider $tokenProvider,
+		IAuthTokenProvider $tokenProvider,
 		private ISecureRandom $random,
 		private IAvatarManager $avatarManager,
 		private LoggerInterface $logger,
 		private ITimeFactory $timeFactory,
 	) {
+		$this->tokenProvider = $tokenProvider;
 	}
 
 	/**

--- a/lib/Participant.php
+++ b/lib/Participant.php
@@ -55,18 +55,11 @@ class Participant {
 	public const PRIVACY_PUBLIC = 0;
 	public const PRIVACY_PRIVATE = 1;
 
-	protected Room $room;
-	protected Attendee $attendee;
-	protected ?Session $session;
-
 	public function __construct(
-		Room $room,
-		Attendee $attendee,
-		?Session $session,
+		protected Room $room,
+		protected Attendee $attendee,
+		protected ?Session $session,
 	) {
-		$this->room = $room;
-		$this->attendee = $attendee;
-		$this->session = $session;
 	}
 
 	public function getRoom(): Room {

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -163,112 +163,44 @@ class Room {
 
 	public const DESCRIPTION_MAXIMUM_LENGTH = 500;
 
-	private Manager $manager;
-	private IDBConnection $db;
-	private IEventDispatcher $dispatcher;
-	private ITimeFactory $timeFactory;
-
-	private int $id;
-	private int $type;
-	private int $readOnly;
-	private int $listable;
-	private int $messageExpiration;
-	private int $lobbyState;
-	private int $sipEnabled;
-	private ?int $assignedSignalingServer;
-	private ?\DateTime $lobbyTimer;
-	private string $token;
-	private string $name;
-	private string $description;
-	private string $password;
-	private string $avatar;
-	private string $remoteServer;
-	private string $remoteToken;
-	private int $activeGuests;
-	private int $defaultPermissions;
-	private int $callPermissions;
-	private int $callFlag;
-	private ?\DateTime $activeSince;
-	private ?\DateTime $lastActivity;
-	private int $lastMessageId;
-	private ?IComment $lastMessage;
-	private string $objectType;
-	private string $objectId;
-	private int $breakoutRoomMode;
-	private int $breakoutRoomStatus;
-	private int $callRecording;
-
 	protected ?string $currentUser = null;
 	protected ?Participant $participant = null;
 
 	public function __construct(
-		Manager $manager,
-		IDBConnection $db,
-		IEventDispatcher $dispatcher,
-		ITimeFactory $timeFactory,
-		int $id,
-		int $type,
-		int $readOnly,
-		int $listable,
-		int $messageExpiration,
-		int $lobbyState,
-		int $sipEnabled,
-		?int $assignedSignalingServer,
-		string $token,
-		string $name,
-		string $description,
-		string $password,
-		string $avatar,
-		string $remoteServer,
-		string $remoteToken,
-		int $activeGuests,
-		int $defaultPermissions,
-		int $callPermissions,
-		int $callFlag,
-		?\DateTime $activeSince,
-		?\DateTime $lastActivity,
-		int $lastMessageId,
-		?IComment $lastMessage,
-		?\DateTime $lobbyTimer,
-		string $objectType,
-		string $objectId,
-		int $breakoutRoomMode,
-		int $breakoutRoomStatus,
-		int $callRecording,
+		private Manager $manager,
+		private IDBConnection $db,
+		private IEventDispatcher $dispatcher,
+		private ITimeFactory $timeFactory,
+		private int $id,
+		private int $type,
+		private int $readOnly,
+		private int $listable,
+		private int $messageExpiration,
+		private int $lobbyState,
+		private int $sipEnabled,
+		private ?int $assignedSignalingServer,
+		private string $token,
+		private string $name,
+		private string $description,
+		private string $password,
+		private string $avatar,
+		private string $remoteServer,
+		private string $remoteToken,
+		private int $activeGuests,
+		private int $defaultPermissions,
+		private int $callPermissions,
+		private int $callFlag,
+		private ?\DateTime $activeSince,
+		private ?\DateTime $lastActivity,
+		private int $lastMessageId,
+		private ?IComment $lastMessage,
+		private ?\DateTime $lobbyTimer,
+		private string $objectType,
+		private string $objectId,
+		private int $breakoutRoomMode,
+		private int $breakoutRoomStatus,
+		private int $callRecording,
 	) {
-		$this->manager = $manager;
-		$this->db = $db;
-		$this->dispatcher = $dispatcher;
-		$this->timeFactory = $timeFactory;
-		$this->id = $id;
-		$this->type = $type;
-		$this->readOnly = $readOnly;
-		$this->listable = $listable;
-		$this->messageExpiration = $messageExpiration;
-		$this->lobbyState = $lobbyState;
-		$this->sipEnabled = $sipEnabled;
-		$this->assignedSignalingServer = $assignedSignalingServer;
-		$this->token = $token;
-		$this->name = $name;
-		$this->description = $description;
-		$this->password = $password;
-		$this->avatar = $avatar;
-		$this->remoteServer = $remoteServer;
-		$this->remoteToken = $remoteToken;
-		$this->activeGuests = $activeGuests;
-		$this->defaultPermissions = $defaultPermissions;
-		$this->callPermissions = $callPermissions;
-		$this->callFlag = $callFlag;
-		$this->activeSince = $activeSince;
-		$this->lastActivity = $lastActivity;
-		$this->lastMessageId = $lastMessageId;
-		$this->lastMessage = $lastMessage;
-		$this->lobbyTimer = $lobbyTimer;
-		$this->objectType = $objectType;
-		$this->objectId = $objectId;
-		$this->breakoutRoomMode = $breakoutRoomMode;
-		$this->breakoutRoomStatus = $breakoutRoomStatus;
-		$this->callRecording = $callRecording;
 	}
 
 	public function getId(): int {

--- a/lib/TalkSession.php
+++ b/lib/TalkSession.php
@@ -26,10 +26,10 @@ namespace OCA\Talk;
 use OCP\ISession;
 
 class TalkSession {
-	protected ISession $session;
 
-	public function __construct(ISession $session) {
-		$this->session = $session;
+	public function __construct(
+		protected ISession $session,
+	) {
 	}
 
 	/**

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.11.0@c9b192ab8400fdaf04b2b13d110575adc879aa90">
+<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
   <file src="lib/AppInfo/Application.php">
     <UndefinedClass>
       <code>BeforeTemplateRenderedEvent</code>
@@ -190,15 +190,14 @@
       <code><![CDATA[$this->tokenProvider]]></code>
       <code><![CDATA[$this->tokenProvider]]></code>
       <code><![CDATA[$this->tokenProvider]]></code>
-      <code>IAuthTokenProvider</code>
-      <code>IAuthTokenProvider</code>
       <code>IToken</code>
       <code>IToken</code>
+      <code>private</code>
     </UndefinedClass>
   </file>
   <file src="lib/Migration/Version2001Date20170707115443.php">
     <InvalidArrayAccess>
-      <code>$return['num_rooms']</code>
+      <code><![CDATA[$return['num_rooms']]]></code>
     </InvalidArrayAccess>
   </file>
   <file src="lib/Notification/Notifier.php">
@@ -232,7 +231,7 @@
   </file>
   <file src="lib/Share/Listener.php">
     <InvalidArgument>
-      <code>[self::class, 'listenPreShare']</code>
+      <code><![CDATA[[self::class, 'listenPreShare']]]></code>
     </InvalidArgument>
     <UndefinedClass>
       <code><![CDATA[$event->getView()]]></code>


### PR DESCRIPTION
### Summary

This PR is a continuation of the previous PRs regarding refactoring and using PHP8's constructor property promotion:
#9913

I'm splitting the refactoring and the changes into a few PRs to make reviewing the changes easier.

### ☑️ Resolves

* Using PHP8's constructor property promotion in the following files:
- `/lib/Capabilities.php`
- `/lib/Config.php`
- `/lib/GuestManager.php`
- `/lib/Manager.php`
- `/lib/MatterbridgeManager.php`
- `/lib/Participant.php`
- `/lib/Room.php`
- `/lib/TalkSession.php`

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
