### PR TITLE
fix(LeftSidebar): replace three-dot icon with chat-plus icon in

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -80,7 +80,7 @@
 					class="actions"
 					:class="{'hidden-visually': isFocused}">
 					<template #icon>
-						<DotsVertical :size="20" />
+						<ChatPlus :size="20" />
 					</template>
 					<NcActionButton v-if="canStartConversations"
 						close-after-click
@@ -272,7 +272,6 @@ import { ref } from 'vue'
 
 import AtIcon from 'vue-material-design-icons/At.vue'
 import ChatPlus from 'vue-material-design-icons/ChatPlus.vue'
-import DotsVertical from 'vue-material-design-icons/DotsVertical.vue'
 import FilterIcon from 'vue-material-design-icons/Filter.vue'
 import FilterRemoveIcon from 'vue-material-design-icons/FilterRemove.vue'
 import List from 'vue-material-design-icons/FormatListBulleted.vue'
@@ -355,7 +354,6 @@ export default {
 		Plus,
 		ChatPlus,
 		List,
-		DotsVertical,
 		Note,
 		NcEmptyContent,
 	},


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10878

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/4d45460c-742a-4377-b4b2-af70127c42e2)          | ![image](https://github.com/nextcloud/spreed/assets/93392545/96a11deb-2f5f-4299-b1b3-cf726ff82e85)        |


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required