### PR TITLE
fix(messagesStore): avoid usage of `message.token` 

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
@@ -631,10 +631,8 @@ describe('Message.vue', () => {
 			wrapper.findComponent(MessageButtonsBar).vm.$emit('delete')
 
 			expect(deleteMessage).toHaveBeenCalledWith(expect.anything(), {
-				message: {
-					token: TOKEN,
-					id: 123,
-				},
+				token: TOKEN,
+				id: 123,
 				placeholder: expect.anything(),
 			})
 

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -724,7 +724,11 @@ export default {
 			if (this.sendingErrorCanRetry) {
 				if (this.sendingFailure === 'failed-upload') {
 					const caption = this.renderedMessage !== this.message ? this.message : undefined
-					this.$store.dispatch('retryUploadFiles', { uploadId: this.messageObject.uploadId, caption })
+					this.$store.dispatch('retryUploadFiles', {
+						token: this.token,
+						uploadId: this.messageObject.uploadId,
+						caption
+					})
 				} else {
 					EventBus.$emit('retry-message', this.id)
 					EventBus.$emit('focus-chat-input')
@@ -756,10 +760,8 @@ export default {
 			this.isDeleting = true
 			try {
 				const statusCode = await this.$store.dispatch('deleteMessage', {
-					message: {
-						token: this.token,
-						id: this.id,
-					},
+					token: this.token,
+					id: this.id,
 					placeholder: t('spreed', 'Deleting message'),
 				})
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.spec.js
@@ -200,7 +200,7 @@ describe('Reactions.vue', () => {
 		test('dispatches store actions upon picking an emoji from the emojipicker', async () => {
 			// Arrange
 			jest.spyOn(reactionsStore, 'addReactionToMessage')
-			vuexStore.dispatch('processMessage', message)
+			vuexStore.dispatch('processMessage', { token, message })
 
 			const wrapper = shallowMount(Reactions, {
 				propsData: reactionsProps,
@@ -231,7 +231,7 @@ describe('Reactions.vue', () => {
 			jest.spyOn(reactionsStore, 'addReactionToMessage')
 			jest.spyOn(reactionsStore, 'removeReactionFromMessage')
 
-			vuexStore.dispatch('processMessage', message)
+			vuexStore.dispatch('processMessage', { token, message })
 
 			const wrapper = shallowMount(Reactions, {
 				propsData: reactionsProps,

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -37,6 +37,7 @@
 				:key="message.id"
 				ref="message"
 				v-bind="message"
+				:token="token"
 				:is-temporary="message.timestamp === 0"
 				:next-message-id="(messages[index + 1] && messages[index + 1].id) || nextMessageId"
 				:previous-message-id="(index > 0 && messages[index - 1].id) || previousMessageId"

--- a/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
@@ -27,6 +27,7 @@
 			<ul v-if="messagesCollapsed.messages?.length > 1"
 				class="messages messages--header">
 				<Message v-bind="createCombinedSystemMessage(messagesCollapsed)"
+					:token="token"
 					is-combined-system-message
 					:is-combined-system-message-collapsed="messagesCollapsed.collapsed"
 					:next-message-id="getNextMessageId(messagesCollapsed.messages.at(-1))"
@@ -39,6 +40,7 @@
 				<Message v-for="message in messagesCollapsed.messages"
 					:key="message.id"
 					v-bind="message"
+					:token="token"
 					:next-message-id="getNextMessageId(message)"
 					:previous-message-id="getPrevMessageId(message)" />
 			</ul>

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -557,15 +557,15 @@ export default {
 				this.chatExtrasStore.removeParentIdToReply(this.token)
 
 				this.broadcast
-					? await this.broadcastMessage(temporaryMessage, options)
-					: await this.postMessage(temporaryMessage, options)
+					? await this.broadcastMessage(this.token, temporaryMessage.message)
+					: await this.postMessage(this.token, temporaryMessage, options)
 			}
 		},
 
 		// Post message to conversation
-		async postMessage(temporaryMessage, options) {
+		async postMessage(token, temporaryMessage, options) {
 			try {
-				await this.$store.dispatch('postNewMessage', { temporaryMessage, options })
+				await this.$store.dispatch('postNewMessage', { token, temporaryMessage, options })
 				this.$emit('sent')
 			} catch {
 				this.$emit('failure')
@@ -573,9 +573,9 @@ export default {
 		},
 
 		// Broadcast message to all breakout rooms
-		async broadcastMessage(temporaryMessage, options) {
+		async broadcastMessage(token, message) {
 			try {
-				await this.$store.dispatch('broadcastMessageToBreakoutRoomsAction', { temporaryMessage, options })
+				await this.$store.dispatch('broadcastMessageToBreakoutRoomsAction', { token, message })
 				this.$emit('sent')
 			} catch {
 				this.$emit('failure')
@@ -599,9 +599,9 @@ export default {
 			return new Promise(resolve => setTimeout(resolve, ms))
 		},
 
-		handleRetryMessage(temporaryMessageId) {
+		handleRetryMessage(id) {
 			if (this.text === '') {
-				const temporaryMessage = this.$store.getters.message(this.token, temporaryMessageId)
+				const temporaryMessage = this.$store.getters.message(this.token, id)
 				if (temporaryMessage) {
 					this.text = temporaryMessage.message || this.text
 
@@ -613,7 +613,7 @@ export default {
 						})
 					}
 
-					this.$store.dispatch('removeTemporaryMessageFromStore', temporaryMessage)
+					this.$store.dispatch('removeTemporaryMessageFromStore', { token: this.token, id })
 				}
 			}
 		},

--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -206,7 +206,7 @@ export default {
 		},
 
 		handleUpload({ caption, options }) {
-			this.$store.dispatch('uploadFiles', { uploadId: this.currentUploadId, caption, options })
+			this.$store.dispatch('uploadFiles', { token: this.token, uploadId: this.currentUploadId, caption, options })
 		},
 		/**
 		 * Clicks the hidden file input when clicking the correspondent NcActionButton,

--- a/src/services/breakoutRoomsService.js
+++ b/src/services/breakoutRoomsService.js
@@ -96,12 +96,11 @@ const stopBreakoutRooms = async function(token) {
 }
 
 /**
- *
- * @param {string} message The message to be posted
  * @param {string} token the conversation token
+ * @param {string} message The message to be posted
  * @return {Promise<import('axios').AxiosResponse<any>>} The array of conversations
  */
-const broadcastMessageToBreakoutRooms = async function(message, token) {
+const broadcastMessageToBreakoutRooms = async function(token, message) {
 	return await axios.post(generateOcsUrl('/apps/spreed/api/v1/breakout-rooms/{token}/broadcast', {
 		token,
 	}), {

--- a/src/store/breakoutRoomsStore.js
+++ b/src/store/breakoutRoomsStore.js
@@ -188,9 +188,9 @@ const actions = {
 		}
 	},
 
-	async broadcastMessageToBreakoutRoomsAction(context, { temporaryMessage }) {
+	async broadcastMessageToBreakoutRoomsAction(context, { token, message }) {
 		try {
-			await broadcastMessageToBreakoutRooms(temporaryMessage.message, temporaryMessage.token)
+			await broadcastMessageToBreakoutRooms(token, message)
 		} catch (error) {
 			console.error(error)
 			showError(t('spreed', 'An error occurred while sending a message to the breakout rooms'))

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -340,7 +340,7 @@ const actions = {
 		chatExtrasStore.purgeChatExtras(token)
 		const reactionsStore = useReactionsStore()
 		reactionsStore.purgeReactionsStore(token)
-		context.dispatch('deleteMessages', token)
+		context.dispatch('purgeMessagesStore', token)
 		context.commit('deleteConversation', token)
 		context.dispatch('purgeParticipantsStore', token)
 		context.dispatch('cacheConversations')
@@ -456,7 +456,7 @@ const actions = {
 			chatExtrasStore.removeParentIdToReply(token)
 			const reactionsStore = useReactionsStore()
 			reactionsStore.purgeReactionsStore(token)
-			context.dispatch('deleteMessages', token)
+			context.dispatch('purgeMessagesStore', token)
 			return response
 		} catch (error) {
 			console.debug(

--- a/src/store/conversationsStore.spec.js
+++ b/src/store/conversationsStore.spec.js
@@ -112,14 +112,14 @@ describe('conversationsStore', () => {
 
 	describe('conversation list', () => {
 		let talkHashStore
-		let deleteMessagesAction
+		let purgeMessagesStoreAction
 		let checkMaintenanceModeAction
 		let clearMaintenanceModeAction
 		let updateTalkVersionHashAction
 
 		beforeEach(() => {
-			deleteMessagesAction = jest.fn()
-			testStoreConfig.modules.messagesStore.actions.deleteMessages = deleteMessagesAction
+			purgeMessagesStoreAction = jest.fn()
+			testStoreConfig.modules.messagesStore.actions.purgeMessagesStore = purgeMessagesStoreAction
 			talkHashStore = useTalkHashStore()
 			checkMaintenanceModeAction = jest.spyOn(talkHashStore, 'checkMaintenanceMode')
 			clearMaintenanceModeAction = jest.spyOn(talkHashStore, 'clearMaintenanceMode')
@@ -195,7 +195,7 @@ describe('conversationsStore', () => {
 			store.dispatch('addConversation', testConversation)
 
 			store.dispatch('deleteConversation', testToken)
-			expect(deleteMessagesAction).toHaveBeenCalled()
+			expect(purgeMessagesStoreAction).toHaveBeenCalled()
 
 			expect(store.getters.conversation(testToken)).toBeUndefined()
 
@@ -233,7 +233,7 @@ describe('conversationsStore', () => {
 
 			await store.dispatch('deleteConversationFromServer', { token: testToken })
 			expect(deleteConversation).toHaveBeenCalledWith(testToken)
-			expect(deleteMessagesAction).toHaveBeenCalled()
+			expect(purgeMessagesStoreAction).toHaveBeenCalled()
 
 			expect(store.getters.conversation(testToken)).toBeUndefined()
 		})

--- a/src/store/fileUploadStore.spec.js
+++ b/src/store/fileUploadStore.spec.js
@@ -164,7 +164,7 @@ describe('fileUploadStore', () => {
 			findUniquePath.mockResolvedValueOnce({ uniquePath: uniqueFileName, suffix: 1 })
 			shareFile.mockResolvedValue()
 
-			await store.dispatch('uploadFiles', { uploadId: 'upload-id1', caption: 'text-caption', options: { silent: true } })
+			await store.dispatch('uploadFiles', { token: 'XXTOKENXX', uploadId: 'upload-id1', caption: 'text-caption', options: { silent: true } })
 
 			expect(findUniquePath).toHaveBeenCalledTimes(1)
 			expect(findUniquePath).toHaveBeenCalledWith(client, '/files/current-user', '/Talk/' + file.name, undefined)
@@ -213,7 +213,7 @@ describe('fileUploadStore', () => {
 				.mockResolvedValueOnce({ data: { ocs: { data: { id: '1' } } } })
 				.mockResolvedValueOnce({ data: { ocs: { data: { id: '2' } } } })
 
-			await store.dispatch('uploadFiles', { uploadId: 'upload-id1', caption: 'text-caption', options: { silent: false } })
+			await store.dispatch('uploadFiles', { token: 'XXTOKENXX', uploadId: 'upload-id1', caption: 'text-caption', options: { silent: false } })
 
 			expect(findUniquePath).toHaveBeenCalledTimes(2)
 			expect(client.putFileContents).toHaveBeenCalledTimes(2)
@@ -256,15 +256,19 @@ describe('fileUploadStore', () => {
 				},
 			})
 
-			await store.dispatch('uploadFiles', { uploadId: 'upload-id1', options: { silent: false } })
+			await store.dispatch('uploadFiles', { token: 'XXTOKENXX', uploadId: 'upload-id1', options: { silent: false } })
 
 			expect(client.putFileContents).toHaveBeenCalledTimes(1)
 			expect(shareFile).not.toHaveBeenCalled()
 
 			expect(mockedActions.addTemporaryMessage).toHaveBeenCalledTimes(1)
 			expect(mockedActions.markTemporaryMessageAsFailed).toHaveBeenCalledTimes(1)
-			expect(mockedActions.markTemporaryMessageAsFailed.mock.calls[0][1].message.referenceId).toBe('reference-id-1')
-			expect(mockedActions.markTemporaryMessageAsFailed.mock.calls[0][1].reason).toBe('failed-upload')
+			expect(mockedActions.markTemporaryMessageAsFailed).toHaveBeenCalledWith(expect.anything(), {
+				token: 'XXTOKENXX',
+				id: 1,
+				uploadId: 'upload-id1',
+				reason: 'failed-upload'
+			})
 			expect(showError).toHaveBeenCalled()
 			expect(console.error).toHaveBeenCalled()
 		})
@@ -293,15 +297,19 @@ describe('fileUploadStore', () => {
 				},
 			})
 
-			await store.dispatch('uploadFiles', { uploadId: 'upload-id1', options: { silent: false } })
+			await store.dispatch('uploadFiles', { token: 'XXTOKENXX', uploadId: 'upload-id1', options: { silent: false } })
 
 			expect(client.putFileContents).toHaveBeenCalledTimes(1)
 			expect(shareFile).toHaveBeenCalledTimes(1)
 
 			expect(mockedActions.addTemporaryMessage).toHaveBeenCalledTimes(1)
 			expect(mockedActions.markTemporaryMessageAsFailed).toHaveBeenCalledTimes(1)
-			expect(mockedActions.markTemporaryMessageAsFailed.mock.calls[0][1].message.referenceId).toBe('reference-id-1')
-			expect(mockedActions.markTemporaryMessageAsFailed.mock.calls[0][1].reason).toBe('failed-share')
+			expect(mockedActions.markTemporaryMessageAsFailed).toHaveBeenCalledWith(expect.anything(), {
+				token: 'XXTOKENXX',
+				id: 1,
+				uploadId: 'upload-id1',
+				reason: 'failed-share'
+			})
 			expect(showError).toHaveBeenCalled()
 			expect(console.error).toHaveBeenCalled()
 		})

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -283,29 +283,33 @@ const mutations = {
 	 * Adds a message to the store.
 	 *
 	 * @param {object} state current store state;
-	 * @param {object} message the message;
+	 * @param {object} payload payload;
+	 * @param {string} payload.token conversation token;
+	 * @param {object} payload.message message object;
 	 */
-	addMessage(state, message) {
-		if (!state.messages[message.token]) {
-			Vue.set(state.messages, message.token, {})
+	addMessage(state, { token, message }) {
+		if (!state.messages[token]) {
+			Vue.set(state.messages, token, {})
 		}
-		if (state.messages[message.token][message.id]) {
-			Vue.set(state.messages[message.token], message.id,
-				Object.assign(state.messages[message.token][message.id], message)
+		if (state.messages[token][message.id]) {
+			Vue.set(state.messages[token], message.id,
+				Object.assign(state.messages[token][message.id], message)
 			)
 		} else {
-			Vue.set(state.messages[message.token], message.id, message)
+			Vue.set(state.messages[token], message.id, message)
 		}
 	},
 	/**
 	 * Deletes a message from the store.
 	 *
 	 * @param {object} state current store state;
-	 * @param {object} message the message;
+	 * @param {object} payload payload;
+	 * @param {string} payload.token conversation token;
+	 * @param {object} payload.id message id;
 	 */
-	deleteMessage(state, message) {
-		if (state.messages[message.token][message.id]) {
-			Vue.delete(state.messages[message.token], message.id)
+	deleteMessage(state, { token, id }) {
+		if (state.messages[token][id]) {
+			Vue.delete(state.messages[token], id)
 		}
 	},
 
@@ -313,41 +317,45 @@ const mutations = {
 	 * Deletes a message from the store.
 	 *
 	 * @param {object} state current store state;
-	 * @param {object} data the wrapping object;
-	 * @param {object} data.message the message;
-	 * @param {string} data.placeholder Placeholder message until deleting finished
+	 * @param {object} payload payload;
+	 * @param {string} payload.token conversation token;
+	 * @param {number} payload.id conversation token;
+	 * @param {string} payload.placeholder Placeholder message until deleting finished
 	 */
-	markMessageAsDeleting(state, { message, placeholder }) {
-		Vue.set(state.messages[message.token][message.id], 'messageType', 'comment_deleted')
-		Vue.set(state.messages[message.token][message.id], 'message', placeholder)
+	markMessageAsDeleting(state, { token, id, placeholder }) {
+		Vue.set(state.messages[token][id], 'messageType', 'comment_deleted')
+		Vue.set(state.messages[token][id], 'message', placeholder)
 	},
 	/**
 	 * Adds a temporary message to the store.
 	 *
 	 * @param {object} state current store state;
-	 * @param {object} message the temporary message;
+	 * @param {object} payload payload;
+	 * @param {string} payload.token conversation token;
+	 * @param {object} payload.message message object;
 	 */
-	addTemporaryMessage(state, message) {
-		if (!state.messages[message.token]) {
-			Vue.set(state.messages, message.token, {})
+	addTemporaryMessage(state, { token, message }) {
+		if (!state.messages[token]) {
+			Vue.set(state.messages, token, {})
 		}
-		Vue.set(state.messages[message.token], message.id, message)
+		Vue.set(state.messages[token], message.id, message)
 	},
 
 	/**
 	 * Adds a temporary message to the store.
 	 *
 	 * @param {object} state current store state;
-	 * @param {object} data the wrapping object;
-	 * @param {object} data.message the temporary message;
-	 * @param {string|undefined} data.uploadId the internal id of the upload;
-	 * @param {string} data.reason the reason the temporary message failed;
+	 * @param {object} payload payload;
+	 * @param {string} payload.token conversation token;
+	 * @param {object} payload.id message id;
+	 * @param {string|undefined} payload.uploadId the internal id of the upload;
+	 * @param {string} payload.reason the reason the temporary message failed;
 	 */
-	markTemporaryMessageAsFailed(state, { message, uploadId = undefined, reason }) {
-		if (state.messages[message.token][message.id]) {
-			Vue.set(state.messages[message.token][message.id], 'sendingFailure', reason)
+	markTemporaryMessageAsFailed(state, { token, id, uploadId = undefined, reason }) {
+		if (state.messages[token][id]) {
+			Vue.set(state.messages[token][id], 'sendingFailure', reason)
 			if (uploadId) {
-				Vue.set(state.messages[message.token][message.id], 'uploadId', uploadId)
+				Vue.set(state.messages[token][id], 'uploadId', uploadId)
 			}
 		}
 	},
@@ -510,9 +518,11 @@ const actions = {
 	 * first it adds the parent to the store.
 	 *
 	 * @param {object} context default store context;
-	 * @param {object} message the message;
+	 * @param {object} payload payload;
+	 * @param {string} payload.token conversation token;
+	 * @param {object} payload.message message object;
 	 */
-	processMessage(context, message) {
+	processMessage(context, { token, message }) {
 		const sharedItemsStore = useSharedItemsStore()
 
 		if (message.parent && message.systemMessage
@@ -521,24 +531,24 @@ const actions = {
 				|| message.systemMessage === 'reaction_deleted'
 				|| message.systemMessage === 'reaction_revoked')) {
 			// If parent message is presented in store already, we update it
-			const parentInStore = context.getters.message(message.token, message.parent.id)
+			const parentInStore = context.getters.message(token, message.parent.id)
 			if (Object.keys(parentInStore).length !== 0) {
-				context.commit('addMessage', message.parent)
+				context.commit('addMessage', { token, message: message.parent })
 			}
 
 			const reactionsStore = useReactionsStore()
 			if (message.systemMessage === 'message_deleted') {
-				reactionsStore.resetReactions(message.token, message.parent.id)
+				reactionsStore.resetReactions(token, message.parent.id)
 			} else {
 				reactionsStore.processReaction(message)
 			}
 
 			// Check existing messages for having a deleted message as parent, and update them
 			if (message.systemMessage === 'message_deleted') {
-				context.getters.messagesList(message.token)
+				context.getters.messagesList(token)
 					.filter(storedMessage => storedMessage.parent?.id === message.parent.id)
 					.forEach(storedMessage => {
-						context.commit('addMessage', Object.assign({}, storedMessage, { parent: message.parent }))
+						context.commit('addMessage', { token, message: Object.assign({}, storedMessage, { parent: message.parent }) })
 					})
 			}
 
@@ -547,15 +557,15 @@ const actions = {
 		}
 
 		if (message.referenceId) {
-			const tempMessages = context.getters.getTemporaryReferences(message.token, message.referenceId)
+			const tempMessages = context.getters.getTemporaryReferences(token, message.referenceId)
 			tempMessages.forEach(tempMessage => {
-				context.commit('deleteMessage', tempMessage)
+				context.commit('deleteMessage', { token, id: tempMessage.id })
 			})
 		}
 
 		if (message.systemMessage === 'poll_voted') {
 			context.dispatch('debounceGetPollData', {
-				token: message.token,
+				token,
 				pollId: message.messageParameters.poll.id,
 			})
 			// Quit processing
@@ -564,24 +574,24 @@ const actions = {
 
 		if (message.systemMessage === 'poll_closed') {
 			context.dispatch('getPollData', {
-				token: message.token,
+				token,
 				pollId: message.messageParameters.poll.id,
 			})
 		}
 
 		if (message.systemMessage === 'history_cleared') {
 			context.commit('clearMessagesHistory', {
-				token: message.token,
+				token,
 				id: message.id,
 			})
 		}
 
-		context.commit('addMessage', message)
+		context.commit('addMessage', { token, message })
 
 		if (message.messageParameters && (message.messageType === 'comment' || message.messageType === 'voice-message')) {
 			if (message.messageParameters?.object || message.messageParameters?.file) {
 				// Handle voice messages, shares with single file, polls, deck cards, e.t.c
-				sharedItemsStore.addSharedItemFromMessage(message)
+				sharedItemsStore.addSharedItemFromMessage(token, message)
 			} else if (Object.keys(message.messageParameters).some(key => key.startsWith('file'))) {
 				// Handle shares with multiple files
 			}
@@ -592,22 +602,22 @@ const actions = {
 	 * Delete a message
 	 *
 	 * @param {object} context default store context;
-	 * @param {object} data the wrapping object;
-	 * @param {object} data.message the message to be deleted;
-	 * @param {string} data.placeholder Placeholder message until deleting finished
+	 * @param {object} payload payload;
+	 * @param {string} payload.token conversation token;
+	 * @param {object} payload.id message id;
+	 * @param {string} payload.placeholder Placeholder message until deleting finished
 	 */
-	async deleteMessage(context, { message, placeholder }) {
-		const messageObject = Object.assign({}, context.getters.message(message.token, message.id))
-		context.commit('markMessageAsDeleting', { message, placeholder })
+	async deleteMessage(context, { token, id, placeholder }) {
+		const message = Object.assign({}, context.getters.message(token, id))
+		context.commit('markMessageAsDeleting', { token, id, placeholder })
 
-		let response
 		try {
-			response = await deleteMessage(message)
-			context.dispatch('processMessage', response.data.ocs.data)
+			const response = await deleteMessage({ token, id })
+			context.dispatch('processMessage', { token, message: response.data.ocs.data })
 			return response.status
 		} catch (error) {
 			// Restore the previous message state
-			context.commit('addMessage', messageObject)
+			context.commit('addMessage', { token, message })
 			throw error
 		}
 	},
@@ -674,35 +684,40 @@ const actions = {
 	 * message object is received from the server.
 	 *
 	 * @param {object} context default store context;
-	 * @param {object} message the temporary message;
+	 * @param {object} payload payload;
+	 * @param {string} payload.token conversation token;
+	 * @param {object} payload.message message object;
 	 */
-	addTemporaryMessage(context, message) {
-		context.commit('addTemporaryMessage', message)
+	addTemporaryMessage(context, { token, message }) {
+		context.commit('addTemporaryMessage', { token, message })
 		// Update conversations list order
-		context.dispatch('updateConversationLastActive', message.token)
+		context.dispatch('updateConversationLastActive', token)
 	},
 
 	/**
 	 * Mark a temporary message as failed to allow retrying it again
 	 *
 	 * @param {object} context default store context;
-	 * @param {object} data the wrapping object;
-	 * @param {object} data.message the temporary message;
-	 * @param {string} data.uploadId the internal id of the upload;
-	 * @param {string} data.reason the reason the temporary message failed;
+	 * @param {object} payload payload;
+	 * @param {string} payload.token conversation token;
+	 * @param {object} payload.id message id;
+	 * @param {string} payload.uploadId the internal id of the upload;
+	 * @param {string} payload.reason the reason the temporary message failed;
 	 */
-	markTemporaryMessageAsFailed(context, { message, uploadId, reason }) {
-		context.commit('markTemporaryMessageAsFailed', { message, uploadId, reason })
+	markTemporaryMessageAsFailed(context, { token, id, uploadId, reason }) {
+		context.commit('markTemporaryMessageAsFailed', { token, id, uploadId, reason })
 	},
 
 	/**
 	 * Remove temporary message from store after receiving the parsed one from server
 	 *
 	 * @param {object} context default store context;
-	 * @param {object} message the temporary message;
+	 * @param {object} payload payload;
+	 * @param {string} payload.token conversation token;
+	 * @param {object} payload.id message id;
 	 */
-	removeTemporaryMessageFromStore(context, message) {
-		context.commit('deleteMessage', message)
+	removeTemporaryMessageFromStore(context, { token, id }) {
+		context.commit('deleteMessage', { token, id })
 	},
 
 	/**
@@ -854,7 +869,7 @@ const actions = {
 				const guestNameStore = useGuestNameStore()
 				guestNameStore.addGuestName(message, { noUpdate: true })
 			}
-			context.dispatch('processMessage', message)
+			context.dispatch('processMessage', { token, message })
 			newestKnownMessageId = Math.max(newestKnownMessageId, message.id)
 
 			if (message.systemMessage !== 'reaction'
@@ -945,7 +960,7 @@ const actions = {
 				const guestNameStore = useGuestNameStore()
 				guestNameStore.addGuestName(message, { noUpdate: true })
 			}
-			context.dispatch('processMessage', message)
+			context.dispatch('processMessage', { token, message })
 			newestKnownMessageId = Math.max(newestKnownMessageId, message.id)
 			oldestKnownMessageId = Math.min(oldestKnownMessageId, message.id)
 
@@ -1071,7 +1086,7 @@ const actions = {
 				const guestNameStore = useGuestNameStore()
 				guestNameStore.addGuestName(message, { noUpdate: false })
 			}
-			context.dispatch('processMessage', message)
+			context.dispatch('processMessage', { token, message })
 			if (!lastMessage || message.id > lastMessage.id) {
 				if (!message.systemMessage) {
 					if (actorId !== message.actorId || actorType !== message.actorType) {
@@ -1157,11 +1172,12 @@ const actions = {
 	 *
 	 * @param {object} context default store context;
 	 * @param {object} data Passed in parameters
+	 * @param {string} data.token token of the conversation
 	 * @param {object} data.temporaryMessage temporary message, must already have been added to messages list.
 	 * @param {object} data.options post request options.
 	 */
-	async postNewMessage(context, { temporaryMessage, options }) {
-		context.dispatch('addTemporaryMessage', temporaryMessage)
+	async postNewMessage(context, { token, temporaryMessage, options }) {
+		context.dispatch('addTemporaryMessage', { token, message: temporaryMessage })
 
 		const { request, cancel } = CancelableRequest(postNewMessage)
 		context.commit('setCancelPostNewMessage', { messageId: temporaryMessage.id, cancelFunction: cancel })
@@ -1169,7 +1185,8 @@ const actions = {
 		const timeout = setTimeout(() => {
 			context.dispatch('cancelPostNewMessage', { messageId: temporaryMessage.id })
 			context.dispatch('markTemporaryMessageAsFailed', {
-				message: temporaryMessage,
+				token,
+				id: temporaryMessage.id,
 				reason: 'timeout',
 			})
 		}, 30000)
@@ -1182,33 +1199,33 @@ const actions = {
 			if ('x-chat-last-common-read' in response.headers) {
 				const lastCommonReadMessage = parseInt(response.headers['x-chat-last-common-read'], 10)
 				context.dispatch('updateLastCommonReadMessage', {
-					token: temporaryMessage.token,
+					token,
 					lastCommonReadMessage,
 				})
 			}
 
 			// If successful, deletes the temporary message from the store
-			context.dispatch('removeTemporaryMessageFromStore', temporaryMessage)
+			context.dispatch('removeTemporaryMessageFromStore', { token, id: temporaryMessage.id })
 
 			const message = response.data.ocs.data
 			// And adds the complete version of the message received
 			// by the server
-			context.dispatch('processMessage', message)
+			context.dispatch('processMessage', { token, message })
 
-			const conversation = context.getters.conversation(temporaryMessage.token)
+			const conversation = context.getters.conversation(token)
 
 			// update lastMessage and lastReadMessage
 			// do it conditionally because there could have been more messages appearing concurrently
 			if (conversation && conversation.lastMessage && message.id > conversation.lastMessage.id) {
 				context.dispatch('updateConversationLastMessage', {
-					token: conversation.token,
+					token,
 					lastMessage: message,
 				})
 			}
 			if (conversation && message.id > conversation.lastReadMessage) {
 				// no await to make it async
 				context.dispatch('updateLastReadMessage', {
-					token: conversation.token,
+					token,
 					id: message.id,
 					updateVisually: true,
 				})
@@ -1234,19 +1251,22 @@ const actions = {
 			if (statusCode === 403) {
 				showError(t('spreed', 'No permission to post messages in this conversation'))
 				context.dispatch('markTemporaryMessageAsFailed', {
-					message: temporaryMessage,
+					token,
+					id: temporaryMessage.id,
 					reason: 'read-only',
 				})
 			} else if (statusCode === 412) {
 				showError(t('spreed', 'No permission to post messages in this conversation'))
 				context.dispatch('markTemporaryMessageAsFailed', {
-					message: temporaryMessage,
+					token,
+					id: temporaryMessage.id,
 					reason: 'lobby',
 				})
 			} else {
 				showError(t('spreed', 'Could not post message: {errorMessage}', { errorMessage: error.message || error }))
 				context.dispatch('markTemporaryMessageAsFailed', {
-					message: temporaryMessage,
+					token,
+					id: temporaryMessage.id,
 					reason: 'other',
 				})
 			}

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -388,7 +388,7 @@ const mutations = {
 	 * @param {object} state current store state
 	 * @param {string} token Token of the conversation
 	 */
-	deleteMessages(state, token) {
+	purgeMessagesStore(state, token) {
 		if (state.firstKnown[token]) {
 			Vue.delete(state.firstKnown, token)
 		}
@@ -741,8 +741,8 @@ const actions = {
 	 * @param {object} context default store context;
 	 * @param {string} token the token of the conversation to be deleted;
 	 */
-	deleteMessages(context, token) {
-		context.commit('deleteMessages', token)
+	purgeMessagesStore(context, token) {
+		context.commit('purgeMessagesStore', token)
 	},
 
 	/**

--- a/src/store/messagesStore.spec.js
+++ b/src/store/messagesStore.spec.js
@@ -315,7 +315,7 @@ describe('messagesStore', () => {
 		store.dispatch('processMessage', message1)
 		expect(store.getters.messagesList(TOKEN)[0]).toBe(message1)
 
-		store.dispatch('deleteMessages', TOKEN)
+		store.dispatch('purgeMessagesStore', TOKEN)
 		expect(store.getters.messagesList(TOKEN)).toStrictEqual([])
 
 		expect(deleteMessage).not.toHaveBeenCalled()

--- a/src/store/messagesStore.spec.js
+++ b/src/store/messagesStore.spec.js
@@ -83,7 +83,7 @@ describe('messagesStore', () => {
 				token: TOKEN,
 			}
 
-			store.dispatch('processMessage', message1)
+			store.dispatch('processMessage', { token: TOKEN, message: message1 })
 			expect(store.getters.messagesList(TOKEN)[0]).toBe(message1)
 		})
 
@@ -124,7 +124,7 @@ describe('messagesStore', () => {
 			}]
 
 			messages.forEach(message => {
-				store.dispatch('processMessage', message)
+				store.dispatch('processMessage', { token: TOKEN, message })
 			})
 
 			expect(store.getters.messagesList(TOKEN)).toHaveLength(0)
@@ -142,7 +142,7 @@ describe('messagesStore', () => {
 				messageType: 'comment',
 			}
 
-			store.dispatch('processMessage', message1)
+			store.dispatch('processMessage', { token: TOKEN, message: message1 })
 			expect(store.getters.messagesList(TOKEN)).toMatchObject([message1])
 		})
 
@@ -152,7 +152,7 @@ describe('messagesStore', () => {
 				referenceId: 'reference-1',
 				token: TOKEN,
 			}
-			store.dispatch('addTemporaryMessage', temporaryMessage)
+			store.dispatch('addTemporaryMessage', { token: TOKEN, message: temporaryMessage })
 
 			const message1 = {
 				id: 1,
@@ -160,7 +160,7 @@ describe('messagesStore', () => {
 				referenceId: 'reference-1',
 			}
 
-			store.dispatch('processMessage', message1)
+			store.dispatch('processMessage', { token: TOKEN, message: message1 })
 			expect(store.getters.messagesList(TOKEN)).toStrictEqual([message1])
 		})
 
@@ -172,8 +172,8 @@ describe('messagesStore', () => {
 			}
 			const message2 = Object.assign({}, message1, { message: 'replaced' })
 
-			store.dispatch('processMessage', message1)
-			store.dispatch('processMessage', message2)
+			store.dispatch('processMessage', { token: TOKEN, message: message1 })
+			store.dispatch('processMessage', { token: TOKEN, message: message2 })
 			expect(store.getters.messagesList(TOKEN)).toStrictEqual([message2])
 		})
 	})
@@ -192,9 +192,9 @@ describe('messagesStore', () => {
 			token: TOKEN,
 		}
 
-		store.dispatch('processMessage', message1)
-		store.dispatch('processMessage', message2)
-		store.dispatch('processMessage', message3)
+		store.dispatch('processMessage', { token: message1.token, message: message1 })
+		store.dispatch('processMessage', { token: message2.token, message: message2 })
+		store.dispatch('processMessage', { token: message3.token, message: message3 })
 		expect(store.getters.messagesList(TOKEN)[0]).toStrictEqual(message1)
 		expect(store.getters.messagesList(TOKEN)[1]).toStrictEqual(message3)
 		expect(store.getters.messagesList('token-2')[0]).toStrictEqual(message2)
@@ -223,7 +223,7 @@ describe('messagesStore', () => {
 				message: 'hello',
 			}
 
-			store.dispatch('processMessage', message)
+			store.dispatch('processMessage', { token: TOKEN, message })
 		})
 
 		test('deletes from server and replaces deleted message with response', async () => {
@@ -242,9 +242,9 @@ describe('messagesStore', () => {
 			const response = generateOCSResponse({ payload })
 			deleteMessage.mockResolvedValueOnce(response)
 
-			const status = await store.dispatch('deleteMessage', { message, placeholder: 'placeholder-text' })
+			const status = await store.dispatch('deleteMessage', { token: message.token, id: message.id, placeholder: 'placeholder-text' })
 
-			expect(deleteMessage).toHaveBeenCalledWith(message)
+			expect(deleteMessage).toHaveBeenCalledWith({ token: message.token, id: message.id })
 			expect(status).toBe(200)
 
 			expect(store.getters.messagesList(TOKEN)).toMatchObject([{
@@ -271,9 +271,9 @@ describe('messagesStore', () => {
 			const response = generateOCSResponse({ payload })
 			deleteMessage.mockResolvedValueOnce(response)
 
-			const status = await store.dispatch('deleteMessage', { message, placeholder: 'placeholder-text' })
+			const status = await store.dispatch('deleteMessage', { token: message.token, id: message.id, placeholder: 'placeholder-text' })
 
-			expect(deleteMessage).toHaveBeenCalledWith(message)
+			expect(deleteMessage).toHaveBeenCalledWith({ token: message.token, id: message.id })
 			expect(status).toBe(200)
 
 			expect(store.getters.messagesList(TOKEN)).toMatchObject([message])
@@ -283,7 +283,7 @@ describe('messagesStore', () => {
 			const error = generateOCSErrorResponse({ payload: {}, status: 400 })
 			deleteMessage.mockRejectedValueOnce(error)
 
-			await store.dispatch('deleteMessage', { message, placeholder: 'placeholder-text' })
+			await store.dispatch('deleteMessage', { token: message.token, id: message.id, placeholder: 'placeholder-text' })
 				.catch(error => {
 					expect(error.status).toBe(400)
 
@@ -293,7 +293,8 @@ describe('messagesStore', () => {
 
 		test('shows placeholder while deletion is in progress', () => {
 			store.dispatch('deleteMessage', {
-				message,
+				token: message.token,
+				id: message.id,
 				placeholder: 'placeholder-message',
 			}).catch(() => {})
 
@@ -312,7 +313,7 @@ describe('messagesStore', () => {
 			token: TOKEN,
 		}
 
-		store.dispatch('processMessage', message1)
+		store.dispatch('processMessage', { token: TOKEN, message: message1 })
 		expect(store.getters.messagesList(TOKEN)[0]).toBe(message1)
 
 		store.dispatch('purgeMessagesStore', TOKEN)
@@ -386,7 +387,7 @@ describe('messagesStore', () => {
 				message: 'hello',
 			}
 
-			store.dispatch('processMessage', parent)
+			store.dispatch('processMessage', { token: TOKEN, message: parent })
 			chatExtraStore.setParentIdToReply({ token: TOKEN, id: 123 })
 
 			const temporaryMessage = await store.dispatch('createTemporaryMessage', {
@@ -471,7 +472,7 @@ describe('messagesStore', () => {
 				localUrl: null,
 			})
 
-			store.dispatch('addTemporaryMessage', temporaryMessage)
+			store.dispatch('addTemporaryMessage', { token: TOKEN, message: temporaryMessage })
 
 			expect(store.getters.messagesList(TOKEN)).toMatchObject([{
 				id: 'temp-1577908800000',
@@ -494,7 +495,7 @@ describe('messagesStore', () => {
 
 			// add again just replaces it
 			temporaryMessage.message = 'replaced'
-			store.dispatch('addTemporaryMessage', temporaryMessage)
+			store.dispatch('addTemporaryMessage', { token: TOKEN, message: temporaryMessage })
 
 			expect(store.getters.messagesList(TOKEN)).toMatchObject([{
 				id: 'temp-1577908800000',
@@ -524,9 +525,10 @@ describe('messagesStore', () => {
 				localUrl: null,
 			})
 
-			store.dispatch('addTemporaryMessage', temporaryMessage)
+			store.dispatch('addTemporaryMessage', { token: TOKEN, message: temporaryMessage })
 			store.dispatch('markTemporaryMessageAsFailed', {
-				message: temporaryMessage,
+				token: TOKEN,
+				id: temporaryMessage.id,
 				reason: 'failure-reason',
 			})
 
@@ -558,8 +560,8 @@ describe('messagesStore', () => {
 				localUrl: null,
 			})
 
-			store.dispatch('addTemporaryMessage', temporaryMessage)
-			store.dispatch('removeTemporaryMessageFromStore', temporaryMessage)
+			store.dispatch('addTemporaryMessage', { token: TOKEN, message: temporaryMessage })
+			store.dispatch('removeTemporaryMessageFromStore', { token: TOKEN, id: temporaryMessage.id })
 
 			expect(store.getters.messagesList(TOKEN)).toStrictEqual([])
 		})
@@ -574,7 +576,7 @@ describe('messagesStore', () => {
 				localUrl: null,
 			})
 
-			store.dispatch('addTemporaryMessage', temporaryMessage)
+			store.dispatch('addTemporaryMessage', { token: TOKEN, message: temporaryMessage })
 
 			expect(store.getters.getTemporaryReferences(TOKEN, temporaryMessage.referenceId)).toMatchObject([{
 				id: 'temp-1577908800000',
@@ -1566,7 +1568,7 @@ describe('messagesStore', () => {
 				message: 'first',
 			}
 
-			store.dispatch('processMessage', message1)
+			store.dispatch('processMessage', { token: TOKEN, message: message1 })
 		})
 
 		afterEach(() => {
@@ -1601,7 +1603,7 @@ describe('messagesStore', () => {
 			})
 			postNewMessage.mockResolvedValueOnce(response)
 
-			store.dispatch('postNewMessage', { temporaryMessage, options: { silent: false } }).catch(() => {
+			store.dispatch('postNewMessage', { token: TOKEN, temporaryMessage, options: { silent: false } }).catch(() => {
 			})
 			expect(postNewMessage).toHaveBeenCalledWith(temporaryMessage, { silent: false })
 			expect(store.getters.isSendingMessages).toBe(true)
@@ -1640,8 +1642,8 @@ describe('messagesStore', () => {
 				sendingFailure: '',
 			}
 
-			store.dispatch('postNewMessage', { temporaryMessage, options: { silent: false } }).catch(() => {})
-			store.dispatch('postNewMessage', { temporaryMessage: temporaryMessage2, options: { silent: false } }).catch(() => {})
+			store.dispatch('postNewMessage', { token: TOKEN, temporaryMessage, options: { silent: false } }).catch(() => {})
+			store.dispatch('postNewMessage', { token: TOKEN, temporaryMessage: temporaryMessage2, options: { silent: false } }).catch(() => {})
 
 			expect(cancelFunctionMocks[0]).not.toHaveBeenCalled()
 			expect(cancelFunctionMocks[1]).not.toHaveBeenCalled()
@@ -1680,7 +1682,7 @@ describe('messagesStore', () => {
 
 			postNewMessage.mockRejectedValueOnce({ isAxiosError: true, response })
 			await expect(
-				store.dispatch('postNewMessage', { temporaryMessage, options: { silent: false } })
+				store.dispatch('postNewMessage', { token: TOKEN, temporaryMessage, options: { silent: false } })
 			).rejects.toMatchObject({ response })
 
 			expect(store.getters.isSendingMessages).toBe(false)
@@ -1719,7 +1721,7 @@ describe('messagesStore', () => {
 				sendingFailure: '',
 			}
 
-			store.dispatch('postNewMessage', { temporaryMessage, options: { silent: false } }).catch(() => {})
+			store.dispatch('postNewMessage', { token: TOKEN, temporaryMessage, options: { silent: false } }).catch(() => {})
 
 			jest.advanceTimersByTime(60000)
 
@@ -1752,7 +1754,7 @@ describe('messagesStore', () => {
 			const response = generateOCSResponse({ payload })
 			postNewMessage.mockResolvedValueOnce(response)
 
-			await store.dispatch('postNewMessage', { temporaryMessage, options: { silent: false } })
+			await store.dispatch('postNewMessage', { token: TOKEN, temporaryMessage, options: { silent: false } })
 
 			jest.advanceTimersByTime(60000)
 

--- a/src/stores/__tests__/reactions.spec.js
+++ b/src/stores/__tests__/reactions.spec.js
@@ -237,7 +237,7 @@ describe('reactionsStore', () => {
 				timestamp: 1703668230,
 				token
 			}
-			vuexStore.commit('addMessage', message) // add a message to the store
+			vuexStore.commit('addMessage', { token, message }) // add a message to the store
 
 			// Act
 			await reactionsStore.addReactionToMessage({ token, messageId, selectedEmoji: '😅' })
@@ -274,7 +274,7 @@ describe('reactionsStore', () => {
 				token
 			}
 
-			vuexStore.commit('addMessage', message) // add a message to the store
+			vuexStore.commit('addMessage', { token, message }) // add a message to the store
 
 			// Act
 			await reactionsStore.removeReactionFromMessage({ token, messageId, selectedEmoji: '🎄' })

--- a/src/stores/__tests__/sharedItems.spec.js
+++ b/src/stores/__tests__/sharedItems.spec.js
@@ -48,8 +48,8 @@ describe('sharedItemsStore', () => {
 			}
 
 			// Act
-			sharedItemsStore.addSharedItemFromMessage(message)
-			sharedItemsStore.addSharedItemFromMessage(message)
+			sharedItemsStore.addSharedItemFromMessage(token, message)
+			sharedItemsStore.addSharedItemFromMessage(token, message)
 
 			// Assert
 			expect(sharedItemsStore.sharedItems(token)).toEqual({ media: { 1: message } })
@@ -63,7 +63,7 @@ describe('sharedItemsStore', () => {
 				message: '{file}',
 				messageParameters: { file: { mimetype: 'image/jpeg' } },
 			}
-			sharedItemsStore.addSharedItemFromMessage(message)
+			sharedItemsStore.addSharedItemFromMessage(token, message)
 
 			// Act
 			sharedItemsStore.addSharedItemsFromOverview(token, payloadOverview)

--- a/src/stores/sharedItems.js
+++ b/src/stores/sharedItems.js
@@ -101,10 +101,10 @@ export const useSharedItemsStore = defineStore('sharedItems', {
 		},
 
 		/**
+		 * @param {Token} token conversation token
 		 * @param {Message} message message with shared items
 		 */
-		addSharedItemFromMessage(message) {
-			const token = message.token
+		addSharedItemFromMessage(token, message) {
 			const type = getItemTypeFromMessage(message)
 			this.checkForExistence(token, type)
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix prior to federation:
  * federated conversation has `token: a` and `remoteToken: b`. When we're fetching something from remote server, we're using `b`, and messages are coming with `token: b` in the body, which doesn't belong to current instance
  * forcing to use local token for all messages actions / mutations
  * remove all extra payload from request (don't pass the whole message, if only token/id is needed)



## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes

### 🚧 Tasks

- [x] Manual testing
- [x] Code review
- [ ] Follow-up: migrate store to Pinia (not this PR)

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible