### PR TITLE
fix(chat): use the default new message placeholder

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -313,7 +313,8 @@ export default {
 			} else if (!this.currentConversationIsJoined) {
 				return t('spreed', 'Joining conversation …')
 			} else {
-				return t('spreed', 'Write message, @ to mention someone …')
+				// Use the default placeholder
+				return undefined
 			}
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

Current placeholder `Write message, @ to mention someone …` is a bit too long and doesn't fit well in the sidebar. At the same time, the instruction is not complete anyway, without a mention of emoji-picker `:` and smart picker `/` 

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/25978914/43c673b5-8645-4218-978a-b2391b624141) | ![image](https://github.com/nextcloud/spreed/assets/25978914/f03df298-569a-44af-97f5-7cc9a2a45852) |

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required