### PR TITLE
fix(federation): Remove duplicate method isFederatedRemoteRoom() vs isFederatedConversation()

### DIFF
--- a/lib/Federation/CloudFederationProviderTalk.php
+++ b/lib/Federation/CloudFederationProviderTalk.php
@@ -270,7 +270,7 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 		}
 
 		// Sanity check to make sure the room is a remote room
-		if (!$room->isFederatedRemoteRoom()) {
+		if (!$room->isFederatedConversation()) {
 			throw new ShareNotFound(FederationManager::OCM_RESOURCE_NOT_FOUND);
 		}
 
@@ -303,7 +303,7 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 		}
 
 		// Sanity check to make sure the room is a remote room
-		if (!$room->isFederatedRemoteRoom()) {
+		if (!$room->isFederatedConversation()) {
 			throw new ShareNotFound(FederationManager::OCM_RESOURCE_NOT_FOUND);
 		}
 
@@ -341,7 +341,7 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 		}
 
 		// Sanity check to make sure the room is a remote room
-		if (!$room->isFederatedRemoteRoom()) {
+		if (!$room->isFederatedConversation()) {
 			throw new ShareNotFound(FederationManager::OCM_RESOURCE_NOT_FOUND);
 		}
 

--- a/lib/Room.php
+++ b/lib/Room.php
@@ -415,13 +415,6 @@ class Room {
 		return $this->remoteToken;
 	}
 
-	/**
-	 * @deprecated
-	 */
-	public function isFederatedRemoteRoom(): bool {
-		return $this->remoteServer !== '';
-	}
-
 	public function setParticipant(?string $userId, Participant $participant): void {
 		// FIXME Also used with cloudId, need actorType checking?
 		$this->currentUser = $userId;


### PR DESCRIPTION
## 🛠️ API Checklist
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
