### PR TITLE
fix(uploads): allow to send empty uploads as normal messages

### DIFF
--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -82,7 +82,8 @@
 				:token="token"
 				:container="modalContainerId"
 				:aria-label="t('spreed', 'Post message')"
-				@sent="handleUpload"
+				@upload="handleUpload"
+				@sent="handleDismiss"
 				@failure="handleDismiss" />
 		</div>
 	</NcModal>

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -263,6 +263,7 @@ const actions = {
 		if (state.currentUploadId === uploadId) {
 			commit('setCurrentUploadId', undefined)
 		}
+		EventBus.$emit('upload-discard')
 
 		commit('discardUpload', { uploadId })
 	},


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10872 
* Improve connection and syncronize main chat input and upload dialog input:
  * When message / upload is sent, clear both
  * When in the process, jump freely between views with text keeped


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏡 After

https://github.com/nextcloud/spreed/assets/93392545/d28026fa-2feb-4b74-ba2a-90137c50a4c9


### 🚧 Tasks

- [ ] Upstream: NcRichContenEditable should place caret in the end, when focused

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible