### PR TITLE
fix(MessageForwader): provide value to check where component is being used

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -38,6 +38,7 @@
 
 <script>
 import debounce from 'debounce'
+import { provide } from 'vue'
 import PreventUnload from 'vue-prevent-unload'
 
 import { getCurrentUser } from '@nextcloud/auth'
@@ -81,6 +82,9 @@ export default {
 	},
 
 	setup() {
+		// Add provided value to check if we're in the main app or plugin
+		provide('Talk:isMainApp', true)
+
 		return {
 			isInCall: useIsInCall(),
 			isLeavingAfterSessionIssue: useSessionIssueHandler(),

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageForwarder.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageForwarder.vue
@@ -56,6 +56,8 @@
 
 <script>
 
+import { inject } from 'vue'
+
 import Check from 'vue-material-design-icons/Check.vue'
 
 import { showError } from '@nextcloud/dialogs'
@@ -90,6 +92,12 @@ export default {
 	},
 
 	emits: ['close'],
+
+	setup() {
+		return {
+			isTalkMainApp: inject('Talk:isMainApp', false)
+		}
+	},
 
 	data() {
 		return {
@@ -132,9 +140,7 @@ export default {
 		},
 
 		openConversation() {
-			const isTalkApp = IS_DESKTOP || window.location.pathname.includes('/apps/spreed') || window.location.pathname.includes('/call/')
-
-			if (!isTalkApp) {
+			if (!this.isTalkMainApp) {
 				// Native redirect to Talk from Files sidebar
 				const url = generateUrl('/call/{token}#message_{messageId}', {
 					token: this.selectedConversationToken,


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #11616 
  * When check how to handle redirect link, rely on App context, not the window.location or routes
  * Fine to keep as-is for stable releases, but ensure safer check process for future

## 🖌️ UI Checklist

No visual changes

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible