### PR TITLE
fix(CallView): pass method reference instead of result to debounce function

### DIFF
--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -680,7 +680,7 @@ export default {
 			// currently if the user is not on the 'first page', upon resize the
 			// current position in the videos array is lost (first element
 			// in the grid goes back to be first video)
-			debounce(this.makeGrid(), 200)
+			debounce(this.makeGrid, 200)
 		},
 
 		// Find the right size if the grid in rows and columns (we already know


### PR DESCRIPTION
### ☑️ Resolves

* Fix TypeError
![image](https://github.com/nextcloud/spreed/assets/93392545/7eae9892-e062-42b1-a761-537e06b78293)


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences