### PR TITLE
Release 16.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 16.0.8 – 2023-11-23
+### Fixed
+- fix(settings): Remove non-working notification settings for guests
+  [#10976](https://github.com/nextcloud/spreed/issues/10976)
+- fix(settings): Fix option to request an HPB trial
+  [#10967](https://github.com/nextcloud/spreed/issues/10967)
+- fix(settings): Fail recording server test when an HPB was given as recording backend
+  [#10950](https://github.com/nextcloud/spreed/issues/10950)
+- fix(chat): Hide delete option for guests
+  [#10807](https://github.com/nextcloud/spreed/issues/10807)
+
 ## 16.0.7 – 2023-10-27
 ### Changed
 - Update dependencies

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>16.0.7</version>
+	<version>16.0.8</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk",
-	"version": "16.0.7",
+	"version": "16.0.8",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk",
-			"version": "16.0.7",
+			"version": "16.0.8",
 			"license": "agpl",
 			"dependencies": {
 				"@nextcloud/auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "talk",
-	"version": "16.0.7",
+	"version": "16.0.8",
 	"private": true,
 	"description": "",
 	"author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 16.0.8 – 2023-11-23
### Fixed
- fix(settings): Remove non-working notification settings for guests [#10976](https://github.com/nextcloud/spreed/issues/10976)
- fix(settings): Fix option to request an HPB trial [#10967](https://github.com/nextcloud/spreed/issues/10967)
- fix(settings): Fail recording server test when an HPB was given as recording backend [#10950](https://github.com/nextcloud/spreed/issues/10950)
- fix(chat): Hide delete option for guests [#10807](https://github.com/nextcloud/spreed/issues/10807)