### PR TITLE
fix(NewMessage): parse edited message before sending

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -743,7 +743,7 @@ export default {
 				await this.$store.dispatch('editMessage', {
 					token: this.token,
 					messageId: this.messageToEdit.id,
-					updatedMessage: this.text.trim(),
+					updatedMessage: parseSpecialSymbols(this.text.trim()),
 				})
 				this.chatExtrasStore.removeMessageIdToEdit(this.token)
 				this.resetTypingIndicator()


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11955


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

![image](https://github.com/nextcloud/spreed/assets/93392545/f6dba856-4a4c-4109-ade7-1e43522edb76)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 