### PR TITLE
feat(CallTime)- add one hour hint during the call

### DIFF
--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -1037,12 +1037,20 @@ const actions = {
 						token,
 						hasCall: true,
 					})
+					context.dispatch('setConversationProperties', {
+						token: message.token,
+						properties: { callStartTime: message.timestamp },
+					})
 				} else if (message.systemMessage === 'call_ended'
 					|| message.systemMessage === 'call_ended_everyone'
 					|| message.systemMessage === 'call_missed') {
 					context.dispatch('overwriteHasCallByChat', {
 						token,
 						hasCall: false,
+					})
+					context.dispatch('setConversationProperties', {
+						token: message.token,
+						properties: { callStartTime: 0 },
 					})
 				}
 			}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9947 

### Description

The Hint text 
[ [design](https://github.com/nextcloud/spreed/issues/6212#issuecomment-1623340533)]
> Note the call is running since 1 hour already. 

* The Hint gets shown at 1:00:00, and the popover stays open for 10s if the user didn't trigger outside focus.
* After that, The Hint remains in the popover and it is accessed by clicking on the call time.

* If the User is a moderator, the hint is added to the recording buttons popover.


### 🖼️ Screenshots

This is a recording for a hint faked at 2:20 :

https://github.com/nextcloud/spreed/assets/84044328/8ee08983-3f84-4d30-96b5-9035907d8c0f

The moderator's popover ( e.g in case the recording is starting)

![image](https://github.com/nextcloud/spreed/assets/84044328/6b02a952-9a4b-42de-91d9-14438495dc0a)



### 🚧 Tasks

- [ ] To test : 
If you don't want to wait for one hour, change this line and you can only wait for 20 sec and it can be repeated with 1 min interval.
```
      this.untilOneHourHint = (1000 * 20) - this.timer + 1
```
- [ ] code review
- [ ] Visual review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
