### PR TITLE
build: provide Typescript support 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
 	extends: [
 		'@nextcloud',
+		'@nextcloud/eslint-config/typescript',
 	],
 	globals: {
 		// @nextcloud/webpack-vue-config globals
@@ -12,6 +13,7 @@ module.exports = {
 	rules: {
 		'comma-dangle': 'off',
 		'jsdoc/no-defaults': 'off',
+		'@typescript-eslint/no-unused-vars': 'off',
 		'import/newline-after-import': 'warn',
 		'import/no-named-as-default-member': 'off',
 		'import/order': [

--- a/jest.config.js
+++ b/jest.config.js
@@ -86,6 +86,12 @@ module.exports = {
 	},
 
 	transform: {
+		'\\.ts$': ['ts-jest', {
+			useESM: true,
+			tsconfig: {
+				verbatimModuleSyntax: false,
+			},
+		}],
 		'\\.js$': 'babel-jest',
 		'\\.vue$': '@vue/vue2-jest',
 		'\\.tflite$': 'jest-transform-stub',

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "jest-mock-console": "^2.0.0",
         "jest-transform-stub": "^2.0.0",
         "regenerator-runtime": "^0.14.1",
+        "ts-jest": "^29.1.2",
         "vue-template-compiler": "^2.7.16",
         "wasm-check": "^2.1.2",
         "webpack-bundle-analyzer": "^4.10.1",
@@ -6728,6 +6729,18 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -13762,6 +13775,12 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -13859,6 +13878,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -18879,6 +18904,91 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.1.2",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.2.tgz",
+      "integrity": "sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==",
+      "dev": true,
+      "dependencies": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.3",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "^7.5.3",
+        "yargs-parser": "^21.0.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/types": "^29.0.0",
+        "babel-jest": "^29.0.0",
+        "jest": "^29.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/ts-jest/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ts-loader": {
@@ -25713,6 +25823,15 @@
         "update-browserslist-db": "^1.0.13"
       }
     },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
+      }
+    },
     "bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -30934,6 +31053,12 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -31011,6 +31136,12 @@
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "makeerror": {
       "version": "1.0.12",
@@ -34706,6 +34837,54 @@
       "dev": true,
       "peer": true,
       "requires": {}
+    },
+    "ts-jest": {
+      "version": "29.1.2",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.2.tgz",
+      "integrity": "sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==",
+      "dev": true,
+      "requires": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.3",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "^7.5.3",
+        "yargs-parser": "^21.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
+      }
     },
     "ts-loader": {
       "version": "9.4.4",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "jest-mock-console": "^2.0.0",
     "jest-transform-stub": "^2.0.0",
     "regenerator-runtime": "^0.14.1",
+    "ts-jest": "^29.1.2",
     "vue-template-compiler": "^2.7.16",
     "wasm-check": "^2.1.2",
     "webpack-bundle-analyzer": "^4.10.1",

--- a/src/components/AdminSettings/AllowedGroups.vue
+++ b/src/components/AdminSettings/AllowedGroups.vue
@@ -212,14 +212,14 @@ export default {
 			})
 
 			OCP.AppConfig.setValue('spreed', 'allowed_groups', JSON.stringify(groups), {
-				success: function() {
+				success: () => {
 					this.loading = false
 					this.loadingGroups = false
 					this.saveLabelAllowedGroups = t('spreed', 'Saved!')
-					setTimeout(function() {
+					setTimeout(() => {
 						this.saveLabelAllowedGroups = t('spreed', 'Save changes')
-					}.bind(this), 5000)
-				}.bind(this),
+					}, 5000)
+				},
 			})
 		},
 
@@ -233,14 +233,14 @@ export default {
 			})
 
 			OCP.AppConfig.setValue('spreed', 'start_conversations', JSON.stringify(groups), {
-				success: function() {
+				success: () => {
 					this.loading = false
 					this.loadingGroups = false
 					this.saveLabelStartConversations = t('spreed', 'Saved!')
-					setTimeout(function() {
+					setTimeout(() => {
 						this.saveLabelStartConversations = t('spreed', 'Save changes')
-					}.bind(this), 5000)
-				}.bind(this),
+					}, 5000)
+				},
 			})
 		},
 
@@ -248,9 +248,9 @@ export default {
 			this.loadingStartCalls = true
 
 			OCP.AppConfig.setValue('spreed', 'start_calls', this.startCalls.value, {
-				success: function() {
+				success: () => {
 					this.loadingStartCalls = false
-				}.bind(this),
+				},
 			})
 		},
 	},

--- a/src/components/AdminSettings/Federation.vue
+++ b/src/components/AdminSettings/Federation.vue
@@ -162,10 +162,10 @@ export default {
 			this.loading = true
 
 			OCP.AppConfig.setValue('spreed', 'federation_enabled', value ? 'yes' : 'no', {
-				success: function() {
+				success: () => {
 					this.loading = false
 					this.isFederationEnabled = value
-				}.bind(this),
+				},
 			})
 		},
 
@@ -173,10 +173,10 @@ export default {
 			this.loading = true
 
 			OCP.AppConfig.setValue('spreed', 'federation_incoming_enabled', value ? '1' : '0', {
-				success: function() {
+				success: () => {
 					this.loading = false
 					this.isFederationIncomingEnabled = value
-				}.bind(this),
+				},
 			})
 		},
 
@@ -184,10 +184,10 @@ export default {
 			this.loading = true
 
 			OCP.AppConfig.setValue('spreed', 'federation_outgoing_enabled', value ? '1' : '0', {
-				success: function() {
+				success: () => {
 					this.loading = false
 					this.isFederationOutgoingEnabled = value
-				}.bind(this),
+				},
 			})
 		},
 
@@ -195,10 +195,10 @@ export default {
 			this.loading = true
 
 			OCP.AppConfig.setValue('spreed', 'federation_only_trusted_servers', value ? '1' : '0', {
-				success: function() {
+				success: () => {
 					this.loading = false
 					this.isFederationOnlyTrustedServersEnabled = value
-				}.bind(this),
+				},
 			})
 		},
 
@@ -232,14 +232,14 @@ export default {
 			const groups = this.allowedGroups.map(group => typeof group === 'object' ? group.id : group)
 
 			OCP.AppConfig.setValue('spreed', 'federation_allowed_groups', JSON.stringify(groups), {
-				success: function() {
+				success: () => {
 					this.loading = false
 					this.loadingGroups = false
 					this.saveLabelAllowedGroups = t('spreed', 'Saved!')
-					setTimeout(function() {
+					setTimeout(() => {
 						this.saveLabelAllowedGroups = t('spreed', 'Save changes')
-					}.bind(this), 5000)
-				}.bind(this),
+					}, 5000)
+				},
 			})
 		},
 	},

--- a/src/components/AdminSettings/GeneralSettings.vue
+++ b/src/components/AdminSettings/GeneralSettings.vue
@@ -109,9 +109,9 @@ export default {
 			this.loadingDefaultGroupNotification = true
 
 			OCP.AppConfig.setValue('spreed', 'default_group_notification', this.defaultGroupNotification.value, {
-				success: function() {
+				success: () => {
 					this.loadingDefaultGroupNotification = false
-				}.bind(this),
+				},
 			})
 		},
 		saveConversationsFiles(checked) {
@@ -119,19 +119,19 @@ export default {
 			this.conversationsFiles = checked
 
 			OCP.AppConfig.setValue('spreed', 'conversations_files', this.conversationsFiles ? '1' : '0', {
-				success: function() {
+				success: () => {
 					if (!this.conversationsFiles) {
 						// When the file integration is disabled, the share integration is also disabled
 						OCP.AppConfig.setValue('spreed', 'conversations_files_public_shares', '0', {
-							success: function() {
+							success: () => {
 								this.conversationsFilesPublicShares = false
 								this.loadingConversationsFiles = false
-							}.bind(this),
+							},
 						})
 					} else {
 						this.loadingConversationsFiles = false
 					}
-				}.bind(this),
+				},
 			})
 		},
 		saveConversationsFilesPublicShares(checked) {
@@ -139,9 +139,9 @@ export default {
 			this.conversationsFilesPublicShares = checked
 
 			OCP.AppConfig.setValue('spreed', 'conversations_files_public_shares', this.conversationsFilesPublicShares ? '1' : '0', {
-				success: function() {
+				success: () => {
 					this.loadingConversationsFiles = false
-				}.bind(this),
+				},
 			})
 		},
 	},

--- a/src/components/AdminSettings/MatterbridgeIntegration.vue
+++ b/src/components/AdminSettings/MatterbridgeIntegration.vue
@@ -130,11 +130,11 @@ export default {
 		saveMatterbridgeEnabled() {
 			this.matterbridgeEnabled = !this.matterbridgeEnabled
 			OCP.AppConfig.setValue('spreed', 'enable_matterbridge', this.matterbridgeEnabled ? '1' : '0', {
-				success: function() {
+				success: () => {
 					if (!this.matterbridgeEnabled) {
 						stopAllBridges()
 					}
-				}.bind(this),
+				},
 			})
 		},
 

--- a/src/components/AdminSettings/RecordingServers.vue
+++ b/src/components/AdminSettings/RecordingServers.vue
@@ -193,15 +193,14 @@ export default {
 
 			this.servers = this.servers.filter(server => server.server.trim() !== '')
 
-			const self = this
 			OCP.AppConfig.setValue('spreed', 'recording_servers', JSON.stringify({
 				servers: this.servers,
 				secret: this.secret,
 			}), {
-				success() {
+				success: () => {
 					showSuccess(t('spreed', 'Recording backend settings saved'))
-					self.loading = false
-					self.toggleSave()
+					this.loading = false
+					this.toggleSave()
 				},
 			})
 		},
@@ -209,9 +208,9 @@ export default {
 		setRecordingConsent(value) {
 			this.loading = true
 			OCP.AppConfig.setValue('spreed', 'recording_consent', value, {
-				success: function() {
+				success: () => {
 					this.loading = false
-				}.bind(this),
+				},
 			})
 		},
 

--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -152,14 +152,13 @@ export default {
 		},
 
 		updateHideWarning() {
-			const self = this
-			self.loading = true
+			this.loading = true
 
 			OCP.AppConfig.setValue('spreed', 'hide_signaling_warning', this.hideWarning ? 'yes' : 'no', {
-				success() {
+				success: () => {
 					showSuccess(t('spreed', 'Missing high-performance backend warning hidden'))
-					self.loading = false
-					self.toggleSave()
+					this.loading = false
+					this.toggleSave()
 				},
 			})
 		},
@@ -174,15 +173,14 @@ export default {
 
 			this.servers = this.servers.filter(server => server.server.trim() !== '')
 
-			const self = this
 			OCP.AppConfig.setValue('spreed', 'signaling_servers', JSON.stringify({
 				servers: this.servers,
 				secret: this.secret,
 			}), {
-				success() {
+				success: () => {
 					showSuccess(t('spreed', 'High-performance backend settings saved'))
-					self.loading = false
-					self.toggleSave()
+					this.loading = false
+					this.toggleSave()
 				},
 			})
 		},

--- a/src/components/AdminSettings/StunServers.vue
+++ b/src/components/AdminSettings/StunServers.vue
@@ -133,13 +133,12 @@ export default {
 			})
 
 			this.servers = servers
-			const self = this
 
 			OCP.AppConfig.setValue('spreed', 'stun_servers', JSON.stringify(servers), {
-				success() {
+				success: () => {
 					showSuccess(t('spreed', 'STUN settings saved'))
-					self.loading = false
-					self.toggleSave()
+					this.loading = false
+					this.toggleSave()
 				},
 			})
 		},

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -264,10 +264,10 @@ export default {
 			const candidates = []
 
 			const pc = new RTCPeerConnection(config)
-			const timeout = setTimeout(function() {
+			const timeout = setTimeout(() => {
 				this.notifyTurnResult(candidates, timeout)
 				pc.close()
-			}.bind(this), 10000)
+			}, 10000)
 			pc.onicecandidate = this.iceCallback.bind(this, pc, candidates, timeout)
 			pc.onicegatheringstatechange = this.gatheringStateChange.bind(this, pc, candidates, timeout)
 
@@ -279,14 +279,14 @@ export default {
 			pc.createOffer(
 				offerOptions,
 			).then(
-				function(description) {
+				(description) => {
 					pc.setLocalDescription(description)
 				},
-				function(error) {
+				(error) => {
 					console.error('Error creating offer', error)
 					this.notifyTurnResult(candidates, timeout)
 					pc.close()
-				}.bind(this),
+				},
 			)
 		},
 

--- a/src/components/AdminSettings/TurnServers.vue
+++ b/src/components/AdminSettings/TurnServers.vue
@@ -148,14 +148,12 @@ export default {
 				servers.push(data)
 			})
 
-			const self = this
-
 			this.loading = true
 			OCP.AppConfig.setValue('spreed', 'turn_servers', JSON.stringify(servers), {
-				success() {
+				success: () => {
 					showSuccess(t('spreed', 'TURN settings saved'))
-					self.loading = false
-					self.toggleSave()
+					this.loading = false
+					this.toggleSave()
 				},
 			})
 		},

--- a/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsList/Participant/Participant.vue
@@ -376,7 +376,7 @@ import {
 	callSIPUnmutePhone,
 	callSIPSendDTMF,
 } from '../../../../../services/callsService.js'
-import { formattedTime } from '../../../../../utils/formattedTime.js'
+import { formattedTime } from '../../../../../utils/formattedTime.ts'
 import { readableNumber } from '../../../../../utils/readableNumber.js'
 import { getStatusMessage } from '../../../../../utils/userStatus.js'
 

--- a/src/components/TopBar/CallTime.vue
+++ b/src/components/TopBar/CallTime.vue
@@ -81,7 +81,7 @@ import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import NcPopover from '@nextcloud/vue/dist/Components/NcPopover.js'
 
 import { CALL } from '../../constants.js'
-import { formattedTime } from '../../utils/formattedTime.js'
+import { formattedTime } from '../../utils/formattedTime.ts'
 
 export default {
 	name: 'CallTime',

--- a/src/components/VolumeIndicator/VolumeIndicator.vue
+++ b/src/components/VolumeIndicator/VolumeIndicator.vue
@@ -39,7 +39,7 @@
 	</span>
 </template>
 
-<script>
+<script lang="ts">
 import Microphone from 'vue-material-design-icons/Microphone.vue'
 import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff.vue'
 
@@ -103,13 +103,13 @@ export default {
 			return this.size / 8
 		},
 
-		iconPrimaryHeight() {
+		iconPrimaryHeight(): number {
 			return this.audioPreviewAvailable
 				? this.size - this.iconOffsetBottom - this.currentVolumeIndicatorHeight
 				: this.size
 		},
 
-		iconOverlayHeight() {
+		iconOverlayHeight(): number {
 			return this.iconOffsetBottom / 2 + this.currentVolumeIndicatorHeight
 		},
 
@@ -137,9 +137,7 @@ export default {
 		computeVolumeLevel() {
 			const computedLevel = (this.volumeThreshold - this.currentVolume) / (this.volumeThreshold - this.overloadLimit)
 
-			if (computedLevel < 0) return 0
-			else if (computedLevel > 1) return 1
-			else return computedLevel
+			return Math.min(1, Math.max(0, computedLevel))
 		},
 	},
 }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -19,6 +19,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { translate, translatePlural } from '@nextcloud/l10n'
+
 declare global {
 	// @nextcloud/webpack-vue-config build globals
 	const appName: string
@@ -28,6 +30,12 @@ declare global {
 	 * Build constant to divide build for web app and desktop client
 	 */
 	const IS_DESKTOP: false
+
+	let __webpack_nonce__: ReturnType<typeof btoa>
+	let __webpack_public_path__: string
+
+	const t: typeof translate
+	const n: typeof translatePlural
 }
 
 export {}

--- a/src/types/vendor/@nextcloud/vue.d.ts
+++ b/src/types/vendor/@nextcloud/vue.d.ts
@@ -1,1 +1,2 @@
-declare module '@nextcloud/vue/dist/Directives/Tooltip.vue';
+declare module '@nextcloud/vue/dist/*.js'
+declare module '@nextcloud/vue/dist/*.vue'

--- a/src/types/vendor/l10n.d.ts
+++ b/src/types/vendor/l10n.d.ts
@@ -1,5 +1,0 @@
-// TODO re-declare functions from upstream library
-// import { translate, translatePlural } from '@nextcloud/l10n/dist/translation.d.ts'
-
-declare function t(app: string, text: string, vars?: { [key: string]: string }, number?: number, options?: any): string;
-declare function n(app: string, textSingular: string, textPlural: string, number: number, vars?: { [key: string]: string }, options?: any): string;

--- a/src/types/vendor/vue-material-design-icons.d.ts
+++ b/src/types/vendor/vue-material-design-icons.d.ts
@@ -1,2 +1,1 @@
-declare module 'vue-material-design-icons/VideoOff.vue'
-declare module 'vue-material-design-icons/MenuDown.vue'
+declare module 'vue-material-design-icons/*.vue'

--- a/src/utils/formattedTime.ts
+++ b/src/utils/formattedTime.ts
@@ -1,11 +1,10 @@
 /**
  * Calculates the stopwatch string given the time (ms)
  *
- * @param {number} time the time in ms
- * @param {boolean} [condensed=false] the format of string to show
- * @return {string} The formatted time
+ * @param time the time in ms
+ * @param [condensed=false] the format of string to show
  */
-function formattedTime(time, condensed = false) {
+function formattedTime(time: number, condensed: boolean = false): string {
 	if (!time) {
 		return condensed ? '--:--' : '-- : --'
 	}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,20 @@
 {
-	"include": ["./src/**/*.ts"],
+	"include": ["./src/**/*.ts", "./src/**/*.vue"],
 	"exclude": ["node_modules", "vendor"],
 	"compilerOptions": {
 		"outDir": "./js",
 		"allowJs": true,
-		"module": "CommonJS",
+		"checkJs": true,
+		"allowImportingTsExtensions": true,
+		"lib": ["ESNext"],
+		"module": "ESNext",
 		"moduleResolution": "bundler",
 		"verbatimModuleSyntax": true,
 		"target": "ES2020",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
+	},
+	"vueCompilerOptions": {
+		"target": 2.7,
 	}
 }

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -31,6 +31,7 @@ module.exports = mergeWithRules({
 			test: 'match',
 			loader: 'replace',
 			options: 'replace',
+			use: 'replace',
 		},
 	},
 })({
@@ -61,6 +62,17 @@ module.exports = mergeWithRules({
 					'tributejs',
 					'webdav',
 				]),
+			},
+			{
+				test: /\.tsx?$/,
+				use: [{
+					loader: 'esbuild-loader',
+					options: {
+						// Implicitly set as TS loader so only <script lang="ts"> Vue SFCs will be transpiled
+						loader: 'ts',
+						target: 'es2020',
+					},
+				}]
 			},
 			{
 				test: /\.wasm$/i,


### PR DESCRIPTION
### ☑️ Resolves

* Reuse existing options from `@nextloud/webpack-vue-config` to compile Typescript files (standalone and Vue SFC scripts)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes

### 🚧 Tasks

- [ ] Check compile options
- [ ] Check Eslint rules

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible