### PR TITLE
Fix(MessageButtonsBar): hide delete message button for guests

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -485,7 +485,7 @@ export default {
 		},
 
 		isDeleteable() {
-			if (this.isConversationReadOnly) {
+			if (this.isConversationReadOnly || this.participant.participantType === PARTICIPANT.TYPE.GUEST) {
 				return false
 			}
 


### PR DESCRIPTION

* Guest cannot delete a message.

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/84044328/c3284058-2b4f-4785-8ea4-19e54f63b245)   | ![image](https://github.com/nextcloud/spreed/assets/84044328/7083dcd7-45c2-451b-a174-31bc55954188)       |


### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
