### PR TITLE
fix(BrowserStorage) - clear BrowserStorage when different user logged in

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -227,6 +227,22 @@ export default {
 		},
 	},
 
+	beforeCreate() {
+		const authorizedUser = getCurrentUser()?.uid || null
+		const lastLoggedInUser = BrowserStorage.getItem('last_logged_in_user')
+
+		if (authorizedUser !== lastLoggedInUser) {
+			// TODO introduce helper/util to list and clear all sensitive data
+			// or create BrowserSensitiveStorage for this purposes,
+			// if we have more than one source
+			BrowserStorage.removeItem('cachedConversations')
+		}
+
+		if (authorizedUser) {
+			BrowserStorage.setItem('last_logged_in_user', authorizedUser)
+		}
+	},
+
 	beforeDestroy() {
 		if (!getCurrentUser()) {
 			EventBus.$off('should-refresh-conversations', this.debounceRefreshCurrentConversation)


### PR DESCRIPTION
### ☑️ Resolves

* If another user is logged in, we should check, whether it's `uid` matches with last cached `uid`.
  * if it matches, we could safely restore and use data from storage;
  * if not, we wipe everything related to the last user and containing possibly sensitive data;

### 🖼️ Screenshots
No visual changes

### 🚧 Tasks

- [ ] Add encryption?
- [ ] Another possible checks if `uid` is not enough?

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
