### PR TITLE
feat(Message) - 🔔 add frontend support for message reminders

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
@@ -77,6 +77,7 @@ describe('Message.vue', () => {
 				bottom: 0,
 				left: 0,
 			},
+			getMessagesListScroller: jest.fn(),
 		}
 
 		testStoreConfig = cloneDeep(storeConfig)

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
@@ -18,6 +18,7 @@ describe('MessageButtonsBar.vue', () => {
 	let testStoreConfig
 	let store
 	let messageProps
+	let injected
 	let conversationProps
 	let getActorTypeMock
 
@@ -87,6 +88,20 @@ describe('MessageButtonsBar.vue', () => {
 
 		beforeEach(() => {
 			store = new Store(testStoreConfig)
+
+			injected = {
+				scrollerBoundingClientRect: {
+					x: 0,
+					y: 0,
+					width: 0,
+					height: 0,
+					top: 0,
+					right: 0,
+					bottom: 0,
+					left: 0,
+				},
+				getMessagesListScroller: jest.fn(),
+			}
 		})
 
 		describe('reply action', () => {
@@ -103,6 +118,7 @@ describe('MessageButtonsBar.vue', () => {
 						NcButton,
 					},
 					propsData: messageProps,
+					provide: injected,
 				})
 
 				const replyButton = findNcButton(wrapper, 'Reply')
@@ -137,6 +153,7 @@ describe('MessageButtonsBar.vue', () => {
 						NcButton,
 					},
 					propsData: messageProps,
+					provide: injected,
 				})
 
 				const replyButton = findNcButton(wrapper, 'Reply')
@@ -165,6 +182,7 @@ describe('MessageButtonsBar.vue', () => {
 						NcActionButton,
 					},
 					propsData: messageProps,
+					provide: injected,
 				})
 
 				const actionButton = findNcActionButton(wrapper, 'Reply privately')
@@ -199,6 +217,7 @@ describe('MessageButtonsBar.vue', () => {
 						NcActionButton,
 					},
 					propsData: messageProps,
+					provide: injected,
 				})
 
 				const actionButton = findNcActionButton(wrapper, 'Reply privately')
@@ -243,6 +262,7 @@ describe('MessageButtonsBar.vue', () => {
 						NcActionButton,
 					},
 					propsData: messageProps,
+					provide: injected,
 				})
 
 				const actionButton = findNcActionButton(wrapper, 'Delete')
@@ -278,6 +298,7 @@ describe('MessageButtonsBar.vue', () => {
 						NcActionButton,
 					},
 					propsData: messageProps,
+					provide: injected,
 				})
 
 				const actionButton = findNcActionButton(wrapper, 'Delete')
@@ -356,6 +377,7 @@ describe('MessageButtonsBar.vue', () => {
 				},
 
 				propsData: messageProps,
+				provide: injected,
 			})
 
 			const actionButton = findNcActionButton(wrapper, 'Mark as unread')
@@ -397,6 +419,7 @@ describe('MessageButtonsBar.vue', () => {
 				},
 
 				propsData: messageProps,
+				provide: injected,
 			})
 
 			Object.assign(navigator, {
@@ -435,6 +458,7 @@ describe('MessageButtonsBar.vue', () => {
 					NcActionButton,
 				},
 				propsData: messageProps,
+				provide: injected,
 			})
 
 			const actionButton = findNcActionButton(wrapper, 'first action')

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -77,16 +77,16 @@
 					<NcActionSeparator />
 					<NcActionButton v-if="isPrivateReplyable"
 						icon="icon-user"
-						:close-after-click="true"
+						close-after-click
 						@click.stop="handlePrivateReply">
 						{{ t('spreed', 'Reply privately') }}
 					</NcActionButton>
 					<NcActionButton icon="icon-external"
-						:close-after-click="true"
+						close-after-click
 						@click.stop="handleCopyMessageLink">
 						{{ t('spreed', 'Copy message link') }}
 					</NcActionButton>
-					<NcActionButton :close-after-click="true"
+					<NcActionButton close-after-click
 						@click.stop="handleMarkAsUnread">
 						<template #icon>
 							<EyeOffOutline :size="16" />
@@ -101,7 +101,7 @@
 						{{ t('spreed', 'Go to file') }}
 					</NcActionLink>
 					<NcActionButton v-if="canForwardMessage"
-						:close-after-click="true"
+						close-after-click
 						@click.stop="openForwarder">
 						<template #icon>
 							<Share :size="16" />
@@ -112,12 +112,12 @@
 					<NcActionButton v-for="action in messageActions"
 						:key="action.label"
 						:icon="action.icon"
-						:close-after-click="true"
+						close-after-click
 						@click="action.callback(messageApiData)">
 						{{ action.label }}
 					</NcActionButton>
 					<NcActionButton v-if="isTranslationAvailable"
-						:close-after-click="true"
+						close-after-click
 						@click.stop="$emit('show-translate-dialog', true)"
 						@close="$emit('show-translate-dialog', false)">
 						<template #icon>
@@ -128,7 +128,7 @@
 					<template v-if="isDeleteable">
 						<NcActionSeparator />
 						<NcActionButton icon="icon-delete"
-							:close-after-click="true"
+							close-after-click
 							@click.stop="handleDelete">
 							{{ t('spreed', 'Delete') }}
 						</NcActionButton>

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -42,9 +42,9 @@
 				</template>
 			</NcButton>
 			<NcActions :force-menu="true"
-				:container="`#message_${id}`"
 				placement="bottom-end"
-				:boundaries-element="containerElement"
+				:container="messageContainer"
+				:boundaries-element="boundariesElement"
 				@open="onMenuOpen"
 				@close="onMenuClose">
 				<NcActionButton>
@@ -143,8 +143,8 @@
 				</template>
 			</NcButton>
 
-			<NcEmojiPicker :container="`#message_${id} .message-buttons-bar`"
-				:boundary="containerElement"
+			<NcEmojiPicker :container="`${messageContainer} .message-buttons-bar`"
+				:boundary="boundariesElement"
 				placement="auto"
 				@select="handleReactionClick"
 				@after-show="onEmojiPickerOpen"
@@ -222,6 +222,8 @@ export default {
 		Share,
 		Translate,
 	},
+
+	inject: ['getMessagesListScroller'],
 
 	props: {
 		token: {
@@ -384,8 +386,12 @@ export default {
 			return this.$store.getters.conversation(this.token)
 		},
 
-		containerElement() {
-			return document.querySelector('.messages-list__scroller')
+		messageContainer() {
+			return `#message_${this.id}`
+		},
+
+		boundariesElement() {
+			return this.getMessagesListScroller()
 		},
 
 		isDeleteable() {

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -47,79 +47,132 @@
 				:boundaries-element="boundariesElement"
 				@open="onMenuOpen"
 				@close="onMenuClose">
-				<NcActionButton>
-					<template #icon>
-						<span v-if="showCommonReadIcon"
-							:title="commonReadIconTooltip"
-							:aria-label="commonReadIconTooltip">
-							<CheckAll :size="16" />
-						</span>
-						<span v-else-if="showSentIcon"
-							:title="sentIconTooltip"
-							:aria-label="sentIconTooltip">
-							<Check :size="16" />
-						</span>
-						<ClockOutline v-else :size="16" />
-					</template>
-					{{ messageDateTime }}
-				</NcActionButton>
-				<NcActionSeparator />
-				<NcActionButton v-if="isPrivateReplyable"
-					icon="icon-user"
-					:close-after-click="true"
-					@click.stop="handlePrivateReply">
-					{{ t('spreed', 'Reply privately') }}
-				</NcActionButton>
-				<NcActionButton icon="icon-external"
-					:close-after-click="true"
-					@click.stop="handleCopyMessageLink">
-					{{ t('spreed', 'Copy message link') }}
-				</NcActionButton>
-				<NcActionButton :close-after-click="true"
-					@click.stop="handleMarkAsUnread">
-					<template #icon>
-						<EyeOffOutline :size="16" />
-					</template>
-					{{ t('spreed', 'Mark as unread') }}
-				</NcActionButton>
-				<NcActionLink v-if="linkToFile"
-					:href="linkToFile">
-					<template #icon>
-						<File :size="20" />
-					</template>
-					{{ t('spreed', 'Go to file') }}
-				</NcActionLink>
-				<NcActionButton v-if="canForwardMessage"
-					:close-after-click="true"
-					@click.stop="openForwarder">
-					<template #icon>
-						<Share :size="16" />
-					</template>
-					{{ t('spreed', 'Forward message') }}
-				</NcActionButton>
-				<NcActionSeparator v-if="messageActions.length > 0" />
-				<NcActionButton v-for="action in messageActions"
-					:key="action.label"
-					:icon="action.icon"
-					:close-after-click="true"
-					@click="action.callback(messageApiData)">
-					{{ action.label }}
-				</NcActionButton>
-				<NcActionButton v-if="isTranslationAvailable"
-					:close-after-click="true"
-					@click.stop="$emit('show-translate-dialog', true)"
-					@close="$emit('show-translate-dialog', false)">
-					<template #icon>
-						<Translate :size="16" />
-					</template>
-					{{ t('spreed', 'Translate') }}
-				</NcActionButton>
-				<template v-if="isDeleteable">
+				<template v-if="submenu === null">
+					<NcActionButton>
+						<template #icon>
+							<span v-if="showCommonReadIcon"
+								:title="commonReadIconTooltip"
+								:aria-label="commonReadIconTooltip">
+								<CheckAll :size="16" />
+							</span>
+							<span v-else-if="showSentIcon"
+								:title="sentIconTooltip"
+								:aria-label="sentIconTooltip">
+								<Check :size="16" />
+							</span>
+							<ClockOutline v-else :size="16" />
+						</template>
+						{{ messageDateTime }}
+					</NcActionButton>
+
+					<NcActionButton class="action--nested"
+						@click.stop="submenu = 'reminder'">
+						<template #icon>
+							<AlarmIcon :size="20" />
+						</template>
+						{{ t('spreed', 'Set reminder') }}
+					</NcActionButton>
+
 					<NcActionSeparator />
-					<NcActionButton icon="icon-delete"
+					<NcActionButton v-if="isPrivateReplyable"
+						icon="icon-user"
 						:close-after-click="true"
-						@click.stop="handleDelete">
-						{{ t('spreed', 'Delete') }}
+						@click.stop="handlePrivateReply">
+						{{ t('spreed', 'Reply privately') }}
+					</NcActionButton>
+					<NcActionButton icon="icon-external"
+						:close-after-click="true"
+						@click.stop="handleCopyMessageLink">
+						{{ t('spreed', 'Copy message link') }}
+					</NcActionButton>
+					<NcActionButton :close-after-click="true"
+						@click.stop="handleMarkAsUnread">
+						<template #icon>
+							<EyeOffOutline :size="16" />
+						</template>
+						{{ t('spreed', 'Mark as unread') }}
+					</NcActionButton>
+					<NcActionLink v-if="linkToFile"
+						:href="linkToFile">
+						<template #icon>
+							<File :size="20" />
+						</template>
+						{{ t('spreed', 'Go to file') }}
+					</NcActionLink>
+					<NcActionButton v-if="canForwardMessage"
+						:close-after-click="true"
+						@click.stop="openForwarder">
+						<template #icon>
+							<Share :size="16" />
+						</template>
+						{{ t('spreed', 'Forward message') }}
+					</NcActionButton>
+					<NcActionSeparator v-if="messageActions.length > 0" />
+					<NcActionButton v-for="action in messageActions"
+						:key="action.label"
+						:icon="action.icon"
+						:close-after-click="true"
+						@click="action.callback(messageApiData)">
+						{{ action.label }}
+					</NcActionButton>
+					<NcActionButton v-if="isTranslationAvailable"
+						:close-after-click="true"
+						@click.stop="$emit('show-translate-dialog', true)"
+						@close="$emit('show-translate-dialog', false)">
+						<template #icon>
+							<Translate :size="16" />
+						</template>
+						{{ t('spreed', 'Translate') }}
+					</NcActionButton>
+					<template v-if="isDeleteable">
+						<NcActionSeparator />
+						<NcActionButton icon="icon-delete"
+							:close-after-click="true"
+							@click.stop="handleDelete">
+							{{ t('spreed', 'Delete') }}
+						</NcActionButton>
+					</template>
+				</template>
+
+				<template v-else-if="submenu === 'reminder'">
+					<NcActionButton :aria-label="t('spreed', 'Back')"
+						@click.stop="submenu = null">
+						<template #icon>
+							<ArrowLeft />
+						</template>
+						{{ t('spreed', 'Back') }}
+					</NcActionButton>
+
+					<NcActionSeparator />
+
+					<NcActionButton v-for="option in reminderOptions"
+						:key="option.key"
+						:aria-label="option.ariaLabel"
+						close-after-click
+						@click.stop="setReminder(option.timestamp)">
+						{{ option.label }}
+					</NcActionButton>
+
+					<!-- Custom DateTime picker for the reminder -->
+					<NcActionSeparator />
+
+					<NcActionInput type="datetime-local"
+						is-native-picker
+						:value="customReminderDateTime"
+						:min="new Date()"
+						@change="setCustomReminderDateTime">
+						<template #icon>
+							<CalendarClock :size="20" />
+						</template>
+					</NcActionInput>
+
+					<NcActionButton :aria-label="t('spreed', 'Set custom reminder')"
+						close-after-click
+						@click.stop="setCustomReminder(customReminderDateTime)">
+						<template #icon>
+							<Check :size="20" />
+						</template>
+						{{ t('spreed', 'Set custom reminder') }}
 					</NcActionButton>
 				</template>
 			</NcActions>
@@ -167,7 +220,9 @@
 import { frequently, EmojiIndex as EmojiIndexFactory } from 'emoji-mart-vue-fast'
 import data from 'emoji-mart-vue-fast/data/all.json'
 
+import AlarmIcon from 'vue-material-design-icons/Alarm.vue'
 import ArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
+import CalendarClock from 'vue-material-design-icons/CalendarClock.vue'
 import Check from 'vue-material-design-icons/Check.vue'
 import CheckAll from 'vue-material-design-icons/CheckAll.vue'
 import ClockOutline from 'vue-material-design-icons/ClockOutline.vue'
@@ -179,9 +234,11 @@ import Reply from 'vue-material-design-icons/Reply.vue'
 import Share from 'vue-material-design-icons/Share.vue'
 import Translate from 'vue-material-design-icons/Translate.vue'
 
+import { showError, showSuccess } from '@nextcloud/dialogs'
 import moment from '@nextcloud/moment'
 
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
+import NcActionInput from '@nextcloud/vue/dist/Components/NcActionInput.js'
 import NcActionLink from '@nextcloud/vue/dist/Components/NcActionLink.js'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcActionSeparator from '@nextcloud/vue/dist/Components/NcActionSeparator.js'
@@ -192,6 +249,7 @@ import Forwarder from './Forwarder.vue'
 
 import { PARTICIPANT, CONVERSATION, ATTENDEE } from '../../../../../constants.js'
 import { EventBus } from '../../../../../services/EventBus.js'
+import { setMessageReminder } from '../../../../../services/remindersService.js'
 import { copyConversationLinkToClipboard } from '../../../../../services/urlService.js'
 
 // Keep version in sync with @nextcloud/vue in case of issues
@@ -204,13 +262,16 @@ export default {
 	components: {
 		Forwarder,
 		NcActionButton,
+		NcActionInput,
 		NcActionLink,
 		NcActionSeparator,
 		NcActions,
 		NcButton,
 		NcEmojiPicker,
 		// Icons
+		AlarmIcon,
 		ArrowLeft,
+		CalendarClock,
 		Check,
 		CheckAll,
 		ClockOutline,
@@ -378,6 +439,8 @@ export default {
 	data() {
 		return {
 			frequentlyUsedEmojis: [],
+			submenu: null,
+			customReminderDateTime: new Date(moment().add(2, 'hours').minute(0).second(0).valueOf()),
 		}
 	},
 
@@ -465,6 +528,53 @@ export default {
 
 		messageDateTime() {
 			return moment(this.timestamp * 1000).format('lll')
+		},
+
+		reminderOptions() {
+			const currentDateTime = moment()
+
+			// Same day 18:00 PM (or hidden)
+			const laterTodayTime = (currentDateTime.hour() < 18)
+				? moment().hour(18)
+				: null
+
+			// Tomorrow 08:00 AM
+			const tomorrowTime = moment().add(1, 'days').hour(8)
+
+			// Saturday 08:00 AM (or hidden)
+			const thisWeekendTime = (currentDateTime.day() !== 6 && currentDateTime.day() !== 0)
+				? moment().day(6).hour(8)
+				: null
+
+			// Next Monday 08:00 AM
+			const nextWeekTime = moment().add(1, 'weeks').day(1).hour(8)
+
+			return [
+				{
+					key: 'laterToday',
+					timestamp: this.getTimestamp(laterTodayTime),
+					label: t('spreed', 'Later today – {timeLocale}', { timeLocale: laterTodayTime?.format('LT') }),
+					ariaLabel: t('spreed', 'Set reminder for later today'),
+				},
+				{
+					key: 'tomorrow',
+					timestamp: this.getTimestamp(tomorrowTime),
+					label: t('spreed', 'Tomorrow – {timeLocale}', { timeLocale: tomorrowTime?.format('ddd LT') }),
+					ariaLabel: t('spreed', 'Set reminder for tomorrow'),
+				},
+				{
+					key: 'thisWeekend',
+					timestamp: this.getTimestamp(thisWeekendTime),
+					label: t('spreed', 'This weekend – {timeLocale}', { timeLocale: thisWeekendTime?.format('ddd LT') }),
+					ariaLabel: t('spreed', 'Set reminder for this weekend'),
+				},
+				{
+					key: 'nextWeek',
+					timestamp: this.getTimestamp(nextWeekTime),
+					label: t('spreed', 'Next week – {timeLocale}', { timeLocale: nextWeekTime?.format('ddd LT') }),
+					ariaLabel: t('spreed', 'Set reminder for next week'),
+				},
+			].filter(option => option.timestamp !== null)
 		},
 	},
 
@@ -580,6 +690,42 @@ export default {
 				return EmojiIndex.emoji(emojiStrings).native
 			})
 		},
+
+		getTimestamp(momentObject) {
+			return momentObject?.minute(0).second(0).millisecond(0).valueOf() || null
+		},
+
+		async setReminder(timestamp) {
+			try {
+				await setMessageReminder(this.token, this.id, timestamp / 1000)
+				showSuccess(t('spreed', 'A reminder was successfully set at {datetime}', {
+					datetime: moment(timestamp).format('LLL'),
+				}))
+			} catch (error) {
+				console.error(error)
+				showError(t('spreed', 'Error occurred when creating a reminder'))
+			}
+		},
+
+		setCustomReminderDateTime(event) {
+			this.customReminderDateTime = new Date(event.target.value)
+		},
+
+		setCustomReminder() {
+			this.setReminder(this.customReminderDateTime.valueOf())
+		},
 	},
 }
 </script>
+
+<style lang="scss" scoped>
+.action--nested {
+	:deep(.action-button::after) {
+		content: " ";
+		width: 20px;
+		height: 44px;
+		margin-left: auto;
+		background: no-repeat center var(--icon-triangle-e-dark);
+	}
+}
+</style>

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -65,7 +65,8 @@
 						{{ messageDateTime }}
 					</NcActionButton>
 
-					<NcActionButton class="action--nested"
+					<NcActionButton v-if="supportReminders"
+						class="action--nested"
 						@click.stop="submenu = 'reminder'">
 						<template #icon>
 							<AlarmIcon :size="20" />
@@ -134,7 +135,7 @@
 					</template>
 				</template>
 
-				<template v-else-if="submenu === 'reminder'">
+				<template v-else-if="supportReminders && submenu === 'reminder'">
 					<NcActionButton :aria-label="t('spreed', 'Back')"
 						@click.stop="submenu = null">
 						<template #icon>
@@ -234,6 +235,7 @@ import Reply from 'vue-material-design-icons/Reply.vue'
 import Share from 'vue-material-design-icons/Share.vue'
 import Translate from 'vue-material-design-icons/Translate.vue'
 
+import { getCapabilities } from '@nextcloud/capabilities'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import moment from '@nextcloud/moment'
 
@@ -255,6 +257,7 @@ import { copyConversationLinkToClipboard } from '../../../../../services/urlServ
 // Keep version in sync with @nextcloud/vue in case of issues
 
 const EmojiIndex = new EmojiIndexFactory(data)
+const supportReminders = getCapabilities()?.spreed?.features?.includes('remind-me-later')
 
 export default {
 	name: 'MessageButtonsBar',
@@ -435,6 +438,12 @@ export default {
 	},
 
 	emits: ['delete', 'update:isActionMenuOpen', 'update:isEmojiPickerOpen', 'update:isReactionsMenuOpen', 'update:isForwarderOpen', 'show-translate-dialog'],
+
+	setup() {
+		return {
+			supportReminders,
+		}
+	},
 
 	data() {
 		return {

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -93,6 +93,7 @@ export default {
 	provide() {
 		return {
 			scrollerBoundingClientRect: computed(() => this.$refs.scroller.getBoundingClientRect()),
+			getMessagesListScroller: () => this.$refs.scroller,
 		}
 	},
 

--- a/src/services/remindersService.js
+++ b/src/services/remindersService.js
@@ -1,0 +1,73 @@
+/**
+ * @copyright Copyright (c) 2023 Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @author Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+
+/**
+ * Sets the reminder with defined timestamp on the message for the user
+ *
+ * @param {string} token The conversation token
+ * @param {number} messageId The id of selected message
+ * @return {object} The axios response
+ */
+const getMessageReminder = async function(token, messageId) {
+	return axios.get(generateOcsUrl('apps/spreed/api/v1/chat/{token}/{messageId}/reminder', {
+		token,
+		messageId,
+	}))
+}
+
+/**
+ * Sets the reminder with defined timestamp on the message for the user
+ *
+ * @param {string} token The conversation token
+ * @param {number} messageId The id of selected message
+ * @param {number} timestamp The timestamp of reminder (in seconds)
+ * @return {object} The axios response
+ */
+const setMessageReminder = async function(token, messageId, timestamp) {
+	return axios.post(generateOcsUrl('apps/spreed/api/v1/chat/{token}/{messageId}/reminder', {
+		token,
+		messageId,
+	}), { timestamp })
+}
+
+/**
+ * Removes the reminder from the message
+ *
+ * @param {string} token The conversation token
+ * @param {number} messageId The id of selected message
+ * @return {object} The axios response
+ */
+const removeMessageReminder = async function(token, messageId) {
+	return axios.delete(generateOcsUrl('apps/spreed/api/v1/chat/{token}/{messageId}/reminder', {
+		token,
+		messageId,
+	}))
+}
+
+export {
+	getMessageReminder,
+	setMessageReminder,
+	removeMessageReminder,
+}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10076
* Add an item into MessageButtonsBar (with submenu)

### 🖼️ Screenshots
Main menu | Sub menu
--- | ---
![image](https://github.com/nextcloud/spreed/assets/93392545/3ec24910-d1c3-4f56-b7e2-186a99550a55) | ![image](https://github.com/nextcloud/spreed/assets/93392545/afe3cd52-948b-4a04-8b72-1effa30c8d88)

https://github.com/nextcloud/spreed/assets/93392545/b5caa45d-d950-41ad-be25-91e61abec5f7



### 🚧 Tasks

- [ ] Manual testing
- [ ] Design review
- [ ] Code review

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
