### PR TITLE
feat(chat): Allow marking chat as read without a last message ID

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -143,3 +143,4 @@
 * `delete-messages-unlimited` - Whether messages can be deleted at any time (used to be restricted to 6 hours after posting)
 * `edit-messages` - Whether messages can be edited (restricted to 24 hours after posting)
 * `silent-send-state` - Whether messages contain a flag that they were sent silently
+* `chat-read-last` - Whether chat can be marked read without giving a message ID (will fall back to the conversations last message ID)

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -416,9 +416,9 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 * Endpoint: `/chat/{token}/read`
 * Data:
 
-| field             | type | Description              |
-|-------------------|------|--------------------------|
-| `lastReadMessage` | int  | The last read message ID |
+| field             | type     | Description                                                          |
+|-------------------|----------|----------------------------------------------------------------------|
+| `lastReadMessage` | int/null | The last read message ID (Optional with `chat-read-last` capability) |
 
 * Response:
     - Status code:

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -139,6 +139,7 @@ class Capabilities implements IPublicCapability {
 				'delete-messages-unlimited',
 				'edit-messages',
 				'silent-send-state',
+				'chat-read-last',
 			],
 			'config' => [
 				'attachments' => [

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -1046,8 +1046,8 @@ class ChatController extends AEnvironmentAwareController {
 	/**
 	 * Set the read marker to a specific message
 	 *
-	 * @param int $lastReadMessage ID if the last read message
-	 * @psalm-param non-negative-int $lastReadMessage
+	 * @param int|null $lastReadMessage ID if the last read message (Optional only with `chat-read-last` capability)
+	 * @psalm-param non-negative-int|null $lastReadMessage
 	 * @return DataResponse<Http::STATUS_OK, TalkRoom, array{X-Chat-Last-Common-Read?: numeric-string}>
 	 *
 	 * 200: Read marker set successfully
@@ -1055,13 +1055,14 @@ class ChatController extends AEnvironmentAwareController {
 	#[FederationSupported]
 	#[PublicPage]
 	#[RequireAuthenticatedParticipant]
-	public function setReadMarker(int $lastReadMessage): DataResponse {
+	public function setReadMarker(?int $lastReadMessage = null): DataResponse {
 		if ($this->room->getRemoteServer() !== '') {
 			/** @var \OCA\Talk\Federation\Proxy\TalkV1\Controller\ChatController $proxy */
 			$proxy = \OCP\Server::get(\OCA\Talk\Federation\Proxy\TalkV1\Controller\ChatController::class);
 			return $proxy->setReadMarker($this->room, $this->participant, $this->getResponseFormat(), $lastReadMessage);
 		}
 
+		$lastReadMessage = $lastReadMessage ?? $this->room->getLastMessageId();
 		$this->participantService->updateLastReadMessage($this->participant, $lastReadMessage);
 		$attendee = $this->participant->getAttendee();
 

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -6266,11 +6266,11 @@
                     {
                         "name": "lastReadMessage",
                         "in": "query",
-                        "description": "ID if the last read message",
-                        "required": true,
+                        "description": "ID if the last read message (Optional only with `chat-read-last` capability)",
                         "schema": {
                             "type": "integer",
                             "format": "int64",
+                            "nullable": true,
                             "minimum": 0
                         }
                     },

--- a/openapi.json
+++ b/openapi.json
@@ -6148,11 +6148,11 @@
                     {
                         "name": "lastReadMessage",
                         "in": "query",
-                        "description": "ID if the last read message",
-                        "required": true,
+                        "description": "ID if the last read message (Optional only with `chat-read-last` capability)",
                         "schema": {
                             "type": "integer",
                             "format": "int64",
+                            "nullable": true,
                             "minimum": 0
                         }
                     },

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -2431,9 +2431,9 @@ export type operations = {
   /** Set the read marker to a specific message */
   "chat-set-read-marker": {
     parameters: {
-      query: {
-        /** @description ID if the last read message */
-        lastReadMessage: number;
+      query?: {
+        /** @description ID if the last read message (Optional only with `chat-read-last` capability) */
+        lastReadMessage?: number | null;
       };
       header: {
         /** @description Required to be true for the API request to pass */

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -2268,9 +2268,9 @@ export type operations = {
   /** Set the read marker to a specific message */
   "chat-set-read-marker": {
     parameters: {
-      query: {
-        /** @description ID if the last read message */
-        lastReadMessage: number;
+      query?: {
+        /** @description ID if the last read message (Optional only with `chat-read-last` capability) */
+        lastReadMessage?: number | null;
       };
       header: {
         /** @description Required to be true for the API request to pass */

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2365,7 +2365,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->setCurrentUser($user);
 		$this->sendRequest(
 			'POST', '/apps/spreed/api/' . $apiVersion . '/chat/' . self::$identifierToToken[$identifier] . '/read',
-			new TableNode([['lastReadMessage', self::$textToMessageId[$message]]])
+			$message === 'NULL' ? null : new TableNode([['lastReadMessage', self::$textToMessageId[$message]]]),
 		);
 		$this->assertStatusCode($this->response, $statusCode);
 	}

--- a/tests/integration/features/chat-2/unread-messages.feature
+++ b/tests/integration/features/chat-2/unread-messages.feature
@@ -73,6 +73,10 @@ Feature: chat-2/unread-messages
     Then user "participant2" is participant of room "group room" (v4)
       | unreadMessages |
       | 1              |
+    When user "participant2" reads message "NULL" in room "group room" with 200
+    Then user "participant2" is participant of room "group room" (v4)
+      | unreadMessages |
+      | 0              |
 
 
 

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -147,6 +147,7 @@ class CapabilitiesTest extends TestCase {
 			'delete-messages-unlimited',
 			'edit-messages',
 			'silent-send-state',
+			'chat-read-last',
 			'message-expiration',
 			'reactions',
 		];


### PR DESCRIPTION
This is required for federated conversations where the clients might not know the hosted message ID but only the proxy ID instead

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed: `chat-read-last`
