### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "42db7cb19d58d207ae0bc16d616d957bdb1c9fee"
+                "reference": "488e4ad136853e5b24efa745e941c785cf41c51e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/42db7cb19d58d207ae0bc16d616d957bdb1c9fee",
-                "reference": "42db7cb19d58d207ae0bc16d616d957bdb1c9fee",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/488e4ad136853e5b24efa745e941c785cf41c51e",
+                "reference": "488e4ad136853e5b24efa745e941c785cf41c51e",
                 "shasum": ""
             },
             "require": {
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2023-11-17T00:33:21+00:00"
+            "time": "2023-11-18T00:32:35+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency