### PR TITLE
fix(federation): Respect setReadMarker=1 on proxied ChatController::r…

### DIFF
--- a/lib/Federation/Proxy/TalkV1/Controller/ChatController.php
+++ b/lib/Federation/Proxy/TalkV1/Controller/ChatController.php
@@ -172,6 +172,10 @@ class ChatController {
 			],
 		);
 
+		if ($lookIntoFuture && $setReadMarker) {
+			$this->participantService->updateUnreadInfoForProxyParticipant($participant, 0, false, false);
+		}
+
 		if ($proxy->getStatusCode() === Http::STATUS_NOT_MODIFIED) {
 			if ($lookIntoFuture && $this->proxyCacheMessages instanceof ICache) {
 				$cacheData = $this->proxyCacheMessages->get($cacheKey);


### PR DESCRIPTION
…eceiveMessage()

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
