### PR TITLE
fix(session): track mouse movement activity

### DIFF
--- a/src/composables/useActiveSession.js
+++ b/src/composables/useActiveSession.js
@@ -120,23 +120,27 @@ export function useActiveSession() {
 		if (type === 'focus') {
 			setSessionAsActive()
 
-			document.removeEventListener('mouseenter', handleMouseMove)
-			document.removeEventListener('mouseleave', handleMouseMove)
+			document.body.removeEventListener('mouseenter', handleMouseEnter)
+			document.body.removeEventListener('mouseleave', handleMouseLeave)
 		} else if (type === 'blur') {
 			inactiveTimer.value = setTimeout(() => {
 				setSessionAsInactive()
 			}, INACTIVE_TIME_MS)
 
 			// Listen for mouse events to track activity on tab
-			document.addEventListener('mouseenter', handleMouseMove)
-			document.addEventListener('mouseleave', handleMouseMove)
+			document.body.addEventListener('mouseenter', handleMouseEnter)
+			document.body.addEventListener('mouseleave', handleMouseLeave)
 		}
 	}
 
-	const handleMouseMove = (event) => {
+	const handleMouseEnter = (event) => {
 		setSessionAsActive()
-		// Restart timer, if mouse moves around the tab
 		clearTimeout(inactiveTimer.value)
+		inactiveTimer.value = null
+	}
+
+	const handleMouseLeave = (event) => {
+		// Restart timer, if mouse leaves the tab
 		inactiveTimer.value = setTimeout(() => {
 			setSessionAsInactive()
 		}, INACTIVE_TIME_MS)


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11126 
  * `document` => `document.body` fixes behavior on Firefox with event registration
  * `mouseenter` now mark session as active, `mouseleave` restarts a timer
    * moving the mouse and scrolling within tab borders should be covered, as mouse entered the tab by that moment

## 🖌️ UI Checklist


### 🚧 Tasks

- [ ] To test:
  - [ ] Set INACTIVE_TIME_MS to a lesser value (or wait 3 minutes)
  - [ ] Unfocus window (switch to another, or start screenshare)
  - [ ] Enter mouse cursor onto tab and leave like this
  - [ ] Wait for interval - session should be still active 
  - [ ] Move cursor away from tab
  - [ ] Wait for interval - session should be marked as inactive  

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible