### PR TITLE
Fix for Talk-Widget direct mentions

### DIFF
--- a/lib/Dashboard/TalkWidget.php
+++ b/lib/Dashboard/TalkWidget.php
@@ -202,8 +202,8 @@ class TalkWidget implements IAPIWidget, IIconWidget, IButtonWidget, IOptionWidge
 
 		if ($room->getCallFlag() !== Participant::FLAG_DISCONNECTED) {
 			$subtitle = $this->l10n->t('Call in progress');
-		} elseif ($participant->getAttendee()->getLastMentionMessage() > $participant->getAttendee()->getLastReadMessage()) {
-			$subtitle = $this->chatManager->getComment($room, (string)$participant->getAttendee()->getLastMentionMessage())->getMessage();
+		} elseif ($participant->getAttendee()->getLastMentionDirect() > $participant->getAttendee()->getLastReadMessage()) {
+			$subtitle = $this->chatManager->getComment($room, (string)$participant->getAttendee()->getLastMentionDirect())->getMessage();
 		}
 
 		return new WidgetItem(

--- a/lib/Dashboard/TalkWidget.php
+++ b/lib/Dashboard/TalkWidget.php
@@ -177,8 +177,15 @@ class TalkWidget implements IAPIWidget, IIconWidget, IButtonWidget, IOptionWidge
 		$subtitle = '';
 
 		$lastMessage = $room->getLastMessage();
+
+		$lastMentionDirect = $participant->getAttendee()->getLastMentionDirect();
+        $lastReadMessage = $participant->getAttendee()->getLastReadMessage();
+		if ($lastMentionDirect > $lastReadMessage) {
+            $lastMessage = $this->chatManager->getComment($room, (string)$lastMentionDirect);
+		}
+
 		if ($lastMessage instanceof IComment) {
-			$message = $this->messageParser->createMessage($room, $participant, $room->getLastMessage(), $this->l10n);
+			$message = $this->messageParser->createMessage($room, $participant, $lastMessage, $this->l10n);
 			$this->messageParser->parseMessage($message);
 
 			$now = $this->timeFactory->getDateTime();
@@ -202,8 +209,6 @@ class TalkWidget implements IAPIWidget, IIconWidget, IButtonWidget, IOptionWidge
 
 		if ($room->getCallFlag() !== Participant::FLAG_DISCONNECTED) {
 			$subtitle = $this->l10n->t('Call in progress');
-		} elseif ($participant->getAttendee()->getLastMentionDirect() > $participant->getAttendee()->getLastReadMessage()) {
-			$subtitle = $this->chatManager->getComment($room, (string)$participant->getAttendee()->getLastMentionDirect())->getMessage();
 		}
 
 		return new WidgetItem(

--- a/lib/Dashboard/TalkWidget.php
+++ b/lib/Dashboard/TalkWidget.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Dashboard;
 
 use OCA\Talk\Chat\MessageParser;
+use OCA\Talk\Chat\ChatManager;
 use OCA\Talk\Config;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\BreakoutRoom;
@@ -60,6 +61,7 @@ class TalkWidget implements IAPIWidget, IIconWidget, IButtonWidget, IOptionWidge
 		protected AvatarService $avatarService,
 		protected ParticipantService $participantService,
 		protected MessageParser $messageParser,
+		protected ChatManager $chatManager,
 		protected ITimeFactory $timeFactory,
 	) {
 	}
@@ -201,7 +203,7 @@ class TalkWidget implements IAPIWidget, IIconWidget, IButtonWidget, IOptionWidge
 		if ($room->getCallFlag() !== Participant::FLAG_DISCONNECTED) {
 			$subtitle = $this->l10n->t('Call in progress');
 		} elseif ($participant->getAttendee()->getLastMentionMessage() > $participant->getAttendee()->getLastReadMessage()) {
-			$subtitle = $this->l10n->t('You were mentioned');
+			$subtitle = $this->chatManager->getComment($room, (string)$participant->getAttendee()->getLastMentionMessage())->getMessage();
 		}
 
 		return new WidgetItem(

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1947,4 +1947,21 @@ class ParticipantService {
 		$this->cacheParticipant($room, $participant);
 		return $participant;
 	}
+
+	/**
+	 * @param int $mentionId
+	 * @return string
+	 */
+	public function getLastUnreadMentionMessage(int $mentionId)
+	{
+		$query = $this->connection->getQueryBuilder();
+		$query->select('c.message')
+			->from('comments', 'c')
+			->where('c.id = :mentionId')
+			->setParameter('mentionId', $mentionId)
+			->setMaxResults(1);
+
+		$result = $query->executeQuery();
+		return $result->fetchOne();
+	}
 }

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1947,21 +1947,4 @@ class ParticipantService {
 		$this->cacheParticipant($room, $participant);
 		return $participant;
 	}
-
-	/**
-	 * @param int $mentionId
-	 * @return string
-	 */
-	public function getLastUnreadMentionMessage(int $mentionId)
-	{
-		$query = $this->connection->getQueryBuilder();
-		$query->select('c.message')
-			->from('comments', 'c')
-			->where('c.id = :mentionId')
-			->setParameter('mentionId', $mentionId)
-			->setMaxResults(1);
-
-		$result = $query->executeQuery();
-		return $result->fetchOne();
-	}
 }

--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -320,7 +320,7 @@ class RoomFormatter {
 				$lastMentionDirect = $attendee->getLastMentionDirect();
 				$roomData['unreadMention'] = $lastMention !== 0 && $lastReadMessage < $lastMention;
 				$roomData['unreadMentionDirect'] = $lastMentionDirect !== 0 && $lastReadMessage < $lastMentionDirect;
-				$roomData['lastUnreadMentionMessage'] = ($lastMentionDirect !== 0 or $lastMentionDirect !== null) ? $this->participantService->getLastUnreadMentionMessage($lastMentionDirect) : '';
+				$roomData['lastUnreadMentionMessage'] = $lastMentionDirect ? $this->chatManager->getComment($room, (string)$lastMentionDirect)->getMessage() : '';
 				$roomData['lastReadMessage'] = $lastReadMessage;
 
 				$roomData['canDeleteConversation'] = $room->getType() !== Room::TYPE_ONE_TO_ONE
@@ -342,6 +342,7 @@ class RoomFormatter {
 			$roomData['unreadMessages'] = $this->chatManager->getUnreadCount($room, $lastReadMessage);
 			$roomData['unreadMention'] = $lastMention !== 0 && $lastReadMessage < $lastMention;
 			$roomData['unreadMentionDirect'] = $lastMentionDirect !== 0 && $lastReadMessage < $lastMentionDirect;
+			$roomData['lastUnreadMentionMessage'] = $lastMentionDirect ? $this->chatManager->getComment($room, (string)$lastMentionDirect)->getMessage() : '';
 		} else {
 			$roomData['lastReadMessage'] = $attendee->getLastReadMessage();
 		}

--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -157,6 +157,7 @@ class RoomFormatter {
 			'breakoutRoomMode' => BreakoutRoom::MODE_NOT_CONFIGURED,
 			'breakoutRoomStatus' => BreakoutRoom::STATUS_STOPPED,
 			'recordingConsent' => $this->talkConfig->recordingConsentRequired() === RecordingService::CONSENT_REQUIRED_OPTIONAL ? $room->getRecordingConsent() : $this->talkConfig->recordingConsentRequired(),
+			'lastUnreadMentionMessage' => '',
 		];
 
 		$lastActivity = $room->getLastActivity();
@@ -319,6 +320,7 @@ class RoomFormatter {
 				$lastMentionDirect = $attendee->getLastMentionDirect();
 				$roomData['unreadMention'] = $lastMention !== 0 && $lastReadMessage < $lastMention;
 				$roomData['unreadMentionDirect'] = $lastMentionDirect !== 0 && $lastReadMessage < $lastMentionDirect;
+				$roomData['lastUnreadMentionMessage'] = ($lastMentionDirect !== 0 or $lastMentionDirect !== null) ? $this->participantService->getLastUnreadMentionMessage($lastMentionDirect) : '';
 				$roomData['lastReadMessage'] = $lastReadMessage;
 
 				$roomData['canDeleteConversation'] = $room->getType() !== Room::TYPE_ONE_TO_ONE

--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -320,7 +320,16 @@ class RoomFormatter {
 				$lastMentionDirect = $attendee->getLastMentionDirect();
 				$roomData['unreadMention'] = $lastMention !== 0 && $lastReadMessage < $lastMention;
 				$roomData['unreadMentionDirect'] = $lastMentionDirect !== 0 && $lastReadMessage < $lastMentionDirect;
-				$roomData['lastUnreadMentionMessage'] = $lastMentionDirect ? $this->chatManager->getComment($room, (string)$lastMentionDirect)->getMessage() : '';
+
+				$lastMentionMessage =  $lastMentionDirect ? $this->chatManager->getComment($room, (string)$lastMentionDirect): '';
+				if (!$room->isFederatedConversation() && $lastMentionMessage instanceof IComment) {
+						$roomData['lastUnreadMentionMessage'] = $this->formatLastMessage(
+							$responseFormat,
+							$room,
+							$currentParticipant,
+							$lastMentionMessage,
+						)['message'];
+				}
 				$roomData['lastReadMessage'] = $lastReadMessage;
 
 				$roomData['canDeleteConversation'] = $room->getType() !== Room::TYPE_ONE_TO_ONE
@@ -342,7 +351,17 @@ class RoomFormatter {
 			$roomData['unreadMessages'] = $this->chatManager->getUnreadCount($room, $lastReadMessage);
 			$roomData['unreadMention'] = $lastMention !== 0 && $lastReadMessage < $lastMention;
 			$roomData['unreadMentionDirect'] = $lastMentionDirect !== 0 && $lastReadMessage < $lastMentionDirect;
-			$roomData['lastUnreadMentionMessage'] = $lastMentionDirect ? $this->chatManager->getComment($room, (string)$lastMentionDirect)->getMessage() : '';
+
+			$lastMentionMessage =  $lastMentionDirect ? $this->chatManager->getComment($room, (string)$lastMentionDirect): '';
+			if (!$room->isFederatedConversation() && $lastMentionMessage instanceof IComment) {
+					$roomData['lastUnreadMentionMessage'] = $this->formatLastMessage(
+						$responseFormat,
+						$room,
+						$currentParticipant,
+						$lastMentionMessage,
+					)['message'];
+			}
+
 		} else {
 			$roomData['lastReadMessage'] = $attendee->getLastReadMessage();
 		}

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -149,7 +149,7 @@ export default {
 				}
 
 				if (conversation.unreadMentionDirect) {
-					return t('spreed', conversation.lastUnreadMentionMessage)
+					return conversation.lastUnreadMentionMessage
 				}
 
 				return this.simpleLastChatMessage(conversation.lastMessage)

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -148,8 +148,8 @@ export default {
 					return t('spreed', 'Call in progress')
 				}
 
-				if (conversation.unreadMention) {
-					return t('spreed', 'You were mentioned')
+				if (conversation.unreadMentionDirect) {
+					return t('spreed', conversation.lastUnreadMentionMessage)
 				}
 
 				return this.simpleLastChatMessage(conversation.lastMessage)
@@ -188,7 +188,7 @@ export default {
 				const rooms = allRooms.filter((conversation) => conversation.objectType !== CONVERSATION.OBJECT_TYPE.BREAKOUT_ROOM)
 				const importantRooms = rooms.filter((conversation) => {
 					return conversation.hasCall
-						|| conversation.unreadMention
+						|| conversation.unreadMentionDirect
 						|| (conversation.unreadMessages > 0 && (conversation.type === CONVERSATION.TYPE.ONE_TO_ONE || conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER))
 				})
 


### PR DESCRIPTION
☑️ Resolves

- These changes will display the actual message in the Talk-widget for direct mentions instead of showing "You were mentioned". This makes it more informative and inline with the actual message lines.
- For mention all (Everyone in the group), nothing will be displayed under Talk-widget Mentions.