### PR TITLE
Restore green CI after Lazy Config change in server

### DIFF
--- a/.github/workflows/integration-pgsql.yml
+++ b/.github/workflows/integration-pgsql.yml
@@ -54,7 +54,7 @@ jobs:
         test-suite: ['callapi', 'chat-1', 'chat-2', 'command', 'conversation-1', 'conversation-2', 'conversation-3', 'conversation-4', 'conversation-5', 'federation', 'integration', 'sharing-1', 'sharing-2', 'sharing-3', 'sharing-4']
         php-versions: ['8.3']
         server-versions: ['master']
-        guests-versions: ['master']
+        guests-versions: ['bugfix/noid/dont-break-hard']
         call-summary-bot-versions: ['main']
         notifications-versions: ['master']
 

--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "ef30cb8584a788bf01916ab00c39303e5f58f260"
+                "reference": "30e8e2fb44e06f7698d367fecc125c626929a9c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/ef30cb8584a788bf01916ab00c39303e5f58f260",
-                "reference": "ef30cb8584a788bf01916ab00c39303e5f58f260",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/30e8e2fb44e06f7698d367fecc125c626929a9c7",
+                "reference": "30e8e2fb44e06f7698d367fecc125c626929a9c7",
                 "shasum": ""
             },
             "require": {
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-01-12T00:34:25+00:00"
+            "time": "2024-01-16T00:34:22+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency

- [x] Server commit can be dropped with https://github.com/nextcloud/server/pull/42844
- [ ] Guests commit can be dropped with https://github.com/nextcloud/guests/pull/1100