### PR TITLE
fix(NewMessage, EditabeTextField) - don't parse NcRichContenteditable output before sending

### DIFF
--- a/src/components/ConversationSettings/BasicInfo.vue
+++ b/src/components/ConversationSettings/BasicInfo.vue
@@ -42,6 +42,7 @@
 				:loading="isDescriptionLoading"
 				:edit-button-aria-label="t('spreed', 'Edit conversation description')"
 				:placeholder="t('spreed', 'Enter a description for this conversation')"
+				use-markdown
 				@submit-text="handleUpdateDescription"
 				@update:editing="handleEditDescription" />
 		</template>

--- a/src/components/ConversationSettings/EditableTextField.vue
+++ b/src/components/ConversationSettings/EditableTextField.vue
@@ -217,10 +217,11 @@ export default {
 				return
 			}
 			// Remove leading/trailing whitespaces.
-			// FIXME: remove after issue is resolved: https://github.com/nextcloud/nextcloud-vue/issues/3264
+			// FIXME upstream: https://github.com/nextcloud-libraries/nextcloud-vue/issues/4492
 			const temp = document.createElement('textarea')
-			temp.innerHTML = this.text
-			this.text = temp.value.replace(/\r\n|\n|\r/gm, '\n').trim()
+			temp.innerHTML = this.text.replace(/&/gmi, '&amp;')
+			this.text = temp.value.replace(/\r\n|\n|\r/gm, '\n').replace(/&amp;/gmi, '&')
+				.replace(/&lt;/gmi, '<').replace(/&gt;/gmi, '>').replace(/&sect;/gmi, '§').trim()
 
 			// Submit text
 			this.$emit('submit-text', this.text)

--- a/src/components/ConversationSettings/EditableTextField.vue
+++ b/src/components/ConversationSettings/EditableTextField.vue
@@ -20,14 +20,18 @@
 -->
 
 <template>
-	<div ref="editable-text-field"
-		:key="forceReRenderKey"
-		class="editable-text-field">
-		<NcRichContenteditable ref="richContenteditable"
+	<div ref="editable-text-field" class="editable-text-field">
+		<NcRichText v-if="!editing"
+			class="editable-text-field__output"
+			:text="text"
+			autolink
+			:use-markdown="useMarkdown" />
+		<NcRichContenteditable v-else
+			ref="richContenteditable"
 			:value.sync="text"
 			:auto-complete="()=>{}"
 			:maxlength="maxLength"
-			:contenteditable="editing && !loading"
+			:contenteditable="!loading"
 			:placeholder="placeholder"
 			@submit="handleSubmitText"
 			@keydown.esc="handleCancelEditing" />
@@ -77,11 +81,13 @@ import Pencil from 'vue-material-design-icons/Pencil.vue'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcRichContenteditable from '@nextcloud/vue/dist/Components/NcRichContenteditable.js'
+import NcRichText from '@nextcloud/vue/dist/Components/NcRichText.js'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 export default {
 	name: 'EditableTextField',
 	components: {
+		NcRichText,
 		Pencil,
 		Check,
 		Close,
@@ -147,6 +153,11 @@ export default {
 			type: String,
 			required: true,
 		},
+
+		useMarkdown: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	emits: ['update:editing', 'submit-text'],
@@ -154,7 +165,6 @@ export default {
 	data() {
 		return {
 			text: this.initialText,
-			forceReRenderKey: 0,
 			overflows: null,
 		}
 	},
@@ -225,12 +235,6 @@ export default {
 
 			// Submit text
 			this.$emit('submit-text', this.text)
-			/**
-			 * Change the NcRichContenteditable key in order to trigger a re-render
-			 * without this all the trimmed new lines and whitespaces would
-			 * still be present in the contenteditable element.
-			 */
-			this.forceReRenderKey += 1
 		},
 
 		handleCancelEditing() {
@@ -258,6 +262,12 @@ export default {
 	&__edit {
 		margin-left: var(--default-clickable-area);
 	}
+
+  &__output {
+    width: 100%;
+    padding: 10px;
+    line-height: var(--default-line-height);
+  }
 }
 
 .spinner {

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -474,10 +474,11 @@ export default {
 			}
 
 			if (this.hasText) {
-				// FIXME: remove after issue is resolved: https://github.com/nextcloud/nextcloud-vue/issues/3264
+				// FIXME upstream: https://github.com/nextcloud-libraries/nextcloud-vue/issues/4492
 				const temp = document.createElement('textarea')
-				temp.innerHTML = this.text
-				this.text = temp.value
+				temp.innerHTML = this.text.replace(/&/gmi, '&amp;')
+				this.text = temp.value.replace(/&amp;/gmi, '&').replace(/&lt;/gmi, '<')
+					.replace(/&gt;/gmi, '>').replace(/&sect;/gmi, '§')
 
 				const temporaryMessage = await this.$store.dispatch('createTemporaryMessage', {
 					text: this.text.trim(),


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10227
* Follow-ups FIXME in the https://github.com/nextcloud-libraries/nextcloud-vue/issues/4492

### 🖼️ Screenshots
Input:
```
&amp &lt &gt &sect
&amp; &lt; &gt; &sect;
https://instance.com/?editor=globaladmin&section=Invitation
```

Output:
🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/02bdb940-f129-4a9b-9998-02a837756f81) | ![image](https://github.com/nextcloud/spreed/assets/93392545/99c9c143-e901-4279-a752-73023b3d9b74)
![image](https://github.com/nextcloud/spreed/assets/93392545/bd4c9d96-b1f0-432c-82f7-b2c9e2630739) | ![image](https://github.com/nextcloud/spreed/assets/93392545/83f5b3ed-7bae-425f-8da5-557028a7289d)
``` & < > § & < > § https://instancae.com/?editor=globaladmin§ion=Invitation ``` | ```&amp &lt &gt &sect & < > § https://instancae.com/?editor=globaladmin&section=Invitation ```





### 🚧 Tasks

- [ ] Code review
- [ ] Visual check

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required (should be tested upstream)
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
