### PR TITLE
Revert mapping of cjs module

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -82,8 +82,6 @@ module.exports = {
 	moduleNameMapper: {
 		'\\.(css|scss)$': 'jest-transform-stub',
 		'vendor/tflite/(.*).wasm$': '<rootDir>/src/utils/media/effects/virtual-background/vendor/tflite/$1.js',
-		// Axios using ESM since v1.0.0, so we need to replace it with CJS for tests
-		axios: '<rootDir>/node_modules/@nextcloud/axios/node_modules/axios/dist/node/axios.cjs',
 	},
 
 	transform: {


### PR DESCRIPTION
### ☑️ Resolves

* Regression from #9919 
* After bumping #9915, all the packages are using a new major version of `axios`, which makes it unnecessary to map it with CJS module 
* Affects only Jest work, so as long as tests have passed, rest should be fine

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
