### PR TITLE
Lazy load files sidebar of Talk 

### DIFF
--- a/src/FilesSidebarCallViewApp.vue
+++ b/src/FilesSidebarCallViewApp.vue
@@ -48,9 +48,9 @@ export default {
 	name: 'FilesSidebarCallViewApp',
 
 	components: {
-		CallView: () => import(/* webpackChunkName: "talk-call" */'./components/CallView/CallView.vue'),
+		CallView: () => import(/* webpackChunkName: "files-sidebar-call-chunk" */'./components/CallView/CallView.vue'),
 		PreventUnload,
-		TopBar: () => import(/* webpackChunkName: "talk-call" */'./components/TopBar/TopBar.vue'),
+		TopBar: () => import(/* webpackChunkName: "files-sidebar-call-chunk" */'./components/TopBar/TopBar.vue'),
 	},
 
 	mixins: [

--- a/src/FilesSidebarCallViewApp.vue
+++ b/src/FilesSidebarCallViewApp.vue
@@ -22,10 +22,10 @@
 
 <template>
 	<div v-if="isInFile" class="talk-sidebar-callview">
-		<TopBar v-show="showCallView"
+		<TopBar v-if="showCallView"
 			:is-in-call="true"
 			:is-sidebar="true" />
-		<CallView v-show="showCallView"
+		<CallView v-if="showCallView"
 			:token="token"
 			:is-sidebar="true" />
 		<PreventUnload :when="warnLeaving" />
@@ -34,9 +34,6 @@
 
 <script>
 import PreventUnload from 'vue-prevent-unload'
-
-import CallView from './components/CallView/CallView.vue'
-import TopBar from './components/TopBar/TopBar.vue'
 
 import { useIsInCall } from './composables/useIsInCall.js'
 import participant from './mixins/participant.js'
@@ -51,9 +48,9 @@ export default {
 	name: 'FilesSidebarCallViewApp',
 
 	components: {
-		CallView,
+		CallView: () => import(/* webpackChunkName: "talk-call" */'./components/CallView/CallView.vue'),
 		PreventUnload,
-		TopBar,
+		TopBar: () => import(/* webpackChunkName: "talk-call" */'./components/TopBar/TopBar.vue'),
 	},
 
 	mixins: [

--- a/src/FilesSidebarCallViewApp.vue
+++ b/src/FilesSidebarCallViewApp.vue
@@ -35,6 +35,8 @@
 <script>
 import PreventUnload from 'vue-prevent-unload'
 
+import LoadingComponent from './components/LoadingComponent.vue'
+
 import { useIsInCall } from './composables/useIsInCall.js'
 import participant from './mixins/participant.js'
 import sessionIssueHandler from './mixins/sessionIssueHandler.js'
@@ -48,7 +50,12 @@ export default {
 	name: 'FilesSidebarCallViewApp',
 
 	components: {
-		CallView: () => import(/* webpackChunkName: "files-sidebar-call-chunk" */'./components/CallView/CallView.vue'),
+		CallView: () => ({
+			component: import(/* webpackChunkName: "files-sidebar-call-chunk" */'./components/CallView/CallView.vue'),
+			loading: {
+				render: (h) => h(LoadingComponent, { class: 'call-loading' }),
+			},
+		}),
 		PreventUnload,
 		TopBar: () => import(/* webpackChunkName: "files-sidebar-call-chunk" */'./components/TopBar/TopBar.vue'),
 	},
@@ -286,6 +293,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import './assets/variables';
+
 #call-container {
 	position: relative;
 
@@ -296,5 +305,11 @@ export default {
 	 * width. */
 	padding-bottom: 56.25%;
 	max-height: 56.25%;
+}
+
+.call-loading{
+	padding-bottom: 56.25%;
+	max-height: 56.25%;
+	background-color: $color-call-background;
 }
 </style>

--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -54,10 +54,6 @@ import { loadState } from '@nextcloud/initial-state'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 
-import ChatView from './components/ChatView.vue'
-import MediaSettings from './components/MediaSettings/MediaSettings.vue'
-import CallButton from './components/TopBar/CallButton.vue'
-
 import browserCheck from './mixins/browserCheck.js'
 import sessionIssueHandler from './mixins/sessionIssueHandler.js'
 import { EventBus } from './services/EventBus.js'
@@ -76,9 +72,9 @@ export default {
 	name: 'FilesSidebarTabApp',
 
 	components: {
-		CallButton,
-		ChatView,
-		MediaSettings,
+		CallButton: () => import(/* webpackChunkName: "talk-chat" */'./components/TopBar/CallButton.vue'),
+		ChatView: () => import(/* webpackChunkName: "talk-chat" */'./components/ChatView.vue'),
+		MediaSettings: () => import(/* webpackChunkName: "talk-chat" */'./components/MediaSettings/MediaSettings.vue'),
 		NcButton,
 	},
 

--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -38,11 +38,7 @@
 				{{ t('spreed', 'Join conversation') }}
 			</NcButton>
 		</div>
-		<template v-else>
-			<CallButton class="call-button" />
-			<ChatView />
-			<MediaSettings :initialize-on-mounted="false" />
-		</template>
+		<FilesSidebarChatView v-else />
 	</div>
 </template>
 
@@ -53,6 +49,8 @@ import Axios from '@nextcloud/axios'
 import { loadState } from '@nextcloud/initial-state'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+
+import LoadingComponent from './components/LoadingComponent.vue'
 
 import browserCheck from './mixins/browserCheck.js'
 import sessionIssueHandler from './mixins/sessionIssueHandler.js'
@@ -72,9 +70,12 @@ export default {
 	name: 'FilesSidebarTabApp',
 
 	components: {
-		CallButton: () => import(/* webpackChunkName: "talk-chat" */'./components/TopBar/CallButton.vue'),
-		ChatView: () => import(/* webpackChunkName: "talk-chat" */'./components/ChatView.vue'),
-		MediaSettings: () => import(/* webpackChunkName: "talk-chat" */'./components/MediaSettings/MediaSettings.vue'),
+		FilesSidebarChatView: () => ({
+			component: import(/* webpackChunkName: "files-sidebar-tab-chunk" */'./views/FilesSidebarChatView.vue'),
+			loading: {
+				render: (h) => h(LoadingComponent, { class: 'tab-loading' }),
+			},
+		}),
 		NcButton,
 	},
 
@@ -422,16 +423,7 @@ export default {
 	justify-content: center;
 }
 
-.call-button {
-	/* Center button horizontally. */
-	margin-left: auto;
-	margin-right: auto;
-
-	margin-top: 10px;
-	margin-bottom: 10px;
-}
-
-.chatView {
-	overflow: hidden;
+.tab-loading {
+	height: 100%;
 }
 </style>

--- a/src/components/LoadingComponent.vue
+++ b/src/components/LoadingComponent.vue
@@ -1,0 +1,31 @@
+<!--
+  - @copyright Copyright (c) 2023 Dorra Jaouad <dorra.jaoued1@gmail.com>
+  -
+  - @author Dorra Jaouad <dorra.jaoued1@gmail.com>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+	<div class="icon-loading spinner" />
+</template>
+<script>
+export default {
+
+	name: 'LoadingComponent',
+
+}
+</script>

--- a/src/views/FilesSidebarChatView.vue
+++ b/src/views/FilesSidebarChatView.vue
@@ -1,0 +1,68 @@
+<!--
+  - @copyright Copyright (c) 2023 Dorra Jaouad <dorra.jaoued1@gmail.com>
+  -
+  - @author Dorra Jaouad <dorra.jaoued1@gmail.com>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+	<div class="talk-tab__wrapper">
+		<CallButton class="call-button" />
+		<ChatView />
+		<MediaSettings :initialize-on-mounted="false" />
+	</div>
+</template>
+<script>
+
+import ChatView from '../components/ChatView.vue'
+import MediaSettings from '../components/MediaSettings/MediaSettings.vue'
+import CallButton from '../components/TopBar/CallButton.vue'
+
+export default {
+
+	name: 'FilesSidebarChatView',
+
+	components: {
+		CallButton,
+		ChatView,
+		MediaSettings,
+	},
+
+}
+
+</script>
+
+<style scoped>
+.talk-tab__wrapper{
+	height: 100%;
+}
+
+.call-button {
+	/* Center button horizontally. */
+	margin-left: auto;
+	margin-right: auto;
+
+	margin-top: 10px;
+	margin-bottom: 10px;
+}
+
+.chatView {
+	overflow: hidden;
+	/* Considering the call button height (44px + 10px * 2) */
+	height: calc(100% - 64px);
+}
+</style>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,6 +39,13 @@ module.exports = mergeWithRules({
 	},
 
 	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				defaultVendors: {
+					reuseExistingChunk: true,
+				},
+			},
+		},
 		minimizer: [
 			new EsbuildPlugin({
 				target: 'es2020',


### PR DESCRIPTION
### ☑️ Resolves

* Fix #8755 

+ Added `loadingComponent `
+ Webpack optimization
+ Async import one component that contains `MediaSettings`, `ChatView `and `CallButton` in `FilesSidebarTabApp`

### 🖼️ Stats

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/84044328/e92594e6-0467-4ed1-81bf-4cf2782d5ef3) | ![image](https://github.com/nextcloud/spreed/assets/84044328/a2b23348-c9a5-4f87-a8eb-866b0cc098c2)

Unused JS upon loading

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/84044328/c6a40b7a-39c9-4bfe-90b1-68d2331abed0) | ![image](https://github.com/nextcloud/spreed/assets/84044328/3e404903-80b9-4518-9d0b-d26d6879db49)

Total unused JS

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/84044328/2ef94f20-95ae-408f-93d5-8cce33abfba3) | ![image](https://github.com/nextcloud/spreed/assets/84044328/34aa9e3a-e877-41db-8049-462742324a57)

### 🚧 Tasks

- [ ] code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
