### PR TITLE
fix(federation): Don't remove federation rooms while waiting for accept/reject

### DIFF
--- a/lib/BackgroundJob/RemoveEmptyRooms.php
+++ b/lib/BackgroundJob/RemoveEmptyRooms.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\BackgroundJob;
 
+use OCA\Talk\Federation\FederationManager;
 use OCA\Talk\Manager;
 use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
@@ -47,6 +48,7 @@ class RemoveEmptyRooms extends TimedJob {
 		protected Manager $manager,
 		protected RoomService $roomService,
 		protected ParticipantService $participantService,
+		protected FederationManager $federationManager,
 		protected LoggerInterface $logger,
 		protected IUserMountCache $userMountCache,
 	) {
@@ -86,6 +88,11 @@ class RemoveEmptyRooms extends TimedJob {
 		}
 
 		if ($this->participantService->getNumberOfActors($room) !== 0) {
+			return false;
+		}
+
+		if ($room->getRemoteServer() && $room->getRemoteToken()
+			&& $this->federationManager->getNumberOfInvitations($room) !== 0) {
 			return false;
 		}
 

--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -113,17 +113,22 @@ class FederationController extends OCSController {
 			throw new UnauthorizedException();
 		}
 		$invitations = $this->federationManager->getRemoteRoomShares($user);
-		return new DataResponse(array_map(function (Invitation $invitation) {
+
+		/** @var TalkFederationInvite[] $data */
+		$data = array_filter(array_map(function (Invitation $invitation) {
 			$data = $invitation->asArray();
 
 			try {
 				$room = $this->talkManager->getRoomById($invitation->getRoomId());
 				$data['remote_token'] = $room->getRemoteToken();
 				$data['remote_server'] = $room->getRemoteServer();
-			} catch (RoomNotFoundException $exception) {
+			} catch (RoomNotFoundException) {
+				return null;
 			}
 
 			return $data;
 		}, $invitations));
+
+		return new DataResponse($data);
 	}
 }

--- a/lib/Federation/FederationManager.php
+++ b/lib/Federation/FederationManager.php
@@ -131,6 +131,13 @@ class FederationManager {
 	}
 
 	/**
+	 * @throws DoesNotExistException
+	 */
+	public function getRemoteShareById(int $shareId): Invitation {
+		return $this->invitationMapper->getInvitationById($shareId);
+	}
+
+	/**
 	 * @throws UnauthorizedException
 	 * @throws DoesNotExistException
 	 */

--- a/lib/Federation/FederationManager.php
+++ b/lib/Federation/FederationManager.php
@@ -36,8 +36,6 @@ use OCA\Talk\Model\InvitationMapper;
 use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\MultipleObjectsReturnedException;
-use OCP\DB\Exception as DBException;
 use OCP\IConfig;
 use OCP\IUser;
 
@@ -81,7 +79,6 @@ class FederationManager {
 	 * @param string $remoteUrl
 	 * @param string $sharedSecret
 	 * @return int share id for this specific remote room share
-	 * @throws DBException
 	 */
 	public function addRemoteRoom(IUser $user, string $remoteId, int $roomType, string $roomName, string $roomToken, string $remoteUrl, string $sharedSecret): int {
 		try {
@@ -100,9 +97,7 @@ class FederationManager {
 	}
 
 	/**
-	 * @throws DBException
 	 * @throws UnauthorizedException
-	 * @throws MultipleObjectsReturnedException
 	 * @throws DoesNotExistException
 	 * @throws CannotReachRemoteException
 	 */
@@ -136,9 +131,7 @@ class FederationManager {
 	}
 
 	/**
-	 * @throws DBException
 	 * @throws UnauthorizedException
-	 * @throws MultipleObjectsReturnedException
 	 * @throws DoesNotExistException
 	 */
 	public function rejectRemoteRoomShare(IUser $user, int $shareId): void {
@@ -157,15 +150,11 @@ class FederationManager {
 	/**
 	 * @param IUser $user
 	 * @return Invitation[]
-	 * @throws DBException
 	 */
 	public function getRemoteRoomShares(IUser $user): array {
 		return $this->invitationMapper->getInvitationsForUser($user);
 	}
 
-	/**
-	 * @throws DBException
-	 */
 	public function getNumberOfInvitations(Room $room): int {
 		return $this->invitationMapper->countInvitationsForRoom($room);
 	}

--- a/lib/Model/InvitationMapper.php
+++ b/lib/Model/InvitationMapper.php
@@ -27,9 +27,7 @@ namespace OCA\Talk\Model;
 
 use OCA\Talk\Room;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Db\QBMapper;
-use OCP\DB\Exception as DBException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\IUser;
@@ -50,8 +48,6 @@ class InvitationMapper extends QBMapper {
 	}
 
 	/**
-	 * @throws DBException
-	 * @throws MultipleObjectsReturnedException
 	 * @throws DoesNotExistException
 	 */
 	public function getInvitationById(int $id): Invitation {
@@ -67,7 +63,6 @@ class InvitationMapper extends QBMapper {
 	/**
 	 * @param Room $room
 	 * @return Invitation[]
-	 * @throws DBException
 	 */
 	public function getInvitationsForRoom(Room $room): array {
 		$qb = $this->db->getQueryBuilder();
@@ -82,7 +77,6 @@ class InvitationMapper extends QBMapper {
 	/**
 	 * @param IUser $user
 	 * @return Invitation[]
-	 * @throws DBException
 	 */
 	public function getInvitationsForUser(IUser $user): array {
 		$qb = $this->db->getQueryBuilder();
@@ -94,9 +88,6 @@ class InvitationMapper extends QBMapper {
 		return $this->findEntities($qb);
 	}
 
-	/**
-	 * @throws DBException
-	 */
 	public function countInvitationsForRoom(Room $room): int {
 		$qb = $this->db->getQueryBuilder();
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -31,6 +31,7 @@ use OCA\Talk\Chat\MessageParser;
 use OCA\Talk\Config;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Exceptions\RoomNotFoundException;
+use OCA\Talk\Federation\FederationManager;
 use OCA\Talk\GuestManager;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
@@ -45,7 +46,6 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
 use OCP\Files\IRootFolder;
-use OCP\HintException;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -90,6 +90,7 @@ class Notifier implements INotifier {
 		protected Definitions $definitions,
 		protected AddressHandler $addressHandler,
 		protected BotServerMapper $botServerMapper,
+		protected FederationManager $federationManager,
 	) {
 		$this->commentManager = $commentManager;
 	}
@@ -395,11 +396,19 @@ class Notifier implements INotifier {
 		return $notification;
 	}
 
-	/**
-	 * @throws HintException
-	 */
 	protected function parseRemoteInvitationMessage(INotification $notification, IL10N $l): INotification {
 		$subjectParameters = $notification->getSubjectParameters();
+
+		try {
+			$invite = $this->federationManager->getRemoteShareById((int) $notification->getObjectId());
+			if ($invite->getUserId() !== $notification->getUser()) {
+				throw new AlreadyProcessedException();
+			}
+			$this->manager->getRoomById($invite->getRoomId());
+		} catch (RoomNotFoundException $e) {
+			// Room does not exist
+			throw new AlreadyProcessedException();
+		}
 
 		[$sharedById, $sharedByServer] = $this->addressHandler->splitUserRemote($subjectParameters['sharedByFederatedId']);
 

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -98,8 +98,8 @@ namespace OCA\Talk;
  *     access_token: string,
  *     id: int,
  *     remote_id: string,
- *     remote_server: ?string,
- *     remote_token: ?string,
+ *     remote_server: string,
+ *     remote_token: string,
  *     room_id: int,
  *     user_id: string,
  * }

--- a/openapi.json
+++ b/openapi.json
@@ -323,12 +323,10 @@
                         "type": "string"
                     },
                     "remote_server": {
-                        "type": "string",
-                        "nullable": true
+                        "type": "string"
                     },
                     "remote_token": {
-                        "type": "string",
-                        "nullable": true
+                        "type": "string"
                     },
                     "room_id": {
                         "type": "integer",

--- a/tests/integration/features/federation/invite.feature
+++ b/tests/integration/features/federation/invite.feature
@@ -29,6 +29,7 @@ Feature: federation/invite
       | room | actorType     | actorId      | systemMessage        | message                      | messageParameters |
       | room | users         | participant1 | federated_user_added | You invited {user}           | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
       | room | users         | participant1 | conversation_created | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
+    And force run "OCA\Talk\BackgroundJob\RemoveEmptyRooms" background jobs
     And user "participant2" has the following invitations (v1)
       | remote_server | remote_token |
       | LOCAL         | room         |

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -27,6 +27,7 @@ use OCA\Talk\Chat\MessageParser;
 use OCA\Talk\Config;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Exceptions\RoomNotFoundException;
+use OCA\Talk\Federation\FederationManager;
 use OCA\Talk\GuestManager;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
@@ -95,6 +96,8 @@ class NotifierTest extends TestCase {
 	protected $addressHandler;
 	/** @var BotServerMapper|MockObject */
 	protected $botServerMapper;
+	/** @var FederationManager|MockObject */
+	protected $federationManager;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -118,6 +121,7 @@ class NotifierTest extends TestCase {
 		$this->definitions = $this->createMock(Definitions::class);
 		$this->addressHandler = $this->createMock(AddressHandler::class);
 		$this->botServerMapper = $this->createMock(BotServerMapper::class);
+		$this->federationManager = $this->createMock(FederationManager::class);
 
 		$this->notifier = new Notifier(
 			$this->lFactory,
@@ -139,6 +143,7 @@ class NotifierTest extends TestCase {
 			$this->definitions,
 			$this->addressHandler,
 			$this->botServerMapper,
+			$this->federationManager,
 		);
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

* Fixes this comment https://github.com/nextcloud/spreed/issues/5723#issuecomment-1152386582

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░█████████░░░███████████░░█████░
░░███░░░░░███░░░███░░░░░███░░███░░
░░███░░░░░███░░░███░░░░░███░░███░░
░░███████████░░░██████████░░░███░░
░░███░░░░░███░░░███░░░░░░░░░░███░░
░░███░░░░░███░░░███░░░░░░░░░░███░░
░█████░░░█████░█████░░░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Keep rooms if they have pending invites
- [x] Remove notifications when the invite or room got deleted
- [x] Remove unwanted exposure of internal exceptions that are not part of the API

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
