### PR TITLE
fix(Quote): restrict overflow content for quotes / replies

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -1066,6 +1066,7 @@ export default {
 	&__input {
 		flex-grow: 1;
 		position: relative;
+		min-width: 0;
 	}
 
 	// Override NcRichContenteditable styles

--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -56,15 +56,16 @@ components.
 				<p dir="auto">{{ shortenedQuoteMessage }}</p>
 			</blockquote>
 		</div>
-		<div v-if="canCancel" class="quote__main__right">
-			<NcButton type="tertiary"
-				:aria-label="cancelQuoteLabel"
-				@click="handleAbort">
-				<template #icon>
-					<Close :size="20" />
-				</template>
-			</NcButton>
-		</div>
+
+		<NcButton v-if="canCancel"
+			class="quote__close"
+			type="tertiary"
+			:aria-label="cancelQuoteLabel"
+			@click="handleAbort">
+			<template #icon>
+				<Close :size="20" />
+			</template>
+		</NcButton>
 	</a>
 </template>
 
@@ -297,6 +298,7 @@ export default {
 	border-radius: var(--border-radius-large);
 	border: 2px solid var(--color-border);
 	background-color: var(--color-main-background);
+	overflow: hidden;
 
 	&::before {
 		content: ' ';
@@ -343,13 +345,11 @@ export default {
 			gap: 4px;
 		}
 	}
-	&__right {
-		flex: 0 0 44px;
-		color: var(--color-text-maxcontrast);
-		font-size: 13px;
-		padding: 0 8px 0 8px;
-		position: relative;
-		margin: auto;
+
+	&__close {
+		position: absolute !important;
+		top: 4px;
+		right: 4px;
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix broken styles for Quote components


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![Screenshot from 2024-03-26 15-48-25](https://github.com/nextcloud/spreed/assets/93392545/1012133e-7efc-4b7c-af97-3a81c2d79ea2) | ![Screenshot from 2024-03-26 15-48-12](https://github.com/nextcloud/spreed/assets/93392545/58408775-ed8b-4647-847f-cc35f30cea8d)
![Screenshot from 2024-03-26 15-46-59](https://github.com/nextcloud/spreed/assets/93392545/08b984f8-7727-4676-b801-28e04e69bafa) | ![Screenshot from 2024-03-26 15-46-47](https://github.com/nextcloud/spreed/assets/93392545/35676064-d841-4bad-9842-e77f804b6348)


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 