### PR TITLE
Fix "Unread mentions" button appearing

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -111,10 +111,8 @@
 		</div>
 
 		<template #list>
-			<li ref="container" class="left-sidebar__list">
-				<ul ref="scroller"
-					class="scroller"
-					@scroll="debounceHandleScroll">
+			<li ref="container" class="left-sidebar__list" @scroll="debounceHandleScroll">
+				<ul class="scroller">
 					<NcListItem v-if="noMatchFound && searchText"
 						:title="t('spreed', 'Create a new conversation')"
 						@click="createConversation(searchText)">

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -35,7 +35,7 @@
 					@abort-search="abortSearch" />
 			</div>
 
-			<transition-group name="radial-reveal">
+			<TransitionGroup name="radial-reveal">
 				<!-- Filters -->
 				<div v-show="!isFocused" key="filters" class="filters">
 					<NcActions class="filter-actions"
@@ -101,7 +101,7 @@
 						</NcActionButton>
 					</NcActions>
 				</div>
-			</transition-group>
+			</TransitionGroup>
 
 			<!-- All open conversations list -->
 			<OpenConversationsList ref="openConversationsList" />
@@ -823,7 +823,6 @@ export default {
 		border-radius: var(--border-radius-pill);
 	}
 	&--expanded {
-
 		width : calc(100% - 8px);
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

Seems to be a regression of: https://github.com/nextcloud/spreed/pull/9068

"Unread mentions" button doesn't appear anymore.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![before](https://github.com/nextcloud/spreed/assets/25978914/fa3d675b-cbf7-4f61-b0f2-0ed88c7594e9) | ![after](https://github.com/nextcloud/spreed/assets/25978914/77b98dc5-b0ec-48fe-a765-14f15059f14b)

### 🚧 Tasks

- [x] Handle scroll on `container` element instead of `scroller`
- [x] Lint

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
