### PR TITLE
fix(messages): minor render enhancements

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -144,7 +144,7 @@ export default {
 			 */
 			messagesGroupedByDateByAuthor: {},
 
-			viewId: null,
+			viewId: uniqueId('messagesList'),
 
 			/**
 			 * When scrolling to the top of the div .scroller we start loading previous
@@ -316,7 +316,6 @@ export default {
 		this.debounceUpdateReadMarkerPosition = debounce(this.updateReadMarkerPosition, 1000)
 		this.debounceHandleScroll = debounce(this.handleScroll, 50)
 
-		this.viewId = uniqueId('messagesList')
 		this.scrollToBottom()
 		EventBus.$on('scroll-chat-to-bottom', this.handleScrollChatToBottomEvent)
 		EventBus.$on('smooth-scroll-chat-to-bottom', this.smoothScrollToBottom)


### PR DESCRIPTION

### ☑️ Resolves

- assign `viewId` on Options API initialising: chatIdentifier is no longer updated at `mounted()` - no cancelled requests
-  don't check system messages for parents:
    -  weird, but for federated conversations system conversations `getContext` at the moment response is processed, doesn't contain message parent - false check - system message is rendered as-is

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/7aa88c38-b03a-4759-82a4-da21479aba9d) | ![image](https://github.com/nextcloud/spreed/assets/93392545/9f7d81fe-37ec-4867-8fa3-b8eee126e9d3)


### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possible