### PR TITLE
fix(federation): Don't notify ourselves when we leave

### DIFF
--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -835,7 +835,7 @@ class ParticipantService {
 	 * @psalm-param AAttendeeRemovedEvent::REASON_* $reason
 	 */
 	public function removeAttendee(Room $room, Participant $participant, string $reason, bool $attendeeEventIsTriggeredAlready = false): void {
-		if ($participant->getAttendee()->getActorType() === Attendee::ACTOR_FEDERATED_USERS) {
+		if ($participant->getAttendee()->getActorType() === Attendee::ACTOR_FEDERATED_USERS && $reason !== AAttendeeRemovedEvent::REASON_LEFT) {
 			$attendee = $participant->getAttendee();
 			$cloudId = $this->cloudIdManager->resolveCloudId($attendee->getActorId());
 


### PR DESCRIPTION
## 🛠️ API Checklist

### 🦶 Steps

- Invite a user
- As recipient accept the invite
- As recipient leave the conversation
- :eyes: See a `'Share not found'` 404 message being logged in the nextcloud.log

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
