### PR TITLE
fix(federation): Don't double convert the actor info in the last message

### DIFF
--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -394,7 +394,7 @@ class RoomFormatter {
 					$room->getRemoteToken(),
 					$room->getLastMessageId(),
 				);
-				$roomData['lastMessage'] = $this->userConverter->convertAttendee($room, $cachedMessage->jsonSerialize(), 'actorType', 'actorId', 'actorDisplayName');
+				$roomData['lastMessage'] = $cachedMessage->jsonSerialize();
 			} catch (DoesNotExistException) {
 			}
 		}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -460,6 +460,14 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			if (isset($expectedRoom['lastMessage'])) {
 				$data['lastMessage'] = $room['lastMessage'] ? $room['lastMessage']['message'] : '';
 			}
+			if (isset($expectedRoom['lastMessageActorType'])) {
+				$data['lastMessageActorType'] = $room['lastMessage'] ? $room['lastMessage']['actorType'] : '';
+			}
+			if (isset($expectedRoom['lastMessageActorId'])) {
+				$data['lastMessageActorId'] = $room['lastMessage'] ? $room['lastMessage']['actorId'] : '';
+				$data['lastMessageActorId'] = str_replace(rtrim($this->baseUrl, '/'), '{$BASE_URL}', $data['lastMessageActorId']);
+				$data['lastMessageActorId'] = str_replace(rtrim($this->baseRemoteUrl, '/'), '{$REMOTE_URL}', $data['lastMessageActorId']);
+			}
 			if (isset($expectedRoom['lastReadMessage'])) {
 				$data['lastReadMessage'] = self::$messageIdToText[(int) $room['lastReadMessage']] ?? (!$room['lastReadMessage'] ? 'ZERO': 'UNKNOWN_MESSAGE');
 			}


### PR DESCRIPTION
The PCM cache is already converted, so converting again on rendering, would create a conflict if there is a user1 from host and proxy in the room.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
