### PR TITLE
Add a welcome window to set username for guests

### DIFF
--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -23,7 +23,7 @@
 		@dragover.prevent="handleDragOver"
 		@dragleave.prevent="handleDragLeave"
 		@drop.prevent="handleDropFiles">
-		<GuestWelcomeWindow v-if="isGuestAndhasNotUserName" />
+		<GuestWelcomeWindow v-if="isGuestAndhasNotUsername" :token="token" />
 		<TransitionWrapper name="slide-up" mode="out-in">
 			<div v-show="isDraggingOver"
 				class="dragover">
@@ -113,8 +113,8 @@ export default {
 			return this.$store.getters.getActorType() === 'guests'
 		},
 
-		isGuestAndhasNotUserName() {
-			const userName = localStorage.getItem('nick')
+		isGuestAndhasNotUsername() {
+			const userName = this.$store.getters.getDisplayName()
 			return !userName && this.isGuest
 		},
 

--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -23,6 +23,7 @@
 		@dragover.prevent="handleDragOver"
 		@dragleave.prevent="handleDragLeave"
 		@drop.prevent="handleDropFiles">
+		<GuestWelcomeWindow v-if="isGuestAndhasNotUserName" />
 		<TransitionWrapper name="slide-up" mode="out-in">
 			<div v-show="isDraggingOver"
 				class="dragover">
@@ -70,6 +71,7 @@ import ChevronDoubleDown from 'vue-material-design-icons/ChevronDoubleDown.vue'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 
+import GuestWelcomeWindow from './GuestWelcomeWindow.vue'
 import MessagesList from './MessagesList/MessagesList.vue'
 import NewMessage from './NewMessage/NewMessage.vue'
 import TransitionWrapper from './TransitionWrapper.vue'
@@ -87,6 +89,7 @@ export default {
 		MessagesList,
 		NewMessage,
 		TransitionWrapper,
+		GuestWelcomeWindow,
 	},
 
 	props: {
@@ -109,6 +112,12 @@ export default {
 		isGuest() {
 			return this.$store.getters.getActorType() === 'guests'
 		},
+
+		isGuestAndhasNotUserName() {
+			const userName = localStorage.getItem('nick')
+			return !userName && this.isGuest
+		},
+
 		dropHintText() {
 			if (this.isGuest) {
 				return t('spreed', 'You need to be logged in to upload files')

--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -23,7 +23,7 @@
 		@dragover.prevent="handleDragOver"
 		@dragleave.prevent="handleDragLeave"
 		@drop.prevent="handleDropFiles">
-		<GuestWelcomeWindow v-if="isGuestAndhasNotUsername" :token="token" />
+		<GuestWelcomeWindow v-if="isGuestWithoutDisplayName" :token="token" />
 		<TransitionWrapper name="slide-up" mode="out-in">
 			<div v-show="isDraggingOver"
 				class="dragover">
@@ -113,7 +113,7 @@ export default {
 			return this.$store.getters.getActorType() === 'guests'
 		},
 
-		isGuestAndhasNotUsername() {
+		isGuestWithoutDisplayName() {
 			const userName = this.$store.getters.getDisplayName()
 			return !userName && this.isGuest
 		},

--- a/src/components/GuestWelcomeWindow.vue
+++ b/src/components/GuestWelcomeWindow.vue
@@ -1,0 +1,149 @@
+<!--
+  - @copyright Copyright (c) 2022, Dorra Jaouad <dorra.jaoued1@gmail.com>
+  -
+  - @author Dorra Jaouad <dorra.jaoued1@gmail.com>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<NcModal v-if="showModal"
+		:container="container"
+		:can-close="false"
+		:close-on-click-outside="false"
+		size="small">
+		<div class="modal__content">
+			<div class="conversation-information">
+				<ConversationIcon :item="conversation"
+					:show-user-status="false"
+					:disable-menu="true" />
+				<h2>{{ conversationDisplayName }}</h2>
+			</div>
+			<h3 class="description">
+				{{ conversationDescription }}
+			</h3>
+
+			<h3 class="input-label">
+				{{ t('spreed', 'Enter your name') }}
+			</h3>
+			<SetGuestUsername ref="setGuestUsername"
+				class="guest-user-form"
+				first-welcome
+				@keydown.enter="handleChooseUserName" />
+
+			<NcButton class="submit-button"
+				type="primary"
+				@click="handleChooseUserName">
+				{{ submitMessage }}
+				<template #icon>
+					<Check :size="20" />
+				</template>
+			</NcButton>
+		</div>
+	</NcModal>
+</template>
+
+<script>
+import Check from 'vue-material-design-icons/CheckBold.vue'
+
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
+
+import ConversationIcon from './ConversationIcon.vue'
+import SetGuestUsername from './SetGuestUsername.vue'
+
+export default {
+	name: 'GuestWelcomeWindow',
+
+	components: {
+		NcModal,
+		SetGuestUsername,
+		ConversationIcon,
+		NcButton,
+		Check,
+	},
+
+	data() {
+		return {
+			showModal: true,
+		}
+	},
+
+	computed: {
+		container() {
+			return this.$store.getters.getMainContainerSelector()
+		},
+
+		token() {
+			return this.$store.getters.getToken()
+		},
+
+		conversation() {
+			return this.$store.getters.conversation(this.token)
+		},
+
+		conversationDisplayName() {
+			return this.conversation && this.conversation.displayName
+		},
+
+		conversationDescription() {
+			return this.conversation && this.conversation.description
+		},
+
+		submitMessage() {
+			return t('spreed', 'Submit name and join')
+		},
+	},
+
+	methods: {
+		handleChooseUserName() {
+			this.$refs.setGuestUsername.handleChooseUserName()
+			this.showModal = false
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.modal__content {
+	padding: calc(var(--default-grid-baseline) * 4);
+	background-color: var(--color-main-background);
+
+	:deep(.username-form__input) {
+		width: auto !important;
+	}
+}
+
+.conversation-information {
+	margin-top: 5px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+}
+
+.description {
+	margin: 0px 12px 12px 12px;
+}
+
+.input-label {
+	margin: 0px 12px;
+}
+
+.submit-button {
+	margin: 0 auto;
+}
+</style>

--- a/src/components/GuestWelcomeWindow.vue
+++ b/src/components/GuestWelcomeWindow.vue
@@ -21,8 +21,7 @@
   -->
 
 <template>
-	<NcModal v-if="showModal"
-		:container="container"
+	<NcModal :container="container"
 		:can-close="false"
 		:close-on-click-outside="false"
 		size="small">
@@ -30,19 +29,21 @@
 			<div class="conversation-information">
 				<ConversationIcon :item="conversation"
 					:show-user-status="false"
-					:disable-menu="true" />
+					disable-menu />
 				<h2>{{ conversationDisplayName }}</h2>
 			</div>
-			<h3 class="description">
+			<p class="description">
 				{{ conversationDescription }}
-			</h3>
+			</p>
 
-			<h3 class="input-label">
+			<p class="input-label">
 				{{ t('spreed', 'Enter your name') }}
-			</h3>
-			<SetGuestUsername ref="setGuestUsername"
-				class="guest-user-form"
-				first-welcome
+			</p>
+
+			<NcTextField :value.sync="guestUserName"
+				:placeholder="t('spreed', 'Guest')"
+				class="username-form__input"
+				:show-trailing-button="false"
 				@keydown.enter="handleChooseUserName" />
 
 			<NcButton class="submit-button"
@@ -62,24 +63,31 @@ import Check from 'vue-material-design-icons/CheckBold.vue'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
+import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 
 import ConversationIcon from './ConversationIcon.vue'
-import SetGuestUsername from './SetGuestUsername.vue'
 
 export default {
 	name: 'GuestWelcomeWindow',
 
 	components: {
 		NcModal,
-		SetGuestUsername,
+		NcTextField,
 		ConversationIcon,
 		NcButton,
 		Check,
 	},
 
+	props: {
+		token: {
+			type: String,
+			required: true,
+		},
+	},
+
 	data() {
 		return {
-			showModal: true,
+			guestUserName: '',
 		}
 	},
 
@@ -88,20 +96,16 @@ export default {
 			return this.$store.getters.getMainContainerSelector()
 		},
 
-		token() {
-			return this.$store.getters.getToken()
-		},
-
 		conversation() {
 			return this.$store.getters.conversation(this.token)
 		},
 
 		conversationDisplayName() {
-			return this.conversation && this.conversation.displayName
+			return this.conversation?.displayName
 		},
 
 		conversationDescription() {
-			return this.conversation && this.conversation.description
+			return this.conversation?.description
 		},
 
 		submitMessage() {
@@ -111,8 +115,10 @@ export default {
 
 	methods: {
 		handleChooseUserName() {
-			this.$refs.setGuestUsername.handleChooseUserName()
-			this.showModal = false
+			this.$store.dispatch('SubmitUserName', {
+				token: this.token,
+				name: this.guestUserName,
+			})
 		},
 	},
 }
@@ -122,10 +128,7 @@ export default {
 .modal__content {
 	padding: calc(var(--default-grid-baseline) * 4);
 	background-color: var(--color-main-background);
-
-	:deep(.username-form__input) {
-		width: auto !important;
-	}
+	margin: 0px 12px;
 }
 
 .conversation-information {
@@ -136,11 +139,11 @@ export default {
 }
 
 .description {
-	margin: 0px 12px 12px 12px;
+	margin-bottom: 12px;
 }
 
-.input-label {
-	margin: 0px 12px;
+.username-form__input {
+	margin-bottom: 20px;
 }
 
 .submit-button {

--- a/src/components/GuestWelcomeWindow.vue
+++ b/src/components/GuestWelcomeWindow.vue
@@ -36,20 +36,20 @@
 				{{ conversationDescription }}
 			</p>
 
-			<p class="input-label">
-				{{ t('spreed', 'Enter your name') }}
-			</p>
-
-			<NcTextField :value.sync="guestUserName"
+			<label for="textField">{{ t('spreed', 'Enter your name') }}</label>
+			<NcTextField id="textField"
+				:value.sync="guestUserName"
 				:placeholder="t('spreed', 'Guest')"
 				class="username-form__input"
 				:show-trailing-button="false"
+				label-outside
 				@keydown.enter="handleChooseUserName" />
 
 			<NcButton class="submit-button"
 				type="primary"
+				:disabled="invalidGuestUsername"
 				@click="handleChooseUserName">
-				{{ submitMessage }}
+				{{ t('spreed', 'Submit name and join') }}
 				<template #icon>
 					<Check :size="20" />
 				</template>
@@ -115,14 +115,14 @@ export default {
 			return this.conversation?.description
 		},
 
-		submitMessage() {
-			return t('spreed', 'Submit name and join')
+		invalidGuestUsername() {
+			return this.guestUserName.trim() === ''
 		},
 	},
 
 	methods: {
 		handleChooseUserName() {
-			this.guestNameStore.submitUserName(this.token, this.guestUserName)
+			this.guestNameStore.submitGuestUsername(this.token, this.guestUserName)
 		},
 	},
 }

--- a/src/components/GuestWelcomeWindow.vue
+++ b/src/components/GuestWelcomeWindow.vue
@@ -1,5 +1,5 @@
 <!--
-  - @copyright Copyright (c) 2022, Dorra Jaouad <dorra.jaoued1@gmail.com>
+  - @copyright Copyright (c) 2023, Dorra Jaouad <dorra.jaoued1@gmail.com>
   -
   - @author Dorra Jaouad <dorra.jaoued1@gmail.com>
   -
@@ -67,6 +67,8 @@ import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 
 import ConversationIcon from './ConversationIcon.vue'
 
+import { useGuestNameStore } from '../stores/guestName.js'
+
 export default {
 	name: 'GuestWelcomeWindow',
 
@@ -83,6 +85,11 @@ export default {
 			type: String,
 			required: true,
 		},
+	},
+
+	setup() {
+		const guestNameStore = useGuestNameStore()
+		return { guestNameStore }
 	},
 
 	data() {
@@ -115,10 +122,7 @@ export default {
 
 	methods: {
 		handleChooseUserName() {
-			this.$store.dispatch('SubmitUserName', {
-				token: this.token,
-				name: this.guestUserName,
-			})
+			this.guestNameStore.submitUserName(this.token, this.guestUserName)
 		},
 	},
 }

--- a/src/components/LobbyScreen.vue
+++ b/src/components/LobbyScreen.vue
@@ -20,7 +20,7 @@
 
 <template>
 	<div class="lobby">
-		<GuestWelcomeWindow v-if="isGuestAndhasNotUserName" />
+		<GuestWelcomeWindow v-if="isGuestAndhasNotUsername" :token="token" />
 		<div class="lobby emptycontent">
 			<Lobby :size="64" />
 			<h2>{{ currentConversationName }}</h2>
@@ -111,8 +111,8 @@ export default {
 			return !this.$store.getters.getUserId()
 		},
 
-		isGuestAndhasNotUserName() {
-			const userName = localStorage.getItem('nick')
+		isGuestAndhasNotUsername() {
+			const userName = this.$store.getters.getDisplayName()
 			return !userName && this.currentUserIsGuest
 		},
 	},

--- a/src/components/LobbyScreen.vue
+++ b/src/components/LobbyScreen.vue
@@ -20,6 +20,7 @@
 
 <template>
 	<div class="lobby">
+		<GuestWelcomeWindow v-if="isGuestAndhasNotUserName" />
 		<div class="lobby emptycontent">
 			<Lobby :size="64" />
 			<h2>{{ currentConversationName }}</h2>
@@ -52,6 +53,7 @@ import moment from '@nextcloud/moment'
 
 import NcRichText from '@nextcloud/vue/dist/Components/NcRichText.js'
 
+import GuestWelcomeWindow from './GuestWelcomeWindow.vue'
 import Lobby from './missingMaterialDesignIcons/Lobby.vue'
 import SetGuestUsername from './SetGuestUsername.vue'
 
@@ -63,6 +65,7 @@ export default {
 		SetGuestUsername,
 		NcRichText,
 		Lobby,
+		GuestWelcomeWindow,
 	},
 
 	computed: {
@@ -106,6 +109,11 @@ export default {
 		// Determines whether the current user is a guest user
 		currentUserIsGuest() {
 			return !this.$store.getters.getUserId()
+		},
+
+		isGuestAndhasNotUserName() {
+			const userName = localStorage.getItem('nick')
+			return !userName && this.currentUserIsGuest
 		},
 	},
 

--- a/src/components/LobbyScreen.vue
+++ b/src/components/LobbyScreen.vue
@@ -20,7 +20,7 @@
 
 <template>
 	<div class="lobby">
-		<GuestWelcomeWindow v-if="isGuestAndhasNotUsername" :token="token" />
+		<GuestWelcomeWindow v-if="isGuestWithoutDisplayName" :token="token" />
 		<div class="lobby emptycontent">
 			<Lobby :size="64" />
 			<h2>{{ currentConversationName }}</h2>
@@ -111,7 +111,7 @@ export default {
 			return !this.$store.getters.getUserId()
 		},
 
-		isGuestAndhasNotUsername() {
+		isGuestWithoutDisplayName() {
 			const userName = this.$store.getters.getDisplayName()
 			return !userName && this.currentUserIsGuest
 		},

--- a/src/components/SetGuestUsername.vue
+++ b/src/components/SetGuestUsername.vue
@@ -22,7 +22,7 @@
 <template>
 	<div class="username-form">
 		<!-- eslint-disable-next-line vue/no-v-html -->
-		<h3 class="display-name__label" v-html="displayNameLabel" />
+		<h3 v-html="displayNameLabel" />
 
 		<NcButton v-if="!isEditingUsername"
 			@click="handleEditUsername">
@@ -128,7 +128,7 @@ export default {
 
 	methods: {
 		handleChooseUserName() {
-			this.guestNameStore.submitUserName(this.token, this.guestUserName)
+			this.guestNameStore.submitGuestUsername(this.token, this.guestUserName)
 			this.isEditingUsername = false
 		},
 

--- a/src/components/SetGuestUsername.vue
+++ b/src/components/SetGuestUsername.vue
@@ -22,9 +22,9 @@
 <template>
 	<div class="username-form">
 		<!-- eslint-disable-next-line vue/no-v-html -->
-		<h3 v-html="displayNameLabel" />
+		<h3 v-if="!firstWelcome" class="display-name__label" v-html="displayNameLabel" />
 
-		<NcButton v-if="!isEditingUsername"
+		<NcButton v-if="!isEditingUsername && !firstWelcome"
 			@click="handleEditUsername">
 			{{ t('spreed', 'Edit') }}
 			<template #icon>
@@ -37,9 +37,11 @@
 			:value.sync="guestUserName"
 			:placeholder="t('spreed', 'Guest')"
 			class="username-form__input"
-			:show-trailing-button="!!guestUserName"
+			v-bind="$attrs"
+			:show-trailing-button="!!guestUserName && !firstWelcome"
 			trailing-button-icon="arrowRight"
 			:trailing-button-label="t('spreed', 'Save name')"
+			v-on="$listeners"
 			@trailing-button-click="handleChooseUserName"
 			@keydown.enter="handleChooseUserName"
 			@keydown.esc="handleEditUsername" />
@@ -104,6 +106,11 @@ export default {
 				this.delayHandleUserNameFromBrowserStorage = false
 			}
 		},
+		// Update the input field text
+		actorDisplayName(newName) {
+			this.guestUserName = newName
+		},
+
 	},
 
 	mounted() {
@@ -121,6 +128,8 @@ export default {
 			}
 		}
 	},
+
+	expose: ['handleChooseUserName'],
 
 	methods: {
 		async handleChooseUserName() {

--- a/src/components/SetGuestUsername.vue
+++ b/src/components/SetGuestUsername.vue
@@ -54,7 +54,6 @@ import Pencil from 'vue-material-design-icons/Pencil.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 
-import { setGuestUserName } from '../services/participantsService.js'
 import { useGuestNameStore } from '../stores/guestName.js'
 
 export default {
@@ -128,31 +127,9 @@ export default {
 	},
 
 	methods: {
-		async handleChooseUserName() {
-			const previousName = this.$store.getters.getDisplayName()
-			try {
-				this.$store.dispatch('setDisplayName', this.guestUserName)
-				this.guestNameStore.addGuestName({
-					token: this.token,
-					actorId: this.$store.getters.getActorId(),
-					actorDisplayName: this.guestUserName,
-				}, { noUpdate: false })
-				await setGuestUserName(this.token, this.guestUserName)
-				if (this.guestUserName !== '') {
-					localStorage.setItem('nick', this.guestUserName)
-				} else {
-					localStorage.removeItem('nick')
-				}
-				this.isEditingUsername = false
-			} catch (exception) {
-				this.$store.dispatch('setDisplayName', previousName)
-				this.guestNameStore.addGuestName({
-					token: this.token,
-					actorId: this.$store.getters.getActorId(),
-					actorDisplayName: previousName,
-				}, { noUpdate: false })
-				console.debug(exception)
-			}
+		handleChooseUserName() {
+			this.guestNameStore.submitUserName(this.token, this.guestUserName)
+			this.isEditingUsername = false
 		},
 
 		handleEditUsername() {

--- a/src/components/SetGuestUsername.vue
+++ b/src/components/SetGuestUsername.vue
@@ -22,9 +22,9 @@
 <template>
 	<div class="username-form">
 		<!-- eslint-disable-next-line vue/no-v-html -->
-		<h3 v-if="!firstWelcome" class="display-name__label" v-html="displayNameLabel" />
+		<h3 class="display-name__label" v-html="displayNameLabel" />
 
-		<NcButton v-if="!isEditingUsername && !firstWelcome"
+		<NcButton v-if="!isEditingUsername"
 			@click="handleEditUsername">
 			{{ t('spreed', 'Edit') }}
 			<template #icon>
@@ -37,11 +37,9 @@
 			:value.sync="guestUserName"
 			:placeholder="t('spreed', 'Guest')"
 			class="username-form__input"
-			v-bind="$attrs"
-			:show-trailing-button="!!guestUserName && !firstWelcome"
+			:show-trailing-button="!!guestUserName"
 			trailing-button-icon="arrowRight"
 			:trailing-button-label="t('spreed', 'Save name')"
-			v-on="$listeners"
 			@trailing-button-click="handleChooseUserName"
 			@keydown.enter="handleChooseUserName"
 			@keydown.esc="handleEditUsername" />
@@ -128,8 +126,6 @@ export default {
 			}
 		}
 	},
-
-	expose: ['handleChooseUserName'],
 
 	methods: {
 		async handleChooseUserName() {

--- a/src/stores/guestName.js
+++ b/src/stores/guestName.js
@@ -93,7 +93,7 @@ export const useGuestNameStore = defineStore('guestName', {
 		 * @param {string} token the token of the conversation
 		 * @param {string} name the new guest name
 		 */
-		async submitUserName(token, name) {
+		async submitGuestUsername(token, name) {
 			const actorId = store.getters.getActorId()
 			const previousName = this.getGuestName(token, actorId)
 

--- a/src/stores/guestName.js
+++ b/src/stores/guestName.js
@@ -23,6 +23,9 @@
 import { defineStore } from 'pinia'
 import Vue from 'vue'
 
+import { setGuestUserName } from '../services/participantsService.js'
+import store from '../store/index.js'
+
 export const useGuestNameStore = defineStore('guestName', {
 	state: () => ({
 		guestNames: {},
@@ -81,6 +84,43 @@ export const useGuestNameStore = defineStore('guestName', {
 
 			if (actorDisplayName) {
 				Vue.set(this.guestNames[token], actorId, actorDisplayName)
+			}
+		},
+
+		/**
+		 * Add the submitted guest name to the store
+		 *
+		 * @param {string} token the token of the conversation
+		 * @param {string} name the new guest name
+		 */
+		async submitUserName(token, name) {
+			const actorId = store.getters.getActorId()
+			const previousName = this.getGuestName(token, actorId)
+
+			try {
+				store.dispatch('setDisplayName', name)
+				this.addGuestName({
+					token,
+					actorId,
+					actorDisplayName: name,
+				}, { noUpdate: false })
+
+				await setGuestUserName(token, name)
+
+				if (name !== '') {
+					localStorage.setItem('nick', name)
+				} else {
+					localStorage.removeItem('nick')
+				}
+
+			} catch (error) {
+				store.dispatch('setDisplayName', previousName)
+				this.addGuestName({
+					token,
+					actorId,
+					actorDisplayName: previousName,
+				}, { noUpdate: false })
+				console.debug(error)
 			}
 		},
 	},


### PR DESCRIPTION
### ☑️ Resolves

* Fix #855
- The window is shown only when there is no username set previously. 

### 🖼️ Screenshots

🏚️ Chat View | 🏡 Lobby view
---|---
![image](https://github.com/nextcloud/spreed/assets/84044328/b306ade6-53cc-471c-b686-9b2170f7f61a) | ![image](https://github.com/nextcloud/spreed/assets/84044328/4ddbec54-f522-46e7-a6e5-84161ea4632f)


### 🚧 Tasks

- [ ] visual review
- [ ] code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
