### PR TITLE
feat: Allow guests to contacts user via public profile "Talk to" link

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -48,6 +48,7 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use OCP\Notification\IManager as INotificationManager;
+use OCP\Profile\IProfileManager;
 use OCP\Security\Bruteforce\IThrottler;
 use OCP\Security\RateLimiting\ILimiter;
 use OCP\Security\RateLimiting\IRateLimitExceededException;
@@ -75,6 +76,7 @@ class PageController extends Controller {
 		protected Config $talkConfig,
 		protected IGroupManager $groupManager,
 		protected IUserManager $userManager,
+		protected IProfileManager $profileManager,
 		protected ILimiter $limiter,
 		protected IFactory $l10nFactory,
 	) {
@@ -148,25 +150,26 @@ class PageController extends Controller {
 		return $this->pageHandler($token, $callUser);
 	}
 
-	protected function createPrivateRoom(string $targetUserId): ?Room {
+	/**
+	 * @throws \InvalidArgumentException
+	 */
+	protected function createPrivateRoom(string $targetUserId): Room {
 		$user = $this->userManager->get($targetUserId);
 		if (!$user instanceof IUser) {
-			return null;
+			throw new \InvalidArgumentException('user');
+		}
+
+		if ($this->profileManager->isProfileFieldVisible('talk', $user, null)) {
+			throw new \InvalidArgumentException('profile');
 		}
 
 		$l = $this->l10nFactory->get('spreed', $this->l10nFactory->getUserLanguage($user));
 
-		try {
-			$room = $this->roomService->createConversation(
-				Room::TYPE_PUBLIC,
-				$l->t('Contact request'),
-				$user,
-			);
-		} catch (\InvalidArgumentException) {
-			return null;
-		}
-
-		return $room;
+		return $this->roomService->createConversation(
+			Room::TYPE_PUBLIC,
+			$l->t('Contact request'),
+			$user,
+		);
 	}
 
 	/**
@@ -199,8 +202,9 @@ class PageController extends Controller {
 					return new TooManyRequestsResponse();
 				}
 
-				$room = $this->createPrivateRoom($callUser);
-				if ($room === null) {
+				try {
+					$room = $this->createPrivateRoom($callUser);
+				} catch (\InvalidArgumentException) {
 					$response = new TemplateResponse('core', '404-profile', [], TemplateResponse::RENDER_AS_GUEST);
 					$response->throttle(['action' => 'callUser', 'callUser' => $callUser]);
 					return $response;

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -148,24 +148,21 @@ class PageController extends Controller {
 		return $this->pageHandler($token, $callUser);
 	}
 
-	/**
-	 * @param string $forUser
-	 * @return ?Room
-	 */
-	protected function createPrivateRoom(string $forUser): ?Room {
-		$user = $this->userManager->get($forUser);
+	protected function createPrivateRoom(string $targetUserId): ?Room {
+		$user = $this->userManager->get($targetUserId);
 		if (!$user instanceof IUser) {
 			return null;
 		}
 
+		$l = $this->l10nFactory->get('spreed', $this->l10nFactory->getUserLanguage($user));
+
 		try {
-			$objectType = '';
-			$objectId = '';
-			$l = $this->l10nFactory->get('spreed', $this->l10nFactory->getUserLanguage($user));
-			$room = $this->roomService->createConversation(Room::TYPE_PUBLIC,
-				$l->t('Contact request'), $user, $objectType, $objectId,
+			$room = $this->roomService->createConversation(
+				Room::TYPE_PUBLIC,
+				$l->t('Contact request'),
+				$user,
 			);
-		} catch (\InvalidArgumentException $e) {
+		} catch (\InvalidArgumentException) {
 			return null;
 		}
 
@@ -191,14 +188,6 @@ class PageController extends Controller {
 		$user = $this->userSession->getUser();
 		if (!$user instanceof IUser) {
 			if ($token === '') {
-				$room = $this->createPrivateRoom($callUser);
-				if ($room === null) {
-					$response = new TemplateResponse('core', '404-profile', [], 'guest');
-					$response->throttle(['action' => 'callUser', 'callUser' => $callUser]);
-
-					return $response;
-				}
-
 				try {
 					$this->limiter->registerAnonRequest(
 						'create-anonymous-conversation',
@@ -210,10 +199,14 @@ class PageController extends Controller {
 					return new TooManyRequestsResponse();
 				}
 
-				// FIXME: add rate limiting
+				$room = $this->createPrivateRoom($callUser);
+				if ($room === null) {
+					$response = new TemplateResponse('core', '404-profile', [], TemplateResponse::RENDER_AS_GUEST);
+					$response->throttle(['action' => 'callUser', 'callUser' => $callUser]);
+					return $response;
+				}
+
 				return $this->redirectToConversation($room->getToken());
-			} else {
-				return $this->guestEnterRoom($token, $password);
 			}
 			return $this->guestEnterRoom($token, $password, $email, $accessToken);
 		}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -153,13 +153,17 @@ class PageController extends Controller {
 	/**
 	 * @throws \InvalidArgumentException
 	 */
-	protected function createPrivateRoom(string $targetUserId): Room {
+	protected function createContactRequestRoom(string $targetUserId): Room {
 		$user = $this->userManager->get($targetUserId);
 		if (!$user instanceof IUser) {
 			throw new \InvalidArgumentException('user');
 		}
 
-		if ($this->profileManager->isProfileFieldVisible('talk', $user, null)) {
+		if ($this->talkConfig->isNotAllowedToCreateConversations($user)) {
+			throw new \InvalidArgumentException('config');
+		}
+
+		if (!$this->profileManager->isProfileFieldVisible('talk', $user, null)) {
 			throw new \InvalidArgumentException('profile');
 		}
 
@@ -203,7 +207,7 @@ class PageController extends Controller {
 				}
 
 				try {
-					$room = $this->createPrivateRoom($callUser);
+					$room = $this->createContactRequestRoom($callUser);
 				} catch (\InvalidArgumentException) {
 					$response = new TemplateResponse('core', '404-profile', [], TemplateResponse::RENDER_AS_GUEST);
 					$response->throttle(['action' => 'callUser', 'callUser' => $callUser]);

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -34,6 +34,7 @@ use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\Template\PublicTemplateResponse;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Http\TooManyRequestsResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\Collaboration\Reference\RenderReferenceEvent;
 use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent;
@@ -43,9 +44,13 @@ use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\L10N\IFactory;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Security\Bruteforce\IThrottler;
+use OCP\Security\RateLimiting\ILimiter;
+use OCP\Security\RateLimiting\IRateLimitExceededException;
 use Psr\Log\LoggerInterface;
 use SensitiveParameter;
 
@@ -69,6 +74,9 @@ class PageController extends Controller {
 		private IThrottler $throttler,
 		protected Config $talkConfig,
 		protected IGroupManager $groupManager,
+		protected IUserManager $userManager,
+		protected ILimiter $limiter,
+		protected IFactory $l10nFactory,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -125,7 +133,7 @@ class PageController extends Controller {
 	/**
 	 * @param string $token
 	 * @param string $callUser
-	 * @return TemplateResponse|RedirectResponse
+	 * @return TemplateResponse|RedirectResponse|TooManyRequestsResponse
 	 * @throws HintException
 	 */
 	#[NoCSRFRequired]
@@ -141,10 +149,34 @@ class PageController extends Controller {
 	}
 
 	/**
+	 * @param string $forUser
+	 * @return ?Room
+	 */
+	protected function createPrivateRoom(string $forUser): ?Room {
+		$user = $this->userManager->get($forUser);
+		if (!$user instanceof IUser) {
+			return null;
+		}
+
+		try {
+			$objectType = '';
+			$objectId = '';
+			$l = $this->l10nFactory->get('spreed', $this->l10nFactory->getUserLanguage($user));
+			$room = $this->roomService->createConversation(Room::TYPE_PUBLIC,
+				$l->t('Contact request'), $user, $objectType, $objectId,
+			);
+		} catch (\InvalidArgumentException $e) {
+			return null;
+		}
+
+		return $room;
+	}
+
+	/**
 	 * @param string $token
 	 * @param string $callUser
 	 * @param string $password
-	 * @return TemplateResponse|RedirectResponse
+	 * @return TemplateResponse|RedirectResponse|TooManyRequestsResponse
 	 * @throws HintException
 	 */
 	protected function pageHandler(
@@ -158,6 +190,31 @@ class PageController extends Controller {
 		$bruteForceToken = $token;
 		$user = $this->userSession->getUser();
 		if (!$user instanceof IUser) {
+			if ($token === '') {
+				$room = $this->createPrivateRoom($callUser);
+				if ($room === null) {
+					$response = new TemplateResponse('core', '404-profile', [], 'guest');
+					$response->throttle(['action' => 'callUser', 'callUser' => $callUser]);
+
+					return $response;
+				}
+
+				try {
+					$this->limiter->registerAnonRequest(
+						'create-anonymous-conversation',
+						5, // Five conversations
+						60 * 60, // Per hour
+						$this->request->getRemoteAddress(),
+					);
+				} catch (IRateLimitExceededException) {
+					return new TooManyRequestsResponse();
+				}
+
+				// FIXME: add rate limiting
+				return $this->redirectToConversation($room->getToken());
+			} else {
+				return $this->guestEnterRoom($token, $password);
+			}
 			return $this->guestEnterRoom($token, $password, $email, $accessToken);
 		}
 

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -34,7 +34,6 @@ use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\Template\PublicTemplateResponse;
 use OCP\AppFramework\Http\TemplateResponse;
-use OCP\AppFramework\Http\TooManyRequestsResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\Collaboration\Reference\RenderReferenceEvent;
 use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent;
@@ -46,12 +45,9 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
-use OCP\L10N\IFactory;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Profile\IProfileManager;
 use OCP\Security\Bruteforce\IThrottler;
-use OCP\Security\RateLimiting\ILimiter;
-use OCP\Security\RateLimiting\IRateLimitExceededException;
 use Psr\Log\LoggerInterface;
 use SensitiveParameter;
 
@@ -77,8 +73,6 @@ class PageController extends Controller {
 		protected IGroupManager $groupManager,
 		protected IUserManager $userManager,
 		protected IProfileManager $profileManager,
-		protected ILimiter $limiter,
-		protected IFactory $l10nFactory,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -132,12 +126,6 @@ class PageController extends Controller {
 		return $this->pageHandler();
 	}
 
-	/**
-	 * @param string $token
-	 * @param string $callUser
-	 * @return TemplateResponse|RedirectResponse|TooManyRequestsResponse
-	 * @throws HintException
-	 */
 	#[NoCSRFRequired]
 	#[PublicPage]
 	#[BruteForceProtection(action: 'talkRoomToken')]
@@ -145,42 +133,48 @@ class PageController extends Controller {
 	#[FrontpageRoute(verb: 'GET', url: '/')]
 	public function index(string $token = '', string $callUser = ''): Response {
 		if ($callUser !== '') {
+			$user = $this->userSession->getUser();
+			if (!$user instanceof IUser) {
+				return new RedirectResponse($this->url->linkToRoute('spreed.Page.meetUser', ['user' => $callUser]));
+			}
 			$token = '';
 		}
 		return $this->pageHandler($token, $callUser);
 	}
 
-	/**
-	 * @throws \InvalidArgumentException
-	 */
-	protected function createContactRequestRoom(string $targetUserId): Room {
-		$user = $this->userManager->get($targetUserId);
-		if (!$user instanceof IUser) {
-			throw new \InvalidArgumentException('user');
+	#[NoCSRFRequired]
+	#[PublicPage]
+	#[BruteForceProtection(action: 'callUser')]
+	#[FrontpageRoute(verb: 'GET', url: '/meet/{user}', root: '')]
+	public function meetUser(string $user): Response {
+		$loggedInUser = $this->userSession->getUser();
+		if ($loggedInUser instanceof IUser) {
+			$response = $this->api->createRoom(Room::TYPE_ONE_TO_ONE, $user);
+			if ($response->getStatus() === Http::STATUS_OK
+				|| $response->getStatus() === Http::STATUS_CREATED) {
+				$data = $response->getData();
+				return $this->redirectToConversation($data['token']);
+			}
+			return new RedirectResponse($this->url->linkToRoute('spreed.Page.index'));
 		}
 
-		if ($this->talkConfig->isNotAllowedToCreateConversations($user)) {
-			throw new \InvalidArgumentException('config');
+		$targetUser = $this->userManager->get($user);
+		if (!$targetUser instanceof IUser
+			|| $this->talkConfig->isNotAllowedToCreateConversations($targetUser)
+			|| !$this->profileManager->isProfileFieldVisible('talk', $targetUser, null)) {
+			$response = new TemplateResponse('core', '404', [], TemplateResponse::RENDER_AS_GUEST);
+			$response->throttle(['action' => 'callUser', 'callUser' => $user]);
+			return $response;
 		}
 
-		if (!$this->profileManager->isProfileFieldVisible('talk', $user, null)) {
-			throw new \InvalidArgumentException('profile');
-		}
+		$this->initialState->provideInitialState('meet_target_user_id', $user);
+		$this->initialState->provideInitialState('meet_target_display_name', $targetUser->getDisplayName());
 
-		$l = $this->l10nFactory->get('spreed', $this->l10nFactory->getUserLanguage($user));
-
-		return $this->roomService->createConversation(
-			Room::TYPE_PUBLIC,
-			$l->t('Contact request'),
-			$user,
-		);
+		return new TemplateResponse($this->appName, 'meet', [], TemplateResponse::RENDER_AS_GUEST);
 	}
 
 	/**
-	 * @param string $token
-	 * @param string $callUser
-	 * @param string $password
-	 * @return TemplateResponse|RedirectResponse|TooManyRequestsResponse
+	 * @return TemplateResponse|RedirectResponse
 	 * @throws HintException
 	 */
 	protected function pageHandler(
@@ -194,28 +188,6 @@ class PageController extends Controller {
 		$bruteForceToken = $token;
 		$user = $this->userSession->getUser();
 		if (!$user instanceof IUser) {
-			if ($token === '') {
-				try {
-					$this->limiter->registerAnonRequest(
-						'create-anonymous-conversation',
-						5, // Five conversations
-						60 * 60, // Per hour
-						$this->request->getRemoteAddress(),
-					);
-				} catch (IRateLimitExceededException) {
-					return new TooManyRequestsResponse();
-				}
-
-				try {
-					$room = $this->createContactRequestRoom($callUser);
-				} catch (\InvalidArgumentException) {
-					$response = new TemplateResponse('core', '404-profile', [], TemplateResponse::RENDER_AS_GUEST);
-					$response->throttle(['action' => 'callUser', 'callUser' => $callUser]);
-					return $response;
-				}
-
-				return $this->redirectToConversation($room->getToken());
-			}
 			return $this->guestEnterRoom($token, $password, $email, $accessToken);
 		}
 
@@ -341,7 +313,6 @@ class PageController extends Controller {
 	}
 
 	/**
-	 * @param string $token
 	 * @return TemplateResponse|NotFoundResponse
 	 */
 	#[NoCSRFRequired]

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -10,6 +10,7 @@ namespace OCA\Talk\Controller;
 
 use OCA\DAV\CalDAV\TimezoneService;
 use OCA\Talk\Capabilities;
+use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Config;
 use OCA\Talk\Events\AAttendeeRemovedEvent;
 use OCA\Talk\Events\BeforeRoomsFetchEvent;
@@ -104,7 +105,11 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use OCP\Profile\IProfileManager;
 use OCP\Security\Bruteforce\IThrottler;
+use OCP\Security\RateLimiting\ILimiter;
+use OCP\Security\RateLimiting\IRateLimitExceededException;
 use OCP\Server;
 use OCP\User\Events\UserLiveStatusEvent;
 use OCP\UserStatus\IManager as IUserStatusManager;
@@ -160,6 +165,10 @@ class RoomController extends AEnvironmentAwareOCSController {
 		protected IL10N $l,
 		protected ThreadService $threadService,
 		protected Forced $forcedParameters,
+		protected IProfileManager $profileManager,
+		protected ILimiter $limiter,
+		protected IFactory $l10nFactory,
+		protected ChatManager $chatManager,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -853,6 +862,86 @@ class RoomController extends AEnvironmentAwareOCSController {
 		} catch (RoomNotFoundException $e) {
 			return new DataResponse(['error' => 'invite'], Http::STATUS_FORBIDDEN);
 		}
+	}
+
+	/**
+	 * Create a meet room for a guest reaching out to a user via their public profile
+	 *
+	 * @param string $targetUserId ID of the user to contact
+	 * @param string $message Initial chat message posted in the conversation
+	 * @param string $displayName Guest display name
+	 * @return DataResponse<Http::STATUS_CREATED, array{token: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND|Http::STATUS_FORBIDDEN|Http::STATUS_TOO_MANY_REQUESTS, null, array{}>
+	 *
+	 * 201: Room created successfully
+	 * 403: Not allowed to create conversations
+	 * 404: User not found or profile not visible
+	 * 429: Rate limit exceeded
+	 */
+	#[PublicPage]
+	#[BruteForceProtection(action: 'talkRoomToken')]
+	#[ApiRoute(verb: 'POST', url: '/api/{apiVersion}/meet/{targetUserId}', requirements: [
+		'apiVersion' => '(v4)',
+	])]
+	public function createMeetRoom(string $targetUserId, string $message = '', string $displayName = ''): DataResponse {
+		try {
+			$this->limiter->registerAnonRequest(
+				'create-anonymous-conversation',
+				5,
+				60 * 60,
+				$this->request->getRemoteAddress(),
+			);
+		} catch (IRateLimitExceededException) {
+			return new DataResponse(null, Http::STATUS_TOO_MANY_REQUESTS);
+		}
+
+		$user = $this->userManager->get($targetUserId);
+		if (!$user instanceof IUser) {
+			$response = new DataResponse(null, Http::STATUS_NOT_FOUND);
+			$response->throttle(['action' => 'talkRoomToken']);
+			return $response;
+		}
+
+		if ($this->talkConfig->isNotAllowedToCreateConversations($user)) {
+			return new DataResponse(null, Http::STATUS_FORBIDDEN);
+		}
+
+		if (!$this->profileManager->isProfileFieldVisible('talk', $user, null)) {
+			$response = new DataResponse(null, Http::STATUS_NOT_FOUND);
+			$response->throttle(['action' => 'talkRoomToken']);
+			return $response;
+		}
+
+		$l = $this->l10nFactory->get('spreed', $this->l10nFactory->getUserLanguage($user));
+
+		$trimmedDisplayName = trim($displayName);
+		if ($trimmedDisplayName !== '') {
+			$roomName = $l->t('Contact request from %s', [$trimmedDisplayName]);
+		} else {
+			$roomName = $l->t('Contact request');
+		}
+
+		$room = $this->roomService->createConversation(
+			Room::TYPE_PUBLIC,
+			$roomName,
+			$user,
+			lobbyState: Webinary::LOBBY_NON_MODERATORS,
+		);
+
+		$message = trim($message);
+		if ($message !== '') {
+			$participant = $this->participantService->joinRoomAsNewGuest($this->roomService, $room, '', true, null, trim($displayName) ?: null);
+			$this->chatManager->sendMessage(
+				$room,
+				$participant,
+				Attendee::ACTOR_GUESTS,
+				$participant->getAttendee()->getActorId(),
+				$message,
+				$this->timeFactory->getDateTime(),
+			);
+			$this->participantService->leaveRoomAsSession($room, $participant);
+		}
+
+		return new DataResponse(['token' => $room->getToken()], Http::STATUS_CREATED);
 	}
 
 	/**

--- a/lib/Profile/TalkAction.php
+++ b/lib/Profile/TalkAction.php
@@ -87,6 +87,6 @@ class TalkAction implements ILinkAction {
 			return null;
 		}
 
-		return $this->urlGenerator->linkToRouteAbsolute('spreed.Page.index') . '?callUser=' . $this->targetUser->getUID();
+		return $this->urlGenerator->linkToRouteAbsolute('spreed.Page.meetUser', ['user' => $this->targetUser->getUID()]);
 	}
 }

--- a/lib/Profile/TalkAction.php
+++ b/lib/Profile/TalkAction.php
@@ -51,9 +51,10 @@ class TalkAction implements ILinkAction {
 	#[\Override]
 	public function getTitle(): string {
 		$visitingUser = $this->userSession->getUser();
-		if (!$visitingUser || $visitingUser === $this->targetUser) {
+		if ($visitingUser === $this->targetUser) {
 			return $this->l->t('Open Talk');
 		}
+
 		return $this->l->t('Talk to %s', [$this->targetUser->getDisplayName()]);
 	}
 
@@ -71,9 +72,8 @@ class TalkAction implements ILinkAction {
 	public function getTarget(): ?string {
 		$visitingUser = $this->userSession->getUser();
 		if (
-			!$visitingUser
-			|| $this->config->isDisabledForUser($this->targetUser)
-			|| $this->config->isDisabledForUser($visitingUser)
+			$this->config->isDisabledForUser($this->targetUser)
+			|| ($visitingUser && $this->config->isDisabledForUser($visitingUser))
 		) {
 			return null;
 		}

--- a/lib/Profile/TalkAction.php
+++ b/lib/Profile/TalkAction.php
@@ -70,16 +70,23 @@ class TalkAction implements ILinkAction {
 
 	#[\Override]
 	public function getTarget(): ?string {
-		$visitingUser = $this->userSession->getUser();
-		if (
-			$this->config->isDisabledForUser($this->targetUser)
-			|| ($visitingUser && $this->config->isDisabledForUser($visitingUser))
-		) {
+		if ($this->config->isDisabledForUser($this->targetUser)) {
 			return null;
 		}
+
+		$visitingUser = $this->userSession->getUser();
 		if ($visitingUser === $this->targetUser) {
 			return $this->urlGenerator->linkToRouteAbsolute('spreed.Page.index');
 		}
+
+		if ($visitingUser && $this->config->isDisabledForUser($visitingUser)) {
+			return null;
+		}
+
+		if (!$visitingUser && $this->config->isNotAllowedToCreateConversations($this->targetUser)) {
+			return null;
+		}
+
 		return $this->urlGenerator->linkToRouteAbsolute('spreed.Page.index') . '?callUser=' . $this->targetUser->getUID();
 	}
 }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -18070,6 +18070,209 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/meet/{targetUserId}": {
+            "post": {
+                "operationId": "room-create-meet-room",
+                "summary": "Create a meet room for a guest reaching out to a user via their public profile",
+                "tags": [
+                    "room"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "message": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Initial chat message posted in the conversation"
+                                    },
+                                    "displayName": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Guest display name"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v4"
+                            ],
+                            "default": "v4"
+                        }
+                    },
+                    {
+                        "name": "targetUserId",
+                        "in": "path",
+                        "description": "ID of the user to contact",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Room created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "token"
+                                                    ],
+                                                    "properties": {
+                                                        "token": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found or profile not visible",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Not allowed to create conversations",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "Rate limit exceeded",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/favorite": {
             "post": {
                 "operationId": "room-add-to-favorites",

--- a/openapi.json
+++ b/openapi.json
@@ -17958,6 +17958,209 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/meet/{targetUserId}": {
+            "post": {
+                "operationId": "room-create-meet-room",
+                "summary": "Create a meet room for a guest reaching out to a user via their public profile",
+                "tags": [
+                    "room"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "message": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Initial chat message posted in the conversation"
+                                    },
+                                    "displayName": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Guest display name"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v4"
+                            ],
+                            "default": "v4"
+                        }
+                    },
+                    {
+                        "name": "targetUserId",
+                        "in": "path",
+                        "description": "ID of the user to contact",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Room created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "token"
+                                                    ],
+                                                    "properties": {
+                                                        "token": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found or profile not visible",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Not allowed to create conversations",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "Rate limit exceeded",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/favorite": {
             "post": {
                 "operationId": "room-add-to-favorites",

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -47,6 +47,7 @@ module.exports = defineConfig((env) => {
 				path.join(__dirname, 'src', 'mainFilesSidebar.js'),
 				path.join(__dirname, 'src', 'mainFilesSidebarLoader.js'),
 			],
+			meet: path.join(__dirname, 'src', 'meet.ts'),
 			'public-share-auth-form': path.join(__dirname, 'src', 'publicShareAuthForm.ts'),
 			'public-share-auth-sidebar': path.join(__dirname, 'src', 'mainPublicShareAuthSidebar.js'),
 			'public-share-sidebar': path.join(__dirname, 'src', 'mainPublicShareSidebar.js'),

--- a/src/meet.ts
+++ b/src/meet.ts
@@ -1,0 +1,17 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { getCSPNonce } from '@nextcloud/auth'
+import { generateFilePath } from '@nextcloud/router'
+import { createApp } from 'vue'
+import MeetView from './views/MeetView.vue'
+import { NextcloudGlobalsVuePlugin } from './utils/NextcloudGlobalsVuePlugin.js'
+
+__webpack_nonce__ = getCSPNonce()
+__webpack_public_path__ = generateFilePath('spreed', '', 'js/')
+
+createApp(MeetView)
+	.use(NextcloudGlobalsVuePlugin)
+	.mount('#talk-meet')

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1168,6 +1168,23 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/ocs/v2.php/apps/spreed/api/{apiVersion}/meet/{targetUserId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a meet room for a guest reaching out to a user via their public profile */
+        post: operations["room-create-meet-room"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/favorite": {
         parameters: {
             query?: never;
@@ -9865,6 +9882,97 @@ export interface operations {
             };
             /** @description Current user is not logged in */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "room-create-meet-room": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v4";
+                /** @description ID of the user to contact */
+                targetUserId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /**
+                     * @description Initial chat message posted in the conversation
+                     * @default
+                     */
+                    message?: string;
+                    /**
+                     * @description Guest display name
+                     * @default
+                     */
+                    displayName?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Room created successfully */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                token: string;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Not allowed to create conversations */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description User not found or profile not visible */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1168,6 +1168,23 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/ocs/v2.php/apps/spreed/api/{apiVersion}/meet/{targetUserId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a meet room for a guest reaching out to a user via their public profile */
+        post: operations["room-create-meet-room"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/favorite": {
         parameters: {
             query?: never;
@@ -9298,6 +9315,97 @@ export interface operations {
             };
             /** @description Current user is not logged in */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "room-create-meet-room": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v4";
+                /** @description ID of the user to contact */
+                targetUserId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /**
+                     * @description Initial chat message posted in the conversation
+                     * @default
+                     */
+                    message?: string;
+                    /**
+                     * @description Guest display name
+                     * @default
+                     */
+                    displayName?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Room created successfully */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                token: string;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Not allowed to create conversations */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description User not found or profile not visible */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/src/views/MeetView.vue
+++ b/src/views/MeetView.vue
@@ -1,0 +1,96 @@
+<!--
+ - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ - SPDX-License-Identifier: AGPL-3.0-or-later
+ -->
+
+<script setup lang="ts">
+import { getGuestNickname, setGuestNickname } from '@nextcloud/auth'
+import axios from '@nextcloud/axios'
+import { loadState } from '@nextcloud/initial-state'
+import { t } from '@nextcloud/l10n'
+import { generateOcsUrl, generateUrl } from '@nextcloud/router'
+import { computed, ref } from 'vue'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcGuestContent from '@nextcloud/vue/components/NcGuestContent'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+import NcTextArea from '@nextcloud/vue/components/NcTextArea'
+import NcTextField from '@nextcloud/vue/components/NcTextField'
+import { isAxiosErrorResponse } from '../types/guards.ts'
+
+const targetUserId = loadState<string>('spreed', 'meet_target_user_id')
+const targetDisplayName = loadState<string>('spreed', 'meet_target_display_name')
+
+const guestName = ref(getGuestNickname() || '')
+const message = ref('')
+const loading = ref(false)
+const error = ref('')
+const canSubmit = computed(() => guestName.value.trim() !== '' && !loading.value)
+
+/**
+ * Create a meet room and redirect to the conversation.
+ */
+async function startConversation() {
+	loading.value = true
+	error.value = ''
+
+	setGuestNickname(guestName.value)
+
+	try {
+		const response = await axios.post(
+			generateOcsUrl('/apps/spreed/api/v4/meet/{targetUserId}', { targetUserId }),
+			{ message: message.value, displayName: guestName.value },
+		)
+		window.location.href = generateUrl('/call/{token}', { token: response.data.ocs.data.token })
+	} catch (e) {
+		if (isAxiosErrorResponse(e) && e.response) {
+			if (e.response.status === 429) {
+				error.value = t('spreed', 'Too many requests. Please try again later.')
+			} else if (e.response.status === 404) {
+				error.value = t('spreed', 'The user could not be found.')
+			} else if (e.response.status === 403) {
+				error.value = t('spreed', 'This action is not allowed.')
+			} else {
+				error.value = t('spreed', 'An error occurred. Please try again later.')
+			}
+		} else {
+			error.value = t('spreed', 'An error occurred. Please try again later.')
+		}
+		loading.value = false
+	}
+}
+</script>
+
+<template>
+	<NcGuestContent class="meet__content">
+		<h2>{{ t('spreed', 'Meet {displayName}', { displayName: targetDisplayName }) }}</h2>
+		<NcNoteCard
+			v-if="error"
+			type="error">
+			{{ error }}
+		</NcNoteCard>
+		<NcTextField
+			v-model="guestName"
+			:label="t('spreed', 'Your name')"
+			:disabled="loading"
+			@keydown.enter="canSubmit && startConversation()" />
+		<NcTextArea
+			v-model="message"
+			:label="t('spreed', 'Your message')"
+			:disabled="loading"
+			resize="vertical" />
+		<NcButton
+			variant="primary"
+			wide
+			:disabled="!canSubmit"
+			@click="startConversation">
+			{{ t('spreed', 'Start conversation') }}
+		</NcButton>
+	</NcGuestContent>
+</template>
+
+<style scoped lang="scss">
+.meet__content {
+	box-sizing: border-box;
+	width: fit-content;
+}
+</style>

--- a/templates/meet.php
+++ b/templates/meet.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+\OCP\Util::addStyle('spreed', 'talk-meet');
+\OCP\Util::addScript('spreed', 'talk-meet');
+?>
+<div id="talk-meet"></div>

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1164,6 +1164,48 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		}
 	}
 
+	#[Then('/^user "([^"]*)" sets the Talk profile visibility to "([^"]*)"$/')]
+	public function userSetsTalkProfileVisibility(string $user, string $visibility): void {
+		$this->setCurrentUser($user);
+		$this->sendRequest('PUT', '/profile/' . $user, [
+			'paramId' => 'talk',
+			'visibility' => $visibility,
+		]);
+		$this->assertStatusCode($this->response, 200);
+	}
+
+	#[Then('/^guest creates meet room "([^"]*)" for "([^"]*)" with (\d+) \((v4)\)$/')]
+	public function guestCreatesMeetRoom(string $identifier, string $targetUserId, int $statusCode, string $apiVersion, ?TableNode $formData = null): void {
+		$body = [];
+		if ($formData instanceof TableNode) {
+			$body = $formData->getRowsHash();
+		}
+
+		$this->setCurrentUser(null);
+		$this->sendRequest('POST', '/apps/spreed/api/' . $apiVersion . '/meet/' . $targetUserId, $body);
+		$this->assertStatusCode($this->response, $statusCode);
+
+		if ($statusCode === 201) {
+			$response = $this->getDataFromResponse($this->response);
+			self::$identifierToToken[$identifier] = $response['token'];
+			self::$tokenToIdentifier[$response['token']] = $identifier;
+
+			// If a message was sent, register the guest actor ID for message assertions
+			if (!empty($body['message'])) {
+				$this->setCurrentUser($targetUserId);
+				$this->sendRequest('GET', '/apps/spreed/api/v1/chat/' . $response['token'] . '?lookIntoFuture=0');
+				$messages = $this->getDataFromResponse($this->response);
+				foreach ($messages as $message) {
+					if ($message['actorType'] === 'guests' && $message['systemMessage'] === '') {
+						self::$sessionIdToUser[$message['actorId']] = 'MEET_GUEST_ACTOR_ID';
+						break;
+					}
+				}
+				$this->setCurrentUser(null);
+			}
+		}
+	}
+
 	#[Then('/^user "([^"]*)" tries to create room with (\d+) \((v4)\)$/')]
 	public function userTriesToCreateRoom(string $user, int $statusCode, string $apiVersion = 'v1', ?TableNode $formData = null): void {
 		$this->setCurrentUser($user);

--- a/tests/integration/features/conversation-4/meet.feature
+++ b/tests/integration/features/conversation-4/meet.feature
@@ -1,0 +1,54 @@
+Feature: conversation-4/meet
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+    And user "participant1" sets the Talk profile visibility to "show"
+
+  Scenario: Guest creates a meet room
+    Given guest creates meet room "room" for "participant1" with 201 (v4)
+    Then user "participant1" is participant of room "room" (v4)
+      | name            | type | lobbyState |
+      | Contact request | 3    | 1          |
+
+  Scenario: Guest creates a meet room with display name
+    Given guest creates meet room "room" for "participant1" with 201 (v4)
+      | displayName | Guest User |
+    Then user "participant1" is participant of room "room" (v4)
+      | name                            | type | lobbyState |
+      | Contact request from Guest User | 3    | 1          |
+
+  Scenario: Guest creates a meet room with message and display name
+    Given guest creates meet room "room" for "participant1" with 201 (v4)
+      | message     | Hello, I need help! |
+      | displayName | Guest User          |
+    Then user "participant1" is participant of room "room" (v4)
+      | name                            | type | lobbyState |
+      | Contact request from Guest User | 3    | 1          |
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId              | actorDisplayName | message             | messageParameters |
+      | room | guests    | MEET_GUEST_ACTOR_ID  | Guest User       | Hello, I need help! | []                |
+
+  Scenario: Guest creates a meet room with message but no display name
+    Given guest creates meet room "room" for "participant1" with 201 (v4)
+      | message | Hello there |
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId              | actorDisplayName | message     | messageParameters |
+      | room | guests    | MEET_GUEST_ACTOR_ID  |                  | Hello there | []                |
+
+  Scenario: Guest creates a meet room without message does not leave a guest participant
+    Given guest creates meet room "room" for "participant1" with 201 (v4)
+    Then user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | actorType | participantType |
+      | users     | 1               |
+
+  Scenario: Guest creates a meet room for a non-existing user
+    Given guest creates meet room "room" for "non-existing-user" with 404 (v4)
+
+  Scenario: Guest creates a meet room for a user that cannot create conversations
+    Given the following "spreed" app config is set
+      | start_conversations | ["admin"] |
+    Given guest creates meet room "room" for "participant1" with 403 (v4)
+
+  Scenario: Guest cannot create a meet room when Talk profile is hidden
+    Given user "participant1" sets the Talk profile visibility to "hide"
+    Given guest creates meet room "room" for "participant1" with 404 (v4)


### PR DESCRIPTION
### ☑️ Resolves

* Fix #674

Depends on https://github.com/nextcloud/server/pull/40288

### 🚧 Tasks

- [x] Conversation name should be in recipient language
- [x] Admin config to disable globally/per-user? (will be done in another PR)
- [x] Check that API endpoint respects the users profile setting (right now only the button is hidden) https://github.com/nextcloud/server/pull/41055
- [x] Make sure the actual conversation is only created on a subsequent POST request. Otherwise like preview generation etc. will randomly create new conversations.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
