### PR TITLE
chore(PR): Split PR templates for UI and API work

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,12 +2,57 @@
 
 * Fix #…
 
-### 🖼️ Screenshots
+<!--
+░░░░░░░░░░░░░░░░░░░░
+░█████░░█████░█████░
+░░███░░░░███░░░███░░
+░░███░░░░███░░░███░░
+░░███░░░░███░░░███░░
+░░███░░░░███░░░███░░
+░░███░░░░███░░░███░░
+░░░████████░░░█████░
+░░░░░░░░░░░░░░░░░░░░
 
-🏚️ Before | 🏡 After
----|---
-B | A
+Feel free to remove this section when your PR is only touching backend/API code
+-->
 
+## 🖌️ UI Checklist
+
+### 🖼️ Screenshots / Screencasts
+
+| 🏚️ Before | 🏡 After |
+|------------|----------|
+| B          | A        |
+
+### 🚧 Tasks
+
+- [ ] ...
+- [ ] ...
+
+### 🏁 Checklist
+
+- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
+- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
+- [ ] ⛑️ Tests are included or not possible
+- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
+
+---
+
+<!--
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+░░░█████████░░░███████████░░█████░
+░░███░░░░░███░░░███░░░░░███░░███░░
+░░███░░░░░███░░░███░░░░░███░░███░░
+░░███████████░░░██████████░░░███░░
+░░███░░░░░███░░░███░░░░░░░░░░███░░
+░░███░░░░░███░░░███░░░░░░░░░░███░░
+░█████░░░█████░█████░░░░░░░░█████░
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+
+Feel free to remove this section when your PR is only touching frontend/UI code
+-->
+
+## 🛠️ API Checklist
 
 ### 🚧 Tasks
 
@@ -15,7 +60,6 @@ B | A
 
 ### 🏁 Checklist
 
-- [ ] ⛑️ Tests (unit and/or integration) are included or not required
+- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
 - [ ] 📘 API documentation in `docs/` has been updated or is not required
-- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
 - [ ] 🔖 Capability is added or not needed 


### PR DESCRIPTION
* Made it a bit easier to remove unneeded things when a PR is only frontend or backend
* Adjusted the list of tasks a bit to match more what @Antreesy is posting all the time :P

> ![grafik](https://github.com/nextcloud/spreed/assets/213943/35a72bde-4917-4470-b5de-ba3370dd86da)

