### PR TITLE
fix(SearchBox) - unify component handling

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -866,9 +866,6 @@ export default {
 	// Total : 100 px
 	width : calc(100% - 100px);
 	display : flex;
-	:deep(.input-field__input) {
-		border-radius: var(--border-radius-pill);
-	}
 	&--expanded {
 		width : calc(100% - 8px);
 	}
@@ -886,10 +883,6 @@ export default {
 
 .settings-button {
 	justify-content: flex-start !important;
-}
-
-:deep(.input-field__clear-button) {
-	border-radius: var(--border-radius-pill) !important;
 }
 
 :deep(.app-navigation ul) {

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -27,10 +27,7 @@
 				:class="{'conversations-search--expanded': isFocused}">
 				<SearchBox ref="searchBox"
 					:value.sync="searchText"
-					:is-focused="isFocused"
-					@focus="setIsFocused"
-					@blur="setIsFocused"
-					@trailing-blur="setIsFocused"
+					:is-focused.sync="isFocused"
 					@input="debounceFetchSearchResults"
 					@abort-search="abortSearch" />
 			</div>
@@ -495,13 +492,6 @@ export default {
 
 		showModalListConversations() {
 			this.$refs.openConversationsList.showModal()
-		},
-
-		setIsFocused(event) {
-			if (this.searchText !== '') {
-				return
-			}
-			this.isFocused = event.type === 'focus'
 		},
 
 		handleFilter(filter) {

--- a/src/components/LeftSidebar/SearchBox/SearchBox.vue
+++ b/src/components/LeftSidebar/SearchBox/SearchBox.vue
@@ -85,6 +85,18 @@ export default {
 		},
 	},
 
+	watch: {
+		isFocused(value) {
+			if (value) {
+				this.$nextTick(() => {
+					this.getTrailingButton()?.addEventListener('keydown', this.handleTrailingKeyDown)
+				})
+			} else {
+				this.getTrailingButton()?.removeEventListener('keydown', this.handleTrailingKeyDown)
+			}
+		},
+	},
+
 	methods: {
 		updateValue(value) {
 			this.$emit('update:value', value)
@@ -94,6 +106,18 @@ export default {
 		focus() {
 			this.$refs.searchConversations.focus()
 		},
+
+		getTrailingButton() {
+			return this.$refs.searchConversations.$el.querySelector('.input-field__clear-button')
+		},
+
+		handleTrailingKeyDown(event) {
+			if (event.key === 'Enter') {
+				event.stopPropagation()
+				this.abortSearch()
+			}
+		},
+
 		/**
 		 * Emits the abort-search event and blurs the input
 		 */
@@ -113,7 +137,7 @@ export default {
 		handleBlur(event) {
 			if (event.relatedTarget?.classList.contains('input-field__clear-button')) {
 				event.preventDefault()
-				this.$refs.searchConversations.$el.querySelector('.input-field__clear-button').addEventListener('blur', (trailingEvent) => {
+				this.getTrailingButton()?.addEventListener('blur', (trailingEvent) => {
 					this.handleBlur(trailingEvent)
 				})
 			} else {

--- a/src/components/LeftSidebar/SearchBox/SearchBox.vue
+++ b/src/components/LeftSidebar/SearchBox/SearchBox.vue
@@ -24,6 +24,7 @@
 		:value="value"
 		:label="placeholderText"
 		:show-trailing-button="isFocused"
+		class="search-box"
 		trailing-button-icon="close"
 		v-on="listeners"
 		@update:value="updateValue"
@@ -153,9 +154,14 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.search-box {
+	:deep(.input-field__input) {
+		border-radius: var(--border-radius-pill);
+	}
 
-:deep(.input-field__input) {
-	border-radius: var(--border-radius-pill);
+  :deep(.input-field__clear-button) {
+    border-radius: var(--border-radius-pill) !important;
+  }
 }
 
 </style>

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -23,8 +23,8 @@
 	<div>
 		<SearchBox v-if="canSearch"
 			:value.sync="searchText"
+			:is-focused.sync="isFocused"
 			:placeholder-text="searchBoxPlaceholder"
-			:is-searching="isSearching"
 			@input="handleInput"
 			@abort-search="abortSearch" />
 		<NcAppNavigationCaption v-if="isSearching && canAdd"
@@ -83,6 +83,7 @@ export default {
 	data() {
 		return {
 			searchText: '',
+			isFocused: false,
 			searchResults: [],
 			contactsLoading: false,
 			isCirclesEnabled: loadState('spreed', 'circles_enabled'),


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10305
* Any changes of input value or `isFocused` state is now handled internally by component (and emitted, like before)
* `:deep` styles were moved from parents to the component
* component now looks and behaves the same in left and right sidebars
* traling button `X` now responds to Enter key



### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/050f74a6-54ef-43d8-82b2-d1b629cdbff3) | ![image](https://github.com/nextcloud/spreed/assets/93392545/945fdc41-b986-45f0-bfff-e159b4f7524f)



### 🚧 Tasks

- [ ] Manual testing
- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
