### PR TITLE
fix(Message | JSDOC) - trim space, fix lint warnings

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -757,7 +757,7 @@ export default {
 			const code = this.codeBlocks[this.currentCodeBlock].textContent
 			try {
 				await navigator.clipboard.writeText(code)
-				showSuccess(t('spreed', 'Code  block copied to clipboard'))
+				showSuccess(t('spreed', 'Code block copied to clipboard'))
 			} catch (error) {
 				showError(t('spreed', 'Code block could not be copied'))
 			}

--- a/src/utils/webrtc/simplewebrtc/getscreenmedia.js
+++ b/src/utils/webrtc/simplewebrtc/getscreenmedia.js
@@ -25,9 +25,9 @@ const cache = {}
 
 /**
  *
- * @param mode
- * @param constraints
- * @param cb
+ * @param {string} mode screen or window
+ * @param {object} constraints media constraints
+ * @param {Function} cb callback
  */
 export default function(mode, constraints, cb) {
 	const hasConstraints = arguments.length === 3


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10525 regression in translatable string
* Add description to getScreenMedia function, fix JSDOC warning

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
