### PR TITLE
fix(OCP): Move away from deprecated RedirectToDefaultAppResponse

### DIFF
--- a/lib/Middleware/CanUseTalkMiddleware.php
+++ b/lib/Middleware/CanUseTalkMiddleware.php
@@ -34,7 +34,7 @@ use OCA\Talk\Middleware\Exceptions\UnsupportedClientVersionException;
 use OCA\Talk\Room;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\RedirectToDefaultAppResponse;
+use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Middleware;
 use OCP\AppFramework\OCS\OCSException;
@@ -42,6 +42,7 @@ use OCP\AppFramework\OCSController;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
 
@@ -61,6 +62,7 @@ class CanUseTalkMiddleware extends Middleware {
 		protected Config $talkConfig,
 		protected IConfig $serverConfig,
 		protected IRequest $request,
+		protected IURLGenerator $url
 	) {
 	}
 
@@ -122,7 +124,7 @@ class CanUseTalkMiddleware extends Middleware {
 				throw new OCSException($exception->getMinVersion(), Http::STATUS_UPGRADE_REQUIRED);
 			}
 
-			return new RedirectToDefaultAppResponse();
+			return new RedirectResponse($this->url->linkToDefaultPageUrl());
 		}
 
 		if ($exception instanceof CanNotUseTalkException ||
@@ -131,7 +133,7 @@ class CanUseTalkMiddleware extends Middleware {
 				throw new OCSException($exception->getMessage(), Http::STATUS_FORBIDDEN);
 			}
 
-			return new RedirectToDefaultAppResponse();
+			return new RedirectResponse($this->url->linkToDefaultPageUrl());
 		}
 
 		throw $exception;

--- a/lib/Middleware/InjectionMiddleware.php
+++ b/lib/Middleware/InjectionMiddleware.php
@@ -49,13 +49,14 @@ use OCA\Talk\Webinary;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\BruteForceProtection;
-use OCP\AppFramework\Http\RedirectToDefaultAppResponse;
+use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Middleware;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCSController;
 use OCP\Federation\ICloudIdManager;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 use OCP\Security\Bruteforce\IThrottler;
 use OCP\Security\Bruteforce\MaxDelayReached;
 
@@ -70,6 +71,7 @@ class InjectionMiddleware extends Middleware {
 		protected Manager $manager,
 		protected ICloudIdManager $cloudIdManager,
 		protected IThrottler $throttler,
+		protected IURLGenerator $url,
 		protected ?string $userId,
 	) {
 	}
@@ -329,7 +331,7 @@ class InjectionMiddleware extends Middleware {
 				throw new OCSException('', Http::STATUS_NOT_FOUND);
 			}
 
-			return new RedirectToDefaultAppResponse();
+			return new RedirectResponse($this->url->linkToDefaultPageUrl());
 		}
 
 		if ($exception instanceof LobbyException) {
@@ -337,7 +339,7 @@ class InjectionMiddleware extends Middleware {
 				throw new OCSException('', Http::STATUS_PRECONDITION_FAILED);
 			}
 
-			return new RedirectToDefaultAppResponse();
+			return new RedirectResponse($this->url->linkToDefaultPageUrl());
 		}
 
 		if ($exception instanceof NotAModeratorException ||
@@ -347,7 +349,7 @@ class InjectionMiddleware extends Middleware {
 				throw new OCSException('', Http::STATUS_FORBIDDEN);
 			}
 
-			return new RedirectToDefaultAppResponse();
+			return new RedirectResponse($this->url->linkToDefaultPageUrl());
 		}
 
 		throw $exception;


### PR DESCRIPTION
## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
