### PR TITLE
fix(desktop): allow avatar menu on desktop

### DIFF
--- a/src/components/AvatarWrapper/AvatarWrapper.vue
+++ b/src/components/AvatarWrapper/AvatarWrapper.vue
@@ -35,7 +35,7 @@
 			:display-name="name"
 			:menu-container="menuContainerWithFallback"
 			:disable-tooltip="disableTooltip"
-			:disable-menu="isDisabledMenu"
+			:disable-menu="disableMenu"
 			:show-user-status="showUserStatus"
 			:show-user-status-compact="showUserStatusCompact"
 			:preloaded-user-status="preloadedUserStatus"
@@ -172,11 +172,6 @@ export default {
 		},
 		menuContainerWithFallback() {
 			return this.menuContainer ?? this.$store.getters.getMainContainerSelector()
-		},
-		isDisabledMenu() {
-			// NcAvatarMenu doesn't work on Desktop
-			// See: https://github.com/nextcloud/talk-desktop/issues/34
-			return IS_DESKTOP || this.disableMenu
 		},
 	},
 }

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -25,7 +25,7 @@
 			class="conversation-icon"
 			:offline="isPeerInactive"
 			:item="conversation"
-			:disable-menu="disableMenu"
+			:disable-menu="false"
 			show-user-online-status
 			:hide-favorite="false"
 			:hide-call="false" />
@@ -298,12 +298,6 @@ export default {
 
 		participantsInCallAriaLabel() {
 			return n('spreed', '%n participant in call', '%n participants in call', this.$store.getters.participantsInCall(this.token))
-		},
-
-		disableMenu() {
-			// NcAvatarMenu doesn't work on Desktop
-			// See: https://github.com/nextcloud/talk-desktop/issues/34
-			return IS_DESKTOP
 		},
 
 		supportedReactions() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/talk-desktop/issues/34
* Requires https://github.com/nextcloud/talk-desktop/pull/540

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏚️ Before | 🏡 After |
|------------|----------|
| ![image](https://github.com/nextcloud/spreed/assets/25978914/816deda8-a038-4861-919d-41b45a02db81) | ![image](https://github.com/nextcloud/spreed/assets/25978914/ece702a2-d070-42de-9215-2ee6370cf207)|

### 🚧 Tasks

- [x] Remove disabling the avatar menu on desktop

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
