### PR TITLE
feat(federation): Federate unread information to proxies

### DIFF
--- a/docs/chat.md
+++ b/docs/chat.md
@@ -426,6 +426,10 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
         + `404 Not Found` When the room could not be found for the participant,
         or the participant is a guest.
 
+    - Data in case of `200 OK`:
+        + **Without** `federation-v1` capability empty
+        + **With** `federation-v1` capability, see array definition in [Get user´s conversations](conversation.md#get-user-s-conversations)
+
     - Header:
 
 | field                     | type | Description                                                                                                                                                                                                     |

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -448,6 +448,10 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
         + `404 Not Found` When the room could not be found for the participant,
         or the participant is a guest.
 
+    - Data in case of `200 OK`:
+        + **Without** `federation-v1` capability empty
+        + **With** `federation-v1` capability, see array definition in [Get user´s conversations](conversation.md#get-user-s-conversations)
+
     - Header:
 
 | field                     | type | Description                                                                                                                                                                                                     |

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -1082,13 +1082,20 @@ class ChatController extends AEnvironmentAwareController {
 	/**
 	 * Mark a chat as unread
 	 *
-	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{X-Chat-Last-Common-Read?: numeric-string}>
+	 * @return DataResponse<Http::STATUS_OK, TalkRoom, array{X-Chat-Last-Common-Read?: numeric-string}>
 	 *
 	 * 200: Read marker set successfully
 	 */
-	#[NoAdminRequired]
-	#[RequireParticipant]
+	#[FederationSupported]
+	#[PublicPage]
+	#[RequireAuthenticatedParticipant]
 	public function markUnread(): DataResponse {
+		if ($this->room->getRemoteServer() !== '') {
+			/** @var \OCA\Talk\Federation\Proxy\TalkV1\Controller\ChatController $proxy */
+			$proxy = \OCP\Server::get(\OCA\Talk\Federation\Proxy\TalkV1\Controller\ChatController::class);
+			return $proxy->markUnread($this->room, $this->participant, $this->getResponseFormat());
+		}
+
 		$message = $this->room->getLastMessage();
 		$unreadId = 0;
 

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -55,6 +55,7 @@ use OCA\Talk\Service\AvatarService;
 use OCA\Talk\Service\BotService;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\ReminderService;
+use OCA\Talk\Service\RoomFormatter;
 use OCA\Talk\Service\SessionService;
 use OCA\Talk\Share\Helper\FilesMetadataCache;
 use OCA\Talk\Share\RoomShareProvider;
@@ -90,6 +91,7 @@ use OCP\UserStatus\IUserStatus;
  * @psalm-import-type TalkChatMessage from ResponseDefinitions
  * @psalm-import-type TalkChatMessageWithParent from ResponseDefinitions
  * @psalm-import-type TalkChatReminder from ResponseDefinitions
+ * @psalm-import-type TalkRoom from ResponseDefinitions
  */
 class ChatController extends AEnvironmentAwareController {
 	/** @var string[] */
@@ -102,6 +104,7 @@ class ChatController extends AEnvironmentAwareController {
 		private IUserManager $userManager,
 		private IAppManager $appManager,
 		private ChatManager $chatManager,
+		private RoomFormatter $roomFormatter,
 		private ReactionManager $reactionManager,
 		private ParticipantService $participantService,
 		private SessionService $sessionService,
@@ -1045,19 +1048,35 @@ class ChatController extends AEnvironmentAwareController {
 	 *
 	 * @param int $lastReadMessage ID if the last read message
 	 * @psalm-param non-negative-int $lastReadMessage
-	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{X-Chat-Last-Common-Read?: numeric-string}>
+	 * @return DataResponse<Http::STATUS_OK, TalkRoom, array{X-Chat-Last-Common-Read?: numeric-string}>
 	 *
 	 * 200: Read marker set successfully
 	 */
-	#[NoAdminRequired]
-	#[RequireParticipant]
+	#[FederationSupported]
+	#[PublicPage]
+	#[RequireAuthenticatedParticipant]
 	public function setReadMarker(int $lastReadMessage): DataResponse {
-		$this->participantService->updateLastReadMessage($this->participant, $lastReadMessage);
-		$headers = [];
-		if ($this->participant->getAttendee()->getReadPrivacy() === Participant::PRIVACY_PUBLIC) {
-			$headers = ['X-Chat-Last-Common-Read' => (string) $this->chatManager->getLastCommonReadMessage($this->room)];
+		if ($this->room->getRemoteServer() !== '') {
+			/** @var \OCA\Talk\Federation\Proxy\TalkV1\Controller\ChatController $proxy */
+			$proxy = \OCP\Server::get(\OCA\Talk\Federation\Proxy\TalkV1\Controller\ChatController::class);
+			return $proxy->setReadMarker($this->room, $this->participant, $this->getResponseFormat(), $lastReadMessage);
 		}
-		return new DataResponse([], Http::STATUS_OK, $headers);
+
+		$this->participantService->updateLastReadMessage($this->participant, $lastReadMessage);
+		$attendee = $this->participant->getAttendee();
+
+		$headers = $lastCommonRead = [];
+		if ($attendee->getReadPrivacy() === Participant::PRIVACY_PUBLIC) {
+			$lastCommonRead[$this->room->getId()] = $this->chatManager->getLastCommonReadMessage($this->room);
+			$headers = ['X-Chat-Last-Common-Read' => (string) $lastCommonRead[$this->room->getId()]];
+		}
+
+		return new DataResponse($this->roomFormatter->formatRoom(
+			$this->getResponseFormat(),
+			$lastCommonRead,
+			$this->room,
+			$this->participant,
+		), Http::STATUS_OK, $headers);
 	}
 
 	/**

--- a/lib/Federation/BackendNotifier.php
+++ b/lib/Federation/BackendNotifier.php
@@ -278,6 +278,8 @@ class BackendNotifier {
 	/**
 	 * Send information to remote participants that a message was posted
 	 * Sent from Host server to Remote participant server
+	 *
+	 * @param array{unreadMessages: int, unreadMention: bool, unreadMentionDirect: bool} $unreadInfo
 	 */
 	public function sendMessageUpdate(
 		string $remoteServer,
@@ -286,6 +288,7 @@ class BackendNotifier {
 		string $accessToken,
 		string $localToken,
 		array $messageData,
+		array $unreadInfo,
 	): void {
 		$remote = $this->prepareRemoteUrl($remoteServer);
 
@@ -299,6 +302,7 @@ class BackendNotifier {
 				'sharedSecret' => $accessToken,
 				'remoteToken' => $localToken,
 				'messageData' => $messageData,
+				'unreadInfo' => $unreadInfo,
 			],
 		);
 
@@ -324,6 +328,8 @@ class BackendNotifier {
 	}
 
 	protected function sendUpdateToRemote(string $remote, ICloudFederationNotification $notification, int $try = 0): void {
+		\OC::$server->getLogger()->error('sendUpdateToRemote');
+		\OC::$server->getLogger()->error(json_encode($notification->getMessage()));
 		$response = $this->federationProviderManager->sendNotification($remote, $notification);
 		if (!is_array($response)) {
 			$this->jobList->add(RetryJob::class,

--- a/lib/Federation/CloudFederationProviderTalk.php
+++ b/lib/Federation/CloudFederationProviderTalk.php
@@ -32,6 +32,7 @@ use OCA\Talk\Config;
 use OCA\Talk\Events\AAttendeeRemovedEvent;
 use OCA\Talk\Events\ARoomModifiedEvent;
 use OCA\Talk\Events\AttendeesAddedEvent;
+use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Exceptions\RoomNotFoundException;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
@@ -309,7 +310,7 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 
 	/**
 	 * @param int $remoteAttendeeId
-	 * @param array{remoteServerUrl: string, sharedSecret: string, remoteToken: string, messageData: array{remoteMessageId: int, actorType: string, actorId: string, actorDisplayName: string, messageType: string, systemMessage: string, expirationDatetime: string, message: string, messageParameter: string}} $notification
+	 * @param array{remoteServerUrl: string, sharedSecret: string, remoteToken: string, messageData: array{remoteMessageId: int, actorType: string, actorId: string, actorDisplayName: string, messageType: string, systemMessage: string, expirationDatetime: string, message: string, messageParameter: string}, unreadInfo: array{unreadMessages: int, unreadMention: bool, unreadMentionDirect: bool}} $notification
 	 * @return array
 	 * @throws ActionNotSupportedException
 	 * @throws AuthenticationFailedException
@@ -338,7 +339,9 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 		$message->setActorDisplayName($notification['messageData']['actorDisplayName']);
 		$message->setMessageType($notification['messageData']['messageType']);
 		$message->setSystemMessage($notification['messageData']['systemMessage']);
-		$message->setExpirationDateTime(new \DateTimeImmutable($notification['messageData']['expirationDatetime']));
+		if ($notification['messageData']['expirationDatetime']) {
+			$message->setExpirationDateTime(new \DateTimeImmutable($notification['messageData']['expirationDatetime']));
+		}
 		$message->setMessage($notification['messageData']['message']);
 		$message->setMessageParameters($notification['messageData']['messageParameter']);
 		$this->proxyCacheMessagesMapper->insert($message);
@@ -350,6 +353,19 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 				$this->proxyCacheMessages->set($cacheKey, $notification['messageData']['remoteMessageId'], 300);
 			}
 		}
+
+		try {
+			$participant = $this->participantService->getParticipant($room, $invite->getUserId(), false);
+		} catch (ParticipantNotFoundException) {
+			throw new ShareNotFound();
+		}
+
+		$this->participantService->updateUnreadInfoForProxyParticipant(
+			$participant,
+			$notification['unreadInfo']['unreadMessages'],
+			$notification['unreadInfo']['unreadMention'],
+			$notification['unreadInfo']['unreadMentionDirect'],
+		);
 
 		return [];
 	}

--- a/lib/Federation/CloudFederationProviderTalk.php
+++ b/lib/Federation/CloudFederationProviderTalk.php
@@ -340,11 +340,18 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 		$message->setMessageType($notification['messageData']['messageType']);
 		$message->setSystemMessage($notification['messageData']['systemMessage']);
 		if ($notification['messageData']['expirationDatetime']) {
-			$message->setExpirationDateTime(new \DateTimeImmutable($notification['messageData']['expirationDatetime']));
+			$message->setExpirationDatetime(new \DateTimeImmutable($notification['messageData']['expirationDatetime']));
 		}
 		$message->setMessage($notification['messageData']['message']);
 		$message->setMessageParameters($notification['messageData']['messageParameter']);
+		// FIXME catch unique constraint violation
 		$this->proxyCacheMessagesMapper->insert($message);
+
+		$lastMessageId = $room->getLastMessageId();
+		if ($notification['messageData']['remoteMessageId'] > $lastMessageId) {
+			$lastMessageId = (int) $notification['messageData']['remoteMessageId'];
+		}
+		$this->roomService->setLastMessageInfo($room, $lastMessageId, new \DateTime());
 
 		if ($this->proxyCacheMessages instanceof ICache) {
 			$cacheKey = sha1(json_encode([$notification['remoteServerUrl'], $notification['remoteToken']]));

--- a/lib/Model/ProxyCacheMessages.php
+++ b/lib/Model/ProxyCacheMessages.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Model;
 
+use OCA\Talk\ResponseDefinitions;
 use OCP\AppFramework\Db\Entity;
 
 /**
@@ -47,14 +48,16 @@ use OCP\AppFramework\Db\Entity;
  * @method string getMessageType()
  * @method void setSystemMessage(?string $systemMessage)
  * @method string|null getSystemMessage()
- * @method void setExpirationDateTime(?\DateTimeImmutable $expirationDateTime)
- * @method \DateTimeImmutable|null getExpirationDateTime()
+ * @method void setExpirationDatetime(?\DateTimeImmutable $expirationDatetime)
+ * @method \DateTimeImmutable|null getExpirationDatetime()
  * @method void setMessage(?string $message)
  * @method string|null getMessage()
  * @method void setMessageParameters(?string $messageParameters)
  * @method string|null getMessageParameters()
+ *
+ * @psalm-import-type TalkRoomProxyMessage from ResponseDefinitions
  */
-class ProxyCacheMessages extends Entity {
+class ProxyCacheMessages extends Entity implements \JsonSerializable {
 
 	protected string $localToken = '';
 	protected string $remoteServerUrl = '';
@@ -82,5 +85,26 @@ class ProxyCacheMessages extends Entity {
 		$this->addType('expirationDatetime', 'datetime');
 		$this->addType('message', 'string');
 		$this->addType('messageParameters', 'string');
+	}
+
+	/**
+	 * @return TalkRoomProxyMessage
+	 */
+	public function jsonSerialize(): array {
+		$expirationTimestamp = 0;
+		if ($this->getExpirationDatetime()) {
+			$expirationTimestamp = $this->getExpirationDatetime()->getTimestamp();
+		}
+
+		return [
+			'actorType' => $this->getActorType(),
+			'actorId' => $this->getActorId(),
+			'actorDisplayName' => $this->getActorDisplayName(),
+			'expirationTimestamp' => $expirationTimestamp,
+			'messageType' => $this->getMessageType(),
+			'systemMessage' => $this->getSystemMessage() ?? '',
+			'message' => $this->getMessage() ?? '',
+			'messageParameters' => json_decode($this->getMessageParameters() ?? '[]', true),
+		];
 	}
 }

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -91,6 +91,19 @@ namespace OCA\Talk;
  *     silent?: bool,
  * }
  *
+ * @psalm-type TalkRoomProxyMessage = array{
+ *     actorDisplayName: string,
+ *     actorId: string,
+ *     actorType: string,
+ *     expirationTimestamp: int,
+ *     message: string,
+ *     messageParameters: array<string, array<string, mixed>>,
+ *     messageType: string,
+ *     systemMessage: string,
+ * }
+ *
+ * @psalm-type TalkRoomLastMessage = TalkChatMessage|TalkRoomProxyMessage
+ *
  * @psalm-type TalkChatMessageWithParent = TalkChatMessage&array{parent?: TalkChatMessage}
  *
  * @psalm-type TalkChatReminder = array{
@@ -208,7 +221,7 @@ namespace OCA\Talk;
  *     isFavorite: bool,
  *     lastActivity: int,
  *     lastCommonReadMessage: int,
- *     lastMessage: TalkChatMessage|array<empty>,
+ *     lastMessage: TalkRoomLastMessage|array<empty>,
  *     lastPing: int,
  *     lastReadMessage: int,
  *     listable: int,

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -342,8 +342,16 @@ class Room {
 		$this->lastActivity = $now;
 	}
 
+	public function getLastMessageId(): int {
+		return $this->lastMessageId;
+	}
+
+	public function setLastMessageId(int $lastMessageId): void {
+		$this->lastMessageId = $lastMessageId;
+	}
+
 	public function getLastMessage(): ?IComment {
-		if ($this->lastMessageId && $this->lastMessage === null) {
+		if ($this->lastMessageId && $this->lastMessage === null && $this->getRemoteServer() === '') {
 			$this->lastMessage = $this->manager->loadLastCommentInfo($this->lastMessageId);
 			if ($this->lastMessage === null) {
 				$this->lastMessageId = 0;

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -249,6 +249,14 @@ class ParticipantService {
 		$this->attendeeMapper->update($attendee);
 	}
 
+	public function updateUnreadInfoForProxyParticipant(Participant $participant, int $unreadMessageCount, bool $hasMention, bool $hadDirectMention): void {
+		$attendee = $participant->getAttendee();
+		$attendee->setLastReadMessage($unreadMessageCount);
+		$attendee->setLastMentionMessage($hasMention ? 1 : 0);
+		$attendee->setLastMentionDirect($hadDirectMention ? 1 : 0);
+		$this->attendeeMapper->update($attendee);
+	}
+
 	public function updateFavoriteStatus(Participant $participant, bool $isFavorite): void {
 		$attendee = $participant->getAttendee();
 		$attendee->setFavorite($isFavorite);

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1283,28 +1283,26 @@ class ParticipantService {
 	}
 
 	/**
-	 * @param Room $room
-	 * @param string[] $userIds
-	 * @param int $messageId
+	 * @param string[] $actorIds
 	 * @param string[] $usersDirectlyMentioned
 	 */
-	public function markUsersAsMentioned(Room $room, array $userIds, int $messageId, array $usersDirectlyMentioned): void {
+	public function markUsersAsMentioned(Room $room, string $actorType, array $actorIds, int $messageId, array $actorsDirectlyMentioned): void {
 		$update = $this->connection->getQueryBuilder();
 		$update->update('talk_attendees')
 			->set('last_mention_message', $update->createNamedParameter($messageId, IQueryBuilder::PARAM_INT))
 			->where($update->expr()->eq('room_id', $update->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))
-			->andWhere($update->expr()->eq('actor_type', $update->createNamedParameter(Attendee::ACTOR_USERS)))
-			->andWhere($update->expr()->in('actor_id', $update->createNamedParameter($userIds, IQueryBuilder::PARAM_STR_ARRAY)))
+			->andWhere($update->expr()->eq('actor_type', $update->createNamedParameter($actorType)))
+			->andWhere($update->expr()->in('actor_id', $update->createNamedParameter($actorIds, IQueryBuilder::PARAM_STR_ARRAY)))
 			->andWhere($update->expr()->lt('last_mention_message', $update->createNamedParameter($messageId, IQueryBuilder::PARAM_INT)));
 		$update->executeStatement();
 
-		if (!empty($usersDirectlyMentioned)) {
+		if (!empty($actorsDirectlyMentioned)) {
 			$update = $this->connection->getQueryBuilder();
 			$update->update('talk_attendees')
 				->set('last_mention_direct', $update->createNamedParameter($messageId, IQueryBuilder::PARAM_INT))
 				->where($update->expr()->eq('room_id', $update->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)))
-				->andWhere($update->expr()->eq('actor_type', $update->createNamedParameter(Attendee::ACTOR_USERS)))
-				->andWhere($update->expr()->in('actor_id', $update->createNamedParameter($usersDirectlyMentioned, IQueryBuilder::PARAM_STR_ARRAY)))
+				->andWhere($update->expr()->eq('actor_type', $update->createNamedParameter($actorType)))
+				->andWhere($update->expr()->in('actor_id', $update->createNamedParameter($actorsDirectlyMentioned, IQueryBuilder::PARAM_STR_ARRAY)))
 				->andWhere($update->expr()->lt('last_mention_direct', $update->createNamedParameter($messageId, IQueryBuilder::PARAM_INT)));
 			$update->executeStatement();
 		}

--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -329,6 +329,13 @@ class RoomFormatter {
 					&& $currentParticipant->hasModeratorPermissions(false)
 					&& $this->talkConfig->canUserEnableSIP($currentUser);
 			}
+		} elseif ($attendee->getActorType() === Attendee::ACTOR_FEDERATED_USERS) {
+			$lastReadMessage = $attendee->getLastReadMessage();
+			$lastMention = $attendee->getLastMentionMessage();
+			$lastMentionDirect = $attendee->getLastMentionDirect();
+			$roomData['unreadMessages'] = $this->chatManager->getUnreadCount($room, $lastReadMessage);
+			$roomData['unreadMention'] = $lastMention !== 0 && $lastReadMessage < $lastMention;
+			$roomData['unreadMentionDirect'] = $lastMentionDirect !== 0 && $lastReadMessage < $lastMentionDirect;
 		} else {
 			$roomData['lastReadMessage'] = $attendee->getLastReadMessage();
 		}

--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -287,7 +287,13 @@ class RoomFormatter {
 
 		if ($attendee->getActorType() === Attendee::ACTOR_USERS) {
 			$currentUser = $this->userManager->get($attendee->getActorId());
-			if ($currentUser instanceof IUser) {
+			if ($room->getRemoteServer() !== '') {
+				// For proxy conversations the information is the real counter,
+				// not the message ID requiring math afterward.
+				$roomData['unreadMessages'] = $attendee->getLastReadMessage();
+				$roomData['unreadMention'] = (bool) $attendee->getLastMentionMessage();
+				$roomData['unreadMentionDirect'] = (bool) $attendee->getLastMentionDirect();
+			} elseif ($currentUser instanceof IUser) {
 				$lastReadMessage = $attendee->getLastReadMessage();
 				if ($lastReadMessage === -1) {
 					/*

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -874,6 +874,18 @@ class RoomService {
 		$room->setLastActivity($message->getCreationDateTime());
 	}
 
+	public function setLastMessageInfo(Room $room, int $messageId, \DateTime $dateTime): void {
+		$update = $this->db->getQueryBuilder();
+		$update->update('talk_rooms')
+			->set('last_message', $update->createNamedParameter($messageId))
+			->set('last_activity', $update->createNamedParameter($dateTime, 'datetime'))
+			->where($update->expr()->eq('id', $update->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)));
+		$update->executeStatement();
+
+		$room->setLastMessageId($messageId);
+		$room->setLastActivity($dateTime);
+	}
+
 	public function setLastActivity(Room $room, \DateTime $now): void {
 		$update = $this->db->getQueryBuilder();
 		$update->update('talk_rooms')

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -478,7 +478,7 @@
                     "lastMessage": {
                         "oneOf": [
                             {
-                                "$ref": "#/components/schemas/ChatMessage"
+                                "$ref": "#/components/schemas/RoomLastMessage"
                             },
                             {
                                 "type": "array",
@@ -586,6 +586,62 @@
                     "unreadMessages": {
                         "type": "integer",
                         "format": "int64"
+                    }
+                }
+            },
+            "RoomLastMessage": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/ChatMessage"
+                    },
+                    {
+                        "$ref": "#/components/schemas/RoomProxyMessage"
+                    }
+                ]
+            },
+            "RoomProxyMessage": {
+                "type": "object",
+                "required": [
+                    "actorDisplayName",
+                    "actorId",
+                    "actorType",
+                    "expirationTimestamp",
+                    "message",
+                    "messageParameters",
+                    "messageType",
+                    "systemMessage"
+                ],
+                "properties": {
+                    "actorDisplayName": {
+                        "type": "string"
+                    },
+                    "actorId": {
+                        "type": "string"
+                    },
+                    "actorType": {
+                        "type": "string"
+                    },
+                    "expirationTimestamp": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "messageParameters": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "messageType": {
+                        "type": "string"
+                    },
+                    "systemMessage": {
+                        "type": "string"
                     }
                 }
             }

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -537,7 +537,7 @@
                     "lastMessage": {
                         "oneOf": [
                             {
-                                "$ref": "#/components/schemas/ChatMessage"
+                                "$ref": "#/components/schemas/RoomLastMessage"
                             },
                             {
                                 "type": "array",
@@ -645,6 +645,62 @@
                     "unreadMessages": {
                         "type": "integer",
                         "format": "int64"
+                    }
+                }
+            },
+            "RoomLastMessage": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/ChatMessage"
+                    },
+                    {
+                        "$ref": "#/components/schemas/RoomProxyMessage"
+                    }
+                ]
+            },
+            "RoomProxyMessage": {
+                "type": "object",
+                "required": [
+                    "actorDisplayName",
+                    "actorId",
+                    "actorType",
+                    "expirationTimestamp",
+                    "message",
+                    "messageParameters",
+                    "messageType",
+                    "systemMessage"
+                ],
+                "properties": {
+                    "actorDisplayName": {
+                        "type": "string"
+                    },
+                    "actorId": {
+                        "type": "string"
+                    },
+                    "actorType": {
+                        "type": "string"
+                    },
+                    "expirationTimestamp": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "messageParameters": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "messageType": {
+                        "type": "string"
+                    },
+                    "systemMessage": {
+                        "type": "string"
                     }
                 }
             }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -6198,6 +6198,7 @@
                     "chat"
                 ],
                 "security": [
+                    {},
                     {
                         "bearer_auth": []
                     },
@@ -6277,7 +6278,9 @@
                                                 "meta": {
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
-                                                "data": {}
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Room"
+                                                }
                                             }
                                         }
                                     }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -6297,6 +6297,7 @@
                     "chat"
                 ],
                 "security": [
+                    {},
                     {
                         "bearer_auth": []
                     },
@@ -6365,7 +6366,9 @@
                                                 "meta": {
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
-                                                "data": {}
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Room"
+                                                }
                                             }
                                         }
                                     }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -1002,7 +1002,7 @@
                     "lastMessage": {
                         "oneOf": [
                             {
-                                "$ref": "#/components/schemas/ChatMessage"
+                                "$ref": "#/components/schemas/RoomLastMessage"
                             },
                             {
                                 "type": "array",
@@ -1110,6 +1110,62 @@
                     "unreadMessages": {
                         "type": "integer",
                         "format": "int64"
+                    }
+                }
+            },
+            "RoomLastMessage": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/ChatMessage"
+                    },
+                    {
+                        "$ref": "#/components/schemas/RoomProxyMessage"
+                    }
+                ]
+            },
+            "RoomProxyMessage": {
+                "type": "object",
+                "required": [
+                    "actorDisplayName",
+                    "actorId",
+                    "actorType",
+                    "expirationTimestamp",
+                    "message",
+                    "messageParameters",
+                    "messageType",
+                    "systemMessage"
+                ],
+                "properties": {
+                    "actorDisplayName": {
+                        "type": "string"
+                    },
+                    "actorId": {
+                        "type": "string"
+                    },
+                    "actorType": {
+                        "type": "string"
+                    },
+                    "expirationTimestamp": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "messageParameters": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "messageType": {
+                        "type": "string"
+                    },
+                    "systemMessage": {
+                        "type": "string"
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -884,7 +884,7 @@
                     "lastMessage": {
                         "oneOf": [
                             {
-                                "$ref": "#/components/schemas/ChatMessage"
+                                "$ref": "#/components/schemas/RoomLastMessage"
                             },
                             {
                                 "type": "array",
@@ -992,6 +992,62 @@
                     "unreadMessages": {
                         "type": "integer",
                         "format": "int64"
+                    }
+                }
+            },
+            "RoomLastMessage": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/ChatMessage"
+                    },
+                    {
+                        "$ref": "#/components/schemas/RoomProxyMessage"
+                    }
+                ]
+            },
+            "RoomProxyMessage": {
+                "type": "object",
+                "required": [
+                    "actorDisplayName",
+                    "actorId",
+                    "actorType",
+                    "expirationTimestamp",
+                    "message",
+                    "messageParameters",
+                    "messageType",
+                    "systemMessage"
+                ],
+                "properties": {
+                    "actorDisplayName": {
+                        "type": "string"
+                    },
+                    "actorId": {
+                        "type": "string"
+                    },
+                    "actorType": {
+                        "type": "string"
+                    },
+                    "expirationTimestamp": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "messageParameters": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "messageType": {
+                        "type": "string"
+                    },
+                    "systemMessage": {
+                        "type": "string"
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -6179,6 +6179,7 @@
                     "chat"
                 ],
                 "security": [
+                    {},
                     {
                         "bearer_auth": []
                     },
@@ -6247,7 +6248,9 @@
                                                 "meta": {
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
-                                                "data": {}
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Room"
+                                                }
                                             }
                                         }
                                     }

--- a/openapi.json
+++ b/openapi.json
@@ -6080,6 +6080,7 @@
                     "chat"
                 ],
                 "security": [
+                    {},
                     {
                         "bearer_auth": []
                     },
@@ -6159,7 +6160,9 @@
                                                 "meta": {
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
-                                                "data": {}
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Room"
+                                                }
                                             }
                                         }
                                     }

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -40,6 +40,7 @@ use OCA\Talk\Service\AvatarService;
 use OCA\Talk\Service\BotService;
 use OCA\Talk\Service\ParticipantService;
 use OCA\Talk\Service\ReminderService;
+use OCA\Talk\Service\RoomFormatter;
 use OCA\Talk\Service\SessionService;
 use OCA\Talk\Share\Helper\FilesMetadataCache;
 use OCA\Talk\Share\RoomShareProvider;
@@ -71,6 +72,7 @@ class ChatControllerTest extends TestCase {
 	private $appManager;
 	/** @var ChatManager|MockObject */
 	protected $chatManager;
+	private RoomFormatter|MockObject $roomFormatter;
 	/** @var ReactionManager|MockObject */
 	protected $reactionManager;
 	/** @var ParticipantService|MockObject */
@@ -129,6 +131,7 @@ class ChatControllerTest extends TestCase {
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->chatManager = $this->createMock(ChatManager::class);
+		$this->roomFormatter = $this->createMock(RoomFormatter::class);
 		$this->reactionManager = $this->createMock(ReactionManager::class);
 		$this->participantService = $this->createMock(ParticipantService::class);
 		$this->sessionService = $this->createMock(SessionService::class);
@@ -172,6 +175,7 @@ class ChatControllerTest extends TestCase {
 			$this->userManager,
 			$this->appManager,
 			$this->chatManager,
+			$this->roomFormatter,
 			$this->reactionManager,
 			$this->participantService,
 			$this->sessionService,


### PR DESCRIPTION
## 🛠️ API Checklist

### 🚧 Tasks

- [x] Federate unread and mention info
- [x] Populate unread and mention info on conversation object on proxy
- [x] Proxy read marker updates
- [x] Expose last message info again
- [x] Actually track mentioning

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
