### PR TITLE
fix(calls): Explicitly block calls in former one-to-one

### DIFF
--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1148,7 +1148,9 @@ class ParticipantService {
 	}
 
 	public function changeInCall(Room $room, Participant $participant, int $flags, bool $endCallForEveryone = false, bool $silent = false): bool {
-		if ($room->getType() === Room::TYPE_CHANGELOG || $room->getType() === Room::TYPE_NOTE_TO_SELF) {
+		if ($room->getType() === Room::TYPE_CHANGELOG
+			|| $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER
+			|| $room->getType() === Room::TYPE_NOTE_TO_SELF) {
 			return false;
 		}
 

--- a/tests/integration/features/callapi/one-to-one.feature
+++ b/tests/integration/features/callapi/one-to-one.feature
@@ -122,3 +122,20 @@ Feature: callapi/one-to-one
     And user "participant1" sees 1 peers in call "room" with 200 (v4)
     And user "participant2" sees 1 peers in call "room" with 200 (v4)
 
+  Scenario: Can not join a call in former one-to-one
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" is participant of room "room" (v4)
+    And user "participant2" is participant of room "room" (v4)
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | type | participantType |
+      | room | 1    | 1               |
+    When user "participant2" is deleted
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | type | participantType |
+      | room | 5    | 1               |
+    When user "participant1" joins room "room" with 200 (v4)
+    And user "participant1" joins call "room" with 403 (v4)
+    Then user "participant1" is participant of room "room" (v4)
+    And user "participant1" sees 0 peers in call "room" with 403 (v4)


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10595

## 🛠️ API Checklist

### 🚧 Tasks

- Was already blocked indirectly because the room is read only, but now it's more clear and tested.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
