### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "d1cf95fdadf4fdc9bc8fa693d0e7e2943fca5e72"
+                "reference": "3159cf7101a6490f5f780b2312bada1768aef0ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/d1cf95fdadf4fdc9bc8fa693d0e7e2943fca5e72",
-                "reference": "d1cf95fdadf4fdc9bc8fa693d0e7e2943fca5e72",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/3159cf7101a6490f5f780b2312bada1768aef0ed",
+                "reference": "3159cf7101a6490f5f780b2312bada1768aef0ed",
                 "shasum": ""
             },
             "require": {
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-02-24T00:30:01+00:00"
+            "time": "2024-02-28T13:29:33+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency