### PR TITLE
Follow-up: chat scrolling refactoring

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -78,7 +78,6 @@ import uniqueId from 'lodash/uniqueId.js'
 import Message from 'vue-material-design-icons/Message.vue'
 
 import Axios from '@nextcloud/axios'
-import { getCapabilities } from '@nextcloud/capabilities'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import moment from '@nextcloud/moment'
 
@@ -241,7 +240,7 @@ export default {
 				return false
 			}
 
-			return !!this.$store.getters.findParticipant(this.token, this.$store.getters.getParticipantIdentifier())
+			return !!this.$store.getters.findParticipant(this.token, this.conversation)
 		},
 
 		isInLobby() {
@@ -644,7 +643,6 @@ export default {
 
 		async handleStartGettingMessagesPreconditions() {
 			if (this.token && this.isParticipant && !this.isInLobby) {
-
 				// prevent sticky mode before we have loaded anything
 				this.isInitialisingMessages = true
 				const focusMessageId = this.getMessageIdFromHash()

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -1045,7 +1045,7 @@ export default {
 		 */
 		scrollToBottom(options = {}) {
 			this.$nextTick(() => {
-				if (!this.$refs.scroller) {
+				if (!this.$refs.scroller || this.isFocusingMessage) {
 					return
 				}
 
@@ -1068,7 +1068,6 @@ export default {
 					newTop = this.$refs.scroller.scrollHeight
 					this.setChatScrolledToBottom(true)
 				}
-
 				this.$refs.scroller.scrollTo({
 					top: newTop,
 					behavior: options?.smooth ? 'smooth' : 'auto',
@@ -1109,7 +1108,7 @@ export default {
 			}
 
 			if (highlightAnimation) {
-				EventBus.$emit('highlight-message', messageId)
+				EventBus.emit('highlight-message', messageId)
 			}
 			this.isFocusingMessage = false
 

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -706,6 +706,12 @@ export default {
 				if (Axios.isCancel(exception)) {
 					console.debug('The request has been canceled', exception)
 				}
+
+				if (exception?.response?.status === 304 && exception?.response?.data === '') {
+					// 304 - Not modified
+					// Empty chat, no messages to load
+					this.$store.dispatch('loadedMessagesOfConversation', { token: this.token })
+				}
 			}
 			this.loadingOldMessages = false
 		},

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -1410,6 +1410,10 @@ const actions = {
 	async easeMessageList(context, { token }) {
 		context.commit('easeMessageList', { token })
 	},
+
+	loadedMessagesOfConversation(context, { token }) {
+		context.commit('loadedMessagesOfConversation', { token })
+	}
 }
 
 export default { state, mutations, getters, actions }

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -230,29 +230,16 @@ const getters = {
 		}
 
 		if (participantIdentifier.attendeeId) {
-			if (state.attendees[token][participantIdentifier.attendeeId]) {
-				return state.attendees[token][participantIdentifier.attendeeId]
-			}
-			return null
+			return state.attendees[token][participantIdentifier.attendeeId] ?? null
 		}
 
-		let foundAttendee = null
-		Object.keys(state.attendees[token]).forEach((attendeeId) => {
-			if (participantIdentifier.actorType && participantIdentifier.actorId
-				&& state.attendees[token][attendeeId].actorType === participantIdentifier.actorType
-				&& state.attendees[token][attendeeId].actorId === participantIdentifier.actorId) {
-				foundAttendee = attendeeId
-			}
-			if (participantIdentifier.sessionId && state.attendees[token][attendeeId].sessionIds.includes(participantIdentifier.sessionId)) {
-				foundAttendee = attendeeId
-			}
-		})
-
-		if (!foundAttendee) {
-			return null
-		}
-
-		return state.attendees[token][foundAttendee]
+		// Fallback, sometimes actorId and actorType are set before the attendeeId
+		return Object.entries(state.attendees[token]).find(([attendeeId, attendee]) => {
+			return (participantIdentifier.actorType && participantIdentifier.actorId
+					&& attendee.actorType === participantIdentifier.actorType
+					&& attendee.actorId === participantIdentifier.actorId)
+				|| (participantIdentifier.sessionId && attendee.sessionIds.includes(participantIdentifier.sessionId))
+		})?.[1] ?? null
 	},
 	getPeer: (state) => (token, sessionId, userId) => {
 		if (state.peers[token]) {


### PR DESCRIPTION
### ☑️ Resolves

* follow-up to #11934

## TO-DO
- [x] 👷🏻‍♀️ Refactor 
- [x] ⚠️ Fix conversation jumping on opening
- [x] 🔴 Empty content is not shown anymore because of loadedMessages flag does not change to true in empty conv
- [ ] 💚 Addition: add a floating button at the bottom in case you are scrolled up and new messages come in ( aka indicator for new messages while opening the chat in top)

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Conversation switching before


https://github.com/nextcloud/spreed/assets/84044328/480f1393-a9ad-4912-8fde-f2e5248ef616



Conversation switching after

https://github.com/nextcloud/spreed/assets/84044328/34e1e285-68e1-456e-a919-6e8ded5537ef

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
