### PR TITLE
fix(MessagesGroup) : remove edit indicator for deleted messages

### DIFF
--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -131,7 +131,7 @@ export default {
 		},
 
 		getLastEditor() {
-			if (!this.lastEditTimestamp) {
+			if (!this.lastEditTimestamp || this.messages[0].messageType === 'comment_deleted') {
 				return ''
 			} else if (this.messages[0].lastEditActorId === this.actorId
 				&& this.messages[0].lastEditActorType === this.actorType) {


### PR DESCRIPTION
### ☑️ Resolves

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/84044328/b80772c9-986a-461c-af45-08f6e3abfd0f)     |![image](https://github.com/nextcloud/spreed/assets/84044328/5077dce3-8705-49aa-99df-60ad7225c15f)      |

