### PR TITLE
fix(chat): Also send a 202 when editing and deleting and a bot is ena…

### DIFF
--- a/docs/chat.md
+++ b/docs/chat.md
@@ -289,7 +289,7 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 * Response:
     - Status code:
         + `200 OK` - When deleting was successful
-        + `202 Accepted` - When deleting was successful but Matterbridge is enabled so the message was leaked to other services
+        + `202 Accepted` - When deleting was successful, but a bot or Matterbridge is configured, so the information can be replicated to other services
         + `400 Bad Request` The message is already older than 6 hours
         + `403 Forbidden` When the message is not from the current user and the user not a moderator
         + `403 Forbidden` When the conversation is read-only
@@ -323,7 +323,7 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 * Response:
     - Status code:
         + `200 OK` - When editing was successful
-        + `202 Accepted` - When editing was successful but Matterbridge is enabled so the message was leaked to other services
+        + `202 Accepted` - When editing was successful, but a bot or Matterbridge is configured, so the information can be replicated to other services
         + `400 Bad Request` The message is already older than 24 hours or another reason why editing is not okay
         + `403 Forbidden` When the message is not from the current user and the user not a moderator
         + `403 Forbidden` When the conversation is read-only

--- a/openapi.json
+++ b/openapi.json
@@ -5989,7 +5989,7 @@
                         }
                     },
                     "202": {
-                        "description": "Message deleted successfully, but Matterbridge is configured, so the information can be replicated elsewhere",
+                        "description": "Message deleted successfully, but a bot or Matterbridge is configured, so the information can be replicated elsewhere",
                         "headers": {
                             "X-Chat-Last-Common-Read": {
                                 "schema": {
@@ -6245,7 +6245,7 @@
                         }
                     },
                     "202": {
-                        "description": "Message edited successfully, but Matterbridge is configured, so the information can be replicated elsewhere",
+                        "description": "Message edited successfully, but a bot or Matterbridge is configured, so the information can be replicated to other services",
                         "headers": {
                             "X-Chat-Last-Common-Read": {
                                 "schema": {

--- a/tests/integration/features/chat-1/bots.feature
+++ b/tests/integration/features/chat-1/bots.feature
@@ -320,3 +320,19 @@ Feature: chat/bots
       | reaction  | 👍 |
     Then user "participant1" retrieve reactions "👍" of message "Message 1" in room "room1" with 200
       | actorType | actorId           | actorDisplayName | reaction |
+
+  Scenario: Editing and deleting messages returns a 202 status code with a bot
+    When user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" sends message "Message 1" to room "room" with 201
+    Then user "participant1" edits message "Message 1" in room "room" to "Message 1 - Edit 1" with 200
+    And user "participant1" deletes message "Message 1 - Edit 1" from room "room" with 200
+    Given invoking occ with "talk:bot:install Bot Secret1234567890123456789012345678901234567890 https://localhost/bot1 --feature=webhook"
+    And the command was successful
+    And read bot ids from OCC
+    And invoking occ with "talk:bot:setup BOT(Bot) ROOM(room)"
+    And the command was successful
+    When user "participant1" sends message "Message 2" to room "room" with 201
+    Then user "participant1" edits message "Message 2" in room "room" to "Message 2 - Edit 2" with 202
+    And user "participant1" deletes message "Message 2 - Edit 2" from room "room" with 202

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -36,6 +36,7 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\AttachmentService;
 use OCA\Talk\Service\AvatarService;
+use OCA\Talk\Service\BotService;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\ReminderService;
 use OCA\Talk\Service\SessionService;
@@ -95,6 +96,7 @@ class ChatControllerTest extends TestCase {
 	protected $statusManager;
 	/** @var MatterbridgeManager|MockObject */
 	protected $matterbridgeManager;
+	protected BotService|MockObject $botService;
 	/** @var SearchPlugin|MockObject */
 	protected $searchPlugin;
 	/** @var ISearchResult|MockObject */
@@ -138,6 +140,7 @@ class ChatControllerTest extends TestCase {
 		$this->autoCompleteManager = $this->createMock(IManager::class);
 		$this->statusManager = $this->createMock(IUserStatusManager::class);
 		$this->matterbridgeManager = $this->createMock(MatterbridgeManager::class);
+		$this->botService = $this->createMock(BotService::class);
 		$this->searchPlugin = $this->createMock(SearchPlugin::class);
 		$this->searchResult = $this->createMock(ISearchResult::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
@@ -179,6 +182,7 @@ class ChatControllerTest extends TestCase {
 			$this->autoCompleteManager,
 			$this->statusManager,
 			$this->matterbridgeManager,
+			$this->botService,
 			$this->searchPlugin,
 			$this->searchResult,
 			$this->timeFactory,


### PR DESCRIPTION
…bled

## 🛠️ API Checklist

- [x] Based on https://github.com/nextcloud/spreed/pull/11207

### 🚧 Tasks

- [x] 202 status when editing/deleting with a bot enabled

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
