### PR TITLE
fix(LeftSidebar): reuse logic for unread mentions in pop-up button

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -318,7 +318,7 @@ import { EventBus } from '../../services/EventBus.js'
 import { talkBroadcastChannel } from '../../services/talkBroadcastChannel.js'
 import CancelableRequest from '../../utils/cancelableRequest.js'
 import { requestTabLeadership } from '../../utils/requestTabLeadership.js'
-import { filterFunction } from '../../utils/conversation.js'
+import { hasUnreadMentions, filterFunction } from '../../utils/conversation.js'
 
 const canModerateSipDialOut = getCapabilities()?.spreed?.features?.includes('sip-support-dialout')
 	&& getCapabilities()?.spreed?.config.call['sip-enabled']
@@ -866,7 +866,7 @@ export default {
 			this.lastUnreadMentionBelowViewportIndex = null
 			const lastConversationInViewport = this.$refs.scroller.getLastItemInViewportIndex()
 			for (let i = this.filteredConversationsList.length - 1; i > lastConversationInViewport; i--) {
-				if (this.filteredConversationsList[i].unreadMention) {
+				if (hasUnreadMentions(this.filteredConversationsList[i])) {
 					this.lastUnreadMentionBelowViewportIndex = i
 					return
 				}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10882
* Same logic as for filters reused

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

[Screencast from 14.11.2023 15:47:45.webm](https://github.com/nextcloud/spreed/assets/93392545/f71f1177-c56b-4e0c-b47e-5ce9827b591e)

### 🚧 Tasks

- [x] Backport for stable27 should be done manually, because of diff conflict

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences