### PR TITLE
Release/18.0.0 beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 18.0.0-beta.2 – 2023-11-09
+### Changed
+- Replace various confirmation screens with the NcDialog component
+  [#10812](https://github.com/nextcloud/spreed/issues/10812)
+- Update several dependencies
+
+### Fixed
+- Fix mentions at the beginning of the text in captions
+  [#10831](https://github.com/nextcloud/spreed/issues/10831)
+- Fix not breaking the JSON response when removing the last reaction of a message
+  [#10832](https://github.com/nextcloud/spreed/issues/10832)
+- Remove previous style adjustments from left sidebar
+  [#10818](https://github.com/nextcloud/spreed/issues/10818)
+- Migrate the last set of event listeners to be service listeners
+
 ## 18.0.0-beta.1 – 2023-11-02
 ### Added
 - 🗒️ Note to self

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>18.0.0-beta.1</version>
+	<version>18.0.0-beta.2</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "18.0.0-beta.1",
+  "version": "18.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "18.0.0-beta.1",
+      "version": "18.0.0-beta.2",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "18.0.0-beta.1",
+  "version": "18.0.0-beta.2",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
### Changed
- Replace various confirmation screens with the NcDialog component [#10812](https://github.com/nextcloud/spreed/issues/10812)
- Update several dependencies

### Fixed
- Fix mentions at the beginning of the text in captions [#10831](https://github.com/nextcloud/spreed/issues/10831)
- Fix not breaking the JSON response when removing the last reaction of a message [#10832](https://github.com/nextcloud/spreed/issues/10832)
- Remove previous style adjustments from left sidebar [#10818](https://github.com/nextcloud/spreed/issues/10818)
-  Migrate the last set of event listeners to be service listeners