### PR TITLE
chore(deps): bump nextcloud/vue from 8.9.1 to 8.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^3.0.0",
         "@nextcloud/upload": "^1.0.5",
-        "@nextcloud/vue": "^8.9.1",
+        "@nextcloud/vue": "^8.10.0",
         "crypto-js": "^4.2.0",
         "debounce": "^2.0.0",
         "emoji-mart-vue-fast": "^15.0.0",
@@ -3844,9 +3844,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.9.1.tgz",
-      "integrity": "sha512-Mj+CovsPqAwUsCxeQfhYc9thx7synLTi95htwHu1s0XEg6SlaOV3BRarxD0m4C236ZpaIQ4DDfezDtuBln/mIA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.10.0.tgz",
+      "integrity": "sha512-HQ/6upw/sviCOe5jtFmZh7KK+QzLNj4a1TnJt3nJQWEZSgt1FFj48tjrmP8ztqnd8pCCOAF8843VLWCCivrF0w==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -23549,9 +23549,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.9.1.tgz",
-      "integrity": "sha512-Mj+CovsPqAwUsCxeQfhYc9thx7synLTi95htwHu1s0XEg6SlaOV3BRarxD0m4C236ZpaIQ4DDfezDtuBln/mIA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.10.0.tgz",
+      "integrity": "sha512-HQ/6upw/sviCOe5jtFmZh7KK+QzLNj4a1TnJt3nJQWEZSgt1FFj48tjrmP8ztqnd8pCCOAF8843VLWCCivrF0w==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^3.0.0",
     "@nextcloud/upload": "^1.0.5",
-    "@nextcloud/vue": "^8.9.1",
+    "@nextcloud/vue": "^8.10.0",
     "crypto-js": "^4.2.0",
     "debounce": "^2.0.0",
     "emoji-mart-vue-fast": "^15.0.0",


### PR DESCRIPTION
### ☑️ Resolves

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [x] Test
- [x] Find related issues
- [x] List new updates in https://github.com/nextcloud/spreed/issues/11494

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required