### PR TITLE
fix(Message): optimize getters and provided props

### DIFF
--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -387,7 +387,7 @@ export default {
 		},
 
 		hasCall() {
-			return this.conversation.hasCall || this.conversation.hasCallOverwrittenByChat
+			return this.conversation.hasCall
 		},
 
 		isCurrentlyRecording() {

--- a/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
@@ -64,16 +64,6 @@ describe('Message.vue', () => {
 		}
 
 		injected = {
-			scrollerBoundingClientRect: {
-				x: 0,
-				y: 0,
-				width: 0,
-				height: 0,
-				top: 0,
-				right: 0,
-				bottom: 0,
-				left: 0,
-			},
 			getMessagesListScroller: jest.fn(),
 		}
 

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -247,9 +247,6 @@ const isTranslationAvailable = getCapabilities()?.spreed?.config?.chat?.['has-tr
 	// Fallback for the desktop client when connecting to Talk 17
 	?? getCapabilities()?.spreed?.config?.chat?.translations?.length > 0
 
-/**
- * @property {object} scrollerBoundingClientRect provided by MessageList.vue
- */
 export default {
 	name: 'Message',
 
@@ -271,8 +268,6 @@ export default {
 		UnfoldLess,
 		UnfoldMore,
 	},
-
-	inject: ['scrollerBoundingClientRect'],
 
 	inheritAttrs: false,
 

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -503,23 +503,12 @@ export default {
 				&& !this.isDeletedMessage
 		},
 
-		messagesList() {
-			return this.$store.getters.messagesList(this.token)
-		},
-
 		isLastCallStartedMessage() {
-			// FIXME: remove dependency to messages list and convert to property
-			const messages = this.messagesList
-			// FIXME: don't reverse the whole array as it would create a copy, just do an actual reverse search
-			const lastCallStartedMessage = messages.reverse().find((message) => message.systemMessage === 'call_started')
-			return lastCallStartedMessage ? (this.id === lastCallStartedMessage.id) : false
+			return this.systemMessage === 'call_started' && this.id === this.$store.getters.getLastCallStartedMessageId
 		},
 
 		showJoinCallButton() {
-			return this.systemMessage === 'call_started'
-				&& this.conversation.hasCall
-				&& this.isLastCallStartedMessage
-				&& !this.isInCall
+			return this.conversation.hasCall && !this.isInCall && this.isLastCallStartedMessage
 		},
 
 		showResultsButton() {

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
@@ -93,16 +93,6 @@ describe('MessageButtonsBar.vue', () => {
 			store = new Store(testStoreConfig)
 
 			injected = {
-				scrollerBoundingClientRect: {
-					x: 0,
-					y: 0,
-					width: 0,
-					height: 0,
-					top: 0,
-					right: 0,
-					bottom: 0,
-					left: 0,
-				},
 				getMessagesListScroller: jest.fn(),
 			}
 		})

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -69,7 +69,6 @@ get the messagesList array and loop through the list to generate the messages.
 <script>
 import debounce from 'debounce'
 import uniqueId from 'lodash/uniqueId.js'
-import { computed } from 'vue'
 
 import Message from 'vue-material-design-icons/Message.vue'
 
@@ -98,7 +97,6 @@ export default {
 
 	provide() {
 		return {
-			scrollerBoundingClientRect: computed(() => this.$refs.scroller.getBoundingClientRect()),
 			getMessagesListScroller: () => this.$refs.scroller,
 		}
 	},

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -226,7 +226,7 @@ export default {
 		},
 
 		hasCall() {
-			return this.conversation.hasCall || this.conversation.hasCallOverwrittenByChat
+			return this.conversation.hasCall
 		},
 
 		startCallButtonDisabled() {

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -215,14 +215,6 @@ const mutations = {
 		}
 	},
 
-	overwriteHasCallByChat(state, { token, hasCall }) {
-		if (hasCall) {
-			Vue.set(state.conversations[token], 'hasCallOverwrittenByChat', hasCall)
-		} else {
-			Vue.delete(state.conversations[token], 'hasCallOverwrittenByChat')
-		}
-	},
-
 	setNotificationLevel(state, { token, notificationLevel }) {
 		Vue.set(state.conversations[token], 'notificationLevel', notificationLevel)
 	},
@@ -792,8 +784,16 @@ const actions = {
 		commit('updateConversationLastReadMessage', { token, lastReadMessage })
 	},
 
-	async overwriteHasCallByChat({ commit }, { token, hasCall }) {
-		commit('overwriteHasCallByChat', { token, hasCall })
+	async overwriteHasCallByChat({ commit, dispatch }, { token, hasCall, lastActivity }) {
+		dispatch('setConversationProperties', {
+			token,
+			properties: {
+				hasCall,
+				callFlag: hasCall ? PARTICIPANT.CALL_FLAG.IN_CALL : PARTICIPANT.CALL_FLAG.DISCONNECTED,
+				lastActivity,
+				callStartTime: hasCall ? lastActivity : 0,
+			}
+		})
 	},
 
 	async fetchConversation({ dispatch }, { token }) {

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -750,6 +750,11 @@ const actions = {
 
 		const activeSince = (new Date(notification.datetime)).getTime() / 1000
 
+		// Check if notification information is older than in known conversation object
+		if (activeSince < getters.conversations[token].lastActivity) {
+			return
+		}
+
 		const conversation = Object.assign({}, getters.conversations[token], {
 			hasCall: true,
 			callFlag: PARTICIPANT.CALL_FLAG.WITH_VIDEO,

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -210,6 +210,10 @@ const getters = {
 		return null
 	},
 
+	getLastCallStartedMessageId: (state, getters, rootState, rootGetters) => {
+		return getters.messagesList(rootGetters.getToken()).findLast((message) => message.systemMessage === 'call_started')?.id
+	},
+
 	getFirstDisplayableMessageIdAfterReadMarker: (state, getters) => (token, readMessageId) => {
 		if (!state.messages[token]) {
 			return null

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -1090,25 +1090,11 @@ const actions = {
 			// Overwrite the conversation.hasCall property so people can join
 			// after seeing the message in the chat.
 			if (conversation && conversation.lastMessage && message.id > conversation.lastMessage.id) {
-				if (message.systemMessage === 'call_started') {
+				if (['call_started', 'call_ended', 'call_ended_everyone', 'call_missed'].includes(message.systemMessage)) {
 					context.dispatch('overwriteHasCallByChat', {
 						token,
-						hasCall: true,
-					})
-					context.dispatch('setConversationProperties', {
-						token: message.token,
-						properties: { callStartTime: message.timestamp },
-					})
-				} else if (message.systemMessage === 'call_ended'
-					|| message.systemMessage === 'call_ended_everyone'
-					|| message.systemMessage === 'call_missed') {
-					context.dispatch('overwriteHasCallByChat', {
-						token,
-						hasCall: false,
-					})
-					context.dispatch('setConversationProperties', {
-						token: message.token,
-						properties: { callStartTime: 0 },
+						hasCall: message.systemMessage === 'call_started',
+						lastActivity: message.timestamp,
 					})
 				}
 			}


### PR DESCRIPTION
### ☑️ Resolves

* Delete unused `scrollerBoundingClientRect` prop
* Move computation of `isLastCallStartedMessage` to store
* Make update of `hasCall` more clear across the app
  * Prevent notifications from updating store if already done
## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] ⛑️ Tests are included or not possible