### PR TITLE
fix(shares): reserve space for file preview while it's loading

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -308,6 +308,9 @@ export default {
 		},
 
 		fallbackLocalUrl() {
+			if (!this.mimetype.startsWith('image/') && !this.mimetype.startsWith('video/')) {
+				return undefined
+			}
 			return this.$store.getters.getLocalUrl(this.referenceId)
 		},
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -584,10 +584,7 @@ export default {
 .file-preview {
 	position: relative;
 	min-width: 0;
-	width: 100%;
-	/* The file preview can not be a block; otherwise it would fill the whole
-	width of the container and the loading icon would not be centered on the
-	image. */
+	max-width: 100%;
 	display: inline-block;
 
 	border-radius: 16px;
@@ -615,7 +612,7 @@ export default {
 
 	.loading {
 		display: inline-block;
-		width: 100%;
+		min-width: 32px;
 		background-color: var(--color-background-dark);
 	}
 
@@ -650,7 +647,8 @@ export default {
 	}
 
 	.image-container {
-		display: flex;
+		position: relative;
+		display: inline-flex;
 		height: 100%;
 
 		&.playable {


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up for web for #11093
* Fix #11041 

:warning: Metadata requires "Photos" app to be enabled

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts


| 🏚️ Before | 🏡 After |
|------------|----------|
| Uploaded non-media files preview (text, audio) | - |
| ![image](https://github.com/nextcloud/spreed/assets/93392545/fa2836e2-6c7f-44a7-bed4-3dfda899c4a5)          | ![image](https://github.com/nextcloud/spreed/assets/93392545/3c562662-7f45-44fc-b3db-f5a30badd85c)        |
| Jump after preview loaded | - |
| ![image](https://github.com/nextcloud/spreed/assets/93392545/753b509b-5188-4339-877c-f6c270b5fe35) | ![image](https://github.com/nextcloud/spreed/assets/93392545/4e074b75-565a-4432-8ed2-c85b3f616aff) |
| Double hover on message | - |
| ![image](https://github.com/nextcloud/spreed/assets/93392545/8f4928a3-7521-4d7e-ba22-481fb2ef77cb) | ![image](https://github.com/nextcloud/spreed/assets/93392545/0f7f2bd9-225e-49a2-862d-8c3e52831edd) |

#### Using preview metadata

🏚️ Before 

https://github.com/nextcloud/spreed/assets/93392545/0306c018-77f9-41d8-b772-fc4ca127d9dd

🏡 After
Metadata is used as soon as component is mounted. Chat is still jumping sometimes, but feels better anyway

https://github.com/nextcloud/spreed/assets/93392545/0ca46203-ee1f-4d91-88a2-9f698905c5ed


### 🚧 Tasks

- [ ] Test different files / cases

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible