### PR TITLE
fix(federation): Error the POST /participant request when federation failed

### DIFF
--- a/lib/BackgroundJob/RetryJob.php
+++ b/lib/BackgroundJob/RetryJob.php
@@ -30,7 +30,7 @@ declare(strict_types=1);
  */
 namespace OCA\Talk\BackgroundJob;
 
-use OCA\Talk\Federation\Notifications;
+use OCA\Talk\Federation\BackendNotifier;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\Job;
@@ -51,7 +51,7 @@ class RetryJob extends Job {
 
 
 	public function __construct(
-		private Notifications $notifications,
+		private BackendNotifier $backendNotifier,
 		ITimeFactory $timeFactory,
 	) {
 		parent::__construct($timeFactory);
@@ -79,7 +79,7 @@ class RetryJob extends Job {
 		$data = json_decode($argument['data'], true);
 		$try = (int)$argument['try'] + 1;
 
-		$this->notifications->sendUpdateDataToRemote($remote, $data, $try);
+		$this->backendNotifier->sendUpdateDataToRemote($remote, $data, $try);
 	}
 
 	/**

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -32,6 +32,7 @@ use InvalidArgumentException;
 use OCA\Talk\Config;
 use OCA\Talk\Events\BeforeRoomsFetchEvent;
 use OCA\Talk\Events\UserEvent;
+use OCA\Talk\Exceptions\CannotReachRemoteException;
 use OCA\Talk\Exceptions\ForbiddenException;
 use OCA\Talk\Exceptions\InvalidPasswordException;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
@@ -1140,7 +1141,11 @@ class RoomController extends AEnvironmentAwareController {
 		}
 
 		// add the remaining users in batch
-		$this->participantService->addUsers($this->room, $participantsToAdd, $addedBy);
+		try {
+			$this->participantService->addUsers($this->room, $participantsToAdd, $addedBy);
+		} catch (CannotReachRemoteException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
 
 		return new DataResponse([]);
 	}

--- a/lib/Federation/BackendNotifier.php
+++ b/lib/Federation/BackendNotifier.php
@@ -41,7 +41,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
-class Notifications {
+class BackendNotifier {
 
 	public function __construct(
 		private ICloudFederationFactory $cloudFederationFactory,

--- a/lib/Federation/FederationManager.php
+++ b/lib/Federation/FederationManager.php
@@ -58,7 +58,7 @@ class FederationManager {
 		private Manager $manager,
 		private ParticipantService $participantService,
 		private InvitationMapper $invitationMapper,
-		private Notifications $notifications,
+		private BackendNotifier $backendNotifier,
 	) {
 	}
 
@@ -115,7 +115,7 @@ class FederationManager {
 		// Add user to the room
 		$room = $this->manager->getRoomById($invitation->getRoomId());
 		if (
-			!$this->notifications->sendShareAccepted($room->getRemoteServer(), $invitation->getRemoteId(), $invitation->getAccessToken())
+			!$this->backendNotifier->sendShareAccepted($room->getRemoteServer(), $invitation->getRemoteId(), $invitation->getAccessToken())
 		) {
 			throw new CannotReachRemoteException();
 		}
@@ -151,7 +151,7 @@ class FederationManager {
 
 		$this->invitationMapper->delete($invitation);
 
-		$this->notifications->sendShareDeclined($room->getRemoteServer(), $invitation->getRemoteId(), $invitation->getAccessToken());
+		$this->backendNotifier->sendShareDeclined($room->getRemoteServer(), $invitation->getRemoteId(), $invitation->getAccessToken());
 	}
 
 	/**

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -46,6 +46,7 @@ use OCA\Talk\Events\RemoveUserEvent;
 use OCA\Talk\Events\RoomEvent;
 use OCA\Talk\Events\SendCallNotificationEvent;
 use OCA\Talk\Events\SilentModifyParticipantEvent;
+use OCA\Talk\Exceptions\CannotReachRemoteException;
 use OCA\Talk\Exceptions\ForbiddenException;
 use OCA\Talk\Exceptions\InvalidPasswordException;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
@@ -431,6 +432,7 @@ class ParticipantService {
 	 * @param Room $room
 	 * @param array $participants
 	 * @param IUser|null $addedBy User that is attempting to add these users (must be set for federated users to be added)
+	 * @throws CannotReachRemoteException thrown when sending the federation request didn't work
 	 * @throws \Exception thrown if $addedBy is not set when adding a federated user
 	 */
 	public function addUsers(Room $room, array $participants, ?IUser $addedBy = null): void {
@@ -478,11 +480,15 @@ class ParticipantService {
 			$attendee->setLastReadMessage($lastMessage);
 			$attendee->setReadPrivacy($readPrivacy);
 			try {
-				$entity = $this->attendeeMapper->insert($attendee);
+				$this->attendeeMapper->insert($attendee);
 				$attendees[] = $attendee;
 
 				if ($attendee->getActorType() === Attendee::ACTOR_FEDERATED_USERS) {
-					$this->notifications->sendRemoteShare((string) $entity->getId(), $participant['accessToken'], $participant['actorId'], $addedBy->getDisplayName(), $addedBy->getCloudId(), 'user', $room, $this->getHighestPermissionAttendee($room));
+					$inviteSent = $this->notifications->sendRemoteShare((string) $attendee->getId(), $participant['accessToken'], $participant['actorId'], $addedBy->getDisplayName(), $addedBy->getCloudId(), 'user', $room, $this->getHighestPermissionAttendee($room));
+					if (!$inviteSent) {
+						$this->attendeeMapper->delete($attendee);
+						throw new CannotReachRemoteException();
+					}
 				}
 			} catch (Exception $e) {
 				if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -51,8 +51,8 @@ use OCA\Talk\Exceptions\ForbiddenException;
 use OCA\Talk\Exceptions\InvalidPasswordException;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Exceptions\UnauthorizedException;
+use OCA\Talk\Federation\BackendNotifier;
 use OCA\Talk\Federation\FederationManager;
-use OCA\Talk\Federation\Notifications;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\AttendeeMapper;
@@ -98,7 +98,7 @@ class ParticipantService {
 		private IUserManager $userManager,
 		private IGroupManager $groupManager,
 		private MembershipService $membershipService,
-		private Notifications $notifications,
+		private BackendNotifier $backendNotifier,
 		private ITimeFactory $timeFactory,
 		private ICacheFactory $cacheFactory,
 	) {
@@ -484,7 +484,7 @@ class ParticipantService {
 				$attendees[] = $attendee;
 
 				if ($attendee->getActorType() === Attendee::ACTOR_FEDERATED_USERS) {
-					$inviteSent = $this->notifications->sendRemoteShare((string) $attendee->getId(), $participant['accessToken'], $participant['actorId'], $addedBy->getDisplayName(), $addedBy->getCloudId(), 'user', $room, $this->getHighestPermissionAttendee($room));
+					$inviteSent = $this->backendNotifier->sendRemoteShare((string) $attendee->getId(), $participant['accessToken'], $participant['actorId'], $addedBy->getDisplayName(), $addedBy->getCloudId(), 'user', $room, $this->getHighestPermissionAttendee($room));
 					if (!$inviteSent) {
 						$this->attendeeMapper->delete($attendee);
 						throw new CannotReachRemoteException();

--- a/tests/integration/features/federation/invite.feature
+++ b/tests/integration/features/federation/invite.feature
@@ -14,6 +14,17 @@ Feature: federation/invite
       | actorType  | actorId      | participantType |
       | users      | participant1 | 1               |
 
+  Scenario: Invite an invalid user
+    Given the following "spreed" app config is set
+      | federation_enabled | yes |
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds remote "invalid-user" to room "room" with 404 (v4)
+    When user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+
   Scenario: Accepting an invite
     Given the following "spreed" app config is set
       | federation_enabled | yes |

--- a/tests/php/Federation/FederationTest.php
+++ b/tests/php/Federation/FederationTest.php
@@ -25,9 +25,9 @@ namespace OCA\Talk\Tests\php\Federation;
 use OC\Federation\CloudFederationShare;
 use OCA\FederatedFileSharing\AddressHandler;
 use OCA\Talk\Config;
+use OCA\Talk\Federation\BackendNotifier;
 use OCA\Talk\Federation\CloudFederationProviderTalk;
 use OCA\Talk\Federation\FederationManager;
-use OCA\Talk\Federation\Notifications;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\AttendeeMapper;
@@ -52,7 +52,7 @@ use Test\TestCase;
 class FederationTest extends TestCase {
 	protected ?FederationManager $federationManager = null;
 
-	protected ?Notifications $notifications = null;
+	protected ?BackendNotifier $backendNotifier = null;
 
 	/** @var ICloudFederationProviderManager|MockObject */
 	protected $cloudFederationProviderManager;
@@ -90,7 +90,7 @@ class FederationTest extends TestCase {
 		$this->config = $this->createMock(Config::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 
-		$this->notifications = new Notifications(
+		$this->backendNotifier = new BackendNotifier(
 			$this->cloudFederationFactory,
 			$this->addressHandler,
 			$this->logger,
@@ -194,7 +194,7 @@ class FederationTest extends TestCase {
 			->with($shareWith)
 			->willReturn(['test', 'remote.test.local']);
 
-		$this->notifications->sendRemoteShare($providerId, $token, $shareWith, $sharedBy, $sharedByFederatedId, $shareType, $room, $attendee);
+		$this->backendNotifier->sendRemoteShare($providerId, $token, $shareWith, $sharedBy, $sharedByFederatedId, $shareType, $room, $attendee);
 	}
 
 	public function testReceiveRemoteShare() {
@@ -337,7 +337,7 @@ class FederationTest extends TestCase {
 			->with($remote)
 			->willReturn(true);
 
-		$success = $this->notifications->sendShareAccepted($remote, $id, $token);
+		$success = $this->backendNotifier->sendShareAccepted($remote, $id, $token);
 
 		$this->assertEquals(true, $success);
 	}
@@ -374,7 +374,7 @@ class FederationTest extends TestCase {
 			->with($remote)
 			->willReturn(true);
 
-		$success = $this->notifications->sendShareDeclined($remote, $id, $token);
+		$success = $this->backendNotifier->sendShareDeclined($remote, $id, $token);
 
 		$this->assertEquals(true, $success);
 	}

--- a/tests/php/Service/ParticipantServiceTest.php
+++ b/tests/php/Service/ParticipantServiceTest.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Tests\php\Service;
 
 use OCA\Talk\Config;
-use OCA\Talk\Federation\Notifications;
+use OCA\Talk\Federation\BackendNotifier;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\AttendeeMapper;
 use OCA\Talk\Model\Session;
@@ -67,8 +67,8 @@ class ParticipantServiceTest extends TestCase {
 	protected $groupManager;
 	/** @var MembershipService|MockObject */
 	protected $membershipService;
-	/** @var Notifications|MockObject */
-	protected $federationNotifications;
+	/** @var BackendNotifier|MockObject */
+	protected $federationBackendNotifier;
 	/** @var ITimeFactory|MockObject */
 	protected $time;
 	/** @var ICacheFactory|MockObject */
@@ -89,7 +89,7 @@ class ParticipantServiceTest extends TestCase {
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->membershipService = $this->createMock(MembershipService::class);
-		$this->federationNotifications = $this->createMock(Notifications::class);
+		$this->federationBackendNotifier = $this->createMock(BackendNotifier::class);
 		$this->time = $this->createMock(ITimeFactory::class);
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
 		$this->service = new ParticipantService(
@@ -104,7 +104,7 @@ class ParticipantServiceTest extends TestCase {
 			$this->userManager,
 			$this->groupManager,
 			$this->membershipService,
-			$this->federationNotifications,
+			$this->federationBackendNotifier,
 			$this->time,
 			$this->cacheFactory
 		);

--- a/tests/php/Signaling/BackendNotifierTest.php
+++ b/tests/php/Signaling/BackendNotifierTest.php
@@ -27,7 +27,6 @@ use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Config;
 use OCA\Talk\Events\SignalingRoomPropertiesEvent;
-use OCA\Talk\Federation\Notifications;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\AttendeeMapper;
@@ -165,7 +164,7 @@ class BackendNotifierTest extends TestCase {
 			$this->userManager,
 			$groupManager,
 			\OC::$server->get(MembershipService::class),
-			\OC::$server->get(Notifications::class),
+			\OC::$server->get(\OCA\Talk\Federation\BackendNotifier::class),
 			$this->timeFactory,
 			\OC::$server->get(ICacheFactory::class)
 		);


### PR DESCRIPTION
### ☑️ Resolves

* Fix adding a person from a non-existing server, have a cert error, etc.
* Currently there is no user feedback to be aware.

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
