### PR TITLE
Release 18.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 18.0.6 – 2024-04-04
+### Changed
+- Update translations
+- Update several dependencies
+
+### Fixed
+- fix(FilePicker): Provide correct container for FilePicker
+  [#11940](https://github.com/nextcloud/spreed/issues/11940)
+- fix(flow): Fix flow notifications in note-to-self and on own actions
+  [#11919](https://github.com/nextcloud/spreed/issues/11919)
+- fix(call): Keep the talk time information when changing active tab
+  [#11797](https://github.com/nextcloud/spreed/issues/11797)
+
+## 17.1.7 – 2024-04-04
+### Changed
+- Update translations
+- Update several dependencies
+
+### Fixed
+- fix(conversation): skip unread marker increasing from notification
+  [#11735](https://github.com/nextcloud/spreed/issues/11735)
+- fix(modal): mount nested modals inside global modals
+  [#11891](https://github.com/nextcloud/spreed/issues/11891)
+
 ## 18.0.5 – 2024-03-08
 ### Changed
 - Update translations

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>18.0.5</version>
+	<version>18.0.6</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "18.0.5",
+  "version": "18.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "18.0.5",
+      "version": "18.0.6",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "18.0.5",
+  "version": "18.0.6",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
# 18.0.6 – 2024-04-04
## Changed
- Update translations
- Update several dependencies

### Fixed
- fix(FilePicker): Provide correct container for FilePicker [#11940](https://github.com/nextcloud/spreed/issues/11940)
- fix(flow): Fix flow notifications in note-to-self and on own actions [#11919](https://github.com/nextcloud/spreed/issues/11919)
- fix(call): Keep the talk time information when changing active tab [#11797](https://github.com/nextcloud/spreed/issues/11797)