### PR TITLE
feat(Participant) - count total talking time within call for participants

### DIFF
--- a/src/components/AvatarWrapper/AvatarWrapper.vue
+++ b/src/components/AvatarWrapper/AvatarWrapper.vue
@@ -25,6 +25,7 @@
 			'avatar-wrapper--offline': offline,
 			'avatar-wrapper--small': small,
 			'avatar-wrapper--condensed': condensed,
+			'avatar-wrapper--highlighted': highlighted,
 		}"
 		:style="{'--condensed-overlap': condensedOverlap}">
 		<div v-if="iconClass"
@@ -86,6 +87,10 @@ export default {
 			default: 2,
 		},
 		offline: {
+			type: Boolean,
+			default: false,
+		},
+		highlighted: {
 			type: Boolean,
 			default: false,
 		},
@@ -160,11 +165,13 @@ export default {
 .avatar-wrapper {
 	height: 44px;
 	width: 44px;
+	border-radius: 44px;
 	@include avatar-mixin(44px);
 
 	&--small {
 		height: 22px;
 		width: 22px;
+		border-radius: 22px;
 		@include avatar-mixin(22px);
 	}
 
@@ -187,6 +194,10 @@ export default {
 		& :deep(.avatardiv) {
 			background: rgba(var(--color-main-background-rgb), .4) !important;
 		}
+	}
+
+	&--highlighted {
+		outline: 2px solid var(--color-primary-element);
 	}
 }
 

--- a/src/components/TopBar/CallTime.vue
+++ b/src/components/TopBar/CallTime.vue
@@ -39,7 +39,7 @@
 						:size="20"
 						fill-color="var(--color-loading-light)" />
 				</template>
-				{{ formattedTime }}
+				{{ formattedTime(callTime) }}
 			</NcButton>
 		</template>
 
@@ -83,6 +83,7 @@ import NcPopover from '@nextcloud/vue/dist/Components/NcPopover.js'
 
 import { CALL } from '../../constants.js'
 import isInLobby from '../../mixins/isInLobby.js'
+import { formattedTime } from '../../utils/formattedTime.js'
 
 export default {
 	name: 'CallTime',
@@ -129,30 +130,6 @@ export default {
 		 */
 		callStart() {
 			return new Date(this.start * 1000)
-		},
-
-		/**
-		 * Calculates the stopwatch string given the callTime (ms)
-		 *
-		 * @return {string} The formatted time
-		 */
-		formattedTime() {
-			if (!this.callTime) {
-				return '-- : --'
-			}
-			let seconds = Math.floor((this.callTime / 1000) % 60)
-			if (seconds < 10) {
-				seconds = '0' + seconds
-			}
-			let minutes = Math.floor((this.callTime / (1000 * 60)) % 60)
-			if (minutes < 10) {
-				minutes = '0' + minutes
-			}
-			const hours = Math.floor((this.callTime / (1000 * 60 * 60)) % 24)
-			if (hours === 0) {
-				return minutes + ' : ' + seconds
-			}
-			return hours + ' : ' + minutes + ' : ' + seconds
 		},
 
 		token() {
@@ -213,6 +190,12 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Calculates the stopwatch string given the callTime (ms)
+		 *
+		 */
+		formattedTime,
+
 		stopRecording() {
 			this.$store.dispatch('stopCallRecording', {
 				token: this.token,

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -141,6 +141,24 @@ const getters = {
 	},
 
 	/**
+	 * Gets the speaking information for the participant.
+	 *
+	 * @param {object} state - the state object.
+	 * param {string} token - the conversation token.
+	 * param {Array<string>} sessionIds - session identifiers for the participant.
+	 * @return {object|undefined}
+	 */
+	getParticipantSpeakingInformation: (state) => (token, sessionIds) => {
+		if (!state.speaking[token]) {
+			return undefined
+		}
+
+		// look for existing sessionId in the store
+		const sessionId = sessionIds.find(sessionId => state.speaking[token][sessionId])
+		return state.speaking[token][sessionId]
+	},
+
+	/**
 	 * Replaces the legacy getParticipant getter. Returns a callback function in which you can
 	 * pass in the token and attendeeId as arguments to get the participant object.
 	 *

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -57,6 +57,8 @@ const state = {
 	},
 	typing: {
 	},
+	speaking: {
+	},
 }
 
 const getters = {
@@ -319,6 +321,58 @@ const mutations = {
 		} else {
 			Vue.delete(state.typing[token], sessionId)
 		}
+	},
+
+	/**
+	 * Sets the speaking status of a participant in a conversation / call.
+	 *
+	 * Note that "updateParticipant" should not be called to add a "speaking"
+	 * property to an existing participant, as the participant would be reset
+	 * when the participants are purged whenever they are fetched again.
+	 * Similarly, "addParticipant" can not be called either to add a participant
+	 * if it was not fetched yet but the signaling reported it as being speaking,
+	 * as the attendeeId would be unknown.
+	 *
+	 * @param {object} state - current store state.
+	 * @param {object} data - the wrapping object.
+	 * @param {string} data.token - the conversation token participant is speaking in.
+	 * @param {string} data.sessionId - the Nextcloud session ID of the participant.
+	 * @param {boolean} data.speaking - whether the participant is speaking or not
+	 */
+	setSpeaking(state, { token, sessionId, speaking }) {
+		// create a dummy object for current call
+		if (!state.speaking[token]) {
+			Vue.set(state.speaking, token, {})
+		}
+		if (!state.speaking[token][sessionId]) {
+			Vue.set(state.speaking[token], sessionId, { speaking: null, lastTimestamp: 0, totalCountedTime: 0 })
+		}
+
+		const currentTimestamp = Date.now()
+		const currentSpeakingState = state.speaking[token][sessionId].speaking
+
+		// when speaking has stopped, update the total talking time
+		if (!speaking && state.speaking[token][sessionId].lastTimestamp) {
+			state.speaking[token][sessionId].totalCountedTime += (currentTimestamp - state.speaking[token][sessionId].lastTimestamp)
+		}
+
+		// don't change state for consecutive identical signals
+		if (currentSpeakingState !== speaking) {
+			state.speaking[token][sessionId].speaking = speaking
+			state.speaking[token][sessionId].lastTimestamp = currentTimestamp
+		}
+	},
+
+	/**
+	 * Purge the speaking information for recent call when local participant leaves call
+	 * (including cases when the call ends for everyone).
+	 *
+	 * @param {object} state - current store state.
+	 * @param {object} data - the wrapping object.
+	 * @param {string} data.token - the conversation token.
+	 */
+	purgeSpeakingStore(state, { token }) {
+		Vue.delete(state.speaking, token)
 	},
 
 	/**
@@ -749,6 +803,14 @@ const actions = {
 			}, 15000)
 			context.commit('setTyping', { token, sessionId, typing: true, expirationTimeout })
 		}
+	},
+
+	setSpeaking(context, { token, sessionId, speaking }) {
+		context.commit('setSpeaking', { token, sessionId, speaking })
+	},
+
+	purgeSpeakingStore(context, { token }) {
+		context.commit('purgeSpeakingStore', { token })
 	},
 }
 

--- a/src/utils/formattedTime.js
+++ b/src/utils/formattedTime.js
@@ -1,0 +1,26 @@
+/**
+ * Calculates the stopwatch string given the time (ms)
+ *
+ * @param {number} time the time in ms
+ * @param {boolean} [condensed=false] the format of string to show
+ * @return {string} The formatted time
+ */
+function formattedTime(time, condensed = false) {
+	if (!time) {
+		return condensed ? '--:--' : '-- : --'
+	}
+
+	const seconds = Math.floor((time / 1000) % 60)
+	const minutes = Math.floor((time / (1000 * 60)) % 60)
+	const hours = Math.floor((time / (1000 * 60 * 60)) % 24)
+
+	return [
+		hours,
+		minutes.toString().padStart(2, '0'),
+		seconds.toString().padStart(2, '0'),
+	].filter(num => !!num).join(condensed ? ':' : ' : ')
+}
+
+export {
+	formattedTime,
+}

--- a/src/utils/webrtc/SpeakingStatusHandler.js
+++ b/src/utils/webrtc/SpeakingStatusHandler.js
@@ -1,0 +1,129 @@
+/**
+ *
+ * @copyright Copyright (c) 2023 Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @author Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Helper to handle speaking status changes notified by call models.
+ *
+ * The store is updated when local or remote participants change their speaking status.
+ * It is expected that the speaking status of participant will be
+ * modified only when the current conversation is joined and call is started.
+ */
+export default class SpeakingStatusHandler {
+
+	// Constants, properties
+	#store
+	#localMediaModel
+	#callParticipantCollection
+
+	// Methods (bound to have access to 'this')
+	#handleAddParticipantBound
+	#handleRemoveParticipantBound
+	#handleLocalSpeakingBound
+	#handleSpeakingBound
+
+	constructor(store, localMediaModel, callParticipantCollection) {
+		this.#store = store
+		this.#localMediaModel = localMediaModel
+		this.#callParticipantCollection = callParticipantCollection
+
+		this.#handleAddParticipantBound = this.#handleAddParticipant.bind(this)
+		this.#handleRemoveParticipantBound = this.#handleRemoveParticipant.bind(this)
+		this.#handleLocalSpeakingBound = this.#handleLocalSpeaking.bind(this)
+		this.#handleSpeakingBound = this.#handleSpeaking.bind(this)
+
+		this.#localMediaModel.on('change:speaking', this.#handleLocalSpeakingBound)
+		this.#localMediaModel.on('change:stoppedSpeaking', this.#handleLocalSpeakingBound)
+
+		this.#callParticipantCollection.on('add', this.#handleAddParticipantBound)
+		this.#callParticipantCollection.on('remove', this.#handleRemoveParticipantBound)
+	}
+
+	/**
+	 * Destroy a handler, remove all listeners, purge the speaking state from store
+	 */
+	destroy() {
+		this.#localMediaModel.off('change:speaking', this.#handleLocalSpeakingBound)
+		this.#localMediaModel.off('change:stoppedSpeaking', this.#handleLocalSpeakingBound)
+
+		this.#callParticipantCollection.off('add', this.#handleAddParticipantBound)
+		this.#callParticipantCollection.off('remove', this.#handleRemoveParticipantBound)
+
+		this.#callParticipantCollection.callParticipantModels.forEach(callParticipantModel => {
+			callParticipantModel.off('change:speaking', this.#handleSpeakingBound)
+			callParticipantModel.off('change:stoppedSpeaking', this.#handleSpeakingBound)
+		})
+
+		this.#store.dispatch('purgeSpeakingStore', { token: this.#store.getters.getToken() })
+	}
+
+	/**
+	 * Add listeners for speaking status changes on added participants model
+	 *
+	 * @param {object} callParticipantCollection the collection of external participant models
+	 * @param {object} callParticipantModel the added participant model
+	 */
+	#handleAddParticipant(callParticipantCollection, callParticipantModel) {
+		callParticipantModel.on('change:speaking', this.#handleSpeakingBound)
+		callParticipantModel.on('change:stoppedSpeaking', this.#handleSpeakingBound)
+	}
+
+	/**
+	 * Remove listeners for speaking status changes on removed participants model
+	 *
+	 * @param {object} callParticipantCollection the collection of external participant models
+	 * @param {object} callParticipantModel the removed participant model
+	 */
+	#handleRemoveParticipant(callParticipantCollection, callParticipantModel) {
+		callParticipantModel.off('change:speaking', this.#handleSpeakingBound)
+		callParticipantModel.off('change:stoppedSpeaking', this.#handleSpeakingBound)
+	}
+
+	/**
+	 * Dispatch speaking status of local participant to the store
+	 *
+	 * @param {object} localMediaModel the local media model
+	 * @param {boolean} speaking whether the participant is speaking or not
+	 */
+	#handleLocalSpeaking(localMediaModel, speaking) {
+		this.#store.dispatch('setSpeaking', {
+			token: this.#store.getters.getToken(),
+			sessionId: this.#store.getters.getSessionId(),
+			speaking,
+		})
+	}
+
+	/**
+	 * Dispatch speaking status of participant to the store
+	 *
+	 * @param {object} callParticipantModel the participant model
+	 * @param {boolean} speaking whether the participant is speaking or not
+	 */
+	#handleSpeaking(callParticipantModel, speaking) {
+		this.#store.dispatch('setSpeaking', {
+			token: this.#store.getters.getToken(),
+			sessionId: callParticipantModel.attributes.nextcloudSessionId,
+			speaking,
+		})
+	}
+
+}

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -37,6 +37,7 @@ import LocalMediaModel from './models/LocalMediaModel.js'
 import SentVideoQualityThrottler from './SentVideoQualityThrottler.js'
 import './shims/MediaStream.js'
 import './shims/MediaStreamTrack.js'
+import SpeakingStatusHandler from './SpeakingStatusHandler.js'
 import initWebRtc from './webrtc.js'
 
 let webRtc = null
@@ -46,6 +47,7 @@ const localMediaModel = new LocalMediaModel()
 const mediaDevicesManager = new MediaDevicesManager()
 let callAnalyzer = null
 let sentVideoQualityThrottler = null
+let speakingStatusHandler = null
 
 // This does not really belongs here, as it is unrelated to WebRTC, but it is
 // included here for the time being until signaling and WebRTC are split.
@@ -213,6 +215,7 @@ async function signalingJoinCall(token, flags, silent) {
 		setupWebRtc()
 
 		sentVideoQualityThrottler = new SentVideoQualityThrottler(localMediaModel, callParticipantCollection, webRtc.webrtc._videoTrackConstrainer)
+		speakingStatusHandler = new SpeakingStatusHandler(store, localMediaModel, callParticipantCollection)
 
 		if (signaling.hasFeature('mcu')) {
 			callAnalyzer = new CallAnalyzer(localMediaModel, localCallParticipantModel, callParticipantCollection)
@@ -415,6 +418,9 @@ async function signalingJoinCallForRecording(token, settings, internalClientAuth
 async function signalingLeaveCall(token, all = false) {
 	sentVideoQualityThrottler.destroy()
 	sentVideoQualityThrottler = null
+
+	speakingStatusHandler.destroy()
+	speakingStatusHandler = null
 
 	callAnalyzer.destroy()
 	callAnalyzer = null

--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -63,15 +63,18 @@ function LocalMedia(opts) {
 
 	this._blackVideoEnforcer = new BlackVideoEnforcer()
 
+	this._speaking = undefined
 	this._speakingMonitor = new SpeakingMonitor()
 	this._speakingMonitor.on('speaking', () => {
 		this.emit('speaking')
+		this._speaking = true
 	})
 	this._speakingMonitor.on('speakingWhileMuted', () => {
 		this.emit('speakingWhileMuted')
 	})
 	this._speakingMonitor.on('stoppedSpeaking', () => {
 		this.emit('stoppedSpeaking')
+		this._speaking = false
 	})
 	this._speakingMonitor.on('stoppedSpeakingWhileMuted', () => {
 		this.emit('stoppedSpeakingWhileMuted')
@@ -414,6 +417,10 @@ LocalMedia.prototype._setAudioEnabled = function(bool) {
 }
 LocalMedia.prototype._setVideoEnabled = function(bool) {
 	this._videoTrackEnabler.setEnabled(bool)
+}
+
+LocalMedia.prototype.isSpeaking = function() {
+	return this._speaking
 }
 
 // check if all audio streams are enabled

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -211,6 +211,12 @@ function sendCurrentMediaState() {
 		webrtc.webrtc.emit('audioOff')
 	} else {
 		webrtc.webrtc.emit('audioOn')
+
+		if (!webrtc.webrtc.isSpeaking()) {
+			webrtc.webrtc.emit('stoppedSpeaking')
+		} else {
+			webrtc.webrtc.emit('speaking')
+		}
 	}
 }
 
@@ -1601,7 +1607,7 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 				const name = typeof (data.payload) === 'string' ? data.payload : data.payload.name
 				webrtc.emit('nick', { id: peer.id, name })
 			} else if (data.type === 'speaking' || data.type === 'stoppedSpeaking') {
-				// Valid known messages, but handled elsewhere
+				// Valid known messages, handled by CallParticipantModel.js
 			} else {
 				console.debug('Unknown message type %s from %s datachannel', data.type, label, data, peer.id, peer)
 			}
@@ -1633,10 +1639,10 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 		}
 	})
 
+	// Send the speaking status events via data channel
 	webrtc.on('speaking', function() {
 		sendDataChannelToAll('status', 'speaking')
 	})
-
 	webrtc.on('stoppedSpeaking', function() {
 		sendDataChannelToAll('status', 'stoppedSpeaking')
 	})


### PR DESCRIPTION
### ☑️ Resolves

* Close #9903 
* Known issues:
  * Signaling server doesn't notify for leaving participants - they're still could 'speaking' for 5 seconds
* Follow-ups:
  * Share speaking time information between models on connection
  * Test on force reconections https://github.com/nextcloud/spreed/pull/10068#pullrequestreview-1565565757

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/13077cb2-291d-42d2-8a15-64d39031ec51)| ![image](https://github.com/nextcloud/spreed/assets/93392545/fe6c694f-4a04-46d7-89ff-4f17216c09b8)
For currently speaking: | ![image](https://github.com/nextcloud/spreed/assets/93392545/82cf2ceb-f38f-4f6b-be47-ac7d6de879da)

### 🚧 Tasks

- [ ] Code review
- [ ] Design review
  - [ ] Additional highlight for currently speaking partcipants (apart from different text and bold font-weight)?
- [ ] Test fix

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
