### PR TITLE
chore(deps): Bump nextcloud/vue from 8.0.1 to 8.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nextcloud/moment": "^1.2.2",
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^2.2.0",
-        "@nextcloud/vue": "^8.0.1",
+        "@nextcloud/vue": "^8.1.0",
         "attachmediastream": "^2.1.0",
         "crypto-js": "^4.2.0",
         "debounce": "^1.2.1",
@@ -3798,9 +3798,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.0.1.tgz",
-      "integrity": "sha512-x2RqRb+/hB94mkZ465zWct0a3A5m5KQniIO4RuwtBssMwlJdyv0MXZF3k7iE3omwChkbgNOkFDiZ/Ch+pfMm1g==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.1.0.tgz",
+      "integrity": "sha512-heDYX+RWTynSQkovQtA94aGL7pDFAf7TJUWRFfD9dyjhRPsiEvlPEtOXhzPtTgZ7xJpBqvWoef3UxzA+xVsWZw==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@nextcloud/auth": "^2.0.0",
@@ -23779,9 +23779,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.0.1.tgz",
-      "integrity": "sha512-x2RqRb+/hB94mkZ465zWct0a3A5m5KQniIO4RuwtBssMwlJdyv0MXZF3k7iE3omwChkbgNOkFDiZ/Ch+pfMm1g==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.1.0.tgz",
+      "integrity": "sha512-heDYX+RWTynSQkovQtA94aGL7pDFAf7TJUWRFfD9dyjhRPsiEvlPEtOXhzPtTgZ7xJpBqvWoef3UxzA+xVsWZw==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@nextcloud/auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@nextcloud/moment": "^1.2.2",
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^2.2.0",
-    "@nextcloud/vue": "^8.0.1",
+    "@nextcloud/vue": "^8.1.0",
     "attachmediastream": "^2.1.0",
     "crypto-js": "^4.2.0",
     "debounce": "^1.2.1",


### PR DESCRIPTION
### ☑️ Resolves

* Bump nextcloud/vue library

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/7bf2c7bd-9cb5-4630-b135-a4b921218118)         | ![image](https://github.com/nextcloud/spreed/assets/93392545/2594e55b-a6bc-472d-838f-a9e7a9a94d65)        |
| ![image](https://github.com/nextcloud/spreed/assets/93392545/176c07df-a6c5-4f92-a4d8-2359d866b22e)          | ![image](https://github.com/nextcloud/spreed/assets/93392545/305442f2-c6f9-4c7d-9c11-91cc9313e01c)       |

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team