### PR TITLE
feat(recording) - add frontend support for recording consent

### DIFF
--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -46,7 +46,7 @@
 				<PreventUnload :when="warnLeaving" />
 				<CallButton class="call-button" />
 				<ChatView />
-				<MediaSettings :initialize-on-mounted="false" />
+				<MediaSettings :initialize-on-mounted="false" :recording-consent-given.sync="recordingConsentGiven" />
 			</template>
 		</aside>
 	</TransitionWrapper>
@@ -125,6 +125,7 @@ export default {
 		return {
 			fetchCurrentConversationIntervalId: null,
 			joiningConversation: false,
+			recordingConsentGiven: false,
 		}
 	},
 

--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -39,11 +39,14 @@
 				id="notifications"
 				:name="t('spreed', 'Personal')">
 				<NcCheckboxRadioSwitch type="switch"
+					:disabled="recordingConsentRequired"
 					:checked="showMediaSettings"
 					@update:checked="setShowMediaSettings">
 					{{ t('spreed', 'Always show the device preview screen before joining a call in this conversation.') }}
 				</NcCheckboxRadioSwitch>
-
+				<p v-if="recordingConsentRequired">
+					{{ t('spreed', 'The consent to be recorded will be required for each participant before joining every call.') }}
+				</p>
 				<NotificationsSettings :conversation="conversation" />
 			</NcAppSettingsSection>
 
@@ -248,6 +251,10 @@ export default {
 
 		recordingConsentAvailable() {
 			return recordingEnabled && recordingConsentCapability && recordingConsent
+		},
+
+		recordingConsentRequired() {
+			return this.conversation.recordingConsent === CALL.RECORDING_CONSENT.REQUIRED
 		}
 	},
 

--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -50,6 +50,7 @@
 				:name="canFullModerate ? t('spreed', 'Moderation') : t('spreed', 'Setup overview')">
 				<ListableSettings v-if="!isNoteToSelf && !isGuest" :token="token" :can-full-moderate="canFullModerate" />
 				<LinkShareSettings v-if="!isNoteToSelf" :token="token" :can-full-moderate="canFullModerate" />
+				<RecordingConsentSettings v-if="!isNoteToSelf && recordingConsentAvailable" :token="token" :can-full-moderate="canFullModerate" />
 				<ExpirationSettings :token="token" :can-full-moderate="canFullModerate" />
 			</NcAppSettingsSection>
 
@@ -123,10 +124,15 @@ import LobbySettings from './LobbySettings.vue'
 import LockingSettings from './LockingSettings.vue'
 import MatterbridgeSettings from './Matterbridge/MatterbridgeSettings.vue'
 import NotificationsSettings from './NotificationsSettings.vue'
+import RecordingConsentSettings from './RecordingConsentSettings.vue'
 import SipSettings from './SipSettings.vue'
 
-import { PARTICIPANT, CONVERSATION } from '../../constants.js'
+import { CALL, PARTICIPANT, CONVERSATION } from '../../constants.js'
 import BrowserStorage from '../../services/BrowserStorage.js'
+
+const recordingEnabled = getCapabilities()?.spreed?.config?.call?.recording || false
+const recordingConsentCapability = getCapabilities()?.spreed?.features?.includes('recording-consent')
+const recordingConsent = getCapabilities()?.spreed?.config?.call?.['recording-consent'] !== CALL.RECORDING_CONSENT.OFF
 
 export default {
 	name: 'ConversationSettingsDialog',
@@ -147,6 +153,7 @@ export default {
 		NcAppSettingsSection,
 		NcCheckboxRadioSwitch,
 		NotificationsSettings,
+		RecordingConsentSettings,
 		SipSettings,
 	},
 
@@ -229,6 +236,10 @@ export default {
 				&& breakoutRoomsEnabled
 				&& this.conversation.type === CONVERSATION.TYPE.GROUP
 		},
+
+		recordingConsentAvailable() {
+			return recordingEnabled && recordingConsentCapability && recordingConsent
+		}
 	},
 
 	watch: {

--- a/src/components/ConversationSettings/RecordingConsentSettings.vue
+++ b/src/components/ConversationSettings/RecordingConsentSettings.vue
@@ -1,0 +1,123 @@
+<!--
+  - @copyright Copyright (c) 2023 Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @author Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+	<div class="app-settings-subsection">
+		<h4 class="app-settings-section__subtitle">
+			{{ t('spreed', 'Recording Consent') }}
+		</h4>
+		<NcCheckboxRadioSwitch v-if="canFullModerate && !isGlobalConsent"
+			type="switch"
+			:checked.sync="recordingConsentSelected"
+			:disabled="disabled"
+			@update:checked="setRecordingConsent">
+			{{ t('spreed', 'Require recording consent before joining call in this conversation') }}
+		</NcCheckboxRadioSwitch>
+		<p v-else-if="isGlobalConsent">
+			{{ t('spreed', 'Recording consent is required for all calls') }}
+		</p>
+		<p v-else>
+			{{ summaryLabel }}
+		</p>
+	</div>
+</template>
+
+<script>
+import { showError, showSuccess } from '@nextcloud/dialogs'
+
+import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
+
+import { CALL } from '../../constants.js'
+import { getCapabilities } from '@nextcloud/capabilities'
+
+const recordingConsent = getCapabilities()?.spreed?.config?.call?.['recording-consent']
+
+export default {
+	name: 'RecordingConsentSettings',
+
+	components: {
+		NcCheckboxRadioSwitch,
+	},
+
+	props: {
+		token: {
+			type: String,
+			default: null,
+		},
+
+		canFullModerate: {
+			type: Boolean,
+			default: true,
+		},
+	},
+
+	data() {
+		return {
+			loading: false,
+			recordingConsentSelected: !!CALL.RECORDING_CONSENT.OFF,
+		}
+	},
+
+	computed: {
+		conversation() {
+			return this.$store.getters.conversation(this.token) || this.$store.getters.dummyConversation
+		},
+
+		isGlobalConsent() {
+			return recordingConsent === CALL.RECORDING_CONSENT.REQUIRED
+		},
+
+		disabled() {
+			return this.loading || this.conversation.hasCall
+		},
+
+		summaryLabel() {
+			return this.conversation.recordingConsent === CALL.RECORDING_CONSENT.REQUIRED
+				? t('spreed', 'Recording consent is required for calls in this conversation')
+				: t('spreed', 'Recording consent is not required for calls in this conversation')
+		},
+	},
+
+	mounted() {
+		this.recordingConsentSelected = !!this.conversation.recordingConsent
+	},
+
+	methods: {
+		async setRecordingConsent(value) {
+			this.loading = true
+			try {
+				await this.$store.dispatch('setRecordingConsent', {
+					token: this.token,
+					state: value ? CALL.RECORDING_CONSENT.REQUIRED : CALL.RECORDING_CONSENT.OFF,
+				})
+				showSuccess(t('spreed', 'Recording consent requirement was updated'))
+			} catch (error) {
+				showError(t('spreed', 'Error occurred while updating recording consent'))
+				console.error(error)
+			}
+			this.loading = false
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/src/components/MediaDevicesSelector.vue
+++ b/src/components/MediaDevicesSelector.vue
@@ -200,7 +200,7 @@ export default {
 <style lang="scss" scoped>
 .media-devices-selector {
 	display: flex;
-	margin: 16px 8px 16px 4px;
+	margin: 16px 0;
 	&__icon {
 		display: flex;
 		justify-content: flex-start;

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -571,12 +571,7 @@ export default {
 
 <style lang="scss" scoped>
 .media-settings {
-	padding: calc(var(--default-grid-baseline) * 4);
-	background-color: var(--color-main-background);
-	overflow-y: auto;
-	overflow-x: hidden;
-	margin: auto;
-	width: 100%;
+	padding: calc(var(--default-grid-baseline) * 5);
 
 	&__title {
 		text-align: center;
@@ -591,8 +586,8 @@ export default {
 		overflow: hidden;
 		border-radius: calc(var(--default-grid-baseline) * 3);
 		background-color: var(--color-loading-dark);
-		height: 300px;
-		width: 400px;
+		width: 100%;
+		aspect-ratio: 4/3;
 	}
 
 	&__toggles-wrapper {

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -120,7 +120,9 @@
 				@update-background="handleUpdateVirtualBackground" />
 
 			<!-- "Always show" setting -->
-			<NcCheckboxRadioSwitch :checked.sync="showMediaSettings" class="checkbox">
+			<NcCheckboxRadioSwitch class="checkbox"
+				:checked="showMediaSettings"
+				@update:checked="setShowMediaSettings">
 				{{ t('spreed', 'Always show preview for this conversation') }}
 			</NcCheckboxRadioSwitch>
 
@@ -228,6 +230,7 @@ import { devices } from '../../mixins/devices.js'
 import isInLobby from '../../mixins/isInLobby.js'
 import BrowserStorage from '../../services/BrowserStorage.js'
 import { useGuestNameStore } from '../../stores/guestName.js'
+import { useSettingsStore } from '../../stores/settings.js'
 import { localMediaModel } from '../../utils/webrtc/index.js'
 
 const recordingEnabled = getCapabilities()?.spreed?.config?.call?.recording || false
@@ -275,7 +278,8 @@ export default {
 	setup() {
 		const isInCall = useIsInCall()
 		const guestNameStore = useGuestNameStore()
-		return { AVATAR, isInCall, guestNameStore }
+		const settingsStore = useSettingsStore()
+		return { AVATAR, isInCall, guestNameStore, settingsStore }
 	},
 
 	data() {
@@ -285,7 +289,6 @@ export default {
 			tabContent: 'none',
 			audioOn: undefined,
 			videoOn: undefined,
-			showMediaSettings: true,
 			silentCall: false,
 			updatedBackground: undefined,
 			deviceIdChanged: false,
@@ -321,6 +324,10 @@ export default {
 
 		token() {
 			return this.$store.getters.getToken()
+		},
+
+		showMediaSettings() {
+			return this.settingsStore.getShowMediaSettings(this.token)
 		},
 
 		showVideo() {
@@ -392,6 +399,7 @@ export default {
 		isVirtualBackgroundAvailable() {
 			return this.virtualBackground.isAvailable()
 		},
+
 		showUpdateChangesButton() {
 			return this.updatedBackground || this.deviceIdChanged || this.audioDeviceStateChanged
 				|| this.videoDeviceStateChanged
@@ -416,14 +424,6 @@ export default {
 				this.initializeDevicesMixin()
 			} else {
 				this.stopDevicesMixin()
-			}
-		},
-
-		showMediaSettings(newValue) {
-			if (newValue) {
-				BrowserStorage.setItem('showMediaSettings' + this.token, 'true')
-			} else {
-				BrowserStorage.setItem('showMediaSettings' + this.token, 'false')
 			}
 		},
 
@@ -604,6 +604,10 @@ export default {
 			} else {
 				this.tabContent = 'none'
 			}
+		},
+
+		setShowMediaSettings(newValue) {
+			this.settingsStore.setShowMediaSettings(this.token, newValue)
 		},
 
 		setRecordingConsentGiven(value) {

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -121,7 +121,8 @@
 
 			<!-- "Always show" setting -->
 			<NcCheckboxRadioSwitch class="checkbox"
-				:checked="showMediaSettings"
+				:checked="showMediaSettings || showRecordingWarning"
+				:disabled="showRecordingWarning"
 				@update:checked="setShowMediaSettings">
 				{{ t('spreed', 'Always show preview for this conversation') }}
 			</NcCheckboxRadioSwitch>
@@ -135,7 +136,7 @@
 
 			<!-- Recording warning -->
 			<NcNoteCard v-if="showRecordingWarning" type="warning">
-				<p v-if="isStartingRecording || isRecording">
+				<p v-if="isCurrentlyRecording">
 					<strong>{{ t('spreed', 'The call is being recorded.') }}</strong>
 				</p>
 				<p v-else>
@@ -356,14 +357,9 @@ export default {
 			return this.conversation.hasCall || this.conversation.hasCallOverwrittenByChat
 		},
 
-		isStartingRecording() {
-			return this.conversation.callRecording === CALL.RECORDING.VIDEO_STARTING
-				|| this.conversation.callRecording === CALL.RECORDING.AUDIO_STARTING
-		},
-
-		isRecording() {
-			return this.conversation.callRecording === CALL.RECORDING.VIDEO
-				|| this.conversation.callRecording === CALL.RECORDING.AUDIO
+		isCurrentlyRecording() {
+			return [CALL.RECORDING.VIDEO_STARTING, CALL.RECORDING.AUDIO_STARTING,
+				CALL.RECORDING.VIDEO, CALL.RECORDING.AUDIO].includes(this.conversation.callRecording)
 		},
 
 		canFullModerate() {
@@ -381,7 +377,7 @@ export default {
 		},
 
 		showRecordingWarning() {
-			return !this.isInCall && (this.isStartingRecording || this.isRecording || this.isRecordingConsentRequired)
+			return !this.isInCall && (this.isCurrentlyRecording || this.isRecordingConsentRequired)
 		},
 
 		showSilentCallOption() {

--- a/src/components/MediaSettings/VideoBackgroundEditor.vue
+++ b/src/components/MediaSettings/VideoBackgroundEditor.vue
@@ -286,21 +286,21 @@ export default {
 
 <style scoped lang="scss">
 .background-editor {
-	display: flex;
-	flex-wrap: wrap;
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
 	gap: calc(var(--default-grid-baseline) * 2);
 	margin-top: calc(var(--default-grid-baseline) * 2);
 
 	&__element {
 		border: none;
-		margin: 0;
+		margin: 0 !important;
 		border-radius: calc(var(--border-radius-large)* 1.5);
-		background: #1cafff2e;
 		height: calc(var(--default-grid-baseline) * 16);
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
 		align-items: center;
+		background-color: #1cafff2e;
 		background-size: cover;
 		background-position: center;
 		flex: 1 0 108px;

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -188,14 +188,10 @@ export default {
 			return this.$store.getters.conversation(this.token) || this.$store.getters.dummyConversation
 		},
 
-		isStartingRecording() {
-			return this.conversation.callRecording === CALL.RECORDING.VIDEO_STARTING
-				|| this.conversation.callRecording === CALL.RECORDING.AUDIO_STARTING
-		},
-
-		isRecording() {
-			return this.conversation.callRecording === CALL.RECORDING.VIDEO
-				|| this.conversation.callRecording === CALL.RECORDING.AUDIO
+		showRecordingWarning() {
+			return [CALL.RECORDING.VIDEO_STARTING, CALL.RECORDING.AUDIO_STARTING,
+				CALL.RECORDING.VIDEO, CALL.RECORDING.AUDIO].includes(this.conversation.callRecording)
+			|| this.conversation.recordingConsent === CALL.RECORDING_CONSENT.REQUIRED
 		},
 
 		showMediaSettings() {
@@ -371,7 +367,7 @@ export default {
 				return
 			}
 
-			if (this.isStartingRecording || this.isRecording || this.showMediaSettings) {
+			if (this.showRecordingWarning || this.showMediaSettings) {
 				emit('talk:media-settings:show')
 			} else {
 				emit('talk:media-settings:hide')

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -127,6 +127,11 @@ export default {
 	],
 
 	props: {
+		disabled: {
+			type: Boolean,
+			default: false,
+		},
+
 		/**
 		 * Whether the component is used in MediaSettings or not
 		 * (when click will directly start a call)
@@ -148,7 +153,12 @@ export default {
 		isRecordingFromStart: {
 			type: Boolean,
 			default: false,
-		}
+		},
+
+		recordingConsentGiven: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	setup() {
@@ -203,8 +213,8 @@ export default {
 		},
 
 		startCallButtonDisabled() {
-			return (!this.conversation.canStartCall
-					&& !this.hasCall)
+			return this.disabled
+				|| (!this.conversation.canStartCall && !this.hasCall)
 				|| this.isInLobby
 				|| this.conversation.readOnly
 				|| this.isNextcloudTalkHashDirty
@@ -311,6 +321,7 @@ export default {
 				participantIdentifier: this.$store.getters.getParticipantIdentifier(),
 				flags,
 				silent: this.hasCall ? true : this.silentCall,
+				recordingConsent: this.recordingConsentGiven,
 			})
 			this.loading = false
 

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -100,8 +100,8 @@ import { CALL, CONVERSATION, PARTICIPANT } from '../../constants.js'
 import browserCheck from '../../mixins/browserCheck.js'
 import isInLobby from '../../mixins/isInLobby.js'
 import participant from '../../mixins/participant.js'
-import BrowserStorage from '../../services/BrowserStorage.js'
 import { EventBus } from '../../services/EventBus.js'
+import { useSettingsStore } from '../../stores/settings.js'
 
 export default {
 	name: 'CallButton',
@@ -163,7 +163,8 @@ export default {
 
 	setup() {
 		const isInCall = useIsInCall()
-		return { isInCall }
+		const settingsStore = useSettingsStore()
+		return { isInCall, settingsStore }
 	},
 
 	data() {
@@ -195,6 +196,10 @@ export default {
 		isRecording() {
 			return this.conversation.callRecording === CALL.RECORDING.VIDEO
 				|| this.conversation.callRecording === CALL.RECORDING.AUDIO
+		},
+
+		showMediaSettings() {
+			return this.settingsStore.getShowMediaSettings(this.token)
 		},
 
 		participantType() {
@@ -366,11 +371,7 @@ export default {
 				return
 			}
 
-			const showMediaSettings = BrowserStorage.getItem('showMediaSettings' + this.token)
-			const shouldShowMediaSettingsScreen = (showMediaSettings === null || showMediaSettings === 'true')
-			console.debug('showMediaSettings:', shouldShowMediaSettingsScreen)
-
-			if (this.isStartingRecording || this.isRecording || shouldShowMediaSettingsScreen) {
+			if (this.isStartingRecording || this.isRecording || this.showMediaSettings) {
 				emit('talk:media-settings:show')
 			} else {
 				emit('talk:media-settings:hide')

--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -71,7 +71,7 @@
 
 				<!-- Device settings -->
 				<NcActionButton close-after-click
-					@click="showMediaSettings">
+					@click="showMediaSettingsDialog">
 					<template #icon>
 						<VideoIcon :size="20" />
 					</template>
@@ -446,7 +446,7 @@ export default {
 			this.$store.dispatch('selectedVideoPeerId', null)
 		},
 
-		showMediaSettings() {
+		showMediaSettingsDialog() {
 			emit('talk:media-settings:show')
 		},
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -46,6 +46,11 @@ export const CALL = {
 		AUDIO_STARTING: 4,
 		FAILED: 5,
 	},
+	RECORDING_CONSENT: {
+		OFF: 0,
+		REQUIRED: 1,
+		OPTIONAL: 2,
+	},
 }
 
 export const CONVERSATION = {

--- a/src/services/callsService.js
+++ b/src/services/callsService.js
@@ -43,11 +43,12 @@ import {
  * @param {number} flags The available PARTICIPANT.CALL_FLAG for this participants
  * @param {boolean} silent Whether the call should trigger a notifications and
  * sound for other participants or not
+ * @param {boolean} recordingConsent Whether the participant gave his consent to be recorded
  * @return {number} The actual flags based on the available media
  */
-const joinCall = async function(token, flags, silent) {
+const joinCall = async function(token, flags, silent, recordingConsent) {
 	try {
-		return await signalingJoinCall(token, flags, silent)
+		return await signalingJoinCall(token, flags, silent, recordingConsent)
 	} catch (error) {
 		console.debug('Error while joining call: ', error)
 	}

--- a/src/services/conversationsService.js
+++ b/src/services/conversationsService.js
@@ -327,6 +327,18 @@ const setSIPEnabled = async function(token, newState) {
 }
 
 /**
+ * Change the recording consent per conversation
+ *
+ * @param {string} token The token of the conversation to be modified
+ * @param {number} newState The new recording consent state to set
+ */
+const setRecordingConsent = async function(token, newState) {
+	return axios.put(generateOcsUrl('apps/spreed/api/v4/room/{token}/recording-consent', { token }), {
+		recordingConsent: newState,
+	})
+}
+
+/**
  * Change the lobby state
  *
  * @param {string} token The token of the conversation to be modified
@@ -461,6 +473,7 @@ export {
 	makePublic,
 	makePrivate,
 	setSIPEnabled,
+	setRecordingConsent,
 	changeLobbyState,
 	changeReadOnlyState,
 	changeListable,

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -36,6 +36,7 @@ import {
 	makePublic,
 	makePrivate,
 	setSIPEnabled,
+	setRecordingConsent,
 	changeLobbyState,
 	changeReadOnlyState,
 	changeListable,
@@ -561,6 +562,18 @@ const actions = {
 		await setSIPEnabled(token, state)
 
 		const conversation = Object.assign({}, getters.conversations[token], { sipEnabled: state })
+
+		commit('addConversation', conversation)
+	},
+
+	async setRecordingConsent({ commit, getters }, { token, state }) {
+		if (!getters.conversations[token]) {
+			return
+		}
+
+		await setRecordingConsent(token, state)
+
+		const conversation = Object.assign({}, getters.conversations[token], { recordingConsent: state })
 
 		commit('addConversation', conversation)
 	},

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -627,7 +627,7 @@ const actions = {
 		return false
 	},
 
-	async joinCall({ commit, getters }, { token, participantIdentifier, flags, silent }) {
+	async joinCall({ commit, getters }, { token, participantIdentifier, flags, silent, recordingConsent }) {
 		if (!participantIdentifier?.sessionId) {
 			console.error('Trying to join call without sessionId')
 			return
@@ -645,7 +645,7 @@ const actions = {
 			flags,
 		})
 
-		const actualFlags = await joinCall(token, flags, silent)
+		const actualFlags = await joinCall(token, flags, silent, recordingConsent)
 
 		const updatedData = {
 			inCall: actualFlags,

--- a/src/store/participantsStore.spec.js
+++ b/src/store/participantsStore.spec.js
@@ -521,12 +521,13 @@ describe('participantsStore', () => {
 				},
 				flags,
 				silent: false,
+				recordingConsent: false,
 			})
 		})
 
 		test('joins call', async () => {
 			// Assert
-			expect(joinCall).toHaveBeenCalledWith(TOKEN, flags, false)
+			expect(joinCall).toHaveBeenCalledWith(TOKEN, flags, false, false)
 			expect(store.getters.isInCall(TOKEN)).toBe(true)
 			expect(store.getters.isConnecting(TOKEN)).toBe(true)
 			expect(store.getters.participantsList(TOKEN)).toStrictEqual([

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -20,18 +20,65 @@
  *
  */
 
+import Vue from 'vue'
 import { defineStore } from 'pinia'
 
 import { loadState } from '@nextcloud/initial-state'
 
 import { PRIVACY } from '../constants.js'
+import BrowserStorage from '../services/BrowserStorage.js'
 import { setReadStatusPrivacy, setTypingStatusPrivacy } from '../services/settingsService.js'
 
+/**
+ * @typedef {string} Token
+ */
+
+/**
+ * @typedef {object} State
+ * @property {PRIVACY.PUBLIC|PRIVACY.PRIVATE} readStatusPrivacy - The overview loaded state.
+ * @property {PRIVACY.PUBLIC|PRIVACY.PRIVATE} typingStatusPrivacy - The overview loaded state.
+ * @property {{[key: Token]: boolean}} showMediaSettings - The shared items pool.
+ */
+
+/**
+ * Store for shared items shown in RightSidebar
+ *
+ * @param {string} id store name
+ * @param {State} options.state store state structure
+ */
 export const useSettingsStore = defineStore('settings', {
 	state: () => ({
 		readStatusPrivacy: loadState('spreed', 'read_status_privacy', PRIVACY.PRIVATE),
 		typingStatusPrivacy: loadState('spreed', 'typing_privacy', PRIVACY.PRIVATE),
+		showMediaSettings: {}
 	}),
+
+	getters: {
+		getShowMediaSettings: (state) => (token) => {
+			if (state.showMediaSettings[token] !== undefined) {
+				return state.showMediaSettings[token]
+			}
+
+			const storedValue = BrowserStorage.getItem('showMediaSettings_' + token)
+
+			switch (storedValue) {
+			case 'true': {
+				Vue.set(state.showMediaSettings, token, true)
+				return true
+			}
+			case 'false': {
+				Vue.set(state.showMediaSettings, token, false)
+				return false
+			}
+			case null:
+			default: {
+				BrowserStorage.setItem('showMediaSettings_' + token, 'true')
+				Vue.set(state.showMediaSettings, token, true)
+				return true
+			}
+			}
+		},
+	},
 
 	actions: {
 		/**
@@ -52,6 +99,15 @@ export const useSettingsStore = defineStore('settings', {
 		async updateTypingStatusPrivacy(privacy) {
 			await setTypingStatusPrivacy(privacy)
 			this.typingStatusPrivacy = privacy
+		},
+
+		setShowMediaSettings(token, value) {
+			if (value) {
+				BrowserStorage.setItem('showMediaSettings_' + token, 'true')
+			} else {
+				BrowserStorage.setItem('showMediaSettings_' + token, 'false')
+			}
+			Vue.set(this.showMediaSettings, token, value)
 		},
 	},
 })

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -152,8 +152,9 @@ let failedToStartCall = null
  * @param {object} configuration Media to connect with
  * @param {boolean} silent Whether the call should trigger a notifications and
  * sound for other participants or not
+ * @param {boolean} recordingConsent Whether the participant gave his consent to be recorded
  */
-function startCall(signaling, configuration, silent) {
+function startCall(signaling, configuration, silent, recordingConsent) {
 	let flags = PARTICIPANT.CALL_FLAG.IN_CALL
 	if (configuration) {
 		if (configuration.audio) {
@@ -164,7 +165,7 @@ function startCall(signaling, configuration, silent) {
 		}
 	}
 
-	signaling.joinCall(pendingJoinCallToken, flags, silent).then(() => {
+	signaling.joinCall(pendingJoinCallToken, flags, silent, recordingConsent).then(() => {
 		startedCall(flags)
 	}).catch(error => {
 		failedToStartCall(error)
@@ -209,10 +210,11 @@ async function signalingJoinConversation(token, sessionId) {
  * @param {number} flags Bitwise combination of PARTICIPANT.CALL_FLAG
  * @param {boolean} silent Whether the call should trigger a notifications and
  * sound for other participants or not
+ * @param {boolean} recordingConsent Whether the participant gave his consent to be recorded
  * @return {Promise<void>} Resolved with the actual flags based on the
  *          available media
  */
-async function signalingJoinCall(token, flags, silent) {
+async function signalingJoinCall(token, flags, silent, recordingConsent) {
 	if (tokensInSignaling[token]) {
 		pendingJoinCallToken = token
 
@@ -269,13 +271,13 @@ async function signalingJoinCall(token, flags, silent) {
 				webRtc.off('localMediaStarted', startCallOnceLocalMediaStarted)
 				webRtc.off('localMediaError', startCallOnceLocalMediaError)
 
-				startCall(_signaling, configuration, silent)
+				startCall(_signaling, configuration, silent, recordingConsent)
 			}
 			const startCallOnceLocalMediaError = () => {
 				webRtc.off('localMediaStarted', startCallOnceLocalMediaStarted)
 				webRtc.off('localMediaError', startCallOnceLocalMediaError)
 
-				startCall(_signaling, null, silent)
+				startCall(_signaling, null, silent, recordingConsent)
 			}
 
 			// ".once" can not be used, as both handlers need to be removed when

--- a/src/views/FilesSidebarChatView.vue
+++ b/src/views/FilesSidebarChatView.vue
@@ -23,7 +23,7 @@
 	<div class="talk-tab__wrapper">
 		<CallButton class="call-button" />
 		<ChatView />
-		<MediaSettings :initialize-on-mounted="false" />
+		<MediaSettings :initialize-on-mounted="false" :recording-consent-given.sync="recordingConsentGiven" />
 	</div>
 </template>
 <script>
@@ -42,6 +42,11 @@ export default {
 		MediaSettings,
 	},
 
+	data() {
+		return {
+			recordingConsentGiven: false,
+		}
+	},
 }
 
 </script>


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10409
* Solution is based on MVP + V2 description (https://github.com/nextcloud/spreed/issues/10348#issuecomment-1725333919)
  * Option to require consent globally in Admin settings
  * When consent is required `1`:
    * Enforce the media settings dialog
    * Show a checkbox that needs ticking before moderator/user can start or join call
    * Moderator setting is visible but disabled
  * When consent is optional `2`:
    * Moderator setting is enabled with "Off" and "Required"
    * Disabled, while call is currently on
  * If user accidentally joined without consent, will be blocked by API
* Increase preview size in MediaSettings, align all content elements up to its width

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

#### Admin settings
![image](https://github.com/nextcloud/spreed/assets/93392545/5d1bfb75-f407-4474-a76c-12f43a419a62)

#### Moderator settings

| Off (hidden) | Required (disabled) | Configurable V2 |
|---|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/0d0557c4-0ef5-42ae-8c0b-1c781490a94a) | ![image](https://github.com/nextcloud/spreed/assets/93392545/b0786ffc-0a6f-47c7-95b7-d3f255fa6dd2) | ![image](https://github.com/nextcloud/spreed/assets/93392545/1336e343-86a7-4efd-9d5e-7848037bdbd5)

#### User view (Media settings)

| Off (hidden) | Required (not checked) | Required (checked) |
|---|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/f6d67c72-d7a0-4739-b2d3-e86025097e57) | ![image](https://github.com/nextcloud/spreed/assets/93392545/401e51a8-cd3d-46ec-8320-55eb0f61bbb3) | ![image](https://github.com/nextcloud/spreed/assets/93392545/bb846010-33c6-4dc9-8906-dba3fe108774)

### 🚧 Tasks

- [ ] Adjust wording / styles
- [ ] Test with recording package
- [ ] Test frontend (enter in AdminSettings -> Recording backend credentials for working signaling server)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
