### PR TITLE
[stable28] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "c7da216aabe19d083caf2a1f44caa30a2e3b4fdd"
+                "reference": "ab6acaabffc6a58f2b703fc10f425ec7e99383ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/c7da216aabe19d083caf2a1f44caa30a2e3b4fdd",
-                "reference": "c7da216aabe19d083caf2a1f44caa30a2e3b4fdd",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/ab6acaabffc6a58f2b703fc10f425ec7e99383ce",
+                "reference": "ab6acaabffc6a58f2b703fc10f425ec7e99383ce",
                 "shasum": ""
             },
             "require": {
@@ -294,7 +294,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable28"
             },
-            "time": "2024-02-02T00:32:38+00:00"
+            "time": "2024-02-04T00:34:59+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency