### PR TITLE
feat(federation): Add capabilities for the federation feature and con…

### DIFF
--- a/docs/avatar.md
+++ b/docs/avatar.md
@@ -70,6 +70,7 @@
 ## Get conversations avatar (binary)
 
 * Required capability: `avatar`
+* Federation capability: `federation-v1`
 * Method: `GET`
 * Endpoint: `/room/{token}/avatar`
 
@@ -82,6 +83,7 @@
 ## Get dark mode conversations avatar (binary)
 
 * Required capability: `avatar`
+* Federation capability: `federation-v1`
 * Method: `GET`
 * Endpoint: `/room/{token}/avatar/dark`
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -144,3 +144,8 @@
 * `edit-messages` - Whether messages can be edited (restricted to 24 hours after posting)
 * `silent-send-state` - Whether messages contain a flag that they were sent silently
 * `chat-read-last` - Whether chat can be marked read without giving a message ID (will fall back to the conversations last message ID)
+* `federation-v1` - Whether basic chatting is possible with federation
+* `config => federation => enabled` - Boolean, whether federation is enabled on instance
+* `config => federation => incoming-enabled` - Boolean, whether users are allowed to be invited into federated conversations on other servers
+* `config => federation => outgoing-enabled` - Boolean, whether users are allowed to invited federated users of other servers into conversations
+* `config => federation => only-trusted-servers` - Boolean, whether federation invites are limited to trusted servers

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -10,6 +10,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`: since Nextcloud 13
     It is therefor recommended to use `format=json` or send the `Accept: application/json` header,
     to receive a JSON response.
 
+* Federation capability: `federation-v1`
 * Method: `GET`
 * Endpoint: `/chat/{token}`
 * Data:
@@ -90,6 +91,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`: since Nextcloud 13
     to receive a JSON response.
 
 * Required capability: `chat-get-context`
+* Federation capability: `federation-v1`
 * Method: `GET`
 * Endpoint: `/chat/{token}/{messageId}/context`
 * Data:
@@ -115,6 +117,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`: since Nextcloud 13
 
 ## Sending a new chat message
 
+* Federation capability: `federation-v1`
 * Method: `POST`
 * Endpoint: `/chat/{token}`
 * Data:
@@ -284,6 +287,7 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 ## Deleting a chat message
 
 * Required capability: `delete-messages` - `rich-object-delete` indicates if shared objects can be deleted from the chat
+* Federation capability: `federation-v1`
 * Method: `DELETE`
 * Endpoint: `/chat/{token}/{messageId}`
 
@@ -313,6 +317,7 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 ## Editing a chat message
 
 * Required capability: `edit-messages`
+* Federation capability: `federation-v1`
 * Method: `PUT`
 * Endpoint: `/chat/{token}/{messageId}`
 * Data:
@@ -412,6 +417,7 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 ## Mark chat as read
 
 * Required capability: `chat-read-marker`
+* Federation capability: `federation-v1`
 * Method: `POST`
 * Endpoint: `/chat/{token}/read`
 * Data:
@@ -439,6 +445,7 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 ## Mark chat as unread
 
 * Required capability: `chat-unread`
+* Federation capability: `federation-v1`
 * Method: `DELETE`
 * Endpoint: `/chat/{token}/read`
 
@@ -460,6 +467,7 @@ See [OCP\RichObjectStrings\Definitions](https://github.com/nextcloud/server/blob
 
 ## Get mention autocomplete suggestions
 
+* Federation capability: `federation-v1`
 * Method: `GET`
 * Endpoint: `/chat/{token}/mentions`
 * Data:

--- a/docs/conversation.md
+++ b/docs/conversation.md
@@ -365,6 +365,7 @@ Get all (for moderators and in case of "free selection") or the assigned breakou
 ## Add conversation to favorites
 
 * Required capability: `favorites`
+* Federation capability: `federation-v1`
 * Method: `POST`
 * Endpoint: `/room/{token}/favorite`
 
@@ -377,6 +378,7 @@ Get all (for moderators and in case of "free selection") or the assigned breakou
 ## Remove conversation from favorites
 
 * Required capability: `favorites`
+* Federation capability: `federation-v1`
 * Method: `DELETE`
 * Endpoint: `/room/{token}/favorite`
 
@@ -389,6 +391,7 @@ Get all (for moderators and in case of "free selection") or the assigned breakou
 ## Set notification level
 
 * Required capability: `notification-levels`
+* Federation capability: `federation-v1`
 * Method: `POST`
 * Endpoint: `/room/{token}/notify`
 * Data:
@@ -478,3 +481,23 @@ Get all (for moderators and in case of "free selection") or the assigned breakou
         + `400 Bad Request` When the conversation is a breakout room
         + `403 Forbidden` When the current user is not a moderator/owner or the conversation is not a public conversation
         + `404 Not Found` When the conversation could not be found for the participant
+
+## Get conversation capabilities
+
+* Required capability: `federation-v1`
+* Method: `GET`
+* Endpoint: `/room/{token}/capabilities`
+
+* Response:
+    - Status code:
+        + `200 OK` Get capabilities
+        + `404 Not Found` When the conversation could not be found for the participant
+
+    - Header:
+
+| field                         | type   | Description                                                                                |
+|-------------------------------|--------|--------------------------------------------------------------------------------------------|
+| `X-Nextcloud-Talk-Proxy-Hash` | string | Sha1 value over the capabilities in case the conversation is hosted **on another server**. |
+| `X-Nextcloud-Talk-Hash`       | string | Sha1 value over the capabilities in case the conversation is hosted **on this server**.    |
+
+    - Data: Server capabilities limited to the `spreed` sub-array or an empty array in case the app is disabled (for the user)

--- a/docs/global.md
+++ b/docs/global.md
@@ -40,3 +40,19 @@ From time to time it is unavoidable to break compatibility. In such cases we try
        + `426 Upgrade Required`
     - Body:
        + `ocs.meta.message` contains the minimum required version of the used client
+
+## Federation - Not supported
+
+Endpoints without a "Federation capability: `federation-vX`" will return a `406 Not Acceptable` status code, when called with tokens that actually refer to a so-called proxy conversation on the local server.
+
+* Response:
+    - Status code:
+       + `406 Not Acceptable`
+
+## Federation - Remote error
+
+When a request is performed on a proxy conversation and the host can not be reached `422 Unprocessable Content` will be returned. The only exception will be leaving the room, where the request will still execute it's part locally so the user is no longer bothered. A background job will be queued to retry informing the remote server about the leave automatically.
+
+* Response:
+    - Status code:
+       + `422 Unprocessable Content`

--- a/docs/participant.md
+++ b/docs/participant.md
@@ -7,6 +7,7 @@
 
 ## Get list of participants in a conversation
 
+* Federation capability: `federation-v1`
 * Method: `GET`
 * Endpoint: `/room/{token}/participants`
 * Data:
@@ -108,6 +109,7 @@
 
 ## Remove yourself from a conversation
 
+* Federation capability: `federation-v1`
 * Method: `DELETE`
 * Endpoint: `/room/{token}/participants/self`
 
@@ -119,6 +121,7 @@
 
 ## Join a conversation (available for call and chat)
 
+* Federation capability: `federation-v1`
 * Method: `POST`
 * Endpoint: `/room/{token}/participants/active`
 * Data:
@@ -165,6 +168,7 @@
 ## Set session state
 
 * Required capability: `session-state`
+* Federation capability: `federation-v1`
 * Method: `PUT`
 * Endpoint: `/room/{token}/participants/state`
 
@@ -176,6 +180,7 @@
 
 ## Leave a conversation (not available for call and chat anymore)
 
+* Federation capability: `federation-v1`
 * Method: `DELETE`
 * Endpoint: `/room/{token}/participants/active`
 

--- a/docs/reaction.md
+++ b/docs/reaction.md
@@ -5,6 +5,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`: since Nextcloud 24
 ## React to a message
 
 * Required capability: `reactions`
+* Federation capability: `federation-v1`
 * Method: `POST`
 * Endpoint: `/reaction/{token}/{messageId}`
 * Data:
@@ -33,6 +34,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`: since Nextcloud 24
 ## Delete a reaction
 
 * Required capability: `reactions`
+* Federation capability: `federation-v1`
 * Method: `DELETE`
 * Endpoint: `/reaction/{token}/{messageId}`
 * Data:
@@ -60,6 +62,7 @@ Base endpoint is: `/ocs/v2.php/apps/spreed/api/v1`: since Nextcloud 24
 ## Retrieve reactions of a message by type
 
 * Required capability: `reactions`
+* Federation capability: `federation-v1`
 * Method: `GET`
 * Endpoint: `/reaction/{token}/{messageId}`
 * Data:

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -308,6 +308,12 @@ namespace OCA\Talk;
  *         conversations: array{
  *             can-create: bool,
  *         },
+ *         federation: array{
+ *             enabled: bool,
+ *             incoming-enabled: bool,
+ *             outgoing-enabled: bool,
+ *             only-trusted-servers: bool,
+ *         },
  *         previews: array{
  *             max-gif-size: int,
  *         },

--- a/lib/Settings/Admin/AdminSettings.php
+++ b/lib/Settings/Admin/AdminSettings.php
@@ -31,6 +31,7 @@ use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\CommandService;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -49,6 +50,7 @@ class AdminSettings implements ISettings {
 	public function __construct(
 		private Config $talkConfig,
 		private IConfig $serverConfig,
+		private IAppConfig $appConfig,
 		private CommandService $commandService,
 		private IInitialState $initialState,
 		private ICacheFactory $memcacheFactory,
@@ -111,11 +113,11 @@ class AdminSettings implements ISettings {
 	}
 
 	protected function initFederation(): void {
-		$this->initialState->provideInitialState('federation_enabled', $this->serverConfig->getAppValue('spreed', 'federation_enabled', 'no'));
-		$this->initialState->provideInitialState('federation_incoming_enabled', $this->serverConfig->getAppValue('spreed', 'federation_incoming_enabled', '1'));
-		$this->initialState->provideInitialState('federation_outgoing_enabled', $this->serverConfig->getAppValue('spreed', 'federation_outgoing_enabled', '1'));
-		$this->initialState->provideInitialState('federation_only_trusted_servers', $this->serverConfig->getAppValue('spreed', 'federation_only_trusted_servers', '0'));
-		$this->initialState->provideInitialState('federation_allowed_groups', $this->serverConfig->getAppValue('spreed', 'federation_allowed_groups', '[]'));
+		$this->initialState->provideInitialState('federation_enabled', $this->talkConfig->isFederationEnabled());
+		$this->initialState->provideInitialState('federation_incoming_enabled', $this->appConfig->getAppValueBool('federation_incoming_enabled', true));
+		$this->initialState->provideInitialState('federation_outgoing_enabled', $this->appConfig->getAppValueBool('federation_outgoing_enabled', true));
+		$this->initialState->provideInitialState('federation_only_trusted_servers', $this->appConfig->getAppValueBool('federation_only_trusted_servers'));
+		$this->initialState->provideInitialState('federation_allowed_groups', $this->appConfig->getAppValueArray('federation_allowed_groups'));
 	}
 
 	protected function initMatterbridge(): void {

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -108,6 +108,7 @@
                             "call",
                             "chat",
                             "conversations",
+                            "federation",
                             "previews",
                             "signaling"
                         ],
@@ -213,6 +214,29 @@
                                 ],
                                 "properties": {
                                     "can-create": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            },
+                            "federation": {
+                                "type": "object",
+                                "required": [
+                                    "enabled",
+                                    "incoming-enabled",
+                                    "outgoing-enabled",
+                                    "only-trusted-servers"
+                                ],
+                                "properties": {
+                                    "enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "incoming-enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "outgoing-enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "only-trusted-servers": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-backend-recording.json
+++ b/openapi-backend-recording.json
@@ -41,6 +41,7 @@
                             "call",
                             "chat",
                             "conversations",
+                            "federation",
                             "previews",
                             "signaling"
                         ],
@@ -146,6 +147,29 @@
                                 ],
                                 "properties": {
                                     "can-create": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            },
+                            "federation": {
+                                "type": "object",
+                                "required": [
+                                    "enabled",
+                                    "incoming-enabled",
+                                    "outgoing-enabled",
+                                    "only-trusted-servers"
+                                ],
+                                "properties": {
+                                    "enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "incoming-enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "outgoing-enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "only-trusted-servers": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-backend-signaling.json
+++ b/openapi-backend-signaling.json
@@ -41,6 +41,7 @@
                             "call",
                             "chat",
                             "conversations",
+                            "federation",
                             "previews",
                             "signaling"
                         ],
@@ -146,6 +147,29 @@
                                 ],
                                 "properties": {
                                     "can-create": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            },
+                            "federation": {
+                                "type": "object",
+                                "required": [
+                                    "enabled",
+                                    "incoming-enabled",
+                                    "outgoing-enabled",
+                                    "only-trusted-servers"
+                                ],
+                                "properties": {
+                                    "enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "incoming-enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "outgoing-enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "only-trusted-servers": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -41,6 +41,7 @@
                             "call",
                             "chat",
                             "conversations",
+                            "federation",
                             "previews",
                             "signaling"
                         ],
@@ -146,6 +147,29 @@
                                 ],
                                 "properties": {
                                     "can-create": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            },
+                            "federation": {
+                                "type": "object",
+                                "required": [
+                                    "enabled",
+                                    "incoming-enabled",
+                                    "outgoing-enabled",
+                                    "only-trusted-servers"
+                                ],
+                                "properties": {
+                                    "enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "incoming-enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "outgoing-enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "only-trusted-servers": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-bots.json
+++ b/openapi-bots.json
@@ -41,6 +41,7 @@
                             "call",
                             "chat",
                             "conversations",
+                            "federation",
                             "previews",
                             "signaling"
                         ],
@@ -146,6 +147,29 @@
                                 ],
                                 "properties": {
                                     "can-create": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            },
+                            "federation": {
+                                "type": "object",
+                                "required": [
+                                    "enabled",
+                                    "incoming-enabled",
+                                    "outgoing-enabled",
+                                    "only-trusted-servers"
+                                ],
+                                "properties": {
+                                    "enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "incoming-enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "outgoing-enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "only-trusted-servers": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -41,6 +41,7 @@
                             "call",
                             "chat",
                             "conversations",
+                            "federation",
                             "previews",
                             "signaling"
                         ],
@@ -146,6 +147,29 @@
                                 ],
                                 "properties": {
                                     "can-create": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            },
+                            "federation": {
+                                "type": "object",
+                                "required": [
+                                    "enabled",
+                                    "incoming-enabled",
+                                    "outgoing-enabled",
+                                    "only-trusted-servers"
+                                ],
+                                "properties": {
+                                    "enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "incoming-enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "outgoing-enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "only-trusted-servers": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -158,6 +158,7 @@
                             "call",
                             "chat",
                             "conversations",
+                            "federation",
                             "previews",
                             "signaling"
                         ],
@@ -263,6 +264,29 @@
                                 ],
                                 "properties": {
                                     "can-create": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            },
+                            "federation": {
+                                "type": "object",
+                                "required": [
+                                    "enabled",
+                                    "incoming-enabled",
+                                    "outgoing-enabled",
+                                    "only-trusted-servers"
+                                ],
+                                "properties": {
+                                    "enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "incoming-enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "outgoing-enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "only-trusted-servers": {
                                         "type": "boolean"
                                     }
                                 }

--- a/openapi.json
+++ b/openapi.json
@@ -99,6 +99,7 @@
                             "call",
                             "chat",
                             "conversations",
+                            "federation",
                             "previews",
                             "signaling"
                         ],
@@ -204,6 +205,29 @@
                                 ],
                                 "properties": {
                                     "can-create": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            },
+                            "federation": {
+                                "type": "object",
+                                "required": [
+                                    "enabled",
+                                    "incoming-enabled",
+                                    "outgoing-enabled",
+                                    "only-trusted-servers"
+                                ],
+                                "properties": {
+                                    "enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "incoming-enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "outgoing-enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "only-trusted-servers": {
                                         "type": "boolean"
                                     }
                                 }

--- a/src/components/AdminSettings/Federation.vue
+++ b/src/components/AdminSettings/Federation.vue
@@ -107,11 +107,11 @@ import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
 
-const FEDERATION_ENABLED = loadState('spreed', 'federation_enabled', 'no') === 'yes'
-const FEDERATION_INCOMING_ENABLED = loadState('spreed', 'federation_incoming_enabled', '0') === '1'
-const FEDERATION_OUTGOING_ENABLED = loadState('spreed', 'federation_outgoing_enabled', '0') === '1'
-const FEDERATION_ONLY_TRUSTED_SERVERS = loadState('spreed', 'federation_only_trusted_servers', '0') === '1'
-const FEDERATION_ALLOWED_GROUPS = JSON.parse(loadState('spreed', 'federation_allowed_groups', '[]'))
+const FEDERATION_ENABLED = loadState('spreed', 'federation_enabled', false)
+const FEDERATION_INCOMING_ENABLED = loadState('spreed', 'federation_incoming_enabled', true)
+const FEDERATION_OUTGOING_ENABLED = loadState('spreed', 'federation_outgoing_enabled', true)
+const FEDERATION_ONLY_TRUSTED_SERVERS = loadState('spreed', 'federation_only_trusted_servers', false)
+const FEDERATION_ALLOWED_GROUPS = loadState('spreed', 'federation_allowed_groups', [])
 
 export default {
 	name: 'Federation',

--- a/src/types/openapi/openapi-administration.ts
+++ b/src/types/openapi/openapi-administration.ts
@@ -131,6 +131,12 @@ export type components = {
         conversations: {
           "can-create": boolean;
         };
+        federation: {
+          enabled: boolean;
+          "incoming-enabled": boolean;
+          "outgoing-enabled": boolean;
+          "only-trusted-servers": boolean;
+        };
         previews: {
           /** Format: int64 */
           "max-gif-size": number;

--- a/src/types/openapi/openapi-backend-recording.ts
+++ b/src/types/openapi/openapi-backend-recording.ts
@@ -56,6 +56,12 @@ export type components = {
         conversations: {
           "can-create": boolean;
         };
+        federation: {
+          enabled: boolean;
+          "incoming-enabled": boolean;
+          "outgoing-enabled": boolean;
+          "only-trusted-servers": boolean;
+        };
         previews: {
           /** Format: int64 */
           "max-gif-size": number;

--- a/src/types/openapi/openapi-backend-signaling.ts
+++ b/src/types/openapi/openapi-backend-signaling.ts
@@ -55,6 +55,12 @@ export type components = {
         conversations: {
           "can-create": boolean;
         };
+        federation: {
+          enabled: boolean;
+          "incoming-enabled": boolean;
+          "outgoing-enabled": boolean;
+          "only-trusted-servers": boolean;
+        };
         previews: {
           /** Format: int64 */
           "max-gif-size": number;

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -72,6 +72,12 @@ export type components = {
         conversations: {
           "can-create": boolean;
         };
+        federation: {
+          enabled: boolean;
+          "incoming-enabled": boolean;
+          "outgoing-enabled": boolean;
+          "only-trusted-servers": boolean;
+        };
         previews: {
           /** Format: int64 */
           "max-gif-size": number;

--- a/src/types/openapi/openapi-bots.ts
+++ b/src/types/openapi/openapi-bots.ts
@@ -61,6 +61,12 @@ export type components = {
         conversations: {
           "can-create": boolean;
         };
+        federation: {
+          enabled: boolean;
+          "incoming-enabled": boolean;
+          "outgoing-enabled": boolean;
+          "only-trusted-servers": boolean;
+        };
         previews: {
           /** Format: int64 */
           "max-gif-size": number;

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -71,6 +71,12 @@ export type components = {
         conversations: {
           "can-create": boolean;
         };
+        federation: {
+          enabled: boolean;
+          "incoming-enabled": boolean;
+          "outgoing-enabled": boolean;
+          "only-trusted-servers": boolean;
+        };
         previews: {
           /** Format: int64 */
           "max-gif-size": number;

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -576,6 +576,12 @@ export type components = {
         conversations: {
           "can-create": boolean;
         };
+        federation: {
+          enabled: boolean;
+          "incoming-enabled": boolean;
+          "outgoing-enabled": boolean;
+          "only-trusted-servers": boolean;
+        };
         previews: {
           /** Format: int64 */
           "max-gif-size": number;

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -431,6 +431,12 @@ export type components = {
         conversations: {
           "can-create": boolean;
         };
+        federation: {
+          enabled: boolean;
+          "incoming-enabled": boolean;
+          "outgoing-enabled": boolean;
+          "only-trusted-servers": boolean;
+        };
         previews: {
           /** Format: int64 */
           "max-gif-size": number;

--- a/tests/php/CapabilitiesTest.php
+++ b/tests/php/CapabilitiesTest.php
@@ -31,6 +31,7 @@ use OCA\Talk\Config;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCP\App\IAppManager;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\Capabilities\IPublicCapability;
 use OCP\ICache;
 use OCP\ICacheFactory;
@@ -44,6 +45,7 @@ use Test\TestCase;
 class CapabilitiesTest extends TestCase {
 	protected IConfig|MockObject $serverConfig;
 	protected Config|MockObject $talkConfig;
+	protected IAppConfig|MockObject $appConfig;
 	protected CommentsManager|MockObject $commentsManager;
 	protected IUserSession|MockObject $userSession;
 	protected IAppManager|MockObject $appManager;
@@ -56,6 +58,7 @@ class CapabilitiesTest extends TestCase {
 		parent::setUp();
 		$this->serverConfig = $this->createMock(IConfig::class);
 		$this->talkConfig = $this->createMock(Config::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->commentsManager = $this->createMock(CommentsManager::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->appManager = $this->createMock(IAppManager::class);
@@ -148,6 +151,7 @@ class CapabilitiesTest extends TestCase {
 			'edit-messages',
 			'silent-send-state',
 			'chat-read-last',
+			'federation-v1',
 			'message-expiration',
 			'reactions',
 		];
@@ -157,6 +161,7 @@ class CapabilitiesTest extends TestCase {
 		$capabilities = new Capabilities(
 			$this->serverConfig,
 			$this->talkConfig,
+			$this->appConfig,
 			$this->commentsManager,
 			$this->userSession,
 			$this->appManager,
@@ -223,6 +228,12 @@ class CapabilitiesTest extends TestCase {
 					'conversations' => [
 						'can-create' => false,
 					],
+					'federation' => [
+						'enabled' => false,
+						'incoming-enabled' => false,
+						'outgoing-enabled' => false,
+						'only-trusted-servers' => true,
+					],
 					'previews' => [
 						'max-gif-size' => 200000,
 					],
@@ -255,6 +266,7 @@ class CapabilitiesTest extends TestCase {
 		$capabilities = new Capabilities(
 			$this->serverConfig,
 			$this->talkConfig,
+			$this->appConfig,
 			$this->commentsManager,
 			$this->userSession,
 			$this->appManager,
@@ -351,6 +363,12 @@ class CapabilitiesTest extends TestCase {
 					'conversations' => [
 						'can-create' => $canCreate,
 					],
+					'federation' => [
+						'enabled' => false,
+						'incoming-enabled' => false,
+						'outgoing-enabled' => false,
+						'only-trusted-servers' => true,
+					],
 					'previews' => [
 						'max-gif-size' => 200000,
 					],
@@ -382,6 +400,7 @@ class CapabilitiesTest extends TestCase {
 		$capabilities = new Capabilities(
 			$this->serverConfig,
 			$this->talkConfig,
+			$this->appConfig,
 			$this->commentsManager,
 			$this->userSession,
 			$this->appManager,
@@ -407,6 +426,7 @@ class CapabilitiesTest extends TestCase {
 		$capabilities = new Capabilities(
 			$this->serverConfig,
 			$this->talkConfig,
+			$this->appConfig,
 			$this->commentsManager,
 			$this->userSession,
 			$this->appManager,
@@ -429,6 +449,7 @@ class CapabilitiesTest extends TestCase {
 		$capabilities = new Capabilities(
 			$this->serverConfig,
 			$this->talkConfig,
+			$this->appConfig,
 			$this->commentsManager,
 			$this->userSession,
 			$this->appManager,
@@ -455,6 +476,7 @@ class CapabilitiesTest extends TestCase {
 		$capabilities = new Capabilities(
 			$this->serverConfig,
 			$this->talkConfig,
+			$this->appConfig,
 			$this->commentsManager,
 			$this->userSession,
 			$this->appManager,

--- a/tests/php/Settings/Admin/AdminSettingsTest.php
+++ b/tests/php/Settings/Admin/AdminSettingsTest.php
@@ -27,6 +27,7 @@ use OCA\Talk\Config;
 use OCA\Talk\MatterbridgeManager;
 use OCA\Talk\Service\CommandService;
 use OCA\Talk\Settings\Admin\AdminSettings;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -43,6 +44,7 @@ class AdminSettingsTest extends TestCase {
 	protected $talkConfig;
 	/** @var IConfig|MockObject */
 	protected $serverConfig;
+	protected IAppConfig|MockObject $appConfig;
 	/** @var CommandService|MockObject */
 	protected $commandService;
 	/** @var IInitialState|MockObject */
@@ -66,6 +68,7 @@ class AdminSettingsTest extends TestCase {
 
 		$this->talkConfig = $this->createMock(Config::class);
 		$this->serverConfig = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->commandService = $this->createMock(CommandService::class);
 		$this->initialState = $this->createMock(IInitialState::class);
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
@@ -87,6 +90,7 @@ class AdminSettingsTest extends TestCase {
 			return new AdminSettings(
 				$this->talkConfig,
 				$this->serverConfig,
+				$this->appConfig,
 				$this->commandService,
 				$this->initialState,
 				$this->cacheFactory,
@@ -102,6 +106,7 @@ class AdminSettingsTest extends TestCase {
 			->setConstructorArgs([
 				$this->talkConfig,
 				$this->serverConfig,
+				$this->appConfig,
 				$this->commandService,
 				$this->initialState,
 				$this->cacheFactory,


### PR DESCRIPTION
## 🛠️ API Checklist

* `federation-v1` - Whether basic chatting is possible with federation
* `config => federation => enabled` - Boolean, whether federation is enabled on instance
* `config => federation => incoming-enabled` - Boolean, whether users are allowed to be invited into federated conversations on other servers
* `config => federation => outgoing-enabled` - Boolean, whether users are allowed to invited federated users of other servers into conversations
* `config => federation => only-trusted-servers` - Boolean, whether federation invites are limited to trusted servers

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
