### PR TITLE
fix(docs): Fix navigation nesting of the documentation

### DIFF
--- a/docs/TURN.md
+++ b/docs/TURN.md
@@ -1,6 +1,6 @@
 # TURN server configuration
 
-### Background
+## Background
 The configuration of Nextcloud Talk mainly depends on your desired usage:
 
 - As long as it shall be used only **within one local network**, besides the app, nothing else should be required. Just verify that all browsers support the underlying [WebRTC](https://en.wikipedia.org/wiki/WebRTC) protocol - most contemporary browsers do with current versions, though mobile browsers tend to lag behind a little - and you should be good to go. Browser support can be tested for example here: [https://test.webrtc.org/](https://test.webrtc.org/)
@@ -11,7 +11,7 @@ The configuration of Nextcloud Talk mainly depends on your desired usage:
 
 - Nextcloud Talk will try direct P2P in the first place, use STUN if needed and TURN as last resort fallback. Thus, to be most flexible and guarantee functionality of your Nextcloud Talk instance, in all possible connection cases, you would want to set up a TURN server.
 
-#### TURN server and Nextcloud Talk High Performance Backend
+### TURN server and Nextcloud Talk High Performance Backend
 
 A TURN server might be needed even if the Nextcloud Talk High Performance Backend is used and publicly accessible.
 
@@ -19,7 +19,7 @@ The High Performance Backend uses a certain range of ports for WebRTC media conn
 
 For maximum compatibility the TURN server should be configured to listen on port 443. Therefore, when both a TURN server and the High Performance Backend are used each one should run in its own server, or in the same server but each one with its own IP address, as the High Performance Backend will need to bind to port 443 too.
 
-## Install and setup your TURN server
+## Install and set up your TURN server
 
 This documentation provides two examples for TURN server implementations:
 

--- a/docs/coturn.md
+++ b/docs/coturn.md
@@ -4,7 +4,7 @@
 
 It is recommended to install the latest _coTURN_ version; at the very minimum _coTURN_ 4.5.0.8 should be used. In previous versions there is a bug that causes [the IPv6 UDP sockets created by coTURN not to be freed](https://github.com/coturn/coturn/issues/217). Due to this the _turn_ process ends not being able to open new ports and thus not being able to serve new connections. Moreover, when that happens, even if there are no connections a high CPU load will be caused by the _turn_ process. Therefore, if you can not install _coTURN_ 4.5.0.8 or a later version you should restart the _turn_ process periodically to work around that issue.
 
-#### 1. Download and install
+## 1. Download and install
 
 - On **Debian and Ubuntu** there are official repository packages available:
     ```
@@ -14,7 +14,7 @@ It is recommended to install the latest _coTURN_ version; at the very minimum _c
 - For all **other** cases check out the [Downloads in the wiki of coTURN](https://github.com/coturn/coturn/wiki/Downloads)
 
 
-#### 2. Make coturn run as daemon on startup
+## 2. Make coturn run as daemon on startup
 
 - On **Debian and Ubuntu** you just need to enable the deployed sysvinit service by adjusting the related environment variable:
     ```
@@ -34,7 +34,7 @@ It is recommended to install the latest _coTURN_ version; at the very minimum _c
 - `-o` starts the server in daemon mode, `-c` defines the path to the config file.
 - There is also an official example available at [https://github.com/coturn/coturn/blob/master/examples/etc/coturn.service](https://github.com/coturn/coturn/blob/master/examples/etc/coturn.service)
 
-##### Running coTURN on privileged ports
+### Running coTURN on privileged ports
 
 On some GNU/Linux distributions (for example, **Ubuntu Focal and later**) when _coTURN_ is installed from the official package the _coturn_ service is executed as an unprivileged user like _turnserver_. Due to this by default _coTURN_ can not use privileged ports, like port 443.
 
@@ -54,7 +54,7 @@ User=root
 Group=root
 ```
 
-#### 3. Configure `turnserver.conf` for usage with Nextcloud Talk
+## 3. Configure `turnserver.conf` for usage with Nextcloud Talk
 
 - Next you need to adjust the coTURN configuration file to work with Nextcloud Talk.
 - Choose the listening port (default is _3478_) and an authentication secret, where a random hex is recommended
@@ -111,7 +111,7 @@ simple-log
 
 - `sudo systemctl restart coturn` or corresponding restart method
 
-##### Disabling UDP or TCP protocols
+### Disabling UDP or TCP protocols
 
 Unless you have some special need, you should always enable both UDP and TCP protocols in your TURN server, as that provides the maximum compatibility. However, if you must limit the connections from clients to the TURN server through UDP or TCP protocols you can do that by enabling one the following settings, depending on the case:
 ```
@@ -123,7 +123,7 @@ Please note that those settings only limit the protocols from the client to the 
 
 Also keep in mind that disabling the UDP protocol from clients to the TURN server with `no-udp` in practice disables STUN on that server, as neither Janus nor the clients currently support STUN over TCP.
 
-##### TURN server and internal networks
+### TURN server and internal networks
 
 If your TURN server has access to an internal network you should prevent access to the local/internal IPs from the TURN server, except those that are actually needed (like the High Performance Backend if you are using it) by setting the [`denied-peer-ip` and `allowed-peer-ip` parameters](https://github.com/coturn/coturn/blob/upstream/4.5.1.3/README.turnserver#L523-L537). For example:
 ```
@@ -148,6 +148,6 @@ Otherwise, [a malicious user could access services in that internal network thro
 
 Alternatively you could of course prevent access to that internal network from the TURN server by means of a firewall.
 
-##### Continue with the integration into Nextcloud Talk
+## Continue with the integration into Nextcloud Talk
 
 Now you can go back to the [TURN overview page](TURN.md#4-configure-nextcloud-talk-to-use-your-turn-server). 

--- a/docs/eturnal.md
+++ b/docs/eturnal.md
@@ -4,12 +4,12 @@
 
 Quick-Test instructions in a [Linux Shell](https://github.com/processone/eturnal/blob/master/QUICK-TEST.md) or with [Docker](https://github.com/processone/eturnal/blob/master/docker-k8s/QUICK-TEST.md) are available as well.
 
-#### 1. Download and install
+## 1. Download and install
 
 eturnal is available from a variety of sources such as native package managers, binary packages, installation from source or [container image](https://eturnal.net/documentation/code/docker.html). They are all described [here](https://github.com/processone/eturnal#installation).
 
 
-#### 2. Make eturnal run as daemon on startup
+## 2. Make eturnal run as daemon on startup
 
 - On Linux systems, the eturnal server is usually invoked by systemd. 
     ```
@@ -23,7 +23,7 @@ eturnal is available from a variety of sources such as native package managers, 
     eturnalctl help
     ```
 
-##### Running eturnal on privileged ports
+### Running eturnal on privileged ports
 
 On systemd-managed systems, the systemd unit grants `NET_BIND_SERVICE` capability to the [service](https://github.com/processone/eturnal/blob/29e82f260d369a39bd4a395cb981e914b141875b/config/eturnal.service#L23).
 
@@ -32,7 +32,7 @@ Depending on the system configuration Linux kernel capabilities could be used to
 setcap 'cap_net_bind_service=+ep' $(find /opt/eturnal -name beam.smp)
 ```
 
-#### 3. Configure `eturnal.yml` for usage with Nextcloud Talk
+## 3. Configure `eturnal.yml` for usage with Nextcloud Talk
 
 - Next you need to adjust eturnal's configuration file in `/etc/eturnal.yml` to work with Nextcloud Talk. This file uses the (indentation-sensitive!) YAML format. The shipped configuration file contains further explanations.
 - Choose the listening port (default is _3478_) and an authentication secret, where a random hex is recommended
@@ -99,7 +99,7 @@ eturnal:
 
 - `sudo systemctl restart eturnal` or corresponding restart method
 
-##### TURN server and internal networks
+### TURN server and internal networks
 
 If your TURN server has access to an internal network you should prevent access to the local/internal IPs from the TURN server, except those that are actually needed (like the High Performance Backend if you are using it) by setting the `blacklist`, [see also the official documentation](https://eturnal.net/documentation/#blacklist):
 
@@ -142,6 +142,6 @@ Alternatively you could of course prevent access to that internal network from t
 
 Hint: If `eturnalctl` is not part of your `$PATH`, consider either sym-linking it (e.g. ´ln -s /opt/eturnal/bin/eturnalctl /usr/local/bin/eturnalctl´) or call it from the default `eturnal` directory directly: e.g. `/opt/eturnal/bin/eturnalctl info`
 
-##### Continue with the integration into Nextcloud Talk
+## Continue with the integration into Nextcloud Talk
 
 Now you can go back to the [TURN overview page](TURN.md#4-configure-nextcloud-talk-to-use-your-turn-server). 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,10 +21,6 @@ nav:
       - 'User system requirements': 'user-requirements.md'
   - 'Administration documentation':
       - 'Server system requirements': 'system-requirements.md'
-      - 'Configuring a TURN server':
-          - 'Overview': 'TURN.md'
-          - 'coTURN': 'coturn.md'
-          - 'eturnal': 'eturnal.md'
       - 'Scalability': 'scalability.md'
       - 'Call experience': 'call-experience.md'
       - 'Occ commands': 'occ.md'
@@ -49,3 +45,7 @@ nav:
       - 'Webinar management': 'webinar.md'
       - 'Settings': 'settings.md'
       - 'Signaling API': 'internal-signaling.md'
+  - 'Configuring a TURN server':
+      - 'Overview': 'TURN.md'
+      - 'coTURN': 'coturn.md'
+      - 'eturnal': 'eturnal.md'


### PR DESCRIPTION
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
https://nextcloud-talk.readthedocs.io/en/latest/ | https://nextcloud-talk.readthedocs.io/en/bugfix-noid-fix-docs-navigation/
Root page shows "Turn" as selected | Turn is it's own section and the normal "Overview" is opened

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
