### PR TITLE
chore(deps): bump nextcloud/vue from 8.10.0 to 8.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^3.0.0",
         "@nextcloud/upload": "^1.0.5",
-        "@nextcloud/vue": "^8.10.0",
+        "@nextcloud/vue": "^8.11.0",
         "crypto-js": "^4.2.0",
         "debounce": "^2.0.0",
         "emoji-mart-vue-fast": "^15.0.0",
@@ -3845,9 +3845,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.10.0.tgz",
-      "integrity": "sha512-HQ/6upw/sviCOe5jtFmZh7KK+QzLNj4a1TnJt3nJQWEZSgt1FFj48tjrmP8ztqnd8pCCOAF8843VLWCCivrF0w==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.0.tgz",
+      "integrity": "sha512-kJ0plDKuWYFpfG0DeLbS6XZvajH55FdxpoRW+ZaWbMgFo4CJPYIsmCt4FtfqUx6uBjRNFW6vU7wYtlGLDNdHww==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -23562,9 +23562,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.10.0.tgz",
-      "integrity": "sha512-HQ/6upw/sviCOe5jtFmZh7KK+QzLNj4a1TnJt3nJQWEZSgt1FFj48tjrmP8ztqnd8pCCOAF8843VLWCCivrF0w==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.0.tgz",
+      "integrity": "sha512-kJ0plDKuWYFpfG0DeLbS6XZvajH55FdxpoRW+ZaWbMgFo4CJPYIsmCt4FtfqUx6uBjRNFW6vU7wYtlGLDNdHww==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^3.0.0",
     "@nextcloud/upload": "^1.0.5",
-    "@nextcloud/vue": "^8.10.0",
+    "@nextcloud/vue": "^8.11.0",
     "crypto-js": "^4.2.0",
     "debounce": "^2.0.0",
     "emoji-mart-vue-fast": "^15.0.0",


### PR DESCRIPTION
### ☑️ Resolves

* Fix:
  * font-weight in conversations
  * user status icon in NcAvatar menu
  * flickering widgets in chat


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/07ee6801-26f2-4faf-b042-70d19ade1f84) | ![image](https://github.com/nextcloud/spreed/assets/93392545/ddb6b26e-0ee6-46ca-a63d-81d665698efe)
![image](https://github.com/nextcloud/spreed/assets/93392545/bc8f9f5c-c3d0-4001-9a07-66bfb630e2eb) | ![image](https://github.com/nextcloud/spreed/assets/93392545/7137c954-1533-4d0b-97ed-2931d006b8ae)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 