### PR TITLE
Log error when starting a screen share fails

### DIFF
--- a/src/utils/webrtc/simplewebrtc/localmedia.js
+++ b/src/utils/webrtc/simplewebrtc/localmedia.js
@@ -316,6 +316,8 @@ LocalMedia.prototype.startScreenShare = function(mode, constraints, cb) {
 
 			self.emit('localScreen', stream)
 		} else {
+			console.error('Error when starting screen share: ', err)
+
 			self.emit('localScreenRequestFailed')
 		}
 


### PR DESCRIPTION
When a screen share fails a message is shown in the UI. However, the detailed message was not logged anywhere, which is specially relevant when [an unknown error without an explicit message in the UI occurs](https://github.com/nextcloud/spreed/blob/e4692febc97dc52d40369de67750e9a3d43b114b/src/components/TopBar/TopBarMediaControls.vue#L537).
