### PR TITLE
chore(browserCheck): unify ua-parser usage through the utils

### DIFF
--- a/src/utils/browserCheck.js
+++ b/src/utils/browserCheck.js
@@ -27,6 +27,16 @@ export const isYandex = browser.name === 'Yandex'
 export const majorVersion = browser.version ? parseInt(browser.version.split('.')[0], 10) : 0
 
 /**
+ * Is the browser Chromium-based
+ */
+export const isChromium = isChrome
+	|| isOpera
+	|| isSafari
+	|| isEdge
+	|| isBrave
+	|| isYandex
+
+/**
  * Is the browser fully supported by Talk
  */
 export const isFullySupported = (isFirefox && majorVersion >= 52)

--- a/src/utils/media/pipeline/MediaDevicesSource.js
+++ b/src/utils/media/pipeline/MediaDevicesSource.js
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import UAParser from 'ua-parser-js'
-
 import TrackSource from './TrackSource.js'
+import { isChromium } from '../../browserCheck.js'
 import { mediaDevicesManager } from '../../webrtc/index.js'
 
 /**
@@ -234,15 +233,7 @@ export default class MediaDevicesSource extends TrackSource {
 	 * @param {object} constraints the constraints to be adjusted
 	 */
 	_adjustVideoConstraintsForChromium(constraints) {
-		const parser = new UAParser()
-		const browserName = parser.getBrowser().name
-
-		if (browserName !== 'Chrome'
-			&& browserName !== 'Chromium'
-			&& browserName !== 'Opera'
-			&& browserName !== 'Safari'
-			&& browserName !== 'Mobile Safari'
-			&& browserName !== 'Edge') {
+		if (!isChromium) {
 			return
 		}
 


### PR DESCRIPTION
### ☑️ Resolves

* Perform browser checks via single utils module
* Tested with Chrome and Firefox

## 🖌️ UI Checklist

### Follow-ups
- [ ] replace `webrtc-adapter` library with `ua-parser` if possible

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possible