### PR TITLE
Fix speaking time sometimes updated when participants do not speak

### DIFF
--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -370,7 +370,7 @@ const mutations = {
 		const currentSpeakingState = state.speaking[token][sessionId].speaking
 
 		// when speaking has stopped, update the total talking time
-		if (!speaking && state.speaking[token][sessionId].lastTimestamp) {
+		if (currentSpeakingState && !speaking && state.speaking[token][sessionId].lastTimestamp) {
 			state.speaking[token][sessionId].totalCountedTime += (currentTimestamp - state.speaking[token][sessionId].lastTimestamp)
 		}
 


### PR DESCRIPTION
Follow up to #10068

## How to test

- Start a call
- In a private window, join the call with audio disabled
- Leave the call
- Wait a few minutes
- Join the call again with audio still disabled
- Enable audio and speak
- In the original window, check the speaking time of the participant of the private window

### Result with this pull request

The speaking time is a few seconds

### Result without this pull request

The speaking time is a few minutes
