### PR TITLE
Fix(File share authentication): Remove unnecessary options

### DIFF
--- a/src/PublicShareAuthRequestPasswordButton.vue
+++ b/src/PublicShareAuthRequestPasswordButton.vue
@@ -19,7 +19,7 @@
   -->
 
 <template>
-	<div>
+	<Fragment>
 		<!-- "submit-wrapper" is used to mimic the login button and thus get
 			automatic colouring of the confirm icon by the Theming app. -->
 		<div id="submit-wrapper" class="request-password-wrapper">
@@ -35,10 +35,11 @@
 		<p v-if="hasRequestFailed" class="warning error-message">
 			{{ t('spreed', 'Error requesting the password.') }}
 		</p>
-	</div>
+	</Fragment>
 </template>
 
 <script>
+import { Fragment } from 'vue-frag'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 
 import { getPublicShareAuthConversationToken } from './services/publicShareAuthService.js'
@@ -50,6 +51,7 @@ export default {
 
 	components: {
 		NcButton,
+		Fragment,
 	},
 
 	props: {

--- a/src/PublicShareAuthSidebar.vue
+++ b/src/PublicShareAuthSidebar.vue
@@ -172,7 +172,7 @@ export default {
 				// has been set, which is done once the conversation has been
 				// fetched. MediaSettings are called to set up audio and video devices
 				// and also to give a consent to recording, if set up
-				emit('talk:media-settings:show')
+				emit('talk:media-settings:show', 'video-verification')
 			}
 		},
 
@@ -206,7 +206,7 @@ export default {
 			// Guest needs to add their display name right after joining conversation,
 			// before fetching and showing media settings. Then, this latter will be triggered
 			// by the guest name addition event.
-			emit('talk:media-settings:show')
+			emit('talk:media-settings:show', 'video-verification')
 			unsubscribe('talk:guest-name:added', this.showGuestMediaSettings)
 		}
 	},

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -120,7 +120,8 @@
 				@update-background="handleUpdateVirtualBackground" />
 
 			<!-- "Always show" setting -->
-			<NcCheckboxRadioSwitch class="checkbox"
+			<NcCheckboxRadioSwitch v-if="!isPublicShareAuthSidebar"
+				class="checkbox"
 				:checked="showMediaSettings || showRecordingWarning"
 				:disabled="showRecordingWarning"
 				@update:checked="setShowMediaSettings">
@@ -296,6 +297,7 @@ export default {
 			audioDeviceStateChanged: false,
 			videoDeviceStateChanged: false,
 			isRecordingFromStart: false,
+			isPublicShareAuthSidebar: false,
 		}
 	},
 
@@ -381,7 +383,7 @@ export default {
 		},
 
 		showSilentCallOption() {
-			return !(this.hasCall && !this.isInLobby)
+			return !(this.hasCall && !this.isInLobby) && !this.isPublicShareAuthSidebar
 		},
 
 		showDeviceSelection() {
@@ -453,8 +455,11 @@ export default {
 	},
 
 	methods: {
-		showModal() {
+		showModal(page) {
 			this.modal = true
+			if (page === 'video-verification') {
+				this.isPublicShareAuthSidebar = true
+			}
 		},
 
 		closeModal() {
@@ -463,6 +468,7 @@ export default {
 			this.deviceIdChanged = false
 			this.audioDeviceStateChanged = false
 			this.videoDeviceStateChanged = false
+			this.isPublicShareAuthSidebar = false
 		},
 
 		toggleAudio() {
@@ -497,7 +503,6 @@ export default {
 			if (this.videoDeviceStateChanged) {
 				emit('local-video-control-button:toggle-video')
 			}
-
 			this.closeModal()
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fixes partially #10759

What's changed ? 
- Media Settings doesn't include _"always show preview for this conversation"_ as the password request generates a new room each time.
- "silent call" option is hidden as it is important to ping the share owner about the request call.
- Removed an extra div in the button component of requesting password


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
|![image](https://github.com/nextcloud/spreed/assets/84044328/1a671721-446d-41b3-a9b9-87e604ddddaa) | ![image](https://github.com/nextcloud/spreed/assets/84044328/3b8f9ca1-861d-4fd9-8af5-63499162a354)   |

### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
