### PR TITLE
chore(deps): bump nextcloud/vue from 7.12.4 to 7.12.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nextcloud/moment": "^1.2.1",
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^2.1.2",
-        "@nextcloud/vue": "^7.12.4",
+        "@nextcloud/vue": "^7.12.5",
         "attachmediastream": "^2.1.0",
         "crypto-js": "^4.1.1",
         "debounce": "^1.2.1",
@@ -3600,9 +3600,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "7.12.4",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.12.4.tgz",
-      "integrity": "sha512-ZW3DtIhD+aoaj9S4EB+X/kXCfIKgKXXMKKbECHkxl/CqtIvASmtxCNpt9DAlIETYKHwfuT3GWduxSnFCuLe1bQ==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.12.5.tgz",
+      "integrity": "sha512-gXqJrWFvXpF4w/JGZfNH9fDXOOCSK5i+/G6pwcrpG2YFbQ4wgvrqGKmiNwTHcAqTI26lCFrnVDZ6f5CwBorknA==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@nextcloud/auth": "^2.0.0",
@@ -3629,9 +3629,9 @@
         "linkify-string": "^4.0.0",
         "md5": "^2.3.0",
         "node-polyfill-webpack-plugin": "^2.0.1",
+        "rehype-external-links": "^3.0.0",
         "rehype-react": "^7.1.2",
         "remark-breaks": "^3.0.2",
-        "remark-external-links": "^9.0.1",
         "remark-parse": "^10.0.1",
         "remark-rehype": "^10.1.0",
         "splitpanes": "^2.4.1",
@@ -4659,6 +4659,11 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/@vue/compiler-sfc": {
       "version": "2.7.14",
@@ -10096,6 +10101,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element/node_modules/@types/hast": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.1.tgz",
+      "integrity": "sha512-hs/iBJx2aydugBQx5ETV3ZgeSS0oIreQrFJ4bjBl0XvM4wAmDjFEALY7p0rTSLt2eL+ibjRAAs9dTPiCLtmbqQ==",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/hast-util-whitespace": {
@@ -15651,6 +15676,75 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/rehype-external-links": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "is-absolute-url": "^4.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-external-links/node_modules/@types/hast": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.1.tgz",
+      "integrity": "sha512-hs/iBJx2aydugBQx5ETV3ZgeSS0oIreQrFJ4bjBl0XvM4wAmDjFEALY7p0rTSLt2eL+ibjRAAs9dTPiCLtmbqQ==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/rehype-external-links/node_modules/@types/unist": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+      "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
+    },
+    "node_modules/rehype-external-links/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-external-links/node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-external-links/node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-react": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-7.1.2.tgz",
@@ -15676,25 +15770,6 @@
       "integrity": "sha512-x96YDJ9X+Ry0/JNZFKfr1hpcAKvGYWfUTszxY9RbxKEqq6uzPPoLCuHdZsLPZZUdAv3nCROyc7FPrQLWr2rxyw==",
       "dependencies": {
         "@types/mdast": "^3.0.0",
-        "unified": "^10.0.0",
-        "unist-util-visit": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-external-links": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/remark-external-links/-/remark-external-links-9.0.1.tgz",
-      "integrity": "sha512-EYw+p8Zqy5oT5+W8iSKzInfRLY+zeKWHCf0ut+Q5SwnaSIDGXd2zzvp4SWqyAuVbinNmZ0zjMrDKaExWZnTYqQ==",
-      "dependencies": {
-        "@types/hast": "^2.3.2",
-        "@types/mdast": "^3.0.0",
-        "extend": "^3.0.0",
-        "is-absolute-url": "^4.0.0",
-        "mdast-util-definitions": "^5.0.0",
-        "space-separated-tokens": "^2.0.0",
         "unified": "^10.0.0",
         "unist-util-visit": "^4.0.0"
       },
@@ -21747,9 +21822,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "7.12.4",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.12.4.tgz",
-      "integrity": "sha512-ZW3DtIhD+aoaj9S4EB+X/kXCfIKgKXXMKKbECHkxl/CqtIvASmtxCNpt9DAlIETYKHwfuT3GWduxSnFCuLe1bQ==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.12.5.tgz",
+      "integrity": "sha512-gXqJrWFvXpF4w/JGZfNH9fDXOOCSK5i+/G6pwcrpG2YFbQ4wgvrqGKmiNwTHcAqTI26lCFrnVDZ6f5CwBorknA==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@nextcloud/auth": "^2.0.0",
@@ -21776,9 +21851,9 @@
         "linkify-string": "^4.0.0",
         "md5": "^2.3.0",
         "node-polyfill-webpack-plugin": "^2.0.1",
+        "rehype-external-links": "^3.0.0",
         "rehype-react": "^7.1.2",
         "remark-breaks": "^3.0.2",
-        "remark-external-links": "^9.0.1",
         "remark-parse": "^10.0.1",
         "remark-rehype": "^10.1.0",
         "splitpanes": "^2.4.1",
@@ -22618,6 +22693,11 @@
           "peer": true
         }
       }
+    },
+    "@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "@vue/compiler-sfc": {
       "version": "2.7.14",
@@ -26763,6 +26843,24 @@
         "web-namespaces": "^2.0.0"
       }
     },
+    "hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "requires": {
+        "@types/hast": "^3.0.0"
+      },
+      "dependencies": {
+        "@types/hast": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.1.tgz",
+          "integrity": "sha512-hs/iBJx2aydugBQx5ETV3ZgeSS0oIreQrFJ4bjBl0XvM4wAmDjFEALY7p0rTSLt2eL+ibjRAAs9dTPiCLtmbqQ==",
+          "requires": {
+            "@types/unist": "*"
+          }
+        }
+      }
+    },
     "hast-util-whitespace": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
@@ -30751,6 +30849,61 @@
         }
       }
     },
+    "rehype-external-links": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "is-absolute-url": "^4.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "dependencies": {
+        "@types/hast": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.1.tgz",
+          "integrity": "sha512-hs/iBJx2aydugBQx5ETV3ZgeSS0oIreQrFJ4bjBl0XvM4wAmDjFEALY7p0rTSLt2eL+ibjRAAs9dTPiCLtmbqQ==",
+          "requires": {
+            "@types/unist": "*"
+          }
+        },
+        "@types/unist": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+          "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
+        },
+        "unist-util-is": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+          "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+          "requires": {
+            "@types/unist": "^3.0.0"
+          }
+        },
+        "unist-util-visit": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+          "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-is": "^6.0.0",
+            "unist-util-visit-parents": "^6.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+          "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-is": "^6.0.0"
+          }
+        }
+      }
+    },
     "rehype-react": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-7.1.2.tgz",
@@ -30769,21 +30922,6 @@
       "integrity": "sha512-x96YDJ9X+Ry0/JNZFKfr1hpcAKvGYWfUTszxY9RbxKEqq6uzPPoLCuHdZsLPZZUdAv3nCROyc7FPrQLWr2rxyw==",
       "requires": {
         "@types/mdast": "^3.0.0",
-        "unified": "^10.0.0",
-        "unist-util-visit": "^4.0.0"
-      }
-    },
-    "remark-external-links": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/remark-external-links/-/remark-external-links-9.0.1.tgz",
-      "integrity": "sha512-EYw+p8Zqy5oT5+W8iSKzInfRLY+zeKWHCf0ut+Q5SwnaSIDGXd2zzvp4SWqyAuVbinNmZ0zjMrDKaExWZnTYqQ==",
-      "requires": {
-        "@types/hast": "^2.3.2",
-        "@types/mdast": "^3.0.0",
-        "extend": "^3.0.0",
-        "is-absolute-url": "^4.0.0",
-        "mdast-util-definitions": "^5.0.0",
-        "space-separated-tokens": "^2.0.0",
         "unified": "^10.0.0",
         "unist-util-visit": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@nextcloud/moment": "^1.2.1",
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^2.1.2",
-    "@nextcloud/vue": "^7.12.4",
+    "@nextcloud/vue": "^7.12.5",
     "attachmediastream": "^2.1.0",
     "crypto-js": "^4.1.1",
     "debounce": "^1.2.1",

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -1057,17 +1057,6 @@ export default {
 
 .message-body__main__text--markdown {
 	:deep(.rich-text--wrapper) {
-		h1, h2, h3, h4, h5, h6 {
-			font-weight: bold;
-			margin: 12px 0;
-			color: var(--color-text-light);
-		}
-
-		h1 {
-			font-size: 32px;
-			line-height: 36px;
-		}
-
 		// Overwrite core styles, otherwise h4 is lesser than default font-size
 		h4 {
 			font-size: 100%;
@@ -1077,21 +1066,12 @@ export default {
 			font-style: italic;
 		}
 
-		ul {
-			padding-left: 20px;
-			list-style-type: disc;
-		}
-
-		ol {
-			padding-left: 20px;
-			list-style-type: decimal;
-		}
-
 		pre {
 			padding: 4px;
 			margin: 2px 0;
 			border-radius: var(--border-radius);
 			background-color: var(--color-background-dark);
+			overflow-x: auto;
 
 			& code {
 				margin: 0;
@@ -1109,8 +1089,7 @@ export default {
 
 		blockquote {
 			position: relative;
-			color: var(--color-text-lighter);
-			padding-left: 10px;
+			border-left: none;
 
 			&::before {
 				content: ' ';
@@ -1122,10 +1101,6 @@ export default {
 				border-radius: 2px;
 				background-color: var(--color-border);
 			}
-		}
-
-		pre {
-			overflow-x: auto;
 		}
 	}
 }


### PR DESCRIPTION
* Release notes: https://github.com/nextcloud-libraries/nextcloud-vue/releases/tag/v7.12.5
* Some styles were reverted to align with default lib styles fro markdown