### PR TITLE
[stable28] Debug starting a big call takes long

### DIFF
--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -74,6 +74,9 @@ class Listener implements IEventListener {
 	}
 
 	protected function setActive(ParticipantModifiedEvent $event): void {
+		if ($event->getRoom()->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #8: ' . microtime(true));
+		}
 		if ($event->getProperty() !== AParticipantModifiedEvent::PROPERTY_IN_CALL) {
 			return;
 		}
@@ -82,7 +85,6 @@ class Listener implements IEventListener {
 			|| $event->getNewValue() === Participant::FLAG_DISCONNECTED) {
 			return;
 		}
-
 		$participant = $event->getParticipant();
 		$this->roomService->setActiveSince(
 			$event->getRoom(),
@@ -90,6 +92,9 @@ class Listener implements IEventListener {
 			$participant->getSession() ? $participant->getSession()->getInCall() : Participant::FLAG_DISCONNECTED,
 			$participant->getAttendee()->getActorType() !== Attendee::ACTOR_USERS
 		);
+		if ($event->getRoom()->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #9: ' . microtime(true));
+		}
 	}
 
 	protected function handleParticipantModified(ParticipantModifiedEvent $event): void {

--- a/lib/Controller/CallController.php
+++ b/lib/Controller/CallController.php
@@ -141,6 +141,9 @@ class CallController extends AEnvironmentAwareController {
 	#[RequireParticipant]
 	#[RequireReadWriteConversation]
 	public function joinCall(?int $flags = null, ?int $forcePermissions = null, bool $silent = false, bool $recordingConsent = false): DataResponse {
+		if ($this->room->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #0: ' . microtime(true));
+		}
 		if (!$recordingConsent && $this->talkConfig->recordingConsentRequired() !== RecordingService::CONSENT_REQUIRED_NO) {
 			if ($this->talkConfig->recordingConsentRequired() === RecordingService::CONSENT_REQUIRED_YES) {
 				return new DataResponse(['error' => 'consent'], Http::STATUS_BAD_REQUEST);
@@ -169,9 +172,13 @@ class CallController extends AEnvironmentAwareController {
 		if ($forcePermissions !== null && $this->participant->hasModeratorPermissions()) {
 			$this->roomService->setPermissions($this->room, 'call', Attendee::PERMISSIONS_MODIFY_SET, $forcePermissions, true);
 		}
-
+		if ($this->room->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #1: ' . microtime(true));
+		}
 		$joined = $this->participantService->changeInCall($this->room, $this->participant, $flags, false, $silent);
-
+		if ($this->room->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #2: ' . microtime(true));
+		}
 		if (!$joined) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}

--- a/lib/Listener/RestrictStartingCalls.php
+++ b/lib/Listener/RestrictStartingCalls.php
@@ -53,6 +53,9 @@ class RestrictStartingCalls implements IEventListener {
 		if (!$event instanceof BeforeParticipantModifiedEvent) {
 			return;
 		}
+		if ($event->getRoom()->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #10: ' . microtime(true));
+		}
 
 		if ($event->getProperty() !== AParticipantModifiedEvent::PROPERTY_IN_CALL) {
 			return;
@@ -73,6 +76,9 @@ class RestrictStartingCalls implements IEventListener {
 		if (!$event->getParticipant()->canStartCall($this->serverConfig)
 			&& !$this->participantService->hasActiveSessionsInCall($room)) {
 			throw new ForbiddenException('Can not start a call');
+		}
+		if ($event->getRoom()->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #11: ' . microtime(true));
 		}
 	}
 }

--- a/lib/Notification/Listener.php
+++ b/lib/Notification/Listener.php
@@ -227,9 +227,18 @@ class Listener implements IEventListener {
 			return;
 		}
 
+		if ($event->getRoom()->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #12: ' . microtime(true));
+		}
 		$this->markCallNotificationsRead($event->getRoom());
+		if ($event->getRoom()->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #13: ' . microtime(true));
+		}
 		if ($this->shouldSendCallNotification) {
 			$this->sendCallNotifications($event->getRoom());
+		}
+		if ($event->getRoom()->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #14: ' . microtime(true));
 		}
 	}
 

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1155,6 +1155,9 @@ class ParticipantService {
 	}
 
 	public function changeInCall(Room $room, Participant $participant, int $flags, bool $endCallForEveryone = false, bool $silent = false): bool {
+		if ($room->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #3: ' . microtime(true));
+		}
 		if ($room->getType() === Room::TYPE_CHANGELOG
 			|| $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER
 			|| $room->getType() === Room::TYPE_NOTE_TO_SELF) {
@@ -1177,6 +1180,9 @@ class ParticipantService {
 		$oldFlags = $session->getInCall();
 		$details = [];
 
+		if ($room->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #4: ' . microtime(true));
+		}
 		if ($flags !== Participant::FLAG_DISCONNECTED) {
 			if ($silent) {
 				$legacyEvent = new SilentModifyParticipantEvent($room, $participant, 'inCall', $flags, $session->getInCall());
@@ -1194,10 +1200,14 @@ class ParticipantService {
 			}
 			$this->dispatcher->dispatch(Room::EVENT_BEFORE_SESSION_LEAVE_CALL, $legacyEvent);
 		}
-
+		if ($room->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #4.1: ' . microtime(true));
+		}
 		$event = new BeforeParticipantModifiedEvent($room, $participant, AParticipantModifiedEvent::PROPERTY_IN_CALL, $flags, $oldFlags, $details);
 		$this->dispatcher->dispatchTyped($event);
-
+		if ($room->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #5: ' . microtime(true));
+		}
 		$session->setInCall($flags);
 		if (!$endCallForEveryone) {
 			$this->sessionMapper->update($session);
@@ -1211,14 +1221,22 @@ class ParticipantService {
 			$attendee->setCallId('');
 			$this->attendeeMapper->update($attendee);
 		}
-
+		if ($room->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #6: ' . microtime(true));
+		}
 		if ($flags !== Participant::FLAG_DISCONNECTED) {
 			$this->dispatcher->dispatch(Room::EVENT_AFTER_SESSION_JOIN_CALL, $legacyEvent);
 		} else {
 			$this->dispatcher->dispatch(Room::EVENT_AFTER_SESSION_LEAVE_CALL, $legacyEvent);
 		}
+		if ($room->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #6.1: ' . microtime(true));
+		}
 		$event = new ParticipantModifiedEvent($room, $participant, AParticipantModifiedEvent::PROPERTY_IN_CALL, $flags, $oldFlags, $details);
 		$this->dispatcher->dispatchTyped($event);
+		if ($room->getToken() === 'c9bui2ju') {
+			\OC::$server->getLogger()->warning('Debugging step #7: ' . microtime(true));
+		}
 
 		return true;
 	}


### PR DESCRIPTION
```json
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":2,"time":"2023-12-12T14:01:37+00:00","remoteAddr":"2001:…","user":"me","app":"no app in context","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Debugging step #0: 1702389697.4765","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":[]}
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":2,"time":"2023-12-12T14:01:37+00:00","remoteAddr":"2001:…","user":"me","app":"no app in context","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Debugging step #1: 1702389697.478","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":[]}
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":2,"time":"2023-12-12T14:01:37+00:00","remoteAddr":"2001:…","user":"me","app":"no app in context","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Debugging step #3: 1702389697.4782","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":[]}
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":2,"time":"2023-12-12T14:01:37+00:00","remoteAddr":"2001:…","user":"me","app":"no app in context","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Debugging step #4: 1702389697.4783","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":[]}
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":2,"time":"2023-12-12T14:01:37+00:00","remoteAddr":"2001:…","user":"me","app":"no app in context","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Debugging step #10: 1702389697.4785","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":[]}
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":2,"time":"2023-12-12T14:01:37+00:00","remoteAddr":"2001:…","user":"me","app":"no app in context","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Debugging step #11: 1702389697.4786","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":[]}
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":0,"time":"2023-12-12T14:01:38+00:00","remoteAddr":"2001:…","user":"me","app":"spreed-hpb","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Send room message: … {\"type\":\"chat\",\"chat\":{\"refresh\":true}} (0.33)","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":{"app":"spreed-hpb"}}
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":2,"time":"2023-12-12T14:01:38+00:00","remoteAddr":"2001:…","user":"me","app":"no app in context","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Debugging step #5: 1702389698.0529","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":[]}
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":2,"time":"2023-12-12T14:01:38+00:00","remoteAddr":"2001:…","user":"me","app":"no app in context","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Debugging step #6: 1702389698.0546","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":[]}
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":2,"time":"2023-12-12T14:01:38+00:00","remoteAddr":"2001:…","user":"me","app":"no app in context","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Debugging step #12: 1702389698.0548","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":[]}
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":2,"time":"2023-12-12T14:01:38+00:00","remoteAddr":"2001:…","user":"me","app":"no app in context","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Debugging step #13: 1702389698.0565","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":[]}
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":2,"time":"2023-12-12T14:01:43+00:00","remoteAddr":"2001:…","user":"me","app":"no app in context","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Debugging step #14: 1702389703.1234","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":[]}
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":0,"time":"2023-12-12T14:01:44+00:00","remoteAddr":"2001:…","user":"me","app":"spreed-hpb","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Room in-call status changed: … 7 Array\n(\n    [0] => iSoYEIheDKmTYj8Roc44sQj9XCRlISabgfbEFoIJgJP3Tn/A38jW5JM3VeI/1joLpDW1ETTBKlL8P6b+YyjUFUJ7+2I0nHOG0BoAc7xKwmiPX9keqk94vqSNFOjYzkDCbrPZplZmGi89+O8Xt9X0fmD0jE1b5hpd0GYr+Il3Aor6oE9i37MH6lfpYwligr/2ZND4YrOl0SAILs1EuKo4Y0qD4lmO15bqmMivCk64iNuqiDCLSidyNFN0G8IqLfr\n)\n (0.94)","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":{"app":"spreed-hpb"}}
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":2,"time":"2023-12-12T14:01:44+00:00","remoteAddr":"2001:…","user":"me","app":"no app in context","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Debugging step #8: 1702389704.0691","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":[]}
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":2,"time":"2023-12-12T14:01:44+00:00","remoteAddr":"2001:…","user":"me","app":"no app in context","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Debugging step #9: 1702389704.0728","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":[]}
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":2,"time":"2023-12-12T14:01:44+00:00","remoteAddr":"2001:…","user":"me","app":"no app in context","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Debugging step #7: 1702389704.0729","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":[]}
{"reqId":"j9UxMXl1CcVRQo3cCNkj","level":2,"time":"2023-12-12T14:01:44+00:00","remoteAddr":"2001:…","user":"me","app":"no app in context","method":"POST","url":"/ocs/v2.php/apps/spreed/api/v4/call/…","message":"Debugging step #2: 1702389704.073","userAgent":"Mozilla/5.0 (Linux) Nextcloud-Talk v0.19.0","version":"28.0.0.11","data":[]}

```