### PR TITLE
refactor(signaling): Rename sendMessages endpoint for clarification

### DIFF
--- a/appinfo/routes/routesSignalingController.php
+++ b/appinfo/routes/routesSignalingController.php
@@ -43,8 +43,8 @@ return [
 		])],
 		/** @see \OCA\Talk\Controller\SignalingController::backend() */
 		['name' => 'Signaling#backend', 'url' => '/api/{apiVersion}/signaling/backend', 'verb' => 'POST', 'requirements' => $requirements],
-		/** @see \OCA\Talk\Controller\SignalingController::signaling() */
-		['name' => 'Signaling#signaling', 'url' => '/api/{apiVersion}/signaling/{token}', 'verb' => 'POST', 'requirements' => $requirementsWithToken],
+		/** @see \OCA\Talk\Controller\SignalingController::sendMessages() */
+		['name' => 'Signaling#sendMessages', 'url' => '/api/{apiVersion}/signaling/{token}', 'verb' => 'POST', 'requirements' => $requirementsWithToken],
 		/** @see \OCA\Talk\Controller\SignalingController::pullMessages() */
 		['name' => 'Signaling#pullMessages', 'url' => '/api/{apiVersion}/signaling/{token}', 'verb' => 'GET', 'requirements' => $requirementsWithToken],
 	],

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -310,7 +310,7 @@ class SignalingController extends OCSController {
 	 * 400: Sending signaling message is not possible
 	 */
 	#[PublicPage]
-	public function signaling(string $token, string $messages): DataResponse {
+	public function sendMessages(string $token, string $messages): DataResponse {
 		if ($this->talkConfig->getSignalingMode() !== Config::SIGNALING_INTERNAL) {
 			return new DataResponse('Internal signaling disabled.', Http::STATUS_BAD_REQUEST);
 		}

--- a/openapi.json
+++ b/openapi.json
@@ -16159,7 +16159,7 @@
         },
         "/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/{token}": {
             "post": {
-                "operationId": "signaling-signaling",
+                "operationId": "signaling-send-messages",
                 "summary": "Send signaling messages",
                 "tags": [
                     "signaling"


### PR DESCRIPTION
## 🛠️ API Checklist

The name of the method is not helpful for consumers of the OpenAPI spec. `sendMessages` correctly communicates what the endpoint does without looking at the description.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
