### PR TITLE
feat(CI): Bump OCP package as prerequirement for the SIP work

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -134,12 +134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "54b06fd311d50109fa02e79165f4df6fac6ed8e5"
+                "reference": "6ab43b9e406ef9500b5a5ea5563e57c3cb3b898c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/54b06fd311d50109fa02e79165f4df6fac6ed8e5",
-                "reference": "54b06fd311d50109fa02e79165f4df6fac6ed8e5",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6ab43b9e406ef9500b5a5ea5563e57c3cb3b898c",
+                "reference": "6ab43b9e406ef9500b5a5ea5563e57c3cb3b898c",
                 "shasum": ""
             },
             "require": {
@@ -171,7 +171,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2023-09-21T00:30:50+00:00"
+            "time": "2023-09-27T00:31:40+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
### ☑️ Resolves

* Brings in https://github.com/nextcloud/server/pull/40620

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
