### PR TITLE
enh(participants): extract and reuse `patchParticipants` action

### DIFF
--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomItem.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomItem.vue
@@ -46,7 +46,8 @@
 				</NcButton>
 				<NcActions v-if="canModerate"
 					:container="container"
-					:force-menu="true">
+					:inline="showAssistanceButton ? 1 : 0"
+					:force-menu="!showAssistanceButton">
 					<NcActionButton v-if="showAssistanceButton"
 						@click="dismissRequestAssistance">
 						<template #icon>

--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -379,8 +379,7 @@ export default {
 		// True if current conversation is a breakout room and the breakout room has started
 		// And a call is in progress
 		userIsInBreakoutRoomAndInCall() {
-			return this.conversation.breakoutRoomMode === CONVERSATION.BREAKOUT_ROOM_MODE.NOT_CONFIGURED
-				&& this.conversation.breakoutRoomStatus === CONVERSATION.BREAKOUT_ROOM_STATUS.STARTED
+			return this.conversation.objectType === CONVERSATION.OBJECT_TYPE.BREAKOUT_ROOM
 				&& this.isInCall
 		},
 	},
@@ -468,9 +467,9 @@ export default {
 			// If the current conversation is a break-out room and the user is not a moderator,
 			// also send request for assistance to the moderators.
 			if (this.userIsInBreakoutRoomAndInCall && !this.canModerate) {
-				this.$store.dispatch('requestAssistanceAction', {
-					token: this.token,
-				})
+				if (newState) {
+					this.$store.dispatch('requestAssistanceAction', { token: this.token })
+				}
 			}
 		},
 

--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -467,8 +467,17 @@ export default {
 			// If the current conversation is a break-out room and the user is not a moderator,
 			// also send request for assistance to the moderators.
 			if (this.userIsInBreakoutRoomAndInCall && !this.canModerate) {
-				if (newState) {
+				const hasRaisedHands = Object.keys(this.$store.getters.participantRaisedHandList)
+					.filter(sessionId => sessionId !== this.$store.getters.getSessionId())
+					.length !== 0
+				if (hasRaisedHands) {
+					return // Assistance is already requested by someone in the room
+				}
+				const hasAssistanceRequested = this.conversation.breakoutRoomStatus === CONVERSATION.BREAKOUT_ROOM_STATUS.STATUS_ASSISTANCE_REQUESTED
+				if (newState && !hasAssistanceRequested) {
 					this.$store.dispatch('requestAssistanceAction', { token: this.token })
+				} else if (!newState && hasAssistanceRequested) {
+					this.$store.dispatch('resetRequestAssistanceAction', { token: this.token })
 				}
 			}
 		},

--- a/src/store/breakoutRoomsStore.js
+++ b/src/store/breakoutRoomsStore.js
@@ -221,6 +221,10 @@ const actions = {
 			const response = await requestAssistance(token)
 			// Add the updated parent conversation to the conversations store
 			context.commit('addConversation', response.data.ocs.data)
+			context.commit('addBreakoutRoom', {
+				parentRoomToken: response.data.ocs.data.objectId,
+				breakoutRoom: response.data.ocs.data,
+			})
 		} catch (error) {
 			console.error(error)
 			showError(t('spreed', 'An error occurred while requesting assistance'))
@@ -232,6 +236,10 @@ const actions = {
 			const response = await resetRequestAssistance(token)
 			// Add the updated parent conversation to the conversations store
 			context.commit('addConversation', response.data.ocs.data)
+			context.commit('addBreakoutRoom', {
+				parentRoomToken: response.data.ocs.data.objectId,
+				breakoutRoom: response.data.ocs.data,
+			})
 		} catch (error) {
 			console.error(error)
 			showError(t('spreed', 'An error occurred while resetting the request for assistance'))

--- a/src/store/callViewStore.js
+++ b/src/store/callViewStore.js
@@ -54,6 +54,9 @@ const getters = {
 		return state.selectedVideoPeerId
 	},
 	isQualityWarningTooltipDismissed: (state) => state.qualityWarningTooltipDismissed,
+	participantRaisedHandList: (state) => {
+		return state.participantRaisedHands
+	},
 	getParticipantRaisedHand: (state) => (sessionIds) => {
 		for (let i = 0; i < sessionIds.length; i++) {
 			if (state.participantRaisedHands[sessionIds[i]]) {

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -385,6 +385,13 @@ const actions = {
 				const conversationHasChanged = context.dispatch('updateConversationIfHasChanged', newConversation)
 				storeHasChanged = conversationHasChanged || storeHasChanged
 			}
+
+			if (newConversation.objectType === CONVERSATION.OBJECT_TYPE.BREAKOUT_ROOM) {
+				context.commit('addBreakoutRoom', {
+					parentRoomToken: newConversation.objectId,
+					breakoutRoom: newConversation,
+				})
+			}
 		}
 
 		if (withCaching && storeHasChanged) {

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -627,7 +627,6 @@ const actions = {
 	 * @return {object|null}
 	 */
 	async fetchParticipants(context, { token }) {
-		const guestNameStore = useGuestNameStore()
 		// Cancel a previous request
 		context.dispatch('cancelFetchParticipants')
 		// Get a new cancelable request function and cancel function pair
@@ -639,33 +638,7 @@ const actions = {
 			const response = await request(token)
 			const hasUserStatuses = !!response.headers['x-nextcloud-has-user-statuses']
 
-			const currentParticipants = context.state.attendees[token]
-			const newParticipants = response.data.ocs.data
-			for (const attendeeId of Object.keys(Object(currentParticipants))) {
-				if (!newParticipants.some(participant => participant.attendeeId === +attendeeId)) {
-					context.commit('deleteParticipant', { token, attendeeId })
-				}
-			}
-
-			newParticipants.forEach(participant => {
-				if (context.state.attendees[token]?.[participant.attendeeId]) {
-					context.dispatch('updateParticipantIfHasChanged', { token, participant, hasUserStatuses })
-				} else {
-					context.dispatch('addParticipant', { token, participant })
-					if (hasUserStatuses) {
-						emitUserStatusUpdated(participant)
-					}
-				}
-
-				if (participant.participantType === PARTICIPANT.TYPE.GUEST
-					|| participant.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR) {
-					guestNameStore.addGuestName({
-						token,
-						actorId: Hex.stringify(SHA1(participant.sessionIds[0])),
-						actorDisplayName: participant.displayName,
-					}, { noUpdate: false })
-				}
-			})
+			context.dispatch('patchParticipants', { token, newParticipants: response.data.ocs.data, hasUserStatuses })
 
 			if (context.state.initialised[token] === false) {
 				context.commit('setParticipantsInitialised', { token, initialised: true })
@@ -683,6 +656,46 @@ const actions = {
 			}
 			return null
 		}
+	},
+
+	/**
+	 * Update participants in the store with specified token.
+	 *
+	 * @param {object} context default store context;
+	 * @param {object} data the wrapping object;
+	 * @param {string} data.token the conversation token;
+	 * @param {object} data.newParticipants the participant array;
+	 * @param {boolean} data.hasUserStatuses whether participants has user statuses or not;
+	 */
+	async patchParticipants(context, { token, newParticipants, hasUserStatuses }) {
+		const guestNameStore = useGuestNameStore()
+
+		const currentParticipants = context.state.attendees[token]
+		for (const attendeeId of Object.keys(Object(currentParticipants))) {
+			if (!newParticipants.some(participant => participant.attendeeId === +attendeeId)) {
+				context.commit('deleteParticipant', { token, attendeeId })
+			}
+		}
+
+		newParticipants.forEach(participant => {
+			if (context.state.attendees[token]?.[participant.attendeeId]) {
+				context.dispatch('updateParticipantIfHasChanged', { token, participant, hasUserStatuses })
+			} else {
+				context.dispatch('addParticipant', { token, participant })
+				if (hasUserStatuses) {
+					emitUserStatusUpdated(participant)
+				}
+			}
+
+			if (participant.participantType === PARTICIPANT.TYPE.GUEST
+				|| participant.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR) {
+				guestNameStore.addGuestName({
+					token,
+					actorId: Hex.stringify(SHA1(participant.sessionIds[0])),
+					actorDisplayName: participant.displayName,
+				}, { noUpdate: false })
+			}
+		})
 	},
 
 	/**


### PR DESCRIPTION
## 🖌️ UI Checklist

### ☑️ Resolves

* `breakoutRoomsStore` used the old way of update: purge each room -> populate again
  * With extracting method at `participantsStore`, it could be reused
* On fetching conversations, breakout rooms are also updated
  * Moderators can see the request for assistance on the tab
* Non-moderators can also dismiss request for assistance, if no one else is asked for it
  * has edge-cases, which should be covered by signaling patch (see mentioned issue)
  
>[!IMPORTANT]
> HPB is required to be enabled, to receive signaling messages

>[!NOTE]
>Does not required API patch from splitted out PR, but works better with it :rocket: 

### 🖼️ Screenshots / Screencasts

Before | After
-|-
![image](https://github.com/nextcloud/spreed/assets/93392545/d36fec7c-bad3-4cb2-820d-6ed07054f886) | ![Screenshot from 2024-01-19 09-40-32](https://github.com/nextcloud/spreed/assets/93392545/4fffd230-4157-41e8-8271-61a11f036478)


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible