### PR TITLE
fix(editing): don't show system message 'message_edited' in sidebar

### DIFF
--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -700,6 +700,7 @@ const actions = {
 			&& lastMessage.systemMessage !== 'reaction_deleted'
 			&& lastMessage.systemMessage !== 'reaction_revoked'
 			&& lastMessage.systemMessage !== 'message_deleted'
+			&& lastMessage.systemMessage !== 'message_edited'
 			&& !(typeof lastMessage.id.startsWith === 'function'
 				&& lastMessage.id.startsWith('temp-')
 				&& lastMessage.message.startsWith('/'))) {

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -547,6 +547,15 @@ const actions = {
 				context.commit('addMessage', { token, message: message.parent })
 			}
 
+			// update conversation lastMessage, if it was edited
+			if (message.systemMessage === 'message_edited'
+				&& message.parent.id === context.getters.conversation(token).lastMessage.id) {
+				context.dispatch('updateConversationLastMessage', {
+					token,
+					lastMessage: message.parent,
+				})
+			}
+
 			const reactionsStore = useReactionsStore()
 			if (message.systemMessage === 'message_deleted') {
 				reactionsStore.resetReactions(token, message.parent.id)


### PR DESCRIPTION
### ☑️ Resolves

* don't show system message 'message_edited' in sidebar
* update last message if was edited

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏡 After

[Screencast from 28.03.2024 10:06:04.webm](https://github.com/nextcloud/spreed/assets/93392545/b16f078e-83eb-4a5c-8974-f8089b02e315)



### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possible