### PR TITLE
feat(chat): API specs for "Edit message"

### DIFF
--- a/appinfo/routes/routesChatController.php
+++ b/appinfo/routes/routesChatController.php
@@ -44,6 +44,8 @@ return [
 		['name' => 'Chat#clearHistory', 'url' => '/api/{apiVersion}/chat/{token}', 'verb' => 'DELETE', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\ChatController::deleteMessage() */
 		['name' => 'Chat#deleteMessage', 'url' => '/api/{apiVersion}/chat/{token}/{messageId}', 'verb' => 'DELETE', 'requirements' => $requirementsWithMessageId],
+		/** @see \OCA\Talk\Controller\ChatController::editMessage() */
+		['name' => 'Chat#editMessage', 'url' => '/api/{apiVersion}/chat/{token}/{messageId}', 'verb' => 'PUT', 'requirements' => $requirementsWithMessageId],
 		/** @see \OCA\Talk\Controller\ChatController::getMessageContext() */
 		['name' => 'Chat#getMessageContext', 'url' => '/api/{apiVersion}/chat/{token}/{messageId}/context', 'verb' => 'GET', 'requirements' => $requirementsWithMessageId],
 		/** @see \OCA\Talk\Controller\ChatController::setReminder() */

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -314,12 +314,17 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 * Required capability: `edit-messages`
 * Method: `PUT`
 * Endpoint: `/chat/{token}/{messageId}`
+* Data:
+
+| field              | type   | Description                       |
+|--------------------|--------|-----------------------------------|
+| `message`          | string | The message the user wants to say |
 
 * Response:
     - Status code:
         + `200 OK` - When editing was successful
         + `202 Accepted` - When editing was successful but Matterbridge is enabled so the message was leaked to other services
-        + `400 Bad Request` The message is already older than 24 hours or another reason why deleting is not okay
+        + `400 Bad Request` The message is already older than 24 hours or another reason why editing is not okay
         + `403 Forbidden` When the message is not from the current user and the user not a moderator
         + `403 Forbidden` When the conversation is read-only
         + `404 Not Found` When the conversation or chat message could not be found for the participant

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -43,25 +43,29 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`: since Nextcloud 13
     - Data:
         Array of messages, each message has at least:
 
-| field                 | type     | Description                                                                                                                                                            |
-|-----------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `id`                  | int      | ID of the comment                                                                                                                                                      |
-| `token`               | string   | Conversation token                                                                                                                                                     |
-| `actorType`           | string   | See [Constants - Actor types of chat messages](constants.md#actor-types-of-chat-messages)                                                                              |
-| `actorId`             | string   | Actor id of the message author                                                                                                                                         |
-| `actorDisplayName`    | string   | Display name of the message author                                                                                                                                     |
-| `timestamp`           | int      | Timestamp in seconds and UTC time zone                                                                                                                                 |
-| `systemMessage`       | string   | empty for normal chat message or the type of the system message (untranslated)                                                                                         |
-| `messageType`         | string   | Currently known types are `comment`, `comment_deleted`, `system` and `command`                                                                                         |
-| `isReplyable`         | bool     | True if the user can post a reply to this message (only available with `chat-replies` capability)                                                                      |
-| `referenceId`         | string   | A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability)           |
-| `message`             | string   | Message string with placeholders (see [Rich Object String](https://github.com/nextcloud/server/issues/1706))                                                           |
-| `messageParameters`   | array    | Message parameters for `message` (see [Rich Object String](https://github.com/nextcloud/server/issues/1706))                                                           |
-| `expirationTimestamp` | int      | Unix time stamp when the message expires and show be removed from the clients UI without further note or warning (only available with `message-expiration` capability) |
-| `parent`              | array    | **Optional:** See `Parent data` below                                                                                                                                  |
-| `reactions`           | int[]    | **Optional:** An array map with relation between reaction emoji and total count of reactions with this emoji                                                           |
-| `reactionsSelf`       | string[] | **Optional:** When the user reacted this is the list of emojis the user reacted with                                                                                   |
-| `markdown`            | bool     | **Optional:** Whether the message should be rendered as markdown or shown as plain text                                                                                |
+| field                      | type     | Description                                                                                                                                                                                                                 |
+|----------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`                       | int      | ID of the comment                                                                                                                                                                                                           |
+| `token`                    | string   | Conversation token                                                                                                                                                                                                          |
+| `actorType`                | string   | See [Constants - Actor types of chat messages](constants.md#actor-types-of-chat-messages)                                                                                                                                   |
+| `actorId`                  | string   | Actor id of the message author                                                                                                                                                                                              |
+| `actorDisplayName`         | string   | Display name of the message author                                                                                                                                                                                          |
+| `timestamp`                | int      | Timestamp in seconds and UTC time zone                                                                                                                                                                                      |
+| `systemMessage`            | string   | empty for normal chat message or the type of the system message (untranslated)                                                                                                                                              |
+| `messageType`              | string   | Currently known types are `comment`, `comment_deleted`, `system` and `command`                                                                                                                                              |
+| `isReplyable`              | bool     | True if the user can post a reply to this message (only available with `chat-replies` capability)                                                                                                                           |
+| `referenceId`              | string   | A reference string that was given while posting the message to be able to identify a sent message again (only available with `chat-reference-id` capability)                                                                |
+| `message`                  | string   | Message string with placeholders (see [Rich Object String](https://github.com/nextcloud/server/issues/1706))                                                                                                                |
+| `messageParameters`        | array    | Message parameters for `message` (see [Rich Object String](https://github.com/nextcloud/server/issues/1706))                                                                                                                |
+| `expirationTimestamp`      | int      | Unix time stamp when the message expires and show be removed from the clients UI without further note or warning (only available with `message-expiration` capability)                                                      |
+| `parent`                   | array    | **Optional:** See `Parent data` below                                                                                                                                                                                       |
+| `reactions`                | int[]    | **Optional:** An array map with relation between reaction emoji and total count of reactions with this emoji                                                                                                                |
+| `reactionsSelf`            | string[] | **Optional:** When the user reacted this is the list of emojis the user reacted with                                                                                                                                        |
+| `markdown`                 | bool     | **Optional:** Whether the message should be rendered as markdown or shown as plain text                                                                                                                                     |
+| `lastEditActorType`        | string   | Actor type of the last editing author - See [Constants - Actor types of chat messages](constants.md#actor-types-of-chat-messages) (only available with `edit-messages` capability and when the message was actually edited) |
+| `lastEditActorId`          | string   | Actor id of the last editing author (only available with `edit-messages` capability and when the message was actually edited)                                                                                               |
+| `lastEditActorDisplayName` | string   | Display name of the last editing author (only available with `edit-messages` capability and when the message was actually edited)                                                                                           |
+| `lastEditTimestamp`        | int      | Unix time stamp when the message was last edited (only available with `edit-messages` capability and when the message was actually edited)                                                                                  |
 
 #### Parent data
 
@@ -304,6 +308,35 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
         The parent message is the object of the deleted message with the replaced text "Message deleted by you".
         This message should **NOT** be displayed to the user but instead be used to remove the original message from any cache/storage of the device.
 
+
+## Editing a chat message
+
+* Required capability: `edit-messages`
+* Method: `PUT`
+* Endpoint: `/chat/{token}/{messageId}`
+
+* Response:
+    - Status code:
+        + `200 OK` - When editing was successful
+        + `202 Accepted` - When editing was successful but Matterbridge is enabled so the message was leaked to other services
+        + `400 Bad Request` The message is already older than 24 hours or another reason why deleting is not okay
+        + `403 Forbidden` When the message is not from the current user and the user not a moderator
+        + `403 Forbidden` When the conversation is read-only
+        + `404 Not Found` When the conversation or chat message could not be found for the participant
+        + `405 Method Not Allowed` When the message is not a normal chat message
+        + `412 Precondition Failed` When the lobby is active and the user is not a moderator
+
+    - Header:
+
+| field                     | type | Description                                                                                                                                                                                                     |
+|---------------------------|------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `X-Chat-Last-Common-Read` | int  | ID of the last message read by every user that has read privacy set to public. When the user themself has it set to private the value the header is not set (only available with `chat-read-status` capability) |
+
+    - Data:
+        The full message array of the new system message "You edited a message", as defined in [Receive chat messages of a conversation](#receive-chat-messages-of-a-conversation)
+        The parent message is the object of the edited message with the new content.
+        This message should **NOT** be displayed to the user but instead be used to update the original message from any cache/storage of the device.
+
 ## Set reminder for chat message
 
 * Required capability: `remind-me-later`
@@ -478,6 +511,7 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 * `guest_moderator_promoted` - {actor} promoted {user} to moderator
 * `guest_moderator_demoted` - {actor} demoted {user} from moderator
 * `message_deleted` - Message deleted by {actor} (Should not be shown to the user)
+* `message_edited` - Message edited by {actor} (Should not be shown to the user)
 * `history_cleared` - {actor} cleared the history of the conversation
 * `file_shared` - {file}
 * `object_shared` - {object}

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -516,6 +516,11 @@ class SystemMessage implements IEventListener {
 			if ($currentUserIsActor) {
 				$parsedMessage = $this->l->t('You deleted a message');
 			}
+		} elseif ($message === 'message_edited') {
+			$parsedMessage = $this->l->t('{actor} edited a message');
+			if ($currentUserIsActor) {
+				$parsedMessage = $this->l->t('You edited a message');
+			}
 		} elseif ($message === 'reaction_revoked') {
 			$parsedMessage = $this->l->t('{actor} deleted a reaction');
 			if ($currentUserIsActor) {

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -677,7 +677,7 @@ class ChatController extends AEnvironmentAwareController {
 	 * 400: Deleting message is not possible
 	 * 403: Missing permissions to delete message
 	 * 404: Message not found
-	 * 405: Deleting message is not allowed
+	 * 405: Deleting this message type is not allowed
 	 */
 	#[NoAdminRequired]
 	#[RequireModeratorOrNoLobby]
@@ -745,6 +745,28 @@ class ChatController extends AEnvironmentAwareController {
 			$headers = ['X-Chat-Last-Common-Read' => (string) $this->chatManager->getLastCommonReadMessage($this->room)];
 		}
 		return new DataResponse($data, $bridge['enabled'] ? Http::STATUS_ACCEPTED : Http::STATUS_OK, $headers);
+	}
+
+	/**
+	 * Edit a chat message
+	 *
+	 * @param int $messageId ID of the message
+	 * @psalm-param non-negative-int $messageId
+	 * @return DataResponse<Http::STATUS_OK|Http::STATUS_ACCEPTED, TalkChatMessageWithParent, array{X-Chat-Last-Common-Read?: numeric-string}>|DataResponse<Http::STATUS_BAD_REQUEST|Http::STATUS_FORBIDDEN|Http::STATUS_NOT_FOUND|Http::STATUS_METHOD_NOT_ALLOWED, array<empty>, array{}>
+	 *
+	 * 200: Message edited successfully
+	 * 202: Message edited successfully, but Matterbridge is configured, so the information can be replicated elsewhere
+	 * 400: Editing message is not possible
+	 * 403: Missing permissions to edit message
+	 * 404: Message not found
+	 * 405: Editing this message type is not allowed
+	 */
+	#[NoAdminRequired]
+	#[RequireModeratorOrNoLobby]
+	#[RequireParticipant]
+	#[RequirePermission(permission: RequirePermission::CHAT)]
+	#[RequireReadWriteConversation]
+	public function editMessage(int $messageId): DataResponse {
 	}
 
 	/**

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -237,6 +237,7 @@ class Manager {
 			'latest_child_timestamp' => $row['comment_latest_child_timestamp'],
 			'reactions' => $row['comment_reactions'],
 			'expire_date' => $row['comment_expire_date'],
+			'meta_data' => $row['comment_meta_data'],
 		]);
 	}
 
@@ -1308,5 +1309,6 @@ class Manager {
 		$query->selectAlias('c.latest_child_timestamp', 'comment_latest_child_timestamp');
 		$query->selectAlias('c.reactions', 'comment_reactions');
 		$query->selectAlias('c.expire_date', 'comment_expire_date');
+		$query->selectAlias('c.meta_data', 'comment_meta_data');
 	}
 }

--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -190,6 +190,17 @@ class Message {
 			'markdown' => $this->getMessageType() === ChatManager::VERB_SYSTEM ? false : true,
 		];
 
+		$metaData = $this->getComment()->getMetaData();
+		if (!empty($metaData)) {
+			if (isset($metaData['last_edited_by_type'], $metaData['last_edited_by_id'], $metaData['last_edited_time'])) {
+				// FIXME @see MessageParser::setActor
+				$data['lastEditActorDisplayName'] = $metaData['last_edited_by_id'];
+				$data['lastEditActorId'] = $metaData['last_edited_by_id'];
+				$data['lastEditActorType'] = $metaData['last_edited_by_type'];
+				$data['lastEditTimestamp'] = $metaData['last_edited_time'];
+			}
+		}
+
 		if ($this->getMessageType() === ChatManager::VERB_MESSAGE_DELETED) {
 			$data['deleted'] = true;
 		}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -83,6 +83,10 @@ namespace OCA\Talk;
  *     systemMessage: string,
  *     timestamp: int,
  *     token: string,
+ *     lastEditActorDisplayName?: string,
+ *     lastEditActorId?: string,
+ *     lastEditActorType?: string,
+ *     lastEditTimestamp?: int,
  * }
  *
  * @psalm-type TalkChatMessageWithParent = TalkChatMessage&array{parent?: TalkChatMessage}

--- a/openapi.json
+++ b/openapi.json
@@ -257,6 +257,19 @@
                     },
                     "token": {
                         "type": "string"
+                    },
+                    "lastEditActorDisplayName": {
+                        "type": "string"
+                    },
+                    "lastEditActorId": {
+                        "type": "string"
+                    },
+                    "lastEditActorType": {
+                        "type": "string"
+                    },
+                    "lastEditTimestamp": {
+                        "type": "integer",
+                        "format": "int64"
                     }
                 }
             },
@@ -6070,7 +6083,263 @@
                         }
                     },
                     "405": {
-                        "description": "Deleting message is not allowed",
+                        "description": "Deleting this message type is not allowed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "operationId": "chat-edit-message",
+                "summary": "Edit a chat message",
+                "tags": [
+                    "chat"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "message",
+                        "in": "query",
+                        "description": "the message to send",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "messageId",
+                        "in": "path",
+                        "description": "ID of the message",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Message edited successfully",
+                        "headers": {
+                            "X-Chat-Last-Common-Read": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/ChatMessageWithParent"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "202": {
+                        "description": "Message edited successfully, but Matterbridge is configured, so the information can be replicated elsewhere",
+                        "headers": {
+                            "X-Chat-Last-Common-Read": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/ChatMessageWithParent"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Editing message is not possible",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Missing permissions to edit message",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Message not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "description": "Editing this message type is not allowed",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/tests/integration/features/chat-1/edit-message.feature
+++ b/tests/integration/features/chat-1/edit-message.feature
@@ -1,0 +1,52 @@
+Feature: chat-1/edit-message
+  Background:
+    Given user "participant1" exists
+    Given user "participant2" exists
+
+  Scenario: Moderator edits their own message
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    And user "participant1" sends message "Message 1" to room "room" with 201
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | room | users     | participant1 | participant1-displayname | Message 1   | []                |               |
+    And user "participant1" edits message "Message 1" in room "room" to "Message 1 - Edit 1" with 200
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message            | messageParameters | parentMessage |
+      | room | users     | participant1 | participant1-displayname | Message 1 - Edit 1 | []                |               |
+    Then user "participant2" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message            | messageParameters | parentMessage |
+      | room | users     | participant1 | participant1-displayname | Message 1 - Edit 1 | []                |               |
+    And user "participant2" edits message "Message 1 - Edit 1" in room "room" to "Message 1 - Edit 2" with 403
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message            | messageParameters | parentMessage |
+      | room | users     | participant1 | participant1-displayname | Message 1 - Edit 1 | []                |               |
+    Then user "participant2" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message            | messageParameters | parentMessage |
+      | room | users     | participant1 | participant1-displayname | Message 1 - Edit 1 | []                |               |
+
+  Scenario: User and moderator edit user message
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    And user "participant2" sends message "Message 1" to room "room" with 201
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
+      | room | users     | participant2 | participant2-displayname | Message 1   | []                |               |
+    And user "participant1" edits message "Message 1" in room "room" to "Message 1 - Edit 1" with 200
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message            | messageParameters | parentMessage |
+      | room | users     | participant2 | participant2-displayname | Message 1 - Edit 1 | []                |               |
+    Then user "participant2" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message            | messageParameters | parentMessage |
+      | room | users     | participant2 | participant2-displayname | Message 1 - Edit 1 | []                |               |
+    And user "participant2" edits message "Message 1 - Edit 1" in room "room" to "Message 1 - Edit 2" with 200
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message            | messageParameters | parentMessage |
+      | room | users     | participant2 | participant2-displayname | Message 1 - Edit 2 | []                |               |
+    Then user "participant2" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message            | messageParameters | parentMessage |
+      | room | users     | participant2 | participant2-displayname | Message 1 - Edit 2 | []                |               |


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11206 


## 🛠️ API Checklist

- [x] Requires https://github.com/nextcloud/server/pull/42209

### 🚧 Tasks

- System message hidden like with delete
    - [x] Implement
- Time limitation like for delete?
    - [x] Limit editing to X hours (draft 24 hours, check what others do and discuss again)
- What about bots?
    - [x] Can not edit bot messages, moderators can
    - If a message triggered a bot already it's yolo and will not be retriggered with the new content automatically (bot can do based on the system message?)


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included
- [x] 📘 API documentation in `docs/` has been updated
