### PR TITLE
fix(status): Don't emit event when the user status did not update

### DIFF
--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -240,13 +240,21 @@ const actions = {
 	 */
 	postAddConversation(context, conversation) {
 		if (conversation.type === CONVERSATION.TYPE.ONE_TO_ONE && conversation.status) {
-			emit('user_status:status.updated', {
-				status: conversation.status,
-				message: conversation.statusMessage,
-				icon: conversation.statusIcon,
-				clearAt: conversation.statusClearAt,
-				userId: conversation.name,
-			})
+			const prevStatus = context.state.conversations[conversation.token] || {}
+
+			// Only emit the event when something actually changed
+			if (prevStatus?.status !== conversation.status
+				|| prevStatus?.statusMessage !== conversation.statusMessage
+				|| prevStatus?.statusIcon !== conversation.statusIcon
+				|| prevStatus?.statusClearAt !== conversation.statusClearAt) {
+				emit('user_status:status.updated', {
+					status: conversation.status,
+					message: conversation.statusMessage,
+					icon: conversation.statusIcon,
+					clearAt: conversation.statusClearAt,
+					userId: conversation.name,
+				})
+			}
 		}
 
 		let currentUser = {


### PR DESCRIPTION
### ☑️ Resolves

* Attempt to contribute to #9630 
* If you think it makes sense, we can also apply it here: https://github.com/nextcloud/spreed/blob/04c973ed6aee1d8113ccf44d91b5431b954d6c70/src/mixins/getParticipants.js#L145-L153


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
