### PR TITLE
Fix(MessagesList): Limit relative date up to a week.

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -561,8 +561,10 @@ export default {
 				return t('spreed', 'Today')
 			case 1:
 				return t('spreed', 'Yesterday')
+			case 7:
+				return t('spreed', 'A week ago')
 			default:
-				return t('spreed', '{n} days ago', { n: diffDays })
+				return n('spreed', '%n day ago', '%n days ago', diffDays)
 			}
 		},
 
@@ -574,15 +576,22 @@ export default {
 		 */
 		generateDateSeparator(dateTimestamp) {
 			const date = moment.unix(dateTimestamp).startOf('day')
-			// <Today>, <November 11th, 2019>
-			return t('spreed', '{relativeDate}, {absoluteDate}', {
-				relativeDate: this.getRelativePrefix(date),
-				// 'LL' formats a localized date including day of month, month
-				// name and year
-				absoluteDate: date.format('LL'),
-			}, undefined, {
-				escape: false, // French "Today" has a ' in it
-			})
+			// <Today>, <March 18th, 2024>
+			// Relative date is only shown until a week ago
+			if (moment().startOf('day').diff(date, 'days') <= 7) {
+				return t('spreed', '{relativeDate}, {absoluteDate}', {
+					relativeDate: this.getRelativePrefix(date),
+					// 'LL' formats a localized date including day of month, month
+					// name and year
+					absoluteDate: date.format('LL'),
+				}, undefined, {
+					escape: false, // French "Today" has a ' in it
+				})
+			} else {
+				// <March 18th, 2024>
+				return t('spreed', '{absoluteDate}', { absoluteDate: date.format('LL') })
+			}
+
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

* Relative dates are better shown until a week ago (as it used to be).

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/84044328/c11a65dc-0cd2-41c2-b20a-ac5fbd511522) | ![image](https://github.com/nextcloud/spreed/assets/84044328/2e54c12c-3130-421c-a536-b209e525bff0)

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
