### PR TITLE
Fix(MessageButtonsBar): Hide copy message button for files

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -83,7 +83,8 @@
 						</template>
 						{{ t('spreed', 'Reply privately') }}
 					</NcActionButton>
-					<NcActionButton close-after-click
+					<NcActionButton v-if="!isFileShareOnly"
+						close-after-click
 						@click.stop="handleCopyMessageText">
 						<template #icon>
 							<ContentCopy :size="20" />
@@ -523,6 +524,10 @@ export default {
 
 		isFileShare() {
 			return Object.keys(Object(this.messageParameters)).some(key => key.startsWith('file'))
+		},
+
+		isFileShareOnly() {
+			return this.isFileShare && this.message === '{file}'
 		},
 
 		isCurrentGuest() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10829

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/84044328/08265404-89be-4323-8835-ae0ee7a9b4b7)         | ![image](https://github.com/nextcloud/spreed/assets/84044328/e91c057f-c75d-4692-9527-983d30ca5916)     |

### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
