### PR TITLE
Follow-up(Edit message)

### DIFF
--- a/src/components/ConversationSettings/EditableTextField.vue
+++ b/src/components/ConversationSettings/EditableTextField.vue
@@ -85,6 +85,8 @@ import NcRichContenteditable from '@nextcloud/vue/dist/Components/NcRichContente
 import NcRichText from '@nextcloud/vue/dist/Components/NcRichText.js'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
+import { parseSpecialSymbols } from '../../utils/textParse.js'
+
 export default {
 	name: 'EditableTextField',
 	components: {
@@ -232,12 +234,9 @@ export default {
 			if (!this.canSubmit) {
 				return
 			}
-			// Remove leading/trailing whitespaces.
-			// FIXME upstream: https://github.com/nextcloud-libraries/nextcloud-vue/issues/4492
-			const temp = document.createElement('textarea')
-			temp.innerHTML = this.text.replace(/&/gmi, '&amp;')
-			this.text = temp.value.replace(/\r\n|\n|\r/gm, '\n').replace(/&amp;/gmi, '&')
-				.replace(/&lt;/gmi, '<').replace(/&gt;/gmi, '>').replace(/&sect;/gmi, '§').trim()
+
+			// Parse special symbols
+			this.text = parseSpecialSymbols(this.text)
 
 			// Submit text
 			this.$emit('submit-text', this.text)

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -489,7 +489,11 @@ export default {
 			if (this.isFileShareOnly) {
 				this.chatExtrasStore.setChatEditInput({ token: this.token, text: '' })
 			} else {
-				this.chatExtrasStore.setChatEditInput({ token: this.token, text: this.message })
+				this.chatExtrasStore.setChatEditInput({
+					token: this.token,
+					text: this.message,
+					parameters: this.messageParameters
+				})
 			}
 			EventBus.$emit('editing-message')
 			EventBus.$emit('focus-chat-input')

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -485,18 +485,12 @@ export default {
 		},
 
 		handleEdit() {
-			this.chatExtrasStore.setMessageIdToEdit(this.token, this.id)
-			if (this.isFileShareOnly) {
-				this.chatExtrasStore.setChatEditInput({ token: this.token, text: '' })
-			} else {
-				this.chatExtrasStore.setChatEditInput({
-					token: this.token,
-					text: this.message,
-					parameters: this.messageParameters
-				})
-			}
-			EventBus.$emit('editing-message')
-			EventBus.$emit('focus-chat-input')
+			this.chatExtrasStore.initiateEditingMessage({
+				token: this.token,
+				id: this.id,
+				message: this.message,
+				messageParameters: this.messageParameters,
+			})
 		},
 
 		async handleDelete() {

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -226,6 +226,7 @@ import { useChatExtrasStore } from '../../stores/chatExtras.js'
 import { useSettingsStore } from '../../stores/settings.js'
 import { fetchClipboardContent } from '../../utils/clipboard.js'
 import { isDarkTheme } from '../../utils/isDarkTheme.js'
+import { parseSpecialSymbols } from '../../utils/textParse.js'
 
 const disableKeyboardShortcuts = OCP.Accessibility.disableKeyboardShortcuts()
 const supportTypingStatus = getCapabilities()?.spreed?.config?.chat?.['typing-privacy'] !== undefined
@@ -461,7 +462,8 @@ export default {
 		},
 
 		showMentionEditHint() {
-			return this.chatEditInput?.includes('@')
+			const mentionPattern = /(^|\s)@/
+			return mentionPattern.test(this.chatEditInput)
 		},
 	},
 
@@ -614,12 +616,8 @@ export default {
 				}
 			}
 
-			// FIXME upstream: https://github.com/nextcloud-libraries/nextcloud-vue/issues/4492
 			if (this.hasText) {
-				const temp = document.createElement('textarea')
-				temp.innerHTML = this.text.replace(/&/gmi, '&amp;')
-				this.text = temp.value.replace(/&amp;/gmi, '&').replace(/&lt;/gmi, '<')
-					.replace(/&gt;/gmi, '>').replace(/&sect;/gmi, '§')
+				this.text = parseSpecialSymbols(this.text)
 			}
 
 			if (this.upload) {

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -87,6 +87,10 @@
 						:can-cancel="!!parentMessage"
 						:edit-message="!!messageToEdit" />
 				</div>
+				<!-- mention editing hint -->
+				<NcNoteCard v-if="showMentionEditHint" type="warning">
+					<p>{{ t('spreed','Adding a mention will only notify users who did not read the message.') }}</p>
+				</NcNoteCard>
 				<NcRichContenteditable ref="richContenteditable"
 					v-shortkey.once="$options.disableKeyboardShortcuts ? null : ['c']"
 					:value.sync="text"
@@ -194,6 +198,7 @@ import EmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
 import Send from 'vue-material-design-icons/Send.vue'
 
 import { getCapabilities } from '@nextcloud/capabilities'
+import { showError } from '@nextcloud/dialogs'
 import { FilePickerVue } from '@nextcloud/dialogs/filepicker.js'
 import { generateOcsUrl } from '@nextcloud/router'
 
@@ -201,6 +206,7 @@ import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcEmojiPicker from '@nextcloud/vue/dist/Components/NcEmojiPicker.js'
+import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
 import NcRichContenteditable from '@nextcloud/vue/dist/Components/NcRichContenteditable.js'
 
 import NewMessageAbsenceInfo from './NewMessageAbsenceInfo.vue'
@@ -235,6 +241,7 @@ export default {
 		NcActions,
 		NcButton,
 		NcEmojiPicker,
+		NcNoteCard,
 		NcRichContenteditable,
 		NewMessageAbsenceInfo,
 		NewMessageAttachments,
@@ -451,6 +458,10 @@ export default {
 
 		chatEditInput() {
 			return this.chatExtrasStore.getChatEditInput(this.token)
+		},
+
+		showMentionEditHint() {
+			return this.chatEditInput?.includes('@')
 		},
 	},
 
@@ -689,6 +700,7 @@ export default {
 				this.chatExtrasStore.removeMessageIdToEdit(this.token)
 			} catch {
 				this.$emit('failure')
+				showError(t('spreed', 'The message could not be edited'))
 			}
 		},
 

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -461,7 +461,11 @@ export default {
 
 		text(newValue) {
 			if (this.messageToEdit) {
-				this.chatExtrasStore.setChatEditInput({ token: this.token, text: newValue })
+				this.chatExtrasStore.setChatEditInput({
+					token: this.token,
+					text: newValue,
+					parameters: this.messageToEdit.messageParameters
+				})
 			} else {
 				this.chatExtrasStore.setChatInput({ token: this.token, text: newValue })
 			}

--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -119,6 +119,12 @@
 					</dd>
 				</div>
 				<div>
+					<dt><kbd>Ctrl</kbd> + <kbd>↑</kbd></dt>
+					<dd class="shortcut-description">
+						{{ t('spreed', 'Edit your last message') }}
+					</dd>
+				</div>
+				<div>
 					<dt><kbd>F</kbd></dt>
 					<dd class="shortcut-description">
 						{{ t('spreed', 'Fullscreen the chat or call') }}

--- a/src/stores/__tests__/chatExtras.spec.js
+++ b/src/stores/__tests__/chatExtras.spec.js
@@ -1,5 +1,6 @@
 import { setActivePinia, createPinia } from 'pinia'
 
+import { EventBus } from '../../services/EventBus.js'
 import { getUserAbsence } from '../../services/participantsService.js'
 import { generateOCSErrorResponse, generateOCSResponse } from '../../test-helpers.js'
 import { useChatExtrasStore } from '../chatExtras.js'
@@ -194,6 +195,43 @@ describe('chatExtrasStore', () => {
 			chatExtrasStore.setChatInput({ token: 'token-1', text: message })
 			// Assert
 			expect(chatExtrasStore.getChatInput('token-1')).toBe('Many whitespaces')
+		})
+	})
+
+	describe('initiateEditingMessage', () => {
+		it('should set the message ID to edit, set the chat edit input, and emit an event', () => {
+			// Arrange
+			const payload = {
+				token: 'token-1',
+				id: 'id-1',
+				message: 'Hello, world!',
+				messageParameters: {}
+			}
+			const emitSpy = jest.spyOn(EventBus, '$emit')
+
+			// Act
+			chatExtrasStore.initiateEditingMessage(payload)
+
+			// Assert
+			expect(chatExtrasStore.getMessageIdToEdit('token-1')).toBe('id-1')
+			expect(chatExtrasStore.getChatEditInput('token-1')).toEqual('Hello, world!')
+			expect(emitSpy).toHaveBeenCalledWith('editing-message')
+		})
+
+		it('should set the chat edit input text to empty if the message is a file share only', () => {
+			// Arrange
+			const payload = {
+				token: 'token-1',
+				id: 'id-1',
+				message: '{file}',
+				messageParameters: { file0: 'file-path' }
+			}
+
+			// Act
+			chatExtrasStore.initiateEditingMessage(payload)
+
+			// Assert
+			expect(chatExtrasStore.getChatEditInput('token-1')).toEqual('')
 		})
 	})
 })

--- a/src/stores/__tests__/chatExtras.spec.js
+++ b/src/stores/__tests__/chatExtras.spec.js
@@ -161,4 +161,39 @@ describe('chatExtrasStore', () => {
 			expect(chatExtrasStore.chatInput['token-1']).not.toBeDefined()
 		})
 	})
+
+	describe('text parsing', () => {
+		it('should render mentions properly when editing message', () => {
+			// Arrange
+			const parameters = {
+				'mention-call1': { type: 'call', name: 'Conversation101' },
+				'mention-user1': { type: 'user', name: 'Alice Joel', id: 'alice' },
+			}
+			// Act
+			chatExtrasStore.setChatEditInput({
+				token: 'token-1',
+				text: 'Hello {mention-call1} and {mention-user1}',
+				parameters
+			})
+			// Assert
+			expect(chatExtrasStore.getChatEditInput('token-1')).toBe('Hello @all and @alice')
+		})
+
+		it('should store chat input without escaping special symbols', () => {
+			// Arrange
+			const message = 'These are special symbols &amp; &lt; &gt; &sect;'
+			// Act
+			chatExtrasStore.setChatInput({ token: 'token-1', text: message })
+			// Assert
+			expect(chatExtrasStore.getChatInput('token-1')).toBe('These are special symbols & < > §')
+		})
+		it('should remove leading/trailing whitespaces', () => {
+			// Arrange
+			const message = '   Many whitespaces   '
+			// Act
+			chatExtrasStore.setChatInput({ token: 'token-1', text: message })
+			// Assert
+			expect(chatExtrasStore.getChatInput('token-1')).toBe('Many whitespaces')
+		})
+	})
 })

--- a/src/stores/chatExtras.js
+++ b/src/stores/chatExtras.js
@@ -24,6 +24,7 @@
 import { defineStore } from 'pinia'
 import Vue from 'vue'
 
+import { EventBus } from '../services/EventBus.js'
 import { getUserAbsence } from '../services/participantsService.js'
 import { parseSpecialSymbols, parseMentions } from '../utils/textParse.js'
 
@@ -186,6 +187,23 @@ export const useChatExtrasStore = defineStore('chatExtras', {
 		 */
 		removeChatInput(token) {
 			Vue.delete(this.chatInput, token)
+		},
+
+		initiateEditingMessage({ token, id, message, messageParameters }) {
+			this.setMessageIdToEdit(token, id)
+			const isFileShareOnly = Object.keys(Object(messageParameters)).some(key => key.startsWith('file'))
+				&& message === '{file}'
+			if (isFileShareOnly) {
+				this.setChatEditInput({ token, text: '' })
+			} else {
+				this.setChatEditInput({
+					token,
+					text: message,
+					parameters: messageParameters
+				})
+			}
+			EventBus.$emit('editing-message')
+			EventBus.$emit('focus-chat-input')
 		},
 
 		/**

--- a/src/stores/chatExtras.js
+++ b/src/stores/chatExtras.js
@@ -151,12 +151,25 @@ export const useChatExtrasStore = defineStore('chatExtras', {
 		 * @param {object} payload action payload
 		 * @param {string} payload.token The conversation token
 		 * @param {string} payload.text The string to store
+		 * @param {object} payload.parameters message parameters
 		 */
-		setChatEditInput({ token, text }) {
+		setChatEditInput({ token, text, parameters = {} }) {
+			let parsedText = text
+
+			// Handle mentions
+			if (parameters.length !== 0) {
+				for (const [key, value] of Object.entries(parameters)) {
+					if (value?.type === 'call') {
+						parsedText = parsedText.replace(new RegExp(`{${key}}`, 'g'), '@all')
+					} else if (value?.type === 'user') {
+						parsedText = parsedText.replace(new RegExp(`{${key}}`, 'g'), `@${value.id}`)
+					}
+				}
+			}
 			// FIXME upstream: https://github.com/nextcloud-libraries/nextcloud-vue/issues/4492
 			const temp = document.createElement('textarea')
-			temp.innerHTML = text.replace(/&/gmi, '&amp;')
-			const parsedText = temp.value.replace(/&amp;/gmi, '&').replace(/&lt;/gmi, '<')
+			temp.innerHTML = parsedText.replace(/&/gmi, '&amp;')
+			parsedText = temp.value.replace(/&amp;/gmi, '&').replace(/&lt;/gmi, '<')
 				.replace(/&gt;/gmi, '>').replace(/&sect;/gmi, '§')
 
 			Vue.set(this.chatEditInput, token, parsedText)

--- a/src/utils/textParse.js
+++ b/src/utils/textParse.js
@@ -1,0 +1,68 @@
+/**
+ * @copyright Copyright (c) 2024 Dorra Jaouad <dorra.jaoued1@gmail.com>
+ *
+ * @author Dorra Jaouad <dorra.jaoued1@gmail.com>
+ * @author Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Parse message text to return proper formatting for mentions
+ *
+ * @param {string} text The string to parse
+ * @param {object} parameters The parameters that contain the mentions
+ * @return {string}
+ */
+function parseMentions(text, parameters) {
+	if (Object.keys(parameters).some(key => key.startsWith('mention'))) {
+		for (const [key, value] of Object.entries(parameters)) {
+			let mention = ''
+			if (value?.type === 'call') {
+				mention = '@all'
+			} else if (value?.type === 'user') {
+				mention = value.id.includes(' ') ? `@"${value.id}"` : `@${value.id}`
+			}
+			if (mention) {
+				text = text.replace(new RegExp(`{${key}}`, 'g'), mention)
+			}
+		}
+	}
+	return text
+}
+
+/**
+ * Parse special symbols in text like &amp; &lt; &gt; &sect;
+ * FIXME upstream: https://github.com/nextcloud-libraries/nextcloud-vue/issues/4492
+ *
+ * @param {string} text The string to parse
+ * @return {string}
+ */
+function parseSpecialSymbols(text) {
+	const temp = document.createElement('textarea')
+	temp.innerHTML = text.replace(/&/gmi, '&amp;')
+	text = temp.value.replace(/&amp;/gmi, '&').replace(/&lt;/gmi, '<')
+		.replace(/&gt;/gmi, '>').replace(/&sect;/gmi, '§')
+		.replace(/^\s+|\s+$/g, '') // remove trailing and leading whitespaces
+		.replace(/\r\n|\n|\r/gm, '\n') // remove line breaks
+	return text
+}
+
+export {
+	parseSpecialSymbols,
+	parseMentions,
+}


### PR DESCRIPTION
### ☑️ Resolves

* Partially fix #11403

**Remark** 
Mention hint  when editing ( NcNoteCard ) will be shown if the message has `@` initially (before editing it). Otherwise, we will need to compute diff every time the text is edited (not worth it and can be large for long messages) 

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/84044328/278c6d5d-00f3-4cca-8332-eeb5eb707199)    | ![image](https://github.com/nextcloud/spreed/assets/84044328/6ff524b1-0731-449d-8755-d0ba27505220)      |


Newly added 
![image](https://github.com/nextcloud/spreed/assets/84044328/c10481c6-f736-4cac-b250-36c8003f4752)

### 🚧 Tasks

- [ ] Visual review
- [ ] Code review

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required