### PR TITLE
fix(messages): revert "sort messages within one group"

### DIFF
--- a/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
@@ -51,22 +51,6 @@ import Message from './Message/Message.vue'
 
 import { useCombinedSystemMessage } from '../../../composables/useCombinedSystemMessage.js'
 
-// List only sortable messages with order, in which they should be sorted
-const MESSAGES = {
-	user_added: 1,
-	user_removed: 1,
-	moderator_promoted: 11,
-	guest_moderator_promoted: 11,
-	moderator_demoted: 11,
-	guest_moderator_demoted: 11,
-	call_started: 20,
-	recording_started: 21,
-	call_joined: 22,
-	call_left: 22,
-	call_ended: 23,
-	call_ended_everyone: 23,
-}
-
 export default {
 	name: 'MessagesSystemGroup',
 
@@ -125,7 +109,7 @@ export default {
 			deep: true,
 			immediate: true,
 			handler(value) {
-				this.messagesGroupedBySystemMessage = this.groupMessages(this.sortMessages(value))
+				this.messagesGroupedBySystemMessage = this.groupMessages(value)
 			},
 		},
 	},
@@ -195,18 +179,6 @@ export default {
 			}
 
 			return ''
-		},
-
-		sortMessages(messages) {
-			return messages.slice().sort((message1, message2) => {
-				// Don't sort messages if they're not intended to be sorted
-				if (!MESSAGES[message1.systemMessage] || !MESSAGES[message2.systemMessage]) {
-					return 0
-				}
-
-				// Don't sort related system messages (call join - call left) between each other
-				return MESSAGES[message1.systemMessage] - MESSAGES[message2.systemMessage]
-			})
 		},
 
 		groupMessages(messages) {


### PR DESCRIPTION
### ☑️ Resolves

* Part of #10758
* Reverts message sorting in system messages group, and show them in natural order

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before (weird sort) | 🏡 After (original order) |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/8f590a80-2672-4d80-b47a-ccc4a5da69c0)          | ![image](https://github.com/nextcloud/spreed/assets/93392545/a8a0d9c8-f727-42e9-a7be-a505649cdfa0)        |


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required