### PR TITLE
fix(MessagesList) - check if list is rendered before scrolling

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -945,7 +945,11 @@ export default {
 		 * Scrolls to the bottom of the list smoothly.
 		 */
 		smoothScrollToBottom() {
-			this.$nextTick(function() {
+			this.$nextTick(() => {
+				if (!this.$refs.scroller) {
+					return
+				}
+
 				if (this.isWindowVisible && (document.hasFocus() || this.isInCall)) {
 					// scrollTo is used when the user is watching
 					this.$refs.scroller.scrollTo({
@@ -970,7 +974,11 @@ export default {
 		 * Scrolls to the bottom of the list.
 		 */
 		scrollToBottom() {
-			this.$nextTick(function() {
+			this.$nextTick(() => {
+				if (!this.$refs.scroller) {
+					return
+				}
+
 				this.$refs.scroller.scrollTop = this.$refs.scroller.scrollHeight
 				this.setChatScrolledToBottom(true)
 			})


### PR DESCRIPTION
### ☑️ Resolves

* Fix Vue warn errors in the console, when joining the call:
  * In that moment we destroying main `MessageList` component and creating a new one in the sidebar
  * Although `this.$nextTick` is an async function, and it will be called after unmounting, then `this.$refs.scroller` isn't existing already

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2023-07-24 09-38-19](https://github.com/nextcloud/spreed/assets/93392545/cb28062d-6fa2-44e6-a1fb-5abb240498bb) | ![Screenshot from 2023-07-24 09-43-19](https://github.com/nextcloud/spreed/assets/93392545/931bf3f5-a0b5-403b-87c7-35d400920542)



### 🚧 Tasks

- [ ] Manual testing
- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
