### PR TITLE
fix(messages): apply ltr styles to system messages

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -1155,11 +1155,6 @@ export default {
 	:deep(.rich-text--wrapper) {
 		text-align: start;
 
-		// Hardcode to prevent RTL affecting on user mentions
-		.rich-text--component {
-			direction: ltr;
-		}
-
 		// Overwrite core styles, otherwise h4 is lesser than default font-size
 		h4 {
 			font-size: 100%;
@@ -1203,5 +1198,10 @@ export default {
 			border-inline-start: 4px solid var(--color-border);
 		}
 	}
+}
+
+// Hardcode to prevent RTL affecting on user mentions
+:deep(.rich-text--component) {
+	direction: ltr;
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #10687
* Originates from #11159
* User mention is forced LTR in system messages as well


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/11176039-f007-4be6-a5b9-d45ad559cafb)          | ![image](https://github.com/nextcloud/spreed/assets/93392545/753e951d-bebf-44f8-93ff-180f2a62c4cc)        |

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
