### PR TITLE
fix(participants): move interval update of talking time counter to the store

### DIFF
--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -80,7 +80,7 @@
 
 		<!-- Phone participant dial action -->
 		<div v-if="isInCall && canBeModerated && isPhoneActor"
-			id="participantNavigationId"
+			:id="participantNavigationId"
 			class="participant-row__dial-actions">
 			<NcButton v-if="!participant.inCall"
 				type="success"
@@ -464,8 +464,6 @@ export default {
 			isUserNameTooltipVisible: false,
 			isStatusTooltipVisible: false,
 			permissionsEditor: false,
-			speakingInterval: null,
-			timeSpeaking: null,
 			disabled: false,
 		}
 	},
@@ -864,22 +862,17 @@ export default {
 			}
 			return ''
 		},
-	},
-	watch: {
-		isParticipantSpeaking(speaking) {
-			if (speaking) {
-				if (!this.speakingInterval) {
-					this.speakingInterval = setInterval(this.computeElapsedTime, 1000)
-				}
-			} else {
-				if (speaking === undefined) {
-					this.timeSpeaking = 0
-				}
-				clearInterval(this.speakingInterval)
-				this.speakingInterval = null
-			}
-		},
 
+		timeSpeaking() {
+			if (!this.participantSpeakingInformation || this.isParticipantSpeaking === undefined) {
+				return 0
+			}
+
+			return this.participantSpeakingInformation.totalCountedTime
+		},
+	},
+
+	watch: {
 		phoneCallStatus(value) {
 			if (!value || !(value === 'ringing' || value === 'accepted')) {
 				this.disabled = false
@@ -1009,20 +1002,6 @@ export default {
 				}
 			} catch (error) {
 				showError(t('spreed', 'Could not modify permissions for {displayName}', { displayName: this.computedName }))
-			}
-		},
-
-		computeElapsedTime() {
-			if (!this.participantSpeakingInformation) {
-				return null
-			}
-
-			const { speaking, lastTimestamp, totalCountedTime } = this.participantSpeakingInformation
-
-			if (!speaking) {
-				this.timeSpeaking = totalCountedTime
-			} else {
-				this.timeSpeaking = Date.now() - lastTimestamp + totalCountedTime
 			}
 		},
 

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -704,7 +704,7 @@ export default {
 		},
 
 		participantSpeakingInformation() {
-			return this.$store.getters.getParticipantSpeakingInformation(this.token, this.attendeeId)
+			return this.$store.getters.getParticipantSpeakingInformation(this.attendeeId)
 		},
 
 		isParticipantSpeaking() {

--- a/src/utils/webrtc/SpeakingStatusHandler.js
+++ b/src/utils/webrtc/SpeakingStatusHandler.js
@@ -81,7 +81,7 @@ export default class SpeakingStatusHandler {
 			callParticipantModel.off('change:stoppedSpeaking', this.#handleSpeakingBound)
 		})
 
-		this.#store.dispatch('purgeSpeakingStore', { token: this.#store.getters.getToken() })
+		this.#store.dispatch('purgeSpeakingStore')
 	}
 
 	/**
@@ -114,7 +114,6 @@ export default class SpeakingStatusHandler {
 	 */
 	#handleLocalSpeaking(localMediaModel, speaking) {
 		this.#store.dispatch('setSpeaking', {
-			token: this.#store.getters.getToken(),
 			attendeeId: this.#store.getters.getAttendeeId(),
 			speaking,
 		})
@@ -126,7 +125,6 @@ export default class SpeakingStatusHandler {
 	 */
 	#handleLocalPeerId() {
 		this.#store.dispatch('setSpeaking', {
-			token: this.#store.getters.getToken(),
 			attendeeId: this.#store.getters.getAttendeeId(),
 			speaking: this.#localMediaModel.attributes.speaking,
 		})
@@ -149,7 +147,6 @@ export default class SpeakingStatusHandler {
 		}
 
 		this.#store.dispatch('setSpeaking', {
-			token: this.#store.getters.getToken(),
 			attendeeId,
 			speaking,
 		})


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11501
	* Data in the store are correct and accessible by token + attendeeId
	* Because of virtual scroller in the participant list, interval update in the component can't be used, as it attached to the Vue component object, not the participant data
	* Moved interval update to the store, so each second we update a value there
	* Component rely only on store update and re-rendered once per second (as before), but with correct value

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Reproducible | Non-reproducible

### 🚧 Tasks

- [ ] speaking don't rely on participantStore, so may be moved to `callExtras` store :pineapple: 
  - [ ] Check if SpeakingStatusHandler class supports Pinia

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possible