### PR TITLE
feat(conversationsStore) - cache conversations to BrowserStorage

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.spec.js
+++ b/src/components/LeftSidebar/LeftSidebar.spec.js
@@ -14,6 +14,7 @@ import { searchPossibleConversations, searchListedConversations } from '../../se
 import { EventBus } from '../../services/EventBus.js'
 import storeConfig from '../../store/storeConfig.js'
 import { findNcListItems, findNcActionButton } from '../../test-helpers.js'
+import { requestTabLeadership } from '../../utils/requestTabLeadership.js'
 
 jest.mock('@nextcloud/initial-state', () => ({
 	loadState: jest.fn(),
@@ -131,6 +132,8 @@ describe('LeftSidebar.vue', () => {
 
 			const wrapper = mountComponent()
 
+			await requestTabLeadership()
+
 			expect(fetchConversationsAction).toHaveBeenCalledWith(expect.anything(), expect.anything())
 			expect(conversationsListMock).toHaveBeenCalled()
 
@@ -157,6 +160,9 @@ describe('LeftSidebar.vue', () => {
 
 		test('re-fetches conversations every 30 seconds', async () => {
 			const wrapper = mountComponent()
+
+			await requestTabLeadership()
+
 			expect(wrapper.exists()).toBeTruthy()
 			expect(fetchConversationsAction).toHaveBeenCalled()
 
@@ -175,6 +181,9 @@ describe('LeftSidebar.vue', () => {
 
 		test('re-fetches conversations when receiving bus event', async () => {
 			const wrapper = mountComponent()
+
+			await requestTabLeadership()
+
 			expect(wrapper.exists()).toBeTruthy()
 			expect(fetchConversationsAction).toHaveBeenCalled()
 
@@ -302,6 +311,8 @@ describe('LeftSidebar.vue', () => {
 			}
 
 			const wrapper = mountComponent()
+
+			await requestTabLeadership()
 
 			expect(fetchConversationsAction).toHaveBeenCalledWith(expect.anything(), expect.anything())
 			expect(conversationsListMock).toHaveBeenCalled()

--- a/src/services/talkBroadcastChannel.js
+++ b/src/services/talkBroadcastChannel.js
@@ -1,0 +1,31 @@
+/**
+ *
+ * @copyright Copyright (c) 2023 Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @author Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Broadcast channel to send messages between active tabs.
+ */
+const talkBroadcastChannel = new BroadcastChannel('nextcloud:talk')
+
+export {
+	talkBroadcastChannel,
+}

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -63,6 +63,7 @@ import {
 	startCallRecording,
 	stopCallRecording,
 } from '../services/recordingService.js'
+import { talkBroadcastChannel } from '../services/talkBroadcastChannel.js'
 
 const DUMMY_CONVERSATION = {
 	token: '',
@@ -393,6 +394,7 @@ const actions = {
 		await deleteConversation(token)
 		// upon success, also delete from store
 		await context.dispatch('deleteConversation', token)
+		talkBroadcastChannel.postMessage({ message: 'force-fetch-all-conversations' })
 	},
 
 	/**
@@ -766,6 +768,12 @@ const actions = {
 
 			dispatch('cacheConversations')
 
+			// Inform other tabs about successful fetch
+			talkBroadcastChannel.postMessage({
+				message: 'update-conversations',
+				conversations: response.data.ocs.data,
+				withRemoving: modifiedSince === 0,
+			})
 			return response
 		} catch (error) {
 			if (error?.response) {

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -31,6 +31,7 @@ import {
 	PARTICIPANT,
 	WEBINAR,
 } from '../constants.js'
+import BrowserStorage from '../services/BrowserStorage.js'
 import {
 	makePublic,
 	makePrivate,
@@ -315,8 +316,9 @@ const actions = {
 	 * @param {object} payload the payload
 	 * @param {object[]} payload.conversations new conversations list
 	 * @param {boolean} payload.withRemoving whether to remove conversations that are not in the new list
+	 * @param {boolean} payload.withCaching whether to cache conversations to BrowserStorage with patch
 	 */
-	patchConversations(context, { conversations, withRemoving = false }) {
+	patchConversations(context, { conversations, withRemoving = false, withCaching = false }) {
 		const currentConversations = context.state.conversations
 		const newConversations = Object.fromEntries(
 			conversations.map((conversation) => [conversation.token, conversation])
@@ -339,6 +341,45 @@ const actions = {
 				context.dispatch('updateConversationIfHasChanged', newConversation)
 			}
 		}
+
+		if (withCaching) {
+			context.dispatch('cacheConversations')
+		}
+	},
+
+	/**
+	 * Restores conversations from BrowserStorage and add them to the store state
+	 *
+	 * @param {object} context default store context
+	 */
+	restoreConversations(context) {
+		const cachedConversations = BrowserStorage.getItem('cachedConversations')
+		if (!cachedConversations?.length) {
+			return
+		}
+
+		context.dispatch('patchConversations', {
+			conversations: JSON.parse(cachedConversations),
+			withRemoving: true,
+		})
+
+		console.debug('Conversations have been restored from BrowserStorage')
+	},
+
+	/**
+	 * Save conversations to BrowserStorage from the store state
+	 *
+	 * @param {object} context default store context
+	 */
+	cacheConversations(context) {
+		const conversations = context.getters.conversationsList
+		if (!conversations.length) {
+			return
+		}
+
+		const serializedConversations = JSON.stringify(conversations)
+		BrowserStorage.setItem('cachedConversations', serializedConversations)
+		console.debug(`Conversations were saved to BrowserStorage. Estimated object size: ${(serializedConversations.length / 1024).toFixed(2)} kB`)
 	},
 
 	/**
@@ -722,6 +763,8 @@ const actions = {
 				// Remove only when fetching a full list, not fresh updates
 				withRemoving: modifiedSince === 0,
 			})
+
+			dispatch('cacheConversations')
 
 			return response
 		} catch (error) {

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -45,6 +45,7 @@ import {
 	setTyping,
 } from '../services/participantsService.js'
 import SessionStorage from '../services/SessionStorage.js'
+import { talkBroadcastChannel } from '../services/talkBroadcastChannel.js'
 
 const state = {
 	attendees: {
@@ -742,6 +743,7 @@ const actions = {
 		await removeCurrentUserFromConversation(token)
 		// If successful, deletes the conversation from the store
 		await context.dispatch('deleteConversation', token)
+		talkBroadcastChannel.postMessage({ message: 'force-fetch-all-conversations' })
 	},
 
 	/**

--- a/src/store/talkHashStore.js
+++ b/src/store/talkHashStore.js
@@ -22,6 +22,8 @@
 
 import { showError, TOAST_PERMANENT_TIMEOUT } from '@nextcloud/dialogs'
 
+import { talkBroadcastChannel } from '../services/talkBroadcastChannel.js'
+
 const state = {
 	initialNextcloudTalkHash: '',
 	isNextcloudTalkHashDirty: false,
@@ -94,6 +96,12 @@ const actions = {
 		}
 
 		context.dispatch('setNextcloudTalkHash', newTalkCacheBusterHash)
+
+		// Inform other tabs about changed hash
+		talkBroadcastChannel.postMessage({
+			message: 'update-nextcloud-talk-hash',
+			hash: newTalkCacheBusterHash,
+		})
 	},
 
 	checkMaintenanceMode(context, response) {

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -98,6 +98,11 @@ function myArrayBuffer() {
 
 global.Blob.prototype.arrayBuffer = Blob.prototype.arrayBuffer || myArrayBuffer
 
+global.BroadcastChannel = jest.fn(() => ({
+	postMessage: jest.fn(),
+	addEventListener: jest.fn(),
+}))
+
 const originalConsoleError = console.error
 console.error = function(error) {
 	if (error?.message?.includes('Could not parse CSS stylesheet')) {

--- a/src/utils/requestTabLeadership.js
+++ b/src/utils/requestTabLeadership.js
@@ -1,0 +1,56 @@
+/**
+ * @copyright Copyright (c) 2023 Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @author Maksim Sukharev <antreesy.web@gmail.com>
+ * @author Grigorii Shartsev <me@shgk.me>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @type {Promise|null}
+ */
+let requestingTabLeadershipPromise = null
+
+/**
+ * Assign the first window, which requested that, a 'fetching leader'.
+ * It will fetch conversations with defined interval and cache to BrowserStorage
+ * Other will update list with defined interval from the BrowserStorage
+ * Once 'leader' is closed, next requested tab will be assigned, and so on
+ */
+export function requestTabLeadership() {
+	if (!requestingTabLeadershipPromise) {
+		requestingTabLeadershipPromise = new Promise((resolve) => {
+			// Locks are supported only with HTTPS protocol,
+			// so we don't lock anything for another cases
+			if (navigator.locks === undefined) {
+				resolve()
+				return
+			}
+
+			navigator.locks.request('talk:leader', () => {
+				// resolve a promise for the first requested tab
+				resolve()
+
+				// return an infinity promise, resource is blocked until 'leader' tab is closed
+				return new Promise(() => {
+				})
+			})
+		})
+	}
+	return requestingTabLeadershipPromise
+}


### PR DESCRIPTION
### ☑️ Resolves

* Allow to store fetched conversations in BrowserStorage, and recover it instantly from cache, while waiting for a server response
* Conversations updated with `patchConversations()` action, which is called approx. every 30 seconds
* If conversation was deleted, it will be removed from the view with the next full fetch, with redirect to `/apps/spreed/not-found`

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/eef37c44-e6ef-447f-a964-04ce0077abce) | ![image](https://github.com/nextcloud/spreed/assets/93392545/ffd5e476-a516-4d0b-a3cc-3fe9dfb29d95)



### 🚧 Tasks

- [ ] Manual testing
- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
