### PR TITLE
fix(bots): Add missing bots v1 capability

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -120,6 +120,7 @@ class Capabilities implements IPublicCapability {
 				'chat-keep-notifications',
 				'typing-privacy',
 				'remind-me-later',
+				'bots-v1',
 			],
 			'config' => [
 				'attachments' => [

--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -85,7 +85,7 @@
 			</NcAppSettingsSection>
 
 			<!-- Bots settings -->
-			<NcAppSettingsSection v-if="selfIsOwnerOrModerator"
+			<NcAppSettingsSection v-if="selfIsOwnerOrModerator && hasBotV1API"
 				id="bots"
 				:title="t('spreed', 'Bots')">
 				<BotsSettings :token="token" />
@@ -211,6 +211,10 @@ export default {
 
 		isBreakoutRoom() {
 			return this.conversation.objectType === 'room'
+		},
+
+		hasBotV1API() {
+			return getCapabilities()?.spreed?.features?.includes('bots-v1')
 		},
 
 		canConfigureBreakoutRooms() {

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -138,6 +138,7 @@ class CapabilitiesTest extends TestCase {
 			'chat-keep-notifications',
 			'typing-privacy',
 			'remind-me-later',
+			'bots-v1',
 			'message-expiration',
 			'reactions',
 		];


### PR DESCRIPTION
### ☑️ Resolves

* Fix add missing capability
* Hide section in desktop client when connecting to Talk 16 or 17.0

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
