### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "5da2030113ea8c39dbf5033529b86f625d2bf6fa"
+                "reference": "87b3c656978db13d16372d3bddc4117a0f1f273d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5da2030113ea8c39dbf5033529b86f625d2bf6fa",
-                "reference": "5da2030113ea8c39dbf5033529b86f625d2bf6fa",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/87b3c656978db13d16372d3bddc4117a0f1f273d",
+                "reference": "87b3c656978db13d16372d3bddc4117a0f1f273d",
                 "shasum": ""
             },
             "require": {
@@ -277,7 +277,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "29.0.0-dev"
+                    "dev-master": "30.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-03-21T18:32:57+00:00"
+            "time": "2024-03-28T10:47:18+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency