### PR TITLE
feat(NewGroupConversation): Always show create conversation button

### DIFF
--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -90,7 +90,7 @@
 				placement are rendered depending on the current page -->
 			<div class="new-group-conversation__footer">
 				<!-- First page -->
-				<NcButton v-if="page===0 && isPublic"
+				<NcButton v-if="page===0 && conversationName"
 					:disabled="disabled"
 					type="tertiary"
 					@click="handleCreateConversation">


### PR DESCRIPTION


### ☑️ Resolves

* Fix #11039

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/84044328/a1b6a67b-7583-428f-b015-59fb4c839ab9)   | ![image](https://github.com/nextcloud/spreed/assets/84044328/954e92f8-65c6-45a6-a905-8d3f5916ac81) |

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required