### PR TITLE
Allow non-moderators to leave conversation with enabled lobby

### DIFF
--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -264,6 +264,7 @@ class RoomFormatter {
 			!($currentParticipant->getPermissions() & Attendee::PERMISSIONS_LOBBY_IGNORE)) {
 			// No participants and chat messages for users in the lobby.
 			$roomData['hasCall'] = false;
+			$roomData['canLeaveConversation'] = true;
 			return $roomData;
 		}
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10420

### 🖼️ Screenshots

| 🏡 After
| ---
| ![image](https://github.com/nextcloud/spreed/assets/93392545/a0f062e4-ccb8-47f6-ad72-daeff0cd589d)



### 🚧 Tasks

- [ ] Code review
- [ ] PHP tests?

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not required
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
