### PR TITLE
feat(NewMessageUploadEditor) - caption to file share

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
@@ -325,6 +325,7 @@ describe('Message.vue', () => {
 				const messageEl = wrapper.findComponent({ name: 'NcRichText' })
 				// note: indices as object keys are on purpose
 				expect(messageEl.props('arguments')).toMatchObject(expectedRichParameters)
+				return messageEl
 			}
 
 			test('renders mentions', () => {
@@ -364,7 +365,7 @@ describe('Message.vue', () => {
 				)
 			})
 
-			test('renders file previews', () => {
+			test('renders single file preview', () => {
 				const params = {
 					actor: {
 						id: 'alice',
@@ -389,6 +390,36 @@ describe('Message.vue', () => {
 						},
 					}
 				)
+			})
+
+			test('renders single file preview with caption', () => {
+				const caption = 'text caption'
+				const params = {
+					actor: {
+						id: 'alice',
+						name: 'Alice',
+						type: 'user',
+					},
+					file: {
+						path: 'some/path',
+						type: 'file',
+					},
+				}
+				const messageEl = renderRichObject(
+					caption,
+					params, {
+						actor: {
+							component: Mention,
+							props: params.actor,
+						},
+						file: {
+							component: FilePreview,
+							props: params.file,
+						},
+					}
+				)
+
+				expect(messageEl.props('text')).toBe('{file}' + '\n\n' + caption)
 			})
 
 			test('renders deck cards', () => {

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -457,6 +457,11 @@ export default {
 			type: Array,
 			default: () => { return [] },
 		},
+
+		referenceId: {
+			type: String,
+			default: '',
+		},
 	},
 
 	emits: ['toggle-combined-system-message'],
@@ -609,6 +614,7 @@ export default {
 						props: Object.assign({
 							token: this.token,
 							itemType,
+							referenceId: this.referenceId,
 						}, this.messageParameters[p]),
 					}
 				} else if (type === 'deck-card') {

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -47,11 +47,11 @@ the main body of the message as well as a quote.
 					class="message-body__main__text">
 					<Quote v-if="parent" v-bind="parent" />
 					<div class="single-emoji">
-						{{ message }}
+						{{ renderedMessage }}
 					</div>
 				</div>
 				<div v-else-if="showJoinCallButton" class="message-body__main__text call-started">
-					<NcRichText :text="message"
+					<NcRichText :text="renderedMessage"
 						:arguments="richParameters"
 						autolink
 						dir="auto"
@@ -59,7 +59,7 @@ the main body of the message as well as a quote.
 					<CallButton />
 				</div>
 				<div v-else-if="showResultsButton || isSystemMessage" class="message-body__main__text system-message">
-					<NcRichText :text="message"
+					<NcRichText :text="renderedMessage"
 						:arguments="richParameters"
 						autolink
 						dir="auto"
@@ -72,7 +72,7 @@ the main body of the message as well as a quote.
 						show-as-button />
 				</div>
 				<div v-else-if="isDeletedMessage" class="message-body__main__text deleted-message">
-					<NcRichText :text="message"
+					<NcRichText :text="renderedMessage"
 						:arguments="richParameters"
 						autolink
 						dir="auto"
@@ -83,7 +83,7 @@ the main body of the message as well as a quote.
 					@mouseover="handleMarkdownMouseOver"
 					@mouseleave="handleMarkdownMouseLeave">
 					<Quote v-if="parent" v-bind="parent" />
-					<NcRichText :text="message"
+					<NcRichText :text="renderedMessage"
 						:arguments="richParameters"
 						autolink
 						dir="auto"
@@ -502,6 +502,15 @@ export default {
 			return !this.isLastMessage && this.id === this.$store.getters.getVisualLastReadMessageId(this.token)
 		},
 
+		renderedMessage() {
+			if (this.messageParameters?.file && this.message !== '{file}') {
+				// Add a new line after file to split content into different paragraphs
+				return '{file}' + '\n\n' + this.message
+			} else {
+				return this.message
+			}
+		},
+
 		messageObject() {
 			return this.$store.getters.message(this.token, this.id)
 		},
@@ -568,7 +577,7 @@ export default {
 			let match
 			let emojiStrings = ''
 			let emojiCount = 0
-			const trimmedMessage = this.message.trim()
+			const trimmedMessage = this.renderedMessage.trim()
 
 			// eslint-disable-next-line no-cond-assign
 			while (match = regex.exec(trimmedMessage)) {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -32,7 +32,7 @@
 			'file-preview--row-layout': rowLayout }"
 		@click.exact="handleClick"
 		@keydown.enter="handleClick">
-		<div v-if="!isLoading"
+		<div v-if="!isLoading || fallbackLocalUrl"
 			class="image-container"
 			:class="{'playable': isPlayable}">
 			<span v-if="isPlayable && !smallPreview" class="play-video-button">
@@ -120,6 +120,13 @@ export default {
 		id: {
 			type: String,
 			required: true,
+		},
+		/**
+		 * Reference id from the message
+		 */
+		referenceId: {
+			type: String,
+			default: '',
 		},
 		/**
 		 * File name
@@ -283,6 +290,10 @@ export default {
 			return this.name
 		},
 
+		fallbackLocalUrl() {
+			return this.$store.getters.getLocalUrl(this.referenceId)
+		},
+
 		previewTooltip() {
 			if (this.shouldShowFileDetail) {
 				// no tooltip as the file name is already visible directly
@@ -362,6 +373,9 @@ export default {
 
 			if (this.previewType === PREVIEW_TYPE.TEMPORARY) {
 				return this.localUrl
+			}
+			if (this.fallbackLocalUrl) {
+				return this.fallbackLocalUrl
 			}
 			if (this.previewType === PREVIEW_TYPE.MIME_ICON || this.rowLayout) {
 				return OC.MimeType.getIconUrl(this.mimetype)

--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -40,9 +40,9 @@
 					tag="div"
 					group>
 					<template v-for="file in files">
-						<FilePreview :key="file.temporaryMessage.id"
+						<FilePreview :key="file[1].temporaryMessage.id"
 							:token="token"
-							v-bind="file.temporaryMessage.messageParameters.file"
+							v-bind="file[1].temporaryMessage.messageParameters.file"
 							:is-upload-editor="true"
 							@remove-file="handleRemoveFileFromSelection" />
 					</template>
@@ -117,10 +117,7 @@ export default {
 		},
 
 		files() {
-			if (this.currentUploadId) {
-				return this.$store.getters.getInitialisedUploads(this.currentUploadId)
-			}
-			return []
+			return this.$store.getters.getInitialisedUploads(this.currentUploadId)
 		},
 
 		showModal() {
@@ -136,7 +133,7 @@ export default {
 		},
 
 		firstFile() {
-			return this.files[Object.keys(this.files)[0]]
+			return this.files?.at(0)?.at(1)
 		},
 
 		// Hide the plus button in case this editor is used while sending a voice message

--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -21,6 +21,7 @@
 
 <template>
 	<NcModal v-if="showModal"
+		ref="modal"
 		:size="isVoiceMessage ? 'small' : 'normal'"
 		class="upload-editor"
 		:container="container"
@@ -62,14 +63,15 @@
 				<AudioPlayer :name="voiceMessageName"
 					:local-url="voiceMessageLocalURL" />
 			</template>
-			<div class="upload-editor__actions">
-				<NcButton type="tertiary" @click="handleDismiss">
-					{{ t('spreed', 'Dismiss') }}
-				</NcButton>
-				<NcButton ref="submitButton" type="primary" @click="handleUpload">
-					{{ t('spreed', 'Send') }}
-				</NcButton>
-			</div>
+			<NewMessage v-if="modalContainerId"
+				ref="newMessage"
+				role="region"
+				upload
+				:token="token"
+				:container="modalContainerId"
+				:aria-label="t('spreed', 'Post message')"
+				@sent="handleUpload"
+				@failure="handleDismiss" />
 		</div>
 	</NcModal>
 </template>
@@ -83,6 +85,7 @@ import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 
 import AudioPlayer from '../MessagesList/MessagesGroup/Message/MessagePart/AudioPlayer.vue'
 import FilePreview from '../MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue'
+import NewMessage from './NewMessage.vue'
 import TransitionWrapper from '../TransitionWrapper.vue'
 
 export default {
@@ -94,7 +97,14 @@ export default {
 		Plus,
 		AudioPlayer,
 		NcButton,
+		NewMessage,
 		TransitionWrapper,
+	},
+
+	data() {
+		return {
+			modalContainerId: null,
+		}
 	},
 
 	computed: {
@@ -129,8 +139,7 @@ export default {
 			return this.files[Object.keys(this.files)[0]]
 		},
 
-		// Hide the plus button in case this editor is used while sending a voice
-		// message
+		// Hide the plus button in case this editor is used while sending a voice message
 		isVoiceMessage() {
 			if (!this.firstFile) {
 				return false
@@ -154,17 +163,21 @@ export default {
 	},
 
 	watch: {
-		showModal(show) {
+		async showModal(show) {
 			if (show) {
-				this.focus()
+				await this.getContainerId()
+				this.$nextTick(() => {
+					this.$refs.newMessage?.focusInput()
+				})
 			}
 		},
 	},
 
 	methods: {
-		focus() {
+		async getContainerId() {
 			this.$nextTick(() => {
-				this.$refs.submitButton.$el.focus()
+				// Postpone render of NewMessage until modal container is mounted
+				this.modalContainerId = `#modal-description-${this.$refs.modal.randId}`
 			})
 		},
 
@@ -172,8 +185,8 @@ export default {
 			this.$store.dispatch('discardUpload', this.currentUploadId)
 		},
 
-		handleUpload() {
-			this.$store.dispatch('uploadFiles', this.currentUploadId)
+		handleUpload(caption) {
+			this.$store.dispatch('uploadFiles', { uploadId: this.currentUploadId, caption })
 		},
 		/**
 		 * Clicks the hidden file input when clicking the correspondent NcActionButton,
@@ -204,20 +217,10 @@ export default {
 	padding: 16px;
 
 	&__previews {
-		overflow-x: hidden !important;
 		display: flex;
 		position: relative;
 		overflow: auto;
 		flex-wrap: wrap;
-	}
-	&__actions {
-		display: flex;
-		justify-content: space-between;
-		margin-top: 16px;
-		margin-bottom: 4px;
-		button {
-			margin: 0 4px 0 4px;
-		}
 	}
 }
 
@@ -230,5 +233,4 @@ export default {
 		margin: auto;
 	}
 }
-
 </style>

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -282,9 +282,11 @@ const actions = {
 	 * @param {Function} context.dispatch the contexts dispatch function.
 	 * @param {object} context.getters the contexts getters object.
 	 * @param {object} context.state the contexts state object.
-	 * @param {string} uploadId The unique uploadId
+	 * @param {object} data the wrapping object
+	 * @param {string} data.uploadId The unique uploadId
+	 * @param {string} [data.caption] The text caption to the media
 	 */
-	async uploadFiles({ commit, dispatch, state, getters }, uploadId) {
+	async uploadFiles({ commit, dispatch, state, getters }, { uploadId, caption }) {
 		if (state.currentUploadId === uploadId) {
 			commit('setCurrentUploadId', undefined)
 		}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10414

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/spreed/assets/93392545/92d8d274-5ec5-468a-a86d-32a1067d8c0b) | ![Screenshot from 2023-10-18 17-22-50](https://github.com/nextcloud/spreed/assets/93392545/690db6d8-b8a2-402d-89a0-e166ff6d1b2a)
![image](https://github.com/nextcloud/spreed/assets/93392545/c9d681fb-79ab-40fb-8665-2821892dc38f) | ![Screenshot from 2023-10-18 17-29-01](https://github.com/nextcloud/spreed/assets/93392545/9c38f268-e4a4-4990-9612-cb42367e9e2a)

### 🚧 Tasks

- [ ] To check
  - [ ] User mentions don't render for me in NewMessage (known bug)
  - [ ] Caught it once, the order of shared files was different, because they are now being loaded in parallel
- [ ] Follow-up
  - [ ] Support multiple file shares (requires a lot of rework in frontend/backend) - draft at #8949

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

