### PR TITLE
fix(CI): Kill stray child proccesses now that the php server is spawning multiple childs

### DIFF
--- a/tests/integration/config/behat.yml
+++ b/tests/integration/config/behat.yml
@@ -1,4 +1,8 @@
 default:
+  formatters:
+    pretty:
+      output_styles:
+        comment: [ 'bright-blue' ]
   autoload:
     '': '%paths.base%/../features/bootstrap'
   suites:

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -8,19 +8,18 @@ CSB_BRANCH="main"
 APP_INTEGRATION_DIR=$PWD
 ROOT_DIR=${APP_INTEGRATION_DIR}/../../../..
 echo ''
-echo '#'
-echo '# Installing composer dependencies from tests/integration/'
-echo '#'
+echo -e "\033[0;36m#\033[0m"
+echo -e "\033[0;36m# Installing composer dependencies from tests/integration/\033[0m"
+echo -e "\033[0;36m#\033[0m"
 composer install
 
 echo ''
-echo '#'
-echo '# Starting PHP webserver'
-echo '#'
+echo -e "\033[0;36m#\033[0m"
+echo -e "\033[0;36m# Starting PHP webserver\033[0m"
+echo -e "\033[0;36m#\033[0m"
 PHP_CLI_SERVER_WORKERS=3 php -S localhost:8080 -t ${ROOT_DIR} &
 PHPPID1=$!
-echo 'Running on process ID:'
-echo $PHPPID1
+echo -e "Running on process ID: \033[1;35m$PHPPID1\033[0m"
 
 # also kill php process in case of ctrl+c
 trap 'pkill -P $PHPPID1; kill -TERM $PHPPID1; wait $PHPPID1' TERM
@@ -31,8 +30,7 @@ export PORT_FED
 
 php -S localhost:${PORT_FED} -t ${ROOT_DIR} &
 PHPPID2=$!
-echo 'Running on process ID:'
-echo $PHPPID2
+echo -e "Running on process ID: \033[1;35m$PHPPID2\033[0m"
 
 # also kill php process in case of ctrl+c
 trap 'pkill -P $PHPPID2; kill -TERM $PHPPID2; wait $PHPPID2' TERM
@@ -52,9 +50,9 @@ if [[ "$SKELETON_DIR" ]]; then
 fi
 
 echo ''
-echo '#'
-echo '# Setting up apps'
-echo '#'
+echo -e "\033[0;36m#\033[0m"
+echo -e "\033[0;36m# Setting up apps\033[0m"
+echo -e "\033[0;36m#\033[0m"
 cp -R ./spreedcheats ../../../spreedcheats
 ${ROOT_DIR}/occ app:getpath spreedcheats
 
@@ -76,9 +74,9 @@ ${ROOT_DIR}/occ app:list | grep guests
 ${ROOT_DIR}/occ app:list | grep call_summary_bot
 
 echo ''
-echo '#'
-echo '# Optimizing configuration'
-echo '#'
+echo -e "\033[0;36m#\033[0m"
+echo -e "\033[0;36m# Optimizing configuration\033[0m"
+echo -e "\033[0;36m#\033[0m"
 # Disable bruteforce protection because the integration tests do trigger them
 ${ROOT_DIR}/occ config:system:set auth.bruteforce.protection.enabled --value false --type bool
 # Disable rate limit protection because the integration tests do trigger them
@@ -87,21 +85,30 @@ ${ROOT_DIR}/occ config:system:set ratelimit.protection.enabled --value false --t
 ${ROOT_DIR}/occ config:system:set allow_local_remote_servers --value true --type bool
 
 echo ''
-echo '#'
-echo '# Running tests'
-echo '#'
+echo -e "\033[1;33m#\033[0m"
+echo -e "\033[1;33m# ██████╗ ██╗   ██╗███╗   ██╗    ████████╗███████╗███████╗████████╗███████╗\033[0m"
+echo -e "\033[1;33m# ██╔══██╗██║   ██║████╗  ██║    ╚══██╔══╝██╔════╝██╔════╝╚══██╔══╝██╔════╝\033[0m"
+echo -e "\033[1;33m# ██████╔╝██║   ██║██╔██╗ ██║       ██║   █████╗  ███████╗   ██║   ███████╗\033[0m"
+echo -e "\033[1;33m# ██╔══██╗██║   ██║██║╚██╗██║       ██║   ██╔══╝  ╚════██║   ██║   ╚════██║\033[0m"
+echo -e "\033[1;33m# ██║  ██║╚██████╔╝██║ ╚████║       ██║   ███████╗███████║   ██║   ███████║\033[0m"
+echo -e "\033[1;33m# ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═══╝       ╚═╝   ╚══════╝╚══════╝   ╚═╝   ╚══════╝\033[0m"
+echo -e "\033[1;33m#\033[0m"
 ${APP_INTEGRATION_DIR}/vendor/bin/behat --colors -f junit -f pretty $1 $2
 RESULT=$?
 
 echo ''
-echo '#'
-echo '# Stopping PHP webserver and disabling spreedcheats'
-echo '#'
+echo -e "\033[0;36m#\033[0m"
+echo -e "\033[0;36m# Stopping PHP webserver\033[0m"
+echo -e "\033[0;36m#\033[0m"
 pkill -P $PHPPID1
 kill $PHPPID1
 pkill -P $PHPPID2
 kill $PHPPID2
 
+echo ''
+echo -e "\033[0;36m#\033[0m"
+echo -e "\033[0;36m# Reverting configuration changes and disabling spreedcheats\033[0m"
+echo -e "\033[0;36m#\033[0m"
 ${ROOT_DIR}/occ app:disable spreedcheats
 ${ROOT_DIR}/occ config:system:set overwrite.cli.url --value $OVERWRITE_CLI_URL
 if [[ "$SKELETON_DIR" ]]; then

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -23,7 +23,7 @@ echo 'Running on process ID:'
 echo $PHPPID1
 
 # also kill php process in case of ctrl+c
-trap 'kill -TERM $PHPPID1; wait $PHPPID1' TERM
+trap 'pkill -P $PHPPID1; kill -TERM $PHPPID1; wait $PHPPID1' TERM
 
 # The federated server is started and stopped by the tests themselves
 PORT_FED=8180
@@ -35,7 +35,7 @@ echo 'Running on process ID:'
 echo $PHPPID2
 
 # also kill php process in case of ctrl+c
-trap 'kill -TERM $PHPPID2; wait $PHPPID2' TERM
+trap 'pkill -P $PHPPID2; kill -TERM $PHPPID2; wait $PHPPID2' TERM
 
 NEXTCLOUD_ROOT_DIR=${ROOT_DIR}
 export NEXTCLOUD_ROOT_DIR
@@ -97,7 +97,9 @@ echo ''
 echo '#'
 echo '# Stopping PHP webserver and disabling spreedcheats'
 echo '#'
+pkill -P $PHPPID1
 kill $PHPPID1
+pkill -P $PHPPID2
 kill $PHPPID2
 
 ${ROOT_DIR}/occ app:disable spreedcheats


### PR DESCRIPTION
### ☑️ Resolves

* Fix leaving behind stray PHP built-in server processes

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/nextcloud/spreed/assets/213943/7cf9f05b-682f-4303-8701-9a082b7ccee0) | ![grafik](https://github.com/nextcloud/spreed/assets/213943/6a4dbfdd-4369-42de-bee2-1b642e3febe3)


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
