### PR TITLE
feat(ConversationSettings) - add frontend support for enabling bots / webhooks

### DIFF
--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -3,7 +3,7 @@
   -
   - @author Vincent Petry <vincent@nextcloud.com>
   -
-  - @license GNU AGPL version 3 or any later version
+  - @license AGPL-3.0-or-later
   -
   - This program is free software: you can redistribute it and/or modify
   - it under the terms of the GNU Affero General Public License as
@@ -84,6 +84,13 @@
 				<MatterbridgeSettings />
 			</NcAppSettingsSection>
 
+			<!-- Bots settings -->
+			<NcAppSettingsSection v-if="selfIsOwnerOrModerator"
+				id="bots"
+				:title="t('spreed', 'Bots')">
+				<BotsSettings :token="token" />
+			</NcAppSettingsSection>
+
 			<!-- Destructive actions -->
 			<NcAppSettingsSection v-if="canLeaveConversation || canDeleteConversation"
 				id="dangerzone"
@@ -107,6 +114,7 @@ import NcAppSettingsSection from '@nextcloud/vue/dist/Components/NcAppSettingsSe
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 
 import BasicInfo from './BasicInfo.vue'
+import BotsSettings from './BotsSettings.vue'
 import BreakoutRoomsSettings from './BreakoutRoomsSettings.vue'
 import ConversationPermissionsSettings from './ConversationPermissionsSettings.vue'
 import DangerZone from './DangerZone.vue'
@@ -126,21 +134,22 @@ export default {
 	name: 'ConversationSettingsDialog',
 
 	components: {
-		NcAppSettingsDialog,
-		NcAppSettingsSection,
+		BasicInfo,
+		BotsSettings,
+		BreakoutRoomsSettings,
+		ConversationPermissionsSettings,
+		DangerZone,
 		ExpirationSettings,
 		LinkShareSettings,
-		LobbySettings,
 		ListableSettings,
+		LobbySettings,
 		LockingSettings,
-		SipSettings,
 		MatterbridgeSettings,
-		DangerZone,
-		NotificationsSettings,
+		NcAppSettingsDialog,
+		NcAppSettingsSection,
 		NcCheckboxRadioSwitch,
-		ConversationPermissionsSettings,
-		BreakoutRoomsSettings,
-		BasicInfo,
+		NotificationsSettings,
+		SipSettings,
 	},
 
 	data() {
@@ -173,9 +182,12 @@ export default {
 			return this.conversation.participantType
 		},
 
+		selfIsOwnerOrModerator() {
+			return (this.participantType === PARTICIPANT.TYPE.OWNER || this.participantType === PARTICIPANT.TYPE.MODERATOR)
+		},
+
 		canFullModerate() {
-			return (this.participantType === PARTICIPANT.TYPE.OWNER
-				|| this.participantType === PARTICIPANT.TYPE.MODERATOR)
+			return this.selfIsOwnerOrModerator
 				&& this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE
 				&& this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE_FORMER
 		},

--- a/src/constants.js
+++ b/src/constants.js
@@ -216,3 +216,11 @@ export const VIRTUAL_BACKGROUND = {
 		DEFAULT: 10,
 	},
 }
+
+export const BOT = {
+	STATE: {
+		DISABLED: 0,
+		ENABLED: 1,
+		FORCE_ENABLED: 2,
+	},
+}

--- a/src/services/botsService.js
+++ b/src/services/botsService.js
@@ -1,0 +1,83 @@
+/**
+ * @copyright Copyright (c) 2023 Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @author Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+
+/**
+ * Get information about available bots for this conversation
+ *
+ * @param {string} token The conversation token
+ * @return {object} The axios response
+ */
+const getConversationBots = async function(token) {
+	return axios.get(generateOcsUrl('/apps/spreed/api/v1/bot/{token}', { token }))
+}
+
+/**
+ * Enable bot for conversation
+ *
+ * @param {string} token The conversation token
+ * @param {number} id The bot id
+ * @return {object} The axios response
+ */
+const enableBotForConversation = async function(token, id) {
+	return axios.post(generateOcsUrl('/apps/spreed/api/v1/bot/{token}/{id}', { token, id }))
+}
+
+/**
+ * Disable bot for conversation
+ *
+ * @param {string} token The conversation token
+ * @param {number} id The bot id
+ * @return {object} The axios response
+ */
+const disableBotForConversation = async function(token, id) {
+	return axios.delete(generateOcsUrl('/apps/spreed/api/v1/bot/{token}/{id}', { token, id }))
+}
+
+/**
+ * Send a message to bot in conversation
+ *
+ * @param {string} token The conversation token
+ * @param {object} object Object with arguments
+ * @param {string} object.message The message to send
+ * @param {string} object.referenceId for the message to be able to later identify it again
+ * @param {number} object.replyTo Parent id which this message is a reply to
+ * @param {boolean} object.silent If sent silent the chat message will not create any notifications
+ * @return {object} The axios response
+ */
+const sendMessageToBot = async function(token, { message, referenceId, replyTo, silent }) {
+	return axios.post(generateOcsUrl('/apps/spreed/api/v1/bot/{token}/message', { token }), {
+		message,
+		referenceId,
+		replyTo,
+		silent,
+	})
+}
+
+export {
+	getConversationBots,
+	enableBotForConversation,
+	disableBotForConversation,
+	sendMessageToBot,
+}

--- a/src/stores/bots.js
+++ b/src/stores/bots.js
@@ -1,0 +1,73 @@
+/**
+ * @copyright Copyright (c) 2023 Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @author Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { defineStore } from 'pinia'
+import Vue from 'vue'
+
+import { BOT } from '../constants.js'
+import { disableBotForConversation, enableBotForConversation, getConversationBots } from '../services/botsService.js'
+
+export const useBotsStore = defineStore('bots', {
+	state: () => ({
+		bots: {},
+	}),
+
+	actions: {
+		getConversationBots(token) {
+			return this.bots[token] ? Object.values(this.bots[token]) : []
+		},
+
+		/**
+		 * Fetch a list of available bots for conversation and save them to store
+		 *
+		 * @param {string} token The conversation token
+		 * @return {Array} An array of bots ids
+		 */
+		async loadConversationBots(token) {
+			if (!this.bots[token]) {
+				Vue.set(this.bots, token, {})
+			}
+
+			const response = await getConversationBots(token)
+
+			return response.data.ocs.data.map((bot) => {
+				Vue.set(this.bots[token], bot.id, bot)
+				return bot.id
+			})
+		},
+
+		/**
+		 * Enable or disable a bot for conversation
+		 *
+		 * @param {string} token The conversation token
+		 * @param {object} bot The bot to toggle state
+		 */
+		async toggleBotState(token, bot) {
+			const response = bot.state === BOT.STATE.ENABLED
+				? await disableBotForConversation(token, bot.id)
+				: await enableBotForConversation(token, bot.id)
+
+			Vue.set(this.bots[token], bot.id, response.data.ocs.data)
+		},
+
+	},
+})


### PR DESCRIPTION
### ☑️ Resolves

* Close #9676 
* Rebased on top of #9458 

### 🖼️ Screenshots

| 🏡 After |
|--- |
| ![image](https://github.com/nextcloud/spreed/assets/93392545/2bf1f5a7-ab14-47b5-9cd4-cf1094c1b4ce) |

Notes:
 - to test install https://github.com/nextcloud/call_summary_bot
 - to mock bot for the list, modify the code in store as follows:
 ```
async updateBotsInformation(token) {
  ...
  response.data.ocs.data.concat([
      { id: 122, name: 'Dummy bot 1 ', description: 'It does nothing', state: 0 },
      { id: 123, name: 'Dummy bot 2 ', description: '  - This program is free software...', state: 2 },
    ]).forEach((bot) => {
  ...
```

### 🚧 Tasks

- [ ] Visual check
- [ ] Manual testing
- [ ] Code review
- [ ] Render this block based on the capability
- [ ] If it's going to be backported, #9892 should be backported as well

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
