### PR TITLE
fix(federation): Prevent duplicated invites with different casing and…

### DIFF
--- a/lib/Federation/BackendNotifier.php
+++ b/lib/Federation/BackendNotifier.php
@@ -148,6 +148,7 @@ class BackendNotifier {
 		#[SensitiveParameter]
 		string $accessToken,
 		string $displayName,
+		string $cloudId,
 	): bool {
 		$remote = $this->prepareRemoteUrl($remoteServerUrl);
 
@@ -161,6 +162,7 @@ class BackendNotifier {
 				'sharedSecret' => $accessToken,
 				'message' => 'Recipient accepted the share',
 				'displayName' => $displayName,
+				'cloudId' => $cloudId,
 			]
 		);
 

--- a/lib/Federation/CloudFederationProviderTalk.php
+++ b/lib/Federation/CloudFederationProviderTalk.php
@@ -219,6 +219,11 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 		if (!empty($notification['displayName'])) {
 			$attendee->setDisplayName($notification['displayName']);
 			$attendee->setState(Invitation::STATE_ACCEPTED);
+
+			if (!empty($notification['cloudId'])) {
+				$attendee->setActorId($notification['cloudId']);
+			}
+
 			$this->attendeeMapper->update($attendee);
 		}
 

--- a/lib/Model/InvitationMapper.php
+++ b/lib/Model/InvitationMapper.php
@@ -98,14 +98,18 @@ class InvitationMapper extends QBMapper {
 	/**
 	 * @throws DoesNotExistException
 	 */
-	public function getInvitationForUserByLocalRoom(Room $room, string $userId): Invitation {
+	public function getInvitationForUserByLocalRoom(Room $room, string $userId, bool $caseInsensitive = false): Invitation {
 		$query = $this->db->getQueryBuilder();
 
 		$query->select('*')
 			->from($this->getTableName())
-			->where($query->expr()->eq('user_id', $query->createNamedParameter($userId)))
-			->andWhere($query->expr()->eq('local_room_id', $query->createNamedParameter($room->getId())));
+			->where($query->expr()->eq('local_room_id', $query->createNamedParameter($room->getId())));
 
+		if ($caseInsensitive) {
+			$query->andWhere($query->expr()->eq($query->func()->lower('user_id'), $query->createNamedParameter(strtolower($userId))));
+		} else {
+			$query->andWhere($query->expr()->eq('user_id', $query->createNamedParameter($userId)));
+		}
 		return $this->findEntity($query);
 	}
 

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -586,6 +586,9 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			if (isset($expectedInvite['state'])) {
 				$data['state'] = $invite['state'];
 			}
+			if (isset($expectedInvite['localCloudId'])) {
+				$data['localCloudId'] = $invite['localCloudId'];
+			}
 
 			return $data;
 		}, $invites, $expectedInvites));

--- a/tests/integration/features/federation/invite.feature
+++ b/tests/integration/features/federation/invite.feature
@@ -89,6 +89,70 @@ Feature: federation/invite
       | room | users         | participant1 | federated_user_added    | You invited {federated_user} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
       | room | users         | participant1 | conversation_created    | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
 
+  Scenario: Invite user with wrong casing
+    Given the following "spreed" app config is set
+      | federation_enabled | yes |
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 3 |
+      | roomName | room |
+    And user "participant1" adds federated_user "PARTICIPANT2" to room "room" with 200 (v4)
+    When user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | actorType       | actorId      | participantType |
+      | users           | participant1 | 1               |
+      | federated_users | PARTICIPANT2 | 3               |
+    Then user "participant1" sees the following system messages in room "room" with 200
+      | room | actorType     | actorId      | systemMessage        | message                      | messageParameters |
+      | room | users         | participant1 | federated_user_added | You invited {federated_user} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"PARTICIPANT2","name":"PARTICIPANT2@localhost:8180","server":"http:\/\/localhost:8180"}} |
+      | room | users         | participant1 | conversation_created | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
+    And user "participant1" adds federated_user "participant2" to room "room" with 404 (v4)
+    When user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | actorType       | actorId      | participantType |
+      | users           | participant1 | 1               |
+      | federated_users | PARTICIPANT2 | 3               |
+    Then user "participant1" sees the following system messages in room "room" with 200
+      | room | actorType     | actorId      | systemMessage        | message                      | messageParameters |
+      | room | users         | participant1 | federated_user_added | You invited {federated_user} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"PARTICIPANT2","name":"PARTICIPANT2@localhost:8180","server":"http:\/\/localhost:8180"}} |
+      | room | users         | participant1 | conversation_created | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
+    And force run "OCA\Talk\BackgroundJob\RemoveEmptyRooms" background jobs
+    And user "participant2" has the following invitations (v1)
+      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       | localCloudId |
+      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname | PARTICIPANT2@http://localhost:8180 |
+    Then user "participant2" has the following notifications
+      | app    | object_type       | object_id              | subject                                                           | message                                                                     |
+      | spreed | remote_talk_share | INVITE_ID(LOCAL::room) | @participant1-displayname invited you to a federated conversation | @participant1-displayname invited you to join room on http://localhost:8080 |
+    And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
+      | id   | name | type | remoteServer | remoteToken |
+      | room | room | 3    | LOCAL        | room        |
+    And user "participant2" accepts invite to room "room" of server "LOCAL" with 400 (v1)
+      | error | state |
+    And user "participant2" declines invite to room "room" of server "LOCAL" with 400 (v1)
+      | error | state |
+    And user "participant2" has the following invitations (v1)
+      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
+      | LOCAL           | room        | 1     | participant1@http://localhost:8080 | participant1-displayname |
+    When user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | actorType       | actorId      | participantType |
+      | users           | participant1 | 1               |
+      | federated_users | participant2 | 3               |
+    Then user "participant1" sees the following system messages in room "room" with 200
+      | room | actorType     | actorId      | systemMessage           | message                      | messageParameters |
+      | room | federated_users | participant2@http://localhost:8180 | federated_user_added | {federated_user} accepted the invitation | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname","server":"http:\/\/localhost:8180"},"federated_user":{"type":"user","id":"participant2","name":"participant2-displayname","server":"http:\/\/localhost:8180"}} |
+      | room | users         | participant1 | federated_user_added    | You invited {federated_user} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"PARTICIPANT2","name":"PARTICIPANT2@localhost:8180","server":"http:\/\/localhost:8180"}} |
+      | room | users         | participant1 | conversation_created    | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
+    # Remove a remote user after they joined
+    When user "participant1" removes remote "participant2" from room "room" with 200 (v4)
+    And user "participant2" has the following invitations (v1)
+    Then user "participant2" is participant of the following rooms (v4)
+    When user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | actorType       | actorId      | participantType |
+      | users           | participant1 | 1               |
+    Then user "participant1" sees the following system messages in room "room" with 200
+      | room | actorType     | actorId      | systemMessage           | message                      | messageParameters |
+      | room | users         | participant1 | federated_user_removed  | You removed {federated_user} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
+      | room | federated_users | participant2@http://localhost:8180 | federated_user_added | {federated_user} accepted the invitation | {"actor":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"},"federated_user":{"type":"user","id":"participant2","name":"participant2@localhost:8180","server":"http:\/\/localhost:8180"}} |
+      | room | users         | participant1 | federated_user_added    | You invited {federated_user} | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"},"federated_user":{"type":"user","id":"PARTICIPANT2","name":"PARTICIPANT2@localhost:8180","server":"http:\/\/localhost:8180"}} |
+      | room | users         | participant1 | conversation_created    | You created the conversation | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}} |
+
   Scenario: Declining an invite
     Given the following "spreed" app config is set
       | federation_enabled | yes |

--- a/tests/php/Federation/FederationTest.php
+++ b/tests/php/Federation/FederationTest.php
@@ -417,6 +417,7 @@ class FederationTest extends TestCase {
 					'message' => 'Recipient accepted the share',
 					'remoteServerUrl' => 'http://example.tld',
 					'displayName' => 'Foo Bar',
+					'cloudId' => 'cloudId@example.tld',
 				]
 			);
 
@@ -441,7 +442,7 @@ class FederationTest extends TestCase {
 			->with('/')
 			->willReturn('http://example.tld/index.php/');
 
-		$success = $this->backendNotifier->sendShareAccepted($remote, $id, $token, 'Foo Bar');
+		$success = $this->backendNotifier->sendShareAccepted($remote, $id, $token, 'Foo Bar', 'cloudId@example.tld');
 
 		$this->assertTrue($success);
 	}


### PR DESCRIPTION
… heal the cloudId

### ☑️ Resolves

* Fix #11888 

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Requires https://github.com/nextcloud/server/pull/44453

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
