### PR TITLE
fix(AuthSidebar): Order popups

### DIFF
--- a/src/stores/guestName.js
+++ b/src/stores/guestName.js
@@ -25,6 +25,7 @@ import Vue from 'vue'
 
 import { setGuestUserName } from '../services/participantsService.js'
 import store from '../store/index.js'
+import { emit } from '@nextcloud/event-bus'
 
 export const useGuestNameStore = defineStore('guestName', {
 	state: () => ({
@@ -112,6 +113,7 @@ export const useGuestNameStore = defineStore('guestName', {
 				} else {
 					localStorage.removeItem('nick')
 				}
+				emit('talk:guest-name:added')
 
 			} catch (error) {
 				store.dispatch('setDisplayName', previousName)


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10959

The condition in MediaSettings for displaying the display name input ( theoretically) should be valid only in `PublicShareAuthSidebar` when the user is a guest because in all other windows, the guest name pop up window is always shown first and cannot be bypassed. 
<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before (opacity to show both) 
 ![image](https://github.com/nextcloud/spreed/assets/93392545/dbce2920-39f4-4516-b9fa-9adc31c34884) 

🏡 After

https://github.com/nextcloud/spreed/assets/84044328/60ca1239-f475-4eaa-832d-0b4231edfaf3



### 🚧 Tasks

TODO
- [x] fix style ( it feels like it is missing padding)
- [x] Double-check if `guestName` ( the removed computed prop) is not needed in MediaSettings

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required