### PR TITLE
fix(leftSidebar)- Keep the opened conversation in the list

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -378,13 +378,15 @@ export default {
 			}
 
 			if (this.isFiltered === 'unread') {
-				return this.conversationsList.filter(conversation => conversation.unreadMessages > 0 || conversation.hasCall)
+				return this.conversationsList.filter(conversation => conversation.unreadMessages > 0
+				|| conversation.hasCall || conversation.token === this.$store.getters.getToken())
 			}
 
 			if (this.isFiltered === 'mentions') {
 				return this.conversationsList.filter(conversation => conversation.unreadMention
 				|| conversation.hasCall
-				|| (conversation.unreadMessages > 0 && (conversation.type === CONVERSATION.TYPE.ONE_TO_ONE || conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER)))
+				|| (conversation.unreadMessages > 0 && (conversation.type === CONVERSATION.TYPE.ONE_TO_ONE || conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER))
+				|| conversation.token === this.$store.getters.getToken())
 			}
 
 			return this.conversationsList


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10498
Note ! When activating a filter, the current conversation now stays in list ( even when it doesn't have unread messages/mentions ) 

### 🖼️ Screenshots

Conversation remains in the list after being opened and the unread marker has been removed.
![image](https://github.com/nextcloud/spreed/assets/84044328/c26e510c-3e5d-450d-a339-8495aa11c2cd)



### 🚧 Tasks

- [ ] Code review
- [ ] Concept review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
