### PR TITLE
fix(NewMessage): re-mount NewMessage component upon id change

### DIFF
--- a/src/components/BreakoutRoomsEditor/SendMessageDialog.vue
+++ b/src/components/BreakoutRoomsEditor/SendMessageDialog.vue
@@ -28,6 +28,7 @@
 				{{ dialogTitle }}
 			</h2>
 			<NewMessage v-if="modalContainerId"
+				:key="modalContainerId"
 				ref="newMessage"
 				role="region"
 				:token="token"

--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -76,6 +76,7 @@
 				</NcButton>
 			</div>
 			<NewMessage v-else-if="modalContainerId"
+				:key="modalContainerId"
 				ref="newMessage"
 				role="region"
 				upload


### PR DESCRIPTION
### ☑️ Resolves

* Fix showing an autocomplete tribute behind modal
  * NewMessageUploadEditor is never unmounted, so child component persist all the time
  * If it's opened again, modal gets a new id, and NewMessage should be rerendered accordingly, so autocomplete tributes will get a new container for mounting
  * Already have been done in ChatView :eyes: 
  * Now also works in Fullscreen mode :see_no_evil: 

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/6dfea0db-c655-456a-9280-0f880b76ce17)          | ![image](https://github.com/nextcloud/spreed/assets/93392545/eaaf7fe1-7a98-495b-a05d-7c09540ed6c7)        |


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible