### PR TITLE
Fix "silent" parameter not sent again when reconnecting

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -169,11 +169,15 @@ Signaling.Base.prototype.getCurrentCallFlags = function() {
 	return this.currentCallFlags
 }
 
+Signaling.Base.prototype._resetCurrentCallParameters = function() {
+	this.currentCallToken = null
+	this.currentCallFlags = null
+}
+
 Signaling.Base.prototype.disconnect = function() {
 	this.sessionId = ''
 	this._trigger('sessionId', [this.sessionId])
-	this.currentCallToken = null
-	this.currentCallFlags = null
+	this._resetCurrentCallParameters()
 }
 
 Signaling.Base.prototype.hasFeature = function(feature) {
@@ -222,8 +226,7 @@ Signaling.Base.prototype.leaveCurrentCall = function() {
 	return new Promise((resolve, reject) => {
 		if (this.currentCallToken) {
 			this.leaveCall(this.currentCallToken).then(() => { resolve() }).catch(reason => { reject(reason) })
-			this.currentCallToken = null
-			this.currentCallFlags = null
+			this._resetCurrentCallParameters()
 		} else {
 			resolve()
 		}
@@ -241,8 +244,7 @@ Signaling.Base.prototype.joinRoom = function(token, sessionId) {
 			// We were in this call before, join again.
 			this.joinCall(token, this.currentCallFlags)
 		} else {
-			this.currentCallToken = null
-			this.currentCallFlags = null
+			this._resetCurrentCallParameters()
 		}
 		this._joinRoomSuccess(token, sessionId)
 	})
@@ -358,8 +360,7 @@ Signaling.Base.prototype.leaveCall = function(token, keepToken, all = false) {
 				resolve()
 				// We left the current call.
 				if (!keepToken && token === this.currentCallToken) {
-					this.currentCallToken = null
-					this.currentCallFlags = null
+					this._resetCurrentCallParameters()
 				}
 			}.bind(this))
 			.catch(function() {
@@ -367,8 +368,7 @@ Signaling.Base.prototype.leaveCall = function(token, keepToken, all = false) {
 				reject(new Error())
 				// We left the current call.
 				if (!keepToken && token === this.currentCallToken) {
-					this.currentCallToken = null
-					this.currentCallFlags = null
+					this._resetCurrentCallParameters()
 				}
 			}.bind(this))
 	})

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -83,6 +83,7 @@ function Base(settings) {
 	this.currentRoomToken = null
 	this.currentCallToken = null
 	this.currentCallFlags = null
+	this.currentCallSilent = null
 	this.nextcloudSessionId = null
 	this.handlers = {}
 	this.features = {}
@@ -172,6 +173,7 @@ Signaling.Base.prototype.getCurrentCallFlags = function() {
 Signaling.Base.prototype._resetCurrentCallParameters = function() {
 	this.currentCallToken = null
 	this.currentCallFlags = null
+	this.currentCallSilent = null
 }
 
 Signaling.Base.prototype.disconnect = function() {
@@ -242,7 +244,7 @@ Signaling.Base.prototype.joinRoom = function(token, sessionId) {
 		resolve()
 		if (this.currentCallToken === token) {
 			// We were in this call before, join again.
-			this.joinCall(token, this.currentCallFlags)
+			this.joinCall(token, this.currentCallFlags, this.currentCallSilent)
 		} else {
 			this._resetCurrentCallParameters()
 		}
@@ -295,6 +297,7 @@ Signaling.Base.prototype.joinCall = function(token, flags, silent) {
 			.then(function() {
 				this.currentCallToken = token
 				this.currentCallFlags = flags
+				this.currentCallSilent = silent
 				this._trigger('joinCall', [token])
 				resolve()
 				this._joinCallSuccess(token)
@@ -520,7 +523,7 @@ Signaling.Internal.prototype._startPullingMessages = function() {
 					localParticipant = message.data.find(participant => participant.sessionId === this.sessionId)
 					if (this._joinCallAgainOnceDisconnected && !localParticipant.inCall) {
 						this._joinCallAgainOnceDisconnected = false
-						this.joinCall(this.currentCallToken, this.currentCallFlags)
+						this.joinCall(this.currentCallToken, this.currentCallFlags, this.currentCallSilent)
 					}
 
 					break
@@ -1181,7 +1184,7 @@ Signaling.Standalone.prototype._joinRoomSuccess = function(token, nextcloudSessi
 	}.bind(this))
 }
 
-Signaling.Standalone.prototype.joinCall = function(token, flags) {
+Signaling.Standalone.prototype.joinCall = function(token, flags, silent) {
 	if (this.signalingRoomJoined !== token) {
 		console.debug('Not joined room yet, not joining call', token)
 
@@ -1195,6 +1198,7 @@ Signaling.Standalone.prototype.joinCall = function(token, flags) {
 			this.pendingJoinCall = {
 				token,
 				flags,
+				silent,
 				resolve,
 				reject,
 			}
@@ -1214,6 +1218,7 @@ Signaling.Standalone.prototype.joinCall = function(token, flags) {
 
 			this.currentCallToken = token
 			this.currentCallFlags = flags
+			this.currentCallSilent = silent
 			this._trigger('joinCall', [token])
 
 			resolve()
@@ -1230,7 +1235,7 @@ Signaling.Standalone.prototype.joinResponseReceived = function(data, token) {
 		const pendingJoinCallResolve = this.pendingJoinCall.resolve
 		const pendingJoinCallReject = this.pendingJoinCall.reject
 
-		this.joinCall(this.pendingJoinCall.token, this.pendingJoinCall.flags).then(() => {
+		this.joinCall(this.pendingJoinCall.token, this.pendingJoinCall.flags, this.pendingJoinCall.silent).then(() => {
 			pendingJoinCallResolve()
 		}).catch(error => {
 			pendingJoinCallReject(error)


### PR DESCRIPTION
When a call was joined the value of the `silent` parameter was not tracked by the signaling object, so if the call was joined again (for example, in a forced reconnection, or if joining the call was deferred because the room was not joined yet by the signaling) `silent` was undefined, which [was treated as `false` by the API](https://github.com/nextcloud/spreed/blob/4d292fe9599f1598b4a44b094595404f1e465dec/lib/Controller/CallController.php#L134).

The current set of scenarios that could trigger the issue is unlikely to happen in the real world, although it is possible nevertheless. Other slightly more common cases, like the participant starting without audio and video and then selecting the devices while already in the call [would not trigger a reconnection, just an update of flags](https://github.com/nextcloud/spreed/blob/dbcf46c232e7b68eaae6217f6958623d41090fa5/src/utils/webrtc/webrtc.js#L1524-L1540) (at least if no one else joined yet, but if someone else joined then the reconnection will not cause the call to be started again, it would be just a participant leaving and then joining again).

I was surprised to find that the second scenario below is also fixed by this pull request. But it turns out that when another participant joins the call [it always uses `silent = true`](https://github.com/nextcloud/spreed/blob/8f989237c6e98e6aafec71d05303d6d0b2136796/src/components/TopBar/CallButton.vue#L308), no matter how the call was originally started (I assumed that, as the call was already started and no notification would be sent anyway, `silent` would be `false`, which would have caused a notification to be sent if the rest of participants left and a participant that joined once the call was already started then had a reconnection, as that would cause the call to be started again). But it is fixed, so :partying_face: 

## How to test (scenario 1)

- Enable the notifications app
- Create a conversation and add user A and user B
- Set default permissions of the conversation to allow starting a call, but do not allow publishing audio and video
- In a private window, log in as user A
- Open the conversation
- Start a silent call
- In another browser, log in as user B
- In the original browser window, grant all permissions to user A

### Result with this pull request

The user B does not receive any notification about a started call, even if the call was started again due to the reconnection of user A

### Result without this pull request

The user B receives a notification about a started call



## How to test (scenario 2)

- Enable the notifications app
- Create a conversation and add user A and user B
- Set default permissions of the conversation to allow starting a call, but do not allow publishing audio and video
- Start a silent call
- In a private window, log in as user A
- Open the conversation
- Join the call
- In another browser, log in as user B
- In the original browser window, leave the call
- Grant all permissions to user A

### Result with this pull request

The user B does not receive any notification about a started call, even if the call was started again due to the reconnection of user A

### Result without this pull request

The user B receives a notification about a started call
