### PR TITLE
fix(release): Exclude .editorconfig from release package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ appstore:
 	--exclude=docs \
 	--exclude=.drone.jsonnet \
 	--exclude=.drone.yml \
+	--exclude=.editorconfig \
 	--exclude=.eslintignore \
 	--exclude=.eslintrc.js \
 	--exclude=.git \


### PR DESCRIPTION
### ☑️ Resolves

* Ref from https://github.com/nextcloud/spreed/issues/10166

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
