### PR TITLE
fix: Stop using Symfony event dispatcher directly

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -134,12 +134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "13aca78b1a060e2e2274e660b6954597e13a7035"
+                "reference": "7840fe73084751b843b69d263b4ba70e59c63750"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/13aca78b1a060e2e2274e660b6954597e13a7035",
-                "reference": "13aca78b1a060e2e2274e660b6954597e13a7035",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/7840fe73084751b843b69d263b4ba70e59c63750",
+                "reference": "7840fe73084751b843b69d263b4ba70e59c63750",
                 "shasum": ""
             },
             "require": {
@@ -171,7 +171,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2023-07-29T00:34:58+00:00"
+            "time": "2023-08-04T12:45:05+00:00"
         },
         {
             "name": "psr/clock",

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -206,7 +206,7 @@ class Application extends App implements IBootstrap {
 		/** @var IProviderManager $resourceManager */
 		$resourceManager = $server->get(IProviderManager::class);
 		$resourceManager->registerResourceProvider(ConversationProvider::class);
-		$server->getEventDispatcher()->addListener(LoadAdditionalScriptsEvent::class, static function () {
+		$server->get(IEventDispatcher::class)->addListener(LoadAdditionalScriptsEvent::class, static function () {
 			Util::addScript(self::APP_ID, 'talk-collections');
 		});
 	}

--- a/lib/Share/Listener.php
+++ b/lib/Share/Listener.php
@@ -27,20 +27,20 @@ use OC\Files\Filesystem;
 use OCA\Talk\Config;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Server;
+use OCP\Share\Events\BeforeShareCreatedEvent;
 use OCP\Share\Events\VerifyMountPointEvent;
 use OCP\Share\IShare;
-use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Listener {
 	public static function register(IEventDispatcher $dispatcher): void {
 		/**
 		 * @psalm-suppress UndefinedClass
 		 */
-		$dispatcher->addListener('OCP\Share::preShare', [self::class, 'listenPreShare'], 1000);
+		$dispatcher->addListener(BeforeShareCreatedEvent::class, [self::class, 'listenPreShare'], 1000);
 		$dispatcher->addListener(VerifyMountPointEvent::class, [self::class, 'listenVerifyMountPointEvent'], 1000);
 	}
 
-	public static function listenPreShare(GenericEvent $event): void {
+	public static function listenPreShare(BeforeShareCreatedEvent $event): void {
 		$listener = Server::get(self::class);
 		$listener->overwriteShareTarget($event);
 	}
@@ -55,9 +55,8 @@ class Listener {
 	) {
 	}
 
-	public function overwriteShareTarget(GenericEvent $event): void {
-		/** @var IShare $share */
-		$share = $event->getSubject();
+	public function overwriteShareTarget(BeforeShareCreatedEvent $event): void {
+		$share = $event->getShare();
 
 		if ($share->getShareType() !== IShare::TYPE_ROOM
 			&& $share->getShareType() !== RoomShareProvider::SHARE_TYPE_USERROOM) {

--- a/psalm.xml
+++ b/psalm.xml
@@ -61,7 +61,6 @@
 				<referencedClass name="OCA\Circles\Model\Member" />
 				<referencedClass name="OCA\DAV\CardDAV\PhotoCache" />
 				<referencedClass name="OCA\FederatedFileSharing\AddressHandler" />
-				<referencedClass name="Symfony\Component\EventDispatcher\EventDispatcherInterface" />
 			</errorLevel>
 		</UndefinedDocblockClass>
 		<UndefinedInterfaceMethod>
@@ -87,6 +86,5 @@
 		<file name="tests/stubs/GuzzleHttp_Exception_ClientException.php" />
 		<file name="tests/stubs/GuzzleHttp_Exception_ConnectException.php" />
 		<file name="tests/stubs/GuzzleHttp_Exception_ServerException.php" />
-		<file name="tests/stubs/Symfony_Component_EventDispatcher_GenericEvent.php" />
 	</stubs>
 </psalm>

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
+<files psalm-version="5.14.1@b9d355e0829c397b9b3b47d0c0ed042a8a70284d">
   <file src="lib/AppInfo/Application.php">
     <UndefinedClass>
       <code>BeforeTemplateRenderedEvent</code>
@@ -236,9 +236,6 @@
     </UndefinedClass>
   </file>
   <file src="lib/Share/Listener.php">
-    <InvalidArgument>
-      <code><![CDATA[[self::class, 'listenPreShare']]]></code>
-    </InvalidArgument>
     <UndefinedClass>
       <code><![CDATA[$event->getView()]]></code>
       <code><![CDATA[$event->getView()]]></code>

--- a/tests/stubs/Symfony_Component_EventDispatcher_GenericEvent.php
+++ b/tests/stubs/Symfony_Component_EventDispatcher_GenericEvent.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Symfony\Component\EventDispatcher;
-
-class GenericEvent {
-	public function getSubject() {
-	}
-}


### PR DESCRIPTION
### ☑️ Resolves

* Ref https://github.com/nextcloud/server/pull/38546
* Missing app icon in top bar
* System messages are broken

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Bildschirmfoto vom 2023-08-04 14-42-07](https://github.com/nextcloud/spreed/assets/213943/905e6dd0-c63a-4458-93cb-5f8567f1d30c) | ![Bildschirmfoto vom 2023-08-04 14-41-49](https://github.com/nextcloud/spreed/assets/213943/5dd794eb-0994-4781-87fd-b32fde683bd9)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
