### PR TITLE
chore(deps): bump nextcloud/vue from 8.11.0 to 8.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^3.0.0",
         "@nextcloud/upload": "^1.0.5",
-        "@nextcloud/vue": "^8.11.0",
+        "@nextcloud/vue": "^8.11.1",
         "crypto-js": "^4.2.0",
         "debounce": "^2.0.0",
         "emoji-mart-vue-fast": "^15.0.0",
@@ -3845,9 +3845,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.0.tgz",
-      "integrity": "sha512-kJ0plDKuWYFpfG0DeLbS6XZvajH55FdxpoRW+ZaWbMgFo4CJPYIsmCt4FtfqUx6uBjRNFW6vU7wYtlGLDNdHww==",
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.1.tgz",
+      "integrity": "sha512-tK/OpRasvjVwKBe8k7T5WfvNbeimYPF7TGNq3P2UO8ir6mDoO0aymAW8qKfPU56elH7bqqr8qk0d8rC/jZuLaQ==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -23559,9 +23559,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.0.tgz",
-      "integrity": "sha512-kJ0plDKuWYFpfG0DeLbS6XZvajH55FdxpoRW+ZaWbMgFo4CJPYIsmCt4FtfqUx6uBjRNFW6vU7wYtlGLDNdHww==",
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.1.tgz",
+      "integrity": "sha512-tK/OpRasvjVwKBe8k7T5WfvNbeimYPF7TGNq3P2UO8ir6mDoO0aymAW8qKfPU56elH7bqqr8qk0d8rC/jZuLaQ==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^3.0.0",
     "@nextcloud/upload": "^1.0.5",
-    "@nextcloud/vue": "^8.11.0",
+    "@nextcloud/vue": "^8.11.1",
     "crypto-js": "^4.2.0",
     "debounce": "^2.0.0",
     "emoji-mart-vue-fast": "^15.0.0",

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -1031,16 +1031,6 @@ export default {
 	overflow-y: auto !important;
 	overflow-x: hidden !important;
 	padding: 0;
-
-	// FIXME upstream: subname color was dropped
-	:deep(.list-item-content__subname) {
-		color: var(--color-text-maxcontrast);
-	}
-
-	:deep(.list-item-content__name),
-	:deep(.list-item-content__subname--bold) {
-		font-weight: 500;
-	}
 }
 
 .unread-mention-button {


### PR DESCRIPTION
### ☑️ Resolves

* NcListItem native font-weight is 500
* LeftSidebar animation is smooth
* autocomplete avatars in dark mode are correct

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it