### PR TITLE
fix(dashboard): Adjust dashboard API response after server PR

### DIFF
--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1962,6 +1962,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			$widget['widget_url'] = str_replace('{$BASE_URL}', $this->baseUrl, $widget['widget_url']);
 			$widget['buttons'] = str_replace('{$BASE_URL}', $this->baseUrl, $widget['buttons']);
 			$widget['buttons'] = json_decode($widget['buttons'], true);
+			$widget['item_api_versions'] = json_decode($widget['item_api_versions'], true);
 
 			Assert::assertEquals($widget, $data[$id], 'Mismatch of data for widget ' . $id);
 			Assert::assertStringEndsWith($widgetIconUrl, $dataIconUrl, 'Mismatch of icon URL for widget ' . $id);

--- a/tests/integration/features/integration/dashboard.feature
+++ b/tests/integration/features/integration/dashboard.feature
@@ -5,8 +5,8 @@ Feature: integration/dashboard
 
   Scenario: User gets the available dashboard widgets
     When user "participant1" sees the following entry when loading the list of dashboard widgets (v1)
-      | id     | title         | icon_class          | icon_url         | widget_url                       | item_icons_round | order | buttons |
-      | spreed | Talk mentions | dashboard-talk-icon | img/app-dark.svg | {$BASE_URL}index.php/apps/spreed/ | true             | 10    | [{"type":"more","text":"More unread mentions","link":"{$BASE_URL}index.php/apps/spreed/"}] |
+      | id     | title         | icon_class          | icon_url         | widget_url                       | item_icons_round | order | buttons | item_api_versions | reload_interval |
+      | spreed | Talk mentions | dashboard-talk-icon | img/app-dark.svg | {$BASE_URL}index.php/apps/spreed/ | true             | 10    | [{"type":"more","text":"More unread mentions","link":"{$BASE_URL}index.php/apps/spreed/"}] | [1] | 0 |
 
   Scenario: User gets the dashboard widget content
     When user "participant1" sees the following entries for dashboard widgets "spreed" (v1)
@@ -36,7 +36,7 @@ Feature: integration/dashboard
     And user "participant2" starts breakout rooms in room "breakout room parent" with 200 (v1)
     And user "participant2" broadcasts message "@participant1 hello" to room "breakout room parent" with 201 (v1)
     Then user "participant1" sees the following entries for dashboard widgets "spreed" (v1)
-      | title                    | subtitle            | link            | iconUrl                                                      | sinceId |
-      | call room                |  Call in progress   | call room       | {$BASE_URL}ocs/v2.php/apps/spreed/api/v1/room/{token}/avatar{version} |         |
-      | group room               |  You were mentioned | group room      | {$BASE_URL}ocs/v2.php/apps/spreed/api/v1/room/{token}/avatar{version} |         |
-      | participant2-displayname |  Hello              | one-to-one room | {$BASE_URL}ocs/v2.php/apps/spreed/api/v1/room/{token}/avatar{version} |         |
+      | title                    | subtitle            | link            | iconUrl                                                               | sinceId | overlayIconUrl |
+      | call room                |  Call in progress   | call room       | {$BASE_URL}ocs/v2.php/apps/spreed/api/v1/room/{token}/avatar{version} |         |                |
+      | group room               |  You were mentioned | group room      | {$BASE_URL}ocs/v2.php/apps/spreed/api/v1/room/{token}/avatar{version} |         |                |
+      | participant2-displayname |  Hello              | one-to-one room | {$BASE_URL}ocs/v2.php/apps/spreed/api/v1/room/{token}/avatar{version} |         |                |


### PR DESCRIPTION
Ref https://github.com/nextcloud/server/pull/39937

### ☑️ Resolves

* Fix red integration test on master

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
