### PR TITLE
fix(Participant): show all federated users in remote conversations as online

### DIFF
--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -353,6 +353,7 @@ import PhonePaused from 'vue-material-design-icons/PhonePaused.vue'
 import Tune from 'vue-material-design-icons/Tune.vue'
 import VideoIcon from 'vue-material-design-icons/Video.vue'
 
+import { getCapabilities } from '@nextcloud/capabilities'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 
@@ -380,6 +381,8 @@ import {
 import { formattedTime } from '../../../utils/formattedTime.ts'
 import { readableNumber } from '../../../utils/readableNumber.ts'
 import { getStatusMessage } from '../../../utils/userStatus.js'
+
+const supportFederationV1 = getCapabilities()?.spreed?.features?.includes('federation-v1')
 
 export default {
 	name: 'Participant',
@@ -610,6 +613,10 @@ export default {
 			return this.participant.actorType === ATTENDEE.ACTOR_TYPE.USERS
 		},
 
+		isFederatedActor() {
+			return this.participant.actorType === ATTENDEE.ACTOR_TYPE.FEDERATED_USERS
+		},
+
 		isGuestActor() {
 			return this.participant.actorType === ATTENDEE.ACTOR_TYPE.GUESTS
 		},
@@ -752,7 +759,9 @@ export default {
 		 * return this.participant.status === 'offline' ||  !this.sessionIds.length && !this.isSearched
 		 */
 		isOffline() {
-			return !this.sessionIds.length && !this.isSearched && (this.isUserActor || this.isGuestActor)
+			return !this.sessionIds.length && !this.isSearched
+				&& (this.isUserActor || this.isFederatedActor || this.isGuestActor)
+				&& (!supportFederationV1 || (!this.conversation.remoteServer && !this.isFederatedActor))
 		},
 
 		isGuest() {


### PR DESCRIPTION
### ☑️ Resolves

* Requires `federation-v1` capability


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Remote | 🏡 Host
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/a805eef8-944a-4a2f-8b57-599df8ea7b18) | ![image](https://github.com/nextcloud/spreed/assets/93392545/7d870bb5-daa9-456b-99e8-857dcd0a84f6)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required