### PR TITLE
fix(SystemMessage): Use link parameter for Circle URL in rich object parameters

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -963,7 +963,7 @@ class SystemMessage implements IEventListener {
 			'type' => 'circle',
 			'id' => $circleId,
 			'name' => $this->circleNames[$circleId],
-			'url' => $this->circleLinks[$circleId],
+			'link' => $this->circleLinks[$circleId],
 		];
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

According to https://github.com/nextcloud/server/blob/9aa7225ed3e78c2e418c983e65bdc1f1787b9940/lib/public/RichObjectStrings/Definitions.php#L227 only `link` exists and `url` doesn't.

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
