### PR TITLE
chore(deps): add @types/jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "@nextcloud/eslint-config": "^8.2.1",
         "@nextcloud/stylelint-config": "^2.3.1",
         "@nextcloud/webpack-vue-config": "^5.5.1",
+        "@types/jest": "^29.5.3",
         "@vue/test-utils": "^1.3.6",
         "@vue/vue2-jest": "^29.2.4",
         "babel-loader-exclude-node-modules-except": "^1.2.1",
@@ -3664,6 +3665,16 @@
       "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.3.tgz",
+      "integrity": "sha512-1Nq7YrO/vJE/FYnqYyw0FS8LdrjExSgIiHyKg7xPpn+yi8Q4huZryKnkJatN1ZRH89Kw2v33/8ZMB7DuZeSLlA==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/jquery": {
@@ -20945,6 +20956,16 @@
       "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
       "requires": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "29.5.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.3.tgz",
+      "integrity": "sha512-1Nq7YrO/vJE/FYnqYyw0FS8LdrjExSgIiHyKg7xPpn+yi8Q4huZryKnkJatN1ZRH89Kw2v33/8ZMB7DuZeSLlA==",
+      "dev": true,
+      "requires": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "@types/jquery": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@nextcloud/eslint-config": "^8.2.1",
     "@nextcloud/stylelint-config": "^2.3.1",
     "@nextcloud/webpack-vue-config": "^5.5.1",
+    "@types/jest": "^29.5.3",
     "@vue/test-utils": "^1.3.6",
     "@vue/vue2-jest": "^29.2.4",
     "babel-loader-exclude-node-modules-except": "^1.2.1",


### PR DESCRIPTION
### ☑️ Resolves

We use global Jest function without typings. IDEs doesn't understand them, show warnings and no auto-complete.

`@types/jest` adds global jest typings.

**Alternative solution**: use `@jest/globals` with explicit import everywhere:

```js
import { describe, it, test, expect, jest } from '@jest/globals'

describe('...', () => {
  it('..', () => {})
})
```

**Docs**: https://jestjs.io/docs/getting-started#type-definitions

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
JetBrains IDEs | -
![image](https://github.com/nextcloud/spreed/assets/25978914/72adbcdf-d53f-4082-b834-bc4d288c07d6) | ![image](https://github.com/nextcloud/spreed/assets/25978914/5df294a0-c3fa-4b1c-8ac9-cb5fb4585f12)
Microsoft VSCode | -
![image](https://github.com/nextcloud/spreed/assets/25978914/f649581b-6220-4782-8e11-e525035d97cd) | ![image](https://github.com/nextcloud/spreed/assets/25978914/c267020c-18ab-4535-b615-66d282eb3826)
JetBrains Fleet | -
![image](https://github.com/nextcloud/spreed/assets/25978914/39d1852c-d103-4d11-9b68-4532973b4313) | ![image](https://github.com/nextcloud/spreed/assets/25978914/d711ae97-c4cf-432c-9e16-1419535c2c0c)


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
