### PR TITLE
fix(recording): Fail the recording server check when a HPB is configured

### DIFF
--- a/lib/Controller/RecordingController.php
+++ b/lib/Controller/RecordingController.php
@@ -104,6 +104,12 @@ class RecordingController extends AEnvironmentAwareController {
 				],
 			]);
 
+			if ($response->getHeader(\OCA\Talk\Signaling\Manager::FEATURE_HEADER)) {
+				return new DataResponse([
+					'error' => 'IS_SIGNALING_SERVER',
+				], Http::STATUS_INTERNAL_SERVER_ERROR);
+			}
+
 			$body = $response->getBody();
 			$data = json_decode($body, true);
 

--- a/src/components/AdminSettings/RecordingServer.vue
+++ b/src/components/AdminSettings/RecordingServer.vue
@@ -169,6 +169,8 @@ export default {
 
 				if (error === 'CAN_NOT_CONNECT') {
 					this.errorMessage = t('spreed', 'Error: Cannot connect to server')
+				} else if (error === 'IS_SIGNALING_SERVER') {
+					this.errorMessage = t('spreed', 'Error: Server seems to be a Signaling server')
 				} else if (error === 'JSON_INVALID') {
 					this.errorMessage = t('spreed', 'Error: Server did not respond with proper JSON')
 				} else if (error === 'CERTIFICATE_EXPIRED') {


### PR DESCRIPTION
### ☑️ Resolves

* Ref https://github.com/nextcloud/nextcloud-talk-recording/issues/8

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![grafik](https://github.com/nextcloud/spreed/assets/213943/1a078a30-4804-47a4-b994-034076bf6f19)        | ![Bildschirmfoto vom 2023-10-26 17-20-06](https://github.com/nextcloud/spreed/assets/213943/b0bad3a7-ce94-40e4-b726-2f68bf32508f)  |

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
