### PR TITLE
feat(user_status): Increase participant limit to 1k users

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -43,6 +43,13 @@ class Config {
 	public const SIGNALING_TICKET_V1 = 1;
 	public const SIGNALING_TICKET_V2 = 2;
 
+	/**
+	 * Currently limiting to 1k users because the user_status API would yield
+	 * an error on Oracle otherwise. Clients should use a virtual scrolling
+	 * mechanism so the data should not be a problem nowadays
+	 */
+	public const USER_STATUS_INTEGRATION_LIMIT = 1000;
+
 	protected array $canEnableSIP = [];
 
 	public function __construct(

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -688,7 +688,7 @@ class RoomController extends AEnvironmentAwareController {
 
 		if ($this->userId !== null
 			&& $includeStatus
-			&& count($participants) < 100
+			&& count($participants) < Config::USER_STATUS_INTEGRATION_LIMIT
 			&& $this->appManager->isEnabledForUser('user_status')) {
 			$userIds = array_filter(array_map(static function (Participant $participant) {
 				if ($participant->getAttendee()->getActorType() === Attendee::ACTOR_USERS) {


### PR DESCRIPTION
Currently limiting to 1k users because the user_status API would yield an error on Oracle otherwise. Clients should use a virtual scrolling mechanism so the data should not be a problem nowadays

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
