### PR TITLE
fix(API): Require recording consent compatible version of clients

### DIFF
--- a/lib/Middleware/CanUseTalkMiddleware.php
+++ b/lib/Middleware/CanUseTalkMiddleware.php
@@ -46,26 +46,13 @@ use OCP\IUser;
 use OCP\IUserSession;
 
 class CanUseTalkMiddleware extends Middleware {
-	/**
-	 * Talk Desktop user agent but with a regex match for the version
-	 * @see IRequest::USER_AGENT_TALK_DESKTOP
-	 */
-	public const USER_AGENT_TALK_DESKTOP = '/^Mozilla\/5\.0 \((?!Android|iOS)[A-Za-z ]+\) Nextcloud-Talk v([^ ]*).*$/';
 	public const TALK_DESKTOP_MIN_VERSION = '0.6.0';
-
-	/**
-	 * Talk Android user agent but with a regex match for the version
-	 * @see IRequest::USER_AGENT_TALK_ANDROID
-	 */
-	public const USER_AGENT_TALK_ANDROID = '/^Mozilla\/5\.0 \(Android\) Nextcloud\-Talk v([^ ]*).*$/';
+	public const TALK_DESKTOP_MIN_VERSION_RECORDING_CONSENT = '0.16.0';
 	public const TALK_ANDROID_MIN_VERSION = '15.0.0';
+	public const TALK_ANDROID_MIN_VERSION_RECORDING_CONSENT = '18.0.0';
 
-	/**
-	 * Talk iOS user agent but with a regex match for the version
-	 * @see IRequest::USER_AGENT_TALK_IOS
-	 */
-	public const USER_AGENT_TALK_IOS = '/^Mozilla\/5\.0 \(iOS\) Nextcloud\-Talk v([^ ]*).*$/';
 	public const TALK_IOS_MIN_VERSION = '15.0.0';
+	public const TALK_IOS_MIN_VERSION_RECORDING_CONSENT = '18.0.0';
 
 
 	public function __construct(
@@ -159,14 +146,26 @@ class CanUseTalkMiddleware extends Middleware {
 		$configMinVersion = $this->serverConfig->getAppValue('spreed', 'minimum.supported.' . $client . '.version');
 
 		if ($client === 'desktop') {
-			$versionRegex = self::USER_AGENT_TALK_DESKTOP;
+			$versionRegex = IRequest::USER_AGENT_TALK_DESKTOP;
 			$minVersion = self::TALK_DESKTOP_MIN_VERSION;
+
+			if ($this->talkConfig->recordingConsentRequired()) {
+				$minVersion = self::TALK_DESKTOP_MIN_VERSION_RECORDING_CONSENT;
+			}
 		} elseif ($client === 'android') {
-			$versionRegex = self::USER_AGENT_TALK_ANDROID;
+			$versionRegex = IRequest::USER_AGENT_TALK_ANDROID;
 			$minVersion = self::TALK_ANDROID_MIN_VERSION;
+
+			if ($this->talkConfig->recordingConsentRequired()) {
+				$minVersion = self::TALK_ANDROID_MIN_VERSION_RECORDING_CONSENT;
+			}
 		} elseif ($client === 'ios') {
-			$versionRegex = self::USER_AGENT_TALK_IOS;
+			$versionRegex = IRequest::USER_AGENT_TALK_IOS;
 			$minVersion = self::TALK_IOS_MIN_VERSION;
+
+			if ($this->talkConfig->recordingConsentRequired()) {
+				$minVersion = self::TALK_IOS_MIN_VERSION_RECORDING_CONSENT;
+			}
 		} else {
 			return;
 		}

--- a/tests/integration/features/integration/outdated-client.feature
+++ b/tests/integration/features/integration/outdated-client.feature
@@ -22,3 +22,27 @@ Feature: integration/outdated-client
     When client "Mozilla/5.0 (Windows) Nextcloud-Talk v0.3.2" requests room list with 426 (v4)
     Then last response body contains "0.6.0"
     When client "Mozilla/5.0 (Windows) Nextcloud-Talk v0.6.0" requests room list with 200 (v4)
+
+  Scenario: Check if outdated clients correctly receive a 426 error with recording consent enabled
+    Given as user "participant1"
+    Given recording server is started
+    And the following "spreed" app config is set
+      | recording_consent | 2 |
+    # Android
+    When client "Mozilla/5.0 (Android) Nextcloud-Talk v17.0.0" requests room list with 426 (v4)
+    Then last response body contains "18.0.0"
+    When client "Mozilla/5.0 (Android) Nextcloud-Talk v18.0.0" requests room list with 200 (v4)
+    # iOS
+    When client "Mozilla/5.0 (iOS) Nextcloud-Talk v17.0.0" requests room list with 426 (v4)
+    Then last response body contains "18.0.0"
+    When client "Mozilla/5.0 (iOS) Nextcloud-Talk v18.0.0" requests room list with 200 (v4)
+    # Desktop
+    When client "Mozilla/5.0 (Linux) Nextcloud-Talk v0.8.0" requests room list with 426 (v4)
+    Then last response body contains "0.16.0"
+    When client "Mozilla/5.0 (Linux) Nextcloud-Talk v0.16.0" requests room list with 200 (v4)
+    When client "Mozilla/5.0 (Mac) Nextcloud-Talk v0.8.0" requests room list with 426 (v4)
+    Then last response body contains "0.16.0"
+    When client "Mozilla/5.0 (Mac) Nextcloud-Talk v0.16.0" requests room list with 200 (v4)
+    When client "Mozilla/5.0 (Windows) Nextcloud-Talk v0.8.0" requests room list with 426 (v4)
+    Then last response body contains "0.16.0"
+    When client "Mozilla/5.0 (Windows) Nextcloud-Talk v0.16.0" requests room list with 200 (v4)


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10726 

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Only required when recording consent is not Off (enabled or optional)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
