### PR TITLE
fix(federation): Correctly convert message on deleting

### DIFF
--- a/lib/Federation/Proxy/TalkV1/Controller/ChatController.php
+++ b/lib/Federation/Proxy/TalkV1/Controller/ChatController.php
@@ -331,14 +331,9 @@ class ChatController {
 			return new DataResponse([], $statusCode);
 		}
 
-		/** @var ?TalkChatMessageWithParent $data */
+		/** @var TalkChatMessageWithParent $data */
 		$data = $this->proxy->getOCSData($proxy, [Http::STATUS_OK, Http::STATUS_ACCEPTED]);
-		if (!empty($data)) {
-			$data = $this->userConverter->convertAttendee($room, $data, 'actorType', 'actorId', 'actorDisplayName');
-			$data = $this->userConverter->convertAttendee($room, $data, 'lastEditActorType', 'lastEditActorId', 'lastEditActorDisplayName');
-		} else {
-			$data = null;
-		}
+		$data = $this->userConverter->convertMessage($room, $data);
 
 		$headers = [];
 		if ($proxy->getHeader('X-Chat-Last-Common-Read')) {


### PR DESCRIPTION
## 🛠️ API Checklist

### 🚧 Tasks

- [x] System message 'message_deleted' parent doesn't transform user in federated conversation 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
