### PR TITLE
feat(LeftSidebar): rearrange conversation fast creating options

### DIFF
--- a/src/components/LeftSidebar/CallPhoneDialog/CallPhoneDialog.vue
+++ b/src/components/LeftSidebar/CallPhoneDialog/CallPhoneDialog.vue
@@ -67,9 +67,9 @@ import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 
-import DialpadPanel from '../../UIShared/DialpadPanel.vue'
 import LoadingComponent from '../../LoadingComponent.vue'
 import SelectPhoneNumber from '../../SelectPhoneNumber.vue'
+import DialpadPanel from '../../UIShared/DialpadPanel.vue'
 
 import { CONVERSATION, PARTICIPANT } from '../../../constants.js'
 import { callSIPDialOut } from '../../../services/callsService.js'

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -182,19 +182,6 @@
 
 				<!-- Search results -->
 				<ul v-else class="h-100 scroller">
-					<!-- Create a new conversation -->
-					<NcListItem v-if="canStartConversations"
-						:name="t('spreed', 'Create a new conversation')"
-						data-nav-id="conversation_create_new"
-						@click="createConversation(searchText)">
-						<template #icon>
-							<ChatPlus :size="30" />
-						</template>
-						<template #subname>
-							{{ searchText }}
-						</template>
-					</NcListItem>
-
 					<!-- Search results: user's conversations -->
 					<NcAppNavigationCaption :name="t('spreed', 'Conversations')" />
 					<Conversation v-for="item of searchResultsConversationList"
@@ -203,6 +190,19 @@
 						:item="item"
 						@click="abortSearch" />
 					<Hint v-if="searchResultsConversationList.length === 0" :hint="t('spreed', 'No matches found')" />
+
+					<!-- Create a new conversation -->
+					<NcListItem v-if="canStartConversations"
+						:name="searchText"
+						data-nav-id="conversation_create_new"
+						@click="createConversation(searchText)">
+						<template #icon>
+							<ChatPlus :size="44" />
+						</template>
+						<template #subname>
+							{{ t('spreed', 'New group conversation') }}
+						</template>
+					</NcListItem>
 
 					<!-- Search results: listed (open) conversations -->
 					<template v-if="!listedConversationsLoading && searchResultsListedConversations.length !== 0">
@@ -225,6 +225,9 @@
 							<template #icon>
 								<ConversationIcon :item="iconData(item)" />
 							</template>
+							<template #subname>
+								{{ t('spreed', 'New private conversation') }}
+							</template>
 						</NcListItem>
 					</template>
 
@@ -241,6 +244,9 @@
 								<template #icon>
 									<ConversationIcon :item="iconData(item)" />
 								</template>
+								<template #subname>
+									{{ t('spreed', 'New group conversation') }}
+								</template>
 							</NcListItem>
 						</template>
 
@@ -255,14 +261,19 @@
 								<template #icon>
 									<ConversationIcon :item="iconData(item)" />
 								</template>
+								<template #subname>
+									{{ t('spreed', 'New group conversation') }}
+								</template>
 							</NcListItem>
 						</template>
 					</template>
 
 					<!-- Search results: no results (yet) -->
-					<NcAppNavigationCaption v-if="sourcesWithoutResults" :name="sourcesWithoutResultsList" />
-					<Hint v-if="contactsLoading" :hint="t('spreed', 'Loading')" />
-					<Hint v-else :hint="t('spreed', 'No search results')" />
+					<template v-if="sourcesWithoutResults">
+						<NcAppNavigationCaption :name="sourcesWithoutResultsList" />
+						<Hint :hint="t('spreed', 'No search results')" />
+					</template>
+					<Hint v-else-if="contactsLoading" :hint="t('spreed', 'Loading')" />
 				</ul>
 			</li>
 		</template>
@@ -1072,6 +1083,14 @@ export default {
 
 :deep(.app-navigation__list) {
 	padding: 0 !important;
+}
+
+:deep(.app-navigation-caption):not(:first-child) {
+	margin-top: 12px !important;
+}
+
+:deep(.app-navigation-caption__name) {
+	margin: 0 !important;
 }
 
 :deep(.list-item) {

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -400,7 +400,7 @@ export default {
 
 		const federationStore = useFederationStore()
 		const talkHashStore = useTalkHashStore()
-		const { initializeNavigation, resetNavigation } = useArrowNavigation(leftSidebar, searchBox, '.list-item')
+		const { initializeNavigation, resetNavigation } = useArrowNavigation(leftSidebar, searchBox)
 		const isMobile = useIsMobile()
 
 		return {

--- a/src/components/NewConversationDialog/NewConversationContactsPage.vue
+++ b/src/components/NewConversationDialog/NewConversationContactsPage.vue
@@ -83,10 +83,10 @@ import { showError } from '@nextcloud/dialogs'
 
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 
-import ContactSelectionBubble from '../UIShared/ContactSelectionBubble.vue'
-import DialpadPanel from '../UIShared/DialpadPanel.vue'
 import ParticipantSearchResults from '../RightSidebar/Participants/ParticipantsSearchResults.vue'
 import SelectPhoneNumber from '../SelectPhoneNumber.vue'
+import ContactSelectionBubble from '../UIShared/ContactSelectionBubble.vue'
+import DialpadPanel from '../UIShared/DialpadPanel.vue'
 import TransitionWrapper from '../UIShared/TransitionWrapper.vue'
 
 import { useArrowNavigation } from '../../composables/useArrowNavigation.js'

--- a/src/components/NewConversationDialog/NewConversationContactsPage.vue
+++ b/src/components/NewConversationDialog/NewConversationContactsPage.vue
@@ -131,7 +131,7 @@ export default {
 		const wrapper = ref(null)
 		const setContacts = ref(null)
 
-		const { initializeNavigation, resetNavigation } = useArrowNavigation(wrapper, setContacts, '.participant-row')
+		const { initializeNavigation, resetNavigation } = useArrowNavigation(wrapper, setContacts)
 
 		return {
 			initializeNavigation,

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -31,7 +31,7 @@
 			'selected': isSelected }"
 		:aria-label="participantAriaLabel"
 		:role="isSearched ? 'listitem' : undefined"
-		:tabindex="isSearched ? 0 : undefined"
+		:tabindex="0"
 		v-on="isSearched ? { click: handleClick, 'keydown.enter': handleClick } : {}"
 		@keydown.enter="handleClick">
 		<!-- Participant's avatar -->

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -80,10 +80,10 @@ import NcAppNavigationCaption from '@nextcloud/vue/dist/Components/NcAppNavigati
 import ParticipantsList from './ParticipantsList.vue'
 import ParticipantsListVirtual from './ParticipantsListVirtual.vue'
 import ParticipantsSearchResults from './ParticipantsSearchResults.vue'
+import SelectPhoneNumber from '../../SelectPhoneNumber.vue'
 import DialpadPanel from '../../UIShared/DialpadPanel.vue'
 import Hint from '../../UIShared/Hint.vue'
 import SearchBox from '../../UIShared/SearchBox.vue'
-import SelectPhoneNumber from '../../SelectPhoneNumber.vue'
 
 import { useArrowNavigation } from '../../../composables/useArrowNavigation.js'
 import { useGetParticipants } from '../../../composables/useGetParticipants.js'


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11632
  * Move "Create new conversation" under current conversations
  * Add sublines to indicate that user is starting a new conversation from search results
  * Decrease margin between sections
* Show user status for known users in search results
* Add fast option to create group conversation with federated user from search results
  * API provides entrypoint, would be a good base for follow-up 1-1 federated rooms

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After | 🏚️ Before | 🏡 After
-- | -- | -- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/c756d3fd-9fdd-41d1-a5f2-5da87dfb0e35) | ![image](https://github.com/nextcloud/spreed/assets/93392545/82d988d4-e377-47b9-976c-e192792f6cd5) | ![image](https://github.com/nextcloud/spreed/assets/93392545/805e7d24-c539-4e7f-996e-0e9533c2bd34) | ![image](https://github.com/nextcloud/spreed/assets/93392545/e6d3d923-a4b8-41b9-9a45-5e3ed3561073)
![image](https://github.com/nextcloud/spreed/assets/93392545/e73fbb3f-10cb-44f2-9e78-d4e8e2c38751) | ![image](https://github.com/nextcloud/spreed/assets/93392545/0d0eaf87-61dd-42f4-9266-0bad41935ea6) | ![image](https://github.com/nextcloud/spreed/assets/93392545/08fb656b-6111-400e-befa-4b4e14a28035) | ![image](https://github.com/nextcloud/spreed/assets/93392545/af27ca93-d847-490a-b53a-db054283fe8d)
Not available | ![image](https://github.com/nextcloud/spreed/assets/93392545/2ea1e75c-8c10-48cd-ae07-d631a1af33ac) | - | -

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team