### PR TITLE
fix(chat): Adjust "author" when creating "Note to self" and "changelo…

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -143,13 +143,18 @@ class SystemMessage implements IEventListener {
 				$participant->getAttendee()->getActorId() === $parsedParameters['actor']['id'];
 		}
 		$cliIsActor = $parsedParameters['actor']['type'] === 'guest' &&
-			'guest/cli' === $parsedParameters['actor']['id'];
+			'guest/' . Attendee::ACTOR_ID_CLI === $parsedParameters['actor']['id'];
 
 		if ($message === 'conversation_created') {
+			$systemIsActor = $parsedParameters['actor']['type'] === 'guest' &&
+				'guest/' . Attendee::ACTOR_ID_SYSTEM === $parsedParameters['actor']['id'];
+
 			$parsedMessage = $this->l->t('{actor} created the conversation');
 			if ($currentUserIsActor) {
 				$parsedMessage = $this->l->t('You created the conversation');
-			} elseif ($cliIsActor) {
+			} elseif ($systemIsActor) {
+				$parsedMessage = $this->l->t('System created the conversation');
+			}if ($cliIsActor) {
 				$parsedMessage = $this->l->t('An administrator created the conversation');
 			}
 		} elseif ($message === 'conversation_renamed') {

--- a/lib/Model/Attendee.php
+++ b/lib/Model/Attendee.php
@@ -79,6 +79,7 @@ class Attendee extends Entity {
 	// Special actor IDs
 	public const ACTOR_BOT_PREFIX = 'bot-';
 	public const ACTOR_ID_CLI = 'cli';
+	public const ACTOR_ID_SYSTEM = 'system';
 	public const ACTOR_ID_CHANGELOG = 'changelog';
 
 	public const PERMISSIONS_DEFAULT = 0;

--- a/tests/integration/features/chat/mentions.feature
+++ b/tests/integration/features/chat/mentions.feature
@@ -627,9 +627,9 @@ Feature: chat/mentions
   Scenario: At-all in note-to-self broke the mention parsing
     And user "participant1" creates note-to-self (v4)
     And user "participant1" sends message "Test @all" to room "participant1-note-to-self" with 201
-    And user "participant1" is participant of the following rooms (v4)
-#      | id                        | type | name          |
-#      | participant1-note-to-self | 6    | Note to self  |
+    And user "participant1" is participant of the following note-to-self rooms (v4)
+      | id                        | type | name          |
+      | participant1-note-to-self | 6    | Note to self  |
     Then user "participant1" sees the following messages in room "participant1-note-to-self" with 200
       | room                      | actorType | actorId      | actorDisplayName         | message                | messageParameters |
       | participant1-note-to-self | users     | participant1 | participant1-displayname | Test {mention-call1}   | "IGNORE"          |

--- a/tests/integration/features/chat/note-to-self.feature
+++ b/tests/integration/features/chat/note-to-self.feature
@@ -1,0 +1,24 @@
+Feature: chat/note-to-self
+
+  Background:
+    Given user "participant1" exists
+
+  Scenario: Created manually via the endpoint
+    When user "participant1" reset note-to-self preference
+    When user "participant1" creates note-to-self (v4)
+    And user "participant1" is participant of the following note-to-self rooms (v4)
+      | id                        | type | name          |
+      | participant1-note-to-self | 6    | Note to self  |
+    Then user "participant1" sees the following system messages in room "participant1-note-to-self" with 200
+      | room                      | actorType | actorId      | actorDisplayName         | message                        | messageParameters                                                               | systemMessage        |
+      | participant1-note-to-self | users     | participant1 | participant1-displayname | You created the conversation   | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} | conversation_created |
+
+
+  Scenario: Created automatically when fetching the room list
+    When user "participant1" reset note-to-self preference
+    And user "participant1" is participant of the following note-to-self rooms (v4)
+      | id           | type | name          |
+      | Note to self | 6    | Note to self  |
+    Then user "participant1" sees the following system messages in room "Note to self" with 200
+      | room         | actorType | actorId | actorDisplayName | message                         | messageParameters                                              | systemMessage        |
+      | Note to self | guests    | system  |                  | System created the conversation | {"actor":{"type":"guest","id":"guest\/system","name":"Guest"}} | conversation_created |

--- a/tests/integration/spreedcheats/lib/AppInfo/Application.php
+++ b/tests/integration/spreedcheats/lib/AppInfo/Application.php
@@ -23,12 +23,14 @@ declare(strict_types=1);
 
 namespace OCA\SpreedCheats\AppInfo;
 
+use OCA\SpreedCheats\PreferenceListener;
 use OCA\SpreedCheats\SpeechToText\LoremIpsumSpeechToTextProvider;
 use OCA\SpreedCheats\Translation\LoremIpsumTranslationProvider;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\Config\BeforePreferenceDeletedEvent;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'spreedcheats';
@@ -40,6 +42,7 @@ class Application extends App implements IBootstrap {
 	public function register(IRegistrationContext $context): void {
 		$context->registerSpeechToTextProvider(LoremIpsumSpeechToTextProvider::class);
 		$context->registerTranslationProvider(LoremIpsumTranslationProvider::class);
+		$context->registerEventListener(BeforePreferenceDeletedEvent::class, PreferenceListener::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/tests/integration/spreedcheats/lib/PreferenceListener.php
+++ b/tests/integration/spreedcheats/lib/PreferenceListener.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\SpreedCheats;
+
+use OCP\Config\BeforePreferenceDeletedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+/**
+ * @template-implements IEventListener<Event>
+ */
+class PreferenceListener implements IEventListener {
+	public function handle(Event $event): void {
+		if (!$event instanceof BeforePreferenceDeletedEvent) {
+			return;
+		}
+
+		if ($event->getAppId() === 'spreed') {
+			$event->setValid(true);
+		}
+	}
+}


### PR DESCRIPTION
…g" conversations

### ☑️ Resolves

* Fix #10875

## 🛠️ API Checklist

Before | After
---|---
![grafik](https://github.com/nextcloud/spreed/assets/213943/d37d809c-1158-4124-9580-a2958f37dab7) | ![grafik](https://github.com/nextcloud/spreed/assets/213943/6cc14a29-3c02-44f2-acb5-d9a158755778)
![grafik](https://github.com/nextcloud/spreed/assets/213943/79ffe7cb-c82b-438c-998d-889f432e8874) | ![grafik](https://github.com/nextcloud/spreed/assets/213943/1da5fc83-47a6-46cc-8890-43a0b586a4fc)


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
