### PR TITLE
fix(RightSidebar) update active tab on mount and conversation change

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -299,6 +299,15 @@ export default {
 			}
 		},
 
+		isOneToOne: {
+			immediate: true,
+			handler(value) {
+				if (value) {
+					this.activeTab = 'shared-items'
+				}
+			},
+		},
+
 		isInCall(newValue) {
 			if (newValue) {
 				// Set 'chat' tab as active, and switch to it if sidebar is open

--- a/src/components/RightSidebar/SharedItems/SharedItemsTab.vue
+++ b/src/components/RightSidebar/SharedItems/SharedItemsTab.vue
@@ -145,10 +145,22 @@ export default {
 	},
 
 	watch: {
-		active(newValue) {
-			if (newValue) {
-				this.getSharedItemsOverview()
-			}
+		active: {
+			immediate: true,
+			handler(newValue) {
+				if (newValue && this.token) {
+					this.getSharedItemsOverview()
+				}
+			},
+		},
+
+		token: {
+			immediate: true,
+			handler(newValue) {
+				if (newValue && this.active) {
+					this.getSharedItemsOverview()
+				}
+			},
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix missing "Shared items tab" for 1-1 conversations
* By default, active tab after mount is `participants` for all types of conversations
  * Now it checks for 1-1 conversations on mount as well
* When switching conversations to 1-1, only a change from tab other than 'shared-items' triggers content fetch  
  *  Now it checks combination `active && token` as well

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/c0c5fce2-58df-4046-98e3-52f561e2bbd9) | ![image](https://github.com/nextcloud/spreed/assets/93392545/b0168b85-939f-4752-b6e6-5fcdffc49352)


### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
