### PR TITLE
feat(Federation): list pending invitations

### DIFF
--- a/src/components/LeftSidebar/InvitationHandler.vue
+++ b/src/components/LeftSidebar/InvitationHandler.vue
@@ -1,0 +1,216 @@
+<!--
+  - @copyright Copyright (c) 2024 Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @author Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+	<NcModal v-if="modal"
+		:container="container"
+		@close="closeModal">
+		<div class="inbox">
+			<h2 class="inbox__heading">
+				{{ t('spreed', 'Pending invitations') }}
+			</h2>
+			<p class="inbox__disclaimer">
+				{{ t('spreed', 'Join conversations from remote Nextcloud servers') }}
+			</p>
+			<ul class="inbox__list">
+				<li v-for="item of invitations"
+					:key="`invitation_${item.id}`"
+					class="inbox__item">
+					<ConversationIcon :item="item" />
+					<div class="inbox__item-desc">
+						<span class="inbox__item-desc__name">
+							{{ item.roomName }}
+						</span>
+						<span class="inbox__item-desc__subname">
+							{{ t('spreed', 'From {user} at {remoteServer}', {
+								user: item.inviterDisplayName,
+								remoteServer: item.remoteServerUrl,
+							}) }}
+						</span>
+					</div>
+					<NcButton type="tertiary"
+						aria-label="t('spreed', 'Decline invitation')"
+						title="t('spreed', 'Decline invitation')"
+						:disabled="isLoading"
+						@click="rejectShare(item.id)">
+						<template #icon>
+							<NcLoadingIcon v-if="isLoading" :size="20" />
+							<CancelIcon v-else :size="20" />
+						</template>
+					</NcButton>
+					<NcButton type="primary"
+						aria-label="t('spreed', 'Accept invitation')"
+						:disabled="isLoading"
+						@click="acceptShare(item.id)">
+						<template #icon>
+							<NcLoadingIcon v-if="isLoading" :size="20" />
+							<CheckIcon v-else :size="20" />
+						</template>
+						{{ t('spreed', 'Accept') }}
+					</NcButton>
+				</li>
+			</ul>
+		</div>
+	</NcModal>
+</template>
+
+<script>
+import CancelIcon from 'vue-material-design-icons/Cancel.vue'
+import CheckIcon from 'vue-material-design-icons/Check.vue'
+
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
+import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
+
+import ConversationIcon from '../ConversationIcon.vue'
+
+import { CONVERSATION } from '../../constants.js'
+import { useFederationStore } from '../../stores/federation.js'
+
+export default {
+	name: 'InvitationHandler',
+
+	components: {
+		ConversationIcon,
+		NcButton,
+		NcLoadingIcon,
+		NcModal,
+		// Icons
+		CancelIcon,
+		CheckIcon,
+	},
+
+	setup() {
+		return {
+			federationStore: useFederationStore(),
+		}
+	},
+
+	data() {
+		return {
+			modal: false,
+			isLoading: false,
+		}
+	},
+
+	computed: {
+		container() {
+			return this.$store.getters.getMainContainerSelector()
+		},
+
+		invitations() {
+			return Object.values(this.federationStore.pendingShares)
+				.map(item => ({
+					...item,
+					type: CONVERSATION.TYPE.GROUP,
+				}))
+		},
+	},
+
+	expose: ['showModal'],
+
+	methods: {
+		showModal() {
+			this.modal = true
+		},
+
+		closeModal() {
+			this.modal = false
+		},
+
+		async acceptShare(id) {
+			this.isLoading = true
+			const conversation = await this.federationStore.acceptShare(id)
+			this.isLoading = false
+			if (conversation?.token) {
+				this.$store.dispatch('addConversation', conversation)
+				this.$router.push({ name: 'conversation', params: { token: conversation.token } })
+				this.closeModal()
+			}
+		},
+
+		async rejectShare(id) {
+			this.isLoading = true
+			await this.federationStore.rejectShare(id)
+			this.isLoading = false
+			if (this.invitations.length === 0) {
+				this.closeModal()
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.inbox {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	height: 100%;
+	max-height: 700px;
+	padding: 20px;
+
+	&__heading {
+		margin-bottom: 4px;
+	}
+
+	&__disclaimer {
+		margin-bottom: 12px;
+		color: var(--color-text-maxcontrast)
+	}
+
+	&__list {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		width: 100%;
+		height: 100%;
+		flex: 0 1 auto;
+		overflow-y: auto;
+	}
+
+	&__item {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 8px 0;
+		border-bottom: 1px solid var(--color-border);
+		&:last-child {
+			border-bottom: none;
+		}
+
+		&-desc {
+			display: flex;
+			flex-direction: column;
+			margin-right: auto;
+
+			&__name {
+				font-weight: bold;
+				color: var(--color-main-text);
+			}
+
+			&__subname {
+				color: var(--color-text-maxcontrast);
+			}
+		}
+	}
+}
+</style>

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -127,7 +127,24 @@
 
 			<!-- New phone (SIP dial-out) dialog -->
 			<CallPhoneDialog ref="callPhoneDialog" />
+
+			<!-- New Pending Invitations dialog -->
+			<InvitationHandler v-if="isFederationEnabled" ref="invitationHandler" />
 		</div>
+
+		<NcAppNavigationItem v-if="pendingInvitationsCount"
+			class="invitation-button"
+			:name="t('spreed', 'Pending invitations')"
+			@click="showInvitationHandler">
+			<template #icon>
+				<AccountMultiplePlus :size="20" />
+			</template>
+			<template #counter>
+				<NcCounterBubble type="highlighted">
+					{{ pendingInvitationsCount }}
+				</NcCounterBubble>
+			</template>
+		</NcAppNavigationItem>
 
 		<template #list>
 			<li ref="container" class="left-sidebar__list">
@@ -268,6 +285,7 @@
 import debounce from 'debounce'
 import { ref } from 'vue'
 
+import AccountMultiplePlus from 'vue-material-design-icons/AccountMultiplePlus.vue'
 import AtIcon from 'vue-material-design-icons/At.vue'
 import ChatPlus from 'vue-material-design-icons/ChatPlus.vue'
 import FilterIcon from 'vue-material-design-icons/Filter.vue'
@@ -288,7 +306,9 @@ import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcAppNavigation from '@nextcloud/vue/dist/Components/NcAppNavigation.js'
 import NcAppNavigationCaption from '@nextcloud/vue/dist/Components/NcAppNavigationCaption.js'
+import NcAppNavigationItem from '@nextcloud/vue/dist/Components/NcAppNavigationItem.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcCounterBubble from '@nextcloud/vue/dist/Components/NcCounterBubble.js'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import NcListItem from '@nextcloud/vue/dist/Components/NcListItem.js'
 import { useIsMobile } from '@nextcloud/vue/dist/Composables/useIsMobile.js'
@@ -296,6 +316,7 @@ import { useIsMobile } from '@nextcloud/vue/dist/Composables/useIsMobile.js'
 import CallPhoneDialog from './CallPhoneDialog/CallPhoneDialog.vue'
 import Conversation from './ConversationsList/Conversation.vue'
 import ConversationsListVirtual from './ConversationsList/ConversationsListVirtual.vue'
+import InvitationHandler from './InvitationHandler.vue'
 import OpenConversationsList from './OpenConversationsList/OpenConversationsList.vue'
 import SearchBox from './SearchBox/SearchBox.vue'
 import ConversationIcon from '../ConversationIcon.vue'
@@ -314,11 +335,13 @@ import {
 } from '../../services/conversationsService.js'
 import { EventBus } from '../../services/EventBus.js'
 import { talkBroadcastChannel } from '../../services/talkBroadcastChannel.js'
+import { useFederationStore } from '../../stores/federation.js'
 import { useTalkHashStore } from '../../stores/talkHash.js'
 import CancelableRequest from '../../utils/cancelableRequest.js'
 import { hasUnreadMentions, filterFunction } from '../../utils/conversation.js'
 import { requestTabLeadership } from '../../utils/requestTabLeadership.js'
 
+const isFederationEnabled = loadState('spreed', 'federation_enabled')
 const canModerateSipDialOut = getCapabilities()?.spreed?.features?.includes('sip-support-dialout')
 	&& getCapabilities()?.spreed?.config.call['sip-enabled']
 	&& getCapabilities()?.spreed?.config.call['sip-dialout-enabled']
@@ -329,9 +352,12 @@ export default {
 
 	components: {
 		CallPhoneDialog,
+		InvitationHandler,
 		NcAppNavigation,
 		NcAppNavigationCaption,
+		NcAppNavigationItem,
 		NcButton,
+		NcCounterBubble,
 		Hint,
 		SearchBox,
 		NewConversationDialog,
@@ -344,6 +370,7 @@ export default {
 		TransitionWrapper,
 		ConversationsListVirtual,
 		// Icons
+		AccountMultiplePlus,
 		AtIcon,
 		MessageBadge,
 		MessageOutline,
@@ -362,6 +389,7 @@ export default {
 		const searchBox = ref(null)
 		const list = ref(null)
 
+		const federationStore = useFederationStore()
 		const talkHashStore = useTalkHashStore()
 		const { initializeNavigation, resetNavigation } = useArrowNavigation(leftSidebar, searchBox, '.list-item')
 		const isMobile = useIsMobile()
@@ -372,9 +400,11 @@ export default {
 			leftSidebar,
 			searchBox,
 			list,
+			federationStore,
 			talkHashStore,
 			isMobile,
 			canModerateSipDialOut,
+			isFederationEnabled,
 		}
 	},
 
@@ -487,6 +517,12 @@ export default {
 			return this.conversationsList.find(conversation => conversation.type === CONVERSATION.TYPE.NOTE_TO_SELF)
 		},
 
+		pendingInvitationsCount() {
+			return isFederationEnabled
+				? Object.keys(this.federationStore.pendingShares).length
+				: 0
+		},
+
 		sourcesWithoutResults() {
 			return !this.searchResultsUsers.length
 				|| !this.searchResultsGroups.length
@@ -542,6 +578,10 @@ export default {
 			this.refreshTimer = window.setInterval(() => {
 				this.fetchConversations()
 			}, 30000)
+
+			if (isFederationEnabled) {
+				this.federationStore.getShares()
+			}
 		})
 
 		talkBroadcastChannel.addEventListener('message', (event) => {
@@ -613,6 +653,10 @@ export default {
 
 		showModalCallPhoneDialog() {
 			this.$refs.callPhoneDialog.showModal()
+		},
+
+		showInvitationHandler() {
+			this.$refs.invitationHandler.showModal()
 		},
 
 		handleFilter(filter) {
@@ -933,7 +977,7 @@ export default {
 <style lang="scss" scoped>
 .scroller {
 	padding: 0 4px;
-	overflow-y: scroll; // reserve a place for scrollbar
+	overflow-y: scroll !important; // reserve a place for scrollbar
 }
 
 .h-100 {
@@ -960,6 +1004,21 @@ export default {
 		position: absolute;
 		top: 8px;
 		right: 8px;
+	}
+}
+
+.invitation-button {
+	padding: 0 10px;
+	overflow-y: scroll; // align total width with list items
+	margin-bottom: 4px;
+
+	:deep(.app-navigation-entry-link) {
+		padding-left: 10px;
+	}
+
+	:deep(.app-navigation-entry__name) {
+		padding-left: 8px;
+		font-weight: bold;
 	}
 }
 

--- a/src/components/LeftSidebar/OpenConversationsList/OpenConversationsList.vue
+++ b/src/components/LeftSidebar/OpenConversationsList/OpenConversationsList.vue
@@ -1,6 +1,7 @@
 <!--
-  - @copyright Copyright (c) 2023
+  - @copyright Copyright (c) 2023 Dorra Jaouad <dorra.jaoued1@gmail.com>
   -
+  - @author Dorra Jaouad <dorra.jaoued1@gmail.com>
   - @license GNU AGPL version 3 or any later version
   -
   - This program is free software: you can redistribute it and/or modify

--- a/src/constants.js
+++ b/src/constants.js
@@ -267,3 +267,10 @@ export const AVATAR = {
 		FULL: 512,
 	},
 }
+
+export const FEDERATION = {
+	STATE: {
+		PENDING: 0,
+		ACCEPTED: 1,
+	},
+}

--- a/src/services/federationService.js
+++ b/src/services/federationService.js
@@ -1,0 +1,59 @@
+/**
+ * @copyright Copyright (c) 2024 Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @author Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+
+/**
+ * Fetches list of shares for a current user
+ *
+ * @param {object} [options] options;
+ */
+const getShares = async function(options) {
+	return axios.get(generateOcsUrl('apps/spreed/api/v1/federation/invitation', undefined, options), options)
+}
+
+/**
+ * Accept an invitation by provided id.
+ *
+ * @param {number} id invitation id;
+ * @param {object} [options] options;
+ */
+const acceptShare = async function(id, options) {
+	return axios.post(generateOcsUrl('apps/spreed/api/v1/federation/invitation/{id}', { id }, options), {}, options)
+}
+
+/**
+ * Reject an invitation by provided id.
+ *
+ * @param {number} id invitation id;
+ * @param {object} [options] options;
+ */
+const rejectShare = async function(id, options) {
+	return axios.delete(generateOcsUrl('apps/spreed/api/v1/federation/invitation/{id}', { id }, options), options)
+}
+
+export {
+	getShares,
+	acceptShare,
+	rejectShare,
+}

--- a/src/stores/__tests__/federation.spec.js
+++ b/src/stores/__tests__/federation.spec.js
@@ -1,0 +1,262 @@
+import { setActivePinia, createPinia } from 'pinia'
+
+import { getShares, acceptShare, rejectShare } from '../../services/federationService.js'
+import { generateOCSErrorResponse, generateOCSResponse } from '../../test-helpers.js'
+import { useFederationStore } from '../federation.js'
+
+jest.mock('../../services/federationService', () => ({
+	getShares: jest.fn(),
+	acceptShare: jest.fn(),
+	rejectShare: jest.fn(),
+}))
+
+describe('federationStore', () => {
+	const invites = [
+		{
+			id: 2,
+			userId: 'user0',
+			state: 0,
+			localRoomId: 10,
+			accessToken: 'ACCESS_TOKEN',
+			remoteServerUrl: 'remote.nextcloud.com',
+			remoteToken: 'TOKEN_2',
+			remoteAttendeeId: 11,
+			inviterCloudId: 'user2@remote.nextcloud.com',
+			inviterDisplayName: 'User Two',
+			roomName: 'Federation room 2'
+		},
+		{
+			id: 1,
+			userId: 'user0',
+			state: 1,
+			localRoomId: 9,
+			accessToken: 'ACCESS_TOKEN',
+			remoteServerUrl: 'remote.nextcloud.com',
+			remoteToken: 'TOKEN_1',
+			remoteAttendeeId: 11,
+			inviterCloudId: 'user1@remote.nextcloud.com',
+			inviterDisplayName: 'User One',
+			roomName: 'Federation room 1'
+		},
+	]
+	const notifications = [
+		{
+			notificationId: 122,
+			app: 'spreed',
+			user: 'user0',
+			objectType: 'remote_talk_share',
+			objectId: '2',
+			messageRichParameters: {
+				user1: {
+					type: 'user',
+					id: 'user2',
+					name: 'User Two',
+					server: 'remote.nextcloud.com'
+				},
+				roomName: {
+					type: 'highlight',
+					id: 'remote.nextcloud.com::TOKEN_2',
+					name: 'Federation room 2'
+				},
+			},
+		},
+		{
+			notificationId: 123,
+			app: 'spreed',
+			user: 'user0',
+			objectType: 'remote_talk_share',
+			objectId: '3',
+			messageRichParameters: {
+				user1: {
+					type: 'user',
+					id: 'user3',
+					name: 'User Three',
+					server: 'remote.nextcloud.com'
+				},
+				roomName: {
+					type: 'highlight',
+					id: 'remote.nextcloud.com::TOKEN_3',
+					name: 'Federation room 3'
+				},
+			},
+		}
+	]
+	let federationStore
+
+	beforeEach(async () => {
+		setActivePinia(createPinia())
+		federationStore = useFederationStore()
+	})
+
+	afterEach(async () => {
+		jest.clearAllMocks()
+	})
+
+	it('returns an empty objects when invitations are not loaded yet', async () => {
+		// Assert: check initial state of the store
+		expect(federationStore.pendingShares).toStrictEqual({})
+		expect(federationStore.acceptedShares).toStrictEqual({})
+	})
+
+	it('does not handle accepted invitations when missing in the store', async () => {
+		// Act: accept invite from notification
+		await federationStore.markInvitationAccepted(invites[0].id, {})
+
+		// Assert: check initial state of the store
+		expect(federationStore.pendingShares).toStrictEqual({})
+		expect(federationStore.acceptedShares).toStrictEqual({})
+	})
+
+	it('processes a response from server and stores invites', async () => {
+		// Arrange
+		const response = generateOCSResponse({ payload: invites })
+		getShares.mockResolvedValueOnce(response)
+
+		// Act: load invites from server
+		await federationStore.getShares()
+
+		// Assert
+		expect(getShares).toHaveBeenCalled()
+		expect(federationStore.pendingShares).toMatchObject({ [invites[0].id]: invites[0] })
+		expect(federationStore.acceptedShares).toMatchObject({ [invites[1].id]: invites[1] })
+	})
+
+	it('handles error in server request for getShares', async () => {
+		// Arrange
+		const response = generateOCSErrorResponse({ status: 404, payload: [] })
+		getShares.mockRejectedValueOnce(response)
+		console.error = jest.fn()
+
+		// Act
+		await federationStore.getShares()
+
+		// Assert: store hasn't changed
+		expect(federationStore.pendingShares).toStrictEqual({})
+		expect(federationStore.acceptedShares).toStrictEqual({})
+	})
+
+	it('updates invites in the store after receiving a notification', async () => {
+		// Arrange
+		const response = generateOCSResponse({ payload: invites })
+		getShares.mockResolvedValueOnce(response)
+		await federationStore.getShares()
+
+		// Act: trigger notification handling
+		notifications.forEach(federationStore.addInvitationFromNotification)
+
+		// Assert
+		expect(federationStore.pendingShares).toMatchObject({
+			[invites[0].id]: invites[0],
+			[notifications[1].objectId]: { id: notifications[1].objectId },
+		})
+		expect(federationStore.acceptedShares).toMatchObject({ [invites[1].id]: invites[1] })
+	})
+
+	it('accepts invitation and modify store', async () => {
+		// Arrange
+		const response = generateOCSResponse({ payload: invites })
+		getShares.mockResolvedValueOnce(response)
+		await federationStore.getShares()
+
+		const room = {
+			id: 10,
+			remoteAccessToken: 'ACCESS_TOKEN',
+		}
+		const acceptResponse = generateOCSResponse({ payload: room })
+		acceptShare.mockResolvedValueOnce(acceptResponse)
+
+		// Act: accept invite
+		const conversation = await federationStore.acceptShare(invites[0].id)
+
+		// Assert
+		expect(acceptShare).toHaveBeenCalledWith(invites[0].id)
+		expect(conversation).toMatchObject(room)
+		expect(federationStore.pendingShares).toStrictEqual({})
+		expect(federationStore.acceptedShares).toMatchObject({
+			[invites[0].id]: { ...invites[0], state: 1 },
+			[invites[1].id]: invites[1],
+		})
+	})
+
+	it('skip already accepted invitations', async () => {
+		// Arrange
+		const response = generateOCSResponse({ payload: invites })
+		getShares.mockResolvedValueOnce(response)
+		await federationStore.getShares()
+
+		// Act: accept invite
+		await federationStore.acceptShare(invites[1].id)
+
+		// Assert
+		expect(acceptShare).not.toHaveBeenCalled()
+		expect(federationStore.pendingShares).toMatchObject({ [invites[0].id]: invites[0] })
+		expect(federationStore.acceptedShares).toMatchObject({ [invites[1].id]: invites[1] })
+	})
+
+	it('handles error in server request for acceptShare', async () => {
+		// Arrange
+		const response = generateOCSResponse({ payload: invites })
+		getShares.mockResolvedValueOnce(response)
+		await federationStore.getShares()
+		const errorResponse = generateOCSErrorResponse({ status: 404, payload: [] })
+		acceptShare.mockRejectedValueOnce(errorResponse)
+		console.error = jest.fn()
+
+		// Act
+		await federationStore.acceptShare(invites[0].id)
+
+		// Assert: store hasn't changed
+		expect(federationStore.pendingShares).toMatchObject({ [invites[0].id]: invites[0] })
+		expect(federationStore.acceptedShares).toMatchObject({ [invites[1].id]: invites[1] })
+	})
+
+	it('rejects invitation and modify store', async () => {
+		// Arrange
+		const response = generateOCSResponse({ payload: invites })
+		getShares.mockResolvedValueOnce(response)
+		await federationStore.getShares()
+
+		const rejectResponse = generateOCSResponse({ payload: [] })
+		rejectShare.mockResolvedValueOnce(rejectResponse)
+
+		// Act: reject invite
+		await federationStore.rejectShare(invites[0].id)
+
+		// Assert
+		expect(rejectShare).toHaveBeenCalledWith(invites[0].id)
+		expect(federationStore.pendingShares).toStrictEqual({})
+		expect(federationStore.acceptedShares).toMatchObject({ [invites[1].id]: invites[1] })
+	})
+
+	it('skip already rejected invitations', async () => {
+		// Arrange
+		const response = generateOCSResponse({ payload: invites })
+		getShares.mockResolvedValueOnce(response)
+		await federationStore.getShares()
+
+		// Act: reject invite
+		await federationStore.rejectShare(invites[1].id)
+
+		// Assert
+		expect(rejectShare).not.toHaveBeenCalled()
+		expect(federationStore.pendingShares).toMatchObject({ [invites[0].id]: invites[0] })
+		expect(federationStore.acceptedShares).toMatchObject({ [invites[1].id]: invites[1] })
+	})
+
+	it('handles error in server request for rejectShare', async () => {
+		// Arrange
+		const response = generateOCSResponse({ payload: invites })
+		getShares.mockResolvedValueOnce(response)
+		await federationStore.getShares()
+		const errorResponse = generateOCSErrorResponse({ status: 404, payload: [] })
+		rejectShare.mockRejectedValueOnce(errorResponse)
+		console.error = jest.fn()
+
+		// Act
+		await federationStore.rejectShare(invites[0].id)
+
+		// Assert: store hasn't changed
+		expect(federationStore.pendingShares).toMatchObject({ [invites[0].id]: invites[0] })
+		expect(federationStore.acceptedShares).toMatchObject({ [invites[1].id]: invites[1] })
+	})
+})

--- a/src/stores/federation.js
+++ b/src/stores/federation.js
@@ -1,0 +1,168 @@
+/**
+ * @copyright Copyright (c) 2024 Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @author Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { defineStore } from 'pinia'
+import Vue from 'vue'
+
+import { showError } from '@nextcloud/dialogs'
+
+import { FEDERATION } from '../constants.js'
+import { getShares, acceptShare, rejectShare } from '../services/federationService.js'
+
+/**
+ * @typedef {object} Share
+ * @property {string} accessToken the invitation access token
+ * @property {number} id the invitation id
+ * @property {number} localRoomId the invitation local room id
+ * @property {number} remoteAttendeeId the invitation remote attendee id
+ * @property {string} remoteServerUrl the invitation remote server URL
+ * @property {string} remoteToken the invitation remote token
+ * @property {string} roomName the invitation room name
+ * @property {number} state the invitation state
+ * @property {string} userId the invitation user id
+ * @property {string} inviterCloudId the inviter cloud id
+ * @property {string} inviterDisplayName the inviter display name
+ */
+
+/**
+ * @typedef {object} State
+ * @property {{[key: string]: Share}} pendingShares - pending invitations
+ * @property {{[key: string]: Share}} acceptedShares - accepted invitations
+ */
+
+/**
+ * Store for other app integrations (additional actions for messages, participants, e.t.c)
+ *
+ * @param {string} id store name
+ * @param {State} options.state store state structure
+ */
+export const useFederationStore = defineStore('federation', {
+	state: () => ({
+		pendingShares: {},
+		acceptedShares: {},
+	}),
+
+	actions: {
+		/**
+		 * Fetch pending invitations and keep them in store
+		 *
+		 */
+		async getShares() {
+			try {
+				const response = await getShares()
+				response.data.ocs.data.forEach(item => {
+					if (item.state === FEDERATION.STATE.ACCEPTED) {
+						Vue.set(this.acceptedShares, item.id, item)
+					} else {
+						Vue.set(this.pendingShares, item.id, item)
+					}
+				})
+			} catch (error) {
+				console.error(error)
+			}
+		},
+
+		/**
+		 * Add an invitation from notification to the store.
+		 *
+		 * @param {object} notification notification object
+		 */
+		addInvitationFromNotification(notification) {
+			if (this.pendingShares[notification.objectId]) {
+				return
+			}
+			const [remoteServerUrl, remoteToken] = notification.messageRichParameters.roomName.id.split('::')
+			const { id, name } = notification.messageRichParameters.user1
+			const invitation = {
+				accessToken: null,
+				id: notification.objectId,
+				localRoomId: null,
+				remoteAttendeeId: null,
+				remoteServerUrl,
+				remoteToken,
+				roomName: notification.messageRichParameters.roomName.name,
+				state: FEDERATION.STATE.PENDING,
+				userId: notification.user,
+				inviterCloudId: id + '@' + remoteServerUrl,
+				inviterDisplayName: name,
+			}
+			Vue.set(this.pendingShares, invitation.id, invitation)
+		},
+
+		/**
+		 * Mark an invitation as accepted in store.
+		 *
+		 * @param {number} id invitation id
+		 * @param {object} conversation conversation object
+		 */
+		markInvitationAccepted(id, conversation) {
+			if (!this.pendingShares[id]) {
+				return
+			}
+			Vue.set(this.acceptedShares, id, {
+				...this.pendingShares[id],
+				accessToken: conversation.remoteAccessToken,
+				localRoomId: conversation.id,
+				state: FEDERATION.STATE.ACCEPTED,
+			})
+			Vue.delete(this.pendingShares, id)
+		},
+
+		/**
+		 * Accept an invitation by provided id.
+		 *
+		 * @param {number} id invitation id
+		 * @return {object} conversation to join
+		 */
+		async acceptShare(id) {
+			if (!this.pendingShares[id]) {
+				return
+			}
+			try {
+				const response = await acceptShare(id)
+				this.markInvitationAccepted(id, response.data.ocs.data)
+				return response.data.ocs.data
+			} catch (error) {
+				console.error(error)
+				showError(t('spreed', 'An error occurred while accepting an invitation'))
+			}
+		},
+
+		/**
+		 * Reject an invitation by provided id.
+		 *
+		 * @param {number} id invitation id
+		 */
+		async rejectShare(id) {
+			if (!this.pendingShares[id]) {
+				return
+			}
+			try {
+				await rejectShare(id)
+				Vue.delete(this.pendingShares, id)
+			} catch (error) {
+				console.error(error)
+				showError(t('spreed', 'An error occurred while rejecting an invitation'))
+			}
+		},
+	},
+})


### PR DESCRIPTION
### ☑️ Resolves

* Ref #11279 
* Add federation store, handle notifications with it
* Introduce dialog to list and manage invitations

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

![image](https://github.com/nextcloud/spreed/assets/93392545/96039abb-f6c9-40e2-b961-27fc3c585afd)
![image](https://github.com/nextcloud/spreed/assets/93392545/89ac8f3d-ca6a-4c4d-bdce-c8b93c18c926)


### 🚧 Tasks

Design review:
- [x] It could look like a list item "Pending invitations" as the first item in the conversation list with the MDI icon \`account-mutiple-plus\`
- [x] Modal view: Accept button should have text "\[checkmark icon\] Accept"
- [ ] Modal heading can have a subline explaining that it - check wording:
`Join conversations from remote Nextcloud servers`
- [x] Subline in each item "from Alice Smith at nextcloud.local", no "Invitation from"
- [x] Hide item in conversation list if there are no pending invitations

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required