### PR TITLE
fix(activeSession): don't set state for cases when token is undefined

### DIFF
--- a/src/composables/useActiveSession.js
+++ b/src/composables/useActiveSession.js
@@ -73,7 +73,8 @@ export function useActiveSession() {
 	})
 
 	const setSessionAsActive = async () => {
-		if (currentState.value === SESSION.STATE.ACTIVE) {
+		if (currentState.value === SESSION.STATE.ACTIVE
+			|| !token.value) {
 			return
 		}
 		clearTimeout(inactiveTimer.value)
@@ -89,7 +90,8 @@ export function useActiveSession() {
 	}
 
 	const setSessionAsInactive = async () => {
-		if (currentState.value === SESSION.STATE.INACTIVE) {
+		if (currentState.value === SESSION.STATE.INACTIVE
+			|| !token.value) {
 			return
 		}
 		clearTimeout(inactiveTimer.value)


### PR DESCRIPTION
### ☑️ Resolves

* Fix 404 in the console, when there is no session for logged in user (at least conversation is not joined => token is empty)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts
No visual changes. Also no errors in the console

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] ⛑️ Tests are included or not possible (relies on useStore composable, which will be removed with Vue 3)