### PR TITLE
fix(MessagesList): Fix chat jumping on reference widgets

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -35,26 +35,28 @@
 			<ul v-if="displayMessagesLoader" class="scroller__loading icon-loading" />
 		</TransitionWrapper>
 
-		<ul v-for="(list, dateTimestamp) in messagesGroupedByDateByAuthor"
-			:key="`section_${dateTimestamp}`"
-			:ref="`dateGroup-${token}`"
-			:data-date-timestamp="dateTimestamp"
-			:class="{'has-sticky': dateTimestamp === stickyDate}">
-			<li class="messages-group__date">
-				<span class="messages-group__date-text" role="heading" aria-level="3">
-					{{ dateSeparatorLabels[dateTimestamp] }}
-				</span>
-			</li>
-			<component :is="messagesGroupComponent(group)"
-				v-for="group in list"
-				:key="group.id"
-				ref="messagesGroup"
-				class="messages-group"
-				:token="token"
-				:messages="group.messages"
-				:previous-message-id="group.previousMessageId"
-				:next-message-id="group.nextMessageId" />
-		</ul>
+		<div class="messages-list-wrapper__reversed">
+			<ul v-for="[dateTimestamp, list] in Object.entries(messagesGroupedByDateByAuthor).reverse()"
+				:key="`section_${dateTimestamp}`"
+				:ref="`dateGroup-${token}`"
+				:data-date-timestamp="dateTimestamp"
+				:class="{'has-sticky': dateTimestamp === stickyDate}">
+				<li class="messages-group__date">
+					<span class="messages-group__date-text" role="heading" aria-level="3">
+						{{ dateSeparatorLabels[dateTimestamp] }}
+					</span>
+				</li>
+				<component :is="messagesGroupComponent(group)"
+					v-for="group in list"
+					:key="group.id"
+					ref="messagesGroup"
+					class="messages-group"
+					:token="token"
+					:messages="group.messages"
+					:previous-message-id="group.previousMessageId"
+					:next-message-id="group.nextMessageId" />
+			</ul>
+		</div>
 
 		<template v-if="showLoadingAnimation">
 			<LoadingPlaceholder type="messages"
@@ -1366,5 +1368,10 @@ export default {
 .scroller--isScrolling .has-sticky .messages-group__date {
 	opacity: 1;
 	transition: opacity 0s;
+}
+
+.messages-list-wrapper__reversed {
+	display: flex;
+	flex-direction: column-reverse;
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

* This will make messages load from bottom to the top, so whatever height added from above, it won't affect the bottom message position.


However, a few things to look into them soon:
- If last message contains reference widget, only height of ( regular message height + loading spinner) will be shown when loaded for the first time -> track loading widget and scroll down once loaded OR mutation/resize observer on last message.
- There is jumping when you open the conversation because scroll bottom takes time to be called (depending on the network), I am not sure how to solve this ( what should be done is that the visible part of the scroller should be kept at the bottom, default behavior of a scrolling div is that its visible part is at the top when adding items, so the only way to keep it is to maintain a list when switching conversations and inject the new messages in its items OR caching will solve it anyway) 
- Scrolling process is duplicated when executed, `handleStartGettingMessagesPreconditions` and `handleScroll` are the roots of each process -> can be improved.

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

- [ ] add some reference widgets 
- [ ]  a/ Load the conversation with the URL
   b/ Load the conversation from switching conversations

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required