### PR TITLE
fix(chat): Fix primary color selection on quotes

### DIFF
--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -283,7 +283,7 @@ export default {
 	}
 
 	&.quote-own-message::before {
-		background-color: var(--color-primary-default);
+		background-color: var(--color-primary-element);
 	}
 
 	&__main {


### PR DESCRIPTION
### ☑️ Resolves

* Fix my primary color is pink, but the quotes were blue

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Bildschirmfoto vom 2023-08-25 10-13-02](https://github.com/nextcloud/spreed/assets/213943/d694897c-7f2b-4a9b-b462-0d4f6c4631cf) | ![Bildschirmfoto vom 2023-08-25 10-13-10](https://github.com/nextcloud/spreed/assets/213943/d7c97269-0ced-45db-98a2-b937cf460d1c)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
