### PR TITLE
fix(LeftSidebar): Disable blur event in order to click on a conversation

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -28,6 +28,7 @@
 				<SearchBox ref="searchBox"
 					:value.sync="searchText"
 					:is-focused.sync="isFocused"
+					:list="list"
 					@input="debounceFetchSearchResults"
 					@abort-search="abortSearch" />
 			</div>
@@ -137,7 +138,7 @@
 								</NcButton>
 							</template>
 						</NcEmptyContent>
-						<li v-show="filteredConversationsList.length > 0" class="h-100">
+						<li v-show="filteredConversationsList.length > 0" ref="list" class="h-100">
 							<ConversationsListVirtual ref="scroller"
 								:conversations="filteredConversationsList"
 								:loading="!initialisedConversations"
@@ -344,6 +345,7 @@ export default {
 	setup() {
 		const leftSidebar = ref(null)
 		const searchBox = ref(null)
+		const list = ref(null)
 
 		const { initializeNavigation, resetNavigation } = useArrowNavigation(leftSidebar, searchBox, '.list-item')
 
@@ -352,6 +354,7 @@ export default {
 			resetNavigation,
 			leftSidebar,
 			searchBox,
+			list,
 		}
 	},
 
@@ -864,6 +867,7 @@ export default {
 				}
 			}
 			if (to.name === 'conversation') {
+				this.abortSearch()
 				this.$store.dispatch('joinConversation', { token: to.params.token })
 				this.scrollToConversation(to.params.token)
 			}

--- a/src/components/LeftSidebar/SearchBox/SearchBox.vue
+++ b/src/components/LeftSidebar/SearchBox/SearchBox.vue
@@ -67,6 +67,13 @@ export default {
 			type: Boolean,
 			required: true,
 		},
+		/**
+		 * Conversations list reference for handling click trigger
+		 */
+		 list: {
+			type: HTMLElement,
+			default: null,
+		},
 	},
 
 	expose: ['focus'],
@@ -136,16 +143,22 @@ export default {
 		},
 
 		handleBlur(event) {
+			// Blur triggered by clicking on the trailing button
 			if (event.relatedTarget?.classList.contains('input-field__clear-button')) {
 				event.preventDefault()
 				this.getTrailingButton()?.addEventListener('blur', (trailingEvent) => {
 					this.handleBlur(trailingEvent)
 				})
-			} else {
-				this.$emit('blur', event)
-				if (this.value === '') {
-					this.$emit('update:is-focused', false)
-				}
+				return
+			}
+			// Blur triggered by clicking on a conversation item
+			if (this.list?.contains(event.relatedTarget)) {
+				return
+			}
+			 // Blur in other cases
+			this.$emit('blur', event)
+			if (this.value === '') {
+				this.$emit('update:is-focused', false)
 			}
 		},
 


### PR DESCRIPTION

### ☑️ Resolves

* Fix #10734

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

 🏚️ Before  

https://github.com/nextcloud/spreed/assets/84044328/ab3105d8-1aca-492d-adc2-bbe606fe1031   

🏡 After 

   

https://github.com/nextcloud/spreed/assets/84044328/7273a193-46d8-45c7-a7e7-dbe9fc287b92



### 🚧 Tasks

- [ ] Code review
- [ ] Visual review
### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

