### PR TITLE
fix(BrowserStorage): don't generate empty entries in BrowserStorage

### DIFF
--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -455,6 +455,8 @@ export default {
 					} else if (BrowserStorage.getItem('virtualBackgroundType_' + this.token) === VIRTUAL_BACKGROUND.BACKGROUND_TYPE.IMAGE) {
 						this.setVirtualBackgroundImage(BrowserStorage.getItem('virtualBackgroundUrl_' + this.token))
 					}
+				} else {
+					this.clearVirtualBackground()
 				}
 
 				this.initializeDevices()

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -55,6 +55,10 @@ export const useSettingsStore = defineStore('settings', {
 
 	getters: {
 		getShowMediaSettings: (state) => (token) => {
+			if (!token) {
+				return true
+			}
+
 			if (state.showMediaSettings[token] !== undefined) {
 				return state.showMediaSettings[token]
 			}

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -244,6 +244,8 @@ async function signalingJoinCall(token, flags, silent, recordingConsent) {
 			const virtualBackgroundBlurStrength = BrowserStorage.getItem('virtualBackgroundBlurStrength_' + token)
 			const virtualBackgroundUrl = BrowserStorage.getItem('virtualBackgroundUrl_' + token)
 
+			localMediaModel.set('token', token)
+
 			if (enableAudio) {
 				localMediaModel.enableAudio()
 			} else {


### PR DESCRIPTION
### ☑️ Resolves

* Fix empty entries like `'virtualBackgroundType_'` in local storage without defined key
  * `this.get('token')` sometime returns nothing, as webrtc isn't always initialising it
  * Prevent generating empty entries again by providing a token
  * Add init function to cleanup them while initialising
* reset virtualBackground at media preview, if none is set for conversation

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏡 After

[reset-virtual-bg.webm](https://github.com/nextcloud/spreed/assets/93392545/00b4d070-e0e4-4339-955c-9396aa53945a)

### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possible