### PR TITLE
fix(SetContacts ): Remove unnecessary scroll

### DIFF
--- a/src/components/LeftSidebar/NewGroupConversation/SetContacts/ContactSelectionBubble/ContactSelectionBubble.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/SetContacts/ContactSelectionBubble/ContactSelectionBubble.vue
@@ -102,6 +102,7 @@ $bubble-height: 24px;
 	background-color: var(--color-primary-element-light);
 	border-radius: $bubble-height;
 	height: $bubble-height;
+	overflow: hidden;
 	&__avatar {
 		margin-right: 4px;
 	}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10755

Close Button has height 44px in `ContactSelectionBubble` whereas selected contacts div goes lower ( 40.8px), causing the extra scroll. 

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/84044328/17c91f00-9966-4870-bc07-761eb833fa8a)  | ![image](https://github.com/nextcloud/spreed/assets/84044328/7eccf7a7-63fe-4f74-ab2c-769a784f6283)  |

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
