### PR TITLE
fix(chat): Handle basic editing of captions

### DIFF
--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -483,9 +483,13 @@ class ChatManager {
 	 * @param \DateTime $editTime
 	 * @param string $message
 	 * @return IComment
-	 * @throws \InvalidArgumentException
+	 * @throws \InvalidArgumentException When the message is empty or the shared object is not a file share with caption
 	 */
 	public function editMessage(Room $chat, IComment $comment, Participant $participant, \DateTime $editTime, string $message): IComment {
+		if (trim($message) === '') {
+			throw new \InvalidArgumentException('message');
+		}
+
 		if ($comment->getVerb() === ChatManager::VERB_OBJECT_SHARED) {
 			$messageData = json_decode($comment->getMessage(), true);
 			if (!isset($messageData['message']) || $messageData['message'] !== 'file_shared') {

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -753,11 +753,11 @@ class ChatController extends AEnvironmentAwareController {
 	 * @param int $messageId ID of the message
 	 * @param string $message the message to send
 	 * @psalm-param non-negative-int $messageId
-	 * @return DataResponse<Http::STATUS_OK|Http::STATUS_ACCEPTED, TalkChatMessageWithParent, array{X-Chat-Last-Common-Read?: numeric-string}>|DataResponse<Http::STATUS_BAD_REQUEST|Http::STATUS_FORBIDDEN|Http::STATUS_NOT_FOUND|Http::STATUS_METHOD_NOT_ALLOWED, array<empty>, array{}>
+	 * @return DataResponse<Http::STATUS_OK|Http::STATUS_ACCEPTED, TalkChatMessageWithParent, array{X-Chat-Last-Common-Read?: numeric-string}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_NOT_FOUND|Http::STATUS_METHOD_NOT_ALLOWED, array<empty>, array{}>
 	 *
 	 * 200: Message edited successfully
 	 * 202: Message edited successfully, but Matterbridge is configured, so the information can be replicated elsewhere
-	 * 400: Editing message is not possible
+	 * 400: Editing message is not possible, e.g. when the new message is empty or the message is too old
 	 * 403: Missing permissions to edit message
 	 * 404: Message not found
 	 * 405: Editing this message type is not allowed
@@ -797,7 +797,7 @@ class ChatController extends AEnvironmentAwareController {
 		$maxAge->sub(new \DateInterval('P1D'));
 		if ($comment->getCreationDateTime() < $maxAge) {
 			// Message is too old
-			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['error' => 'age'], Http::STATUS_BAD_REQUEST);
 		}
 
 		try {
@@ -812,7 +812,7 @@ class ChatController extends AEnvironmentAwareController {
 			if ($e->getMessage() === 'object_share') {
 				return new DataResponse([], Http::STATUS_METHOD_NOT_ALLOWED);
 			}
-			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}
 
 		$systemMessage = $this->messageParser->createMessage($this->room, $this->participant, $systemMessageComment, $this->l);

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -800,13 +800,20 @@ class ChatController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
-		$systemMessageComment = $this->chatManager->editMessage(
-			$this->room,
-			$comment,
-			$this->participant,
-			$this->timeFactory->getDateTime(),
-			$message
-		);
+		try {
+			$systemMessageComment = $this->chatManager->editMessage(
+				$this->room,
+				$comment,
+				$this->participant,
+				$this->timeFactory->getDateTime(),
+				$message
+			);
+		} catch (\InvalidArgumentException $e) {
+			if ($e->getMessage() === 'object_share') {
+				return new DataResponse([], Http::STATUS_METHOD_NOT_ALLOWED);
+			}
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
 
 		$systemMessage = $this->messageParser->createMessage($this->room, $this->participant, $systemMessageComment, $this->l);
 		$this->messageParser->parseMessage($systemMessage);

--- a/openapi.json
+++ b/openapi.json
@@ -6282,7 +6282,7 @@
                         }
                     },
                     "400": {
-                        "description": "Editing message is not possible",
+                        "description": "Editing message is not possible, e.g. when the new message is empty or the message is too old",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -6301,7 +6301,17 @@
                                                 "meta": {
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
-                                                "data": {}
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "error"
+                                                    ],
+                                                    "properties": {
+                                                        "error": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
                                             }
                                         }
                                     }

--- a/tests/integration/features/chat-1/edit-message.feature
+++ b/tests/integration/features/chat-1/edit-message.feature
@@ -50,3 +50,17 @@ Feature: chat-1/edit-message
     Then user "participant2" sees the following messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | message            | messageParameters | parentMessage |
       | room | users     | participant2 | participant2-displayname | Message 1 - Edit 2 | []                |               |
+
+  Scenario: Editing a caption
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" shares "welcome.txt" with room "room"
+      | talkMetaData | {"caption":"Caption 1"} |
+    And user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message  | messageParameters |
+      | room | users     | participant1 | participant1-displayname | Caption 1 | "IGNORE"          |
+    When user "participant1" edits message "Caption 1" in room "room" to "Caption 1 - Edit 1" with 200
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message            | messageParameters |
+      | room | users     | participant1 | participant1-displayname | Caption 1 - Edit 1 | "IGNORE"          |

--- a/tests/integration/features/chat-1/edit-message.feature
+++ b/tests/integration/features/chat-1/edit-message.feature
@@ -50,6 +50,10 @@ Feature: chat-1/edit-message
     Then user "participant2" sees the following messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | message            | messageParameters | parentMessage |
       | room | users     | participant2 | participant2-displayname | Message 1 - Edit 2 | []                |               |
+    And user "participant2" edits message "Message 1 - Edit 1" in room "room" to "" with 400
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message            | messageParameters | parentMessage |
+      | room | users     | participant2 | participant2-displayname | Message 1 - Edit 2 | []                |               |
 
   Scenario: Editing a caption
     Given user "participant1" creates room "room" (v4)
@@ -61,6 +65,10 @@ Feature: chat-1/edit-message
       | room | actorType | actorId      | actorDisplayName         | message  | messageParameters |
       | room | users     | participant1 | participant1-displayname | Caption 1 | "IGNORE"          |
     When user "participant1" edits message "Caption 1" in room "room" to "Caption 1 - Edit 1" with 200
+    Then user "participant1" sees the following messages in room "room" with 200
+      | room | actorType | actorId      | actorDisplayName         | message            | messageParameters |
+      | room | users     | participant1 | participant1-displayname | Caption 1 - Edit 1 | "IGNORE"          |
+    When user "participant1" edits message "Caption 1" in room "room" to "" with 400
     Then user "participant1" sees the following messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | message            | messageParameters |
       | room | users     | participant1 | participant1-displayname | Caption 1 - Edit 1 | "IGNORE"          |


### PR DESCRIPTION
### ☑️ Resolves

* Ref  #11206 

## 🛠️ API Checklist

- [x] Handle captions
- [x] Prevent empty messages

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
