### PR TITLE
fix(App): switch toggle button to dark theme in call

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -230,6 +230,18 @@ export default {
 				this.recordingConsentGiven = false
 			}
 		},
+
+		isInCall: {
+			immediate: true,
+			handler(value) {
+				const toggle = this.$refs.leftSidebar?.$refs.leftSidebar?.$el.querySelector('button.app-navigation-toggle')
+				if (value) {
+					toggle?.setAttribute('data-theme-dark', true)
+				} else {
+					toggle?.removeAttribute('data-theme-dark')
+				}
+			}
+		}
 	},
 
 	beforeCreate() {
@@ -718,16 +730,9 @@ export default {
 </script>
 
 <style lang="scss">
-
 /* FIXME: remove after https://github.com/nextcloud/nextcloud-vue/issues/2097 is solved */
 .mx-datepicker-main.mx-datepicker-popup {
 	z-index: 10001 !important;
-}
-
-/* FIXME: remove after https://github.com/nextcloud-libraries/nextcloud-vue/pull/4350 regression is solved */
-/* Force modal close button to be above modal content */
-.modal-container__close {
-	z-index: 1;
 }
 </style>
 
@@ -737,23 +742,6 @@ export default {
 	&.in-call {
 		:deep(.app-content) {
 			background-color: transparent;
-		}
-
-		&:hover :deep(.app-navigation-toggle) {
-			background-color: rgba(0, 0, 0, .1) !important;
-
-			&:hover {
-				background-color: rgba(0, 0, 0, .2) !important;
-			}
-		}
-
-		:deep(.app-navigation-toggle) {
-			/* Force white handle when inside a call */
-			color: #D8D8D8;
-
-			&:active {
-				color: #FFFFFF;
-			}
 		}
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

* Drop overwritten styles for AppNavigationToggle  in call
* change theme to dark specifically for the toggle button

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Light theme | Dark theme
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/1200c7b1-0674-48ef-94a4-c852c0f4a1ad) | ![image](https://github.com/nextcloud/spreed/assets/93392545/187a9cf7-8cb4-48e8-b42a-b97fe259dc32)
![image](https://github.com/nextcloud/spreed/assets/93392545/e0a4f415-a0d9-4f10-9819-f172fce0744b) | ![image](https://github.com/nextcloud/spreed/assets/93392545/e0a4f415-a0d9-4f10-9819-f172fce0744b)

[Screencast from 04.12.2023 11:18:58.webm](https://github.com/nextcloud/spreed/assets/93392545/290a1208-f997-4df5-9e4a-9e8034db1891)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences