### PR TITLE
fix(deps): Update CuyZ/Valinor after upstream fixed the regression from 1.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 	},
 	"require": {
 		"bamarni/composer-bin-plugin": "^1.8",
-		"cuyz/valinor": "1.6.0",
+		"cuyz/valinor": "^1.7",
 		"firebase/php-jwt": "^6.3"
 	},
 	"extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3511dcbfcd3ad98d5005ffb496cba03c",
+    "content-hash": "f83bdae2520edeac90dc4a51229840fc",
     "packages": [
         {
             "name": "bamarni/composer-bin-plugin",
@@ -65,16 +65,16 @@
         },
         {
             "name": "cuyz/valinor",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CuyZ/Valinor.git",
-                "reference": "f3f3429d90be77f59903923f9bb5ce93c484dfd7"
+                "reference": "e384ad6d6801c3d4a03b444d267dbfec91ee23da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CuyZ/Valinor/zipball/f3f3429d90be77f59903923f9bb5ce93c484dfd7",
-                "reference": "f3f3429d90be77f59903923f9bb5ce93c484dfd7",
+                "url": "https://api.github.com/repos/CuyZ/Valinor/zipball/e384ad6d6801c3d4a03b444d267dbfec91ee23da",
+                "reference": "e384ad6d6801c3d4a03b444d267dbfec91ee23da",
                 "shasum": ""
             },
             "require": {
@@ -126,7 +126,7 @@
             ],
             "support": {
                 "issues": "https://github.com/CuyZ/Valinor/issues",
-                "source": "https://github.com/CuyZ/Valinor/tree/1.6.0"
+                "source": "https://github.com/CuyZ/Valinor/tree/1.7.0"
             },
             "funding": [
                 {
@@ -134,7 +134,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-25T10:26:38+00:00"
+            "time": "2023-10-23T11:05:23+00:00"
         },
         {
             "name": "firebase/php-jwt",


### PR DESCRIPTION
Ref https://github.com/CuyZ/Valinor/pull/437#issuecomment-1768779626

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
