### PR TITLE
feat(UX): Show a warning when bruteforce protection is throttling

### DIFF
--- a/src/services/participantsService.js
+++ b/src/services/participantsService.js
@@ -22,6 +22,9 @@
 
 import axios from '@nextcloud/axios'
 import {
+	showWarning
+} from '@nextcloud/dialogs'
+import {
 	generateOcsUrl,
 } from '@nextcloud/router'
 
@@ -47,6 +50,20 @@ const joinConversation = async ({ token, forceJoin = false }, options) => {
 	const response = await axios.post(generateOcsUrl('apps/spreed/api/v4/room/{token}/participants/active', { token }), {
 		force: forceJoin,
 	}, options)
+
+	if (response.headers.get('X-Nextcloud-Bruteforce-Throttled')) {
+		console.error(
+			'Remote address is bruteforce throttled: '
+			+ response.headers.get('X-Nextcloud-Bruteforce-Throttled')
+			+ ' (Request ID: ' + response.headers.get('X-Request-ID') + ')'
+		)
+		const throttleMs = parseInt(response.headers.get('X-Nextcloud-Bruteforce-Throttled'), 10)
+		if (throttleMs > 5000) {
+			showWarning(
+				t('spreed', 'Your requests are throttled at the moment due to brute force protection')
+			)
+		}
+	}
 
 	// FIXME Signaling should not be synchronous
 	await signalingJoinConversation(token, response.data.ocs.data.sessionId)


### PR DESCRIPTION
### ☑️ Resolves

![Bildschirmfoto vom 2024-03-25 17-27-50](https://github.com/nextcloud/spreed/assets/213943/e75da45d-383a-4f5b-9f89-091e95ccd835)

For testing add:
```php
$response->addHeader('X-Nextcloud-Bruteforce-Throttled', '25000ms');
```
Before
https://github.com/nextcloud/server/blob/25309bcb45232bf30fe719bac1776f0136f7cd7a/lib/private/AppFramework/Middleware/Security/BruteForceMiddleware.php#L136


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
