### PR TITLE
Fix(LeftSidebar): Show hint when no filtered results

### DIFF
--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -580,7 +580,7 @@ const actions = {
 			return
 		}
 
-		commit('updateUnreadMessages', { token, unreadMessages: 0, unreadMention: false })
+		commit('updateUnreadMessages', { token, unreadMessages: 0, unreadMention: false, unreadMentionDirect: false })
 	},
 
 	async markConversationUnread({ commit, dispatch, getters }, { token }) {

--- a/src/utils/conversation.js
+++ b/src/utils/conversation.js
@@ -1,0 +1,59 @@
+/**
+ * @copyright Copyright (c) 2023 <dorra.jaoued7@gmail.com>
+ *
+ * @author Dorra Jaouad <dorra.jaoued7@gmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import { CONVERSATION } from '../constants.js'
+
+/**
+ * check if the conversation has unread messages
+ *
+ * @param {object} conversation conversation object
+ * @return {boolean}
+ */
+export function hasUnreadMessages(conversation) {
+	return conversation.unreadMessages > 0
+}
+
+/**
+ * check if the conversation has unread mentions
+ *
+ * @param {object} conversation conversation object
+ * @return {boolean}
+ */
+export function hasUnreadMentions(conversation) {
+	return conversation.unreadMention
+		|| conversation.unreadMentionDirect
+		|| (conversation.unreadMessages > 0
+			&& (conversation.type === CONVERSATION.TYPE.ONE_TO_ONE || conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER))
+}
+
+/**
+ * apply the active filter
+ *
+ * @param {string} filter the filter option
+ * @param {object} conversation conversation object
+ */
+export function filterFunction(filter, conversation) {
+	if (filter === 'unread') {
+		return hasUnreadMessages(conversation)
+	} else if (filter === 'mentions') {
+		return hasUnreadMentions(conversation)
+	}
+}


### PR DESCRIPTION
### ☑️ Resolves

`Hint` component was at the bottom of the `LeftSidebar` because the `ConversationListVirtual` is always present at full height.
* Added utility for conversation
* Refactored filter handling in leftSidebar
* Added captions for unread messages and unread mentions filter
* Add the empty content when there are no results

The filtering logic : 
"Standard Condition" :  if conversation  has call , mentions / unread message and is currently active in the chat view. 
"Special Condition" : if conversation is currently active, the only one in the list and has no flag. 
* At the moment the filter is first applied:

  - Apply Standard Condition.
  - Check Special Condition:
     * If yes, hide the current conversation by returning an empty list. This handles the case of clicking the filter initially and showing empty content if there are 0 unread conversations
      * If no, show the filtered list

* After filters are applied (during subsequent filter navigation):

  - Apply Standard Condition.

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After | Rare but possible ( empty list) |
|------------|----------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/84044328/6a6d9ef9-e22a-41fc-b195-a4bd8b7f53ac)   | ![image](https://github.com/nextcloud/spreed/assets/84044328/00b1abb8-b39e-4b34-94e7-60072eaa6989)    |![image](https://github.com/nextcloud/spreed/assets/84044328/631fab8f-9981-4f62-ba85-e6b3180288d7) |


### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required