### PR TITLE
Fix(ParticipantsList): Update list when needed

### DIFF
--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -83,6 +83,7 @@ import ParticipantsListVirtual from './ParticipantsList/ParticipantsListVirtual.
 import ParticipantsSearchResults from './ParticipantsSearchResults/ParticipantsSearchResults.vue'
 
 import { useSortParticipants } from '../../../composables/useSortParticipants.js'
+import { useIsInCall } from '../../../composables/useIsInCall.js'
 import getParticipants from '../../../mixins/getParticipants.js'
 import { searchPossibleConversations } from '../../../services/conversationsService.js'
 import { EventBus } from '../../../services/EventBus.js'
@@ -122,9 +123,11 @@ export default {
 
 	setup() {
 		const { sortParticipants } = useSortParticipants()
+		const isInCall = useIsInCall()
 
 		return {
 			sortParticipants,
+			isInCall,
 		}
 	},
 
@@ -185,6 +188,12 @@ export default {
 	watch: {
 		searchText(value) {
 			this.isFocused = !!value
+		},
+
+		isActive(value) {
+			if (value && this.pendingChanges) {
+				this.debounceUpdateParticipants()
+			}
 		}
 	},
 

--- a/src/mixins/getParticipants.js
+++ b/src/mixins/getParticipants.js
@@ -34,6 +34,7 @@ const getParticipants = {
 		return {
 			participantsInitialised: false,
 			fetchingParticipants: false,
+			pendingChanges: false,
 		}
 	},
 
@@ -79,7 +80,9 @@ const getParticipants = {
 		},
 
 		debounceUpdateParticipants() {
-			if (!this.isActive) {
+			if (!this.isActive && !this.isInCall) {
+				// Update is ignored but there is a flag to force the participants update
+				this.pendingChanges = true
 				return
 			}
 
@@ -88,7 +91,7 @@ const getParticipants = {
 			} else {
 				this.debounceSlowUpdateParticipants()
 			}
-
+			this.pendingChanges = false
 		},
 
 		debounceSlowUpdateParticipants: debounce(function() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10677
The list is always updated unless the participants tab is inactive and there is no call. 

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist


### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
