### PR TITLE
feat(chat): Edit message mention support

### DIFF
--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1267,7 +1267,8 @@ class ParticipantService {
 			->set('last_mention_message', $update->createNamedParameter($messageId, IQueryBuilder::PARAM_INT))
 			->where($update->expr()->eq('room_id', $update->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))
 			->andWhere($update->expr()->eq('actor_type', $update->createNamedParameter(Attendee::ACTOR_USERS)))
-			->andWhere($update->expr()->in('actor_id', $update->createNamedParameter($userIds, IQueryBuilder::PARAM_STR_ARRAY)));
+			->andWhere($update->expr()->in('actor_id', $update->createNamedParameter($userIds, IQueryBuilder::PARAM_STR_ARRAY)))
+			->andWhere($update->expr()->lt('last_mention_message', $update->createNamedParameter($messageId, IQueryBuilder::PARAM_INT)));
 		$update->executeStatement();
 
 		if (!empty($usersDirectlyMentioned)) {
@@ -1276,7 +1277,8 @@ class ParticipantService {
 				->set('last_mention_direct', $update->createNamedParameter($messageId, IQueryBuilder::PARAM_INT))
 				->where($update->expr()->eq('room_id', $update->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))
 				->andWhere($update->expr()->eq('actor_type', $update->createNamedParameter(Attendee::ACTOR_USERS)))
-				->andWhere($update->expr()->in('actor_id', $update->createNamedParameter($usersDirectlyMentioned, IQueryBuilder::PARAM_STR_ARRAY)));
+				->andWhere($update->expr()->in('actor_id', $update->createNamedParameter($usersDirectlyMentioned, IQueryBuilder::PARAM_STR_ARRAY)))
+				->andWhere($update->expr()->lt('last_mention_direct', $update->createNamedParameter($messageId, IQueryBuilder::PARAM_INT)));
 			$update->executeStatement();
 		}
 	}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -3140,7 +3140,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 
 		if ($body === null) {
 			self::$lastNotifications = [];
-			Assert::assertCount(0, $data);
+			Assert::assertCount(0, $data, json_encode($data, JSON_PRETTY_PRINT));
 			return;
 		}
 
@@ -3149,7 +3149,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	private function assertNotifications($notifications, TableNode $formData) {
-		Assert::assertCount(count($formData->getHash()), $notifications, 'Notifications count does not match');
+		Assert::assertCount(count($formData->getHash()), $notifications, 'Notifications count does not match:' . "\n" . json_encode($notifications, JSON_PRETTY_PRINT));
 		Assert::assertEquals($formData->getHash(), array_map(function ($notification, $expectedNotification) {
 			$data = [];
 			if (isset($expectedNotification['object_id'])) {
@@ -3181,7 +3181,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			}
 
 			return $data;
-		}, $notifications, $formData->getHash()));
+		}, $notifications, $formData->getHash()), json_encode($notifications, JSON_PRETTY_PRINT));
 	}
 
 	/**

--- a/tests/integration/features/chat-1/edit-message.feature
+++ b/tests/integration/features/chat-1/edit-message.feature
@@ -72,3 +72,148 @@ Feature: chat-1/edit-message
     Then user "participant1" sees the following messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | message            | messageParameters |
       | room | users     | participant1 | participant1-displayname | Caption 1 - Edit 1 | "IGNORE"          |
+
+  Scenario: Notification handling - None vs Direct mention
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    # Join and leave to clear the invite notification
+    Given user "participant2" joins room "room" with 200 (v4)
+    And user "participant2" sends message "Message 1" to room "room" with 201
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message     | messageParameters |
+      | room | users     | participant2 | participant2-displayname | Message 1   | []                |
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | unreadMessages | unreadMention | unreadMentionDirect |
+      | room | 1              | 0             | 0                   |
+    Then user "participant1" has the following notifications
+    And user "participant2" edits message "Message 1" in room "room" to "Message 1 - Edit @participant1" with 200
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message                          | messageParameters |
+      | room | users     | participant2 | participant2-displayname | Message 1 - Edit {mention-user1} | {"mention-user1":{"type":"user","id":"participant1","name":"participant1-displayname"}}                |
+    Then user "participant1" has the following notifications
+      | app    | object_type | object_id                            | subject                                                      |
+      | spreed | chat        | room/Message 1 - Edit {mention-user1} | participant2-displayname mentioned you in conversation room |
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | unreadMessages | unreadMention | unreadMentionDirect |
+      | room | 1              | 1             | 1                   |
+    And user "participant2" edits message "Message 1" in room "room" to "Message 1 - Edit 2" with 200
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message                        | messageParameters |
+      | room | users     | participant2 | participant2-displayname | Message 1 - Edit 2             | []                |
+    Then user "participant1" has the following notifications
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | unreadMessages | unreadMention | unreadMentionDirect |
+      | room | 1              | 1             | 1                   |
+
+  Scenario: Notification handling - None vs All
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    # Join and leave to clear the invite notification
+    Given user "participant2" joins room "room" with 200 (v4)
+    And user "participant2" sends message "Message 1" to room "room" with 201
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message     | messageParameters |
+      | room | users     | participant2 | participant2-displayname | Message 1   | []                |
+    Then user "participant1" has the following notifications
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | unreadMessages | unreadMention | unreadMentionDirect |
+      | room | 1              | 0             | 0                   |
+    And user "participant2" edits message "Message 1" in room "room" to "Message 1 - Edit @all" with 200
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message                          | messageParameters |
+      | room | users     | participant2 | participant2-displayname | Message 1 - Edit {mention-call1} | "IGNORE"          |
+    Then user "participant1" has the following notifications
+      | app    | object_type | object_id                            | subject                                                           |
+      | spreed | chat        | room/Message 1 - Edit {mention-call1} | participant2-displayname mentioned everyone in conversation room |
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | unreadMessages | unreadMention | unreadMentionDirect |
+      | room | 1              | 1             | 0                   |
+    And user "participant2" edits message "Message 1" in room "room" to "Message 1 - Edit 2" with 200
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message                        | messageParameters |
+      | room | users     | participant2 | participant2-displayname | Message 1 - Edit 2             | []                |
+    Then user "participant1" has the following notifications
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | unreadMessages | unreadMention | unreadMentionDirect |
+      | room | 1              | 1             | 0                   |
+
+  Scenario: Notification handling - Direct mention vs All
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    # Join and leave to clear the invite notification
+    Given user "participant2" joins room "room" with 200 (v4)
+    And user "participant2" sends message "Message 1 - @participant1" to room "room" with 201
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message                     | messageParameters                                                                       |
+      | room | users     | participant2 | participant2-displayname | Message 1 - {mention-user1} | {"mention-user1":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
+    Then user "participant1" has the following notifications
+      | app    | object_type | object_id                            | subject                                                      |
+      | spreed | chat        | room/Message 1 - {mention-user1} | participant2-displayname mentioned you in conversation room |
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | unreadMessages | unreadMention | unreadMentionDirect |
+      | room | 1              | 1             | 1                   |
+    And user "participant2" edits message "Message 1 - @participant1" in room "room" to "Message 1 - Edit @all" with 200
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message                          | messageParameters |
+      | room | users     | participant2 | participant2-displayname | Message 1 - Edit {mention-call1} | "IGNORE"          |
+    Then user "participant1" has the following notifications
+      | app    | object_type | object_id                            | subject                                                      |
+      | spreed | chat        | room/Message 1 - Edit {mention-call1} | participant2-displayname mentioned you in conversation room |
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | unreadMessages | unreadMention | unreadMentionDirect |
+      | room | 1              | 1             | 1                   |
+    And user "participant2" edits message "Message 1 - @participant1" in room "room" to "Message 1 - Edit @participant1" with 200
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message                          | messageParameters |
+      | room | users     | participant2 | participant2-displayname | Message 1 - Edit {mention-user1} | {"mention-user1":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
+    Then user "participant1" has the following notifications
+      | app    | object_type | object_id                            | subject                                                      |
+      | spreed | chat        | room/Message 1 - Edit {mention-user1} | participant2-displayname mentioned you in conversation room |
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | unreadMessages | unreadMention | unreadMentionDirect |
+      | room | 1              | 1             | 1                   |
+
+
+  Scenario: Notification handling - All vs Direct mention
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    # Join and leave to clear the invite notification
+    Given user "participant2" joins room "room" with 200 (v4)
+    And user "participant2" sends message "Message 1 - @all" to room "room" with 201
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message                     | messageParameters |
+      | room | users     | participant2 | participant2-displayname | Message 1 - {mention-call1} | "IGNORE"          |
+    Then user "participant1" has the following notifications
+      | app    | object_type | object_id                        | subject                                                          |
+      | spreed | chat        | room/Message 1 - {mention-call1} | participant2-displayname mentioned everyone in conversation room |
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | unreadMessages | unreadMention | unreadMentionDirect |
+      | room | 1              | 1             | 0                   |
+    And user "participant2" edits message "Message 1 - @all" in room "room" to "Message 1 - Edit @participant1" with 200
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message                          | messageParameters |
+      | room | users     | participant2 | participant2-displayname | Message 1 - Edit {mention-user1} | {"mention-user1":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
+    Then user "participant1" has the following notifications
+      | app    | object_type | object_id                        | subject                                                          |
+      | spreed | chat        | room/Message 1 - Edit {mention-user1} | participant2-displayname mentioned everyone in conversation room |
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | unreadMessages | unreadMention | unreadMentionDirect |
+      | room | 1              | 1             | 1                   |
+    And user "participant2" edits message "Message 1 - Edit @participant1" in room "room" to "Message 1 - Edit @all" with 200
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message                          | messageParameters |
+      | room | users     | participant2 | participant2-displayname | Message 1 - Edit {mention-call1} | "IGNORE"          |
+    Then user "participant1" has the following notifications
+      | app    | object_type | object_id                        | subject                                                          |
+      | spreed | chat        | room/Message 1 - Edit {mention-call1} | participant2-displayname mentioned everyone in conversation room |
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | unreadMessages | unreadMention | unreadMentionDirect |
+      | room | 1              | 1             | 1                   |


### PR DESCRIPTION
### ☑️ Resolves

Ref #11206 

## 🛠️ API Checklist

- It is known that the indicator for unread mentions can not be removed/reverted in the left sidebar, due to complexity of the necessary database query we would need to run.

### 🚧 Tasks

- [x] Should diff mentions and add/remove notifications accordingly
- [x] Make sure people don't get 1 for the message and 2 for followup edits

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
