### PR TITLE
fix(ChatView) - adjust 'scrollToBottom' button position in call

### DIFF
--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -134,14 +134,13 @@ export default {
 	},
 
 	watch: {
-		typingParticipants: {
+		isVisible: {
 			immediate: true,
-			handler() {
-				this.$nextTick(() => {
-					// offset from NewMessage component by 8px, with its min-height: 69px as a fallback
-					this.scrollButtonOffset = (this.$refs.newMessage?.$el?.clientHeight ?? 69) + 8
-				})
-			},
+			handler: 'setScrollToBottomPosition',
+		},
+
+		typingParticipants: {
+			handler: 'setScrollToBottomPosition',
 		},
 	},
 
@@ -185,6 +184,13 @@ export default {
 
 		smoothScrollToBottom() {
 			EventBus.$emit('smooth-scroll-chat-to-bottom')
+		},
+
+		setScrollToBottomPosition() {
+			this.$nextTick(() => {
+				// offset from NewMessage component by 8px, with its min-height: 69px as a fallback
+				this.scrollButtonOffset = (this.$refs.newMessage?.$el?.clientHeight ?? 69) + 8
+			})
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10148 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/cf8dc431-aa45-4847-a449-3e36eed2c26e) | ![image](https://github.com/nextcloud/spreed/assets/93392545/7fe56f01-8679-4dfd-83fc-3fe641d6e543)


### 🚧 Tasks

- [ ] Code review
- [ ] Manual test

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
