### PR TITLE
fix(Message) - correctly show users reacted to message 

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -133,17 +133,17 @@ the main body of the message as well as a quote.
 			<div v-if="hasReactions"
 				class="message-body__reactions"
 				@mouseover="handleReactionsMouseOver">
-				<NcPopover v-for="reaction in Object.keys(simpleReactions)"
+				<NcPopover v-for="reaction in Object.keys(reactions)"
 					:key="reaction"
 					:delay="200"
 					:focus-trap="false"
 					:triggers="['hover']">
 					<template #trigger>
-						<NcButton v-if="simpleReactions[reaction] !== 0"
+						<NcButton v-if="reactions[reaction] !== 0"
 							:type="userHasReacted(reaction) ? 'primary' : 'secondary'"
 							class="reaction-button"
 							@click="handleReactionClick(reaction)">
-							{{ reaction }} {{ simpleReactions[reaction] }}
+							{{ reaction }} {{ reactions[reaction] }}
 						</NcButton>
 					</template>
 
@@ -669,7 +669,7 @@ export default {
 		},
 
 		hasReactions() {
-			return this.$store.getters.hasReactions(this.token, this.id)
+			return Object.keys(this.reactions).length !== 0
 		},
 
 		canReact() {
@@ -677,10 +677,6 @@ export default {
 				&& (this.conversation.permissions & PARTICIPANT.PERMISSIONS.CHAT) !== 0
 				&& this.messageObject.messageType !== 'command'
 				&& this.messageObject.messageType !== 'comment_deleted'
-		},
-
-		simpleReactions() {
-			return this.messageObject.reactions
 		},
 
 		detailedReactions() {
@@ -698,14 +694,14 @@ export default {
 		},
 
 		// Scroll list to the bottom if reaction to the message was added, as it expands the list
-		simpleReactions() {
+		reactions() {
 			EventBus.$emit('scroll-chat-to-bottom-if-sticky')
 		},
 	},
 
 	methods: {
 		userHasReacted(reaction) {
-			return this.reactionsSelf && this.reactionsSelf.includes(reaction)
+			return this.reactionsSelf?.includes(reaction)
 		},
 
 		lastReadMessageVisibilityChanged(isVisible) {

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -657,7 +657,7 @@ export default {
 
 		handleReactionClick(selectedEmoji) {
 			// Add reaction only if user hasn't reacted yet
-			if (!this.$store.getters.userHasReacted(this.$store.getters.getActorType(), this.$store.getters.getActorId(), this.token, this.messageObject.id, selectedEmoji)) {
+			if (!this.messageObject.reactionsSelf?.includes(selectedEmoji)) {
 				this.$store.dispatch('addReactionToMessage', {
 					token: this.token,
 					messageId: this.messageObject.id,

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -422,16 +422,17 @@ const mutations = {
 
 	// Increases reaction count for a particular reaction on a message
 	addReactionToMessage(state, { token, messageId, reaction }) {
-		if (!state.messages[token][messageId].reactions[reaction]) {
-			Vue.set(state.messages[token][messageId].reactions, reaction, 0)
+		const message = state.messages[token][messageId]
+		if (!message.reactions[reaction]) {
+			Vue.set(message.reactions, reaction, 0)
 		}
-		const reactionCount = state.messages[token][messageId].reactions[reaction] + 1
-		Vue.set(state.messages[token][messageId].reactions, reaction, reactionCount)
+		const reactionCount = message.reactions[reaction] + 1
+		Vue.set(message.reactions, reaction, reactionCount)
 
-		if (!state.messages[token][messageId].reactionsSelf) {
-			Vue.set(state.messages[token][messageId], 'reactionsSelf', [reaction])
+		if (!message.reactionsSelf) {
+			Vue.set(message, 'reactionsSelf', [reaction])
 		} else {
-			state.messages[token][messageId].reactionsSelf.push(reaction)
+			Vue.set(message, 'reactionsSelf', message.reactionsSelf.concat(reaction))
 		}
 	},
 
@@ -441,17 +442,16 @@ const mutations = {
 
 	// Decreases reaction count for a particular reaction on a message
 	removeReactionFromMessage(state, { token, messageId, reaction }) {
-		const reactionCount = state.messages[token][messageId].reactions[reaction] - 1
-		Vue.set(state.messages[token][messageId].reactions, reaction, reactionCount)
-		if (state.messages[token][messageId].reactions[reaction] <= 0) {
-			Vue.delete(state.messages[token][messageId].reactions, reaction)
+		const message = state.messages[token][messageId]
+		const reactionCount = message.reactions[reaction] - 1
+		if (reactionCount <= 0) {
+			Vue.delete(message.reactions, reaction)
+		} else {
+			Vue.set(message.reactions, reaction, reactionCount)
 		}
 
-		if (state.messages[token][messageId].reactionsSelf) {
-			const i = state.messages[token][messageId].reactionsSelf.indexOf(reaction)
-			if (i !== -1) {
-				Vue.delete(state.messages[token][messageId], 'reactionsSelf', i)
-			}
+		if (message.reactionsSelf?.includes(reaction)) {
+			Vue.set(message, 'reactionsSelf', message.reactionsSelf.filter(item => item !== reaction))
 		}
 	},
 

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -243,11 +243,6 @@ const getters = {
 		// the cancel handler only exists when a message is being sent
 		return Object.keys(state.cancelPostNewMessage).length !== 0
 	},
-
-	// Returns true if the message has reactions
-	hasReactions: (state) => (token, messageId) => {
-		return Object.keys(Object(state.messages[token]?.[messageId]?.reactions)).length !== 0
-	},
 }
 
 const mutations = {

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -516,7 +516,7 @@ const actions = {
 				context.commit('addMessage', message.parent)
 				context.dispatch('resetReactions', {
 					token: message.token,
-					messageId: message.parent,
+					messageId: message.parent.id,
 				})
 			}
 			// Quit processing

--- a/src/store/reactionsStore.js
+++ b/src/store/reactionsStore.js
@@ -49,16 +49,6 @@ const getters = {
 			return false
 		}
 	},
-
-	// Checks if a user has already reacted to a message with a particular reaction
-	userHasReacted: (state) => (actorType, actorId, token, messageId, reaction) => {
-		if (!state?.reactions?.[token]?.[messageId]?.[reaction]) {
-			return false
-		}
-		return state?.reactions?.[token]?.[messageId]?.[reaction].filter(item => {
-			return item.actorType === actorType && item.actorId === actorId
-		}).length !== 0
-	},
 }
 
 const mutations = {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10395
* Detailed reactions are now resetted, if new one come from server
* Self reactions don't flicker anymore, if one of reactions was deleted
* Remove redundant store getters:
  * `hasReactions()` - we can get this info from prop `reactions` in component
  * `userHasReacted()` - we can get this info from prop `reactionsSelf` in component
* Refactor related tests for `Message` component

### 🖼️ Screenshots
No visual changes

### 🚧 Tasks

- [ ] Manual testing
- [ ] Code review
- [ ] Follow-up:
  - [ ] convert reactionsStore to Pinia :pineapple: 
  - [ ] cover reactionsStore with tests :abacus: 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
