### PR TITLE
fix(reactions): Don't break mobile clients when the reactions list is…

### DIFF
--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -132,7 +132,7 @@ class ChatController extends AEnvironmentAwareController {
 			}
 			return [Attendee::ACTOR_GUESTS, $this->participant->getAttendee()->getActorId()];
 		}
-		
+
 		if ($this->userId === MatterbridgeManager::BRIDGE_BOT_USERID && $actorDisplayName) {
 			return [Attendee::ACTOR_BRIDGED, str_replace(['/', '"'], '', $actorDisplayName)];
 		}
@@ -936,7 +936,6 @@ class ChatController extends AEnvironmentAwareController {
 			Attachment::TYPE_VOICE,
 		];
 
-		$messages = [];
 		$messageIdsByType = [];
 		// Get all attachments
 		foreach ($objectTypes as $objectType) {

--- a/tests/integration/features/chat-2/rich-object-share.feature
+++ b/tests/integration/features/chat-2/rich-object-share.feature
@@ -64,6 +64,7 @@ Feature: chat-2/rich-object-share
     Given user "participant1" creates room "public room" (v4)
       | roomType | 3 |
       | roomName | room |
+    Then user "participant1" sees the following shared summarized overview in room "public room" with 200
     When user "participant1" shares rich-object "call" "R4nd0mT0k3n" '{"name":"Another room","call-type":"group"}' to room "public room" with 201 (v1)
     Then user "participant1" sees the following shared other in room "public room" with 200
       | room        | actorType | actorId      | actorDisplayName         | message  | messageParameters |


### PR DESCRIPTION
… empty

### ☑️ Resolves

* Ref https://github.com/nextcloud/talk-ios/pull/1408

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
