### PR TITLE
fix(federation): show Federation section in AdminSettings, hide federated conversations from plugins

### DIFF
--- a/src/components/RoomSelector.vue
+++ b/src/components/RoomSelector.vue
@@ -69,6 +69,8 @@ import { provide, ref } from 'vue'
 import Magnify from 'vue-material-design-icons/Magnify.vue'
 import MessageOutline from 'vue-material-design-icons/MessageOutline.vue'
 
+import { getCapabilities } from '@nextcloud/capabilities'
+
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
@@ -78,6 +80,8 @@ import ConversationsSearchListVirtual from './LeftSidebar/ConversationsList/Conv
 
 import { CONVERSATION } from '../constants.js'
 import { searchListedConversations, fetchConversations } from '../services/conversationsService.js'
+
+const supportFederationV1 = getCapabilities()?.spreed?.features?.includes('federation-v1')
 
 export default {
 	name: 'RoomSelector',
@@ -193,6 +197,7 @@ export default {
 				: await fetchConversations({})
 
 			this.rooms = response.data.ocs.data.sort(this.sortConversations)
+				.filter(conversation => !supportFederationV1 || !conversation.remoteServer)
 			this.loading = false
 		},
 

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -25,8 +25,7 @@
 		<GeneralSettings />
 		<MatterbridgeIntegration />
 		<AllowedGroups />
-		<!-- TODO remove OC.debug when Federation feature is ready -->
-		<Federation v-if="OC.debug" />
+		<Federation v-if="supportFederation" />
 		<BotsSettings />
 		<Commands />
 		<WebServerSetupChecks />
@@ -40,6 +39,8 @@
 </template>
 
 <script>
+import { getCapabilities } from '@nextcloud/capabilities'
+
 import AllowedGroups from '../components/AdminSettings/AllowedGroups.vue'
 import BotsSettings from '../components/AdminSettings/BotsSettings.vue'
 import Commands from '../components/AdminSettings/Commands.vue'
@@ -53,6 +54,8 @@ import SIPBridge from '../components/AdminSettings/SIPBridge.vue'
 import StunServers from '../components/AdminSettings/StunServers.vue'
 import TurnServers from '../components/AdminSettings/TurnServers.vue'
 import WebServerSetupChecks from '../components/AdminSettings/WebServerSetupChecks.vue'
+
+const supportFederation = getCapabilities()?.spreed?.features?.includes('federation-v1')
 
 export default {
 	name: 'AdminSettings',
@@ -72,5 +75,9 @@ export default {
 		TurnServers,
 		WebServerSetupChecks,
 	},
+
+	setup() {
+		return { supportFederation }
+	}
 }
 </script>

--- a/src/views/FlowPostToConversation.vue
+++ b/src/views/FlowPostToConversation.vue
@@ -16,11 +16,14 @@
 
 <script>
 import axios from '@nextcloud/axios'
+import { getCapabilities } from '@nextcloud/capabilities'
 import { generateOcsUrl } from '@nextcloud/router'
 
 import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
 
 import { FLOW, CONVERSATION, PARTICIPANT } from '../constants.js'
+
+const supportFederationV1 = getCapabilities()?.spreed?.features?.includes('federation-v1')
 
 export default {
 	name: 'FlowPostToConversation',
@@ -86,6 +89,7 @@ export default {
 				this.roomOptions = response.data.ocs.data.filter(function(room) {
 					return room.readOnly === CONVERSATION.STATE.READ_WRITE
 						&& (room.permissions & PARTICIPANT.PERMISSIONS.CHAT) !== 0
+						&& (!supportFederationV1 || !room.remoteServer)
 				})
 			})
 		},
@@ -95,7 +99,7 @@ export default {
 </script>
 
 <style scoped>
-	.multiselect {
+	:deep(.v-select) {
 		width: 100%;
 		margin: auto;
 		text-align: center;


### PR DESCRIPTION
### ☑️ Resolves

* Show admin options in  production, if capability is there
* Hide federated rooms from:
  * MessageForwarder, Deck plugin, Maps plugin (where RoomSelector is used)
  * Flow plugin


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Talk | Plugins | Flow
-- | -- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/839f15e0-385c-4544-a14e-26ed83ee79ac) | ![image](https://github.com/nextcloud/spreed/assets/93392545/a1e28d07-7707-4d85-9efd-1638eb3a41c6) | ![image](https://github.com/nextcloud/spreed/assets/93392545/381b58cf-3f3d-4ce3-9a8a-5b1c3fc7da91)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 