### PR TITLE
fix(federation): Inform federated servers/users when deleting a conversation

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -84,6 +84,7 @@ use OCA\Talk\Events\SystemMessageSentEvent;
 use OCA\Talk\Events\SystemMessagesMultipleSentEvent;
 use OCA\Talk\Events\UserJoinedRoomEvent;
 use OCA\Talk\Federation\CloudFederationProviderTalk;
+use OCA\Talk\Federation\Proxy\TalkV1\Notifier\BeforeRoomDeletedListener as TalkV1BeforeRoomDeletedListener;
 use OCA\Talk\Federation\Proxy\TalkV1\Notifier\CancelRetryOCMListener as TalkV1CancelRetryOCMListener;
 use OCA\Talk\Federation\Proxy\TalkV1\Notifier\MessageSentListener as TalkV1MessageSentListener;
 use OCA\Talk\Federation\Proxy\TalkV1\Notifier\RoomModifiedListener as TalkV1RoomModifiedListener;
@@ -281,6 +282,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(TranscriptionFailedEvent::class, RecordingListener::class);
 
 		// Federation listeners
+		$context->registerEventListener(BeforeRoomDeletedEvent::class, TalkV1BeforeRoomDeletedListener::class);
 		$context->registerEventListener(RoomModifiedEvent::class, TalkV1RoomModifiedListener::class);
 		$context->registerEventListener(ChatMessageSentEvent::class, TalkV1MessageSentListener::class);
 		$context->registerEventListener(SystemMessageSentEvent::class, TalkV1MessageSentListener::class);

--- a/lib/Federation/Proxy/TalkV1/Notifier/BeforeRoomDeletedListener.php
+++ b/lib/Federation/Proxy/TalkV1/Notifier/BeforeRoomDeletedListener.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2024 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Federation\Proxy\TalkV1\Notifier;
+
+use OCA\Talk\Events\BeforeRoomDeletedEvent;
+use OCA\Talk\Federation\BackendNotifier;
+use OCA\Talk\Model\Attendee;
+use OCA\Talk\Service\ParticipantService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Federation\ICloudIdManager;
+
+/**
+ * @template-implements IEventListener<Event>
+ */
+class BeforeRoomDeletedListener implements IEventListener {
+	public function __construct(
+		protected BackendNotifier $backendNotifier,
+		protected ParticipantService $participantService,
+		protected ICloudIdManager $cloudIdManager,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof BeforeRoomDeletedEvent) {
+			return;
+		}
+
+		$participants = $this->participantService->getParticipantsByActorType($event->getRoom(), Attendee::ACTOR_FEDERATED_USERS);
+		foreach ($participants as $participant) {
+			$cloudId = $this->cloudIdManager->resolveCloudId($participant->getAttendee()->getActorId());
+
+			$this->backendNotifier->sendRemoteUnShare(
+				$cloudId->getRemote(),
+				$participant->getAttendee()->getId(),
+				$participant->getAttendee()->getAccessToken(),
+			);
+		}
+	}
+}


### PR DESCRIPTION
### ☑️ Resolves

* Create a room
* Add a federated user
* As FU accept the invite
* As host delete the room
* Before: The room and invite is still present in the DB
* After: Now the invite and participant are cleaned up immediately (and the room after the next cron run)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
