### PR TITLE
fix(LeftSidebar): Adjust wording to be less email like

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -122,10 +122,11 @@
 					<!-- Conversations List -->
 					<template v-if="!isSearching">
 						<NcEmptyContent v-if="initialisedConversations && filteredConversationsList.length === 0"
-							:name="t('spreed', 'No matches found')"
-							:description="displayedMessage">
+							:name="emptyContentLabel"
+							:description="emptyContentDescription">
 							<template #icon>
-								<MessageBadge v-if="isFiltered" :size="64" />
+								<AtIcon v-if="isFiltered === 'mentions'" :size="64" />
+								<MessageBadge v-else-if="isFiltered === 'unread'" :size="64" />
 								<MessageOutline v-else :size="64" />
 							</template>
 							<template #action>
@@ -409,14 +410,24 @@ export default {
 			return this.$store.getters.getToken()
 		},
 
-		displayedMessage() {
+		emptyContentLabel() {
 			switch (this.isFiltered) {
 			case 'mentions':
-				return t('spreed', 'You have no unread mentions in your inbox.')
 			case 'unread':
-				return t('spreed', 'You have no unread messages in your inbox.')
+				return t('spreed', 'No matches found')
 			default:
-				return t('spreed', 'Your inbox is empty.')
+				return t('spreed', 'No conversations found')
+			}
+		},
+
+		emptyContentDescription() {
+			switch (this.isFiltered) {
+			case 'mentions':
+				return t('spreed', 'You have no unread mentions.')
+			case 'unread':
+				return t('spreed', 'You have no unread messages.')
+			default:
+				return ''
 			}
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Filter | 🏚️ Before | 🏡 After
---|---|---
Mentions | ![Bildschirmfoto vom 2023-10-23 14-37-38](https://github.com/nextcloud/spreed/assets/213943/3cc13aec-8bcc-4133-8e0c-5ab2db63c1f4) | ![Bildschirmfoto vom 2023-10-23 14-35-22](https://github.com/nextcloud/spreed/assets/213943/bb5218b8-29a0-4d8a-9afa-67123827b521)
Unread | ![Bildschirmfoto vom 2023-10-23 14-37-33](https://github.com/nextcloud/spreed/assets/213943/ae23261d-4ad7-4c57-9b5c-daa4abe47c61) | ![Bildschirmfoto vom 2023-10-23 14-35-27](https://github.com/nextcloud/spreed/assets/213943/4739ac6f-5676-4c7a-b822-846e9036f289)
Empty | ![Bildschirmfoto vom 2023-10-23 14-37-27](https://github.com/nextcloud/spreed/assets/213943/e3f8729e-0780-46a5-824b-dfe9c86cb4ca) | ![Bildschirmfoto vom 2023-10-23 14-35-15](https://github.com/nextcloud/spreed/assets/213943/59ea4fd3-d331-4a89-bef8-95f0e76e1b6e)



### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required