### PR TITLE
feat: handle callUser links in Talk without page reload

### DIFF
--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -164,6 +164,10 @@ const getters = {
 				&& !getters.isModerator
 				&& (conversation.permissions & PARTICIPANT.PERMISSIONS.LOBBY_IGNORE) === 0
 	},
+	getConversationForUser: (state, getters) => {
+		return (userId) => getters.conversationsList
+			.find((conversation) => conversation.type === CONVERSATION.TYPE.ONE_TO_ONE && conversation.name === userId)
+	},
 }
 
 const mutations = {

--- a/src/views/WelcomeView.vue
+++ b/src/views/WelcomeView.vue
@@ -1,14 +1,19 @@
 <template>
-	<EmptyView :name="t('spreed', 'Join a conversation or start a new one')"
-		:description="t('spreed', 'Say hi to your friends and colleagues!')">
+	<EmptyView :name="text.name"
+		:description="text.description">
 		<template #icon>
-			<NcIconSvgWrapper :svg="IconTalk" />
+			<NcLoadingIcon v-if="callUser" />
+			<NcIconSvgWrapper v-else :svg="IconTalk" />
 		</template>
 	</EmptyView>
 </template>
 
 <script>
+import { showError } from '@nextcloud/dialogs'
+import { translate as t } from '@nextcloud/l10n'
+
 import NcIconSvgWrapper from '@nextcloud/vue/dist/Components/NcIconSvgWrapper.js'
+import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 
 import EmptyView from '../components/EmptyView.vue'
 
@@ -19,12 +24,86 @@ export default {
 
 	components: {
 		EmptyView,
-		NcIconSvgWrapper
+		NcIconSvgWrapper,
+		NcLoadingIcon,
 	},
+
 	setup() {
 		return {
 			IconTalk,
 		}
+	},
+
+	data() {
+		return {
+			isCreatingConversationForCallUser: false,
+		}
+	},
+
+	computed: {
+		callUser() {
+			return this.$route.query.callUser
+		},
+
+		text() {
+			if (this.isCreatingConversationForCallUser) {
+				return {
+					name: t('spreed', 'Creating and joining a conversation with "{userid}"', { userid: this.callUser }),
+					description: '',
+				}
+			}
+
+			if (this.callUser) {
+				return {
+					name: t('spreed', 'Joining a conversation with "{userid}"', { userid: this.callUser }),
+					description: '',
+				}
+			}
+
+			return {
+				name: t('spreed', 'Join a conversation or start a new one'),
+				description: t('spreed', 'Say hi to your friends and colleagues!'),
+			}
+		}
+	},
+
+	watch: {
+		callUser: {
+			immediate: true,
+			handler() {
+				if (this.callUser) {
+					this.createAndJoinConversationForCallUser()
+				}
+			}
+		}
+	},
+
+	methods: {
+		async createAndJoinConversationForCallUser() {
+			// Try to find an existing conversation
+			const conversation = this.$store.getters.getConversationForUser(this.callUser)
+			if (conversation) {
+				this.$router.push({
+					name: 'conversation',
+					params: { token: conversation.token },
+				})
+				return
+			}
+
+			// Create a new one-to-one conversation
+			this.isCreatingConversationForCallUser = true
+			try {
+				const newConversation = await this.$store.dispatch('createOneToOneConversation', this.callUser)
+				this.$router.push({
+					name: 'conversation',
+					params: { token: newConversation.token },
+				})
+			} catch (error) {
+				showError(t('spreed', 'Error while joining the conversation'))
+				console.error(error)
+				this.$router.push({ name: 'notfound' })
+			}
+		},
 	}
 }
 </script>


### PR DESCRIPTION
### ☑️ Resolves

* Allows to handle `/apps/spreed?callUser=...` without page reloading, for example, for:
  - Links in the chat, like with links to a conversation
  - Contacts menu on Talk Desktop (not in the Web, requires ` feat/in-app-talk-links-support` branch for desktop build)
    ![image](https://github.com/nextcloud/spreed/assets/25978914/e38ad372-4b11-44d5-b6a0-ce02d02a6d19)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

#### During loading

![image](https://github.com/nextcloud/spreed/assets/25978914/0b6295ae-078a-4a35-b6e4-5dcbcc0120f4)

#### In case of error - redirect to not found

![image](https://github.com/nextcloud/spreed/assets/25978914/e8908d13-9c05-4ed2-b663-581bd47d09f3)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required