### PR TITLE
store self as unique user in combined system message

### DIFF
--- a/src/composables/useCombinedSystemMessage.js
+++ b/src/composables/useCombinedSystemMessage.js
@@ -153,13 +153,15 @@ export function useCombinedSystemMessage() {
 				if (storedUniqueUsers.includes(actorReference)) {
 					return
 				}
+
 				if (checkIfSelfIsOneOfActors(message)) {
 					selfIsUser = true
 				} else {
 					combinedMessage.messageParameters[`user${referenceIndex}`] = message.messageParameters.actor
-					storedUniqueUsers.push(actorReference)
 					referenceIndex++
 				}
+
+				storedUniqueUsers.push(actorReference)
 				usersCounter++
 			})
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix broken system message, when for some reason user joined or left call several times in a row

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2023-08-29 13-55-07](https://github.com/nextcloud/spreed/assets/93392545/0b250d8e-dd6f-4643-bbc6-97e273bd2d17) | ![Screenshot from 2023-08-29 13-54-26](https://github.com/nextcloud/spreed/assets/93392545/7abc3985-7483-4fa5-98e9-61c7d22672ad)


### 🚧 Tasks

- [ ] Code review
- [ ] Manual check

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
