### PR TITLE
Improve room selector modal

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
@@ -45,13 +45,13 @@ describe('Conversation.vue', () => {
 		testStoreConfig = cloneDeep(storeConfig)
 		messagesMock = jest.fn().mockReturnValue({})
 		testStoreConfig.modules.messagesStore.getters.messages = () => messagesMock
-		testStoreConfig.modules.actorStore.getters.getUserId = () => jest.fn().mockReturnValue('user-id-self')
 		store = new Vuex.Store(testStoreConfig)
 
 		// common defaults
 		item = {
 			token: TOKEN,
 			actorId: 'actor-id-1',
+			actorType: ATTENDEE.ACTOR_TYPE.USERS,
 			participants: [
 			],
 			participantType: PARTICIPANT.TYPE.USER,
@@ -155,7 +155,7 @@ describe('Conversation.vue', () => {
 			})
 
 			test('displays own last chat message with "You" as author', () => {
-				item.lastMessage.actorId = 'user-id-self'
+				item.lastMessage.actorId = 'actor-id-1'
 
 				testConversationLabel(item, 'You: hello')
 			})
@@ -174,7 +174,7 @@ describe('Conversation.vue', () => {
 
 			test('displays own last message with "You" author in one to one conversations', () => {
 				item.type = CONVERSATION.TYPE.ONE_TO_ONE
-				item.lastMessage.actorId = 'user-id-self'
+				item.lastMessage.actorId = 'actor-id-1'
 
 				testConversationLabel(item, 'You: hello')
 			})

--- a/src/components/LeftSidebar/ConversationsList/ConversationSearchResult.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationSearchResult.vue
@@ -1,0 +1,187 @@
+<!--
+  - @copyright Copyright (c) 2024 Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @author Joas Schilling <coding@schilljs.com>
+  - @author Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+	<NcListItem :key="item.token"
+		:name="item.displayName"
+		:title="item.displayName"
+		:active="item.token === selectedRoom"
+		:bold="!!item.unreadMessages"
+		:counter-number="item.unreadMessages"
+		:counter-type="counterType"
+		@click="onClick">
+		<template #icon>
+			<ConversationIcon :item="item" :hide-favorite="!item?.attendeeId" :hide-call="!item?.attendeeId" />
+		</template>
+		<template v-if="conversationInformation" #subname>
+			{{ conversationInformation }}
+		</template>
+	</NcListItem>
+</template>
+
+<script>
+import { inject } from 'vue'
+
+import NcListItem from '@nextcloud/vue/dist/Components/NcListItem.js'
+
+import ConversationIcon from './../../ConversationIcon.vue'
+
+import { CONVERSATION, ATTENDEE } from '../../../constants.js'
+
+export default {
+	name: 'ConversationSearchResult',
+
+	components: {
+		ConversationIcon,
+		NcListItem,
+	},
+
+	props: {
+		item: {
+			type: Object,
+			default() {
+				return {
+					token: '',
+					participants: [],
+					participantType: 0,
+					unreadMessages: 0,
+					unreadMention: false,
+					objectType: '',
+					type: 0,
+					displayName: '',
+					isFavorite: false,
+					notificationLevel: 0,
+					lastMessage: {},
+				}
+			},
+		},
+	},
+
+	emits: ['click'],
+
+	setup() {
+		const selectedRoom = inject('selectedRoom', null)
+
+		return {
+			selectedRoom,
+		}
+	},
+
+	computed: {
+		counterType() {
+			if (this.item.unreadMentionDirect || (this.item.unreadMessages !== 0 && (
+				this.item.type === CONVERSATION.TYPE.ONE_TO_ONE || this.item.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER
+			))) {
+				return 'highlighted'
+			} else if (this.item.unreadMention) {
+				return 'outlined'
+			} else {
+				return ''
+			}
+		},
+
+		conversationInformation() {
+			if (!Object.keys(Object(this.item?.lastMessage)).length) {
+				return ''
+			}
+
+			if (this.shortLastChatMessageAuthor === '') {
+				return this.simpleLastChatMessage
+			}
+
+			if (this.item.lastMessage.actorId === this.item.actorId) {
+				return t('spreed', 'You: {lastMessage}', {
+					lastMessage: this.simpleLastChatMessage,
+				}, undefined, {
+					escape: false,
+					sanitize: false,
+				})
+			}
+
+			if (this.item.type === CONVERSATION.TYPE.ONE_TO_ONE
+				|| this.item.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER
+				|| this.item.type === CONVERSATION.TYPE.CHANGELOG) {
+				return this.simpleLastChatMessage
+			}
+
+			return t('spreed', '{actor}: {lastMessage}', {
+				actor: this.shortLastChatMessageAuthor,
+				lastMessage: this.simpleLastChatMessage,
+			}, undefined, {
+				escape: false,
+				sanitize: false,
+			})
+		},
+
+		/**
+		 * This is a simplified version of the last chat message.
+		 * Parameters are parsed without markup (just replaced with the name),
+		 * e.g. no avatars on mentions.
+		 *
+		 * @return {string} A simple message to show below the conversation name
+		 */
+		simpleLastChatMessage() {
+			if (!Object.keys(this.item.lastMessage).length) {
+				return ''
+			}
+
+			const params = this.item.lastMessage.messageParameters
+			let subtitle = this.item.lastMessage.message.trim()
+
+			// We don't really use rich objects in the subtitle, instead we fall back to the name of the item
+			Object.keys(params).forEach((parameterKey) => {
+				subtitle = subtitle.replace('{' + parameterKey + '}', params[parameterKey].name)
+			})
+
+			return subtitle
+		},
+
+		/**
+		 * @return {string} Part of the name until the first space
+		 */
+		shortLastChatMessageAuthor() {
+			if (!Object.keys(this.item.lastMessage).length
+				|| this.item.lastMessage.systemMessage.length) {
+				return ''
+			}
+
+			let author = this.item.lastMessage.actorDisplayName.trim()
+			const spacePosition = author.indexOf(' ')
+			if (spacePosition !== -1) {
+				author = author.substring(0, spacePosition)
+			}
+
+			if (author.length === 0 && this.item.lastMessage.actorType === ATTENDEE.ACTOR_TYPE.GUESTS) {
+				return t('spreed', 'Guest')
+			}
+
+			return author
+		},
+	},
+
+	methods: {
+		onClick() {
+			this.$emit('click', this.item)
+		},
+	},
+}
+</script>

--- a/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
@@ -37,8 +37,8 @@
 <script>
 import { RecycleScroller } from 'vue-virtual-scroller'
 
-import Conversation from './ConversationsList/Conversation.vue'
-import LoadingPlaceholder from '../LoadingPlaceholder.vue'
+import Conversation from './Conversation.vue'
+import LoadingPlaceholder from '../../LoadingPlaceholder.vue'
 
 import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'
 

--- a/src/components/LeftSidebar/ConversationsList/ConversationsSearchListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsSearchListVirtual.vue
@@ -1,0 +1,83 @@
+<!--
+  - @copyright Copyright (c) 2024 Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @author Grigorii Shartsev <me@shgk.me>
+  - @author Maksim Sukharev <antreesy.web@gmail.com>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<template>
+	<RecycleScroller ref="scroller"
+		item-tag="ul"
+		:items="conversations"
+		:item-size="CONVERSATION_ITEM_SIZE"
+		key-field="token">
+		<template #default="{ item }">
+			<ConversationSearchResult :item="item" @click="onClick" />
+		</template>
+		<template #after>
+			<LoadingPlaceholder v-if="loading" type="conversations" />
+		</template>
+	</RecycleScroller>
+</template>
+
+<script>
+import { RecycleScroller } from 'vue-virtual-scroller'
+
+import ConversationSearchResult from './ConversationSearchResult.vue'
+import LoadingPlaceholder from '../../LoadingPlaceholder.vue'
+
+import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'
+
+const CONVERSATION_ITEM_SIZE = 66
+
+export default {
+	name: 'ConversationsSearchListVirtual',
+
+	components: {
+		LoadingPlaceholder,
+		ConversationSearchResult,
+		RecycleScroller,
+	},
+
+	props: {
+		conversations: {
+			type: Array,
+			required: true,
+		},
+
+		loading: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	emits: ['select'],
+
+	setup() {
+		return {
+			CONVERSATION_ITEM_SIZE,
+		}
+	},
+
+	methods: {
+		onClick(item) {
+			this.$emit('select', item)
+		},
+	},
+}
+</script>

--- a/src/components/LeftSidebar/ConversationsList/ConversationsSearchListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsSearchListVirtual.vue
@@ -27,7 +27,7 @@
 		:item-size="CONVERSATION_ITEM_SIZE"
 		key-field="token">
 		<template #default="{ item }">
-			<ConversationSearchResult :item="item" @click="onClick" />
+			<ConversationSearchResult :item="item" :expose-messages="exposeMessages" @click="onClick" />
 		</template>
 		<template #after>
 			<LoadingPlaceholder v-if="loading" type="conversations" />
@@ -59,7 +59,10 @@ export default {
 			type: Array,
 			required: true,
 		},
-
+		exposeMessages: {
+			type: Boolean,
+			default: false,
+		},
 		loading: {
 			type: Boolean,
 			default: false,

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -297,7 +297,7 @@ import { useIsMobile } from '@nextcloud/vue/dist/Composables/useIsMobile.js'
 
 import CallPhoneDialog from './CallPhoneDialog/CallPhoneDialog.vue'
 import Conversation from './ConversationsList/Conversation.vue'
-import ConversationsListVirtual from './ConversationsListVirtual.vue'
+import ConversationsListVirtual from './ConversationsList/ConversationsListVirtual.vue'
 import OpenConversationsList from './OpenConversationsList/OpenConversationsList.vue'
 import SearchBox from './SearchBox/SearchBox.vue'
 import ConversationIcon from '../ConversationIcon.vue'

--- a/src/components/RoomSelector.vue
+++ b/src/components/RoomSelector.vue
@@ -41,15 +41,11 @@
 					<Magnify :size="16" />
 				</NcTextField>
 				<div id="room-list">
-					<ul v-if="!loading && availableRooms.length > 0">
-						<li v-for="room in availableRooms"
-							:key="room.token"
-							:class="{selected: selectedRoom === room.token }"
-							@click="selectedRoom=room.token">
-							<ConversationIcon :item="room" :hide-favorite="false" />
-							<span>{{ room.displayName }}</span>
-						</li>
-					</ul>
+					<ConversationsSearchListVirtual v-if="loading || availableRooms.length > 0"
+						:conversations="availableRooms"
+						:loading="loading"
+						class="scroller h-100"
+						@select="onSelect" />
 					<div v-else-if="!loading" class="no-match-message">
 						<h2 class="no-match-title">
 							{{ noMatchFoundTitle }}
@@ -73,13 +69,15 @@
 </template>
 
 <script>
+import { provide, ref } from 'vue'
+
 import Magnify from 'vue-material-design-icons/Magnify.vue'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 
-import ConversationIcon from './ConversationIcon.vue'
+import ConversationsSearchListVirtual from './LeftSidebar/ConversationsList/ConversationsSearchListVirtual.vue'
 
 import { CONVERSATION } from '../constants.js'
 import { searchListedConversations, fetchConversations } from '../services/conversationsService.js'
@@ -87,10 +85,11 @@ import { searchListedConversations, fetchConversations } from '../services/conve
 export default {
 	name: 'RoomSelector',
 	components: {
-		ConversationIcon,
-		NcModal,
+		ConversationsSearchListVirtual,
 		NcButton,
+		NcModal,
 		NcTextField,
+		// Icons
 		Magnify,
 	},
 	props: {
@@ -124,10 +123,19 @@ export default {
 		},
 	},
 	emits: ['close', 'select'],
+
+	setup() {
+		const selectedRoom = ref(null)
+		provide('selectedRoom', selectedRoom)
+
+		return {
+			selectedRoom,
+		}
+	},
+
 	data() {
 		return {
 			rooms: [],
-			selectedRoom: null,
 			currentRoom: null,
 			searchText: '',
 			loading: true,
@@ -194,6 +202,9 @@ export default {
 			this.$root.$emit('close')
 			this.$emit('close')
 		},
+		onSelect(item) {
+			this.selectedRoom = item.token
+		},
 		select() {
 			this.$root.$emit('select', this.selectedRoom)
 			this.$emit('select', this.selectedRoom)
@@ -258,31 +269,6 @@ export default {
 	font-weight: normal;
 }
 
-li {
-	padding: 6px;
-	border: 1px solid transparent;
-	display: flex;
-
-	&:hover,
-	&:focus {
-		background-color: var(--color-background-dark);
-		border-radius: var(--border-radius-pill);
-	}
-
-	&.selected {
-		background-color: var(--color-primary-element-light);
-		border-radius: var(--border-radius-pill);
-	}
-
-	& > span {
-		padding: 8px 5px 8px 10px;
-		vertical-align: middle;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		overflow: hidden;
-	}
-}
-
 #modal-buttons {
 	overflow: hidden;
 	flex-shrink: 0;
@@ -296,5 +282,13 @@ li {
 
 .search-form {
 	margin-bottom: 10px;
+}
+
+.scroller {
+	padding: 0 4px;
+}
+
+.h-100 {
+	height: 100%;
 }
 </style>

--- a/src/composables/useConversationInfo.js
+++ b/src/composables/useConversationInfo.js
@@ -1,0 +1,138 @@
+/*
+ * @copyright Copyright (c) 2024 Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ * @author Maksim Sukharev <antreesy.web@gmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { computed, ref } from 'vue'
+
+import { ATTENDEE, CONVERSATION } from '../constants.js'
+
+/**
+ * Reusable properties for Conversation... items
+ * @param {object} payload function payload
+ * @param {import('vue').Ref} payload.item conversation item
+ * @param {import('vue').Ref} [payload.isSearchResult] whether conversation item appears as search result
+ * @param {import('vue').Ref} [payload.exposeMessages] whether to show messages in conversation item
+ */
+export function useConversationInfo({
+	item,
+	isSearchResult = ref(null),
+	exposeMessages = ref(null),
+}) {
+	const counterType = computed(() => {
+		if (exposeMessages.value === false) {
+			return ''
+		} else if (item.value.unreadMentionDirect || (item.value.unreadMessages !== 0
+			&& [CONVERSATION.TYPE.ONE_TO_ONE, CONVERSATION.TYPE.ONE_TO_ONE_FORMER].includes(item.value.type)
+		)) {
+			return 'highlighted'
+		} else if (item.value.unreadMention) {
+			return 'outlined'
+		} else {
+			return ''
+		}
+	})
+
+	const hasLastMessage = computed(() => {
+		return !!Object.keys(Object(item.value?.lastMessage)).length
+	})
+
+	/**
+	 * Simplified version of the last chat message.
+	 * Parameters are parsed without markup (just replaced with the name),
+	 * e.g. no avatars on mentions.
+	 */
+	const simpleLastChatMessage = computed(() => {
+		if (exposeMessages.value === false || !hasLastMessage.value) {
+			return ''
+		}
+
+		const params = item.value?.lastMessage.messageParameters
+		let subtitle = item.value?.lastMessage.message.trim()
+
+		// We don't really use rich objects in the subtitle, instead we fall back to the name of the item
+		Object.keys(params).forEach((parameterKey) => {
+			subtitle = subtitle.replace('{' + parameterKey + '}', params[parameterKey].name)
+		})
+
+		return subtitle
+	})
+
+	/**
+	 * @return {string} Part of the name until the first space
+	 */
+	const shortLastChatMessageAuthor = computed(() => {
+		if (exposeMessages.value === false || !hasLastMessage.value || item.value.lastMessage.systemMessage.length) {
+			return ''
+		}
+
+		const author = item.value.lastMessage.actorDisplayName.trim().split(' ').shift()
+
+		if (author.length === 0 && item.value.lastMessage.actorType === ATTENDEE.ACTOR_TYPE.GUESTS) {
+			return t('spreed', 'Guest')
+		}
+
+		return author
+	})
+
+	const conversationInformation = computed(() => {
+		// temporary item while joining, only for Conversation component
+		if (isSearchResult.value === false && !item.value.actorId) {
+			return t('spreed', 'Joining conversation …')
+		}
+
+		if (exposeMessages.value === false || !hasLastMessage.value) {
+			return ''
+		}
+
+		if (shortLastChatMessageAuthor.value === '') {
+			return simpleLastChatMessage.value
+		}
+
+		if (item.value?.lastMessage.actorId === item.value.actorId
+			&& item.value?.lastMessage.actorType === item.value.actorType) {
+			return t('spreed', 'You: {lastMessage}', {
+				lastMessage: simpleLastChatMessage.value,
+			}, undefined, {
+				escape: false,
+				sanitize: false,
+			})
+		}
+
+		if ([CONVERSATION.TYPE.ONE_TO_ONE,
+			CONVERSATION.TYPE.ONE_TO_ONE_FORMER,
+			CONVERSATION.TYPE.CHANGELOG].includes(item.value.type)) {
+			return simpleLastChatMessage.value
+		}
+
+		return t('spreed', '{actor}: {lastMessage}', {
+			actor: shortLastChatMessageAuthor.value,
+			lastMessage: simpleLastChatMessage.value,
+		}, undefined, {
+			escape: false,
+			sanitize: false,
+		})
+	})
+
+	return {
+		counterType,
+		conversationInformation,
+	}
+}


### PR DESCRIPTION
### ☑️ Resolves

* Refactor of RoomSelector
  * Use ConversationsListVirtual and ConversationSearchResult for conversations list:
    * improve accessibility, optimize rendering
    * show last message if provided :warning: optionally, disabled atm
    * resolve issue with immediate load of all avatars
  * Test coverage

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
![image](https://github.com/nextcloud/spreed/assets/93392545/12465c4c-e47f-4210-afac-37227b5464a4) | ![image](https://github.com/nextcloud/spreed/assets/93392545/2a561f0f-9ce3-4a27-83f6-327a349ba5a5)
![image](https://github.com/nextcloud/spreed/assets/93392545/b59c8a9c-ecaf-4ca1-8e8c-29c8d038747b) | ![image](https://github.com/nextcloud/spreed/assets/93392545/98c6af30-22ea-4e09-9593-30904e068e36)


Test coverage:
![image](https://github.com/nextcloud/spreed/assets/93392545/887bf5dd-189c-462b-ab34-4e882692b387)

### 🚧 Tasks

- [ ] Code review
- [ ] Design review
- [ ] **TODO**:
  - [x] emit full conversation instead of token on 'Select conversation' - https://github.com/nextcloud/spreed/pull/11589
  - [x] Split virtual list into two components => Conversation pulls all dependencies
  - [x] reuse shared computed/methods between ConversationSearchResult / Conversation
  - [ ] check ConversationSearchResult component for reuse in LeftSidebar (need to provide actions)