### PR TITLE
Fix consent in breakout rooms and missing updates on the room list

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -49,6 +49,7 @@ use OCA\Talk\Events\BeforeRoomsFetchEvent;
 use OCA\Talk\Events\BotInstallEvent;
 use OCA\Talk\Events\BotUninstallEvent;
 use OCA\Talk\Events\RoomEvent;
+use OCA\Talk\Events\RoomModifiedEvent;
 use OCA\Talk\Events\SendCallNotificationEvent;
 use OCA\Talk\Federation\CloudFederationProviderTalk;
 use OCA\Talk\Files\Listener as FilesListener;
@@ -148,6 +149,9 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(AttendeesAddedEvent::class, SystemMessageListener::class);
 		$context->registerEventListener(AttendeesRemovedEvent::class, SystemMessageListener::class);
 		$context->registerEventListener(SendCallNotificationEvent::class, NotificationListener::class);
+
+		// Talk internal listeners
+		$context->registerEventListener(RoomModifiedEvent::class, SignalingListener::class);
 
 		$context->registerEventListener(CircleDestroyedEvent::class, CircleDeletedListener::class);
 		$context->registerEventListener(AddingCircleMemberEvent::class, CircleMembershipListener::class);

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -302,13 +302,17 @@ class RoomService {
 		$event = new BeforeRoomModifiedEvent($room, 'recordingConsent', $recordingConsent, $oldRecordingConsent);
 		$this->dispatcher->dispatchTyped($event);
 
+		$now = $this->timeFactory->getDateTime();
+
 		$update = $this->db->getQueryBuilder();
 		$update->update('talk_rooms')
 			->set('recording_consent', $update->createNamedParameter($recordingConsent, IQueryBuilder::PARAM_INT))
+			->set('last_activity', $update->createNamedParameter($now, IQueryBuilder::PARAM_DATE))
 			->where($update->expr()->eq('id', $update->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)));
 		$update->executeStatement();
 
 		$room->setRecordingConsent($recordingConsent);
+		$room->setLastActivity($now);
 
 		$event = new RoomModifiedEvent($room, 'recordingConsent', $recordingConsent, $oldRecordingConsent);
 		$this->dispatcher->dispatchTyped($event);

--- a/lib/Signaling/Listener.php
+++ b/lib/Signaling/Listener.php
@@ -36,6 +36,7 @@ use OCA\Talk\Events\ParticipantEvent;
 use OCA\Talk\Events\RemoveParticipantEvent;
 use OCA\Talk\Events\RemoveUserEvent;
 use OCA\Talk\Events\RoomEvent;
+use OCA\Talk\Events\RoomModifiedEvent;
 use OCA\Talk\GuestManager;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\BreakoutRoom;
@@ -43,10 +44,22 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\SessionService;
+use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\EventDispatcher\IEventListener;
 use OCP\Server;
 
-class Listener {
+/**
+ * @template-implements IEventListener<Event>
+ */
+class Listener implements IEventListener {
+
+	public function handle(Event $event): void {
+		if ($event instanceof RoomModifiedEvent) {
+			self::notifyAfterRoomSettingsChanged($event);
+		}
+	}
+
 	public static function register(IEventDispatcher $dispatcher): void {
 		self::registerInternalSignaling($dispatcher);
 		self::registerExternalSignaling($dispatcher);

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -3455,7 +3455,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
-	 * @Given user :user set the message expiration to :messageExpiration of room :identifier with :statusCode (:apiVersion)
+	 * @Given /^user "([^"]*)" set the message expiration to (\d+) of room "([^"]*)" with (\d+) \((v4)\)$/
 	 */
 	public function userSetTheMessageExpirationToXWithStatusCode(string $user, int $messageExpiration, string $identifier, int $statusCode, string $apiVersion = 'v4'): void {
 		$this->setCurrentUser($user);

--- a/tests/integration/features/conversation/breakout-rooms.feature
+++ b/tests/integration/features/conversation/breakout-rooms.feature
@@ -843,3 +843,36 @@ Feature: conversation/breakout-rooms
     And user "participant1" sets password "Test123!" for room "Room 1" with 403 (v4)
     # Can not set message expiration
     And user "participant1" set the message expiration to 3600 of room "Room 1" with 400 (v4)
+    # Can enable recording consent
+    Given recording server is started
+    And the following "spreed" app config is set
+      | recording_consent | 2 |
+    Then user "participant1" sets the recording consent to 1 for room "Room 1" with 400 (v4)
+
+  Scenario: Handle recording consent for all breakout rooms on the parent
+    Given recording server is started
+    And the following "spreed" app config is set
+      | recording_consent | 2 |
+    And user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    And user "participant1" sees the following attendees in room "class room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+    And user "participant1" creates 2 automatic breakout rooms for "class room" with 200 (v1)
+    And user "participant1" is participant of the following unordered rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus | recordingConsent |
+      | 2    | class room | 0          | 1                | 0                  | 0                |
+      | 2    | Room 1     | 1          | 0                | 0                  | 0                |
+      | 2    | Room 2     | 1          | 0                | 0                  | 0                |
+    # Enabling recording consent on the parent is not allowed with breakout rooms running
+    And user "participant1" starts breakout rooms in room "class room" with 200 (v1)
+    Then user "participant1" sets the recording consent to 1 for room "class room" with 400 (v4)
+    And user "participant1" stops breakout rooms in room "class room" with 200 (v1)
+    # Enabling recording consent on the parent updates all breakout rooms
+    Then user "participant1" sets the recording consent to 1 for room "class room" with 200 (v4)
+    And user "participant1" is participant of the following unordered rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus | recordingConsent |
+      | 2    | class room | 0          | 1                | 0                  | 1                |
+      | 2    | Room 1     | 1          | 0                | 0                  | 1                |
+      | 2    | Room 2     | 1          | 0                | 0                  | 1                |


### PR DESCRIPTION
### ☑️ Resolves

* Fix comments from https://github.com/nextcloud/spreed/pull/10633#pullrequestreview-1684412801

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Keep breakout room's recording consent in sync with the parent room
- [x] Update last activity when enabling consent so the roomlist updates
- [x] Trigger signaling message when consent is changed

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
