### PR TITLE
fix(session): Don't attempt to set session state without a session

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1691,17 +1691,22 @@ class RoomController extends AEnvironmentAwareController {
 	 * Set active state for a session
 	 *
 	 * @param int $state of the room
-	 * @return DataResponse<Http::STATUS_OK, TalkRoom, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array<empty>, array{}>
+	 * @return DataResponse<Http::STATUS_OK, TalkRoom, array{}>|DataResponse<Http::STATUS_BAD_REQUEST|Http::STATUS_NOT_FOUND, array<empty>, array{}>
 	 *
 	 * 200: Session state set successfully
 	 * 400: The provided new state was invalid
+	 * 404: The participant did not have a session
 	 */
 	#[PublicPage]
 	#[RequireParticipant]
 	public function setSessionState(int $state): DataResponse {
+		if (!$this->participant->getSession() instanceof Session) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
 		try {
 			$this->sessionService->updateSessionState($this->participant->getSession(), $state);
-		} catch (\InvalidArgumentException $e) {
+		} catch (\InvalidArgumentException) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 

--- a/openapi.json
+++ b/openapi.json
@@ -14333,6 +14333,34 @@
                                 }
                             }
                         }
+                    },
+                    "404": {
+                        "description": "The participant did not have a session",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/tests/integration/features/chat/notifications.feature
+++ b/tests/integration/features/chat/notifications.feature
@@ -10,6 +10,7 @@ Feature: chat/notifications
     When user "participant1" creates room "one-to-one room" (v4)
       | roomType | 1 |
       | invite   | participant2 |
+    Given user "participant1" sets session state to 2 in room "one-to-one room" with 404 (v4)
     Given user "participant2" joins room "one-to-one room" with 200 (v4)
     When user "participant1" sends message "Message 1" to room "one-to-one room" with 201
     Then user "participant2" has the following notifications


### PR DESCRIPTION
### ☑️ Resolves

```
OCA\Talk\Service\SessionService::updateSessionState(): Argument #1 ($session) must be of type OCA\Talk\Model\Session, null given, called in /…/apps/spreed/lib/Controller/RoomController.php on line 1703 in file …/apps/spreed/lib/Service/SessionService.php line 71
```

## 🛠️ API Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
