### PR TITLE
feat(federation): chat functionality for remote server

### DIFF
--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -53,14 +53,19 @@
 			<span class="hidden-visually">{{ t('spreed', 'Call in progress') }}</span>
 		</div>
 		<div v-else-if="showFavorite" class="overlap-icon">
-			<Star :size="20" :fill-color="'#FFCC00'" />
+			<StarIcon :size="20" :fill-color="'#FFCC00'" />
 			<span class="hidden-visually">{{ t('spreed', 'Favorite') }}</span>
+		</div>
+		<div v-else-if="showAsFederated" class="overlap-icon">
+			<NetworkIcon :size="20" :fill-color="'#69009E'" />
+			<span class="hidden-visually">{{ t('spreed', 'Federation') }}</span>
 		</div>
 	</div>
 </template>
 
 <script>
-import Star from 'vue-material-design-icons/Star.vue'
+import NetworkIcon from 'vue-material-design-icons/Network.vue'
+import StarIcon from 'vue-material-design-icons/Star.vue'
 import VideoIcon from 'vue-material-design-icons/Video.vue'
 
 import { getCapabilities } from '@nextcloud/capabilities'
@@ -78,7 +83,8 @@ export default {
 
 	components: {
 		NcAvatar,
-		Star,
+		NetworkIcon,
+		StarIcon,
 		VideoIcon,
 	},
 
@@ -144,6 +150,10 @@ export default {
 
 		showFavorite() {
 			return !this.hideFavorite && this.item.isFavorite
+		},
+
+		showAsFederated() {
+			return !!this.item.remoteServer
 		},
 
 		preloadedUserStatus() {

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -519,7 +519,7 @@ export default {
 
 		isEditable() {
 			if (!this.isModifiable || this.isObjectShare
-					|| (!this.$store.getters.isModerator && !this.isMyMsg)) {
+					|| (!this.$store.getters.isModerator && !this.isOwnMessage)) {
 				return false
 			}
 
@@ -534,7 +534,7 @@ export default {
 			return (moment(this.timestamp * 1000).add(6, 'h')) > moment()
 				&& (this.messageType === 'comment' || this.messageType === 'voice-message')
 				&& !this.isDeleting
-				&& (this.isMyMsg
+				&& (this.isOwnMessage
 					|| (this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE
 						&& this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE_FORMER
 						&& (this.conversation.participantType === PARTICIPANT.TYPE.OWNER
@@ -545,7 +545,7 @@ export default {
 			return this.isReplyable
 				&& (this.conversation.type === CONVERSATION.TYPE.PUBLIC
 					|| this.conversation.type === CONVERSATION.TYPE.GROUP)
-				&& !this.isMyMsg
+				&& !this.isOwnMessage
 				&& this.actorType === ATTENDEE.ACTOR_TYPE.USERS
 				&& this.$store.getters.getActorType() === ATTENDEE.ACTOR_TYPE.USERS
 		},
@@ -575,7 +575,11 @@ export default {
 			return this.$store.getters.getActorType() === 'guests'
 		},
 
-		isMyMsg() {
+		isOwnMessage() {
+			if (this.conversation?.remoteToken) {
+				return this.actorId === this.$store.getters.getActorId() + '@' + window.location.host
+					&& this.actorType === ATTENDEE.ACTOR_TYPE.FEDERATED_USERS
+			}
 			return this.actorId === this.$store.getters.getActorId()
 				&& this.actorType === this.$store.getters.getActorType()
 		},

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -215,7 +215,6 @@ import { CONVERSATION, PARTICIPANT, PRIVACY } from '../../constants.js'
 import { EventBus } from '../../services/EventBus.js'
 import { shareFile } from '../../services/filesSharingServices.js'
 import { searchPossibleMentions } from '../../services/mentionsService.js'
-import { editMessage } from '../../services/messagesService.js'
 import { useChatExtrasStore } from '../../stores/chatExtras.js'
 import { useSettingsStore } from '../../stores/settings.js'
 import { fetchClipboardContent } from '../../utils/clipboard.js'
@@ -676,12 +675,11 @@ export default {
 
 		async handleEdit() {
 			try {
-				const response = await editMessage({
+				await this.$store.dispatch('editMessage', {
 					token: this.token,
 					messageId: this.messageToEdit.id,
-					updatedMessage: this.text.trim()
+					updatedMessage: this.text.trim(),
 				})
-				this.$store.dispatch('processMessage', { token: this.token, message: response.data.ocs.data })
 				this.chatExtrasStore.removeMessageIdToEdit(this.token)
 			} catch {
 				this.$emit('failure')

--- a/src/composables/useFederationAccess.js
+++ b/src/composables/useFederationAccess.js
@@ -1,0 +1,50 @@
+/**
+ * @copyright Copyright (c) 2024 Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @author Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Provide access credentials and params to access a remote server
+ * @param {object} conversation conversation object
+ * @param {string} userId current user id
+ * @return {object}
+ */
+export function useFederationAccess(conversation, userId) {
+	// FIXME useStore() is not accessible outside of components in Vue2
+	// Fix after using conversation and userId from the Pinia stores
+	const { remoteServer, remoteToken, remoteAccessToken } = conversation || {}
+	if (!remoteServer || !remoteToken || !remoteAccessToken) {
+		return {}
+	}
+	const authString = userId + '@' + window.location.host + ':' + remoteAccessToken
+
+	return {
+		remoteServer,
+		remoteToken,
+		headers: {
+			Authorization: 'Basic ' + window.btoa(authString),
+			'X-Nextcloud-Federation': '1',
+			// FIXME check headers and keep only needed (* is for CORS)
+			'Access-Control-Allow-Origin': '*',
+			'Access-Control-Allow-Methods': 'HEAD, GET, POST, PUT, PATCH, DELETE',
+			'Access-Control-Allow-Headers': 'Origin, Content-Type, X-Auth-Token',
+		}
+	}
+}

--- a/src/services/messagesService.spec.js
+++ b/src/services/messagesService.spec.js
@@ -7,14 +7,19 @@ import {
 	lookForNewMessages,
 	postNewMessage,
 	deleteMessage,
+	editMessage,
 	postRichObjectToConversation,
 	updateLastReadMessage,
+	addReactionToMessage,
+	removeReactionFromMessage,
+	getReactionsDetails,
 } from './messagesService.js'
 import { CHAT } from '../constants.js'
 
 jest.mock('@nextcloud/axios', () => ({
 	get: jest.fn(),
 	post: jest.fn(),
+	put: jest.fn(),
 	delete: jest.fn(),
 }))
 
@@ -146,10 +151,25 @@ describe('messagesService', () => {
 		deleteMessage({
 			token: 'XXTOKENXX',
 			id: 1234,
-		})
+		}, { dummyOption: true })
 
 		expect(axios.delete).toHaveBeenCalledWith(
 			generateOcsUrl('apps/spreed/api/v1/chat/XXTOKENXX/1234'),
+			{ dummyOption: true }
+		)
+	})
+
+	test('editMessage calls the chat API endpoint', () => {
+		editMessage({
+			token: 'XXTOKENXX',
+			messageId: 1234,
+			updatedMessage: 'edited message text',
+		}, { dummyOption: true })
+
+		expect(axios.put).toHaveBeenCalledWith(
+			generateOcsUrl('apps/spreed/api/v1/chat/XXTOKENXX/1234'),
+			{ message: 'edited message text' },
+			{ dummyOption: true }
 		)
 	})
 
@@ -159,7 +179,7 @@ describe('messagesService', () => {
 			objectId: 999,
 			metaData: '{"x":1}',
 			referenceId: 'reference-id',
-		})
+		}, { dummyOption: true })
 
 		expect(axios.post).toHaveBeenCalledWith(
 			generateOcsUrl('apps/spreed/api/v1/chat/XXTOKENXX/share'),
@@ -168,7 +188,8 @@ describe('messagesService', () => {
 				objectId: 999,
 				metaData: '{"x":1}',
 				referenceId: 'reference-id',
-			}
+			},
+			{ dummyOption: true }
 		)
 	})
 
@@ -177,7 +198,7 @@ describe('messagesService', () => {
 			objectType: 'deck',
 			objectId: 999,
 			metaData: '{"x":1}',
-		})
+		}, { dummyOption: true })
 
 		expect(axios.post).toHaveBeenCalledWith(
 			generateOcsUrl('apps/spreed/api/v1/chat/XXTOKENXX/share'),
@@ -186,17 +207,56 @@ describe('messagesService', () => {
 				objectId: 999,
 				metaData: '{"x":1}',
 				referenceId: expect.stringMatching(/^[a-z0-9]{64}$/),
-			}
+			},
+			{ dummyOption: true }
 		)
 	})
 
 	test('updateLastReadMessage calls the chat API endpoint', () => {
-		updateLastReadMessage('XXTOKENXX', 1234)
+		updateLastReadMessage('XXTOKENXX', 1234, { dummyOption: true })
 
 		expect(axios.post).toHaveBeenCalledWith(
 			generateOcsUrl('apps/spreed/api/v1/chat/XXTOKENXX/read'),
 			{
 				lastReadMessage: 1234,
+			},
+			{ dummyOption: true }
+		)
+	})
+
+	test('addReactionToMessage calls the reaction API endpoint', () => {
+		addReactionToMessage('XXTOKENXX', 1234, '👍', { dummyOption: true })
+
+		expect(axios.post).toHaveBeenCalledWith(
+			generateOcsUrl('apps/spreed/api/v1/reaction/XXTOKENXX/1234'),
+			{
+				reaction: '👍',
+			},
+			{ dummyOption: true }
+		)
+	})
+
+	test('removeReactionFromMessage calls the reaction API endpoint', () => {
+		removeReactionFromMessage('XXTOKENXX', 1234, '👍', { dummyOption: true })
+
+		expect(axios.delete).toHaveBeenCalledWith(
+			generateOcsUrl('apps/spreed/api/v1/reaction/XXTOKENXX/1234'),
+			{
+				dummyOption: true,
+				params: {
+					reaction: '👍',
+				},
+			}
+		)
+	})
+
+	test('getReactionsDetails calls the reaction API endpoint', () => {
+		getReactionsDetails('XXTOKENXX', 1234, { dummyOption: true })
+
+		expect(axios.get).toHaveBeenCalledWith(
+			generateOcsUrl('apps/spreed/api/v1/reaction/XXTOKENXX/1234'),
+			{
+				dummyOption: true,
 			}
 		)
 	})

--- a/src/services/urlService.js
+++ b/src/services/urlService.js
@@ -20,7 +20,7 @@
  */
 
 import { showError, showSuccess } from '@nextcloud/dialogs'
-import { generateUrl } from '@nextcloud/router'
+import { generateUrl, generateOcsUrl as _generateOcsUrl } from '@nextcloud/router'
 
 /**
  * Generate a full absolute link with @nextcloud/router.generateUrl
@@ -74,4 +74,27 @@ export async function copyConversationLinkToClipboard(token, messageId) {
 	} catch (error) {
 		showError(t('spreed', 'The link could not be copied'))
 	}
+}
+
+/**
+ * Get the base path for the given OCS API service (remote, if provided)
+ *
+ * @param {string} url OCS API service url
+ * @param {object} params parameters to be replaced into the service url
+ * @param {object} options options for the parameter replacement (UrlOptions)
+ * @param {string} [options.remoteServer] host name of remote instance
+ * @param {string} [options.remoteToken] remote token of conversation on remote instance
+ * @return {string} Absolute path for the OCS URL
+ */
+export const generateOcsUrl = (url, params, options = {}) => {
+	if (!params.token) {
+		// Fallback to default function
+		return _generateOcsUrl(url, params, options)
+	}
+
+	const { remoteServer, remoteToken, ...rest } = options
+	return remoteServer && remoteToken
+		? _generateOcsUrl(url, { ...params, token: remoteToken }, rest)
+			.replace(window.location.host, remoteServer)
+		: _generateOcsUrl(url, params, rest)
 }

--- a/src/store/messagesStore.spec.js
+++ b/src/store/messagesStore.spec.js
@@ -244,7 +244,7 @@ describe('messagesStore', () => {
 
 			const status = await store.dispatch('deleteMessage', { token: message.token, id: message.id, placeholder: 'placeholder-text' })
 
-			expect(deleteMessage).toHaveBeenCalledWith({ token: message.token, id: message.id })
+			expect(deleteMessage).toHaveBeenCalledWith({ token: message.token, id: message.id }, {})
 			expect(status).toBe(200)
 
 			expect(store.getters.messagesList(TOKEN)).toMatchObject([{
@@ -273,7 +273,7 @@ describe('messagesStore', () => {
 
 			const status = await store.dispatch('deleteMessage', { token: message.token, id: message.id, placeholder: 'placeholder-text' })
 
-			expect(deleteMessage).toHaveBeenCalledWith({ token: message.token, id: message.id })
+			expect(deleteMessage).toHaveBeenCalledWith({ token: message.token, id: message.id }, {})
 			expect(status).toBe(200)
 
 			expect(store.getters.messagesList(TOKEN)).toMatchObject([message])
@@ -611,14 +611,13 @@ describe('messagesStore', () => {
 	})
 
 	describe('last read message markers', () => {
-		let conversationsMock
+		let conversationMock
 		let markConversationReadAction
 		let getUserIdMock
 		let updateConversationLastReadMessageMock
 
 		beforeEach(() => {
-			const conversations = {}
-			conversations[TOKEN] = {
+			const conversation = {
 				lastMessage: {
 					id: 123,
 				},
@@ -627,10 +626,10 @@ describe('messagesStore', () => {
 			testStoreConfig = cloneDeep(messagesStore)
 
 			getUserIdMock = jest.fn()
-			conversationsMock = jest.fn().mockReturnValue(conversations)
+			conversationMock = jest.fn().mockReturnValue(conversation)
 			markConversationReadAction = jest.fn()
 			updateConversationLastReadMessageMock = jest.fn()
-			testStoreConfig.getters.conversations = conversationsMock
+			testStoreConfig.getters.conversation = jest.fn().mockReturnValue(conversationMock)
 			testStoreConfig.getters.getUserId = jest.fn().mockReturnValue(getUserIdMock)
 			testStoreConfig.actions.markConversationRead = markConversationReadAction
 			testStoreConfig.actions.updateConversationLastReadMessage = updateConversationLastReadMessageMock
@@ -657,7 +656,7 @@ describe('messagesStore', () => {
 				updateVisually: false,
 			})
 
-			expect(conversationsMock).toHaveBeenCalled()
+			expect(conversationMock).toHaveBeenCalled()
 			expect(markConversationReadAction).toHaveBeenCalledWith(expect.anything(), TOKEN)
 			expect(getUserIdMock).toHaveBeenCalled()
 			expect(updateConversationLastReadMessageMock).toHaveBeenCalledWith(expect.anything(), {
@@ -665,7 +664,7 @@ describe('messagesStore', () => {
 				lastReadMessage: 123,
 			})
 
-			expect(updateLastReadMessage).toHaveBeenCalledWith(TOKEN, 123)
+			expect(updateLastReadMessage).toHaveBeenCalledWith(TOKEN, 123, {})
 			expect(store.getters.getVisualLastReadMessageId(TOKEN)).toBe(100)
 		})
 
@@ -678,7 +677,7 @@ describe('messagesStore', () => {
 				updateVisually: true,
 			})
 
-			expect(conversationsMock).toHaveBeenCalled()
+			expect(conversationMock).toHaveBeenCalled()
 			expect(markConversationReadAction).toHaveBeenCalledWith(expect.anything(), TOKEN)
 			expect(getUserIdMock).toHaveBeenCalled()
 			expect(updateConversationLastReadMessageMock).toHaveBeenCalledWith(expect.anything(), {
@@ -686,7 +685,7 @@ describe('messagesStore', () => {
 				lastReadMessage: 123,
 			})
 
-			expect(updateLastReadMessage).toHaveBeenCalledWith(TOKEN, 123)
+			expect(updateLastReadMessage).toHaveBeenCalledWith(TOKEN, 123, {})
 			expect(store.getters.getVisualLastReadMessageId(TOKEN)).toBe(123)
 		})
 
@@ -699,7 +698,7 @@ describe('messagesStore', () => {
 				updateVisually: true,
 			})
 
-			expect(conversationsMock).toHaveBeenCalled()
+			expect(conversationMock).toHaveBeenCalled()
 			expect(markConversationReadAction).toHaveBeenCalledWith(expect.anything(), TOKEN)
 			expect(getUserIdMock).toHaveBeenCalled()
 			expect(updateConversationLastReadMessageMock).toHaveBeenCalledWith(expect.anything(), {
@@ -721,7 +720,7 @@ describe('messagesStore', () => {
 				updateVisually: false,
 			})
 
-			expect(conversationsMock).toHaveBeenCalled()
+			expect(conversationMock).toHaveBeenCalled()
 			expect(markConversationReadAction).not.toHaveBeenCalled()
 			expect(getUserIdMock).toHaveBeenCalled()
 			expect(updateConversationLastReadMessageMock).toHaveBeenCalledWith(expect.anything(), {
@@ -729,7 +728,7 @@ describe('messagesStore', () => {
 				lastReadMessage: 200,
 			})
 
-			expect(updateLastReadMessage).toHaveBeenCalledWith(TOKEN, 200)
+			expect(updateLastReadMessage).toHaveBeenCalledWith(TOKEN, 200, {})
 			expect(store.getters.getVisualLastReadMessageId(TOKEN)).toBe(100)
 		})
 
@@ -743,7 +742,7 @@ describe('messagesStore', () => {
 				updateVisually: true,
 			})
 
-			expect(conversationsMock).toHaveBeenCalled()
+			expect(conversationMock).toHaveBeenCalled()
 			expect(markConversationReadAction).not.toHaveBeenCalled()
 			expect(getUserIdMock).toHaveBeenCalled()
 			expect(updateConversationLastReadMessageMock).toHaveBeenCalledWith(expect.anything(), {
@@ -751,7 +750,7 @@ describe('messagesStore', () => {
 				lastReadMessage: 200,
 			})
 
-			expect(updateLastReadMessage).toHaveBeenCalledWith(TOKEN, 200)
+			expect(updateLastReadMessage).toHaveBeenCalledWith(TOKEN, 200, {})
 			expect(store.getters.getVisualLastReadMessageId(TOKEN)).toBe(200)
 		})
 
@@ -765,7 +764,7 @@ describe('messagesStore', () => {
 				updateVisually: true,
 			})
 
-			expect(conversationsMock).toHaveBeenCalled()
+			expect(conversationMock).toHaveBeenCalled()
 			expect(markConversationReadAction).not.toHaveBeenCalled()
 			expect(getUserIdMock).toHaveBeenCalled()
 			expect(updateConversationLastReadMessageMock).toHaveBeenCalledWith(expect.anything(), {
@@ -780,6 +779,8 @@ describe('messagesStore', () => {
 
 	describe('fetchMessages', () => {
 		let updateLastCommonReadMessageAction
+		let conversationMock
+		let getUserIdMock
 		let addGuestNameAction
 		let cancelFunctionMock
 
@@ -791,6 +792,10 @@ describe('messagesStore', () => {
 			addGuestNameAction = jest.fn()
 			testStoreConfig.actions.updateLastCommonReadMessage = updateLastCommonReadMessageAction
 			guestNameStore.addGuestName = addGuestNameAction
+			conversationMock = jest.fn().mockReturnValue({})
+			getUserIdMock = jest.fn()
+			testStoreConfig.getters.conversation = jest.fn().mockReturnValue(conversationMock)
+			testStoreConfig.getters.getUserId = jest.fn().mockReturnValue(getUserIdMock)
 
 			cancelFunctionMock = jest.fn()
 			CancelableRequest.mockImplementation((request) => {
@@ -939,12 +944,12 @@ describe('messagesStore', () => {
 		let cancelFunctionMock
 
 		beforeEach(() => {
-			testStoreConfig = cloneDeep(messagesStore)
+			testStoreConfig = cloneDeep(storeConfig)
 			const guestNameStore = useGuestNameStore()
 
 			updateLastCommonReadMessageAction = jest.fn()
 			addGuestNameAction = jest.fn()
-			testStoreConfig.actions.updateLastCommonReadMessage = updateLastCommonReadMessageAction
+			testStoreConfig.modules.conversationsStore.actions.updateLastCommonReadMessage = updateLastCommonReadMessageAction
 			guestNameStore.addGuestName = addGuestNameAction
 
 			cancelFunctionMock = jest.fn()
@@ -1062,7 +1067,7 @@ describe('messagesStore', () => {
 				lastKnownMessageId: 3,
 				includeLastKnown: false,
 				limit: CHAT.FETCH_LIMIT,
-			}, undefined)
+			}, {})
 
 			expect(updateLastCommonReadMessageAction).toHaveBeenCalledTimes(2)
 			expect(updateLastCommonReadMessageAction).toHaveBeenNthCalledWith(1, expect.anything(), { token: TOKEN, lastCommonReadMessage: 2 })
@@ -1528,6 +1533,7 @@ describe('messagesStore', () => {
 	describe('posting new message', () => {
 		let message1
 		let conversationMock
+		let userIdMock
 		let updateLastCommonReadMessageAction
 		let updateLastReadMessageAction
 		let updateConversationLastMessageAction
@@ -1541,10 +1547,12 @@ describe('messagesStore', () => {
 
 			restoreConsole = mockConsole(['error'])
 			conversationMock = jest.fn()
+			userIdMock = jest.fn()
 			updateConversationLastMessageAction = jest.fn()
 			updateLastCommonReadMessageAction = jest.fn()
 			updateLastReadMessageAction = jest.fn()
 			testStoreConfig.getters.conversation = jest.fn().mockReturnValue(conversationMock)
+			testStoreConfig.getters.getUserId = jest.fn().mockReturnValue(userIdMock)
 			testStoreConfig.actions.updateConversationLastMessage = updateConversationLastMessageAction
 			testStoreConfig.actions.updateLastCommonReadMessage = updateLastCommonReadMessageAction
 			// mock this complex local action as we already tested it elsewhere
@@ -1931,6 +1939,7 @@ describe('messagesStore', () => {
 					metaData: JSON.stringify(objectToBeForwarded),
 					referenceId: '',
 				},
+				{}
 			)
 
 		})

--- a/src/stores/reactions.js
+++ b/src/stores/reactions.js
@@ -26,6 +26,7 @@ import Vue from 'vue'
 
 import { showError } from '@nextcloud/dialogs'
 
+import { useFederationAccess } from '../composables/useFederationAccess.js'
 import {
 	getReactionsDetails,
 	addReactionToMessage,
@@ -238,8 +239,9 @@ export const useReactionsStore = defineStore('reactions', {
 					messageId,
 					reaction: selectedEmoji,
 				})
+				const remoteOptions = useFederationAccess(store.getters.conversation(token), store.getters.getUserId())
 				// The response return an array with the reaction details for this message
-				const response = await addReactionToMessage(token, messageId, selectedEmoji)
+				const response = await addReactionToMessage(token, messageId, selectedEmoji, remoteOptions)
 				this.updateReactions({
 					token,
 					messageId,
@@ -272,8 +274,9 @@ export const useReactionsStore = defineStore('reactions', {
 					messageId,
 					reaction: selectedEmoji,
 				})
+				const remoteOptions = useFederationAccess(store.getters.conversation(token), store.getters.getUserId())
 				// The response return an array with the reaction details for this message
-				const response = await removeReactionFromMessage(token, messageId, selectedEmoji)
+				const response = await removeReactionFromMessage(token, messageId, selectedEmoji, remoteOptions)
 				this.updateReactions({
 					token,
 					messageId,
@@ -301,7 +304,8 @@ export const useReactionsStore = defineStore('reactions', {
 		async fetchReactions(token, messageId) {
 			console.debug('getting reactions details')
 			try {
-				const response = await getReactionsDetails(token, messageId)
+				const remoteOptions = useFederationAccess(store.getters.conversation(token), store.getters.getUserId())
+				const response = await getReactionsDetails(token, messageId, remoteOptions)
 				this.updateReactions({
 					token,
 					messageId,


### PR DESCRIPTION
### ☑️ Resolves

* Part of #11273 
* Works only locally with #10686 

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏡 After |
|----------|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/4a05c848-02b0-4140-a49b-bb20ef267cb3) |
### 🚧 Tasks

- [x] General way to generate remote OCS URL link
- [x] General way to get remote credentials from given data
  - [ ] Getting messages (context, new, old)
  - [ ] Posting messages (plain)
  - [ ] Forwarding messages (plain, objects (deck cards-like))
  - [ ] Reacting to messages
  - [x] Deleting messages
  - [x] Editing messages
  - [ ] Marking messages as unread / read
- [ ] Follow-ups:
  - [ ] Conversation avatars
  - [ ] Participants matching (local <-> remote) - frontend or backend?

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required