### PR TITLE
fix(reactions): add guardian before resetting reactions

### DIFF
--- a/src/stores/reactions.js
+++ b/src/stores/reactions.js
@@ -148,6 +148,9 @@ export const useReactionsStore = defineStore('reactions', {
 		 *
 		 */
 		resetReactions(token, messageId) {
+			if (!this.reactions[token]?.[messageId]) {
+				return
+			}
 			Vue.delete(this.reactions[token], messageId)
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix `resetReactions` action, which prevents rendering of following messages
* Add test for `purgeReactionsStore`

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/93aee645-4de7-4f37-8e6b-f4cc87f2142b)          | ![image](https://github.com/nextcloud/spreed/assets/93392545/6618dd11-543a-4af1-bde8-22022cdc4265)        |


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] ⛑️ Tests are included or not possible