### PR TITLE
Hide 'Failed to poll event' in integration tests

### DIFF
--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -26,7 +26,7 @@ PHPPID1=$!
 echo -e "Running on process ID: \033[1;35m$PHPPID1\033[0m"
 
 # Output filtered php server logs
-tail -f phpserver.log | grep --line-buffered -v -E ":[0-9]+ Accepted$" | grep --line-buffered -v -E ":[0-9]+ Closing$" &
+tail -f phpserver.log | grep --line-buffered -v -E ":[0-9]+ Accepted$" | grep --line-buffered -v -E ":[0-9]+ Closing$" | grep --line-buffered -v -E "] Failed to poll event$" &
 
 # The federated server is started and stopped by the tests themselves
 PORT_FED=8180
@@ -38,7 +38,7 @@ PHPPID2=$!
 echo -e "Running on process ID: \033[1;35m$PHPPID2\033[0m"
 
 # Output filtered federated php server logs
-tail -f phpserver_fed.log | grep --line-buffered -v -E ":[0-9]+ Accepted$" | grep --line-buffered -v -E ":[0-9]+ Closing$" &
+tail -f phpserver_fed.log | grep --line-buffered -v -E ":[0-9]+ Accepted$" | grep --line-buffered -v -E ":[0-9]+ Closing$" | grep --line-buffered -v -E "] Failed to poll event$" &
 
 # Kill all sub-processes in case of ctrl+c
 trap 'pkill -P $PHPPID1; pkill -P $PHPPID2; pkill -P $PROCESS_ID; wait $PHPPID1; wait $PHPPID2;' INT TERM


### PR DESCRIPTION
Currently:

<img width="792" alt="image" src="https://github.com/nextcloud/spreed/assets/1580193/6c562d71-3ed6-4f89-bf48-eb8a8c3f3948">

"Failed to poll event" does not give any information about the test and is just noisy -> hide it from output.
