### PR TITLE
feat(search): move search api implementation to private namespace

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -29,17 +29,17 @@ import { generateFilePath, imagePath } from '@nextcloud/router'
 
 import '@nextcloud/dialogs/style.css'
 
-(function(OC, OCP, t, n) {
+(function(OC, OCA, t, n) {
 
 	/**
 	 *
 	 */
 	function init() {
-		if (!OCP.UnifiedSearch) {
+		if (!OCA.UnifiedSearch) {
 			return
 		}
 		console.debug('Initializing unified search plugin-filters from talk')
-		OCP.UnifiedSearch.registerFilterAction({
+		OCA.UnifiedSearch.registerFilterAction({
 			id: 'talk-message',
 			appId: 'spreed',
 			label: t('spreed', 'In conversation'),
@@ -94,8 +94,8 @@ import '@nextcloud/dialogs/style.css'
 	Vue.prototype.t = translate
 	Vue.prototype.n = translatePlural
 	Vue.prototype.OC = OC
-	Vue.prototype.OCP = OCP
+	Vue.prototype.OCA = OCA
 
 	document.addEventListener('DOMContentLoaded', init)
 
-})(window.OC, window.OCP, t, n)
+})(window.OC, window.OCA, t, n)


### PR DESCRIPTION
We decided to move the current search API implemented via global functions to a the private namespace so we can remove it at any time without need for deprecation.

Context: The current implementation of the API is not considered good enough and is scheduled for removal.
