### PR TITLE
fix(recording): Fix duplicate share message when sharing a recording …

### DIFF
--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -397,7 +397,7 @@ class Listener implements IEventListener {
 			return;
 		}
 
-		if ($this->request->getParam('_route') === 'ocs.spreed.Recording.shareToChat') {
+		if (strtolower($this->request->getParam('_route')) === 'ocs.spreed.recording.sharetochat') {
 			return;
 		}
 		$room = $this->manager->getRoomByToken($share->getSharedWith());

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2650,6 +2650,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$includeReactions = in_array('reactions', $formData->getRow(0), true);
 		$includeReactionsSelf = in_array('reactionsSelf', $formData->getRow(0), true);
 		$includeLastEdit = in_array('lastEditActorId', $formData->getRow(0), true);
+		$includeMessageType = in_array('messageType', $formData->getRow(0), true);
 
 		$expected = $formData->getHash();
 		$count = count($expected);
@@ -2712,7 +2713,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			}
 		}
 
-		Assert::assertEquals($expected, array_map(function ($message, $expected) use ($includeParents, $includeReferenceId, $includeReactions, $includeReactionsSelf, $includeLastEdit) {
+		Assert::assertEquals($expected, array_map(function ($message, $expected) use ($includeParents, $includeReferenceId, $includeReactions, $includeReactionsSelf, $includeLastEdit, $includeMessageType) {
 			$data = [
 				'room' => self::$tokenToIdentifier[$message['token']],
 				'actorType' => $message['actorType'],
@@ -2729,6 +2730,9 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			}
 			if ($includeReferenceId) {
 				$data['referenceId'] = $message['referenceId'];
+			}
+			if ($includeMessageType) {
+				$data['messageType'] = $message['messageType'];
 			}
 			if (isset($expected['silent'])) {
 				$data['silent'] = isset($message['silent']) ? json_encode($message['silent']) : '!ISSET';

--- a/tests/integration/features/callapi/recording.feature
+++ b/tests/integration/features/callapi/recording.feature
@@ -467,12 +467,25 @@ Feature: callapi/recording
       | spreed | recording   | room1     | Transcript now available     | The transcript for the call in room1 was uploaded to /Talk/Recording/ROOM(room1)/join_call.txt. |
       | spreed | recording   | room1     | Call recording now available | The recording for the call in room1 was uploaded to /Talk/Recording/ROOM(room1)/join_call.ogg.  |
     When user "participant1" shares file from the last notification to room "room1" with 200 (v1)
+    Then user "participant1" sees the following system messages in room "room1" with 200 (v1)
+      | room  | actorType | actorId               | actorDisplayName         | systemMessage        |
+      | room1 | users     | participant1          | participant1-displayname | conversation_created |
+    And user "participant1" sees the following messages in room "room1" with 200 (v1)
+      | room  | actorType | actorId               | actorDisplayName         | messageType  | message | messageParameters |
+      | room1 | users     | participant1          | participant1-displayname | record-audio | {file}  | "IGNORE"          |
     Then user "participant1" has the following notifications
       | app    | object_type | object_id | subject                      | message                                                                                       |
       | spreed | recording   | room1     | Transcript now available     | The transcript for the call in room1 was uploaded to /Talk/Recording/ROOM(room1)/join_call.txt. |
     When user "participant1" shares file from the first notification to room "room1" with 200 (v1)
     Then user "participant1" has the following notifications
       | app    | object_type | object_id | subject                      | message                                                                                       |
+    Then user "participant1" sees the following system messages in room "room1" with 200 (v1)
+      | room  | actorType | actorId               | actorDisplayName         | systemMessage        |
+      | room1 | users     | participant1          | participant1-displayname | conversation_created |
+    And user "participant1" sees the following messages in room "room1" with 200 (v1)
+      | room  | actorType | actorId               | actorDisplayName         | messageType  | message | messageParameters |
+      | room1 | users     | participant1          | participant1-displayname | record-audio | {file}  | "IGNORE"          |
+      | room1 | users     | participant1          | participant1-displayname | record-audio | {file}  | "IGNORE"          |
 
   Scenario: Store recording with success but fail to transcript
     Given the following spreed app config is set


### PR DESCRIPTION
…or transcript

### ☑️ Resolves

* Regression from https://github.com/nextcloud/server/pull/42801/files#diff-e9bf496c8b197d60a7640f88f6fc4b5ff13cd41657c4e14f225ede16797e721eR139-R145

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
