### PR TITLE
Keep track of senders to allow unmutung with Safari

### DIFF
--- a/src/utils/webrtc/simplewebrtc/peer.js
+++ b/src/utils/webrtc/simplewebrtc/peer.js
@@ -41,6 +41,7 @@ function Peer(options) {
 	this._pendingReplaceTracksQueue = []
 	this._processPendingReplaceTracksPromise = null
 	this._initialStreamSetup = false
+	this._localSenders = []
 	this.sid = options.sid || Date.now().toString()
 	this.pc = new RTCPeerConnection(this.parent.config.peerConnectionConfig)
 	this.pc.addEventListener('icecandidate', this.onIceCandidate.bind(this))
@@ -674,6 +675,7 @@ Peer.prototype.end = function() {
 	}
 	this.pc.close()
 	this.handleStreamRemoved()
+	this._localSenders = []
 	this.parent.off('sentTrackReplaced', this.handleSentTrackReplacedBound)
 	this.parent.off('sentTrackEnabledChanged', this.handleSentTrackEnabledChangedBound)
 
@@ -770,7 +772,10 @@ Peer.prototype._replaceTrack = async function(newTrack, oldTrack, stream) {
 	// is used to be on the safe side.
 	const replaceTrackPromises = []
 
-	this.pc.getSenders().forEach(sender => {
+	for (const sender of this.pc.getSenders()) {
+		// Keep reference, so that safari does not remove the tracks
+		this._localSenders.push(sender)
+
 		if (sender.track !== oldTrack && sender.trackDisabled !== oldTrack) {
 			return
 		}
@@ -849,7 +854,7 @@ Peer.prototype._replaceTrack = async function(newTrack, oldTrack, stream) {
 		})
 
 		replaceTrackPromises.push(replaceTrackPromise)
-	})
+	}
 
 	// If the call started when the audio or video device was not active there
 	// will be no sender for that type. In that case the track needs to be added


### PR DESCRIPTION
### ☑️ Resolves

* Fix #6094 

Currently based on `fix/fork-attachmediastream` branch!

### How to reproduce?

* Start/Join a call with Safari
* Mute yourself 
* Wait a bit (~1 minute)
* Try to unmute yourself

With `fix/fork-attachmediastream`
=> the UI shows as unmuted, but no audio is transmitted (most of the time)

With this PR:
=> Works

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

