### PR TITLE
feat(chat): Add capability for editing messages

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -138,3 +138,7 @@
 * `config => call => sip-enabled` - Whether SIP is configured on the server allowing for SIP dial-in
 * `config => call => sip-dialout-enabled` - Whether SIP dial-out is configured on the server, additionally requires `config => call => sip-enabled`
 * `config => call => can-enable-sip` - Whether the current user is a member of the groups that are allowed to enable SIP dial-in on a conversation or use SIP dial-out
+
+## 19
+* `delete-messages-unlimited` - Whether messages can be deleted at any time (used to be restricted to 6 hours after posting)
+* `edit-messages` - Whether messages can be edited (restricted to 24 hours after posting)

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -170,6 +170,8 @@ class Capabilities implements IPublicCapability {
 				'note-to-self',
 				'recording-consent',
 				'sip-support-dialout',
+				'delete-messages-unlimited',
+				'edit-messages',
 			],
 			'config' => [
 				'attachments' => [

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -713,13 +713,6 @@ class ChatController extends AEnvironmentAwareController {
 			return new DataResponse([], Http::STATUS_METHOD_NOT_ALLOWED);
 		}
 
-		$maxDeleteAge = $this->timeFactory->getDateTime();
-		$maxDeleteAge->sub(new \DateInterval('PT6H'));
-		if ($message->getCreationDateTime() < $maxDeleteAge) {
-			// Message is too old
-			return new DataResponse([], Http::STATUS_BAD_REQUEST);
-		}
-
 		try {
 			$systemMessageComment = $this->chatManager->deleteMessage(
 				$this->room,

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -144,6 +144,8 @@ class CapabilitiesTest extends TestCase {
 			'note-to-self',
 			'recording-consent',
 			'sip-support-dialout',
+			'delete-messages-unlimited',
+			'edit-messages',
 			'message-expiration',
 			'reactions',
 		];


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11206 

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Add capability for editing messages
- [x] Add capability for "unlimited" deleting messages

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
