### PR TITLE
fix(DAVClient): wrap DAV client creation in a function

### DIFF
--- a/src/components/MediaSettings/VideoBackgroundEditor.vue
+++ b/src/components/MediaSettings/VideoBackgroundEditor.vue
@@ -92,7 +92,7 @@ import { imagePath, generateUrl } from '@nextcloud/router'
 
 import { VIRTUAL_BACKGROUND } from '../../constants.js'
 import BrowserStorage from '../../services/BrowserStorage.js'
-import client from '../../services/DavClient.js'
+import { getDavClient } from '../../services/DavClient.js'
 import { findUniquePath } from '../../utils/fileUpload.js'
 
 const canUploadBackgrounds = getCapabilities()?.spreed?.config?.call?.['can-upload-background']
@@ -176,6 +176,7 @@ export default {
 
 		try {
 			// Create the backgrounds folder if it doesn't exist
+			const client = getDavClient()
 			if (await client.exists(absoluteBackgroundsFolderPath) === false) {
 				await client.createDirectory(absoluteBackgroundsFolderPath)
 			}
@@ -219,6 +220,7 @@ export default {
 
 			const filePath = this.$store.getters.getAttachmentFolder() + '/Backgrounds/' + file.name
 
+			const client = getDavClient()
 			// Get a unique relative path based on the previous path variable
 			const uniquePath = await findUniquePath(client, userRoot, filePath)
 

--- a/src/services/DavClient.js
+++ b/src/services/DavClient.js
@@ -26,8 +26,8 @@ import { getRequestToken } from '@nextcloud/auth'
 import { generateRemoteUrl } from '@nextcloud/router'
 
 // init webdav client on default dav endpoint
-const client = createClient(generateRemoteUrl('dav'),
-	{ headers: { requesttoken: getRequestToken() || '' } },
-)
-
-export default client
+export const getDavClient = () => {
+	return createClient(generateRemoteUrl('dav'),
+		{ headers: { requesttoken: getRequestToken() || '' } },
+	)
+}

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -26,7 +26,7 @@ import { showError } from '@nextcloud/dialogs'
 import { loadState } from '@nextcloud/initial-state'
 import moment from '@nextcloud/moment'
 
-import client from '../services/DavClient.js'
+import { getDavClient } from '../services/DavClient.js'
 import { EventBus } from '../services/EventBus.js'
 import {
 	getFileTemplates,
@@ -312,6 +312,7 @@ const actions = {
 			const fileName = (currentFile.newName || currentFile.name)
 			// Candidate rest of the path
 			const path = getters.getAttachmentFolder() + '/' + fileName
+			const client = getDavClient()
 			// Get a unique relative path based on the previous path variable
 			const uniquePath = await findUniquePath(client, userRoot, path)
 			try {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10851 
* Solution initially was copied from https://github.com/nextcloud/viewer/commit/ab86d7f001327c6bc193a00f72005f3cd6ff0d17, but I've missed that request token can be updated and thus new client object is required

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts
No visual changes

### 🏁 Checklist
- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] ⛑️ Tests are included or not possible