### PR TITLE
fix(chat): Handle `at-all` in note to self

### DIFF
--- a/lib/Chat/Parser/UserMention.php
+++ b/lib/Chat/Parser/UserMention.php
@@ -214,6 +214,7 @@ class UserMention implements IEventListener {
 		switch ($room->getType()) {
 			case Room::TYPE_ONE_TO_ONE:
 			case Room::TYPE_ONE_TO_ONE_FORMER:
+			case Room::TYPE_NOTE_TO_SELF:
 				return 'one2one';
 			case Room::TYPE_GROUP:
 				return 'group';

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -238,6 +238,7 @@ class Room {
 	protected ?Participant $participant = null;
 
 	/**
+	 * @psalm-param Room::TYPE_* $type
 	 * @psalm-param RecordingService::CONSENT_REQUIRED_* $recordingConsent
 	 */
 	public function __construct(
@@ -282,10 +283,18 @@ class Room {
 		return $this->id;
 	}
 
+	/**
+	 * @return int
+	 * @psalm-return Room::TYPE_*
+	 */
 	public function getType(): int {
 		return $this->type;
 	}
 
+	/**
+	 * @param int $type
+	 * @psalm-param Room::TYPE_* $type
+	 */
 	public function setType(int $type): void {
 		$this->type = $type;
 	}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -896,6 +896,23 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" creates note-to-self \((v4)\)$/
+	 *
+	 * @param string $user
+	 * @param string $apiVersion
+	 */
+	public function userCreatesNoteToSelf(string $user, string $apiVersion): void {
+		$this->setCurrentUser($user);
+		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/room/note-to-self');
+		$this->assertStatusCode($this->response, 200);
+
+		$response = $this->getDataFromResponse($this->response);
+		self::$identifierToToken[$user . '-note-to-self'] = $response['token'];
+		self::$identifierToId[$user . '-note-to-self'] = $response['id'];
+		self::$tokenToIdentifier[$response['token']] = $user . '-note-to-self';
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" creates room "([^"]*)" with (\d+) \((v4)\)$/
 	 *
 	 * @param string $user

--- a/tests/integration/features/chat/mentions.feature
+++ b/tests/integration/features/chat/mentions.feature
@@ -623,3 +623,13 @@ Feature: chat/mentions
     And user "participant3" is participant of the following rooms (v4)
       | id         | unreadMention | unreadMentionDirect |
       | group room | 0             | 0                   |
+
+  Scenario: At-all in note-to-self broke the mention parsing
+    And user "participant1" creates note-to-self (v4)
+    And user "participant1" sends message "Test @all" to room "participant1-note-to-self" with 201
+    And user "participant1" is participant of the following rooms (v4)
+#      | id                        | type | name          |
+#      | participant1-note-to-self | 6    | Note to self  |
+    Then user "participant1" sees the following messages in room "participant1-note-to-self" with 200
+      | room                      | actorType | actorId      | actorDisplayName         | message                | messageParameters |
+      | participant1-note-to-self | users     | participant1 | participant1-displayname | Test {mention-call1}   | "IGNORE"          |


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10880

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
