### PR TITLE
Feat(MessagesList): Soft update messages list AND add sticky date separator.

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.vue
@@ -22,7 +22,7 @@
 
 <template>
 	<!-- reactions buttons and popover with details -->
-	<div class="reactions-wrapper">
+	<div v-if="reactionsCount && reactionsSorted" class="reactions-wrapper">
 		<NcPopover v-for="reaction in reactionsSorted"
 			:key="reaction"
 			:delay="200"
@@ -175,11 +175,14 @@ export default {
 		},
 
 		reactionsSorted() {
-			return this.detailedReactions
-				? Object.keys(this.detailedReactions)
+			if (this.detailedReactions) {
+				return Object.keys(this.detailedReactions)
 					.sort((a, b) => this.detailedReactions[b].length - this.detailedReactions[a].length)
-				: Object.keys(this.plainReactions)
+			} else if (this.plainReactions) {
+				return Object.keys(this.plainReactions)
 					.sort((a, b) => this.plainReactions[b] - this.plainReactions[a])
+			}
+			return undefined
 		},
 
 		/**
@@ -243,6 +246,9 @@ export default {
 		},
 
 		reactionsCount(reaction) {
+			if (!this.detailedReactions || !this.plainReactions) {
+				return undefined
+			}
 			return this.detailedReactions
 				? this.detailedReactions[reaction]?.length
 				: this.plainReactions[reaction]

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -20,7 +20,7 @@
 -->
 
 <template>
-	<div class="wrapper">
+	<li class="wrapper">
 		<div class="messages__avatar">
 			<AvatarWrapper :id="actorId"
 				:name="actorDisplayName"
@@ -47,7 +47,7 @@
 				:actor-type="actorType"
 				:actor-id="actorId" />
 		</ul>
-	</div>
+	</li>
 </template>
 
 <script>

--- a/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
@@ -20,7 +20,7 @@
 -->
 
 <template>
-	<div class="wrapper wrapper--system">
+	<li class="wrapper wrapper--system">
 		<div v-for="messagesCollapsed in messagesGroupedBySystemMessage"
 			:key="messagesCollapsed.id"
 			class="messages-group__system">
@@ -45,7 +45,7 @@
 					:previous-message-id="getPrevMessageId(message)" />
 			</ul>
 		</div>
-	</div>
+	</li>
 </template>
 
 <script>

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -35,7 +35,9 @@ get the messagesList array and loop through the list to generate the messages.
 			'scroller--isScrolling': isScrolling}"
 		@scroll="onScroll"
 		@scrollend="endScroll">
-		<div v-if="displayMessagesLoader" class="scroller__loading icon-loading" />
+		<TransitionWrapper name="fade">
+			<ul v-if="displayMessagesLoader" class="scroller__loading icon-loading" />
+		</TransitionWrapper>
 
 		<ul v-for="(list, dateTimestamp) in messagesGroupedByDateByAuthor"
 			:key="`section_${dateTimestamp}`"
@@ -89,6 +91,7 @@ import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import MessagesGroup from './MessagesGroup/MessagesGroup.vue'
 import MessagesSystemGroup from './MessagesGroup/MessagesSystemGroup.vue'
 import LoadingPlaceholder from '../LoadingPlaceholder.vue'
+import TransitionWrapper from '../TransitionWrapper.vue'
 
 import { useIsInCall } from '../../composables/useIsInCall.js'
 import { ATTENDEE, CHAT } from '../../constants.js'
@@ -100,6 +103,7 @@ export default {
 		LoadingPlaceholder,
 		Message,
 		NcEmptyContent,
+		TransitionWrapper
 	},
 
 	provide() {
@@ -822,9 +826,6 @@ export default {
 		 * @param {boolean} includeLastKnown Include or exclude the last known message in the response
 		 */
 		async getOldMessages(includeLastKnown) {
-			if (this.stopFetchingOldMessages) {
-				return
-			}
 			// Make the request
 			this.loadingOldMessages = true
 			try {
@@ -990,7 +991,7 @@ export default {
 			this.setChatScrolledToBottom(false)
 
 			if (scrollHeight > clientHeight && scrollTop < 800 && scrollTop < this.previousScrollTopValue) {
-				if (this.loadingOldMessages) {
+				if (this.loadingOldMessages || this.stopFetchingOldMessages) {
 					// already loading, don't do it twice
 					return
 				}
@@ -999,9 +1000,9 @@ export default {
 				this.displayMessagesLoader = false
 
 				if (this.$refs.scroller.scrollHeight !== scrollHeight) {
-					// scroll to previous position + added height
+					// scroll to previous position + added height - loading spinner height
 					this.$refs.scroller.scrollTo({
-						top: scrollTop + (this.$refs.scroller.scrollHeight - scrollHeight),
+						top: scrollTop + (this.$refs.scroller.scrollHeight - scrollHeight) - 40,
 					})
 				}
 			}
@@ -1365,11 +1366,8 @@ export default {
 	}
 
 	&__loading {
-		position: absolute;
-		top: 17px;
-		left: 50%;
 		height: 40px;
-		transform: translatex(-380px);
+		transform: translatex(-64px);
 	}
 }
 

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -537,7 +537,7 @@ const actions = {
 			if (Object.keys(parentInStore).length !== 0 && JSON.stringify(parentInStore) !== JSON.stringify(message.parent)) {
 				context.commit('addMessage', { token, message: message.parent })
 				if (message.systemMessage === 'message_edited') {
-					EventBus.$emit('message-edited')
+					EventBus.$emit('message-edited', message.parent)
 					return
 				}
 			}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #4610 

* Refactor messages groups. It is now broken down by Date then by Author+time .
* Light refactoring for MessagesList, it was necessary 😶.
* Soft update messages list, keep the same object and modify only what was changed.
* Added sticky date separator.


> [!NOTE]  
> As the date is sticky and the loading spinner needs to be in absolute position, it will be overlapped. Therefore, the loading spinner should be in another position other than middle, change the loading visualisation, or removed ( like in other messengers where the date separator is sticky) 


**Issues found to fix:**
- [x] ~~Need more accurate calculation in the comparison between viewport and ul top values ( there is a slight positive gap that should be taken into account)~~
- [ ] The loading spinner ( see above )

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts


https://github.com/nextcloud/spreed/assets/84044328/0c848091-eae4-4162-bb2b-f6188fa7fa22



### 🚧 Tasks

- [ ] Check Soft update thoroughly
- [ ] Reduce the opacity when it is shown sticky and/or make it darker in order to not to blend with system messages? 

Follow-up 
- [ ]  Date separators label are updating when today becomes yesterday ( leave chat open and pass midnight).
- [ ]  Spinner position is not perfect

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
