### PR TITLE
feat(federations): provide admin setting to enable Federation in Talk

### DIFF
--- a/lib/Settings/Admin/AdminSettings.php
+++ b/lib/Settings/Admin/AdminSettings.php
@@ -68,6 +68,7 @@ class AdminSettings implements ISettings {
 		$this->initGeneralSettings();
 		$this->initAllowedGroups();
 		$this->initCommands();
+		$this->initFederation();
 		$this->initMatterbridge();
 		$this->initStunServers();
 		$this->initTurnServers();
@@ -107,6 +108,10 @@ class AdminSettings implements ISettings {
 		}, $commands);
 
 		$this->initialState->provideInitialState('commands', $result);
+	}
+
+	protected function initFederation(): void {
+		$this->initialState->provideInitialState('federation_enabled', $this->serverConfig->getAppValue('spreed', 'federation_enabled', 'no'));
 	}
 
 	protected function initMatterbridge(): void {

--- a/src/components/AdminSettings/Federation.vue
+++ b/src/components/AdminSettings/Federation.vue
@@ -1,0 +1,80 @@
+<!--
+ - @copyright Copyright (c) 2024 Maksim Sukharev <antreesy.web@gmail.com>
+ -
+ - @author Maksim Sukharev <antreesy.web@gmail.com>
+ -
+ - @license AGPL-3.0-or-later
+ -
+ - This program is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ -
+ -->
+
+<template>
+	<section id="general_settings" class="federation section">
+		<h2>
+			{{ t('spreed', 'Federation') }}
+			<small>{{ t('spreed', 'Beta') }}</small>
+		</h2>
+
+		<NcCheckboxRadioSwitch :checked="isFederationEnabled"
+			:disabled="loading"
+			type="switch"
+			@update:checked="saveFederationEnabled">
+			{{ t('spreed', 'Enable Federation in Talk app') }}
+		</NcCheckboxRadioSwitch>
+	</section>
+</template>
+
+<script>
+import { loadState } from '@nextcloud/initial-state'
+
+import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
+
+export default {
+	name: 'Federation',
+
+	components: {
+		NcCheckboxRadioSwitch,
+	},
+
+	data() {
+		return {
+			loading: false,
+			isFederationEnabled: loadState('spreed', 'federation_enabled') === 'yes',
+		}
+	},
+
+	methods: {
+		saveFederationEnabled(value) {
+			this.loading = true
+
+			OCP.AppConfig.setValue('spreed', 'federation_enabled', value ? 'yes' : 'no', {
+				success: function() {
+					this.loading = false
+					this.isFederationEnabled = value
+				}.bind(this),
+			})
+		},
+	},
+}
+</script>
+
+<style scoped lang="scss">
+small {
+	color: var(--color-warning);
+	border: 1px solid var(--color-warning);
+	border-radius: 16px;
+	padding: 0 9px;
+}
+</style>

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -25,6 +25,8 @@
 		<GeneralSettings />
 		<MatterbridgeIntegration />
 		<AllowedGroups />
+		<!-- TODO remove OC.debug when Federation feature is ready -->
+		<Federation v-if="OC.debug" />
 		<BotsSettings />
 		<Commands />
 		<WebServerSetupChecks />
@@ -41,6 +43,7 @@
 import AllowedGroups from '../components/AdminSettings/AllowedGroups.vue'
 import BotsSettings from '../components/AdminSettings/BotsSettings.vue'
 import Commands from '../components/AdminSettings/Commands.vue'
+import Federation from '../components/AdminSettings/Federation.vue'
 import GeneralSettings from '../components/AdminSettings/GeneralSettings.vue'
 import HostedSignalingServer from '../components/AdminSettings/HostedSignalingServer.vue'
 import MatterbridgeIntegration from '../components/AdminSettings/MatterbridgeIntegration.vue'
@@ -58,6 +61,7 @@ export default {
 		AllowedGroups,
 		BotsSettings,
 		Commands,
+		Federation,
 		GeneralSettings,
 		HostedSignalingServer,
 		MatterbridgeIntegration,


### PR DESCRIPTION
### ☑️ Resolves

* Part of #11279
  * Add Admin setting section for Federation (in debug mode only)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

![image](https://github.com/nextcloud/spreed/assets/93392545/90aea25d-954d-4469-bb4b-0f8b5a759714)

### 🚧 Tasks

- [x] Check wording

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

---

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] Check code changes

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
