### PR TITLE
fix(tests): Allow negative expiration time in tests

### DIFF
--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -3780,7 +3780,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" set the message expiration to (\d+) of room "([^"]*)" with (\d+) \((v4)\)$/
+	 * @Given /^user "([^"]*)" set the message expiration to ([-\d]+) of room "([^"]*)" with (\d+) \((v4)\)$/
 	 */
 	public function userSetTheMessageExpirationToXWithStatusCode(string $user, int $messageExpiration, string $identifier, int $statusCode, string $apiVersion = 'v4'): void {
 		$this->setCurrentUser($user);


### PR DESCRIPTION
Fix #11115 

🏚️ Before | 🏡 After
-- | --
![Bildschirmfoto vom 2024-03-22 12-22-38](https://github.com/nextcloud/spreed/assets/213943/564d9264-85b3-4a2f-9abc-68b48872bd95) | ![Bildschirmfoto vom 2024-03-22 12-22-25](https://github.com/nextcloud/spreed/assets/213943/0db7596b-8f58-45df-a211-efce5a52bee4)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
