### PR TITLE
chore(deps): update all debounce methods

### DIFF
--- a/src/components/AdminSettings/AllowedGroups.vue
+++ b/src/components/AdminSettings/AllowedGroups.vue
@@ -54,7 +54,7 @@
 				track-by="id"
 				label="displayname"
 				no-wrap
-				@search-change="searchGroup" />
+				@search-change="debounceSearchGroup" />
 
 			<NcButton type="primary"
 				:disabled="loading"
@@ -84,7 +84,7 @@
 				track-by="id"
 				label="displayname"
 				no-wrap
-				@search-change="searchGroup" />
+				@search-change="debounceSearchGroup" />
 
 			<NcButton type="primary"
 				:disabled="loading"
@@ -155,6 +155,8 @@ export default {
 
 			startCallOptions,
 			startCalls: startCallOptions[0],
+
+			debounceSearchGroup: () => {},
 		}
 	},
 
@@ -183,11 +185,16 @@ export default {
 		})
 		this.loading = false
 
-		this.searchGroup('')
+		this.debounceSearchGroup = debounce(this.searchGroup, 500)
+		this.debounceSearchGroup('')
+	},
+
+	beforeDestroy() {
+		this.debounceSearchGroup.clear?.()
 	},
 
 	methods: {
-		searchGroup: debounce(async function(query) {
+		async searchGroup(query) {
 			this.loadingGroups = true
 			try {
 				const response = await axios.get(generateOcsUrl('cloud/groups/details'), {
@@ -203,7 +210,7 @@ export default {
 			} finally {
 				this.loadingGroups = false
 			}
-		}, 500),
+		},
 
 		saveAllowedGroups() {
 			this.loading = true

--- a/src/components/AdminSettings/RecordingServers.vue
+++ b/src/components/AdminSettings/RecordingServers.vue
@@ -143,6 +143,7 @@ export default {
 			loading: false,
 			saved: false,
 			recordingConsentSelected: loadState('spreed', 'recording_consent').toString(),
+			debounceUpdateServers: () => {},
 		}
 	},
 
@@ -158,10 +159,15 @@ export default {
 	},
 
 	beforeMount() {
+		this.debounceUpdateServers = debounce(this.updateServers, 1000)
 		const state = loadState('spreed', 'recording_servers')
 		this.servers = state.servers
 		this.secret = state.secret
 		this.uploadLimit = parseInt(state.uploadLimit, 10)
+	},
+
+	beforeDestroy() {
+		this.debounceUpdateServers.clear?.()
 	},
 
 	methods: {
@@ -181,10 +187,6 @@ export default {
 			this.secret = value
 			this.debounceUpdateServers()
 		},
-
-		debounceUpdateServers: debounce(function() {
-			this.updateServers()
-		}, 1000),
 
 		async updateServers() {
 			this.loading = true

--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -122,14 +122,20 @@ export default {
 			saved: false,
 			isCacheConfigured: loadState('spreed', 'has_cache_configured'),
 			isClusteredMode: loadState('spreed', 'signaling_mode') === SIGNALING.MODE.CLUSTER_CONVERSATION,
+			debounceUpdateServers: () => {},
 		}
 	},
 
 	beforeMount() {
+		this.debounceUpdateServers = debounce(this.updateServers, 1000)
 		const state = loadState('spreed', 'signaling_servers')
 		this.servers = state.servers
 		this.secret = state.secret
 		this.hideWarning = state.hideWarning
+	},
+
+	beforeDestroy() {
+		this.debounceUpdateServers.clear?.()
 	},
 
 	methods: {
@@ -162,10 +168,6 @@ export default {
 			this.secret = value
 			this.debounceUpdateServers()
 		},
-
-		debounceUpdateServers: debounce(function() {
-			this.updateServers()
-		}, 1000),
 
 		async updateServers() {
 			this.loading = true

--- a/src/components/AdminSettings/StunServers.vue
+++ b/src/components/AdminSettings/StunServers.vue
@@ -84,12 +84,18 @@ export default {
 			hasInternetConnection: true,
 			loading: false,
 			saved: false,
+			debounceUpdateServers: () => {},
 		}
 	},
 
 	beforeMount() {
 		this.servers = loadState('spreed', 'stun_servers')
 		this.hasInternetConnection = loadState('spreed', 'has_internet_connection')
+		this.debounceUpdateServers = debounce(this.updateServers, 1000)
+	},
+
+	beforeDestroy() {
+		this.debounceUpdateServers.clear?.()
 	},
 
 	methods: {
@@ -110,10 +116,6 @@ export default {
 				this.servers.push('stun.nextcloud.com:443')
 			}
 		},
-
-		debounceUpdateServers: debounce(function() {
-			this.updateServers()
-		}, 1000),
 
 		async updateServers() {
 			this.loading = true

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -164,6 +164,7 @@ export default {
 			testing: false,
 			testingError: false,
 			testingSuccess: false,
+			debounceTestServer: () => {},
 		}
 	},
 
@@ -210,16 +211,17 @@ export default {
 	},
 
 	mounted() {
+		this.debounceTestServer = debounce(this.testServer, 1000)
 		this.testing = false
 		this.testingError = false
 		this.testingSuccess = false
 	},
 
-	methods: {
-		debounceTestServer: debounce(function() {
-			this.testServer()
-		}, 1000),
+	beforeDestroy() {
+		this.debounceTestServer.clear?.()
+	},
 
+	methods: {
 		testServer() {
 			this.testing = true
 			this.testingError = false

--- a/src/components/AdminSettings/TurnServers.vue
+++ b/src/components/AdminSettings/TurnServers.vue
@@ -88,6 +88,7 @@ export default {
 			servers: [],
 			loading: false,
 			saved: false,
+			debounceUpdateServers: () => {},
 		}
 	},
 
@@ -100,7 +101,12 @@ export default {
 	},
 
 	beforeMount() {
+		this.debounceUpdateServers = debounce(this.updateServers, 1000)
 		this.servers = loadState('spreed', 'turn_servers')
+	},
+
+	beforeDestroy() {
+		this.debounceUpdateServers.clear?.()
 	},
 
 	methods: {
@@ -117,10 +123,6 @@ export default {
 				protocols: 'udp,tcp', // default to udp AND tcp
 			})
 		},
-
-		debounceUpdateServers: debounce(function() {
-			this.updateServers()
-		}, 1000),
 
 		async updateServers() {
 			const servers = []

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -250,6 +250,7 @@ export default {
 			callParticipantCollection,
 			isBackgroundBlurred: true,
 			showPresenterOverlay: true,
+			debounceFetchPeers: () => {},
 		}
 	},
 	computed: {
@@ -493,6 +494,7 @@ export default {
 		this.isBackgroundBlurred = BrowserStorage.getItem('background-blurred') !== 'false'
 	},
 	mounted() {
+		this.debounceFetchPeers = debounce(this.fetchPeers, 1500)
 		EventBus.$on('refresh-peer-list', this.debounceFetchPeers)
 
 		callParticipantCollection.on('remove', this._lowerHandWhenParticipantLeaves)
@@ -501,6 +503,7 @@ export default {
 		subscribe('set-background-blurred', this.setBackgroundBlurred)
 	},
 	beforeDestroy() {
+		this.debounceFetchPeers.clear?.()
 		EventBus.$off('refresh-peer-list', this.debounceFetchPeers)
 
 		callParticipantCollection.off('remove', this._lowerHandWhenParticipantLeaves)
@@ -719,7 +722,7 @@ export default {
 			this.$store.dispatch('startPresentation')
 		},
 
-		debounceFetchPeers: debounce(async function() {
+		async fetchPeers() {
 			// The recording participant does not have a Nextcloud session, so
 			// it can not fetch the peers. This should not be a problem, as all
 			// the needed data for the recording should be (eventually)
@@ -743,7 +746,7 @@ export default {
 				// Just means guests have no name, so don't error …
 				console.error(exception)
 			}
-		}, 1500),
+		},
 
 		adjustSimulcastQuality() {
 			this.callParticipantModels.forEach(callParticipantModel => {

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -304,6 +304,7 @@ export default {
 			showVideoOverlay: true,
 			// Timer for the videos bottom bar
 			showVideoOverlayTimer: null,
+			debounceMakeGrid: () => {},
 		}
 	},
 
@@ -546,6 +547,7 @@ export default {
 
 	// bind event handlers to the `handleResize` method
 	mounted() {
+		this.debounceMakeGrid = debounce(this.makeGrid, 200)
 		window.addEventListener('resize', this.handleResize)
 		subscribe('navigation-toggled', this.handleResize)
 		this.makeGrid()
@@ -553,6 +555,7 @@ export default {
 		window.OCA.Talk.gridDebugInformation = this.gridDebugInformation
 	},
 	beforeDestroy() {
+		this.debounceMakeGrid.clear?.()
 		window.OCA.Talk.gridDebugInformation = () => console.debug('Not in a call')
 
 		window.removeEventListener('resize', this.handleResize)
@@ -672,7 +675,7 @@ export default {
 			// currently if the user is not on the 'first page', upon resize the
 			// current position in the videos array is lost (first element
 			// in the grid goes back to be first video)
-			debounce(this.makeGrid, 200)
+			this.debounceMakeGrid()
 		},
 
 		// Find the right size if the grid in rows and columns (we already know

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -165,6 +165,10 @@ export default {
 			destroying: false,
 
 			expirationInterval: null,
+
+			debounceUpdateReadMarkerPosition: () => {},
+
+			debounceHandleScroll: () => {},
 		}
 	},
 
@@ -276,6 +280,9 @@ export default {
 	},
 
 	mounted() {
+		this.debounceUpdateReadMarkerPosition = debounce(this.updateReadMarkerPosition, 1000)
+		this.debounceHandleScroll = debounce(this.handleScroll, 50)
+
 		this.viewId = uniqueId('messagesList')
 		this.scrollToBottom()
 		EventBus.$on('scroll-chat-to-bottom', this.handleScrollChatToBottomEvent)
@@ -297,6 +304,9 @@ export default {
 	},
 
 	beforeDestroy() {
+		this.debounceUpdateReadMarkerPosition.clear?.()
+		this.debounceHandleScroll.clear?.()
+
 		window.removeEventListener('focus', this.onWindowFocus)
 		EventBus.$off('scroll-chat-to-bottom', this.handleScrollChatToBottomEvent)
 		EventBus.$off('smooth-scroll-chat-to-bottom', this.smoothScrollToBottom)
@@ -753,10 +763,6 @@ export default {
 			}, 500)
 		},
 
-		debounceHandleScroll: debounce(function() {
-			this.handleScroll()
-		}, 50),
-
 		/**
 		 * When the div is scrolled, this method checks if it's been scrolled to the top
 		 * or to the bottom of the list bottom.
@@ -878,10 +884,6 @@ export default {
 				id: this.conversation.lastReadMessage,
 			})
 		},
-
-		debounceUpdateReadMarkerPosition: debounce(function() {
-			this.updateReadMarkerPosition()
-		}, 1000),
 
 		/**
 		 * Finds the last visual read message element

--- a/src/components/NewConversationDialog/NewConversationContactsPage.vue
+++ b/src/components/NewConversationDialog/NewConversationContactsPage.vue
@@ -152,6 +152,7 @@ export default {
 			noResults: false,
 			participantPhoneItem: {},
 			cancelSearchPossibleConversations: () => {},
+			debounceFetchSearchResults: () => {},
 		}
 	},
 
@@ -174,6 +175,8 @@ export default {
 	},
 
 	mounted() {
+		this.debounceFetchSearchResults = debounce(this.fetchSearchResults, 250)
+
 		this.$nextTick(() => {
 			// Focus the input field of the current component.
 			this.focusInput()
@@ -183,6 +186,8 @@ export default {
 	},
 
 	beforeDestroy() {
+		this.debounceFetchSearchResults.clear?.()
+
 		this.cancelSearchPossibleConversations()
 		this.cancelSearchPossibleConversations = null
 	},
@@ -204,12 +209,8 @@ export default {
 			this.focusInput()
 		},
 
-		debounceFetchSearchResults: debounce(function() {
-			this.resetNavigation()
-			this.fetchSearchResults()
-		}, 250),
-
 		async fetchSearchResults() {
+			this.resetNavigation()
 			this.contactsLoading = true
 			try {
 				this.cancelSearchPossibleConversations('canceled')

--- a/src/components/RightSidebar/SharedItems/SharedItemsBrowser.vue
+++ b/src/components/RightSidebar/SharedItems/SharedItemsBrowser.vue
@@ -97,6 +97,7 @@ export default {
 			firstItemsLoaded: {},
 			isRequestingMoreItems: {},
 			hasFetchedAllItems: {},
+			debounceHandleScroll: () => {},
 		}
 	},
 
@@ -117,7 +118,12 @@ export default {
 	},
 
 	mounted() {
+		this.debounceHandleScroll = debounce(this.handleScroll, 50)
 		this.firstFetchItems(this.activeTab)
+	},
+
+	beforeDestroy() {
+		this.debounceHandleScroll.clear?.()
 	},
 
 	methods: {
@@ -141,10 +147,6 @@ export default {
 			this.isRequestingMoreItems[this.activeTab] = false
 		},
 
-		debounceHandleScroll: debounce(function() {
-			this.handleScroll()
-		}, 50),
-
 		async handleScroll() {
 			const scrollHeight = this.scroller.scrollHeight
 			const scrollTop = this.scroller.scrollTop
@@ -152,7 +154,7 @@ export default {
 			if ((scrollHeight - scrollTop - containerHeight < 300)
 				&& !this.isRequestingMoreItems?.[this.activeTab]
 				&& !this.hasFetchedAllItems?.[this.activeTab]) {
-				this.fetchItems(this.activeTab)
+				await this.fetchItems(this.activeTab)
 			}
 		},
 	},

--- a/src/composables/useArrowNavigation.js
+++ b/src/composables/useArrowNavigation.js
@@ -70,7 +70,7 @@ export function useArrowNavigation(listElementRef, defaultElementRef, selector, 
 
 	// Reset focused index if focus moved out of navigation area or moved to the defaultRef
 	const handleBlurEvent = (event) => {
-		if (!listRef.value.contains(event.relatedTarget)
+		if (!listRef.value?.contains(event.relatedTarget)
 			|| defaultRef.value?.$el.contains(event.relatedTarget)
 			|| defaultRef.value.contains?.(event.relatedTarget)) {
 			focusedIndex.value = null
@@ -84,7 +84,7 @@ export function useArrowNavigation(listElementRef, defaultElementRef, selector, 
 		defaultRef.value = unref(defaultElementRef)
 		isConfirmationEnabled.value = options.confirmEnter
 
-		listRef.value.addEventListener('keydown', (event) => {
+		listRef.value?.addEventListener('keydown', (event) => {
 			if (itemElementsIdMap.value?.length) {
 				if (event.key === 'ArrowDown') {
 					focusNextElement(event)
@@ -104,11 +104,11 @@ export function useArrowNavigation(listElementRef, defaultElementRef, selector, 
 	 * Put a listener for focus/blur events on navigation area
 	 */
 	function initializeNavigation() {
-		itemElements.value = Array.from(listRef.value.querySelectorAll(itemSelector.value))
+		itemElements.value = Array.from(listRef.value?.querySelectorAll(itemSelector.value))
 		focusedIndex.value = null
 
-		listRef.value.addEventListener('focus', handleFocusEvent, true)
-		listRef.value.addEventListener('blur', handleBlurEvent, true)
+		listRef.value?.addEventListener('focus', handleFocusEvent, true)
+		listRef.value?.addEventListener('blur', handleBlurEvent, true)
 	}
 
 	/**
@@ -118,8 +118,8 @@ export function useArrowNavigation(listElementRef, defaultElementRef, selector, 
 	function resetNavigation() {
 		itemElements.value = []
 
-		listRef.value.removeEventListener('focus', handleFocusEvent, true)
-		listRef.value.removeEventListener('blur', handleBlurEvent, true)
+		listRef.value?.removeEventListener('focus', handleFocusEvent, true)
+		listRef.value?.removeEventListener('blur', handleBlurEvent, true)
 	}
 
 	/**
@@ -166,7 +166,7 @@ export function useArrowNavigation(listElementRef, defaultElementRef, selector, 
 			// if confirmEnter = false, first Enter keydown clicks on item, otherwise only focuses it
 			// Additionally check whether the Element is still in the DOM
 			if (!isConfirmationEnabled.value && event?.key === 'Enter'
-				&& listRef.value.contains(itemElements.value[0])) {
+				&& listRef.value?.contains(itemElements.value[0])) {
 				itemElements.value[0].click()
 			}
 		}


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #10933 
* Similar solution to https://github.com/nextcloud/spreed/commit/d55ce12868405f2a20465d4e947977e7428f09e6
* Function creation is modified to get rid of error `debounce called with different context`

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/4e1f0cb5-d5b9-4042-bd02-18a1b1a0f241)         | ![image](https://github.com/nextcloud/spreed/assets/93392545/a2c1181d-f64a-415a-9a96-fd2cfd13d10e)       |

### 🚧 Tasks

- [x] Manual testing:
  - [x] src/App.vue
  - [x] src/components/AdminSettings/AllowedGroups.vue
  - [x] src/components/AdminSettings/RecordingServers.vue
  - [x] src/components/AdminSettings/SIPBridge.vue
  - [x] src/components/AdminSettings/SignalingServers.vue
  - [x] src/components/AdminSettings/StunServers.vue
  - [x] src/components/AdminSettings/TurnServer.vue
  - [x] src/components/AdminSettings/TurnServers.vue
  - [x] src/components/CallView/CallView.vue
  - [x] src/components/CallView/Grid/Grid.vue
  - [x] src/components/LeftSidebar/LeftSidebar.vue
  - [x] src/components/MessagesList/MessagesList.vue (spam messages, then join the call)
  - [x] src/components/NewConversationDialog/NewConversationContactsPage.vue
  - [x] src/components/RightSidebar/Participants/ParticipantsTab.vue
  - [x] src/components/RightSidebar/SharedItems/SharedItemsBrowser.vue
  - [x] src/composables/useArrowNavigation.js
- [ ] Try to reproduce error again

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences