### PR TITLE
Fix(ReactionMenu): Correct gap value

### DIFF
--- a/src/components/TopBar/ReactionMenu.vue
+++ b/src/components/TopBar/ReactionMenu.vue
@@ -138,6 +138,7 @@ export default {
 		:deep(.nc-button-group-content) {
 			flex-wrap: wrap;
 			justify-content: flex-start;
+			gap: 0;
 			width: calc(var(--reactions-in-single-row) * var(--default-clickable-area))
 		}
 	}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11539

To make the Math right in reactions layout, gap is set to 0. 

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
|![image](https://github.com/nextcloud/spreed/assets/84044328/5357dce4-565c-4517-8e05-37af9cad2eec)    | ![image](https://github.com/nextcloud/spreed/assets/84044328/d77999fc-201c-4ea7-a448-79c3325ff00c)   |

### 🚧 Tasks

- [x] code review

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
