### PR TITLE
fix(conversation): skip unread marker increasing from notification

### DIFF
--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -722,6 +722,11 @@ const actions = {
 		}
 
 		const conversation = Object.assign({}, getters.conversations[token])
+		if (conversation.lastMessage.id === parseInt(messageId, 10)
+			|| conversation.lastMessage.timestamp >= Date.parse(notification.datetime) / 1000) {
+			// Already updated from other source, skipping
+			return
+		}
 
 		const actor = notification.subjectRichParameters.user || notification.subjectRichParameters.guest || {
 			type: 'guest',


### PR DESCRIPTION
### ☑️ Resolves

* There could be a race condition between room and notification fetch
* If room comes first, unread marker is already updated there, no need to do it again
* For federated rooms, lastMessage.id is not presented, so checked by timestamp

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

[Screencast from 07.03.2024 12:25:29.webm](https://github.com/nextcloud/spreed/assets/93392545/8bd3a0f8-890a-4d3a-bca5-d91992e51fb8)



[Screencast from 07.03.2024 13:13:34.webm](https://github.com/nextcloud/spreed/assets/93392545/64ca819d-d496-43a4-a51a-5ffff9fde14d)


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possible