### PR TITLE
fix(conversations): Allow accessing avatars of listable conversations

### DIFF
--- a/lib/Controller/AvatarController.php
+++ b/lib/Controller/AvatarController.php
@@ -28,7 +28,7 @@ namespace OCA\Talk\Controller;
 
 use InvalidArgumentException;
 use OCA\Talk\Middleware\Attribute\RequireModeratorParticipant;
-use OCA\Talk\Middleware\Attribute\RequireParticipant;
+use OCA\Talk\Middleware\Attribute\RequireParticipantOrLoggedInAndListedConversation;
 use OCA\Talk\Service\AvatarService;
 use OCA\Talk\Service\RoomFormatter;
 use OCP\AppFramework\Http;
@@ -102,7 +102,7 @@ class AvatarController extends AEnvironmentAwareController {
 
 	#[PublicPage]
 	#[NoCSRFRequired]
-	#[RequireParticipant]
+	#[RequireParticipantOrLoggedInAndListedConversation]
 	public function getAvatar(bool $darkTheme = false): Response {
 		$file = $this->avatarService->getAvatar($this->getRoom(), $this->userSession->getUser(), $darkTheme);
 
@@ -115,7 +115,7 @@ class AvatarController extends AEnvironmentAwareController {
 
 	#[PublicPage]
 	#[NoCSRFRequired]
-	#[RequireParticipant]
+	#[RequireParticipantOrLoggedInAndListedConversation]
 	public function getAvatarDark(): Response {
 		return $this->getAvatar(true);
 	}

--- a/lib/Middleware/Attribute/RequireParticipantOrLoggedInAndListedConversation.php
+++ b/lib/Middleware/Attribute/RequireParticipantOrLoggedInAndListedConversation.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Talk\Middleware\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class RequireParticipantOrLoggedInAndListedConversation extends RequireRoom {
+}

--- a/tests/integration/features/conversation/avatar.feature
+++ b/tests/integration/features/conversation/avatar.feature
@@ -2,6 +2,8 @@ Feature: conversation/avatar
   Background:
     Given user "participant1" exists
     Given user "participant2" exists
+    And guest accounts can be created
+    And user "user-guest@example.com" is a guest account user
 
   Scenario: Misteps
     Given user "participant1" creates room "room1" (v4)
@@ -43,6 +45,35 @@ Feature: conversation/avatar
     And user "participant1" gets room "room3" with 200 (v4)
       | avatarVersion | NOT_EMPTY |
       | isCustomAvatar | 0 |
+
+  Scenario: Get avatar of conversation without being a participant
+    Given user "participant1" creates room "room3" (v4)
+      | roomType | 3 |
+      | roomName | room3 |
+    Then the room "room3" has an avatar with 200
+    And user "participant1" gets room "room3" with 200 (v4)
+      | avatarVersion | NOT_EMPTY |
+      | isCustomAvatar | 0 |
+    And as user "participant2"
+    And the room "room3" has an avatar with 404
+    And as user "user-guest@example.com"
+    And the room "room3" has an avatar with 404
+    And as user "guest"
+    And the room "room3" has an avatar with 404
+    When user "participant1" allows listing room "room3" for "users" with 200 (v4)
+    And as user "participant2"
+    And the room "room3" has an avatar with 200
+    And as user "user-guest@example.com"
+    And the room "room3" has an avatar with 404
+    And as user "guest"
+    And the room "room3" has an avatar with 404
+    When user "participant1" allows listing room "room3" for "all" with 200 (v4)
+    And as user "participant2"
+    And the room "room3" has an avatar with 200
+    And as user "user-guest@example.com"
+    And the room "room3" has an avatar with 200
+    And as user "guest"
+    And the room "room3" has an avatar with 404
 
   Scenario: Get avatar of one2one without custom avatar (fallback)
     When user "participant1" creates room "one2one" (v4)


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9600 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/nextcloud/spreed/assets/213943/23f23c23-b0ab-4ce0-b2e0-674c7a49f4a2) | ![Bildschirmfoto vom 2023-08-16 10-06-45](https://github.com/nextcloud/spreed/assets/213943/9b2f1f68-050f-4edd-8416-7d9df052b547)

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
