### PR TITLE
[stable27] chore(deps): audit dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,12 +122,13 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
-			"integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.18.6"
+				"@babel/highlight": "^7.23.4",
+				"chalk": "^2.4.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -211,12 +212,12 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.5.tgz",
-			"integrity": "sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
+			"integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.21.5",
+				"@babel/types": "^7.23.5",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -358,9 +359,9 @@
 			}
 		},
 		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.21.5.tgz",
-			"integrity": "sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -379,25 +380,25 @@
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
-			"integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/template": "^7.20.7",
-				"@babel/types": "^7.21.0"
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -527,30 +528,30 @@
 			}
 		},
 		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz",
-			"integrity": "sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+			"integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.19.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -595,13 +596,13 @@
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.18.6",
-				"chalk": "^2.0.0",
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0"
 			},
 			"engines": {
@@ -609,9 +610,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.21.8",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.8.tgz",
-			"integrity": "sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
+			"integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -1761,33 +1762,33 @@
 			"integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
 		},
 		"node_modules/@babel/template": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
-			"integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/code-frame": "^7.22.13",
+				"@babel/parser": "^7.22.15",
+				"@babel/types": "^7.22.15"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.5.tgz",
-			"integrity": "sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.5.tgz",
+			"integrity": "sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.21.4",
-				"@babel/generator": "^7.21.5",
-				"@babel/helper-environment-visitor": "^7.21.5",
-				"@babel/helper-function-name": "^7.21.0",
-				"@babel/helper-hoist-variables": "^7.18.6",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.21.5",
-				"@babel/types": "^7.21.5",
+				"@babel/code-frame": "^7.23.5",
+				"@babel/generator": "^7.23.5",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.23.5",
+				"@babel/types": "^7.23.5",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -1796,13 +1797,13 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.5.tgz",
-			"integrity": "sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
+			"integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.21.5",
-				"@babel/helper-validator-identifier": "^7.19.1",
+				"@babel/helper-string-parser": "^7.23.4",
+				"@babel/helper-validator-identifier": "^7.22.20",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
@@ -5064,9 +5065,9 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-			"integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+			"integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
 			"dependencies": {
 				"follow-redirects": "^1.15.0",
 				"form-data": "^4.0.0",
@@ -5557,19 +5558,22 @@
 			}
 		},
 		"node_modules/browserify-sign": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
-			"integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.2.tgz",
+			"integrity": "sha512-1rudGyeYY42Dk6texmv7c4VcQ0EsvVbLwZkA+AQB7SxvXxmcD93jcHie8bzecJ+ChDlmAm2Qyu0+Ccg5uhZXCg==",
 			"dependencies": {
-				"bn.js": "^5.1.1",
-				"browserify-rsa": "^4.0.1",
+				"bn.js": "^5.2.1",
+				"browserify-rsa": "^4.1.0",
 				"create-hash": "^1.2.0",
 				"create-hmac": "^1.1.7",
-				"elliptic": "^6.5.3",
+				"elliptic": "^6.5.4",
 				"inherits": "^2.0.4",
-				"parse-asn1": "^5.1.5",
-				"readable-stream": "^3.6.0",
-				"safe-buffer": "^5.2.0"
+				"parse-asn1": "^5.1.6",
+				"readable-stream": "^3.6.2",
+				"safe-buffer": "^5.2.1"
+			},
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/browserify-sign/node_modules/safe-buffer": {
@@ -6419,9 +6423,9 @@
 			}
 		},
 		"node_modules/crypto-js": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+			"integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
 		},
 		"node_modules/css-functions-list": {
 			"version": "3.1.0",
@@ -13299,9 +13303,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-			"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
 			"funding": [
 				{
 					"type": "github",
@@ -14042,9 +14046,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.26",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.26.tgz",
-			"integrity": "sha512-jrXHFF8iTloAenySjM/ob3gSj7pCu0Ji49hnjqzsgSRa50hkWCKD0HQ+gMNJkW38jBI68MpAAg7ZWwHwX8NMMw==",
+			"version": "8.4.32",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+			"integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -14060,7 +14064,7 @@
 				}
 			],
 			"dependencies": {
-				"nanoid": "^3.3.6",
+				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			},
@@ -14617,9 +14621,9 @@
 			}
 		},
 		"node_modules/readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -17265,9 +17269,9 @@
 			"peer": true
 		},
 		"node_modules/vue-loader": {
-			"version": "15.10.1",
-			"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.10.1.tgz",
-			"integrity": "sha512-SaPHK1A01VrNthlix6h1hq4uJu7S/z0kdLUb6klubo738NeQoLbS6V9/d8Pv19tU0XdQKju3D1HSKuI8wJ5wMA==",
+			"version": "15.11.1",
+			"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.11.1.tgz",
+			"integrity": "sha512-0iw4VchYLePqJfJu9s62ACWUXeSqM30SQqlIftbYWM3C+jpPcEHKSPUZBLjSF9au4HTHQ/naF6OGnO3Q/qGR3Q==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -17283,6 +17287,9 @@
 			},
 			"peerDependenciesMeta": {
 				"cache-loader": {
+					"optional": true
+				},
+				"prettier": {
 					"optional": true
 				},
 				"vue-template-compiler": {
@@ -18008,9 +18015,9 @@
 			"integrity": "sha512-UMmSUoIQSir+XbBpTxOTS53uJ8s/lVhADCkEbhfRjUGFDPme/XGOb0sBWLx5sTz7Wx/2+TlAw1eK9O5lw5PiEw=="
 		},
 		"node_modules/word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -18279,12 +18286,13 @@
 			}
 		},
 		"@babel/code-frame": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
-			"integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.18.6"
+				"@babel/highlight": "^7.23.4",
+				"chalk": "^2.4.2"
 			}
 		},
 		"@babel/compat-data": {
@@ -18346,12 +18354,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.5.tgz",
-			"integrity": "sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
+			"integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.21.5",
+				"@babel/types": "^7.23.5",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -18461,9 +18469,9 @@
 			}
 		},
 		"@babel/helper-environment-visitor": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.21.5.tgz",
-			"integrity": "sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
 			"dev": true
 		},
 		"@babel/helper-explode-assignable-expression": {
@@ -18476,22 +18484,22 @@
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
-			"integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.20.7",
-				"@babel/types": "^7.21.0"
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -18588,24 +18596,24 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/helper-string-parser": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz",
-			"integrity": "sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+			"integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
 			"dev": true
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.19.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
 			"dev": true
 		},
 		"@babel/helper-validator-option": {
@@ -18638,20 +18646,20 @@
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.18.6",
-				"chalk": "^2.0.0",
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.21.8",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.8.tgz",
-			"integrity": "sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA=="
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
+			"integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ=="
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
 			"version": "7.18.6",
@@ -19445,42 +19453,42 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
-			"integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/code-frame": "^7.22.13",
+				"@babel/parser": "^7.22.15",
+				"@babel/types": "^7.22.15"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.5.tgz",
-			"integrity": "sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.5.tgz",
+			"integrity": "sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.21.4",
-				"@babel/generator": "^7.21.5",
-				"@babel/helper-environment-visitor": "^7.21.5",
-				"@babel/helper-function-name": "^7.21.0",
-				"@babel/helper-hoist-variables": "^7.18.6",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.21.5",
-				"@babel/types": "^7.21.5",
+				"@babel/code-frame": "^7.23.5",
+				"@babel/generator": "^7.23.5",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.23.5",
+				"@babel/types": "^7.23.5",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/types": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.5.tgz",
-			"integrity": "sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
+			"integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-string-parser": "^7.21.5",
-				"@babel/helper-validator-identifier": "^7.19.1",
+				"@babel/helper-string-parser": "^7.23.4",
+				"@babel/helper-validator-identifier": "^7.22.20",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -21981,9 +21989,9 @@
 			"integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA=="
 		},
 		"axios": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-			"integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+			"integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
 			"requires": {
 				"follow-redirects": "^1.15.0",
 				"form-data": "^4.0.0",
@@ -22386,19 +22394,19 @@
 			}
 		},
 		"browserify-sign": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
-			"integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.2.tgz",
+			"integrity": "sha512-1rudGyeYY42Dk6texmv7c4VcQ0EsvVbLwZkA+AQB7SxvXxmcD93jcHie8bzecJ+ChDlmAm2Qyu0+Ccg5uhZXCg==",
 			"requires": {
-				"bn.js": "^5.1.1",
-				"browserify-rsa": "^4.0.1",
+				"bn.js": "^5.2.1",
+				"browserify-rsa": "^4.1.0",
 				"create-hash": "^1.2.0",
 				"create-hmac": "^1.1.7",
-				"elliptic": "^6.5.3",
+				"elliptic": "^6.5.4",
 				"inherits": "^2.0.4",
-				"parse-asn1": "^5.1.5",
-				"readable-stream": "^3.6.0",
-				"safe-buffer": "^5.2.0"
+				"parse-asn1": "^5.1.6",
+				"readable-stream": "^3.6.2",
+				"safe-buffer": "^5.2.1"
 			},
 			"dependencies": {
 				"safe-buffer": {
@@ -23049,9 +23057,9 @@
 			}
 		},
 		"crypto-js": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+			"integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
 		},
 		"css-functions-list": {
 			"version": "3.1.0",
@@ -28144,9 +28152,9 @@
 			}
 		},
 		"nanoid": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-			"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -28675,11 +28683,11 @@
 			}
 		},
 		"postcss": {
-			"version": "8.4.26",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.26.tgz",
-			"integrity": "sha512-jrXHFF8iTloAenySjM/ob3gSj7pCu0Ji49hnjqzsgSRa50hkWCKD0HQ+gMNJkW38jBI68MpAAg7ZWwHwX8NMMw==",
+			"version": "8.4.32",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+			"integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
 			"requires": {
-				"nanoid": "^3.3.6",
+				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			}
@@ -29076,9 +29084,9 @@
 			}
 		},
 		"readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
 			"requires": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -31087,9 +31095,9 @@
 			"peer": true
 		},
 		"vue-loader": {
-			"version": "15.10.1",
-			"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.10.1.tgz",
-			"integrity": "sha512-SaPHK1A01VrNthlix6h1hq4uJu7S/z0kdLUb6klubo738NeQoLbS6V9/d8Pv19tU0XdQKju3D1HSKuI8wJ5wMA==",
+			"version": "15.11.1",
+			"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.11.1.tgz",
+			"integrity": "sha512-0iw4VchYLePqJfJu9s62ACWUXeSqM30SQqlIftbYWM3C+jpPcEHKSPUZBLjSF9au4HTHQ/naF6OGnO3Q/qGR3Q==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -31653,9 +31661,9 @@
 			"integrity": "sha512-UMmSUoIQSir+XbBpTxOTS53uJ8s/lVhADCkEbhfRjUGFDPme/XGOb0sBWLx5sTz7Wx/2+TlAw1eK9O5lw5PiEw=="
 		},
 		"word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true
 		},
 		"worker-factory": {


### PR DESCRIPTION
### ☑️ Resolves

🏚️ Before
```yaml
# npm audit report

@babel/traverse  <7.23.2
Severity: critical
Babel vulnerable to arbitrary code execution when compiling specifically crafted malicious code - https://github.com/advisories/GHSA-67hx-6x53-jw92
fix available via `npm audit fix`
node_modules/@babel/traverse

axios  0.8.1 - 1.5.1
Severity: moderate
Axios Cross-Site Request Forgery Vulnerability - https://github.com/advisories/GHSA-wf5p-g6vw-rhxx
fix available via `npm audit fix`
node_modules/axios

browserify-sign  2.6.0 - 4.2.1
Severity: high
browserify-sign upper bound check issue in `dsaVerify` leads to a signature forgery attack - https://github.com/advisories/GHSA-x9w5-v3q2-3rhw
fix available via `npm audit fix`
node_modules/browserify-sign

crypto-js  <4.2.0
Severity: critical
crypto-js PBKDF2 1,000 times weaker than specified in 1993 and 1.3M times weaker than current standard - https://github.com/advisories/GHSA-xwcq-pm8m-c4vf
fix available via `npm audit fix`
node_modules/crypto-js

word-wrap  <1.2.4
Severity: moderate
word-wrap vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-j8xg-fqg3-53r7
fix available via `npm audit fix`
node_modules/word-wrap

10 vulnerabilities (7 moderate, 1 high, 2 critical)
```

🏡 After
```yaml
# npm audit report

postcss  <8.4.31
Severity: moderate
PostCSS line return parsing error - https://github.com/advisories/GHSA-7fh5-64p2-3v2j
No fix available
node_modules/@vue/component-compiler-utils/node_modules/postcss
  @vue/component-compiler-utils  *
  Depends on vulnerable versions of postcss
  node_modules/@vue/component-compiler-utils
    @vue/vue2-jest  *
    Depends on vulnerable versions of @vue/component-compiler-utils
    node_modules/@vue/vue2-jest
    vue-loader  15.0.0-beta.1 - 15.11.1
    Depends on vulnerable versions of @vue/component-compiler-utils
    node_modules/vue-loader
      @nextcloud/webpack-vue-config  *
      Depends on vulnerable versions of vue-loader
      node_modules/@nextcloud/webpack-vue-config

5 moderate severity vulnerabilities
```

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences