### PR TITLE
fix(chat): patch stored message input

### DIFF
--- a/src/store/quoteReplyStore.js
+++ b/src/store/quoteReplyStore.js
@@ -77,7 +77,13 @@ const mutations = {
 	 */
 	setCurrentMessageInput(state, { token, text = null }) {
 		if (text !== null) {
-			Vue.set(state.currentMessageInput, token, text)
+			// FIXME upstream: https://github.com/nextcloud-libraries/nextcloud-vue/issues/4492
+			const temp = document.createElement('textarea')
+			temp.innerHTML = text?.replace(/&/gmi, '&amp;') || ''
+			const parsedText = temp.value.replace(/&amp;/gmi, '&').replace(/&lt;/gmi, '<')
+				.replace(/&gt;/gmi, '>').replace(/&sect;/gmi, '§')
+
+			Vue.set(state.currentMessageInput, token, parsedText)
 		} else {
 			Vue.delete(state.currentMessageInput, token)
 		}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11023 
* Duplicate code from NewMessage component: https://github.com/nextcloud/spreed/blob/54655bf99144848c48ef064387a65f6d552bac75/src/components/NewMessage/NewMessage.vue#L524-L528


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

[Screencast from 30.11.2023 14:10:29.webm](https://github.com/nextcloud/spreed/assets/93392545/7802299d-ca09-4cc3-93e2-c11ee2d06c00)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible
