### PR TITLE
fix(activeSession): minor fixes

### DIFF
--- a/src/composables/useActiveSession.js
+++ b/src/composables/useActiveSession.js
@@ -24,6 +24,7 @@ import { showInfo } from '@nextcloud/dialogs'
 
 import { SESSION } from '../constants.js'
 import { setSessionState } from '../services/participantsService.js'
+import { useIsInCall } from './useIsInCall.js'
 import { useStore } from './useStore.js'
 
 const supportSessionState = getCapabilities()?.spreed?.features?.includes('session-state')
@@ -42,6 +43,7 @@ export function useActiveSession() {
 	}
 
 	const store = useStore()
+	const isInCall = useIsInCall()
 	const token = computed(() => store.getters.getToken())
 	const windowIsVisible = computed(() => store.getters.windowIsVisible())
 
@@ -94,6 +96,9 @@ export function useActiveSession() {
 			|| !token.value) {
 			return
 		}
+		if (isInCall.value) {
+			return
+		}
 		clearTimeout(inactiveTimer.value)
 		inactiveTimer.value = null
 		currentState.value = SESSION.STATE.INACTIVE
@@ -111,13 +116,13 @@ export function useActiveSession() {
 	}
 
 	const handleWindowFocus = ({ type }) => {
+		clearTimeout(inactiveTimer.value)
 		if (type === 'focus') {
 			setSessionAsActive()
 
 			document.removeEventListener('mouseenter', handleMouseMove)
 			document.removeEventListener('mouseleave', handleMouseMove)
 		} else if (type === 'blur') {
-			clearTimeout(inactiveTimer.value)
 			inactiveTimer.value = setTimeout(() => {
 				setSessionAsInactive()
 			}, INACTIVE_TIME_MS)


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10887
* always reset timer on window focus change
* do not set inactive state when in call


## 🖌️ UI Checklist

### 🚧 Tasks

- [ ] To test:
  - [ ] 0. Set INACTIVE_TIME_MS to a lesser value (or wait 3 minutes)
  - [ ] 1. Join call
  - [ ] 1. Unfocus window (switch to another, or start screenshare)
  - [ ] 1. Wait for interval - session should be still active 
  - [ ] 2. Unfocus window
  - [ ] 2. Focus back (within interval, so session still active)
  - [ ] 2. Wait for interval - session should be still active 

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible