### PR TITLE
fix(messagesStore) - clean conversation history for participants in call

### DIFF
--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -395,6 +395,31 @@ const mutations = {
 		}
 	},
 
+	/**
+	 * Clears the messages entry from the store for the given conversation token
+	 * starting from defined id.
+	 *
+	 * @param {object} state current store state
+	 * @param {object} payload payload;
+	 * @param {string} payload.token the token of the conversation to be cleared;
+	 * @param {number} payload.id the id of the message to be the first one after clear;
+	 */
+	clearMessagesHistory(state, { token, id }) {
+		Vue.set(state.firstKnown, token, id)
+
+		if (state.visualLastReadMessageId[token] && state.visualLastReadMessageId[token] < id) {
+			Vue.set(state.visualLastReadMessageId, token, id)
+		}
+
+		if (state.messages[token]) {
+			for (const messageId of Object.keys(state.messages[token])) {
+				if (messageId < id) {
+					Vue.delete(state.messages[token], messageId)
+				}
+			}
+		}
+	},
+
 	// Increases reaction count for a particular reaction on a message
 	addReactionToMessage(state, { token, messageId, reaction }) {
 		if (!state.messages[token][messageId].reactions[reaction]) {
@@ -512,6 +537,13 @@ const actions = {
 			context.dispatch('getPollData', {
 				token: message.token,
 				pollId: message.messageParameters.poll.id,
+			})
+		}
+
+		if (message.systemMessage === 'history_cleared') {
+			context.commit('clearMessagesHistory', {
+				token: message.token,
+				id: message.id,
 			})
 		}
 
@@ -692,6 +724,18 @@ const actions = {
 	 */
 	deleteMessages(context, token) {
 		context.commit('deleteMessages', token)
+	},
+
+	/**
+	 * Clear all messages before defined id from the store only.
+	 *
+	 * @param {object} context default store context;
+	 * @param {object} payload payload;
+	 * @param {string} payload.token the token of the conversation to be cleared;
+	 * @param {number} payload.id the id of the message to be the first one after clear;
+	 */
+	clearMessagesHistory(context, { token, id }) {
+		context.commit('clearMessagesHistory', { token, id })
 	},
 
 	/**


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10298

Solution might be a bit overkill, so here are some explanations:
* System message `history_cleared` will be the first one in conversation by definition, so only previous messages should be cleared
* Depending on internet connection, or after conversation switching - there could be a new messages after clearing, so we can't purge the whole room, because it also could clear new ones.
* When scroll to the top and fetch - system message will be last processed and first known, so no mutations should occur

### 🖼️ Screenshots

[clear-history.webm](https://github.com/nextcloud/spreed/assets/93392545/1e1c1d82-0715-4906-8e0e-30a6807764f2)



### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
