### PR TITLE
Add minor RTL support for chat messages

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -54,6 +54,7 @@ the main body of the message as well as a quote.
 					<NcRichText :text="message"
 						:arguments="richParameters"
 						autolink
+						dir="auto"
 						:reference-limit="0" />
 					<CallButton />
 				</div>
@@ -61,6 +62,7 @@ the main body of the message as well as a quote.
 					<NcRichText :text="message"
 						:arguments="richParameters"
 						autolink
+						dir="auto"
 						:reference-limit="0" />
 					<!-- Displays only the "see results" button with the results modal -->
 					<Poll v-if="showResultsButton"
@@ -73,6 +75,7 @@ the main body of the message as well as a quote.
 					<NcRichText :text="message"
 						:arguments="richParameters"
 						autolink
+						dir="auto"
 						:reference-limit="0" />
 				</div>
 				<div v-else
@@ -83,6 +86,7 @@ the main body of the message as well as a quote.
 					<NcRichText :text="message"
 						:arguments="richParameters"
 						autolink
+						dir="auto"
 						:use-markdown="markdown"
 						:reference-limit="1" />
 
@@ -992,6 +996,10 @@ export default {
 				display: flex;
 				border-radius: var(--border-radius-large);
 				align-items: center;
+				:deep(.rich-text--wrapper) {
+					flex-grow: 1;
+					text-align: start;
+				}
 			}
 
 			&--quote {
@@ -1120,17 +1128,24 @@ export default {
 }
 
 .message-body__main__text--markdown {
-  position: relative;
+	position: relative;
 
-  .message-copy-code {
-    position: absolute;
-    top: 0;
-    right: 4px;
-    margin-top: 4px;
-    background-color: var(--color-background-dark);
-  }
+	.message-copy-code {
+		position: absolute;
+		top: 0;
+		right: 4px;
+		margin-top: 4px;
+		background-color: var(--color-background-dark);
+	}
 
 	:deep(.rich-text--wrapper) {
+		text-align: start;
+
+		// Hardcode to prevent RTL affecting on user mentions
+		.rich-text--component {
+			direction: ltr;
+		}
+
 		// Overwrite core styles, otherwise h4 is lesser than default font-size
 		h4 {
 			font-size: 100%;
@@ -1138,6 +1153,12 @@ export default {
 
 		em {
 			font-style: italic;
+		}
+
+		ul,
+		ol {
+			padding-left: 0;
+			padding-inline-start: 15px;
 		}
 
 		pre {
@@ -1162,19 +1183,10 @@ export default {
 		}
 
 		blockquote {
-			position: relative;
+			padding-left: 0;
+			padding-inline-start: 13px;
 			border-left: none;
-
-			&::before {
-				content: ' ';
-				position: absolute;
-				top: 0;
-				left: 0;
-				height: 100%;
-				width: 4px;
-				border-radius: 2px;
-				background-color: var(--color-border);
-			}
+			border-inline-start: 4px solid var(--color-border);
 		}
 	}
 }

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -421,8 +421,8 @@ export default {
 				return false
 			}
 
-			// Only group messages within a short period of time, so unrelated messages are not grouped together
-			return (this.getDateOfMessage(message1).format('X') - this.getDateOfMessage(message2).format('X')) < 300
+			// Only group messages within a short period of time (5 minutes), so unrelated messages are not grouped together
+			return this.getDateOfMessage(message1).diff(this.getDateOfMessage(message2)) < 300 * 1000
 		},
 
 		/**

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -91,6 +91,7 @@
 					:menu-container="containerElement"
 					:placeholder="placeholderText"
 					:aria-label="placeholderText"
+					dir="auto"
 					@shortkey="focusInput"
 					@keydown.esc="handleInputEsc"
 					@tribute-active-true.native="isTributePickerActive = true"
@@ -857,5 +858,10 @@ export default {
 	&:disabled {
 		opacity: .5 !important;
 	}
+}
+
+// Hardcode to prevent RTL affecting on user mentions
+:deep(.mention-bubble) {
+	direction: ltr;
 }
 </style>

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -49,7 +49,7 @@ components.
 			</div>
 			<blockquote v-else
 				class="quote__main__text">
-				<p>{{ shortenedQuoteMessage }}</p>
+				<p dir="auto">{{ shortenedQuoteMessage }}</p>
 			</blockquote>
 		</div>
 		<div v-if="isNewMessageQuote" class="quote__main__right">
@@ -313,6 +313,7 @@ export default {
 				display: -webkit-box;
 				-webkit-line-clamp: 1;
 				-webkit-box-orient: vertical;
+				text-align: start;
 			}
 		}
 	}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10522 and provide for:
  * System messages
  * Deleted messages
  * User messages (including markdown)
  * New message input
  * :warning:  User mentions and mention bubbles are locked to LTR, to show icon on a left side
* Fix message grouping:
  * :warning: `moment().format()` transforms date based on locale, so result of comparison was NaN
  * Now, it compares only timestamps in ms
* Make markdown styles language-independent:
  * Applicable for ol, ul, blockquote
    * blockquote left border doesn't have rounded corners anymore :large_blue_circle: => :blue_square: 

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/b7321381-9bd3-4bc5-a758-e5466b876ec6)          | ![image](https://github.com/nextcloud/spreed/assets/93392545/3e653329-710c-4167-9f25-c22cf50b7ae7)       |
| ![image](https://github.com/nextcloud/spreed/assets/93392545/217d0373-42c1-4f53-b514-9fe45399acc5) | ![image](https://github.com/nextcloud/spreed/assets/93392545/df45b7e8-6b2f-48af-b633-b76b955bb7e0) |
![image](https://github.com/nextcloud/spreed/assets/93392545/9e190752-e07e-4efe-9894-28916147efc6) | ![Screenshot from 2023-10-11 18-48-15](https://github.com/nextcloud/spreed/assets/93392545/ab93446d-1b97-4f48-a596-1b3c2d72cc9c)


### 🚧 Tasks

- [ ] Check affected components

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required