### PR TITLE
fix(federation)!: Add room name to invite and fix casing of properties

### DIFF
--- a/lib/Model/Invitation.php
+++ b/lib/Model/Invitation.php
@@ -67,18 +67,18 @@ class Invitation extends Entity implements \JsonSerializable {
 	}
 
 	/**
-	 * @return array{access_token: string, id: int, local_room_id: int, remote_attendee_id: int, remote_server_url: string, remote_token: string, state: int, user_id: string}
+	 * @return array{accessToken: string, id: int, localRoomId: int, remoteAttendeeId: int, remoteServerUrl: string, remoteToken: string, state: int, userId: string}
 	 */
 	public function jsonSerialize(): array {
 		return [
 			'id' => $this->getId(),
-			'user_id' => $this->getUserId(),
+			'userId' => $this->getUserId(),
 			'state' => $this->getState(),
-			'local_room_id' => $this->getLocalRoomId(),
-			'access_token' => $this->getAccessToken(),
-			'remote_server_url' => $this->getRemoteServerUrl(),
-			'remote_token' => $this->getRemoteToken(),
-			'remote_attendee_id' => $this->getRemoteAttendeeId(),
+			'localRoomId' => $this->getLocalRoomId(),
+			'accessToken' => $this->getAccessToken(),
+			'remoteServerUrl' => $this->getRemoteServerUrl(),
+			'remoteToken' => $this->getRemoteToken(),
+			'remoteAttendeeId' => $this->getRemoteAttendeeId(),
 		];
 	}
 }

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -100,13 +100,15 @@ namespace OCA\Talk;
  * }
  *
  * @psalm-type TalkFederationInvite = array{
- *     access_token: string,
+ *     accessToken: string,
  *     id: int,
- *     local_room_id: int,
- *     remote_attendee_id: string,
- *     remote_server_url: string,
- *     remote_token: string,
- *     user_id: string,
+ *     state: int,
+ *     localRoomId: int,
+ *     remoteAttendeeId: int,
+ *     remoteServerUrl: string,
+ *     remoteToken: string,
+ *     roomName: string,
+ *     userId: string,
  * }
  *
  * @psalm-type TalkMatterbridgeConfigFields = array<array<string, mixed>>

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -125,36 +125,46 @@
             "FederationInvite": {
                 "type": "object",
                 "required": [
-                    "access_token",
+                    "accessToken",
                     "id",
-                    "local_room_id",
-                    "remote_attendee_id",
-                    "remote_server_url",
-                    "remote_token",
-                    "user_id"
+                    "state",
+                    "localRoomId",
+                    "remoteAttendeeId",
+                    "remoteServerUrl",
+                    "remoteToken",
+                    "roomName",
+                    "userId"
                 ],
                 "properties": {
-                    "access_token": {
+                    "accessToken": {
                         "type": "string"
                     },
                     "id": {
                         "type": "integer",
                         "format": "int64"
                     },
-                    "local_room_id": {
+                    "state": {
                         "type": "integer",
                         "format": "int64"
                     },
-                    "remote_attendee_id": {
+                    "localRoomId": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "remoteAttendeeId": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "remoteServerUrl": {
                         "type": "string"
                     },
-                    "remote_server_url": {
+                    "remoteToken": {
                         "type": "string"
                     },
-                    "remote_token": {
+                    "roomName": {
                         "type": "string"
                     },
-                    "user_id": {
+                    "userId": {
                         "type": "string"
                     }
                 }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -322,36 +322,46 @@
             "FederationInvite": {
                 "type": "object",
                 "required": [
-                    "access_token",
+                    "accessToken",
                     "id",
-                    "local_room_id",
-                    "remote_attendee_id",
-                    "remote_server_url",
-                    "remote_token",
-                    "user_id"
+                    "state",
+                    "localRoomId",
+                    "remoteAttendeeId",
+                    "remoteServerUrl",
+                    "remoteToken",
+                    "roomName",
+                    "userId"
                 ],
                 "properties": {
-                    "access_token": {
+                    "accessToken": {
                         "type": "string"
                     },
                     "id": {
                         "type": "integer",
                         "format": "int64"
                     },
-                    "local_room_id": {
+                    "state": {
                         "type": "integer",
                         "format": "int64"
                     },
-                    "remote_attendee_id": {
+                    "localRoomId": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "remoteAttendeeId": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "remoteServerUrl": {
                         "type": "string"
                     },
-                    "remote_server_url": {
+                    "remoteToken": {
                         "type": "string"
                     },
-                    "remote_token": {
+                    "roomName": {
                         "type": "string"
                     },
-                    "user_id": {
+                    "userId": {
                         "type": "string"
                     }
                 }

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -512,8 +512,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->assertInvites($invites, $formData);
 
 		foreach ($invites as $data) {
-			self::$remoteToInviteId[$this->translateRemoteServer($data['remote_server_url']) . '::' . self::$tokenToIdentifier[$data['remote_token']]] = $data['id'];
-			self::$inviteIdToRemote[$data['id']] = $this->translateRemoteServer($data['remote_server_url']) . '::' . self::$tokenToIdentifier[$data['remote_token']];
+			self::$remoteToInviteId[$this->translateRemoteServer($data['remoteServerUrl']) . '::' . self::$tokenToIdentifier[$data['remoteToken']]] = $data['id'];
+			self::$inviteIdToRemote[$data['id']] = $this->translateRemoteServer($data['remoteServerUrl']) . '::' . self::$tokenToIdentifier[$data['remoteToken']];
 		}
 	}
 
@@ -556,14 +556,14 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			if (isset($expectedInvite['id'])) {
 				$data['id'] = self::$tokenToIdentifier[$invite['token']];
 			}
-			if (isset($expectedInvite['access_token'])) {
-				$data['access_token'] = (string) $invite['access_token'];
+			if (isset($expectedInvite['accessToken'])) {
+				$data['accessToken'] = (string) $invite['accessToken'];
 			}
-			if (isset($expectedInvite['remote_token'])) {
-				$data['remote_token'] = self::$tokenToIdentifier[$invite['remote_token']] ?? 'unknown-token';
+			if (isset($expectedInvite['remoteToken'])) {
+				$data['remoteToken'] = self::$tokenToIdentifier[$invite['remoteToken']] ?? 'unknown-token';
 			}
-			if (isset($expectedInvite['remote_server_url'])) {
-				$data['remote_server_url'] = $this->translateRemoteServer($invite['remote_server_url']);
+			if (isset($expectedInvite['remoteServerUrl'])) {
+				$data['remoteServerUrl'] = $this->translateRemoteServer($invite['remoteServerUrl']);
 			}
 			if (isset($expectedInvite['state'])) {
 				$data['state'] = (int) $invite['state'];

--- a/tests/integration/features/federation/invite.feature
+++ b/tests/integration/features/federation/invite.feature
@@ -42,8 +42,8 @@ Feature: federation/invite
       | room | users         | participant1 | conversation_created | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
     And force run "OCA\Talk\BackgroundJob\RemoveEmptyRooms" background jobs
     And user "participant2" has the following invitations (v1)
-      | remote_server_url | remote_token | state |
-      | LOCAL             | room         | 0     |
+      | remoteServerUrl | remoteToken | state |
+      | LOCAL           | room        | 0     |
     Then user "participant2" has the following notifications
       | app    | object_type       | object_id              | subject                                                                      |
       | spreed | remote_talk_share | INVITE_ID(LOCAL::room) | @participant1-displayname shared room room on http://localhost:8080 with you |
@@ -51,8 +51,8 @@ Feature: federation/invite
       | id   | name | type | remoteServer | remoteToken |
       | room | room | 3    | LOCAL        | room        |
     And user "participant2" has the following invitations (v1)
-      | remote_server_url | remote_token | state |
-      | LOCAL             | room         | 1     |
+      | remoteServerUrl | remoteToken | state |
+      | LOCAL           | room        | 1     |
     When user "participant1" sees the following attendees in room "room" with 200 (v4)
       | actorType       | actorId      | participantType |
       | users           | participant1 | 1               |
@@ -92,8 +92,8 @@ Feature: federation/invite
       | room | users         | participant1 | federated_user_added | You invited {federated_user} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
       | room | users         | participant1 | conversation_created | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
     And user "participant2" has the following invitations (v1)
-      | remote_server_url | remote_token | state |
-      | LOCAL             | room         | 0     |
+      | remoteServerUrl | remoteToken | state |
+      | LOCAL           | room        | 0     |
     Then user "participant2" has the following notifications
       | app    | object_type       | object_id              | subject                                                                      |
       | spreed | remote_talk_share | INVITE_ID(LOCAL::room) | @participant1-displayname shared room room on http://localhost:8080 with you |
@@ -125,8 +125,8 @@ Feature: federation/invite
       | room | users         | participant1 | conversation_created | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
     And force run "OCA\Talk\BackgroundJob\RemoveEmptyRooms" background jobs
     And user "participant2" has the following invitations (v1)
-      | remote_server_url | remote_token | state |
-      | LOCAL             | room         | 0     |
+      | remoteServerUrl | remoteToken | state |
+      | LOCAL           | room        | 0     |
     Then user "participant2" has the following notifications
       | app    | object_type       | object_id              | subject                                                                      |
       | spreed | remote_talk_share | INVITE_ID(LOCAL::room) | @participant1-displayname shared room room on http://localhost:8080 with you |
@@ -151,14 +151,14 @@ Feature: federation/invite
       | roomName | room |
     And user "participant1" adds remote "participant2" to room "room" with 200 (v4)
     And user "participant2" has the following invitations (v1)
-      | remote_server_url | remote_token | state |
-      | LOCAL             | room         | 0     |
+      | remoteServerUrl | remoteToken | state |
+      | LOCAL           | room        | 0     |
     And user "participant2" accepts invite to room "room" of server "LOCAL" (v1)
       | id   | name | type | remoteServer | remoteToken |
       | room | room | 2    | LOCAL        | room        |
     And user "participant2" has the following invitations (v1)
-      | remote_server_url | remote_token | state |
-      | LOCAL             | room         | 1     |
+      | remoteServerUrl | remoteToken | state |
+      | LOCAL           | room        | 1     |
     Then user "participant2" is participant of the following rooms (v4)
       | id   | type |
       | room | 2    |
@@ -177,8 +177,8 @@ Feature: federation/invite
       | roomName | room |
     And user "participant1" adds remote "participant2" to room "room" with 200 (v4)
     And user "participant2" has the following invitations (v1)
-      | remote_server_url | remote_token | state |
-      | LOCAL             | room         | 0     |
+      | remoteServerUrl | remoteToken | state |
+      | LOCAL           | room        | 0     |
     And user "participant2" accepts invite to room "room" of server "LOCAL" (v1)
       | id   | name | type | remoteServer | remoteToken |
       | room | room | 2    | LOCAL        | room        |


### PR DESCRIPTION
### ☑️ Resolves

* Ref https://github.com/nextcloud/spreed/issues/11278#issuecomment-1920068400

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Add room name and document state
- [x] Change from `_` casing to camelCase like on all other APIs

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
