### PR TITLE
chore(deps): bump '@nextcloud/router' from 2.2.1 to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@nextcloud/l10n": "^2.2.0",
         "@nextcloud/moment": "^1.3.1",
         "@nextcloud/paths": "^2.1.0",
-        "@nextcloud/router": "^2.2.1",
+        "@nextcloud/router": "^3.0.0",
         "@nextcloud/vue": "^8.6.0",
         "crypto-js": "^4.2.0",
         "debounce": "^2.0.0",
@@ -3340,6 +3340,19 @@
         "npm": "^9.0.0"
       }
     },
+    "node_modules/@nextcloud/axios/node_modules/@nextcloud/router": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+      "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+      "dependencies": {
+        "@nextcloud/typings": "^1.7.0",
+        "core-js": "^3.6.4"
+      },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
+      }
+    },
     "node_modules/@nextcloud/babel-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/babel-config/-/babel-config-1.0.0.tgz",
@@ -3483,6 +3496,19 @@
       "peerDependencies": {
         "@nextcloud/vue": "^8.2.0",
         "vue": "^2.7.16"
+      }
+    },
+    "node_modules/@nextcloud/dialogs/node_modules/@nextcloud/router": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+      "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+      "dependencies": {
+        "@nextcloud/typings": "^1.7.0",
+        "core-js": "^3.6.4"
+      },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/dialogs/node_modules/@types/web-bluetooth": {
@@ -3677,6 +3703,19 @@
         "npm": "^9.0.0"
       }
     },
+    "node_modules/@nextcloud/files/node_modules/@nextcloud/router": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+      "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+      "dependencies": {
+        "@nextcloud/typings": "^1.7.0",
+        "core-js": "^3.6.4"
+      },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
+      }
+    },
     "node_modules/@nextcloud/files/node_modules/is-svg": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-5.0.0.tgz",
@@ -3716,6 +3755,19 @@
         "npm": "^9.0.0"
       }
     },
+    "node_modules/@nextcloud/l10n/node_modules/@nextcloud/router": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+      "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+      "dependencies": {
+        "@nextcloud/typings": "^1.7.0",
+        "core-js": "^3.6.4"
+      },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
+      }
+    },
     "node_modules/@nextcloud/logger": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-2.7.0.tgz",
@@ -3752,12 +3804,11 @@
       }
     },
     "node_modules/@nextcloud/router": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
-      "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-3.0.0.tgz",
+      "integrity": "sha512-RlPrOPw94yT9rmt3+2sUs2cmWzqhX5eFW+i/EHymJEKgURVtnqCcXjIcAiLTfgsCCdAS1hGapBL8j8rhHk1FHQ==",
       "dependencies": {
-        "@nextcloud/typings": "^1.7.0",
-        "core-js": "^3.6.4"
+        "@nextcloud/typings": "^1.7.0"
       },
       "engines": {
         "node": "^20.0.0",
@@ -3884,6 +3935,19 @@
       "peerDependencies": {
         "ical.js": "^1.5.0",
         "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@nextcloud/router": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+      "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+      "dependencies": {
+        "@nextcloud/typings": "^1.7.0",
+        "core-js": "^3.6.4"
+      },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/vue/node_modules/@types/unist": {
@@ -15171,6 +15235,19 @@
         "vue": "^2.7.14"
       }
     },
+    "node_modules/nextcloud-vue-collections/node_modules/@nextcloud/router": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+      "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+      "dependencies": {
+        "@nextcloud/typings": "^1.7.0",
+        "core-js": "^3.6.4"
+      },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
+      }
+    },
     "node_modules/nextcloud-vue-collections/node_modules/@nextcloud/vue": {
       "version": "7.12.6",
       "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.12.6.tgz",
@@ -24008,6 +24085,17 @@
         "@nextcloud/auth": "^2.1.0",
         "@nextcloud/router": "^2.1.2",
         "axios": "^1.4.0"
+      },
+      "dependencies": {
+        "@nextcloud/router": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+          "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+          "requires": {
+            "@nextcloud/typings": "^1.7.0",
+            "core-js": "^3.6.4"
+          }
+        }
       }
     },
     "@nextcloud/babel-config": {
@@ -24108,6 +24196,15 @@
         "webdav": "^5.3.1"
       },
       "dependencies": {
+        "@nextcloud/router": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+          "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+          "requires": {
+            "@nextcloud/typings": "^1.7.0",
+            "core-js": "^3.6.4"
+          }
+        },
         "@types/web-bluetooth": {
           "version": "0.0.20",
           "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
@@ -24218,6 +24315,15 @@
         "webdav": "^5.3.1"
       },
       "dependencies": {
+        "@nextcloud/router": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+          "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+          "requires": {
+            "@nextcloud/typings": "^1.7.0",
+            "core-js": "^3.6.4"
+          }
+        },
         "is-svg": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-5.0.0.tgz",
@@ -24243,6 +24349,17 @@
         "dompurify": "^3.0.3",
         "escape-html": "^1.0.3",
         "node-gettext": "^3.0.0"
+      },
+      "dependencies": {
+        "@nextcloud/router": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+          "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+          "requires": {
+            "@nextcloud/typings": "^1.7.0",
+            "core-js": "^3.6.4"
+          }
+        }
       }
     },
     "@nextcloud/logger": {
@@ -24273,12 +24390,11 @@
       }
     },
     "@nextcloud/router": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
-      "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-3.0.0.tgz",
+      "integrity": "sha512-RlPrOPw94yT9rmt3+2sUs2cmWzqhX5eFW+i/EHymJEKgURVtnqCcXjIcAiLTfgsCCdAS1hGapBL8j8rhHk1FHQ==",
       "requires": {
-        "@nextcloud/typings": "^1.7.0",
-        "core-js": "^3.6.4"
+        "@nextcloud/typings": "^1.7.0"
       }
     },
     "@nextcloud/stylelint-config": {
@@ -24368,6 +24484,15 @@
           "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.0.1.tgz",
           "integrity": "sha512-iv6iPw20vp0CinVVrH4ptcuWPdAAx1AawMrYLqFg4vSEr0eVbwz6SW4P8GbxjzzRFJ0xqFXsmFeudiVAhvBaxA==",
           "requires": {}
+        },
+        "@nextcloud/router": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+          "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+          "requires": {
+            "@nextcloud/typings": "^1.7.0",
+            "core-js": "^3.6.4"
+          }
         },
         "@types/unist": {
           "version": "3.0.0",
@@ -32807,6 +32932,15 @@
             "vue-frag": "^1.4.3",
             "vue-material-design-icons": "^5.2.0",
             "webdav": "^5.2.3"
+          }
+        },
+        "@nextcloud/router": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+          "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+          "requires": {
+            "@nextcloud/typings": "^1.7.0",
+            "core-js": "^3.6.4"
           }
         },
         "@nextcloud/vue": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@nextcloud/l10n": "^2.2.0",
     "@nextcloud/moment": "^1.3.1",
     "@nextcloud/paths": "^2.1.0",
-    "@nextcloud/router": "^2.2.1",
+    "@nextcloud/router": "^3.0.0",
     "@nextcloud/vue": "^8.6.0",
     "crypto-js": "^4.2.0",
     "debounce": "^2.0.0",


### PR DESCRIPTION
Changelog: https://github.com/nextcloud-libraries/nextcloud-router/releases/tag/v3.0.0

Should be no breaking changes, but I'd leave it for 29 only