### PR TITLE
Releasing 19.0.0 beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 19.0.0-beta.4 – 2024-03-19
+## 19.0.0-beta.5 – 2024-03-26
+### Changed
+- Update translations
+- Update several dependencies
+
+### Fixed
+- Fix handling of cloud ID when provided in wrong casing
+  [#11922](https://github.com/nextcloud/spreed/issues/11922)
+- Fix flow notifications triggered by own actions and in note-to-self conversations
+  [#11918](https://github.com/nextcloud/spreed/issues/11918)
+- Hide call related user settings in federated conversations
+  [#11892](https://github.com/nextcloud/spreed/issues/11892)
+
+## 19.0.0-beta.4 – 2024-03-21
 ### Changed
 - Update translations
 - Update several dependencies

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>19.0.0-beta.4</version>
+	<version>19.0.0-beta.5</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "19.0.0-beta.4",
+  "version": "19.0.0-beta.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "19.0.0-beta.4",
+      "version": "19.0.0-beta.5",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "19.0.0-beta.4",
+  "version": "19.0.0-beta.5",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
### Changed
- Update translations
- Update several dependencies

### Fixed
- Fix handling of cloud ID when provided in wrong casing [#11922](https://github.com/nextcloud/spreed/issues/11922)
- Fix flow notifications triggered by own actions and in note-to-self conversations [#11918](https://github.com/nextcloud/spreed/issues/11918)
- Hide call related user settings in federated conversations [#11892](https://github.com/nextcloud/spreed/issues/11892)

### :construction: Todo

- [ ] https://github.com/nextcloud/spreed/issues/9902
- [x] https://github.com/nextcloud/spreed/issues/11922