### PR TITLE
Log internal signaling messages in debug mode

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -478,6 +478,10 @@ Signaling.Internal.prototype._doLeaveRoom = function(token) {
 }
 
 Signaling.Internal.prototype.sendCallMessage = function(data) {
+	if (OC.debug) {
+		console.debug('Sending', data)
+	}
+
 	if (data.type === 'answer') {
 		console.debug('ANSWER', data)
 	} else if (data.type === 'offer') {
@@ -517,6 +521,10 @@ Signaling.Internal.prototype._startPullingMessages = function() {
 
 			result.data.ocs.data.forEach(message => {
 				let localParticipant
+
+				if (OC.debug) {
+					console.debug('Received', message)
+				}
 
 				this._trigger('onBeforeReceiveMessage', [message])
 				switch (message.type) {


### PR DESCRIPTION
The signaling messages were already logged in debug mode, but only [if the external signaling server was used](https://github.com/nextcloud/spreed/blob/da7064279773936ae72f5ab0beda5ae445f54f24/src/utils/signaling.js#L762-L764). This extends the logging also to internal signaling messages.