### PR TITLE
Add key prop to NclistItem to re-render conversation with the appropr…

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -21,6 +21,7 @@
 
 <template>
 	<NcListItem ref="listItem"
+		:key="item.token"
 		:name="item.displayName"
 		class="conversation-item"
 		:class="{'unread-mention-conversation': item.unreadMention}"


### PR DESCRIPTION
### ☑️ Resolves

Sometimes ( not sure what the trigger is yet), the active conversation class gets passed to all conversation items in the virtual scroller one by one successively.

Adding a key prop to NcListItem will force proper re-render.

### 🚧 Tasks

- [ ] code review

