### PR TITLE
fix(notification): Render the actions and remove notification on click

### DIFF
--- a/lib/Federation/CloudFederationProviderTalk.php
+++ b/lib/Federation/CloudFederationProviderTalk.php
@@ -290,16 +290,6 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 				'roomToken' => $roomToken,
 			]);
 
-		$declineAction = $notification->createAction();
-		$declineAction->setLabel('decline')
-			->setLink($this->urlGenerator->linkToOCSRouteAbsolute('spreed.Federation.rejectShare', ['apiVersion' => 'v1', 'id' => $shareId]), 'DELETE');
-		$notification->addAction($declineAction);
-
-		$acceptAction = $notification->createAction();
-		$acceptAction->setLabel('accept')
-			->setLink($this->urlGenerator->linkToOCSRouteAbsolute('spreed.Federation.acceptShare', ['apiVersion' => 'v1', 'id' => $shareId]), 'POST');
-		$notification->addAction($acceptAction);
-
 		$this->notificationManager->notify($notification);
 	}
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -84,7 +84,6 @@ class Notifier implements INotifier {
 		protected INotificationManager $notificationManager,
 		CommentsManager $commentManager,
 		protected MessageParser $messageParser,
-		protected IURLGenerator $urlGenerator,
 		protected IRootFolder $rootFolder,
 		protected ITimeFactory $timeFactory,
 		protected Definitions $definitions,
@@ -331,7 +330,7 @@ class Notifier implements INotifier {
 			->setParsedLabel($l->t('Share to chat'))
 			->setPrimary(true)
 			->setLink(
-				$this->urlGenerator->linkToOCSRouteAbsolute(
+				$this->url->linkToOCSRouteAbsolute(
 					'spreed.Recording.shareToChat',
 					[
 						'apiVersion' => 'v1',
@@ -345,7 +344,7 @@ class Notifier implements INotifier {
 		$dismissAction = $notification->createAction()
 			->setParsedLabel($l->t('Dismiss notification'))
 			->setLink(
-				$this->urlGenerator->linkToOCSRouteAbsolute(
+				$this->url->linkToOCSRouteAbsolute(
 					'spreed.Recording.notificationDismiss',
 					[
 						'apiVersion' => 'v1',
@@ -442,6 +441,23 @@ class Notifier implements INotifier {
 				$replacements[] = $parameter['name'];
 			}
 		}
+
+		$acceptAction = $notification->createAction();
+		$acceptAction->setParsedLabel($l->t('Accept'));
+		$acceptAction->setLink($this->url->linkToOCSRouteAbsolute(
+			'spreed.Federation.acceptShare',
+			['apiVersion' => 'v1', 'id' => (int) $notification->getObjectId()]
+		), IAction::TYPE_POST);
+		$acceptAction->setPrimary(true);
+		$notification->addParsedAction($acceptAction);
+
+		$declineAction = $notification->createAction();
+		$declineAction->setParsedLabel($l->t('Decline'));
+		$declineAction->setLink($this->url->linkToOCSRouteAbsolute(
+			'spreed.Federation.rejectShare',
+			['apiVersion' => 'v1', 'id' => (int) $notification->getObjectId()]
+		), IAction::TYPE_DELETE);
+		$notification->addParsedAction($declineAction);
 
 		$notification->setParsedSubject(str_replace($placeholders, $replacements, $message));
 		$notification->setRichSubject($message, $rosParameters);
@@ -780,7 +796,7 @@ class Notifier implements INotifier {
 			$action->setLabel($l->t('Dismiss reminder'))
 				->setParsedLabel($l->t('Dismiss reminder'))
 				->setLink(
-					$this->urlGenerator->linkToOCSRouteAbsolute(
+					$this->url->linkToOCSRouteAbsolute(
 						'spreed.Chat.deleteReminder',
 						[
 							'apiVersion' => 'v1',

--- a/tests/php/Notification/NotifierTest.php
+++ b/tests/php/Notification/NotifierTest.php
@@ -83,8 +83,6 @@ class NotifierTest extends TestCase {
 	protected $commentsManager;
 	/** @var MessageParser|MockObject */
 	protected $messageParser;
-	/** @var IURLGenerator|MockObject */
-	protected $urlGenerator;
 	/** @var IRootFolder|MockObject */
 	protected $rootFolder;
 	/** @var ITimeFactory|MockObject */
@@ -115,7 +113,6 @@ class NotifierTest extends TestCase {
 		$this->notificationManager = $this->createMock(INotificationManager::class);
 		$this->commentsManager = $this->createMock(CommentsManager::class);
 		$this->messageParser = $this->createMock(MessageParser::class);
-		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->rootFolder = $this->createMock(IRootFolder::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->definitions = $this->createMock(Definitions::class);
@@ -137,7 +134,6 @@ class NotifierTest extends TestCase {
 			$this->notificationManager,
 			$this->commentsManager,
 			$this->messageParser,
-			$this->urlGenerator,
 			$this->rootFolder,
 			$this->timeFactory,
 			$this->definitions,


### PR DESCRIPTION
### ☑️ Resolves

* Fix #…


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![grafik](https://github.com/nextcloud/spreed/assets/213943/d64702d0-b3bc-4e2a-b960-8ba9ffb624e9)          | ![Bildschirmfoto vom 2023-10-11 17-07-54](https://github.com/nextcloud/spreed/assets/213943/f0aca481-4b7d-4d2a-bf1d-c6c20ed3e626)        |

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Make sure invite actions are shown and actionable
- [x] Immediately mark notifications as processed instead of on the next request due to missing invite object

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
