### PR TITLE
Release 19.0.0 beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 19.0.0-beta.4 – 2024-03-19
+### Changed
+- Update translations
+- Update several dependencies
+
+### Fixed
+- Adjust read handling in received federated conversations to match normal conversations
+  [#11861](https://github.com/nextcloud/spreed/issues/11861)
+- Allow inviting federated users while creating a conversation
+  [#11862](https://github.com/nextcloud/spreed/issues/11862)
+- Fix duplicate messages when sharing recordings or transcripts
+  [#11863](https://github.com/nextcloud/spreed/issues/11863)
+- Prevent manipulating receiving federated conversations via OCC
+  [#11855](https://github.com/nextcloud/spreed/issues/11855)
+
 ## 19.0.0-beta.3 – 2024-03-19
 ### Added
 - Preview: Federated chatting - Implemented reminders

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>19.0.0-beta.3</version>
+	<version>19.0.0-beta.4</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "19.0.0-beta.3",
+  "version": "19.0.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "19.0.0-beta.3",
+      "version": "19.0.0-beta.4",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "19.0.0-beta.3",
+  "version": "19.0.0-beta.4",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## Changed
- Update translations
- Update several dependencies

## Fixed
- Adjust read handling in received federated conversations to match normal conversations [#11861](https://github.com/nextcloud/spreed/issues/11861)
- Allow inviting federated users while creating a conversation [#11862](https://github.com/nextcloud/spreed/issues/11862)
- Fix duplicate messages when sharing recordings or transcripts [#11863](https://github.com/nextcloud/spreed/issues/11863)
- Prevent manipulating receiving federated conversations via OCC [#11855](https://github.com/nextcloud/spreed/issues/11855)
