### PR TITLE
Fix checking if WebAssembly is supported for virtual background

### DIFF
--- a/src/utils/media/pipeline/VirtualBackground.js
+++ b/src/utils/media/pipeline/VirtualBackground.js
@@ -292,16 +292,34 @@ export default class VirtualBackground extends TrackSinkSource {
 		this._outputStream = null
 	}
 
+	/**
+	 * Gets the virtual background properties.
+	 *
+	 * @return {object|undefined} undefined if WebAssembly is not supported, an object
+	 *         with the virtual background properties otherwise.
+	 */
 	getVirtualBackground() {
+		if (!this.isAvailable()) {
+			return undefined
+		}
+
 		return this._jitsiStreamBackgroundEffect.getVirtualBackground()
 	}
 
 	/**
+	 * Sets the virtual background properties.
+	 *
+	 * Nothing is set if the virtual background is not available.
+	 *
 	 * @param {object} virtualBackground the virtual background properties; see
 	 *        JitsiStreamBackgroundEffect.setVirtualBackground().
 	 */
 	setVirtualBackground(virtualBackground) {
-		return this._jitsiStreamBackgroundEffect.setVirtualBackground(virtualBackground)
+		if (!this.isAvailable()) {
+			return
+		}
+
+		this._jitsiStreamBackgroundEffect.setVirtualBackground(virtualBackground)
 	}
 
 }

--- a/src/utils/media/pipeline/VirtualBackground.js
+++ b/src/utils/media/pipeline/VirtualBackground.js
@@ -72,16 +72,19 @@ export default class VirtualBackground extends TrackSinkSource {
 	}
 
 	static _checkWasmSupport() {
-		try {
-			const wasmCheck = require('wasm-check')
-			this._wasmSupported = true
+		const wasmCheck = require('wasm-check')
 
-			this._wasmSimd = wasmCheck.feature.simd
-		} catch (error) {
+		if (!wasmCheck.support()) {
 			this._wasmSupported = false
 
 			console.error('Looks like WebAssembly is disabled or not supported on this browser, virtual background will not be available')
+
+			return
 		}
+
+		this._wasmSupported = true
+
+		this._wasmSimd = wasmCheck.feature.simd
 	}
 
 	static isWasmSupported() {

--- a/src/utils/media/pipeline/VirtualBackground.js
+++ b/src/utils/media/pipeline/VirtualBackground.js
@@ -76,11 +76,7 @@ export default class VirtualBackground extends TrackSinkSource {
 			const wasmCheck = require('wasm-check')
 			this._wasmSupported = true
 
-			if (wasmCheck.feature.simd) {
-				this._wasmSimd = true
-			} else {
-				this._wasmSimd = false
-			}
+			this._wasmSimd = wasmCheck.feature.simd
 		} catch (error) {
 			this._wasmSupported = false
 

--- a/src/utils/media/pipeline/VirtualBackground.js
+++ b/src/utils/media/pipeline/VirtualBackground.js
@@ -76,7 +76,7 @@ export default class VirtualBackground extends TrackSinkSource {
 			const wasmCheck = require('wasm-check')
 			this._wasmSupported = true
 
-			if (wasmCheck?.feature?.simd) {
+			if (wasmCheck.feature.simd) {
 				this._wasmSimd = true
 			} else {
 				this._wasmSimd = false

--- a/src/utils/media/pipeline/VirtualBackground.spec.js
+++ b/src/utils/media/pipeline/VirtualBackground.spec.js
@@ -77,6 +77,9 @@ describe('VirtualBackground', () => {
 
 		jest.spyOn(VirtualBackground.prototype, '_initJitsiStreamBackgroundEffect').mockImplementation(function() {
 			this._jitsiStreamBackgroundEffect = {
+				getVirtualBackground: jest.fn(() => {
+					return this._jitsiStreamBackgroundEffect.virtualBackground
+				}),
 				setVirtualBackground: jest.fn(() => {
 				}),
 				startEffect: jest.fn((inputStream) => {
@@ -118,14 +121,54 @@ describe('VirtualBackground', () => {
 		jest.restoreAllMocks()
 	})
 
-	test('set virtual background type and parameters', () => {
-		virtualBackground.setVirtualBackground({
-			objectWithoutValidation: true,
+	describe('get virtual background', () => {
+		beforeEach(() => {
+			virtualBackground._jitsiStreamBackgroundEffect.virtualBackground = {
+				objectWithoutValidation: true,
+			}
 		})
 
-		expect(virtualBackground._jitsiStreamBackgroundEffect.setVirtualBackground).toHaveBeenCalledTimes(1)
-		expect(virtualBackground._jitsiStreamBackgroundEffect.setVirtualBackground).toHaveBeenNthCalledWith(1, {
-			objectWithoutValidation: true,
+		test('gets virtual background', () => {
+			expect(virtualBackground.getVirtualBackground()).toEqual({
+				objectWithoutValidation: true,
+			})
+			expect(virtualBackground._jitsiStreamBackgroundEffect.getVirtualBackground).toHaveBeenCalledTimes(1)
+		})
+
+		test('returns null if get when not available', () => {
+			available = false
+
+			expect(virtualBackground.getVirtualBackground()).toBe(undefined)
+			// A real VirtualBackground object would not even have a
+			// _jitsiStreamBackgroundEffect object if not available, but the
+			// mock is kept to perform the assertion.
+			expect(virtualBackground._jitsiStreamBackgroundEffect.getVirtualBackground).toHaveBeenCalledTimes(0)
+		})
+	})
+
+	describe('set virtual background', () => {
+		test('sets virtual background type and parameters', () => {
+			virtualBackground.setVirtualBackground({
+				objectWithoutValidation: true,
+			})
+
+			expect(virtualBackground._jitsiStreamBackgroundEffect.setVirtualBackground).toHaveBeenCalledTimes(1)
+			expect(virtualBackground._jitsiStreamBackgroundEffect.setVirtualBackground).toHaveBeenNthCalledWith(1, {
+				objectWithoutValidation: true,
+			})
+		})
+
+		test('does nothing if set when not available', () => {
+			available = false
+
+			virtualBackground.setVirtualBackground({
+				objectWithoutValidation: true,
+			})
+
+			// A real VirtualBackground object would not even have a
+			// _jitsiStreamBackgroundEffect object if not available, but the
+			// mock is kept to perform the assertion.
+			expect(virtualBackground._jitsiStreamBackgroundEffect.setVirtualBackground).toHaveBeenCalledTimes(0)
 		})
 	})
 

--- a/src/utils/webrtc/models/LocalMediaModel.js
+++ b/src/utils/webrtc/models/LocalMediaModel.js
@@ -132,7 +132,9 @@ LocalMediaModel.prototype = {
 		this.set('videoEnabled', false)
 		this.set('virtualBackgroundAvailable', this._webRtc.webrtc.isVirtualBackgroundAvailable())
 		this.set('virtualBackgroundEnabled', this._webRtc.webrtc.isVirtualBackgroundEnabled())
-		this._setVirtualBackgroundTypeAndParameters(this._webRtc.webrtc.getVirtualBackground())
+		if (this._webRtc.webrtc.isVirtualBackgroundAvailable()) {
+			this._setVirtualBackgroundTypeAndParameters(this._webRtc.webrtc.getVirtualBackground())
+		}
 		this.set('localScreen', null)
 
 		this._webRtc.webrtc.on('localStreamRequested', this._handleLocalStreamRequestedBound)


### PR DESCRIPTION
Before _wasm-check 2.1.0_ (@ShGKme I knew that the try/catch was there [for a reason](https://github.com/nextcloud/spreed/commit/773d24f1ddfaaf65c9aed0c8148f1a0fffb9b2a8#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R88) :-P ) if WebAssembly was disabled in Firefox an exception was thrown when loading _wasm-check_. However, [this was not the expected behaviour, but a bug](https://github.com/MaxGraey/wasm-check/commit/86565b3ca4559257410dd57c4bcc395ee44f88f6). The proper way is to check it using `support()`, which returns `false` if not supported.

Besides that, [when support for using images as a virtual background was added](https://github.com/nextcloud/spreed/pull/9296) _someone_ :-P forgot that `_jitsiStreamBackgroundEffect` is not defined when the virtual background is not available. The getter and setter are now guarded in that case, which also requires not using the getter if an object is expected when the virtual background is not available.

I am not sure if this deserves a backport below _stable27_ :thinking: (only for the first and second commits, as the third one fixes a bug introduced in Talk 17)

## How to test (scenario 1)

- In Firefox, open `about:config` and set `javascript.options.wasm` to `false` to disable WebAssembly
- Open Talk

### Result with this pull request

_Looks like WebAssembly is disabled or not supported on this browser, virtual background will not be available_ is logged to the console

### Result without this pull request

_tflite compilation failed. The web server may not be properly configured to send wasm and/or tflite files._ is logged to the console



## How to test (scenario 2)

- Use Firefox
- Open Talk
- Start a call to open the device picker
- Enable a virtual background
- Open `about:config` and set `javascript.options.wasm` to `false` to disable WebAssembly
- Reload Talk 
- Start a call to open the device picker

### Result with the third commit of this pull request

Microphone and camera are available, although not the virtual background

### Result with the second commit of this pull request

No devices are available and `this._jitsiStreamBackgroundEffect_ is undefined` is logged to the console
