### PR TITLE
Release 16.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 16.0.9 – 2023-12-19
+### Fixed
+- fix(occ): Fix verification of STUN server details
+  [#11195](https://github.com/nextcloud/spreed/issues/11195)
+- fix(hosted-hpb): Correctly handle API response codes of hosted High-performance backend when the account expired
+  [#11045](https://github.com/nextcloud/spreed/issues/11045)
+
 ## 16.0.8 – 2023-11-23
 ### Fixed
 - fix(settings): Remove non-working notification settings for guests

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>16.0.8</version>
+	<version>16.0.9</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk",
-	"version": "16.0.8",
+	"version": "16.0.9",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk",
-			"version": "16.0.8",
+			"version": "16.0.9",
 			"license": "agpl",
 			"dependencies": {
 				"@nextcloud/auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "talk",
-	"version": "16.0.8",
+	"version": "16.0.9",
 	"private": true,
 	"description": "",
 	"author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 16.0.9 – 2023-12-19
### Fixed
- fix(occ): Fix verification of STUN server details [#11195](https://github.com/nextcloud/spreed/issues/11195)
- fix(hosted-hpb): Correctly handle API response codes of hosted High-performance backend when the account expired [#11045](https://github.com/nextcloud/spreed/issues/11045)