### PR TITLE
fix(messagesStore): allow defined falsy (0) values at state.firstKnown

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -567,6 +567,7 @@ export default {
 				})
 
 				if (this.$store.getters.getFirstKnownMessageId(this.token) === null) {
+					let startingMessageId = 0
 					// first time load, initialize important properties
 					if (this.loadChatInLegacyMode || focusMessageId === null) {
 						// Start from unread marker
@@ -574,6 +575,7 @@ export default {
 							token: this.token,
 							id: this.conversation.lastReadMessage,
 						})
+						startingMessageId = this.conversation.lastReadMessage
 						this.$store.dispatch('setLastKnownMessageId', {
 							token: this.token,
 							id: this.conversation.lastReadMessage,
@@ -584,6 +586,7 @@ export default {
 							token: this.token,
 							id: focusMessageId,
 						})
+						startingMessageId = focusMessageId
 						this.$store.dispatch('setLastKnownMessageId', {
 							token: this.token,
 							id: focusMessageId,
@@ -599,7 +602,6 @@ export default {
 
 					} else {
 						// Get chat messages before last read message and after it
-						const startingMessageId = this.$store.getters.getFirstKnownMessageId(this.token)
 						await this.getMessageContext(startingMessageId)
 						const startingMessageFound = this.focusMessage(startingMessageId, false, focusMessageId !== null)
 

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -192,7 +192,7 @@ const getters = {
 	},
 
 	getFirstKnownMessageId: (state) => (token) => {
-		if (state.firstKnown[token]) {
+		if (state.firstKnown[token] !== undefined) {
 			return state.firstKnown[token]
 		}
 		return null


### PR DESCRIPTION
### ☑️ Resolves

* Fix broken `getContext`, when `conversation.lastReadMessage === 0`

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/93392545/82f3dc32-e23e-45ce-9dce-8fc189c9f3fc)          | ![image](https://github.com/nextcloud/spreed/assets/93392545/785d5cfe-3f1f-4d2e-b39e-1d4ccf85ba96)        |

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible