### PR TITLE
chore(deps): bump nextcloud/vue from 8.5.1 to 8.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nextcloud/moment": "^1.3.1",
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^2.2.1",
-        "@nextcloud/vue": "^8.5.1",
+        "@nextcloud/vue": "^8.6.0",
         "crypto-js": "^4.2.0",
         "debounce": "^2.0.0",
         "emoji-mart-vue-fast": "^15.0.0",
@@ -3794,9 +3794,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.5.1.tgz",
-      "integrity": "sha512-uXzd+pAYbUbhYtVm/EAtEPbaJsicH1LsWJiph85uWwYKVN3zxKAhF4BpR0uk9WYEOQRFTEKmFG4TWO/S5T8ktg==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.6.0.tgz",
+      "integrity": "sha512-0nW8qHvPHAmF/NuWWMiYnWSGNNtDAtfev3OK/mjcwru6G6lBRlEcxHleud03d8f4FMEReLpgdtVcAPNLORPEnQ==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -3816,7 +3816,7 @@
         "clone": "^2.1.2",
         "debounce": "2.0.0",
         "dompurify": "^3.0.5",
-        "emoji-mart-vue-fast": "^15.0.0",
+        "emoji-mart-vue-fast": "^15.0.1",
         "escape-html": "^1.0.3",
         "floating-vue": "^1.0.0-beta.19",
         "focus-trap": "^7.4.3",
@@ -8218,9 +8218,9 @@
       }
     },
     "node_modules/emoji-mart-vue-fast": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.0.tgz",
-      "integrity": "sha512-3BzkDrs60JyT00dLHMAxWKbpFhbyaW9C+q1AjtqGovSxTu8TC2mYAGsvTmXNYKm39IRRAS56v92TihOcB98IsQ==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.1.tgz",
+      "integrity": "sha512-FcBio4MZsad+IwbaD2+1/obaK7W0F8EXlVXOXKgNCICaxkJD5WnA5bAtSXR0+FSBrMWz7DCAOqOojm7EapZ1eg==",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "core-js": "^3.23.5"
@@ -24299,9 +24299,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.5.1.tgz",
-      "integrity": "sha512-uXzd+pAYbUbhYtVm/EAtEPbaJsicH1LsWJiph85uWwYKVN3zxKAhF4BpR0uk9WYEOQRFTEKmFG4TWO/S5T8ktg==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.6.0.tgz",
+      "integrity": "sha512-0nW8qHvPHAmF/NuWWMiYnWSGNNtDAtfev3OK/mjcwru6G6lBRlEcxHleud03d8f4FMEReLpgdtVcAPNLORPEnQ==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -24321,7 +24321,7 @@
         "clone": "^2.1.2",
         "debounce": "2.0.0",
         "dompurify": "^3.0.5",
-        "emoji-mart-vue-fast": "^15.0.0",
+        "emoji-mart-vue-fast": "^15.0.1",
         "escape-html": "^1.0.3",
         "floating-vue": "^1.0.0-beta.19",
         "focus-trap": "^7.4.3",
@@ -27739,9 +27739,9 @@
       "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ=="
     },
     "emoji-mart-vue-fast": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.0.tgz",
-      "integrity": "sha512-3BzkDrs60JyT00dLHMAxWKbpFhbyaW9C+q1AjtqGovSxTu8TC2mYAGsvTmXNYKm39IRRAS56v92TihOcB98IsQ==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.1.tgz",
+      "integrity": "sha512-FcBio4MZsad+IwbaD2+1/obaK7W0F8EXlVXOXKgNCICaxkJD5WnA5bAtSXR0+FSBrMWz7DCAOqOojm7EapZ1eg==",
       "requires": {
         "@babel/runtime": "^7.18.6",
         "core-js": "^3.23.5"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@nextcloud/moment": "^1.3.1",
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^2.2.1",
-    "@nextcloud/vue": "^8.5.1",
+    "@nextcloud/vue": "^8.6.0",
     "crypto-js": "^4.2.0",
     "debounce": "^2.0.0",
     "emoji-mart-vue-fast": "^15.0.0",


### PR DESCRIPTION
### ☑️ Resolves

* Bumps nextcloud/vue from 8.5.1 to 8.6.0
  * Release [v8.6.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.6.0) (2024-01-30)
  * [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.5.1...v8.6.0)
* Fix #10895

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
|![image](https://github.com/nextcloud/spreed/assets/93392545/6023b433-5873-42e9-9997-be0e4fef4635)          | ![image](https://github.com/nextcloud/spreed/assets/93392545/ff1fddfe-7560-4ac9-8e0c-1200fac1e547)        |

### 🚧 Tasks

- [x] feat: Implement widget flag for requesting interactive view
- [x] feat(NcListItem): introduce 'details' slot
  - [ ] follow-up for #11450 
- [x] feat(NcNoteCard): provide a slot for inserting a custom icon instead of default
  - [ ] follow-up for `NewMessageAbsenceInfo`
- [x] fix(NcActions): keyboard navigation
- [x] fix(NcSelect): list width on page scaling
- [x] fix(NcColorPicker): define a container prop
  - fix falling on body Popover with emoji skin color
- [x] fix(NcActions): intercept into current focus trap stack
- [x] fix(NcRichText): Make URL_PATTERN match localhost and URLs with ports
- [x] fix(NcActions): hotfix for custom children
- [x] fix(NcDateTimePickerNative): create possibility to change a color theme on system default