### PR TITLE
fix(MessageButtonsBar) - adjust predefined reminders conditions

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -554,21 +554,23 @@ export default {
 		reminderOptions() {
 			const currentDateTime = moment()
 
-			// Same day 18:00 PM (or hidden)
-			const laterTodayTime = (currentDateTime.hour() < 18)
+			// Same day 18:00 PM (hidden if after 17:00 PM now)
+			const laterTodayTime = (currentDateTime.hour() < 17)
 				? moment().hour(18)
 				: null
 
 			// Tomorrow 08:00 AM
 			const tomorrowTime = moment().add(1, 'days').hour(8)
 
-			// Saturday 08:00 AM (or hidden)
-			const thisWeekendTime = (currentDateTime.day() !== 6 && currentDateTime.day() !== 0)
+			// Saturday 08:00 AM (hidden if Friday, Saturday or Sunday now)
+			const thisWeekendTime = (currentDateTime.day() > 0 && currentDateTime.day() < 5)
 				? moment().day(6).hour(8)
 				: null
 
-			// Next Monday 08:00 AM
-			const nextWeekTime = moment().add(1, 'weeks').day(1).hour(8)
+			// Next Monday 08:00 AM (hidden if Sunday now)
+			const nextWeekTime = (currentDateTime.day() !== 0)
+				? moment().add(1, 'weeks').day(1).hour(8)
+				: null
 
 			return [
 				{


### PR DESCRIPTION
### ☑️ Resolves

* Aligned with discussion at https://github.com/nextcloud/server/issues/39181

### 🖼️ Screenshots

Normal day | Normal day after 17:00 PM | Friday
---|---|---
![Screenshot from 2023-08-10 09-36-06](https://github.com/nextcloud/spreed/assets/93392545/c2dcd60c-047a-4be2-92d6-b4a13cbf7505) | ![Screenshot from 2023-08-10 17-36-07](https://github.com/nextcloud/spreed/assets/93392545/11675456-e651-4a0a-9ffe-8ab72f023ac7) | ![Screenshot from 2023-08-11 09-36-50](https://github.com/nextcloud/spreed/assets/93392545/8496c709-ff89-497f-b09d-8c334928e875)
Saturday | Sunday
![Screenshot from 2023-08-12 09-37-14](https://github.com/nextcloud/spreed/assets/93392545/8f9c9d5a-06c7-4692-b196-0ca027d04bc8) | ![Screenshot from 2023-08-13 09-37-09](https://github.com/nextcloud/spreed/assets/93392545/2d8244f9-bfd4-4653-8e47-0b0d308b9b7c)


### 🚧 Tasks

- [ ] Code review
- [ ] Visual check

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
