### PR TITLE
align styles for h1-h4 tags

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -1088,12 +1088,20 @@ export default {
 
 .message-body__main__text--markdown {
 	:deep(.rich-text--wrapper) {
-		h1 {
+		h1, h2, h3, h4, h5, h6 {
 			font-weight: bold;
-			font-size: 32px;
-			margin-bottom: 12px;
-			line-height: 36px;
+			margin: 12px 0;
 			color: var(--color-text-light);
+		}
+
+		h1 {
+			font-size: 32px;
+			line-height: 36px;
+		}
+
+		// Overwrite core styles, otherwise h4 is lesser than default font-size
+		h4 {
+			font-size: 100%;
 		}
 
 		em {


### PR DESCRIPTION
### ☑️ Resolves

* Fix `margin`, `color`, and `font-weight` for h1-5 tags

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/e7e55f1b-2ac6-4559-87c1-c4e8bfcbc301) | ![image](https://github.com/nextcloud/spreed/assets/93392545/8765255a-4fb7-480d-8732-b7a851f1b304)

### 🚧 Tasks

- [ ] .Visual check
- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
