### PR TITLE
Fix(Quote): Don't trim the quote when it is not image share with caption

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -380,8 +380,8 @@ export default {
 			// Fallback for loading mimeicons (preview for audio files is not provided)
 			if (this.previewAvailable !== 'yes' || this.mimetype.startsWith('audio/')) {
 				return {
-					width: '128px',
-					height: '128px',
+					width: this.smallPreview ? '32px' : '128px',
+					height: this.smallPreview ? '32px' : '128px',
 				}
 			}
 

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -44,7 +44,6 @@ components.
 			<!-- file preview-->
 			<NcRichText v-if="isFileShareMessage"
 				text="{file}"
-				class="quote__file-preview"
 				:arguments="richParameters" />
 			<!-- text -->
 			<blockquote v-if="!isFileShareWithoutCaption"
@@ -189,6 +188,7 @@ export default {
 						props: Object.assign({
 							token: this.token,
 							smallPreview: true,
+							rowLayout: !this.messageParameters[p].mimetype.startsWith('image/'),
 						}, this.messageParameters[p]),
 					}
 				} else {
@@ -327,9 +327,6 @@ export default {
 		padding: 0 8px 0 8px;
 		position: relative;
 		margin: auto;
-	}
-	&__file-preview {
-		line-height: 0.5 !important;
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

- Regression from #11120 
-  Trimming is only applicable when it is an image with a caption

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/3a638e2c-392f-448f-bf7a-597c9e5a249c)  | ![image](https://github.com/nextcloud/spreed/assets/93392545/abb1111d-a1e2-4a29-a33a-4531eb97d59e)  |

### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
