### PR TITLE
fix(participantStore): update the whole participant object

### DIFF
--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -317,7 +317,7 @@ const mutations = {
 
 	updateParticipant(state, { token, attendeeId, updatedData }) {
 		if (state.attendees[token] && state.attendees[token][attendeeId]) {
-			state.attendees[token][attendeeId] = Object.assign(state.attendees[token][attendeeId], updatedData)
+			state.attendees[token][attendeeId] = Object.assign({}, state.attendees[token][attendeeId], updatedData)
 		} else {
 			console.error('Error while updating the participant')
 		}

--- a/src/store/participantsStore.spec.js
+++ b/src/store/participantsStore.spec.js
@@ -617,6 +617,7 @@ describe('participantsStore', () => {
 	})
 
 	describe('joining conversation', () => {
+		let getTokenMock
 		let getParticipantIdentifierMock
 		let participantData
 		let joinedConversationEventMock
@@ -625,6 +626,7 @@ describe('participantsStore', () => {
 			joinedConversationEventMock = jest.fn()
 			EventBus.$once('joined-conversation', joinedConversationEventMock)
 
+			getTokenMock = jest.fn().mockReturnValue(TOKEN)
 			getParticipantIdentifierMock = jest.fn().mockReturnValue({
 				attendeeId: 1,
 			})
@@ -636,6 +638,7 @@ describe('participantsStore', () => {
 				inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
 			}
 
+			testStoreConfig.getters.getToken = () => getTokenMock
 			testStoreConfig.getters.getParticipantIdentifier = () => getParticipantIdentifierMock
 			testStoreConfig.actions.setCurrentParticipant = jest.fn()
 			testStoreConfig.actions.addConversation = jest.fn().mockImplementation((context) => {
@@ -683,8 +686,8 @@ describe('participantsStore', () => {
 
 			expect(joinConversation).toHaveBeenCalledWith({ token: TOKEN, forceJoin: true })
 
-			expect(testStoreConfig.actions.setCurrentParticipant).toHaveBeenCalledWith(expect.anything(), participantData)
-			expect(testStoreConfig.actions.addConversation).toHaveBeenCalledWith(expect.anything(), participantData)
+			expect(testStoreConfig.actions.setCurrentParticipant).toHaveBeenCalledWith(expect.anything(), updatedParticipantData)
+			expect(testStoreConfig.actions.addConversation).toHaveBeenCalledWith(expect.anything(), updatedParticipantData)
 
 			expect(getParticipantIdentifierMock).toHaveBeenCalled()
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11441
* Explanation here: https://v2.vuejs.org/v2/guide/reactivity.html#For-Objects

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

[Screencast from 25.01.2024 10:48:41.webm](https://github.com/nextcloud/spreed/assets/93392545/fc96bd9c-7053-4562-a5e5-33622a887763)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible