### PR TITLE
feat(federation): show proxy avatars when creating new conversation or accepting invitation

### DIFF
--- a/src/components/ContactSelectionBubble.vue
+++ b/src/components/ContactSelectionBubble.vue
@@ -22,6 +22,7 @@
 <template>
 	<div class="contact-selection-bubble">
 		<AvatarWrapper :id="participant.id"
+			token="new"
 			class="contact-selection-bubble__avatar"
 			:name="participant.label"
 			:source="participant.source"

--- a/src/components/LeftSidebar/InvitationHandler.vue
+++ b/src/components/LeftSidebar/InvitationHandler.vue
@@ -162,7 +162,7 @@ export default {
 			return {
 				user: {
 					component: Mention,
-					props: { id, name: item.inviterDisplayName, server, token: item.token, type: 'user' }
+					props: { id, name: item.inviterDisplayName, server, token: item.token || 'new', type: 'user' }
 				}
 			}
 		},

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -36,7 +36,7 @@
 		@keydown.enter="handleClick">
 		<!-- Participant's avatar -->
 		<AvatarWrapper :id="computedId"
-			:token="token"
+			:token="isSearched ? 'new' : token"
 			:name="computedName"
 			:source="participant.source || participant.actorType"
 			:disable-menu="isSearched"


### PR DESCRIPTION


### ☑️ Resolves

* Fix #…

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

