### PR TITLE
Fix(BreakoutRoomsEditor): Add amount validation

### DIFF
--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
@@ -30,7 +30,11 @@
 			<template v-if="!isEditingParticipants">
 				<div class="breakout-rooms-editor__main">
 					<label class="breakout-rooms-editor__caption" for="room-number">{{ t('spreed', 'Number of breakout rooms') }} </label>
+					<p v-if="isInvalidAmount" class="breakout-rooms-editor__error-hint">
+						{{ t('spreed', 'You can create from 1 to 20 breakout rooms.') }}
+					</p>
 					<NcTextField id="room-number"
+						ref="textField"
 						:value="amount.toString()"
 						class="breakout-rooms-editor__number-input"
 						type="number"
@@ -61,10 +65,16 @@
 					</fieldset>
 				</div>
 				<div class="breakout-rooms-editor__buttons">
-					<NcButton v-if="mode === '2'" type="primary" @click="isEditingParticipants = true">
+					<NcButton v-if="mode === '2'"
+						type="primary"
+						:disabled="isInvalidAmount"
+						@click="isEditingParticipants = true">
 						{{ t('spreed', 'Assign participants to rooms') }}
 					</NcButton>
-					<NcButton v-else type="primary" @click="handleCreateRooms">
+					<NcButton v-else
+						type="primary"
+						:disabled="isInvalidAmount"
+						@click="handleCreateRooms">
 						{{ t('spreed', 'Create rooms') }}
 					</NcButton>
 				</div>
@@ -114,6 +124,7 @@ export default {
 			amount: 2,
 			attendeeMap: '',
 			isEditingParticipants: false,
+			isInvalidAmount: false,
 		}
 	},
 
@@ -147,6 +158,7 @@ export default {
 		// now it breaks validation. Another option: Create NcNumberField component
 		setAmount(value) {
 			this.amount = parseFloat(value)
+			this.isInvalidAmount = isNaN(this.amount) || !this.$refs.textField.$refs.inputField.$refs.input?.checkValidity()
 		},
 	},
 }
@@ -169,6 +181,11 @@ export default {
 		font-weight: bold;
 		display: block;
 		margin: calc(var(--default-grid-baseline)*3) 0 calc(var(--default-grid-baseline)*2) 0;
+	}
+
+	&__error-hint {
+		color: var(--color-error);
+		font-size: 0.8rem;
 	}
 
 	&__participants-step {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11355

Hint is conditioned because the user will likely pick an amount from 1 to 20, but it will be shown in case they attempt to choose outside that range.

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/84044328/62e17678-595d-4b89-a462-65381ab1a936)      | ![image](https://github.com/nextcloud/spreed/assets/84044328/4b6abf2a-3f07-4343-89d8-62d7e5ab4017)     |

### 🚧 Tasks

- [ ] Code review
- [ ] Visual review

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required