### PR TITLE
fix(tests): Increase health-retries for mysql tests

### DIFF
--- a/.github/workflows/integration-mysql.yml
+++ b/.github/workflows/integration-mysql.yml
@@ -68,7 +68,7 @@ jobs:
           - 4444:3306/tcp
         env:
           MYSQL_ROOT_PASSWORD: rootpassword
-        options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 5
+        options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 10
 
     steps:
       - name: Set app env

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -71,7 +71,7 @@ jobs:
           - 4444:3306/tcp
         env:
           MYSQL_ROOT_PASSWORD: rootpassword
-        options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 5
+        options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 10
 
     steps:
       - name: Set app env


### PR DESCRIPTION
Looks like the mysql container switches to `unhealthy` too fast (could be dependent on how busy the server is). Since github waits longer then our 25 seconds (5s interval * 5 retries), we should increase the retries.
Relevant github code is at https://github.com/actions/runner/blob/d5c7097d2c4f3f40a029124bbf1bc4c9994929f5/src/Runner.Worker/ContainerOperationProvider.cs#L411-L426

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
