### PR TITLE
Redirect desktop client when 426 response is received

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -268,6 +268,8 @@ export default {
 			}
 		})
 
+		EventBus.$on('navigate-to-upgrade-required', this.navigateToUpgradeRequired)
+
 		EventBus.$on('switch-to-conversation', (params) => {
 			if (this.isInCall) {
 				this.$store.dispatch('setForceCallView', true)
@@ -648,6 +650,10 @@ export default {
 				open: true,
 			})
 			document.querySelector('.conversations-search')[0].focus()
+		},
+
+		navigateToUpgradeRequired() {
+		  this.$router.push({ name: 'upgraderequired', params: { skipLeaveWarning: true } })
 		},
 	},
 }

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -29,6 +29,7 @@ import CallView from '../components/CallView/CallView.vue'
 import MainView from '../views/MainView.vue'
 import NotFoundView from '../views/NotFoundView.vue'
 import SessionConflictView from '../views/SessionConflictView.vue'
+import UpgradeRequiredView from '../views/UpgradeRequiredView.vue'
 import WelcomeView from '../views/WelcomeView.vue'
 
 Vue.use(Router)
@@ -68,6 +69,12 @@ export default new Router({
 			path: '/apps/spreed/not-found',
 			name: 'notfound',
 			component: NotFoundView,
+			props: true,
+		},
+		{
+			path: '/apps/spreed/upgrade-required',
+			name: 'upgraderequired',
+			component: UpgradeRequiredView,
 			props: true,
 		},
 		{

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -694,7 +694,7 @@ const actions = {
 			return response
 		} catch (error) {
 			if (error?.response) {
-				dispatch('checkMaintenanceMode', error.response)
+				dispatch('checkForMaintenanceOrUpgrade', error.response)
 			}
 			throw error
 		}
@@ -726,7 +726,7 @@ const actions = {
 			return response
 		} catch (error) {
 			if (error?.response) {
-				dispatch('checkMaintenanceMode', error.response)
+				dispatch('checkForMaintenanceOrUpgrade', error.response)
 			}
 			throw error
 		}

--- a/src/store/conversationsStore.spec.js
+++ b/src/store/conversationsStore.spec.js
@@ -113,7 +113,7 @@ describe('conversationsStore', () => {
 			checkMaintenanceModeAction = jest.fn()
 			clearMaintenanceModeAction = jest.fn()
 			updateTalkVersionHashAction = jest.fn()
-			testStoreConfig.modules.talkHashStore.actions.checkMaintenanceMode = checkMaintenanceModeAction
+			testStoreConfig.modules.talkHashStore.actions.checkForMaintenanceOrUpgrade = checkMaintenanceModeAction
 			testStoreConfig.modules.talkHashStore.actions.clearMaintenanceMode = clearMaintenanceModeAction
 			testStoreConfig.modules.talkHashStore.actions.updateTalkVersionHash = updateTalkVersionHashAction
 

--- a/src/store/talkHashStore.spec.js
+++ b/src/store/talkHashStore.spec.js
@@ -103,7 +103,7 @@ describe('talkHashStore', () => {
 
 			expect(store.state.maintenanceWarningToast).toBe(null)
 
-			store.dispatch('checkMaintenanceMode', {
+			store.dispatch('checkForMaintenanceOrUpgrade', {
 				status: 503,
 			})
 
@@ -116,8 +116,17 @@ describe('talkHashStore', () => {
 			expect(store.state.maintenanceWarningToast).toBe(null)
 		})
 
-		test('does not display toast if status is not 503', () => {
-			store.dispatch('checkMaintenanceMode', {
+		test('do not display toast (for web client) if status is 426', () => {
+			store.dispatch('checkForMaintenanceOrUpgrade', {
+				status: 426,
+			})
+
+			expect(store.state.upgradeWarningToast).toBe(null)
+			expect(showError).not.toHaveBeenCalled()
+		})
+
+		test('does not display toast if status is not 426 or 503', () => {
+			store.dispatch('checkForMaintenanceOrUpgrade', {
 				status: 200,
 			})
 
@@ -125,8 +134,8 @@ describe('talkHashStore', () => {
 			expect(showError).not.toHaveBeenCalled()
 		})
 
-		test('does not display toast if status is not 503', () => {
-			store.dispatch('checkMaintenanceMode', {
+		test('does not display toast if status is not 426 or 503', () => {
+			store.dispatch('checkForMaintenanceOrUpgrade', {
 				status: 200,
 			})
 

--- a/src/views/UpgradeRequiredView.vue
+++ b/src/views/UpgradeRequiredView.vue
@@ -1,0 +1,42 @@
+<template>
+	<div id="emptycontent">
+		<div id="emptycontent-icon" class="icon-search" />
+		<h2>{{ t('spreed', 'The app is too old and no longer supported by this server.') }}</h2>
+		<p class="emptycontent-additional">
+			{{ t('spreed', 'Update is required.') }}
+		</p>
+
+		<NcButton class="browser-button"
+			type="primary"
+			:href="browserLink"
+			target="_blank">
+			{{ t('spreed', 'Continue in Web-Browser') }}
+		</NcButton>
+	</div>
+</template>
+
+<script>
+import { generateUrl } from '@nextcloud/router'
+
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+
+export default {
+	name: 'UpgradeRequiredView',
+
+	components: {
+		NcButton,
+	},
+
+	computed: {
+		browserLink() {
+			return generateUrl('apps/spreed')
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.browser-button {
+	margin: var(--default-grid-baseline) auto 0;
+}
+</style>


### PR DESCRIPTION
### ☑️ Resolves

* Fix nextcloud/talk-desktop#209
* Fix #9660 
* Wording is aligned with mobile clients

### 🖼️ Screenshots

| 🏡 After |
|---|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/bf57e953-7c7f-47f3-b20b-98ccee3a50d1) |


### 🚧 Tasks

- [ ] Visual check
- [ ] Code review

To test: adjust constant to be higher than current Talk Desktop version (0.9.0):

https://github.com/nextcloud/spreed/blob/67c22f97d7d9a10fe085f7bc65ee4f0c23c9e652/lib/Middleware/CanUseTalkMiddleware.php#L53

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
