### PR TITLE
feat(LocalVideo): Show self talking indicator

### DIFF
--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -168,12 +168,12 @@ export default {
 		videoContainerClass() {
 			return {
 				'not-connected': this.isNotConnected,
-				speaking: this.localMediaModel.attributes.speaking,
 				'video-container-grid': this.isGrid,
 				'video-container-stripe': this.isStripe,
 				'video-container-big': this.isBig,
 				'video-container-small': this.isSmall,
 				'hover-shadow': this.isSelectable && this.mouseover,
+				speaking: this.localMediaModel.attributes.speaking,
 			}
 		},
 
@@ -441,16 +441,24 @@ export default {
 	margin: auto;
 }
 
-.hover-shadow:after {
+.localVideoContainer:after {
 	position: absolute;
 	height: 100%;
 	width: 100%;
 	top: 0;
 	left: 0;
+	border-radius: calc(var(--default-clickable-area) / 2);
+}
+
+.hover-shadow:after {
 	content: '';
 	box-shadow: inset 0 0 0 3px white;
 	cursor: pointer;
-	border-radius: calc(var(--default-clickable-area) / 2);
+}
+
+.speaking:after {
+	content: '';
+	box-shadow: inset 0 0 0 2px white;
 }
 
 .bottom-bar {

--- a/src/components/CallView/shared/VideoVue.vue
+++ b/src/components/CallView/shared/VideoVue.vue
@@ -23,11 +23,7 @@
 		:id="(placeholderForPromoted ? 'placeholder-' : '') + 'container_' + peerId + '_video_incoming'"
 		ref="videoContainer"
 		class="video-container"
-		:class="[containerClass, {
-			speaking: isSpeaking && !isBig,
-			hover: mouseover && !unSelectable && !isBig,
-			presenter: isPresenterOverlay && mouseover
-		}]"
+		:class="containerClass"
 		@mouseover="mouseover = true"
 		@mouseleave="mouseover = false"
 		@click="$emit('click-video')">
@@ -300,10 +296,11 @@ export default {
 			return {
 				'videoContainer-dummy': this.placeholderForPromoted,
 				'not-connected': !this.placeholderForPromoted && !this.isConnected,
-				speaking: !this.placeholderForPromoted && this.model.attributes.speaking,
+				speaking: !this.placeholderForPromoted && this.isSpeaking && !this.isBig,
+				hover: this.mouseover && !this.unSelectable && !this.isBig,
 				promoted: !this.placeholderForPromoted && this.sharedData.promoted && !this.isGrid,
+				presenter: this.isPresenterOverlay && this.mouseover,
 				'video-container-grid': this.isGrid,
-				'video-container-grid--speaking': this.isSpeaking,
 				'video-container-big': this.isBig,
 				'one-to-one': this.isOneToOne,
 			}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10563

Summary:
- Added speaking class to local video
- Slight improvement in Video component but with no visual changes.

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Talking indicator is now shown on local video just like other participants videos

https://github.com/nextcloud/spreed/assets/84044328/f8607689-4e21-440b-9e2c-26eeadbbbf4e


### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required