### PR TITLE
fix(email): Fix sending re-invites to all emails

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1441,6 +1441,7 @@ class RoomController extends AEnvironmentAwareController {
 	#[NoAdminRequired]
 	#[RequireModeratorParticipant]
 	public function resendInvitations(?int $attendeeId): DataResponse {
+		/** @var Participant[] $participants */
 		$participants = [];
 
 		// targeting specific participant
@@ -1451,7 +1452,7 @@ class RoomController extends AEnvironmentAwareController {
 				return new DataResponse([], Http::STATUS_NOT_FOUND);
 			}
 		} else {
-			$participants = $this->participantService->getActorsByType($this->room, Attendee::ACTOR_EMAILS);
+			$participants = $this->participantService->getParticipantsByActorType($this->room, Attendee::ACTOR_EMAILS);
 		}
 
 		foreach ($participants as $participant) {

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -811,6 +811,9 @@ class ParticipantService {
 		}
 	}
 
+	/**
+	 * @return Attendee[]
+	 */
 	public function getActorsByType(Room $room, string $actorType): array {
 		return $this->attendeeMapper->getActorsByType($room->getId(), $actorType);
 	}
@@ -1383,6 +1386,14 @@ class ParticipantService {
 		}
 
 		return array_values($uniqueAttendees);
+	}
+
+	/**
+	 * @return Participant[]
+	 */
+	public function getParticipantsByActorType(Room $room, string $actorType): array {
+		$attendees = $this->getActorsByType($room, $actorType);
+		return array_map(static fn (Attendee $attendee) => new Participant($room, $attendee, null), $attendees);
 	}
 
 	/**

--- a/tests/integration/features/conversation/invite-email.feature
+++ b/tests/integration/features/conversation/invite-email.feature
@@ -1,0 +1,21 @@
+Feature: conversation/invite-email)
+  Background:
+    Given user "participant1" exists
+
+  Scenario: Resend email invites
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    When user "participant1" adds email "test@example.tld" to room "room" with 200 (v4)
+    Then user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | participantType | inCall   | actorType | actorId           |
+      | 4               | 0        | emails    | test@example.tld  |
+      | 1               | 0        | users     | participant1      |
+    # Reinvite all emails
+    When user "participant1" resends invite for room "room" with 200 (v4)
+    # Reinvite only one
+    When user "participant1" resends invite for room "room" with 200 (v4)
+      | attendeeId | test@example.tld |
+    # Reinvite failure
+    When user "participant1" resends invite for room "room" with 404 (v4)
+      | attendeeId | not-found@example.tld |


### PR DESCRIPTION
Psalm reported
```
ERROR: UndefinedMagicMethod - lib/Controller/RoomController.php:1459:22
    Magic method OCA\Talk\Model\Attendee::getattendee does not exist (see https://psalm.dev/219)
```


### ☑️ Resolves

* Little oopsy found when adding the return type for `getActorsByType` in https://github.com/nextcloud/spreed/pull/10608
* So I extracted it to a new PR and added integration tests for the endpoint.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not required
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
- [x] 🔖 Capability is added or not needed 
