### PR TITLE
Simplify tracking of total counted time

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -40,7 +40,7 @@
 			disable-tooltip
 			:show-user-status="showUserStatus && !isSearched"
 			:preloaded-user-status="preloadedUserStatus"
-			:highlighted="isParticipantSpeaking"
+			:highlighted="isSpeakingStatusAvailable && isParticipantSpeaking"
 			:offline="isOffline" />
 
 		<!-- Participant's data -->
@@ -349,8 +349,12 @@ export default {
 			return text
 		},
 
+		isSpeakingStatusAvailable() {
+			return this.isInCall && !!this.participant.inCall && !!this.timeSpeaking
+		},
+
 		statusMessage() {
-			if (this.isInCall && this.participant.inCall && this.timeSpeaking) {
+			if (this.isSpeakingStatusAvailable) {
 				return this.isParticipantSpeaking
 					? '💬 ' + t('spreed', '{time} talking …', { time: formattedTime(this.timeSpeaking, true) })
 					: '💬 ' + t('spreed', '{time} talking time', { time: formattedTime(this.timeSpeaking, true) })

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -370,7 +370,7 @@ const mutations = {
 		const currentSpeakingState = state.speaking[token][sessionId].speaking
 
 		// when speaking has stopped, update the total talking time
-		if (currentSpeakingState && !speaking && state.speaking[token][sessionId].lastTimestamp) {
+		if (currentSpeakingState && !speaking) {
 			state.speaking[token][sessionId].speaking = false
 			state.speaking[token][sessionId].totalCountedTime += (currentTimestamp - state.speaking[token][sessionId].lastTimestamp)
 		} else if (!currentSpeakingState && speaking) {

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -369,13 +369,13 @@ const mutations = {
 		const currentTimestamp = Date.now()
 		const currentSpeakingState = state.speaking[token][sessionId].speaking
 
-		// when speaking has stopped, update the total talking time
-		if (currentSpeakingState && !speaking) {
-			state.speaking[token][sessionId].speaking = false
-			state.speaking[token][sessionId].totalCountedTime += (currentTimestamp - state.speaking[token][sessionId].lastTimestamp)
-		} else if (!currentSpeakingState && speaking) {
+		if (!currentSpeakingState && speaking) {
 			state.speaking[token][sessionId].speaking = true
 			state.speaking[token][sessionId].lastTimestamp = currentTimestamp
+		} else if (currentSpeakingState && !speaking) {
+			// when speaking has stopped, update the total talking time
+			state.speaking[token][sessionId].speaking = false
+			state.speaking[token][sessionId].totalCountedTime += (currentTimestamp - state.speaking[token][sessionId].lastTimestamp)
 		}
 	},
 

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -348,8 +348,8 @@ const mutations = {
 	 * property to an existing participant, as the participant would be reset
 	 * when the participants are purged whenever they are fetched again.
 	 * Similarly, "addParticipant" can not be called either to add a participant
-	 * if it was not fetched yet but the signaling reported it as being speaking,
-	 * as the attendeeId would be unknown.
+	 * if it was not fetched yet but the call model reported it as being
+	 * speaking, as the attendeeId would be unknown.
 	 *
 	 * @param {object} state - current store state.
 	 * @param {object} data - the wrapping object.

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -371,12 +371,10 @@ const mutations = {
 
 		// when speaking has stopped, update the total talking time
 		if (currentSpeakingState && !speaking && state.speaking[token][sessionId].lastTimestamp) {
+			state.speaking[token][sessionId].speaking = false
 			state.speaking[token][sessionId].totalCountedTime += (currentTimestamp - state.speaking[token][sessionId].lastTimestamp)
-		}
-
-		// don't change state for consecutive identical signals
-		if (currentSpeakingState !== speaking) {
-			state.speaking[token][sessionId].speaking = speaking
+		} else if (!currentSpeakingState && speaking) {
+			state.speaking[token][sessionId].speaking = true
 			state.speaking[token][sessionId].lastTimestamp = currentTimestamp
 		}
 	},


### PR DESCRIPTION
Follow up to #10174

The timestamp is only used to calculate the elapsed speaking time when stopping to speak, so it needs to be updated only when starting to speak. Note that before this change the timestamp was updated not only when changing from `true` to `false, but also from `false` to `undefined` (because `speaking` can be undefined in some cases, for example, [when the media stream is removed](https://github.com/nextcloud/spreed/blob/05c22aa430da92746f34a01920bc986cf19a59db/src/utils/webrtc/models/CallParticipantModel.js#L163)).

@Antreesy Feel free to adjust or even drop any of the commits; I think the code and data state is easier to understand with them, but it can be of course a matter of taste :-)
