### PR TITLE
Fix local participant data not updated after forced reconnection

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -362,6 +362,13 @@ export default {
 		},
 	},
 	watch: {
+		'localCallParticipantModel.attributes.peerId'(newValue, previousValue) {
+			const index = this.screens.indexOf(previousValue)
+			if (index !== -1) {
+				this.screens[index] = newValue
+			}
+		},
+
 		localScreen(localScreen) {
 			this._setScreenAvailable(localCallParticipantModel.attributes.peerId, localScreen)
 		},

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -157,6 +157,7 @@ Signaling.Base.prototype.getCurrentCallFlags = function() {
 
 Signaling.Base.prototype.disconnect = function() {
 	this.sessionId = ''
+	this._trigger('sessionId', [this.sessionId])
 	this.currentCallToken = null
 	this.currentCallFlags = null
 }
@@ -446,6 +447,7 @@ Signaling.Internal.prototype._joinRoomSuccess = function(token, sessionId) {
 	this._joinCallAgainOnceDisconnected = false
 
 	this.sessionId = sessionId
+	this._trigger('sessionId', [this.sessionId])
 	this._startPullingMessages()
 }
 
@@ -1044,6 +1046,7 @@ Signaling.Standalone.prototype.helloResponseReceived = function(data) {
 		return
 	}
 	this.sessionId = data.hello.sessionid
+	this._trigger('sessionId', [this.sessionId])
 	this.resumeId = data.hello.resumeid
 	this.features = {}
 	let i

--- a/src/utils/webrtc/SpeakingStatusHandler.js
+++ b/src/utils/webrtc/SpeakingStatusHandler.js
@@ -33,26 +33,32 @@ export default class SpeakingStatusHandler {
 	// Constants, properties
 	#store
 	#localMediaModel
+	#localCallParticipantModel
 	#callParticipantCollection
 
 	// Methods (bound to have access to 'this')
 	#handleAddParticipantBound
 	#handleRemoveParticipantBound
 	#handleLocalSpeakingBound
+	#handleLocalPeerIdBound
 	#handleSpeakingBound
 
-	constructor(store, localMediaModel, callParticipantCollection) {
+	constructor(store, localMediaModel, localCallParticipantModel, callParticipantCollection) {
 		this.#store = store
 		this.#localMediaModel = localMediaModel
+		this.#localCallParticipantModel = localCallParticipantModel
 		this.#callParticipantCollection = callParticipantCollection
 
 		this.#handleAddParticipantBound = this.#handleAddParticipant.bind(this)
 		this.#handleRemoveParticipantBound = this.#handleRemoveParticipant.bind(this)
 		this.#handleLocalSpeakingBound = this.#handleLocalSpeaking.bind(this)
+		this.#handleLocalPeerIdBound = this.#handleLocalPeerId.bind(this)
 		this.#handleSpeakingBound = this.#handleSpeaking.bind(this)
 
 		this.#localMediaModel.on('change:speaking', this.#handleLocalSpeakingBound)
 		this.#localMediaModel.on('change:stoppedSpeaking', this.#handleLocalSpeakingBound)
+
+		this.#localCallParticipantModel.on('change:peerId', this.#handleLocalPeerIdBound)
 
 		this.#callParticipantCollection.on('add', this.#handleAddParticipantBound)
 		this.#callParticipantCollection.on('remove', this.#handleRemoveParticipantBound)
@@ -64,6 +70,8 @@ export default class SpeakingStatusHandler {
 	destroy() {
 		this.#localMediaModel.off('change:speaking', this.#handleLocalSpeakingBound)
 		this.#localMediaModel.off('change:stoppedSpeaking', this.#handleLocalSpeakingBound)
+
+		this.#localCallParticipantModel.off('change:peerId', this.#handleLocalPeerIdBound)
 
 		this.#callParticipantCollection.off('add', this.#handleAddParticipantBound)
 		this.#callParticipantCollection.off('remove', this.#handleRemoveParticipantBound)
@@ -109,6 +117,18 @@ export default class SpeakingStatusHandler {
 			token: this.#store.getters.getToken(),
 			sessionId: this.#store.getters.getSessionId(),
 			speaking,
+		})
+	}
+
+	/**
+	 * Dispatch speaking status of local participant to the store on peer ID
+	 * changes.
+	 */
+	#handleLocalPeerId() {
+		this.#store.dispatch('setSpeaking', {
+			token: this.#store.getters.getToken(),
+			sessionId: this.#store.getters.getSessionId(),
+			speaking: this.#localMediaModel.attributes.speaking,
 		})
 	}
 

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -219,7 +219,7 @@ async function signalingJoinCall(token, flags, silent) {
 		setupWebRtc()
 
 		sentVideoQualityThrottler = new SentVideoQualityThrottler(localMediaModel, callParticipantCollection, webRtc.webrtc._videoTrackConstrainer)
-		speakingStatusHandler = new SpeakingStatusHandler(store, localMediaModel, callParticipantCollection)
+		speakingStatusHandler = new SpeakingStatusHandler(store, localMediaModel, localCallParticipantModel, callParticipantCollection)
 
 		if (signaling.hasFeature('mcu')) {
 			callAnalyzer = new CallAnalyzer(localMediaModel, localCallParticipantModel, callParticipantCollection)

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -182,6 +182,10 @@ function setupWebRtc() {
 	webRtc = initWebRtc(signaling, callParticipantCollection, localCallParticipantModel)
 	localCallParticipantModel.setWebRtc(webRtc)
 	localMediaModel.setWebRtc(webRtc)
+
+	signaling.on('sessionId', sessionId => {
+		localCallParticipantModel.setPeerId(sessionId)
+	})
 }
 
 /**

--- a/src/utils/webrtc/models/LocalCallParticipantModel.js
+++ b/src/utils/webrtc/models/LocalCallParticipantModel.js
@@ -75,6 +75,10 @@ LocalCallParticipantModel.prototype = {
 		this._unwatchDisplayNameChange = store.watch(state => state.actorStore.displayName, this.setGuestName.bind(this))
 	},
 
+	setPeerId(peerId) {
+		this.set('peerId', peerId)
+	},
+
 	setPeer(peer) {
 		if (peer && this.get('peerId') !== peer.id) {
 			console.warn('Mismatch between stored peer ID and ID of given peer: ', this.get('peerId'), peer.id)


### PR DESCRIPTION
After a forced reconnection both the Nextcloud and the signaling session ID change. Neither the `peerId` in LocalCallParticipantModel nor the session in the actor store were updated, which caused some issues.

It was mostly visible in the speaking time of the local participant after a forced reconnection, as [the speaking time was no longer updated](https://github.com/nextcloud/spreed/pull/10068#pullrequestreview-1565565757) (due to being set to the previous Nextcloud session ID, which is no longer in the call or conversation); something similar happens for the raised hand. There is also a subtler issue with the typing notifications (being sent to both the previous and current session of the self participant, [as they do not match](https://github.com/nextcloud/spreed/blob/f755a2c8edbdd89581912f4c4d35648a1e126d81/src/utils/SignalingTypingHandler.js#L93-L98)).

I am not fond of modifying the store directly from the signaling; probably a better approach would be to add a `rejoinConversation` or `forceReconnect` action to the store (to be called instead of `signaling.forceReconnect`) which would call the service and this, in turn, call the API and the signaling, and then update the store from the returned response (that is, the same done for joining a conversation). But refactoring all that is far from an easy task so, for now... modifying the store from the signaling should suffice :see_no_evil:

## How to test (common setup)
- Add a function to force reconnect from the console in [_src/utils/webrtc/webrtc.js_](https://github.com/nextcloud/spreed/blob/e1b60c0e360c322db078a0b8d6f349382338c61d/src/utils/webrtc/webrtc.js#L965):
```
	webrtc.forceReconnect = function() {
		forceReconnect(signaling)
	}
```
- Rebuild the code
- Setup the HPB



## How to test (scenario 1)

- Start a call
- Enable audio and start speaking
- In the browser console, run `OCA.Talk.SimpleWebRTC.forceReconnect()`

### Result with this pull request

The speaking time for the local participant is updated

### Result without this pull request

The speaking time for the local participant is neither updated nor even shown



## How to test (scenario 2)

- Start a call
- In the browser console, run `OCA.Talk.SimpleWebRTC.forceReconnect()`
- Raise the hand

### Result with this pull request

The raised hand is shown in the sidebar

### Result without this pull request

The raised hand is not shown in the sidebar
