### PR TITLE
chore(deps): bump @nextcloud/vue from 8.8.1 to 8.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^3.0.0",
         "@nextcloud/upload": "^1.0.5",
-        "@nextcloud/vue": "^8.8.1",
+        "@nextcloud/vue": "^8.9.1",
         "crypto-js": "^4.2.0",
         "debounce": "^2.0.0",
         "emoji-mart-vue-fast": "^15.0.0",
@@ -3827,21 +3827,21 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.8.1.tgz",
-      "integrity": "sha512-INQS0boqH4CAzRHESSaKgvaTOsOJ/0fyOB9sC5TIJpqkrPo1Oj229U9XUUf8HV/Xs6FpA5YmQFvQ0gKZ5a1GRw==",
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.9.1.tgz",
+      "integrity": "sha512-Mj+CovsPqAwUsCxeQfhYc9thx7synLTi95htwHu1s0XEg6SlaOV3BRarxD0m4C236ZpaIQ4DDfezDtuBln/mIA==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
-        "@nextcloud/auth": "^2.0.0",
-        "@nextcloud/axios": "^2.0.0",
+        "@nextcloud/auth": "^2.2.1",
+        "@nextcloud/axios": "^2.4.0",
         "@nextcloud/browser-storage": "^0.3.0",
-        "@nextcloud/calendar-js": "^6.0.0",
-        "@nextcloud/capabilities": "^1.0.4",
-        "@nextcloud/event-bus": "^3.0.0",
-        "@nextcloud/initial-state": "^2.0.0",
-        "@nextcloud/l10n": "^2.0.1",
-        "@nextcloud/logger": "^2.2.1",
+        "@nextcloud/calendar-js": "^6.1.0",
+        "@nextcloud/capabilities": "^1.1.0",
+        "@nextcloud/event-bus": "^3.1.0",
+        "@nextcloud/initial-state": "^2.1.0",
+        "@nextcloud/l10n": "^2.2.0",
+        "@nextcloud/logger": "^2.7.0",
         "@nextcloud/router": "^3.0.0",
         "@nextcloud/vue-select": "^3.25.0",
         "@vueuse/components": "^10.9.0",
@@ -3907,12 +3907,12 @@
       }
     },
     "node_modules/@nextcloud/vue/node_modules/@nextcloud/calendar-js": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.0.1.tgz",
-      "integrity": "sha512-iv6iPw20vp0CinVVrH4ptcuWPdAAx1AawMrYLqFg4vSEr0eVbwz6SW4P8GbxjzzRFJ0xqFXsmFeudiVAhvBaxA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.1.0.tgz",
+      "integrity": "sha512-thVS6Bz+TV7rUB+LO5yFbOhdm65zICDRKcHDUquaZiWL9r6TyV9hCYDcP7cDRV+62wZJh8QPmf1E+d7ZFUOVeA==",
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.0.0",
+        "npm": "^9.0.0"
       },
       "peerDependencies": {
         "ical.js": "^1.5.0",
@@ -23523,21 +23523,21 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.8.1.tgz",
-      "integrity": "sha512-INQS0boqH4CAzRHESSaKgvaTOsOJ/0fyOB9sC5TIJpqkrPo1Oj229U9XUUf8HV/Xs6FpA5YmQFvQ0gKZ5a1GRw==",
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.9.1.tgz",
+      "integrity": "sha512-Mj+CovsPqAwUsCxeQfhYc9thx7synLTi95htwHu1s0XEg6SlaOV3BRarxD0m4C236ZpaIQ4DDfezDtuBln/mIA==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
-        "@nextcloud/auth": "^2.0.0",
-        "@nextcloud/axios": "^2.0.0",
+        "@nextcloud/auth": "^2.2.1",
+        "@nextcloud/axios": "^2.4.0",
         "@nextcloud/browser-storage": "^0.3.0",
-        "@nextcloud/calendar-js": "^6.0.0",
-        "@nextcloud/capabilities": "^1.0.4",
-        "@nextcloud/event-bus": "^3.0.0",
-        "@nextcloud/initial-state": "^2.0.0",
-        "@nextcloud/l10n": "^2.0.1",
-        "@nextcloud/logger": "^2.2.1",
+        "@nextcloud/calendar-js": "^6.1.0",
+        "@nextcloud/capabilities": "^1.1.0",
+        "@nextcloud/event-bus": "^3.1.0",
+        "@nextcloud/initial-state": "^2.1.0",
+        "@nextcloud/l10n": "^2.2.0",
+        "@nextcloud/logger": "^2.7.0",
         "@nextcloud/router": "^3.0.0",
         "@nextcloud/vue-select": "^3.25.0",
         "@vueuse/components": "^10.9.0",
@@ -23588,9 +23588,9 @@
           }
         },
         "@nextcloud/calendar-js": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.0.1.tgz",
-          "integrity": "sha512-iv6iPw20vp0CinVVrH4ptcuWPdAAx1AawMrYLqFg4vSEr0eVbwz6SW4P8GbxjzzRFJ0xqFXsmFeudiVAhvBaxA==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.1.0.tgz",
+          "integrity": "sha512-thVS6Bz+TV7rUB+LO5yFbOhdm65zICDRKcHDUquaZiWL9r6TyV9hCYDcP7cDRV+62wZJh8QPmf1E+d7ZFUOVeA==",
           "requires": {}
         },
         "@types/unist": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^3.0.0",
     "@nextcloud/upload": "^1.0.5",
-    "@nextcloud/vue": "^8.8.1",
+    "@nextcloud/vue": "^8.9.1",
     "crypto-js": "^4.2.0",
     "debounce": "^2.0.0",
     "emoji-mart-vue-fast": "^15.0.0",


### PR DESCRIPTION
### ☑️ Resolves

Release: 				https://github.com/nextcloud-libraries/nextcloud-vue/releases/tag/v8.9.0
https://github.com/nextcloud-libraries/nextcloud-vue/releases/tag/v8.9.1


<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required