### PR TITLE
fix(chat): Fix responding with "X-Chat-Last-Common-Read" when request…

### DIFF
--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -423,7 +423,7 @@ class ChatController extends AEnvironmentAwareController {
 			$comments = $this->chatManager->getHistory($this->room, $lastKnownMessageId, $limit, (bool)$includeLastKnown);
 		}
 
-		return $this->prepareCommentsAsDataResponse($comments);
+		return $this->prepareCommentsAsDataResponse($comments, $lastCommonReadId);
 	}
 
 	protected function prepareCommentsAsDataResponse(array $comments, int $lastCommonReadId = 0): DataResponse {

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -70,6 +70,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	protected static $botNameToId;
 	/** @var array<string, string> */
 	protected static $botNameToHash;
+	/** @var array<string, mixed>|null */
+	protected static ?array $nextChatRequestParameters;
 
 
 	protected static $permissionsMap = [
@@ -2159,17 +2161,37 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" sees the following messages in room "([^"]*)" with (\d+)(?: \((v1)\))?$/
-	 *
-	 * @param string $user
-	 * @param string $identifier
-	 * @param string $statusCode
-	 * @param string $apiVersion
+	 * @Then /^next message request has the following parameters set$/
 	 */
-	public function userSeesTheFollowingMessagesInRoom($user, $identifier, $statusCode, $apiVersion = 'v1', TableNode $formData = null) {
+	public function setChatParametersForNextRequest(TableNode $formData = null): void {
+		$parameters = [];
+		foreach ($formData->getRowsHash() as $key => $value) {
+			if (in_array($key, ['lastCommonReadId', 'lastKnownMessageId'], true)) {
+				$parameters[$key] = self::$textToMessageId[$value];
+			} else {
+				$parameters[$key] = $value;
+			}
+		}
+		self::$nextChatRequestParameters = $parameters;
+	}
+
+	/**
+	 * @Then /^user "([^"]*)" sees the following messages in room "([^"]*)" with (\d+)(?: \((v1)\))?$/
+	 */
+	public function userSeesTheFollowingMessagesInRoom(string $user, string $identifier, int $statusCode, string $apiVersion = 'v1', TableNode $formData = null) {
+		$query = ['lookIntoFuture' => 0];
+		if (self::$nextChatRequestParameters !== null) {
+			$query = array_merge($query, self::$nextChatRequestParameters);
+			self::$nextChatRequestParameters = null;
+		}
+
 		$this->setCurrentUser($user);
-		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/chat/' . self::$identifierToToken[$identifier] . '?lookIntoFuture=0');
+		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/chat/' . self::$identifierToToken[$identifier] . '?' . http_build_query($query));
 		$this->assertStatusCode($this->response, $statusCode);
+
+		if ($statusCode === 304) {
+			return;
+		}
 
 		$this->compareDataResponse($formData);
 	}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -71,7 +71,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	/** @var array<string, string> */
 	protected static $botNameToHash;
 	/** @var array<string, mixed>|null */
-	protected static ?array $nextChatRequestParameters;
+	protected static ?array $nextChatRequestParameters = null;
 
 
 	protected static $permissionsMap = [

--- a/tests/integration/features/chat-2/read-status.feature
+++ b/tests/integration/features/chat-2/read-status.feature
@@ -54,6 +54,30 @@ Feature: chat-2/read-status
     When user "participant2" reads message "Message 3" in room "chatting" with 200
     Then last response has last common read message header set to "Message 3"
 
+    When next message request has the following parameters set
+      | lastCommonReadId         | Message 1 |
+      | lastKnownMessageId       | Message 1 |
+      | timeout                  | 0         |
+      | lookIntoFuture           | 1         |
+    Then user "participant1" sees the following messages in room "chatting" with 200
+      | room     | actorType | actorId      | actorDisplayName         | message   | messageParameters |
+      | chatting | users     | participant2 | participant2-displayname | Message 2 | []                |
+      | chatting | users     | participant2 | participant2-displayname | Message 3 | []                |
+    Then last response has last common read message header set to "Message 3"
+    When next message request has the following parameters set
+      | lastCommonReadId         | Message 1 |
+      | lastKnownMessageId       | Message 3 |
+      | timeout                  | 0         |
+      | lookIntoFuture           | 1         |
+    Then user "participant1" sees the following messages in room "chatting" with 200
+    Then last response has last common read message header set to "Message 3"
+    When next message request has the following parameters set
+      | lastCommonReadId         | Message 3 |
+      | lastKnownMessageId       | Message 3 |
+      | timeout                  | 0         |
+      | lookIntoFuture           | 1         |
+    Then user "participant1" sees the following messages in room "chatting" with 304
+
 
   Scenario: User switching to private is not considered anymore
     Given user "participant1" creates room "chatting" (v4)


### PR DESCRIPTION
…ed by the client

### ☑️ Resolves

Before
```
    Then last response has last common read message header set to "Message 3"               # FeatureContext::hasChatLastCommonReadHeader()
    When next message request has the following parameters set                              # FeatureContext::setChatParametersForNextRequest()
      | lastCommonReadId   | Message 1 |
      | lastKnownMessageId | Message 3 |
      | timeout            | 0         |
      | lookIntoFuture     | 1         |
    Then user "participant1" sees the following messages in room "chatting" with 200        # FeatureContext::userSeesTheFollowingMessagesInRoom()
      ❌ Failed asserting that 304 matches expected 200.
```

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
