### PR TITLE
feat(shares): add drag-n-drop option in the modal

### DIFF
--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -26,7 +26,10 @@
 		class="upload-editor"
 		:container="container"
 		@close="handleDismiss">
-		<div class="upload-editor">
+		<div class="upload-editor"
+			@dragover.prevent="handleDragOver"
+			@dragleave.prevent="handleDragLeave"
+			@drop.prevent="handleDropFiles">
 			<template v-if="!isVoiceMessage">
 				<!--native file picker, hidden -->
 				<input id="file-upload"
@@ -36,6 +39,7 @@
 					class="hidden-visually"
 					@change="handleFileInput">
 				<TransitionWrapper class="upload-editor__previews"
+					:class="{'dragging-over': isDraggingOver}"
 					name="fade"
 					tag="div"
 					group>
@@ -104,6 +108,7 @@ export default {
 	data() {
 		return {
 			modalContainerId: null,
+			isDraggingOver: false,
 		}
 	},
 
@@ -201,6 +206,29 @@ export default {
 		handleRemoveFileFromSelection(id) {
 			this.$store.dispatch('removeFileFromSelection', id)
 		},
+
+		handleDragOver(event) {
+			if (event.dataTransfer.types.includes('Files')) {
+				this.isDraggingOver = true
+			}
+		},
+
+		handleDragLeave(event) {
+			if (!event.currentTarget.contains(event.relatedTarget)) {
+				this.isDraggingOver = false
+			}
+		},
+
+		handleDropFiles(event) {
+			if (!this.isDraggingOver) {
+				return
+			}
+
+			this.isDraggingOver = false
+
+			const files = Object.values(event.dataTransfer.files)
+			this.$store.dispatch('initialiseUpload', { files, token: this.token, uploadId: this.currentUploadId })
+		},
 	},
 }
 </script>
@@ -218,6 +246,11 @@ export default {
 		position: relative;
 		overflow: auto;
 		flex-wrap: wrap;
+
+		&.dragging-over {
+			outline: 3px dashed var(--color-primary-element);
+			border-radius: var(--border-radius-large);
+		}
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10883 
* Logic is copied from https://github.com/nextcloud/spreed/blob/f4d3343e20eb8390ccc55279fe8e64080562dfc7/src/components/ChatView.vue#L23-L25

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts
Style overview (when dragged over):
![image](https://github.com/nextcloud/spreed/assets/93392545/353bf6ca-063e-464a-9b0a-bfbf8fb85214)

In action:

https://github.com/nextcloud/spreed/assets/93392545/6ddd1f15-63de-4a84-bb79-52e835e02b2e

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
