### PR TITLE
feat(conversation) - add Note to self conversation

### DIFF
--- a/docs/constants.md
+++ b/docs/constants.md
@@ -8,6 +8,7 @@
 * `3` Public
 * `4` Changelog
 * `5` Former "One to one" (When a user is deleted from the server or removed from all their conversations, `1` "One to one" rooms are converted to this type)
+* `6` Note to self 
 
 ### Object types
 

--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -36,7 +36,8 @@
 
 		<template v-if="!isBreakoutRoom">
 			<!-- Notifications settings and devices preview screen -->
-			<NcAppSettingsSection id="notifications"
+			<NcAppSettingsSection v-if="!isNoteToSelf"
+				id="notifications"
 				:title="t('spreed', 'Personal')">
 				<NcCheckboxRadioSwitch :checked.sync="showMediaSettings"
 					type="switch">
@@ -49,8 +50,8 @@
 			<NcAppSettingsSection v-if="canFullModerate"
 				id="conversation-settings"
 				:title="t('spreed', 'Moderation')">
-				<ListableSettings :token="token" />
-				<LinkShareSettings ref="linkShareSettings" />
+				<ListableSettings v-if="!isNoteToSelf" :token="token" />
+				<LinkShareSettings v-if="!isNoteToSelf" ref="linkShareSettings" />
 				<ExpirationSettings :token="token" can-full-moderate />
 			</NcAppSettingsSection>
 			<NcAppSettingsSection v-else
@@ -60,7 +61,7 @@
 			</NcAppSettingsSection>
 
 			<!-- Meeting: lobby and sip -->
-			<NcAppSettingsSection v-if="canFullModerate"
+			<NcAppSettingsSection v-if="canFullModerate && !isNoteToSelf"
 				id="meeting"
 				:title="t('spreed', 'Meeting')">
 				<LobbySettings :token="token" />
@@ -68,7 +69,7 @@
 			</NcAppSettingsSection>
 
 			<!-- Conversation permissions -->
-			<NcAppSettingsSection v-if="canFullModerate"
+			<NcAppSettingsSection v-if="canFullModerate && !isNoteToSelf"
 				id="permissions"
 				:title="t('spreed', 'Permissions')">
 				<ConversationPermissionsSettings :token="token" />
@@ -99,7 +100,7 @@
 			<NcAppSettingsSection v-if="canLeaveConversation || canDeleteConversation"
 				id="dangerzone"
 				:title="t('spreed', 'Danger zone')">
-				<LockingSettings :token="token" />
+				<LockingSettings v-if="canFullModerate && !isNoteToSelf" :token="token" />
 				<DangerZone :conversation="conversation"
 					:can-leave-conversation="canLeaveConversation"
 					:can-delete-conversation="canDeleteConversation" />
@@ -171,6 +172,10 @@ export default {
 
 		canUserEnableSIP() {
 			return this.conversation.canEnableSIP
+		},
+
+		isNoteToSelf() {
+			return this.conversation.type === CONVERSATION.TYPE.NOTE_TO_SELF
 		},
 
 		token() {

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -80,7 +80,7 @@
 				</template>
 				{{ t('spreed', 'Conversation settings') }}
 			</NcActionButton>
-			<NcActionButton v-if="canLeaveConversation"
+			<NcActionButton v-if="canLeaveConversation && !isNoteToSelf"
 				:close-after-click="true"
 				@click="leaveConversation">
 				<template #icon>

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -80,7 +80,7 @@
 				</template>
 				{{ t('spreed', 'Conversation settings') }}
 			</NcActionButton>
-			<NcActionButton v-if="canLeaveConversation && !isNoteToSelf"
+			<NcActionButton v-if="canLeaveConversation"
 				:close-after-click="true"
 				@click="leaveConversation">
 				<template #icon>

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -96,7 +96,7 @@
 						<template #icon>
 							<Note :size="20" />
 						</template>
-						{{ t('spreed','New Personal Note') }}
+						{{ t('spreed','New personal note') }}
 					</NcActionButton>
 
 					<NcActionButton close-after-click
@@ -409,7 +409,7 @@ export default {
 		},
 
 		hasNoteToSelf() {
-			return this.conversationsList.filter(conversation => conversation.type === CONVERSATION.TYPE.NOTE_TO_SELF).length
+			return this.conversationsList.find(conversation => conversation.type === CONVERSATION.TYPE.NOTE_TO_SELF)
 		},
 
 		sourcesWithoutResults() {
@@ -632,7 +632,7 @@ export default {
 			}
 		},
 
-		addAndOpenConversation(conversation) {
+		switchToConversation(conversation) {
 			this.$store.dispatch('addConversation', conversation)
 			this.abortSearch()
 			this.$router.push({
@@ -644,13 +644,13 @@ export default {
 		async createConversation(name) {
 			const response = await createPrivateConversation(name)
 			const conversation = response.data.ocs.data
-			this.addAndOpenConversation(conversation)
+			this.switchToConversation(conversation)
 		},
 
 		async restoreNoteToSelfConversation() {
 			const response = await fetchNoteToSelfConversation()
 			const conversation = response.data.ocs.data
-			this.addAndOpenConversation(conversation)
+			this.switchToConversation(conversation)
 		},
 
 		hasOneToOneConversationWith(userId) {

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -90,6 +90,15 @@
 						{{ t('spreed','Create a new conversation') }}
 					</NcActionButton>
 
+					<NcActionButton v-if="!hasNoteToSelf"
+						close-after-click
+						@click="restoreNoteToSelfConversation">
+						<template #icon>
+							<Note :size="20" />
+						</template>
+						{{ t('spreed','New Personal Note') }}
+					</NcActionButton>
+
 					<NcActionButton close-after-click
 						@click="showModalListConversations">
 						<template #icon>
@@ -239,6 +248,7 @@ import FilterIcon from 'vue-material-design-icons/Filter.vue'
 import FilterRemoveIcon from 'vue-material-design-icons/FilterRemove.vue'
 import List from 'vue-material-design-icons/FormatListBulleted.vue'
 import MessageBadge from 'vue-material-design-icons/MessageBadge.vue'
+import Note from 'vue-material-design-icons/NoteEditOutline.vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
 
 import { showError } from '@nextcloud/dialogs'
@@ -267,6 +277,7 @@ import { CONVERSATION } from '../../constants.js'
 import BrowserStorage from '../../services/BrowserStorage.js'
 import {
 	createPrivateConversation,
+	fetchNoteToSelfConversation,
 	searchPossibleConversations,
 	searchListedConversations,
 } from '../../services/conversationsService.js'
@@ -303,6 +314,7 @@ export default {
 		ChatPlus,
 		List,
 		DotsVertical,
+		Note,
 	},
 
 	mixins: [
@@ -394,6 +406,10 @@ export default {
 
 		isSearching() {
 			return this.searchText !== ''
+		},
+
+		hasNoteToSelf() {
+			return this.conversationsList.filter(conversation => conversation.type === CONVERSATION.TYPE.NOTE_TO_SELF).length
 		},
 
 		sourcesWithoutResults() {
@@ -616,15 +632,25 @@ export default {
 			}
 		},
 
-		async createConversation(name) {
-			const response = await createPrivateConversation(name)
-			const conversation = response.data.ocs.data
+		addAndOpenConversation(conversation) {
 			this.$store.dispatch('addConversation', conversation)
 			this.abortSearch()
 			this.$router.push({
 				name: 'conversation',
 				params: { token: conversation.token },
 			}).catch(err => console.debug(`Error while pushing the new conversation's route: ${err}`))
+		},
+
+		async createConversation(name) {
+			const response = await createPrivateConversation(name)
+			const conversation = response.data.ocs.data
+			this.addAndOpenConversation(conversation)
+		},
+
+		async restoreNoteToSelfConversation() {
+			const response = await fetchNoteToSelfConversation()
+			const conversation = response.data.ocs.data
+			this.addAndOpenConversation(conversation)
 		},
 
 		hasOneToOneConversationWith(userId) {

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -117,7 +117,7 @@
 						<template #icon>
 							<Note :size="16" />
 						</template>
-						{{ t('spreed', 'Add to Note') }}
+						{{ t('spreed', 'Note to self') }}
 					</NcActionButton>
 					<NcActionButton v-if="canForwardMessage"
 						close-after-click
@@ -287,6 +287,7 @@ import NcEmojiPicker from '@nextcloud/vue/dist/Components/NcEmojiPicker.js'
 import Forwarder from './Forwarder.vue'
 
 import { PARTICIPANT, CONVERSATION, ATTENDEE } from '../../../../../constants.js'
+import { fetchNoteToSelfConversation } from '../../../../../services/conversationsService.js'
 import { getMessageReminder, removeMessageReminder, setMessageReminder } from '../../../../../services/remindersService.js'
 import { copyConversationLinkToClipboard } from '../../../../../services/urlService.js'
 
@@ -718,7 +719,12 @@ export default {
 		},
 
 		async forwardToNote() {
-			const NoteToSelf = this.$store.getters.conversationsList.filter(conversation => conversation.type === CONVERSATION.TYPE.NOTE_TO_SELF)[0]
+			let NoteToSelf = this.$store.getters.conversationsList.filter(conversation => conversation.type === CONVERSATION.TYPE.NOTE_TO_SELF)?.[0]
+			if (!NoteToSelf) {
+				const response = await fetchNoteToSelfConversation()
+				NoteToSelf = response.data.ocs.data
+				this.$store.dispatch('addConversation', NoteToSelf)
+			}
 			const messageToBeForwarded = cloneDeep(this.messageObject)
 			// Overwrite the Note-To-Self conversation token
 			messageToBeForwarded.token = NoteToSelf.token
@@ -739,10 +745,10 @@ export default {
 							referenceId: '',
 						},
 					})
-					showSuccess(t('spreed', 'Message added to Note to self'))
+					showSuccess(t('spreed', 'Message forwarded to "Note to self"'))
 				} catch (error) {
-					console.error('Error while adding message to Note', error)
-					showError(t('spreed', 'Error while adding message to Note'))
+					console.error('Error while forwarding message to "Note to self"', error)
+					showError(t('spreed', 'Error while forwarding message to "Note to self"'))
 				}
 				return
 			}
@@ -757,10 +763,10 @@ export default {
 
 			try {
 				await this.$store.dispatch('forwardMessage', { messageToBeForwarded })
-				showSuccess(t('spreed', 'Message added to Note to self'))
+				showSuccess(t('spreed', 'Message forwarded to "Note to self"'))
 			} catch (error) {
-				console.error('Error while adding message to Note', error)
-				showError(t('spreed', 'Error while adding message to Note'))
+				console.error('Error while forwarding message to "Note to self"', error)
+				showError(t('spreed', 'Error while forwarding message to "Note to self"'))
 			}
 
 		},

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -41,7 +41,7 @@
 			</template>
 			<ChatView :is-visible="opened" />
 		</NcAppSidebarTab>
-		<NcAppSidebarTab v-if="(getUserId || isModeratorOrUser) && !isOneToOne"
+		<NcAppSidebarTab v-if="showParticipantsTab"
 			id="participants"
 			ref="participantsTab"
 			:order="2"
@@ -266,6 +266,14 @@ export default {
 				&& (this.breakoutRoomsConfigured || this.conversation.breakoutRoomMode === CONVERSATION.BREAKOUT_ROOM_MODE.FREE || this.conversation.objectType === 'room')
 		},
 
+		showParticipantsTab() {
+			return (this.getUserId || this.isModeratorOrUser) && !this.isOneToOne && !this.isNoteToSelf
+		},
+
+		isNoteToSelf() {
+			return this.conversation.type === CONVERSATION.TYPE.NOTE_TO_SELF
+		},
+
 		breakoutRoomsText() {
 			return t('spreed', 'Breakout rooms')
 		},
@@ -292,6 +300,15 @@ export default {
 			} else {
 				this.activeTab = 'participants'
 			}
+		},
+
+		isNoteToSelf: {
+			immediate: true,
+			handler(value) {
+				if (value) {
+					this.activeTab = 'shared-items'
+				}
+			},
 		},
 
 		isOneToOne: {

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -285,7 +285,7 @@ export default {
 				this.conversationName = this.conversation.displayName
 			}
 
-			if (newConversation.token === oldConversation.token || this.isOneToOne) {
+			if (newConversation.token === oldConversation.token || !this.showParticipantsTab) {
 				return
 			}
 
@@ -302,19 +302,10 @@ export default {
 			}
 		},
 
-		isNoteToSelf: {
+		showParticipantsTab: {
 			immediate: true,
 			handler(value) {
-				if (value) {
-					this.activeTab = 'shared-items'
-				}
-			},
-		},
-
-		isOneToOne: {
-			immediate: true,
-			handler(value) {
-				if (value) {
+				if (!value) {
 					this.activeTab = 'shared-items'
 				}
 			},

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -254,6 +254,7 @@ export default {
 
 		showStartCallButton() {
 			return this.callEnabled
+				&& this.conversation.type !== CONVERSATION.TYPE.NOTE_TO_SELF
 				&& this.conversation.readOnly === CONVERSATION.STATE.READ_WRITE
 				&& !this.isInCall
 		},

--- a/src/constants.js
+++ b/src/constants.js
@@ -72,6 +72,7 @@ export const CONVERSATION = {
 		PUBLIC: 3,
 		CHANGELOG: 4,
 		ONE_TO_ONE_FORMER: 5,
+		NOTE_TO_SELF: 6,
 	},
 
 	BREAKOUT_ROOM_MODE: {

--- a/src/services/conversationsService.js
+++ b/src/services/conversationsService.js
@@ -62,6 +62,14 @@ const searchListedConversations = async function({ searchText }, options) {
 }
 
 /**
+ * Generate note-to-self conversation
+ *
+ */
+const fetchNoteToSelfConversation = async function() {
+	return axios.get(generateOcsUrl('apps/spreed/api/v4/room/note-to-self'))
+}
+
+/**
  * Fetch possible conversations
  *
  * @param {object} data the wrapping object;
@@ -438,6 +446,7 @@ const deleteConversationAvatar = async function(token) {
 export {
 	fetchConversations,
 	fetchConversation,
+	fetchNoteToSelfConversation,
 	searchListedConversations,
 	searchPossibleConversations,
 	createOneToOneConversation,

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -1264,7 +1264,7 @@ const actions = {
 	 * @param {object} context default store context;
 	 * will be forwarded;
 	 * @param {object} data the wrapping object;
-	 * @param {object} data.targetToken the conversation token to where the message will be forwarded;
+	 * @param {string} [data.targetToken] the conversation token to where the message will be forwarded;
 	 * @param {object} data.messageToBeForwarded the message object;
 	 */
 	async forwardMessage(context, { targetToken, messageToBeForwarded }) {
@@ -1306,11 +1306,11 @@ const actions = {
 		for (const key in message.messageParameters) {
 			if (key.startsWith('mention')) {
 				const mention = message.messageParameters[key]
-				message.message = message.message.replace(`{${key}}`, `@'${mention.name}'`)
+				message.message = message.message.replace(`{${key}}`, `@${mention.name}`)
 			}
 		}
 
-		const response = await postNewMessage(message, { silent: true })
+		const response = await postNewMessage(message, { silent: false })
 		return response
 
 	},

--- a/src/store/messagesStore.spec.js
+++ b/src/store/messagesStore.spec.js
@@ -1800,7 +1800,6 @@ describe('messagesStore', () => {
 			localVue.use(Vuex)
 
 			testStoreConfig = cloneDeep(storeConfig)
-			// eslint-disable-next-line import/no-named-as-default-member
 			store = new Vuex.Store(testStoreConfig)
 
 			message1 = {
@@ -1813,17 +1812,17 @@ describe('messagesStore', () => {
 				{
 					token: TOKEN,
 					type: 3,
-					dispalyName: 'conversation 1',
+					displayName: 'conversation 1',
 				},
 				{
 					token: 'token-self',
 					type: 6,
-					dispalyName: 'Note to self',
+					displayName: 'Note to self',
 				},
 				{
 					token: 'token-2',
 					type: 3,
-					dispalyName: 'conversation 2',
+					displayName: 'conversation 2',
 				},
 			]
 		})
@@ -1839,7 +1838,7 @@ describe('messagesStore', () => {
 			store.dispatch('forwardMessage', { targetToken, messageToBeForwarded })
 
 			// Assert
-			expect(postNewMessage).toHaveBeenCalledWith(messageExpected, { silent: true })
+			expect(postNewMessage).toHaveBeenCalledWith(messageExpected, { silent: false })
 		})
 		test('forwards a message to Note to self when no token is given ', () => {
 			// Arrange
@@ -1854,7 +1853,7 @@ describe('messagesStore', () => {
 			store.dispatch('forwardMessage', { messageToBeForwarded })
 
 			// Assert
-			expect(postNewMessage).toHaveBeenCalledWith(messageExpected, { silent: true })
+			expect(postNewMessage).toHaveBeenCalledWith(messageExpected, { silent: false })
 		})
 
 		test('generates Note to self when it does not exist ', async () => {
@@ -1878,7 +1877,7 @@ describe('messagesStore', () => {
 
 			// Assert
 			expect(store.getters.conversationsList).toContain(conversations[1])
-			expect(postNewMessage).toHaveBeenCalledWith(messageExpected, { silent: true })
+			expect(postNewMessage).toHaveBeenCalledWith(messageExpected, { silent: false })
 		})
 		test('removes parent message ', () => {
 			// Arrange : prepare the expected message to be forwarded
@@ -1898,7 +1897,7 @@ describe('messagesStore', () => {
 			store.dispatch('forwardMessage', { targetToken, messageToBeForwarded })
 
 			// Assert
-			expect(postNewMessage).toHaveBeenCalledWith(messageExpected, { silent: true })
+			expect(postNewMessage).toHaveBeenCalledWith(messageExpected, { silent: false })
 		})
 		test('forwards an object message', () => {
 			// Arrange
@@ -1932,6 +1931,7 @@ describe('messagesStore', () => {
 
 		})
 		test('forwards a message with mentions and remove the latter', () => {
+			// Arrange
 			messageToBeForwarded = {
 				id: 1,
 				token: TOKEN,
@@ -1950,19 +1950,15 @@ describe('messagesStore', () => {
 				},
 			}
 			targetToken = 'token-2'
-			const mentions = [
-				messageToBeForwarded.messageParameters['mention-user1'],
-				messageToBeForwarded.messageParameters['mention-user2'],
-			]
 			messageExpected = cloneDeep(messageToBeForwarded)
-			messageExpected.message = `Hello @'${mentions[0].name}', @'${mentions[1].name}'`
+			messageExpected.message = 'Hello @Taylor, @Adam'
 			messageExpected.token = targetToken
 
 			// Act
 			store.dispatch('forwardMessage', { targetToken, messageToBeForwarded })
 
 			// Assert
-			expect(postNewMessage).toHaveBeenCalledWith(messageExpected, { silent: true })
+			expect(postNewMessage).toHaveBeenCalledWith(messageExpected, { silent: false })
 		})
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

* Feature #10405

### 🖼️ Screenshots

Forward a message to Note to self
https://github.com/nextcloud/spreed/assets/84044328/6335d4b9-7221-4842-8f86-0770ae325646

Restore
https://github.com/nextcloud/spreed/assets/84044328/1e3f593f-5be0-4604-9a6a-df601f829c1f


### 🚧 Tasks

- [x] Remove the non-applicable settings
- [x] Add the option to restore the note to self conversation if it was removed
- [x] Add the option to forward a message to note to self 
- [x] Add forward message action to the store and some follow-up refactoring where it is used
- [x] Write the relevant tests for the new action


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
