### PR TITLE
fix(NewMessage): fix broken caret

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -523,7 +523,7 @@ export default {
 		},
 
 		chatInput(newValue) {
-			if (this.text !== newValue) {
+			if (parseSpecialSymbols(this.text) !== newValue) {
 				this.text = newValue
 			}
 		},

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -621,6 +621,8 @@ export default {
 				return
 			}
 			this.$nextTick(() => {
+				// reset or fill main input in chat view from the store
+				this.text = this.chatInput
 				// refocus input as the user might want to type further
 				this.focusInput()
 			})

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -104,8 +104,6 @@
 					@shortkey="focusInput"
 					@keydown.esc="handleInputEsc"
 					@keydown.ctrl.up="handleEditLastMessage"
-					@tribute-active-true.native="isTributePickerActive = true"
-					@tribute-active-false.native="isTributePickerActive = false"
 					@input="handleTyping"
 					@paste="handlePastedFiles"
 					@submit="handleSubmit" />
@@ -335,7 +333,6 @@ export default {
 			showPollEditor: false,
 			showNewFileDialog: -1,
 			showFilePicker: false,
-			isTributePickerActive: false,
 			// Check empty template by default
 			userData: {},
 			clipboardTimeStamp: null,
@@ -960,17 +957,12 @@ export default {
 		},
 
 		handleInputEsc() {
-			if (this.messageToEdit && !this.isTributePickerActive) {
+			if (this.messageToEdit) {
 				this.handleAbortEdit()
 				this.focusInput()
 				return
 			}
-			// When the tribute picker (e.g. emoji picker or mentions) is open
-			// ESC should only close the picker but not blur
-			if (!this.isTributePickerActive) {
-				this.blurInput()
-			}
-
+			this.blurInput()
 		},
 
 		handleEditLastMessage() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11803 
  * compare value from store with parsed value to avoid issues with special symbols
  * revert removed line from 9efb614ac0ec6346176dfc75384a3f1b42f6621b
    * could fill the input again after posting a message, if was sent before debounced update
  * don't check for autocomplete open
    * component is capturing Esc event by itself after nextcloud/vue@8.10.0

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

![Peek 2024-03-14 17-23](https://github.com/nextcloud/spreed/assets/93392545/a97092eb-20fa-495a-9305-9a1a29d1e053)


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possible