### PR TITLE
Add presenter overlay when sharing screen

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -66,6 +66,32 @@
 									:call-participant-model="callParticipantModel"
 									:shared-data="sharedDatas[shownRemoteScreenPeerId]"
 									:is-big="true" />
+								<!-- presenter overlay -->
+								<TransitionWrapper v-if="shouldShowPresenterOverlay(callParticipantModel)"
+									:key="'presenter-overlay-video' + callParticipantModel.attributes.peerId"
+									name="slide-down">
+									<VideoVue :key="'video-overlay-' + callParticipantModel.attributes.peerId"
+										class="presenter-overlay__video"
+										:token="token"
+										:model="callParticipantModel"
+										:shared-data="sharedDatas[shownRemoteScreenPeerId]"
+										is-presenter-overlay
+										un-selectable
+										hide-bottom-bar
+										@click-video="toggleShowPresenterOverlay" />
+								</TransitionWrapper>
+								<!-- presenter button when presenter overlay is collapsed -->
+								<NcButton v-else-if="isPresenterCollapsed(callParticipantModel)"
+									:key="'presenter-overlay-button' + callParticipantModel.attributes.peerId"
+									:aria-label="t('spreed', 'Show presenter')"
+									:title="t('spreed', 'Show presenter')"
+									class="presenter-overlay--collapse"
+									type="tertiary-no-background"
+									@click="toggleShowPresenterOverlay">
+									<template #icon>
+										<AccountBox fill-color="#ffffff" :size="20" />
+									</template>
+								</NcButton>
 							</template>
 						</template>
 					</div>
@@ -153,6 +179,8 @@ import { showMessage } from '@nextcloud/dialogs'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { loadState } from '@nextcloud/initial-state'
 
+import AccountBox from 'vue-material-design-icons/AccountBoxOutline.vue'
+
 import Grid from './Grid/Grid.vue'
 import EmptyCallView from './shared/EmptyCallView.vue'
 import LocalVideo from './shared/LocalVideo.vue'
@@ -160,25 +188,30 @@ import ReactionToaster from './shared/ReactionToaster.vue'
 import Screen from './shared/Screen.vue'
 import VideoVue from './shared/VideoVue.vue'
 import ViewerOverlayCallView from './shared/ViewerOverlayCallView.vue'
+import TransitionWrapper from '../TransitionWrapper.vue'
 
 import { SIMULCAST } from '../../constants.js'
 import BrowserStorage from '../../services/BrowserStorage.js'
 import { fetchPeers } from '../../services/callsService.js'
 import { EventBus } from '../../services/EventBus.js'
 import { localMediaModel, localCallParticipantModel, callParticipantCollection } from '../../utils/webrtc/index.js'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import RemoteVideoBlocker from '../../utils/webrtc/RemoteVideoBlocker.js'
 
 export default {
 	name: 'CallView',
 
 	components: {
+		AccountBox,
 		EmptyCallView,
 		ViewerOverlayCallView,
 		Grid,
 		LocalVideo,
+		NcButton,
 		ReactionToaster,
 		Screen,
 		VideoVue,
+		TransitionWrapper,
 	},
 
 	props: {
@@ -214,6 +247,7 @@ export default {
 			},
 			callParticipantCollection,
 			isBackgroundBlurred: true,
+			showPresenterOverlay: true,
 		}
 	},
 	computed: {
@@ -362,6 +396,11 @@ export default {
 		supportedReactions() {
 			return getCapabilities()?.spreed?.config?.call?.['supported-reactions']
 		},
+
+		presenterVideoBlockerEnabled() {
+			return this.sharedDatas[this.shownRemoteScreenPeerId]?.remoteVideoBlocker?.isVideoEnabled()
+		},
+
 	},
 	watch: {
 		'localCallParticipantModel.attributes.peerId'(newValue, previousValue) {
@@ -435,6 +474,10 @@ export default {
 			if (newVal) {
 				this.$store.dispatch('setCallViewMode', { isGrid: false })
 			}
+		},
+
+		presenterVideoBlockerEnabled(value) {
+			this.showPresenterOverlay = value
 		},
 	},
 	created() {
@@ -713,6 +756,28 @@ export default {
 		setBackgroundBlurred(value) {
 			this.isBackgroundBlurred = value
 		},
+
+		isPresenterCollapsed(callParticipantModel) {
+			return (callParticipantModel.attributes.peerId === this.shownRemoteScreenPeerId
+				&& !this.showPresenterOverlay
+				&& callParticipantModel.attributes.videoAvailable)
+
+		},
+
+		shouldShowPresenterOverlay(callParticipantModel) {
+			return callParticipantModel.attributes.peerId === this.shownRemoteScreenPeerId
+				&& this.showPresenterOverlay
+				&& this.callParticipantModelsWithVideo.includes(callParticipantModel)
+
+		},
+
+		toggleShowPresenterOverlay() {
+			if (!this.presenterVideoBlockerEnabled) {
+				this.sharedDatas[this.shownRemoteScreenPeerId].remoteVideoBlocker.setVideoEnabled(true)
+			} else {
+				this.showPresenterOverlay = !this.showPresenterOverlay
+			}
+		},
 	},
 }
 </script>
@@ -734,6 +799,35 @@ export default {
 
 	&.blurred {
 		backdrop-filter: blur(25px);
+	}
+}
+
+.presenter-overlay__video {
+	position: absolute;
+	bottom: 48px;
+	right: 8px;
+	--max-size: 242px;
+	width: 10vw;
+	height: 10vw;
+	max-width: var(--max-size);
+	max-height: var(--max-size);
+	z-index: 10;
+}
+
+.presenter-overlay--collapse {
+	position : absolute !important;
+	opacity: .7;
+	bottom: 48px;
+	right: 0;
+
+	#call-container:hover & {
+		background-color: rgba(0, 0, 0, 0.1) !important;
+
+		&:hover,
+		&:focus {
+			opacity: 1;
+			background-color: rgba(0, 0, 0, 0.2) !important;
+		}
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #4478
* You can hide and unhide by clicking on the presenter overlay
* When hidden, a button will be shown.
* If the video is disabled from the stripe, the presenter overlay will be hidden. Pressing on the presenter button will enable the video and show the overlay.

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Default | 🏡 On hover |  🏡 Clicked | 🏡 Stripe Open |
|------------|----------|----------|----------|
| ![Presenter1](https://github.com/nextcloud/spreed/assets/84044328/646e561f-b3ae-4811-95c5-506f7b7c86f4)      | ![image](https://github.com/nextcloud/spreed/assets/84044328/b31891b1-b6ad-48f6-b9d1-8a24090728a4)  |  ![Screenshot 2023-10-09 230256](https://github.com/nextcloud/spreed/assets/84044328/4e77ad55-4dcd-41aa-9bb2-ba392be0a75a) | ![Screenshot 2023-10-09 230406](https://github.com/nextcloud/spreed/assets/84044328/6ce76b6e-8184-4d5e-9fc7-f074030b305e)
 

### 🚧 Tasks

- [ ] Design/icons review
- [x] Code review

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
