### PR TITLE
Release 17.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,39 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 17.1.6 – 2024-02-29
+### Changed
+- Update translations
+
+### Fixed
+- fix(webrtc): Ignore label of data channel when processing received messages for Janus 1.x compatibility
+  [#11668](https://github.com/nextcloud/spreed/issues/11668)
+- fix(notifications): Fix notification action label length with utf8 languages
+  [#11620](https://github.com/nextcloud/spreed/issues/11620)
+- fix(chat): Fix forwarding messages from conversations in the right sidebar
+  [#11609](https://github.com/nextcloud/spreed/issues/11609)
+
+## 16.0.11 – 2024-02-29
+### Changed
+- Update translations
+
+### Fixed
+- fix(webrtc): Ignore label of data channel when processing received messages for Janus 1.x compatibility
+  [#11669](https://github.com/nextcloud/spreed/issues/11669)
+- fix(notifications): Fix notification action label length with utf8 languages
+  [#11619](https://github.com/nextcloud/spreed/issues/11619)
+- fix(chat): Fix forwarding messages from conversations in the right sidebar
+  [#11611](https://github.com/nextcloud/spreed/issues/11611)
+
 ## 17.1.5 – 2024-01-25
 ### Fixed
--  fix(attachments): Don't allow selecting shared folders as attachment folder
-   [#11430](https://github.com/nextcloud/spreed/issues/11430)
+- fix(attachments): Don't allow selecting shared folders as attachment folder
+  [#11430](https://github.com/nextcloud/spreed/issues/11430)
 
 ## 16.0.10 – 2024-01-25
 ### Fixed
--  fix(attachments): Don't allow selecting shared folders as attachment folder
-   [#11431](https://github.com/nextcloud/spreed/issues/11431)
+- fix(attachments): Don't allow selecting shared folders as attachment folder
+  [#11431](https://github.com/nextcloud/spreed/issues/11431)
 
 ## 17.1.4 – 2023-12-19
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>17.1.5</version>
+	<version>17.1.6</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk",
-	"version": "17.1.5",
+	"version": "17.1.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk",
-			"version": "17.1.5",
+			"version": "17.1.6",
 			"license": "agpl",
 			"dependencies": {
 				"@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "talk",
-	"version": "17.1.5",
+	"version": "17.1.6",
 	"private": true,
 	"description": "",
 	"author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 17.1.6 – 2024-02-29
### Changed
- Update translations

### Fixed
- fix(webrtc): Ignore label of data channel when processing received messages for Janus 1.x compatibility [#11668](https://github.com/nextcloud/spreed/issues/11668)
- fix(notifications): Fix notification action label length with utf8 languages [#11620](https://github.com/nextcloud/spreed/issues/11620)
- fix(chat): Fix forwarding messages from conversations in the right sidebar [#11609](https://github.com/nextcloud/spreed/issues/11609)