### PR TITLE
fix(participants): Don't throw an exception when inviting the same em…

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1070,9 +1070,12 @@ class RoomController extends AEnvironmentAwareController {
 				$data = ['type' => $this->room->getType()];
 			}
 
-			$participant = $this->participantService->inviteEmailAddress($this->room, $newParticipant);
-
-			$this->guestManager->sendEmailInvitation($this->room, $participant);
+			try {
+				$this->participantService->getParticipantByActor($this->room, Attendee::ACTOR_EMAILS, $newParticipant);
+			} catch (ParticipantNotFoundException) {
+				$participant = $this->participantService->inviteEmailAddress($this->room, $newParticipant);
+				$this->guestManager->sendEmailInvitation($this->room, $participant);
+			}
 
 			return new DataResponse($data);
 		} elseif ($source === 'remotes') {

--- a/tests/integration/features/conversation/invite-email.feature
+++ b/tests/integration/features/conversation/invite-email.feature
@@ -7,6 +7,9 @@ Feature: conversation/invite-email)
       | roomType | 3 |
       | roomName | room |
     When user "participant1" adds email "test@example.tld" to room "room" with 200 (v4)
+    # Adding the same email again should not error to help the Calendar integration
+    # Ref https://github.com/nextcloud/calendar/pull/5380
+    When user "participant1" adds email "test@example.tld" to room "room" with 200 (v4)
     Then user "participant1" sees the following attendees in room "room" with 200 (v4)
       | participantType | inCall   | actorType | actorId           |
       | 4               | 0        | emails    | test@example.tld  |


### PR DESCRIPTION
…ail twice

### ☑️ Resolves

* Was brought up by groupware team after developing https://github.com/nextcloud/calendar/pull/5380

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
