### PR TITLE
Migrate to NcTextArea

### DIFF
--- a/src/components/AdminSettings/SIPBridge.vue
+++ b/src/components/AdminSettings/SIPBridge.vue
@@ -74,8 +74,8 @@
 			<label for="dial-in-info" class="form__label additional-top-margin">
 				{{ t('spreed', 'Dial-in information') }}
 			</label>
-			<textarea id="dial-in-info"
-				v-model="dialInInfo"
+			<NcTextArea id="dial-in-info"
+				:value.sync="dialInInfo"
 				name="message"
 				class="form form__textarea"
 				rows="4"
@@ -107,6 +107,7 @@ import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
 import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
+import NcTextArea from '@nextcloud/vue/dist/Components/NcTextArea.js'
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 
 import { setSIPSettings } from '../../services/settingsService.js'
@@ -120,6 +121,7 @@ export default {
 		NcButton,
 		NcNoteCard,
 		NcSelect,
+		NcTextArea,
 		NcTextField,
 	},
 

--- a/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
+++ b/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
@@ -70,7 +70,12 @@
 						:container="container"
 						@close="closeLogModal">
 						<div class="modal__content">
-							<textarea v-model="processLog" class="log-content" />
+							<NcTextArea :value="processLog"
+								class="log-content"
+								:label="t('spreed', 'Log content')"
+								rows="29"
+								readonly
+								resize="vertical" />
 						</div>
 					</NcModal>
 				</div>
@@ -104,6 +109,7 @@ import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
+import NcTextArea from '@nextcloud/vue/dist/Components/NcTextArea.js'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import BridgePart from './BridgePart.vue'
@@ -125,6 +131,7 @@ export default {
 		BridgePart,
 		Message,
 		NcModal,
+		NcTextArea,
 		Plus,
 	},
 
@@ -739,7 +746,10 @@ export default {
 }
 
 .log-content {
-	width: 600px;
-	height: 400px;
+	width: 590px;
+}
+
+:deep(.modal-container__content) {
+	padding: 5px;
 }
 </style>


### PR DESCRIPTION
Migrate to NcTextArea from native textarea in 
* SIP bridge ( dial-in info)
* Matterbridge settings ( log)

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

* No visual changes in SIP bridge
* Matterbridge log ( with dummy log)

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![Screenshot 2023-10-31 121533](https://github.com/nextcloud/spreed/assets/84044328/86a0d0f7-f8d5-438a-b3d8-a717f4bec3fc)       | ![Matterbridge-after](https://github.com/nextcloud/spreed/assets/84044328/2eb7bbf2-cafb-43ea-99d3-383d76dedd20)       |

### 🚧 Tasks

- [ ] visual review
- [ ] code review

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
