### PR TITLE
chore(release): Add changelog for 18.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 18.0.3 – 2024-01-31
+### Changed
+- Update translations
+- Update several dependencies
+
+### Fixed
+-  fix(chat): Fix scrolling behaviour when loading older messages
+   [#11481](https://github.com/nextcloud/spreed/issues/11481)
+-  fix(chat): Fix showing mention and emoji suggestions when writing a caption
+   [#11458](https://github.com/nextcloud/spreed/issues/11458)
+-  fix(chat): Show mention chips when inserting a suggested mention
+   [#11493](https://github.com/nextcloud/spreed/issues/11493)
+
 ## 18.0.2 – 2024-01-25
 ### Fixed
 -  fix(calls): Device preview not visible when editing, uploading or viewing a file

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,12 +23,12 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 	<author>Dorra Jaouad</author>
 	<author>Grigorii Shartsev</author>
 	<author>Ivan Sein</author>
-	<author>Jan-Christoph Borchardt</author>
 	<author>Joas Schilling</author>
+	<author>Julius Linus</author>
 	<author>Maksim Sukharev</author>
 	<author>Marcel Hibbe</author>
 	<author>Marcel Müller</author>
-	<author>Marco Ambrosini</author>
+	<author>Sowjanya Kota</author>
 
 	<namespace>Talk</namespace>
 


### PR DESCRIPTION
## 18.0.3 – 2024-01-31
### Changed
- Update translations
- Update several dependencies

### Fixed
-  fix(chat): Fix scrolling behaviour when loading older messages  [#11481](https://github.com/nextcloud/spreed/issues/11481)
-  fix(chat): Fix showing mention and emoji suggestions when writing a caption  [#11458](https://github.com/nextcloud/spreed/issues/11458)
-  fix(chat): Show mention chips when inserting a suggested mention  [#11493](https://github.com/nextcloud/spreed/issues/11493)