### PR TITLE
Tighten MessageType and ActorType usage

### DIFF
--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -84,6 +84,9 @@ class ChatManager {
 	public const VERB_MESSAGE_DELETED = 'comment_deleted';
 	public const VERB_REACTION = 'reaction';
 	public const VERB_REACTION_DELETED = 'reaction_deleted';
+	public const VERB_VOICE_MESSAGE = 'voice-message';
+	public const VERB_RECORD_AUDIO = 'record-audio';
+	public const VERB_RECORD_VIDEO = 'record-video';
 
 	protected ICache $cache;
 	protected ICache $unreadCountCache;

--- a/lib/Chat/ChatManager.php
+++ b/lib/Chat/ChatManager.php
@@ -116,6 +116,7 @@ class ChatManager {
 	/**
 	 * Sends a new message to the given chat.
 	 *
+	 * @psalm-param Attendee::ACTOR_* $actorType
 	 * @param bool $shouldSkipLastMessageUpdate If multiple messages will be posted
 	 *             (e.g. when adding multiple users to a room) we can skip the last
 	 *             message and last activity update until the last entry was created

--- a/lib/Chat/CommentsManager.php
+++ b/lib/Chat/CommentsManager.php
@@ -25,6 +25,7 @@ namespace OCA\Talk\Chat;
 
 use OC\Comments\Comment;
 use OC\Comments\Manager;
+use OCA\Talk\Model\Attendee;
 use OCP\Comments\IComment;
 use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -66,7 +67,7 @@ class CommentsManager extends Manager {
 	}
 
 	/**
-	 * @param string $actorType
+	 * @psalm-param Attendee::ACTOR_* $actorType
 	 * @param string $actorId
 	 * @param string[] $messageIds
 	 * @return array
@@ -100,6 +101,7 @@ class CommentsManager extends Manager {
 	 * @param string $objectType Limit the search by object type
 	 * @param string[] $objectIds Limit the search by object ids
 	 * @param string $verb Limit the verb of the comment
+	 * @psalm-param ?Attendee::ACTOR_* $actorType
 	 * @return list<IComment>
 	 */
 	public function searchForObjectsWithFilters(string $search, string $objectType, array $objectIds, string $verb, ?\DateTimeImmutable $since, ?\DateTimeImmutable $until, ?string $actorType, ?string $actorId, int $offset, int $limit = 50): array {

--- a/lib/Chat/MessageParser.php
+++ b/lib/Chat/MessageParser.php
@@ -112,6 +112,9 @@ class MessageParser {
 		}
 	}
 
+	/**
+	 * @psalm-param Attendee::ACTOR_* $actorType
+	 */
 	protected function getActorInformation(Message $message, string $actorType, string $actorId, string $displayName = ''): array {
 		if ($actorType === Attendee::ACTOR_USERS) {
 			$tempDisplayName = $this->userManager->getDisplayName($actorId);

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -490,11 +490,11 @@ class SystemMessage implements IEventListener {
 				$metaData = $parameters['metaData'] ?? [];
 				if (isset($metaData['messageType'])) {
 					if ($metaData['messageType'] === 'voice-message') {
-						$chatMessage->setMessageType('voice-message');
+						$chatMessage->setMessageType(ChatManager::VERB_VOICE_MESSAGE);
 					} elseif ($metaData['messageType'] === 'record-audio') {
-						$chatMessage->setMessageType('record-audio');
+						$chatMessage->setMessageType(ChatManager::VERB_RECORD_AUDIO);
 					} elseif ($metaData['messageType'] === 'record-video') {
-						$chatMessage->setMessageType('record-video');
+						$chatMessage->setMessageType(ChatManager::VERB_RECORD_VIDEO);
 					} else {
 						$chatMessage->setMessageType(ChatManager::VERB_MESSAGE);
 					}

--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -843,6 +843,9 @@ class SystemMessage implements IEventListener {
 		return $this->getActor($room, $comment->getActorType(), $comment->getActorId());
 	}
 
+	/**
+	 * @psalm-param Attendee::ACTOR_* $actorType
+	 */
 	protected function getActor(Room $room, string $actorType, string $actorId): array {
 		if ($actorType === Attendee::ACTOR_GUESTS || $actorType === Attendee::ACTOR_EMAILS) {
 			return $this->getGuest($room, $actorType, $actorId);

--- a/lib/Chat/ReactionManager.php
+++ b/lib/Chat/ReactionManager.php
@@ -28,6 +28,7 @@ namespace OCA\Talk\Chat;
 use OCA\Talk\Exceptions\ReactionAlreadyExistsException;
 use OCA\Talk\Exceptions\ReactionNotSupportedException;
 use OCA\Talk\Exceptions\ReactionOutOfContextException;
+use OCA\Talk\Model\Attendee;
 use OCA\Talk\Participant;
 use OCA\Talk\ResponseDefinitions;
 use OCA\Talk\Room;
@@ -56,7 +57,7 @@ class ReactionManager {
 	 * Add reaction
 	 *
 	 * @param Room $chat
-	 * @param string $actorType
+	 * @psalm-param Attendee::ACTOR_* $actorType
 	 * @param string $actorId
 	 * @param integer $messageId
 	 * @param string $reaction
@@ -99,7 +100,7 @@ class ReactionManager {
 	 * Delete reaction
 	 *
 	 * @param Room $chat
-	 * @param string $actorType
+	 * @psalm-param Attendee::ACTOR_* $actorType
 	 * @param string $actorId
 	 * @param integer $messageId
 	 * @param string $reaction
@@ -159,8 +160,10 @@ class ReactionManager {
 			$message = $this->messageParser->createMessage($chat, $participant, $comment, $this->l);
 			$this->messageParser->parseMessage($message);
 
+			/** @var Attendee::ACTOR_* $actorType */
+			$actorType = $comment->getActorType();
 			$reactions[$comment->getMessage()][] = [
-				'actorType' => $comment->getActorType(),
+				'actorType' => $actorType,
 				'actorId' => $comment->getActorId(),
 				'actorDisplayName' => $message->getActorDisplayName(),
 				'timestamp' => $comment->getCreationDateTime()->getTimestamp(),

--- a/lib/Listener/DisplayNameListener.php
+++ b/lib/Listener/DisplayNameListener.php
@@ -51,6 +51,9 @@ class DisplayNameListener implements IEventListener {
 		}
 	}
 
+	/**
+	 * @psalm-param Attendee::ACTOR_* $actorType
+	 */
 	protected function updateCachedName(string $actorType, string $actorId, string $newName): void {
 		$this->participantService->updateDisplayNameForActor(
 			$actorType,

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -318,7 +318,7 @@ class Manager {
 	}
 
 	/**
-	 * @param string $actorType
+	 * @psalm-param Attendee::ACTOR_* $actorType
 	 * @param string $actorId
 	 * @param array $sessionIds A list of talk sessions to consider for loading (otherwise no session is loaded)
 	 * @param bool $includeLastMessage

--- a/lib/Model/Attachment.php
+++ b/lib/Model/Attachment.php
@@ -34,8 +34,6 @@ use OCP\AppFramework\Db\Entity;
  * @method int getMessageTime()
  * @method void setObjectType(string $objectType)
  * @method string getObjectType()
- * @method void setActorType(string $actorType)
- * @method string getActorType()
  * @method void setActorId(string $actorId)
  * @method string getActorId()
  */
@@ -62,7 +60,10 @@ class Attachment extends Entity {
 	/** @var string */
 	protected $objectType;
 
-	/** @var string */
+	/**
+	 * @var string
+	 * @psalm-var Attendee::ACTOR_*
+	 */
 	protected $actorType;
 
 	/** @var string */
@@ -75,6 +76,20 @@ class Attachment extends Entity {
 		$this->addType('objectType', 'string');
 		$this->addType('actorType', 'string');
 		$this->addType('actorId', 'string');
+	}
+
+	/**
+	 * @psalm-param Attendee::ACTOR_* $actorType
+	 */
+	public function setActorType(string $actorType): void {
+		$this->actorType = $actorType;
+	}
+
+	/**
+	 * @psalm-return Attendee::ACTOR_*
+	 */
+	public function getActorType(): string {
+		return $this->actorType;
 	}
 
 	/**

--- a/lib/Model/Attendee.php
+++ b/lib/Model/Attendee.php
@@ -28,8 +28,6 @@ use OCP\AppFramework\Db\Entity;
 /**
  * @method void setRoomId(int $roomId)
  * @method int getRoomId()
- * @method void setActorType(string $actorType)
- * @method string getActorType()
  * @method void setActorId(string $actorId)
  * @method string getActorId()
  * @method void setDisplayName(string $displayName)
@@ -111,7 +109,10 @@ class Attendee extends Entity {
 	/** @var int */
 	protected $roomId;
 
-	/** @var string */
+	/**
+	 * @var string
+	 * @psalm-var Attendee::ACTOR_*
+	 */
 	protected $actorType;
 
 	/** @var string */
@@ -189,6 +190,20 @@ class Attendee extends Entity {
 		$this->addType('invitedCloudId', 'string');
 		$this->addType('phoneNumber', 'string');
 		$this->addType('callId', 'string');
+	}
+
+	/**
+	 * @psalm-param Attendee::ACTOR_* $actorType
+	 */
+	public function setActorType(string $actorType): void {
+		$this->actorType = $actorType;
+	}
+
+	/**
+	 * @psalm-return Attendee::ACTOR_*
+	 */
+	public function getActorType(): string {
+		return $this->actorType;
 	}
 
 	public function getDisplayName(): string {

--- a/lib/Model/AttendeeMapper.php
+++ b/lib/Model/AttendeeMapper.php
@@ -46,7 +46,7 @@ class AttendeeMapper extends QBMapper {
 
 	/**
 	 * @param int $roomId
-	 * @param string $actorType
+	 * @psalm-param Attendee::ACTOR_* $actorType
 	 * @param string $actorId
 	 * @return Attendee
 	 * @throws DoesNotExistException

--- a/lib/Model/Consent.php
+++ b/lib/Model/Consent.php
@@ -30,8 +30,6 @@ use OCP\AppFramework\Db\Entity;
 /**
  * @method void setToken(string $token)
  * @method string getToken()
- * @method void setActorType(string $actorType)
- * @method string getActorType()
  * @method void setActorId(string $actorId)
  * @method string getActorId()
  * @method void setDateTime(\DateTime $dateTime)
@@ -39,7 +37,10 @@ use OCP\AppFramework\Db\Entity;
  */
 class Consent extends Entity implements \JsonSerializable {
 	protected string $token = '';
-	protected string $actorType = '';
+	/**
+	 * @psalm-var Attendee::ACTOR_*
+	 */
+	protected string $actorType;
 	protected string $actorId = '';
 	protected ?\DateTime $dateTime = null;
 
@@ -48,6 +49,20 @@ class Consent extends Entity implements \JsonSerializable {
 		$this->addType('actorType', 'string');
 		$this->addType('actorId', 'string');
 		$this->addType('dateTime', 'datetime');
+	}
+
+	/**
+	 * @psalm-param Attendee::ACTOR_* $actorType
+	 */
+	public function setActorType(string $actorType): void {
+		$this->actorType = $actorType;
+	}
+
+	/**
+	 * @psalm-return Attendee::ACTOR_*
+	 */
+	public function getActorType(): string {
+		return $this->actorType;
 	}
 
 	public function jsonSerialize(): array {

--- a/lib/Model/ConsentMapper.php
+++ b/lib/Model/ConsentMapper.php
@@ -63,6 +63,7 @@ class ConsentMapper extends QBMapper {
 	}
 
 	/**
+	 * @psalm-param Attendee::ACTOR_* $actorType
 	 * @return Consent[]
 	 */
 	public function findForActor(string $actorType, string $actorId): array {
@@ -75,6 +76,9 @@ class ConsentMapper extends QBMapper {
 		return $this->findEntities($query);
 	}
 
+	/**
+	 * @psalm-param Attendee::ACTOR_* $actorType
+	 */
 	public function deleteByActor(string $actorType, string $actorId): int {
 		$query = $this->db->getQueryBuilder();
 		$query->delete($this->getTableName())
@@ -85,6 +89,7 @@ class ConsentMapper extends QBMapper {
 	}
 
 	/**
+	 * @psalm-param Attendee::ACTOR_* $actorType
 	 * @return Consent[]
 	 */
 	public function findForTokenByActor(string $token, string $actorType, string $actorId): array {

--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -40,8 +40,11 @@ class Message {
 	/** @var bool */
 	protected $visible = true;
 
-	/** @var string */
-	protected $type = '';
+	/**
+	 * @var string
+	 * @psalm-var ChatManager::VERB_*
+	 */
+	protected $type;
 
 	/** @var string */
 	protected $message = '';
@@ -131,10 +134,16 @@ class Message {
 		return $this->rawMessage;
 	}
 
+	/**
+	 * @psalm-param ChatManager::VERB_* $type
+	 */
 	public function setMessageType(string $type): void {
 		$this->type = $type;
 	}
 
+	/**
+	 * @return ChatManager::VERB_* $type
+	 */
 	public function getMessageType(): string {
 		return $this->type;
 	}

--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -55,8 +55,11 @@ class Message {
 	/** @var array */
 	protected $parameters = [];
 
-	/** @var string */
-	protected $actorType = '';
+	/**
+	 * @var string
+	 * @psalm-var Attendee::ACTOR_*
+	 */
+	protected $actorType;
 
 	/** @var string */
 	protected $actorId = '';
@@ -148,6 +151,9 @@ class Message {
 		return $this->type;
 	}
 
+	/**
+	 * @psalm-param Attendee::ACTOR_* $type
+	 */
 	public function setActor(string $type, string $id, string $displayName): void {
 		$this->actorType = $type;
 		$this->actorId = $id;
@@ -161,6 +167,9 @@ class Message {
 		$this->lastEditTimestamp = $timestamp;
 	}
 
+	/**
+	 * @psalm-return Attendee::ACTOR_*
+	 */
 	public function getActorType(): string {
 		return $this->actorType;
 	}

--- a/lib/Model/Poll.php
+++ b/lib/Model/Poll.php
@@ -40,8 +40,6 @@ use OCP\AppFramework\Db\Entity;
  * @method string getVotes()
  * @method void setNumVoters(int $numVoters)
  * @method int getNumVoters()
- * @method void setActorType(string $actorType)
- * @method string getActorType()
  * @method void setActorId(string $actorId)
  * @method string getActorId()
  * @method void setDisplayName(string $displayName)
@@ -67,7 +65,10 @@ class Poll extends Entity {
 	protected string $options = '';
 	protected string $votes = '';
 	protected int $numVoters = 0;
-	protected string $actorType = '';
+	/**
+	 * @psalm-var Attendee::ACTOR_*
+	 */
+	protected string $actorType;
 	protected string $actorId = '';
 	protected ?string $displayName = null;
 	protected int $status = self::STATUS_OPEN;
@@ -86,6 +87,20 @@ class Poll extends Entity {
 		$this->addType('status', 'int');
 		$this->addType('resultMode', 'int');
 		$this->addType('maxVotes', 'int');
+	}
+
+	/**
+	 * @psalm-param Attendee::ACTOR_* $actorType
+	 */
+	public function setActorType(string $actorType): void {
+		$this->actorType = $actorType;
+	}
+
+	/**
+	 * @psalm-return Attendee::ACTOR_*
+	 */
+	public function getActorType(): string {
+		return $this->actorType;
 	}
 
 	/**

--- a/lib/Model/ProxyCacheMessages.php
+++ b/lib/Model/ProxyCacheMessages.php
@@ -39,8 +39,6 @@ use OCP\AppFramework\Db\Entity;
  * @method string getRemoteToken()
  * @method void setRemoteMessageId(int $remoteMessageId)
  * @method int getRemoteMessageId()
- * @method void setActorType(string $actorType)
- * @method string getActorType()
  * @method void setActorId(string $actorId)
  * @method string getActorId()
  * @method void setActorDisplayName(string $actorDisplayName)
@@ -62,7 +60,10 @@ class ProxyCacheMessages extends Entity implements \JsonSerializable {
 	protected string $remoteServerUrl = '';
 	protected string $remoteToken = '';
 	protected int $remoteMessageId = 0;
-	protected string $actorType = '';
+	/**
+	 * @psalm-var Attendee::ACTOR_*
+	 */
+	protected string $actorType;
 	protected string $actorId = '';
 	protected ?string $actorDisplayName = null;
 	/**
@@ -102,6 +103,20 @@ class ProxyCacheMessages extends Entity implements \JsonSerializable {
 	 */
 	public function getMessageType(): string {
 		return $this->messageType;
+	}
+
+	/**
+	 * @psalm-param Attendee::ACTOR_* $actorType
+	 */
+	public function setActorType(string $actorType): void {
+		$this->actorType = $actorType;
+	}
+
+	/**
+	 * @psalm-return Attendee::ACTOR_*
+	 */
+	public function getActorType(): string {
+		return $this->actorType;
 	}
 
 	/**

--- a/lib/Model/ProxyCacheMessages.php
+++ b/lib/Model/ProxyCacheMessages.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Model;
 
+use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\ResponseDefinitions;
 use OCP\AppFramework\Db\Entity;
 
@@ -44,8 +45,6 @@ use OCP\AppFramework\Db\Entity;
  * @method string getActorId()
  * @method void setActorDisplayName(string $actorDisplayName)
  * @method string getActorDisplayName()
- * @method void setMessageType(string $messageType)
- * @method string getMessageType()
  * @method void setSystemMessage(?string $systemMessage)
  * @method string|null getSystemMessage()
  * @method void setExpirationDatetime(?\DateTimeImmutable $expirationDatetime)
@@ -66,7 +65,11 @@ class ProxyCacheMessages extends Entity implements \JsonSerializable {
 	protected string $actorType = '';
 	protected string $actorId = '';
 	protected ?string $actorDisplayName = null;
-	protected ?string $messageType = null;
+	/**
+	 * @var string
+	 * @psalm-var ChatManager::VERB_*
+	 */
+	protected string $messageType;
 	protected ?string $systemMessage = null;
 	protected ?\DateTimeImmutable $expirationDatetime = null;
 	protected ?string $message = null;
@@ -85,6 +88,20 @@ class ProxyCacheMessages extends Entity implements \JsonSerializable {
 		$this->addType('expirationDatetime', 'datetime');
 		$this->addType('message', 'string');
 		$this->addType('messageParameters', 'string');
+	}
+
+	/**
+	 * @psalm-param ChatManager::VERB_* $type
+	 */
+	public function setMessageType(string $type): void {
+		$this->messageType = $type;
+	}
+
+	/**
+	 * @return ChatManager::VERB_* $type
+	 */
+	public function getMessageType(): string {
+		return $this->messageType;
 	}
 
 	/**

--- a/lib/Model/Vote.php
+++ b/lib/Model/Vote.php
@@ -35,8 +35,6 @@ use OCP\AppFramework\Db\Entity;
  * @method int getPollId()
  * @method void setRoomId(int $roomId)
  * @method int getRoomId()
- * @method void setActorType(string $actorType)
- * @method string getActorType()
  * @method void setActorId(string $actorId)
  * @method string getActorId()
  * @method void setDisplayName(string $displayName)
@@ -49,7 +47,10 @@ use OCP\AppFramework\Db\Entity;
 class Vote extends Entity {
 	protected int $pollId = 0;
 	protected int $roomId = 0;
-	protected string $actorType = '';
+	/**
+	 * @psalm-var Attendee::ACTOR_*
+	 */
+	protected string $actorType;
 	protected string $actorId = '';
 	protected ?string $displayName = null;
 	protected ?int $optionId = null;
@@ -61,6 +62,20 @@ class Vote extends Entity {
 		$this->addType('actorId', 'string');
 		$this->addType('displayName', 'string');
 		$this->addType('optionId', 'int');
+	}
+
+	/**
+	 * @psalm-param Attendee::ACTOR_* $actorType
+	 */
+	public function setActorType(string $actorType): void {
+		$this->actorType = $actorType;
+	}
+
+	/**
+	 * @psalm-return Attendee::ACTOR_*
+	 */
+	public function getActorType(): string {
+		return $this->actorType;
 	}
 
 	/**

--- a/lib/Model/VoteMapper.php
+++ b/lib/Model/VoteMapper.php
@@ -56,7 +56,7 @@ class VoteMapper extends QBMapper {
 
 	/**
 	 * @param int $pollId
-	 * @param string $actorType
+	 * @psalm-param Attendee::ACTOR_* $actorType
 	 * @param string $actorId
 	 * @return Vote[]
 	 */
@@ -89,6 +89,9 @@ class VoteMapper extends QBMapper {
 		$query->executeStatement();
 	}
 
+	/**
+	 * @psalm-param Attendee::ACTOR_* $actorType
+	 */
 	public function deleteVotesByActor(int $pollId, string $actorType, string $actorId): void {
 		$query = $this->db->getQueryBuilder();
 

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -47,9 +47,11 @@ namespace OCA\Talk;
  *     secret: string,
  * }
  *
+ * @psalm-type TalkActorType = 'bot-'|'bots'|'bridged'|'changelog'|'circles'|'cli'|'emails'|'federated_users'|'groups'|'guests'|'phones'|'system'|'users'
+ *
  * @psalm-type TalkCallPeer = array{
  *     actorId: string,
- *     actorType: string,
+ *     actorType: TalkActorType,
  *     displayName: string,
  *     lastPing: int,
  *     sessionId: string,
@@ -72,7 +74,7 @@ namespace OCA\Talk;
  * @psalm-type TalkChatMessage = array{
  *     actorDisplayName: string,
  *     actorId: string,
- *     actorType: string,
+ *     actorType: TalkActorType,
  *     deleted?: true,
  *     expirationTimestamp: int,
  *     id: int,
@@ -96,7 +98,7 @@ namespace OCA\Talk;
  * @psalm-type TalkRoomProxyMessage = array{
  *     actorDisplayName: string,
  *     actorId: string,
- *     actorType: string,
+ *     actorType: TalkActorType,
  *     expirationTimestamp: int,
  *     message: string,
  *     messageParameters: array<string, array<string, mixed>>,
@@ -147,7 +149,7 @@ namespace OCA\Talk;
  *
  * @psalm-type TalkParticipant = array{
  *     actorId: string,
- *     actorType: string,
+ *     actorType: TalkActorType,
  *     attendeeId: int,
  *     attendeePermissions: int,
  *     attendeePin: string,
@@ -169,14 +171,14 @@ namespace OCA\Talk;
  * @psalm-type TalkPollVote = array{
  *     actorDisplayName: string,
  *     actorId: string,
- *     actorType: string,
+ *     actorType: TalkActorType,
  *     optionId: int,
  *  }
  *
  * @psalm-type TalkPoll = array{
  *     actorDisplayName: string,
  *     actorId: string,
- *     actorType: string,
+ *     actorType: TalkActorType,
  *     details?: TalkPollVote[],
  *     id: int,
  *     maxVotes: int,
@@ -192,13 +194,13 @@ namespace OCA\Talk;
  * @psalm-type TalkReaction = array{
  *     actorDisplayName: string,
  *     actorId: string,
- *     actorType: string,
+ *     actorType: TalkActorType,
  *     timestamp: int,
  * }
  *
  * @psalm-type TalkRoom = array{
  *     actorId: string,
- *     actorType: string,
+ *     actorType: TalkActorType|'',
  *     attendeeId: int,
  *     attendeePermissions: int,
  *     attendeePin: ?string,

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -67,6 +67,8 @@ namespace OCA\Talk;
  *     statusMessage: ?string,
  * }
  *
+ * @psalm-type TalkMessageType = 'command'|'comment'|'comment_deleted'|'object_shared'|'reaction'|'reaction_deleted'|'record-audio'|'record-video'|'system'|'voice-message'
+ *
  * @psalm-type TalkChatMessage = array{
  *     actorDisplayName: string,
  *     actorId: string,
@@ -78,7 +80,7 @@ namespace OCA\Talk;
  *     markdown: bool,
  *     message: string,
  *     messageParameters: array<string, array<string, mixed>>,
- *     messageType: string,
+ *     messageType: TalkMessageType,
  *     reactions: array<string, integer>|\stdClass,
  *     referenceId: string,
  *     systemMessage: string,
@@ -98,7 +100,7 @@ namespace OCA\Talk;
  *     expirationTimestamp: int,
  *     message: string,
  *     messageParameters: array<string, array<string, mixed>>,
- *     messageType: string,
+ *     messageType: TalkMessageType,
  *     systemMessage: string,
  * }
  *

--- a/lib/Service/AttachmentService.php
+++ b/lib/Service/AttachmentService.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Service;
 
+use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Model\Attachment;
 use OCA\Talk\Model\AttachmentMapper;
 use OCA\Talk\Room;
@@ -38,6 +39,9 @@ class AttachmentService {
 	) {
 	}
 
+	/**
+	 * @param ChatManager::VERB_* $messageType
+	 */
 	public function createAttachmentEntry(Room $room, IComment $comment, string $messageType, array $parameters): void {
 		$attachment = new Attachment();
 		$attachment->setRoomId($room->getId());

--- a/lib/Service/BreakoutRoomService.php
+++ b/lib/Service/BreakoutRoomService.php
@@ -556,7 +556,7 @@ class BreakoutRoomService {
 
 	/**
 	 * @param Room $parent
-	 * @param string $actorType
+	 * @psalm-param Attendee::ACTOR_* $actorType
 	 * @param string $actorId
 	 * @param bool $throwOnModerator
 	 * @return void

--- a/lib/Service/ConsentService.php
+++ b/lib/Service/ConsentService.php
@@ -39,6 +39,9 @@ class ConsentService {
 	) {
 	}
 
+	/**
+	 * @psalm-param Attendee::ACTOR_* $actorType
+	 */
 	public function storeConsent(Room $room, string $actorType, string $actorId): Consent {
 		$consent = new Consent();
 		$consent->setToken($room->getToken());

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -364,6 +364,7 @@ class ParticipantService {
 	}
 
 	/**
+	 * @psalm-param Attendee::ACTOR_* $actorType
 	 * @throws UnauthorizedException
 	 */
 	public function joinRoomAsFederatedUser(Room $room, string $actorType, string $actorId): Participant {

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Service;
 
 use OCA\Talk\Exceptions\WrongPermissionsException;
+use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\Poll;
 use OCA\Talk\Model\PollMapper;
 use OCA\Talk\Model\Vote;
@@ -46,6 +47,9 @@ class PollService {
 	) {
 	}
 
+	/**
+	 * @psalm-param Attendee::ACTOR_* $actorType
+	 */
 	public function createPoll(int $roomId, string $actorType, string $actorId, string $displayName, string $question, array $options, int $resultMode, int $maxVotes): Poll {
 		$question = trim($question);
 

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -20,6 +20,24 @@
             }
         },
         "schemas": {
+            "ActorType": {
+                "type": "string",
+                "enum": [
+                    "bot-",
+                    "bots",
+                    "bridged",
+                    "changelog",
+                    "circles",
+                    "cli",
+                    "emails",
+                    "federated_users",
+                    "groups",
+                    "guests",
+                    "phones",
+                    "system",
+                    "users"
+                ]
+            },
             "Capabilities": {
                 "type": "object",
                 "required": [
@@ -211,7 +229,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "deleted": {
                         "type": "boolean",
@@ -403,7 +421,14 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/ActorType"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
                     },
                     "attendeeId": {
                         "type": "integer",
@@ -634,7 +659,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "expirationTimestamp": {
                         "type": "integer",

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -246,7 +246,7 @@
                         }
                     },
                     "messageType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/MessageType"
                     },
                     "reactions": {
                         "type": "object",
@@ -285,6 +285,21 @@
                         "type": "boolean"
                     }
                 }
+            },
+            "MessageType": {
+                "type": "string",
+                "enum": [
+                    "command",
+                    "comment",
+                    "comment_deleted",
+                    "object_shared",
+                    "reaction",
+                    "reaction_deleted",
+                    "record-audio",
+                    "record-video",
+                    "system",
+                    "voice-message"
+                ]
             },
             "OCSMeta": {
                 "type": "object",
@@ -638,7 +653,7 @@
                         }
                     },
                     "messageType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/MessageType"
                     },
                     "systemMessage": {
                         "type": "string"

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -20,6 +20,24 @@
             }
         },
         "schemas": {
+            "ActorType": {
+                "type": "string",
+                "enum": [
+                    "bot-",
+                    "bots",
+                    "bridged",
+                    "changelog",
+                    "circles",
+                    "cli",
+                    "emails",
+                    "federated_users",
+                    "groups",
+                    "guests",
+                    "phones",
+                    "system",
+                    "users"
+                ]
+            },
             "Capabilities": {
                 "type": "object",
                 "required": [
@@ -211,7 +229,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "deleted": {
                         "type": "boolean",
@@ -462,7 +480,14 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/ActorType"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
                     },
                     "attendeeId": {
                         "type": "integer",
@@ -693,7 +718,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "expirationTimestamp": {
                         "type": "integer",

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -246,7 +246,7 @@
                         }
                     },
                     "messageType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/MessageType"
                     },
                     "reactions": {
                         "type": "object",
@@ -344,6 +344,21 @@
                         "type": "string"
                     }
                 }
+            },
+            "MessageType": {
+                "type": "string",
+                "enum": [
+                    "command",
+                    "comment",
+                    "comment_deleted",
+                    "object_shared",
+                    "reaction",
+                    "reaction_deleted",
+                    "record-audio",
+                    "record-video",
+                    "system",
+                    "voice-message"
+                ]
             },
             "OCSMeta": {
                 "type": "object",
@@ -697,7 +712,7 @@
                         }
                     },
                     "messageType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/MessageType"
                     },
                     "systemMessage": {
                         "type": "string"

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -407,7 +407,7 @@
                         }
                     },
                     "messageType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/MessageType"
                     },
                     "reactions": {
                         "type": "object",
@@ -598,6 +598,21 @@
                     {
                         "$ref": "#/components/schemas/MatterbridgeProcessState"
                     }
+                ]
+            },
+            "MessageType": {
+                "type": "string",
+                "enum": [
+                    "command",
+                    "comment",
+                    "comment_deleted",
+                    "object_shared",
+                    "reaction",
+                    "reaction_deleted",
+                    "record-audio",
+                    "record-video",
+                    "system",
+                    "voice-message"
                 ]
             },
             "OCSMeta": {
@@ -1162,7 +1177,7 @@
                         }
                     },
                     "messageType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/MessageType"
                     },
                     "systemMessage": {
                         "type": "string"

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -20,6 +20,24 @@
             }
         },
         "schemas": {
+            "ActorType": {
+                "type": "string",
+                "enum": [
+                    "bot-",
+                    "bots",
+                    "bridged",
+                    "changelog",
+                    "circles",
+                    "cli",
+                    "emails",
+                    "federated_users",
+                    "groups",
+                    "guests",
+                    "phones",
+                    "system",
+                    "users"
+                ]
+            },
             "Bot": {
                 "type": "object",
                 "required": [
@@ -120,7 +138,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "displayName": {
                         "type": "string"
@@ -372,7 +390,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "deleted": {
                         "type": "boolean",
@@ -660,7 +678,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "attendeeId": {
                         "type": "integer",
@@ -748,7 +766,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "details": {
                         "type": "array",
@@ -817,7 +835,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "optionId": {
                         "type": "integer",
@@ -860,7 +878,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "timestamp": {
                         "type": "integer",
@@ -927,7 +945,14 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/ActorType"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
                     },
                     "attendeeId": {
                         "type": "integer",
@@ -1158,7 +1183,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "expirationTimestamp": {
                         "type": "integer",

--- a/openapi.json
+++ b/openapi.json
@@ -20,6 +20,24 @@
             }
         },
         "schemas": {
+            "ActorType": {
+                "type": "string",
+                "enum": [
+                    "bot-",
+                    "bots",
+                    "bridged",
+                    "changelog",
+                    "circles",
+                    "cli",
+                    "emails",
+                    "federated_users",
+                    "groups",
+                    "guests",
+                    "phones",
+                    "system",
+                    "users"
+                ]
+            },
             "Bot": {
                 "type": "object",
                 "required": [
@@ -61,7 +79,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "displayName": {
                         "type": "string"
@@ -313,7 +331,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "deleted": {
                         "type": "boolean",
@@ -542,7 +560,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "attendeeId": {
                         "type": "integer",
@@ -630,7 +648,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "details": {
                         "type": "array",
@@ -699,7 +717,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "optionId": {
                         "type": "integer",
@@ -742,7 +760,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "timestamp": {
                         "type": "integer",
@@ -809,7 +827,14 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/ActorType"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
                     },
                     "attendeeId": {
                         "type": "integer",
@@ -1040,7 +1065,7 @@
                         "type": "string"
                     },
                     "actorType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/ActorType"
                     },
                     "expirationTimestamp": {
                         "type": "integer",

--- a/openapi.json
+++ b/openapi.json
@@ -348,7 +348,7 @@
                         }
                     },
                     "messageType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/MessageType"
                     },
                     "reactions": {
                         "type": "object",
@@ -480,6 +480,21 @@
                     {
                         "$ref": "#/components/schemas/MatterbridgeProcessState"
                     }
+                ]
+            },
+            "MessageType": {
+                "type": "string",
+                "enum": [
+                    "command",
+                    "comment",
+                    "comment_deleted",
+                    "object_shared",
+                    "reaction",
+                    "reaction_deleted",
+                    "record-audio",
+                    "record-video",
+                    "system",
+                    "voice-message"
                 ]
             },
             "OCSMeta": {
@@ -1044,7 +1059,7 @@
                         }
                     },
                     "messageType": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/MessageType"
                     },
                     "systemMessage": {
                         "type": "string"

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -40,6 +40,8 @@ export type webhooks = Record<string, never>;
 
 export type components = {
   schemas: {
+    /** @enum {string} */
+    ActorType: "bot-" | "bots" | "bridged" | "changelog" | "circles" | "cli" | "emails" | "federated_users" | "groups" | "guests" | "phones" | "system" | "users";
     Capabilities: {
       features: string[];
       config: {
@@ -87,7 +89,7 @@ export type components = {
     ChatMessage: {
       actorDisplayName: string;
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       /** @enum {boolean} */
       deleted?: true;
       /** Format: int64 */
@@ -132,7 +134,7 @@ export type components = {
     }, unknown[]]>;
     Room: {
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"] | string;
       /** Format: int64 */
       attendeeId: number;
       /** Format: int64 */
@@ -219,7 +221,7 @@ export type components = {
     RoomProxyMessage: {
       actorDisplayName: string;
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       /** Format: int64 */
       expirationTimestamp: number;
       message: string;

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -102,7 +102,7 @@ export type components = {
           [key: string]: Record<string, never>;
         };
       };
-      messageType: string;
+      messageType: components["schemas"]["MessageType"];
       reactions: {
         [key: string]: number;
       };
@@ -118,6 +118,8 @@ export type components = {
       lastEditTimestamp?: number;
       silent?: boolean;
     };
+    /** @enum {string} */
+    MessageType: "command" | "comment" | "comment_deleted" | "object_shared" | "reaction" | "reaction_deleted" | "record-audio" | "record-video" | "system" | "voice-message";
     OCSMeta: {
       status: string;
       statuscode: number;
@@ -226,7 +228,7 @@ export type components = {
           [key: string]: Record<string, never>;
         };
       };
-      messageType: string;
+      messageType: components["schemas"]["MessageType"];
       systemMessage: string;
     };
   };

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -97,7 +97,7 @@ export type components = {
           [key: string]: Record<string, never>;
         };
       };
-      messageType: string;
+      messageType: components["schemas"]["MessageType"];
       reactions: {
         [key: string]: number;
       };
@@ -131,6 +131,8 @@ export type components = {
       inviterCloudId: string;
       inviterDisplayName: string;
     };
+    /** @enum {string} */
+    MessageType: "command" | "comment" | "comment_deleted" | "object_shared" | "reaction" | "reaction_deleted" | "record-audio" | "record-video" | "system" | "voice-message";
     OCSMeta: {
       status: string;
       statuscode: number;
@@ -239,7 +241,7 @@ export type components = {
           [key: string]: Record<string, never>;
         };
       };
-      messageType: string;
+      messageType: components["schemas"]["MessageType"];
       systemMessage: string;
     };
   };

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -35,6 +35,8 @@ export type webhooks = Record<string, never>;
 
 export type components = {
   schemas: {
+    /** @enum {string} */
+    ActorType: "bot-" | "bots" | "bridged" | "changelog" | "circles" | "cli" | "emails" | "federated_users" | "groups" | "guests" | "phones" | "system" | "users";
     Capabilities: {
       features: string[];
       config: {
@@ -82,7 +84,7 @@ export type components = {
     ChatMessage: {
       actorDisplayName: string;
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       /** @enum {boolean} */
       deleted?: true;
       /** Format: int64 */
@@ -145,7 +147,7 @@ export type components = {
     }, unknown[]]>;
     Room: {
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"] | string;
       /** Format: int64 */
       attendeeId: number;
       /** Format: int64 */
@@ -232,7 +234,7 @@ export type components = {
     RoomProxyMessage: {
       actorDisplayName: string;
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       /** Format: int64 */
       expirationTimestamp: number;
       message: string;

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -613,7 +613,7 @@ export type components = {
           [key: string]: Record<string, never>;
         };
       };
-      messageType: string;
+      messageType: components["schemas"]["MessageType"];
       reactions: {
         [key: string]: number;
       };
@@ -672,6 +672,8 @@ export type components = {
       running: boolean;
     };
     MatterbridgeWithProcessState: components["schemas"]["Matterbridge"] & components["schemas"]["MatterbridgeProcessState"];
+    /** @enum {string} */
+    MessageType: "command" | "comment" | "comment_deleted" | "object_shared" | "reaction" | "reaction_deleted" | "record-audio" | "record-video" | "system" | "voice-message";
     OCSMeta: {
       status: string;
       statuscode: number;
@@ -843,7 +845,7 @@ export type components = {
           [key: string]: Record<string, never>;
         };
       };
-      messageType: string;
+      messageType: components["schemas"]["MessageType"];
       systemMessage: string;
     };
     SignalingSession: {

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -509,6 +509,8 @@ export type webhooks = Record<string, never>;
 
 export type components = {
   schemas: {
+    /** @enum {string} */
+    ActorType: "bot-" | "bots" | "bridged" | "changelog" | "circles" | "cli" | "emails" | "federated_users" | "groups" | "guests" | "phones" | "system" | "users";
     Bot: {
       description: string | null;
       /** Format: int64 */
@@ -533,7 +535,7 @@ export type components = {
     };
     CallPeer: {
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       displayName: string;
       /** Format: int64 */
       lastPing: number;
@@ -598,7 +600,7 @@ export type components = {
     ChatMessage: {
       actorDisplayName: string;
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       /** @enum {boolean} */
       deleted?: true;
       /** Format: int64 */
@@ -683,7 +685,7 @@ export type components = {
     };
     Participant: {
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       /** Format: int64 */
       attendeeId: number;
       /** Format: int64 */
@@ -711,7 +713,7 @@ export type components = {
     Poll: {
       actorDisplayName: string;
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       details?: components["schemas"]["PollVote"][];
       /** Format: int64 */
       id: number;
@@ -733,7 +735,7 @@ export type components = {
     PollVote: {
       actorDisplayName: string;
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       /** Format: int64 */
       optionId: number;
     };
@@ -743,13 +745,13 @@ export type components = {
     Reaction: {
       actorDisplayName: string;
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       /** Format: int64 */
       timestamp: number;
     };
     Room: {
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"] | string;
       /** Format: int64 */
       attendeeId: number;
       /** Format: int64 */
@@ -836,7 +838,7 @@ export type components = {
     RoomProxyMessage: {
       actorDisplayName: string;
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       /** Format: int64 */
       expirationTimestamp: number;
       message: string;

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -472,7 +472,7 @@ export type components = {
           [key: string]: Record<string, never>;
         };
       };
-      messageType: string;
+      messageType: components["schemas"]["MessageType"];
       reactions: {
         [key: string]: number;
       };
@@ -513,6 +513,8 @@ export type components = {
       running: boolean;
     };
     MatterbridgeWithProcessState: components["schemas"]["Matterbridge"] & components["schemas"]["MatterbridgeProcessState"];
+    /** @enum {string} */
+    MessageType: "command" | "comment" | "comment_deleted" | "object_shared" | "reaction" | "reaction_deleted" | "record-audio" | "record-video" | "system" | "voice-message";
     OCSMeta: {
       status: string;
       statuscode: number;
@@ -684,7 +686,7 @@ export type components = {
           [key: string]: Record<string, never>;
         };
       };
-      messageType: string;
+      messageType: components["schemas"]["MessageType"];
       systemMessage: string;
     };
     SignalingSession: {

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -382,6 +382,8 @@ export type webhooks = Record<string, never>;
 
 export type components = {
   schemas: {
+    /** @enum {string} */
+    ActorType: "bot-" | "bots" | "bridged" | "changelog" | "circles" | "cli" | "emails" | "federated_users" | "groups" | "guests" | "phones" | "system" | "users";
     Bot: {
       description: string | null;
       /** Format: int64 */
@@ -392,7 +394,7 @@ export type components = {
     };
     CallPeer: {
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       displayName: string;
       /** Format: int64 */
       lastPing: number;
@@ -457,7 +459,7 @@ export type components = {
     ChatMessage: {
       actorDisplayName: string;
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       /** @enum {boolean} */
       deleted?: true;
       /** Format: int64 */
@@ -524,7 +526,7 @@ export type components = {
     };
     Participant: {
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       /** Format: int64 */
       attendeeId: number;
       /** Format: int64 */
@@ -552,7 +554,7 @@ export type components = {
     Poll: {
       actorDisplayName: string;
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       details?: components["schemas"]["PollVote"][];
       /** Format: int64 */
       id: number;
@@ -574,7 +576,7 @@ export type components = {
     PollVote: {
       actorDisplayName: string;
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       /** Format: int64 */
       optionId: number;
     };
@@ -584,13 +586,13 @@ export type components = {
     Reaction: {
       actorDisplayName: string;
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       /** Format: int64 */
       timestamp: number;
     };
     Room: {
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"] | string;
       /** Format: int64 */
       attendeeId: number;
       /** Format: int64 */
@@ -677,7 +679,7 @@ export type components = {
     RoomProxyMessage: {
       actorDisplayName: string;
       actorId: string;
-      actorType: string;
+      actorType: components["schemas"]["ActorType"];
       /** Format: int64 */
       expirationTimestamp: number;
       message: string;


### PR DESCRIPTION
### ☑️ Resolves

I added the missing message types and tightened the types of the message type and actor type methods to ensure only valid values will be passed. It's not possible to do this with virtual methods (`@psalm-method` exists but doesn't seem to work).

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
