### PR TITLE
fix(breakout): stop breakout rooms on removing

### DIFF
--- a/lib/Service/BreakoutRoomService.php
+++ b/lib/Service/BreakoutRoomService.php
@@ -36,6 +36,7 @@ use OCA\Talk\Model\BreakoutRoom;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Webinary;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IL10N;
 use OCP\Notification\IManager as INotificationManager;
@@ -48,6 +49,7 @@ class BreakoutRoomService {
 		protected ParticipantService $participantService,
 		protected ChatManager $chatManager,
 		protected INotificationManager $notificationManager,
+		protected ITimeFactory $timeFactory,
 		protected IEventDispatcher $dispatcher,
 		protected IL10N $l,
 	) {
@@ -337,6 +339,7 @@ class BreakoutRoomService {
 	public function removeBreakoutRooms(Room $parent): void {
 		$this->deleteBreakoutRooms($parent);
 		$this->roomService->setBreakoutRoomMode($parent, BreakoutRoom::MODE_NOT_CONFIGURED);
+		$this->roomService->setBreakoutRoomStatus($parent, BreakoutRoom::STATUS_STOPPED);
 	}
 
 	protected function deleteBreakoutRooms(Room $parent): void {
@@ -403,6 +406,7 @@ class BreakoutRoomService {
 		}
 
 		$this->roomService->setBreakoutRoomStatus($breakoutRoom, $status);
+		$this->roomService->setLastActivity($breakoutRoom, $this->timeFactory->getDateTime());
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2927,6 +2927,20 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" removes breakout rooms from "([^"]*)" with (\d+) \((v1)\)$/
+	 *
+	 * @param string $user
+	 * @param string $identifier
+	 * @param int $status
+	 * @param string $apiVersion
+	 */
+	public function userRemovesBreakoutRooms(string $user, string $identifier, int $status, string $apiVersion): void {
+		$this->setCurrentUser($user);
+		$this->sendRequest('DELETE', '/apps/spreed/api/' . $apiVersion . '/breakout-rooms/' . self::$identifierToToken[$identifier]);
+		$this->assertStatusCode($this->response, $status);
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" moves participants into different breakout rooms for "([^"]*)" with (\d+) \((v1)\)$/
 	 *
 	 * @param string $user

--- a/tests/integration/features/conversation-1/breakout-rooms.feature
+++ b/tests/integration/features/conversation-1/breakout-rooms.feature
@@ -575,6 +575,40 @@ Feature: conversation/breakout-rooms
     And user "participant1" is participant of the following rooms (v4)
     And user "participant2" is participant of the following rooms (v4)
 
+  Scenario: Removing breakout rooms also stops them on the parent
+    Given user "participant1" creates room "class room" (v4)
+      | roomType | 2 |
+      | roomName | class room |
+    And user "participant1" adds user "participant2" to room "class room" with 200 (v4)
+    And user "participant1" sees the following attendees in room "class room" with 200 (v4)
+      | actorType  | actorId      | participantType |
+      | users      | participant1 | 1               |
+      | users      | participant2 | 3               |
+    And user "participant1" is participant of the following unordered rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 0                | 0                  |
+    And user "participant1" creates 2 automatic breakout rooms for "class room" with 200 (v1)
+      | users::participant2 | 0 |
+    And user "participant1" is participant of the following unordered rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 1                | 0                  |
+      | 2    | Room 1     | 1          | 0                | 0                  |
+      | 2    | Room 2     | 1          | 0                | 0                  |
+    And user "participant1" starts breakout rooms in room "class room" with 200 (v1)
+    And user "participant1" is participant of the following unordered rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 1                | 1                  |
+      | 2    | Room 1     | 0          | 0                | 0                  |
+      | 2    | Room 2     | 0          | 0                | 0                  |
+    And user "participant2" is participant of the following unordered rooms (v4)
+      | type | name       |
+      | 2    | class room |
+      | 2    | Room 1     |
+    When user "participant1" removes breakout rooms from "class room" with 200 (v1)
+    And user "participant1" is participant of the following unordered rooms (v4)
+      | type | name       | lobbyState | breakoutRoomMode | breakoutRoomStatus |
+      | 2    | class room | 0          | 0                | 0                  |
+
   Scenario: Deleting a single breakout room unassigned the students from the mapping
     Given user "participant1" creates room "class room" (v4)
       | roomType | 2 |

--- a/tests/php/Service/BreakoutRoomServiceTest.php
+++ b/tests/php/Service/BreakoutRoomServiceTest.php
@@ -32,6 +32,7 @@ use OCA\Talk\Manager;
 use OCA\Talk\Service\BreakoutRoomService;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\RoomService;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IL10N;
 use OCP\Notification\IManager as INotificationManager;
@@ -53,6 +54,8 @@ class BreakoutRoomServiceTest extends TestCase {
 	private $chatManager;
 	/** @var INotificationManager|MockObject */
 	private $notificationManager;
+	/** @var ITimeFactory|MockObject */
+	protected $timeFactory;
 	/** @var IEventDispatcher|MockObject */
 	private $dispatcher;
 	/** @var IL10N|MockObject */
@@ -67,6 +70,7 @@ class BreakoutRoomServiceTest extends TestCase {
 		$this->participantService = $this->createMock(ParticipantService::class);
 		$this->chatManager = $this->createMock(ChatManager::class);
 		$this->notificationManager = $this->createMock(INotificationManager::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->dispatcher = $this->createMock(IEventDispatcher::class);
 		$this->l = $this->createMock(IL10N::class);
 		$this->service = new BreakoutRoomService(
@@ -76,6 +80,7 @@ class BreakoutRoomServiceTest extends TestCase {
 			$this->participantService,
 			$this->chatManager,
 			$this->notificationManager,
+			$this->timeFactory,
 			$this->dispatcher,
 			$this->l
 		);


### PR DESCRIPTION
### ☑️ Resolves

* API part is splitted out from #11394 
* When removing breakout rooms, status at parent is now reset (if create rooms again, they will not be marked as started)
* Updating lastActivity when requesting / dismissing the assistance allows moderators to re-fetch breakout rooms within 30s interval (`?modifiedSince`) and actually see the request (before it was once in 10 requests on a full fetch)

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░█████████░░░███████████░░█████░
░░███░░░░░███░░░███░░░░░███░░███░░
░░███░░░░░███░░░███░░░░░███░░███░░
░░███████████░░░██████████░░░███░░
░░███░░░░░███░░░███░░░░░░░░░░███░░
░░███░░░░░███░░░███░░░░░░░░░░███░░
░█████░░░█████░█████░░░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Write tests

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
