### PR TITLE
feat: support flavored markdown in messages

### DIFF
--- a/src/assets/markdown.scss
+++ b/src/assets/markdown.scss
@@ -31,6 +31,19 @@
 	ol {
 		padding-left: 0;
 		padding-inline-start: 15px;
+
+		&.contains-task-list {
+			padding: 0;
+		}
+	}
+
+	input:disabled + .checkbox-content {
+		opacity: 1 !important;
+		pointer-events: none !important;
+	}
+
+	div:has(table) {
+		overflow-x: auto;
 	}
 
 	pre {

--- a/src/assets/markdown.scss
+++ b/src/assets/markdown.scss
@@ -1,0 +1,63 @@
+/*
+ * @copyright Copyright (c) 2024 Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@mixin markdown {
+	// Overwrite core styles, otherwise h4 is lesser than default font-size
+	h4 {
+		font-size: 100%;
+	}
+
+	em {
+		font-style: italic;
+	}
+
+	ul,
+	ol {
+		padding-left: 0;
+		padding-inline-start: 15px;
+	}
+
+	pre {
+		padding: 4px;
+		margin: 2px 0;
+		border-radius: var(--border-radius);
+		background-color: var(--color-background-dark);
+		overflow-x: auto;
+
+		& code {
+			margin: 0;
+			padding: 0;
+		}
+	}
+
+	code {
+		display: inline-block;
+		padding: 2px 4px;
+		margin: 2px 0;
+		border-radius: var(--border-radius);
+		background-color: var(--color-background-dark);
+	}
+
+	blockquote {
+		padding-left: 0;
+		padding-inline-start: 13px;
+		border-left: none;
+		border-inline-start: 4px solid var(--color-border);
+	}
+}

--- a/src/components/ConversationSettings/EditableTextField.vue
+++ b/src/components/ConversationSettings/EditableTextField.vue
@@ -23,11 +23,13 @@
 	<div ref="editable-text-field" class="editable-text-field">
 		<NcRichText v-if="!editing"
 			class="editable-text-field__output"
+			dir="auto"
 			:text="text"
 			autolink
 			:use-markdown="useMarkdown" />
 		<NcRichContenteditable v-else
 			ref="richContenteditable"
+			dir="auto"
 			:value.sync="text"
 			:auto-complete="()=>{}"
 			:maxlength="maxLength"
@@ -256,6 +258,7 @@ export default {
 
 <style lang="scss" scoped>
 @import '../../assets/variables';
+@import '../../assets/markdown';
 
 .editable-text-field {
 	display: flex;
@@ -278,6 +281,11 @@ export default {
 	// Restyle NcRichContenteditable component from our library.
 	:deep(.rich-contenteditable) {
 		flex-grow: 1;
+	}
+
+	:deep(.rich-text--wrapper) {
+		text-align: start;
+		@include markdown;
 	}
 }
 

--- a/src/components/ConversationSettings/EditableTextField.vue
+++ b/src/components/ConversationSettings/EditableTextField.vue
@@ -26,7 +26,7 @@
 			dir="auto"
 			:text="text"
 			autolink
-			:use-markdown="useMarkdown" />
+			:use-extended-markdown="useMarkdown" />
 		<NcRichContenteditable v-else
 			ref="richContenteditable"
 			dir="auto"

--- a/src/components/LobbyScreen.vue
+++ b/src/components/LobbyScreen.vue
@@ -42,7 +42,8 @@
 			<div class="lobby__description">
 				<NcRichText :text="conversation.description"
 					dir="auto"
-					:autolink="true" />
+					autolink
+					use-extended-markdown />
 			</div>
 		</div>
 		<SetGuestUsername v-if="currentUserIsGuest" />

--- a/src/components/LobbyScreen.vue
+++ b/src/components/LobbyScreen.vue
@@ -39,10 +39,11 @@
 				</span>
 			</p>
 
-			<p class="lobby__description">
+			<div class="lobby__description">
 				<NcRichText :text="conversation.description"
+					dir="auto"
 					:autolink="true" />
-			</p>
+			</div>
 		</div>
 		<SetGuestUsername v-if="currentUserIsGuest" />
 	</div>
@@ -123,6 +124,7 @@ export default {
 
 <style lang="scss" scoped>
 @import '../assets/variables';
+@import '../assets/markdown';
 
 .lobby {
 	display: flex;
@@ -138,6 +140,11 @@ export default {
 		max-width: $messages-list-max-width;
 		margin: 0 auto;
 		margin-top: 25px;
+	}
+
+	:deep(.rich-text--wrapper) {
+		text-align: start;
+		@include markdown;
 	}
 }
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -60,7 +60,7 @@
 				:class="{'single-emoji': isSingleEmoji}"
 				autolink
 				dir="auto"
-				:use-markdown="markdown"
+				:use-extended-markdown="markdown"
 				:reference-limit="1" />
 
 			<!-- Additional controls -->

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -416,6 +416,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '../../../../../assets/markdown';
+
 .message-main {
 	display: flex;
 	justify-content: space-between;
@@ -471,49 +473,7 @@ export default {
 
 			:deep(.rich-text--wrapper) {
 				text-align: start;
-
-				// Overwrite core styles, otherwise h4 is lesser than default font-size
-				h4 {
-				font-size: 100%;
-				}
-
-				em {
-				font-style: italic;
-				}
-
-				ul,
-				ol {
-				padding-left: 0;
-				padding-inline-start: 15px;
-				}
-
-				pre {
-				padding: 4px;
-				margin: 2px 0;
-				border-radius: var(--border-radius);
-				background-color: var(--color-background-dark);
-				overflow-x: auto;
-
-				& code {
-					margin: 0;
-					padding: 0;
-				}
-				}
-
-				code {
-				display: inline-block;
-				padding: 2px 4px;
-				margin: 2px 0;
-				border-radius: var(--border-radius);
-				background-color: var(--color-background-dark);
-				}
-
-				blockquote {
-				padding-left: 0;
-				padding-inline-start: 13px;
-				border-left: none;
-				border-inline-start: 4px solid var(--color-border);
-				}
+				@include markdown;
 			}
 		}
 	}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10066 
* Fix #11405
* Styles are moved to scss file, to be reused by all required components
* Follow-up: interactive checkboxes (align with message editing)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
![Screenshot from 2024-01-30 20-22-22](https://github.com/nextcloud/spreed/assets/93392545/d5f2ffc7-ff75-4e5f-afb2-99ae733256b6) | ![Screenshot from 2024-01-30 20-09-00](https://github.com/nextcloud/spreed/assets/93392545/ca429f61-1450-4590-aea7-fa4c492c1f96)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required