### PR TITLE
fix(searchBox) - Conversation search UX improvements 

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.spec.js
+++ b/src/components/LeftSidebar/LeftSidebar.spec.js
@@ -313,7 +313,6 @@ describe('LeftSidebar.vue', () => {
 			await flushPromises()
 
 			await searchBox.find('input[type="text"]').setValue(searchTerm)
-			expect(searchBox.props('isSearching')).toBeTruthy()
 
 			await flushPromises()
 

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -446,6 +446,7 @@ export default {
 		},
 
 		setIsFocused(event) {
+			console.log(event.type)
 			if (this.searchText !== '') {
 				return
 			}

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -27,9 +27,10 @@
 				:class="{'conversations-search--expanded': isFocused}">
 				<SearchBox ref="searchBox"
 					:value.sync="searchText"
-					:is-searching="isSearching"
+					:is-focused="isFocused"
 					@focus="setIsFocused"
 					@blur="setIsFocused"
+					@trailing-blur="setIsFocused"
 					@input="debounceFetchSearchResults"
 					@abort-search="abortSearch" />
 			</div>
@@ -75,7 +76,8 @@
 			</div>
 
 			<!-- Actions -->
-			<div class="actions">
+			<div class="actions"
+				:class="{'hidden-visually': isFocused}">
 				<NcActions class="conversations-actions">
 					<template #icon>
 						<DotsVertical :size="20" />
@@ -219,6 +221,7 @@ import debounce from 'debounce'
 import { ref } from 'vue'
 
 import AtIcon from 'vue-material-design-icons/At.vue'
+import ChatPlus from 'vue-material-design-icons/ChatPlus.vue'
 import DotsVertical from 'vue-material-design-icons/DotsVertical.vue'
 import FilterIcon from 'vue-material-design-icons/Filter.vue'
 import FilterRemoveIcon from 'vue-material-design-icons/FilterRemove.vue'
@@ -279,6 +282,7 @@ export default {
 		FilterIcon,
 		FilterRemoveIcon,
 		Plus,
+		ChatPlus,
 		List,
 		DotsVertical,
 	},
@@ -446,7 +450,6 @@ export default {
 		},
 
 		setIsFocused(event) {
-			console.log(event.type)
 			if (this.searchText !== '') {
 				return
 			}

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -35,71 +35,73 @@
 					@abort-search="abortSearch" />
 			</div>
 
-			<!-- Filters -->
-			<div class="filters"
-				:class="{'hidden-visually': isFocused}">
-				<NcActions class="filter-actions"
-					:primary="isFiltered !== null">
-					<template #icon>
-						<FilterIcon :size="15" />
-					</template>
-					<NcActionButton close-after-click
-						class="filter-actions__button"
-						:class="{'filter-actions__button--active': isFiltered === 'mentions'}"
-						@click="handleFilter('mentions')">
+			<transition-group name="radial-reveal">
+				<!-- Filters -->
+				<div v-show="!isFocused" key="filters" class="filters">
+					<NcActions class="filter-actions"
+						:primary="isFiltered !== null">
 						<template #icon>
-							<AtIcon :size="20" />
+							<FilterIcon :size="15" />
 						</template>
-						{{ t('spreed','Filter unread mentions') }}
-					</NcActionButton>
+						<NcActionButton close-after-click
+							class="filter-actions__button"
+							:class="{'filter-actions__button--active': isFiltered === 'mentions'}"
+							@click="handleFilter('mentions')">
+							<template #icon>
+								<AtIcon :size="20" />
+							</template>
+							{{ t('spreed','Filter unread mentions') }}
+						</NcActionButton>
 
-					<NcActionButton close-after-click
-						class="filter-actions__button"
-						:class="{'filter-actions__button--active': isFiltered === 'unread'}"
-						@click="handleFilter('unread')">
-						<template #icon>
-							<MessageBadge :size="20" />
-						</template>
-						{{ t('spreed','Filter unread messages') }}
-					</NcActionButton>
+						<NcActionButton close-after-click
+							class="filter-actions__button"
+							:class="{'filter-actions__button--active': isFiltered === 'unread'}"
+							@click="handleFilter('unread')">
+							<template #icon>
+								<MessageBadge :size="20" />
+							</template>
+							{{ t('spreed','Filter unread messages') }}
+						</NcActionButton>
 
-					<NcActionButton v-if="isFiltered"
-						close-after-click
-						class="filter-actions__clearbutton"
-						@click="handleFilter(null)">
-						<template #icon>
-							<FilterRemoveIcon :size="20" />
-						</template>
-						{{ t('spreed', 'Clear filters') }}
-					</NcActionButton>
-				</NcActions>
-			</div>
+						<NcActionButton v-if="isFiltered"
+							close-after-click
+							class="filter-actions__clearbutton"
+							@click="handleFilter(null)">
+							<template #icon>
+								<FilterRemoveIcon :size="20" />
+							</template>
+							{{ t('spreed', 'Clear filters') }}
+						</NcActionButton>
+					</NcActions>
+				</div>
 
-			<!-- Actions -->
-			<div class="actions"
-				:class="{'hidden-visually': isFocused}">
-				<NcActions class="conversations-actions">
-					<template #icon>
-						<DotsVertical :size="20" />
-					</template>
-					<NcActionButton v-if="canStartConversations"
-						close-after-click
-						@click="showModalNewConversation">
+				<!-- Actions -->
+				<div v-show="!isFocused"
+					key="actions"
+					class="actions">
+					<NcActions class="conversations-actions">
 						<template #icon>
-							<Plus :size="20" />
+							<DotsVertical :size="20" />
 						</template>
-						{{ t('spreed','Create a new conversation') }}
-					</NcActionButton>
+						<NcActionButton v-if="canStartConversations"
+							close-after-click
+							@click="showModalNewConversation">
+							<template #icon>
+								<Plus :size="20" />
+							</template>
+							{{ t('spreed','Create a new conversation') }}
+						</NcActionButton>
 
-					<NcActionButton close-after-click
-						@click="showModalListConversations">
-						<template #icon>
-							<List :size="20" />
-						</template>
-						{{ t('spreed','Join open conversations') }}
-					</NcActionButton>
-				</NcActions>
-			</div>
+						<NcActionButton close-after-click
+							@click="showModalListConversations">
+							<template #icon>
+								<List :size="20" />
+							</template>
+							{{ t('spreed','Join open conversations') }}
+						</NcActionButton>
+					</NcActions>
+				</div>
+			</transition-group>
 
 			<!-- All open conversations list -->
 			<OpenConversationsList ref="openConversationsList" />
@@ -809,7 +811,7 @@ export default {
 }
 
 .conversations-search {
-	transition: all 0.3s ease;
+	transition: all 0.15s ease;
 	z-index: 1;
 	// New conversation button width : 52 px
 	// Filters button width : 44 px
@@ -830,6 +832,7 @@ export default {
 .filters {
 	position: absolute;
 	right : 52px; // New conversation button's width
+	top : 5px;
 	display: flex;
 	height: var(--default-clickable-area);
 }
@@ -837,6 +840,7 @@ export default {
 .actions {
 	position: absolute;
 	right: 5px;
+	top : 5px;
 }
 
 .filter-actions__button--active {
@@ -852,6 +856,24 @@ export default {
 	justify-content: flex-start !important;
 }
 
+  .radial-reveal-enter-active {
+    animation: radial-reveal 0.15s forwards;
+  }
+
+  @keyframes radial-reveal {
+      0% {
+        transform: scale(0); /* Start as a point */
+        opacity: 0;
+      }
+      100% {
+        transform: scale(1); /* Expand to full size */
+        opacity: 1;
+      }
+    }
+
+:deep(.input-field__clear-button) {
+	border-radius: var(--border-radius-pill) !important;
+}
 :deep(.app-navigation ul) {
 	padding: 0 !important;
 }

--- a/src/components/LeftSidebar/SearchBox/SearchBox.vue
+++ b/src/components/LeftSidebar/SearchBox/SearchBox.vue
@@ -74,12 +74,11 @@ export default {
 
 	expose: ['focus'],
 
-	emits: ['update:value', 'input', 'submit', 'abort-search'],
+	emits: ['update:value', 'input', 'submit', 'abort-search', 'blur', 'trailing-blur'],
 
 	computed: {
 		listeners() {
 			return Object.assign({}, this.$listeners, {
-				focus: this.handleFocus,
 				blur: this.handleBlur,
 			})
 		},
@@ -150,6 +149,17 @@ export default {
 					console.log('trailing blur')
 					console.log(event)
 					// check if focus goes back to native input or outside, and proceed accordingly
+				})
+			} else {
+				this.$emit('blur', event)
+			}
+		},
+
+		handleBlur(event) {
+			if ((event.relatedTarget) && (Array.from(event.relatedTarget.classList).includes('input-field__clear-button'))) {
+				event.preventDefault()
+				this.$refs.searchConversations.$el.querySelector('.input-field__clear-button').addEventListener('blur', (event) => {
+					this.$emit('trailing-blur', event)
 				})
 			} else {
 				this.$emit('blur', event)

--- a/src/components/LeftSidebar/SearchBox/SearchBox.vue
+++ b/src/components/LeftSidebar/SearchBox/SearchBox.vue
@@ -64,7 +64,7 @@ export default {
 		/**
 		 * If true, this component displays an 'x' button to abort the search
 		 */
-		isSearching: {
+		isFocused: {
 			type: Boolean,
 			default: false,
 		},

--- a/src/components/LeftSidebar/SearchBox/SearchBox.vue
+++ b/src/components/LeftSidebar/SearchBox/SearchBox.vue
@@ -23,9 +23,11 @@
 	<NcTextField ref="searchConversations"
 		:value="value"
 		:label="placeholderText"
-		:show-trailing-button="isSearching"
+		:show-trailing-button="isFocused"
 		trailing-button-icon="close"
-		v-on="$listeners"
+		v-on="listeners"
+		@focus="handleFocus"
+		@blur="handleBlur"
 		@update:value="updateValue"
 		@trailing-button-click="abortSearch"
 		@keydown.esc="abortSearch">
@@ -75,6 +77,13 @@ export default {
 	emits: ['update:value', 'input', 'submit', 'abort-search'],
 
 	computed: {
+		listeners() {
+			return Object.assign({}, this.$listeners, {
+				focus: this.handleFocus,
+				blur: this.handleBlur,
+			})
+		},
+
 		cancelSearchLabel() {
 			return t('spreed', 'Cancel search')
 		},
@@ -111,6 +120,40 @@ export default {
 		abortSearch() {
 			this.$emit('abort-search')
 			this.focus()
+		},
+
+		handleFocus(event) {
+			this.$emit('focus', event)
+		},
+		handleBlur(event) {
+			console.log('inner blur')
+			if (Array.from(event.relatedTarget.classList).includes('input-field__clear-button')) {
+				event.preventDefault()
+				this.$refs.searchConversations.$el.querySelector('.input-field__clear-button').addEventListener('blur', (event) => {
+					console.log('trailing blur')
+					console.log(event)
+					// check if focus goes back to native input or outside, and proceed accordingly
+				})
+			} else {
+				this.$emit('blur', event)
+			}
+		},
+
+		handleFocus(event) {
+			this.$emit('focus', event)
+		},
+		handleBlur(event) {
+			console.log('inner blur')
+			if (Array.from(event.relatedTarget.classList).includes('input-field__clear-button')) {
+				event.preventDefault()
+				this.$refs.searchConversations.$el.querySelector('.input-field__clear-button').addEventListener('blur', (event) => {
+					console.log('trailing blur')
+					console.log(event)
+					// check if focus goes back to native input or outside, and proceed accordingly
+				})
+			} else {
+				this.$emit('blur', event)
+			}
 		},
 	},
 }

--- a/src/components/LeftSidebar/SearchBox/SearchBox.vue
+++ b/src/components/LeftSidebar/SearchBox/SearchBox.vue
@@ -26,7 +26,6 @@
 		:show-trailing-button="isFocused"
 		trailing-button-icon="close"
 		v-on="listeners"
-		@focus="handleFocus"
 		@blur="handleBlur"
 		@update:value="updateValue"
 		@trailing-button-click="abortSearch"
@@ -118,41 +117,6 @@ export default {
 		 */
 		abortSearch() {
 			this.$emit('abort-search')
-			this.focus()
-		},
-
-		handleFocus(event) {
-			this.$emit('focus', event)
-		},
-		handleBlur(event) {
-			console.log('inner blur')
-			if (Array.from(event.relatedTarget.classList).includes('input-field__clear-button')) {
-				event.preventDefault()
-				this.$refs.searchConversations.$el.querySelector('.input-field__clear-button').addEventListener('blur', (event) => {
-					console.log('trailing blur')
-					console.log(event)
-					// check if focus goes back to native input or outside, and proceed accordingly
-				})
-			} else {
-				this.$emit('blur', event)
-			}
-		},
-
-		handleFocus(event) {
-			this.$emit('focus', event)
-		},
-		handleBlur(event) {
-			console.log('inner blur')
-			if (Array.from(event.relatedTarget.classList).includes('input-field__clear-button')) {
-				event.preventDefault()
-				this.$refs.searchConversations.$el.querySelector('.input-field__clear-button').addEventListener('blur', (event) => {
-					console.log('trailing blur')
-					console.log(event)
-					// check if focus goes back to native input or outside, and proceed accordingly
-				})
-			} else {
-				this.$emit('blur', event)
-			}
 		},
 
 		handleBlur(event) {
@@ -165,6 +129,7 @@ export default {
 				this.$emit('blur', event)
 			}
 		},
+
 	},
 }
 </script>


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9974


* The new conversation '+' button is now hidden when the search field is expanded
* The abort search button is visible whenever the search box is focused.
* The list gets immediately cleared out from filters once the search field is clicked on. 
* If the search results are empty, a new button shows up to quickly create a conversation with the search text as a name
* The animation is more expedited ( set to 0.15s instead of 0.3s) as it requires to be quick.

https://github.com/nextcloud/spreed/assets/84044328/0f19a2ef-9d79-4573-8f0c-19f4e3ed8310

### Other
And if the search results are empty, you can create a new conversation with the search text, it will be set to private by default.
![image](https://github.com/nextcloud/spreed/assets/84044328/27367282-ae2b-411f-b568-5b04188d4dae)

# screenshots

Before
![image](https://github.com/nextcloud/spreed/assets/84044328/e602339e-233f-4efc-9da3-821ad17b53d4)

After 
![image](https://github.com/nextcloud/spreed/assets/84044328/9540d89e-f467-428e-9aea-c79a971fcf4a)


### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
