### PR TITLE
fix(shares): handle silent sending and input paste correctly

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -679,7 +679,7 @@ export default {
 		 */
 		async handleFiles(files, rename = false, isVoiceMessage = false) {
 			// Create a unique id for the upload operation
-			const uploadId = new Date().getTime()
+			const uploadId = this.$store.getters.currentUploadId ?? new Date().getTime()
 			// Uploads and shares the files
 			await this.$store.dispatch('initialiseUpload', { files, token: this.token, uploadId, rename, isVoiceMessage })
 		},

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -113,11 +113,11 @@
 
 			<!-- Send buttons -->
 			<template v-else>
-				<NcActions v-if="!broadcast && !upload"
+				<NcActions v-if="!broadcast"
 					:container="container"
-					:force-menu="true">
+					force-menu>
 					<!-- Silent send -->
-					<NcActionButton :close-after-click="true"
+					<NcActionButton close-after-click
 						icon="icon-upload"
 						:name="t('spreed', 'Send without notification')"
 						@click="handleSubmit({ silent: true })">
@@ -512,7 +512,7 @@ export default {
 
 				if (this.$store.getters.getInitialisedUploads(this.$store.getters.currentUploadId).length) {
 					// If dialog contains files to upload, delegate sending
-					this.$emit('upload', this.text)
+					this.$emit('upload', { caption: this.text, options })
 					return
 				} else {
 					// Dismiss dialog, process as normal message sending otherwise

--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -205,8 +205,8 @@ export default {
 			this.$store.dispatch('discardUpload', this.currentUploadId)
 		},
 
-		handleUpload(caption) {
-			this.$store.dispatch('uploadFiles', { uploadId: this.currentUploadId, caption })
+		handleUpload({ caption, options }) {
+			this.$store.dispatch('uploadFiles', { uploadId: this.currentUploadId, caption, options })
 		},
 		/**
 		 * Clicks the hidden file input when clicking the correspondent NcActionButton,

--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -285,8 +285,9 @@ const actions = {
 	 * @param {object} data the wrapping object
 	 * @param {string} data.uploadId The unique uploadId
 	 * @param {string} [data.caption] The text caption to the media
+	 * @param {object} data.options The share options
 	 */
-	async uploadFiles({ commit, dispatch, state, getters }, { uploadId, caption }) {
+	async uploadFiles({ commit, dispatch, state, getters }, { uploadId, caption, options }) {
 		if (state.currentUploadId === uploadId) {
 			commit('setCurrentUploadId', undefined)
 		}
@@ -366,9 +367,16 @@ const actions = {
 		const performShare = async ([index, shareableFile]) => {
 			const path = shareableFile.sharePath
 			const temporaryMessage = shareableFile.temporaryMessage
-			const metadata = (caption && index === lastIndex)
-				? JSON.stringify({ messageType: temporaryMessage.messageType, caption })
-				: JSON.stringify({ messageType: temporaryMessage.messageType })
+
+			const rawMetadata = { messageType: temporaryMessage.messageType }
+			if (caption && index === lastIndex) {
+				Object.assign(rawMetadata, { caption })
+			}
+			if (options?.silent) {
+				Object.assign(rawMetadata, { silent: options.silent })
+			}
+			const metadata = JSON.stringify(rawMetadata)
+
 			try {
 				const token = temporaryMessage.token
 				dispatch('markFileAsSharing', { uploadId, index })

--- a/src/store/fileUploadStore.spec.js
+++ b/src/store/fileUploadStore.spec.js
@@ -138,7 +138,7 @@ describe('fileUploadStore', () => {
 			}
 		})
 
-		test('performs upload and sharing of single file', async () => {
+		test('performs silent upload and sharing of single file with caption', async () => {
 			const file = {
 				name: 'pngimage.png',
 				type: 'image/png',
@@ -159,7 +159,7 @@ describe('fileUploadStore', () => {
 			findUniquePath.mockResolvedValueOnce({ uniquePath: uniqueFileName, suffix: 1 })
 			shareFile.mockResolvedValue()
 
-			await store.dispatch('uploadFiles', { uploadId: 'upload-id1', caption: 'text-caption' })
+			await store.dispatch('uploadFiles', { uploadId: 'upload-id1', caption: 'text-caption', options: { silent: true } })
 
 			expect(findUniquePath).toHaveBeenCalledTimes(1)
 			expect(findUniquePath).toHaveBeenCalledWith(client, '/files/current-user', '/Talk/' + file.name, undefined)
@@ -168,13 +168,13 @@ describe('fileUploadStore', () => {
 			expect(client.putFileContents).toHaveBeenCalledWith(`/files/current-user${uniqueFileName}`, fileBuffer, expect.anything())
 
 			expect(shareFile).toHaveBeenCalledTimes(1)
-			expect(shareFile).toHaveBeenCalledWith(`/${uniqueFileName}`, 'XXTOKENXX', 'reference-id-1', '{"caption":"text-caption"}')
+			expect(shareFile).toHaveBeenCalledWith(`/${uniqueFileName}`, 'XXTOKENXX', 'reference-id-1', '{"caption":"text-caption","silent":true}')
 
 			expect(mockedActions.addTemporaryMessage).toHaveBeenCalledTimes(1)
 			expect(store.getters.currentUploadId).not.toBeDefined()
 		})
 
-		test('performs upload and sharing of multiple files', async () => {
+		test('performs upload and sharing of multiple files with caption', async () => {
 			const file1 = {
 				name: 'pngimage.png',
 				type: 'image/png',
@@ -208,7 +208,7 @@ describe('fileUploadStore', () => {
 				.mockResolvedValueOnce({ data: { ocs: { data: { id: '1' } } } })
 				.mockResolvedValueOnce({ data: { ocs: { data: { id: '2' } } } })
 
-			await store.dispatch('uploadFiles', { uploadId: 'upload-id1', caption: 'text-caption' })
+			await store.dispatch('uploadFiles', { uploadId: 'upload-id1', caption: 'text-caption', options: { silent: false } })
 
 			expect(findUniquePath).toHaveBeenCalledTimes(2)
 			expect(client.putFileContents).toHaveBeenCalledTimes(2)
@@ -251,7 +251,7 @@ describe('fileUploadStore', () => {
 				},
 			})
 
-			await store.dispatch('uploadFiles', { uploadId: 'upload-id1' })
+			await store.dispatch('uploadFiles', { uploadId: 'upload-id1', options: { silent: false } })
 
 			expect(client.putFileContents).toHaveBeenCalledTimes(1)
 			expect(shareFile).not.toHaveBeenCalled()
@@ -288,7 +288,7 @@ describe('fileUploadStore', () => {
 				},
 			})
 
-			await store.dispatch('uploadFiles', { uploadId: 'upload-id1' })
+			await store.dispatch('uploadFiles', { uploadId: 'upload-id1', options: { silent: false } })
 
 			expect(client.putFileContents).toHaveBeenCalledTimes(1)
 			expect(shareFile).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11117 
  * Button for silent send is brought back to upload dialog
  * Following API, silent flag is passed with share metadata
* Fix #11118 
  * Same as for drag-n-drop in dialog, if current upload is existing, we reuse it


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts


### 🚧 Tasks

- [x] To test 11117:
  - [x] as user 2, enable notification in conversation for "All messages"
- [x] To test 11118:
  - [x] Ctrl+C, Ctrl+V

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] ⛑️ Tests are included or not possible