### PR TITLE
Feat/noid/multi file support

### DIFF
--- a/appinfo/routes/routesChatController.php
+++ b/appinfo/routes/routesChatController.php
@@ -60,6 +60,8 @@ return [
 		['name' => 'Chat#mentions', 'url' => '/api/{apiVersion}/chat/{token}/mentions', 'verb' => 'GET', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\ChatController::shareObjectToChat() */
 		['name' => 'Chat#shareObjectToChat', 'url' => '/api/{apiVersion}/chat/{token}/share', 'verb' => 'POST', 'requirements' => $requirements],
+		/** @see \OCA\Talk\Controller\ChatController::shareMultipleFilesToChat() */
+		['name' => 'Chat#shareMultipleFilesToChat', 'url' => '/api/{apiVersion}/chat/{token}/share-files', 'verb' => 'POST', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\ChatController::getObjectsSharedInRoomOverview() */
 		['name' => 'Chat#getObjectsSharedInRoomOverview', 'url' => '/api/{apiVersion}/chat/{token}/share/overview', 'verb' => 'GET', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\ChatController::getObjectsSharedInRoom() */

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -128,6 +128,7 @@
 * `markdown-messages` - Chat messages support markdown and are rendered automatically
 
 ## 18
+* `media-caption` - Whether media caption can be added to shared files and the endpoint to share multiple files in one message exists
 * `session-state` - Sessions can mark themselves as inactive, so the participant receives notifications again
 * `note-to-self` - Support for "Note-to-self" conversation exists
 * `recording-consent` - Whether admins and moderators can require recording consent before joining a call

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -191,11 +191,43 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 
     - `talkMetaData` array:
 
-| field         | type   | Description                                                                                            |
-|---------------|--------|--------------------------------------------------------------------------------------------------------|
-| `messageType` | string | A message type to show the message in different styles. Currently known: `voice-message` and `comment` |
+| field         | type   | Description                                                                                                                                                          |
+|---------------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `messageType` | string | A message type to show the message in different styles. Currently known: `voice-message` and `comment`                                                               |
+| `caption`     | string | A caption message that should be shown together with the shared file (only available with `media-caption` capability)                                                |
+| `noMessage`   | bool   | When no "X shared a file" message should be generated, because a combined caption message will be posted afterwards (only available with `media-caption` capability) |
 
 * Response: [See official OCS Share API docs](https://docs.nextcloud.com/server/latest/developer_manual/client_apis/OCS/ocs-share-api.html?highlight=sharing#create-a-new-share)
+
+## Share multiple files to the chat
+
+* Required capability: `media-caption`
+* Method: `POST`
+* Endpoint: `/chat/{token}/share-files`
+* Data:
+
+| field              | type   | Description                                                                                                                       |
+|--------------------|--------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `shareIds`         | int[]  | Array with the integer ID of the shares                                                                                           |
+| `caption`          | string | A caption message that should be shown together with the shared files                                                             |
+| `actorDisplayName` | string | Guest display name (ignored for logged in users)                                                                                  |
+| `referenceId`      | string | A reference string to be able to identify the generated chat message again in a "get messages" request, should be a random sha256 |
+
+* Response:
+    - Status code:
+        + `201 Created`
+        + `400 Bad Request` In case the meta data is invalid
+        + `403 Forbidden` When the conversation is read-only
+        + `404 Not Found` When the conversation could not be found for the participant
+        + `412 Precondition Failed` When the lobby is active and the user is not a moderator
+        + `413 Payload Too Large` When the message was longer than the allowed limit of 32000 characters (check the `spreed => config => chat => max-length` capability for the limit)
+        + `413 Payload Too Large` When more than 64 share IDs were provided in one request
+
+    - Header:
+
+| field                     | type | Description                                                                                                                                                                                                     |
+|---------------------------|------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `X-Chat-Last-Common-Read` | int  | ID of the last message read by every user that has read privacy set to public. When the user themself has it set to private the value the header is not set (only available with `chat-read-status` capability) |
 
 ## List overview of items shared into a chat
 

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -162,6 +162,7 @@ class Capabilities implements IPublicCapability {
 				'remind-me-later',
 				'bots-v1',
 				'markdown-messages',
+				'media-caption',
 				'session-state',
 				'note-to-self',
 				'recording-consent',

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -191,6 +191,8 @@ class ChatManager {
 
 		if ($messageType === 'object_shared' || $messageType === 'file_shared') {
 			$this->attachmentService->createAttachmentEntry($chat, $comment, $messageType, $messageDecoded['parameters'] ?? []);
+		} elseif ($messageType === 'multiple_files_shared') {
+			$this->attachmentService->createAttachmentEntriesForAllShares($chat, $comment, $messageDecoded['parameters'] ?? []);
 		}
 
 		return $comment;

--- a/lib/Chat/Parser/Listener.php
+++ b/lib/Chat/Parser/Listener.php
@@ -86,7 +86,7 @@ class Listener {
 
 		try {
 			$parser->parseMessage($message);
-			$event->stopPropagation();
+			// Disabled so we can parse mentions in captions: $event->stopPropagation();
 		} catch (\OutOfBoundsException $e) {
 			// Unknown message, ignore
 		}

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -419,6 +419,35 @@ class SystemMessage {
 					$parsedMessage = $this->l->t('You shared a file which is no longer available');
 				}
 			}
+		} elseif ($message === 'multiple_files_shared') {
+			$chatMessage->setMessageType(ChatManager::VERB_MESSAGE);
+
+			$parsedMessage = '';
+			if (isset($parameters['caption']) && $parameters['caption'] !== '') {
+				$parsedMessage = $parameters['caption'];
+			}
+
+			$foundShares = $missingShares = [];
+			foreach ($parameters['shares'] as $key => $shareId) {
+				try {
+					$foundShares['file-' . ($key + 1)] = $this->getFileFromShare($participant, $shareId);
+				} catch (\Exception) {
+					$missingShares['file-missing-' . ($key + 1)] = [
+						'type' => 'highlight',
+						'id' => $shareId,
+						'name' => $this->l->t('Deleted file'),
+					];
+				}
+			}
+
+			if (empty($foundShares)) {
+				$parsedMessage = $this->l->t('{actor} shared files which are no longer available');
+				if ($currentUserIsActor) {
+					$parsedMessage = $this->l->t('You shared files which are no longer available');
+				}
+			} else {
+				$parsedParameters = array_merge($parsedParameters, $foundShares, $missingShares);
+			}
 		} elseif ($message === 'object_shared') {
 			$parsedParameters['object'] = $parameters['metaData'];
 			$parsedParameters['object']['id'] = (string) $parsedParameters['object']['id'];

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -409,6 +409,10 @@ class SystemMessage {
 				} else {
 					$chatMessage->setMessageType(ChatManager::VERB_MESSAGE);
 				}
+
+				if (isset($metaData['caption']) && $metaData['caption'] !== '') {
+					$parsedMessage = $metaData['caption'];
+				}
 			} catch (\Exception $e) {
 				$parsedMessage = $this->l->t('{actor} shared a file which is no longer available');
 				if ($currentUserIsActor) {

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -373,6 +373,10 @@ class Listener implements IEventListener {
 		$metaData = json_decode($metaData, true);
 		$metaData = is_array($metaData) ? $metaData : [];
 
+		if (!empty($metaData['noMessage'])) {
+			return;
+		}
+
 		if (isset($metaData['messageType']) && $metaData['messageType'] === 'voice-message') {
 			if ($share->getNode()->getMimeType() !== 'audio/mpeg'
 				&& $share->getNode()->getMimeType() !== 'audio/wav') {
@@ -380,6 +384,8 @@ class Listener implements IEventListener {
 			}
 		}
 		$metaData['mimeType'] = $share->getNode()->getMimeType();
+
+		$metaData['caption'] = $metaData['caption'] ?? '';
 
 		$listener->sendSystemMessage($room, 'file_shared', ['share' => $share->getId(), 'metaData' => $metaData]);
 	}

--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -385,7 +385,13 @@ class Listener implements IEventListener {
 		}
 		$metaData['mimeType'] = $share->getNode()->getMimeType();
 
-		$metaData['caption'] = $metaData['caption'] ?? '';
+		if (isset($metaData['caption'])) {
+			if (is_string($metaData['caption']) && trim($metaData['caption']) !== '') {
+				$metaData['caption'] = trim($metaData['caption']);
+			} else {
+				unset($metaData['caption']);
+			}
+		}
 
 		$listener->sendSystemMessage($room, 'file_shared', ['share' => $share->getId(), 'metaData' => $metaData]);
 	}

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -308,7 +308,7 @@ class ChatController extends AEnvironmentAwareController {
 	/**
 	 * Share multiple files and a caption into the chat
 	 *
-	 * @param int[] $shareIds The share IDs that should be shown with this message
+	 * @param string[] $shareIds The share IDs that should be shown with this message
 	 * @param string $caption The message to send
 	 * @param string $actorDisplayName for guests
 	 * @param string $referenceId for the message to be able to later identify it again

--- a/openapi.json
+++ b/openapi.json
@@ -6654,6 +6654,220 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share-files": {
+            "post": {
+                "operationId": "chat-share-multiple-files-to-chat",
+                "summary": "Share multiple files and a caption into the chat",
+                "tags": [
+                    "chat"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "shareIds[]",
+                        "in": "query",
+                        "description": "The share IDs that should be shown with this message",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer",
+                                "format": "int64"
+                            }
+                        }
+                    },
+                    {
+                        "name": "caption",
+                        "in": "query",
+                        "description": "The message to send",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "actorDisplayName",
+                        "in": "query",
+                        "description": "for guests",
+                        "schema": {
+                            "type": "string",
+                            "default": ""
+                        }
+                    },
+                    {
+                        "name": "referenceId",
+                        "in": "query",
+                        "description": "for the message to be able to later identify it again",
+                        "schema": {
+                            "type": "string",
+                            "default": ""
+                        }
+                    },
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Files shared successfully",
+                        "headers": {
+                            "X-Chat-Last-Common-Read": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/ChatMessageWithParent",
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Sharing files is not possible",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Shares not found for actor",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "Message too long",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share/overview": {
             "get": {
                 "operationId": "chat-get-objects-shared-in-room-overview",

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -139,6 +139,7 @@ class CapabilitiesTest extends TestCase {
 			'remind-me-later',
 			'bots-v1',
 			'markdown-messages',
+			'media-caption',
 			'session-state',
 			'note-to-self',
 			'recording-consent',


### PR DESCRIPTION
Split off from #10053  because it has more problems


- [ ] Test that multiple files are unshared when deleting the message
- [ ] These methods should return messages with multiple objects:

https://github.com/nextcloud/spreed/blob/d0d52ce2901c56ef9b03012c029a09a641c21bac/lib/Controller/ChatController.php#L924

https://github.com/nextcloud/spreed/blob/d0d52ce2901c56ef9b03012c029a09a641c21bac/lib/Controller/ChatController.php#L977