### PR TITLE
fix(messagesStore): clear deleted messages from replies

### DIFF
--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -521,6 +521,16 @@ const actions = {
 					messageId: message.parent.id,
 				})
 			}
+
+			// Check existing messages for having a deleted message as parent, and update them
+			if (message.systemMessage === 'message_deleted') {
+				context.getters.messagesList(message.token)
+					.filter(storedMessage => storedMessage.parent?.id === message.parent.id)
+					.forEach(storedMessage => {
+						context.commit('addMessage', Object.assign({}, storedMessage, { parent: message.parent }))
+					})
+			}
+
 			// Quit processing
 			return
 		}


### PR DESCRIPTION
### ☑️ Resolves

* Regression from #10296
* If several messages has one as a parent, and parent has been deleted, now we loop through all exisiting messages and clear a parent from each one

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

[Screencast from 15.10.2023 15:13:11.webm](https://github.com/nextcloud/spreed/assets/93392545/7b87ae59-13d2-44d5-8dde-1b9ade06f94e)


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] ⛑️ Tests are included or not possible