### PR TITLE
fix(fullscreen): reset isFullscreen state when exiting with ESC key

### DIFF
--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -394,6 +394,13 @@ export default {
 			BrowserStorage.setItem('sidebarOpen', 'true')
 		},
 
+		fullScreenChanged() {
+			this.$store.dispatch(
+				'setIsFullscreen',
+				document.webkitIsFullScreen || document.mozFullScreen || document.msFullscreenElement
+			)
+		},
+
 		openConversationSettings() {
 			emit('show-conversation-settings', { token: this.token })
 		},

--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -390,13 +390,6 @@ export default {
 			})
 		},
 
-		fullScreenChanged() {
-			this.$store.dispatch(
-				'setIsFullscreen',
-				document.webkitIsFullScreen || document.mozFullScreen || document.msFullscreenElement
-			)
-		},
-
 		toggleFullscreen() {
 			if (this.isFullscreen) {
 				this.disableFullscreen()


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10928
* Regression from https://github.com/nextcloud/spreed/commit/426487f0bc71a660510cf681bf2a4e31fd4ec475

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences