### PR TITLE
fix(federation): Expose local token with the invite so UI can render proxy avatars

### DIFF
--- a/lib/Controller/AEnvironmentAwareController.php
+++ b/lib/Controller/AEnvironmentAwareController.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Controller;
 
 use OC\AppFramework\Http\Dispatcher;
+use OCA\Talk\Model\Invitation;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCP\AppFramework\OCSController;
@@ -36,6 +37,7 @@ abstract class AEnvironmentAwareController extends OCSController {
 	protected int $apiVersion = 1;
 	protected ?Room $room = null;
 	protected ?Participant $participant = null;
+	protected ?Invitation $invitation = null;
 
 	public function setAPIVersion(int $apiVersion): void {
 		$this->apiVersion = $apiVersion;
@@ -59,6 +61,14 @@ abstract class AEnvironmentAwareController extends OCSController {
 
 	public function getParticipant(): ?Participant {
 		return $this->participant;
+	}
+
+	public function setInvitation(Invitation $invitation): void {
+		$this->invitation = $invitation;
+	}
+
+	public function getInvitation(): ?Invitation {
+		return $this->invitation;
 	}
 
 	/**

--- a/lib/Controller/AvatarController.php
+++ b/lib/Controller/AvatarController.php
@@ -29,6 +29,7 @@ namespace OCA\Talk\Controller;
 
 use InvalidArgumentException;
 use OCA\Talk\Exceptions\CannotReachRemoteException;
+use OCA\Talk\Middleware\Attribute\AllowWithoutParticipantWhenPendingInvitation;
 use OCA\Talk\Middleware\Attribute\FederationSupported;
 use OCA\Talk\Middleware\Attribute\RequireLoggedInParticipant;
 use OCA\Talk\Middleware\Attribute\RequireModeratorParticipant;
@@ -143,13 +144,14 @@ class AvatarController extends AEnvironmentAwareController {
 	#[FederationSupported]
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AllowWithoutParticipantWhenPendingInvitation]
 	#[RequireParticipantOrLoggedInAndListedConversation]
 	public function getAvatar(bool $darkTheme = false): FileDisplayResponse {
 		if ($this->room->getRemoteServer() !== '') {
 			/** @var \OCA\Talk\Federation\Proxy\TalkV1\Controller\AvatarController $proxy */
 			$proxy = \OCP\Server::get(\OCA\Talk\Federation\Proxy\TalkV1\Controller\AvatarController::class);
 			try {
-				return $proxy->getAvatar($this->room, $this->participant, $darkTheme);
+				return $proxy->getAvatar($this->room, $this->participant, $this->invitation, $darkTheme);
 			} catch (CannotReachRemoteException) {
 				// Falling back to a local "globe" avatar for indicating the federation
 			}
@@ -172,6 +174,7 @@ class AvatarController extends AEnvironmentAwareController {
 	#[FederationSupported]
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AllowWithoutParticipantWhenPendingInvitation]
 	#[RequireParticipantOrLoggedInAndListedConversation]
 	public function getAvatarDark(): FileDisplayResponse {
 		return $this->getAvatar(true);
@@ -193,6 +196,7 @@ class AvatarController extends AEnvironmentAwareController {
 	#[OpenAPI(scope: OpenAPI::SCOPE_FEDERATION)]
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AllowWithoutParticipantWhenPendingInvitation]
 	#[RequireLoggedInParticipant]
 	public function getUserProxyAvatar(int $size, string $cloudId, bool $darkTheme = false): FileDisplayResponse {
 		try {
@@ -252,6 +256,7 @@ class AvatarController extends AEnvironmentAwareController {
 	#[OpenAPI(scope: OpenAPI::SCOPE_FEDERATION)]
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AllowWithoutParticipantWhenPendingInvitation]
 	#[RequireLoggedInParticipant]
 	public function getUserProxyAvatarDark(int $size, string $cloudId): FileDisplayResponse {
 		return $this->getUserProxyAvatar($size, $cloudId, true);

--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -180,7 +180,6 @@ class FederationController extends OCSController {
 	 * @return TalkFederationInvite|null
 	 */
 	protected function enrichInvite(Invitation $invitation): ?array {
-
 		try {
 			$room = $this->talkManager->getRoomById($invitation->getLocalRoomId());
 		} catch (RoomNotFoundException) {
@@ -189,6 +188,7 @@ class FederationController extends OCSController {
 
 		$federationInvite = $invitation->jsonSerialize();
 		$federationInvite['roomName'] = $room->getName();
+		$federationInvite['localToken'] = $room->getToken();
 		return $federationInvite;
 	}
 }

--- a/lib/Federation/Proxy/TalkV1/Controller/AvatarController.php
+++ b/lib/Federation/Proxy/TalkV1/Controller/AvatarController.php
@@ -28,6 +28,7 @@ namespace OCA\Talk\Federation\Proxy\TalkV1\Controller;
 
 use OCA\Talk\Exceptions\CannotReachRemoteException;
 use OCA\Talk\Federation\Proxy\TalkV1\ProxyRequest;
+use OCA\Talk\Model\Invitation;
 use OCA\Talk\Participant;
 use OCA\Talk\ResponseDefinitions;
 use OCA\Talk\Room;
@@ -53,10 +54,14 @@ class AvatarController {
 	 *
 	 * 200: Room avatar returned
 	 */
-	public function getAvatar(Room $room, Participant $participant, bool $darkTheme): FileDisplayResponse {
+	public function getAvatar(Room $room, ?Participant $participant, ?Invitation $invitation, bool $darkTheme): FileDisplayResponse {
+		if ($participant === null && $invitation === null) {
+			throw new CannotReachRemoteException('Must receive either participant or invitation');
+		}
+
 		$proxy = $this->proxy->get(
-			$participant->getAttendee()->getInvitedCloudId(),
-			$participant->getAttendee()->getAccessToken(),
+			$participant ? $participant->getAttendee()->getInvitedCloudId() : $invitation->getLocalCloudId(),
+			$participant ? $participant->getAttendee()->getAccessToken() : $invitation->getAccessToken(),
 			$room->getRemoteServer() . '/ocs/v2.php/apps/spreed/api/v1/room/' . $room->getRemoteToken() . '/avatar' . ($darkTheme ? '/dark' : ''),
 		);
 

--- a/lib/Middleware/Attribute/AllowWithoutParticipantWhenPendingInvitation.php
+++ b/lib/Middleware/Attribute/AllowWithoutParticipantWhenPendingInvitation.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Talk\Middleware\Attribute;
+
+use Attribute;
+use OCA\Talk\Middleware\InjectionMiddleware;
+
+/**
+ * @see InjectionMiddleware::getRoomByInvite()
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+class AllowWithoutParticipantWhenPendingInvitation extends RequireRoom {
+}

--- a/lib/Model/Invitation.php
+++ b/lib/Model/Invitation.php
@@ -79,14 +79,13 @@ class Invitation extends Entity implements \JsonSerializable {
 	}
 
 	/**
-	 * @return array{id: int, localRoomId: int, localCloudId: string, remoteAttendeeId: int, remoteServerUrl: string, remoteToken: string, state: int, userId: string, inviterCloudId: string, inviterDisplayName: string}
+	 * @return array{id: int, localCloudId: string, remoteAttendeeId: int, remoteServerUrl: string, remoteToken: string, state: int, userId: string, inviterCloudId: string, inviterDisplayName: string}
 	 */
 	public function jsonSerialize(): array {
 		return [
 			'id' => $this->getId(),
 			'userId' => $this->getUserId(),
 			'state' => $this->getState(),
-			'localRoomId' => $this->getLocalRoomId(),
 			'localCloudId' => $this->getLocalCloudId(),
 			'remoteServerUrl' => $this->getRemoteServerUrl(),
 			'remoteToken' => $this->getRemoteToken(),

--- a/lib/Model/InvitationMapper.php
+++ b/lib/Model/InvitationMapper.php
@@ -95,6 +95,20 @@ class InvitationMapper extends QBMapper {
 		return $this->findEntities($qb);
 	}
 
+	/**
+	 * @throws DoesNotExistException
+	 */
+	public function getInvitationsForUserByLocalRoom(Room $room, string $userId): Invitation {
+		$query = $this->db->getQueryBuilder();
+
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->eq('user_id', $query->createNamedParameter($userId)))
+			->andWhere($query->expr()->eq('local_room_id', $query->createNamedParameter($room->getId())));
+
+		return $this->findEntity($query);
+	}
+
 	public function countInvitationsForLocalRoom(Room $room): int {
 		$qb = $this->db->getQueryBuilder();
 

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -117,7 +117,7 @@ namespace OCA\Talk;
  *     id: int,
  *     state: int,
  *     localCloudId: string,
- *     localRoomId: int,
+ *     localToken: string,
  *     remoteAttendeeId: int,
  *     remoteServerUrl: string,
  *     remoteToken: string,

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -316,7 +316,7 @@
                     "id",
                     "state",
                     "localCloudId",
-                    "localRoomId",
+                    "localToken",
                     "remoteAttendeeId",
                     "remoteServerUrl",
                     "remoteToken",
@@ -337,9 +337,8 @@
                     "localCloudId": {
                         "type": "string"
                     },
-                    "localRoomId": {
-                        "type": "integer",
-                        "format": "int64"
+                    "localToken": {
+                        "type": "string"
                     },
                     "remoteAttendeeId": {
                         "type": "integer",

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -517,7 +517,7 @@
                     "id",
                     "state",
                     "localCloudId",
-                    "localRoomId",
+                    "localToken",
                     "remoteAttendeeId",
                     "remoteServerUrl",
                     "remoteToken",
@@ -538,9 +538,8 @@
                     "localCloudId": {
                         "type": "string"
                     },
-                    "localRoomId": {
-                        "type": "integer",
-                        "format": "int64"
+                    "localToken": {
+                        "type": "string"
                     },
                     "remoteAttendeeId": {
                         "type": "integer",

--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -179,7 +179,7 @@ export default {
 			if (this.item.isDummyConversation) {
 				// Prevent a 404 when trying to load an avatar before the conversation data is actually loaded
 				// Also used in new conversation / invitation handler dialog
-				const isFed = this.item.isFederatedConversation && 'icon-conversation-federation'
+				const isFed = this.item.remoteServer && 'icon-conversation-federation'
 				const type = this.item.type === CONVERSATION.TYPE.PUBLIC ? 'icon-conversation-public' : 'icon-conversation-group'
 				const theme = isDarkTheme ? 'dark' : 'bright'
 				return `${isFed || type} icon--dummy icon--${theme}`

--- a/src/stores/__tests__/federation.spec.js
+++ b/src/stores/__tests__/federation.spec.js
@@ -16,7 +16,7 @@ describe('federationStore', () => {
 			id: 2,
 			userId: 'user0',
 			state: 0,
-			localRoomId: 10,
+			localToken: 'TOKEN_LOCAL_2',
 			remoteServerUrl: 'remote.nextcloud.com',
 			remoteToken: 'TOKEN_2',
 			remoteAttendeeId: 11,
@@ -28,7 +28,7 @@ describe('federationStore', () => {
 			id: 1,
 			userId: 'user0',
 			state: 1,
-			localRoomId: 9,
+			localToken: 'TOKEN_LOCAL_1',
 			remoteServerUrl: 'remote.nextcloud.com',
 			remoteToken: 'TOKEN_1',
 			remoteAttendeeId: 11,
@@ -158,6 +158,7 @@ describe('federationStore', () => {
 
 		const room = {
 			id: 10,
+			token: 'TOKEN_LOCAL_2'
 		}
 		const acceptResponse = generateOCSResponse({ payload: room })
 		acceptShare.mockResolvedValueOnce(acceptResponse)

--- a/src/stores/federation.ts
+++ b/src/stores/federation.ts
@@ -72,7 +72,7 @@ export const useFederationStore = defineStore('federation', {
 			const { id, name } = notification.messageRichParameters.user1
 			const invitation: FederationInvite = {
 				id: notification.objectId,
-				localRoomId: 0,
+				localToken: '',
 				localCloudId: notification.user + '@' + getBaseUrl().replace('https://', ''),
 				remoteAttendeeId: 0,
 				remoteServerUrl,
@@ -99,7 +99,7 @@ export const useFederationStore = defineStore('federation', {
 			Vue.delete(this.pendingShares[id], 'loading')
 			Vue.set(this.acceptedShares, id, {
 				...this.pendingShares[id],
-				localRoomId: conversation.id,
+				localToken: conversation.token,
 				state: FEDERATION.STATE.ACCEPTED,
 			})
 			Vue.delete(this.pendingShares, id)

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -137,8 +137,7 @@ export type components = {
       /** Format: int64 */
       state: number;
       localCloudId: string;
-      /** Format: int64 */
-      localRoomId: number;
+      localToken: string;
       /** Format: int64 */
       remoteAttendeeId: number;
       remoteServerUrl: string;

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -664,8 +664,7 @@ export type components = {
       /** Format: int64 */
       state: number;
       localCloudId: string;
-      /** Format: int64 */
-      localRoomId: number;
+      localToken: string;
       /** Format: int64 */
       remoteAttendeeId: number;
       remoteServerUrl: string;


### PR DESCRIPTION
 - Fix #11722

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Fix missing token so the UI can start the avatar
- [x] Handle invites as "OK" on the avatar endpoint even when not accepted yet

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
