### PR TITLE
fix(LeftSidebar): create a conversation button is shown when forbidden

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -113,7 +113,7 @@
 		<template #list>
 			<li ref="container" class="left-sidebar__list" @scroll="debounceHandleScroll">
 				<ul class="scroller">
-					<NcListItem v-if="noMatchFound && searchText"
+					<NcListItem v-if="noMatchFound && searchText && canStartConversations"
 						:title="t('spreed', 'Create a new conversation')"
 						@click="createConversation(searchText)">
 						<template #icon>


### PR DESCRIPTION
### ☑️ Resolves

"Create a new conversation button" is shown in the empty search results for a user who cannot create a conversation

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
