### PR TITLE
fix(call): reset Media settings checkbox on modal close

### DIFF
--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -469,6 +469,7 @@ export default {
 			this.audioDeviceStateChanged = false
 			this.videoDeviceStateChanged = false
 			this.isPublicShareAuthSidebar = false
+			this.isRecordingFromStart = false
 		},
 
 		toggleAudio() {


### PR DESCRIPTION
### ☑️ Resolves

*  reset 'Start recording immediately with the call' checkbox on modal close




<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

[Screencast from 14.12.2023 11:59:57.webm](https://github.com/nextcloud/spreed/assets/93392545/2fd188bc-f5e9-44cd-90d8-9b0c93727f6f)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible