### PR TITLE
hide description and status from 1-1 conversation settings

### DIFF
--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -36,6 +36,7 @@
 			:disable-menu="disableMenu"
 			:display-name="item.displayName"
 			:preloaded-user-status="preloadedUserStatus"
+			:show-user-status="showUserStatus"
 			:show-user-status-compact="disableMenu"
 			:menu-container="menuContainer"
 			menu-position="left"
@@ -97,6 +98,11 @@ export default {
 			default: false,
 		},
 
+		showUserStatus: {
+			type: Boolean,
+			default: true,
+		},
+
 		item: {
 			type: Object,
 			default() {
@@ -143,7 +149,7 @@ export default {
 		},
 
 		preloadedUserStatus() {
-			if (Object.prototype.hasOwnProperty.call(this.item, 'statusMessage')) {
+			if (this.showUserStatus && Object.prototype.hasOwnProperty.call(this.item, 'statusMessage')) {
 				// We preloaded the status
 				return {
 					status: this.item.status || null,

--- a/src/components/ConversationSettings/BasicInfo.vue
+++ b/src/components/ConversationSettings/BasicInfo.vue
@@ -32,17 +32,19 @@
 			:edit-button-aria-label="t('spreed', 'Edit conversation name')"
 			@submit-text="handleUpdateName"
 			@update:editing="handleEditName" />
-		<h4 class="app-settings-section__subtitle">
-			{{ t('spreed', 'Description') }}
-		</h4>
-		<EditableTextField :editable="canFullModerate"
-			:initial-text="description"
-			:editing="isEditingDescription"
-			:loading="isDescriptionLoading"
-			:edit-button-aria-label="t('spreed', 'Edit conversation description')"
-			:placeholder="t('spreed', 'Enter a description for this conversation')"
-			@submit-text="handleUpdateDescription"
-			@update:editing="handleEditDescription" />
+		<template v-if="!isOneToOne">
+			<h4 class="app-settings-section__subtitle">
+				{{ t('spreed', 'Description') }}
+			</h4>
+			<EditableTextField :editable="canFullModerate"
+				:initial-text="description"
+				:editing="isEditingDescription"
+				:loading="isDescriptionLoading"
+				:edit-button-aria-label="t('spreed', 'Edit conversation description')"
+				:placeholder="t('spreed', 'Enter a description for this conversation')"
+				@submit-text="handleUpdateDescription"
+				@update:editing="handleEditDescription" />
+		</template>
 		<template v-if="supportsAvatar">
 			<h4 class="app-settings-section__subtitle">
 				{{ t('spreed', 'Picture') }}
@@ -61,6 +63,8 @@ import { showError } from '@nextcloud/dialogs'
 
 import ConversationAvatarEditor from './ConversationAvatarEditor.vue'
 import EditableTextField from './EditableTextField.vue'
+
+import { CONVERSATION } from '../../constants.js'
 
 const supportsAvatar = getCapabilities()?.spreed?.features?.includes('avatar')
 
@@ -99,6 +103,11 @@ export default {
 	},
 
 	computed: {
+		isOneToOne() {
+			return this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE
+				|| this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER
+		},
+
 		conversationName() {
 			return this.conversation.displayName
 		},

--- a/src/components/ConversationSettings/ConversationAvatarEditor.vue
+++ b/src/components/ConversationSettings/ConversationAvatarEditor.vue
@@ -33,6 +33,7 @@
 				<ConversationIcon v-else-if="!loading"
 					:item="conversation"
 					:is-big="true"
+					:show-user-status="false"
 					:disable-menu="true" />
 				<div v-else class="icon-loading" />
 			</div>


### PR DESCRIPTION
### ☑️ Resolves

* Hide unused description and status in conversation settings for 1-1 conversation

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/d9d4024a-0e59-43b7-b0a9-49b506505949) | ![image](https://github.com/nextcloud/spreed/assets/93392545/13dc87a5-bea9-421e-99d6-b86a8707a232)


### 🚧 Tasks

- [ ] Code review
- [ ] Visual check

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
