### PR TITLE
fix(participantsStore) - use attendeeId as a key to store speaking information

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -503,7 +503,7 @@ export default {
 		},
 
 		participantSpeakingInformation() {
-			return this.$store.getters.getParticipantSpeakingInformation(this.token, this.sessionIds)
+			return this.$store.getters.getParticipantSpeakingInformation(this.token, this.attendeeId)
 		},
 
 		isParticipantSpeaking() {

--- a/src/store/participantsStore.spec.js
+++ b/src/store/participantsStore.spec.js
@@ -164,7 +164,7 @@ describe('participantsStore', () => {
 		})
 
 		test('find participant by session', () => {
-			const attendee = { sessionId: '1234567890' }
+			const attendee = { sessionIds: ['1234567890'] }
 			store.dispatch('addParticipant', {
 				token: TOKEN,
 				participant: attendee,

--- a/src/utils/webrtc/SpeakingStatusHandler.js
+++ b/src/utils/webrtc/SpeakingStatusHandler.js
@@ -115,7 +115,7 @@ export default class SpeakingStatusHandler {
 	#handleLocalSpeaking(localMediaModel, speaking) {
 		this.#store.dispatch('setSpeaking', {
 			token: this.#store.getters.getToken(),
-			sessionId: this.#store.getters.getSessionId(),
+			attendeeId: this.#store.getters.getAttendeeId(),
 			speaking,
 		})
 	}
@@ -127,7 +127,7 @@ export default class SpeakingStatusHandler {
 	#handleLocalPeerId() {
 		this.#store.dispatch('setSpeaking', {
 			token: this.#store.getters.getToken(),
-			sessionId: this.#store.getters.getSessionId(),
+			attendeeId: this.#store.getters.getAttendeeId(),
 			speaking: this.#localMediaModel.attributes.speaking,
 		})
 	}
@@ -139,9 +139,18 @@ export default class SpeakingStatusHandler {
 	 * @param {boolean} speaking whether the participant is speaking or not
 	 */
 	#handleSpeaking(callParticipantModel, speaking) {
+		const attendeeId = this.#store.getters.findParticipant(
+			this.#store.getters.getToken(),
+			{ sessionId: callParticipantModel.attributes.nextcloudSessionId }
+		)?.attendeeId
+
+		if (!attendeeId) {
+			return
+		}
+
 		this.#store.dispatch('setSpeaking', {
 			token: this.#store.getters.getToken(),
-			sessionId: callParticipantModel.attributes.nextcloudSessionId,
+			attendeeId,
 			speaking,
 		})
 	}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10226 
* After reconnection to call (or page reload), participant joins with new sessionId - previously stored data become inaccessible anymore. This could be observable at 'speaking time' jumping from somewhere to 0:00 again
* `attendeeId` is a unique number for participant within conversation, so it could be used to store speaking information and retreive it after reconnection
* P.S. (fixed) - at some point code was moved to support multiple sessionIds for user - there was one place to not check it properly

### 🖼️ Screenshots
No visual changes


### 🚧 Tasks
To test: 
1. Join a group call as two different users
2. Gain some numbers on speaking timer
3. Reload page as one of the users, join call again and speak - second user should still see elapsed time from first connection + new time
4. Optionally: force reconnect to call (require webrtc.js file modification) - both users should still see elapsed time from first connection + new time

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
