### PR TITLE
fix(federation): Don't expose the accessToken anymore to the frontend/clients

### DIFF
--- a/lib/Model/Attendee.php
+++ b/lib/Model/Attendee.php
@@ -216,7 +216,6 @@ class Attendee extends Entity {
 			'last_mention_direct' => $this->getLastMentionDirect(),
 			'read_privacy' => $this->getReadPrivacy(),
 			'permissions' => $this->getPermissions(),
-			'access_token' => $this->getAccessToken(),
 			'remote_id' => $this->getRemoteId(),
 			'invited_cloud_id' => $this->getInvitedCloudId(),
 			'phone_number' => $this->getPhoneNumber(),

--- a/lib/Model/Invitation.php
+++ b/lib/Model/Invitation.php
@@ -79,7 +79,7 @@ class Invitation extends Entity implements \JsonSerializable {
 	}
 
 	/**
-	 * @return array{accessToken: string, id: int, localRoomId: int, localCloudId: string, remoteAttendeeId: int, remoteServerUrl: string, remoteToken: string, state: int, userId: string, inviterCloudId: string, inviterDisplayName: string}
+	 * @return array{id: int, localRoomId: int, localCloudId: string, remoteAttendeeId: int, remoteServerUrl: string, remoteToken: string, state: int, userId: string, inviterCloudId: string, inviterDisplayName: string}
 	 */
 	public function jsonSerialize(): array {
 		return [
@@ -88,7 +88,6 @@ class Invitation extends Entity implements \JsonSerializable {
 			'state' => $this->getState(),
 			'localRoomId' => $this->getLocalRoomId(),
 			'localCloudId' => $this->getLocalCloudId(),
-			'accessToken' => $this->getAccessToken(),
 			'remoteServerUrl' => $this->getRemoteServerUrl(),
 			'remoteToken' => $this->getRemoteToken(),
 			'remoteAttendeeId' => $this->getRemoteAttendeeId(),

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -114,7 +114,6 @@ namespace OCA\Talk;
  * }
  *
  * @psalm-type TalkFederationInvite = array{
- *     accessToken: string,
  *     id: int,
  *     state: int,
  *     localCloudId: string,

--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -348,7 +348,6 @@ class RoomFormatter {
 		if ($room->getRemoteServer() && $room->getRemoteToken()) {
 			$roomData['remoteServer'] = $room->getRemoteServer();
 			$roomData['remoteToken'] = $room->getRemoteToken();
-			$roomData['remoteAccessToken'] = $attendee->getAccessToken();
 		}
 
 		// FIXME This should not be done, but currently all the clients use it to get the avatar of the user …

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -313,7 +313,6 @@
             "FederationInvite": {
                 "type": "object",
                 "required": [
-                    "accessToken",
                     "id",
                     "state",
                     "localCloudId",
@@ -327,9 +326,6 @@
                     "inviterDisplayName"
                 ],
                 "properties": {
-                    "accessToken": {
-                        "type": "string"
-                    },
                     "id": {
                         "type": "integer",
                         "format": "int64"

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -514,7 +514,6 @@
             "FederationInvite": {
                 "type": "object",
                 "required": [
-                    "accessToken",
                     "id",
                     "state",
                     "localCloudId",
@@ -528,9 +527,6 @@
                     "inviterDisplayName"
                 ],
                 "properties": {
-                    "accessToken": {
-                        "type": "string"
-                    },
                     "id": {
                         "type": "integer",
                         "format": "int64"

--- a/src/stores/federation.js
+++ b/src/stores/federation.js
@@ -121,7 +121,6 @@ export const useFederationStore = defineStore('federation', {
 			Vue.delete(this.pendingShares[id], 'loading')
 			Vue.set(this.acceptedShares, id, {
 				...this.pendingShares[id],
-				accessToken: conversation.remoteAccessToken,
 				localRoomId: conversation.id,
 				state: FEDERATION.STATE.ACCEPTED,
 			})

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -132,7 +132,6 @@ export type components = {
       silent?: boolean;
     };
     FederationInvite: {
-      accessToken: string;
       /** Format: int64 */
       id: number;
       /** Format: int64 */

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -659,7 +659,6 @@ export type components = {
       userId: string;
     };
     FederationInvite: {
-      accessToken: string;
       /** Format: int64 */
       id: number;
       /** Format: int64 */

--- a/tests/integration/features/federation/invite.feature
+++ b/tests/integration/features/federation/invite.feature
@@ -156,32 +156,6 @@ Feature: federation/invite
       | room | users         | participant1 | federated_user_added    | You invited {federated_user} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
       | room | users         | participant1 | conversation_created    | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
 
-  Scenario: Authenticate as a federation user
-    Given the following "spreed" app config is set
-      | federation_enabled | yes |
-    Given user "participant1" creates room "room" (v4)
-      | roomType | 2 |
-      | roomName | room |
-    And user "participant1" adds federated_user "participant2" to room "room" with 200 (v4)
-    And user "participant2" has the following invitations (v1)
-      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
-      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
-    And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
-    And user "participant2" has the following invitations (v1)
-      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
-      | LOCAL           | room        | 1     | participant1@http://localhost:8080 | participant1-displayname |
-    Then user "participant2" is participant of the following rooms (v4)
-      | id   | type |
-      | room | 2    |
-    Then user "federation/participant2" gets room "room" with 200 (v4)
-    Then user "federation/participant2" joins room "room" with 200 (v4)
-    And user "federation/participant2" sends message "Message 1" to room "room" with 201
-    Then user "participant1" sees the following messages in room "room" with 200
-      | room | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
-      | room |federated_users | participant2@http://localhost:8180 | participant2@localhost:8180 | Message 1   | []                |               |
-
   Scenario: Federate conversation meta data
     Given the following "spreed" app config is set
       | federation_enabled | yes |


### PR DESCRIPTION
## 🛠️ API Checklist
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
