### PR TITLE
fix(federation): Mark notifications for federated rooms read similarly

### DIFF
--- a/lib/Notification/Listener.php
+++ b/lib/Notification/Listener.php
@@ -160,7 +160,7 @@ class Listener implements IEventListener {
 	 * Reaction: "{user} reacted with {reaction} in {call}"
 	 *
 	 * We should not mark reactions read based on the read-status of the comment
-	 * they apply to, but the point in time when the reaction as done.
+	 * they apply to, but the point in time when the reaction was done.
 	 * However, these messages are not visible and don't update the read marker,
 	 * so we purge them on joining the conversation.
 	 * This already happened before on the initial loading of a chat with

--- a/tests/integration/features/federation/chat.feature
+++ b/tests/integration/features/federation/chat.feature
@@ -226,6 +226,13 @@ Feature: federation/chat
       | spreed | chat        | room/Hi @all bye         | participant1-displayname mentioned everyone in conversation room       | Hi room bye |
       | spreed | chat        | room/Hi @"federated_user/participant2@{$REMOTE_URL}" bye | participant1-displayname mentioned you in conversation room | Hi @participant2-displayname bye |
       | spreed | chat        | room/Message 1-1         | participant1-displayname replied to your message in conversation room  | Message 1-1 |
+    When next message request has the following parameters set
+      | timeout                  | 0         |
+      | lookIntoFuture           | 1         |
+      | lastKnownMessageId       | Hi @all bye         |
+    And user "participant2" sees the following messages in room "LOCAL::room" with 304
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id                | subject                                                                | message     |
 
   Scenario: Mentioning a federated user as a guest also triggers a notification for them
     Given the following "spreed" app config is set

--- a/tests/integration/features/federation/chat.feature
+++ b/tests/integration/features/federation/chat.feature
@@ -255,9 +255,13 @@ Feature: federation/chat
     Given user "participant2" leaves room "LOCAL::room" with 200 (v4)
     And user "guest" joins room "room" with 200 (v4)
     When user "guest" sends message 'Hi @"federated_user/participant2@{$REMOTE_URL}" bye' to room "room" with 201
+    When user "guest" sends message "Message 2" to room "room" with 201
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                | subject                                                                | message     |
       | spreed | chat        | room/Hi @"federated_user/participant2@{$REMOTE_URL}" bye | A guest mentioned you in conversation room | Hi @participant2-displayname bye |
+    Then user "participant2" reads message "Message 2" in room "LOCAL::room" with 200 (v1)
+    Then user "participant2" has the following notifications
+      | app    | object_type | object_id                | subject                                                                | message     |
 
   Scenario: Mentioning a federated user as a federated user that is a local user to the mentioned one also triggers a notification for them
     Given the following "spreed" app config is set

--- a/tests/php/Controller/ChatControllerTest.php
+++ b/tests/php/Controller/ChatControllerTest.php
@@ -26,6 +26,7 @@ namespace OCA\Talk\Tests\php\Controller;
 use OCA\Talk\Chat\AutoComplete\SearchPlugin;
 use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Chat\MessageParser;
+use OCA\Talk\Chat\Notifier;
 use OCA\Talk\Chat\ReactionManager;
 use OCA\Talk\Controller\ChatController;
 use OCA\Talk\Federation\Authenticator;
@@ -117,6 +118,7 @@ class ChatControllerTest extends TestCase {
 	private $l;
 	private Authenticator|MockObject $federationAuthenticator;
 	private ProxyCacheMessageService|MockObject $pcmService;
+	private Notifier|MockObject $notifier;
 
 	/** @var Room|MockObject */
 	protected $room;
@@ -157,6 +159,7 @@ class ChatControllerTest extends TestCase {
 		$this->l = $this->createMock(IL10N::class);
 		$this->federationAuthenticator = $this->createMock(Authenticator::class);
 		$this->pcmService = $this->createMock(ProxyCacheMessageService::class);
+		$this->notifier = $this->createMock(Notifier::class);
 
 		$this->room = $this->createMock(Room::class);
 
@@ -202,6 +205,7 @@ class ChatControllerTest extends TestCase {
 			$this->l,
 			$this->federationAuthenticator,
 			$this->pcmService,
+			$this->notifier,
 		);
 	}
 


### PR DESCRIPTION
## 🛠️ API Checklist

Following the pattern of normal chats we are marking read in `getMessageContext() > waitForNewMessages()` and `receiveMessages() > waitForNewMessages()`

Fix #11121

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
