### PR TITLE
fix(federation): Fix federation invite system messages

### DIFF
--- a/css/icons.css
+++ b/css/icons.css
@@ -71,12 +71,12 @@
  * .app-Talk rules above.
  * "forced-white" needs to be included in the class name as the Avatar does
  * not accept several classes. */
-.mention-bubble__icon.icon-group-forced-white,
+.user-bubble__avatar .avatar-class-icon.icon-group-forced-white,
 .tribute-container .icon-group-forced-white {
 	background-image: url(../img/icon-contacts-white.svg);
 }
 
-.mention-bubble__icon.icon-user-forced-white,
+.user-bubble__avatar .avatar-class-icon.icon-user-forced-white,
 .tribute-container .icon-user-forced-white {
 	background-image: url(../img/icon-user-white.svg)
 }

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -498,3 +498,5 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 * `audio_recording_stopped` - {actor} stopped an audio recording
 * `avatar_set` - {actor} set the conversation avatar
 * `avatar_removed` - {actor} removed the conversation avatar
+* `federated_user_added` - {actor} invited {federated_user} / {federated_user} accepted the invitation
+* `federated_user_removed` - {actor} removed {federated_user} / {federated_user} declined the invitation

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -289,11 +289,11 @@ class SystemMessage {
 			}
 		} elseif ($message === 'federated_user_added') {
 			$parsedParameters['federated_user'] = $this->getRemoteUser($parameters['federated_user']);
-			$parsedMessage = $this->l->t('{actor} invited {user}');
+			$parsedMessage = $this->l->t('{actor} invited {federated_user}');
 			if ($currentUserIsActor) {
-				$parsedMessage = $this->l->t('You invited {user}');
+				$parsedMessage = $this->l->t('You invited {federated_user}');
 			} elseif ($cliIsActor) {
-				$parsedMessage = $this->l->t('An administrator invited {user}');
+				$parsedMessage = $this->l->t('An administrator invited {federated_user}');
 			} elseif ($parsedParameters['federated_user']['id'] === $parsedParameters['actor']['id']) {
 				$parsedMessage = $this->l->t('{federated_user} accepted the invitation');
 			}

--- a/src/components/AvatarWrapper/AvatarWrapper.vue
+++ b/src/components/AvatarWrapper/AvatarWrapper.vue
@@ -121,6 +121,9 @@ export default {
 			if (!this.source || this.isUser || this.isBot || this.isGuest || this.isDeletedUser) {
 				return ''
 			}
+			if (this.isRemoteUser) {
+				return 'icon-user'
+			}
 			if (this.source === 'emails') {
 				return 'icon-mail'
 			}
@@ -145,6 +148,9 @@ export default {
 		},
 		isUser() {
 			return this.source === 'users' || this.source === ATTENDEE.ACTOR_TYPE.BRIDGED
+		},
+		isRemoteUser() {
+			return this.source === 'federated_users'
 		},
 		isBot() {
 			return this.source === 'bots' && this.id !== 'changelog'

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
@@ -33,6 +33,10 @@
 			:display-name="name"
 			:avatar-image="'icon-user-forced-white'"
 			:primary="isCurrentGuest" />
+		<NcUserBubble v-else-if="isRemoteUser"
+			:display-name="name"
+			:avatar-image="'icon-user-forced-white'"
+			:primary="isCurrentUser" />
 		<NcUserBubble v-else
 			:display-name="name"
 			:user="id"
@@ -69,6 +73,10 @@ export default {
 			type: String,
 			required: true,
 		},
+		server: {
+			type: String,
+			default: '',
+		},
 	},
 
 	computed: {
@@ -81,6 +89,9 @@ export default {
 		isMentionToGuest() {
 			return this.type === 'guest'
 		},
+		isRemoteUser() {
+			return this.type === 'user' && this.server !== ''
+		},
 		isCurrentGuest() {
 			// On mention bubbles the id is actually "guest/ACTOR_ID" for guests
 			// This is to make sure guests can never collide with users,
@@ -91,6 +102,11 @@ export default {
 				&& this.id === ('guest/' + this.$store.getters.getActorId())
 		},
 		isCurrentUser() {
+			if (this.isRemoteUser) {
+				// For now, we don't highlight remote users even if they are the one
+				return false
+			}
+
 			return this.$store.getters.getActorType() === 'users'
 				&& this.id === this.$store.getters.getUserId()
 		},

--- a/tests/integration/features/federation/invite.feature
+++ b/tests/integration/features/federation/invite.feature
@@ -27,7 +27,7 @@ Feature: federation/invite
       | federated_users | participant2 | 3               |
     Then user "participant1" sees the following system messages in room "room" with 200
       | room | actorType     | actorId      | systemMessage        | message                      | messageParameters |
-      | room | users         | participant1 | federated_user_added | You invited {user}           | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
+      | room | users         | participant1 | federated_user_added | You invited {federated_user} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
       | room | users         | participant1 | conversation_created | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
     And user "participant2" has the following invitations (v1)
       | remote_server | remote_token |
@@ -44,7 +44,7 @@ Feature: federation/invite
     Then user "participant1" sees the following system messages in room "room" with 200
       | room | actorType     | actorId      | systemMessage           | message                      | messageParameters |
       | room | federated_users | participant2@http://localhost:8180 | federated_user_added | {federated_user} accepted the invitation | {"actor":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
-      | room | users         | participant1 | federated_user_added    | You invited {user}           | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
+      | room | users         | participant1 | federated_user_added    | You invited {federated_user} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
       | room | users         | participant1 | conversation_created    | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
 
   Scenario: Declining an invite
@@ -60,7 +60,7 @@ Feature: federation/invite
       | federated_users | participant2 | 3               |
     Then user "participant1" sees the following system messages in room "room" with 200
       | room | actorType     | actorId      | systemMessage        | message                      | messageParameters |
-      | room | users         | participant1 | federated_user_added | You invited {user}           | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
+      | room | users         | participant1 | federated_user_added | You invited {federated_user} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
       | room | users         | participant1 | conversation_created | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
     And user "participant2" has the following invitations (v1)
       | remote_server | remote_token |
@@ -76,7 +76,7 @@ Feature: federation/invite
     Then user "participant1" sees the following system messages in room "room" with 200
       | room | actorType     | actorId      | systemMessage           | message                      | messageParameters |
       | room | federated_users | participant2@http://localhost:8180 | federated_user_removed | {federated_user} declined the invitation | {"actor":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
-      | room | users         | participant1 | federated_user_added    | You invited {user}           | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
+      | room | users         | participant1 | federated_user_added    | You invited {federated_user} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
       | room | users         | participant1 | conversation_created    | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
 
   Scenario: Authenticate as a federation user


### PR DESCRIPTION
### ☑️ Resolves

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Step | Screenshot
---|---
🏚️ Before | ![Bildschirmfoto vom 2023-10-11 10-43-32](https://github.com/nextcloud/spreed/assets/213943/adc5858e-0915-432d-9cae-d1eba9956244)
With only backend changed |  ![Bildschirmfoto vom 2023-10-11 10-43-11](https://github.com/nextcloud/spreed/assets/213943/a28ca4d8-26d1-4e01-b3ed-dbb0a8c8ed60)
🏠 After | ![grafik](https://github.com/nextcloud/spreed/assets/213943/ff896575-87bf-48ca-a804-3733958828a4)


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

---

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 

---

## Steps to produce

1. Enable federation on your instance `occ config:app:set spreed federation_enabled --value yes`
2. Use the OCS viewer app https://github.com/provokateurin/ocs_api_viewer and invite your own user to a conversation (adjust the IP to whatever you use to open your own Nextcloud)
![grafik](https://github.com/nextcloud/spreed/assets/213943/fea281db-8f75-4638-ba3d-175920194472)
