### PR TITLE
fix(OpenAPI): Set rich object size parameter to integer

### DIFF
--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -78,7 +78,7 @@ namespace OCA\Talk;
  *     'message-id'?: string,
  *     boardname?: string,
  *     stackname?: string,
- *     size?: string,
+ *     size?: int,
  *     path?: string,
  *     mimetype?: string,
  *     'preview-available'?: 'yes'|'no',

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -394,7 +394,8 @@
                         "type": "string"
                     },
                     "size": {
-                        "type": "string"
+                        "type": "integer",
+                        "format": "int64"
                     },
                     "path": {
                         "type": "string"

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -448,7 +448,8 @@
                         "type": "string"
                     },
                     "size": {
-                        "type": "string"
+                        "type": "integer",
+                        "format": "int64"
                     },
                     "path": {
                         "type": "string"

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -913,7 +913,8 @@
                         "type": "string"
                     },
                     "size": {
-                        "type": "string"
+                        "type": "integer",
+                        "format": "int64"
                     },
                     "path": {
                         "type": "string"

--- a/openapi.json
+++ b/openapi.json
@@ -800,7 +800,8 @@
                         "type": "string"
                     },
                     "size": {
-                        "type": "string"
+                        "type": "integer",
+                        "format": "int64"
                     },
                     "path": {
                         "type": "string"

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -144,7 +144,8 @@ export type components = {
       "message-id"?: string;
       boardname?: string;
       stackname?: string;
-      size?: string;
+      /** Format: int64 */
+      size?: number;
       path?: string;
       mimetype?: string;
       /** @enum {string} */

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -175,7 +175,8 @@ export type components = {
       "message-id"?: string;
       boardname?: string;
       stackname?: string;
-      size?: string;
+      /** Format: int64 */
+      size?: number;
       path?: string;
       mimetype?: string;
       /** @enum {string} */

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -782,7 +782,8 @@ export type components = {
       "message-id"?: string;
       boardname?: string;
       stackname?: string;
-      size?: string;
+      /** Format: int64 */
+      size?: number;
       path?: string;
       mimetype?: string;
       /** @enum {string} */

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -605,7 +605,8 @@ export type components = {
       "message-id"?: string;
       boardname?: string;
       stackname?: string;
-      size?: string;
+      /** Format: int64 */
+      size?: number;
       path?: string;
       mimetype?: string;
       /** @enum {string} */


### PR DESCRIPTION
### ☑️ Resolves

https://github.com/nextcloud/spreed/blob/1e0bebf4dea14021081f183e35a61a27f6b04de8/lib/Chat/Parser/SystemMessage.php#L803 is always the result of `$node->getSize()` and therefore an integer.

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
