### PR TITLE
fix(API): Reuse participant objects we already created

### DIFF
--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -204,7 +204,7 @@ class ChatManager {
 	 * @return IComment
 	 */
 	public function addChangelogMessage(Room $chat, string $message): IComment {
-		$comment = $this->commentsManager->create(Attendee::ACTOR_GUESTS, 'changelog', 'chat', (string) $chat->getId());
+		$comment = $this->commentsManager->create(Attendee::ACTOR_GUESTS, Attendee::ACTOR_ID_CHANGELOG, 'chat', (string) $chat->getId());
 
 		$comment->setMessage($message, self::MAX_CHAT_LENGTH);
 		$comment->setCreationDateTime($this->timeFactory->getDateTime());
@@ -274,7 +274,9 @@ class ChatManager {
 			}
 
 			// Update last_message
-			if ($comment->getActorType() !== Attendee::ACTOR_BOTS || $comment->getActorId() === 'changelog' || str_starts_with($comment->getActorId(), Attendee::ACTOR_BOT_PREFIX)) {
+			if ($comment->getActorType() !== Attendee::ACTOR_BOTS
+				|| $comment->getActorId() === Attendee::ACTOR_ID_CHANGELOG
+				|| str_starts_with($comment->getActorId(), Attendee::ACTOR_BOT_PREFIX)) {
 				$this->roomService->setLastMessage($chat, $comment);
 				$this->unreadCountCache->clear($chat->getId() . '-');
 			} else {

--- a/lib/Chat/MessageParser.php
+++ b/lib/Chat/MessageParser.php
@@ -84,6 +84,12 @@ class MessageParser {
 		} elseif ($comment->getActorType() === Attendee::ACTOR_BRIDGED) {
 			$displayName = $comment->getActorId();
 			$actorId = MatterbridgeManager::BRIDGE_BOT_USERID;
+		} elseif ($comment->getActorType() === Attendee::ACTOR_GUESTS
+			&& $comment->getActorId() === Attendee::ACTOR_ID_CLI) {
+			$actorId = Attendee::ACTOR_ID_CLI;
+		} elseif ($comment->getActorType() === Attendee::ACTOR_GUESTS
+			&& $comment->getActorId() === Attendee::ACTOR_ID_CHANGELOG) {
+			$actorId = Attendee::ACTOR_ID_CHANGELOG;
 		} elseif ($comment->getActorType() === Attendee::ACTOR_GUESTS) {
 			if (isset($guestNames[$comment->getActorId()])) {
 				$displayName = $this->guestNames[$comment->getActorId()];

--- a/lib/Chat/Parser/Changelog.php
+++ b/lib/Chat/Parser/Changelog.php
@@ -33,11 +33,11 @@ class Changelog {
 	 */
 	public function parseMessage(Message $chatMessage): void {
 		if ($chatMessage->getActorType() !== Attendee::ACTOR_GUESTS ||
-			$chatMessage->getActorId() !== 'changelog') {
+			$chatMessage->getActorId() !== Attendee::ACTOR_ID_CHANGELOG) {
 			throw new \OutOfBoundsException('Not a changelog');
 		}
 
 		$l = $chatMessage->getL10n();
-		$chatMessage->setActor('bots', 'changelog', $l->t('Talk updates ✅'));
+		$chatMessage->setActor(Attendee::ACTOR_BOTS, Attendee::ACTOR_ID_CHANGELOG, $l->t('Talk updates ✅'));
 	}
 }

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -823,6 +823,10 @@ class SystemMessage {
 	}
 
 	protected function getGuestName(Room $room, string $actorType, string $actorId): string {
+		if ($actorId === Attendee::ACTOR_ID_CLI) {
+			return $this->l->t('Guest');
+		}
+
 		try {
 			$participant = $this->participantService->getParticipantByActor($room, $actorType, $actorId);
 			$name = $participant->getAttendee()->getDisplayName();

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -427,7 +427,7 @@ class Listener implements IEventListener {
 				$actorId = $user->getUID();
 			} elseif (\OC::$CLI || $this->session->exists('talk-overwrite-actor-cli')) {
 				$actorType = Attendee::ACTOR_GUESTS;
-				$actorId = 'cli';
+				$actorId = Attendee::ACTOR_ID_CLI;
 			} elseif ($this->session->exists('talk-overwrite-actor-type')) {
 				$actorType = $this->session->get('talk-overwrite-actor-type');
 				$actorId = $this->session->get('talk-overwrite-actor-id');

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -355,7 +355,9 @@ class Manager {
 
 			$room = $this->createRoomObject($row);
 			if ($actorType === Attendee::ACTOR_USERS && isset($row['actor_id'])) {
-				$room->setParticipant($row['actor_id'], $this->createParticipantObject($room, $row));
+				$participant = $this->createParticipantObject($room, $row);
+				$this->participantService->cacheParticipant($room, $participant);
+				$room->setParticipant($row['actor_id'], $participant);
 			}
 			$rooms[] = $room;
 		}
@@ -542,7 +544,9 @@ class Manager {
 
 		$room = $this->createRoomObject($row);
 		if ($userId !== null && isset($row['actor_id'])) {
-			$room->setParticipant($row['actor_id'], $this->createParticipantObject($room, $row));
+			$participant = $this->createParticipantObject($room, $row);
+			$this->participantService->cacheParticipant($room, $participant);
+			$room->setParticipant($row['actor_id'], $participant);
 		}
 
 		if ($userId === null && $room->getType() !== Room::TYPE_PUBLIC) {
@@ -613,7 +617,9 @@ class Manager {
 
 		$room = $this->createRoomObject($row);
 		if ($userId !== null && isset($row['actor_id'])) {
-			$room->setParticipant($row['actor_id'], $this->createParticipantObject($room, $row));
+			$participant = $this->createParticipantObject($room, $row);
+			$this->participantService->cacheParticipant($room, $participant);
+			$room->setParticipant($row['actor_id'], $participant);
 		}
 
 		if ($isSIPBridgeRequest || $room->getType() === Room::TYPE_PUBLIC) {
@@ -716,7 +722,9 @@ class Manager {
 
 		$room = $this->createRoomObject($row);
 		if ($actorType === Attendee::ACTOR_USERS && isset($row['actor_id'])) {
-			$room->setParticipant($row['actor_id'], $this->createParticipantObject($room, $row));
+			$participant = $this->createParticipantObject($room, $row);
+			$this->participantService->cacheParticipant($room, $participant);
+			$room->setParticipant($row['actor_id'], $participant);
 		}
 
 		return $room;
@@ -870,6 +878,7 @@ class Manager {
 
 		$room = $this->createRoomObject($row);
 		$participant = $this->createParticipantObject($room, $row);
+		$this->participantService->cacheParticipant($room, $participant);
 		$room->setParticipant($row['actor_id'], $participant);
 
 		if ($room->getType() === Room::TYPE_PUBLIC || !in_array($participant->getAttendee()->getParticipantType(), [Participant::GUEST, Participant::GUEST_MODERATOR, Participant::USER_SELF_JOINED], true)) {

--- a/lib/Model/Attendee.php
+++ b/lib/Model/Attendee.php
@@ -70,7 +70,11 @@ class Attendee extends Entity {
 	public const ACTOR_BRIDGED = 'bridged';
 	public const ACTOR_BOTS = 'bots';
 	public const ACTOR_FEDERATED_USERS = 'federated_users';
+
+	// Special actor IDs
 	public const ACTOR_BOT_PREFIX = 'bot-';
+	public const ACTOR_ID_CLI = 'cli';
+	public const ACTOR_ID_CHANGELOG = 'changelog';
 
 	public const PERMISSIONS_DEFAULT = 0;
 	public const PERMISSIONS_CUSTOM = 1;

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1580,6 +1580,21 @@ class ParticipantService {
 		return (bool) $row;
 	}
 
+	public function cacheParticipant(Room $room, Participant $participant): void {
+		$attendee = $participant->getAttendee();
+		if ($attendee->getActorType() !== Attendee::ACTOR_USERS) {
+			return;
+		}
+
+		$this->userCache[$room->getId()] ??= [];
+		$this->userCache[$room->getId()][$attendee->getActorId()] = $participant;
+		if ($participant->getSession()) {
+			$participantSessionId = $participant->getSession()->getSessionId();
+			$this->sessionCache[$room->getId()] ??= [];
+			$this->sessionCache[$room->getId()][$participantSessionId] = $participant;
+		}
+	}
+
 	/**
 	 * @param Room $room
 	 * @return bool


### PR DESCRIPTION
Instead of querying the database yet again

### ☑️ Resolves

* Fix #10502 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
