### PR TITLE
feat(federation): Send room modifications via OCM notifications to re…

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -59,6 +59,7 @@ use OCA\Talk\Events\RoomDeletedEvent;
 use OCA\Talk\Events\RoomModifiedEvent;
 use OCA\Talk\Events\SystemMessageSentEvent;
 use OCA\Talk\Federation\CloudFederationProviderTalk;
+use OCA\Talk\Federation\Listener as FederationListener;
 use OCA\Talk\Files\Listener as FilesListener;
 use OCA\Talk\Files\TemplateLoader as FilesTemplateLoader;
 use OCA\Talk\Flow\RegisterOperationsListener;
@@ -183,6 +184,9 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(RoomDeletedEvent::class, RecordingListener::class);
 		$context->registerEventListener(TranscriptionSuccessfulEvent::class, RecordingListener::class);
 		$context->registerEventListener(TranscriptionFailedEvent::class, RecordingListener::class);
+
+		// Federation listeners
+		$context->registerEventListener(RoomModifiedEvent::class, FederationListener::class);
 
 		// Signaling listeners
 		$context->registerEventListener(RoomModifiedEvent::class, SignalingListener::class);

--- a/lib/Federation/FederationManager.php
+++ b/lib/Federation/FederationManager.php
@@ -53,6 +53,7 @@ class FederationManager {
 	public const NOTIFICATION_SHARE_ACCEPTED = 'SHARE_ACCEPTED';
 	public const NOTIFICATION_SHARE_DECLINED = 'SHARE_DECLINED';
 	public const NOTIFICATION_SHARE_UNSHARED = 'SHARE_UNSHARED';
+	public const NOTIFICATION_ROOM_MODIFIED = 'ROOM_MODIFIED';
 	public const TOKEN_LENGTH = 64;
 
 	public function __construct(

--- a/lib/Federation/Listener.php
+++ b/lib/Federation/Listener.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Federation;
+
+use OCA\Talk\Events\ARoomModifiedEvent;
+use OCA\Talk\Events\RoomModifiedEvent;
+use OCA\Talk\Model\Attendee;
+use OCA\Talk\Service\ParticipantService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Federation\ICloudIdManager;
+
+/**
+ * @template-implements IEventListener<Event>
+ */
+class Listener implements IEventListener {
+	public function __construct(
+		protected BackendNotifier $backendNotifier,
+		protected ParticipantService $participantService,
+		protected ICloudIdManager $cloudIdManager,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof RoomModifiedEvent) {
+			return;
+		}
+
+		if (!in_array($event->getProperty(), [
+			ARoomModifiedEvent::PROPERTY_AVATAR,
+			ARoomModifiedEvent::PROPERTY_DESCRIPTION,
+			ARoomModifiedEvent::PROPERTY_NAME,
+			ARoomModifiedEvent::PROPERTY_READ_ONLY,
+			ARoomModifiedEvent::PROPERTY_TYPE,
+		], true)) {
+			return;
+		}
+
+		$participants = $this->participantService->getParticipantsByActorType($event->getRoom(), Attendee::ACTOR_FEDERATED_USERS);
+		foreach ($participants as $participant) {
+			$cloudId = $this->cloudIdManager->resolveCloudId($participant->getAttendee()->getActorId());
+
+			$this->backendNotifier->sendRoomModifiedUpdate(
+				$cloudId->getRemote(),
+				$participant->getAttendee()->getId(),
+				$participant->getAttendee()->getAccessToken(),
+				$event->getRoom()->getToken(),
+				$event->getProperty(),
+				$event->getNewValue(),
+				$event->getOldValue(),
+			);
+		}
+	}
+}

--- a/lib/Model/InvitationMapper.php
+++ b/lib/Model/InvitationMapper.php
@@ -61,6 +61,20 @@ class InvitationMapper extends QBMapper {
 	}
 
 	/**
+	 * @throws DoesNotExistException
+	 */
+	public function getByRemoteIdAndToken(int $remoteId, string $accessToken): Invitation {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('remote_id', $qb->createNamedParameter($remoteId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('access_token', $qb->createNamedParameter($accessToken)));
+
+		return $this->findEntity($qb);
+	}
+
+	/**
 	 * @param Room $room
 	 * @return Invitation[]
 	 */

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -403,7 +403,7 @@ class Notifier implements INotifier {
 			if ($invite->getUserId() !== $notification->getUser()) {
 				throw new AlreadyProcessedException();
 			}
-			$this->manager->getRoomById($invite->getRoomId());
+			$room = $this->manager->getRoomById($invite->getRoomId());
 		} catch (RoomNotFoundException $e) {
 			// Room does not exist
 			throw new AlreadyProcessedException();
@@ -423,7 +423,7 @@ class Notifier implements INotifier {
 			'roomName' => [
 				'type' => 'highlight',
 				'id' => $subjectParameters['serverUrl'] . '::' . $subjectParameters['roomToken'],
-				'name' => $subjectParameters['roomName'],
+				'name' => $room->getName(),
 			],
 			'remoteServer' => [
 				'type' => 'highlight',

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -380,14 +380,15 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		}
 
 		Assert::assertEquals($expected, array_map(function ($room, $expectedRoom) {
-			if (isset($room['remoteAccessToken'])) {
-				self::$remoteAuth[self::translateRemoteServer($room['remoteServer']) . '#' . self::$identifierToToken[$room['name']]] = $room['remoteAccessToken'];
-			}
 			if (!isset(self::$identifierToToken[$room['name']])) {
 				self::$identifierToToken[$room['name']] = $room['token'];
 			}
 			if (!isset(self::$tokenToIdentifier[$room['token']])) {
 				self::$tokenToIdentifier[$room['token']] = $room['name'];
+			}
+
+			if (isset($room['remoteAccessToken'])) {
+				self::$remoteAuth[self::translateRemoteServer($room['remoteServer']) . '#' . self::$identifierToToken[$room['name']]] = $room['remoteAccessToken'];
 			}
 
 			$data = [];

--- a/tests/integration/features/federation/invite.feature
+++ b/tests/integration/features/federation/invite.feature
@@ -112,3 +112,22 @@ Feature: federation/invite
     Then user "participant1" sees the following messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
       | room |federated_users | participant2@http://localhost:8180 | participant2@http://localhost:8180 | Message 1   | []                |               |
+
+  Scenario: Federate conversation meta data
+    Given the following "spreed" app config is set
+      | federation_enabled | yes |
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds remote "participant2" to room "room" with 200 (v4)
+    And user "participant2" has the following invitations (v1)
+      | remote_server | remote_token |
+      | LOCAL         | room         |
+    And user "participant2" accepts invite to room "room" of server "LOCAL" (v1)
+    Then user "participant2" is participant of the following rooms (v4)
+      | id   | name | type |
+      | room | room | 2    |
+    And user "participant1" renames room "room" to "Federated room" with 200 (v4)
+    Then user "participant2" is participant of the following rooms (v4)
+      | id   | name           | type |
+      | room | Federated room | 2    |

--- a/tests/php/Federation/FederationTest.php
+++ b/tests/php/Federation/FederationTest.php
@@ -31,8 +31,10 @@ use OCA\Talk\Federation\FederationManager;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\AttendeeMapper;
+use OCA\Talk\Model\InvitationMapper;
 use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
+use OCA\Talk\Service\RoomService;
 use OCP\BackgroundJob\IJobList;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudFederationFactory;
@@ -110,7 +112,9 @@ class FederationTest extends TestCase {
 			$this->notificationManager,
 			$this->createMock(IURLGenerator::class),
 			$this->createMock(ParticipantService::class),
+			$this->createMock(RoomService::class),
 			$this->attendeeMapper,
+			$this->createMock(InvitationMapper::class),
 			$this->createMock(Manager::class),
 			$this->createMock(ISession::class),
 			$this->createMock(IEventDispatcher::class),


### PR DESCRIPTION
…motes

### ☑️ Resolves

* Ref #5723 

## 🛠️ API Checklist

### 📺 Samples

- Create a conversation as userA
- Invite remote userB
- Invite remote userC
- Accept invite as userB
- Rename conversation as userA
- As userB check the name in the left sidebar
- As userC check the name in the invite notification

### 🚧 Tasks

- [x] Integration test for the name sample
- [x] Specifically handle invited but not accepted users (caused BFP locally on testing)
- [x] Specify list of supported props and increase it https://github.com/nextcloud/spreed/pull/10731
- [x] Check list of types for new and old values on the events

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
