### PR TITLE
fix(LeftSidebar): wrong user status after scrolling

### DIFF
--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -35,7 +35,11 @@
 			:height="size"
 			:alt="item.displayName"
 			class="avatar icon">
+		<!-- NcAvatar doesn't fully support props update and works only for 1 user -->
+		<!-- Using key on NcAvatar forces NcAvatar re-mount and solve the problem, could not really optimal -->
+		<!-- TODO: Check if props update support in NcAvatar is more performant -->
 		<NcAvatar v-else
+			:key="item.token"
 			:size="size"
 			:user="item.name"
 			:disable-menu="disableMenu"
@@ -48,14 +52,12 @@
 			class="conversation-icon__avatar" />
 		<div v-if="showCall"
 			class="overlap-icon">
-			<VideoIcon :size="20"
-				:fill-color="'#E9322D'" />
+			<VideoIcon :size="20" :fill-color="'#E9322D'" />
 			<span class="hidden-visually">{{ t('spreed', 'Call in progress') }}</span>
 		</div>
 		<div v-else-if="showFavorite"
 			class="overlap-icon">
-			<Star :size="20"
-				:fill-color="'#FFCC00'" />
+			<Star :size="20" :fill-color="'#FFCC00'" />
 			<span class="hidden-visually">{{ t('spreed', 'Favorite') }}</span>
 		</div>
 	</div>


### PR DESCRIPTION
### ☑️ Resolves

On scrolling user status in 1-1 conversations in the `LeftSidebar` is not correct.

- User's avatar and user status is displayed by `NcAvatar` component.
- With virtual scrolling components are reused. During scrolling new visible conversations are just given props of previous.
- It works only for components that react on props update
- `NcAvatar` supports `user` update but doesn't support `preloadedUserStatus` update

### 🚧 Tasks

- [x] Add `key` to `NcAvatar` and re-mount avatar for 1-1 conversation during scrolling.

### Drawbacks and alternative solution

It is less performant that adding support of `preloadUserStatus` change to `NcAvatar`.

Ideally it should be fixed on `@nextcloud/vue`. But I cannot say how much is the difference.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
