### PR TITLE
fix(federation): scope button disabling to invitation user interacted with

### DIFF
--- a/src/stores/federation.js
+++ b/src/stores/federation.js
@@ -118,6 +118,7 @@ export const useFederationStore = defineStore('federation', {
 			if (!this.pendingShares[id]) {
 				return
 			}
+			Vue.delete(this.pendingShares[id], 'loading')
 			Vue.set(this.acceptedShares, id, {
 				...this.pendingShares[id],
 				accessToken: conversation.remoteAccessToken,
@@ -138,6 +139,7 @@ export const useFederationStore = defineStore('federation', {
 				return
 			}
 			try {
+				Vue.set(this.pendingShares[id], 'loading', 'accept')
 				const response = await acceptShare(id)
 				this.markInvitationAccepted(id, response.data.ocs.data)
 				return response.data.ocs.data
@@ -157,6 +159,7 @@ export const useFederationStore = defineStore('federation', {
 				return
 			}
 			try {
+				Vue.set(this.pendingShares[id], 'loading', 'reject')
 				await rejectShare(id)
 				Vue.delete(this.pendingShares, id)
 			} catch (error) {


### PR DESCRIPTION
 ☑️ Resolves

* Fix showing a loading spinner on all ivitations

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Clicking "Accept -> Decline -> Accept"

[Screencast from 01.03.2024 14:36:47.webm](https://github.com/nextcloud/spreed/assets/93392545/ce8610e2-1d71-4249-bafe-046641340d59)

UPD: when rejecting, spinner is shown as well
![image](https://github.com/nextcloud/spreed/assets/93392545/00eedfd3-7101-47dd-9770-d003f0ff86b3)



### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 