### PR TITLE
fix(LeftSidebar): adjust conversation padding and size

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -462,16 +462,4 @@ export default {
 		color: var(--color-error) !important;
 	}
 }
-
-.scroller {
-	flex: 1 0;
-}
-
-.ellipsis {
-	text-overflow: ellipsis;
-}
-
-.forced-active {
-	background-color: var(--color-primary-element-light) !important //Overrides gray hover feedback;
-}
 </style>

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -22,6 +22,7 @@
 <template>
 	<NcListItem ref="listItem"
 		:title="item.displayName"
+		class="conversation-item"
 		:class="{'unread-mention-conversation': item.unreadMention}"
 		:anchor-id="`conversation_${item.token}`"
 		:actions-aria-label="t('spreed', 'Conversation actions')"
@@ -443,6 +444,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.conversation-item {
+	padding-left: 2px;
+	padding-right: 2px;
+}
+
 .subtitle {
 	font-weight: bold;
 }

--- a/src/components/LeftSidebar/ConversationsListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsListVirtual.vue
@@ -42,7 +42,7 @@ import Conversation from './ConversationsList/Conversation.vue'
 
 import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'
 
-const CONVERSATION_ITEM_SIZE = 64
+const CONVERSATION_ITEM_SIZE = 66
 
 export default {
 	name: 'ConversationsListVirtual',


### PR DESCRIPTION
### ☑️ Resolves

Focus outline is a little bit cut and overlaps conversations above and below.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/25978914/eb5c7f58-a16a-4e98-bc7c-4dcdaa2c1dfc) | ![image](https://github.com/nextcloud/spreed/assets/25978914/82a34b99-0ff1-43b5-a1f5-2ecf94217e28)
![before](https://github.com/nextcloud/spreed/assets/25978914/fb779319-8a54-40fb-ad86-61edc45404ba) | ![after](https://github.com/nextcloud/spreed/assets/25978914/91d6f831-8445-4520-91a2-e7018f12c404)


### 🚧 Tasks

- [x] Update Conversation element size to 66 taking into account margin between conversations
- [x] Add 2px left and right padding to conversation item to save space for focus outline
- [x] Remove unused styles

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
