### PR TITLE
fix(sip-dialout): Fix the successful dialout case when error is null

### DIFF
--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1265,7 +1265,7 @@ class ParticipantService {
 			throw new \InvalidArgumentException('backend');
 		}
 
-		if ($dialOutResponse->dialOut->error->message) {
+		if ($dialOutResponse->dialOut->error?->code) {
 			throw new DialOutFailedException(
 				$dialOutResponse->dialOut->error->code,
 				$dialOutResponse->dialOut->error->message,


### PR DESCRIPTION
### ☑️ Resolves

* Fix `Attempt to read property \"message\" on null at …/apps/spreed/lib/Service/ParticipantService.php#1268`


## 🛠️ API Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
