### PR TITLE
Bugfix/4468/talk widget mention fix v2

### DIFF
--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1947,4 +1947,21 @@ class ParticipantService {
 		$this->cacheParticipant($room, $participant);
 		return $participant;
 	}
+
+	/**
+	 * @param int $mentionId
+	 * @return string
+	 */
+	public function getLastUnreadMentionMessage(int $mentionId)
+	{
+		$query = $this->connection->getQueryBuilder();
+		$query->select('c.message')
+			->from('comments', 'c')
+			->where('c.id = :mentionId')
+			->setParameter('mentionId', $mentionId)
+			->setMaxResults(1);
+
+		$result = $query->executeQuery();
+		return $result->fetchOne();
+	}
 }

--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -157,6 +157,7 @@ class RoomFormatter {
 			'breakoutRoomMode' => BreakoutRoom::MODE_NOT_CONFIGURED,
 			'breakoutRoomStatus' => BreakoutRoom::STATUS_STOPPED,
 			'recordingConsent' => $this->talkConfig->recordingConsentRequired() === RecordingService::CONSENT_REQUIRED_OPTIONAL ? $room->getRecordingConsent() : $this->talkConfig->recordingConsentRequired(),
+			'lastUnreadMentionMessage' => '',
 		];
 
 		$lastActivity = $room->getLastActivity();
@@ -319,6 +320,7 @@ class RoomFormatter {
 				$lastMentionDirect = $attendee->getLastMentionDirect();
 				$roomData['unreadMention'] = $lastMention !== 0 && $lastReadMessage < $lastMention;
 				$roomData['unreadMentionDirect'] = $lastMentionDirect !== 0 && $lastReadMessage < $lastMentionDirect;
+				$roomData['lastUnreadMentionMessage'] = ($lastMentionDirect !== 0 or $lastMentionDirect !== null) ? $this->participantService->getLastUnreadMentionMessage($lastMentionDirect) : '';
 				$roomData['lastReadMessage'] = $lastReadMessage;
 
 				$roomData['canDeleteConversation'] = $room->getType() !== Room::TYPE_ONE_TO_ONE

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -149,7 +149,7 @@ export default {
 				}
 
 				if (conversation.unreadMentionDirect) {
-					return t('spreed', conversation.lastUnreadMentionMessage)
+					return conversation.lastUnreadMentionMessage
 				}
 
 				return this.simpleLastChatMessage(conversation.lastMessage)

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -148,8 +148,8 @@ export default {
 					return t('spreed', 'Call in progress')
 				}
 
-				if (conversation.unreadMention) {
-					return t('spreed', 'You were mentioned')
+				if (conversation.unreadMentionDirect) {
+					return t('spreed', conversation.lastUnreadMentionMessage)
 				}
 
 				return this.simpleLastChatMessage(conversation.lastMessage)
@@ -188,7 +188,7 @@ export default {
 				const rooms = allRooms.filter((conversation) => conversation.objectType !== CONVERSATION.OBJECT_TYPE.BREAKOUT_ROOM)
 				const importantRooms = rooms.filter((conversation) => {
 					return conversation.hasCall
-						|| conversation.unreadMention
+						|| conversation.unreadMentionDirect
 						|| (conversation.unreadMessages > 0 && (conversation.type === CONVERSATION.TYPE.ONE_TO_ONE || conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER))
 				})
 


### PR DESCRIPTION
☑️ Resolves

- These changes will display the actual message in the Talk-widget for direct mentions instead of showing "You were mentioned". This makes it more informative and inline with the actual message lines.
- For mention all (Everyone in the group), nothing will be displayed under Talk-widget Mentions.
- This v2 version contains an additional change compared to last pull request- which is removal of unnecessary translation function in Dashboard.vue file for printing the actual message.