### PR TITLE
fix(tests): Fix integration tests after merge of Translation capabili…

### DIFF
--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -3842,10 +3842,14 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
-	 * @When /^last response body (contains|does not contain|starts with|starts not with|ends with|ends not with) "([^"]*)"$/
+	 * @When /^last response body (contains|does not contain|starts with|starts not with|ends with|ends not with) "([^"]*)"(| with newlines)$/
 	 * @param string $needle
 	 */
-	public function lastResponseBodyContains(string $comparison, string $needle) {
+	public function lastResponseBodyContains(string $comparison, string $needle, string $replaceNWithNewlines) {
+		if ($replaceNWithNewlines) {
+			$needle = str_replace('\n', "\n", $needle);
+		}
+
 		if ($comparison === 'contains') {
 			Assert::assertStringContainsString($needle, $this->response->getBody()->getContents());
 		} elseif ($comparison === 'does not contain') {

--- a/tests/integration/features/integration/capabilities.feature
+++ b/tests/integration/features/integration/capabilities.feature
@@ -2,7 +2,7 @@ Feature: integration/dashboard
   Background:
     Given user "participant1" exists
 
-  Scenario: User gets the available dashboard widgets
+  Scenario: Check that users can read the capabilities as XML
     Given as user "participant1"
     When sending "GET" to "/cloud/capabilities" for xml with
-    Then last response body contains "<toLabel>Lorem ipsum</toLabel>"
+    Then last response body contains "<predefined-backgrounds>\n       <element>1_office.jpg</element>" with newlines


### PR DESCRIPTION
…ty change

### ☑️ Resolves

* Fix red CI after merge of https://github.com/nextcloud/spreed/pull/10317

### 🚧  Todo

- [ ] Adjust `integration-summary-when-unrelated.yml` so it works correctly when a PR touches backend and frontend. => https://github.com/nextcloud/spreed/issues/10600

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
