### PR TITLE
Allow users to recieve notifications when a chat is open in background

### DIFF
--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -576,6 +576,16 @@ class ChatManager {
 
 		return array_pop($messages);
 	}
+	
+	/**
+ 	* Proxy function for Notifier->markMentionNotificationsRead
+	* @param Room $chat
+ 	* @param string $userid
+  	*/
+	public function markMentionNotificationsRead($chat, $userid){
+		$this->notifier->markMentionNotificationsRead($chat, $userid);
+	}
+	
 
 	/**
 	 * If there are currently no messages the response will not be sent
@@ -599,9 +609,6 @@ class ChatManager {
 	 *         timeout expired.
 	 */
 	public function waitForNewMessages(Room $chat, int $offset, int $limit, int $timeout, ?IUser $user, bool $includeLastKnown, bool $markNotificationsAsRead = true): array {
-		if ($markNotificationsAsRead && $user instanceof IUser) {
-			$this->notifier->markMentionNotificationsRead($chat, $user->getUID());
-		}
 
 		if ($this->cache instanceof NullCache
 			|| $this->cache instanceof ArrayCache) {

--- a/lib/Chat/Notifier.php
+++ b/lib/Chat/Notifier.php
@@ -594,11 +594,6 @@ class Notifier {
 			}
 		}
 
-		if ($participant->getSession() instanceof Session) {
-			// User is online
-			return $participant->getSession()->getLastPing() < $this->timeFactory->getTime() - Session::SESSION_TIMEOUT;
-		}
-
 		return true;
 	}
 }

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -789,6 +789,7 @@ class ChatController extends AEnvironmentAwareController {
 		$response = new DataResponse();
 		if ($this->participant->getAttendee()->getReadPrivacy() === Participant::PRIVACY_PUBLIC) {
 			$response->addHeader('X-Chat-Last-Common-Read', (string) $this->chatManager->getLastCommonReadMessage($this->room));
+			$this->chatManager->markMentionNotificationsRead($this->room, $this->userId);
 		}
 		return $response;
 	}


### PR DESCRIPTION
### ☑️ Resolves #10641
🏁 Checklist

[X] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
[]🖌️ Design was reviewed, approved or inspired by the design team
[]⛑️ Tests are included or not possible
[X]📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required