### PR TITLE
chore(deps): bump nextcloud/vue from 8.8.1 to 8.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nextcloud/moment": "^1.2.2",
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^2.2.1",
-        "@nextcloud/vue": "^8.8.1",
+        "@nextcloud/vue": "^8.11.0",
         "crypto-js": "^4.2.0",
         "debounce": "^1.2.1",
         "emoji-mart-vue-fast": "^15.0.0",
@@ -3708,21 +3708,21 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.8.1.tgz",
-      "integrity": "sha512-INQS0boqH4CAzRHESSaKgvaTOsOJ/0fyOB9sC5TIJpqkrPo1Oj229U9XUUf8HV/Xs6FpA5YmQFvQ0gKZ5a1GRw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.0.tgz",
+      "integrity": "sha512-kJ0plDKuWYFpfG0DeLbS6XZvajH55FdxpoRW+ZaWbMgFo4CJPYIsmCt4FtfqUx6uBjRNFW6vU7wYtlGLDNdHww==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
-        "@nextcloud/auth": "^2.0.0",
-        "@nextcloud/axios": "^2.0.0",
+        "@nextcloud/auth": "^2.2.1",
+        "@nextcloud/axios": "^2.4.0",
         "@nextcloud/browser-storage": "^0.3.0",
-        "@nextcloud/calendar-js": "^6.0.0",
-        "@nextcloud/capabilities": "^1.0.4",
-        "@nextcloud/event-bus": "^3.0.0",
-        "@nextcloud/initial-state": "^2.0.0",
-        "@nextcloud/l10n": "^2.0.1",
-        "@nextcloud/logger": "^2.2.1",
+        "@nextcloud/calendar-js": "^6.1.0",
+        "@nextcloud/capabilities": "^1.1.0",
+        "@nextcloud/event-bus": "^3.1.0",
+        "@nextcloud/initial-state": "^2.1.0",
+        "@nextcloud/l10n": "^2.2.0",
+        "@nextcloud/logger": "^2.7.0",
         "@nextcloud/router": "^3.0.0",
         "@nextcloud/vue-select": "^3.25.0",
         "@vueuse/components": "^10.9.0",
@@ -3788,12 +3788,12 @@
       }
     },
     "node_modules/@nextcloud/vue/node_modules/@nextcloud/calendar-js": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.0.1.tgz",
-      "integrity": "sha512-iv6iPw20vp0CinVVrH4ptcuWPdAAx1AawMrYLqFg4vSEr0eVbwz6SW4P8GbxjzzRFJ0xqFXsmFeudiVAhvBaxA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.1.0.tgz",
+      "integrity": "sha512-thVS6Bz+TV7rUB+LO5yFbOhdm65zICDRKcHDUquaZiWL9r6TyV9hCYDcP7cDRV+62wZJh8QPmf1E+d7ZFUOVeA==",
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.0.0",
+        "npm": "^9.0.0"
       },
       "peerDependencies": {
         "ical.js": "^1.5.0",
@@ -9959,9 +9959,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -24043,21 +24043,21 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.8.1.tgz",
-      "integrity": "sha512-INQS0boqH4CAzRHESSaKgvaTOsOJ/0fyOB9sC5TIJpqkrPo1Oj229U9XUUf8HV/Xs6FpA5YmQFvQ0gKZ5a1GRw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.0.tgz",
+      "integrity": "sha512-kJ0plDKuWYFpfG0DeLbS6XZvajH55FdxpoRW+ZaWbMgFo4CJPYIsmCt4FtfqUx6uBjRNFW6vU7wYtlGLDNdHww==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
-        "@nextcloud/auth": "^2.0.0",
-        "@nextcloud/axios": "^2.0.0",
+        "@nextcloud/auth": "^2.2.1",
+        "@nextcloud/axios": "^2.4.0",
         "@nextcloud/browser-storage": "^0.3.0",
-        "@nextcloud/calendar-js": "^6.0.0",
-        "@nextcloud/capabilities": "^1.0.4",
-        "@nextcloud/event-bus": "^3.0.0",
-        "@nextcloud/initial-state": "^2.0.0",
-        "@nextcloud/l10n": "^2.0.1",
-        "@nextcloud/logger": "^2.2.1",
+        "@nextcloud/calendar-js": "^6.1.0",
+        "@nextcloud/capabilities": "^1.1.0",
+        "@nextcloud/event-bus": "^3.1.0",
+        "@nextcloud/initial-state": "^2.1.0",
+        "@nextcloud/l10n": "^2.2.0",
+        "@nextcloud/logger": "^2.7.0",
         "@nextcloud/router": "^3.0.0",
         "@nextcloud/vue-select": "^3.25.0",
         "@vueuse/components": "^10.9.0",
@@ -24108,9 +24108,9 @@
           }
         },
         "@nextcloud/calendar-js": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.0.1.tgz",
-          "integrity": "sha512-iv6iPw20vp0CinVVrH4ptcuWPdAAx1AawMrYLqFg4vSEr0eVbwz6SW4P8GbxjzzRFJ0xqFXsmFeudiVAhvBaxA==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.1.0.tgz",
+          "integrity": "sha512-thVS6Bz+TV7rUB+LO5yFbOhdm65zICDRKcHDUquaZiWL9r6TyV9hCYDcP7cDRV+62wZJh8QPmf1E+d7ZFUOVeA==",
           "requires": {}
         },
         "@nextcloud/router": {
@@ -28866,9 +28866,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "for-each": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@nextcloud/moment": "^1.2.2",
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^2.2.1",
-    "@nextcloud/vue": "^8.8.1",
+    "@nextcloud/vue": "^8.11.0",
     "crypto-js": "^4.2.0",
     "debounce": "^1.2.1",
     "emoji-mart-vue-fast": "^15.0.0",


### PR DESCRIPTION
Backport of #11818

Hopefully last bump for stable28, fix:
- focus trap errors
- reference widgets flickering
- capture tribute closing
- require leading space for tribute
- extra spaces when mentioning
- status icons in Safari
- status icons in NcAvatar menu

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 