### PR TITLE
techdebt(Jest) - introduce response helper, clear output, raise coverage

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.spec.js
+++ b/src/components/LeftSidebar/LeftSidebar.spec.js
@@ -16,9 +16,6 @@ import storeConfig from '../../store/storeConfig.js'
 import { findNcListItems, findNcActionButton } from '../../test-helpers.js'
 import { requestTabLeadership } from '../../utils/requestTabLeadership.js'
 
-jest.mock('@nextcloud/initial-state', () => ({
-	loadState: jest.fn(),
-}))
 jest.mock('../../services/conversationsService', () => ({
 	searchPossibleConversations: jest.fn(),
 	searchListedConversations: jest.fn(),

--- a/src/services/conversationsService.spec.js
+++ b/src/services/conversationsService.spec.js
@@ -9,10 +9,6 @@ jest.mock('@nextcloud/axios', () => ({
 	get: jest.fn(),
 }))
 
-jest.mock('@nextcloud/initial-state', () => ({
-	loadState: jest.fn(),
-}))
-
 describe('conversationsService', () => {
 	let loadStateSettings
 

--- a/src/store/participantsStore.spec.js
+++ b/src/store/participantsStore.spec.js
@@ -20,6 +20,7 @@ import {
 	grantAllPermissionsToParticipant,
 	removeAllPermissionsFromParticipant,
 } from '../services/participantsService.js'
+import { generateOCSErrorResponse, generateOCSResponse } from '../test-helpers.js'
 import participantsStore from './participantsStore.js'
 
 jest.mock('../services/participantsService', () => ({
@@ -527,14 +528,7 @@ describe('participantsStore', () => {
 
 		test('joins conversation', async () => {
 			store = new Vuex.Store(testStoreConfig)
-			const response = {
-				status: 200,
-				data: {
-					ocs: {
-						data: participantData,
-					},
-				},
-			}
+			const response = generateOCSResponse({ payload: participantData })
 			joinConversation.mockResolvedValue(response)
 
 			const returnedResponse = await store.dispatch('joinConversation', { token: TOKEN })
@@ -556,14 +550,7 @@ describe('participantsStore', () => {
 		test('force join conversation', async () => {
 			store = new Vuex.Store(testStoreConfig)
 			const updatedParticipantData = Object.assign({}, participantData, { sessionId: 'another-session-id' })
-			const response = {
-				status: 200,
-				data: {
-					ocs: {
-						data: updatedParticipantData,
-					},
-				},
-			}
+			const response = generateOCSResponse({ payload: updatedParticipantData })
 			joinConversation.mockResolvedValue(response)
 
 			sessionStorage.getItem.mockReturnValueOnce(TOKEN)
@@ -613,15 +600,8 @@ describe('participantsStore', () => {
 				jest.spyOn(global, 'Date')
 					.mockImplementation(() => mockDate)
 
-				const response = {
-					status: 409,
-					data: {
-						ocs: {
-							data: participantData,
-						},
-					},
-				}
-				joinConversation.mockRejectedValue({ response })
+				const error = generateOCSErrorResponse({ payload: participantData, status: 409 })
+				joinConversation.mockRejectedValue(error)
 			}
 
 			describe('when not in call', () => {

--- a/src/stores/__tests__/bots.spec.js
+++ b/src/stores/__tests__/bots.spec.js
@@ -1,0 +1,92 @@
+import { setActivePinia, createPinia } from 'pinia'
+
+import {
+	getConversationBots,
+	disableBotForConversation,
+	enableBotForConversation,
+} from '../../services/botsService.js'
+import { generateOCSResponse } from '../../test-helpers.js'
+import { useBotsStore } from '../bots.js'
+
+jest.mock('../../services/botsService', () => ({
+	getConversationBots: jest.fn(),
+	disableBotForConversation: jest.fn(),
+	enableBotForConversation: jest.fn(),
+}))
+
+describe('botsStore', () => {
+	const token = 'TOKEN'
+	const bots = [
+		{ id: 1, name: 'Dummy bot 1', state: 0 },
+		{ id: 2, name: 'Dummy bot 2', state: 1 },
+	]
+	let botsStore
+
+	beforeEach(async () => {
+		setActivePinia(createPinia())
+		botsStore = useBotsStore()
+	})
+
+	afterEach(async () => {
+		jest.clearAllMocks()
+	})
+
+	it('returns an empty array when bots are not loaded yet for conversation', async () => {
+		// Assert: check initial state of the store
+		expect(botsStore.getConversationBots(token)).toEqual([])
+	})
+
+	it('processes a response from server and stores bots', async () => {
+		// Arrange
+		const response = generateOCSResponse({ payload: bots })
+		getConversationBots.mockResolvedValueOnce(response)
+
+		// Act: load bots from server
+		await botsStore.loadConversationBots(token)
+
+		// Assert
+		expect(getConversationBots).toHaveBeenCalledWith(token)
+		expect(botsStore.getConversationBots(token)).toEqual(bots)
+	})
+
+	it('updates bots in the store after new response from server', async () => {
+		// Arrange
+		const newBot = { id: 3, name: 'Dummy bot 3', state: 2 }
+		const responseFirst = generateOCSResponse({ payload: bots })
+		const responseSecond = generateOCSResponse({ payload: [...bots, newBot] })
+		getConversationBots
+			.mockResolvedValueOnce(responseFirst)
+			.mockResolvedValueOnce(responseSecond)
+
+		// Act: load bots from server twice
+		await botsStore.loadConversationBots(token)
+		await botsStore.loadConversationBots(token)
+
+		// Assert
+		expect(getConversationBots).toHaveBeenCalledTimes(2)
+		expect(botsStore.getConversationBots(token)).toEqual([...bots, newBot])
+	})
+
+	it('toggles bots state according to their current state', async () => {
+		// Arrange
+		const response = generateOCSResponse({ payload: bots })
+		getConversationBots.mockResolvedValueOnce(response)
+		await botsStore.loadConversationBots(token)
+
+		const enabledBot = { ...bots[0], state: 1 }
+		const responseEnabled = generateOCSResponse({ payload: enabledBot })
+		enableBotForConversation.mockResolvedValueOnce(responseEnabled)
+		const disabledBot = { ...bots[1], state: 0 }
+		const responseDisabled = generateOCSResponse({ payload: disabledBot })
+		disableBotForConversation.mockResolvedValueOnce(responseDisabled)
+
+		// Act: enable bot with id 1, disable bot with id 2
+		await botsStore.toggleBotState(token, bots[0])
+		await botsStore.toggleBotState(token, bots[1])
+
+		// Assert
+		expect(enableBotForConversation).toHaveBeenCalledWith(token, bots[0].id)
+		expect(disableBotForConversation).toHaveBeenCalledWith(token, bots[1].id)
+		expect(botsStore.getConversationBots(token)).toEqual([enabledBot, disabledBot])
+	})
+})

--- a/src/stores/__tests__/settings.spec.js
+++ b/src/stores/__tests__/settings.spec.js
@@ -3,36 +3,46 @@ import { setActivePinia, createPinia } from 'pinia'
 import { loadState } from '@nextcloud/initial-state'
 
 import { PRIVACY } from '../../constants.js'
+import { setReadStatusPrivacy, setTypingStatusPrivacy } from '../../services/settingsService.js'
+import { generateOCSResponse } from '../../test-helpers.js'
 import { useSettingsStore } from '../settings.js'
 
-jest.mock('../../services/settingsService',
-	() => ({
-		setReadStatusPrivacy: jest.fn().mockReturnValue('success'),
-		setTypingStatusPrivacy: jest.fn().mockReturnValue('success'),
-	}))
+jest.mock('../../services/settingsService', () => ({
+	setReadStatusPrivacy: jest.fn(),
+	setTypingStatusPrivacy: jest.fn(),
+}))
 
 describe('settingsStore', () => {
+	let settingsStore
+
 	beforeEach(() => {
 		loadState.mockImplementation(() => PRIVACY.PUBLIC)
 		setActivePinia(createPinia())
+		settingsStore = useSettingsStore()
+	})
+
+	afterEach(async () => {
+		jest.clearAllMocks()
 	})
 
 	it('shows correct loaded values for statuses', () => {
-		const settingsStore = useSettingsStore()
-
+		// Assert
 		expect(settingsStore.readStatusPrivacy).toBe(PRIVACY.PUBLIC)
 		expect(settingsStore.typingStatusPrivacy).toBe(PRIVACY.PUBLIC)
 	})
 
-	it('toggles statuses correctly', async () => {
-		const settingsStore = useSettingsStore()
+	it('updates statuses correctly', async () => {
+		// Arrange
+		const response = generateOCSResponse({ payload: [] })
+		setReadStatusPrivacy.mockResolvedValueOnce(response)
+		setTypingStatusPrivacy.mockResolvedValueOnce(response)
 
-		expect(settingsStore.readStatusPrivacy).toBe(PRIVACY.PUBLIC)
+		// Act: update read status and typing status privacy
 		await settingsStore.updateReadStatusPrivacy(PRIVACY.PRIVATE)
-		expect(settingsStore.readStatusPrivacy).toBe(PRIVACY.PRIVATE)
-
-		expect(settingsStore.typingStatusPrivacy).toBe(PRIVACY.PUBLIC)
 		await settingsStore.updateTypingStatusPrivacy(PRIVACY.PRIVATE)
+
+		// Assert
+		expect(settingsStore.readStatusPrivacy).toBe(PRIVACY.PRIVATE)
 		expect(settingsStore.typingStatusPrivacy).toBe(PRIVACY.PRIVATE)
 	})
 })

--- a/src/stores/__tests__/settings.spec.js
+++ b/src/stores/__tests__/settings.spec.js
@@ -1,12 +1,9 @@
 import { setActivePinia, createPinia } from 'pinia'
 
+import { loadState } from '@nextcloud/initial-state'
+
 import { PRIVACY } from '../../constants.js'
 import { useSettingsStore } from '../settings.js'
-
-jest.mock('@nextcloud/initial-state',
-	() => ({
-		loadState: jest.fn().mockReturnValue(0),
-	}))
 
 jest.mock('../../services/settingsService',
 	() => ({
@@ -16,9 +13,7 @@ jest.mock('../../services/settingsService',
 
 describe('settingsStore', () => {
 	beforeEach(() => {
-		// creates a fresh pinia and make it active, so it's automatically picked
-		// up by any useStore() call without having to pass it to it:
-		// `useStore(pinia)`
+		loadState.mockImplementation(() => PRIVACY.PUBLIC)
 		setActivePinia(createPinia())
 	})
 

--- a/src/test-helpers.js
+++ b/src/test-helpers.js
@@ -20,6 +20,8 @@
  *
  */
 
+import { cloneDeep } from 'lodash'
+
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcListItem from '@nextcloud/vue/dist/Components/NcListItem.js'
@@ -72,8 +74,69 @@ function findNcListItems(wrapper, text) {
 		: listItems.filter(listItem => listItem.vm.title === text)
 }
 
+/**
+ *
+ * @param {object} data response from the server
+ * @param {object} [data.headers = {}] headers of response
+ * @param {object} [data.payload = {}] payload of response
+ * @param {number} [data.status = 200] status code of response
+ * @return {object}
+ */
+function generateOCSResponse({ headers = {}, payload = {}, status = 200 }) {
+	return {
+		headers,
+		status,
+		data: {
+			ocs: {
+				data: cloneDeep(payload),
+				meta: (status >= 200 && status < 400)
+					? {
+						status: 'ok',
+						statuscode: status,
+						message: 'OK',
+					}
+					: {
+						status: 'failure',
+						statuscode: status,
+						message: '',
+					},
+			},
+		},
+	}
+}
+
+/**
+ *
+ * @param {object} data response from the server
+ * @param {object} [data.headers = {}] headers of response
+ * @param {object} [data.payload = {}] payload of response
+ * @param {number} data.status status code of response
+ * @return {object}
+ */
+function generateOCSErrorResponse({ headers = {}, payload = {}, status }) {
+	return {
+		headers,
+		status,
+		response: {
+			status,
+			data: {
+				ocs: {
+					data: cloneDeep(payload),
+					meta: {
+						status: 'failure',
+						statuscode: status,
+						message: '',
+					},
+				},
+			},
+		},
+	}
+}
+
 export {
 	findNcActionButton,
 	findNcButton,
 	findNcListItems,
+	generateOCSResponse,
+	generateOCSErrorResponse,
 }

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -33,6 +33,12 @@ jest.mock('extendable-media-recorder-wav-encoder', () => ({
 	connect: jest.fn(),
 }))
 
+window.IntersectionObserver = jest.fn(() => ({
+	observe: jest.fn(),
+	unobserve: jest.fn(),
+	disconnect: jest.fn(),
+}))
+
 global.appName = 'spreed'
 
 global.OC = {

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -33,6 +33,12 @@ jest.mock('extendable-media-recorder-wav-encoder', () => ({
 	connect: jest.fn(),
 }))
 
+jest.mock('@nextcloud/initial-state', () => ({
+	loadState: jest.fn().mockImplementation((app, key, fallback) => {
+		return fallback
+	}),
+}))
+
 window.IntersectionObserver = jest.fn(() => ({
 	observe: jest.fn(),
 	unobserve: jest.fn(),


### PR DESCRIPTION
### ☑️ Resolves

* add test helpers `generateOCSResponse` and `generateOCSErrorResponse` to ease codebase, unify request mocks and enhance typings
* mock `IntersectionObserver` and `@nextcloud/initial-state` to reduce amount of senseless logs in jest output
* update tests for :pineapple: Pinia stores, increase coverage (part of #9202) 

### 🖼️ Screenshots
No visual changes

Jest output:
🏚️ Before | 🏡 After
---|---
**3 212 lines** (323 lines - test coverage) | **634 lines** :arrow_down_small: 90%  (323 lines - test coverage)


### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
