### PR TITLE
Fix(RoomSelector) - Align text vertically

### DIFF
--- a/src/components/RoomSelector.vue
+++ b/src/components/RoomSelector.vue
@@ -271,7 +271,7 @@ li {
 	}
 
 	& > span {
-		padding: 5px 5px 5px 10px;
+		padding: 8px 5px 8px 10px;
 		vertical-align: middle;
 		text-overflow: ellipsis;
 		white-space: nowrap;


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10210

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/84044328/59c75ef7-4c38-41cb-a70d-279fce406297) | ![image](https://github.com/nextcloud/spreed/assets/84044328/b59b9a63-8c04-4150-b8ad-c1a3e574f559)


### 🚧 Tasks

- [ ] visual review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
