### PR TITLE
fix(API): Move away from own deprecated constants

### DIFF
--- a/lib/Command/Room/TRoomCommand.php
+++ b/lib/Command/Room/TRoomCommand.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Command\Room;
 
 use InvalidArgumentException;
+use OCA\Talk\Events\AAttendeeRemovedEvent;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Exceptions\RoomNotFoundException;
 use OCA\Talk\Manager;
@@ -298,7 +299,7 @@ trait TRoomCommand {
 		}
 
 		foreach ($users as $user) {
-			$this->participantService->removeUser($room, $user, Room::PARTICIPANT_REMOVED);
+			$this->participantService->removeUser($room, $user, AAttendeeRemovedEvent::REASON_REMOVED);
 		}
 	}
 

--- a/lib/Command/User/TransferOwnership.php
+++ b/lib/Command/User/TransferOwnership.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Command\User;
 
 use OC\Core\Command\Base;
+use OCA\Talk\Events\AAttendeeRemovedEvent;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
@@ -136,7 +137,7 @@ class TransferOwnership extends Base {
 			}
 
 			if ($removeSourceUser) {
-				$this->participantService->removeAttendee($room, $sourceParticipant, Room::PARTICIPANT_REMOVED);
+				$this->participantService->removeAttendee($room, $sourceParticipant, AAttendeeRemovedEvent::REASON_REMOVED);
 			}
 		}
 

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -30,6 +30,7 @@ namespace OCA\Talk\Controller;
 
 use InvalidArgumentException;
 use OCA\Talk\Config;
+use OCA\Talk\Events\AAttendeeRemovedEvent;
 use OCA\Talk\Events\BeforeRoomsFetchEvent;
 use OCA\Talk\Events\UserEvent;
 use OCA\Talk\Exceptions\CannotReachRemoteException;
@@ -1253,7 +1254,7 @@ class RoomController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
-		$this->participantService->removeUser($room, $currentUser, Room::PARTICIPANT_LEFT);
+		$this->participantService->removeUser($room, $currentUser, AAttendeeRemovedEvent::REASON_LEFT);
 
 		return new DataResponse();
 	}
@@ -1296,7 +1297,7 @@ class RoomController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		$this->participantService->removeAttendee($this->room, $targetParticipant, Room::PARTICIPANT_REMOVED);
+		$this->participantService->removeAttendee($this->room, $targetParticipant, AAttendeeRemovedEvent::REASON_REMOVED);
 		return new DataResponse([]);
 	}
 

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -28,6 +28,7 @@ namespace OCA\Talk\Controller;
 
 use GuzzleHttp\Exception\ConnectException;
 use OCA\Talk\Config;
+use OCA\Talk\Events\AAttendeeRemovedEvent;
 use OCA\Talk\Events\BeforeSignalingResponseSentEvent;
 use OCA\Talk\Events\SignalingEvent;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
@@ -769,7 +770,7 @@ class SignalingController extends OCSController {
 			// Emails are retained as their PIN needs to remain and stay
 			// valid.
 			if ($participant->getAttendee()->getActorType() === Attendee::ACTOR_GUESTS) {
-				$this->participantService->removeAttendee($room, $participant, Room::PARTICIPANT_LEFT);
+				$this->participantService->removeAttendee($room, $participant, AAttendeeRemovedEvent::REASON_LEFT);
 			} else {
 				$this->participantService->leaveRoomAsSession($room, $participant);
 			}

--- a/lib/Listener/AMembershipListener.php
+++ b/lib/Listener/AMembershipListener.php
@@ -25,6 +25,7 @@ namespace OCA\Talk\Listener;
 
 use OCA\Circles\CirclesManager;
 use OCA\Circles\Model\Member;
+use OCA\Talk\Events\AAttendeeRemovedEvent;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
@@ -61,7 +62,7 @@ abstract class AMembershipListener implements IEventListener {
 				$participant = $room->getParticipant($user->getUID());
 				$participantType = $participant->getAttendee()->getParticipantType();
 				if ($participantType === Participant::USER) {
-					$this->participantService->removeUser($room, $user, Room::PARTICIPANT_REMOVED);
+					$this->participantService->removeUser($room, $user, AAttendeeRemovedEvent::REASON_REMOVED);
 				}
 			} catch (ParticipantNotFoundException $e) {
 			}

--- a/lib/Listener/CircleDeletedListener.php
+++ b/lib/Listener/CircleDeletedListener.php
@@ -24,9 +24,9 @@ declare(strict_types=1);
 namespace OCA\Talk\Listener;
 
 use OCA\Circles\Events\CircleDestroyedEvent;
+use OCA\Talk\Events\AAttendeeRemovedEvent;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
-use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -54,7 +54,7 @@ class CircleDeletedListener implements IEventListener {
 		$rooms = $this->manager->getRoomsForActor(Attendee::ACTOR_CIRCLES, $circleId);
 		foreach ($rooms as $room) {
 			$participant = $this->participantService->getParticipantByActor($room, Attendee::ACTOR_CIRCLES, $circleId);
-			$this->participantService->removeAttendee($room, $participant, Room::PARTICIPANT_REMOVED);
+			$this->participantService->removeAttendee($room, $participant, AAttendeeRemovedEvent::REASON_REMOVED);
 		}
 	}
 }

--- a/lib/Listener/GroupDeletedListener.php
+++ b/lib/Listener/GroupDeletedListener.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Listener;
 
+use OCA\Talk\Events\AAttendeeRemovedEvent;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
-use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -60,7 +60,7 @@ class GroupDeletedListener implements IEventListener {
 		$rooms = $this->manager->getRoomsForActor(Attendee::ACTOR_GROUPS, $gid);
 		foreach ($rooms as $room) {
 			$participant = $this->participantService->getParticipantByActor($room, Attendee::ACTOR_GROUPS, $gid);
-			$this->participantService->removeAttendee($room, $participant, Room::PARTICIPANT_REMOVED);
+			$this->participantService->removeAttendee($room, $participant, AAttendeeRemovedEvent::REASON_REMOVED);
 		}
 	}
 

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace OCA\Talk;
 
 use OCA\Talk\Chat\CommentsManager;
+use OCA\Talk\Events\AAttendeeRemovedEvent;
 use OCA\Talk\Events\RoomCreatedEvent;
 use OCA\Talk\Events\RoomEvent;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
@@ -416,7 +417,7 @@ class Manager {
 			if ($this->participantService->getNumberOfUsers($room) === 1) {
 				Server::get(RoomService::class)->deleteRoom($room);
 			} else {
-				$this->participantService->removeUser($room, $user, Room::PARTICIPANT_REMOVED_ALL);
+				$this->participantService->removeUser($room, $user, AAttendeeRemovedEvent::REASON_REMOVED_ALL);
 			}
 		}
 

--- a/lib/MatterbridgeManager.php
+++ b/lib/MatterbridgeManager.php
@@ -28,6 +28,7 @@ namespace OCA\Talk;
 use OC\Authentication\Token\IProvider as IAuthTokenProvider;
 use OC\Authentication\Token\IToken;
 use OCA\Talk\Chat\ChatManager;
+use OCA\Talk\Events\AAttendeeRemovedEvent;
 use OCA\Talk\Exceptions\ImpossibleToKillException;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Exceptions\RoomNotFoundException;
@@ -278,7 +279,7 @@ class MatterbridgeManager {
 		try {
 			$this->participantService->getParticipant($room, self::BRIDGE_BOT_USERID, false);
 			if (!$isBridgeEnabled) {
-				$this->participantService->removeUser($room, $botUser, Room::PARTICIPANT_REMOVED);
+				$this->participantService->removeUser($room, $botUser, AAttendeeRemovedEvent::REASON_REMOVED);
 			}
 		} catch (ParticipantNotFoundException $e) {
 			if ($isBridgeEnabled) {

--- a/lib/Service/BreakoutRoomService.php
+++ b/lib/Service/BreakoutRoomService.php
@@ -28,6 +28,7 @@ namespace OCA\Talk\Service;
 use InvalidArgumentException;
 use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Config;
+use OCA\Talk\Events\AAttendeeRemovedEvent;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
@@ -238,7 +239,7 @@ class BreakoutRoomService {
 		}
 
 		foreach ($removals as $removal) {
-			$this->participantService->removeAttendee($removal['room'], $removal['participant'], Room::PARTICIPANT_REMOVED);
+			$this->participantService->removeAttendee($removal['room'], $removal['participant'], AAttendeeRemovedEvent::REASON_REMOVED);
 		}
 
 		$map = [];
@@ -489,7 +490,7 @@ class BreakoutRoomService {
 					$this->participantService->removeAttendee(
 						$breakoutRoom,
 						$removeParticipant,
-						Room::PARTICIPANT_LEFT
+						AAttendeeRemovedEvent::REASON_LEFT
 					);
 				}
 			} catch (ParticipantNotFoundException $e) {
@@ -572,7 +573,7 @@ class BreakoutRoomService {
 					throw new \InvalidArgumentException('moderator');
 				}
 
-				$this->participantService->removeAttendee($breakoutRoom, $participant, Room::PARTICIPANT_REMOVED);
+				$this->participantService->removeAttendee($breakoutRoom, $participant, AAttendeeRemovedEvent::REASON_REMOVED);
 			} catch (ParticipantNotFoundException $e) {
 				// Skip this room
 			}


### PR DESCRIPTION
## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
