### PR TITLE
Fix(MessageForwarder + NewGroupConversation) - The confirmation page enhancement

### DIFF
--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -22,9 +22,9 @@
 <template>
 	<div class="wrapper">
 		<!-- New group form -->
-		<NcModal v-if="modal"
+		<NcModal v-if="modal && page !== 2"
+			class="conversation-form"
 			:container="container"
-			size="normal"
 			@close="closeModal">
 			<h2 class="new-group-conversation__header">
 				{{ t('spreed', 'Create a new group conversation') }}
@@ -83,37 +83,6 @@
 				<SetContacts v-if="page === 1"
 					class="new-group-conversation__content"
 					:conversation-name="conversationNameTrimmed" />
-
-				<!-- Third page -->
-				<div v-else-if="page === 2" class="new-group-conversation__content">
-					<template v-if="isLoading && !error">
-						<template v-if="!success">
-							<div class="icon-loading confirmation__icon" />
-							<p class="confirmation__warning">
-								{{ t('spreed', 'Creating your conversation') }}
-							</p>
-						</template>
-						<template v-if="success && isPublic">
-							<div class="icon-checkmark confirmation__icon" />
-							<p class="confirmation__warning">
-								{{ t('spreed', 'All set') }}
-							</p>
-							<NcButton id="copy-link"
-								ref="copyLink"
-								type="secondary"
-								class="confirmation__copy-link"
-								@click="onClickCopyLink">
-								{{ t('spreed', 'Copy conversation link') }}
-							</NcButton>
-						</template>
-					</template>
-					<template v-else>
-						<div class="icon-error confirmation__icon" />
-						<p class="confirmation__warning">
-							{{ t('spreed', 'Error while creating the conversation') }}
-						</p>
-					</template>
-				</div>
 			</div>
 
 			<!-- Navigation: different buttons with different actions and
@@ -145,15 +114,48 @@
 					@click="handleCreateConversation">
 					{{ t('spreed', 'Create conversation') }}
 				</NcButton>
-				<!-- Third page -->
-				<NcButton v-if="page===2 && (error || isPublic)"
-					ref="closeButton"
-					type="primary"
-					class="new-group-conversation__button"
-					@click="closeModal">
-					{{ t('spreed', 'Close') }}
-				</NcButton>
 			</div>
+		</NcModal>
+
+		<!-- Third page : this is the confirmation page-->
+		<NcModal v-else-if="page === 2"
+			:container="container"
+			@close="closeModal">
+			<NcEmptyContent>
+				<template #icon>
+					<Check v-if="!error && success && isPublic" :size="64" />
+					<div v-if="isLoading && !error && !success" class="icon-loading spinner" />
+					<AlertCircle v-if="error" :size="64" />
+				</template>
+
+				<template #description>
+					<p v-if="isLoading && !error && !success" class="confirmation__warning">
+						{{ t('spreed', 'Creating the conversation …') }}
+					</p>
+					<p v-if="!error && success && isPublic" class="confirmation__warning">
+						{{ t('spreed', 'All set, the conversation "{conversationName}" was created.', { conversationName }) }}
+					</p>
+					<p v-if="error" class="confirmation__warning">
+						{{ t('spreed', 'Error while creating the conversation') }}
+					</p>
+				</template>
+
+				<template #action>
+					<NcButton v-if="error || isPublic"
+						ref="closeButton"
+						type="primary"
+						@click="closeModal">
+						{{ t('spreed', 'Close') }}
+					</NcButton>
+					<NcButton v-if="!error && success && isPublic"
+						id="copy-link"
+						ref="copyLink"
+						type="secondary"
+						@click="onClickCopyLink">
+						{{ t('spreed', 'Copy conversation link') }}
+					</NcButton>
+				</template>
+			</NcEmptyContent>
 		</NcModal>
 	</div>
 </template>
@@ -162,6 +164,8 @@
 
 import { getCapabilities } from '@nextcloud/capabilities'
 import { showError } from '@nextcloud/dialogs'
+import Check from 'vue-material-design-icons/Check.vue'
+import AlertCircle from 'vue-material-design-icons/AlertCircle.vue'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
@@ -171,6 +175,7 @@ import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 
 import ConversationAvatarEditor from '../../ConversationSettings/ConversationAvatarEditor.vue'
 import ListableSettings from '../../ConversationSettings/ListableSettings.vue'
+import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import SetContacts from './SetContacts/SetContacts.vue'
 
 import { useIsInCall } from '../../../composables/useIsInCall.js'
@@ -204,10 +209,13 @@ export default {
 		ListableSettings,
 		NcButton,
 		NcCheckboxRadioSwitch,
+		NcEmptyContent,
 		NcModal,
 		NcPasswordField,
 		NcTextField,
 		SetContacts,
+		Check,
+		AlertCircle,
 	},
 
 	mixins: [participant],
@@ -263,6 +271,9 @@ export default {
 		selectedParticipants() {
 			return this.$store.getters.selectedParticipants
 		},
+		getSize() {
+			return this.page === 2 ? '' : 'normal'
+		}
 	},
 
 	watch: {
@@ -527,12 +538,13 @@ export default {
 		margin-left: auto;
 	}
 }
-
-:deep(.modal-wrapper .modal-container) {
+.conversation-form{
+	:deep(.modal-wrapper .modal-container) {
 	display: flex !important;
 	flex-direction: column;
 	height: 90%;
 	overflow: hidden !important;
+	}
 }
 
 :deep(.app-settings-section__hint) {
@@ -544,6 +556,10 @@ export default {
 	&:first-child {
 		margin-top: 0;
 	}
+}
+
+:deep(.empty-content__action) {
+	gap: 10px;
 }
 
 </style>

--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -123,27 +123,27 @@
 			@close="closeModal">
 			<NcEmptyContent>
 				<template #icon>
-					<Check v-if="!error && success && isPublic" :size="64" />
-					<div v-if="isLoading && !error && !success" class="icon-loading spinner" />
-					<AlertCircle v-if="error" :size="64" />
+					<LoadingComponent v-if="isLoading" />
+					<AlertCircle v-else-if="error" :size="64" />
+					<Check v-else-if="success && isPublic" :size="64" />
 				</template>
 
 				<template #description>
-					<p v-if="isLoading && !error && !success" class="confirmation__warning">
+					<p v-if="isLoading">
 						{{ t('spreed', 'Creating the conversation …') }}
 					</p>
-					<p v-if="!error && success && isPublic" class="confirmation__warning">
-						{{ t('spreed', 'All set, the conversation "{conversationName}" was created.', { conversationName }) }}
-					</p>
-					<p v-if="error" class="confirmation__warning">
+					<p v-else-if="error">
 						{{ t('spreed', 'Error while creating the conversation') }}
+					</p>
+					<p v-else-if="success && isPublic">
+						{{ t('spreed', 'All set, the conversation "{conversationName}" was created.', { conversationName }) }}
 					</p>
 				</template>
 
 				<template #action>
-					<NcButton v-if="error || isPublic"
+					<NcButton v-if="(error || isPublic) && !isLoading"
 						ref="closeButton"
-						type="primary"
+						type="tertiary"
 						@click="closeModal">
 						{{ t('spreed', 'Close') }}
 					</NcButton>
@@ -169,13 +169,14 @@ import AlertCircle from 'vue-material-design-icons/AlertCircle.vue'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
+import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 import NcPasswordField from '@nextcloud/vue/dist/Components/NcPasswordField.js'
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 
 import ConversationAvatarEditor from '../../ConversationSettings/ConversationAvatarEditor.vue'
 import ListableSettings from '../../ConversationSettings/ListableSettings.vue'
-import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
+import LoadingComponent from '../../LoadingComponent.vue'
 import SetContacts from './SetContacts/SetContacts.vue'
 
 import { useIsInCall } from '../../../composables/useIsInCall.js'
@@ -207,6 +208,7 @@ export default {
 	components: {
 		ConversationAvatarEditor,
 		ListableSettings,
+		LoadingComponent,
 		NcButton,
 		NcCheckboxRadioSwitch,
 		NcEmptyContent,
@@ -271,9 +273,6 @@ export default {
 		selectedParticipants() {
 			return this.$store.getters.selectedParticipants
 		},
-		getSize() {
-			return this.page === 2 ? '' : 'normal'
-		}
 	},
 
 	watch: {
@@ -403,6 +402,7 @@ export default {
 			}
 
 			this.success = true
+			this.isLoading = false
 
 			if (!this.isInCall) {
 				// Push the newly created conversation's route.
@@ -479,21 +479,6 @@ export default {
 
 <style lang="scss" scoped>
 
-.confirmation {
-	&__icon {
-		padding-top: 80px;
-	}
-
-	&__warning {
-		margin-top: 10px;
-		text-align: center;
-	}
-
-	&__copy-link {
-		margin: 50px auto 0 auto;
-	}
-}
-
 .new-group-conversation {
 	&__header {
 		flex-shrink: 0;
@@ -538,13 +523,11 @@ export default {
 		margin-left: auto;
 	}
 }
-.conversation-form{
-	:deep(.modal-wrapper .modal-container) {
+.conversation-form :deep(.modal-wrapper .modal-container) {
 	display: flex !important;
 	flex-direction: column;
 	height: 90%;
 	overflow: hidden !important;
-	}
 }
 
 :deep(.app-settings-section__hint) {
@@ -556,6 +539,10 @@ export default {
 	&:first-child {
 		margin-top: 0;
 	}
+}
+
+:deep(.empty-content) {
+	padding: 20px;
 }
 
 :deep(.empty-content__action) {

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -241,7 +241,7 @@
 				</NcButton>
 			</NcEmojiPicker>
 		</template>
-		<Forwarder v-if="isForwarderOpen"
+		<MessageForwarder v-if="isForwarderOpen"
 			:message-object="messageObject"
 			@close="closeForwarder" />
 	</div>
@@ -283,7 +283,7 @@ import NcActionSeparator from '@nextcloud/vue/dist/Components/NcActionSeparator.
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcEmojiPicker from '@nextcloud/vue/dist/Components/NcEmojiPicker.js'
 
-import Forwarder from './Forwarder.vue'
+import MessageForwarder from './MessageForwarder.vue'
 
 import { PARTICIPANT, CONVERSATION, ATTENDEE } from '../../../../../constants.js'
 import { getMessageReminder, removeMessageReminder, setMessageReminder } from '../../../../../services/remindersService.js'
@@ -298,7 +298,7 @@ export default {
 	name: 'MessageButtonsBar',
 
 	components: {
-		Forwarder,
+		MessageForwarder,
 		NcActionButton,
 		NcActionInput,
 		NcActionLink,

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageForwarder.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageForwarder.vue
@@ -20,25 +20,12 @@
 -->
 
 <template>
-	<div class="forwarder">
-		<NcEmptyContent :description="t('spreed', 'The message has been forwarded to {selectedConversationName}')">
-			<template #icon>
-				<Check :size="64" />
-			</template>
-			<template #action>
-				<NcButton type="tertiary" @click="handleClose">
-					{{ t('spreed', 'Dismiss') }}
-				</NcButton>
-				<NcButton type="primary" @click="openConversation">
-					{{ t('spreed', 'Go to conversation') }}
-				</NcButton>
-			</template>
-		</NcEmptyContent>
+	<div class="message-forwarder">
 		<!-- First step of the flow: selection of the room to which forward the
 		message to -->
 		<RoomSelector v-if="!showForwardedConfirmation"
 			:container="container"
-			:show-postable-only="true"
+			show-postable-only
 			:dialog-title="dialogTitle"
 			:dialog-subtitle="dialogSubtitle"
 			@select="setSelectedConversationToken"
@@ -80,7 +67,7 @@ import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 import RoomSelector from '../../../../RoomSelector.vue'
 
 export default {
-	name: 'Forwarder',
+	name: 'MessageForwarder',
 
 	components: {
 		RoomSelector,
@@ -107,6 +94,7 @@ export default {
 			selectedConversationToken: null,
 			showForwardedConfirmation: false,
 			forwardedMessageID: '',
+			error: false,
 		}
 	},
 
@@ -168,8 +156,7 @@ export default {
 
 <style lang="scss" scoped>
 
-.forwarder {
-	padding: 20px;
+:deep(.empty-content__action) {
+	gap: 10px;
 }
-
 </style>

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageForwarder.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageForwarder.vue
@@ -94,7 +94,6 @@ export default {
 			selectedConversationToken: null,
 			showForwardedConfirmation: false,
 			forwardedMessageID: '',
-			error: false,
 		}
 	},
 
@@ -156,6 +155,9 @@ export default {
 
 <style lang="scss" scoped>
 
+:deep(.empty-content) {
+	padding: 20px;
+}
 :deep(.empty-content__action) {
 	gap: 10px;
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10630

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/84044328/a7c92c57-9892-4b29-b485-c812ace3bab7) |![image](https://github.com/nextcloud/spreed/assets/84044328/b5116185-a610-49b4-8907-071f06e53789)|
| ![image](https://github.com/nextcloud/spreed/assets/84044328/ba880bea-ef7c-4464-bfef-3963a3040c7b) | ![image](https://github.com/nextcloud/spreed/assets/84044328/303830e6-f40b-4caf-95b4-6ac0b06c2681)|
| ![image](https://github.com/nextcloud/spreed/assets/84044328/5fc27db9-a539-40c3-a357-1cc033e34e87) | ![image](https://github.com/nextcloud/spreed/assets/84044328/020df4c5-5ac6-484d-a94d-2313bc4e35f0)|
|![image](https://github.com/nextcloud/spreed/assets/84044328/5cef67a2-342e-4a9f-8ce3-dbe782b7a7c0) | ![image](https://github.com/nextcloud/spreed/assets/84044328/dcacee61-0fa9-45bc-9209-76768b2b700a)|




### 🚧 Tasks

- [x] Component renaming ( MessageForwarder)
- [x] Fixing the UI ( NcEmptyContent duplication and the buttons bar )
- [x] Replacing the new conversation page confirmation with NcEmptyContent
- [x] Show loading status before the confirmation page.

To do:
- [ ] Visual review
- [ ] Code review

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
