### PR TITLE
Release 18.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 18.0.3 – 2024-01-31
+### Changed
+- Update translations
+- Update several dependencies
+
+### Fixed
+-  fix(chat): Fix scrolling behaviour when loading older messages
+   [#11481](https://github.com/nextcloud/spreed/issues/11481)
+-  fix(chat): Fix showing mention and emoji suggestions when writing a caption
+   [#11458](https://github.com/nextcloud/spreed/issues/11458)
+-  fix(chat): Show mention chips when inserting a suggested mention
+   [#11493](https://github.com/nextcloud/spreed/issues/11493)
+
 ## 18.0.2 – 2024-01-25
 ### Fixed
 -  fix(calls): Device preview not visible when editing, uploading or viewing a file

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>18.0.2</version>
+	<version>18.0.3</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,12 +23,12 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 	<author>Dorra Jaouad</author>
 	<author>Grigorii Shartsev</author>
 	<author>Ivan Sein</author>
-	<author>Jan-Christoph Borchardt</author>
 	<author>Joas Schilling</author>
+	<author>Julius Linus</author>
 	<author>Maksim Sukharev</author>
 	<author>Marcel Hibbe</author>
 	<author>Marcel Müller</author>
-	<author>Marco Ambrosini</author>
+	<author>Sowjanya Kota</author>
 
 	<namespace>Talk</namespace>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "18.0.2",
+  "version": "18.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "18.0.2",
+      "version": "18.0.3",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "18.0.2",
+  "version": "18.0.3",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
### Changed
- Update translations
- Update several dependencies

### Fixed
-  fix(chat): Fix scrolling behaviour when loading older messages  [#11481](https://github.com/nextcloud/spreed/issues/11481)
-  fix(chat): Fix showing mention and emoji suggestions when writing a caption  [#11458](https://github.com/nextcloud/spreed/issues/11458)
-  fix(chat): Show mention chips when inserting a suggested mention  [#11493](https://github.com/nextcloud/spreed/issues/11493)