### PR TITLE
fix(search): Hide "Messages in current conversation" when not on talk

### DIFF
--- a/lib/Search/CurrentMessageSearch.php
+++ b/lib/Search/CurrentMessageSearch.php
@@ -47,14 +47,14 @@ class CurrentMessageSearch extends MessageSearch {
 	/**
 	 * @inheritDoc
 	 */
-	public function getOrder(string $route, array $routeParameters): int {
+	public function getOrder(string $route, array $routeParameters): ?int {
 		if ($route === 'spreed.Page.showCall') {
 			// In conversation, prefer this search results
 			return -3;
 		}
 
 		// We are not returning something anyway.
-		return 999;
+		return null;
 	}
 
 	protected function getSublineTemplate(): string {

--- a/lib/Search/MessageSearch.php
+++ b/lib/Search/MessageSearch.php
@@ -75,7 +75,7 @@ class MessageSearch implements IProvider, IFilteringProvider {
 	/**
 	 * @inheritDoc
 	 */
-	public function getOrder(string $route, array $routeParameters): int {
+	public function getOrder(string $route, array $routeParameters): ?int {
 		if (strpos($route, Application::APP_ID . '.') === 0) {
 			// Active app, prefer Talk results
 			return -2;


### PR DESCRIPTION
Possible since https://github.com/nextcloud/server/pull/41646

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
