### PR TITLE
fix(messagesStore): don't update parent message in the store, if it hasn't been unchanged

### DIFF
--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -516,8 +516,7 @@ const actions = {
 	/**
 	 * Adds message to the store.
 	 *
-	 * If the message has a parent message object,
-	 * first it adds the parent to the store.
+	 * If the message has a parent message presented in the store, updates it as well.
 	 *
 	 * @param {object} context default store context;
 	 * @param {object} payload payload;
@@ -533,9 +532,9 @@ const actions = {
 				|| message.systemMessage === 'reaction_deleted'
 				|| message.systemMessage === 'reaction_revoked'
 				|| message.systemMessage === 'message_edited')) {
-			// If parent message is presented in store already, we update it
+			// If parent message is presented in store and is different, we update it
 			const parentInStore = context.getters.message(token, message.parent.id)
-			if (Object.keys(parentInStore).length !== 0) {
+			if (Object.keys(parentInStore).length !== 0 && JSON.stringify(parentInStore) !== JSON.stringify(message.parent)) {
 				context.commit('addMessage', { token, message: message.parent })
 				if (message.systemMessage === 'message_edited') {
 					EventBus.$emit('message-edited')
@@ -553,7 +552,7 @@ const actions = {
 			// Check existing messages for having a deleted message as parent, and update them
 			if (message.systemMessage === 'message_deleted') {
 				context.getters.messagesList(token)
-					.filter(storedMessage => storedMessage.parent?.id === message.parent.id)
+					.filter(storedMessage => storedMessage.parent?.id === message.parent.id && JSON.stringify(storedMessage.parent) !== JSON.stringify(message.parent))
 					.forEach(storedMessage => {
 						context.commit('addMessage', { token, message: Object.assign({}, storedMessage, { parent: message.parent }) })
 					})


### PR DESCRIPTION
### ☑️ Resolves

* Fix excessive store updates:
  * When first time loading the chat, we already have the parent message up-to-date from the API
  * `message_deleted`, `message_edited`, `reaction...` requested at the same time (not new) contains same parent message without changes, so we don't need to update it again and trigger sideEffect (messagesList re-render)
  * deleteMessage, editMessage, addReaction API requests return parent to update it. When it comes again with message long polling, we also don't need to update it

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible