### PR TITLE
fix(CI): Fix autoapproval to ignore nextcloud/vue and webrtc-adapter …

### DIFF
--- a/.github/workflows/dependabot-approve-merge.yml
+++ b/.github/workflows/dependabot-approve-merge.yml
@@ -28,15 +28,20 @@ jobs:
       pull-requests: write
 
     steps:
-      # Github actions bot approve
+      - uses: mdecoleman/pr-branch-name@bab4c71506bcd299fb350af63bb8e53f2940a599 # v2.0.0
+        id: branchname
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # GitHub actions bot approve
       - uses: hmarr/auto-approve-action@b40d6c9ed2fa10c9a2749eca7eb004418a705501 # v2
-        if: contains(fromJSON('["/nextcloud/vue-", "/webrtc-adapter-"]'), github.ref) != true
+        if: contains(steps.branchname.outputs.branch, '/webrtc-adapter-') != true && contains(steps.branchname.outputs.branch, '/nextcloud/vue-') != true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Nextcloud bot approve and merge request
       - uses: ahmadnassri/action-dependabot-auto-merge@45fc124d949b19b6b8bf6645b6c9d55f4f9ac61a # v2
-        if: contains(fromJSON('["/nextcloud/vue-", "/webrtc-adapter-"]'), github.ref) != true
+        if: contains(steps.branchname.outputs.branch, '/webrtc-adapter-') != true && contains(steps.branchname.outputs.branch, '/nextcloud/vue-') != true
         with:
           target: minor
           github-token: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}


### PR DESCRIPTION
Maybe this worked in the past, but nowadays `github.ref` returns `refs/pull/10935/merge` for PRs.
Also the contains function works the other way around: https://docs.github.com/en/actions/learn-github-actions/expressions#contains

Ref #10934 should not have been automerged