### PR TITLE
perf(CallView) - add an option to disable background blur in call

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -21,7 +21,7 @@
 -->
 
 <template>
-	<div id="call-container">
+	<div id="call-container" :class="{ 'blurred': isBackgroundBlurred }">
 		<ViewerOverlayCallView v-if="isViewerOverlay"
 			:token="token"
 			:model="promotedParticipantModel"
@@ -162,6 +162,7 @@ import VideoVue from './shared/VideoVue.vue'
 import ViewerOverlayCallView from './shared/ViewerOverlayCallView.vue'
 
 import { SIMULCAST } from '../../constants.js'
+import BrowserStorage from '../../services/BrowserStorage.js'
 import { fetchPeers } from '../../services/callsService.js'
 import { EventBus } from '../../services/EventBus.js'
 import { localMediaModel, localCallParticipantModel, callParticipantCollection } from '../../utils/webrtc/index.js'
@@ -212,6 +213,7 @@ export default {
 				screenVisible: true,
 			},
 			callParticipantCollection,
+			isBackgroundBlurred: true,
 		}
 	},
 	computed: {
@@ -439,6 +441,7 @@ export default {
 		// Ensure that data is properly initialized before mounting the
 		// subviews.
 		this.updateDataFromCallParticipantModels(this.callParticipantModels)
+		this.isBackgroundBlurred = BrowserStorage.getItem('background-blurred') !== 'false'
 	},
 	mounted() {
 		EventBus.$on('refresh-peer-list', this.debounceFetchPeers)
@@ -446,6 +449,7 @@ export default {
 		callParticipantCollection.on('remove', this._lowerHandWhenParticipantLeaves)
 
 		subscribe('switch-screen-to-id', this._switchScreenToId)
+		subscribe('set-background-blurred', this.setBackgroundBlurred)
 	},
 	beforeDestroy() {
 		EventBus.$off('refresh-peer-list', this.debounceFetchPeers)
@@ -453,6 +457,7 @@ export default {
 		callParticipantCollection.off('remove', this._lowerHandWhenParticipantLeaves)
 
 		unsubscribe('switch-screen-to-id', this._switchScreenToId)
+		unsubscribe('set-background-blurred', this.setBackgroundBlurred)
 	},
 	methods: {
 		/**
@@ -704,6 +709,10 @@ export default {
 				callParticipantModel.setSimulcastVideoQuality(SIMULCAST.LOW)
 			}
 		},
+
+		setBackgroundBlurred(value) {
+			this.isBackgroundBlurred = value
+		},
 	},
 }
 </script>
@@ -722,7 +731,10 @@ export default {
 	width: 100%;
 	height: 100%;
 	background-color: $color-call-background;
-	backdrop-filter: blur(25px);
+
+	&.blurred {
+		backdrop-filter: blur(25px);
+	}
 }
 
 #videos {

--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -90,6 +90,17 @@
 				{{ t('spreed', 'Sounds for chat and call notifications can be adjusted in the personal settings.') }} ↗
 			</a>
 		</NcAppSettingsSection>
+		<NcAppSettingsSection id="performance"
+			:title="t('spreed', 'Performance')"
+			class="app-settings-section">
+			<NcCheckboxRadioSwitch id="blur-call-background"
+				:checked="isBackgroundBlurred"
+				type="switch"
+				class="checkbox"
+				@update:checked="toggleBackgroundBlurred">
+				{{ t('spreed', 'Blur background image in the call (may increase GPU load)') }}
+			</NcCheckboxRadioSwitch>
+		</NcAppSettingsSection>
 		<NcAppSettingsSection v-if="!disableKeyboardShortcuts"
 			id="shortcuts"
 			:title="t('spreed', 'Keyboard shortcuts')">
@@ -156,7 +167,7 @@
 <script>
 import { getCapabilities } from '@nextcloud/capabilities'
 import { getFilePickerBuilder, showError, showSuccess } from '@nextcloud/dialogs'
-import { subscribe, unsubscribe } from '@nextcloud/event-bus'
+import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { generateUrl } from '@nextcloud/router'
 
 import NcAppSettingsDialog from '@nextcloud/vue/dist/Components/NcAppSettingsDialog.js'
@@ -168,6 +179,7 @@ import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 import MediaDevicesPreview from '../MediaDevicesPreview.vue'
 
 import { PRIVACY } from '../../constants.js'
+import BrowserStorage from '../../services/BrowserStorage.js'
 import { useSettingsStore } from '../../stores/settings.js'
 
 const supportTypingStatus = getCapabilities()?.spreed?.config?.chat?.['typing-privacy'] !== undefined
@@ -199,6 +211,7 @@ export default {
 			attachmentFolderLoading: true,
 			privacyLoading: false,
 			playSoundsLoading: false,
+			isBackgroundBlurred: true,
 		}
 	},
 
@@ -238,6 +251,15 @@ export default {
 		disableKeyboardShortcuts() {
 			return OCP.Accessibility.disableKeyboardShortcuts()
 		},
+	},
+
+	created() {
+		const blurred = BrowserStorage.getItem('background-blurred')
+		if (blurred === null) {
+			BrowserStorage.setItem('background-blurred', 'true')
+		}
+
+		this.isBackgroundBlurred = blurred !== 'false'
 	},
 
 	mounted() {
@@ -297,6 +319,12 @@ export default {
 				showError(t('spreed', 'Error while setting typing status privacy'))
 			}
 			this.privacyLoading = false
+		},
+
+		toggleBackgroundBlurred(value) {
+			this.isBackgroundBlurred = value
+			BrowserStorage.setItem('background-blurred', value)
+			emit('set-background-blurred', value)
 		},
 
 		async togglePlaySounds() {


### PR DESCRIPTION
### ☑️ Resolves

* Partial solution for #7896

### 🖼️ Screenshots

Menu (enabled by default, reset on logout, same as all information in BrowserStorage): 
![image](https://github.com/nextcloud/spreed/assets/93392545/7a1cccd6-6017-4c37-9d6d-615f93e733eb)


:computer:  Screen | 🏚️ Before (Enabled) | 🏡 After (Disabled)
---|---|---
3840 x 2160 pixels (4K) | ![image](https://github.com/nextcloud/spreed/assets/93392545/309a7acc-1f41-4f23-8b66-723cd07e9bd9) | ![image](https://github.com/nextcloud/spreed/assets/93392545/615267e1-1669-4735-a061-01d4a7e82468)
1920 x 1080 pixels (Full HD) | ![image](https://github.com/nextcloud/spreed/assets/93392545/945510e0-7bff-412d-907f-d5b14cc0b0be) | ![image](https://github.com/nextcloud/spreed/assets/93392545/ca72c7d6-4775-47ff-a210-5d35b9eedee8)



### 🚧 Tasks

- [ ] Code review
- [ ] Visual check
- [ ] Known issue (upstream) - doesn't survive on log out - https://github.com/nextcloud-libraries/nextcloud-browser-storage/issues/293

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
