### PR TITLE
follow-up(LeftSidebar) - caching optimization

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -445,6 +445,7 @@ export default {
 				switch (event.data.message) {
 				case 'force-fetch-all-conversations':
 					this.roomListModifiedBefore = 0
+					this.forceFullRoomListRefreshAfterXLoops = 10
 					this.debounceFetchConversations()
 					break
 				}
@@ -656,6 +657,7 @@ export default {
 			if (options?.all === true) {
 				if (this.isCurrentTabLeader) {
 					this.roomListModifiedBefore = 0
+					this.forceFullRoomListRefreshAfterXLoops = 10
 				} else {
 					// Force leader tab to do a full fetch
 					talkBroadcastChannel.postMessage({ message: 'force-fetch-all-conversations' })

--- a/src/store/conversationsStore.spec.js
+++ b/src/store/conversationsStore.spec.js
@@ -202,7 +202,7 @@ describe('conversationsStore', () => {
 			expect(deleteConversation).not.toHaveBeenCalled()
 		})
 
-		test('restores conversations cached in BrowserStorage', () => {
+		test('restores conversations cached in BrowserStorage', async () => {
 			const testConversations = [
 				{
 					token: 'one_token',
@@ -220,7 +220,7 @@ describe('conversationsStore', () => {
 				'[{"token":"one_token","attendeeId":"attendee-id-1","lastActivity":1675209600},{"token":"another_token","attendeeId":"attendee-id-2","lastActivity":1672531200}]'
 			)
 
-			store.dispatch('restoreConversations')
+			await store.dispatch('restoreConversations')
 
 			expect(BrowserStorage.getItem).toHaveBeenCalledWith('cachedConversations')
 			expect(store.getters.conversationsList).toHaveLength(2)
@@ -313,7 +313,8 @@ describe('conversationsStore', () => {
 
 			fetchConversations.mockResolvedValue(response)
 
-			await store.dispatch('fetchConversations', {})
+			store.dispatch('fetchConversations', { })
+			await flushPromises()
 
 			expect(BrowserStorage.setItem).toHaveBeenCalledWith('cachedConversations',
 				'[{"token":"one_token","attendeeId":"attendee-id-1","lastActivity":1675209600},{"token":"another_token","attendeeId":"attendee-id-2","lastActivity":1672531200}]'
@@ -399,7 +400,10 @@ describe('conversationsStore', () => {
 			}
 			fetchConversations.mockResolvedValue(response)
 			emit.mockClear()
-			await store.dispatch('fetchConversations', { })
+
+			store.dispatch('fetchConversations', { })
+			await flushPromises()
+
 			// Only new conversation emits event
 			expect(emit).toHaveBeenCalledTimes(1)
 			expect(emit.mock.calls.at(-1)).toEqual([
@@ -593,7 +597,8 @@ describe('conversationsStore', () => {
 
 			fetchConversations.mockResolvedValue(response)
 
-			await store.dispatch('fetchConversations', {})
+			store.dispatch('fetchConversations', { })
+			await flushPromises()
 
 			expect(fetchConversations).toHaveBeenCalledWith({})
 			expect(store.getters.conversationsList).toStrictEqual(testConversations)


### PR DESCRIPTION
### ☑️ Resolves

* Part of #10283
* If full fetch was forced from signaling (leader or sub-tab), counter will be reset to 10 again (like we do after usual full fetch)
* cashing was moved to `patchConversations` action called by `fetchConversations` action
* a flag was added to `patchConversations` to watch, if there was changes after fetch to cache them
* `updateConversationIfHasChanged` logic was moved from mutation to the action

---
### 🖼️ Screenshots
No visual changes

### 🚧 Tasks
No due tasks

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
