### PR TITLE
fix(MessagesList) - check for temporary messages while soft updating

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -339,13 +339,25 @@ export default {
 
 			// Check if we have this group in the old list already and it is unchanged
 			return newGroups.map(newGroup => oldGroupsMap.has(newGroup.id)
-				&& newGroup.messages.length === oldGroupsMap.get(newGroup.id).messages.length
-				&& newGroup.dateSeparator === oldGroupsMap.get(newGroup.id).dateSeparator
-				&& newGroup.previousMessageId === oldGroupsMap.get(newGroup.id).previousMessageId
-				&& newGroup.nextMessageId === oldGroupsMap.get(newGroup.id).nextMessageId
+				&& this.areGroupsIdentical(newGroup, oldGroupsMap.get(newGroup.id))
 				? oldGroupsMap.get(newGroup.id)
 				: newGroup
 			).sort((a, b) => a.id - b.id)
+		},
+
+		areGroupsIdentical(group1, group2) {
+			if (group1.messages.length !== group2.messages.length
+				|| group1.dateSeparator !== group2.dateSeparator
+				|| group1.previousMessageId !== group2.previousMessageId
+				|| group1.nextMessageId !== group2.nextMessageId) {
+				return false
+			}
+
+			// Check for temporary messages, replaced with messages from server
+			const array1 = group1.messages.map(message => message.id)
+			const array2 = group2.messages.map(message => message.id)
+
+			return array1.every(item => array2.includes(item))
 		},
 
 		removeExpiredMessagesFromStore() {


### PR DESCRIPTION
### ☑️ Resolves

* Regression from #9897 
* When post a new message (not the first in the message group), response from server replaces temporary message, but group length remains the same, and component with temp message won't re-render => infinite loading

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/435684f3-7d46-4c42-b5ce-36242a9a718d) | ![image](https://github.com/nextcloud/spreed/assets/93392545/be768e2e-de23-47d6-afc9-f534bb4f7690)



### 🚧 Tasks

- [ ] Code review
- [ ] Manual testing

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
