### PR TITLE
fix(LeftSidebar): remove unused NcListItem.isActive

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -25,7 +25,6 @@
 		:class="{'unread-mention-conversation': item.unreadMention}"
 		:anchor-id="`conversation_${item.token}`"
 		:actions-aria-label="t('spreed', 'Conversation actions')"
-		:active="isActive"
 		:to="to"
 		:bold="!!item.unreadMessages"
 		:counter-number="item.unreadMessages"
@@ -325,14 +324,6 @@ export default {
 					params: { token: this.item.token },
 				}
 				: ''
-		},
-
-		isActive() {
-			if (!this.isSearchResult) {
-				return this.$store.getters.getToken() === this.to.params.token
-			} else {
-				return false
-			}
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

`active` state of `NcListItem` link is controlled by `RouterLink` since https://github.com/nextcloud/nextcloud-vue/pull/3775

So `NcListItem` doesn't use `isActive` prop and we don't need to compute `isActive` flag manually.

Removing this computed also a very little bit decreases a number of re-renderings on each conversation switch (`Conversation.vue` is not re-rendering now, but `NcListItem` is re-rendering anyway).

### 🖼️ Screenshots

No visual changes

### 🚧 Tasks

- [x] Remove unused `NcListItem.isActive`
- [x] Remove unused `isActive` computed

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
