### PR TITLE
Migrate to NcEmptyContent

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,11 @@ module.exports = {
 				warnOnUnassignedImports: true,
 			},
 		],
+		'import/no-unresolved': ['error', {
+			// Ignore Webpack query parameters, not supported by eslint-plugin-import
+			// https://github.com/import-js/eslint-plugin-import/issues/2562
+			ignore: ['\\?raw$'],
+		}],
 		// Prepare for Vue 3 Migration
 		'vue/no-deprecated-data-object-declaration': 'warn',
 		'vue/no-deprecated-events-api': 'warn',

--- a/src/components/EmptyView.vue
+++ b/src/components/EmptyView.vue
@@ -1,0 +1,37 @@
+<template>
+	<NcEmptyContent class="empty-view" :name="name" :description="description">
+		<template #icon>
+			<slot name="icon" />
+		</template>
+	</NcEmptyContent>
+</template>
+
+<script>
+import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
+
+export default {
+	name: 'EmptyView',
+
+	components: {
+		NcEmptyContent,
+	},
+
+	props: {
+		name: {
+			type: String,
+			required: true,
+		},
+		description: {
+			type: String,
+			required: true,
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.empty-view {
+	height: 100%;
+	padding: calc(var(--default-grid-baseline) * 4);
+}
+</style>

--- a/src/views/NotFoundView.vue
+++ b/src/views/NotFoundView.vue
@@ -1,15 +1,22 @@
 <template>
-	<div id="emptycontent">
-		<div id="emptycontent-icon" class="icon-search" />
-		<h2>{{ t('spreed', 'The conversation does not exist') }}</h2>
-		<p class="emptycontent-additional">
-			{{ t('spreed', 'Join a conversation or start a new one!') }}
-		</p>
-	</div>
+	<EmptyView :name="t('spreed', 'The conversation does not exist')"
+		:description="t('spreed', 'Join a conversation or start a new one!')">
+		<template #icon>
+			<IconMagnify />
+		</template>
+	</EmptyView>
 </template>
 
 <script>
+import EmptyView from '../components/EmptyView.vue'
+import IconMagnify from 'vue-material-design-icons/Magnify.vue'
+
 export default {
 	name: 'NotFoundView',
+
+	components: {
+		EmptyView,
+		IconMagnify,
+	},
 }
 </script>

--- a/src/views/SessionConflictView.vue
+++ b/src/views/SessionConflictView.vue
@@ -1,16 +1,24 @@
 <template>
-	<div id="emptycontent">
-		<div id="emptycontent-icon" class="icon-info" />
-		<h2>{{ t('spreed', 'Duplicate session') }}</h2>
-		<p class="emptycontent-additional">
-			{{ t('spreed', 'You joined the conversation in another window or device. This is currently not supported by Nextcloud Talk so this session was closed.') }}
-		</p>
-	</div>
+	<EmptyView :name="t('spreed', 'Duplicate session')"
+		:description="t('spreed', 'You joined the conversation in another window or device. This is currently not supported by Nextcloud Talk so this session was closed.')">
+		<template #icon>
+			<!-- TODO: use information-slab-symbol after update to MDI 7 -->
+			<IconInformationOutline />
+		</template>
+	</EmptyView>
 </template>
 
 <script>
+import EmptyView from '../components/EmptyView.vue'
+import IconInformationOutline from 'vue-material-design-icons/InformationOutline.vue'
+
 export default {
 	name: 'SessionConflictView',
+
+	components: {
+		EmptyView,
+		IconInformationOutline,
+	},
 
 	mounted() {
 		this.setPageTitle()

--- a/src/views/WelcomeView.vue
+++ b/src/views/WelcomeView.vue
@@ -1,15 +1,28 @@
 <template>
-	<div id="emptycontent">
-		<div id="emptycontent-icon" class="icon-talk" />
-		<h2>{{ t('spreed', 'Join a conversation or start a new one') }}</h2>
-		<p class="emptycontent-additional">
-			{{ t('spreed', 'Say hi to your friends and colleagues!') }}
-		</p>
-	</div>
+	<EmptyView :name="t('spreed', 'Join a conversation or start a new one')"
+		:description="t('spreed', 'Say hi to your friends and colleagues!')">
+		<template #icon>
+			<NcIconSvgWrapper :svg="IconTalk" />
+		</template>
+	</EmptyView>
 </template>
 
 <script>
+import NcIconSvgWrapper from '@nextcloud/vue/dist/Components/NcIconSvgWrapper.js'
+import EmptyView from '../components/EmptyView.vue'
+import IconTalk from '../../img/app-dark.svg?raw'
+
 export default {
 	name: 'WelcomeView',
+
+	components: {
+		EmptyView,
+		NcIconSvgWrapper
+	},
+	setup() {
+		return {
+			IconTalk,
+		}
+	}
 }
 </script>

--- a/src/views/WelcomeView.vue
+++ b/src/views/WelcomeView.vue
@@ -5,7 +5,6 @@
 		<p class="emptycontent-additional">
 			{{ t('spreed', 'Say hi to your friends and colleagues!') }}
 		</p>
-		<div id="shareRoomContainer" />
 	</div>
 </template>
 

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -74,6 +74,10 @@ module.exports = mergeWithRules({
 				test: /\.worker\.js$/,
 				use: { loader: 'worker-loader' },
 			},
+			{
+				resourceQuery: /raw/,
+				type: 'asset/source',
+			}
 		],
 	},
 })


### PR DESCRIPTION
### ☑️ Resolves

Use `<NcEmptyContent>` instead our own copy.

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
![image](https://github.com/nextcloud/spreed/assets/25978914/00c5b7cd-8341-44f7-931c-a3b3b05b4f87) | ![image](https://github.com/nextcloud/spreed/assets/25978914/ec5d8bcc-c4ef-4160-b2e8-9119d2d011ba)
![image](https://github.com/nextcloud/spreed/assets/25978914/c264f9c9-65b6-49de-adec-bc6887b57e1e) | ![image](https://github.com/nextcloud/spreed/assets/25978914/d6909cfa-3468-477f-8957-1ddeea098471)
![image](https://github.com/nextcloud/spreed/assets/25978914/04b9cb22-c6dd-4215-ba60-bf604cc0bca3) | ![image](https://github.com/nextcloud/spreed/assets/25978914/04a7172e-1631-4a57-94dc-b2083d10b02a)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
