### PR TITLE
fix(CallView): reduce computations amount

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -35,21 +35,18 @@
 			<div id="videos">
 				<template v-if="!isGrid">
 					<!-- Selected video override mode -->
-					<div v-if="showSelectedVideo"
+					<div v-if="showSelectedVideo && selectedCallParticipantModel"
 						class="video__promoted selected-video"
 						:class="{'full-page': isOneToOne}">
-						<template v-for="callParticipantModel in reversedCallParticipantModels">
-							<VideoVue v-if="callParticipantModel.attributes.peerId === selectedVideoPeerId"
-								:key="callParticipantModel.attributes.selectedVideoPeerId"
-								:token="token"
-								:model="callParticipantModel"
-								:shared-data="sharedDatas[selectedVideoPeerId]"
-								:show-talking-highlight="false"
-								:is-grid="true"
-								:is-big="true"
-								:is-one-to-one="isOneToOne"
-								:fit-video="true" />
-						</template>
+						<VideoVue :key="selectedVideoPeerId"
+							:token="token"
+							:model="selectedCallParticipantModel"
+							:shared-data="sharedDatas[selectedVideoPeerId]"
+							:show-talking-highlight="false"
+							:is-one-to-one="isOneToOne"
+							is-grid
+							is-big
+							fit-video />
 					</div>
 					<!-- Screens -->
 					<div v-else-if="showLocalScreen || showRemoteScreen || showSelectedScreen" id="screens">
@@ -299,6 +296,15 @@ export default {
 			return this.$store.getters.selectedVideoPeerId
 		},
 
+		selectedCallParticipantModel() {
+			if (!this.showSelectedVideo || !this.selectedVideoPeerId) {
+				return null
+			}
+			return this.callParticipantModels.find(callParticipantModel => {
+				return callParticipantModel.attributes.peerId === this.selectedVideoPeerId
+			})
+		},
+
 		hasSelectedScreen() {
 			return this.selectedVideoPeerId !== null && this.screens.includes(this.selectedVideoPeerId)
 		},
@@ -310,12 +316,9 @@ export default {
 		isOneToOne() {
 			return this.callParticipantModels.length === 1
 		},
+
 		hasLocalVideo() {
 			return this.localMediaModel.attributes.videoEnabled
-		},
-
-		hasRemoteVideo() {
-			return this.callParticipantModelsWithVideo.length > 0
 		},
 
 		hasLocalScreen() {

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -33,94 +33,85 @@
 			<EmptyCallView v-if="!callParticipantModels.length && !screenSharingActive && !isGrid" :is-sidebar="isSidebar" />
 
 			<div id="videos">
-				<template v-if="!isGrid">
+				<div v-if="!isGrid" class="video__promoted" :class="{'full-page': showFullPage}">
 					<!-- Selected video override mode -->
-					<div v-if="showSelectedVideo && selectedCallParticipantModel"
-						class="video__promoted selected-video"
-						:class="{'full-page': isOneToOne}">
-						<VideoVue :key="selectedVideoPeerId"
-							:token="token"
-							:model="selectedCallParticipantModel"
-							:shared-data="sharedDatas[selectedVideoPeerId]"
-							:show-talking-highlight="false"
-							:is-one-to-one="isOneToOne"
-							is-grid
-							is-big
-							fit-video />
-					</div>
-					<!-- Screens -->
-					<div v-else-if="showLocalScreen || showRemoteScreen || showSelectedScreen" id="screens">
-						<!-- local screen -->
-						<Screen v-if="showLocalScreen"
-							key="screen-local"
-							:token="token"
-							:local-media-model="localMediaModel"
-							:shared-data="localSharedData"
-							is-big />
-						<!-- remote screen -->
-						<template v-else>
-							<Screen v-if="shownRemoteScreenCallParticipantModel"
-								:key="`screen-${shownRemoteScreenPeerId}`"
-								:token="token"
-								:call-participant-model="shownRemoteScreenCallParticipantModel"
-								:shared-data="sharedDatas[shownRemoteScreenPeerId]"
-								is-big />
-							<!-- presenter overlay -->
-							<TransitionWrapper v-if="shouldShowPresenterOverlay"
-								name="slide-down">
-								<VideoVue class="presenter-overlay__video"
-									:token="token"
-									:model="shownRemoteScreenCallParticipantModel"
-									:shared-data="sharedDatas[shownRemoteScreenPeerId]"
-									is-presenter-overlay
-									un-selectable
-									hide-bottom-bar
-									@click-video="toggleShowPresenterOverlay" />
-							</TransitionWrapper>
-							<!-- presenter button when presenter overlay is collapsed -->
-							<NcButton v-else-if="isPresenterCollapsed"
-								:aria-label="t('spreed', 'Show presenter')"
-								:title="t('spreed', 'Show presenter')"
-								class="presenter-overlay--collapse"
-								type="tertiary-no-background"
-								@click="toggleShowPresenterOverlay">
-								<template #icon>
-									<AccountBox fill-color="#ffffff" :size="20" />
-								</template>
-							</NcButton>
-						</template>
-					</div>
+					<VideoVue v-if="showSelectedVideo && selectedCallParticipantModel"
+						:key="selectedVideoPeerId"
+						:token="token"
+						:model="selectedCallParticipantModel"
+						:shared-data="sharedDatas[selectedVideoPeerId]"
+						:show-talking-highlight="false"
+						:is-one-to-one="isOneToOne"
+						is-grid
+						is-big
+						fit-video />
+
 					<!-- Local Video Override mode (following own video) -->
-					<div v-else-if="showLocalVideo"
-						class="video__promoted selected-video--local"
-						:class="{'full-page': isOneToOne}">
-						<LocalVideo ref="localVideo"
-							:fit-video="true"
-							:is-stripe="false"
-							:show-controls="false"
-							:is-big="true"
+					<LocalVideo v-else-if="showLocalVideo"
+						ref="localVideo"
+						:token="token"
+						:local-media-model="localMediaModel"
+						:local-call-participant-model="localCallParticipantModel"
+						:is-stripe="false"
+						:show-controls="false"
+						:is-sidebar="false"
+						is-big
+						fit-video />
+
+					<!-- Screens -->
+					<!-- Local screen -->
+					<Screen v-else-if="showLocalScreen"
+						key="screen-local"
+						:token="token"
+						:local-media-model="localMediaModel"
+						:shared-data="localSharedData"
+						is-big />
+					<!-- Remote or selected screen -->
+					<template v-else-if="showRemoteScreen || showSelectedScreen">
+						<Screen v-if="shownRemoteScreenCallParticipantModel"
+							:key="`screen-${shownRemoteScreenPeerId}`"
 							:token="token"
-							:local-media-model="localMediaModel"
-							:local-call-participant-model="localCallParticipantModel"
-							:is-sidebar="false" />
-					</div>
+							:call-participant-model="shownRemoteScreenCallParticipantModel"
+							:shared-data="sharedDatas[shownRemoteScreenPeerId]"
+							is-big />
+						<!-- presenter overlay -->
+						<TransitionWrapper v-if="shouldShowPresenterOverlay"
+							name="slide-down">
+							<VideoVue class="presenter-overlay__video"
+								:token="token"
+								:model="shownRemoteScreenCallParticipantModel"
+								:shared-data="sharedDatas[shownRemoteScreenPeerId]"
+								is-presenter-overlay
+								un-selectable
+								hide-bottom-bar
+								@click-video="toggleShowPresenterOverlay" />
+						</TransitionWrapper>
+						<!-- presenter button when presenter overlay is collapsed -->
+						<NcButton v-else-if="isPresenterCollapsed"
+							:aria-label="t('spreed', 'Show presenter')"
+							:title="t('spreed', 'Show presenter')"
+							class="presenter-overlay--collapse"
+							type="tertiary-no-background"
+							@click="toggleShowPresenterOverlay">
+							<template #icon>
+								<AccountBox fill-color="#ffffff" :size="20" />
+							</template>
+						</NcButton>
+					</template>
+
 					<!-- Promoted "autopilot" mode -->
-					<div v-else
-						class="video__promoted autopilot"
-						:class="{'full-page': isOneToOne}">
-						<VideoVue v-if="promotedParticipantModel"
-							:key="promotedParticipantModel.attributes.peerId"
-							:token="token"
-							:model="promotedParticipantModel"
-							:shared-data="sharedDatas[promotedParticipantModel.attributes.peerId]"
-							:show-talking-highlight="false"
-							:is-grid="true"
-							:fit-video="true"
-							:is-big="true"
-							:is-one-to-one="isOneToOne"
-							:is-sidebar="isSidebar" />
-					</div>
-				</template>
+					<VideoVue v-else-if="promotedParticipantModel"
+						:key="promotedParticipantModel.attributes.peerId"
+						:token="token"
+						:model="promotedParticipantModel"
+						:shared-data="sharedDatas[promotedParticipantModel.attributes.peerId]"
+						:show-talking-highlight="false"
+						is-grid
+						fit-video
+						is-big
+						:is-one-to-one="isOneToOne"
+						:is-sidebar="isSidebar" />
+				</div>
 
 				<!-- Stripe or fullscreen grid depending on `isGrid` -->
 				<Grid v-if="!isSidebar"
@@ -299,6 +290,10 @@ export default {
 
 		isOneToOne() {
 			return this.callParticipantModels.length === 1
+		},
+
+		showFullPage() {
+			return this.isOneToOne && !(this.showLocalScreen || this.showRemoteScreen || this.showSelectedScreen)
 		},
 
 		hasLocalVideo() {
@@ -792,7 +787,7 @@ export default {
 }
 
 .presenter-overlay--collapse {
-	position : absolute !important;
+	position: absolute !important;
 	opacity: .7;
 	bottom: 48px;
 	right: 0;
@@ -828,15 +823,15 @@ export default {
 }
 
 .video__promoted {
-	position:relative;
+	position: relative;
 	height: 100%;
 	width: 100%;
-	display: block;
-}
 
-.video__promoted.full-page {
-	/* make the promoted video cover the whole call view */
-	position: static;
+	&.full-page {
+		// force the promoted remote or local video to cover the whole call view
+		// doesn't affect screen shares, as it's a different MediaStream
+		position: static;
+	}
 }
 
 .local-video {
@@ -845,6 +840,7 @@ export default {
 	bottom: 0;
 	width: 300px;
 	height: 250px;
+
 	&--sidebar {
 		width: 150px;
 		height: 100px;
@@ -907,13 +903,6 @@ export default {
 	bottom: 0;
 	border-top-right-radius: 3px;
 	right: 0;
-}
-
-#screens {
-	position: relative;
-	width: 100%;
-	height: 100%;
-	overflow: hidden;
 }
 
 :deep(.nameIndicator) {

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -156,6 +156,7 @@ import ChevronRight from 'vue-material-design-icons/ChevronRight.vue'
 import ChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
+import { loadState } from '@nextcloud/initial-state'
 import { generateFilePath } from '@nextcloud/router'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
@@ -166,6 +167,10 @@ import EmptyCallView from '../shared/EmptyCallView.vue'
 import LocalVideo from '../shared/LocalVideo.vue'
 import VideoBottomBar from '../shared/VideoBottomBar.vue'
 import VideoVue from '../shared/VideoVue.vue'
+
+// Max number of videos per page. `0`, the default value, means no cap
+const videosCap = parseInt(loadState('spreed', 'grid_videos_limit'), 10) || 0
+const videosCapEnforced = loadState('spreed', 'grid_videos_limit_enforced') || false
 
 export default {
 	name: 'Grid',
@@ -188,35 +193,6 @@ export default {
 	},
 
 	props: {
-		/**
-		 * Minimum width of the video components
-		 */
-		minWidth: {
-			type: Number,
-			default: 200,
-		},
-		/**
-		 * Minimum height of the video components
-		 */
-		minHeight: {
-			type: Number,
-			default: 150,
-		},
-		/**
-		 * Max number of videos per page. `0`, the default value, means no cap
-		 */
-		videosCap: {
-			type: Number,
-			default: 0,
-		},
-		videosCapEnforced: {
-			type: Boolean,
-			default: false,
-		},
-		targetAspectRatio: {
-			type: Number,
-			default: 1,
-		},
 		/**
 		 * Developer mode: If enabled it allows to debug the grid using dummy
 		 * videos
@@ -289,6 +265,13 @@ export default {
 	},
 
 	emits: ['select-video', 'click-local-video'],
+
+	setup() {
+		return {
+			videosCap,
+			videosCapEnforced,
+		}
+	},
 
 	data() {
 		return {
@@ -389,6 +372,19 @@ export default {
 			return devicePixelRatio
 		},
 
+		/**
+		 * Minimum width of the video components
+		 */
+		minWidth() {
+			return (this.isStripe || this.isSidebar) ? 200 : 320
+		},
+		/**
+		 * Minimum height of the video components
+		 */
+		minHeight() {
+			return (this.isStripe || this.isSidebar) ? 150 : 240
+		},
+
 		dpiAwareMinWidth() {
 			return this.minWidth / this.dpiFactor
 		},
@@ -400,6 +396,10 @@ export default {
 		// The aspect ratio of the grid (in terms of px)
 		gridAspectRatio() {
 			return (this.gridWidth / this.gridHeight).toPrecision([2])
+		},
+
+		targetAspectRatio() {
+			return this.isStripe ? 1 : 1.5
 		},
 
 		// Max number of columns possible

--- a/src/components/CallView/shared/Screen.vue
+++ b/src/components/CallView/shared/Screen.vue
@@ -96,6 +96,10 @@ export default {
 		},
 
 		remoteSessionHash() {
+			if (!this.callParticipantModel) {
+				return null
+			}
+
 			return Hex.stringify(SHA1(this.callParticipantModel.attributes.peerId))
 		},
 

--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -140,6 +140,8 @@ export default {
 		tooltip: Tooltip,
 	},
 
+	inheritAttrs: false,
+
 	props: {
 		token: {
 			type: String,


### PR DESCRIPTION
### ☑️ Resolves

* Move and rearrange some computed props for the CallView
  * Remove unused v-for and v-if for promoted views (there is always only one model to handle)
  * Unite multiple redundant wrappers
  * One-time things moved to child component
  * loadState and getCapabilities moved from computed props (to call them once)
  * Prioritize selected LocalVideo over Screen

There's still a lot of things processing each time participants change something, but at least some unused computations were eliminated


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible