### PR TITLE
Add backend url to connection error

### DIFF
--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -1005,6 +1005,10 @@ Signaling.Standalone.prototype.doSend = function(msg, callback) {
 	this.socket.send(JSON.stringify(msg))
 }
 
+Signaling.Standalone.prototype._getBackendUrl = function() {
+	return generateOcsUrl('apps/spreed/api/v3/signaling/backend')
+}
+
 Signaling.Standalone.prototype.sendHello = function() {
 	let msg
 	if (this.resumeId) {
@@ -1019,7 +1023,7 @@ Signaling.Standalone.prototype.sendHello = function() {
 	} else {
 		// Already reconnected with a new session.
 		this._forceReconnect = false
-		const url = generateOcsUrl('apps/spreed/api/v3/signaling/backend')
+		const url = this._getBackendUrl()
 		let helloVersion
 		if (this.hasFeature('hello-v2') && this.settings.helloAuthParams['2.0']) {
 			helloVersion = '2.0'
@@ -1073,7 +1077,8 @@ Signaling.Standalone.prototype.helloResponseReceived = function(data) {
 		}
 
 		// TODO(fancycode): How should this be handled better?
-		console.error('Could not connect to server', data)
+		const url = this._getBackendUrl()
+		console.error('Could not connect to server using backend url ' + url, data)
 		this.reconnect()
 		return
 	}


### PR DESCRIPTION
### ☑️ Resolves

For easier debugging I suggest we include the used backend url in the error message:
<img width="1210" alt="Bildschirmfoto 2023-12-10 um 20 28 13" src="https://github.com/nextcloud/spreed/assets/1580193/c9954ea5-e18d-4879-9952-3477542abc16">

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
