### PR TITLE
fix(chat): Fix mentions at the beginning of captions

### DIFF
--- a/lib/Chat/Parser/UserMention.php
+++ b/lib/Chat/Parser/UserMention.php
@@ -94,7 +94,14 @@ class UserMention implements IEventListener {
 
 		$mentionTypeCount = [];
 
+		// Set the current message as comment content, so that the message finds
+		// mentions which are now part of the message, but were not on the original
+		// comment, e.g. mentions at the beginning of captions
+		$originalCommentMessage = $comment->getMessage();
+		$comment->setMessage($message, ChatManager::MAX_CHAT_LENGTH + 10000);
 		$mentions = $comment->getMentions();
+		$comment->setMessage($originalCommentMessage, ChatManager::MAX_CHAT_LENGTH);
+
 		// TODO This can be removed once getMentions() returns sorted results (Nextcloud 21+)
 		usort($mentions, static function (array $m1, array $m2) {
 			return mb_strlen($m2['id']) <=> mb_strlen($m1['id']);

--- a/tests/integration/features/chat/file-share.feature
+++ b/tests/integration/features/chat/file-share.feature
@@ -32,6 +32,16 @@ Feature: chat/file-share
       | room        | actorType | actorId      | actorDisplayName         | message                                                           | messageParameters |
       | public room | users     | participant1 | participant1-displayname | Hello {mention-user1} this is a caption for the attached document | "IGNORE"          |
 
+  Scenario: Share a file with caption that only is a mention
+    Given user "participant1" creates room "public room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    When user "participant1" shares "welcome.txt" with room "public room"
+      | talkMetaData | {"caption":"@participant2"} |
+    Then user "participant1" sees the following messages in room "public room" with 200
+      | room        | actorType | actorId      | actorDisplayName         | message         | messageParameters |
+      | public room | users     | participant1 | participant1-displayname | {mention-user1} | "IGNORE"          |
+
   Scenario: Can not share a file without chat permission
     Given user "participant1" creates room "public room" (v4)
       | roomType | 3 |


### PR DESCRIPTION
Set the current message as comment content, so that the message finds mentions which are now part if the message but were not on the original comment, e.g. mentions at the beginning of captions

### ☑️ Resolves

* Fix #10830 

## 🛠️ API Checklist

### Before
```behat
    Then user "participant1" sees the following messages in room "public room" with 200 # FeatureContext::userSeesTheFollowingMessagesInRoom()
      | room        | actorType | actorId      | actorDisplayName         | message         | messageParameters |
      | public room | users     | participant1 | participant1-displayname | {mention-user1} | "IGNORE"          |
      Failed asserting that two arrays are equal.
      --- Expected
      +++ Actual
      @@ @@
               'actorType' => 'users'
               'actorId' => 'participant1'
               'actorDisplayName' => 'participant1-displayname'
      -        'message' => '{mention-user1}'
      +        'message' => '@participant2'
               'messageParameters' => '"IGNORE"'
           )
       )

```

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
