### PR TITLE
chore(deps): Bump nextcloud/vue to 8.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nextcloud/moment": "^1.2.2",
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^2.2.0",
-        "@nextcloud/vue": "^8.3.0",
+        "@nextcloud/vue": "^8.4.0",
         "crypto-js": "^4.2.0",
         "debounce": "^2.0.0",
         "emoji-mart-vue-fast": "^15.0.0",
@@ -3797,9 +3797,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.3.0.tgz",
-      "integrity": "sha512-2duDJflaeHMmtV+l6MXyhKY2t1TUB5GjkDvSL0KZ9i1QHXLVhhWObhI7cclO/qqu7/yoEdrBLY/Ga7uBPBmr7g==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.4.0.tgz",
+      "integrity": "sha512-K+oDwwpy3ka5VBYi0S92dpBKJYDI78HGe0Ln2cfURtyH69DjtPAbDTj5CjFP8ccY/QsZgIjBekX6Ftw6fg1czQ==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@nextcloud/auth": "^2.0.0",
@@ -3824,7 +3824,6 @@
         "focus-trap": "^7.4.3",
         "linkify-string": "^4.0.0",
         "md5": "^2.3.0",
-        "node-polyfill-webpack-plugin": "^2.0.1",
         "rehype-external-links": "^3.0.0",
         "rehype-react": "^7.1.2",
         "remark-breaks": "^4.0.0",
@@ -23758,9 +23757,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.3.0.tgz",
-      "integrity": "sha512-2duDJflaeHMmtV+l6MXyhKY2t1TUB5GjkDvSL0KZ9i1QHXLVhhWObhI7cclO/qqu7/yoEdrBLY/Ga7uBPBmr7g==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.4.0.tgz",
+      "integrity": "sha512-K+oDwwpy3ka5VBYi0S92dpBKJYDI78HGe0Ln2cfURtyH69DjtPAbDTj5CjFP8ccY/QsZgIjBekX6Ftw6fg1czQ==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@nextcloud/auth": "^2.0.0",
@@ -23785,7 +23784,6 @@
         "focus-trap": "^7.4.3",
         "linkify-string": "^4.0.0",
         "md5": "^2.3.0",
-        "node-polyfill-webpack-plugin": "^2.0.1",
         "rehype-external-links": "^3.0.0",
         "rehype-react": "^7.1.2",
         "remark-breaks": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@nextcloud/moment": "^1.2.2",
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^2.2.0",
-    "@nextcloud/vue": "^8.3.0",
+    "@nextcloud/vue": "^8.4.0",
     "crypto-js": "^4.2.0",
     "debounce": "^2.0.0",
     "emoji-mart-vue-fast": "^15.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,7 +46,7 @@ import { generateUrl } from '@nextcloud/router'
 
 import NcAppContent from '@nextcloud/vue/dist/Components/NcAppContent.js'
 import NcContent from '@nextcloud/vue/dist/Components/NcContent.js'
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
+import { useIsMobile } from '@nextcloud/vue/dist/Composables/useIsMobile.js'
 
 import ConversationSettingsDialog from './components/ConversationSettings/ConversationSettingsDialog.vue'
 import LeftSidebar from './components/LeftSidebar/LeftSidebar.vue'
@@ -81,13 +81,13 @@ export default {
 
 	mixins: [
 		talkHashCheck,
-		isMobile,
 	],
 
 	setup() {
 		return {
 			isInCall: useIsInCall(),
 			isLeavingAfterSessionIssue: useSessionIssueHandler(),
+			isMobile: useIsMobile(),
 			supportSessionState: useActiveSession(),
 		}
 	},

--- a/src/components/ConversationSettings/ConversationAvatarEditor.vue
+++ b/src/components/ConversationSettings/ConversationAvatarEditor.vue
@@ -44,8 +44,7 @@
 				<div class="avatar__buttons">
 					<!-- Set emoji as avatar -->
 					<template v-if="!showCropper">
-						<NcEmojiPicker :per-line="5"
-							@select="setEmoji">
+						<NcEmojiPicker :per-line="5" :container="container" @select="setEmoji">
 							<NcButton :title="t('spreed', 'Set emoji as conversation picture')"
 								:aria-label="t('spreed', 'Set emoji as conversation picture')">
 								<template #icon>
@@ -53,7 +52,7 @@
 								</template>
 							</NcButton>
 						</NcEmojiPicker>
-						<NcColorPicker v-if="emojiAvatar" v-model="backgroundColor">
+						<NcColorPicker v-if="emojiAvatar" v-model="backgroundColor" :container="container">
 							<NcButton :title="t('spreed', 'Set background color for conversation picture')"
 								:aria-label="t('spreed', 'Set background color for conversation picture')">
 								<template #icon>

--- a/src/components/ConversationSettings/EditableTextField.vue
+++ b/src/components/ConversationSettings/EditableTextField.vue
@@ -87,12 +87,12 @@ import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 export default {
 	name: 'EditableTextField',
 	components: {
-		NcRichText,
-		Pencil,
 		Check,
 		Close,
-		NcRichContenteditable,
 		NcButton,
+		NcRichContenteditable,
+		NcRichText,
+		Pencil,
 	},
 
 	directives: {
@@ -170,7 +170,6 @@ export default {
 	},
 
 	computed: {
-
 		canSubmit() {
 			return this.charactersCount <= this.maxLength && this.text !== this.initialText
 		},
@@ -200,6 +199,7 @@ export default {
 		initialText(newValue) {
 			this.text = newValue
 		},
+
 		editing(newValue) {
 			if (!newValue) {
 				this.text = this.initialText
@@ -263,11 +263,16 @@ export default {
 		margin-left: var(--default-clickable-area);
 	}
 
-  &__output {
-    width: 100%;
-    padding: 10px;
-    line-height: var(--default-line-height);
-  }
+	&__output {
+		width: 100%;
+		padding: 10px;
+		line-height: var(--default-line-height) !important;
+	}
+
+	// Restyle NcRichContenteditable component from our library.
+	:deep(.rich-contenteditable) {
+		flex-grow: 1;
+	}
 }
 
 .spinner {
@@ -288,29 +293,4 @@ export default {
 	align-items: center;
 	justify-content: center;
 }
-
-// Restyle NcRichContenteditable component from our library.
-:deep(.rich-contenteditable__input) {
-	align-self: flex-start;
-	min-height: var(--default-line-height);
-	max-height: unset;
-	margin: 12px 0 4px 0;
-	padding: 0 0 4px 0;
-	overflow: visible;
-	width: 100% !important;
-	background-color: transparent;
-	transition: $transition;
-	&::before {
-		position: relative;
-	}
-	&[contenteditable='false'] {
-		background-color: transparent;
-		color: var(--color-main-text);
-		border-color: transparent;
-		opacity: 1;
-		border-radius: 0;
-		user-select: text;
-	}
-}
-
 </style>

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -293,7 +293,7 @@ import NcAppNavigationCaption from '@nextcloud/vue/dist/Components/NcAppNavigati
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import NcListItem from '@nextcloud/vue/dist/Components/NcListItem.js'
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
+import { useIsMobile } from '@nextcloud/vue/dist/Composables/useIsMobile.js'
 
 import CallPhoneDialog from './CallPhoneDialog/CallPhoneDialog.vue'
 import Conversation from './ConversationsList/Conversation.vue'
@@ -358,16 +358,13 @@ export default {
 		NcEmptyContent,
 	},
 
-	mixins: [
-		isMobile,
-	],
-
 	setup() {
 		const leftSidebar = ref(null)
 		const searchBox = ref(null)
 		const list = ref(null)
 
 		const { initializeNavigation, resetNavigation } = useArrowNavigation(leftSidebar, searchBox, '.list-item')
+		const isMobile = useIsMobile()
 
 		return {
 			initializeNavigation,
@@ -375,6 +372,7 @@ export default {
 			leftSidebar,
 			searchBox,
 			list,
+			isMobile,
 			canModerateSipDialOut,
 		}
 	},

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -87,7 +87,6 @@
 				</div>
 				<NcRichContenteditable ref="richContenteditable"
 					v-shortkey.once="$options.disableKeyboardShortcuts ? null : ['c']"
-					class="new-message-form__richContenteditable"
 					:value.sync="text"
 					:auto-complete="autoComplete"
 					:disabled="disabled"
@@ -865,34 +864,27 @@ export default {
 .new-message-form {
 	align-items: flex-end;
 	display: flex;
+	gap: 4px;
 	position: relative;
 	max-width: 700px;
 	margin: 0 auto;
 
 	&__emoji-picker {
 		position: absolute;
-		bottom: 1px;
+		bottom: 0;
 		z-index: 1;
 	}
 
 	&__input {
 		flex-grow: 1;
-		overflow: hidden;
 		position: relative;
 	}
 
 	// Override NcRichContenteditable styles
-	& &__richContenteditable {
-		border: 2px solid var(--color-border-dark);
+	:deep(.rich-contenteditable__input) {
 		border-radius: calc(var(--default-clickable-area) / 2);
 		padding: 8px 16px 8px 44px;
 		max-height: 180px;
-
-		&:hover,
-		&:focus,
-		&:active {
-			border: 2px solid var(--color-main-text);
-		}
 	}
 
 	&__quote {

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -406,6 +406,10 @@ export default {
 		userAbsence() {
 			return this.chatExtrasStore.absence[this.token]
 		},
+
+		isMobileDevice() {
+			return /Android|iPhone|iPad|iPod/i.test(navigator.userAgent)
+		}
 	},
 
 	watch: {
@@ -797,7 +801,7 @@ export default {
 		},
 
 		focusInput() {
-			if (this.isMobile()) {
+			if (this.isMobileDevice) {
 				return
 			}
 			this.$nextTick().then(() => {
@@ -815,10 +819,6 @@ export default {
 			if (!this.isTributePickerActive) {
 				this.blurInput()
 			}
-		},
-
-		isMobile() {
-			return /Android|iPhone|iPad|iPod/i.test(navigator.userAgent)
 		},
 
 		async checkAbsenceStatus() {

--- a/src/stores/__tests__/sharedItems.spec.js
+++ b/src/stores/__tests__/sharedItems.spec.js
@@ -136,7 +136,7 @@ describe('sharedItemsStore', () => {
 
 			const responseOverview = generateOCSResponse({ payload: payloadOverview })
 			getSharedItemsOverview.mockResolvedValueOnce(responseOverview)
-			const response = generateOCSResponse({ payload: [message] })
+			const response = generateOCSResponse({ payload: { 1: message } })
 			getSharedItems.mockResolvedValueOnce(response)
 			await sharedItemsStore.getSharedItemsOverview(token)
 

--- a/src/stores/sharedItems.js
+++ b/src/stores/sharedItems.js
@@ -143,7 +143,7 @@ export const useSharedItemsStore = defineStore('sharedItems', {
 			const lastKnownMessageId = Math.min.apply(Math, Object.keys(this.sharedItemsPool[token][type]))
 			try {
 				const response = await getSharedItems(token, type, lastKnownMessageId, limit)
-				const messages = response.data.ocs.data
+				const messages = Object.values(response.data.ocs.data)
 				if (messages.length) {
 					this.addSharedItemsFromMessages(token, type, messages)
 				}


### PR DESCRIPTION
### ☑️ Resolves

* Bump `@nextcloud/vue` library from 8.3.0 to 8.4.0
* Fix #11285
* Migrate from `isMobile` mixin to composable
* Define containers for pickers in dialog (backport! :ship: )
* Drop some overwritten styles for NcRichContenteditable
* Fix error with fetching in SharedItemsBrowser (backport! :ship: cc @SystemKeeper)
* All visual and a11y changes as per library changelog: https://github.com/nextcloud-libraries/nextcloud-vue/releases/tag/v8.4.0



## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before 
--
![image](https://github.com/nextcloud/spreed/assets/93392545/ae4f40ba-1436-444b-a6f1-798e85ca5fd0)

🏡 After
--
![image](https://github.com/nextcloud/spreed/assets/93392545/4ded9b00-ec49-4bc3-b278-13552f63e08b)

TODO: check why tests worked fine here: https://github.com/nextcloud/spreed/blob/main/src%2Fstores%2F__tests__%2FsharedItems.spec.js#L139 

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences