### PR TITLE
show MediaSettings if coming from notification "Join call"

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -892,7 +892,7 @@ class Notifier implements INotifier {
 		if ($room->getType() === Room::TYPE_ONE_TO_ONE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			$subject = $l->t('{user} invited you to a private conversation');
 			if ($this->participantService->hasActiveSessionsInCall($room)) {
-				$notification = $this->addActionButton($notification, $l->t('Join call'));
+				$notification = $this->addActionButton($notification, $l->t('Join call'), true, true);
 			} else {
 				$notification = $this->addActionButton($notification, $l->t('View chat'), false);
 			}
@@ -918,7 +918,7 @@ class Notifier implements INotifier {
 		} elseif (\in_array($room->getType(), [Room::TYPE_GROUP, Room::TYPE_PUBLIC], true)) {
 			$subject = $l->t('{user} invited you to a group conversation: {call}');
 			if ($this->participantService->hasActiveSessionsInCall($room)) {
-				$notification = $this->addActionButton($notification, $l->t('Join call'));
+				$notification = $this->addActionButton($notification, $l->t('Join call'), true, true);
 			} else {
 				$notification = $this->addActionButton($notification, $l->t('View chat'), false);
 			}
@@ -968,7 +968,7 @@ class Notifier implements INotifier {
 			$userDisplayName = $this->userManager->getDisplayName($calleeId);
 			if ($userDisplayName !== null) {
 				if ($this->notificationManager->isPreparingPushNotification() || $this->participantService->hasActiveSessionsInCall($room)) {
-					$notification = $this->addActionButton($notification, $l->t('Answer call'));
+					$notification = $this->addActionButton($notification, $l->t('Answer call'), true, true);
 					$subject = $l->t('{user} would like to talk with you');
 				} else {
 					$notification = $this->addActionButton($notification, $l->t('Call back'));
@@ -998,7 +998,7 @@ class Notifier implements INotifier {
 			}
 		} elseif (\in_array($room->getType(), [Room::TYPE_GROUP, Room::TYPE_PUBLIC], true)) {
 			if ($this->notificationManager->isPreparingPushNotification() || $this->participantService->hasActiveSessionsInCall($room)) {
-				$notification = $this->addActionButton($notification, $l->t('Join call'));
+				$notification = $this->addActionButton($notification, $l->t('Join call'), true, true);
 				$subject = $l->t('A group call has started in {call}');
 			} else {
 				$notification = $this->addActionButton($notification, $l->t('View chat'), false);
@@ -1056,7 +1056,7 @@ class Notifier implements INotifier {
 
 		$callIsActive = $this->notificationManager->isPreparingPushNotification() || $this->participantService->hasActiveSessionsInCall($room);
 		if ($callIsActive) {
-			$notification = $this->addActionButton($notification, $l->t('Answer call'));
+			$notification = $this->addActionButton($notification, $l->t('Answer call'), true, true);
 		} else {
 			$notification = $this->addActionButton($notification, $l->t('Call back'));
 		}
@@ -1095,11 +1095,16 @@ class Notifier implements INotifier {
 		return $notification;
 	}
 
-	protected function addActionButton(INotification $notification, string $label, bool $primary = true): INotification {
+	protected function addActionButton(INotification $notification, string $label, bool $primary = true, bool $directCallLink = false): INotification {
+		$link = $notification->getLink();
+		if ($directCallLink) {
+			$link .= '#direct-call';
+		}
+
 		$action = $notification->createAction();
 		$action->setLabel($label)
 			->setParsedLabel($label)
-			->setLink($notification->getLink(), IAction::TYPE_WEB)
+			->setLink($link, IAction::TYPE_WEB)
 			->setPrimary($primary);
 
 		$notification->addParsedAction($action);

--- a/src/App.vue
+++ b/src/App.vue
@@ -453,6 +453,10 @@ export default {
 			} else if (to.name === 'notfound') {
 				this.setPageTitle('')
 			}
+
+			if (to.hash === '#direct-call') {
+				emit('talk:media-settings:show')
+			}
 		})
 
 		if (getCurrentUser()) {
@@ -481,6 +485,10 @@ export default {
 			})
 		}
 
+		if (this.$route.hash === '#direct-call') {
+			emit('talk:media-settings:show')
+		}
+
 		subscribe('notifications:action:execute', this.interceptNotificationActions)
 		subscribe('notifications:notification:received', this.interceptNotificationReceived)
 	},
@@ -507,12 +515,12 @@ export default {
 				return
 			}
 
-			const [token, messageId] = load.split('#message_')
+			const [token, hash] = load.split('#')
 			this.$router.push({
 				name: 'conversation',
+				hash: hash ? `#${hash}` : '',
 				params: {
 					token,
-					hash: messageId ? `#message_${messageId}` : '',
 				},
 			})
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #7038

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

No visual changes
* With opening from web client - redirect to the page, media settings dialog is shown
* With opening from NC Desktop client - open new page in browser, media settings dialog is shown

### 🚧 Tasks

- [ ] Talk Desktop - test with
- [ ] Don't show previews for specific conversations:
  - [ ] BrowserStorage should be available atm
  - [ ] Or we force the dialog

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

---

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░█████████░░░███████████░░█████░
░░███░░░░░███░░░███░░░░░███░░███░░
░░███░░░░░███░░░███░░░░░███░░███░░
░░███████████░░░██████████░░░███░░
░░███░░░░░███░░░███░░░░░░░░░░███░░
░░███░░░░░███░░░███░░░░░░░░░░███░░
░█████░░░█████░█████░░░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
