### PR TITLE
fix(ConversationIcon): force light background color for conversation …

### DIFF
--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -20,7 +20,7 @@
 -->
 
 <template>
-	<div class="top-bar" :data-theme-dark="isInCall">
+	<div class="top-bar" :style="topBarStyle" :data-theme-dark="isInCall">
 		<ConversationIcon :key="conversation.token"
 			class="conversation-icon"
 			:offline="isPeerInactive"
@@ -306,6 +306,12 @@ export default {
 		hasReactionSupport() {
 			return this.isInCall && this.supportedReactions?.length > 0
 		},
+
+		topBarStyle() {
+			return {
+				'--original-color-main-background': window.getComputedStyle(document.body).getPropertyValue('--color-main-background')
+			}
+		},
 	},
 
 	watch: {
@@ -464,5 +470,10 @@ export default {
 			color: var(--color-text-maxcontrast);
 		}
 	}
+}
+
+:deep(.conversation-icon__type) {
+	border-color: var(--original-color-main-background) !important;
+	background-color: var(--original-color-main-background) !important;
 }
 </style>


### PR DESCRIPTION
…type when using light theme

### ☑️ Resolves

It is aligned with used theme.


<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/84044328/59afedf4-bb2f-42fb-8342-105b7512d606) | ![image](https://github.com/nextcloud/spreed/assets/84044328/bea3921f-3b31-4ba8-8c83-4b33ffab017f)

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
