### PR TITLE
fix(CI): Make sure the "when unrelated" fake summaries work correctly

### DIFF
--- a/.github/workflows/integration-summary-when-unrelated.yml
+++ b/.github/workflows/integration-summary-when-unrelated.yml
@@ -19,16 +19,79 @@ on:
       - 'composer.json'
       - 'composer.lock'
 
+env:
+  PATHS_IGNORE: '.github/workflows/**;appinfo/**;lib/**;templates/**;tests/integration/**;vendor/**;vendor-bin/**;.php-cs-fixer.dist.php;composer.json;composer.lock'
+
 permissions:
   contents: read
 
 jobs:
+  action-no-summary:
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest
+
+    name: action-not-src
+    outputs:
+      found_file: ${{ steps.confirm-negative-list.outputs.result }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+
+      - name: Get changed files from diff
+        id: changed-files
+        run: |
+          if ${{ github.event_name == 'pull_request' }}; then
+              echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
+          else
+              echo "changed_files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up node 20
+        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3
+        with:
+          node-version: 20
+
+      - name: Install minimatch
+        run: npm i minimatch
+
+      - name: Check if a file is in paths-ignored
+        id: confirm-negative-list
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script: |
+            const { minimatch } = require('minimatch')
+            const changedPaths = "${{ steps.changed-files.outputs.changed_files }}".split(' ')
+
+            let matched = ''
+            process.env.PATHS_IGNORE.split(';').every(pattern => {
+              changedPaths.every(path => {
+                console.info('Testing ' + path + ' for pattern ' + pattern)
+                if (minimatch(path, pattern)) {
+                  console.info(path + ' matched, aborting "unrelated summary"')
+                  matched = '1'
+                  return false
+                }
+                return true
+              })
+              return !matched
+            })
+            return matched
+
   summary-mysql:
     permissions:
       contents: none
     runs-on: ubuntu-latest
 
+    needs: action-no-summary
+
     name: integration-mysql-summary
+
+    if: needs.action-no-summary.outputs.found_file == ''
 
     steps:
       - name: Summary status
@@ -39,7 +102,11 @@ jobs:
       contents: none
     runs-on: ubuntu-latest
 
+    needs: action-no-summary
+
     name: integration-oci-summary
+
+    if: needs.action-no-summary.outputs.found_file == ''
 
     steps:
       - name: Summary status
@@ -50,7 +117,11 @@ jobs:
       contents: none
     runs-on: ubuntu-latest
 
+    needs: action-no-summary
+
     name: integration-pgsql-summary
+
+    if: needs.action-no-summary.outputs.found_file == ''
 
     steps:
       - name: Summary status
@@ -61,7 +132,11 @@ jobs:
       contents: none
     runs-on: ubuntu-latest
 
+    needs: action-no-summary
+
     name: integration-sqlite-summary
+
+    if: needs.action-no-summary.outputs.found_file == ''
 
     steps:
       - name: Summary status

--- a/.github/workflows/lint-eslint-when-unrelated.yml
+++ b/.github/workflows/lint-eslint-when-unrelated.yml
@@ -23,17 +23,80 @@ on:
       - '**.ts'
       - '**.vue'
 
+env:
+  PATHS_IGNORE: '.github/workflows/**;src/**;appinfo/info.xml;package.json;package-lock.json;tsconfig.json;.eslintrc.*;.eslintignore;**.js;**.ts;**.vue'
+
 permissions:
   contents: read
 
 jobs:
+  action-no-eslint:
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest
+
+    name: action-not-src
+    outputs:
+      found_file: ${{ steps.confirm-negative-list.outputs.result }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+
+      - name: Get changed files from diff
+        id: changed-files
+        run: |
+          if ${{ github.event_name == 'pull_request' }}; then
+              echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
+          else
+              echo "changed_files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up node 20
+        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3
+        with:
+          node-version: 20
+
+      - name: Install minimatch
+        run: npm i minimatch
+
+      - name: Check if a file is in paths-ignored
+        id: confirm-negative-list
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script: |
+            const { minimatch } = require('minimatch')
+            const changedPaths = "${{ steps.changed-files.outputs.changed_files }}".split(' ')
+
+            let matched = ''
+            process.env.PATHS_IGNORE.split(';').every(pattern => {
+              changedPaths.every(path => {
+                console.info('Testing ' + path + ' for pattern ' + pattern)
+                if (minimatch(path, pattern)) {
+                  console.info(path + ' matched, aborting "unrelated summary"')
+                  matched = '1'
+                  return false
+                }
+                return true
+              })
+              return !matched
+            })
+            return matched
+
   lint:
     permissions:
       contents: none
 
     runs-on: ubuntu-latest
 
+    needs: action-no-eslint
+
     name: eslint
+
+    if: needs.action-no-eslint.outputs.found_file == ''
 
     steps:
       - run: 'echo "No eslint required"'

--- a/.github/workflows/node-when-unrelated.yml
+++ b/.github/workflows/node-when-unrelated.yml
@@ -26,18 +26,82 @@ on:
       - master
       - stable*
 
+env:
+  PATHS_IGNORE: '.github/workflows/**;src/**;appinfo/info.xml;package.json;package-lock.json;tsconfig.json;**.js;**.ts;**.vue'
+
 concurrency:
   group: node-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
+  action-no-build:
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest
+
+    name: action-not-src
+    outputs:
+      found_file: ${{ steps.confirm-negative-list.outputs.result }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+
+      - name: Get changed files from diff
+        id: changed-files
+        run: |
+          if ${{ github.event_name == 'pull_request' }}; then
+              echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
+          else
+              echo "changed_files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up node 20
+        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3
+        with:
+          node-version: 20
+
+      - name: Install minimatch
+        run: npm i minimatch
+
+      - name: Check if a file is in paths-ignored
+        id: confirm-negative-list
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script: |
+            const { minimatch } = require('minimatch')
+            const changedPaths = "${{ steps.changed-files.outputs.changed_files }}".split(' ')
+
+            let matched = ''
+            process.env.PATHS_IGNORE.split(';').every(pattern => {
+              changedPaths.every(path => {
+                console.info('Testing ' + path + ' for pattern ' + pattern)
+                if (minimatch(path, pattern)) {
+                  console.info(path + ' matched, aborting "unrelated summary"')
+                  matched = '1'
+                  return false
+                }
+                return true
+              })
+              return !matched
+            })
+            return matched
+
   build:
     permissions:
       contents: none
 
     runs-on: ubuntu-latest
 
+    needs: action-no-build
+
     name: node
+
+    if: needs.action-no-build.outputs.found_file == ''
+
     steps:
       - name: Skip
         run: 'echo "No JS/TS files changed, skipped Node"'

--- a/.github/workflows/phpunit-summary-when-unrelated.yml
+++ b/.github/workflows/phpunit-summary-when-unrelated.yml
@@ -19,16 +19,79 @@ on:
       - 'composer.json'
       - 'composer.lock'
 
+env:
+  PATHS_IGNORE: '.github/workflows/**;appinfo/**;lib/**;templates/**;tests/**;vendor/**;vendor-bin/**;.php-cs-fixer.dist.php;composer.json;composer.lock'
+
 permissions:
   contents: read
 
 jobs:
+  action-no-summary:
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest
+
+    name: action-not-src
+    outputs:
+      found_file: ${{ steps.confirm-negative-list.outputs.result }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+
+      - name: Get changed files from diff
+        id: changed-files
+        run: |
+          if ${{ github.event_name == 'pull_request' }}; then
+              echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
+          else
+              echo "changed_files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up node 20
+        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3
+        with:
+          node-version: 20
+
+      - name: Install minimatch
+        run: npm i minimatch
+
+      - name: Check if a file is in paths-ignored
+        id: confirm-negative-list
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script: |
+            const { minimatch } = require('minimatch')
+            const changedPaths = "${{ steps.changed-files.outputs.changed_files }}".split(' ')
+
+            let matched = ''
+            process.env.PATHS_IGNORE.split(';').every(pattern => {
+              changedPaths.every(path => {
+                console.info('Testing ' + path + ' for pattern ' + pattern)
+                if (minimatch(path, pattern)) {
+                  console.info(path + ' matched, aborting "unrelated summary"')
+                  matched = '1'
+                  return false
+                }
+                return true
+              })
+              return !matched
+            })
+            return matched
+
   summary-mysql:
     permissions:
       contents: none
     runs-on: ubuntu-latest
 
+    needs: action-no-summary
+
     name: phpunit-mysql-summary
+
+    if: needs.action-no-summary.outputs.found_file == ''
 
     steps:
       - name: Summary status
@@ -39,7 +102,11 @@ jobs:
       contents: none
     runs-on: ubuntu-latest
 
+    needs: action-no-summary
+
     name: phpunit-oci-summary
+
+    if: needs.action-no-summary.outputs.found_file == ''
 
     steps:
       - name: Summary status
@@ -50,7 +117,11 @@ jobs:
       contents: none
     runs-on: ubuntu-latest
 
+    needs: action-no-summary
+
     name: phpunit-pgsql-summary
+
+    if: needs.action-no-summary.outputs.found_file == ''
 
     steps:
       - name: Summary status
@@ -61,7 +132,11 @@ jobs:
       contents: none
     runs-on: ubuntu-latest
 
+    needs: action-no-summary
+
     name: phpunit-sqlite-summary
+
+    if: needs.action-no-summary.outputs.found_file == ''
 
     steps:
       - name: Summary status


### PR DESCRIPTION
Before they executed when any file outside the defined scope matched. However that means: When a PR touches PHP and JS, both the real and the fake summaries for node, eslint and phpunit got triggered. Since the fake summary is always green it meant one could merge a PR that in the end had red CI on the non-fake summary.

Now the fake summaries are skipped, if any of the files still matches the pattern, instead of being executed whenever a single file did not match it.

Fix #10600

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
