### PR TITLE
fix(shares): handle shares with duplicate names and caption message

### DIFF
--- a/src/store/fileUploadStore.spec.js
+++ b/src/store/fileUploadStore.spec.js
@@ -17,6 +17,8 @@ jest.mock('../services/DavClient', () => ({
 jest.mock('../utils/fileUpload', () => ({
 	findUniquePath: jest.fn(),
 	getFileExtension: jest.fn(),
+	hasDuplicateUploadNames: jest.fn(),
+	separateDuplicateUploads: jest.fn(),
 }))
 jest.mock('../services/filesSharingServices', () => ({
 	shareFile: jest.fn(),

--- a/src/store/fileUploadStore.spec.js
+++ b/src/store/fileUploadStore.spec.js
@@ -8,17 +8,15 @@ import { showError } from '@nextcloud/dialogs'
 import { getDavClient } from '../services/DavClient.js'
 import { shareFile } from '../services/filesSharingServices.js'
 import { setAttachmentFolder } from '../services/settingsService.js'
-import { findUniquePath, getFileExtension } from '../utils/fileUpload.js'
+import { findUniquePath } from '../utils/fileUpload.js'
 import fileUploadStore from './fileUploadStore.js'
 
 jest.mock('../services/DavClient', () => ({
 	getDavClient: jest.fn(),
 }))
 jest.mock('../utils/fileUpload', () => ({
+	...jest.requireActual('../utils/fileUpload'),
 	findUniquePath: jest.fn(),
-	getFileExtension: jest.fn(),
-	hasDuplicateUploadNames: jest.fn(),
-	separateDuplicateUploads: jest.fn(),
 }))
 jest.mock('../services/filesSharingServices', () => ({
 	shareFile: jest.fn(),
@@ -158,13 +156,13 @@ describe('fileUploadStore', () => {
 			expect(store.getters.currentUploadId).toBe('upload-id1')
 
 			const uniqueFileName = '/Talk/' + file.name + 'uniq'
-			findUniquePath.mockResolvedValueOnce(uniqueFileName)
+			findUniquePath.mockResolvedValueOnce({ uniquePath: uniqueFileName, suffix: 1 })
 			shareFile.mockResolvedValue()
 
 			await store.dispatch('uploadFiles', { uploadId: 'upload-id1', caption: 'text-caption' })
 
 			expect(findUniquePath).toHaveBeenCalledTimes(1)
-			expect(findUniquePath).toHaveBeenCalledWith(client, '/files/current-user', '/Talk/' + file.name)
+			expect(findUniquePath).toHaveBeenCalledWith(client, '/files/current-user', '/Talk/' + file.name, undefined)
 
 			expect(client.putFileContents).toHaveBeenCalledTimes(1)
 			expect(client.putFileContents).toHaveBeenCalledWith(`/files/current-user${uniqueFileName}`, fileBuffer, expect.anything())
@@ -204,8 +202,8 @@ describe('fileUploadStore', () => {
 			expect(store.getters.currentUploadId).toBe('upload-id1')
 
 			findUniquePath
-				.mockResolvedValueOnce('/Talk/' + files[0].name + 'uniq')
-				.mockResolvedValueOnce('/Talk/' + files[1].name + 'uniq')
+				.mockResolvedValueOnce({ uniquePath: '/Talk/' + files[0].name + 'uniq', suffix: 1 })
+				.mockResolvedValueOnce({ uniquePath: '/Talk/' + files[1].name + 'uniq', suffix: 1 })
 			shareFile
 				.mockResolvedValueOnce({ data: { ocs: { data: { id: '1' } } } })
 				.mockResolvedValueOnce({ data: { ocs: { data: { id: '2' } } } })
@@ -217,7 +215,7 @@ describe('fileUploadStore', () => {
 			expect(shareFile).toHaveBeenCalledTimes(2)
 
 			for (const index in files) {
-				expect(findUniquePath).toHaveBeenCalledWith(client, '/files/current-user', '/Talk/' + files[index].name)
+				expect(findUniquePath).toHaveBeenCalledWith(client, '/files/current-user', '/Talk/' + files[index].name, undefined)
 				expect(client.putFileContents).toHaveBeenCalledWith(`/files/current-user/Talk/${files[index].name}uniq`, fileBuffers[index], expect.anything())
 			}
 
@@ -246,7 +244,7 @@ describe('fileUploadStore', () => {
 			})
 
 			findUniquePath
-				.mockResolvedValueOnce('/Talk/' + files[0].name + 'uniq')
+				.mockResolvedValueOnce({ uniquePath: '/Talk/' + files[0].name + 'uniq', suffix: 1 })
 			client.putFileContents.mockRejectedValueOnce({
 				response: {
 					status: 403,
@@ -379,10 +377,6 @@ describe('fileUploadStore', () => {
 					lastModified: Date.UTC(2021, 3, 25, 15, 30, 0),
 				},
 			]
-
-			getFileExtension
-				.mockReturnValueOnce('.png')
-				.mockReturnValueOnce('.txt')
 
 			await store.dispatch('initialiseUpload', {
 				uploadId: 'upload-id1',

--- a/src/utils/__tests__/fileUpload.spec.js
+++ b/src/utils/__tests__/fileUpload.spec.js
@@ -1,0 +1,79 @@
+import {
+	getFileExtension,
+	extractFileName,
+	findUniquePath,
+} from '../fileUpload.js'
+
+const client = {
+	exists: jest.fn(),
+}
+
+describe('fileUpload', () => {
+	describe('getFileExtension', () => {
+		it('should return correct file extension when it exists in the path', () => {
+			const path = 'file.mock.txt'
+			const extension = getFileExtension(path)
+			expect(extension).toBe('.txt')
+		})
+
+		it('should return an empty string when no file extension exists in the path', () => {
+			const path = 'file'
+			const extension = getFileExtension(path)
+			expect(extension).toBe('')
+		})
+	})
+
+	describe('extractFileName', () => {
+		it('should return the file name as-is when there is no extension or digit suffix', () => {
+			const path = 'file'
+			const fileName = extractFileName(path)
+			expect(fileName).toBe('file')
+		})
+
+		it('should return the correctly extracted file name without extension and digit suffix', () => {
+			const paths = ['file (1).txt', 'file (1)', 'file.txt', 'file (10).txt', 'file 1.txt', 'file (1) (2).txt', 'file (N).txt']
+			const fileNames = paths.map(path => extractFileName(path))
+			expect(fileNames).toStrictEqual(['file', 'file', 'file', 'file', 'file 1', 'file (1)', 'file (N)'])
+		})
+	})
+
+	describe('findUniquePath', () => {
+		const userRoot = '/files/userid/'
+		const path = 'file.txt'
+
+		afterEach(() => {
+			jest.clearAllMocks()
+		})
+
+		it('should return the input path if it does not exist in the destination folder', async () => {
+			// Arrange
+			client.exists.mockResolvedValue(false) // Simulate resolving unique path on 1st attempt
+
+			// Act
+			const result = await findUniquePath(client, userRoot, path)
+
+			// Assert
+			expect(result).toBe(path)
+			expect(client.exists).toHaveBeenCalledWith(userRoot + path)
+		})
+
+		it('should return a unique path when the input path already exists in the destination folder', async () => {
+			// Arrange
+			const existingPath = 'file (2).txt'
+			const uniquePath = 'file (3).txt'
+			client.exists
+				.mockResolvedValueOnce(true)
+				.mockResolvedValueOnce(true)
+				.mockResolvedValueOnce(false) // Simulate resolving unique path on 3rd attempt
+
+			// Act
+			const result = await findUniquePath(client, userRoot, path)
+
+			// Assert
+			expect(result).toBe(uniquePath)
+			expect(client.exists).toHaveBeenNthCalledWith(1, userRoot + path)
+			expect(client.exists).toHaveBeenNthCalledWith(2, userRoot + existingPath)
+			expect(client.exists).toHaveBeenNthCalledWith(3, userRoot + uniquePath)
+		})
+	})
+})

--- a/src/utils/__tests__/fileUpload.spec.js
+++ b/src/utils/__tests__/fileUpload.spec.js
@@ -91,7 +91,7 @@ describe('fileUpload', () => {
 			const result = await findUniquePath(client, userRoot, path)
 
 			// Assert
-			expect(result).toBe(path)
+			expect(result).toStrictEqual({ uniquePath: path, suffix: 1 })
 			expect(client.exists).toHaveBeenCalledWith(userRoot + path)
 		})
 
@@ -108,7 +108,7 @@ describe('fileUpload', () => {
 			const result = await findUniquePath(client, userRoot, path)
 
 			// Assert
-			expect(result).toBe(uniquePath)
+			expect(result).toStrictEqual({ uniquePath, suffix: 3 })
 			expect(client.exists).toHaveBeenNthCalledWith(1, userRoot + path)
 			expect(client.exists).toHaveBeenNthCalledWith(2, userRoot + existingPath)
 			expect(client.exists).toHaveBeenNthCalledWith(3, userRoot + uniquePath)
@@ -128,7 +128,7 @@ describe('fileUpload', () => {
 			const result = await findUniquePath(client, userRoot, givenPath)
 
 			// Assert
-			expect(result).toBe(uniquePath)
+			expect(result).toStrictEqual({ uniquePath, suffix: 6 })
 			expect(client.exists).toHaveBeenNthCalledWith(1, userRoot + givenPath)
 			expect(client.exists).toHaveBeenNthCalledWith(2, userRoot + existingPath)
 			expect(client.exists).toHaveBeenNthCalledWith(3, userRoot + uniquePath)

--- a/src/utils/__tests__/fileUpload.spec.js
+++ b/src/utils/__tests__/fileUpload.spec.js
@@ -1,7 +1,11 @@
 import {
 	getFileExtension,
+	getFileSuffix,
 	extractFileName,
+	getFileNamePrompt,
 	findUniquePath,
+	hasDuplicateUploadNames,
+	separateDuplicateUploads,
 } from '../fileUpload.js'
 
 const client = {
@@ -23,6 +27,20 @@ describe('fileUpload', () => {
 		})
 	})
 
+	describe('getFileSuffix', () => {
+		it('should return the file suffix when it exists in the path', () => {
+			const path = 'file (3).txt'
+			const suffix = getFileSuffix(path)
+			expect(suffix).toBe(3)
+		})
+
+		it('should return 1 when no file suffix exists in the path', () => {
+			const path = 'file.txt'
+			const suffix = getFileSuffix(path)
+			expect(suffix).toBe(1)
+		})
+	})
+
 	describe('extractFileName', () => {
 		it('should return the file name as-is when there is no extension or digit suffix', () => {
 			const path = 'file'
@@ -34,6 +52,26 @@ describe('fileUpload', () => {
 			const paths = ['file (1).txt', 'file (1)', 'file.txt', 'file (10).txt', 'file 1.txt', 'file (1) (2).txt', 'file (N).txt']
 			const fileNames = paths.map(path => extractFileName(path))
 			expect(fileNames).toStrictEqual(['file', 'file', 'file', 'file', 'file 1', 'file (1)', 'file (N)'])
+		})
+	})
+
+	describe('getFileNamePrompt', () => {
+		it('should return the file name prompt including extension', () => {
+			const path = 'file.mock.txt'
+			const fileNamePrompt = getFileNamePrompt(path)
+			expect(fileNamePrompt).toBe('file.mock.txt')
+		})
+
+		it('should return the file name prompt without extension when the extension is missing', () => {
+			const path = 'file'
+			const fileNamePrompt = getFileNamePrompt(path)
+			expect(fileNamePrompt).toBe('file')
+		})
+
+		it('should return the file name prompt with digit suffix when the suffix exists', () => {
+			const path = 'file (1).txt'
+			const fileNamePrompt = getFileNamePrompt(path)
+			expect(fileNamePrompt).toBe('file.txt')
 		})
 	})
 
@@ -74,6 +112,71 @@ describe('fileUpload', () => {
 			expect(client.exists).toHaveBeenNthCalledWith(1, userRoot + path)
 			expect(client.exists).toHaveBeenNthCalledWith(2, userRoot + existingPath)
 			expect(client.exists).toHaveBeenNthCalledWith(3, userRoot + uniquePath)
+		})
+
+		it('should look for unique path starting from a known suffix when the input path already exists in the destination folder', async () => {
+			// Arrange
+			const givenPath = 'file (4).txt'
+			const existingPath = 'file (5).txt'
+			const uniquePath = 'file (6).txt'
+			client.exists
+				.mockResolvedValueOnce(true)
+				.mockResolvedValueOnce(true)
+				.mockResolvedValueOnce(false) // Simulate resolving unique path on 3rd attempt
+
+			// Act
+			const result = await findUniquePath(client, userRoot, givenPath)
+
+			// Assert
+			expect(result).toBe(uniquePath)
+			expect(client.exists).toHaveBeenNthCalledWith(1, userRoot + givenPath)
+			expect(client.exists).toHaveBeenNthCalledWith(2, userRoot + existingPath)
+			expect(client.exists).toHaveBeenNthCalledWith(3, userRoot + uniquePath)
+		})
+	})
+})
+
+describe('hasDuplicateUploadNames', () => {
+	it('should return true when array includes duplicate upload names', () => {
+		const uploads = [
+			[1, { file: { name: 'file.txt' } }],
+			[2, { file: { name: 'file (1).txt' } }],
+			[3, { file: { name: 'file (copy).txt', newName: 'file (2).txt' } }],
+		]
+
+		expect(hasDuplicateUploadNames(uploads)).toBe(true)
+	})
+
+	it('should return false when array does not include duplicate upload names', () => {
+		const uploads = [
+			[1, { file: { name: 'file.txt' } }],
+			[2, { file: { name: 'file 2.txt' } }],
+			[3, { file: { name: 'file.txt', newName: 'file (copy).txt' } }],
+		]
+
+		expect(hasDuplicateUploadNames(uploads)).toBe(false)
+	})
+
+	describe('separateDuplicateUploads', () => {
+		it('should separate unique and duplicate uploads based on file name prompt', () => {
+			const uploads = [
+				[1, { file: { name: 'file.txt' } }],
+				[2, { file: { name: 'file (1).jpeg' } }],
+				[3, { file: { name: 'file (copy).txt', newName: 'file (2).txt' } }],
+				[4, { file: { name: 'file (unique).txt' } }],
+			]
+
+			const { uniques, duplicates } = separateDuplicateUploads(uploads)
+
+			expect(uniques).toEqual([
+				[1, { file: { name: 'file.txt' } }],
+				[2, { file: { name: 'file (1).jpeg' } }],
+				[4, { file: { name: 'file (unique).txt' } }],
+			])
+
+			expect(duplicates).toEqual([
+				[3, { file: { name: 'file (copy).txt', newName: 'file (2).txt' } }],
+			])
 		})
 	})
 })

--- a/src/utils/fileUpload.js
+++ b/src/utils/fileUpload.js
@@ -20,6 +20,9 @@
  *
  */
 
+const extensionRegex = /\.[0-9a-z]+$/i
+const suffixRegex = / \(\d+\)$/
+
 /**
  * Returns the file extension for the given path
  *
@@ -27,7 +30,21 @@
  * @return {string} file extension including the dot
  */
 const getFileExtension = function(path) {
-	return path.match(/\.[0-9a-z]+$/i) ? path.match(/\.[0-9a-z]+$/i)[0] : ''
+	return path.match(extensionRegex) ? path.match(extensionRegex)[0] : ''
+}
+
+/**
+ * Returns the file name without extension and digit suffix
+ *
+ * @param {string} path path
+ * @return {string} extracted file name
+ */
+const extractFileName = function(path) {
+	return path
+		// If there is a file extension, remove it from the path string
+		.replace(extensionRegex, '')
+		// If a filename ends with suffix ` (n)`, remove it from the path string
+		.replace(suffixRegex, '')
 }
 
 /**
@@ -45,31 +62,21 @@ const findUniquePath = async function(client, userRoot, path) {
 	if (await client.exists(userRoot + path) === false) {
 		return path
 	}
-	// Get the file extension (if any)
+
 	const fileExtension = getFileExtension(path)
-	// If there's a file extention, remove it from the path string
-	if (fileExtension !== '') {
-		path = path.substring(0, path.length - fileExtension.length)
-	}
-	// Check if the path ends with ` (n)`
-	const suffix = path.match(/ \((\d+)\)$/) ? path.match(/ \((\d+)\)$/) : ''
-	// Initialise a pathwithout suffix variable
-	let pathWithoutSuffix = path
-	if (suffix !== '') {
-		// remove the suffix if any
-		pathWithoutSuffix = path.substring(0, path.length - suffix.length)
-	}
+	const fileName = extractFileName(path)
+
 	// Loop until a unique path is found
 	for (let number = 2; true; number++) {
-		const uniquePath = pathWithoutSuffix + ` (${number})` + (fileExtension)
+		const uniquePath = fileName + ` (${number})` + fileExtension
 		if (await client.exists(userRoot + uniquePath) === false) {
 			return uniquePath
 		}
-
 	}
 }
 
 export {
 	findUniquePath,
+	extractFileName,
 	getFileExtension,
 }

--- a/src/utils/fileUpload.js
+++ b/src/utils/fileUpload.js
@@ -41,10 +41,20 @@ const getFileExtension = function(path) {
  */
 const extractFileName = function(path) {
 	return path
-		// If there is a file extension, remove it from the path string
+	// If there is a file extension, remove it from the path string
 		.replace(extensionRegex, '')
-		// If a filename ends with suffix ` (n)`, remove it from the path string
+	// If a filename ends with suffix ` (n)`, remove it from the path string
 		.replace(suffixRegex, '')
+}
+
+/**
+ * Returns the file name prompt for the given path
+ *
+ * @param {string} path path
+ * @return {string} file name prompt
+ */
+const getFileNamePrompt = function(path) {
+	return extractFileName(path) + getFileExtension(path)
 }
 
 /**
@@ -75,8 +85,52 @@ const findUniquePath = async function(client, userRoot, path) {
 	}
 }
 
+/**
+ * Checks the existence of duplicated file names in provided array of uploads.
+ *
+ * @param {Array} uploads The array of uploads to share
+ * @return {boolean} Whether array includes duplicates or not
+ */
+const hasDuplicateUploadNames = function(uploads) {
+	const uploadNames = uploads.map(([_index, { file }]) => {
+		return getFileNamePrompt(file.newName || file.name)
+	})
+	const uploadNamesSet = new Set(uploadNames)
+
+	return uploadNames.length !== uploadNamesSet.size
+}
+
+/**
+ * Process array of upload and returns separated array with unique filenames and duplicates
+ *
+ * @param {Array} uploads The array of uploads to share
+ * @return {object} separated unique and duplicate uploads
+ */
+function separateDuplicateUploads(uploads) {
+	const nameCount = new Set()
+	const uniques = []
+	const duplicates = []
+
+	// Count the occurrences of each name
+	for (const upload of uploads) {
+		const name = getFileNamePrompt(upload.at(1).file.newName || upload.at(1).file.name)
+
+		if (nameCount.has(name)) {
+			duplicates.push(upload)
+		} else {
+			uniques.push(upload)
+			nameCount.add(name)
+		}
+	}
+
+	return { uniques, duplicates }
+}
+
 export {
 	findUniquePath,
 	extractFileName,
 	getFileExtension,
+	getFileNamePrompt,
+	hasDuplicateUploadNames,
+	separateDuplicateUploads,
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10894 

- refactor `utils/fileUpload.js`
  - add test coverage for it (maybe missed some examples?)
- before uploading, check if there are any duplicate names in the list (`file.txt` and `file (2).txt` are counted)
  - if all names are unique, should be safe to upload in parallel
  - if not, extract duplicates and upload one them after uniques one by one (taking longer :snail:, but ensures each upload will have unique path)
- before sharing, check if caption was provided (should not be relevant then group share will be implemented)
  - if not, the order is probably not important, so we can share all files in parallel, and they may end up in chat mixed
  - if yes, share in parallel all except last one, then share last file with caption (taking longer :snail:, but file with caption will be at the end of list)
 
## 🖌️ UI Checklist

Should not be any visual changes


### 🚧 Tasks

- [x] redo extension check, it should affect only last substring
- [x] remove extra parenthesis from path suffix regex
- [x] add check for duplicates function to utils/fileUpload.js, consider suffixes
- [x] add test coverage
- [ ] To test: Network => Fetch/XHR => run different scenarios

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] ⛑️ Tests are included or not possible