### PR TITLE
Fix undefined $participant when calling a lobbied room

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -224,6 +224,7 @@ class Notifier implements INotifier {
 			// we just looped over the participants to create the notification,
 			// they can not be removed between these 2 steps, but we can save
 			// n queries.
+			$participant = null;
 		} else {
 			try {
 				$participant = $this->getParticipant($room, $userId);
@@ -248,8 +249,8 @@ class Notifier implements INotifier {
 			return $this->parseInvitation($notification, $room, $l);
 		}
 		if ($subject === 'call') {
-			if ($room->getLobbyState() !== Webinary::LOBBY_NONE &&
-				$participant instanceof Participant &&
+			if ($participant instanceof Participant &&
+				$room->getLobbyState() !== Webinary::LOBBY_NONE &&
 				!($participant->getPermissions() & Attendee::PERMISSIONS_LOBBY_IGNORE)) {
 				// User is blocked by the lobby, remove notification
 				throw new AlreadyProcessedException();
@@ -261,8 +262,8 @@ class Notifier implements INotifier {
 			return $this->parseCall($notification, $room, $l);
 		}
 		if ($subject === 'reply' || $subject === 'mention' || $subject === 'mention_direct' || $subject === 'mention_group' || $subject === 'mention_all' || $subject === 'chat' || $subject === 'reaction' || $subject === 'reminder') {
-			if ($room->getLobbyState() !== Webinary::LOBBY_NONE &&
-				$participant instanceof Participant &&
+			if ($participant instanceof Participant &&
+				$room->getLobbyState() !== Webinary::LOBBY_NONE &&
 				!($participant->getPermissions() & Attendee::PERMISSIONS_LOBBY_IGNORE)) {
 				// User is blocked by the lobby, remove notification
 				throw new AlreadyProcessedException();

--- a/tests/integration/features/callapi/lobby.feature
+++ b/tests/integration/features/callapi/lobby.feature
@@ -1,0 +1,44 @@
+Feature: callapi/lobby
+  Background:
+    Given user "participant1" exists
+    And user "participant2" exists
+
+  Scenario: Participant1 calls without lobby
+    When user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    Then user "participant1" is participant of room "room" (v4)
+    And user "participant2" is participant of room "room" (v4)
+    Then user "participant1" joins room "room" with 200 (v4)
+    Then user "participant1" joins call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id | subject                                             |
+      | spreed | call        | room      | A group call has started in room |
+
+  Scenario: Participant1 calls while participant2 is blocked by the lobby
+    When user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    Then user "participant1" is participant of room "room" (v4)
+    And user "participant2" is participant of room "room" (v4)
+    When user "participant1" sets lobby state for room "room" to "non moderators" with 200 (v4)
+    Then user "participant1" joins room "room" with 200 (v4)
+    Then user "participant1" joins call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+
+  Scenario: Participant1 calls while participant2 is moderator
+    When user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    Then user "participant1" is participant of room "room" (v4)
+    And user "participant2" is participant of room "room" (v4)
+    And user "participant1" promotes "participant2" in room "room" with 200 (v4)
+    When user "participant1" sets lobby state for room "room" to "non moderators" with 200 (v4)
+    Then user "participant1" joins room "room" with 200 (v4)
+    Then user "participant1" joins call "room" with 200 (v4)
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id | subject                                             |
+      | spreed | call        | room      | A group call has started in room |


### PR DESCRIPTION
### ☑️ Resolves

* Fix `Undefined variable $participant at …/apps/spreed/lib/Notification/Notifier.php#252`

## 🛠️ API Checklist
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
