### PR TITLE
chore(release): Add changelog for 15.0.8, 16.0.6 and 17.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,57 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 17.1.1 – 2023-09-21
+### Added
+- feat(chat): Add copy function to code blocks
+  [#10533](https://github.com/nextcloud/spreed/issues/10533)
+
+### Changed
+- Update dependencies
+
+### Fixed
+- fix(attachments): Allow to navigate between attachments in the viewer
+  [#10549](https://github.com/nextcloud/spreed/issues/10549)
+- fix(bots): Fix notifications of bot messages and reactions
+  [#10530](https://github.com/nextcloud/spreed/issues/10530)
+- fix(conversations): Keep the current conversation in filtered list
+  [#10527](https://github.com/nextcloud/spreed/issues/10527)
+- fix(page): Decouple the index controller from the executing method
+  [#10546](https://github.com/nextcloud/spreed/issues/10546)
+- fix(API): Reuse participant objects already created to reduce number of database queries
+  [#10536](https://github.com/nextcloud/spreed/issues/10536)
+
+## 16.0.6 – 2023-09-21
+### Changed
+- Update dependencies
+
+### Fixed
+- fix(chat): Fix responding with "X-Chat-Last-Common-Read" when requested by the client
+  [#10340](https://github.com/nextcloud/spreed/issues/10340)
+- fix(call): Add an option to disable background blur in call
+  [#10473](https://github.com/nextcloud/spreed/issues/10473)
+- fix(desktop): fix disabling avatar menu for desktop
+  [#10183](https://github.com/nextcloud/spreed/issues/10183)
+- fix(page): Decouple the index controller from the executing method
+  [#10547](https://github.com/nextcloud/spreed/issues/10547)
+- Fix using signaling settings while being refetched
+  [#10259](https://github.com/nextcloud/spreed/issues/10259)
+- fix(chat): clean conversation history for participants in call
+  [#10303](https://github.com/nextcloud/spreed/issues/10303)
+
+## 15.0.8 – 2023-09-21
+### Changed
+- Update dependencies
+
+### Fixed
+- fix(call): Add an option to disable background blur in call
+  [#10474](https://github.com/nextcloud/spreed/issues/10474)
+- fix(page): Decouple the index controller from the executing method
+  [#10548](https://github.com/nextcloud/spreed/issues/10548)
+- Fix using signaling settings while being refetched
+  [#10257](https://github.com/nextcloud/spreed/issues/10257)
+- fix(chat): clean conversation history for participants in call
+  [#10304](https://github.com/nextcloud/spreed/issues/10304)
 
 ## 17.1.0 – 2023-09-16
 ### Added


### PR DESCRIPTION

## 17.1.1 – 2023-09-21
### Added
- feat(chat): Add copy function to code blocks [#10533](https://github.com/nextcloud/spreed/issues/10533)

### Changed
- Update dependencies

### Fixed
- fix(attachments): Allow to navigate between attachments in the viewer [#10549](https://github.com/nextcloud/spreed/issues/10549)
- fix(bots): Fix notifications of bot messages and reactions [#10530](https://github.com/nextcloud/spreed/issues/10530)
- fix(conversations): Keep the current conversation in filtered list [#10527](https://github.com/nextcloud/spreed/issues/10527)
- fix(page): Decouple the index controller from the executing method [#10546](https://github.com/nextcloud/spreed/issues/10546)
- fix(API): Reuse participant objects already created to reduce number of database queries [#10536](https://github.com/nextcloud/spreed/issues/10536)

## 16.0.6 – 2023-09-21
### Changed
- Update dependencies

### Fixed
- fix(chat): Fix responding with "X-Chat-Last-Common-Read" when requested by the client [#10340](https://github.com/nextcloud/spreed/issues/10340)
- fix(call): Add an option to disable background blur in call [#10473](https://github.com/nextcloud/spreed/issues/10473)
- fix(desktop): fix disabling avatar menu for desktop [#10183](https://github.com/nextcloud/spreed/issues/10183)
- fix(page): Decouple the index controller from the executing method [#10547](https://github.com/nextcloud/spreed/issues/10547)
- Fix using signaling settings while being refetched [#10259](https://github.com/nextcloud/spreed/issues/10259)
- fix(chat): clean conversation history for participants in call [#10303](https://github.com/nextcloud/spreed/issues/10303)

## 15.0.8 – 2023-09-21
### Changed
- Update dependencies

### Fixed
- fix(call): Add an option to disable background blur in call [#10474](https://github.com/nextcloud/spreed/issues/10474)
- fix(page): Decouple the index controller from the executing method [#10548](https://github.com/nextcloud/spreed/issues/10548)
- Fix using signaling settings while being refetched [#10257](https://github.com/nextcloud/spreed/issues/10257)
- fix(chat): clean conversation history for participants in call [#10304](https://github.com/nextcloud/spreed/issues/10304)
