### PR TITLE
Fix patch conversation performance

### DIFF
--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -336,7 +336,7 @@ const actions = {
 	 * @param {boolean} payload.withRemoving whether to remove conversations that are not in the new list
 	 * @param {boolean} payload.withCaching whether to cache conversations to BrowserStorage with patch
 	 */
-	async patchConversations(context, { conversations, withRemoving = false, withCaching = false }) {
+	patchConversations(context, { conversations, withRemoving = false, withCaching = false }) {
 		let storeHasChanged = false
 
 		const currentConversations = context.state.conversations
@@ -348,7 +348,7 @@ const actions = {
 		if (withRemoving) {
 			for (const token of Object.keys(currentConversations)) {
 				if (newConversations[token] === undefined) {
-					await context.dispatch('deleteConversation', token)
+					context.dispatch('deleteConversation', token)
 					storeHasChanged = true
 				}
 			}
@@ -357,10 +357,10 @@ const actions = {
 		// Add new conversations and patch existing ones
 		for (const [token, newConversation] of Object.entries(newConversations)) {
 			if (currentConversations[token] === undefined) {
-				await context.dispatch('addConversation', newConversation)
+				context.dispatch('addConversation', newConversation)
 				storeHasChanged = true
 			} else {
-				const conversationHasChanged = await context.dispatch('updateConversationIfHasChanged', newConversation)
+				const conversationHasChanged = context.dispatch('updateConversationIfHasChanged', newConversation)
 				storeHasChanged = conversationHasChanged || storeHasChanged
 			}
 		}


### PR DESCRIPTION
### ☑️ Resolves

Regression of https://github.com/nextcloud/spreed/pull/10284

`await`s in `patchConversations` are redundant as all called actions are synchronous. Each `await` creates a new microtask. For 500 chats it creates 500 microtasks. It blocks the main process.

### 🖼️ `patchConversations` time on 500 chats

🐌 Before | 🚄 After | Increase
---|---|---
`11_000 ms` - `17_000 ms` | `115 ms` - `225 ms` | `x48` - `x147`
#

### 🚧 Tasks

- [x] Remove redundant `await`s

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
