### PR TITLE
fix(ConversationIcon) adjust fallback icon size

### DIFF
--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -259,6 +259,7 @@ $icon-size: var(--icon-size, 44px);
 	position: relative;
 
 	.avatar.icon {
+		display: block;
 		width: $icon-size;
 		height: $icon-size;
 		line-height: $icon-size;


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10534

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2023-09-21 21-10-49](https://github.com/nextcloud/spreed/assets/93392545/cda76ed8-b037-4cab-b5b5-eef343334f0c) | ![Screenshot from 2023-09-21 21-10-54](https://github.com/nextcloud/spreed/assets/93392545/bb10ef96-ee3a-48be-97ad-3e86846ccab9)




### 🚧 Tasks

- [ ] Code review
- [ ] To test: remove or modify `src` attribute of `<image>`

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
