### PR TITLE
fix(chat): disable drag&drop and Ctrl+V if files upload is not allowed

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -199,7 +199,7 @@ import SendIcon from 'vue-material-design-icons/Send.vue'
 import SendVariantOutlineIcon from 'vue-material-design-icons/SendVariantOutline.vue'
 
 import { getCapabilities } from '@nextcloud/capabilities'
-import { showError } from '@nextcloud/dialogs'
+import { showError, showWarning } from '@nextcloud/dialogs'
 import { FilePickerVue } from '@nextcloud/dialogs/filepicker.js'
 import { generateUrl } from '@nextcloud/router'
 
@@ -843,6 +843,10 @@ export default {
 		 * @param {boolean} isVoiceMessage indicates whether the file is a voice message
 		 */
 		async handleFiles(files, rename = false, isVoiceMessage = false) {
+			if (!this.canUploadFiles) {
+				showWarning(t('spreed', 'File upload is not available in this conversation'))
+				return
+			}
 			// Create a unique id for the upload operation
 			const uploadId = this.currentUploadId ?? new Date().getTime()
 			// Uploads and shares the files


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11874 (for federated users, locals still can post files)


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

![image](https://github.com/nextcloud/spreed/assets/93392545/36464e0d-446f-4eec-95ea-55e05ccbae1a)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 