### PR TITLE
Ignore label of data channel when processing received messages.

### DIFF
--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -228,10 +228,6 @@ CallParticipantModel.prototype = {
 			return
 		}
 
-		if (label !== 'status' && label !== 'JanusDataChannel') {
-			return
-		}
-
 		if (data.type === 'speaking') {
 			this.set('speaking', true)
 		} else if (data.type === 'stoppedSpeaking') {

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -1594,25 +1594,21 @@ export default function initWebRtc(signaling, _callParticipantCollection, _local
 	})
 
 	webrtc.on('channelMessage', function(peer, label, data) {
-		if (label === 'status' || label === 'JanusDataChannel') {
-			if (data.type === 'audioOn') {
-				webrtc.emit('unmute', { id: peer.id, name: 'audio' })
-			} else if (data.type === 'audioOff') {
-				webrtc.emit('mute', { id: peer.id, name: 'audio' })
-			} else if (data.type === 'videoOn') {
-				webrtc.emit('unmute', { id: peer.id, name: 'video' })
-			} else if (data.type === 'videoOff') {
-				webrtc.emit('mute', { id: peer.id, name: 'video' })
-			} else if (data.type === 'nickChanged') {
-				const name = typeof (data.payload) === 'string' ? data.payload : data.payload.name
-				webrtc.emit('nick', { id: peer.id, name })
-			} else if (data.type === 'speaking' || data.type === 'stoppedSpeaking') {
-				// Valid known messages, handled by CallParticipantModel.js
-			} else {
-				console.debug('Unknown message type %s from %s datachannel', data.type, label, data, peer.id, peer)
-			}
+		if (data.type === 'audioOn') {
+			webrtc.emit('unmute', { id: peer.id, name: 'audio' })
+		} else if (data.type === 'audioOff') {
+			webrtc.emit('mute', { id: peer.id, name: 'audio' })
+		} else if (data.type === 'videoOn') {
+			webrtc.emit('unmute', { id: peer.id, name: 'video' })
+		} else if (data.type === 'videoOff') {
+			webrtc.emit('mute', { id: peer.id, name: 'video' })
+		} else if (data.type === 'nickChanged') {
+			const name = typeof (data.payload) === 'string' ? data.payload : data.payload.name
+			webrtc.emit('nick', { id: peer.id, name })
+		} else if (data.type === 'speaking' || data.type === 'stoppedSpeaking') {
+			// Valid known messages, handled by CallParticipantModel.js
 		} else {
-			console.debug('Unknown message from %s datachannel', label, data, peer.id, peer)
+			console.debug('Unknown message type %s from %s datachannel', data.type, label, data, peer.id, peer)
 		}
 	})
 


### PR DESCRIPTION
This is necessary for support of Janus 1.x which will use the (random) id of the publisher that sent the message as label.

### ☑️ Resolves

* Fix #10003

### Testing

- Setup HPB with Janux 1.x without this PR
- Notice "talking" indication is not working in the browser
- Apply changes from this PR
- Reload and restart call
- "talking" indication is working again

@ivansss @SystemKeeper @mahibi FYI for the mobile apps.