### PR TITLE
fix(notifications): Fix the order of event listeners 

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -184,7 +184,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(AttendeesAddedEvent::class, ActivityListener::class);
 		$context->registerEventListener(AttendeeRemovedEvent::class, ActivityListener::class);
 		$context->registerEventListener(BeforeCallEndedForEveryoneEvent::class, ActivityListener::class);
-		$context->registerEventListener(ParticipantModifiedEvent::class, ActivityListener::class, -100);
+		$context->registerEventListener(ParticipantModifiedEvent::class, ActivityListener::class, 75);
 		$context->registerEventListener(SessionLeftRoomEvent::class, ActivityListener::class, -100);
 
 		// Bot listeners
@@ -204,7 +204,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(BeforeParticipantModifiedEvent::class, SystemMessageListener::class);
 		$context->registerEventListener(BeforeShareCreatedEvent::class, SystemMessageListener::class);
 		$context->registerEventListener(LobbyModifiedEvent::class, SystemMessageListener::class);
-		$context->registerEventListener(ParticipantModifiedEvent::class, SystemMessageListener::class);
+		$context->registerEventListener(ParticipantModifiedEvent::class, SystemMessageListener::class, 100);
 		$context->registerEventListener(RoomCreatedEvent::class, SystemMessageListener::class);
 		$context->registerEventListener(RoomModifiedEvent::class, SystemMessageListener::class);
 		$context->registerEventListener(ShareCreatedEvent::class, SystemMessageListener::class);
@@ -294,7 +294,7 @@ class Application extends App implements IBootstrap {
 
 		// Signaling listeners (Both)
 		$context->registerEventListener(BeforeRoomDeletedEvent::class, SignalingListener::class);
-		$context->registerEventListener(ParticipantModifiedEvent::class, SignalingListener::class);
+		$context->registerEventListener(ParticipantModifiedEvent::class, SignalingListener::class, 50);
 		$context->registerEventListener(RoomModifiedEvent::class, SignalingListener::class);
 
 		// Signaling listeners (Internal)


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11223 

We change the order of the event listeners so that:
- Call state is updated by the activity listener
- "X left the call" appears before the call summary
- Signaling is triggered after the chat was updated
- Push notifications are send after everything is done

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
