### PR TITLE
fix(desktop): fix disabling avatar menu for desktop

### DIFF
--- a/src/components/MessagesList/MessagesGroup/AuthorAvatar.vue
+++ b/src/components/MessagesList/MessagesGroup/AuthorAvatar.vue
@@ -97,7 +97,7 @@ export default {
 			// NcAvatarMenu doesn't work on Desktop
 			// See: https://github.com/nextcloud/talk-desktop/issues/34
 			if (IS_DESKTOP) {
-				return false
+				return true
 			}
 			// disable the menu if accessing the conversation as guest
 			// or the message sender is a bridged user


### PR DESCRIPTION
### ☑️ Resolves

The author's avatar in the messages list has an avatar menu on the Desktop. It causes infinity requests to loop on click and leads to rate limit.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/25978914/37ddb931-c324-4faf-b5f3-5aee84872c22) | ![image](https://github.com/nextcloud/spreed/assets/25978914/9cfc6205-76ca-4e52-a94f-a12a11f80ae7)


### 🚧 Tasks

- [x] to `disableMenu` we need to pass `true`, not `false` as disabling value 🙈

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
