### PR TITLE
Fix leaving call if a signaling message is received while reconnecting

### DIFF
--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -592,6 +592,11 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 		// cases the call should be kept active from the point of view of
 		// WebRTC.
 		if (reconnect) {
+			// The signaling state must be marked as not in the call to prevent
+			// that after joining the call again the local participant is
+			// treated as in the call before a signaling message confirms it.
+			selfInCall = PARTICIPANT.CALL_FLAG.DISCONNECTED
+
 			return
 		}
 


### PR DESCRIPTION
When the local participant is in the call and a signaling message does not list the participant as being in the call the call is left (as it is assumed that, for example, the participant was kicked out from the call by a moderator). During a forced reconnection the local participant was not marked as "not in the call" when the call was left, so in the time between sending the request to join the call again and receiving a signaling message confirming that the call was joined another signaling message that does not list the participant yet as in the call caused the UI to leave the call (for example, if another participant also joined).

Although the window for the issue is very narrow the chances increase when there are a lot of participants. Nevertheless, the steps below force the issue by adding a long delay between sending the request to join the call and actually joining the call, thus giving enough time to generate other signaling messages to trigger it.

## How to test

- This can be tested with or without HPB
- Create a conversation and add another user
- Start a call with audio and video
- In a private window, log in as the user
- Join the conversation
- Join the call with audio and/or video
- Wait until the participants are connected
- Add `sleep(25);` at [the beginning of the `joinCall` controller](https://github.com/nextcloud/spreed/blob/5e06dce59cf073f1625380353ddc77747059af89/lib/Controller/CallController.php#L141) to delay joining a call
- In the original window, remove all permissions for the user
- _Quickly_ (but after the participant in the private window left the call) open the media settings and select "None" as the camera (this will cause a call flags change and, with it, a signaling message in which the participant in the private window will be listed as not in the call)

### Result with this pull request

The participant in the private window reconnects to the call

### Result without this pull request

In the private window the call is left and the call UI hidden, although the user is still in the call from the point of view of the server or other participant (as the call was left due to the message, but then it was joined again when the reconnection finished), but no media is transmitted
