### PR TITLE
fix(federation): Don't request user status from remote instances

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -845,7 +845,7 @@ class RoomController extends AEnvironmentAwareController {
 		if ($this->room->getRemoteServer()) {
 			/** @var \OCA\Talk\Federation\Proxy\TalkV1\Controller\RoomController $proxy */
 			$proxy = \OCP\Server::get(\OCA\Talk\Federation\Proxy\TalkV1\Controller\RoomController::class);
-			return $proxy->getParticipants($this->room, $this->participant, $includeStatus);
+			return $proxy->getParticipants($this->room, $this->participant);
 		}
 
 		if ($this->participant->getAttendee()->getParticipantType() === Participant::GUEST) {

--- a/lib/Federation/Proxy/TalkV1/Controller/RoomController.php
+++ b/lib/Federation/Proxy/TalkV1/Controller/RoomController.php
@@ -56,20 +56,17 @@ class RoomController {
 	 * 200: Participants returned
 	 * 403: Missing permissions for getting participants
 	 */
-	public function getParticipants(Room $room, Participant $participant, bool $includeStatus = false): DataResponse {
+	public function getParticipants(Room $room, Participant $participant): DataResponse {
 		$proxy = $this->proxy->get(
 			$participant->getAttendee()->getInvitedCloudId(),
 			$participant->getAttendee()->getAccessToken(),
 			$room->getRemoteServer() . '/ocs/v2.php/apps/spreed/api/v4/room/' . $room->getRemoteToken() . '/participants',
-			[
-				'includeStatus' => $includeStatus,
-			],
 		);
 
 		/** @var TalkParticipant[] $data */
 		$data = $this->proxy->getOCSData($proxy);
 
-		// FIXME post-load status information
+		// FIXME post-load status information of now local users
 		/** @var TalkParticipant[] $data */
 		$data = $this->userConverter->convertAttendees($room, $data, 'actorType', 'actorId', 'displayName');
 		$headers = [];


### PR DESCRIPTION
## 🛠️ API Checklist

- Actually No-Op because the host checks and only returns status to "users" and federated users are not authed this way

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
