### PR TITLE
fix(NcCheckboxRadioSwitch): revert flex-shrink for switch labels

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -765,6 +765,11 @@ export default {
 			height: 100vh !important;
 		}
 	}
+
+	// TODO remove after https://github.com/nextcloud-libraries/nextcloud-vue/pull/4760 regression is fixed
+	:deep(.checkbox-radio-switch__text) {
+		flex-shrink: 1;
+	}
 }
 
 </style>


### PR DESCRIPTION
### ☑️ Resolves

* Patch a regression from  https://github.com/nextcloud-libraries/nextcloud-vue/pull/4760

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![Screenshot from 2023-11-30 13-30-45](https://github.com/nextcloud/spreed/assets/93392545/5a77c89a-e9d8-457e-9ee8-83238798f9a4)          | ![Screenshot from 2023-11-30 13-32-27](https://github.com/nextcloud/spreed/assets/93392545/7660fa48-735f-4708-836b-09add0376ca1)        |
![image](https://github.com/nextcloud/spreed/assets/93392545/605191c4-6721-4cd4-a9ce-8770f2d9db59) | ![image](https://github.com/nextcloud/spreed/assets/93392545/7cd090d1-8647-40ff-8e02-d263943c948f)


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences