### PR TITLE
Virtual scrolling for conversations list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "vue-prevent-unload": "^0.2.3",
         "vue-router": "^3.6.5",
         "vue-shortkey": "^3.1.7",
+        "vue-virtual-scroller": "^1.1.2",
         "vue2-leaflet": "^2.7.1",
         "vuex": "^3.6.2",
         "webdav": "^5.2.3",
@@ -15943,6 +15944,11 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA=="
+    },
     "node_modules/sdp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.0.tgz",
@@ -18282,6 +18288,32 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "node_modules/vue-virtual-scroller": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vue-virtual-scroller/-/vue-virtual-scroller-1.1.2.tgz",
+      "integrity": "sha512-SkUyc7QHCJFB5h1Fya7LxVizlVzOZZuFVipBGHYoTK8dwLs08bIz/tclvRApYhksaJIm/nn51inzO2UjpGJPMQ==",
+      "dependencies": {
+        "scrollparent": "^2.0.1",
+        "vue-observe-visibility": "^0.4.4",
+        "vue-resize": "^0.4.5"
+      },
+      "peerDependencies": {
+        "vue": "^2.6.11"
+      }
+    },
+    "node_modules/vue-virtual-scroller/node_modules/vue-observe-visibility": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-0.4.6.tgz",
+      "integrity": "sha512-xo0CEVdkjSjhJoDdLSvoZoQrw/H2BlzB5jrCBKGZNXN2zdZgMuZ9BKrxXDjNP2AxlcCoKc8OahI3F3r3JGLv2Q=="
+    },
+    "node_modules/vue-virtual-scroller/node_modules/vue-resize": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-0.4.5.tgz",
+      "integrity": "sha512-bhP7MlgJQ8TIkZJXAfDf78uJO+mEI3CaLABLjv0WNzr4CcGRGPIAItyWYnP6LsPA4Oq0WE+suidNs6dgpO4RHg==",
+      "peerDependencies": {
+        "vue": "^2.3.0"
+      }
     },
     "node_modules/vue2-datepicker": {
       "version": "3.11.0",
@@ -30660,6 +30692,11 @@
         }
       }
     },
+    "scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA=="
+    },
     "sdp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.0.tgz",
@@ -32463,6 +32500,29 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vue-virtual-scroller": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vue-virtual-scroller/-/vue-virtual-scroller-1.1.2.tgz",
+      "integrity": "sha512-SkUyc7QHCJFB5h1Fya7LxVizlVzOZZuFVipBGHYoTK8dwLs08bIz/tclvRApYhksaJIm/nn51inzO2UjpGJPMQ==",
+      "requires": {
+        "scrollparent": "^2.0.1",
+        "vue-observe-visibility": "^0.4.4",
+        "vue-resize": "^0.4.5"
+      },
+      "dependencies": {
+        "vue-observe-visibility": {
+          "version": "0.4.6",
+          "resolved": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-0.4.6.tgz",
+          "integrity": "sha512-xo0CEVdkjSjhJoDdLSvoZoQrw/H2BlzB5jrCBKGZNXN2zdZgMuZ9BKrxXDjNP2AxlcCoKc8OahI3F3r3JGLv2Q=="
+        },
+        "vue-resize": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-0.4.5.tgz",
+          "integrity": "sha512-bhP7MlgJQ8TIkZJXAfDf78uJO+mEI3CaLABLjv0WNzr4CcGRGPIAItyWYnP6LsPA4Oq0WE+suidNs6dgpO4RHg==",
+          "requires": {}
+        }
+      }
     },
     "vue2-datepicker": {
       "version": "3.11.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "vue-prevent-unload": "^0.2.3",
     "vue-router": "^3.6.5",
     "vue-shortkey": "^3.1.7",
+    "vue-virtual-scroller": "^1.1.2",
     "vue2-leaflet": "^2.7.1",
     "vuex": "^3.6.2",
     "webdav": "^5.2.3",

--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -27,9 +27,14 @@
 		<div v-if="iconClass"
 			class="avatar icon"
 			:class="iconClass" />
-		<NcAvatar v-else-if="!isOneToOne"
-			:url="avatarUrl"
-			:size="size" />
+		<!-- img is used here instead of NcAvatar to explicitly set key required to avoid glitching in virtual scrolling  -->
+		<img v-else-if="!isOneToOne"
+			:key="avatarUrl"
+			:src="avatarUrl"
+			:width="size"
+			:height="size"
+			:alt="item.displayName"
+			class="avatar icon">
 		<NcAvatar v-else
 			:size="size"
 			:user="item.name"

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -180,6 +180,8 @@ export default {
 		},
 	},
 
+	emits: ['click'],
+
 	computed: {
 		counterType() {
 			if (this.item.unreadMentionDirect || (this.item.unreadMessages !== 0 && (
@@ -425,6 +427,7 @@ export default {
 			if (this.isSearchResult) {
 				this.$store.dispatch('addConversation', this.item)
 			}
+			this.$emit('click')
 		},
 
 		onActionClick() {

--- a/src/components/LeftSidebar/ConversationsListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsListVirtual.vue
@@ -1,0 +1,156 @@
+<!--
+  - @copyright Copyright (c) 2023 Grigorii Shartsev <me@shgk.me>
+  -
+  - @author Grigorii Shartsev <me@shgk.me>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<template>
+	<RecycleScroller ref="scroller"
+		item-tag="ul"
+		:items="conversations"
+		:item-size="CONVERSATION_ITEM_SIZE"
+		key-field="token">
+		<template #default="{ item }">
+			<Conversation :item="item" />
+		</template>
+		<template #after>
+			<LoadingPlaceholder v-if="loading" type="conversations" />
+		</template>
+	</RecycleScroller>
+</template>
+
+<script>
+import { RecycleScroller } from 'vue-virtual-scroller'
+
+import LoadingPlaceholder from '../LoadingPlaceholder.vue'
+import Conversation from './ConversationsList/Conversation.vue'
+
+import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'
+
+const CONVERSATION_ITEM_SIZE = 64
+
+export default {
+	name: 'ConversationsListVirtual',
+
+	components: {
+		LoadingPlaceholder,
+		Conversation,
+		RecycleScroller,
+	},
+
+	props: {
+		conversations: {
+			type: Array,
+			required: true,
+		},
+
+		loading: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	setup() {
+		return {
+			CONVERSATION_ITEM_SIZE,
+		}
+	},
+
+	methods: {
+		/**
+		 * Get an index of the first fully visible conversation in viewport
+		 *
+		 * @public
+		 * @return {number}
+		 */
+		getFirstItemInViewportIndex() {
+			// (ceil to include partially) of (absolute number of items above viewport) + 1 (next item is in viewport) - 1 (index starts from 0)
+			return Math.ceil(this.$refs.scroller.$el.scrollTop / CONVERSATION_ITEM_SIZE)
+		},
+
+		/**
+		 * Get an index of the last fully visible conversation in viewport
+		 *
+		 * @public
+		 * @return {number}
+		 */
+		getLastItemInViewportIndex() {
+			// (floor to include only fully visible) of (absolute number of items below and in viewport) - 1 (index starts from 0)
+			return Math.floor((this.$refs.scroller.$el.scrollTop + this.$refs.scroller.$el.clientHeight) / CONVERSATION_ITEM_SIZE) - 1
+		},
+
+		/**
+		 * Scroll to conversation by index
+		 *
+		 * @public
+		 * @param {number} index - index of conversation to scroll to
+		 * @return {Promise<void>}
+		 */
+		async scrollToItem(index) {
+			const firstItemIndex = this.getFirstItemInViewportIndex()
+			const lastItemIndex = this.getLastItemInViewportIndex()
+
+			const viewportHeight = this.$refs.scroller.$el.clientHeight
+
+			/**
+			 * Scroll to a position with smooth scroll imitation
+			 *
+			 * @param {number} to - target position
+			 * @return {void}
+			 */
+			const doScroll = (to) => {
+				const ITEMS_TO_BORDER_AFTER_SCROLL = 1
+				const padding = ITEMS_TO_BORDER_AFTER_SCROLL * CONVERSATION_ITEM_SIZE
+				const from = this.$refs.scroller.$el.scrollTop
+				const direction = from < to ? 1 : -1
+
+				// If we are far from the target - instantly scroll to a close position
+				if (Math.abs(from - to) > viewportHeight) {
+					this.$refs.scroller.scrollToPosition(to - direction * viewportHeight)
+				}
+
+				// Scroll to the target with smooth scroll
+				this.$refs.scroller.$el.scrollTo({
+					top: to + padding * direction,
+					behavior: 'smooth',
+				})
+			}
+
+			if (index < firstItemIndex) { // Item is above
+				await doScroll(index * CONVERSATION_ITEM_SIZE)
+			} else if (index > lastItemIndex) { // Item is below
+				// Position of item + item's height and move to bottom
+				await doScroll((index + 1) * CONVERSATION_ITEM_SIZE - viewportHeight)
+			}
+		},
+
+		/**
+		 * Scroll to conversation by token
+		 *
+		 * @param {string} token - token of conversation to scroll to
+		 * @return {void}
+		 */
+		scrollToConversation(token) {
+			const index = this.conversations.findIndex(conversation => conversation.token === token)
+			if (index !== -1) {
+				this.scrollToItem(index)
+			}
+		},
+	},
+}
+</script>

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -467,9 +467,8 @@ export default {
 
 	mounted() {
 		EventBus.$on('should-refresh-conversations', this.handleShouldRefreshConversations)
-		EventBus.$once('conversations-received', this.handleUnreadMention)
+		EventBus.$once('conversations-received', this.handleConversationsReceived)
 		EventBus.$on('route-change', this.onRouteChange)
-		EventBus.$on('joined-conversation', this.handleJoinedConversation)
 	},
 
 	beforeDestroy() {
@@ -730,6 +729,13 @@ export default {
 			}
 		},
 
+		handleConversationsReceived() {
+			this.handleUnreadMention()
+			if (this.$route.params.token) {
+				this.scrollToConversation(this.$route.params.token)
+			}
+		},
+
 		// Checks whether the conversations list is scrolled all the way to the top
 		// or not
 		handleScroll() {
@@ -782,17 +788,13 @@ export default {
 			}
 			if (to.name === 'conversation') {
 				this.$store.dispatch('joinConversation', { token: to.params.token })
+				this.scrollToConversation(to.params.token)
 			}
 			if (this.isMobile) {
 				emit('toggle-navigation', {
 					open: false,
 				})
 			}
-		},
-
-		handleJoinedConversation({ token }) {
-			this.abortSearch()
-			this.scrollToConversation(token)
 		},
 
 		iconData(item) {

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -123,6 +123,13 @@
 								@scroll.native="debounceHandleScroll" />
 						</li>
 						<Hint v-if="initialisedConversations && filteredConversationsList.length === 0" :hint="t('spreed', 'No matches found')" />
+
+						<NcButton v-if="!preventFindingUnread && lastUnreadMentionBelowViewportIndex !== null"
+							class="unread-mention-button"
+							type="primary"
+							@click="scrollBottomUnread">
+							{{ t('spreed', 'Unread mentions') }}
+						</NcButton>
 					</template>
 
 					<!-- Search results -->
@@ -205,13 +212,6 @@
 					</template>
 				</ul>
 			</li>
-
-			<NcButton v-if="!preventFindingUnread && lastUnreadMentionBelowViewportIndex !== null"
-				class="unread-mention-button"
-				type="primary"
-				@click="scrollBottomUnread">
-				{{ t('spreed', 'Unread mentions') }}
-			</NcButton>
 		</template>
 
 		<template #footer>

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -151,7 +151,8 @@
 						<Conversation v-for="item of searchResultsConversationList"
 							:key="`conversation_${item.id}`"
 							:ref="`conversation-${item.token}`"
-							:item="item" />
+							:item="item"
+							@click="abortSearch" />
 						<Hint v-if="searchResultsConversationList.length === 0" :hint="t('spreed', 'No matches found')" />
 
 						<!-- Search results: listed (open) conversations -->
@@ -160,7 +161,8 @@
 							<Conversation v-for="item of searchResultsListedConversations"
 								:key="`open-conversation_${item.id}`"
 								:item="item"
-								is-search-result />
+								is-search-result
+								@click="abortSearch" />
 						</template>
 
 						<!-- Search results: users -->
@@ -425,11 +427,6 @@ export default {
 	},
 
 	beforeMount() {
-		// After a conversation was created, the search filter is reset
-		EventBus.$once('resetSearchFilter', () => {
-			this.abortSearch()
-		})
-
 		// Restore last fetched conversations from browser storage,
 		// before updated ones come from server
 		this.restoreConversations()
@@ -605,6 +602,7 @@ export default {
 			if (item.source === 'users') {
 				// Create one-to-one conversation directly
 				const conversation = await this.$store.dispatch('createOneToOneConversation', item.id)
+				this.abortSearch()
 				this.$router.push({
 					name: 'conversation',
 					params: { token: conversation.token },


### PR DESCRIPTION
PR is made on top of https://github.com/nextcloud/spreed/pull/10051

### ☑️ Resolves

Performance issues:
1. Too many conversations avatars request: 
   Opening a page with 500 conversations immediately makes 500 requests for conversation avatars
2. Initial loading is slow for long chat lists
3. Scrolling a long conversations list and interacting with the menu could be slow on a long conversations list

### 🖼️ Screenshots

Almost no visual changes, except scrolling behavior.

By default scroll to position in virtual scrolling just "teleport" to a new position instantly:

To the end | To unread
---|---
![instant](https://github.com/nextcloud/spreed/assets/25978914/0c55764d-7f8c-4f07-93b9-6b2aea8078f3) | ![instant-2](https://github.com/nextcloud/spreed/assets/25978914/029331b9-b390-4e0a-8996-272038b9ffb7)

It doesn't look good and it is different from the current Talk behavior. And it makes it less understandable from what direction (up/down) the user have moved.

But we cannot just use smooth scrolling... Smooth scrolling from the beginning to the end means - loading **ALL** avatars in between and not very performant in general.

The idea is "imitating" the smooth scrolling:
1. If the new position is far from the current - first instantly move to a distance of one visual list height from the target
2. Then scroll with smooth just for a small number of elements

Scroll close | Scroll a bit far | Scroll from the end of 500
---|---|---
![scroll-close](https://github.com/nextcloud/spreed/assets/25978914/8f26b7be-faaf-4ca2-8cd3-71c626560e16) | ![scroll-far-1](https://github.com/nextcloud/spreed/assets/25978914/f9829726-8afc-427a-898e-f62f87e0b92f) | ![scroll-far-2](https://github.com/nextcloud/spreed/assets/25978914/46021eba-d49f-4641-ac33-e3c8c7d53f3b)

Throw 500 chats scrolling is not super smooth but smooth a bit :D

### 🚧 Tasks

- [x] Choose and add a virtual scroller
  - Currently, one popular from a Vue core team member is used: https://github.com/Akryum/vue-virtual-scroller
  - But I'd switch to our own scroller in future
- [x] Use a virtual scroller for the conversations list
  - [x] Change scrolling and unread mentions handling with the virtual list
- [x] Use `<img>` with implicit `key` instead of `<NcAvatar>` for conversations
  - Without a `key` on `<img>` there is a glitch effect on scrolling because Vue updates `src` of the images. Even though images are cached after the first load, the glitch effect is still visible.
  - It is still a problem for 1-1

With glitching | Without glitching
---|---
![with-glitch](https://github.com/nextcloud/spreed/assets/25978914/699c1220-b547-42a7-bf1a-38a88fb8d6b1) | ![no-glitch](https://github.com/nextcloud/spreed/assets/25978914/4f987474-7cb7-43e8-bae7-4ad669570444)

### 📝 Notes and drawbacks

#### No virtual scrolling in the search results

A virtual scroller is used ONLY for the main conversations list (incl. filtered conversations) and **NOT** for the search results. The search results are more complicated because it is not a homogeneous list but several lists with different elements in between.

#### Glitching effect with 1-1 conversations avatars

To avoid it we need to stop using `<NcAvatar>` for 1-1 (what is problematic with the user status) or add `key` to `<NcAvatar>` and make it more performant on props updating.

### 👀 Alternative solutions 

If we only want to fix the first problem with avatar fetching, we can just implement lazy loading for conversation avatars.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
