### PR TITLE
Don't require a global backened secret when allowall is not set

### DIFF
--- a/recording/src/nextcloud/talk/recording/Config.py
+++ b/recording/src/nextcloud/talk/recording/Config.py
@@ -126,7 +126,7 @@ class Config:
 
         Defaults to None.
         """
-        if self._configParser.get('backend', 'allowall', fallback=None):
+        if self._configParser.get('backend', 'allowall', fallback=None) == 'true':
             return self._configParser.get('backend', 'secret')
 
         backendUrl = backendUrl.rstrip('/')


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9580 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
