### PR TITLE
Fix call view shown if force reconnected when not in a call

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -905,7 +905,7 @@ Signaling.Standalone.prototype.forceReconnect = function(newSession, flags) {
 				store.commit('setInCall', {
 					token: this.currentRoomToken,
 					sessionId: this.nextcloudSessionId,
-					flags: this.currentCallFlags,
+					flags: this.currentCallFlags || PARTICIPANT.CALL_FLAG.DISCONNECTED,
 				})
 
 				this.sendBye()


### PR DESCRIPTION
This fixes a regression introduced in #10206

After a force reconnection the local participant state is updated in the store. If the participant is not in a call the call flags will be null, but [the store expects an integer as the call flag, and any value different from 0](https://github.com/nextcloud/spreed/blob/1ac74f976047e6394b26a55d2bb51174b34c2881/src/store/participantsStore.js#L281-L282) (disconnected) [is treated as "in the call"](https://github.com/nextcloud/spreed/blob/1ac74f976047e6394b26a55d2bb51174b34c2881/src/store/participantsStore.js#L66).

This should not happen _in the real world_, as forced reconnections are only triggered during calls and in that case the flags are properly set, but better fix it anyway ;-)

## How to test

- Add a helper to expose the signaling object, for example, in [_src/utils/webrtc/index.js_](https://github.com/nextcloud/spreed/blob/650d0dd4d4f423b7a7c4e03e0d3a7cd972ecb81e/src/utils/webrtc/index.js#L60):
```
window.getSignaling = function() {
	return signaling
}
```
- Rebuild the code
- Setup the HPB
- Open a conversation in Talk
In the browser console, run `getSignaling().forceReconnect(true)`

### Result with this pull request

There are no changes in the UI

### Result without this pull request

The call view is shown, although the participant is not actually in the call
