### PR TITLE
Fix(Participant): keep talking time after searching

### DIFF
--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -866,17 +866,21 @@ export default {
 		},
 	},
 	watch: {
-		isParticipantSpeaking(speaking) {
-			if (speaking) {
-				if (!this.speakingInterval) {
-					this.speakingInterval = setInterval(this.computeElapsedTime, 1000)
+		isParticipantSpeaking: {
+			immediate: true,
+			handler(speaking) {
+				this.computeElapsedTime()
+				if (speaking) {
+					if (!this.speakingInterval) {
+						this.speakingInterval = setInterval(this.computeElapsedTime, 1000)
+					}
+				} else {
+					if (speaking === undefined) {
+						this.timeSpeaking = 0
+					}
+					clearInterval(this.speakingInterval)
+					this.speakingInterval = null
 				}
-			} else {
-				if (speaking === undefined) {
-					this.timeSpeaking = 0
-				}
-				clearInterval(this.speakingInterval)
-				this.speakingInterval = null
 			}
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Maybe fix #11501 because talking time is correctly stored and the issue in rendering for each Participant, an immediate watch can reduce the number of erroneous info at least.


<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before

https://github.com/nextcloud/spreed/assets/84044328/5774071d-ad80-4267-8fcb-59142e12754b 

🏡 After

https://github.com/nextcloud/spreed/assets/84044328/e32cb9ca-8cf8-42f6-a435-3cb2724d0cae


<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] Test ?

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

