### PR TITLE
chore(deps) - bump @nextcloud/event-bus from 3.0.2 to 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@nextcloud/browser-storage": "^0.2.0",
         "@nextcloud/capabilities": "^1.1.0",
         "@nextcloud/dialogs": "^4.1.0",
-        "@nextcloud/event-bus": "^3.0.1",
+        "@nextcloud/event-bus": "^3.1.0",
         "@nextcloud/files": "^3.0.0-beta.11",
         "@nextcloud/initial-state": "^2.0.0",
         "@nextcloud/l10n": "^2.2.0",
@@ -5103,15 +5103,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
       }
     },
     "node_modules/babel-code-frame": {
@@ -22666,15 +22657,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
-    },
-    "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
     },
     "babel-code-frame": {
       "version": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@nextcloud/browser-storage": "^0.2.0",
     "@nextcloud/capabilities": "^1.1.0",
     "@nextcloud/dialogs": "^4.1.0",
-    "@nextcloud/event-bus": "^3.0.1",
+    "@nextcloud/event-bus": "^3.1.0",
     "@nextcloud/files": "^3.0.0-beta.11",
     "@nextcloud/initial-state": "^2.0.0",
     "@nextcloud/l10n": "^2.2.0",


### PR DESCRIPTION
* Rebase of #9562 
* Tested on web client (Chrome + Linux)