### PR TITLE
fix(federation): Send display name and last read message with federation

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>19.0.0-beta.1.1</version>
+	<version>19.0.0-beta.1.2</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/lib/Federation/BackendNotifier.php
+++ b/lib/Federation/BackendNotifier.php
@@ -179,6 +179,7 @@ class BackendNotifier {
 		int $remoteAttendeeId,
 		#[SensitiveParameter]
 		string $accessToken,
+		string $displayName,
 	): bool {
 		$remote = $this->prepareRemoteUrl($remoteServerUrl);
 
@@ -191,6 +192,7 @@ class BackendNotifier {
 				'remoteServerUrl' => $this->getServerRemoteUrl(),
 				'sharedSecret' => $accessToken,
 				'message' => 'Recipient accepted the share',
+				'displayName' => $displayName,
 			]
 		);
 

--- a/lib/Federation/BackendNotifier.php
+++ b/lib/Federation/BackendNotifier.php
@@ -292,7 +292,7 @@ class BackendNotifier {
 	 * Sent from Host server to Remote participant server
 	 *
 	 * @param array{remoteMessageId: int, actorType: string, actorId: string, actorDisplayName: string, messageType: string, systemMessage: string, expirationDatetime: string, message: string, messageParameter: string, creationDatetime: string, metaData: string} $messageData
-	 * @param array{unreadMessages: int, unreadMention: bool, unreadMentionDirect: bool} $unreadInfo
+	 * @param array{unreadMessages: int, unreadMention: bool, unreadMentionDirect: bool, lastReadMessage: int} $unreadInfo
 	 */
 	public function sendMessageUpdate(
 		string $remoteServer,

--- a/lib/Federation/CloudFederationProviderTalk.php
+++ b/lib/Federation/CloudFederationProviderTalk.php
@@ -215,6 +215,7 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 
 		if (!empty($notification['displayName'])) {
 			$attendee->setDisplayName($notification['displayName']);
+			$attendee->setState(Invitation::STATE_ACCEPTED);
 			$this->attendeeMapper->update($attendee);
 		}
 
@@ -325,7 +326,7 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 
 	/**
 	 * @param int $remoteAttendeeId
-	 * @param array{remoteServerUrl: string, sharedSecret: string, remoteToken: string, messageData: array{remoteMessageId: int, actorType: string, actorId: string, actorDisplayName: string, messageType: string, systemMessage: string, expirationDatetime: string, message: string, messageParameter: string, creationDatetime: string, metaData: string}, unreadInfo: array{unreadMessages: int, unreadMention: bool, unreadMentionDirect: bool}} $notification
+	 * @param array{remoteServerUrl: string, sharedSecret: string, remoteToken: string, messageData: array{remoteMessageId: int, actorType: string, actorId: string, actorDisplayName: string, messageType: string, systemMessage: string, expirationDatetime: string, message: string, messageParameter: string, creationDatetime: string, metaData: string}, unreadInfo: array{unreadMessages: int, unreadMention: bool, unreadMentionDirect: bool, lastReadMessage: int}} $notification
 	 * @return array
 	 * @throws ActionNotSupportedException
 	 * @throws AuthenticationFailedException
@@ -416,6 +417,7 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 			$notification['unreadInfo']['unreadMessages'],
 			$notification['unreadInfo']['unreadMention'],
 			$notification['unreadInfo']['unreadMentionDirect'],
+			$notification['unreadInfo']['lastReadMessage'],
 		);
 
 		$this->federationChatNotifier->handleChatMessage($room, $participant, $message, $notification);

--- a/lib/Federation/CloudFederationProviderTalk.php
+++ b/lib/Federation/CloudFederationProviderTalk.php
@@ -213,6 +213,11 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 	private function shareAccepted(int $id, array $notification): array {
 		$attendee = $this->getLocalAttendeeAndValidate($id, $notification['sharedSecret']);
 
+		if (!empty($notification['displayName'])) {
+			$attendee->setDisplayName($notification['displayName']);
+			$this->attendeeMapper->update($attendee);
+		}
+
 		$this->session->set('talk-overwrite-actor-type', $attendee->getActorType());
 		$this->session->set('talk-overwrite-actor-id', $attendee->getActorId());
 		$this->session->set('talk-overwrite-actor-displayname', $attendee->getDisplayName());

--- a/lib/Federation/FederationManager.php
+++ b/lib/Federation/FederationManager.php
@@ -147,6 +147,7 @@ class FederationManager {
 				'accessToken' => $invitation->getAccessToken(),
 				'remoteId' => $invitation->getRemoteAttendeeId(),
 				'invitedCloudId' => $invitation->getLocalCloudId(),
+				'lastReadMessage' => $room->getLastMessageId(),
 			]
 		];
 		$attendees = $this->participantService->addUsers($room, $participant, $user);

--- a/lib/Federation/FederationManager.php
+++ b/lib/Federation/FederationManager.php
@@ -134,7 +134,7 @@ class FederationManager {
 		// Add user to the room
 		$room = $this->manager->getRoomById($invitation->getLocalRoomId());
 		if (
-			!$this->backendNotifier->sendShareAccepted($invitation->getRemoteServerUrl(), $invitation->getRemoteAttendeeId(), $invitation->getAccessToken())
+			!$this->backendNotifier->sendShareAccepted($invitation->getRemoteServerUrl(), $invitation->getRemoteAttendeeId(), $invitation->getAccessToken(), $user->getDisplayName())
 		) {
 			throw new CannotReachRemoteException();
 		}

--- a/lib/Federation/Proxy/TalkV1/Controller/ChatController.php
+++ b/lib/Federation/Proxy/TalkV1/Controller/ChatController.php
@@ -173,7 +173,12 @@ class ChatController {
 		);
 
 		if ($lookIntoFuture && $setReadMarker) {
-			$this->participantService->updateUnreadInfoForProxyParticipant($participant, 0, false, false);
+			$this->participantService->updateUnreadInfoForProxyParticipant($participant,
+				0,
+				false,
+				false,
+				(int) ($proxy->getHeader('X-Chat-Last-Given') ?: $lastKnownMessageId),
+			);
 		}
 
 		if ($proxy->getStatusCode() === Http::STATUS_NOT_MODIFIED) {
@@ -384,6 +389,7 @@ class ChatController {
 			$data['unreadMessages'],
 			$data['unreadMention'],
 			$data['unreadMentionDirect'],
+			$data['lastReadMessage'],
 		);
 
 		$headers = $lastCommonRead = [];
@@ -424,6 +430,7 @@ class ChatController {
 			$data['unreadMessages'],
 			$data['unreadMention'],
 			$data['unreadMentionDirect'],
+			$data['lastReadMessage'],
 		);
 
 		$headers = $lastCommonRead = [];

--- a/lib/Federation/Proxy/TalkV1/Notifier/MessageSentListener.php
+++ b/lib/Federation/Proxy/TalkV1/Notifier/MessageSentListener.php
@@ -114,9 +114,10 @@ class MessageSentListener implements IEventListener {
 			$lastMentionDirect = $attendee->getLastMentionDirect();
 
 			$unreadInfo = [
+				'lastReadMessage' => $lastReadMessage,
 				'unreadMessages' => $this->chatManager->getUnreadCount($event->getRoom(), $lastReadMessage),
 				'unreadMention' => $lastMention !== 0 && $lastReadMessage < $lastMention,
-				'unreadMentionDirect' => $lastMentionDirect !== 0 && $lastReadMessage < $lastMentionDirect
+				'unreadMentionDirect' => $lastMentionDirect !== 0 && $lastReadMessage < $lastMentionDirect,
 			];
 
 			$success = $this->backendNotifier->sendMessageUpdate(

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -134,6 +134,7 @@ class Manager {
 			'breakout_room_status' => 0,
 			'call_recording' => 0,
 			'recording_consent' => 0,
+			'has_federation' => 0,
 		], $data));
 	}
 
@@ -202,6 +203,7 @@ class Manager {
 			(int) $row['breakout_room_status'],
 			(int) $row['call_recording'],
 			(int) $row['recording_consent'],
+			(int) $row['has_federation'],
 		);
 	}
 

--- a/lib/Migration/Version19000Date20240313134926.php
+++ b/lib/Migration/Version19000Date20240313134926.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use OCA\Talk\Model\Attendee;
+use OCA\Talk\Model\Invitation;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Cache the invite state in the attendees and room table to allow reducing efforts
+ */
+class Version19000Date20240313134926 extends SimpleMigrationStep {
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('talk_attendees');
+		$table->addColumn('state', Types::SMALLINT, [
+			'default' => 0,
+			'unsigned' => true,
+		]);
+		$table->addColumn('unread_messages', Types::BIGINT, [
+			'default' => 0,
+			'unsigned' => true,
+		]);
+
+		$table = $schema->getTable('talk_rooms');
+		$table->addColumn('has_federation', Types::SMALLINT, [
+			'default' => 0,
+			'unsigned' => true,
+		]);
+
+		return $schema;
+	}
+
+	/**
+	 * Set the invitation state to accepted for existing federated users
+	 * Set the "has federation" for rooms with TalkV1 users
+	 */
+	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+		$query = $this->connection->getQueryBuilder();
+		$query->update('talk_attendees')
+			->set('state', $query->createNamedParameter(Invitation::STATE_ACCEPTED))
+			->where($query->expr()->eq('actor_type', $query->createNamedParameter(Attendee::ACTOR_FEDERATED_USERS)));
+		$query->executeStatement();
+
+		$query = $this->connection->getQueryBuilder();
+		$subQuery = $this->connection->getQueryBuilder();
+		$subQuery->select('room_id')
+			->from('talk_attendees')
+			->where($subQuery->expr()->eq('actor_type', $query->createNamedParameter(Attendee::ACTOR_FEDERATED_USERS)))
+			->groupBy('room_id');
+
+		$query = $this->connection->getQueryBuilder();
+		$query->update('talk_rooms')
+			// Don't use const Room::HAS_FEDERATION_TALKv1 because the file might have been loaded with old content before the migration
+			// ->set('has_federation', $query->createNamedParameter(Room::HAS_FEDERATION_TALKv1))
+			->set('has_federation', $query->createNamedParameter(1))
+			->where($query->expr()->in('id', $query->createFunction($subQuery->getSQL())));
+		$query->executeStatement();
+	}
+}

--- a/lib/Model/Attendee.php
+++ b/lib/Model/Attendee.php
@@ -66,6 +66,10 @@ use OCP\AppFramework\Db\Entity;
  * @method null|string getPhoneNumber()
  * @method void setCallId(?string $callId)
  * @method null|string getCallId()
+ * @method void setState(int $state)
+ * @method int getState()
+ * @method void setUnreadMessages(int $unreadMessages)
+ * @method int getUnreadMessages()
  */
 class Attendee extends Entity {
 	public const ACTOR_USERS = 'users';
@@ -168,6 +172,12 @@ class Attendee extends Entity {
 	/** @var null|string */
 	protected $callId;
 
+	/** @var int */
+	protected $state;
+
+	/** @var int */
+	protected $unreadMessages;
+
 	public function __construct() {
 		$this->addType('roomId', 'int');
 		$this->addType('actorType', 'string');
@@ -189,6 +199,8 @@ class Attendee extends Entity {
 		$this->addType('invitedCloudId', 'string');
 		$this->addType('phoneNumber', 'string');
 		$this->addType('callId', 'string');
+		$this->addType('state', 'int');
+		$this->addType('unreadMessages', 'int');
 	}
 
 	public function getDisplayName(): string {

--- a/lib/Model/AttendeeMapper.php
+++ b/lib/Model/AttendeeMapper.php
@@ -299,6 +299,8 @@ class AttendeeMapper extends QBMapper {
 			'invited_cloud_id' => (string) $row['invited_cloud_id'],
 			'phone_number' => $row['phone_number'],
 			'call_id' => $row['call_id'],
+			'state' => (int) $row['state'],
+			'unread_messages' => (int) $row['unread_messages'],
 		]);
 	}
 }

--- a/lib/Model/SelectHelper.php
+++ b/lib/Model/SelectHelper.php
@@ -87,6 +87,8 @@ class SelectHelper {
 			->addSelect($alias . 'invited_cloud_id')
 			->addSelect($alias . 'phone_number')
 			->addSelect($alias . 'call_id')
+			->addSelect($alias . 'state')
+			->addSelect($alias . 'unread_messages')
 			->selectAlias($alias . 'id', 'a_id');
 	}
 

--- a/lib/Model/SelectHelper.php
+++ b/lib/Model/SelectHelper.php
@@ -59,6 +59,7 @@ class SelectHelper {
 			->addSelect($alias . 'breakout_room_status')
 			->addSelect($alias . 'call_recording')
 			->addSelect($alias . 'recording_consent')
+			->addSelect($alias . 'has_federation')
 			->selectAlias($alias . 'id', 'r_id');
 	}
 

--- a/lib/Notification/FederationChatNotifier.php
+++ b/lib/Notification/FederationChatNotifier.php
@@ -45,7 +45,7 @@ class FederationChatNotifier {
 	}
 
 	/**
-	 * @param array{remoteServerUrl: string, sharedSecret: string, remoteToken: string, messageData: array{remoteMessageId: int, actorType: string, actorId: string, actorDisplayName: string, messageType: string, systemMessage: string, expirationDatetime: string, message: string, messageParameter: string, creationDatetime: string, metaData: string}, unreadInfo: array{unreadMessages: int, unreadMention: bool, unreadMentionDirect: bool}} $inboundNotification
+	 * @param array{remoteServerUrl: string, sharedSecret: string, remoteToken: string, messageData: array{remoteMessageId: int, actorType: string, actorId: string, actorDisplayName: string, messageType: string, systemMessage: string, expirationDatetime: string, message: string, messageParameter: string, creationDatetime: string, metaData: string}, unreadInfo: array{unreadMessages: int, unreadMention: bool, unreadMentionDirect: bool, lastReadMessage: int}} $inboundNotification
 	 */
 	public function handleChatMessage(Room $room, Participant $participant, ProxyCacheMessage $message, array $inboundNotification): void {
 		/** @var array{silent?: bool, last_edited_time?: int, last_edited_by_type?: string, last_edited_by_id?: string, replyToActorType?: string, replyToActorId?: string} $metaData */

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -96,12 +96,16 @@ class Room {
 
 	public const DESCRIPTION_MAXIMUM_LENGTH = 500;
 
+	public const HAS_FEDERATION_NONE = 0;
+	public const HAS_FEDERATION_TALKv1 = 1;
+
 	protected ?string $currentUser = null;
 	protected ?Participant $participant = null;
 
 	/**
 	 * @psalm-param Room::TYPE_* $type
 	 * @psalm-param RecordingService::CONSENT_REQUIRED_* $recordingConsent
+	 * @psalm-param int-mask-of<self::HAS_FEDERATION_*> $hasFederation
 	 */
 	public function __construct(
 		private Manager $manager,
@@ -138,6 +142,7 @@ class Room {
 		private int $breakoutRoomStatus,
 		private int $callRecording,
 		private int $recordingConsent,
+		private int $hasFederation,
 	) {
 	}
 
@@ -410,6 +415,9 @@ class Room {
 		return $this->remoteToken;
 	}
 
+	/**
+	 * @deprecated
+	 */
 	public function isFederatedRemoteRoom(): bool {
 		return $this->remoteServer !== '';
 	}
@@ -557,5 +565,20 @@ class Room {
 	 */
 	public function setRecordingConsent(int $recordingConsent): void {
 		$this->recordingConsent = $recordingConsent;
+	}
+
+	/**
+	 * @psalm-return int-mask-of<self::HAS_FEDERATION_*>
+	 */
+	public function hasFederatedParticipants(): int {
+		return $this->hasFederation;
+	}
+
+	/**
+	 * @param int $hasFederation
+	 * @psalm-param int-mask-of<self::HAS_FEDERATION_*> $hasFederation (bit map)
+	 */
+	public function setFederatedParticipants(int $hasFederation): void {
+		$this->hasFederation = $hasFederation;
 	}
 }

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -249,9 +249,10 @@ class ParticipantService {
 		$this->attendeeMapper->update($attendee);
 	}
 
-	public function updateUnreadInfoForProxyParticipant(Participant $participant, int $unreadMessageCount, bool $hasMention, bool $hadDirectMention): void {
+	public function updateUnreadInfoForProxyParticipant(Participant $participant, int $unreadMessageCount, bool $hasMention, bool $hadDirectMention, int $lastReadMessageId): void {
 		$attendee = $participant->getAttendee();
-		$attendee->setLastReadMessage($unreadMessageCount);
+		$attendee->setUnreadMessages($unreadMessageCount);
+		$attendee->setLastReadMessage($lastReadMessageId);
 		$attendee->setLastMentionMessage($hasMention ? 1 : 0);
 		$attendee->setLastMentionDirect($hadDirectMention ? 1 : 0);
 		$this->attendeeMapper->update($attendee);
@@ -505,7 +506,7 @@ class ParticipantService {
 			}
 			$attendee->setParticipantType($participant['participantType'] ?? Participant::USER);
 			$attendee->setPermissions(Attendee::PERMISSIONS_DEFAULT);
-			$attendee->setLastReadMessage($lastMessage);
+			$attendee->setLastReadMessage($participant['lastReadMessage'] ?? $lastMessage);
 			$attendee->setReadPrivacy($readPrivacy);
 			$attendees[] = $attendee;
 		}

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -886,6 +886,19 @@ class RoomService {
 		$room->setLastActivity($dateTime);
 	}
 
+	/**
+	 * @psalm-param int-mask-of<Room::HAS_FEDERATION_*> $hasFederation
+	 */
+	public function setHasFederation(Room $room, int $hasFederation): void {
+		$update = $this->db->getQueryBuilder();
+		$update->update('talk_rooms')
+			->set('has_federation', $update->createNamedParameter($hasFederation, IQueryBuilder::PARAM_INT))
+			->where($update->expr()->eq('id', $update->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)));
+		$update->executeStatement();
+
+		$room->setFederatedParticipants($hasFederation);
+	}
+
 	public function setLastActivity(Room $room, \DateTime $now): void {
 		$update = $this->db->getQueryBuilder();
 		$update->update('talk_rooms')

--- a/tests/integration/features/federation/chat.feature
+++ b/tests/integration/features/federation/chat.feature
@@ -22,10 +22,10 @@ Feature: federation/chat
       | id   | type |
       | room | 2    |
     And user "participant1" gets the following candidate mentions in room "room" for "" with 200
-      | source          | id                         | label                       | mentionId                                  |
-      | calls           | all                        | room                        | all                                        |
-      | federated_users | participant2@{$REMOTE_URL} | participant2@localhost:8180 | federated_user/participant2@{$REMOTE_URL}  |
-      | users           | participant3               | participant3-displayname    | participant3                               |
+      | source          | id                         | label                    | mentionId                                  |
+      | calls           | all                        | room                     | all                                        |
+      | federated_users | participant2@{$REMOTE_URL} | participant2-displayname | federated_user/participant2@{$REMOTE_URL}  |
+      | users           | participant3               | participant3-displayname | participant3                               |
     And user "participant2" gets the following candidate mentions in room "LOCAL::room" for "" with 200
       | source          | id                       | label                    | mentionId    |
       | calls           | all                      | room                     | all          |
@@ -56,10 +56,10 @@ Feature: federation/chat
       | id   | type |
       | room | 2    |
     And user "participant1" gets the following candidate mentions in room "room" for "" with 200
-      | source          | id                         | label                       | mentionId                                 |
-      | calls           | all                        | room                        | all                                       |
-      | federated_users | participant2@{$REMOTE_URL} | participant2@localhost:8180 | federated_user/participant2@{$REMOTE_URL} |
-      | federated_users | participant3@{$REMOTE_URL} | participant3@localhost:8180 | federated_user/participant3@{$REMOTE_URL} |
+      | source          | id                         | label                    | mentionId                                 |
+      | calls           | all                        | room                     | all                                       |
+      | federated_users | participant2@{$REMOTE_URL} | participant2-displayname | federated_user/participant2@{$REMOTE_URL} |
+      | federated_users | participant3@{$REMOTE_URL} | participant3-displayname | federated_user/participant3@{$REMOTE_URL} |
     And user "participant2" gets the following candidate mentions in room "LOCAL::room" for "" with 200
       | source          | id                       | label                    | mentionId                                 |
       | calls           | all                      | room                     | all                                       |

--- a/tests/integration/features/federation/invite.feature
+++ b/tests/integration/features/federation/invite.feature
@@ -72,8 +72,8 @@ Feature: federation/invite
       | federated_users | participant2 | 3               |
     Then user "participant1" sees the following system messages in room "room" with 200
       | room | actorType     | actorId      | systemMessage           | message                      | messageParameters |
-      | room | federated_users | participant2@http://localhost:8180 | federated_user_added | {federated_user} accepted the invitation | {"actor":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
-      | room | users         | participant1 | federated_user_added    | You invited {federated_user} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
+      | room | federated_users | participant2@http://localhost:8180 | federated_user_added | {federated_user} accepted the invitation | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname","server":"http:\/\/localhost:8180"},"federated_user":{"type":"user","id":"participant2","name":"participant2-displayname","server":"http:\/\/localhost:8180"}} |
+      | room | users         | participant1 | federated_user_added    | You invited {federated_user} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"participant2","name":"participant2-displayname","server":"http:\/\/localhost:8180"}} |
       | room | users         | participant1 | conversation_created    | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
     # Remove a remote user after they joined
     When user "participant1" removes remote "participant2" from room "room" with 200 (v4)

--- a/tests/php/Chat/ChatManagerTest.php
+++ b/tests/php/Chat/ChatManagerTest.php
@@ -29,6 +29,7 @@ use OCA\Talk\Chat\CommentsManager;
 use OCA\Talk\Chat\Notifier;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\AttendeeMapper;
+use OCA\Talk\Model\Invitation;
 use OCA\Talk\Participant;
 use OCA\Talk\Room;
 use OCA\Talk\Service\AttachmentService;
@@ -446,6 +447,8 @@ class ChatManagerTest extends TestCase {
 			'phone_number' => '',
 			'call_id' => '',
 			'invited_cloud_id' => '',
+			'state' => Invitation::STATE_ACCEPTED,
+			'unread_messages' => 0,
 		]);
 		$chat = $this->createMock(Room::class);
 		$chat->expects($this->any())
@@ -505,6 +508,8 @@ class ChatManagerTest extends TestCase {
 			'phone_number' => '',
 			'call_id' => '',
 			'invited_cloud_id' => '',
+			'state' => Invitation::STATE_ACCEPTED,
+			'unread_messages' => 0,
 		]);
 		$chat = $this->createMock(Room::class);
 		$chat->expects($this->any())
@@ -586,6 +591,8 @@ class ChatManagerTest extends TestCase {
 			'phone_number' => '',
 			'call_id' => '',
 			'invited_cloud_id' => '',
+			'state' => Invitation::STATE_ACCEPTED,
+			'unread_messages' => 0,
 		]);
 		$chat = $this->createMock(Room::class);
 		$chat->expects($this->any())

--- a/tests/php/Federation/FederationTest.php
+++ b/tests/php/Federation/FederationTest.php
@@ -404,6 +404,7 @@ class FederationTest extends TestCase {
 					'sharedSecret' => $token,
 					'message' => 'Recipient accepted the share',
 					'remoteServerUrl' => 'http://example.tld',
+					'displayName' => 'Foo Bar',
 				]
 			);
 
@@ -428,7 +429,7 @@ class FederationTest extends TestCase {
 			->with('/')
 			->willReturn('http://example.tld/index.php/');
 
-		$success = $this->backendNotifier->sendShareAccepted($remote, $id, $token);
+		$success = $this->backendNotifier->sendShareAccepted($remote, $id, $token, 'Foo Bar');
 
 		$this->assertTrue($success);
 	}

--- a/tests/php/Service/RoomServiceTest.php
+++ b/tests/php/Service/RoomServiceTest.php
@@ -400,6 +400,7 @@ class RoomServiceTest extends TestCase {
 			BreakoutRoom::STATUS_STOPPED,
 			Room::RECORDING_NONE,
 			RecordingService::CONSENT_REQUIRED_NO,
+			Room::HAS_FEDERATION_NONE,
 		);
 
 		$verificationResult = $service->verifyPassword($room, '1234');


### PR DESCRIPTION
## 🛠️ API Checklist

### 🚧 Tasks

- [x] Fix broken "last read message" being empty
- [x] Send the user display name when accepting an invite
- [x] Cache information whether a room has a federated participant

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
