### PR TITLE
fix(openapi): Bump openapi-extractor for improved API results

### DIFF
--- a/lib/Controller/BreakoutRoomController.php
+++ b/lib/Controller/BreakoutRoomController.php
@@ -62,7 +62,7 @@ class BreakoutRoomController extends AEnvironmentAwareController {
 	 * @param 0|1|2|3 $mode Mode of the breakout rooms
 	 * @psalm-param BreakoutRoom::MODE_* $mode
 	 * @param 1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20 $amount Number of breakout rooms
-	 * @psalm-param int<1, 20> $amount Constants {@see BreakoutRoom::MINIMUM_ROOM_AMOUNT} and {@see BreakoutRoom::MAXIMUM_ROOM_AMOUNT}
+	 * @psalm-param int<1, 20> $amount Number of breakout rooms - Constants {@see BreakoutRoom::MINIMUM_ROOM_AMOUNT} and {@see BreakoutRoom::MAXIMUM_ROOM_AMOUNT}
 	 * @param string $attendeeMap Mapping of the attendees to breakout rooms
 	 * @return DataResponse<Http::STATUS_OK, TalkRoom[], array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
 	 *

--- a/openapi.json
+++ b/openapi.json
@@ -2768,17 +2768,25 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3
+                            ]
                         }
                     },
                     {
                         "name": "amount",
                         "in": "query",
-                        "description": "Number of breakout rooms",
+                        "description": "Number of breakout rooms - Constants {@see BreakoutRoom::MINIMUM_ROOM_AMOUNT} and {@see BreakoutRoom::MAXIMUM_ROOM_AMOUNT}",
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 1,
+                            "maximum": 20
                         }
                     },
                     {
@@ -3997,8 +4005,25 @@
                         "description": "In-Call flags",
                         "schema": {
                             "type": "integer",
-                            "format": "int64",
-                            "nullable": true
+                            "nullable": true,
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10,
+                                11,
+                                12,
+                                13,
+                                14,
+                                15
+                            ]
                         }
                     },
                     {
@@ -4007,8 +4032,265 @@
                         "description": "In-call permissions",
                         "schema": {
                             "type": "integer",
-                            "format": "int64",
-                            "nullable": true
+                            "nullable": true,
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10,
+                                11,
+                                12,
+                                13,
+                                14,
+                                15,
+                                16,
+                                17,
+                                18,
+                                19,
+                                20,
+                                21,
+                                22,
+                                23,
+                                24,
+                                25,
+                                26,
+                                27,
+                                28,
+                                29,
+                                30,
+                                31,
+                                32,
+                                33,
+                                34,
+                                35,
+                                36,
+                                37,
+                                38,
+                                39,
+                                40,
+                                41,
+                                42,
+                                43,
+                                44,
+                                45,
+                                46,
+                                47,
+                                48,
+                                49,
+                                50,
+                                51,
+                                52,
+                                53,
+                                54,
+                                55,
+                                56,
+                                57,
+                                58,
+                                59,
+                                60,
+                                61,
+                                62,
+                                63,
+                                64,
+                                65,
+                                66,
+                                67,
+                                68,
+                                69,
+                                70,
+                                71,
+                                72,
+                                73,
+                                74,
+                                75,
+                                76,
+                                77,
+                                78,
+                                79,
+                                80,
+                                81,
+                                82,
+                                83,
+                                84,
+                                85,
+                                86,
+                                87,
+                                88,
+                                89,
+                                90,
+                                91,
+                                92,
+                                93,
+                                94,
+                                95,
+                                96,
+                                97,
+                                98,
+                                99,
+                                100,
+                                101,
+                                102,
+                                103,
+                                104,
+                                105,
+                                106,
+                                107,
+                                108,
+                                109,
+                                110,
+                                111,
+                                112,
+                                113,
+                                114,
+                                115,
+                                116,
+                                117,
+                                118,
+                                119,
+                                120,
+                                121,
+                                122,
+                                123,
+                                124,
+                                125,
+                                126,
+                                127,
+                                128,
+                                129,
+                                130,
+                                131,
+                                132,
+                                133,
+                                134,
+                                135,
+                                136,
+                                137,
+                                138,
+                                139,
+                                140,
+                                141,
+                                142,
+                                143,
+                                144,
+                                145,
+                                146,
+                                147,
+                                148,
+                                149,
+                                150,
+                                151,
+                                152,
+                                153,
+                                154,
+                                155,
+                                156,
+                                157,
+                                158,
+                                159,
+                                160,
+                                161,
+                                162,
+                                163,
+                                164,
+                                165,
+                                166,
+                                167,
+                                168,
+                                169,
+                                170,
+                                171,
+                                172,
+                                173,
+                                174,
+                                175,
+                                176,
+                                177,
+                                178,
+                                179,
+                                180,
+                                181,
+                                182,
+                                183,
+                                184,
+                                185,
+                                186,
+                                187,
+                                188,
+                                189,
+                                190,
+                                191,
+                                192,
+                                193,
+                                194,
+                                195,
+                                196,
+                                197,
+                                198,
+                                199,
+                                200,
+                                201,
+                                202,
+                                203,
+                                204,
+                                205,
+                                206,
+                                207,
+                                208,
+                                209,
+                                210,
+                                211,
+                                212,
+                                213,
+                                214,
+                                215,
+                                216,
+                                217,
+                                218,
+                                219,
+                                220,
+                                221,
+                                222,
+                                223,
+                                224,
+                                225,
+                                226,
+                                227,
+                                228,
+                                229,
+                                230,
+                                231,
+                                232,
+                                233,
+                                234,
+                                235,
+                                236,
+                                237,
+                                238,
+                                239,
+                                240,
+                                241,
+                                242,
+                                243,
+                                244,
+                                245,
+                                246,
+                                247,
+                                248,
+                                249,
+                                250,
+                                251,
+                                252,
+                                253,
+                                254,
+                                255
+                            ]
                         }
                     },
                     {
@@ -4935,7 +5217,11 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -4955,7 +5241,8 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "default": 0
+                            "default": 0,
+                            "minimum": 0
                         }
                     },
                     {
@@ -4965,7 +5252,8 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "default": 0
+                            "default": 0,
+                            "minimum": 0
                         }
                     },
                     {
@@ -4975,7 +5263,9 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "default": 30
+                            "default": 30,
+                            "minimum": 0,
+                            "maximum": 30
                         }
                     },
                     {
@@ -4985,7 +5275,11 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "default": 1
+                            "default": 1,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -4995,7 +5289,11 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -5005,7 +5303,11 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -5015,7 +5317,11 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "default": 1
+                            "default": 1,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -5194,7 +5500,8 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "default": 0
+                            "default": 0,
+                            "minimum": 0
                         }
                     },
                     {
@@ -5560,7 +5867,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -5788,7 +6096,9 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "default": 50
+                            "default": 50,
+                            "minimum": 1,
+                            "maximum": 100
                         }
                     },
                     {
@@ -5819,7 +6129,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -5950,7 +6261,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -5981,7 +6293,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -6099,7 +6412,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -6217,7 +6531,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -6314,7 +6629,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -6839,7 +7155,8 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "default": 0
+                            "default": 0,
+                            "minimum": 0
                         }
                     },
                     {
@@ -6849,7 +7166,9 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "default": 100
+                            "default": 100,
+                            "minimum": 1,
+                            "maximum": 200
                         }
                     },
                     {
@@ -6952,7 +7271,9 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "default": 7
+                            "default": 7,
+                            "minimum": 1,
+                            "maximum": 20
                         }
                     },
                     {
@@ -8500,7 +8821,11 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -8652,7 +8977,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -8784,7 +9110,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -8931,7 +9258,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -9273,7 +9601,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -9471,7 +9800,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -9633,7 +9963,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -9751,7 +10082,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -10323,7 +10655,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -10451,7 +10784,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -10461,7 +10795,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -10589,7 +10924,11 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -10608,7 +10947,8 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "default": 0
+                            "default": 0,
+                            "minimum": 0
                         }
                     },
                     {
@@ -11949,7 +12289,11 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -12067,7 +12411,12 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "enum": [
+                                0,
+                                1,
+                                2
+                            ]
                         }
                     },
                     {
@@ -12339,7 +12688,265 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10,
+                                11,
+                                12,
+                                13,
+                                14,
+                                15,
+                                16,
+                                17,
+                                18,
+                                19,
+                                20,
+                                21,
+                                22,
+                                23,
+                                24,
+                                25,
+                                26,
+                                27,
+                                28,
+                                29,
+                                30,
+                                31,
+                                32,
+                                33,
+                                34,
+                                35,
+                                36,
+                                37,
+                                38,
+                                39,
+                                40,
+                                41,
+                                42,
+                                43,
+                                44,
+                                45,
+                                46,
+                                47,
+                                48,
+                                49,
+                                50,
+                                51,
+                                52,
+                                53,
+                                54,
+                                55,
+                                56,
+                                57,
+                                58,
+                                59,
+                                60,
+                                61,
+                                62,
+                                63,
+                                64,
+                                65,
+                                66,
+                                67,
+                                68,
+                                69,
+                                70,
+                                71,
+                                72,
+                                73,
+                                74,
+                                75,
+                                76,
+                                77,
+                                78,
+                                79,
+                                80,
+                                81,
+                                82,
+                                83,
+                                84,
+                                85,
+                                86,
+                                87,
+                                88,
+                                89,
+                                90,
+                                91,
+                                92,
+                                93,
+                                94,
+                                95,
+                                96,
+                                97,
+                                98,
+                                99,
+                                100,
+                                101,
+                                102,
+                                103,
+                                104,
+                                105,
+                                106,
+                                107,
+                                108,
+                                109,
+                                110,
+                                111,
+                                112,
+                                113,
+                                114,
+                                115,
+                                116,
+                                117,
+                                118,
+                                119,
+                                120,
+                                121,
+                                122,
+                                123,
+                                124,
+                                125,
+                                126,
+                                127,
+                                128,
+                                129,
+                                130,
+                                131,
+                                132,
+                                133,
+                                134,
+                                135,
+                                136,
+                                137,
+                                138,
+                                139,
+                                140,
+                                141,
+                                142,
+                                143,
+                                144,
+                                145,
+                                146,
+                                147,
+                                148,
+                                149,
+                                150,
+                                151,
+                                152,
+                                153,
+                                154,
+                                155,
+                                156,
+                                157,
+                                158,
+                                159,
+                                160,
+                                161,
+                                162,
+                                163,
+                                164,
+                                165,
+                                166,
+                                167,
+                                168,
+                                169,
+                                170,
+                                171,
+                                172,
+                                173,
+                                174,
+                                175,
+                                176,
+                                177,
+                                178,
+                                179,
+                                180,
+                                181,
+                                182,
+                                183,
+                                184,
+                                185,
+                                186,
+                                187,
+                                188,
+                                189,
+                                190,
+                                191,
+                                192,
+                                193,
+                                194,
+                                195,
+                                196,
+                                197,
+                                198,
+                                199,
+                                200,
+                                201,
+                                202,
+                                203,
+                                204,
+                                205,
+                                206,
+                                207,
+                                208,
+                                209,
+                                210,
+                                211,
+                                212,
+                                213,
+                                214,
+                                215,
+                                216,
+                                217,
+                                218,
+                                219,
+                                220,
+                                221,
+                                222,
+                                223,
+                                224,
+                                225,
+                                226,
+                                227,
+                                228,
+                                229,
+                                230,
+                                231,
+                                232,
+                                233,
+                                234,
+                                235,
+                                236,
+                                237,
+                                238,
+                                239,
+                                240,
+                                241,
+                                242,
+                                243,
+                                244,
+                                245,
+                                246,
+                                247,
+                                248,
+                                249,
+                                250,
+                                251,
+                                252,
+                                253,
+                                254,
+                                255
+                            ]
                         }
                     },
                     {
@@ -13122,7 +13729,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -13297,7 +13905,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -13321,7 +13930,265 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10,
+                                11,
+                                12,
+                                13,
+                                14,
+                                15,
+                                16,
+                                17,
+                                18,
+                                19,
+                                20,
+                                21,
+                                22,
+                                23,
+                                24,
+                                25,
+                                26,
+                                27,
+                                28,
+                                29,
+                                30,
+                                31,
+                                32,
+                                33,
+                                34,
+                                35,
+                                36,
+                                37,
+                                38,
+                                39,
+                                40,
+                                41,
+                                42,
+                                43,
+                                44,
+                                45,
+                                46,
+                                47,
+                                48,
+                                49,
+                                50,
+                                51,
+                                52,
+                                53,
+                                54,
+                                55,
+                                56,
+                                57,
+                                58,
+                                59,
+                                60,
+                                61,
+                                62,
+                                63,
+                                64,
+                                65,
+                                66,
+                                67,
+                                68,
+                                69,
+                                70,
+                                71,
+                                72,
+                                73,
+                                74,
+                                75,
+                                76,
+                                77,
+                                78,
+                                79,
+                                80,
+                                81,
+                                82,
+                                83,
+                                84,
+                                85,
+                                86,
+                                87,
+                                88,
+                                89,
+                                90,
+                                91,
+                                92,
+                                93,
+                                94,
+                                95,
+                                96,
+                                97,
+                                98,
+                                99,
+                                100,
+                                101,
+                                102,
+                                103,
+                                104,
+                                105,
+                                106,
+                                107,
+                                108,
+                                109,
+                                110,
+                                111,
+                                112,
+                                113,
+                                114,
+                                115,
+                                116,
+                                117,
+                                118,
+                                119,
+                                120,
+                                121,
+                                122,
+                                123,
+                                124,
+                                125,
+                                126,
+                                127,
+                                128,
+                                129,
+                                130,
+                                131,
+                                132,
+                                133,
+                                134,
+                                135,
+                                136,
+                                137,
+                                138,
+                                139,
+                                140,
+                                141,
+                                142,
+                                143,
+                                144,
+                                145,
+                                146,
+                                147,
+                                148,
+                                149,
+                                150,
+                                151,
+                                152,
+                                153,
+                                154,
+                                155,
+                                156,
+                                157,
+                                158,
+                                159,
+                                160,
+                                161,
+                                162,
+                                163,
+                                164,
+                                165,
+                                166,
+                                167,
+                                168,
+                                169,
+                                170,
+                                171,
+                                172,
+                                173,
+                                174,
+                                175,
+                                176,
+                                177,
+                                178,
+                                179,
+                                180,
+                                181,
+                                182,
+                                183,
+                                184,
+                                185,
+                                186,
+                                187,
+                                188,
+                                189,
+                                190,
+                                191,
+                                192,
+                                193,
+                                194,
+                                195,
+                                196,
+                                197,
+                                198,
+                                199,
+                                200,
+                                201,
+                                202,
+                                203,
+                                204,
+                                205,
+                                206,
+                                207,
+                                208,
+                                209,
+                                210,
+                                211,
+                                212,
+                                213,
+                                214,
+                                215,
+                                216,
+                                217,
+                                218,
+                                219,
+                                220,
+                                221,
+                                222,
+                                223,
+                                224,
+                                225,
+                                226,
+                                227,
+                                228,
+                                229,
+                                230,
+                                231,
+                                232,
+                                233,
+                                234,
+                                235,
+                                236,
+                                237,
+                                238,
+                                239,
+                                240,
+                                241,
+                                242,
+                                243,
+                                244,
+                                245,
+                                246,
+                                247,
+                                248,
+                                249,
+                                250,
+                                251,
+                                252,
+                                253,
+                                254,
+                                255
+                            ]
                         }
                     },
                     {
@@ -13510,7 +14377,265 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10,
+                                11,
+                                12,
+                                13,
+                                14,
+                                15,
+                                16,
+                                17,
+                                18,
+                                19,
+                                20,
+                                21,
+                                22,
+                                23,
+                                24,
+                                25,
+                                26,
+                                27,
+                                28,
+                                29,
+                                30,
+                                31,
+                                32,
+                                33,
+                                34,
+                                35,
+                                36,
+                                37,
+                                38,
+                                39,
+                                40,
+                                41,
+                                42,
+                                43,
+                                44,
+                                45,
+                                46,
+                                47,
+                                48,
+                                49,
+                                50,
+                                51,
+                                52,
+                                53,
+                                54,
+                                55,
+                                56,
+                                57,
+                                58,
+                                59,
+                                60,
+                                61,
+                                62,
+                                63,
+                                64,
+                                65,
+                                66,
+                                67,
+                                68,
+                                69,
+                                70,
+                                71,
+                                72,
+                                73,
+                                74,
+                                75,
+                                76,
+                                77,
+                                78,
+                                79,
+                                80,
+                                81,
+                                82,
+                                83,
+                                84,
+                                85,
+                                86,
+                                87,
+                                88,
+                                89,
+                                90,
+                                91,
+                                92,
+                                93,
+                                94,
+                                95,
+                                96,
+                                97,
+                                98,
+                                99,
+                                100,
+                                101,
+                                102,
+                                103,
+                                104,
+                                105,
+                                106,
+                                107,
+                                108,
+                                109,
+                                110,
+                                111,
+                                112,
+                                113,
+                                114,
+                                115,
+                                116,
+                                117,
+                                118,
+                                119,
+                                120,
+                                121,
+                                122,
+                                123,
+                                124,
+                                125,
+                                126,
+                                127,
+                                128,
+                                129,
+                                130,
+                                131,
+                                132,
+                                133,
+                                134,
+                                135,
+                                136,
+                                137,
+                                138,
+                                139,
+                                140,
+                                141,
+                                142,
+                                143,
+                                144,
+                                145,
+                                146,
+                                147,
+                                148,
+                                149,
+                                150,
+                                151,
+                                152,
+                                153,
+                                154,
+                                155,
+                                156,
+                                157,
+                                158,
+                                159,
+                                160,
+                                161,
+                                162,
+                                163,
+                                164,
+                                165,
+                                166,
+                                167,
+                                168,
+                                169,
+                                170,
+                                171,
+                                172,
+                                173,
+                                174,
+                                175,
+                                176,
+                                177,
+                                178,
+                                179,
+                                180,
+                                181,
+                                182,
+                                183,
+                                184,
+                                185,
+                                186,
+                                187,
+                                188,
+                                189,
+                                190,
+                                191,
+                                192,
+                                193,
+                                194,
+                                195,
+                                196,
+                                197,
+                                198,
+                                199,
+                                200,
+                                201,
+                                202,
+                                203,
+                                204,
+                                205,
+                                206,
+                                207,
+                                208,
+                                209,
+                                210,
+                                211,
+                                212,
+                                213,
+                                214,
+                                215,
+                                216,
+                                217,
+                                218,
+                                219,
+                                220,
+                                221,
+                                222,
+                                223,
+                                224,
+                                225,
+                                226,
+                                227,
+                                228,
+                                229,
+                                230,
+                                231,
+                                232,
+                                233,
+                                234,
+                                235,
+                                236,
+                                237,
+                                238,
+                                239,
+                                240,
+                                241,
+                                242,
+                                243,
+                                244,
+                                245,
+                                246,
+                                247,
+                                248,
+                                249,
+                                250,
+                                251,
+                                252,
+                                253,
+                                254,
+                                255
+                            ]
                         }
                     },
                     {
@@ -13916,7 +15041,8 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "nullable": true
+                            "nullable": true,
+                            "minimum": 0
                         }
                     },
                     {
@@ -14035,7 +15161,11 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -14184,7 +15314,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -14357,7 +15488,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -14935,7 +16067,8 @@
                         "schema": {
                             "type": "integer",
                             "format": "int64",
-                            "nullable": true
+                            "nullable": true,
+                            "minimum": 0
                         }
                     },
                     {
@@ -15055,7 +16188,12 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "enum": [
+                                0,
+                                1,
+                                2
+                            ]
                         }
                     },
                     {
@@ -15418,7 +16556,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {
@@ -15658,8 +16797,16 @@
                         "in": "query",
                         "description": "New value for the key",
                         "schema": {
-                            "type": "string",
-                            "nullable": true
+                            "nullable": true,
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer",
+                                    "format": "int64"
+                                }
+                            ]
                         }
                     },
                     {
@@ -15920,7 +17067,8 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "minimum": 0
                         }
                     },
                     {

--- a/vendor-bin/openapi-extractor/composer.lock
+++ b/vendor-bin/openapi-extractor/composer.lock
@@ -83,12 +83,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud/openapi-extractor.git",
-                "reference": "d99e9c0fbaa6502a704d53d4ca8b7566566ab4be"
+                "reference": "083417a8f5a8bee639d3bc075af5dcf22f820586"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud/openapi-extractor/zipball/d99e9c0fbaa6502a704d53d4ca8b7566566ab4be",
-                "reference": "d99e9c0fbaa6502a704d53d4ca8b7566566ab4be",
+                "url": "https://api.github.com/repos/nextcloud/openapi-extractor/zipball/083417a8f5a8bee639d3bc075af5dcf22f820586",
+                "reference": "083417a8f5a8bee639d3bc075af5dcf22f820586",
                 "shasum": ""
             },
             "require": {
@@ -113,7 +113,7 @@
                 "source": "https://github.com/nextcloud/openapi-extractor/tree/main",
                 "issues": "https://github.com/nextcloud/openapi-extractor/issues"
             },
-            "time": "2023-10-29T16:42:12+00:00"
+            "time": "2023-12-07T10:30:10+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
| Dev Changes                 | From    | To      | Compare                                                                         |
|-----------------------------|---------|---------|---------------------------------------------------------------------------------|
| nextcloud/openapi-extractor | d99e9c0 | 083417a | [...](https://github.com/nextcloud/openapi-extractor/compare/d99e9c0...083417a) |