### PR TITLE
fix(federation): hide call-related settings for federated conversations

### DIFF
--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -26,9 +26,7 @@
 		:open.sync="showSettings"
 		:show-navigation="true"
 		:container="container">
-		<!-- description -->
-		<NcAppSettingsSection v-if="showDescription"
-			id="basic-info"
+		<NcAppSettingsSection id="basic-info"
 			:name="t('spreed', 'Basic Info')">
 			<BasicInfo :conversation="conversation"
 				:can-full-moderate="canFullModerate" />
@@ -39,7 +37,8 @@
 			<NcAppSettingsSection v-if="!isNoteToSelf"
 				id="notifications"
 				:name="t('spreed', 'Personal')">
-				<NcCheckboxRadioSwitch type="switch"
+				<NcCheckboxRadioSwitch v-if="showMediaSettingsToggle"
+					type="switch"
 					:disabled="recordingConsentRequired"
 					:checked="showMediaSettings"
 					@update:checked="setShowMediaSettings">
@@ -138,6 +137,7 @@ import { useSettingsStore } from '../../stores/settings.js'
 const recordingEnabled = getCapabilities()?.spreed?.config?.call?.recording || false
 const recordingConsentCapability = getCapabilities()?.spreed?.features?.includes('recording-consent')
 const recordingConsent = getCapabilities()?.spreed?.config?.call?.['recording-consent'] !== CALL.RECORDING_CONSENT.OFF
+const supportFederationV1 = getCapabilities()?.spreed?.features?.includes('federation-v1')
 
 export default {
 	name: 'ConversationSettingsDialog',
@@ -196,6 +196,10 @@ export default {
 				|| this.$store.getters.getToken()
 		},
 
+		showMediaSettingsToggle() {
+			return (!supportFederationV1 || !this.conversation.remoteServer)
+		},
+
 		showMediaSettings() {
 			return this.settingsStore.getShowMediaSettings(this.token)
 		},
@@ -224,15 +228,6 @@ export default {
 
 		canLeaveConversation() {
 			return this.conversation.canLeaveConversation
-		},
-
-		showDescription() {
-			if (this.canFullModerate) {
-				return this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE
-					&& this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE_FORMER
-			} else {
-				return this.description !== ''
-			}
 		},
 
 		isBreakoutRoom() {

--- a/src/components/ConversationSettings/NotificationsSettings.vue
+++ b/src/components/ConversationSettings/NotificationsSettings.vue
@@ -38,7 +38,8 @@
 			</span>
 		</NcCheckboxRadioSwitch>
 
-		<NcCheckboxRadioSwitch id="notification_calls"
+		<NcCheckboxRadioSwitch v-if="showCallNotificationSettings"
+			id="notification_calls"
 			type="switch"
 			:checked.sync="notifyCalls"
 			@update:checked="setNotificationCalls">
@@ -52,9 +53,13 @@ import Account from 'vue-material-design-icons/Account.vue'
 import VolumeHigh from 'vue-material-design-icons/VolumeHigh.vue'
 import VolumeOff from 'vue-material-design-icons/VolumeOff.vue'
 
+import { getCapabilities } from '@nextcloud/capabilities'
+
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 
 import { PARTICIPANT } from '../../constants.js'
+
+const supportFederationV1 = getCapabilities()?.spreed?.features?.includes('federation-v1')
 
 const notificationLevels = [
 	{ value: PARTICIPANT.NOTIFY.ALWAYS, label: t('spreed', 'All messages') },
@@ -86,6 +91,12 @@ export default {
 		return {
 			notifyCalls: this.conversation.notificationCalls === PARTICIPANT.NOTIFY_CALLS.ON,
 			notificationLevel: this.conversation.notificationLevel.toString(),
+		}
+	},
+
+	computed: {
+		showCallNotificationSettings() {
+			return (!supportFederationV1 || !this.conversation.remoteServer)
 		}
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11878

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/72d0cb08-3e29-41fd-8dbd-8438f6a3cbcd) | ![image](https://github.com/nextcloud/spreed/assets/93392545/3ac74e2d-cb79-4d5e-9568-2d7314079189)


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 