### PR TITLE
feat(MessagesList) - history mode for old messages

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -27,6 +27,7 @@ export const SIGNALING = {
 export const CHAT = {
 	FETCH_LIMIT: 100,
 	MINIMUM_VISIBLE: 5,
+	HISTORY_LIMIT: 24 * 60 * 60, // 24 hours in seconds
 }
 
 export const CALL = {

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -167,7 +167,7 @@ const getters = {
 		return []
 	},
 	message: (state) => (token, id) => {
-		if (state.messages[token][id]) {
+		if (state.messages[token]?.[id]) {
 			return state.messages[token][id]
 		}
 		return {}
@@ -410,8 +410,8 @@ const mutations = {
 		}
 	},
 
-	loadedMessagesOfConversation(state, { token }) {
-		Vue.set(state.loadedMessages, token, true)
+	setLoadedMessagesOfConversation(state, { token, value }) {
+		Vue.set(state.loadedMessages, token, value)
 	},
 
 	// Decreases reaction count for a particular reaction on a message
@@ -700,6 +700,7 @@ const actions = {
 	 */
 	deleteMessages(context, token) {
 		context.commit('deleteMessages', token)
+		context.commit('setLoadedMessagesOfConversation', { token, value: false })
 	},
 
 	/**
@@ -828,7 +829,7 @@ const actions = {
 			})
 		}
 
-		context.commit('loadedMessagesOfConversation', { token })
+		context.commit('setLoadedMessagesOfConversation', { token, value: true })
 
 		if (minimumVisible > 0) {
 			// There are not yet enough visible messages loaded, so fetch another chunk.
@@ -916,7 +917,7 @@ const actions = {
 			})
 		}
 
-		context.commit('loadedMessagesOfConversation', { token })
+		context.commit('setLoadedMessagesOfConversation', { token, value: true })
 
 		if (minimumVisible > 0) {
 			// There are not yet enough visible messages loaded, so fetch another chunk.
@@ -1079,7 +1080,7 @@ const actions = {
 			}
 		}
 
-		context.commit('loadedMessagesOfConversation', { token })
+		context.commit('setLoadedMessagesOfConversation', { token, value: true })
 
 		return response
 	},

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -150,6 +150,30 @@ const getters = {
 		return getters.getLastKnownMessageId(token) < conversation.lastMessage.id
 	},
 
+	/**
+	 * Returns whether the conversation is in 'history' mode, which means that the current
+	 * message list contain message context which is older than <10 MINUTES>.
+	 * If true, the call to "lookForNewMessages" will be blocked.
+	 * TODO consider other parameters (timestamp, id difference, message distance)
+	 *
+	 * @param {object} state the state object.
+	 * @param {object} getters the getters object.
+	 * @return {boolean} true if context is old enough, false otherwise
+	 */
+	isConversationInHistoryMode: (state, getters) => (token) => {
+		const conversation = getters.conversation(token)
+		if (!conversation) {
+			return false
+		}
+
+		const lastKnownMessage = getters.message(token, getters.getLastKnownMessageId(token))
+		if (!lastKnownMessage) {
+			return false
+		}
+
+		return conversation.lastMessage.timestamp - lastKnownMessage.timestamp > CHAT.HISTORY_LIMIT
+	},
+
 	isMessageListPopulated: (state) => (token) => {
 		return !!state.loadedMessages[token]
 	},


### PR DESCRIPTION
### ☑️ Resolves

* Attempt to close #6046
* Introduce a history mode for old messages:
  * opened via direct link
  * opened via unified search
* after context is loaded, additional parameter is checking, whether context message is old enough to not load new messages after it, and disable polling for new messages
* Old messages are not longer freezing a browser tab

### 🖼️ Screenshots

https://github.com/nextcloud/spreed/assets/93392545/889c7230-b283-41a1-a861-9632bec8fb82


### 🚧 Tasks

- [ ] Known issues:
  - [ ] Normal mode loads context around lastReadMessage - if it exists out of `HISTORY_LIMIT` scheduled time, it is also counted as history mode
  - [ ] Switching between modes purges the messages list, whatever is fetched there
- [ ] Suggestion (current or follow-up):
  - [ ] Don't purge current messages list, instead introduce a new state param `historyMessages` to store them separately
  - [ ] Also don't disable polling for chat, if was previously loaded in normal mode => instead store them for a moment 
- [ ] Manual testing
- [ ] Design review
- [ ] Code review

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
