### PR TITLE
fix: use body element if not the fullscreen

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -734,6 +734,11 @@ export default {
 .mx-datepicker-main.mx-datepicker-popup {
 	z-index: 10001 !important;
 }
+
+/* FIXME: remove after https://github.com/nextcloud-libraries/nextcloud-vue/pull/4959 is released */
+body .modal-wrapper * {
+	box-sizing: border-box;
+}
 </style>
 
 <style lang="scss" scoped>

--- a/src/components/CallView/shared/ViewerOverlayCallView.vue
+++ b/src/components/CallView/shared/ViewerOverlayCallView.vue
@@ -224,7 +224,7 @@ export default {
 		},
 
 		portalSelector() {
-			return this.$store.getters.isFullscreen() ? '#content-vue' : 'body'
+			return this.$store.getters.getMainContainerSelector()
 		},
 
 		hasLocalScreen() {

--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -61,6 +61,7 @@
 
 		<!-- Input field -->
 		<NewMessage v-if="containerId"
+			:key="containerId"
 			role="region"
 			:token="token"
 			:container="containerId"
@@ -145,11 +146,21 @@ export default {
 		token() {
 			return this.$store.getters.getToken()
 		},
+
+		container() {
+			return this.$store.getters.getMainContainerSelector()
+		}
+	},
+
+	watch: {
+		container(value) {
+			this.containerId = value
+		}
 	},
 
 	mounted() {
 		// Postpone render of NewMessage until application is mounted
-		this.containerId = this.$store.getters.getMainContainerSelector()
+		this.containerId = this.container
 	},
 
 	methods: {

--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -176,6 +176,7 @@ import VideoIcon from 'vue-material-design-icons/Video.vue'
 import GridView from 'vue-material-design-icons/ViewGrid.vue'
 
 import { getCapabilities } from '@nextcloud/capabilities'
+import { showWarning } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
@@ -392,6 +393,16 @@ export default {
 		},
 
 		toggleFullscreen() {
+			// Don't toggle fullscreen if there is an open modal
+			// FIXME won't be needed without Fulscreen API
+			if (Array.from(document.body.childNodes).filter(child => {
+				return child.nodeName === 'DIV' && child.classList.contains('modal-mask')
+					&& window.getComputedStyle(child).display !== 'none'
+			}).length !== 0) {
+				showWarning(t('spreed', 'You need to close a dialog to toggle full screen'))
+				return
+			}
+
 			if (this.isFullscreen) {
 				this.disableFullscreen()
 				this.$store.dispatch('setIsFullscreen', false)

--- a/src/store/uiModeStore.js
+++ b/src/store/uiModeStore.js
@@ -31,8 +31,8 @@ const state = {
 }
 
 const getters = {
-	getMainContainerSelector: (state) => () => {
-		return state.mainContainerSelector
+	getMainContainerSelector: (state, getters, rootState, rootGetters) => () => {
+		return rootGetters.isFullscreen() ? state.mainContainerSelector : 'body'
 	},
 }
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #8709
* Fix #9626
* Replaces #9792

Should be safe to use a `body` element while you're not in the fullscreen (as tested with ViewerOverlayCallView).
Also as long as we won't register a fullscreen state in sidebar (for Files page, for example), modal will end up in `body`, so above the Viewer embedded

>[!WARNING]
>Behaviour change: as NcModal component has more reasons against being re-mounted, then pros, hotkey 'F' to toggle Fulscreen mode is now disabled when any modal is open https://github.com/nextcloud/spreed/pull/11222/commits/368e43ab158577f367fc7b2a94543c443e7afa50

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🖼️  Window frame | 🏞️ Fullscreen |
|------------|----------|
| Files Sidebar          | -        |
![Screenshot from 2023-12-13 14-38-32](https://github.com/nextcloud/spreed/assets/93392545/123a3e47-21a6-4191-ad7e-1d5a6c31d8bd) | ![Screenshot from 2023-12-13 14-38-55](https://github.com/nextcloud/spreed/assets/93392545/fbffcf50-37fa-471c-af86-949ab6eed72a)
![Screenshot from 2023-12-13 14-38-22](https://github.com/nextcloud/spreed/assets/93392545/01814c2d-8473-4a04-abdc-b24732938479) | ![Screenshot from 2023-12-13 14-38-46](https://github.com/nextcloud/spreed/assets/93392545/4cfa269d-7f0f-4113-9ee7-429d401582cf)
| Talk main app | - |
![Screenshot from 2023-12-13 14-36-49](https://github.com/nextcloud/spreed/assets/93392545/38de1c53-ef3a-4328-8b7c-c3933d3b03dd) | ![Screenshot from 2023-12-13 14-37-17](https://github.com/nextcloud/spreed/assets/93392545/750af1c5-029e-4a5f-8d13-bcad2f0c782c)
![Screenshot from 2023-12-13 14-36-26](https://github.com/nextcloud/spreed/assets/93392545/a9c2b134-0ac5-4c27-b727-fb4f16007d50) | ![Screenshot from 2023-12-13 14-36-03](https://github.com/nextcloud/spreed/assets/93392545/2509c062-d6ce-43be-a5fc-f9e9b50737af)
![Screenshot from 2023-12-13 14-34-50](https://github.com/nextcloud/spreed/assets/93392545/e378ce67-76f8-48d1-8534-d865ba5105ba) | ![Screenshot from 2023-12-13 14-35-02](https://github.com/nextcloud/spreed/assets/93392545/4706649c-e847-4c46-960c-17da4519efd6)


### 🚧 Tasks

- [ ] Check possible drawbacks?

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences