### PR TITLE
Fix already shared event

### DIFF
--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -26,6 +26,7 @@ namespace OCA\Talk\Chat\SystemMessage;
 use DateInterval;
 use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Events\AddParticipantsEvent;
+use OCA\Talk\Events\AlreadySharedEvent;
 use OCA\Talk\Events\AttendeesAddedEvent;
 use OCA\Talk\Events\AttendeesRemovedEvent;
 use OCA\Talk\Events\ModifyEveryoneEvent;
@@ -353,7 +354,7 @@ class Listener implements IEventListener {
 		$share->setExpirationDate($dateTime);
 	}
 
-	public static function fixMimeTypeOfVoiceMessage(ShareCreatedEvent $event): void {
+	public static function fixMimeTypeOfVoiceMessage(ShareCreatedEvent|AlreadySharedEvent $event): void {
 		$share = $event->getShare();
 
 		if ($share->getShareType() !== IShare::TYPE_ROOM) {

--- a/lib/Events/AlreadySharedEvent.php
+++ b/lib/Events/AlreadySharedEvent.php
@@ -27,19 +27,26 @@ declare(strict_types=1);
 namespace OCA\Talk\Events;
 
 use OCP\EventDispatcher\Event;
+use OCP\Share\IShare;
 
 class AlreadySharedEvent extends Event {
 	public function __construct(
-		private $subject = null,
+		private IShare $share,
 	) {
+		parent::__construct();
 	}
 
 	/**
 	 * Getter for subject property.
 	 *
-	 * @return mixed
+	 * @return IShare
+	 * @deprecated
 	 */
-	public function getSubject() {
-		return $this->subject;
+	public function getSubject(): IShare {
+		return $this->share;
+	}
+
+	public function getShare(): IShare {
+		return $this->share;
 	}
 }


### PR DESCRIPTION
### ☑️ Resolves

* Followup to #10078 
* Actually the red CI was not only because of the broken guests app, but also because of this little fail here.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
