### PR TITLE
feat: Implement team resource provider

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "439198343dcc5bce91a7ceeb981348df26529b71"
+                "reference": "db01c46c748035159b53791271d8a036a4c27c36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/439198343dcc5bce91a7ceeb981348df26529b71",
-                "reference": "439198343dcc5bce91a7ceeb981348df26529b71",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/db01c46c748035159b53791271d8a036a4c27c36",
+                "reference": "db01c46c748035159b53791271d8a036a4c27c36",
                 "shasum": ""
             },
             "require": {
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-02-29T00:31:54+00:00"
+            "time": "2024-03-07T00:26:08+00:00"
         },
         {
             "name": "psr/clock",

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -122,6 +122,7 @@ use OCA\Talk\Settings\Personal;
 use OCA\Talk\Share\Listener as ShareListener;
 use OCA\Talk\Signaling\Listener as SignalingListener;
 use OCA\Talk\Status\Listener as StatusListener;
+use OCA\Talk\Team\TalkTeamResourceProvider;
 use OCP\App\IAppManager;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
@@ -331,6 +332,8 @@ class Application extends App implements IBootstrap {
 		$context->registerReferenceProvider(TalkReferenceProvider::class);
 
 		$context->registerTalkBackend(TalkBackend::class);
+
+		$context->registerTeamResourceProvider(TalkTeamResourceProvider::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Team/TalkTeamResourceProvider.php
+++ b/lib/Team/TalkTeamResourceProvider.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2024 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Talk\Team;
+
+use OCA\Talk\Exceptions\RoomNotFoundException;
+use OCA\Talk\Manager;
+use OCA\Talk\Model\Attendee;
+use OCA\Talk\Participant;
+use OCA\Talk\Room;
+use OCA\Talk\Service\AvatarService;
+use OCA\Talk\Service\ParticipantService;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\Teams\ITeamResourceProvider;
+use OCP\Teams\TeamResource;
+
+class TalkTeamResourceProvider implements ITeamResourceProvider {
+	public function __construct(
+		private ParticipantService $participantService,
+		private Manager $manager,
+		private AvatarService $avatarService,
+		private IL10N $l10n,
+		private IURLGenerator $urlGenerator,
+	) {
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getId(): string {
+		return 'talk';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getName(): string {
+		return $this->l10n->t('Talk conversations');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getIconSvg(): string {
+		return '<svg width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m7.9992 0.999a6.9993 6.9994 0 0 0-6.9992 6.9996 6.9993 6.9994 0 0 0 6.9992 6.9994 6.9993 6.9994 0 0 0 3.6308-1.024c0.86024 0.34184 2.7871 1.356 3.2457 0.91794 0.47922-0.45765-0.56261-2.6116-0.81238-3.412a6.9993 6.9994 0 0 0 0.935-3.4814 6.9993 6.9994 0 0 0-6.9991-6.9993zm8e-4 2.6611a4.34 4.3401 0 0 1 4.34 4.3401 4.34 4.3401 0 0 1-4.34 4.3398 4.34 4.3401 0 0 1-4.34-4.3398 4.34 4.3401 0 0 1 4.34-4.3401z" stroke-width=".14"/></svg>';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getSharedWith(string $teamId): array {
+		$rooms = $this->manager->getRoomsForActor(Attendee::ACTOR_CIRCLES, $teamId);
+		return array_map(function (Room $room) {
+			return new TeamResource(
+				$this,
+				$room->getToken(),
+				$room->getName(),
+				$this->urlGenerator->linkToRouteAbsolute('spreed.Page.showCall', ['token' => $room->getToken()]),
+				iconURL: $this->avatarService->getAvatarUrl($room),
+			);
+		}, $rooms);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function isSharedWithTeam(string $teamId, string $resourceId): bool {
+		try {
+			$this->manager->getRoomByActor($resourceId, Attendee::ACTOR_CIRCLES, $teamId);
+			return true;
+		} catch (RoomNotFoundException) {
+		}
+
+		return false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getTeamsForResource(string $resourceId): array {
+		try {
+			$room = $this->manager->getRoomByToken($resourceId);
+			$participants = $this->participantService->getParticipantsByActorType($room, Attendee::ACTOR_CIRCLES);
+			return array_map(function (Participant $participant) {
+				return $participant->getAttendee()->getActorId();
+			}, $participants);
+		} catch (RoomNotFoundException) {
+		}
+
+		return [];
+	}
+}


### PR DESCRIPTION
Implement a team resource provider for talk that lists team resources in the related resource panel and in the team dashboard in contacts.

There are two bugs with rendering the image I came across unfortunately but need a fix in contacts and the vue lib:
- https://github.com/nextcloud/contacts/pull/3844
- https://github.com/nextcloud-libraries/nextcloud-vue/pull/5364

### ☑️ Resolves

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Screenshot within the team dashboard after the above mentioned fix:

<img width="841" alt="Screenshot 2024-03-07 at 16 30 21" src="https://github.com/nextcloud/spreed/assets/3404133/c7323cce-9ee3-4c69-a526-84ab7628faa8">


## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
