### PR TITLE
feat(federation): Add room to response when accepting an invite

### DIFF
--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -445,12 +445,13 @@ class ParticipantService {
 	 * @param Room $room
 	 * @param array $participants
 	 * @param IUser|null $addedBy User that is attempting to add these users (must be set for federated users to be added)
+	 * @return list<Attendee>
 	 * @throws CannotReachRemoteException thrown when sending the federation request didn't work
 	 * @throws \Exception thrown if $addedBy is not set when adding a federated user
 	 */
-	public function addUsers(Room $room, array $participants, ?IUser $addedBy = null): void {
+	public function addUsers(Room $room, array $participants, ?IUser $addedBy = null): array {
 		if (empty($participants)) {
-			return;
+			return [];
 		}
 
 		$lastMessage = 0;
@@ -524,6 +525,8 @@ class ParticipantService {
 		if ($lastMessage instanceof IComment) {
 			$this->updateRoomLastMessage($room, $lastMessage);
 		}
+
+		return $attendees;
 	}
 
 	protected function updateRoomLastMessage(Room $room, IComment $message): void {

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -20,6 +20,105 @@
             }
         },
         "schemas": {
+            "ChatMessage": {
+                "type": "object",
+                "required": [
+                    "actorDisplayName",
+                    "actorId",
+                    "actorType",
+                    "expirationTimestamp",
+                    "id",
+                    "isReplyable",
+                    "markdown",
+                    "message",
+                    "messageParameters",
+                    "messageType",
+                    "reactions",
+                    "referenceId",
+                    "systemMessage",
+                    "timestamp",
+                    "token"
+                ],
+                "properties": {
+                    "actorDisplayName": {
+                        "type": "string"
+                    },
+                    "actorId": {
+                        "type": "string"
+                    },
+                    "actorType": {
+                        "type": "string"
+                    },
+                    "deleted": {
+                        "type": "boolean",
+                        "enum": [
+                            true
+                        ]
+                    },
+                    "expirationTimestamp": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "isReplyable": {
+                        "type": "boolean"
+                    },
+                    "markdown": {
+                        "type": "boolean"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "messageParameters": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "messageType": {
+                        "type": "string"
+                    },
+                    "reactions": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    "referenceId": {
+                        "type": "string"
+                    },
+                    "systemMessage": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "token": {
+                        "type": "string"
+                    },
+                    "lastEditActorDisplayName": {
+                        "type": "string"
+                    },
+                    "lastEditActorId": {
+                        "type": "string"
+                    },
+                    "lastEditActorType": {
+                        "type": "string"
+                    },
+                    "lastEditTimestamp": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }
+            },
             "FederationInvite": {
                 "type": "object",
                 "required": [
@@ -260,6 +359,266 @@
                         "maxLength": 0
                     }
                 ]
+            },
+            "Room": {
+                "type": "object",
+                "required": [
+                    "actorId",
+                    "actorType",
+                    "attendeeId",
+                    "attendeePermissions",
+                    "attendeePin",
+                    "avatarVersion",
+                    "breakoutRoomMode",
+                    "breakoutRoomStatus",
+                    "callFlag",
+                    "callPermissions",
+                    "callRecording",
+                    "callStartTime",
+                    "canDeleteConversation",
+                    "canEnableSIP",
+                    "canLeaveConversation",
+                    "canStartCall",
+                    "defaultPermissions",
+                    "description",
+                    "displayName",
+                    "hasCall",
+                    "hasPassword",
+                    "id",
+                    "isCustomAvatar",
+                    "isFavorite",
+                    "lastActivity",
+                    "lastCommonReadMessage",
+                    "lastMessage",
+                    "lastPing",
+                    "lastReadMessage",
+                    "listable",
+                    "lobbyState",
+                    "lobbyTimer",
+                    "messageExpiration",
+                    "name",
+                    "notificationCalls",
+                    "notificationLevel",
+                    "objectId",
+                    "objectType",
+                    "participantFlags",
+                    "participantType",
+                    "permissions",
+                    "readOnly",
+                    "recordingConsent",
+                    "sessionId",
+                    "sipEnabled",
+                    "token",
+                    "type",
+                    "unreadMention",
+                    "unreadMentionDirect",
+                    "unreadMessages"
+                ],
+                "properties": {
+                    "actorId": {
+                        "type": "string"
+                    },
+                    "actorType": {
+                        "type": "string"
+                    },
+                    "attendeeId": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "attendeePermissions": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "attendeePin": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "avatarVersion": {
+                        "type": "string"
+                    },
+                    "breakoutRoomMode": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "breakoutRoomStatus": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "callFlag": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "callPermissions": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "callRecording": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "callStartTime": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "canDeleteConversation": {
+                        "type": "boolean"
+                    },
+                    "canEnableSIP": {
+                        "type": "boolean"
+                    },
+                    "canLeaveConversation": {
+                        "type": "boolean"
+                    },
+                    "canStartCall": {
+                        "type": "boolean"
+                    },
+                    "defaultPermissions": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "displayName": {
+                        "type": "string"
+                    },
+                    "hasCall": {
+                        "type": "boolean"
+                    },
+                    "hasPassword": {
+                        "type": "boolean"
+                    },
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "isCustomAvatar": {
+                        "type": "boolean"
+                    },
+                    "isFavorite": {
+                        "type": "boolean"
+                    },
+                    "lastActivity": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "lastCommonReadMessage": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "lastMessage": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/ChatMessage"
+                            },
+                            {
+                                "type": "array",
+                                "maxLength": 0
+                            }
+                        ]
+                    },
+                    "lastPing": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "lastReadMessage": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "listable": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "lobbyState": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "lobbyTimer": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "messageExpiration": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "notificationCalls": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "notificationLevel": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "objectId": {
+                        "type": "string"
+                    },
+                    "objectType": {
+                        "type": "string"
+                    },
+                    "participantFlags": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "participantType": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "permissions": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "readOnly": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "recordingConsent": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "sessionId": {
+                        "type": "string"
+                    },
+                    "sipEnabled": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "statusClearAt": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true
+                    },
+                    "statusIcon": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "statusMessage": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "token": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "unreadMention": {
+                        "type": "boolean"
+                    },
+                    "unreadMentionDirect": {
+                        "type": "boolean"
+                    },
+                    "unreadMessages": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }
             }
         }
     },
@@ -336,7 +695,9 @@
                                                 "meta": {
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
-                                                "data": {}
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Room"
+                                                }
                                             }
                                         }
                                     }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -17764,7 +17764,9 @@
                                                 "meta": {
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
-                                                "data": {}
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Room"
+                                                }
                                             }
                                         }
                                     }

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -425,6 +425,12 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			if (isset($expectedRoom['type'])) {
 				$data['type'] = (string) $room['type'];
 			}
+			if (isset($expectedRoom['remoteServer'])) {
+				$data['remoteServer'] = self::translateRemoteServer($room['remoteServer']);
+			}
+			if (isset($expectedRoom['remoteToken'])) {
+				$data['remoteToken'] = self::$tokenToIdentifier[$room['remoteToken']] ?? 'unknown-token';
+			}
 			if (isset($expectedRoom['hasPassword'])) {
 				$data['hasPassword'] = (string) $room['hasPassword'];
 			}
@@ -530,6 +536,13 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			$this->sendRemoteRequest($verb, '/apps/spreed/api/' . $apiVersion . '/federation/invitation/' . $inviteId);
 		}
 		$this->assertStatusCode($this->response, 200);
+		$response = $this->getDataFromResponse($this->response);
+
+		if ($formData) {
+			$this->assertRooms([$response], $formData);
+		} else {
+			Assert::assertEmpty($response);
+		}
 	}
 
 	/**

--- a/tests/integration/features/federation/invite.feature
+++ b/tests/integration/features/federation/invite.feature
@@ -48,6 +48,8 @@ Feature: federation/invite
       | app    | object_type       | object_id              | subject                                                                      |
       | spreed | remote_talk_share | INVITE_ID(LOCAL::room) | @participant1-displayname shared room room on http://localhost:8080 with you |
     And user "participant2" accepts invite to room "room" of server "LOCAL" (v1)
+      | id   | name | type | remoteServer | remoteToken |
+      | room | room | 3    | LOCAL        | room        |
     And user "participant2" has the following invitations (v1)
       | remote_server_url | remote_token | state |
       | LOCAL             | room         | 1     |
@@ -104,6 +106,8 @@ Feature: federation/invite
       | remote_server_url | remote_token | state |
       | LOCAL             | room         | 0     |
     And user "participant2" accepts invite to room "room" of server "LOCAL" (v1)
+      | id   | name | type | remoteServer | remoteToken |
+      | room | room | 2    | LOCAL        | room        |
     And user "participant2" has the following invitations (v1)
       | remote_server_url | remote_token | state |
       | LOCAL             | room         | 1     |
@@ -128,6 +132,8 @@ Feature: federation/invite
       | remote_server_url | remote_token | state |
       | LOCAL             | room         | 0     |
     And user "participant2" accepts invite to room "room" of server "LOCAL" (v1)
+      | id   | name | type | remoteServer | remoteToken |
+      | room | room | 2    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
       | id   | name | type |
       | room | room | 2    |


### PR DESCRIPTION
### ☑️ Resolves

* Ref https://github.com/nextcloud/spreed/issues/11278

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Add full room object to response when accepting an invite

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
