### PR TITLE
fix(Pinia) - move guestNameStore initialisation from mixin to components

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -69,6 +69,7 @@ import getParticipants from '../../../mixins/getParticipants.js'
 import { searchPossibleConversations } from '../../../services/conversationsService.js'
 import { EventBus } from '../../../services/EventBus.js'
 import { addParticipant } from '../../../services/participantsService.js'
+import { useGuestNameStore } from '../../../stores/guestName.js'
 import CancelableRequest from '../../../utils/cancelableRequest.js'
 
 export default {
@@ -96,8 +97,11 @@ export default {
 
 	setup() {
 		const { sortParticipants } = useSortParticipants()
+		// FIXME move to getParticipants when replace with composable
+		const guestNameStore = useGuestNameStore()
 
 		return {
+			guestNameStore,
 			sortParticipants,
 		}
 	},

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -166,6 +166,7 @@ import TopBarMenu from './TopBarMenu.vue'
 import { CONVERSATION } from '../../constants.js'
 import getParticipants from '../../mixins/getParticipants.js'
 import BrowserStorage from '../../services/BrowserStorage.js'
+import { useGuestNameStore } from '../../stores/guestName.js'
 import { getStatusMessage } from '../../utils/userStatus.js'
 import { localCallParticipantModel, localMediaModel } from '../../utils/webrtc/index.js'
 
@@ -211,6 +212,15 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+	},
+
+	setup() {
+		// FIXME move to getParticipants when replace with composable
+		const guestNameStore = useGuestNameStore()
+
+		return {
+			guestNameStore,
+		}
 	},
 
 	data: () => {

--- a/src/mixins/getParticipants.js
+++ b/src/mixins/getParticipants.js
@@ -31,18 +31,12 @@ import { emit } from '@nextcloud/event-bus'
 import { PARTICIPANT } from '../constants.js'
 import { EventBus } from '../services/EventBus.js'
 import { fetchParticipants } from '../services/participantsService.js'
-import { useGuestNameStore } from '../stores/guestName.js'
 import CancelableRequest from '../utils/cancelableRequest.js'
 import isInLobby from './isInLobby.js'
 
 const getParticipants = {
 
 	mixins: [isInLobby],
-
-	setup() {
-		const guestNameStore = useGuestNameStore()
-		return { guestNameStore }
-	},
 
 	data() {
 		return {
@@ -143,6 +137,8 @@ const getParticipants = {
 					})
 					if (participant.participantType === PARTICIPANT.TYPE.GUEST
 						|| participant.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR) {
+						// FIXME replace mixin with composable. until then
+						// guestNameStore should be set up at component level
 						this.guestNameStore.addGuestName({
 							token,
 							actorId: Hex.stringify(SHA1(participant.sessionIds[0])),


### PR DESCRIPTION
### ☑️ Resolves

* Possibly a regression from #10475 
* Fix cases, then there are guests in the participants list. Mixins aren't configured to work with Pinia stores, so they should be initialised at the component level


### 🚧 Tasks

- [ ] Follow-up: replace getParticipants.js mixin with composable

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
