### PR TITLE
fix(SIPBridge): fix typo when sending shared secret as payload

### DIFF
--- a/src/components/AdminSettings/SIPBridge.vue
+++ b/src/components/AdminSettings/SIPBridge.vue
@@ -51,14 +51,13 @@
 				{{ t('spreed', 'Only users of the following groups can enable SIP in conversations they moderate') }}
 			</p>
 
-			<NcTextField :value="sharedSecret"
+			<NcTextField :value.sync="sharedSecret"
 				name="shared-secret"
 				class="form__textfield additional-top-margin"
 				:disabled="loading"
 				:placeholder="t('spreed', 'Shared secret')"
 				:label="t('spreed', 'Shared secret')"
-				label-visible
-				@update:value="updateSecret" />
+				label-visible />
 
 			<label for="dial-in-info" class="form__label additional-top-margin">
 				{{ t('spreed', 'Dial-in information') }}
@@ -164,10 +163,6 @@ export default {
 
 			this.loading = false
 			showSuccess(t('spreed', 'SIP configuration saved!'))
-		},
-
-		updateSecret(value) {
-			this.secret = value
 		},
 	},
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #9384
* Input value wasn't stored in component => empty payload (should have been `this.sharedSecret = value`)

Before | After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/4a2a2b10-7185-4abb-8a48-6978062d4299) | ![image](https://github.com/nextcloud/spreed/assets/93392545/7a6aa4dc-0ad2-4900-86cf-039811d62115)


