### PR TITLE
fix(conversation): allow to invite federated user when creating a conversation

### DIFF
--- a/src/services/conversationsService.js
+++ b/src/services/conversationsService.js
@@ -92,7 +92,7 @@ const searchPossibleConversations = async function({ searchText, token, onlyUser
 		!onlyUsers ? SHARE.TYPE.GROUP : null,
 		!onlyUsers ? SHARE.TYPE.CIRCLE : null,
 		(!onlyUsers && token !== 'new') ? SHARE.TYPE.EMAIL : null,
-		(!onlyUsers && token !== 'new' && canInviteToFederation) ? SHARE.TYPE.REMOTE : null,
+		(!onlyUsers && canInviteToFederation) ? SHARE.TYPE.REMOTE : null,
 	].filter(type => type !== null)
 
 	return axios.get(generateOcsUrl('core/autocomplete/get'), {

--- a/src/services/conversationsService.spec.js
+++ b/src/services/conversationsService.spec.js
@@ -85,6 +85,7 @@ describe('conversationsService', () => {
 				SHARE.TYPE.USER,
 				SHARE.TYPE.GROUP,
 				SHARE.TYPE.CIRCLE,
+				SHARE.TYPE.REMOTE,
 			],
 		)
 	})


### PR DESCRIPTION
### ☑️ Resolves

- allow to invite federated user when creating a conversation
- conversation creation flow seems to work without errors (with stable network)

### 🖼️ Screenshots / Screencasts

Avatar is only shown, if user is joined to the room, which can proxy this exact avatar from remote server
![image](https://github.com/nextcloud/spreed/assets/93392545/115a57c3-7685-4b96-a28f-2f4117d66b7c)

- LeftSidebar search also returns federated user as an option, but doesn't show it (something for later - private federeated conversation?)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 