### PR TITLE
chore(release): Bump version and add meta changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 18.0.0-beta.1 – 2023-11-02
+### Added
+- 🗒️ Note to self
+  [#2196](https://github.com/nextcloud/spreed/issues/2196)
+- 🎙️ Show speaker while screensharing
+  [#4478](https://github.com/nextcloud/spreed/issues/4478)
+- 🏷️ Add a caption to your file before sharing it into the chat
+  [#5354](https://github.com/nextcloud/spreed/issues/5354)
+- 👤 Ask Guest to enter a name when connecting
+  [#855](https://github.com/nextcloud/spreed/issues/855)
+- 🤩 Animated call reactions
+  [#10561](https://github.com/nextcloud/spreed/issues/10561)
+- 🖋️ Optionally require consent before joining a recorded call
+  [#10348](https://github.com/nextcloud/spreed/issues/10348)
+- 📲 Allow calling phone numbers from within Talk using SIP dialout
+  [#10346](https://github.com/nextcloud/spreed/issues/10346)
+
+### Changed
+- Requires Nextcloud 28
+- Update several dependencies
+
 ## 17.1.2 – 2023-10-27
 ### Changed
 - Update dependencies

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>18.0.0-dev.9</version>
+	<version>18.0.0-beta.1</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "18.0.0-dev.0",
+  "version": "18.0.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "18.0.0-dev.0",
+      "version": "18.0.0-beta.1",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "18.0.0-dev.0",
+  "version": "18.0.0-beta.1",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 18.0.0-beta.1 – 2023-11-02
### Added
- 🗒️ Note to self  [#2196](https://github.com/nextcloud/spreed/issues/2196)
- 🎙️ Show speaker while screensharing  [#4478](https://github.com/nextcloud/spreed/issues/4478)
- 🏷️ Add a caption to your file before sharing it into the chat  [#5354](https://github.com/nextcloud/spreed/issues/5354)
- 👤 Ask Guest to enter a name when connecting  [#855](https://github.com/nextcloud/spreed/issues/855)
- 🤩 Animated call reactions  [#10561](https://github.com/nextcloud/spreed/issues/10561)
- 🖋️ Optionally require consent before joining a recorded call  [#10348](https://github.com/nextcloud/spreed/issues/10348)
- 📲 Allow calling phone numbers from within Talk using SIP dialout  [#10346](https://github.com/nextcloud/spreed/issues/10346)

### Changed
- Requires Nextcloud 28
- Update several dependencies