### PR TITLE
fix(MessagesList): remove deleted groups

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -412,14 +412,20 @@ export default {
 		},
 
 		softUpdateByDateGroups(oldDateGroups, newDateGroups) {
-			// Check if we have this group in the old list already and it is unchanged
-			Object.keys(newDateGroups).forEach(dateTimestamp => {
-				if (oldDateGroups[dateTimestamp]) {
-					// the group by date has changed, we update its content (groups by author)
-					this.softUpdateAuthorGroups(oldDateGroups[dateTimestamp], newDateGroups[dateTimestamp], dateTimestamp)
+			const dateTimestamps = new Set([...Object.keys(oldDateGroups), ...Object.keys(newDateGroups)])
+
+			dateTimestamps.forEach(dateTimestamp => {
+				if (newDateGroups[dateTimestamp]) {
+					if (oldDateGroups[dateTimestamp]) {
+						// the group by date has changed, we update its content (groups by author)
+						this.softUpdateAuthorGroups(oldDateGroups[dateTimestamp], newDateGroups[dateTimestamp], dateTimestamp)
+					} else {
+						// the group is new
+						this.messagesGroupedByDateByAuthor[dateTimestamp] = newDateGroups[dateTimestamp]
+					}
 				} else {
-					// the group is new
-					this.messagesGroupedByDateByAuthor[dateTimestamp] = newDateGroups[dateTimestamp]
+					// the group is not in the new list, remove it
+					delete this.messagesGroupedByDateByAuthor[dateTimestamp]
 				}
 			})
 		},


### PR DESCRIPTION
### ☑️ Resolves

- Removal update was missing for date groups level. So clear history didn't remove past groups by date.

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

