### PR TITLE
fix(MessageButtonsBar): revert to main selector

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -246,7 +246,7 @@
 				</template>
 			</NcButton>
 
-			<NcEmojiPicker :container="`${messageContainer} .message-buttons-bar`"
+			<NcEmojiPicker :container="mainContainer"
 				:boundary="boundariesElement"
 				placement="auto"
 				@select="handleReactionClick"
@@ -501,6 +501,10 @@ export default {
 	computed: {
 		conversation() {
 			return this.$store.getters.conversation(this.token)
+		},
+
+		mainContainer() {
+			return this.$store.getters.getMainContainerSelector()
 		},
 
 		messageContainer() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11932

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/84044328/0af460a4-4c57-4edd-aebd-715b745b87da) | ![image](https://github.com/nextcloud/spreed/assets/84044328/c27e9819-1fc7-41a1-9c7c-f8d9503175c1)

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
