### PR TITLE
[stable25] - fix message grouping for all locales

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -368,8 +368,8 @@ export default {
 				return false
 			}
 
-			// Only group messages within a short period of time, so unrelated messages are not grouped together
-			return (this.getDateOfMessage(message1).format('X') - this.getDateOfMessage(message2).format('X')) < 300
+			// Only group messages within a short period of time (5 minutes), so unrelated messages are not grouped together
+			return this.getDateOfMessage(message1).diff(this.getDateOfMessage(message2)) < 300 * 1000
 		},
 
 		/**


### PR DESCRIPTION
Manual partial backport of #10687

To test:
- switch locale to arabic
- open chat
- post some messages
Output:
- messages should be grouped