### PR TITLE
fix(bruteforce): Fix resetting the bruteforce protection

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -209,7 +209,7 @@ class PageController extends Controller {
 					if ($passwordVerification['result']) {
 						$this->talkSession->renewSessionId();
 						$this->talkSession->setPasswordForRoom($token, $password);
-						$this->throttler->resetDelay($this->request->getRemoteAddress(), 'talkRoomPassword', ['token' => $token]);
+						$this->throttler->resetDelay($this->request->getRemoteAddress(), 'talkRoomPassword', ['token' => $token, 'action' => 'talkRoomPassword']);
 					} else {
 						$this->talkSession->removePasswordForRoom($token);
 						$showBruteForceWarning = $this->throttler->getDelay($this->request->getRemoteAddress(), 'talkRoomPassword') > 5000;
@@ -352,7 +352,7 @@ class PageController extends Controller {
 			if ($passwordVerification['result']) {
 				$this->talkSession->renewSessionId();
 				$this->talkSession->setPasswordForRoom($token, $password);
-				$this->throttler->resetDelay($this->request->getRemoteAddress(), 'talkRoomPassword', ['token' => $token]);
+				$this->throttler->resetDelay($this->request->getRemoteAddress(), 'talkRoomPassword', ['token' => $token, 'action' => 'talkRoomPassword']);
 			} else {
 				$this->talkSession->removePasswordForRoom($token);
 				$showBruteForceWarning = $this->throttler->getDelay($this->request->getRemoteAddress(), 'talkRoomPassword') > 5000;

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1154,7 +1154,8 @@ class RoomController extends AEnvironmentAwareController {
 			} else {
 				$participant = $this->participantService->joinRoomAsNewGuest($this->roomService, $room, $password, $result['result'], $previousParticipant);
 			}
-			$this->throttler->resetDelay($this->request->getRemoteAddress(), 'talkRoomToken', ['token' => $token]);
+			$this->throttler->resetDelay($this->request->getRemoteAddress(), 'talkRoomPassword', ['token' => $token, 'action' => 'talkRoomPassword']);
+			$this->throttler->resetDelay($this->request->getRemoteAddress(), 'talkRoomToken', ['token' => $token, 'action' => 'talkRoomToken']);
 		} catch (InvalidPasswordException $e) {
 			$response = new DataResponse([], Http::STATUS_FORBIDDEN);
 			$response->throttle(['token' => $token, 'action' => 'talkRoomPassword']);


### PR DESCRIPTION
Since the metadata field was extended to track the password and token separately the metadata comparison on the reset did not match anymore.

### ☑️ Resolves

* Ref https://github.com/nextcloud/spreed/pull/9367

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
