### PR TITLE
fix(shares): allow to retry failed uploads

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -118,8 +118,8 @@ the main body of the message as well as a quote.
 						tabindex="0"
 						@mouseover="showReloadButton = true"
 						@focus="showReloadButton = true"
-						@mouseleave="showReloadButton = true"
-						@blur="showReloadButton = true">
+						@mouseleave="showReloadButton = false"
+						@blur="showReloadButton = false">
 						<NcButton v-if="sendingErrorCanRetry && showReloadButton"
 							:aria-label="sendingErrorIconTooltip"
 							@click="handleRetry">

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -695,6 +695,7 @@ export default {
 
 		sendingErrorCanRetry() {
 			return this.sendingFailure === 'timeout' || this.sendingFailure === 'other'
+				|| this.sendingFailure === 'failed-upload'
 		},
 
 		sendingErrorIconTooltip() {
@@ -810,8 +811,13 @@ export default {
 
 		handleRetry() {
 			if (this.sendingErrorCanRetry) {
-				EventBus.$emit('retry-message', this.id)
-				EventBus.$emit('focus-chat-input')
+				if (this.sendingFailure === 'failed-upload') {
+					const caption = this.renderedMessage !== this.message ? this.message : undefined
+					this.$store.dispatch('retryUploadFiles', { uploadId: this.messageObject.uploadId, caption })
+				} else {
+					EventBus.$emit('retry-message', this.id)
+					EventBus.$emit('focus-chat-input')
+				}
 			}
 		},
 

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -89,7 +89,7 @@ const getters = {
 	},
 
 	uploadProgress: (state) => (uploadId, index) => {
-		if (state.uploads[uploadId].files[index]) {
+		if (state.uploads[uploadId]?.files[index]) {
 			return state.uploads[uploadId].files[index].uploadedSize / state.uploads[uploadId].files[index].totalSize * 100
 		} else {
 			return 0
@@ -112,9 +112,8 @@ const getters = {
 const mutations = {
 
 	// Adds a "file to be shared to the store"
-	addFileToBeUploaded(state, { file, temporaryMessage, localUrl }) {
+	addFileToBeUploaded(state, { file, temporaryMessage, localUrl, token }) {
 		const uploadId = temporaryMessage.messageParameters.file.uploadId
-		const token = temporaryMessage.messageParameters.file.token
 		const index = temporaryMessage.messageParameters.file.index
 		// Create upload id if not present
 		if (!state.uploads[uploadId]) {
@@ -253,7 +252,7 @@ const actions = {
 				text: '{file}', token, uploadId, index, file, localUrl, isVoiceMessage,
 			})
 			console.debug('temporarymessage: ', temporaryMessage, 'uploadId', uploadId)
-			commit('addFileToBeUploaded', { file, temporaryMessage, localUrl })
+			commit('addFileToBeUploaded', { file, temporaryMessage, localUrl, token })
 		}
 	},
 
@@ -322,14 +321,14 @@ const actions = {
 			// Candidate rest of the path
 			const path = getters.getAttachmentFolder() + '/' + fileName
 
-			// Check if previous propfind attempt was stored
-			const promptPath = getFileNamePrompt(path)
-			const knownSuffix = knownPaths[promptPath]
-			// Get a unique relative path based on the previous path variable
-			const { uniquePath, suffix } = await findUniquePath(client, userRoot, path, knownSuffix)
-			knownPaths[promptPath] = suffix
-
 			try {
+				// Check if previous propfind attempt was stored
+				const promptPath = getFileNamePrompt(path)
+				const knownSuffix = knownPaths[promptPath]
+				// Get a unique relative path based on the previous path variable
+				const { uniquePath, suffix } = await findUniquePath(client, userRoot, path, knownSuffix)
+				knownPaths[promptPath] = suffix
+
 				// Upload the file
 				const currentFileBuffer = await new Blob([currentFile]).arrayBuffer()
 				await client.putFileContents(userRoot + uniquePath, currentFileBuffer, {

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -359,7 +359,7 @@ const actions = {
 
 				// Mark the upload as failed in the store
 				commit('markFileAsFailedUpload', { uploadId, index })
-				dispatch('markTemporaryMessageAsFailed', { message: uploadedFile.temporaryMessage, reason })
+				dispatch('markTemporaryMessageAsFailed', { message: uploadedFile.temporaryMessage, uploadId, reason })
 			}
 		}
 
@@ -390,7 +390,7 @@ const actions = {
 				} else {
 					showError(t('spreed', 'An error happened when trying to share your file'))
 				}
-				dispatch('markTemporaryMessageAsFailed', { message: temporaryMessage, reason: 'failed-share' })
+				dispatch('markTemporaryMessageAsFailed', { message: temporaryMessage, uploadId, reason: 'failed-share' })
 				console.error('An error happened when trying to share your file: ', error)
 			}
 		}

--- a/src/store/fileUploadStore.spec.js
+++ b/src/store/fileUploadStore.spec.js
@@ -1,10 +1,14 @@
 import { createLocalVue } from '@vue/test-utils'
 import mockConsole from 'jest-mock-console'
 import { cloneDeep } from 'lodash'
+import { createPinia, setActivePinia } from 'pinia'
 import Vuex from 'vuex'
 
 import { showError } from '@nextcloud/dialogs'
 
+// eslint-disable-next-line no-unused-vars -- required for testing
+import storeConfig from './storeConfig.js'
+// eslint-disable-next-line import/order -- required for testing
 import fileUploadStore from './fileUploadStore.js'
 import { getDavClient } from '../services/DavClient.js'
 import { shareFile } from '../services/filesSharingServices.js'
@@ -39,6 +43,7 @@ describe('fileUploadStore', () => {
 
 		localVue = createLocalVue()
 		localVue.use(Vuex)
+		setActivePinia(createPinia())
 
 		mockedActions = {
 			createTemporaryMessage: jest.fn()

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -337,11 +337,15 @@ const mutations = {
 	 * @param {object} state current store state;
 	 * @param {object} data the wrapping object;
 	 * @param {object} data.message the temporary message;
+	 * @param {string|undefined} data.uploadId the internal id of the upload;
 	 * @param {string} data.reason the reason the temporary message failed;
 	 */
-	markTemporaryMessageAsFailed(state, { message, reason }) {
+	markTemporaryMessageAsFailed(state, { message, uploadId = undefined, reason }) {
 		if (state.messages[message.token][message.id]) {
 			Vue.set(state.messages[message.token][message.id], 'sendingFailure', reason)
+			if (uploadId) {
+				Vue.set(state.messages[message.token][message.id], 'uploadId', uploadId)
+			}
 		}
 	},
 
@@ -678,10 +682,11 @@ const actions = {
 	 * @param {object} context default store context;
 	 * @param {object} data the wrapping object;
 	 * @param {object} data.message the temporary message;
+	 * @param {string} data.uploadId the internal id of the upload;
 	 * @param {string} data.reason the reason the temporary message failed;
 	 */
-	markTemporaryMessageAsFailed(context, { message, reason }) {
-		context.commit('markTemporaryMessageAsFailed', { message, reason })
+	markTemporaryMessageAsFailed(context, { message, uploadId, reason }) {
+		context.commit('markTemporaryMessageAsFailed', { message, uploadId, reason })
 	},
 
 	/**


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10768 
  * ATM allows to retry with files marked as 'failed-upload' (in case upload failed when putting on webdav step)


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

[retry-upload.webm](https://github.com/nextcloud/spreed/assets/93392545/cc9fe7a8-e775-49f5-8acb-6d4f7b6312db)


> [!TIP]
> Add `if (Math.random() < 0.5) throw new Error()` to `performUpload` function to fail some uploads

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] ⛑️ Tests are included or not possible