### PR TITLE
Add bot documentation to overview

### DIFF
--- a/docs/bot-management.md
+++ b/docs/bot-management.md
@@ -4,7 +4,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`: (requires the `bots-v1` capa
 
 ## Get list of bots installed on the server
 
-Lists the bots that are enabled and can be enabled for the conversation
+Lists the bots that are installed on the server.
 
 * Required capability: `bots-v1`
 * Method: `GET`
@@ -13,8 +13,7 @@ Lists the bots that are enabled and can be enabled for the conversation
 * Response:
     - Status code:
         + `200 OK`
-        + `403 Forbidden` When the current user is not a moderator/owner
-        + `404 Not Found` When the conversation could not be found for the participant
+        + `403 Forbidden` When the current user is not an administrator
     - Data:
       List of bots, each bot has at least:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,11 +16,13 @@
 * [Scalability](scalability.md)
 * [Call experience](call-experience.md)
 * [Occ commands](occ.md)
-* [Commands](commands.md)
+* [Bots](bot-list.md)
+* [Commands (deprecated)](commands.md)
 * [Matterbridge integration](matterbridge.md)
 
 ## Developer documentation
 
+* [Bots and webhooks](bots.md)
 * [Constants](constants.md)
 * [Capabilities](capabilities.md)
 * [PHP Events](events.md)
@@ -37,6 +39,7 @@
 * [Reaction management](reaction.md)
 * [Poll management](poll.md)
 * [Breakout rooms management](breakout-rooms.md)
+* [Bots management](bot-management.md)
 * [Integration by other apps](integration.md)
 * [Webinar management](webinar.md)
 * [Settings management](settings.md)


### PR DESCRIPTION
### ☑️ Resolves

* Bot documentation is missing from the overview
* Documentation about the `admin` endpoint is wrong

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
