### PR TITLE
[stable27] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -134,12 +134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "5689b815ed71839120dab42e76d2920f44df27ca"
+                "reference": "10d5e8430930a2f18e4c3a2053fb32348853bb78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5689b815ed71839120dab42e76d2920f44df27ca",
-                "reference": "5689b815ed71839120dab42e76d2920f44df27ca",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/10d5e8430930a2f18e4c3a2053fb32348853bb78",
+                "reference": "10d5e8430930a2f18e4c3a2053fb32348853bb78",
                 "shasum": ""
             },
             "require": {
@@ -170,7 +170,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable27"
             },
-            "time": "2023-08-24T00:29:46+00:00"
+            "time": "2023-09-07T00:30:04+00:00"
         },
         {
             "name": "psr/clock",
@@ -1023,5 +1023,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency