### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "3159cf7101a6490f5f780b2312bada1768aef0ed"
+                "reference": "439198343dcc5bce91a7ceeb981348df26529b71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/3159cf7101a6490f5f780b2312bada1768aef0ed",
-                "reference": "3159cf7101a6490f5f780b2312bada1768aef0ed",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/439198343dcc5bce91a7ceeb981348df26529b71",
+                "reference": "439198343dcc5bce91a7ceeb981348df26529b71",
                 "shasum": ""
             },
             "require": {
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-02-28T13:29:33+00:00"
+            "time": "2024-02-29T00:31:54+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency