### PR TITLE
chore(deps): Bump @nextcloud/vue from 8.6.2 to 8.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^3.0.0",
         "@nextcloud/upload": "^1.0.5",
-        "@nextcloud/vue": "^8.6.2",
+        "@nextcloud/vue": "^8.7.0",
         "crypto-js": "^4.2.0",
         "debounce": "^2.0.0",
         "emoji-mart-vue-fast": "^15.0.0",
@@ -3910,9 +3910,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.6.2.tgz",
-      "integrity": "sha512-tlT9OBkuNIKOAajqhmL2owM0KpQzc9Uw+SZ4iOS1AuxSgJoqKU5v2784EXU33xP6kCgneyQt/zd6sxfAr0JzMg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.7.0.tgz",
+      "integrity": "sha512-0SPazCAA7MjvhbNTxZv1kIf6LZ7C9XUq0eovEnBjeD95sd7yu98i4vdPwJw1mIPIaT78rUv4uhUDLxxnS2/IUQ==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -23487,9 +23487,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.6.2.tgz",
-      "integrity": "sha512-tlT9OBkuNIKOAajqhmL2owM0KpQzc9Uw+SZ4iOS1AuxSgJoqKU5v2784EXU33xP6kCgneyQt/zd6sxfAr0JzMg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.7.0.tgz",
+      "integrity": "sha512-0SPazCAA7MjvhbNTxZv1kIf6LZ7C9XUq0eovEnBjeD95sd7yu98i4vdPwJw1mIPIaT78rUv4uhUDLxxnS2/IUQ==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^3.0.0",
     "@nextcloud/upload": "^1.0.5",
-    "@nextcloud/vue": "^8.6.2",
+    "@nextcloud/vue": "^8.7.0",
     "crypto-js": "^4.2.0",
     "debounce": "^2.0.0",
     "emoji-mart-vue-fast": "^15.0.0",

--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
@@ -385,9 +385,4 @@ export default {
 .delete {
 	margin-right: auto;
 }
-
-// TODO remove after https://github.com/nextcloud-libraries/nextcloud-vue/issues/5228
-:deep(.modal-wrapper--small .modal-container) {
-	width: 400px !important;
-}
 </style>

--- a/src/components/ConversationSettings/DangerZone.vue
+++ b/src/components/ConversationSettings/DangerZone.vue
@@ -235,11 +235,6 @@ h4 {
 		color: var(--color-text-maxcontrast);
 	}
 	&__dialog {
-		// TODO remove after https://github.com/nextcloud-libraries/nextcloud-vue/issues/5228
-		:deep(.modal-wrapper--small .modal-container) {
-			width: 400px !important;
-		}
-
 		:deep(.modal-container) {
 			padding-block: 4px 8px;
 			padding-inline: 12px 8px;

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -871,11 +871,6 @@ export default {
 			const possibleMentions = response.data.ocs.data
 
 			possibleMentions.forEach(possibleMention => {
-				// TODO fix backend for userMention
-				if (!possibleMention.title && possibleMention.label) {
-					possibleMention.title = possibleMention.label
-				}
-
 				// Set icon for candidate mentions that are not for users.
 				if (possibleMention.source === 'calls') {
 					possibleMention.icon = 'icon-user-forced-white'

--- a/src/components/PermissionsEditor/PermissionsEditor.vue
+++ b/src/components/PermissionsEditor/PermissionsEditor.vue
@@ -266,9 +266,4 @@ export default {
 .button-update-permission {
 	margin: 0 auto;
 }
-
-// TODO remove after https://github.com/nextcloud-libraries/nextcloud-vue/issues/5228
-:deep(.modal-wrapper--small .modal-container) {
-	width: 400px !important;
-}
 </style>


### PR DESCRIPTION
* Fix #11601
* Fix #10565 
* Fix #8855 

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/fa785d34-0ed8-43e7-a4c2-b6b1f5284070)          | ![image](https://github.com/nextcloud/spreed/assets/93392545/31e732de-cc61-42a3-b682-d2ae0a900490)       |

### 🚧 Tasks

- [ ] NcRichContenteditable tribute is broken - to be fixed in 8.7.1

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required