### PR TITLE
fix(LeftSidebar): revert temp styles and fix conversation styling

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -1025,13 +1025,8 @@ export default {
 	padding: 0 !important;
 }
 
-// FIXME upstream https://github.com/nextcloud-libraries/nextcloud-vue/issues/4625
-:deep(.list-item__wrapper--active) {
-	.list-item:hover,
-	.list-item:focus,
-	.list-item:focus-visible,
-	.list-item:active {
-		background-color: var(--color-primary-element-hover);
-	}
+:deep(.list-item) {
+	overflow: hidden;
+	outline-offset: -2px;
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10443 again :') ( changes of its PR were reverted [here](https://github.com/nextcloud/spreed/commit/948a640bcd7d60078269b19f5fa0d36b6d61f9fb#diff-7a1abf98ca549db81a418814a97629c796bc85dc32b40f9cffb65ce3ad40d555) ). Another workaround is now used which is basically moving the outline inside the element.
* Fix the unexpected outline on favorite conversations ( border radius is changing) . As I checked, there was no explicit style for the border radius coming from the favorite icon node. Setting `overflow: hidden` solved it though 
* Revert some changes after merging https://github.com/nextcloud-libraries/nextcloud-vue/pull/4628
<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/84044328/ce85455c-af0c-48e4-823e-e9514744248a)       | ![image](https://github.com/nextcloud/spreed/assets/84044328/067d68c9-36e7-45a6-88aa-4b1bb7d14702)       |
| ![image](https://github.com/nextcloud/spreed/assets/84044328/150caa2d-057a-4f95-8071-91465608253e) |![image](https://github.com/nextcloud/spreed/assets/84044328/2480346a-4152-4baf-ac19-53ca4172503e) 


### 🚧 Tasks

- [ ] Code review
- [ ] Visual review

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
