### PR TITLE
fix(desktop): do not change welcome page path for desktop

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -58,8 +58,6 @@ export default new Router({
 	routes: [
 		{
 			path: '/apps/spreed',
-			// On desktop add index path as root page
-			alias: IS_DESKTOP ? '/' : undefined,
 			name: 'root',
 			component: WelcomeView,
 			props: true,


### PR DESCRIPTION
### ☑️ Resolves

* Works in a pair with https://github.com/nextcloud/talk-desktop/pull/567
* In path welcome page `/apps/spreed` had alias '/' for desktop. 
  * It allowed to initially open welcome page on Talk Desktop
* Instead, it should be fixed on Talk Desktop side
* Having this `/` router is a problem for determining if a link is a Talk links, for example, `https://nextcloud.ltd/apps/spreed` is a Talk link while `https://nextcloud.ltd/` is not. `/` is not a valid Talk path.

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
