### PR TITLE
fix: audio/video stream in Safari by coping `attachmediastream` to source in `ESM` format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^2.2.0",
         "@nextcloud/vue": "^8.1.0",
-        "attachmediastream": "^2.1.0",
         "crypto-js": "^4.2.0",
         "debounce": "^1.2.1",
         "emoji-mart-vue-fast": "^15.0.0",
@@ -5821,11 +5820,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "node_modules/attachmediastream": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/attachmediastream/-/attachmediastream-2.1.0.tgz",
-      "integrity": "sha512-8zx/3Bwo/PxqwpNrEm2Zf9ZBCjfkLmLhS7lqzfP1eWH69iD/WyKWFpysben+gYxMSHcO9S94qvseGk4FVxba0g=="
     },
     "node_modules/automation-events": {
       "version": "6.0.11",
@@ -25360,11 +25354,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "attachmediastream": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/attachmediastream/-/attachmediastream-2.1.0.tgz",
-      "integrity": "sha512-8zx/3Bwo/PxqwpNrEm2Zf9ZBCjfkLmLhS7lqzfP1eWH69iD/WyKWFpysben+gYxMSHcO9S94qvseGk4FVxba0g=="
     },
     "automation-events": {
       "version": "6.0.11",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^2.2.0",
     "@nextcloud/vue": "^8.1.0",
-    "attachmediastream": "^2.1.0",
     "crypto-js": "^4.2.0",
     "debounce": "^1.2.1",
     "emoji-mart-vue-fast": "^15.0.0",

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -64,7 +64,6 @@
 </template>
 
 <script>
-import attachMediaStream from 'attachmediastream/attachmediastream.bundle.js'
 import Hex from 'crypto-js/enc-hex.js'
 import SHA1 from 'crypto-js/sha1.js'
 
@@ -77,6 +76,7 @@ import VideoBackground from './VideoBackground.vue'
 
 import { AVATAR } from '../../../constants.js'
 import video from '../../../mixins/video.js'
+import attachMediaStream from '../../../utils/attachmediastream.js'
 import { useGuestNameStore } from '../../../stores/guestName.js'
 import { ConnectionState } from '../../../utils/webrtc/models/CallParticipantModel.js'
 

--- a/src/components/CallView/shared/Screen.vue
+++ b/src/components/CallView/shared/Screen.vue
@@ -35,12 +35,12 @@
 </template>
 
 <script>
-import attachMediaStream from 'attachmediastream/attachmediastream.bundle.js'
 import Hex from 'crypto-js/enc-hex.js'
 import SHA1 from 'crypto-js/sha1.js'
 
 import VideoBottomBar from './VideoBottomBar.vue'
 
+import attachMediaStream from '../../../utils/attachmediastream.js'
 import { useGuestNameStore } from '../../../stores/guestName.js'
 
 export default {

--- a/src/components/CallView/shared/VideoVue.vue
+++ b/src/components/CallView/shared/VideoVue.vue
@@ -86,7 +86,6 @@
 </template>
 
 <script>
-import attachMediaStream from 'attachmediastream/attachmediastream.bundle.js'
 import Hex from 'crypto-js/enc-hex.js'
 import SHA1 from 'crypto-js/sha1.js'
 
@@ -103,6 +102,7 @@ import { ATTENDEE, AVATAR } from '../../../constants.js'
 import video from '../../../mixins/video.js'
 import { EventBus } from '../../../services/EventBus.js'
 import { useGuestNameStore } from '../../../stores/guestName.js'
+import attachMediaStream from '../../../utils/attachmediastream.js'
 import { ConnectionState } from '../../../utils/webrtc/models/CallParticipantModel.js'
 
 export default {

--- a/src/mixins/devices.js
+++ b/src/mixins/devices.js
@@ -20,9 +20,9 @@
  *
  */
 
-import attachMediaStream from 'attachmediastream/attachmediastream.bundle.js'
 import hark from 'hark'
 
+import attachMediaStream from '../utils/attachmediastream.js'
 import TrackToStream from '../utils/media/pipeline/TrackToStream.js'
 import VirtualBackground from '../utils/media/pipeline/VirtualBackground.js'
 import { mediaDevicesManager } from '../utils/webrtc/index.js'

--- a/src/utils/attachmediastream.js
+++ b/src/utils/attachmediastream.js
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: 2019 "Henrik Joreteg <henrik@andyet.net>
+ * SPDX-License-Identifier: MIT
+ *
+ * Copy of https://github.com/otalk/attachMediaStream/blob/master/attachmediastream.js
+ * Modifications:
+ * - Adjusted for eslint rules
+ * - Migrated to ESM
+ * - Added JSDoc
+ */
+
+import adapter from 'webrtc-adapter'
+
+/**
+ * Attach a media stream to a video (or audio) element.
+ * It handles the differences between browsers.
+ *
+ * @param {MediaStream} stream The media stream to attach
+ * @param {HTMLVideoElement|null} el The video element where to attach the stream.
+ *                                   If null, a new element will be created.
+ * @param {object} [options] Options
+ * @param {boolean} [options.autoplay=true] Autoplay the video
+ * @param {boolean} [options.mirror=false] Mirror the video (horizontal flip)
+ * @param {boolean} [options.muted=false] Mute the audio
+ * @param {boolean} [options.audio=false] Only use audio
+ * @param {boolean} [options.disableContextMenu=false] Disable the context menu
+ */
+export default function attachmediastream(stream, el, options) {
+	let item
+	let element = el
+	const opts = {
+		autoplay: true,
+		mirror: false,
+		muted: false,
+		audio: false,
+		disableContextMenu: false,
+	}
+
+	if (options) {
+		for (item in options) {
+			opts[item] = options[item]
+		}
+	}
+
+	if (!element) {
+		element = document.createElement(opts.audio ? 'audio' : 'video')
+	} else if (element.tagName.toLowerCase() === 'audio') {
+		opts.audio = true
+	}
+
+	if (opts.disableContextMenu) {
+		element.oncontextmenu = function(e) {
+			e.preventDefault()
+		}
+	}
+
+	if (opts.autoplay) element.autoplay = 'autoplay'
+	element.muted = !!opts.muted
+	if (!opts.audio) {
+		['', 'moz', 'webkit', 'o', 'ms'].forEach(function(prefix) {
+			const styleName = prefix ? prefix + 'Transform' : 'transform'
+			element.style[styleName] = opts.mirror ? 'scaleX(-1)' : 'scaleX(1)'
+		})
+	}
+
+	if (adapter.browserDetails.browser === 'safari') {
+		element.setAttribute('playsinline', true)
+	}
+
+	element.srcObject = stream
+	return element
+}

--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -19,8 +19,7 @@
  *
  */
 
-import attachMediaStream from 'attachmediastream/attachmediastream.bundle.js'
-
+import attachMediaStream from '../../../utils/attachmediastream.js'
 import EmitterMixin from '../../EmitterMixin.js'
 
 export const ConnectionState = {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10910

The [original `attachMediaStream`](https://github.com/otalk/attachMediaStream) provides CJS and AMD versions to use in RequireJS and Browserify.

**The CJS version** has an issue with imported inside `webrtc-adapter` with `export default` behavior in ESM-CJS interop. `webrtc-adapter` defines it as `__esModule`: https://npmfs.com/package/webrtc-adapter/8.2.3/dist/adapter_core.js. This is a commonly used by bundlers approach, but it is not a standard (there is no standard, it is a known undefined behavior).

But old CJS version `attachMediaStream` doesn't respect `__esModule` and imports `webrtc-adapter` wrong. We fixed it with a babel plugin in the past.

**The AMD version** seemed to work. But for an unknown reason breaks the audio stream in Safari.

See also: https://github.com/nextcloud/spreed/pull/10055/commits/f2b67fe4e16cb364d876f88a3e5beb0a9cd18559

**The solution:** making an ESM version of a `attachMediaStream` that uses `webrtc-adapter` with a native ES `import`.

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team or not needed
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required