### PR TITLE
fix(MessagesList): correctly handle scrollTop position

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -811,15 +811,14 @@ export default {
 					// already loading, don't do it twice
 					return
 				}
-				if (scrollTop === 0) {
-					this.displayMessagesLoader = true
-				}
+				this.displayMessagesLoader = true
 				await this.getOldMessages(false)
 				this.displayMessagesLoader = false
 
 				if (this.$refs.scroller.scrollHeight !== scrollHeight) {
+					// scroll to previous position + added height
 					this.$refs.scroller.scrollTo({
-						top: this.$refs.scroller.scrollTop + this.$refs.scroller.scrollHeight - scrollHeight,
+						top: scrollTop + (this.$refs.scroller.scrollHeight - scrollHeight),
 					})
 				}
 			}


### PR DESCRIPTION
### ☑️ Resolves

* Fix weird message scrolling (hopefully, last time)

> [!IMPORTANT]
> It's better to give it a try with a compiled Talk Desktop + c.nc to see if we'll backport it (and how far)

Explanation:
> If you don't manipulate numbers directly and only add items to the chat list, the scroll position (scrollTop) will be automatically adjusted based on the added height of the new content.
When the scrollTop value is 0 (at the top of the scrollable area), adding new items at the top will not change the scroll position. The browser will automatically adjust the scroll position to maintain the view at the same position relative to the newly added items. In this case, the new scrollTop value will also be 0 since the content was added at the top and the scroll position was already at the top.
However, if the scrollTop value is non-zero (not at the top), adding new items at the top will increase the overall height of the content, and the browser will adjust the scroll position to maintain the view at the same position relative to the newly added items. The new scrollTop value will be adjusted based on the added height to ensure that the same content remains in view.
This automatic adjustment of the scrollTop value is a built-in behavior of the browser when manipulating the content inside a scrollable container. It ensures that the user's scroll experience remains smooth and consistent, regardless of the changes made to the content.


<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible