### PR TITLE
Release 19.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 19.0.0-rc.1 – 2024-03-28
+### Added
+- Add a header to the room list indicating pending invites
+  [#11944](https://github.com/nextcloud/spreed/issues/11944)
+
+### Changed
+- Update translations
+- Update several dependencies
+
+### Fixed
+- Don't close the modal on outside click when the user started to fill them
+  [#11942](https://github.com/nextcloud/spreed/issues/11942)
+- Fix user confusion when federating with a user that has the same user ID
+  [#11941](https://github.com/nextcloud/spreed/issues/11941)
+- Don't transfer ownership federated memberships as it doesn't work
+  [#11950](https://github.com/nextcloud/spreed/issues/11950)
+- Provide the correct container for the file picker
+  [#11939](https://github.com/nextcloud/spreed/issues/11939)
+- Adjust the cursor to be a grabbing hand when dragging the presenter view
+  [#11903](https://github.com/nextcloud/spreed/issues/11903)
+- Fix file names overflowing the box when chat is in the right sidebar
+  [#11937](https://github.com/nextcloud/spreed/issues/11937)
+
 ## 19.0.0-beta.5 – 2024-03-26
 ### Changed
 - Update translations

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>19.0.0-beta.5</version>
+	<version>19.0.0-rc.1</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "19.0.0-beta.5",
+  "version": "19.0.0-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "19.0.0-beta.5",
+      "version": "19.0.0-rc.1",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "19.0.0-beta.5",
+  "version": "19.0.0-rc.1",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
### Added
- Add a header to the room list indicating pending invites [#11944](https://github.com/nextcloud/spreed/issues/11944)

### Changed
- Update translations
- Update several dependencies

### Fixed
- Don't close the modal on outside click when the user started to fill them [#11942](https://github.com/nextcloud/spreed/issues/11942)
- Fix user confusion when federating with a user that has the same user ID [#11941](https://github.com/nextcloud/spreed/issues/11941)
- Don't transfer ownership federated memberships as it doesn't work [#11950](https://github.com/nextcloud/spreed/issues/11950)
- Provide the correct container for the file picker [#11939](https://github.com/nextcloud/spreed/issues/11939)
- Adjust the cursor to be a grabbing hand when dragging the presenter view [#11903](https://github.com/nextcloud/spreed/issues/11903)
- Fix file names overflowing the box when chat is in the right sidebar [#11937](https://github.com/nextcloud/spreed/issues/11937)