### PR TITLE
fix(search): Hide search providers when not allowed to use Talk

### DIFF
--- a/lib/Search/ConversationSearch.php
+++ b/lib/Search/ConversationSearch.php
@@ -26,12 +26,14 @@ declare(strict_types=1);
 namespace OCA\Talk\Search;
 
 use OCA\Talk\AppInfo\Application;
+use OCA\Talk\Config;
 use OCA\Talk\Manager;
 use OCA\Talk\Room;
 use OCA\Talk\Service\AvatarService;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
+use OCP\IUserSession;
 use OCP\Search\IProvider;
 use OCP\Search\ISearchQuery;
 use OCP\Search\SearchResult;
@@ -44,6 +46,8 @@ class ConversationSearch implements IProvider {
 		protected Manager $manager,
 		protected IURLGenerator $url,
 		protected IL10N $l,
+		protected Config $talkConfig,
+		protected IUserSession $userSession,
 	) {
 	}
 
@@ -64,7 +68,12 @@ class ConversationSearch implements IProvider {
 	/**
 	 * @inheritDoc
 	 */
-	public function getOrder(string $route, array $routeParameters): int {
+	public function getOrder(string $route, array $routeParameters): ?int {
+		$currentUser = $this->userSession->getUser();
+		if ($currentUser && $this->talkConfig->isDisabledForUser($currentUser)) {
+			return null;
+		}
+
 		if (str_starts_with($route, Application::APP_ID . '.')) {
 			// Active app, prefer Talk results
 			return -1;

--- a/lib/Search/CurrentMessageSearch.php
+++ b/lib/Search/CurrentMessageSearch.php
@@ -48,6 +48,11 @@ class CurrentMessageSearch extends MessageSearch {
 	 * @inheritDoc
 	 */
 	public function getOrder(string $route, array $routeParameters): ?int {
+		$currentUser = $this->userSession->getUser();
+		if ($currentUser && $this->talkConfig->isDisabledForUser($currentUser)) {
+			return null;
+		}
+
 		if ($route === 'spreed.Page.showCall') {
 			// In conversation, prefer this search results
 			return -3;

--- a/lib/Search/MessageSearch.php
+++ b/lib/Search/MessageSearch.php
@@ -26,6 +26,7 @@ namespace OCA\Talk\Search;
 use OCA\Talk\AppInfo\Application;
 use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Chat\MessageParser;
+use OCA\Talk\Config;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Exceptions\RoomNotFoundException;
 use OCA\Talk\Exceptions\UnauthorizedException;
@@ -39,6 +40,7 @@ use OCP\Comments\IComment;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
+use OCP\IUserSession;
 use OCP\Search\FilterDefinition;
 use OCP\Search\IFilter;
 use OCP\Search\IFilteringProvider;
@@ -61,6 +63,8 @@ class MessageSearch implements IProvider, IFilteringProvider {
 		protected ITimeFactory $timeFactory,
 		protected IURLGenerator $url,
 		protected IL10N $l,
+		protected Config $talkConfig,
+		protected IUserSession $userSession,
 	) {
 	}
 
@@ -82,6 +86,11 @@ class MessageSearch implements IProvider, IFilteringProvider {
 	 * @inheritDoc
 	 */
 	public function getOrder(string $route, array $routeParameters): ?int {
+		$currentUser = $this->userSession->getUser();
+		if ($currentUser && $this->talkConfig->isDisabledForUser($currentUser)) {
+			return null;
+		}
+
 		if (str_starts_with($route, Application::APP_ID . '.')) {
 			// Active app, prefer Talk results
 			return -2;


### PR DESCRIPTION
## 🛠️ API Checklist

- Similar to https://github.com/nextcloud/spreed/pull/11615
- But for the providers which exist already on stable branches, so backporting it there to 28 (since then null is supported)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
