### PR TITLE
techdebt(CI): Prepare unit tests for PHPUnit 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 			"\"vendor/bin/mozart\" compose",
 			"composer dump-autoload"
 		],
-		"test:unit": "vendor/bin/phpunit -c tests/php/phpunit.xml --color --fail-on-warning --fail-on-risky"
+		"test:unit": "vendor/bin/phpunit -c tests/php/phpunit.xml --colors=always --fail-on-warning --fail-on-risky"
 	},
 	"require-dev": {
 		"nextcloud/ocp": "dev-master",

--- a/tests/php/Activity/Provider/BaseTest.php
+++ b/tests/php/Activity/Provider/BaseTest.php
@@ -89,23 +89,21 @@ class BaseTest extends TestCase {
 	}
 
 
-	public function dataPreParse(): array {
-		$user = $this->createMock(IUser::class);
+	public static function dataPreParse(): array {
 		return [
-			['other',  null,  true,  true],
-			['spreed', null,  true,  true],
-			['spreed', $user, true,  true],
-			['spreed', $user, false, false],
+			['other',  false,  true,  true],
+			['spreed', false,  true,  true],
+			['spreed', true, true,  true],
+			['spreed', true, false, false],
 		];
 	}
 
 	/**
 	 * @dataProvider dataPreParse
-	 *
-	 * @param bool $validUser
-	 * @param bool $disabledForUser
 	 */
-	public function testPreParse(string $appId, ?IUser $user, bool $disabledForUser, bool $willThrowException): void {
+	public function testPreParse(string $appId, bool $hasUser, bool $disabledForUser, bool $willThrowException): void {
+		$user = $hasUser ? $this->createMock(IUser::class) : null;
+
 		/** @var IEvent|MockObject $event */
 		$event = $this->createMock(IEvent::class);
 		$event->expects($this->once())
@@ -148,7 +146,7 @@ class BaseTest extends TestCase {
 		static::invokePrivate($provider, 'preParse', [$event]);
 	}
 
-	public function dataSetSubject() {
+	public static function dataSetSubject() {
 		return [
 			['No placeholder', [], 'No placeholder'],
 			['This has one {placeholder}', ['placeholder' => ['name' => 'foobar']], 'This has one foobar'],
@@ -179,7 +177,7 @@ class BaseTest extends TestCase {
 		self::invokePrivate($provider, 'setSubjects', [$event, $subject, $parameters]);
 	}
 
-	public function dataGetRoom() {
+	public static function dataGetRoom() {
 		return [
 			[Room::TYPE_ONE_TO_ONE, 23, 'private-call', 'private-call', 'one2one'],
 			[Room::TYPE_GROUP, 42, 'group-call', 'group-call', 'group'],
@@ -232,7 +230,7 @@ class BaseTest extends TestCase {
 		], self::invokePrivate($provider, 'getRoom', [$room, 'user']));
 	}
 
-	public function dataGetUser(): array {
+	public static function dataGetUser(): array {
 		return [
 			['test', true, 'Test'],
 			['foo', false, 'foo'],

--- a/tests/php/Activity/Provider/InvitationTest.php
+++ b/tests/php/Activity/Provider/InvitationTest.php
@@ -128,7 +128,7 @@ class InvitationTest extends TestCase {
 		$provider->parse('en', $event);
 	}
 
-	public function dataParse() {
+	public static function dataParse() {
 		return [
 			['en', true, ['room' => 23, 'user' => 'test1'], ['actor' => ['actor-data'], 'call' => ['call-data']]],
 			['de', false, ['room' => 42, 'user' => 'test2'], ['actor' => ['actor-data'], 'call' => ['call-unknown']]],

--- a/tests/php/Activity/SettingTest.php
+++ b/tests/php/Activity/SettingTest.php
@@ -26,7 +26,7 @@ use OCP\Activity\ISetting;
 use Test\TestCase;
 
 class SettingTest extends TestCase {
-	public function dataSettings() {
+	public static function dataSettings() {
 		return [
 			[Setting::class],
 		];

--- a/tests/php/BackgroundJob/RemoveEmptyRoomsTest.php
+++ b/tests/php/BackgroundJob/RemoveEmptyRoomsTest.php
@@ -111,7 +111,7 @@ class RemoveEmptyRoomsTest extends TestCase {
 		$this->assertEquals($numDeletedRoomsExpected, $numDeletedRoomsActual, 'Invalid final quantity of rooms');
 	}
 
-	public function dataDeleteIfFileIsRemoved(): array {
+	public static function dataDeleteIfFileIsRemoved(): array {
 		return [
 			['', [], 0],
 			['email', [], 0],
@@ -145,7 +145,7 @@ class RemoveEmptyRoomsTest extends TestCase {
 		$this->assertEquals($numDeletedRoomsExpected, $numDeletedRoomsActual, 'Invalid final quantity of rooms');
 	}
 
-	public function dataDeleteIfIsEmpty(): array {
+	public static function dataDeleteIfIsEmpty(): array {
 		return [
 			['', 1, 0],
 			['file', 1, 0],
@@ -169,7 +169,7 @@ class RemoveEmptyRoomsTest extends TestCase {
 		$this->assertEquals($numDeletedRoomsExpected, $numDeletedRoomsActual, 'Invalid final quantity of rooms');
 	}
 
-	public function dataCallback(): array {
+	public static function dataCallback(): array {
 		return [
 			[Room::TYPE_CHANGELOG, '', 0],
 			[Room::TYPE_GROUP, 'file', 1],

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -223,7 +223,7 @@ class CapabilitiesTest extends TestCase {
 		], $capabilities->getCapabilities());
 	}
 
-	public function dataGetCapabilitiesUserAllowed(): array {
+	public static function dataGetCapabilitiesUserAllowed(): array {
 		return [
 			[true, false, 'none', true, Participant::PRIVACY_PRIVATE],
 			[false, true, '1 MB', true, Participant::PRIVACY_PUBLIC],
@@ -428,7 +428,7 @@ class CapabilitiesTest extends TestCase {
 		$this->assertEquals($data['spreed']['config']['call']['recording'], $enabled);
 	}
 
-	public function dataTestConfigRecording(): array {
+	public static function dataTestConfigRecording(): array {
 		return [
 			[true],
 			[false],

--- a/tests/php/Chat/AutoComplete/SearchPluginTest.php
+++ b/tests/php/Chat/AutoComplete/SearchPluginTest.php
@@ -170,7 +170,7 @@ class SearchPluginTest extends TestCase {
 		$plugin->search('fo', 10, 0, $result);
 	}
 
-	public function dataSearchUsers() {
+	public static function dataSearchUsers() {
 		return [
 			['test', [], [], [], []],
 			['test', ['current', 'foo', 'test', 'test1'], [
@@ -216,7 +216,7 @@ class SearchPluginTest extends TestCase {
 		self::invokePrivate($plugin, 'searchUsers', [$search, $userIds, $result]);
 	}
 
-	public function dataSearchGuests() {
+	public static function dataSearchGuests() {
 		return [
 			['test', [], [], []],
 			['', ['abcdef' => ''], [['abcdef' => 'Guest']], []],
@@ -269,7 +269,7 @@ class SearchPluginTest extends TestCase {
 		return $user;
 	}
 
-	public function dataCreateResult() {
+	public static function dataCreateResult() {
 		return [
 			['user', 'foo', 'bar', '', ['label' => 'bar', 'value' => ['shareType' => 'user', 'shareWith' => 'foo']]],
 			['user', 'test', 'Test', '', ['label' => 'Test', 'value' => ['shareType' => 'user', 'shareWith' => 'test']]],
@@ -304,7 +304,7 @@ class SearchPluginTest extends TestCase {
 	}
 
 
-	public function dataCreateGuestResult(): array {
+	public static function dataCreateGuestResult(): array {
 		return [
 			['1234', 'foo', ['label' => 'foo', 'value' => ['shareType' => 'guest', 'shareWith' => 'guest/1234']]],
 			['abcd', 'bar', ['label' => 'bar', 'value' => ['shareType' => 'guest', 'shareWith' => 'guest/abcd']]],
@@ -359,7 +359,7 @@ class SearchPluginTest extends TestCase {
 		$this->assertCount($totalExactMatches, $actual['exact']['groups']);
 	}
 
-	public function dataSearchGroups(): array {
+	public static function dataSearchGroups(): array {
 		return [
 			// $search, $groupIds, $isGroup, $displayName, $totalMatches, $totalExactMatches
 			['',        ['groupid'], true,  'group', 1, 0],

--- a/tests/php/Chat/AutoComplete/SearchPluginTest.php
+++ b/tests/php/Chat/AutoComplete/SearchPluginTest.php
@@ -105,7 +105,7 @@ class SearchPluginTest extends TestCase {
 				$this->userId,
 				$this->l,
 			])
-			->setMethods($methods)
+			->onlyMethods($methods)
 			->getMock();
 	}
 

--- a/tests/php/Chat/AutoComplete/SorterTest.php
+++ b/tests/php/Chat/AutoComplete/SorterTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  *
  */
 
-namespace OCA\Talk\Tests\php\Chat;
+namespace OCA\Talk\Tests\php\Chat\AutoComplete;
 
 use OCA\Talk\Chat\AutoComplete\Sorter;
 use OCA\Talk\Chat\CommentsManager;
@@ -36,7 +36,7 @@ class SorterTest extends TestCase {
 
 	protected ?Sorter $sorter = null;
 
-	protected array $user1 = [
+	protected static array $user1 = [
 		'label' => 'Seattle',
 		'value' => [
 			'shareType' => 'user',
@@ -44,7 +44,7 @@ class SorterTest extends TestCase {
 		],
 	];
 
-	protected array $user2 = [
+	protected static array $user2 = [
 		'label' => 'New York',
 		'value' => [
 			'shareType' => 'user',
@@ -52,7 +52,7 @@ class SorterTest extends TestCase {
 		],
 	];
 
-	protected array $user3 = [
+	protected static array $user3 = [
 		'label' => 'ttle Sea',
 		'value' => [
 			'shareType' => 'user',
@@ -71,15 +71,15 @@ class SorterTest extends TestCase {
 		$this->assertSame('talk_chat_participants', $this->sorter->getId());
 	}
 
-	public function dataSort(): array {
+	public static function dataSort(): array {
 		return [
-			'no user posted' => ['', ['users' => [$this->user1, $this->user2]], [], ['users' => [$this->user1, $this->user2]]],
-			'second user posted' => ['', ['users' => [$this->user1, $this->user2]], ['new_york' => new \DateTime('2000-01-01')], ['users' => [$this->user2, $this->user1]]],
-			'second user posted later' => ['', ['users' => [$this->user1, $this->user2]], ['seattle' => new \DateTime('2017-01-01'), 'new_york' => new \DateTime('2018-01-01')], ['users' => [$this->user2, $this->user1]]],
-			'second user posted earlier' => ['', ['users' => [$this->user1, $this->user2]], ['seattle' => new \DateTime('2018-01-01'), 'new_york' => new \DateTime('2017-01-01')], ['users' => [$this->user1, $this->user2]]],
-			'starting match first1' => ['Sea', ['users' => [$this->user1, $this->user3]], [], ['users' => [$this->user1, $this->user3]]],
-			'starting match first2' => ['Sea', ['users' => [$this->user3, $this->user1]], [], ['users' => [$this->user1, $this->user3]]],
-			'no users' => ['', ['groups' => [$this->user1, $this->user2]], [], ['groups' => [$this->user1, $this->user2]]],
+			'no user posted' => ['', ['users' => [self::$user1, self::$user2]], [], ['users' => [self::$user1, self::$user2]]],
+			'second user posted' => ['', ['users' => [self::$user1, self::$user2]], ['new_york' => new \DateTime('2000-01-01')], ['users' => [self::$user2, self::$user1]]],
+			'second user posted later' => ['', ['users' => [self::$user1, self::$user2]], ['seattle' => new \DateTime('2017-01-01'), 'new_york' => new \DateTime('2018-01-01')], ['users' => [self::$user2, self::$user1]]],
+			'second user posted earlier' => ['', ['users' => [self::$user1, self::$user2]], ['seattle' => new \DateTime('2018-01-01'), 'new_york' => new \DateTime('2017-01-01')], ['users' => [self::$user1, self::$user2]]],
+			'starting match first1' => ['Sea', ['users' => [self::$user1, self::$user3]], [], ['users' => [self::$user1, self::$user3]]],
+			'starting match first2' => ['Sea', ['users' => [self::$user3, self::$user1]], [], ['users' => [self::$user1, self::$user3]]],
+			'no users' => ['', ['groups' => [self::$user1, self::$user2]], [], ['groups' => [self::$user1, self::$user2]]],
 		];
 	}
 

--- a/tests/php/Chat/ChatManagerTest.php
+++ b/tests/php/Chat/ChatManagerTest.php
@@ -210,7 +210,7 @@ class ChatManagerTest extends TestCase {
 		]);
 	}
 
-	public function dataSendMessage(): array {
+	public static function dataSendMessage(): array {
 		return [
 			'simple message' => ['testUser1', 'testMessage1', '', '0'],
 			'reference id' => ['testUser2', 'testMessage2', 'referenceId2', '0'],
@@ -654,7 +654,7 @@ class ChatManagerTest extends TestCase {
 		$manager->clearHistory($chat, 'users', 'admin');
 	}
 
-	public function dataSearchIsPartOfConversationNameOrAtAll(): array {
+	public static function dataSearchIsPartOfConversationNameOrAtAll(): array {
 		return [
 			'found a in all' => [
 				'a', 'room', true
@@ -697,7 +697,7 @@ class ChatManagerTest extends TestCase {
 		$this->assertEquals($expected, $actual);
 	}
 
-	public function dataAddConversationNotify(): array {
+	public static function dataAddConversationNotify(): array {
 		return [
 			[
 				'',
@@ -765,7 +765,7 @@ class ChatManagerTest extends TestCase {
 		$this->assertEquals($expected, $actual);
 	}
 
-	public function dataIsSharedFile(): array {
+	public static function dataIsSharedFile(): array {
 		return [
 			['', false],
 			[json_encode([]), false],
@@ -802,7 +802,7 @@ class ChatManagerTest extends TestCase {
 		$this->assertCount($expectedCount, $result);
 	}
 
-	public function dataFilterCommentsWithNonExistingFiles(): array {
+	public static function dataFilterCommentsWithNonExistingFiles(): array {
 		return [
 			[[], 0],
 			[[json_encode(['parameters' => ['not a shared file']])], 1],

--- a/tests/php/Chat/Command/ExecutorTest.php
+++ b/tests/php/Chat/Command/ExecutorTest.php
@@ -71,7 +71,7 @@ class ExecutorTest extends TestCase {
 		);
 	}
 
-	public function dataExecApp(): array {
+	public static function dataExecApp(): array {
 		return [
 			['arguments1', ''],
 			['arguments2', "output from\nevent"],
@@ -115,7 +115,7 @@ class ExecutorTest extends TestCase {
 		$this->assertSame($expected, self::invokePrivate($executor, 'execApp', [$room, $message, $command, $arguments]));
 	}
 
-	public function dataExecShell(): array {
+	public static function dataExecShell(): array {
 		return [
 			['admin', 'token', '', '', ''],
 			['admin', 'token', '/var/www/nextcloud/script.sh {USER} {ROOM} {ARGUMENTS}', 'foo bar "hello bear"', 'output1'],

--- a/tests/php/Chat/Command/ShellExecutorTest.php
+++ b/tests/php/Chat/Command/ShellExecutorTest.php
@@ -27,7 +27,7 @@ use OCA\Talk\Chat\Command\ShellExecutor;
 use Test\TestCase;
 
 class ShellExecutorTest extends TestCase {
-	public function dataExecShellRun(): array {
+	public static function dataExecShellRun(): array {
 		return [
 			['admin', 'token', 'echo {ARGUMENTS}', '$PATH', '$PATH'],
 			['admin', 'token', 'echo {ARGUMENTS}', '$(pwd)', '$(pwd)'],
@@ -72,7 +72,7 @@ class ShellExecutorTest extends TestCase {
 		$this->assertSame($output, $executor->execShell($cmd, $arguments, $roomToken, $actorId));
 	}
 
-	public function dataExecShell(): array {
+	public static function dataExecShell(): array {
 		return [
 			['admin', 'token', '', '', '', ''],
 			['admin', 'token', '/var/www/nextcloud/script.sh {USER} {ROOM} {ARGUMENTS}', 'foo bar "hello bear"', "/var/www/nextcloud/script.sh 'admin' 'token' 'foo bar \"hello bear\"'", 'output1'],

--- a/tests/php/Chat/NotifierTest.php
+++ b/tests/php/Chat/NotifierTest.php
@@ -175,7 +175,7 @@ class NotifierTest extends TestCase {
 		$this->assertEqualsCanonicalizing($expectedReturn, $actual);
 	}
 
-	public function dataNotifyMentionedUsers(): array {
+	public static function dataNotifyMentionedUsers(): array {
 		return [
 			'no notifications' => [
 				'No mentions', [], [], [],
@@ -212,7 +212,7 @@ class NotifierTest extends TestCase {
 		];
 	}
 
-	public function dataShouldParticipantBeNotified(): array {
+	public static function dataShouldParticipantBeNotified(): array {
 		return [
 			[Attendee::ACTOR_GROUPS, 'test1', null, Attendee::ACTOR_USERS, 'test1', [], false],
 			[Attendee::ACTOR_USERS, 'test1', null, Attendee::ACTOR_USERS, 'test1', [], false],
@@ -340,7 +340,7 @@ class NotifierTest extends TestCase {
 		}
 	}
 
-	public function dataAddMentionAllToList(): array {
+	public static function dataAddMentionAllToList(): array {
 		return [
 			'not notify' => [
 				[],
@@ -396,7 +396,7 @@ class NotifierTest extends TestCase {
 		$notifier->notifyReacted($room, $comment, $reaction);
 	}
 
-	public function dataNotifyReacted(): array {
+	public static function dataNotifyReacted(): array {
 		return [
 			'author react to own message' =>
 				[0, Participant::NOTIFY_MENTION, Room::TYPE_GROUP, 'testUser'],
@@ -420,7 +420,7 @@ class NotifierTest extends TestCase {
 		$this->assertEqualsCanonicalizing($expectedReturn, $actual);
 	}
 
-	public function dataGetMentionedUsers(): array {
+	public static function dataGetMentionedUsers(): array {
 		return [
 			'mention one user' => [
 				'Mention @anotherUser',
@@ -460,8 +460,8 @@ class NotifierTest extends TestCase {
 		$this->assertEqualsCanonicalizing($expectedReturn, $actual);
 	}
 
-	public function dataGetMentionedUserIds(): array {
-		$return = $this->dataGetMentionedUsers();
+	public static function dataGetMentionedUserIds(): array {
+		$return = self::dataGetMentionedUsers();
 		array_walk($return, function (array &$scenario) {
 			array_walk($scenario[1], function (array &$params) {
 				$params = $params['id'];

--- a/tests/php/Chat/Parser/SystemMessageTest.php
+++ b/tests/php/Chat/Parser/SystemMessageTest.php
@@ -143,7 +143,7 @@ class SystemMessageTest extends TestCase {
 		);
 	}
 
-	public function dataParseMessage(): array {
+	public static function dataParseMessage(): array {
 		return [
 			['conversation_created', [], 'recipient',
 				'{actor} created the conversation',
@@ -575,7 +575,7 @@ class SystemMessageTest extends TestCase {
 		}
 	}
 
-	public function dataParseMessageThrows(): array {
+	public static function dataParseMessageThrows(): array {
 		return [
 			['not json'],
 			[json_encode('not a json array')],
@@ -889,7 +889,7 @@ class SystemMessageTest extends TestCase {
 		self::invokePrivate($parser, 'getFileFromShare', [$participant, '23']);
 	}
 
-	public function dataGetActor(): array {
+	public static function dataGetActor(): array {
 		return [
 			['users', [], ['user'], ['user']],
 			['guests', ['guest'], [], ['guest']],
@@ -939,7 +939,7 @@ class SystemMessageTest extends TestCase {
 		$this->assertSame($expected, self::invokePrivate($parser, 'getActorFromComment', [$room, $chatMessage]));
 	}
 
-	public function dataGetUser(): array {
+	public static function dataGetUser(): array {
 		return [
 			['test', [], false, 'Test'],
 			['foo', ['admin' => 'Admin'], false, 'Bar'],
@@ -975,7 +975,7 @@ class SystemMessageTest extends TestCase {
 		$this->assertSame($name, $result['name']);
 	}
 
-	public function dataGetDisplayName(): array {
+	public static function dataGetDisplayName(): array {
 		return [
 			['test', true, 'Test'],
 			['foo', false, 'foo'],
@@ -1007,7 +1007,7 @@ class SystemMessageTest extends TestCase {
 		$this->assertSame($name, self::invokePrivate($parser, 'getDisplayName', [$uid]));
 	}
 
-	public function dataGetGroup(): array {
+	public static function dataGetGroup(): array {
 		return [
 			['test', [], false, 'Test'],
 			['foo', ['admin' => 'Admin'], false, 'Bar'],
@@ -1043,7 +1043,7 @@ class SystemMessageTest extends TestCase {
 		self::assertSame($name, $result['name']);
 	}
 
-	public function dataGetDisplayNameGroup(): array {
+	public static function dataGetDisplayNameGroup(): array {
 		return [
 			['test', true, 'Test'],
 			['foo', false, 'foo'],
@@ -1078,7 +1078,7 @@ class SystemMessageTest extends TestCase {
 		self::assertSame($name, self::invokePrivate($parser, 'getDisplayNameGroup', [$gid]));
 	}
 
-	public function dataGetGuest(): array {
+	public static function dataGetGuest(): array {
 		return [
 			[Attendee::ACTOR_GUESTS, sha1('name')],
 			[Attendee::ACTOR_EMAILS, 'test@test.tld'],
@@ -1114,7 +1114,7 @@ class SystemMessageTest extends TestCase {
 		], self::invokePrivate($parser, 'getGuest', [$room, $attendeeType, $actorId]));
 	}
 
-	public function dataGetGuestName(): array {
+	public static function dataGetGuestName(): array {
 		return [
 			[Attendee::ACTOR_GUESTS, sha1('name'), 'name', 'name (guest)'],
 			[Attendee::ACTOR_GUESTS, sha1('name'), '', 'Guest'],
@@ -1167,7 +1167,7 @@ class SystemMessageTest extends TestCase {
 		$this->assertSame('Guest', self::invokePrivate($parser, 'getGuestName', [$room, Attendee::ACTOR_GUESTS, $actorId]));
 	}
 
-	public function dataParseCall(): array {
+	public static function dataParseCall(): array {
 		return [
 			'1 user + guests' => [
 				'call_ended',
@@ -1423,7 +1423,7 @@ class SystemMessageTest extends TestCase {
 		$this->assertEquals($expected, self::invokePrivate($parser, 'parseCall', [$message, $parameters, ['actor' => $actor]]));
 	}
 
-	public function dataGetDuration(): array {
+	public static function dataGetDuration(): array {
 		return [
 			[30, '0:30'],
 			[140, '2:20'],

--- a/tests/php/Chat/Parser/UserMentionTest.php
+++ b/tests/php/Chat/Parser/UserMentionTest.php
@@ -224,14 +224,10 @@ class UserMentionTest extends TestCase {
 
 		$this->userManager->expects($this->exactly(2))
 			->method('getDisplayName')
-			->withConsecutive(
-				[$longerId],
-				[$baseId]
-			)
-			->willReturnOnConsecutiveCalls(
-				$longerId . ' display name',
-				$baseId . ' display name'
-			);
+			->willReturnMap([
+				[$longerId, $longerId . ' display name'],
+				[$baseId, $baseId . ' display name']
+			]);
 
 		/** @var Room|MockObject $room */
 		$room = $this->createMock(Room::class);
@@ -275,29 +271,19 @@ class UserMentionTest extends TestCase {
 
 		$this->commentsManager->expects($this->exactly(3))
 			->method('resolveDisplayName')
-			->withConsecutive(
-				['user', 'testUser1'],
-				['user', 'testUser2'],
-				['user', 'testUser3']
-			)
-			->willReturn(
-				'testUser1 display name',
-				'testUser2 display name',
-				'testUser3 display name'
-			);
+			->willReturnMap([
+				['user', 'testUser1', 'testUser1 display name'],
+				['user', 'testUser2', 'testUser2 display name'],
+				['user', 'testUser3', 'testUser3 display name'],
+			]);
 
 		$this->userManager->expects($this->exactly(3))
 			->method('getDisplayName')
-			->withConsecutive(
-				['testUser1'],
-				['testUser2'],
-				['testUser3']
-			)
-			->willReturnOnConsecutiveCalls(
-				'testUser1 display name',
-				'testUser2 display name',
-				'testUser3 display name'
-			);
+			->willReturnMap([
+				['testUser1', 'testUser1 display name'],
+				['testUser2', 'testUser2 display name'],
+				['testUser3', 'testUser3 display name'],
+			]);
 
 		/** @var Room|MockObject $room */
 		$room = $this->createMock(Room::class);

--- a/tests/php/Chat/Parser/UserMentionTest.php
+++ b/tests/php/Chat/Parser/UserMentionTest.php
@@ -188,7 +188,7 @@ class UserMentionTest extends TestCase {
 		$this->assertEquals($expectedMessageParameters, $chatMessage->getMessageParameters());
 	}
 
-	public function dataGetRichMessageWithMentionsFullyIncludedInOtherMentions() {
+	public static function dataGetRichMessageWithMentionsFullyIncludedInOtherMentions() {
 		// Based on valid characters from server/lib/private/User/Manager.php
 		return [
 			['testUser', 'testUser1', false],

--- a/tests/php/Chat/SystemMessage/ListenerTest.php
+++ b/tests/php/Chat/SystemMessage/ListenerTest.php
@@ -147,7 +147,7 @@ class ListenerTest extends TestCase {
 		$this->dispatch(Room::EVENT_AFTER_USERS_ADD, $event);
 	}
 
-	public function roomTypesProvider() {
+	public static function dataRoomTypes(): array {
 		$expectedMessages = [
 			[
 				'actorType' => 'users',
@@ -201,7 +201,7 @@ class ListenerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider roomTypesProvider
+	 * @dataProvider dataRoomTypes
 	 *
 	 * @param int $roomType
 	 */
@@ -235,7 +235,7 @@ class ListenerTest extends TestCase {
 		$this->dispatch(Room::EVENT_AFTER_USERS_ADD, $event);
 	}
 
-	public function participantTypeChangeProvider() {
+	public static function dataParticipantTypeChange(): array {
 		return [
 			[
 				Attendee::ACTOR_EMAILS,
@@ -277,12 +277,7 @@ class ListenerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider participantTypeChangeProvider
-	 *
-	 * @param int $actorType
-	 * @param int $oldParticipantType
-	 * @param int $newParticipantType
-	 * @param array $expectedMessages
+	 * @dataProvider dataParticipantTypeChange
 	 */
 	public function testAfterParticipantTypeSet(string $actorType, int $oldParticipantType, int $newParticipantType, array $expectedMessages): void {
 		$this->mockLoggedInUser('alice_actor');
@@ -319,7 +314,7 @@ class ListenerTest extends TestCase {
 		$this->dispatch(Room::EVENT_AFTER_PARTICIPANT_TYPE_SET, $event);
 	}
 
-	public function callRecordingChangeProvider() {
+	public static function dataCallRecordingChange(): array {
 		return [
 			[
 				Room::RECORDING_VIDEO_STARTING,
@@ -549,13 +544,7 @@ class ListenerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider callRecordingChangeProvider
-	 *
-	 * @param int $newStatus
-	 * @param int $oldStatus
-	 * @param string|null $actorType
-	 * @param string|null $actorId
-	 * @param array|null $expectedMessage
+	 * @dataProvider dataCallRecordingChange
 	 */
 	public function testAfterCallRecordingSet(int $newStatus, int $oldStatus, ?string $actorType, ?string $actorId, ?array $expectedMessage): void {
 		$this->mockLoggedInUser('logged_in_user');

--- a/tests/php/Collaboration/Collaborators/RoomPluginTest.php
+++ b/tests/php/Collaboration/Collaborators/RoomPluginTest.php
@@ -102,7 +102,7 @@ class RoomPluginTest extends TestCase {
 		return $room;
 	}
 
-	private function newResult(string $label, string $shareWith): array {
+	private static function newResult(string $label, string $shareWith): array {
 		return [
 			'label' => $label,
 			'value' => [
@@ -112,7 +112,7 @@ class RoomPluginTest extends TestCase {
 		];
 	}
 
-	public function searchProvider(): array {
+	public static function dataSearch(): array {
 		return [
 			// Empty search term with no rooms
 			['', 2, 0, [], [], [], false],
@@ -132,7 +132,7 @@ class RoomPluginTest extends TestCase {
 				[Room::TYPE_GROUP, 'roomToken', 'Room name'],
 				[Room::TYPE_GROUP, 'roomToken2', 'Unmatched name'],
 			], [], [
-				$this->newResult('Room name', 'roomToken'),
+				self::newResult('Room name', 'roomToken'),
 			], false],
 
 			// Chats without chat permission are not returned
@@ -145,7 +145,7 @@ class RoomPluginTest extends TestCase {
 				[Room::TYPE_GROUP, 'roomToken', 'Unmatched name'],
 				[Room::TYPE_GROUP, 'roomToken2', 'Room name'],
 			], [
-				$this->newResult('Room name', 'roomToken2'),
+				self::newResult('Room name', 'roomToken2'),
 			], [], false],
 
 			// Search term with single exact match and single wide match
@@ -153,9 +153,9 @@ class RoomPluginTest extends TestCase {
 				[Room::TYPE_GROUP, 'roomToken', 'Room name that also matches'],
 				[Room::TYPE_GROUP, 'roomToken2', 'Room name'],
 			], [
-				$this->newResult('Room name', 'roomToken2'),
+				self::newResult('Room name', 'roomToken2'),
 			], [
-				$this->newResult('Room name that also matches', 'roomToken'),
+				self::newResult('Room name that also matches', 'roomToken'),
 			], false],
 
 			// Search term matching one-to-one rooms (not possible in practice
@@ -165,9 +165,9 @@ class RoomPluginTest extends TestCase {
 				[Room::TYPE_ONE_TO_ONE, 'roomToken', 'Room name that also matches'],
 				[Room::TYPE_ONE_TO_ONE, 'roomToken2', 'Room name'],
 			], [
-				$this->newResult('Room name', 'roomToken2'),
+				self::newResult('Room name', 'roomToken2'),
 			], [
-				$this->newResult('Room name that also matches', 'roomToken'),
+				self::newResult('Room name that also matches', 'roomToken'),
 			], false],
 
 			// Search term matching public rooms
@@ -175,9 +175,9 @@ class RoomPluginTest extends TestCase {
 				[Room::TYPE_PUBLIC, 'roomToken', 'Room name that also matches'],
 				[Room::TYPE_PUBLIC, 'roomToken2', 'Room name'],
 			], [
-				$this->newResult('Room name', 'roomToken2'),
+				self::newResult('Room name', 'roomToken2'),
 			], [
-				$this->newResult('Room name that also matches', 'roomToken'),
+				self::newResult('Room name that also matches', 'roomToken'),
 			], false],
 
 			// Search term with several wide matches
@@ -187,10 +187,10 @@ class RoomPluginTest extends TestCase {
 				[Room::TYPE_GROUP, 'roomToken3', 'Room name'],
 				[Room::TYPE_GROUP, 'roomToken4', 'Another room name'],
 			], [], [
-				$this->newResult('Room name', 'roomToken'),
-				$this->newResult('Another room name', 'roomToken2'),
-				$this->newResult('Room name', 'roomToken3'),
-				$this->newResult('Another room name', 'roomToken4'),
+				self::newResult('Room name', 'roomToken'),
+				self::newResult('Another room name', 'roomToken2'),
+				self::newResult('Room name', 'roomToken3'),
+				self::newResult('Another room name', 'roomToken4'),
 			], false],
 
 			// Search term with several exact matches
@@ -200,10 +200,10 @@ class RoomPluginTest extends TestCase {
 				[Room::TYPE_GROUP, 'roomToken3', 'Room name'],
 				[Room::TYPE_GROUP, 'roomToken4', 'Room name'],
 			], [
-				$this->newResult('Room name', 'roomToken'),
-				$this->newResult('Room name', 'roomToken2'),
-				$this->newResult('Room name', 'roomToken3'),
-				$this->newResult('Room name', 'roomToken4'),
+				self::newResult('Room name', 'roomToken'),
+				self::newResult('Room name', 'roomToken2'),
+				self::newResult('Room name', 'roomToken3'),
+				self::newResult('Room name', 'roomToken4'),
 			], [], false],
 
 			// Search term with several matches
@@ -220,20 +220,20 @@ class RoomPluginTest extends TestCase {
 				[Room::TYPE_ONE_TO_ONE, 'roomToken10', 'Another room name'],
 				[Room::TYPE_PUBLIC, 'roomToken11', 'Another room name'],
 			], [
-				$this->newResult('Room name', 'roomToken'),
-				$this->newResult('Room name', 'roomToken4'),
-				$this->newResult('Room name', 'roomToken5'),
-				$this->newResult('Room name', 'roomToken6'),
+				self::newResult('Room name', 'roomToken'),
+				self::newResult('Room name', 'roomToken4'),
+				self::newResult('Room name', 'roomToken5'),
+				self::newResult('Room name', 'roomToken6'),
 			], [
-				$this->newResult('Another room name', 'roomToken3'),
-				$this->newResult('Another room name', 'roomToken10'),
-				$this->newResult('Another room name', 'roomToken11'),
+				self::newResult('Another room name', 'roomToken3'),
+				self::newResult('Another room name', 'roomToken10'),
+				self::newResult('Another room name', 'roomToken11'),
 			], false],
 		];
 	}
 
 	/**
-	 * @dataProvider searchProvider
+	 * @dataProvider dataSearch
 	 *
 	 * @param string $searchTerm
 	 * @param int $limit

--- a/tests/php/Collaboration/Reference/TalkReferenceProviderTest.php
+++ b/tests/php/Collaboration/Reference/TalkReferenceProviderTest.php
@@ -75,7 +75,7 @@ class TalkReferenceProviderTest extends TestCase {
 		);
 	}
 
-	public function dataGetTalkAppLinkToken(): array {
+	public static function dataGetTalkAppLinkToken(): array {
 		return [
 			['https://localhost/', null],
 			['https://localhost/call', null],

--- a/tests/php/Collaboration/Resources/ConversationProviderTest.php
+++ b/tests/php/Collaboration/Resources/ConversationProviderTest.php
@@ -155,7 +155,7 @@ class ConversationProviderTest extends TestCase {
 		$this->assertFalse($this->provider->canAccessResource($resource, $user));
 	}
 
-	public function dataCanAccessResourceYes(): array {
+	public static function dataCanAccessResourceYes(): array {
 		return [
 			[Participant::OWNER],
 			[Participant::MODERATOR],

--- a/tests/php/ConfigTest.php
+++ b/tests/php/ConfigTest.php
@@ -260,7 +260,7 @@ class ConfigTest extends TestCase {
 		$this->assertSame($servers, $settings);
 	}
 
-	public function dataGetWebSocketDomainForSignalingServer() {
+	public static function dataGetWebSocketDomainForSignalingServer() {
 		return [
 			['http://blabla.nextcloud.com', 'ws://blabla.nextcloud.com'],
 			['http://blabla.nextcloud.com/', 'ws://blabla.nextcloud.com'],
@@ -333,7 +333,7 @@ class ConfigTest extends TestCase {
 		);
 	}
 
-	public function dataTicketV2Algorithm() {
+	public static function dataTicketV2Algorithm() {
 		return [
 			['ES384'],
 			['ES256'],

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -1069,7 +1069,7 @@ class ChatControllerTest extends TestCase {
 		$this->assertEquals($expected, $response);
 	}
 
-	public function dataMentions() {
+	public static function dataMentions() {
 		return [
 			['tes', 10, ['exact' => []], []],
 			['foo', 20, [

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -55,6 +55,7 @@ use OCP\IUserManager;
 use OCP\RichObjectStrings\IValidator;
 use OCP\Security\ITrustedDomainHelper;
 use OCP\UserStatus\IManager as IUserStatusManager;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
@@ -411,15 +412,23 @@ class ChatControllerTest extends TestCase {
 
 		$this->messageParser->expects($this->exactly(2))
 			->method('createMessage')
-			->withConsecutive(
-				[$this->room, $participant, $parent, $this->l],
-				[$this->room, $participant, $comment, $this->l]
-			)
-			->willReturnOnConsecutiveCalls($parentMessage, $chatMessage);
+			->willReturnMap([
+				[$this->room, $participant, $parent, $this->l, $parentMessage],
+				[$this->room, $participant, $comment, $this->l, $chatMessage],
+			]);
 
+		$i = 0;
+		$expectedCalls = [
+			[$parentMessage],
+			[$chatMessage],
+		];
 		$this->messageParser->expects($this->exactly(2))
 			->method('parseMessage')
-			->withConsecutive([$parentMessage], [$chatMessage]);
+			->willReturnCallback(function () use ($expectedCalls, &$i) {
+				Assert::assertArrayHasKey($i, $expectedCalls);
+				Assert::assertSame($expectedCalls[$i], func_get_args());
+				$i++;
+			});
 
 		$this->controller->setRoom($this->room);
 		$this->controller->setParticipant($participant);
@@ -750,15 +759,18 @@ class ChatControllerTest extends TestCase {
 		$participant = $this->createMock(Participant::class);
 
 		$i = 4;
+		$expectedCalls = [
+			[$this->room, $participant, $comment4, $this->l],
+			[$this->room, $participant, $comment3, $this->l],
+			[$this->room, $participant, $comment2, $this->l],
+			[$this->room, $participant, $comment1, $this->l],
+		];
 		$this->messageParser->expects($this->exactly(4))
 			->method('createMessage')
-			->withConsecutive(
-				[$this->room, $participant, $comment4, $this->l],
-				[$this->room, $participant, $comment3, $this->l],
-				[$this->room, $participant, $comment2, $this->l],
-				[$this->room, $participant, $comment1, $this->l]
-			)
-			->willReturnCallback(function ($room, $participant, IComment $comment, $l) use (&$i) {
+			->willReturnCallback(function ($room, $participant, IComment $comment, $l) use ($expectedCalls, &$i) {
+				Assert::assertArrayHasKey(4 - $i, $expectedCalls);
+				Assert::assertSame($expectedCalls[4 - $i], func_get_args());
+
 				$chatMessage = $this->createMock(Message::class);
 				$chatMessage->expects($this->once())
 					->method('getVisibility')
@@ -816,15 +828,18 @@ class ChatControllerTest extends TestCase {
 			]);
 
 		$i = 4;
+		$expectedCalls = [
+			[$this->room, $participant, $comment4, $this->l],
+			[$this->room, $participant, $comment3, $this->l],
+			[$this->room, $participant, $comment2, $this->l],
+			[$this->room, $participant, $comment1, $this->l],
+		];
 		$this->messageParser->expects($this->exactly(4))
 			->method('createMessage')
-			->withConsecutive(
-				[$this->room, $participant, $comment4, $this->l],
-				[$this->room, $participant, $comment3, $this->l],
-				[$this->room, $participant, $comment2, $this->l],
-				[$this->room, $participant, $comment1, $this->l]
-			)
-			->willReturnCallback(function ($room, $participant, IComment $comment, $l) use (&$i) {
+			->willReturnCallback(function ($room, $participant, IComment $comment, $l) use ($expectedCalls, &$i) {
+				Assert::assertArrayHasKey(4 - $i, $expectedCalls);
+				Assert::assertSame($expectedCalls[4 - $i], func_get_args());
+
 				$chatMessage = $this->createMock(Message::class);
 				$chatMessage->expects($this->once())
 					->method('getVisibility')
@@ -885,15 +900,18 @@ class ChatControllerTest extends TestCase {
 			]);
 
 		$i = 4;
+		$expectedCalls = [
+			[$this->room, $participant, $comment4, $this->l],
+			[$this->room, $participant, $comment3, $this->l],
+			[$this->room, $participant, $comment2, $this->l],
+			[$this->room, $participant, $comment1, $this->l],
+		];
 		$this->messageParser->expects($this->exactly(4))
 			->method('createMessage')
-			->withConsecutive(
-				[$this->room, $participant, $comment4, $this->l],
-				[$this->room, $participant, $comment3, $this->l],
-				[$this->room, $participant, $comment2, $this->l],
-				[$this->room, $participant, $comment1, $this->l]
-			)
-			->willReturnCallback(function ($room, $participant, IComment $comment, $l) use (&$i) {
+			->willReturnCallback(function ($room, $participant, IComment $comment, $l) use ($expectedCalls, &$i) {
+				Assert::assertArrayHasKey(4 - $i, $expectedCalls);
+				Assert::assertSame($expectedCalls[4 - $i], func_get_args());
+
 				$chatMessage = $this->createMock(Message::class);
 				$chatMessage->expects($this->once())
 					->method('getVisibility')
@@ -962,15 +980,18 @@ class ChatControllerTest extends TestCase {
 			->willReturn($testUser);
 
 		$i = 1;
-		$this->messageParser->expects($this->exactly(4))
+		$expectedCalls = [
+			[$this->room, $participant, $comment1, $this->l],
+			[$this->room, $participant, $comment2, $this->l],
+			[$this->room, $participant, $comment3, $this->l],
+			[$this->room, $participant, $comment4, $this->l],
+		];
+		$this->messageParser->expects($this->exactly(count($expectedCalls)))
 			->method('createMessage')
-			->withConsecutive(
-				[$this->room, $participant, $comment1, $this->l],
-				[$this->room, $participant, $comment2, $this->l],
-				[$this->room, $participant, $comment3, $this->l],
-				[$this->room, $participant, $comment4, $this->l]
-			)
-			->willReturnCallback(function ($room, $participant, IComment $comment, $l) use (&$i) {
+			->willReturnCallback(function ($room, $participant, IComment $comment, $l) use ($expectedCalls, &$i) {
+				Assert::assertArrayHasKey($i - 1, $expectedCalls);
+				Assert::assertSame($expectedCalls[$i - 1], func_get_args());
+
 				$chatMessage = $this->createMock(Message::class);
 				$chatMessage->expects($this->once())
 					->method('getVisibility')

--- a/tests/php/Controller/SignalingControllerTest.php
+++ b/tests/php/Controller/SignalingControllerTest.php
@@ -705,7 +705,7 @@ class SignalingControllerTest extends TestCase {
 		], $result->getData());
 	}
 
-	public function dataBackendRoomUserPublicPermissions(): array {
+	public static function dataBackendRoomUserPublicPermissions(): array {
 		return [
 			[Attendee::PERMISSIONS_DEFAULT, []],
 			[Attendee::PERMISSIONS_PUBLISH_AUDIO, ['publish-audio']],

--- a/tests/php/Listener/RestrictStartingCallsTest.php
+++ b/tests/php/Listener/RestrictStartingCallsTest.php
@@ -50,7 +50,7 @@ class RestrictStartingCallsTest extends TestCase {
 		$this->listener = new RestrictStartingCalls($this->serverConfig, $this->participantService);
 	}
 
-	public function dataCheckStartCallPermissions(): array {
+	public static function dataCheckStartCallPermissions(): array {
 		return [
 			'default blocked' => [Room::TYPE_PUBLIC, '', false, false, true],
 

--- a/tests/php/Model/AttendeeMapperTest.php
+++ b/tests/php/Model/AttendeeMapperTest.php
@@ -44,7 +44,7 @@ class AttendeeMapperTest extends TestCase {
 		);
 	}
 
-	public function dataModifyPermissions(): array {
+	public static function dataModifyPermissions(): array {
 		return [
 			0 => [
 				[

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -51,6 +51,7 @@ use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
 use OCP\RichObjectStrings\Definitions;
 use OCP\Share\IManager as IShareManager;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -946,10 +947,15 @@ class NotifierTest extends TestCase {
 			$userManagerGet['with'][] = [$subjectParameters['userId']];
 			$userManagerGet['willReturn'][] = null;
 		}
+		$i = 0;
 		$this->userManager->expects($this->exactly(count($userManagerGet['with'])))
 			->method('getDisplayName')
-			->withConsecutive(...$userManagerGet['with'])
-			->willReturnOnConsecutiveCalls(...$userManagerGet['willReturn']);
+			->willReturnCallback(function () use ($userManagerGet, &$i) {
+				Assert::assertArrayHasKey($i, $userManagerGet['with']);
+				Assert::assertSame($userManagerGet['with'][$i], func_get_args());
+				$i++;
+				return $userManagerGet['willReturn'][$i - 1];
+			});
 
 		$comment = $this->createMock(IComment::class);
 		$comment->expects($this->any())

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -141,7 +141,7 @@ class NotifierTest extends TestCase {
 		);
 	}
 
-	public function dataPrepareOne2One(): array {
+	public static function dataPrepareOne2One(): array {
 		return [
 			['admin', 'Admin', 'Admin invited you to a private conversation'],
 			['test', 'Test user', 'Test user invited you to a private conversation'],
@@ -359,7 +359,7 @@ class NotifierTest extends TestCase {
 		return $n;
 	}
 
-	public function dataPrepareGroup() {
+	public static function dataPrepareGroup() {
 		return [
 			[Room::TYPE_GROUP, 'admin', 'Admin', 'Group', 'Admin invited you to a group conversation: Group'],
 			[Room::TYPE_PUBLIC, 'test', 'Test user', 'Public', 'Test user invited you to a group conversation: Public'],
@@ -491,7 +491,7 @@ class NotifierTest extends TestCase {
 		$this->notifier->prepare($n, 'de');
 	}
 
-	public function dataPrepareChatMessage(): array {
+	public static function dataPrepareChatMessage(): array {
 		return [
 			'one-to-one mention' => [
 				$subject = 'mention', Room::TYPE_ONE_TO_ONE, ['userType' => 'users', 'userId' => 'testUser'], 'Test user', 'Test user',
@@ -1055,7 +1055,7 @@ class NotifierTest extends TestCase {
 		$this->assertEquals($notification, $this->notifier->prepare($notification, 'de'));
 	}
 
-	public function dataPrepareThrows() {
+	public static function dataPrepareThrows() {
 		return [
 			['Incorrect app', 'invalid-app', null, null, null, null, null],
 			'User can not use Talk' => [AlreadyProcessedException::class, 'spreed', true, null, null, null, null],

--- a/tests/php/Service/AvatarServiceTest.php
+++ b/tests/php/Service/AvatarServiceTest.php
@@ -93,7 +93,7 @@ class AvatarServiceTest extends TestCase {
 		}
 	}
 
-	public function dataGetAvatarVersion(): array {
+	public static function dataGetAvatarVersion(): array {
 		return [
 			['', 'STRING WITH 8 CHARS'],
 			['1', '1'],
@@ -101,7 +101,7 @@ class AvatarServiceTest extends TestCase {
 		];
 	}
 
-	public function dataGetFirstCombinedEmoji(): array {
+	public static function dataGetFirstCombinedEmoji(): array {
 		return [
 			['👋 Hello', '👋'],
 			['Only leading emojis 🚀', ''],

--- a/tests/php/Service/BreakoutRoomServiceTest.php
+++ b/tests/php/Service/BreakoutRoomServiceTest.php
@@ -80,7 +80,7 @@ class BreakoutRoomServiceTest extends TestCase {
 			$this->l
 		);
 	}
-	public function dataParseAttendeeMap(): array {
+	public static function dataParseAttendeeMap(): array {
 		return [
 			'Empty string means no map' => ['', 3, [], false],
 			'Empty array means no map' => ['[]', 3, [], false],

--- a/tests/php/Service/ChecksumVerificationServiceTest.php
+++ b/tests/php/Service/ChecksumVerificationServiceTest.php
@@ -38,7 +38,7 @@ class ChecksumVerificationServiceTest extends TestCase {
 		$this->service = new ChecksumVerificationService();
 	}
 
-	public function dataValidateRequest(): array {
+	public static function dataValidateRequest(): array {
 		$validRandom = md5(random_bytes(15));
 		$fakeData = json_encode(['fake' => 'data']);
 		$validSecret = 'valid secret';

--- a/tests/php/Service/RecordingServiceTest.php
+++ b/tests/php/Service/RecordingServiceTest.php
@@ -134,7 +134,7 @@ class RecordingServiceTest extends TestCase {
 		$this->recordingService->validateFileFormat($fileName, $fileRealPath);
 	}
 
-	public function dataValidateFileFormat(): array {
+	public static function dataValidateFileFormat(): array {
 		return [
 			# file_invalid_path
 			['', '', 'file_invalid_path'],
@@ -169,7 +169,7 @@ class RecordingServiceTest extends TestCase {
 		$this->assertEquals($expected, $actual);
 	}
 
-	public function dataGetResourceFromFileArray(): array {
+	public static function dataGetResourceFromFileArray(): array {
 		$fileWithContent = tempnam(sys_get_temp_dir(), 'txt');
 		file_put_contents($fileWithContent, 'bla');
 		return [

--- a/tests/php/Service/RoomServiceTest.php
+++ b/tests/php/Service/RoomServiceTest.php
@@ -191,7 +191,7 @@ class RoomServiceTest extends TestCase {
 		$this->assertSame($room, $this->service->createOneToOneConversation($user1, $user2));
 	}
 
-	public function dataCreateConversationInvalidNames(): array {
+	public static function dataCreateConversationInvalidNames(): array {
 		return [
 			[''],
 			['        '],
@@ -217,7 +217,7 @@ class RoomServiceTest extends TestCase {
 		$this->service->createConversation(Room::TYPE_GROUP, $name);
 	}
 
-	public function dataCreateConversationInvalidTypes(): array {
+	public static function dataCreateConversationInvalidTypes(): array {
 		return [
 			[Room::TYPE_ONE_TO_ONE],
 			[Room::TYPE_UNKNOWN],
@@ -239,7 +239,7 @@ class RoomServiceTest extends TestCase {
 		$this->service->createConversation($type, 'abc');
 	}
 
-	public function dataCreateConversationInvalidObjects(): array {
+	public static function dataCreateConversationInvalidObjects(): array {
 		return [
 			[str_repeat('a', 65), 'a', 'object_type'],
 			['a', str_repeat('a', 65), 'object_id'],
@@ -263,7 +263,7 @@ class RoomServiceTest extends TestCase {
 		$this->service->createConversation(Room::TYPE_PUBLIC, 'a', null, $type, $id);
 	}
 
-	public function dataCreateConversation(): array {
+	public static function dataCreateConversation(): array {
 		return [
 			[Room::TYPE_GROUP, 'Group conversation', 'admin', '', ''],
 			[Room::TYPE_PUBLIC, 'Public conversation', '', 'files', '123456'],
@@ -311,7 +311,7 @@ class RoomServiceTest extends TestCase {
 		$this->assertSame($room, $this->service->createConversation($type, $name, $owner, $objectType, $objectId));
 	}
 
-	public function dataPrepareConversationName(): array {
+	public static function dataPrepareConversationName(): array {
 		return [
 			['', ''],
 			['    ', ''],

--- a/tests/php/Settings/Admin/AdminSettingsTest.php
+++ b/tests/php/Settings/Admin/AdminSettingsTest.php
@@ -34,6 +34,7 @@ use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -165,12 +166,18 @@ class AdminSettingsTest extends TestCase {
 			->with('has_internet_connection', true)
 			->willReturn(true);
 
+		$i = 0;
+		$expectedCalls = [
+			['stun_servers', ['getStunServers']],
+			['has_internet_connection', true],
+		];
 		$this->initialState->expects($this->exactly(2))
 			->method('provideInitialState')
-			->withConsecutive(
-				['stun_servers', ['getStunServers']],
-				['has_internet_connection', true]
-			);
+			->willReturnCallback(function () use ($expectedCalls, &$i) {
+				Assert::assertArrayHasKey($i, $expectedCalls);
+				Assert::assertSame($expectedCalls[$i], func_get_args());
+				$i++;
+			});
 
 		$admin = $this->getAdminSettings();
 		self::invokePrivate($admin, 'initStunServers');

--- a/tests/php/TalkSessionTest.php
+++ b/tests/php/TalkSessionTest.php
@@ -43,7 +43,7 @@ class TalkSessionTest extends TestCase {
 		$this->talkSession = new TalkSession($this->session);
 	}
 
-	public function dataGet(): array {
+	public static function dataGet(): array {
 		return [
 			'session is null' => [null, null],
 			'corrupted json' => ['{invalid json', null],
@@ -80,7 +80,7 @@ class TalkSessionTest extends TestCase {
 		$this->assertSame($expected, $this->talkSession->getPasswordForRoom('t1'));
 	}
 
-	public function dataSet(): array {
+	public static function dataSet(): array {
 		return [
 			'session is null' => [null, json_encode(['t1' => 'd1'])],
 			'corrupted json' => ['{invalid json', json_encode(['t1' => 'd1'])],
@@ -123,7 +123,7 @@ class TalkSessionTest extends TestCase {
 		$this->talkSession->setPasswordForRoom('t1', 'd1');
 	}
 
-	public function dataRemove(): array {
+	public static function dataRemove(): array {
 		return [
 			'session is null' => [null, json_encode([])],
 			'corrupted json' => ['{invalid json', json_encode([])],


### PR DESCRIPTION
### ☑️ Resolves

* Prepares the tests for PHPUnit10 by not using dropped methods anymore.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
