### PR TITLE
Fix "Validation by remoteAttendeeId + accessToken might be ambiguous"

### DIFF
--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -115,18 +115,15 @@ class FederationController extends OCSController {
 		$invitations = $this->federationManager->getRemoteRoomShares($user);
 
 		/** @var TalkFederationInvite[] $data */
-		$data = array_filter(array_map(function (Invitation $invitation) {
-			$data = $invitation->asArray();
+		$data = array_filter(array_map(function (Invitation $invitation): ?array {
 
 			try {
-				$room = $this->talkManager->getRoomById($invitation->getRoomId());
-				$data['remote_token'] = $room->getRemoteToken();
-				$data['remote_server'] = $room->getRemoteServer();
+				$this->talkManager->getRoomById($invitation->getLocalRoomId());
 			} catch (RoomNotFoundException) {
 				return null;
 			}
 
-			return $data;
+			return $invitation->jsonSerialize();
 		}, $invitations));
 
 		return new DataResponse($data);

--- a/lib/Federation/BackendNotifier.php
+++ b/lib/Federation/BackendNotifier.php
@@ -37,6 +37,7 @@ use OCP\Federation\ICloudFederationFactory;
 use OCP\Federation\ICloudFederationNotification;
 use OCP\Federation\ICloudFederationProviderManager;
 use OCP\HintException;
+use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
@@ -51,6 +52,7 @@ class BackendNotifier {
 		private ICloudFederationProviderManager $federationProviderManager,
 		private IJobList $jobList,
 		private IUserManager $userManager,
+		private IURLGenerator $url,
 	) {
 	}
 
@@ -139,6 +141,7 @@ class BackendNotifier {
 			FederationManager::TALK_ROOM_RESOURCE,
 			(string) $remoteAttendeeId,
 			[
+				'remoteServerUrl' => $this->getServerRemoteUrl(),
 				'sharedSecret' => $accessToken,
 				'message' => 'Recipient accepted the share',
 			]);
@@ -166,6 +169,7 @@ class BackendNotifier {
 			FederationManager::TALK_ROOM_RESOURCE,
 			(string) $remoteAttendeeId,
 			[
+				'remoteServerUrl' => $this->getServerRemoteUrl(),
 				'sharedSecret' => $accessToken,
 				'message' => 'Recipient declined the share',
 			]
@@ -190,6 +194,7 @@ class BackendNotifier {
 			FederationManager::TALK_ROOM_RESOURCE,
 			(string) $localAttendeeId,
 			[
+				'remoteServerUrl' => $this->getServerRemoteUrl(),
 				'sharedSecret' => $accessToken,
 				'message' => 'This room has been unshared',
 			]
@@ -220,6 +225,7 @@ class BackendNotifier {
 			FederationManager::TALK_ROOM_RESOURCE,
 			(string) $localAttendeeId,
 			[
+				'remoteServerUrl' => $this->getServerRemoteUrl(),
 				'sharedSecret' => $accessToken,
 				'remoteToken' => $localToken,
 				'changedProperty' => $changedProperty,
@@ -267,5 +273,18 @@ class BackendNotifier {
 			return 'https://' . $remote;
 		}
 		return $remote;
+	}
+
+	protected function getServerRemoteUrl(): string {
+		$server = rtrim($this->url->getAbsoluteURL('/'), '/');
+		if (str_ends_with($server, '/index.php')) {
+			$server = substr($server, 0, -10);
+		}
+
+		if (str_starts_with($server, 'https://')) {
+			return substr($server, strlen('https://'));
+		}
+
+		return $server;
 	}
 }

--- a/lib/Migration/Version13000Date20210625232111.php
+++ b/lib/Migration/Version13000Date20210625232111.php
@@ -68,34 +68,35 @@ class Version13000Date20210625232111 extends SimpleMigrationStep {
 			]);
 		}
 
-		if (!$schema->hasTable('talk_invitations')) {
-			$table = $schema->createTable('talk_invitations');
-			$table->addColumn('id', Types::BIGINT, [
-				'autoincrement' => true,
-				'notnull' => true,
-			]);
-			$table->addColumn('room_id', Types::BIGINT, [
-				'notnull' => true,
-				'unsigned' => true,
-			]);
-			$table->addColumn('user_id', Types::STRING, [
-				'notnull' => true,
-				'length' => 255,
-			]);
-			$table->addColumn('access_token', Types::STRING, [
-				'notnull' => true,
-				'length' => 64,
-			]);
-			$table->addColumn('remote_id', Types::STRING, [
-				'notnull' => true,
-				'length' => 255,
-			]);
-
-			$table->setPrimaryKey(['id']);
-
-			$table->addIndex(['room_id']);
-		}
-
+		/** Removed in {@see \OCA\Talk\Migration\Version18000Date20231024141626} */
+		/** Recreated in {@see \OCA\Talk\Migration\Version18000Date20231024141627} */
+		// if (!$schema->hasTable('talk_invitations')) {
+		// $table = $schema->createTable('talk_invitations');
+		// $table->addColumn('id', Types::BIGINT, [
+		// 'autoincrement' => true,
+		// 'notnull' => true,
+		// ]);
+		// $table->addColumn('room_id', Types::BIGINT, [
+		// 'notnull' => true,
+		// 'unsigned' => true,
+		// ]);
+		// $table->addColumn('user_id', Types::STRING, [
+		// 'notnull' => true,
+		// 'length' => 255,
+		// ]);
+		// $table->addColumn('access_token', Types::STRING, [
+		// 'notnull' => true,
+		// 'length' => 64,
+		// ]);
+		// $table->addColumn('remote_id', Types::STRING, [
+		// 'notnull' => true,
+		// 'length' => 255,
+		// ]);
+		//
+		// $table->setPrimaryKey(['id']);
+		//
+		// $table->addIndex(['room_id']);
+		// }
 
 		return $schema;
 	}

--- a/lib/Migration/Version18000Date20231024141626.php
+++ b/lib/Migration/Version18000Date20231024141626.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version18000Date20231024141626 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('talk_invitations')) {
+			/** Recreated in {@see \OCA\Talk\Migration\Version18000Date20231024141627} */
+			$schema->dropTable('talk_invitations');
+			return $schema;
+		}
+		return null;
+	}
+}

--- a/lib/Migration/Version18000Date20231024141627.php
+++ b/lib/Migration/Version18000Date20231024141627.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version18000Date20231024141627 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('talk_invitations')) {
+			$table = $schema->createTable('talk_invitations');
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+			]);
+			$table->addColumn('user_id', Types::STRING, [
+				'notnull' => true,
+				'length' => 255,
+			]);
+			$table->addColumn('local_room_id', Types::BIGINT, [
+				'notnull' => true,
+				'unsigned' => true,
+			]);
+			$table->addColumn('access_token', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('remote_server_url', Types::STRING, [
+				'notnull' => true,
+				'length' => 512,
+			]);
+			$table->addColumn('remote_token', Types::STRING, [
+				'notnull' => true,
+				'length' => 32,
+			]);
+			$table->addColumn('remote_attendee_id', Types::BIGINT, [
+				'notnull' => true,
+				'unsigned' => true,
+			]);
+
+			$table->setPrimaryKey(['id']);
+
+			$table->addIndex(['local_room_id'], 'talk_fedinv_lri');
+			$table->addUniqueIndex(['remote_server_url', 'remote_attendee_id'], 'talk_fedinv_remote');
+
+			return $schema;
+		}
+		return null;
+	}
+}

--- a/lib/Migration/Version18000Date20231024141627.php
+++ b/lib/Migration/Version18000Date20231024141627.php
@@ -56,6 +56,10 @@ class Version18000Date20231024141627 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 255,
 			]);
+			$table->addColumn('state', Types::SMALLINT, [
+				'default' => 0,
+				'unsigned' => true,
+			]);
 			$table->addColumn('local_room_id', Types::BIGINT, [
 				'notnull' => true,
 				'unsigned' => true,

--- a/lib/Model/Invitation.php
+++ b/lib/Model/Invitation.php
@@ -31,6 +31,8 @@ use OCP\AppFramework\Db\Entity;
 /**
  * @method void setUserId(string $userId)
  * @method string getUserId()
+ * @method void setState(int $state)
+ * @method int getState()
  * @method void setLocalRoomId(int $roomLocalId)
  * @method int getLocalRoomId()
  * @method void setAccessToken(string $accessToken)
@@ -43,7 +45,11 @@ use OCP\AppFramework\Db\Entity;
  * @method int getRemoteAttendeeId()
  */
 class Invitation extends Entity implements \JsonSerializable {
+	public const STATE_PENDING = 0;
+	public const STATE_ACCEPTED = 1;
+
 	protected string $userId = '';
+	protected int $state = self::STATE_PENDING;
 	protected int $localRoomId = 0;
 	protected string $accessToken = '';
 	protected string $remoteServerUrl = '';
@@ -52,6 +58,7 @@ class Invitation extends Entity implements \JsonSerializable {
 
 	public function __construct() {
 		$this->addType('userId', 'string');
+		$this->addType('state', 'int');
 		$this->addType('localRoomId', 'int');
 		$this->addType('accessToken', 'string');
 		$this->addType('remoteServerUrl', 'string');
@@ -60,12 +67,13 @@ class Invitation extends Entity implements \JsonSerializable {
 	}
 
 	/**
-	 * @return array{access_token: string, id: int, local_room_id: int, remote_attendee_id: int, remote_server_url: string, remote_token: string, user_id: string}
+	 * @return array{access_token: string, id: int, local_room_id: int, remote_attendee_id: int, remote_server_url: string, remote_token: string, state: int, user_id: string}
 	 */
 	public function jsonSerialize(): array {
 		return [
 			'id' => $this->getId(),
 			'user_id' => $this->getUserId(),
+			'state' => $this->getState(),
 			'local_room_id' => $this->getLocalRoomId(),
 			'access_token' => $this->getAccessToken(),
 			'remote_server_url' => $this->getRemoteServerUrl(),

--- a/lib/Model/Invitation.php
+++ b/lib/Model/Invitation.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 /**
+ * @copyright Copyright (c) 2023 Joas Schilling <coding@schilljs.com>
  * @copyright Copyright (c) 2021 Gary Kim <gary@garykim.dev>
  *
  * @author Gary Kim <gary@garykim.dev>
@@ -28,46 +29,48 @@ namespace OCA\Talk\Model;
 use OCP\AppFramework\Db\Entity;
 
 /**
- * Class Invitation
- *
- * @package OCA\Talk\Model
- *
- * @method void setRoomId(int $roomId)
- * @method int getRoomId()
  * @method void setUserId(string $userId)
  * @method string getUserId()
+ * @method void setLocalRoomId(int $roomLocalId)
+ * @method int getLocalRoomId()
  * @method void setAccessToken(string $accessToken)
  * @method string getAccessToken()
- * @method void setRemoteId(string $remoteId)
- * @method string getRemoteId()
+ * @method void setRemoteServerUrl(string $remoteServerUrl)
+ * @method string getRemoteServerUrl()
+ * @method void setRemoteToken(string $remoteToken)
+ * @method string getRemoteToken()
+ * @method void setRemoteAttendeeId(int $remoteAttendeeId)
+ * @method int getRemoteAttendeeId()
  */
-class Invitation extends Entity {
-	/** @var int */
-	protected $roomId;
-
-	/** @var string */
-	protected $userId;
-
-	/** @var string */
-	protected $accessToken;
-
-	/** @var string */
-	protected $remoteId;
+class Invitation extends Entity implements \JsonSerializable {
+	protected string $userId = '';
+	protected int $localRoomId = 0;
+	protected string $accessToken = '';
+	protected string $remoteServerUrl = '';
+	protected string $remoteToken = '';
+	protected int $remoteAttendeeId = 0;
 
 	public function __construct() {
-		$this->addType('roomId', 'int');
 		$this->addType('userId', 'string');
+		$this->addType('localRoomId', 'int');
 		$this->addType('accessToken', 'string');
-		$this->addType('remoteId', 'string');
+		$this->addType('remoteServerUrl', 'string');
+		$this->addType('remoteToken', 'string');
+		$this->addType('remoteAttendeeId', 'int');
 	}
 
-	public function asArray(): array {
+	/**
+	 * @return array{access_token: string, id: int, local_room_id: int, remote_attendee_id: int, remote_server_url: string, remote_token: string, user_id: string}
+	 */
+	public function jsonSerialize(): array {
 		return [
 			'id' => $this->getId(),
-			'room_id' => $this->getRoomId(),
 			'user_id' => $this->getUserId(),
+			'local_room_id' => $this->getLocalRoomId(),
 			'access_token' => $this->getAccessToken(),
-			'remote_id' => $this->getRemoteId(),
+			'remote_server_url' => $this->getRemoteServerUrl(),
+			'remote_token' => $this->getRemoteToken(),
+			'remote_attendee_id' => $this->getRemoteAttendeeId(),
 		];
 	}
 }

--- a/lib/Model/InvitationMapper.php
+++ b/lib/Model/InvitationMapper.php
@@ -31,6 +31,7 @@ use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\IUser;
+use SensitiveParameter;
 
 /**
  * Class InvitationMapper
@@ -63,29 +64,21 @@ class InvitationMapper extends QBMapper {
 	/**
 	 * @throws DoesNotExistException
 	 */
-	public function getByRemoteIdAndToken(int $remoteId, string $accessToken): Invitation {
+	public function getByRemoteAndAccessToken(
+		string $remoteServerUrl,
+		int $remoteAttendeeId,
+		#[SensitiveParameter]
+		string $accessToken,
+	): Invitation {
 		$qb = $this->db->getQueryBuilder();
 
 		$qb->select('*')
 			->from($this->getTableName())
-			->where($qb->expr()->eq('remote_id', $qb->createNamedParameter($remoteId, IQueryBuilder::PARAM_INT)))
+			->where($qb->expr()->eq('remote_server_url', $qb->createNamedParameter($remoteServerUrl)))
+			->andWhere($qb->expr()->eq('remote_attendee_id', $qb->createNamedParameter($remoteAttendeeId, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('access_token', $qb->createNamedParameter($accessToken)));
 
 		return $this->findEntity($qb);
-	}
-
-	/**
-	 * @param Room $room
-	 * @return Invitation[]
-	 */
-	public function getInvitationsForRoom(Room $room): array {
-		$qb = $this->db->getQueryBuilder();
-
-		$qb->select('*')
-			->from($this->getTableName())
-			->where($qb->expr()->eq('room_id', $qb->createNamedParameter($room->getId())));
-
-		return $this->findEntities($qb);
 	}
 
 	/**

--- a/lib/Model/InvitationMapper.php
+++ b/lib/Model/InvitationMapper.php
@@ -102,27 +102,17 @@ class InvitationMapper extends QBMapper {
 		return $this->findEntities($qb);
 	}
 
-	public function countInvitationsForRoom(Room $room): int {
+	public function countInvitationsForLocalRoom(Room $room): int {
 		$qb = $this->db->getQueryBuilder();
 
 		$qb->select($qb->func()->count('*', 'num_invitations'))
 			->from($this->getTableName())
-			->where($qb->expr()->eq('room_id', $qb->createNamedParameter($room->getId())));
+			->where($qb->expr()->eq('local_room_id', $qb->createNamedParameter($room->getId())));
 
 		$result = $qb->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 
 		return (int) ($row['num_invitations'] ?? 0);
-	}
-
-	public function createInvitationFromRow(array $row): Invitation {
-		return $this->mapRowToEntity([
-			'id' => $row['id'],
-			'room_id' => (int) $row['room_id'],
-			'user_id' => (string) $row['user_id'],
-			'access_token' => (string) $row['access_token'],
-			'remote_id' => (string) $row['remote_id'],
-		]);
 	}
 }

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -403,8 +403,8 @@ class Notifier implements INotifier {
 			if ($invite->getUserId() !== $notification->getUser()) {
 				throw new AlreadyProcessedException();
 			}
-			$room = $this->manager->getRoomById($invite->getRoomId());
-		} catch (RoomNotFoundException $e) {
+			$room = $this->manager->getRoomById($invite->getLocalRoomId());
+		} catch (RoomNotFoundException) {
 			// Room does not exist
 			throw new AlreadyProcessedException();
 		}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -97,10 +97,10 @@ namespace OCA\Talk;
  * @psalm-type TalkFederationInvite = array{
  *     access_token: string,
  *     id: int,
- *     remote_id: string,
- *     remote_server: string,
+ *     local_room_id: int,
+ *     remote_attendee_id: string,
+ *     remote_server_url: string,
  *     remote_token: string,
- *     room_id: int,
  *     user_id: string,
  * }
  *

--- a/openapi.json
+++ b/openapi.json
@@ -305,10 +305,10 @@
                 "required": [
                     "access_token",
                     "id",
-                    "remote_id",
-                    "remote_server",
+                    "local_room_id",
+                    "remote_attendee_id",
+                    "remote_server_url",
                     "remote_token",
-                    "room_id",
                     "user_id"
                 ],
                 "properties": {
@@ -319,18 +319,18 @@
                         "type": "integer",
                         "format": "int64"
                     },
-                    "remote_id": {
+                    "local_room_id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "remote_attendee_id": {
                         "type": "string"
                     },
-                    "remote_server": {
+                    "remote_server_url": {
                         "type": "string"
                     },
                     "remote_token": {
                         "type": "string"
-                    },
-                    "room_id": {
-                        "type": "integer",
-                        "format": "int64"
                     },
                     "user_id": {
                         "type": "string"

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -490,8 +490,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->assertInvites($invites, $formData);
 
 		foreach ($invites as $data) {
-			self::$remoteToInviteId[$this->translateRemoteServer($data['remote_server']) . '::' . self::$tokenToIdentifier[$data['remote_token']]] = $data['id'];
-			self::$inviteIdToRemote[$data['id']] = $this->translateRemoteServer($data['remote_server']) . '::' . self::$tokenToIdentifier[$data['remote_token']];
+			self::$remoteToInviteId[$this->translateRemoteServer($data['remote_server_url']) . '::' . self::$tokenToIdentifier[$data['remote_token']]] = $data['id'];
+			self::$inviteIdToRemote[$data['id']] = $this->translateRemoteServer($data['remote_server_url']) . '::' . self::$tokenToIdentifier[$data['remote_token']];
 		}
 	}
 
@@ -533,8 +533,11 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			if (isset($expectedInvite['remote_token'])) {
 				$data['remote_token'] = self::$tokenToIdentifier[$invite['remote_token']] ?? 'unknown-token';
 			}
-			if (isset($expectedInvite['remote_server'])) {
-				$data['remote_server'] = $this->translateRemoteServer($invite['remote_server']);
+			if (isset($expectedInvite['remote_server_url'])) {
+				$data['remote_server_url'] = $this->translateRemoteServer($invite['remote_server_url']);
+			}
+			if (isset($expectedInvite['state'])) {
+				$data['state'] = (int) $invite['state'];
 			}
 
 			return $data;

--- a/tests/integration/features/federation/invite.feature
+++ b/tests/integration/features/federation/invite.feature
@@ -42,13 +42,15 @@ Feature: federation/invite
       | room | users         | participant1 | conversation_created | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
     And force run "OCA\Talk\BackgroundJob\RemoveEmptyRooms" background jobs
     And user "participant2" has the following invitations (v1)
-      | remote_server | remote_token |
-      | LOCAL         | room         |
+      | remote_server_url | remote_token | state |
+      | LOCAL             | room         | 0     |
     Then user "participant2" has the following notifications
       | app    | object_type       | object_id              | subject                                                                      |
       | spreed | remote_talk_share | INVITE_ID(LOCAL::room) | @participant1-displayname shared room room on http://localhost:8080 with you |
     And user "participant2" accepts invite to room "room" of server "LOCAL" (v1)
     And user "participant2" has the following invitations (v1)
+      | remote_server_url | remote_token | state |
+      | LOCAL             | room         | 1     |
     When user "participant1" sees the following attendees in room "room" with 200 (v4)
       | actorType       | actorId      | participantType |
       | users           | participant1 | 1               |
@@ -75,8 +77,8 @@ Feature: federation/invite
       | room | users         | participant1 | federated_user_added | You invited {federated_user} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
       | room | users         | participant1 | conversation_created | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
     And user "participant2" has the following invitations (v1)
-      | remote_server | remote_token |
-      | LOCAL         | room         |
+      | remote_server_url | remote_token | state |
+      | LOCAL             | room         | 0     |
     Then user "participant2" has the following notifications
       | app    | object_type       | object_id              | subject                                                                      |
       | spreed | remote_talk_share | INVITE_ID(LOCAL::room) | @participant1-displayname shared room room on http://localhost:8080 with you |
@@ -99,10 +101,12 @@ Feature: federation/invite
       | roomName | room |
     And user "participant1" adds remote "participant2" to room "room" with 200 (v4)
     And user "participant2" has the following invitations (v1)
-      | remote_server | remote_token |
-      | LOCAL         | room         |
+      | remote_server_url | remote_token | state |
+      | LOCAL             | room         | 0     |
     And user "participant2" accepts invite to room "room" of server "LOCAL" (v1)
     And user "participant2" has the following invitations (v1)
+      | remote_server_url | remote_token | state |
+      | LOCAL             | room         | 1     |
     Then user "participant2" is participant of the following rooms (v4)
       | id   | type |
       | room | 2    |
@@ -121,8 +125,8 @@ Feature: federation/invite
       | roomName | room |
     And user "participant1" adds remote "participant2" to room "room" with 200 (v4)
     And user "participant2" has the following invitations (v1)
-      | remote_server | remote_token |
-      | LOCAL         | room         |
+      | remote_server_url | remote_token | state |
+      | LOCAL             | room         | 0     |
     And user "participant2" accepts invite to room "room" of server "LOCAL" (v1)
     Then user "participant2" is participant of the following rooms (v4)
       | id   | name | type |


### PR DESCRIPTION
### ☑️ Resolves

- [x] Fix "Validation by remoteAttendeeId + accessToken might be ambiguous" from https://github.com/nextcloud/spreed/issues/5723#issue-914053512

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Based on #10729 
- [x] Fix "Validation by remoteAttendeeId + accessToken might be ambiguous, maybe we should keep the invites in the DB with an accepted flag and add the remoteServer there?"

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
