### PR TITLE
fix(calls): Remove a query in a loop when ending call for everyone

### DIFF
--- a/lib/Listener/RestrictStartingCalls.php
+++ b/lib/Listener/RestrictStartingCalls.php
@@ -28,6 +28,7 @@ namespace OCA\Talk\Listener;
 use OCA\Talk\Events\AParticipantModifiedEvent;
 use OCA\Talk\Events\BeforeParticipantModifiedEvent;
 use OCA\Talk\Exceptions\ForbiddenException;
+use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\ParticipantService;
 use OCP\EventDispatcher\Event;
@@ -54,6 +55,11 @@ class RestrictStartingCalls implements IEventListener {
 		}
 
 		if ($event->getProperty() !== AParticipantModifiedEvent::PROPERTY_IN_CALL) {
+			return;
+		}
+
+		if ($event->getNewValue() === Participant::FLAG_DISCONNECTED
+			|| $event->getOldValue() !== Participant::FLAG_DISCONNECTED) {
 			return;
 		}
 


### PR DESCRIPTION
### ☑️ Resolves

* Did a performance check with #6983 and noticed that there where O(n) queries more

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
