### PR TITLE
Fix trying to use an audio sink as source

### DIFF
--- a/recording/src/nextcloud/talk/recording/Benchmark.py
+++ b/recording/src/nextcloud/talk/recording/Benchmark.py
@@ -145,8 +145,9 @@ class BenchmarkService:
             self._display.start()
 
             # Start new audio sink for the audio output of the player.
-            self._audioModuleIndex, audioSinkIndex = newAudioSink("nextcloud-talk-recording-benchmark")
+            self._audioModuleIndex, audioSinkIndex, audioSourceIndex = newAudioSink("nextcloud-talk-recording-benchmark")
             audioSinkIndex = str(audioSinkIndex)
+            audioSourceIndex = str(audioSourceIndex)
 
             env = self._display.env()
             env['PULSE_SINK'] = audioSinkIndex
@@ -166,7 +167,7 @@ class BenchmarkService:
             recorderArgumentsBuilder.setFfmpegOutputAudio(args.audio_args.split())
             recorderArgumentsBuilder.setFfmpegOutputVideo(args.video_args.split())
             recorderArgumentsBuilder.setExtension(f".{extension}")
-            self._recorderArguments = recorderArgumentsBuilder.getRecorderArguments(status, self._display.new_display_var, audioSinkIndex, args.width, args.height, extensionlessFileName)
+            self._recorderArguments = recorderArgumentsBuilder.getRecorderArguments(status, self._display.new_display_var, audioSourceIndex, args.width, args.height, extensionlessFileName)
 
             self._fileName = self._recorderArguments[-1]
 

--- a/recording/src/nextcloud/talk/recording/RecorderArgumentsBuilder.py
+++ b/recording/src/nextcloud/talk/recording/RecorderArgumentsBuilder.py
@@ -36,13 +36,14 @@ class RecorderArgumentsBuilder:
         self._ffmpegOutputVideo = None
         self._extension = None
 
-    def getRecorderArguments(self, status, displayId, audioSinkIndex, width, height, extensionlessOutputFileName):
+    def getRecorderArguments(self, status, displayId, audioSourceIndex, width, height, extensionlessOutputFileName):
         """
         Returns the list of arguments to start the recorder process.
 
         :param status: whether to record audio and video or only audio.
         :param displayId: the ID of the display that the browser is running in.
-        :param audioSinkIndex: the index of the sink for the browser audio output.
+        :param audioSourceIndex: the index of the source for the browser audio
+               output.
         :param width: the width of the display and the recording.
         :param height: the height of the display and the recording.
         :param extensionlessOutputFileName: the file name for the recording, without
@@ -51,7 +52,7 @@ class RecorderArgumentsBuilder:
         """
 
         ffmpegCommon = ['ffmpeg', '-loglevel', 'level+warning', '-n']
-        ffmpegInputAudio = ['-f', 'pulse', '-i', audioSinkIndex]
+        ffmpegInputAudio = ['-f', 'pulse', '-i', audioSourceIndex]
         ffmpegInputVideo = ['-f', 'x11grab', '-draw_mouse', '0', '-video_size', f'{width}x{height}', '-i', displayId]
         ffmpegOutputAudio = self.getFfmpegOutputAudio()
         ffmpegOutputVideo = self.getFfmpegOutputVideo()


### PR DESCRIPTION
Well, this fix is an embarrasing one :-P I do not know what I was thinking on when I wrote the code... And it also took me way longer than I would like to admit to figure out what was going on when I hit the bug :facepalm:

[In PulseAudio sinks are output devices, like headphones, and playback streams are written to them, while sources are input devices, like microphones, and recording streams are read from them.](https://gavv.net/articles/pulseaudio-under-the-hood/#devices-and-streams)

It is not possible to directly read data from a sink. However, for each sink a monitor, which is a virtual source, is automatically created, thus making possible to read the data written to the sink using the monitor.

The recording server creates a null sink for each browser instance to write the output audio of the browser to it, but the recorder process was wrongly given the sink index as its audio input. However, this happened to work as long as there were no additional sources other than the monitors created for the null sinks (which is typically the case when run in Docker, or in a server machine), because in that case the index of the sinks matched the index of their monitors, and in practice the recorder process was reading from the monitor of the sink.

## How to test (scenario 1)

- In the recording server, start PulseAudio and prevent it from exiting in ten minutes (so the tests can be run with the module loaded below) with `pulseaudio --start --exit-idle-time=600`
- In the recording server, load a null source with `pactl load-module module-null-source`
- In Talk, start a call
- Start the recording, wait until it started, say something, stop the recording
- Start the recording again

### Result with this pull request

Both recordings have the expected audio

### Result without this pull request

The first recording has silent audio, the second recording directly failed

## How to test (scenario 2)

- In the recording server, start PulseAudio and prevent it from exiting in ten minutes (so the tests can be run with the module loaded below) with `pulseaudio --start --exit-idle-time=600`
- In the recording server, load a null source with `pactl load-module module-null-source`
- In the recording server, run a benchmark (`python3 -m nextcloud.talk.recording.Benchmark --length {BENCHMARK_LENGTH_IN_SECONDS} {INPUT_VIDEO_FILE} {OUTPUT_VIDEO_FILE}`)
- In the recording server, run another benchmark

### Result with this pull request

Both benchmark outputs have the expected audio

### Result without this pull request

The first benchmark output has silent audio, the second benchmark directly failed
