### PR TITLE
fix(NewGroupConversation): minor fix

### DIFF
--- a/src/components/ConversationSettings/ConversationAvatarEditor.vue
+++ b/src/components/ConversationSettings/ConversationAvatarEditor.vue
@@ -238,6 +238,8 @@ export default {
 		},
 	},
 
+	expose: ['saveAvatar'],
+
 	methods: {
 		activateLocalFilePicker() {
 			// Set to null so that selecting the same file will trigger the change event

--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -20,9 +20,9 @@
 -->
 
 <template>
-	<div class="wrapper">
+	<div v-if="modal" class="wrapper">
 		<!-- New group form -->
-		<NcModal v-if="modal && page !== 2"
+		<NcModal v-show=" page !== 2"
 			class="conversation-form"
 			:container="container"
 			@close="closeModal">
@@ -118,7 +118,7 @@
 		</NcModal>
 
 		<!-- Third page : this is the confirmation page-->
-		<NcModal v-else-if="page === 2"
+		<NcModal v-if="page === 2"
 			:container="container"
 			@close="closeModal">
 			<NcEmptyContent>


### PR DESCRIPTION
### ☑️ Resolves

* Fixes `Can't read properties of 'undefined'`
* v-if destroys the first page where there is a ref for the avatar. Accessing the `this.$refs.conversationAvatar` returns `undefined` . v-show will keep the component ref accessible

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

