### PR TITLE
fix(bots): Don't allow empty messages from bots

### DIFF
--- a/docs/bots.md
+++ b/docs/bots.md
@@ -106,7 +106,7 @@ Bots can also send message. On the sending process the same signature/verificati
 * Response:
     - Status code:
         + `201 Created` When the message was posted successfully
-        + `400 Bad Request` When the provided replyTo parameter is invalid
+        + `400 Bad Request` When the provided replyTo parameter is invalid or the message is empty
         + `401 Unauthenticated` When the bot could not be verified for the conversation
         + `404 Not Found` When the conversation could not be found
         + `413 Payload Too Large` When the message was longer than the allowed limit of 32000 characters (or 1000 until Nextcloud 16.0.1, check the `spreed => config => chat => max-length` capability for the limit)

--- a/lib/Controller/BotController.php
+++ b/lib/Controller/BotController.php
@@ -134,7 +134,7 @@ class BotController extends AEnvironmentAwareController {
 	 * @return DataResponse<Http::STATUS_CREATED|Http::STATUS_BAD_REQUEST|Http::STATUS_UNAUTHORIZED|Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array<empty>, array{}>
 	 *
 	 * 201: Message sent successfully
-	 * 400: Sending message is not possible
+	 * 400: When the replyTo is invalid or message is empty
 	 * 401: Sending message is not allowed
 	 * 404: Room or session not found
 	 * 413: Message too long
@@ -142,6 +142,10 @@ class BotController extends AEnvironmentAwareController {
 	#[BruteForceProtection(action: 'bot')]
 	#[PublicPage]
 	public function sendMessage(string $token, string $message, string $referenceId = '', int $replyTo = 0, bool $silent = false): DataResponse {
+		if (trim($message) === '') {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
 		try {
 			$bot = $this->getBotFromHeaders($token, $message);
 		} catch (\InvalidArgumentException $e) {

--- a/openapi.json
+++ b/openapi.json
@@ -1810,7 +1810,7 @@
                         }
                     },
                     "400": {
-                        "description": "Sending message is not possible",
+                        "description": "When the replyTo is invalid or message is empty",
                         "content": {
                             "application/json": {
                                 "schema": {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11295 

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
