### PR TITLE
chore(deps): Bump @nextcloud/vue from 8.7.0 to 8.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^3.0.0",
         "@nextcloud/upload": "^1.0.5",
-        "@nextcloud/vue": "^8.7.0",
+        "@nextcloud/vue": "^8.7.1",
         "crypto-js": "^4.2.0",
         "debounce": "^2.0.0",
         "emoji-mart-vue-fast": "^15.0.0",
@@ -3910,9 +3910,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.7.0.tgz",
-      "integrity": "sha512-0SPazCAA7MjvhbNTxZv1kIf6LZ7C9XUq0eovEnBjeD95sd7yu98i4vdPwJw1mIPIaT78rUv4uhUDLxxnS2/IUQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.7.1.tgz",
+      "integrity": "sha512-vtfUz2OGqodga95Mzid6wNORQhXNnvl8de8+n3pGWNkuQzPojhUMxevnLT+fdxpJ/F9UWvG41C5cRKR7ChyYrQ==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -23487,9 +23487,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.7.0.tgz",
-      "integrity": "sha512-0SPazCAA7MjvhbNTxZv1kIf6LZ7C9XUq0eovEnBjeD95sd7yu98i4vdPwJw1mIPIaT78rUv4uhUDLxxnS2/IUQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.7.1.tgz",
+      "integrity": "sha512-vtfUz2OGqodga95Mzid6wNORQhXNnvl8de8+n3pGWNkuQzPojhUMxevnLT+fdxpJ/F9UWvG41C5cRKR7ChyYrQ==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^3.0.0",
     "@nextcloud/upload": "^1.0.5",
-    "@nextcloud/vue": "^8.7.0",
+    "@nextcloud/vue": "^8.7.1",
     "crypto-js": "^4.2.0",
     "debounce": "^2.0.0",
     "emoji-mart-vue-fast": "^15.0.0",

--- a/src/components/LeftSidebar/LeftSidebar.spec.js
+++ b/src/components/LeftSidebar/LeftSidebar.spec.js
@@ -42,6 +42,9 @@ describe('LeftSidebar.vue', () => {
 			localVue,
 			router,
 			store,
+			provide: {
+				'NcContent:setHasAppNavigation': () => {}
+			},
 			stubs: {
 				// to prevent user status fetching
 				NcAvatar: true,

--- a/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
@@ -1,4 +1,4 @@
-import { createLocalVue, mount, shallowMount } from '@vue/test-utils'
+import { createLocalVue, shallowMount } from '@vue/test-utils'
 import flushPromises from 'flush-promises' // TODO fix after migration to @vue/test-utils v2.0.0
 import { cloneDeep } from 'lodash'
 import { createPinia, setActivePinia } from 'pinia'
@@ -8,7 +8,6 @@ import Vuex, { Store } from 'vuex'
 import Check from 'vue-material-design-icons/Check.vue'
 import CheckAll from 'vue-material-design-icons/CheckAll.vue'
 
-import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 
 import Message from './Message.vue'
@@ -620,11 +619,12 @@ describe('Message.vue', () => {
 
 		test('Buttons bar is rendered on mouse over', async () => {
 			messageProps.sendingFailure = 'timeout'
-			const wrapper = mount(Message, {
+			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
 				stubs: {
 					MessageBody,
+					MessageButtonsBar,
 				},
 				propsData: messageProps,
 				provide: injected,
@@ -658,12 +658,11 @@ describe('Message.vue', () => {
 			jest.spyOn(global.Date, 'now')
 				.mockImplementation(() => mockDate)
 
-			const wrapper = mount(Message, {
+			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
 				stubs: {
 					MessageBody,
-					NcActionButton,
 					MessageButtonsBar,
 				},
 				propsData: messageProps,

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.spec.js
@@ -252,7 +252,10 @@ describe('Reactions.vue', () => {
 			const responseAdded = generateOCSResponse({ payload: addedReaction })
 			addReactionToMessage.mockResolvedValue(responseAdded)
 
-			const removedReaction = [...reactionsStored['🔥'].filter(obj => obj.actorId !== 'admin')] // remove the current user
+			const removedReaction = {
+				...reactionsStored,
+				'🔥': [...reactionsStored['🔥'].filter(obj => obj.actorId !== 'admin')] // remove the current user
+			}
 			const responseRemoved = generateOCSResponse({ payload: removedReaction })
 			removeReactionFromMessage.mockResolvedValue(responseRemoved)
 

--- a/src/store/conversationsStore.spec.js
+++ b/src/store/conversationsStore.spec.js
@@ -104,6 +104,8 @@ describe('conversationsStore', () => {
 
 		addParticipantOnceAction = jest.fn()
 		testStoreConfig.modules.participantsStore.actions.addParticipantOnce = addParticipantOnceAction
+
+		console.debug = jest.fn()
 	})
 
 	afterEach(() => {

--- a/src/stores/__tests__/reactions.spec.js
+++ b/src/stores/__tests__/reactions.spec.js
@@ -261,6 +261,7 @@ describe('reactionsStore', () => {
 			const errorResponse = generateOCSErrorResponse({ status: 500, payload: [] })
 			removeReactionFromMessage.mockResolvedValue(errorResponse)
 			jest.spyOn(vuexStore, 'commit')
+			console.error = jest.fn()
 
 			const message = {
 				actorId: 'admin',

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -120,15 +120,6 @@ global.BroadcastChannel = jest.fn(() => ({
 	addEventListener: jest.fn(),
 }))
 
-const originalConsoleError = console.error
-console.error = function(error) {
-	if (error?.message?.includes('Could not parse CSS stylesheet')) {
-		console.debug(error?.message)
-	} else {
-		originalConsoleError(error)
-	}
-}
-
 // Work around missing "URL.createObjectURL" (which is used in the code but not
 // relevant for the tests) in jsdom: https://github.com/jsdom/jsdom/issues/1721
 window.URL.createObjectURL = jest.fn()

--- a/src/utils/media/pipeline/MediaDevicesSource.spec.js
+++ b/src/utils/media/pipeline/MediaDevicesSource.spec.js
@@ -150,9 +150,11 @@ describe('MediaDevicesSource', () => {
 		getUserMediaVideoTrack = null
 		expectedAudioTrack = null
 		expectedVideoTrack = null
+		console.debug = jest.fn()
 	})
 
 	afterEach(() => {
+		jest.clearAllMocks()
 		mediaDevicesManager.getUserMedia.mockRestore()
 	})
 

--- a/src/utils/webrtc/RemoteVideoBlocker.spec.js
+++ b/src/utils/webrtc/RemoteVideoBlocker.spec.js
@@ -27,12 +27,17 @@ describe('RemoteVideoBlocker', () => {
 
 	beforeEach(() => {
 		jest.useFakeTimers()
+		console.error = jest.fn()
 
 		callParticipantModel = {
 			setVideoBlocked: jest.fn(),
 		}
 
 		remoteVideoBlocker = new RemoteVideoBlocker(callParticipantModel)
+	})
+
+	afterEach(() => {
+		jest.clearAllMocks()
 	})
 
 	test('blocks the video by default if not shown in some seconds', () => {


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from 8.6.2
Changelog: https://github.com/nextcloud-libraries/nextcloud-vue/releases/tag/v8.7.1

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

![image](https://github.com/nextcloud/spreed/assets/93392545/4feadbb3-f67f-40a5-acb9-ca6f8e2fe4d5)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible