### PR TITLE
enh(Message): split out MessageBody component

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
@@ -18,6 +18,7 @@ import DefaultParameter from './MessagePart/DefaultParameter.vue'
 import FilePreview from './MessagePart/FilePreview.vue'
 import Location from './MessagePart/Location.vue'
 import Mention from './MessagePart/Mention.vue'
+import MessageBody from './MessagePart/MessageBody.vue'
 import Quote from '../../../Quote.vue'
 
 import * as useIsInCallModule from '../../../../composables/useIsInCall.js'
@@ -109,6 +110,9 @@ describe('Message.vue', () => {
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
+				stubs: {
+					MessageBody,
+				},
 				propsData: messageProps,
 				provide: injected,
 			})
@@ -123,15 +127,16 @@ describe('Message.vue', () => {
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
+				stubs: {
+					MessageBody,
+				},
 				propsData: messageProps,
 				provide: injected,
 			})
 
-			const emoji = wrapper.find('.message-body__main__text')
-			expect(emoji.text()).toBe('🌧️')
-
 			const message = wrapper.findComponent({ name: 'NcRichText' })
-			expect(message.exists()).toBe(false)
+			expect(message.exists()).toBeTruthy()
+			expect(message.attributes('text')).toBe('🌧️')
 		})
 
 		describe('call button', () => {
@@ -159,6 +164,9 @@ describe('Message.vue', () => {
 				const wrapper = shallowMount(Message, {
 					localVue,
 					store,
+					stubs: {
+						MessageBody,
+					},
 					propsData: messageProps,
 					provide: injected,
 				})
@@ -179,6 +187,9 @@ describe('Message.vue', () => {
 				const wrapper = shallowMount(Message, {
 					localVue,
 					store,
+					stubs: {
+						MessageBody,
+					},
 					propsData: messageProps,
 					provide: injected,
 				})
@@ -196,6 +207,9 @@ describe('Message.vue', () => {
 				const wrapper = shallowMount(Message, {
 					localVue,
 					store,
+					stubs: {
+						MessageBody,
+					},
 					propsData: messageProps,
 					provide: injected,
 				})
@@ -215,6 +229,9 @@ describe('Message.vue', () => {
 				const wrapper = shallowMount(Message, {
 					localVue,
 					store,
+					stubs: {
+						MessageBody,
+					},
 					propsData: messageProps,
 					provide: injected,
 				})
@@ -232,6 +249,9 @@ describe('Message.vue', () => {
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
+				stubs: {
+					MessageBody,
+				},
 				propsData: messageProps,
 				provide: injected,
 			})
@@ -244,6 +264,9 @@ describe('Message.vue', () => {
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
+				stubs: {
+					MessageBody,
+				},
 				propsData: messageProps,
 				provide: injected,
 			})
@@ -273,6 +296,9 @@ describe('Message.vue', () => {
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
+				stubs: {
+					MessageBody,
+				},
 				propsData: messageProps,
 				provide: injected,
 			})
@@ -295,6 +321,7 @@ describe('Message.vue', () => {
 					localVue,
 					store,
 					stubs: {
+						MessageBody,
 						RichText: RichTextStub,
 					},
 					propsData: messageProps,
@@ -482,6 +509,9 @@ describe('Message.vue', () => {
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
+				stubs: {
+					MessageBody,
+				},
 				directives: {
 					observeVisibility,
 				},
@@ -516,6 +546,9 @@ describe('Message.vue', () => {
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
+				stubs: {
+					MessageBody,
+				},
 				directives: {
 					observeVisibility,
 				},
@@ -540,6 +573,9 @@ describe('Message.vue', () => {
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
+				stubs: {
+					MessageBody,
+				},
 				propsData: messageProps,
 				provide: injected,
 			})
@@ -554,6 +590,9 @@ describe('Message.vue', () => {
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
+				stubs: {
+					MessageBody,
+				},
 				propsData: messageProps,
 				provide: injected,
 			})
@@ -568,6 +607,9 @@ describe('Message.vue', () => {
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
+				stubs: {
+					MessageBody,
+				},
 				propsData: messageProps,
 				provide: injected,
 			})
@@ -581,6 +623,9 @@ describe('Message.vue', () => {
 			const wrapper = mount(Message, {
 				localVue,
 				store,
+				stubs: {
+					MessageBody,
+				},
 				propsData: messageProps,
 				provide: injected,
 			})
@@ -617,6 +662,7 @@ describe('Message.vue', () => {
 				localVue,
 				store,
 				stubs: {
+					MessageBody,
 					NcActionButton,
 					MessageButtonsBar,
 				},
@@ -658,6 +704,9 @@ describe('Message.vue', () => {
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
+				stubs: {
+					MessageBody,
+				},
 				propsData: messageProps,
 				provide: injected,
 			})
@@ -669,8 +718,6 @@ describe('Message.vue', () => {
 			expect(reloadButton.exists()).toBe(true)
 
 			await reloadButton.trigger('mouseover')
-
-			expect(wrapper.vm.showReloadButton).toBe(true)
 
 			const reloadNcButton = wrapper.findComponent(NcButton)
 			expect(reloadNcButton.exists()).toBe(true)
@@ -688,6 +735,9 @@ describe('Message.vue', () => {
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
+				stubs: {
+					MessageBody,
+				},
 				propsData: messageProps,
 				provide: injected,
 			})
@@ -703,6 +753,9 @@ describe('Message.vue', () => {
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
+				stubs: {
+					MessageBody,
+				},
 				propsData: messageProps,
 				provide: injected,
 			})
@@ -716,6 +769,9 @@ describe('Message.vue', () => {
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
+				stubs: {
+					MessageBody,
+				},
 				propsData: messageProps,
 				provide: injected,
 			})
@@ -731,6 +787,9 @@ describe('Message.vue', () => {
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
+				stubs: {
+					MessageBody,
+				},
 				propsData: messageProps,
 				provide: injected,
 			})

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -420,10 +420,6 @@ export default {
 					const props = Object.assign({}, this.messageParameters[p])
 					// Add the token to the component props
 					props.token = this.token
-					// The word 'name' is reserved in for the component name in
-					// Vue instances, so we cannot pass that into the component
-					// as a prop, therefore we rename it into pollName
-					props.pollName = this.messageParameters[p].name
 					richParameters[p] = {
 						component: Poll,
 						props,

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -48,6 +48,7 @@
 				:timestamp="timestamp"
 				:is-deleting="isDeleting"
 				:is-temporary="isTemporary"
+				:has-call="conversation.hasCall"
 				:sending-failure="sendingFailure"
 				:show-common-read-icon="showCommonReadIcon"
 				:common-read-icon-tooltip="commonReadIconTooltip"
@@ -585,7 +586,7 @@ export default {
 }
 
 .message-body {
-	padding: 4px;
+	padding: 4px 4px 4px 8px;
 	font-size: var(--default-font-size);
 	line-height: var(--default-line-height);
 	position: relative;
@@ -598,12 +599,6 @@ export default {
 		height: 100%;
 		padding: 8px 8px 0 0;
 	}
-}
-
-// Increase the padding for regular messages to improve readability and
-// allow some space for the reply button
-.message-body:not(.system) {
-	padding: 4px 4px 4px 8px;
 }
 
 .message--highlighted {

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
@@ -60,6 +60,8 @@ describe('MessageButtonsBar.vue', () => {
 			isTranslationAvailable: false,
 			canReact: true,
 			isReactionsMenuOpen: false,
+			isActionMenuOpen: false,
+			isEmojiPickerOpen: false,
 			isLastRead: false,
 			isForwarderOpen: false,
 			timestamp: new Date('2020-05-07 09:23:00').getTime() / 1000,
@@ -67,10 +69,6 @@ describe('MessageButtonsBar.vue', () => {
 			systemMessage: '',
 			messageType: 'comment',
 			previousMessageId: 100,
-			messageObject: {},
-			messageApiData: {
-				apiDummyData: 1,
-			},
 			participant: {
 				actorId: 'user-id-1',
 				actorType: ATTENDEE.ACTOR_TYPE.USERS,
@@ -333,7 +331,7 @@ describe('MessageButtonsBar.vue', () => {
 		test('marks message as unread', async () => {
 			const updateLastReadMessageAction = jest.fn().mockResolvedValueOnce()
 			const fetchConversationAction = jest.fn().mockResolvedValueOnce()
-			testStoreConfig.modules.conversationsStore.actions.updateLastReadMessage = updateLastReadMessageAction
+			testStoreConfig.modules.messagesStore.actions.updateLastReadMessage = updateLastReadMessageAction
 			testStoreConfig.modules.conversationsStore.actions.fetchConversation = fetchConversationAction
 			store = new Store(testStoreConfig)
 
@@ -437,19 +435,23 @@ describe('MessageButtonsBar.vue', () => {
 			})
 
 			const actionButton = findNcActionButton(wrapper, 'first action')
-			expect(actionButton.exists()).toBe(true)
+			expect(actionButton.exists()).toBeTruthy()
 			await actionButton.find('button').trigger('click')
 
 			expect(handler).toHaveBeenCalledWith({
-				apiDummyData: 1,
+				apiVersion: 'v3',
+				message: messageProps,
+				metadata: conversationProps,
 			},)
 
 			const actionButton2 = findNcActionButton(wrapper, 'second action')
-			expect(actionButton2.exists()).toBe(true)
+			expect(actionButton2.exists()).toBeTruthy()
 			await actionButton2.find('button').trigger('click')
 
 			expect(handler2).toHaveBeenCalledWith({
-				apiDummyData: 1,
+				apiVersion: 'v3',
+				message: messageProps,
+				metadata: conversationProps,
 			})
 		})
 	})

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageForwarder.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageForwarder.vue
@@ -3,7 +3,7 @@
   -
   - @author Marco Ambrosini <marcoambrosini@icloud.com>
   -
-  - @license GNU AGPL version 3 or any later version
+  - @license AGPL-3.0-or-later
   -
   - This program is free software: you can redistribute it and/or modify
   - it under the terms of the GNU Affero General Public License as
@@ -78,11 +78,12 @@ export default {
 	},
 
 	props: {
-		/**
-		 * The message to be forwarded
-		 */
-		messageObject: {
-			type: Object,
+		token: {
+			type: String,
+			required: true,
+		},
+		id: {
+			type: [String, Number],
 			required: true,
 		},
 	},
@@ -122,7 +123,7 @@ export default {
 			try {
 				const response = await this.$store.dispatch('forwardMessage', {
 					targetToken: this.selectedConversationToken,
-					messageToBeForwarded: this.messageObject,
+					messageToBeForwarded: this.$store.getters.message(this.token, this.id),
 				 })
 				this.forwardedMessageID = response.data.ocs.data.id
 				this.showForwardedConfirmation = true

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -1,0 +1,563 @@
+<!--
+  - @copyright Copyright (c) 2024 Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @author Maksim Sukharev <antreesy.web@gmail.com>
+  - @author Marco Ambrosini <marcoambrosini@icloud.com>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+	<div ref="messageMain" class="message-body__main">
+		<!-- Message body content -->
+		<div v-if="isSingleEmoji" class="message-body__main__text">
+			<Quote v-if="parent" v-bind="parent" />
+			<div class="single-emoji">
+				{{ renderedMessage }}
+			</div>
+		</div>
+		<div v-else-if="showJoinCallButton" class="message-body__main__text call-started">
+			<NcRichText :text="renderedMessage"
+				:arguments="richParameters"
+				autolink
+				dir="auto"
+				:reference-limit="0" />
+			<CallButton />
+		</div>
+		<div v-else-if="showResultsButton || isSystemMessage" class="message-body__main__text system-message">
+			<NcRichText :text="renderedMessage"
+				:arguments="richParameters"
+				autolink
+				dir="auto"
+				:reference-limit="0" />
+			<!-- Displays only the "see results" button with the results modal -->
+			<Poll v-if="showResultsButton"
+				:id="messageParameters.poll.id"
+				:poll-name="messageParameters.poll.name"
+				:token="token"
+				show-as-button />
+		</div>
+		<div v-else-if="isDeletedMessage" class="message-body__main__text deleted-message">
+			<NcRichText :text="renderedMessage"
+				:arguments="richParameters"
+				autolink
+				dir="auto"
+				:reference-limit="0" />
+		</div>
+
+		<div v-else
+			class="message-body__main__text markdown-message"
+			@mouseover="handleMarkdownMouseOver"
+			@mouseleave="handleMarkdownMouseLeave">
+			<Quote v-if="parent" v-bind="parent" />
+			<NcRichText :text="renderedMessage"
+				:arguments="richParameters"
+				autolink
+				dir="auto"
+				:use-markdown="markdown"
+				:reference-limit="1" />
+
+			<NcButton v-if="containsCodeBlocks"
+				v-show="currentCodeBlock !== null"
+				class="message-copy-code"
+				type="tertiary"
+				:aria-label="t('spreed', 'Copy code block')"
+				:title="t('spreed', 'Copy code block')"
+				:style="{top: copyButtonOffset}"
+				@click="copyCodeBlock">
+				<template #icon>
+					<ContentCopy :size="16" />
+				</template>
+			</NcButton>
+		</div>
+
+		<!-- Additional message info-->
+		<div v-if="!isDeletedMessage" class="message-body__main__right">
+			<span :title="messageDate"
+				class="date"
+				:style="{'visibility': hasDate ? 'visible' : 'hidden'}"
+				:class="{'date--self': showSentIcon}">{{ messageTime }}</span>
+
+			<!-- Message delivery status indicators -->
+			<div v-if="sendingFailure"
+				:title="sendingErrorIconTooltip"
+				class="message-status sending-failed"
+				:class="{'retry-option': sendingErrorCanRetry}"
+				:aria-label="sendingErrorIconTooltip"
+				tabindex="0"
+				@mouseover="showReloadButton = true"
+				@focus="showReloadButton = true"
+				@mouseleave="showReloadButton = false"
+				@blur="showReloadButton = false">
+				<NcButton v-if="sendingErrorCanRetry && showReloadButton"
+					:aria-label="sendingErrorIconTooltip"
+					@click="handleRetry">
+					<template #icon>
+						<Reload :size="16" />
+					</template>
+				</NcButton>
+				<AlertCircle v-else
+					:size="16" />
+			</div>
+			<div v-else-if="isTemporary && !isTemporaryUpload || isDeleting"
+				:title="loadingIconTooltip"
+				class="icon-loading-small message-status"
+				:aria-label="loadingIconTooltip" />
+			<div v-else-if="showCommonReadIcon"
+				:title="commonReadIconTooltip"
+				class="message-status"
+				:aria-label="commonReadIconTooltip">
+				<CheckAll :size="16" />
+			</div>
+			<div v-else-if="showSentIcon"
+				:title="sentIconTooltip"
+				class="message-status"
+				:aria-label="sentIconTooltip">
+				<Check :size="16" />
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import emojiRegex from 'emoji-regex'
+
+import AlertCircle from 'vue-material-design-icons/AlertCircle.vue'
+import Check from 'vue-material-design-icons/Check.vue'
+import CheckAll from 'vue-material-design-icons/CheckAll.vue'
+import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
+import Reload from 'vue-material-design-icons/Reload.vue'
+
+import { showError, showSuccess } from '@nextcloud/dialogs'
+import moment from '@nextcloud/moment'
+
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcRichText from '@nextcloud/vue/dist/Components/NcRichText.js'
+
+import Poll from './Poll.vue'
+import Quote from '../../../../Quote.vue'
+import CallButton from '../../../../TopBar/CallButton.vue'
+
+import { useIsInCall } from '../../../../../composables/useIsInCall.js'
+import { EventBus } from '../../../../../services/EventBus.js'
+
+export default {
+	name: 'MessageBody',
+
+	components: {
+		CallButton,
+		NcButton,
+		NcRichText,
+		Poll,
+		Quote,
+		// Icons
+		AlertCircle,
+		Check,
+		CheckAll,
+		ContentCopy,
+		Reload,
+	},
+
+	props: {
+		id: {
+			type: [String, Number],
+			required: true,
+		},
+		token: {
+			type: String,
+			required: true,
+		},
+		parent: {
+			type: Object,
+			default: undefined,
+		},
+		markdown: {
+			type: Boolean,
+			default: true,
+		},
+		message: {
+			type: String,
+			required: true,
+		},
+		messageType: {
+			type: String,
+			required: true,
+		},
+		systemMessage: {
+			type: String,
+			required: true,
+		},
+		messageParameters: {
+			type: [Array, Object],
+			required: true,
+		},
+		richParameters: {
+			type: Object,
+			required: true,
+		},
+		timestamp: {
+			type: Number,
+			default: 0,
+		},
+		isDeleting: {
+			type: Boolean,
+			default: false,
+		},
+		isTemporary: {
+			type: Boolean,
+			default: false,
+		},
+		sendingFailure: {
+			type: String,
+			default: '',
+		},
+
+		/**
+		 * Message read information
+		 */
+		showCommonReadIcon: {
+			type: Boolean,
+			required: true,
+		},
+		commonReadIconTooltip: {
+			type: String,
+			required: true,
+		},
+		showSentIcon: {
+			type: Boolean,
+			required: true,
+		},
+		sentIconTooltip: {
+			type: String,
+			required: true,
+		},
+	},
+
+	setup() {
+		return {
+			isInCall: useIsInCall(),
+		}
+	},
+
+	data() {
+		return {
+			showReloadButton: false,
+			codeBlocks: null,
+			currentCodeBlock: null,
+			copyButtonOffset: 0,
+		}
+	},
+
+	computed: {
+		renderedMessage() {
+			if (this.messageParameters?.file && this.message !== '{file}') {
+				// Add a new line after file to split content into different paragraphs
+				return '{file}' + '\n\n' + this.message
+			} else {
+				return this.message
+			}
+		},
+
+		messageObject() {
+			return this.$store.getters.message(this.token, this.id)
+		},
+
+		isSystemMessage() {
+			return this.systemMessage !== ''
+		},
+
+		isDeletedMessage() {
+			return this.messageType === 'comment_deleted'
+		},
+
+		messageTime() {
+			return moment(this.timestamp * 1000).format('LT')
+		},
+
+		messageDate() {
+			return moment(this.timestamp * 1000).format('LL')
+		},
+
+		conversation() {
+			return this.$store.getters.conversation(this.token)
+		},
+
+		isLastCallStartedMessage() {
+			return this.systemMessage === 'call_started' && this.id === this.$store.getters.getLastCallStartedMessageId
+		},
+
+		showJoinCallButton() {
+			return this.conversation.hasCall && !this.isInCall && this.isLastCallStartedMessage
+		},
+
+		showResultsButton() {
+			return this.systemMessage === 'poll_closed'
+		},
+
+		isSingleEmoji() {
+			const regex = emojiRegex()
+			let match
+			let emojiStrings = ''
+			let emojiCount = 0
+			const trimmedMessage = this.renderedMessage.trim()
+
+			// eslint-disable-next-line no-cond-assign
+			while (match = regex.exec(trimmedMessage)) {
+				if (emojiCount > 2) {
+					return false
+				}
+
+				emojiStrings += match[0]
+				emojiCount++
+			}
+
+			return emojiStrings === trimmedMessage
+		},
+
+		// Determines whether the date has to be displayed or not
+		hasDate() {
+			return (!this.isTemporary && !this.isDeleting && !this.sendingFailure)
+		},
+
+		isTemporaryUpload() {
+			return this.isTemporary && this.messageParameters.file
+		},
+
+		loadingIconTooltip() {
+			return t('spreed', 'Sending message')
+		},
+
+		sendingErrorCanRetry() {
+			return this.sendingFailure === 'timeout' || this.sendingFailure === 'other'
+				|| this.sendingFailure === 'failed-upload'
+		},
+
+		sendingErrorIconTooltip() {
+			if (this.sendingErrorCanRetry) {
+				return t('spreed', 'Failed to send the message. Click to try again')
+			}
+			if (this.sendingFailure === 'quota') {
+				return t('spreed', 'Not enough free space to upload file')
+			}
+			if (this.sendingFailure === 'failed-share') {
+				return t('spreed', 'You are not allowed to share files')
+			}
+			return t('spreed', 'You cannot send messages to this conversation at the moment')
+		},
+
+		containsCodeBlocks() {
+			return this.message.includes('```')
+		},
+	},
+
+	watch: {
+		showJoinCallButton() {
+			EventBus.$emit('scroll-chat-to-bottom')
+		},
+	},
+
+	mounted() {
+		if (!this.containsCodeBlocks) {
+			return
+		}
+
+		this.codeBlocks = Array.from(this.$refs.messageMain?.querySelectorAll('pre'))
+	},
+
+	methods: {
+		handleMarkdownMouseOver(event) {
+			if (!this.containsCodeBlocks) {
+				return
+			}
+
+			const index = this.codeBlocks.findIndex(item => item.contains(event.target))
+			if (index !== -1) {
+				this.currentCodeBlock = index
+				const el = this.codeBlocks[index]
+				this.copyButtonOffset = `${el.offsetTop}px`
+			}
+		},
+
+		handleMarkdownMouseLeave() {
+			this.currentCodeBlock = null
+			this.copyButtonOffset = 0
+		},
+
+		async copyCodeBlock() {
+			const code = this.codeBlocks[this.currentCodeBlock].textContent
+			try {
+				await navigator.clipboard.writeText(code)
+				showSuccess(t('spreed', 'Code block copied to clipboard'))
+			} catch (error) {
+				showError(t('spreed', 'Code block could not be copied'))
+			}
+		},
+
+		handleRetry() {
+			if (this.sendingErrorCanRetry) {
+				if (this.sendingFailure === 'failed-upload') {
+					const caption = this.renderedMessage !== this.message ? this.message : undefined
+					this.$store.dispatch('retryUploadFiles', { token: this.token, uploadId: this.messageObject.uploadId, caption })
+				} else {
+					EventBus.$emit('retry-message', this.id)
+					EventBus.$emit('focus-chat-input')
+				}
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.message-body__main {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+	min-width: 100%;
+
+	&__text {
+		flex: 0 1 600px;
+		width: 100%;
+		min-width: 0;
+		max-width: 600px;
+		color: var(--color-text-light);
+		.single-emoji {
+			font-size: 250%;
+			line-height: 100%;
+		}
+
+		&.call-started {
+			background-color: var(--color-primary-element-light);
+			padding: 10px;
+			border-radius: var(--border-radius-large);
+			text-align: center;
+		}
+
+		&.system-message {
+			color: var(--color-text-maxcontrast);
+			text-align: center;
+			padding: 0 20px;
+			width: 100%;
+		}
+
+		&.deleted-message {
+			color: var(--color-text-lighter);
+			display: flex;
+			border-radius: var(--border-radius-large);
+			align-items: center;
+			:deep(.rich-text--wrapper) {
+				flex-grow: 1;
+				text-align: start;
+			}
+		}
+
+		&.markdown-message {
+			position: relative;
+
+			.message-copy-code {
+				position: absolute;
+				top: 0;
+				right: 4px;
+				margin-top: 4px;
+				background-color: var(--color-background-dark);
+			}
+
+			:deep(.rich-text--wrapper) {
+				text-align: start;
+
+				// Overwrite core styles, otherwise h4 is lesser than default font-size
+				h4 {
+				font-size: 100%;
+				}
+
+				em {
+				font-style: italic;
+				}
+
+				ul,
+				ol {
+				padding-left: 0;
+				padding-inline-start: 15px;
+				}
+
+				pre {
+				padding: 4px;
+				margin: 2px 0;
+				border-radius: var(--border-radius);
+				background-color: var(--color-background-dark);
+				overflow-x: auto;
+
+				& code {
+					margin: 0;
+					padding: 0;
+				}
+				}
+
+				code {
+				display: inline-block;
+				padding: 2px 4px;
+				margin: 2px 0;
+				border-radius: var(--border-radius);
+				background-color: var(--color-background-dark);
+				}
+
+				blockquote {
+				padding-left: 0;
+				padding-inline-start: 13px;
+				border-left: none;
+				border-inline-start: 4px solid var(--color-border);
+				}
+			}
+		}
+	}
+
+	&__right {
+		justify-self: flex-start;
+		justify-content: flex-end;
+		position: relative;
+		user-select: none;
+		display: flex;
+		color: var(--color-text-maxcontrast);
+		font-size: var(--default-font-size);
+		flex: 1 0 auto;
+		padding: 0 8px 0 8px;
+
+		.date {
+			margin-right: var(--default-clickable-area);
+			&--self {
+				margin-right: 0;
+			}
+		}
+	}
+}
+
+.message-status {
+	width: var(--default-clickable-area);
+	height: 24px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	&.retry-option {
+		cursor: pointer;
+	}
+}
+
+// Hardcode to prevent RTL affecting on user mentions
+:deep(.rich-text--component) {
+	direction: ltr;
+}
+</style>

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -166,6 +166,8 @@ export default {
 		ReloadIcon,
 	},
 
+	inheritAttrs: false,
+
 	props: {
 		id: {
 			type: [String, Number],

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -40,8 +40,7 @@
 			<!-- Additional controls -->
 			<CallButton v-if="showJoinCallButton" />
 			<Poll v-if="showResultsButton"
-				:id="messageParameters.poll.id"
-				:poll-name="messageParameters.poll.name"
+				v-bind="messageParameters.poll"
 				:token="token"
 				show-as-button />
 		</div>

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -31,6 +31,7 @@
 				'call-started': showJoinCallButton,
 			}">
 			<!-- Message content / text -->
+			<CancelIcon v-if="isDeletedMessage" :size="16" />
 			<NcRichText :text="renderedMessage"
 				:arguments="richParameters"
 				autolink
@@ -72,7 +73,7 @@
 				:style="{top: copyButtonOffset}"
 				@click="copyCodeBlock">
 				<template #icon>
-					<ContentCopy :size="16" />
+					<ContentCopyIcon :size="16" />
 				</template>
 			</NcButton>
 		</div>
@@ -96,10 +97,10 @@
 					:aria-label="sendingErrorIconTooltip"
 					@click="handleRetry">
 					<template #icon>
-						<Reload :size="16" />
+						<ReloadIcon :size="16" />
 					</template>
 				</NcButton>
-				<AlertCircle v-else :size="16" />
+				<AlertCircleIcon v-else :size="16" />
 			</div>
 			<div v-else-if="showLoadingIcon"
 				:title="loadingIconTooltip"
@@ -109,13 +110,13 @@
 				:title="commonReadIconTooltip"
 				class="message-status"
 				:aria-label="commonReadIconTooltip">
-				<CheckAll :size="16" />
+				<CheckAllIcon :size="16" />
 			</div>
 			<div v-else-if="showSentIcon"
 				:title="sentIconTooltip"
 				class="message-status"
 				:aria-label="sentIconTooltip">
-				<Check :size="16" />
+				<CheckIcon :size="16" />
 			</div>
 		</div>
 	</div>
@@ -124,11 +125,12 @@
 <script>
 import emojiRegex from 'emoji-regex'
 
-import AlertCircle from 'vue-material-design-icons/AlertCircle.vue'
-import Check from 'vue-material-design-icons/Check.vue'
-import CheckAll from 'vue-material-design-icons/CheckAll.vue'
-import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
-import Reload from 'vue-material-design-icons/Reload.vue'
+import AlertCircleIcon from 'vue-material-design-icons/AlertCircle.vue'
+import CancelIcon from 'vue-material-design-icons/Cancel.vue'
+import CheckIcon from 'vue-material-design-icons/Check.vue'
+import CheckAllIcon from 'vue-material-design-icons/CheckAll.vue'
+import ContentCopyIcon from 'vue-material-design-icons/ContentCopy.vue'
+import ReloadIcon from 'vue-material-design-icons/Reload.vue'
 
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import moment from '@nextcloud/moment'
@@ -156,11 +158,12 @@ export default {
 		Poll,
 		Quote,
 		// Icons
-		AlertCircle,
-		Check,
-		CheckAll,
-		ContentCopy,
-		Reload,
+		AlertCircleIcon,
+		CancelIcon,
+		CheckIcon,
+		CheckAllIcon,
+		ContentCopyIcon,
+		ReloadIcon,
 	},
 
 	props: {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
@@ -31,7 +31,7 @@
 			<div class="poll__header">
 				<PollIcon :size="20" />
 				<p>
-					{{ pollName }}
+					{{ name }}
 				</p>
 			</div>
 			<div class="poll__footer">
@@ -57,7 +57,7 @@
 				<div class="poll__header">
 					<PollIcon :size="20" />
 					<h2 class="poll__modal-title">
-						{{ pollName }}
+						{{ name }}
 					</h2>
 				</div>
 				<p class="poll__summary">
@@ -169,7 +169,7 @@ export default {
 	},
 
 	props: {
-		pollName: {
+		name: {
 			type: String,
 			required: true,
 		},

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -32,7 +32,7 @@
 		<ul class="messages">
 			<li class="messages__author" aria-level="4">
 				{{ actorDisplayName }}
-				<div v-if="lastEditActorDisplayName">
+				<div v-if="lastEditTimestamp">
 					{{ getLastEditor }}
 				</div>
 			</li>
@@ -64,6 +64,7 @@ export default {
 		AvatarWrapper,
 		Message,
 	},
+
 	inheritAttrs: false,
 
 	props: {
@@ -91,55 +92,30 @@ export default {
 			type: [String, Number],
 			default: 0,
 		},
-
-		lastEditTimestamp: {
-			type: Number,
-			default: 0,
-		},
-		lastEditActorId: {
-			type: String,
-			default: '',
-		},
-		lastEditActorType: {
-			type: String,
-			default: '',
-		},
-
-		lastEditActorDisplayName: {
-			type: String,
-			default: ''
-		},
 	},
 
 	setup() {
-		const guestNameStore = useGuestNameStore()
-		return { AVATAR, guestNameStore }
+		return {
+			AVATAR,
+			guestNameStore: useGuestNameStore()
+		}
 	},
 
 	expose: ['highlightMessage'],
 
 	computed: {
-		/**
-		 * The message actor type.
-		 *
-		 * @return {string}
-		 */
-		actorType() {
-			return this.messages[0].actorType
-		},
-		/**
-		 * The message actor id.
-		 *
-		 * @return {string}
-		 */
 		actorId() {
 			return this.messages[0].actorId
 		},
-		/**
-		 * The message actor display name.
-		 *
-		 * @return {string}
-		 */
+
+		actorType() {
+			return this.messages[0].actorType
+		},
+
+		lastEditTimestamp() {
+			return this.messages[0].lastEditTimestamp
+		},
+
 		actorDisplayName() {
 			const displayName = this.messages[0].actorDisplayName.trim()
 
@@ -155,16 +131,18 @@ export default {
 		},
 
 		getLastEditor() {
-			if (this.lastEditActorId === this.actorId && this.lastEditActorType === this.actorType) {
+			if (!this.lastEditTimestamp) {
+				return ''
+			} else if (this.messages[0].lastEditActorId === this.actorId
+				&& this.messages[0].lastEditActorType === this.actorType) {
 				// TRANSLATORS Edited by the author of the message themselves
 				return t('spreed', '(edited)')
-			} else if (this.lastEditActorId === this.$store.getters.getActorId()
-						&& this.lastEditActorType === this.$store.getters.getActorType()) {
+			} else if (this.messages[0].lastEditActorId === this.$store.getters.getActorId()
+				&& this.messages[0].lastEditActorType === this.$store.getters.getActorType()) {
 				return t('spreed', '(edited by you)')
 			} else {
-				return t('spreed', '(edited by {moderator})', { moderator: this.lastEditActorDisplayName })
+				return t('spreed', '(edited by {moderator})', { moderator: this.messages[0].lastEditActorDisplayName })
 			}
-
 		},
 
 		disableMenu() {

--- a/src/components/MessagesList/MessagesList.spec.js
+++ b/src/components/MessagesList/MessagesList.spec.js
@@ -129,23 +129,16 @@ describe('MessagesList.vue', () => {
 			expect(group.props('messages')).toStrictEqual(messagesGroup1)
 			expect(group.props('previousMessageId')).toBe(0)
 			expect(group.props('nextMessageId')).toBe(200)
-			// using attributes to access v-bind props
-			expect(group.attributes('actorid')).toBe('alice')
-			expect(group.attributes('actortype')).toBe(ATTENDEE.ACTOR_TYPE.USERS)
 
 			group = groups.at(1)
 			expect(group.props('messages')).toStrictEqual(messagesGroup2)
 			expect(group.props('previousMessageId')).toBe(110)
 			expect(group.props('nextMessageId')).toBe(300)
-			expect(group.attributes('actorid')).toBe('bob')
-			expect(group.attributes('actortype')).toBe(ATTENDEE.ACTOR_TYPE.USERS)
 
 			group = groups.at(2)
 			expect(group.props('messages')).toStrictEqual(messagesGroup3)
 			expect(group.props('previousMessageId')).toBe(210)
 			expect(group.props('nextMessageId')).toBe(0)
-			expect(group.attributes('actorid')).toBe('alice')
-			expect(group.attributes('actortype')).toBe(ATTENDEE.ACTOR_TYPE.USERS)
 
 			expect(messagesListMock).toHaveBeenCalledWith(TOKEN)
 
@@ -208,23 +201,11 @@ describe('MessagesList.vue', () => {
 
 			const groups = wrapper.findAllComponents({ name: 'MessagesGroup' })
 
-			expect(groups.exists()).toBe(true)
+			expect(groups.exists()).toBeTruthy()
 
-			let group = groups.at(0)
-			expect(group.props('messages')).toStrictEqual([messages[0]])
-			// using attributes to access v-bind props
-			expect(group.attributes('actorid')).toBe('alice')
-			expect(group.attributes('actortype')).toBe(ATTENDEE.ACTOR_TYPE.USERS)
-
-			group = groups.at(1)
-			expect(group.props('messages')).toStrictEqual([messages[1]])
-			expect(group.attributes('actorid')).toBe('alice')
-			expect(group.attributes('actortype')).toBe(ATTENDEE.ACTOR_TYPE.USERS)
-
-			group = groups.at(2)
-			expect(group.props('messages')).toStrictEqual([messages[2]])
-			expect(group.attributes('actorid')).toBe('alice')
-			expect(group.attributes('actortype')).toBe(ATTENDEE.ACTOR_TYPE.USERS)
+			groups.wrappers.forEach((group, index) => {
+				expect(group.props('messages')).toStrictEqual([messages[index]])
+			})
 
 			const dateSeparators = wrapper.findAll('.messages-group__date')
 			expect(dateSeparators).toHaveLength(3)
@@ -279,9 +260,6 @@ describe('MessagesList.vue', () => {
 
 			const group = groups.at(0)
 			expect(group.props('messages')).toStrictEqual(messages)
-			// using attributes to access v-bind props
-			expect(group.attributes('actorid')).toBe('alice')
-			expect(group.attributes('actortype')).toBe(ATTENDEE.ACTOR_TYPE.USERS)
 
 			expect(messagesListMock).toHaveBeenCalledWith(TOKEN)
 		})
@@ -303,12 +281,11 @@ describe('MessagesList.vue', () => {
 
 			const groups = wrapper.findAllComponents({ ref: 'messagesGroup' })
 
-			expect(groups.exists()).toBe(true)
+			expect(groups.exists()).toBeTruthy()
 
-			let group = groups.at(0)
-			expect(group.props('messages')).toStrictEqual([messages[0]])
-			group = groups.at(1)
-			expect(group.props('messages')).toStrictEqual([messages[1]])
+			groups.wrappers.forEach((group, index) => {
+				expect(group.props('messages')).toStrictEqual([messages[index]])
+			})
 		}
 
 		test('does not group system messages with regular messages from the same author', () => {

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -44,7 +44,6 @@ get the messagesList array and loop through the list to generate the messages.
 				:key="item.id"
 				ref="messagesGroup"
 				class="messages-group"
-				v-bind="item.messages"
 				:token="token"
 				:messages="item.messages"
 				:previous-message-id="item.previousMessageId"

--- a/src/components/NewMessage/NewMessageAttachments.vue
+++ b/src/components/NewMessage/NewMessageAttachments.vue
@@ -63,7 +63,7 @@
 			close-after-click
 			@click="$emit('toggle-poll-editor')">
 			<template #icon>
-				<Poll :size="20" />
+				<PollIcon :size="20" />
 			</template>
 			{{ t('spreed', 'Create new poll') }}
 		</NcActionButton>
@@ -73,7 +73,7 @@
 <script>
 import Folder from 'vue-material-design-icons/Folder.vue'
 import Paperclip from 'vue-material-design-icons/Paperclip.vue'
-import Poll from 'vue-material-design-icons/Poll.vue'
+import PollIcon from 'vue-material-design-icons/Poll.vue'
 import Upload from 'vue-material-design-icons/Upload.vue'
 
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
@@ -88,7 +88,7 @@ export default {
 		// Icons
 		Folder,
 		Paperclip,
-		Poll,
+		PollIcon,
 		Upload,
 	},
 

--- a/src/components/RightSidebar/SharedItems/SharedItems.vue
+++ b/src/components/RightSidebar/SharedItems/SharedItems.vue
@@ -34,8 +34,7 @@
 			<Poll v-else-if="isPoll"
 				:key="item.id"
 				:token="token"
-				v-bind="item.messageParameters.object"
-				:poll-name="item.messageParameters.object.name" />
+				v-bind="item.messageParameters.object" />
 
 			<div v-else-if="isOther"
 				:key="item.id"


### PR DESCRIPTION
### ☑️ Resolves

* Split SFC file into smaller parts
* Optimize methods and getters, rename props
* Mark deleted message additionaly (fix https://github.com/nextcloud/spreed/issues/11103)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

* system messages were moved 4px to the right to be aligned with normal messages
* deleted message:

Before | After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/6ee99e96-da3b-4ec0-b20a-f7eca0fade9f) | ![image](https://github.com/nextcloud/spreed/assets/93392545/c88a9689-8227-4cf7-a0a6-7420aa0f2a4b)


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] ⛑️ Tests are included or not possible