### PR TITLE
Remove unneccessary output from php process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@
 /tests/integration/output
 /drone
 
+# PHP Dev server output (integration tests)
+/tests/integration/phpserver.log
+/tests/integration/phpserver_fed.log
+
 # Compiled javascript
 /js
 


### PR DESCRIPTION
### ☑️ Resolves

* Removes unneccessary output of "Accepted" and "Closed" messages from the PHP dev server.
* Fixes the trap. Since we can have only one trap per signal, this is now combined.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/1580193/6610bbe4-a1ba-4dc7-93fd-261b837b3d71) | ![image](https://github.com/nextcloud/spreed/assets/1580193/c36b065b-7ec3-46e1-a500-04f4a9db395b)


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
