### PR TITLE
fix(MessagesGroup) move date separator to the parent component level

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -32,8 +32,7 @@ the main body of the message as well as a quote.
 		:data-next-message-id="nextMessageId"
 		:data-previous-message-id="previousMessageId"
 		class="message"
-		:class="{'message__last': isLastMessage,
-			'message--highlighted': isHighlighted}"
+		:class="{'message--highlighted': isHighlighted}"
 		tabindex="0"
 		@animationend="isHighlighted = false"
 		@mouseover="handleMouseover"
@@ -883,10 +882,6 @@ export default {
 
 .message {
 	position: relative;
-
-	&__last {
-		margin-bottom: 12px;
-	}
 
 	&:hover .normal-message-body,
 	&:hover .combined-system {

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.spec.js
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.spec.js
@@ -37,7 +37,6 @@ describe('MessagesGroup.vue', () => {
 			propsData: {
 				id: 123,
 				token: TOKEN,
-				dateSeparator: '<date separator>',
 				previousMessageId: 90,
 				nextMessageId: 200,
 				messages: [{
@@ -79,9 +78,6 @@ describe('MessagesGroup.vue', () => {
 				}],
 			},
 		})
-
-		const dateEl = wrapper.find('.message-group__date-header')
-		expect(dateEl.text()).toBe('<date separator>')
 
 		const avatarEl = wrapper.findComponent({ name: 'AuthorAvatar' })
 		expect(avatarEl.attributes('authortype')).toBe(ATTENDEE.ACTOR_TYPE.USERS)
@@ -150,21 +146,17 @@ describe('MessagesGroup.vue', () => {
 			propsData: {
 				id: 123,
 				token: TOKEN,
-				dateSeparator: '<date separator>',
 				previousMessageId: 90,
 				nextMessageId: 200,
 				messages: MESSAGES,
 			},
 		})
 
-		const dateEl = wrapper.find('.message-group__date-header')
-		expect(dateEl.text()).toBe('<date separator>')
-
 		const avatarEl = wrapper.findComponent({ name: 'AuthorAvatar' })
 		expect(avatarEl.exists()).toBe(false)
 
 		const messagesEl = wrapper.findAllComponents({ name: 'Message' })
-		// TODO: date separator
+
 		let message = messagesEl.at(0)
 		expect(message.props('id')).toBe(MESSAGES[0].id)
 		expect(message.props('message')).toBe(MESSAGES[0].message)
@@ -194,7 +186,6 @@ describe('MessagesGroup.vue', () => {
 			propsData: {
 				id: 123,
 				token: TOKEN,
-				dateSeparator: '<date separator>',
 				previousMessageId: 90,
 				nextMessageId: 200,
 				messages: [{
@@ -225,9 +216,6 @@ describe('MessagesGroup.vue', () => {
 			},
 		})
 
-		const dateEl = wrapper.find('.message-group__date-header')
-		expect(dateEl.text()).toBe('<date separator>')
-
 		const avatarEl = wrapper.findComponent({ name: 'AuthorAvatar' })
 		expect(avatarEl.attributes('authortype')).toBe(ATTENDEE.ACTOR_TYPE.GUESTS)
 		expect(avatarEl.attributes('authorid')).toBe('actor-1')
@@ -255,7 +243,6 @@ describe('MessagesGroup.vue', () => {
 			propsData: {
 				id: 123,
 				token: TOKEN,
-				dateSeparator: '<date separator>',
 				previousMessageId: 90,
 				nextMessageId: 200,
 				messages: [{

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -20,34 +20,26 @@
 -->
 
 <template>
-	<div class="message-group">
-		<div v-if="dateSeparator"
-			class="message-group__date-header">
-			<span class="date"
-				role="heading"
-				aria-level="3">{{ dateSeparator }}</span>
+	<div class="wrapper">
+		<div class="messages__avatar">
+			<AuthorAvatar :author-type="actorType"
+				:author-id="actorId"
+				:display-name="actorDisplayName" />
 		</div>
-		<div class="wrapper">
-			<div class="messages__avatar">
-				<AuthorAvatar :author-type="actorType"
-					:author-id="actorId"
-					:display-name="actorDisplayName" />
-			</div>
-			<ul class="messages">
-				<li class="messages__author" aria-level="4">
-					{{ actorDisplayName }}
-				</li>
-				<Message v-for="(message, index) of messages"
-					:key="message.id"
-					ref="message"
-					v-bind="message"
-					:is-temporary="message.timestamp === 0"
-					:next-message-id="(messages[index + 1] && messages[index + 1].id) || nextMessageId"
-					:previous-message-id="(index > 0 && messages[index - 1].id) || previousMessageId"
-					:actor-type="actorType"
-					:actor-id="actorId" />
-			</ul>
-		</div>
+		<ul class="messages">
+			<li class="messages__author" aria-level="4">
+				{{ actorDisplayName }}
+			</li>
+			<Message v-for="(message, index) of messages"
+				:key="message.id"
+				ref="message"
+				v-bind="message"
+				:is-temporary="message.timestamp === 0"
+				:next-message-id="(messages[index + 1] && messages[index + 1].id) || nextMessageId"
+				:previous-message-id="(index > 0 && messages[index - 1].id) || previousMessageId"
+				:actor-type="actorType"
+				:actor-id="actorId" />
+		</ul>
 	</div>
 </template>
 
@@ -79,13 +71,6 @@ export default {
 		 */
 		messages: {
 			type: Array,
-			required: true,
-		},
-		/**
-		 * The message date separator.
-		 */
-		dateSeparator: {
-			type: String,
 			required: true,
 		},
 
@@ -154,25 +139,6 @@ export default {
 
 <style lang="scss" scoped>
 @import '../../../assets/variables';
-
-.message-group {
-	&__date-header {
-		display: block;
-		text-align: center;
-		padding-top: 20px;
-		position: relative;
-		margin: 20px 0;
-		.date {
-			margin-right: $clickable-area * 2;
-			content: attr(data-date);
-			padding: 4px 12px;
-			left: 50%;
-			color: var(--color-text-maxcontrast);
-			background-color: var(--color-background-dark);
-			border-radius: var(--border-radius-pill);
-		}
-	}
-}
 
 .wrapper {
 	max-width: $messages-list-max-width;

--- a/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
@@ -20,36 +20,28 @@
 -->
 
 <template>
-	<div class="message-group">
-		<div v-if="dateSeparator"
-			class="message-group__date-header">
-			<span class="date"
-				role="heading"
-				aria-level="3">{{ dateSeparator }}</span>
-		</div>
-		<div class="wrapper wrapper--system">
-			<div v-for="messagesCollapsed in messagesGroupedBySystemMessage"
-				:key="messagesCollapsed.id"
-				class="message-group__system">
-				<ul v-if="messagesCollapsed.messages?.length > 1"
-					class="messages messages--header">
-					<Message v-bind="createCombinedSystemMessage(messagesCollapsed)"
-						is-combined-system-message
-						:is-combined-system-message-collapsed="messagesCollapsed.collapsed"
-						:next-message-id="getNextMessageId(messagesCollapsed.messages.at(-1))"
-						:previous-message-id="getPrevMessageId(messagesCollapsed.messages.at(0))"
-						@toggle-combined-system-message="toggleCollapsed(messagesCollapsed)" />
-				</ul>
-				<ul v-show="messagesCollapsed.messages?.length === 1 || !messagesCollapsed.collapsed"
-					class="messages"
-					:class="{'messages--collapsed': messagesCollapsed.messages?.length > 1}">
-					<Message v-for="message in messagesCollapsed.messages"
-						:key="message.id"
-						v-bind="message"
-						:next-message-id="getNextMessageId(message)"
-						:previous-message-id="getPrevMessageId(message)" />
-				</ul>
-			</div>
+	<div class="wrapper wrapper--system">
+		<div v-for="messagesCollapsed in messagesGroupedBySystemMessage"
+			:key="messagesCollapsed.id"
+			class="messages-group__system">
+			<ul v-if="messagesCollapsed.messages?.length > 1"
+				class="messages messages--header">
+				<Message v-bind="createCombinedSystemMessage(messagesCollapsed)"
+					is-combined-system-message
+					:is-combined-system-message-collapsed="messagesCollapsed.collapsed"
+					:next-message-id="getNextMessageId(messagesCollapsed.messages.at(-1))"
+					:previous-message-id="getPrevMessageId(messagesCollapsed.messages.at(0))"
+					@toggle-combined-system-message="toggleCollapsed(messagesCollapsed)" />
+			</ul>
+			<ul v-show="messagesCollapsed.messages?.length === 1 || !messagesCollapsed.collapsed"
+				class="messages"
+				:class="{'messages--collapsed': messagesCollapsed.messages?.length > 1}">
+				<Message v-for="message in messagesCollapsed.messages"
+					:key="message.id"
+					v-bind="message"
+					:next-message-id="getNextMessageId(message)"
+					:previous-message-id="getPrevMessageId(message)" />
+			</ul>
 		</div>
 	</div>
 </template>
@@ -97,13 +89,6 @@ export default {
 		 */
 		messages: {
 			type: Array,
-			required: true,
-		},
-		/**
-		 * The message date separator.
-		 */
-		dateSeparator: {
-			type: String,
 			required: true,
 		},
 
@@ -282,28 +267,9 @@ export default {
 <style lang="scss" scoped>
 @import '../../../assets/variables';
 
-.message-group {
-	&__date-header {
-		display: block;
-		text-align: center;
-		padding-top: 20px;
-		position: relative;
-		margin: 20px 0;
-		.date {
-			margin-right: $clickable-area * 2;
-			content: attr(data-date);
-			padding: 4px 12px;
-			left: 50%;
-			color: var(--color-text-maxcontrast);
-			background-color: var(--color-background-dark);
-			border-radius: var(--border-radius-pill);
-		}
-	}
-
-	&__system {
-		display: flex;
-		flex-direction: column;
-	}
+.messages-group__system {
+	display: flex;
+	flex-direction: column;
 }
 
 .wrapper {

--- a/src/components/MessagesList/MessagesList.spec.js
+++ b/src/components/MessagesList/MessagesList.spec.js
@@ -215,19 +215,22 @@ describe('MessagesList.vue', () => {
 			// using attributes to access v-bind props
 			expect(group.attributes('actorid')).toBe('alice')
 			expect(group.attributes('actortype')).toBe(ATTENDEE.ACTOR_TYPE.USERS)
-			expect(group.attributes('dateseparator')).toBe('2 days ago, May 9, 2020')
 
 			group = groups.at(1)
 			expect(group.props('messages')).toStrictEqual([messages[1]])
 			expect(group.attributes('actorid')).toBe('alice')
 			expect(group.attributes('actortype')).toBe(ATTENDEE.ACTOR_TYPE.USERS)
-			expect(group.attributes('dateseparator')).toBe('Yesterday, May 10, 2020')
 
 			group = groups.at(2)
 			expect(group.props('messages')).toStrictEqual([messages[2]])
 			expect(group.attributes('actorid')).toBe('alice')
 			expect(group.attributes('actortype')).toBe(ATTENDEE.ACTOR_TYPE.USERS)
-			expect(group.attributes('dateseparator')).toBe('Today, May 11, 2020')
+
+			const dateSeparators = wrapper.findAll('.messages-group__date')
+			expect(dateSeparators).toHaveLength(3)
+			expect(dateSeparators.at(0).text()).toBe('2 days ago, May 9, 2020')
+			expect(dateSeparators.at(1).text()).toBe('Yesterday, May 10, 2020')
+			expect(dateSeparators.at(2).text()).toBe('Today, May 11, 2020')
 
 			expect(messagesListMock).toHaveBeenCalledWith(TOKEN)
 		})

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -33,16 +33,24 @@ get the messagesList array and loop through the list to generate the messages.
 		:class="{'scroller--chatScrolledToBottom': isChatScrolledToBottom}"
 		@scroll="debounceHandleScroll">
 		<div v-if="displayMessagesLoader" class="scroller__loading icon-loading" />
-		<component :is="messagesGroupComponent(item)"
-			v-for="item of messagesGroupedByAuthor"
-			:key="item.id"
-			ref="messagesGroup"
-			v-bind="item.messages"
-			:token="token"
-			:messages="item.messages"
-			:date-separator="item.dateSeparator"
-			:previous-message-id="item.previousMessageId"
-			:next-message-id="item.nextMessageId" />
+
+		<template v-for="item of messagesGroupedByAuthor">
+			<div v-if="item.dateSeparator" :key="`date_${item.id}`" class="messages-group__date">
+				<span class="messages-group__date-text" role="heading" aria-level="3">
+					{{ item.dateSeparator }}
+				</span>
+			</div>
+			<component :is="messagesGroupComponent(item)"
+				:key="item.id"
+				ref="messagesGroup"
+				class="messages-group"
+				v-bind="item.messages"
+				:token="token"
+				:messages="item.messages"
+				:previous-message-id="item.previousMessageId"
+				:next-message-id="item.nextMessageId" />
+		</template>
+
 		<template v-if="showLoadingAnimation">
 			<LoadingPlaceholder type="messages"
 				:count="15" />
@@ -1155,4 +1163,23 @@ export default {
 	}
 }
 
+.messages-group {
+	&__date {
+		display: block;
+		text-align: center;
+		padding-top: 20px;
+		position: relative;
+		margin: 20px 0;
+	}
+
+	&__date-text {
+		margin-right: $clickable-area * 2;
+		content: attr(data-date);
+		padding: 4px 12px;
+		left: 50%;
+		color: var(--color-text-maxcontrast);
+		background-color: var(--color-background-dark);
+		border-radius: var(--border-radius-pill);
+	}
+}
 </style>

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -1181,5 +1181,9 @@ export default {
 		background-color: var(--color-background-dark);
 		border-radius: var(--border-radius-pill);
 	}
+
+	&:last-child {
+		margin-bottom: 16px;
+	}
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

* Moves date-separators from `<MessagesGroup/>` to parent `<MessagesList/>`
* Less props - less re-renders
* Increase margin-bottom of last message group by 4px, to not crop the buttons bar

### 🖼️ Screenshots

🏚️ Before | 🏡 After | Pixel comparison (https://www.img2go.com/)
---|---|---
![Screenshot from 2023-09-24 10-11-53](https://github.com/nextcloud/spreed/assets/93392545/5117f735-f8de-4bdd-9b9d-e991446a5047) | ![Screenshot from 2023-09-24 10-10-01](https://github.com/nextcloud/spreed/assets/93392545/c10c3782-8e47-4e85-86bc-f0f39658748b) | ![Screenshot from 2023-09-24 10-12-28](https://github.com/nextcloud/spreed/assets/93392545/3d209b24-b686-4c07-bae1-2ea40004f94a)
![image](https://github.com/nextcloud/spreed/assets/93392545/61e5679f-fa92-48a0-8cbd-9d8727e2ca81) | ![image](https://github.com/nextcloud/spreed/assets/93392545/0e0cfd82-a237-477e-b298-fa2a200d0128) | ![image](https://github.com/nextcloud/spreed/assets/93392545/159f9f2e-16f3-4d39-b0bd-f5c1d5839bb8)

### 🚧 Tasks

- [ ] Code review
- [ ] Visual check

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
