### PR TITLE
Accept insecure certificates in the browser if "skipverify" is enabled

### DIFF
--- a/recording/src/nextcloud/talk/recording/Participant.py
+++ b/recording/src/nextcloud/talk/recording/Participant.py
@@ -195,9 +195,11 @@ class SeleniumHelper:
     The browser is expected to be available in the local system.
     """
 
-    def __init__(self, parentLogger):
+    def __init__(self, parentLogger, acceptInsecureCerts):
         self._parentLogger = parentLogger
         self._logger = parentLogger.getChild('SeleniumHelper')
+
+        self._acceptInsecureCerts = acceptInsecureCerts
 
         self.driver = None
         self.bidiLogsHelper = None
@@ -221,6 +223,8 @@ class SeleniumHelper:
         """
 
         options = ChromeOptions()
+
+        options.set_capability('acceptInsecureCerts', self._acceptInsecureCerts)
 
         # "webSocketUrl" is needed for BiDi.
         options.set_capability('webSocketUrl', True)
@@ -264,6 +268,8 @@ class SeleniumHelper:
         """
 
         options = FirefoxOptions()
+
+        options.set_capability('acceptInsecureCerts', self._acceptInsecureCerts)
 
         # "webSocketUrl" is needed for BiDi; this should be set already by
         # default, but just in case.
@@ -467,7 +473,9 @@ class Participant():
         # '/' which may prevent Talk UI from loading as expected.
         self.nextcloudUrl = nextcloudUrl.rstrip('/')
 
-        self.seleniumHelper = SeleniumHelper(parentLogger)
+        acceptInsecureCerts = config.getBackendSkipVerify(self.nextcloudUrl)
+
+        self.seleniumHelper = SeleniumHelper(parentLogger, acceptInsecureCerts)
 
         if browser == 'chrome':
             self.seleniumHelper.startChrome(width, height, env)


### PR DESCRIPTION
[`skipverify` can be set in the configuration](https://github.com/nextcloud/spreed/blob/d0ae75785782757632b11797828657a4343c4e01/recording/server.conf.in#L28-L32) to skip certificate validation of the backend endpoints. However, this was honoured only for [requests done by the Python code](https://github.com/nextcloud/spreed/blob/966a851b56700c9a22a3b6496e19c797952e3030/recording/src/nextcloud/talk/recording/BackendNotifier.py#L66); if the Nextcloud server was using an invalid certificate, like a self-signed one, the browser launched by the recording server was not able to load the page that acts as its entry point in the Nextcloud server, and therefore the recording failed. Now [`acceptInsecureCerts` WebDriver capability](https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/acceptInsecureCerts) will honour the `skipverify` value.

Note that this was an issue only in Chromium because, for some reason, [the Selenium Python bindings accept insecure certificates by default in Firefox](https://github.com/SeleniumHQ/selenium/blob/98d464061004eefd1c4c238ec42a91f4e59a232f/py/selenium/webdriver/common/desired_capabilities.py#L47). Nevertheless now `skipverify` will be honoured too when disabled, so Firefox would also fail if `skipverify = false` and Nextcloud uses an invalid certificate.

## How to test

- Setup Nextcloud with a self signed certificate
- Setup the recording server using the Docker compose file
- Configure the recording server and Talk as needed (including `skipverify = true` to ignore the self signed certificate)
- Configure the recording server to use Chromium/Chrome (`browser = chrome`)
- Start a call as a moderator
- Record the call

### Result with this pull request

The call could be recorded

### Result without this pull request

The call could not be recorded. The recording server logs contain _OCA is not defined_ (as due to the invalid certificate the page of Nextcloud that acts as the entry point for the browser of the recording server could not be loaded)
