### PR TITLE
fix(hosted-hpb): Correctly handle API response when the account expir…

### DIFF
--- a/lib/BackgroundJob/CheckHostedSignalingServer.php
+++ b/lib/BackgroundJob/CheckHostedSignalingServer.php
@@ -28,6 +28,7 @@ namespace OCA\Talk\BackgroundJob;
 use OCA\Talk\DataObjects\AccountId;
 use OCA\Talk\Exceptions\HostedSignalingServerAPIException;
 use OCA\Talk\Service\HostedSignalingServerService;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;
@@ -67,9 +68,17 @@ class CheckHostedSignalingServer extends TimedJob {
 		$accountId = new AccountId($accountId);
 		try {
 			$accountInfo = $this->hostedSignalingServerService->fetchAccountInfo($accountId);
-		} catch (HostedSignalingServerAPIException $e) { // API or connection issues
-			// do nothing and just try again later
-			return;
+		} catch (HostedSignalingServerAPIException $e) {
+			if ($e->getCode() === Http::STATUS_NOT_FOUND) {
+				// Account was deleted, so remove the information locally
+				$accountInfo = ['status' => 'deleted'];
+			} elseif ($e->getCode() === Http::STATUS_UNAUTHORIZED) {
+				// Account is expired and deletion is pending unless it's reactivated.
+				$accountInfo = ['status' => 'expired'];
+			} else {
+				// API or connection issues - do nothing and just try again later
+				return;
+			}
 		}
 
 		$oldStatus = $oldAccountInfo['status'] ?? '';
@@ -80,15 +89,13 @@ class CheckHostedSignalingServer extends TimedJob {
 
 		// the status has changed
 		if ($oldStatus !== $newStatus) {
-			if ($oldStatus === 'active') {
+			if ($newStatus === 'deleted') {
 				// remove signaling servers if account is not active anymore
 				$this->config->deleteAppValue('spreed', 'signaling_mode');
 				$this->config->deleteAppValue('spreed', 'signaling_servers');
 
 				$notificationSubject = 'removed';
-			}
-
-			if ($newStatus === 'active') {
+			} elseif ($newStatus === 'active') {
 				// add signaling servers if account got active
 				$this->config->deleteAppValue('spreed', 'signaling_mode');
 				$this->config->setAppValue('spreed', 'signaling_servers', json_encode([

--- a/lib/Controller/HostedSignalingServerController.php
+++ b/lib/Controller/HostedSignalingServerController.php
@@ -133,19 +133,25 @@ class HostedSignalingServerController extends OCSController {
 
 		try {
 			$this->hostedSignalingServerService->deleteAccount(new AccountId($accountId));
-
-			$this->config->deleteAppValue('spreed', 'hosted-signaling-server-account');
-			$this->config->deleteAppValue('spreed', 'hosted-signaling-server-account-id');
-
-			// remove signaling servers if account is not active anymore
-			$this->config->deleteAppValue('spreed', 'signaling_mode');
-			$this->config->deleteAppValue('spreed', 'signaling_servers');
-
-			$this->logger->info('Deleted hosted signaling server account with ID ' . $accountId);
-		} catch (HostedSignalingServerAPIException $e) { // API or connection issues
-			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_INTERNAL_SERVER_ERROR);
+		} catch (HostedSignalingServerAPIException $e) {
+			if ($e->getCode() === Http::STATUS_NOT_FOUND) {
+				// Account was deleted, so remove the information locally
+			} elseif ($e->getCode() === Http::STATUS_UNAUTHORIZED) {
+				// Account is expired and deletion is pending unless it's reactivated.
+			} else {
+				// API or connection issues - do nothing and just try again later
+				return new DataResponse(['message' => $e->getMessage()], Http::STATUS_INTERNAL_SERVER_ERROR);
+			}
 		}
 
+		$this->config->deleteAppValue('spreed', 'hosted-signaling-server-account');
+		$this->config->deleteAppValue('spreed', 'hosted-signaling-server-account-id');
+
+		// remove signaling servers if account is not active anymore
+		$this->config->deleteAppValue('spreed', 'signaling_mode');
+		$this->config->deleteAppValue('spreed', 'signaling_servers');
+
+		$this->logger->info('Deleted hosted signaling server account with ID ' . $accountId);
 
 		return new DataResponse([], Http::STATUS_NO_CONTENT);
 	}

--- a/tests/stubs/GuzzleHttp_Exception_ServerException.php
+++ b/tests/stubs/GuzzleHttp_Exception_ServerException.php
@@ -2,11 +2,9 @@
 
 namespace GuzzleHttp\Exception;
 
-use Psr\Http\Message\ResponseInterface;
-
 class ServerException extends \RuntimeException {
 
-	public function getResponse(): ResponseInterface {
+	public function getResponse() {
 	}
 	public function hasResponse(): bool {
 	}


### PR DESCRIPTION
…ed or was deleted

### ☑️ Resolves

* Fix #9656 

## 🛠️ API Checklist

- Fixed an issue when the HPB expired (401 can be returned together with an empty response)
- Improved the notifications (and fixed missing translations)

Before | After
---|---
![grafik](https://github.com/nextcloud/spreed/assets/213943/883c35b3-36d8-4c24-bf24-5aa5820e4e31) | ![Bildschirmfoto vom 2023-11-22 12-24-54](https://github.com/nextcloud/spreed/assets/213943/0e9b6db3-9a75-4682-b497-3ececc3a74a1)


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
