### PR TITLE
feat(meetings): selectively invite users from lobby

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -238,7 +238,7 @@ export default {
 		},
 
 		chatIdentifier() {
-			return this.token + ':' + this.isParticipant + ':' + this.isInLobby + ':' + this.viewId
+			return this.token + ':' + this.isParticipant + ':' + this.viewId
 		},
 	},
 

--- a/src/services/participantsService.js
+++ b/src/services/participantsService.js
@@ -220,15 +220,16 @@ const removeAllPermissionsFromParticipant = async (token, attendeeId) => {
  *
  * @param {string} token conversation token
  * @param {number} attendeeId attendee id to target
+ * @param {'set'|'add'|'remove'} method permissions update method
  * @param {number} permission the type of permission to be granted. Valid values are
  * any sums of 'DEFAULT', 'CUSTOM', 'CALL_START', 'CALL_JOIN', 'LOBBY_IGNORE',
  * 'PUBLISH_AUDIO', 'PUBLISH_VIDEO', 'PUBLISH_SCREEN'.
  */
-const setPermissions = async (token, attendeeId, permission) => {
+const setPermissions = async (token, attendeeId, method = 'set', permission) => {
 	await axios.put(generateOcsUrl('apps/spreed/api/v4/room/{token}/attendees/permissions', { token }),
 		{
 			attendeeId,
-			method: 'set',
+			method,
 			permissions: permission,
 		})
 }

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -991,10 +991,11 @@ const actions = {
 	 * @param {object} root0 - the arguments object.
 	 * @param {string} root0.token - the conversation token.
 	 * @param {string} root0.attendeeId - the participant-s attendeeId.
+	 * @param {'set'|'add'|'remove'} [root0.method] permissions update method
 	 * @param {number} root0.permissions - bitwise combination of the permissions.
 	 */
-	async setPermissions(context, { token, attendeeId, permissions }) {
-		await setPermissions(token, attendeeId, permissions)
+	async setPermissions(context, { token, attendeeId, method, permissions }) {
+		await setPermissions(token, attendeeId, method, permissions)
 		const updatedData = {
 			permissions,
 			attendeePermissions: permissions,


### PR DESCRIPTION
### ☑️ Resolves

* Fix #8601
* If lobby is enabled, a new button is appeare in participant action to explicitly change lobby permission for that one participant
* `isInLobby` was removed from `chatIdentifier`:
  * chat is mounted/unmounted with param change anyway, so no need to depend on it
  * it leaves outdated cancel requests in the store:
![image](https://github.com/nextcloud/spreed/assets/93392545/e4c32ef8-cfe2-4616-a370-a85bc8cc5533)


>[!IMPORTANT]
> HPB is required to be enabled, to receive signaling messages

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts
In | Out
--|--
![image](https://github.com/nextcloud/spreed/assets/93392545/a2220669-f8d9-4e15-a6a3-32290616a0d9) | ![image](https://github.com/nextcloud/spreed/assets/93392545/e3041afb-6051-413c-81bb-3e180d38a05b)

https://github.com/nextcloud/spreed/assets/93392545/fc5ae076-b86d-42c2-98fe-ca038a52e09e



### 🚧 Tasks

- [x] Check wording
- [x] Decide on selected icons

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required