### PR TITLE
feat(avatar): Allow logged-in users to proxy avatars without a token

### DIFF
--- a/appinfo/routes/routesAvatarController.php
+++ b/appinfo/routes/routesAvatarController.php
@@ -32,6 +32,10 @@ $requirementsWithSize = [
 	'token' => '^[a-z0-9]{4,30}$',
 	'size' => '(64|512)',
 ];
+$requirementsNewWithSize = [
+	'apiVersion' => '(v1)',
+	'size' => '(64|512)',
+];
 
 return [
 	'ocs' => [
@@ -45,6 +49,10 @@ return [
 		['name' => 'Avatar#getAvatarDark', 'url' => '/api/{apiVersion}/room/{token}/avatar/dark', 'verb' => 'GET', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\AvatarController::deleteAvatar() */
 		['name' => 'Avatar#deleteAvatar', 'url' => '/api/{apiVersion}/room/{token}/avatar', 'verb' => 'DELETE', 'requirements' => $requirements],
+		/** @see \OCA\Talk\Controller\AvatarController::getUserProxyAvatarWithoutRoom() */
+		['name' => 'Avatar#getUserProxyAvatarWithoutRoom', 'url' => '/api/{apiVersion}/proxy/new/user-avatar/{size}', 'verb' => 'GET', 'requirements' => $requirementsNewWithSize],
+		/** @see \OCA\Talk\Controller\AvatarController::getUserProxyAvatarDarkWithoutRoom() */
+		['name' => 'Avatar#getUserProxyAvatarDarkWithoutRoom', 'url' => '/api/{apiVersion}/proxy/new/user-avatar/{size}/dark', 'verb' => 'GET', 'requirements' => $requirementsNewWithSize],
 		/** @see \OCA\Talk\Controller\AvatarController::getUserProxyAvatar() */
 		['name' => 'Avatar#getUserProxyAvatar', 'url' => '/api/{apiVersion}/proxy/{token}/user-avatar/{size}', 'verb' => 'GET', 'requirements' => $requirementsWithSize],
 		/** @see \OCA\Talk\Controller\AvatarController::getUserProxyAvatarDark() */

--- a/lib/Controller/AvatarController.php
+++ b/lib/Controller/AvatarController.php
@@ -39,6 +39,7 @@ use OCA\Talk\Service\AvatarService;
 use OCA\Talk\Service\RoomFormatter;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\BruteForceProtection;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\Attribute\PublicPage;
@@ -181,6 +182,43 @@ class AvatarController extends AEnvironmentAwareController {
 	#[RequireParticipantOrLoggedInAndListedConversation]
 	public function getAvatarDark(): FileDisplayResponse {
 		return $this->getAvatar(true);
+	}
+
+	/**
+	 * Get the avatar of a cloudId user when inviting users while creating a conversation
+	 *
+	 * @param int $size Avatar size
+	 * @psalm-param 64|512 $size
+	 * @param string $cloudId Federation CloudID to get the avatar for
+	 * @param bool $darkTheme Theme used for background
+	 * @return FileDisplayResponse<Http::STATUS_OK, array{Content-Type: string}>
+	 *
+	 * 200: User avatar returned
+	 */
+	#[FederationSupported]
+	#[OpenAPI(scope: OpenAPI::SCOPE_FEDERATION)]
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	public function getUserProxyAvatarWithoutRoom(int $size, string $cloudId, bool $darkTheme = false): FileDisplayResponse {
+		return $this->getUserProxyAvatar($size, $cloudId, $darkTheme);
+	}
+
+	/**
+	 * Get the dark mode avatar of a cloudId user when inviting users while creating a conversation
+	 *
+	 * @param int $size Avatar size
+	 * @psalm-param 64|512 $size
+	 * @param string $cloudId Federation CloudID to get the avatar for
+	 * @return FileDisplayResponse<Http::STATUS_OK, array{Content-Type: string}>
+	 *
+	 * 200: User avatar returned
+	 */
+	#[FederationSupported]
+	#[OpenAPI(scope: OpenAPI::SCOPE_FEDERATION)]
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	public function getUserProxyAvatarDarkWithoutRoom(int $size, string $cloudId): FileDisplayResponse {
+		return $this->getUserProxyAvatar($size, $cloudId, true);
 	}
 
 	/**

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -816,6 +816,173 @@
         }
     },
     "paths": {
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/new/user-avatar/{size}": {
+            "get": {
+                "operationId": "avatar-get-user-proxy-avatar-without-room",
+                "summary": "Get the avatar of a cloudId user when inviting users while creating a conversation",
+                "tags": [
+                    "avatar"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "cloudId",
+                        "in": "query",
+                        "description": "Federation CloudID to get the avatar for",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "darkTheme",
+                        "in": "query",
+                        "description": "Theme used for background",
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
+                        }
+                    },
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "size",
+                        "in": "path",
+                        "description": "Avatar size",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64",
+                            "enum": [
+                                64,
+                                512
+                            ]
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User avatar returned",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/new/user-avatar/{size}/dark": {
+            "get": {
+                "operationId": "avatar-get-user-proxy-avatar-dark-without-room",
+                "summary": "Get the dark mode avatar of a cloudId user when inviting users while creating a conversation",
+                "tags": [
+                    "avatar"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "cloudId",
+                        "in": "query",
+                        "description": "Federation CloudID to get the avatar for",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "size",
+                        "in": "path",
+                        "description": "Avatar size",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64",
+                            "enum": [
+                                64,
+                                512
+                            ]
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User avatar returned",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/{token}/user-avatar/{size}": {
             "get": {
                 "operationId": "avatar-get-user-proxy-avatar",

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -16220,6 +16220,173 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/new/user-avatar/{size}": {
+            "get": {
+                "operationId": "avatar-get-user-proxy-avatar-without-room",
+                "summary": "Get the avatar of a cloudId user when inviting users while creating a conversation",
+                "tags": [
+                    "avatar"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "cloudId",
+                        "in": "query",
+                        "description": "Federation CloudID to get the avatar for",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "darkTheme",
+                        "in": "query",
+                        "description": "Theme used for background",
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
+                        }
+                    },
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "size",
+                        "in": "path",
+                        "description": "Avatar size",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64",
+                            "enum": [
+                                64,
+                                512
+                            ]
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User avatar returned",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/new/user-avatar/{size}/dark": {
+            "get": {
+                "operationId": "avatar-get-user-proxy-avatar-dark-without-room",
+                "summary": "Get the dark mode avatar of a cloudId user when inviting users while creating a conversation",
+                "tags": [
+                    "avatar"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "cloudId",
+                        "in": "query",
+                        "description": "Federation CloudID to get the avatar for",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "size",
+                        "in": "path",
+                        "description": "Avatar size",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64",
+                            "enum": [
+                                64,
+                                512
+                            ]
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User avatar returned",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/{token}/user-avatar/{size}": {
             "get": {
                 "operationId": "avatar-get-user-proxy-avatar",

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -10,6 +10,14 @@ type XOR<T, U> = (T | U) extends object ? (Without<T, U> & U) | (Without<U, T> &
 type OneOf<T extends any[]> = T extends [infer Only] ? Only : T extends [infer A, infer B, ...infer Rest] ? OneOf<[XOR<A, B>, ...Rest]> : never;
 
 export type paths = {
+  "/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/new/user-avatar/{size}": {
+    /** Get the avatar of a cloudId user when inviting users while creating a conversation */
+    get: operations["avatar-get-user-proxy-avatar-without-room"];
+  };
+  "/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/new/user-avatar/{size}/dark": {
+    /** Get the dark mode avatar of a cloudId user when inviting users while creating a conversation */
+    get: operations["avatar-get-user-proxy-avatar-dark-without-room"];
+  };
   "/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/{token}/user-avatar/{size}": {
     /** Get the avatar of a cloudId user */
     get: operations["avatar-get-user-proxy-avatar"];
@@ -297,6 +305,60 @@ export type external = Record<string, never>;
 
 export type operations = {
 
+  /** Get the avatar of a cloudId user when inviting users while creating a conversation */
+  "avatar-get-user-proxy-avatar-without-room": {
+    parameters: {
+      query: {
+        /** @description Federation CloudID to get the avatar for */
+        cloudId: string;
+        /** @description Theme used for background */
+        darkTheme?: 0 | 1;
+      };
+      header: {
+        /** @description Required to be true for the API request to pass */
+        "OCS-APIRequest": boolean;
+      };
+      path: {
+        apiVersion: "v1";
+        /** @description Avatar size */
+        size: 64 | 512;
+      };
+    };
+    responses: {
+      /** @description User avatar returned */
+      200: {
+        content: {
+          "*/*": string;
+        };
+      };
+    };
+  };
+  /** Get the dark mode avatar of a cloudId user when inviting users while creating a conversation */
+  "avatar-get-user-proxy-avatar-dark-without-room": {
+    parameters: {
+      query: {
+        /** @description Federation CloudID to get the avatar for */
+        cloudId: string;
+      };
+      header: {
+        /** @description Required to be true for the API request to pass */
+        "OCS-APIRequest": boolean;
+      };
+      path: {
+        apiVersion: "v1";
+        /** @description Avatar size */
+        size: 64 | 512;
+      };
+    };
+    responses: {
+      /** @description User avatar returned */
+      200: {
+        content: {
+          "*/*": string;
+        };
+      };
+    };
+  };
   /** Get the avatar of a cloudId user */
   "avatar-get-user-proxy-avatar": {
     parameters: {

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -372,6 +372,14 @@ export type paths = {
     /** Delete your avatar as a user */
     delete: operations["user_avatar-delete-avatar"];
   };
+  "/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/new/user-avatar/{size}": {
+    /** Get the avatar of a cloudId user when inviting users while creating a conversation */
+    get: operations["avatar-get-user-proxy-avatar-without-room"];
+  };
+  "/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/new/user-avatar/{size}/dark": {
+    /** Get the dark mode avatar of a cloudId user when inviting users while creating a conversation */
+    get: operations["avatar-get-user-proxy-avatar-dark-without-room"];
+  };
   "/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/{token}/user-avatar/{size}": {
     /** Get the avatar of a cloudId user */
     get: operations["avatar-get-user-proxy-avatar"];
@@ -5533,6 +5541,60 @@ export type operations = {
               data: unknown;
             };
           };
+        };
+      };
+    };
+  };
+  /** Get the avatar of a cloudId user when inviting users while creating a conversation */
+  "avatar-get-user-proxy-avatar-without-room": {
+    parameters: {
+      query: {
+        /** @description Federation CloudID to get the avatar for */
+        cloudId: string;
+        /** @description Theme used for background */
+        darkTheme?: 0 | 1;
+      };
+      header: {
+        /** @description Required to be true for the API request to pass */
+        "OCS-APIRequest": boolean;
+      };
+      path: {
+        apiVersion: "v1";
+        /** @description Avatar size */
+        size: 64 | 512;
+      };
+    };
+    responses: {
+      /** @description User avatar returned */
+      200: {
+        content: {
+          "*/*": string;
+        };
+      };
+    };
+  };
+  /** Get the dark mode avatar of a cloudId user when inviting users while creating a conversation */
+  "avatar-get-user-proxy-avatar-dark-without-room": {
+    parameters: {
+      query: {
+        /** @description Federation CloudID to get the avatar for */
+        cloudId: string;
+      };
+      header: {
+        /** @description Required to be true for the API request to pass */
+        "OCS-APIRequest": boolean;
+      };
+      path: {
+        apiVersion: "v1";
+        /** @description Avatar size */
+        size: 64 | 512;
+      };
+    };
+    responses: {
+      /** @description User avatar returned */
+      200: {
+        content: {
+          "*/*": string;
         };
       };
     };


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11873 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
