### PR TITLE
fix(bruteforce): Log assumed bruteforce relevant actions

### DIFF
--- a/lib/Chat/SystemMessage/Listener.php
+++ b/lib/Chat/SystemMessage/Listener.php
@@ -64,6 +64,7 @@ use OCP\IUserSession;
 use OCP\Share\Events\BeforeShareCreatedEvent;
 use OCP\Share\Events\ShareCreatedEvent;
 use OCP\Share\IShare;
+use Psr\Log\LoggerInterface;
 
 /**
  * @template-implements IEventListener<Event>
@@ -81,6 +82,7 @@ class Listener implements IEventListener {
 		protected ParticipantService $participantService,
 		protected MessageParser $messageParser,
 		protected IL10N $l,
+		protected LoggerInterface $logger,
 	) {
 	}
 
@@ -308,6 +310,7 @@ class Listener implements IEventListener {
 			|| $this->getUserId() !== $attendee->getActorId()
 			// - has joined a listable room on their own
 			|| $attendee->getParticipantType() === Participant::USER) {
+			$this->logger->debug('User "' . $attendee->getActorId() . '" added to room "' . $room->getToken() . '"', ['app' => 'spreed-bfp']);
 			$comment = $this->sendSystemMessage(
 				$room,
 				'user_added',
@@ -341,6 +344,7 @@ class Listener implements IEventListener {
 			return;
 		}
 
+		$this->logger->debug('User "' . $event->getAttendee()->getActorId() . '" removed from room "' . $room->getToken() . '"', ['app' => 'spreed-bfp']);
 		$this->sendSystemMessage($room, 'user_removed', ['user' => $event->getAttendee()->getActorId()]);
 	}
 
@@ -440,6 +444,7 @@ class Listener implements IEventListener {
 		}
 
 		foreach ($event->getAttendees() as $attendee) {
+			$this->logger->debug($attendee->getActorType() . ' "' . $attendee->getActorId() . '" added to room "' . $event->getRoom()->getToken() . '"', ['app' => 'spreed-bfp']);
 			if ($attendee->getActorType() === Attendee::ACTOR_GROUPS) {
 				$this->sendSystemMessage($event->getRoom(), 'group_added', ['group' => $attendee->getActorId()]);
 			} elseif ($attendee->getActorType() === Attendee::ACTOR_CIRCLES) {
@@ -460,6 +465,7 @@ class Listener implements IEventListener {
 		}
 
 		foreach ($event->getAttendees() as $attendee) {
+			$this->logger->debug($attendee->getActorType() . ' "' . $attendee->getActorId() . '" removed from room "' . $event->getRoom()->getToken() . '"', ['app' => 'spreed-bfp']);
 			if ($attendee->getActorType() === Attendee::ACTOR_GROUPS) {
 				$this->sendSystemMessage($event->getRoom(), 'group_removed', ['group' => $attendee->getActorId()]);
 			} elseif ($attendee->getActorType() === Attendee::ACTOR_CIRCLES) {

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -240,6 +240,7 @@ class PageController extends Controller {
 							$response = new RedirectResponse($passwordVerification['url']);
 						}
 
+						$this->logger->debug('User "' . ($this->userId ?? 'ANONYMOUS') . '" throttled for accessing "' . $token . '"', ['app' => 'spreed-bfp']);
 						$response->throttle(['token' => $token, 'action' => 'talkRoomPassword']);
 						return $response;
 					}
@@ -284,6 +285,7 @@ class PageController extends Controller {
 		$response->setContentSecurityPolicy($csp);
 		if ($throttle) {
 			// Logged-in user tried to access a chat they can not access
+			$this->logger->debug('User "' . ($this->userId ?? 'ANONYMOUS') . '" throttled for accessing "' . $bruteForceToken . '"', ['app' => 'spreed-bfp']);
 			$response->throttle(['token' => $bruteForceToken, 'action' => 'talkRoomToken']);
 		}
 		return $response;
@@ -301,6 +303,7 @@ class PageController extends Controller {
 			$room = $this->manager->getRoomByToken($token);
 		} catch (RoomNotFoundException $e) {
 			$response = new NotFoundResponse();
+			$this->logger->debug('Recording "' . ($this->userId ?? 'ANONYMOUS') . '" throttled for accessing "' . $token . '"', ['app' => 'spreed-bfp']);
 			$response->throttle(['token' => $token, 'action' => 'talkRoomToken']);
 
 			return $response;

--- a/lib/Middleware/InjectionMiddleware.php
+++ b/lib/Middleware/InjectionMiddleware.php
@@ -67,6 +67,7 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\Security\Bruteforce\IThrottler;
 use OCP\Security\Bruteforce\MaxDelayReached;
+use Psr\Log\LoggerInterface;
 
 class InjectionMiddleware extends Middleware {
 	public function __construct(
@@ -79,6 +80,7 @@ class InjectionMiddleware extends Middleware {
 		protected IURLGenerator $url,
 		protected InvitationMapper $invitationMapper,
 		protected Authenticator $federationAuthenticator,
+		protected LoggerInterface $logger,
 		protected ?string $userId,
 	) {
 	}
@@ -354,6 +356,7 @@ class InjectionMiddleware extends Middleware {
 						$action = $protection->getAction();
 
 						if ($action === 'talkRoomToken') {
+							$this->logger->debug('User "' . ($this->userId ?? 'ANONYMOUS') . '" throttled for accessing "' . ($this->request->getParam('token') ?? 'UNKNOWN') . '"', ['app' => 'spreed-bfp']);
 							try {
 								$this->throttler->sleepDelayOrThrowOnMax($this->request->getRemoteAddress(), $action);
 							} catch (MaxDelayReached $e) {

--- a/tests/php/Chat/SystemMessage/ListenerTest.php
+++ b/tests/php/Chat/SystemMessage/ListenerTest.php
@@ -45,6 +45,7 @@ use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 /**
@@ -75,6 +76,7 @@ class ListenerTest extends TestCase {
 	protected $participantService;
 	/** @var MessageParser|MockObject */
 	protected $messageParser;
+	protected LoggerInterface|MockObject $logger;
 	protected ?array $handlers = null;
 	protected ?\DateTime $dummyTime = null;
 
@@ -99,6 +101,7 @@ class ListenerTest extends TestCase {
 		$this->manager = $this->createMock(Manager::class);
 		$this->participantService = $this->createMock(ParticipantService::class);
 		$this->messageParser = $this->createMock(MessageParser::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$l = $this->createMock(IL10N::class);
 		$l->expects($this->any())
 			->method('t')
@@ -125,6 +128,7 @@ class ListenerTest extends TestCase {
 			$this->participantService,
 			$this->messageParser,
 			$l,
+			$this->logger,
 		);
 	}
 


### PR DESCRIPTION
## 🛠️ API Checklist

```
│[debug] 2024-03-25T18:54:20.000 spreed-bfp       User "admin" throttled for accessing "fgmhy59r423"  
│[debug] 2024-03-25T18:56:51.000 spreed-bfp       users "admin" added to room "5idt5cep"                                                                                 │
│[debug] 2024-03-25T18:56:58.000 spreed-bfp       groups "group-deed-4572-9589-b8c168fcf4fe" added to room "5idt5cep"                                                    │
│[debug] 2024-03-25T18:56:58.000 spreed-bfp       users "3928cdba-f2d7-4c0a-bac4-9a59a0f49b8b" added to room "5idt5cep"                                                  │
│[debug] 2024-03-25T18:56:58.000 spreed-bfp       User "3928cdba-f2d7-4c0a-bac4-9a59a0f49b8b" added to room "5idt5cep"                                                   │
│[debug] 2024-03-25T18:56:58.000 spreed-bfp       users "53c4f4bb-c916-4e87-b5f3-b50ebf0b34a6" added to room "5idt5cep"                                                  │
│[debug] 2024-03-25T18:56:58.000 spreed-bfp       User "53c4f4bb-c916-4e87-b5f3-b50ebf0b34a6" added to room "5idt5cep"                                                   │
│[debug] 2024-03-25T18:56:58.000 spreed-bfp       users "6fbb71a1-2da4-44a6-908a-56c16fd9b79a" added to room "5idt5cep"                                                  │
│[debug] 2024-03-25T18:56:58.000 spreed-bfp       User "6fbb71a1-2da4-44a6-908a-56c16fd9b79a" added to room "5idt5cep"                                                   │
│[debug] 2024-03-25T18:56:58.000 spreed-bfp       users "8498f0bd-49cd-4f1f-9a84-307497d4d176" added to room "5idt5cep"                                                  │
│[debug] 2024-03-25T18:56:58.000 spreed-bfp       User "8498f0bd-49cd-4f1f-9a84-307497d4d176" added to room "5idt5cep"                                                   │
│[debug] 2024-03-25T18:56:58.000 spreed-bfp       users "fad44cc6-5036-4d7e-8381-ac50be12537c" added to room "5idt5cep"                                                  │
│[debug] 2024-03-25T18:56:58.000 spreed-bfp       User "fad44cc6-5036-4d7e-8381-ac50be12537c" added to room "5idt5cep"                                                   │
│[debug] 2024-03-25T18:56:58.000 spreed-bfp       users "fcdbdb38-b0a3-4976-b4f2-0f4cd1625476" added to room "5idt5cep"                                                  │
│[debug] 2024-03-25T18:56:58.000 spreed-bfp       User "fcdbdb38-b0a3-4976-b4f2-0f4cd1625476" added to room "5idt5cep"                                                   │
│[debug] 2024-03-25T18:57:01.000 spreed-bfp       User "8498f0bd-49cd-4f1f-9a84-307497d4d176" removed from room "5idt5cep"                                               │
│[debug] 2024-03-25T18:57:01.000 spreed-bfp       users "8498f0bd-49cd-4f1f-9a84-307497d4d176" removed from room "5idt5cep"                                              │
│[debug] 2024-03-25T18:57:05.000 spreed-bfp       users "8498f0bd-49cd-4f1f-9a84-307497d4d176" added to room "5idt5cep"                                                  │
│[debug] 2024-03-25T18:57:05.000 spreed-bfp       User "8498f0bd-49cd-4f1f-9a84-307497d4d176" added to room "5idt5cep" 
```

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
