### PR TITLE
feat(consent): Save recording consent to DB and allow retrieving with OCC

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>18.0.0-dev.7</version>
+	<version>18.0.0-dev.8</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>
@@ -97,6 +97,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 		<command>OCA\Talk\Command\Monitor\Calls</command>
 		<command>OCA\Talk\Command\Monitor\HasActiveCalls</command>
 		<command>OCA\Talk\Command\Monitor\Room</command>
+		<command>OCA\Talk\Command\Recording\Consent</command>
 		<command>OCA\Talk\Command\Room\Add</command>
 		<command>OCA\Talk\Command\Room\Create</command>
 		<command>OCA\Talk\Command\Room\Delete</command>

--- a/docs/occ.md
+++ b/docs/occ.md
@@ -224,6 +224,21 @@ Prints the number of attendees, active sessions and participant in the call.
 | `--output` | Output format (plain, json or json_pretty, default is plain) | yes | no | no | `'plain'` |
 | `--separator` | Separator for the CSV list when output=csv is used | yes | yes | no | *Required* |
 
+## talk:recording:consent
+
+List all matching consent that were given to be audio and video recorded during a call (requires administrator or moderator configuration)
+
+### Usage
+
+* `talk:recording:consent [--output [OUTPUT]] [--token TOKEN] [--actor-type ACTOR-TYPE] [--actor-id ACTOR-ID]`
+
+| Options | Description | Accept value | Is value required | Is multiple | Default |
+|---|---|---|---|---|---|
+| `--output` | Output format (plain, json or json_pretty, default is plain) | yes | no | no | `'plain'` |
+| `--token` | Limit to the given conversation | yes | yes | no | *Required* |
+| `--actor-type` | Limit to the given actor (only valid when --actor-id is also provided) | yes | yes | no | *Required* |
+| `--actor-id` | Limit to the given actor (only valid when --actor-type is also provided) | yes | yes | no | *Required* |
+
 ## talk:room:add
 
 Adds users to a room

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -48,6 +48,7 @@ use OCA\Talk\Events\AttendeesRemovedEvent;
 use OCA\Talk\Events\BeforeRoomsFetchEvent;
 use OCA\Talk\Events\BotInstallEvent;
 use OCA\Talk\Events\BotUninstallEvent;
+use OCA\Talk\Events\RoomDeletedEvent;
 use OCA\Talk\Events\RoomEvent;
 use OCA\Talk\Events\SendCallNotificationEvent;
 use OCA\Talk\Federation\CloudFederationProviderTalk;
@@ -153,6 +154,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(AddingCircleMemberEvent::class, CircleMembershipListener::class);
 		$context->registerEventListener(RemovingCircleMemberEvent::class, CircleMembershipListener::class);
 
+		$context->registerEventListener(RoomDeletedEvent::class, RecordingListener::class);
 		$context->registerEventListener(TranscriptionSuccessfulEvent::class, RecordingListener::class);
 		$context->registerEventListener(TranscriptionFailedEvent::class, RecordingListener::class);
 

--- a/lib/Command/Recording/Consent.php
+++ b/lib/Command/Recording/Consent.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Command\Recording;
+
+use OC\Core\Command\Base;
+use OCA\Talk\Exceptions\RoomNotFoundException;
+use OCA\Talk\Manager;
+use OCA\Talk\Room;
+use OCA\Talk\Service\ConsentService;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Consent extends Base {
+
+	public function __construct(
+		protected Manager $roomManager,
+		protected ConsentService $consentService,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		parent::configure();
+		$this
+			->setName('talk:recording:consent')
+			->setDescription('List all matching consent that were given to be audio and video recorded during a call (requires administrator or moderator configuration)')
+			->addOption(
+				'token',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'Limit to the given conversation'
+			)
+			->addOption(
+				'actor-type',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'Limit to the given actor (only valid when --actor-id is also provided)'
+			)
+			->addOption(
+				'actor-id',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'Limit to the given actor (only valid when --actor-type is also provided)'
+			)
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$token = $input->getOption('token');
+		$actorType = $input->getOption('actor-type');
+		$actorId = $input->getOption('actor-id');
+		if (($actorType !== null) !== ($actorId !== null)) {
+			$output->writeln('<error>actor-type and actor-id must either both be specified or both left out</error>');
+			return 1;
+		}
+
+		$room = null;
+		if ($token !== null) {
+			try {
+				$room = $this->roomManager->getRoomByToken($token);
+			} catch (RoomNotFoundException) {
+				$output->writeln('<error>Conversation could not be found by token</error>');
+				return 2;
+			}
+		}
+
+		if ($actorType) {
+			if ($room instanceof Room) {
+				$consentData = $this->consentService->getConsentForRoomByActor($room, $actorType, $actorId);
+			} else {
+				$consentData = $this->consentService->getConsentForActor($actorType, $actorId);
+			}
+		} elseif ($room instanceof Room) {
+			$consentData = $this->consentService->getConsentForRoom($room);
+		} else {
+			$output->writeln('<error>No conversation or actor provided</error>');
+			return 3;
+		}
+
+		$this->writeTableInOutputFormat(
+			$input,
+			$output,
+			array_map(static fn (\OCA\Talk\Model\Consent $consent) => $consent->jsonSerialize(), $consentData)
+		);
+
+		return 0;
+	}
+
+}

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -38,6 +38,7 @@ use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\Session;
 use OCA\Talk\Participant;
 use OCA\Talk\ResponseDefinitions;
+use OCA\Talk\Service\ConsentService;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\RecordingService;
 use OCA\Talk\Service\RoomService;
@@ -56,6 +57,7 @@ class CallController extends AEnvironmentAwareController {
 	public function __construct(
 		string $appName,
 		IRequest $request,
+		private ConsentService $consentService,
 		private ParticipantService $participantService,
 		private RoomService $roomService,
 		private IUserManager $userManager,
@@ -140,6 +142,9 @@ class CallController extends AEnvironmentAwareController {
 				&& $this->room->getRecordingConsent() === RecordingService::CONSENT_REQUIRED_YES) {
 				return new DataResponse(['error' => 'consent'], Http::STATUS_BAD_REQUEST);
 			}
+		} elseif ($recordingConsent && $this->talkConfig->recordingConsentRequired() !== RecordingService::CONSENT_REQUIRED_NO) {
+			$attendee = $this->participant->getAttendee();
+			$this->consentService->storeConsent($this->room, $attendee->getActorType(), $attendee->getActorId());
 		}
 
 		$this->participantService->ensureOneToOneRoomIsFilled($this->room);

--- a/lib/Events/BeforeRoomDeletedEvent.php
+++ b/lib/Events/BeforeRoomDeletedEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Events;
+
+class BeforeRoomDeletedEvent extends RoomEvent {
+}

--- a/lib/Events/RoomDeletedEvent.php
+++ b/lib/Events/RoomDeletedEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Events;
+
+class RoomDeletedEvent extends RoomEvent {
+}

--- a/lib/Listener/UserDeletedListener.php
+++ b/lib/Listener/UserDeletedListener.php
@@ -25,6 +25,7 @@ namespace OCA\Talk\Listener;
 
 use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
+use OCA\Talk\Service\ConsentService;
 use OCA\Talk\Service\PollService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -38,6 +39,7 @@ class UserDeletedListener implements IEventListener {
 	public function __construct(
 		private Manager $manager,
 		private PollService $pollService,
+		private ConsentService $consentService,
 	) {
 	}
 
@@ -51,5 +53,7 @@ class UserDeletedListener implements IEventListener {
 		$this->manager->removeUserFromAllRooms($user);
 
 		$this->pollService->neutralizeDeletedUser(Attendee::ACTOR_USERS, $user->getUID());
+
+		$this->consentService->deleteByActor(Attendee::ACTOR_USERS, $user->getUID());
 	}
 }

--- a/lib/Migration/Version18000Date20231018065816.php
+++ b/lib/Migration/Version18000Date20231018065816.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023, Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version18000Date20231018065816 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('talk_consent')) {
+			$table = $schema->createTable('talk_consent');
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+			]);
+			$table->addColumn('token', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('actor_type', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('actor_id', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('date_time', Types::DATETIME, [
+				'notnull' => false,
+			]);
+
+			$table->setPrimaryKey(['id']);
+
+			$table->addIndex(['token'], 'talk_reccons_token');
+			$table->addIndex(['actor_id', 'actor_type'], 'talk_reccons_actor');
+
+			return $schema;
+		}
+		return null;
+	}
+}

--- a/lib/Model/Consent.php
+++ b/lib/Model/Consent.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023, Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Model;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method void setToken(string $token)
+ * @method string getToken()
+ * @method void setActorType(string $actorType)
+ * @method string getActorType()
+ * @method void setActorId(string $actorId)
+ * @method string getActorId()
+ * @method void setDateTime(\DateTime $dateTime)
+ * @method \DateTime getDateTime()
+ */
+class Consent extends Entity implements \JsonSerializable {
+	protected string $token = '';
+	protected string $actorType = '';
+	protected string $actorId = '';
+	protected ?\DateTime $dateTime = null;
+
+	public function __construct() {
+		$this->addType('token', 'string');
+		$this->addType('actorType', 'string');
+		$this->addType('actorId', 'string');
+		$this->addType('dateTime', 'datetime');
+	}
+
+	public function jsonSerialize(): array {
+		return [
+			'token' => $this->getToken(),
+			'actorType' => $this->getActorType(),
+			'actorId' => $this->getActorId(),
+			'timestamp' => $this->getDateTime()->getTimestamp(),
+		];
+	}
+}

--- a/lib/Model/ConsentMapper.php
+++ b/lib/Model/ConsentMapper.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023, Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Model;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * @method Consent mapRowToEntity(array $row)
+ * @method Consent findEntity(IQueryBuilder $query)
+ * @method Consent[] findEntities(IQueryBuilder $query)
+ * @template-extends QBMapper<Consent>
+ */
+class ConsentMapper extends QBMapper {
+	public function __construct(
+		IDBConnection $db,
+	) {
+		parent::__construct($db, 'talk_consent', Consent::class);
+	}
+
+	/**
+	 * @return Consent[]
+	 */
+	public function findForToken(string $token): array {
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->eq('token', $query->createNamedParameter($token)));
+
+		return $this->findEntities($query);
+	}
+
+	public function deleteByToken(string $token): int {
+		$query = $this->db->getQueryBuilder();
+		$query->delete($this->getTableName())
+			->where($query->expr()->eq('token', $query->createNamedParameter($token)));
+
+		return $query->executeStatement();
+	}
+
+	/**
+	 * @return Consent[]
+	 */
+	public function findForActor(string $actorType, string $actorId): array {
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->eq('actor_type', $query->createNamedParameter($actorType)))
+			->andWhere($query->expr()->eq('actor_id', $query->createNamedParameter($actorId)));
+
+		return $this->findEntities($query);
+	}
+
+	public function deleteByActor(string $actorType, string $actorId): int {
+		$query = $this->db->getQueryBuilder();
+		$query->delete($this->getTableName())
+			->where($query->expr()->eq('actor_type', $query->createNamedParameter($actorType)))
+			->andWhere($query->expr()->eq('actor_id', $query->createNamedParameter($actorId)));
+
+		return $query->executeStatement();
+	}
+
+	/**
+	 * @return Consent[]
+	 */
+	public function findForTokenByActor(string $token, string $actorType, string $actorId): array {
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->eq('token', $query->createNamedParameter($token)))
+			->andWhere($query->expr()->eq('actor_type', $query->createNamedParameter($actorType)))
+			->andWhere($query->expr()->eq('actor_id', $query->createNamedParameter($actorId)));
+
+		return $this->findEntities($query);
+	}
+}

--- a/lib/Service/ConsentService.php
+++ b/lib/Service/ConsentService.php
@@ -26,17 +26,11 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Service;
 
-use OCA\Talk\AppInfo\Application;
-use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\Consent;
 use OCA\Talk\Model\ConsentMapper;
-use OCA\Talk\Model\Reminder;
-use OCA\Talk\Model\ReminderMapper;
 use OCA\Talk\Room;
-use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\Notification\IManager;
 
 class ConsentService {
 	public function __construct(

--- a/lib/Service/ConsentService.php
+++ b/lib/Service/ConsentService.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Service;
+
+use OCA\Talk\AppInfo\Application;
+use OCA\Talk\Chat\ChatManager;
+use OCA\Talk\Model\Attendee;
+use OCA\Talk\Model\Consent;
+use OCA\Talk\Model\ConsentMapper;
+use OCA\Talk\Model\Reminder;
+use OCA\Talk\Model\ReminderMapper;
+use OCA\Talk\Room;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Notification\IManager;
+
+class ConsentService {
+	public function __construct(
+		protected ITimeFactory $timeFactory,
+		protected ConsentMapper $consentMapper,
+	) {
+	}
+
+	public function storeConsent(Room $room, string $actorType, string $actorId): Consent {
+		$consent = new Consent();
+		$consent->setToken($room->getToken());
+		$consent->setActorType($actorType);
+		$consent->setActorId($actorId);
+		$consent->setDateTime($this->timeFactory->getDateTime());
+		$this->consentMapper->insert($consent);
+
+		return $consent;
+	}
+
+	/**
+	 * @return Consent[]
+	 */
+	public function getConsentForRoom(Room $room): array {
+		return $this->consentMapper->findForToken($room->getToken());
+	}
+
+	/**
+	 * @param Attendee::ACTOR_* $actorType
+	 * @return Consent[]
+	 */
+	public function getConsentForActor(string $actorType, string $actorId): array {
+		return $this->consentMapper->findForActor($actorType, $actorId);
+	}
+
+	/**
+	 * @param Attendee::ACTOR_* $actorType
+	 * @return Consent[]
+	 */
+	public function getConsentForRoomByActor(Room $room, string $actorType, string $actorId): array {
+		return $this->consentMapper->findForTokenByActor($room->getToken(), $actorType, $actorId);
+	}
+
+	public function deleteByActor(string $actorType, string $actorId): void {
+		$this->consentMapper->deleteByActor($actorType, $actorId);
+	}
+
+	public function deleteByRoom(Room $room): void {
+		$this->consentMapper->deleteByToken($room->getToken());
+	}
+}

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -25,9 +25,11 @@ namespace OCA\Talk\Service;
 
 use InvalidArgumentException;
 use OCA\Talk\Config;
+use OCA\Talk\Events\BeforeRoomDeletedEvent;
 use OCA\Talk\Events\BeforeRoomModifiedEvent;
 use OCA\Talk\Events\ModifyLobbyEvent;
 use OCA\Talk\Events\ModifyRoomEvent;
+use OCA\Talk\Events\RoomDeletedEvent;
 use OCA\Talk\Events\RoomEvent;
 use OCA\Talk\Events\RoomModifiedEvent;
 use OCA\Talk\Events\VerifyRoomPasswordEvent;
@@ -848,8 +850,10 @@ class RoomService {
 	}
 
 	public function deleteRoom(Room $room): void {
-		$event = new RoomEvent($room);
-		$this->dispatcher->dispatch(Room::EVENT_BEFORE_ROOM_DELETE, $event);
+		$event = new BeforeRoomDeletedEvent($room);
+		$this->dispatcher->dispatchTyped($event);
+		$legacyEvent = new RoomEvent($room);
+		$this->dispatcher->dispatch(Room::EVENT_BEFORE_ROOM_DELETE, $legacyEvent);
 
 		// Delete all breakout rooms when deleting a parent room
 		if ($room->getBreakoutRoomMode() !== BreakoutRoom::MODE_NOT_CONFIGURED) {
@@ -871,7 +875,9 @@ class RoomService {
 			->where($delete->expr()->eq('id', $delete->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)));
 		$delete->executeStatement();
 
-		$this->dispatcher->dispatch(Room::EVENT_AFTER_ROOM_DELETE, $event);
+		$event = new RoomDeletedEvent($room);
+		$this->dispatcher->dispatchTyped($event);
+		$this->dispatcher->dispatch(Room::EVENT_AFTER_ROOM_DELETE, $legacyEvent);
 		if (class_exists(CriticalActionPerformedEvent::class)) {
 			$this->dispatcher->dispatchTyped(new CriticalActionPerformedEvent(
 				'Conversation "%s" deleted',

--- a/tests/integration/features/callapi/recording.feature
+++ b/tests/integration/features/callapi/recording.feature
@@ -594,3 +594,9 @@ Feature: callapi/recording
     Then user "participant1" is participant of the following unordered rooms (v4)
       | type | name  | recordingConsent |
       | 2    | room1 | 0                |
+    And the following recording consent is recorded for room "room1"
+      | token | actorType | actorId      |
+      | room1 | users     | participant1 |
+    And the following recording consent is recorded for user "participant1"
+      | token | actorType | actorId      |
+      | room1 | users     | participant1 |

--- a/tests/integration/spreedcheats/lib/Controller/ApiController.php
+++ b/tests/integration/spreedcheats/lib/Controller/ApiController.php
@@ -71,6 +71,9 @@ class ApiController extends OCSController {
 			->executeStatement();
 
 		$delete = $this->db->getQueryBuilder();
+		$delete->delete('talk_consent')->executeStatement();
+
+		$delete = $this->db->getQueryBuilder();
 		$delete->delete('talk_internalsignaling')->executeStatement();
 
 		$delete = $this->db->getQueryBuilder();


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10408 

## 🛠️ API Checklist

- [x] Store consent on "Join call"
- [x] Delete consent of room when deleting the room
- [x] Delete consent of user when deleting the user
- [x] OCC output

### `occ talk:recording:consent --actor-id admin --actor-type users`
```
+-------+-----------+---------+------------+
| token | actorType | actorId | timestamp  |
+-------+-----------+---------+------------+
| abc   | users     | admin   | 1698227737 |
+-------+-----------+---------+------------+
```
### `occ talk:recording:consent --actor-id admin --actor-type users --output json`
```json
[{"token":"abc","actorType":"users","actorId":"admin","timestamp":1698227737}]
```

### `occ talk:recording:consent --actor-id admin --actor-type users --output json_pretty`
```json
[
    {
        "token": "abc",
        "actorType": "users",
        "actorId": "admin",
        "timestamp": 1698227737
    }
]
```


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
