### PR TITLE
feat(ConversationIcon): highlight public conversations

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -46,6 +46,10 @@
 					{{ conversationInformation }}
 				</template>
 			</template>
+			<template v-if="isPublic || isGroup" #details>
+				<LinkIcon v-if="isPublic" :size="16" />
+				<AccountMultipleIcon v-else-if="isGroup" :size="16" />
+			</template>
 			<template v-if="!isSearchResult" #actions>
 				<NcActionButton v-if="canFavorite"
 					:close-after-click="true"
@@ -136,12 +140,14 @@
 import { Fragment } from 'vue-frag'
 import { isNavigationFailure, NavigationFailureType } from 'vue-router'
 
+import AccountMultipleIcon from 'vue-material-design-icons/AccountMultiple.vue'
 import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import Cog from 'vue-material-design-icons/Cog.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
 import ExitToApp from 'vue-material-design-icons/ExitToApp.vue'
 import EyeOffOutline from 'vue-material-design-icons/EyeOffOutline.vue'
 import EyeOutline from 'vue-material-design-icons/EyeOutline.vue'
+import LinkIcon from 'vue-material-design-icons/Link.vue'
 import Star from 'vue-material-design-icons/Star.vue'
 
 import { showError } from '@nextcloud/dialogs'
@@ -168,12 +174,14 @@ export default {
 		NcListItem,
 		Fragment,
 		// Icons
+		AccountMultipleIcon,
 		ArrowRight,
 		Cog,
 		Delete,
 		ExitToApp,
 		EyeOffOutline,
 		EyeOutline,
+		LinkIcon,
 		Star,
 	},
 
@@ -229,6 +237,14 @@ export default {
 
 		canFavorite() {
 			return this.item.participantType !== PARTICIPANT.TYPE.USER_SELF_JOINED
+		},
+
+		isPublic() {
+			return this.item.type === CONVERSATION.TYPE.PUBLIC
+		},
+
+		isGroup() {
+			return this.item.type === CONVERSATION.TYPE.GROUP
 		},
 
 		labelFavorite() {


### PR DESCRIPTION
### ☑️ Resolves

* Conversation (NcListItem) now indicates, if conversation is public (available for guests by link)
* Place is details above the unread counter

* To discuss:
  * Icon for federated conversations:
    * Same place?
    * Should overwrite public icon?
    * Which icon to use? https://pictogrammers.com/library/mdi/icon/shield-link-variant/ as option

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| :sun_with_face: Light theme | :new_moon: Dark theme |
|------------|----------|
| Default with `--color-primary-element-text` for active            | `--color-text-maxcontrast` for others         |
![image](https://github.com/nextcloud/spreed/assets/93392545/cc335ab3-f518-48d5-bd0e-2934b8f7d1b8) | ![image](https://github.com/nextcloud/spreed/assets/93392545/17c307d8-b049-4813-9118-29f5f9fb97a3)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team