### PR TITLE
Allow to offboard only on private conversations

### DIFF
--- a/docs/occ.md
+++ b/docs/occ.md
@@ -467,11 +467,12 @@ Remove a user from all their rooms
 
 ### Usage
 
-* `talk:user:remove [--user USER]`
+* `talk:user:remove [--user USER] [--private-only]`
 
 | Options | Accept value | Is value required | Is multiple | Default |
 |---|---|---|---|---|
 | `--user` | Remove the given users from all rooms | yes | yes | yes | array ()` |
+| `--private-only` | Only remove the user from private rooms, retaining membership in public and open conversations as well as one-to-ones | no | no | no | false` |
 
 ## talk:user:transfer-ownership
 

--- a/lib/Command/User/Remove.php
+++ b/lib/Command/User/Remove.php
@@ -50,11 +50,19 @@ class Remove extends Base {
 				null,
 				InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
 				'Remove the given users from all rooms'
-			);
+			)
+			->addOption(
+				'private-only',
+				null,
+				InputOption::VALUE_NONE,
+				'Only remove the user from private rooms, retaining membership in public and open conversations as well as one-to-ones'
+			)
+		;
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$userIds = $input->getOption('user');
+		$privateOnly = $input->getOption('private-only');
 
 		$users = [];
 		foreach ($userIds as $userId) {
@@ -67,7 +75,7 @@ class Remove extends Base {
 		}
 
 		foreach ($users as $user) {
-			$this->manager->removeUserFromAllRooms($user);
+			$this->manager->removeUserFromAllRooms($user, $privateOnly);
 		}
 
 		$output->writeln('<info>Users successfully removed from all rooms.</info>');

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -392,9 +392,21 @@ class Manager {
 		return $rooms;
 	}
 
-	public function removeUserFromAllRooms(IUser $user): void {
+	public function removeUserFromAllRooms(IUser $user, bool $privateOnly = false): void {
 		$rooms = $this->getRoomsForUser($user->getUID());
 		foreach ($rooms as $room) {
+			if ($privateOnly) {
+				if ($room->getType() === Room::TYPE_ONE_TO_ONE
+					|| $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER
+					|| $room->getType() === Room::TYPE_PUBLIC) {
+					continue;
+				}
+
+				if ($this->isRoomListableByUser($room, $user->getUID())) {
+					continue;
+				}
+			}
+
 			if ($this->participantService->getNumberOfUsers($room) === 1) {
 				Server::get(RoomService::class)->deleteRoom($room);
 			} else {
@@ -402,15 +414,17 @@ class Manager {
 			}
 		}
 
-		$leftRooms = $this->getLeftOneToOneRoomsForUser($user->getUID());
-		foreach ($leftRooms as $room) {
-			// We are changing the room type and name so a potential follow-up
-			// user with the same user-id can not reopen the one-to-one conversation.
-			/** @var RoomService $roomService */
-			$roomService = Server::get(RoomService::class);
-			$roomService->setType($room, Room::TYPE_ONE_TO_ONE_FORMER, true);
-			$roomService->setName($room, $user->getDisplayName(), '');
-			$roomService->setReadOnly($room, Room::READ_ONLY);
+		if (!$privateOnly) {
+			$leftRooms = $this->getLeftOneToOneRoomsForUser($user->getUID());
+			foreach ($leftRooms as $room) {
+				// We are changing the room type and name so a potential follow-up
+				// user with the same user-id can not reopen the one-to-one conversation.
+				/** @var RoomService $roomService */
+				$roomService = Server::get(RoomService::class);
+				$roomService->setType($room, Room::TYPE_ONE_TO_ONE_FORMER, true);
+				$roomService->setName($room, $user->getDisplayName(), '');
+				$roomService->setReadOnly($room, Room::READ_ONLY);
+			}
 		}
 	}
 

--- a/tests/integration/features/command/user-remove.feature
+++ b/tests/integration/features/command/user-remove.feature
@@ -5,29 +5,60 @@ Feature: command/user-remove
     Given user "participant2" exists
 
   Scenario: Remove a user from all their rooms
-    Given user "participant1" creates room "room1" (v4)
+    Given user "participant1" creates room "one-to-one" (v4)
       | roomType | 1 |
       | invite   | participant2 |
-    Given user "participant1" creates room "room2" (v4)
+    Given user "participant1" creates room "public room" (v4)
       | roomType | 3 |
-      | roomName | room |
-    And user "participant1" adds user "participant2" to room "room2" with 200 (v4)
+      | roomName | public room |
+    And user "participant1" adds user "participant2" to room "public room" with 200 (v4)
+    Given user "participant1" creates room "private room" (v4)
+      | roomType | 2 |
+      | roomName | private room |
+    And user "participant1" adds user "participant2" to room "private room" with 200 (v4)
+    Given user "participant1" creates room "listable room" (v4)
+      | roomType | 2 |
+      | roomName | listable room |
+    And user "participant1" allows listing room "listable room" for "users" with 200 (v4)
+    And user "participant1" adds user "participant2" to room "listable room" with 200 (v4)
+    And user "participant2" is participant of the following unordered rooms (v4)
+      | id            | name          | type | participantType | readOnly |
+      | one-to-one    | participant1  | 1    | 1               | 0        |
+      | public room   | public room   | 3    | 3               | 0        |
+      | private room  | private room  | 2    | 3               | 0        |
+      | listable room | listable room | 2    | 3               | 0        |
     And user "participant1" is participant of the following unordered rooms (v4)
-      | id    | name         | type | participantType | readOnly |
-      | room1 | participant2 | 1    | 1               | 0        |
-      | room2 | room         | 3    | 1               | 0        |
+      | id            | name          | type | participantType | readOnly |
+      | one-to-one    | participant2  | 1    | 1               | 0        |
+      | public room   | public room   | 3    | 1               | 0        |
+      | private room  | private room  | 2    | 1               | 0        |
+      | listable room | listable room | 2    | 1               | 0        |
+    And invoking occ with "talk:user:remove --user participant2 --private-only"
+    And the command output contains the text "Users successfully removed from all rooms"
+    Then the command was successful
+    And user "participant2" is participant of the following unordered rooms (v4)
+      | id            | name          | type | participantType | readOnly |
+      | one-to-one    | participant1  | 1    | 1               | 0        |
+      | public room   | public room   | 3    | 3               | 0        |
+      | listable room | listable room | 2    | 3               | 0        |
+    And user "participant1" is participant of the following unordered rooms (v4)
+      | id            | name          | type | participantType | readOnly |
+      | one-to-one    | participant2  | 1    | 1               | 0        |
+      | public room   | public room   | 3    | 1               | 0        |
+      | private room  | private room  | 2    | 1               | 0        |
+      | listable room | listable room | 2    | 1               | 0        |
     And invoking occ with "talk:user:remove --user participant2"
     And the command output contains the text "Users successfully removed from all rooms"
     Then the command was successful
     And user "participant2" is participant of the following rooms (v4)
+    And user "participant2" is participant of the following unordered rooms (v4)
     And user "participant1" is participant of the following unordered rooms (v4)
-      | id    | name                     | type | participantType | readOnly |
-      | room1 | participant2-displayname | 5    | 1               | 1        |
-      | room2 | room                     | 3    | 1               | 0        |
-    And user "participant1" sees the following attendees in room "room1" with 200 (v4)
-      | actorType  | actorId      | participantType |
-      | users      | participant1 | 1               |
-    And user "participant1" sees the following attendees in room "room2" with 200 (v4)
+      | id            | name          | type | participantType | readOnly |
+      | one-to-one    | participant2-displayname | 5    | 1               | 1        |
+      | public room   | public room   | 3    | 1               | 0        |
+      | private room  | private room  | 2    | 1               | 0        |
+      | listable room | listable room | 2    | 1               | 0        |
+    And user "participant1" sees the following attendees in room "one-to-one" with 200 (v4)
       | actorType  | actorId      | participantType |
       | users      | participant1 | 1               |
 


### PR DESCRIPTION
Retaining memberships in public, listable and one-to-one conversations

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
