### PR TITLE
fix(Message) - adjust visual dividers for markdown code fragments

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -1118,13 +1118,25 @@ export default {
 			list-style-type: decimal;
 		}
 
-		pre,
-		code {
-			padding: 6px;
-			margin: 2px;
+		pre {
+			padding: 4px;
+			margin: 2px 0;
 			border-radius: var(--border-radius);
 			background-color: var(--color-background-dark);
+
+      & code {
+        margin: 0;
+        padding: 0;
+      }
 		}
+
+    code {
+      display: inline-block;
+      padding: 2px 4px;
+      margin: 2px 0;
+      border-radius: var(--border-radius);
+      background-color: var(--color-background-dark);
+    }
 
 		blockquote {
 			position: relative;


### PR DESCRIPTION
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/ecef664e-0aa0-4eb7-8511-ead176849711) | ![image](https://github.com/nextcloud/spreed/assets/93392545/13279554-ec28-4aa2-a8fc-16dd214dda7f)



### 🚧 Tasks

- [ ] Visual check
- [ ] Folow-up: upstream styles to NcRichText component

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
