### PR TITLE
fix(NcModal): don't close modals if they were filled

### DIFF
--- a/src/components/NewConversationDialog/NewConversationDialog.vue
+++ b/src/components/NewConversationDialog/NewConversationDialog.vue
@@ -24,6 +24,7 @@
 		<!-- New group form -->
 		<NcModal v-show="page !== 2"
 			class="new-group-conversation"
+			:close-on-click-outside="!isFilled"
 			:container="container"
 			@close="closeModal">
 			<h2 class="new-group-conversation__header">
@@ -226,6 +227,11 @@ export default {
 			return this.conversationName === '' || (this.newConversation.hasPassword && this.password === '')
 				|| this.conversationName.length > CONVERSATION.MAX_NAME_LENGTH
 				|| this.newConversation.description.length > CONVERSATION.MAX_DESCRIPTION_LENGTH
+		},
+
+		isFilled() {
+			return JSON.stringify(this.newConversation) !== JSON.stringify(NEW_CONVERSATION)
+				|| this.listable !== CONVERSATION.LISTABLE.NONE || this.isAvatarEdited
 		},
 	},
 

--- a/src/components/NewMessage/NewMessagePollEditor.vue
+++ b/src/components/NewMessage/NewMessagePollEditor.vue
@@ -23,6 +23,7 @@
 
 <template>
 	<NcModal size="small"
+		:close-on-click-outside="!isFilled"
 		:container="container"
 		v-on="$listeners">
 		<div class="poll-editor">
@@ -132,6 +133,10 @@ export default {
 	computed: {
 		container() {
 			return this.$store.getters.getMainContainerSelector()
+		},
+
+		isFilled() {
+			return !!this.pollQuestion || this.pollOptions.some(option => option)
 		},
 	},
 

--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -23,6 +23,7 @@
 	<NcModal v-if="showModal"
 		ref="modal"
 		:size="isVoiceMessage ? 'small' : 'normal'"
+		:close-on-click-outside="false"
 		:container="container"
 		@close="handleDismiss">
 		<div class="upload-editor"


### PR DESCRIPTION
### ☑️ Resolves

* Fix accidental closing by clicking outside of modals, which require a decent investment of time to fill 


## 🖌️ UI Checklist

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 