### PR TITLE
fix(SIP): Show SIP info also when enabled without user PIN

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -239,7 +239,7 @@ export default {
 		},
 
 		showSIPSettings() {
-			return this.conversation.sipEnabled === WEBINAR.SIP.ENABLED
+			return this.conversation.sipEnabled !== WEBINAR.SIP.DISABLED
 				&& this.conversation.attendeePin
 		},
 


### PR DESCRIPTION
Fix #10061 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
