### PR TITLE
fix(participantsStore) - handle participants fetch through the store

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -70,7 +70,6 @@ import getParticipants from '../../../mixins/getParticipants.js'
 import { searchPossibleConversations } from '../../../services/conversationsService.js'
 import { EventBus } from '../../../services/EventBus.js'
 import { addParticipant } from '../../../services/participantsService.js'
-import { useGuestNameStore } from '../../../stores/guestName.js'
 import CancelableRequest from '../../../utils/cancelableRequest.js'
 
 export default {
@@ -99,11 +98,8 @@ export default {
 
 	setup() {
 		const { sortParticipants } = useSortParticipants()
-		// FIXME move to getParticipants when replace with composable
-		const guestNameStore = useGuestNameStore()
 
 		return {
-			guestNameStore,
 			sortParticipants,
 		}
 	},

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -325,9 +325,14 @@ export default {
 			}
 		},
 
-		// Switch tab for guest if he is demoted from moderators
 		isModeratorOrUser(newValue) {
-			if (!newValue) {
+			if (newValue) {
+				// Fetch participants list if guest was promoted to moderators
+				this.$nextTick(() => {
+					emit('guest-promoted', { token: this.token })
+				})
+			} else {
+				// Switch active tab to chat if guest was demoted from moderators
 				this.activeTab = 'chat'
 			}
 		},

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -164,7 +164,7 @@ import TopBarMediaControls from './TopBarMediaControls.vue'
 import TopBarMenu from './TopBarMenu.vue'
 
 import { CONVERSATION } from '../../constants.js'
-import getParticipants from '../../mixins/getParticipants.js'
+import isInLobby from '../../mixins/isInLobby.js'
 import BrowserStorage from '../../services/BrowserStorage.js'
 import { getStatusMessage } from '../../utils/userStatus.js'
 import { localCallParticipantModel, localMediaModel } from '../../utils/webrtc/index.js'
@@ -195,7 +195,7 @@ export default {
 
 	mixins: [
 		richEditor,
-		getParticipants,
+		isInLobby,
 	],
 
 	props: {
@@ -343,18 +343,6 @@ export default {
 				this.notifyUnreadMessages(null)
 			}
 		},
-
-		isModeratorOrUser(newValue) {
-			if (newValue) {
-				// fetch participants immediately when becomes available
-				this.cancelableGetParticipants()
-			}
-		},
-	},
-
-	beforeMount() {
-		// Initialises the get participants mixin for participants counter
-		this.initialiseGetParticipantsMixin()
 	},
 
 	mounted() {
@@ -372,8 +360,6 @@ export default {
 		document.removeEventListener('MSFullscreenChange', this.fullScreenChanged, false)
 		document.removeEventListener('webkitfullscreenchange', this.fullScreenChanged, false)
 		document.body.classList.remove('has-topbar')
-
-		this.stopGetParticipantsMixin()
 	},
 
 	methods: {

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -166,7 +166,6 @@ import TopBarMenu from './TopBarMenu.vue'
 import { CONVERSATION } from '../../constants.js'
 import getParticipants from '../../mixins/getParticipants.js'
 import BrowserStorage from '../../services/BrowserStorage.js'
-import { useGuestNameStore } from '../../stores/guestName.js'
 import { getStatusMessage } from '../../utils/userStatus.js'
 import { localCallParticipantModel, localMediaModel } from '../../utils/webrtc/index.js'
 
@@ -212,15 +211,6 @@ export default {
 			type: Boolean,
 			default: false,
 		},
-	},
-
-	setup() {
-		// FIXME move to getParticipants when replace with composable
-		const guestNameStore = useGuestNameStore()
-
-		return {
-			guestNameStore,
-		}
 	},
 
 	data: () => {

--- a/src/mixins/getParticipants.js
+++ b/src/mixins/getParticipants.js
@@ -31,12 +31,18 @@ import { emit } from '@nextcloud/event-bus'
 import { PARTICIPANT } from '../constants.js'
 import { EventBus } from '../services/EventBus.js'
 import { fetchParticipants } from '../services/participantsService.js'
+import { useGuestNameStore } from '../stores/guestName.js'
 import CancelableRequest from '../utils/cancelableRequest.js'
 import isInLobby from './isInLobby.js'
 
 const getParticipants = {
 
 	mixins: [isInLobby],
+
+	setup() {
+		const guestNameStore = useGuestNameStore()
+		return { guestNameStore }
+	},
 
 	data() {
 		return {
@@ -137,8 +143,6 @@ const getParticipants = {
 					})
 					if (participant.participantType === PARTICIPANT.TYPE.GUEST
 						|| participant.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR) {
-						// FIXME replace mixin with composable. until then
-						// guestNameStore should be set up at component level
 						this.guestNameStore.addGuestName({
 							token,
 							actorId: Hex.stringify(SHA1(participant.sessionIds[0])),

--- a/src/mixins/getParticipants.js
+++ b/src/mixins/getParticipants.js
@@ -22,6 +22,8 @@
  */
 import debounce from 'debounce'
 
+import { subscribe, unsubscribe } from '@nextcloud/event-bus'
+
 import { EventBus } from '../services/EventBus.js'
 import isInLobby from './isInLobby.js'
 
@@ -52,12 +54,16 @@ const getParticipants = {
 			// Then we have to search for another solution. Maybe the room list which we update
 			// periodically gets a hash of all online sessions?
 			EventBus.$on('signaling-participant-list-changed', this.debounceUpdateParticipants)
+
+			subscribe('guest-promoted', this.onJoinedConversation)
 		},
 
 		stopGetParticipantsMixin() {
 			EventBus.$off('route-change', this.onRouteChange)
 			EventBus.$off('joined-conversation', this.onJoinedConversation)
 			EventBus.$off('signaling-participant-list-changed', this.debounceUpdateParticipants)
+
+			unsubscribe('guest-promoted', this.onJoinedConversation)
 		},
 
 		onRouteChange() {

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -602,7 +602,9 @@ const actions = {
 
 			return response
 		} catch (exception) {
-			if (!CancelableRequest.isCancel(exception)) {
+			if (exception?.response.status === 403) {
+				context.dispatch('fetchConversation', { token })
+			} else if (!CancelableRequest.isCancel(exception)) {
 				console.error(exception)
 				showError(t('spreed', 'An error occurred while fetching the participants'))
 			}

--- a/src/store/participantsStore.spec.js
+++ b/src/store/participantsStore.spec.js
@@ -1,6 +1,7 @@
 import { createLocalVue } from '@vue/test-utils'
 import mockConsole from 'jest-mock-console'
 import { cloneDeep } from 'lodash'
+import { createPinia, setActivePinia } from 'pinia'
 import Vuex from 'vuex'
 
 import { PARTICIPANT } from '../constants.js'
@@ -20,6 +21,7 @@ import {
 	grantAllPermissionsToParticipant,
 	removeAllPermissionsFromParticipant,
 } from '../services/participantsService.js'
+import { useGuestNameStore } from '../stores/guestName.js'
 import { generateOCSErrorResponse, generateOCSResponse } from '../test-helpers.js'
 import participantsStore from './participantsStore.js'
 
@@ -44,10 +46,13 @@ describe('participantsStore', () => {
 	let testStoreConfig = null
 	let localVue = null
 	let store = null
+	let guestNameStore = null
 
 	beforeEach(() => {
 		localVue = createLocalVue()
 		localVue.use(Vuex)
+		setActivePinia(createPinia())
+		guestNameStore = useGuestNameStore()
 
 		testStoreConfig = cloneDeep(participantsStore)
 		store = new Vuex.Store(testStoreConfig)


### PR DESCRIPTION
### ☑️ Resolves

- Fix #10497
  - Previously for users and guest moderators participants were fetched twice, from `RightSidebar` and `TopBar`
  - `CancelledRequest` logic was there, but because it was in mixin, it doesn't work for different components as expected
  - TopBar duplicates request for participants counter in call only - it's not needed for registered users at all
  - TopBar watches if guest was promoted to guest-moderator to fetch participants

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/587ccae1-f094-4149-8ddd-771beaf754e0) | ![image](https://github.com/nextcloud/spreed/assets/93392545/c03f39f7-2806-4fb9-8de7-57f70add76d6)

### 🚧 Tasks

- [x] create `fetchParticipants` action from the current code and move to `participantsStore`
- [x] cover an action with tests
- [x] move logic for guests from TopBar to RightSidebar
- [x] handle case when guest moderator was demoted

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
