### PR TITLE
Release 16.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 16.0.10 – 2024-01-25
+### Fixed
+-  fix(attachments): Don't allow selecting shared folders as attachment folder
+   [#11431](https://github.com/nextcloud/spreed/issues/11431)
+
 ## 16.0.9 – 2023-12-19
 ### Fixed
 - fix(occ): Fix verification of STUN server details

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>16.0.9</version>
+	<version>16.0.10</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk",
-	"version": "16.0.9",
+	"version": "16.0.10",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk",
-			"version": "16.0.9",
+			"version": "16.0.10",
 			"license": "agpl",
 			"dependencies": {
 				"@nextcloud/auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "talk",
-	"version": "16.0.9",
+	"version": "16.0.10",
 	"private": true,
 	"description": "",
 	"author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 16.0.10 – 2024-01-25
### Fixed
-  fix(attachments): Don't allow selecting shared folders as attachment folder  [#11431](https://github.com/nextcloud/spreed/issues/11431)
