### PR TITLE
fix(federation): hide unsupported features from web interface

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -235,6 +235,8 @@ import { parseSpecialSymbols } from '../../utils/textParse.ts'
 const disableKeyboardShortcuts = OCP.Accessibility.disableKeyboardShortcuts()
 const supportTypingStatus = getCapabilities()?.spreed?.config?.chat?.['typing-privacy'] !== undefined
 const canEditMessage = getCapabilities()?.spreed?.features?.includes('edit-messages')
+const attachmentsAllowed = getCapabilities()?.spreed?.config?.attachments?.allowed
+const supportFederationV1 = getCapabilities()?.spreed?.features?.includes('federation-v1')
 
 export default {
 	name: 'NewMessage',
@@ -407,17 +409,18 @@ export default {
 
 		canShareFiles() {
 			return !this.currentUserIsGuest
+				&& (!supportFederationV1 || !this.conversation.remoteServer)
 		},
 
 		canUploadFiles() {
-			return getCapabilities()?.spreed?.config?.attachments?.allowed
+			return attachmentsAllowed && this.canShareFiles
 				&& this.$store.getters.getAttachmentFolderFreeSpace() !== 0
-				&& this.canShareFiles
 		},
 
 		canCreatePoll() {
 			return !this.isOneToOne && !this.noChatPermission
 				&& this.conversation.type !== CONVERSATION.TYPE.NOTE_TO_SELF
+				&& (!supportFederationV1 || !this.conversation.remoteServer)
 		},
 
 		currentConversationIsJoined() {

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -65,7 +65,7 @@
 				:main-conversation="mainConversation"
 				:is-active="activeTab === 'breakout-rooms'" />
 		</NcAppSidebarTab>
-		<NcAppSidebarTab v-if="!getUserId || showSIPSettings"
+		<NcAppSidebarTab v-if="showDetailsTab"
 			id="details-tab"
 			:order="4"
 			:name="t('spreed', 'Details')">
@@ -87,7 +87,7 @@
 				</div>
 			</div>
 		</NcAppSidebarTab>
-		<NcAppSidebarTab v-if="getUserId"
+		<NcAppSidebarTab v-if="showSharedItemsTab"
 			id="shared-items"
 			ref="sharedItemsTab"
 			:order="5"
@@ -108,6 +108,7 @@ import FolderMultipleImage from 'vue-material-design-icons/FolderMultipleImage.v
 import InformationOutline from 'vue-material-design-icons/InformationOutline.vue'
 import Message from 'vue-material-design-icons/Message.vue'
 
+import { getCapabilities } from '@nextcloud/capabilities'
 import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
 
 import NcAppSidebar from '@nextcloud/vue/dist/Components/NcAppSidebar.js'
@@ -124,6 +125,8 @@ import SetGuestUsername from '../SetGuestUsername.vue'
 
 import { CONVERSATION, WEBINAR, PARTICIPANT } from '../../constants.js'
 import BrowserStorage from '../../services/BrowserStorage.js'
+
+const supportFederationV1 = getCapabilities()?.spreed?.features?.includes('federation-v1')
 
 export default {
 	name: 'RightSidebar',
@@ -266,11 +269,20 @@ export default {
 
 		showBreakoutRoomsTab() {
 			return this.getUserId && !this.isOneToOne
+				&& (!supportFederationV1 || !this.conversation.remoteServer)
 				&& (this.breakoutRoomsConfigured || this.conversation.breakoutRoomMode === CONVERSATION.BREAKOUT_ROOM_MODE.FREE || this.conversation.objectType === CONVERSATION.OBJECT_TYPE.BREAKOUT_ROOM)
 		},
 
 		showParticipantsTab() {
 			return (this.getUserId || this.isModeratorOrUser) && !this.isOneToOne && !this.isNoteToSelf
+		},
+
+		showSharedItemsTab() {
+			return this.getUserId && (!supportFederationV1 || !this.conversation.remoteServer)
+		},
+
+		showDetailsTab() {
+			return !this.getUserId || this.showSIPSettings
 		},
 
 		isNoteToSelf() {

--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -102,6 +102,7 @@ import VideoBoxOff from 'vue-material-design-icons/VideoBoxOff.vue'
 import VideoOff from 'vue-material-design-icons/VideoOff.vue'
 import VideoOutlineIcon from 'vue-material-design-icons/VideoOutline.vue'
 
+import { getCapabilities } from '@nextcloud/capabilities'
 import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 import { loadState } from '@nextcloud/initial-state'
@@ -118,6 +119,8 @@ import { EventBus } from '../../services/EventBus.js'
 import { useSettingsStore } from '../../stores/settings.js'
 import { useTalkHashStore } from '../../stores/talkHash.js'
 import { blockCalls, unsupportedWarning } from '../../utils/browserCheck.js'
+
+const supportFederationV1 = getCapabilities()?.spreed?.features?.includes('federation-v1')
 
 export default {
 	name: 'CallButton',
@@ -298,6 +301,7 @@ export default {
 			return this.callEnabled
 				&& this.conversation.type !== CONVERSATION.TYPE.NOTE_TO_SELF
 				&& this.conversation.readOnly === CONVERSATION.STATE.READ_WRITE
+				&& (!supportFederationV1 || !this.conversation.remoteServer)
 				&& !this.isInCall
 		},
 

--- a/src/services/conversationsService.js
+++ b/src/services/conversationsService.js
@@ -21,10 +21,14 @@
  */
 
 import axios from '@nextcloud/axios'
-import { loadState } from '@nextcloud/initial-state'
+import { getCapabilities } from '@nextcloud/capabilities'
 import { generateOcsUrl } from '@nextcloud/router'
 
 import { ATTENDEE, CONVERSATION, SHARE } from '../constants.js'
+
+const canInviteToFederation = getCapabilities()?.spreed?.features?.includes('federation-v1')
+	&& getCapabilities()?.spreed?.config?.federation?.enabled
+	&& getCapabilities()?.spreed?.config?.federation?.['outgoing-enabled']
 
 /**
  * Fetches the conversations from the server.
@@ -88,7 +92,7 @@ const searchPossibleConversations = async function({ searchText, token, onlyUser
 		!onlyUsers ? SHARE.TYPE.GROUP : null,
 		!onlyUsers ? SHARE.TYPE.CIRCLE : null,
 		(!onlyUsers && token !== 'new') ? SHARE.TYPE.EMAIL : null,
-		(!onlyUsers && token !== 'new' && loadState('spreed', 'federation_enabled')) ? SHARE.TYPE.REMOTE : null,
+		(!onlyUsers && token !== 'new' && canInviteToFederation) ? SHARE.TYPE.REMOTE : null,
 	].filter(type => type !== null)
 
 	return axios.get(generateOcsUrl('core/autocomplete/get'), {

--- a/src/services/conversationsService.spec.js
+++ b/src/services/conversationsService.spec.js
@@ -1,5 +1,4 @@
 import axios from '@nextcloud/axios'
-import { loadState } from '@nextcloud/initial-state'
 import { generateOcsUrl } from '@nextcloud/router'
 
 import { searchPossibleConversations } from './conversationsService.js'
@@ -9,22 +8,16 @@ jest.mock('@nextcloud/axios', () => ({
 	get: jest.fn(),
 }))
 
+jest.mock('@nextcloud/capabilities', () => ({
+	getCapabilities: jest.fn(() => ({
+		spreed: {
+			features: ['federation-v1'],
+			config: { federation: { enabled: true, 'outgoing-enabled': true } },
+		},
+	}))
+}))
+
 describe('conversationsService', () => {
-	let loadStateSettings
-
-	beforeEach(() => {
-		loadStateSettings = {
-			federation_enabled: false,
-		}
-
-		loadState.mockImplementation((app, key) => {
-			if (app === 'spreed') {
-				return loadStateSettings[key]
-			}
-			return null
-		})
-	})
-
 	afterEach(() => {
 		// cleaning up the mess left behind the previous test
 		jest.clearAllMocks()
@@ -71,10 +64,6 @@ describe('conversationsService', () => {
 	})
 
 	test('searchPossibleConversations with other share types', () => {
-		loadStateSettings = {
-			federation_enabled: true,
-		}
-
 		testSearchPossibleConversations(
 			'conversation-token',
 			false,


### PR DESCRIPTION
### ☑️ Resolves

* Hide following unavailable features for Federation V1:
  * Joining/starting the call;
  * Posting attachments:
    * Polls
    * Files
    * Voice messages
  * RightSidebar tabs:
    * Breakout rooms
    * Shared items


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

![image](https://github.com/nextcloud/spreed/assets/93392545/71e391ec-1e51-4a1a-b2bb-79ae1383d6ba)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 