### PR TITLE
Hide message expiration set-up for non-moderators

### DIFF
--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -46,12 +46,16 @@
 				<NotificationsSettings :conversation="conversation" />
 			</NcAppSettingsSection>
 
-			<NcAppSettingsSection id="conversation-settings"
+			<NcAppSettingsSection v-if="canFullModerate"
+				id="conversation-settings"
 				:title="t('spreed', 'Moderation')">
-				<ListableSettings v-if="canFullModerate"
-					:token="token" />
-				<LinkShareSettings v-if="canFullModerate"
-					ref="linkShareSettings" />
+				<ListableSettings :token="token" />
+				<LinkShareSettings ref="linkShareSettings" />
+				<ExpirationSettings :token="token" can-full-moderate />
+			</NcAppSettingsSection>
+			<NcAppSettingsSection v-else
+				id="conversation-settings"
+				:title="t('spreed', 'Setup summary')">
 				<ExpirationSettings :token="token" />
 			</NcAppSettingsSection>
 

--- a/src/components/ConversationSettings/ExpirationSettings.vue
+++ b/src/components/ConversationSettings/ExpirationSettings.vue
@@ -27,12 +27,26 @@
 		<div class="app-settings-section__hint">
 			{{ t('spreed', 'Chat messages can be expired after a certain time. Note: Files shared in chat will not be deleted for the owner, but will no longer be shared in the conversation.') }}
 		</div>
-		<NcSelect :value="selectedOption"
-			:options="expirationOptions"
-			label="label"
-			close-on-select
-			:clearable="false"
-			@option:selected="changeExpiration" />
+
+		<template v-if="canFullModerate">
+			<label for="moderation_settings_message_expiration" class="app-settings-section__label">
+				{{ t('spreed', 'Set message expiration') }}
+			</label>
+			<NcSelect id="moderation_settings_message_expiration"
+				:value="selectedOption"
+				:options="expirationOptions"
+				label="label"
+				close-on-select
+				:clearable="false"
+				@option:selected="changeExpiration" />
+		</template>
+
+		<template v-else>
+			<h5 class="app-settings-section__subtitle">
+				{{ t('spreed', 'Current message expiration') }}
+			</h5>
+			<p>{{ selectedOption.label }}</p>
+		</template>
 	</div>
 </template>
 
@@ -52,6 +66,11 @@ export default {
 		token: {
 			type: String,
 			default: null,
+		},
+
+		canFullModerate: {
+			type: Boolean,
+			default: false,
 		},
 	},
 
@@ -132,7 +151,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-:deep(.mx-input) {
-	margin: 0;
+.app-settings-section__label {
+  display: block;
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10419

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
Common | Moderator
![Screenshot from 2023-09-12 13-11-42](https://github.com/nextcloud/spreed/assets/93392545/44a8e29b-e032-4fb0-8854-307b40eee1c5) | ![image](https://github.com/nextcloud/spreed/assets/93392545/3c2e8ab3-c25f-41df-9764-6199fb3b5a70)
-//- | User
![image](https://github.com/nextcloud/spreed/assets/93392545/e6149c03-e45b-468e-8761-84bd428c39d4) | ![Screenshot from 2023-09-12 13-10-48](https://github.com/nextcloud/spreed/assets/93392545/7bf30beb-da76-4e16-8a10-d8323323bd75)

### 🚧 Tasks

- [x] Code review
- [ ] Wording for non-moderators - cc @nextcloud/designers 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
