### PR TITLE
chore(gitignore): ignore JetBrains IDEs settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,11 @@
 /js
 
 # VScode settings
-.vscode
+/.vscode
 *.code-workspace
+
+# JetBrains IDEs settings
+/.idea
+
+# JetBrains Fleet settings
+/.fleet


### PR DESCRIPTION
### ☑️ Resolves

We don't share any IDE settings in the repository, while we ignore only Microsoft Visual Studio Code settings.

This PR propose to ignore also JetBrains IDEs (such as PhpStorm) and JetBrains Fleet (new VSCode like IDE from JetBrains).

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
