### PR TITLE
Add notes for translators for reminder feature

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -544,18 +544,24 @@ class Notifier implements INotifier {
 			];
 			if ($notification->getSubject() === 'reminder') {
 				if ($comment->getActorId() === $notification->getUser()) {
+					// TRANSLATORS Reminder for a message you sent in the conversation {call}
 					$subject = $l->t('Reminder: You in {call}') . "\n{message}";
 				} elseif ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
+					// TRANSLATORS Reminder for a message from {user} in conversation {call}
 					$subject = $l->t('Reminder: {user} in {call}') . "\n{message}";
 				} elseif ($richSubjectUser) {
+					// TRANSLATORS Reminder for a message from {user} in conversation {call}
 					$subject = $l->t('Reminder: {user} in {call}') . "\n{message}";
 				} elseif (!$isGuest) {
+					// TRANSLATORS Reminder for a message from a deleted user in conversation {call}
 					$subject = $l->t('Reminder: Deleted user in {call}') . "\n{message}";
 				} else {
 					try {
 						$richSubjectParameters['guest'] = $this->getGuestParameter($room, $comment->getActorId());
+						// TRANSLATORS Reminder for a message from a guest in conversation {call}
 						$subject = $l->t('Reminder: {guest} (guest) in {call}') . "\n{message}";
 					} catch (ParticipantNotFoundException $e) {
+						// TRANSLATORS Reminder for a message from a guest in conversation {call}
 						$subject = $l->t('Reminder: Guest in {call}') . "\n{message}";
 					}
 				}


### PR DESCRIPTION
### ☑️ Resolves

Judging from the german translations for the reminder feature, the intention of this feature was not clear. To help translators, we add a comment for these strings.

CC: @rakekniven

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
