### PR TITLE
get text color from theme for unread marker

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -1087,7 +1087,7 @@ export default {
 		padding: 0 7px 0 7px;
 		text-align: center;
 		white-space: nowrap;
-
+		color: var(--color-text-light);
 		border-radius: var(--border-radius);
 		background-color: var(--color-main-background);
 	}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11043


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/0754d203-5d48-42e2-a2b0-c0881dc45406)          | ![image](https://github.com/nextcloud/spreed/assets/93392545/91caa1f1-6b6d-433a-a14d-2c3a5561b278)        |


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences