### PR TITLE
Fix "zoom" effect with some cameras when changing the resolution

### DIFF
--- a/src/utils/webrtc/VideoConstrainer.js
+++ b/src/utils/webrtc/VideoConstrainer.js
@@ -197,6 +197,7 @@ VideoConstrainer.prototype = {
 					ideal: 30,
 					min: 20,
 				},
+				resizeMode: 'none',
 			}
 		}
 
@@ -217,6 +218,7 @@ VideoConstrainer.prototype = {
 					ideal: 24,
 					min: 15,
 				},
+				resizeMode: 'none',
 			}
 		}
 
@@ -237,6 +239,7 @@ VideoConstrainer.prototype = {
 					ideal: 15,
 					min: 8,
 				},
+				resizeMode: 'none',
 			}
 		}
 
@@ -251,6 +254,7 @@ VideoConstrainer.prototype = {
 				frameRate: {
 					max: 8,
 				},
+				resizeMode: 'none',
 			}
 		}
 
@@ -264,6 +268,7 @@ VideoConstrainer.prototype = {
 			frameRate: {
 				max: 1,
 			},
+			resizeMode: 'none',
 		}
 	},
 


### PR DESCRIPTION
This pull request is already ready for review, but it is marked as a draft to prevent merging it; @SystemKeeper will take care of that when/if needed :-)

When the video track resolution is changed the browser may crop and downscale the camera output to satisfy the requested constraints ([`resizeMode: "crop-and-scale"`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#resizemode)). However, in some cameras this causes an annoying "zoom" effect when changing between resolutions (it might be caused by the original source being shown for a split second before being cropped and downscaled, which may change the aspect ratio, although the reason is not fully clear). To prevent that, now the browser is asked to provide the camera output as is (although respecting the given constraints), without further adjustments.

Note that the resize mode is not enforced, though. The browser may still crop and scale the camera output if it is not possible to get a native track in the requested resolution range.

The problem (and therefore the steps below) can be reproduced at least with Logitech C920 and integrated Macbook camera, but not with others; nevertheless it should not adversely affect those cameras where the problem did not initially happen (but that should be thoroughly tested ;-) ).

## How to test

- Expose the `sentVideoQualityThrottler` in the browser console by adding something like the following to [_src/utils/webtc/index.js_](https://github.com/nextcloud/spreed/blob/0f9917cb0bad600a38a0d1c47f9c24d4c4f3cd3f/src/utils/webrtc/index.js#L60):
```
if (!OCA.Talk) {
	OCA.Talk = {}
}
OCA.Talk.getSentVideoQualityThrottler = () => {
	return sentVideoQualityThrottler
}
```
- Rebuild the code
- Start a call with camera
- Open the browser console
- Change between the high and very low resolutions running:
```
OCA.Talk.getSentVideoQualityThrottler()._videoConstrainer.applyConstraints(4)
OCA.Talk.getSentVideoQualityThrottler()._videoConstrainer.applyConstraints(1)
```

### Result with this pull request

There is no visible "zoom" (although there could be a tone change, which seems to happen due to the lighting adjustment made by the camera when restarting)

### Request without this pull request

The image might "jump" when the resolution is adjusted

The actual constraints set in the video track can be checked by running the following in the browser console:
```
OCA.Talk.SimpleWebRTC.webrtc._videoTrackConstrainer.getOutputTrack().getSettings()
