### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "30e8e2fb44e06f7698d367fecc125c626929a9c7"
+                "reference": "8db67a98bfa9338dfef1f45cd743c98f0f8ab143"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/30e8e2fb44e06f7698d367fecc125c626929a9c7",
-                "reference": "30e8e2fb44e06f7698d367fecc125c626929a9c7",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/8db67a98bfa9338dfef1f45cd743c98f0f8ab143",
+                "reference": "8db67a98bfa9338dfef1f45cd743c98f0f8ab143",
                 "shasum": ""
             },
             "require": {
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-01-16T00:34:22+00:00"
+            "time": "2024-01-16T09:41:42+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency