### PR TITLE
feat(Poll): live polls pop-ups during the call

### DIFF
--- a/src/PublicShareAuthSidebar.vue
+++ b/src/PublicShareAuthSidebar.vue
@@ -32,6 +32,7 @@
 					:is-sidebar="true" />
 				<CallView :token="token" :is-sidebar="true" />
 				<ChatView />
+				<PollViewer />
 				<MediaSettings :recording-consent-given.sync="recordingConsentGiven" />
 			</template>
 		</aside>
@@ -46,6 +47,7 @@ import { loadState } from '@nextcloud/initial-state'
 import CallView from './components/CallView/CallView.vue'
 import ChatView from './components/ChatView.vue'
 import MediaSettings from './components/MediaSettings/MediaSettings.vue'
+import PollViewer from './components/PollViewer/PollViewer.vue'
 import TopBar from './components/TopBar/TopBar.vue'
 import TransitionWrapper from './components/TransitionWrapper.vue'
 
@@ -66,6 +68,7 @@ export default {
 		CallView,
 		ChatView,
 		MediaSettings,
+		PollViewer,
 		TopBar,
 		TransitionWrapper,
 	},

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -46,6 +46,7 @@
 				<PreventUnload :when="warnLeaving" />
 				<CallButton class="call-button" />
 				<ChatView />
+				<PollViewer />
 				<MediaSettings :recording-consent-given.sync="recordingConsentGiven" />
 			</template>
 		</aside>
@@ -63,6 +64,7 @@ import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import CallView from './components/CallView/CallView.vue'
 import ChatView from './components/ChatView.vue'
 import MediaSettings from './components/MediaSettings/MediaSettings.vue'
+import PollViewer from './components/PollViewer/PollViewer.vue'
 import CallButton from './components/TopBar/CallButton.vue'
 import TopBar from './components/TopBar/TopBar.vue'
 import TransitionWrapper from './components/TransitionWrapper.vue'
@@ -83,12 +85,13 @@ export default {
 	name: 'PublicShareSidebar',
 
 	components: {
-		NcButton,
 		CallButton,
 		CallView,
 		ChatView,
-		PreventUnload,
 		MediaSettings,
+		NcButton,
+		PollViewer,
+		PreventUnload,
 		TopBar,
 		TransitionWrapper,
 	},

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -28,7 +28,7 @@
 			:class="{
 				'system-message': isSystemMessage && !showJoinCallButton,
 				'deleted-message': isDeletedMessage,
-				'call-started': showJoinCallButton,
+				'message-highlighted': showJoinCallButton,
 			}">
 			<!-- Message content / text -->
 			<CancelIcon v-if="isDeletedMessage" :size="16" />
@@ -49,6 +49,7 @@
 		<!-- Normal message body content -->
 		<div v-else
 			class="message-main__text markdown-message"
+			:class="{'message-highlighted': isNewPollMessage }"
 			@mouseover="handleMarkdownMouseOver"
 			@mouseleave="handleMarkdownMouseLeave">
 			<!-- Replied parent message -->
@@ -284,6 +285,14 @@ export default {
 			return this.messageParameters?.file
 		},
 
+		isNewPollMessage() {
+			if (this.messageParameters?.object?.type !== 'talk-poll') {
+				return false
+			}
+
+			return this.isInCall && !!this.$store.getters.getNewPolls[this.messageParameters.object.id]
+		},
+
 		hideDate() {
 			return this.isTemporary || this.isDeleting || !!this.sendingFailure
 		},
@@ -442,7 +451,7 @@ export default {
 			padding: 0 20px;
 		}
 
-		&.call-started {
+		&.message-highlighted {
 			color: var(--color-text-light);
 			background-color: var(--color-primary-element-light);
 			padding: 10px;

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
@@ -3,7 +3,7 @@
   -
   - @author Marco Ambrosini <marcoambrosini@pm.me>
   -
-  - @license GNU AGPL version 3 or any later version
+  - @license AGPL-3.0-or-later
   -
   - This program is free software: you can redistribute it and/or modify
   - it under the terms of the GNU Affero General Public License as
@@ -20,152 +20,43 @@
 -->
 
 <template>
-	<div class="wrapper">
-		<!-- Poll card -->
-		<a v-if="!showAsButton"
-			v-observe-visibility="getPollData"
-			:aria-label="t('spreed', 'Poll')"
-			class="poll"
-			role="button"
-			@click="openPoll">
-			<div class="poll__header">
-				<PollIcon :size="20" />
-				<p>
-					{{ name }}
-				</p>
-			</div>
-			<div class="poll__footer">
-				{{ pollFooterText }}
-			</div>
-
-		</a>
-
-		<!-- Poll results button in system message -->
-		<div v-else class="poll-closed">
-			<NcButton type="secondary" @click="openPoll">
-				{{ t('spreed', 'See results') }}
-			</NcButton>
+	<!-- Poll card -->
+	<a v-if="!showAsButton"
+		v-observe-visibility="getPollData"
+		:aria-label="t('spreed', 'Poll')"
+		class="poll"
+		role="button"
+		@click="openPoll">
+		<div class="poll__header">
+			<PollIcon :size="20" />
+			<p>
+				{{ name }}
+			</p>
+		</div>
+		<div class="poll__footer">
+			{{ pollFooterText }}
 		</div>
 
-		<!-- voting and results dialog -->
-		<NcModal v-if="vote !== undefined && showModal"
-			size="small"
-			:container="container"
-			@close="dismissModal">
-			<div class="poll__modal">
-				<!-- Title -->
-				<div class="poll__header">
-					<PollIcon :size="20" />
-					<h2 class="poll__modal-title">
-						{{ name }}
-					</h2>
-				</div>
-				<p class="poll__summary">
-					{{ pollSummaryText }}
-				</p>
+	</a>
 
-				<!-- options -->
-				<div v-if="modalPage === 'voting'" class="poll__modal-options">
-					<template v-if="checkboxRadioSwitchType">
-						<NcCheckboxRadioSwitch v-for="(option, index) in options"
-							:key="checkboxRadioSwitchType + index"
-							:checked.sync="vote"
-							class="poll__option"
-							:value="index.toString()"
-							:type="checkboxRadioSwitchType"
-							name="answerType">
-							{{ option }}
-						</NcCheckboxRadioSwitch>
-					</template>
-				</div>
-
-				<!-- results -->
-				<div v-else-if="modalPage === 'results'" class="results__options">
-					<div v-for="(option, index) in options"
-						:key="index"
-						class="results__option">
-						<div class="results__option-title">
-							<p>{{ option }}</p>
-							<p class="percentage">
-								{{ getVotePercentage(index) + '%' }}
-							</p>
-						</div>
-						<div v-if="getFilteredDetails(index).length > 0 || selfHasVotedOption(index)"
-							class="results__option__details">
-							<PollVotersDetails v-if="details"
-								:container="container"
-								:details="getFilteredDetails(index)" />
-							<p v-if="selfHasVotedOption(index)" class="results__option-subtitle">
-								{{ t('spreed', 'You voted for this option') }}
-							</p>
-						</div>
-						<NcProgressBar class="results__option-progress"
-							:value="getVotePercentage(index)"
-							size="medium" />
-					</div>
-				</div>
-
-				<div v-if="isPollOpen" class="poll__modal-actions">
-					<!-- Submit vote button-->
-					<NcButton v-if="modalPage === 'voting'"
-						type="primary"
-						:disabled="!canSubmitVote"
-						@click="submitVote">
-						{{ t('spreed', 'Submit vote') }}
-					</NcButton>
-					<!-- Vote again-->
-					<NcButton v-else
-						type="secondary"
-						@click="modalPage = 'voting'">
-						{{ t('spreed', 'Change your vote') }}
-					</NcButton>
-					<!-- End poll button-->
-					<NcActions v-if="canEndPoll"
-						force-menu
-						:container="container">
-						<NcActionButton class="critical" @click="endPoll">
-							{{ t('spreed', 'End poll') }}
-							<template #icon>
-								<FileLock :size="20" />
-							</template>
-						</NcActionButton>
-					</NcActions>
-				</div>
-			</div>
-		</NcModal>
+	<!-- Poll results button in system message -->
+	<div v-else class="poll-closed">
+		<NcButton type="secondary" @click="openPoll">
+			{{ t('spreed', 'See results') }}
+		</NcButton>
 	</div>
 </template>
 
 <script>
-
-import FileLock from 'vue-material-design-icons/FileLock.vue'
 import PollIcon from 'vue-material-design-icons/Poll.vue'
 
-import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
-import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
-import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
-import NcProgressBar from '@nextcloud/vue/dist/Components/NcProgressBar.js'
-
-import PollVotersDetails from './PollVotersDetails.vue'
-
-import { PARTICIPANT } from '../../../../../constants.js'
 
 export default {
-
 	name: 'Poll',
 
 	components: {
-		NcActions,
-		NcActionButton,
-		NcCheckboxRadioSwitch,
-		NcModal,
 		NcButton,
-		NcProgressBar,
-		PollVotersDetails,
-		// icons
-		FileLock,
 		PollIcon,
 	},
 
@@ -191,41 +82,13 @@ export default {
 		},
 	},
 
-	data() {
-		return {
-			vote: undefined,
-			showModal: false,
-			modalPage: '',
-		}
-	},
-
 	computed: {
-		container() {
-			return this.$store.getters.getMainContainerSelector()
-		},
-
 		poll() {
 			return this.$store.getters.getPoll(this.token, this.id)
 		},
 
 		pollLoaded() {
 			return !!this.poll
-		},
-
-		numVoters() {
-			return this.pollLoaded ? this.poll.numVoters : undefined
-		},
-
-		question() {
-			return this.pollLoaded ? this.poll.question : undefined
-		},
-
-		options() {
-			return this.pollLoaded ? this.poll.options : undefined
-		},
-
-		votes() {
-			return this.pollLoaded ? this.poll.votes : undefined
 		},
 
 		selfHasVoted() {
@@ -245,14 +108,6 @@ export default {
 			return this.pollLoaded ? this.poll.votedSelf : undefined
 		},
 
-		resultMode() {
-			return this.pollLoaded ? this.poll.resultMode : undefined
-		},
-
-		isPollPublic() {
-			return this.resultMode === 0
-		},
-
 		status() {
 			return this.pollLoaded ? this.poll.status : undefined
 		},
@@ -265,59 +120,6 @@ export default {
 			return this.status === 1
 		},
 
-		details() {
-			if (!this.pollLoaded || this.isPollOpen) {
-				return undefined
-			} else {
-				return this.poll.details
-			}
-		},
-
-		checkboxRadioSwitchType() {
-			if (this.pollLoaded) {
-				return this.poll.maxVotes === 0 ? 'checkbox' : 'radio'
-			} else {
-				return undefined
-			}
-		},
-
-		canSubmitVote() {
-			if (typeof this.vote === 'object') {
-				return this.vote.length > 0
-			} else {
-				return this.vote !== undefined && this.vote !== ''
-			}
-		},
-
-		participantType() {
-			return this.$store.getters.conversation(this.token).participantType
-		},
-
-		selfIsOwnerOrModerator() {
-			return (this.poll.actorType === this.$store.getters.getActorType() && this.poll.actorId === this.$store.getters.getActorId())
-				|| [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR].includes(this.participantType)
-		},
-
-		pollSummaryText() {
-			if (this.isPollClosed) {
-				return n('spreed', 'Poll results • %n vote', 'Poll results • %n votes', this.numVoters)
-			}
-
-			if (this.selfIsOwnerOrModerator || (this.isPollPublic && this.selfHasVoted)) {
-				return n('spreed', 'Open poll • %n vote', 'Open poll • %n votes', this.numVoters)
-			}
-
-			if (!this.isPollPublic && this.selfHasVoted) {
-				return t('spreed', 'Open poll • You voted already')
-			}
-
-			return t('spreed', 'Open poll')
-		},
-
-		canEndPoll() {
-			return this.isPollOpen && this.selfIsOwnerOrModerator
-		},
-
 		pollFooterText() {
 			if (this.isPollOpen) {
 				return this.selfHasVoted ? t('spreed', 'Open poll • You voted already') : t('spreed', 'Open poll • Click to vote')
@@ -326,23 +128,6 @@ export default {
 			}
 			return t('spreed', 'Poll')
 		},
-	},
-
-	watch: {
-		pollLoaded() {
-			this.setVoteData()
-		},
-
-		modalPage(value) {
-			if (value === 'voting') {
-				this.setVoteData()
-			}
-		},
-
-	},
-
-	mounted() {
-		this.setVoteData()
 	},
 
 	methods: {
@@ -355,85 +140,18 @@ export default {
 			}
 		},
 
-		setVoteData() {
-			if (this.checkboxRadioSwitchType === 'radio') {
-				this.vote = ''
-				if (this.selfHasVoted) {
-					this.vote = this.votedSelf[0].toString()
-				}
-			} else {
-				this.vote = []
-				if (this.selfHasVoted) {
-					this.vote = this.votedSelf.map(element => element.toString())
-				}
-			}
-		},
-
 		openPoll() {
-			if (this.selfHasVoted || this.isPollClosed) {
-				this.modalPage = 'results'
-			} else {
-				this.modalPage = 'voting'
-			}
-			this.showModal = true
-		},
-
-		dismissModal() {
-			this.showModal = false
-			// Reset the data
-			typeof this.vote === 'string' ? this.vote = '' : this.vote = []
-		},
-
-		submitVote() {
-			let voteToSubmit = this.vote
-			// If it's a radio, we add the selected index to the array
-			if (!Array.isArray(this.vote)) {
-				voteToSubmit = [this.vote]
-			}
-			this.$store.dispatch('submitVote', {
+			this.$store.dispatch('setActivePoll', {
 				token: this.token,
 				pollId: this.id,
-				vote: voteToSubmit.map(element => parseInt(element)),
+				name: this.name,
 			})
-			this.modalPage = 'results'
-		},
-
-		endPoll() {
-			this.$store.dispatch('endPoll', {
-				token: this.token,
-				pollId: this.id,
-			})
-			this.modalPage = 'results'
-		},
-
-		selfHasVotedOption(index) {
-			return this.votedSelf.includes(index)
-		},
-
-		getFilteredDetails(index) {
-			if (!this.details) {
-				return []
-			}
-			return this.details.filter((item) => {
-				return item.optionId === index
-			})
-		},
-
-		getVotePercentage(index) {
-			if (this.votes[`option-${index}`] === undefined) {
-				return 0
-			}
-			return parseInt(this.votes[`option-${index}`] / this.numVoters * 100)
 		},
 	},
 }
 </script>
 
 <style lang="scss" scoped>
-.wrapper {
-	display: contents;
-}
-
 .poll {
 	display: flex;
 	border: 2px solid var(--color-border);
@@ -465,7 +183,6 @@ export default {
 		span {
 			margin-bottom: auto;
 		}
-
 	}
 
 	&__footer {
@@ -473,90 +190,11 @@ export default {
 		white-space: normal;
 		margin-top: 8px;
 	}
-
-	&__modal {
-		position: relative;
-		padding: 20px;
-	}
-
-	&__modal-title {
-		margin: 0;
-		font-size: 18px;
-		font-weight: bold;
-	}
-
-	&__modal-options {
-		word-wrap: anywhere;
-		margin-top: 8px;
-	}
-
-	&__modal-actions {
-		position: sticky;
-		bottom: 0;
-		display: flex;
-		justify-content: center;
-		gap: 8px;
-		padding: 8px 0 0;
-		background-color: var(--color-main-background);
-	}
-
-	&__summary {
-		color: var(--color-text-maxcontrast);
-		margin-bottom: 16px;
-	}
-
-	&__option {
-		margin-bottom: 4px;
-	}
-}
-
-.results__options {
-	display: flex;
-	flex-direction: column;
-	gap: 24px;
-	word-wrap: anywhere;
-	margin: 8px 0 20px 0;
-}
-
-.results__option {
-	display: flex;
-	flex-direction: column;
-
-	&__details {
-		display: flex;
-		margin-bottom: 8px;
-	}
-
-	&-subtitle {
-		color: var(--color-text-maxcontrast);
-	}
-
-	&-progress {
-		margin-top: 4px;
-	}
-}
-
-.results__option-title {
-	display: flex;
-	justify-content: space-between;
-	align-items: flex-start;
-	margin-bottom: 4px;
-
-	.percentage {
-		white-space: nowrap;
-		margin-left: 16px;
-	}
 }
 
 .poll-closed {
 	display: flex;
 	justify-content: center;
 	margin-top: 4px;
-}
-
-.critical {
-	:deep(.action-button) {
-		color: var(--color-error) !important;
-	}
 }
 </style>

--- a/src/components/PollViewer/PollViewer.vue
+++ b/src/components/PollViewer/PollViewer.vue
@@ -1,0 +1,484 @@
+<!--
+  - @copyright Copyright (c) 2024 Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @author Marco Ambrosini <marcoambrosini@pm.me>
+  - @author Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+	<NcModal v-if="vote !== undefined && id"
+		size="small"
+		:container="container"
+		@close="dismissModal">
+		<div class="poll-modal">
+			<!-- Title -->
+			<div class="poll-modal__header">
+				<PollIcon :size="20" />
+				<h2 class="poll-modal__title">
+					{{ name }}
+				</h2>
+			</div>
+			<p class="poll-modal__summary">
+				{{ pollSummaryText }}
+			</p>
+
+			<!-- options -->
+			<div v-if="modalPage === 'voting'" class="poll-modal__options">
+				<template v-if="checkboxRadioSwitchType">
+					<NcCheckboxRadioSwitch v-for="(option, index) in options"
+						:key="checkboxRadioSwitchType + index"
+						:checked.sync="vote"
+						class="poll-modal__option"
+						:value="index.toString()"
+						:type="checkboxRadioSwitchType"
+						name="answerType">
+						{{ option }}
+					</NcCheckboxRadioSwitch>
+				</template>
+			</div>
+
+			<!-- results -->
+			<div v-else-if="modalPage === 'results'" class="results__options">
+				<div v-for="(option, index) in options"
+					:key="index"
+					class="results__option">
+					<div class="results__option-title">
+						<p>{{ option }}</p>
+						<p class="percentage">
+							{{ getVotePercentage(index) + '%' }}
+						</p>
+					</div>
+					<div v-if="getFilteredDetails(index).length > 0 || selfHasVotedOption(index)"
+						class="results__option__details">
+						<PollVotersDetails v-if="details"
+							:container="container"
+							:details="getFilteredDetails(index)" />
+						<p v-if="selfHasVotedOption(index)" class="results__option-subtitle">
+							{{ t('spreed', 'You voted for this option') }}
+						</p>
+					</div>
+					<NcProgressBar class="results__option-progress"
+						:value="getVotePercentage(index)"
+						size="medium" />
+				</div>
+			</div>
+
+			<div v-if="isPollOpen" class="poll-modal__actions">
+				<!-- Submit vote button-->
+				<NcButton v-if="modalPage === 'voting'"
+					type="primary"
+					:disabled="!canSubmitVote"
+					@click="submitVote">
+					{{ t('spreed', 'Submit vote') }}
+				</NcButton>
+				<!-- Vote again-->
+				<NcButton v-else
+					type="secondary"
+					@click="modalPage = 'voting'">
+					{{ t('spreed', 'Change your vote') }}
+				</NcButton>
+				<!-- End poll button-->
+				<NcActions v-if="canEndPoll"
+					force-menu
+					:container="container">
+					<NcActionButton class="critical" @click="endPoll">
+						{{ t('spreed', 'End poll') }}
+						<template #icon>
+							<FileLock :size="20" />
+						</template>
+					</NcActionButton>
+				</NcActions>
+			</div>
+		</div>
+	</NcModal>
+</template>
+
+<script>
+import FileLock from 'vue-material-design-icons/FileLock.vue'
+import PollIcon from 'vue-material-design-icons/Poll.vue'
+
+import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
+import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
+import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
+import NcProgressBar from '@nextcloud/vue/dist/Components/NcProgressBar.js'
+
+import PollVotersDetails from './PollVotersDetails.vue'
+
+import { PARTICIPANT } from '../../constants.js'
+
+export default {
+	name: 'PollViewer',
+
+	components: {
+		NcActions,
+		NcActionButton,
+		NcCheckboxRadioSwitch,
+		NcModal,
+		NcButton,
+		NcProgressBar,
+		PollVotersDetails,
+		// icons
+		FileLock,
+		PollIcon,
+	},
+
+	data() {
+		return {
+			vote: undefined,
+			modalPage: '',
+		}
+	},
+
+	computed: {
+		activePoll() {
+			return this.$store.getters.activePoll
+		},
+
+		name() {
+			return this.activePoll?.name
+		},
+
+		id() {
+			return this.activePoll?.id
+		},
+
+		token() {
+			return this.activePoll?.token
+		},
+
+		container() {
+			return this.$store.getters.getMainContainerSelector()
+		},
+
+		poll() {
+			return this.$store.getters.getPoll(this.token, this.id)
+		},
+
+		pollLoaded() {
+			return !!this.poll
+		},
+
+		numVoters() {
+			return this.pollLoaded ? this.poll?.numVoters : undefined
+		},
+
+		question() {
+			return this.pollLoaded ? this.poll?.question : undefined
+		},
+
+		options() {
+			return this.pollLoaded ? this.poll?.options : undefined
+		},
+
+		votes() {
+			return this.pollLoaded ? this.poll?.votes : undefined
+		},
+
+		selfHasVoted() {
+			if (this.pollLoaded) {
+				if (typeof this.votedSelf === 'object') {
+					return this.votedSelf.length > 0
+				} else {
+					return !!this.votedSelf
+				}
+			} else {
+				return undefined
+			}
+		},
+
+		// The actual vote of the user as returned from the server
+		votedSelf() {
+			return this.pollLoaded ? this.poll?.votedSelf : undefined
+		},
+
+		resultMode() {
+			return this.pollLoaded ? this.poll?.resultMode : undefined
+		},
+
+		isPollPublic() {
+			return this.resultMode === 0
+		},
+
+		status() {
+			return this.pollLoaded ? this.poll?.status : undefined
+		},
+
+		isPollOpen() {
+			return this.status === 0
+		},
+
+		isPollClosed() {
+			return this.status === 1
+		},
+
+		details() {
+			if (!this.pollLoaded || this.isPollOpen) {
+				return undefined
+			} else {
+				return this.poll?.details
+			}
+		},
+
+		checkboxRadioSwitchType() {
+			if (this.pollLoaded) {
+				return this.poll?.maxVotes === 0 ? 'checkbox' : 'radio'
+			} else {
+				return undefined
+			}
+		},
+
+		canSubmitVote() {
+			if (typeof this.vote === 'object') {
+				return this.vote.length > 0
+			} else {
+				return this.vote !== undefined && this.vote !== ''
+			}
+		},
+
+		participantType() {
+			return this.$store.getters.conversation(this.token).participantType
+		},
+
+		selfIsOwnerOrModerator() {
+			return (this.poll?.actorType === this.$store.getters.getActorType() && this.poll?.actorId === this.$store.getters.getActorId())
+				|| [PARTICIPANT.TYPE.OWNER, PARTICIPANT.TYPE.MODERATOR, PARTICIPANT.TYPE.GUEST_MODERATOR].includes(this.participantType)
+		},
+
+		pollSummaryText() {
+			if (this.isPollClosed) {
+				return n('spreed', 'Poll results • %n vote', 'Poll results • %n votes', this.numVoters)
+			}
+
+			if (this.selfIsOwnerOrModerator || (this.isPollPublic && this.selfHasVoted)) {
+				return n('spreed', 'Open poll • %n vote', 'Open poll • %n votes', this.numVoters)
+			}
+
+			if (!this.isPollPublic && this.selfHasVoted) {
+				return t('spreed', 'Open poll • You voted already')
+			}
+
+			return t('spreed', 'Open poll')
+		},
+
+		canEndPoll() {
+			return this.isPollOpen && this.selfIsOwnerOrModerator
+		},
+	},
+
+	watch: {
+		pollLoaded() {
+			this.setVoteData()
+		},
+
+		modalPage(value) {
+			if (value === 'voting') {
+				this.setVoteData()
+			}
+		},
+
+		poll: {
+			immediate: true,
+			handler(value) {
+				if (!value) {
+					this.modalPage = ''
+				} else if (this.selfHasVoted || this.isPollClosed) {
+					this.modalPage = 'results'
+				} else {
+					this.modalPage = 'voting'
+				}
+			},
+		},
+	},
+
+	mounted() {
+		this.setVoteData()
+	},
+
+	methods: {
+		getPollData() {
+			if (!this.pollLoaded) {
+				this.$store.dispatch('getPollData', {
+					token: this.token,
+					pollId: this.id,
+				})
+			}
+		},
+
+		setVoteData() {
+			if (this.checkboxRadioSwitchType === 'radio') {
+				this.vote = ''
+				if (this.selfHasVoted) {
+					this.vote = this.votedSelf[0].toString()
+				}
+			} else {
+				this.vote = []
+				if (this.selfHasVoted) {
+					this.vote = this.votedSelf.map(element => element.toString())
+				}
+			}
+		},
+
+		dismissModal() {
+			this.$store.dispatch('removeActivePoll')
+			// Reset the data
+			typeof this.vote === 'string' ? this.vote = '' : this.vote = []
+		},
+
+		submitVote() {
+			let voteToSubmit = this.vote
+			// If it's a radio, we add the selected index to the array
+			if (!Array.isArray(this.vote)) {
+				voteToSubmit = [this.vote]
+			}
+			this.$store.dispatch('submitVote', {
+				token: this.token,
+				pollId: this.id,
+				vote: voteToSubmit.map(element => parseInt(element)),
+			})
+			this.modalPage = 'results'
+		},
+
+		endPoll() {
+			this.$store.dispatch('endPoll', {
+				token: this.token,
+				pollId: this.id,
+			})
+			this.modalPage = 'results'
+		},
+
+		selfHasVotedOption(index) {
+			return this.votedSelf.includes(index)
+		},
+
+		getFilteredDetails(index) {
+			if (!this.details) {
+				return []
+			}
+			return this.details.filter((item) => {
+				return item.optionId === index
+			})
+		},
+
+		getVotePercentage(index) {
+			if (this.votes[`option-${index}`] === undefined) {
+				return 0
+			}
+			return parseInt(this.votes[`option-${index}`] / this.numVoters * 100)
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.poll-modal {
+	position: relative;
+	padding: 20px;
+
+	&__header {
+		display: flex;
+		font-weight: bold;
+		gap: 8px;
+		white-space: normal;
+		align-items: flex-start;
+		top: 0;
+		padding: 20px 0 8px;
+		word-wrap: anywhere;
+
+		span {
+			margin-bottom: auto;
+		}
+
+	}
+
+	&__title {
+		margin: 0;
+		font-size: 18px;
+		font-weight: bold;
+	}
+
+	&__options {
+		word-wrap: anywhere;
+		margin-top: 8px;
+	}
+
+	&__actions {
+		position: sticky;
+		bottom: 0;
+		display: flex;
+		justify-content: center;
+		gap: 8px;
+		padding: 8px 0 0;
+		background-color: var(--color-main-background);
+	}
+
+	&__summary {
+		color: var(--color-text-maxcontrast);
+		margin-bottom: 16px;
+	}
+
+	&__option {
+		margin-bottom: 4px;
+	}
+}
+
+.results__options {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+	word-wrap: anywhere;
+	margin: 8px 0 20px 0;
+}
+
+.results__option {
+	display: flex;
+	flex-direction: column;
+
+	&__details {
+		display: flex;
+		margin-bottom: 8px;
+	}
+
+	&-subtitle {
+		color: var(--color-text-maxcontrast);
+	}
+
+	&-progress {
+		margin-top: 4px;
+	}
+
+	&-title {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		margin-bottom: 4px;
+
+		.percentage {
+			white-space: nowrap;
+			margin-left: 16px;
+		}
+	}
+}
+
+.critical {
+	:deep(.action-button) {
+		color: var(--color-error) !important;
+	}
+}
+</style>

--- a/src/components/PollViewer/PollVotersDetails.vue
+++ b/src/components/PollViewer/PollVotersDetails.vue
@@ -82,7 +82,7 @@ export default {
 		container: {
 			type: String,
 			required: true,
-		}
+		},
 	},
 
 	setup() {

--- a/src/components/PollViewer/PollVotersDetails.vue
+++ b/src/components/PollViewer/PollVotersDetails.vue
@@ -59,9 +59,9 @@
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcPopover from '@nextcloud/vue/dist/Components/NcPopover.js'
 
-import AvatarWrapper from '../../../../AvatarWrapper/AvatarWrapper.vue'
+import AvatarWrapper from '../AvatarWrapper/AvatarWrapper.vue'
 
-import { ATTENDEE, AVATAR } from '../../../../../constants.js'
+import { ATTENDEE, AVATAR } from '../../constants.js'
 
 export default {
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -225,6 +225,23 @@ export const FLOW = {
 	},
 }
 
+export const POLL = {
+	STATUS: {
+		OPEN: 0,
+		CLOSED: 1,
+	},
+
+	MODE: {
+		PUBLIC: 0,
+		HIDDEN: 1,
+	},
+
+	ANSWER_TYPE: {
+		MULTIPLE: 0,
+		SINGLE: 1,
+	},
+}
+
 export const PRIVACY = {
 	PUBLIC: 0,
 	PRIVATE: 1,

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -599,6 +599,9 @@ const actions = {
 			if (message.messageParameters?.object || message.messageParameters?.file) {
 				// Handle voice messages, shares with single file, polls, deck cards, e.t.c
 				sharedItemsStore.addSharedItemFromMessage(token, message)
+				if (message.messageParameters?.object?.type === 'talk-poll') {
+					EventBus.$emit('talk:poll-added', { token, message })
+				}
 			} else if (Object.keys(message.messageParameters).some(key => key.startsWith('file'))) {
 				// Handle shares with multiple files
 			}

--- a/src/store/pollStore.js
+++ b/src/store/pollStore.js
@@ -28,11 +28,16 @@ import pollService from '../services/pollService.js'
 
 const state = {
 	polls: {},
+	activePoll: null,
 }
 
 const getters = {
 	getPoll: (state) => (token, id) => {
 		return state.polls?.[token]?.[id]
+	},
+
+	activePoll: (state) => {
+		return state.activePoll
 	},
 }
 
@@ -42,6 +47,16 @@ const mutations = {
 			Vue.set(state.polls, token, {})
 		}
 		Vue.set(state.polls[token], poll.id, poll)
+	},
+
+	setActivePoll(state, { token, pollId, name }) {
+		Vue.set(state, 'activePoll', { token, id: pollId, name })
+	},
+
+	removeActivePoll(state) {
+		if (state.activePoll) {
+			Vue.set(state, 'activePoll', null)
+		}
 	},
 
 	// Add debounce function for getting the poll data
@@ -125,6 +140,14 @@ const actions = {
 			console.error(error)
 			showError(t('spreed', 'An error occurred while ending the poll'))
 		}
+	},
+
+	setActivePoll(context, { token, pollId, name }) {
+		context.commit('setActivePoll', { token, pollId, name })
+	},
+
+	removeActivePoll(context) {
+		context.commit('removeActivePoll')
 	},
 }
 

--- a/src/store/pollStore.js
+++ b/src/store/pollStore.js
@@ -28,6 +28,7 @@ import pollService from '../services/pollService.js'
 
 const state = {
 	polls: {},
+	pollDebounceFunctions: {},
 	activePoll: null,
 }
 
@@ -61,13 +62,10 @@ const mutations = {
 
 	// Add debounce function for getting the poll data
 	addDebounceGetPollDataFunction(state, { token, pollId, debounceGetPollDataFunction }) {
-		if (!state.polls?.pollDebounceFunctions) {
-			Vue.set(state.polls, 'pollDebounceFunctions', {})
+		if (!state.pollDebounceFunctions[token]) {
+			Vue.set(state.pollDebounceFunctions, token, {})
 		}
-		if (!state.polls.pollDebounceFunctions?.[token]) {
-			Vue.set(state.polls.pollDebounceFunctions, [token], {})
-		}
-		Vue.set(state.polls.pollDebounceFunctions[token], pollId, debounceGetPollDataFunction)
+		Vue.set(state.pollDebounceFunctions[token], pollId, debounceGetPollDataFunction)
 	},
 }
 
@@ -100,7 +98,7 @@ const actions = {
 	debounceGetPollData(context, { token, pollId }) {
 		// Create debounce function for getting this particular poll data
 		// if it does not exist yet
-		if (!context.state.polls?.pollDebounceFunctions?.[token]?.[pollId]) {
+		if (!context.state.pollDebounceFunctions[token]?.[pollId]) {
 			const debounceGetPollDataFunction = debounce(async () => {
 				await context.dispatch('getPollData', {
 					token,
@@ -115,7 +113,7 @@ const actions = {
 			})
 		}
 		// Call the debounce function for getting the poll data
-		context.state.polls.pollDebounceFunctions[token][pollId]()
+		context.state.pollDebounceFunctions[token][pollId]()
 	},
 
 	async submitVote(context, { token, pollId, vote }) {

--- a/src/views/FilesSidebarChatView.vue
+++ b/src/views/FilesSidebarChatView.vue
@@ -23,6 +23,7 @@
 	<div class="talk-tab__wrapper">
 		<CallButton class="call-button" />
 		<ChatView />
+		<PollViewer />
 		<MediaSettings :recording-consent-given.sync="recordingConsentGiven" />
 	</div>
 </template>
@@ -30,6 +31,7 @@
 
 import ChatView from '../components/ChatView.vue'
 import MediaSettings from '../components/MediaSettings/MediaSettings.vue'
+import PollViewer from '../components/PollViewer/PollViewer.vue'
 import CallButton from '../components/TopBar/CallButton.vue'
 
 export default {
@@ -40,6 +42,7 @@ export default {
 		CallButton,
 		ChatView,
 		MediaSettings,
+		PollViewer,
 	},
 
 	data() {

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -9,6 +9,7 @@
 					<CallView :token="token" />
 				</template>
 			</TransitionWrapper>
+			<PollViewer />
 		</template>
 	</div>
 </template>
@@ -17,6 +18,7 @@
 import CallView from '../components/CallView/CallView.vue'
 import ChatView from '../components/ChatView.vue'
 import LobbyScreen from '../components/LobbyScreen.vue'
+import PollViewer from '../components/PollViewer/PollViewer.vue'
 import TopBar from '../components/TopBar/TopBar.vue'
 import TransitionWrapper from '../components/TransitionWrapper.vue'
 
@@ -25,10 +27,11 @@ import { useIsInCall } from '../composables/useIsInCall.js'
 export default {
 	name: 'MainView',
 	components: {
+		CallView,
 		ChatView,
 		LobbyScreen,
+		PollViewer,
 		TopBar,
-		CallView,
 		TransitionWrapper,
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11372
* Poll component is splitted into two:
  * `<Poll />` (card/button), to be shown as message part
  * `<PollViewer />` (dialog), detached and moved up on the `<ChatView />` and `<CallView />` level
  * With newly processed messages, dialog is triggered to be open when participant is in call
  * Necessary evil: components code is optimized 

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Toast message:
![image](https://github.com/nextcloud/spreed/assets/93392545/1d085437-2f73-4056-b10b-d3e23d7ac74d)
Unvoted poll highlight:
![image](https://github.com/nextcloud/spreed/assets/93392545/c2bae70e-3c0a-4451-b921-936b5e44690d)


Talk Main, call view:
Files sidebar (same appearance as with open chat, public share sidebars):

https://github.com/nextcloud/spreed/assets/93392545/d18ebaa5-5a25-4324-aa6b-5cc43dea18df


### 🚧 Tasks

- [ ] Follow-ups:
  - [ ] migrate pollsStore :pineapple: 

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required