### PR TITLE
Release 17.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 17.1.7 – 2024-04-04
+### Changed
+- Update translations
+- Update several dependencies
+
+### Fixed
+- fix(conversation): skip unread marker increasing from notification
+  [#11735](https://github.com/nextcloud/spreed/issues/11735)
+- fix(modal): mount nested modals inside global modals
+  [#11891](https://github.com/nextcloud/spreed/issues/11891)
+
 ## 17.1.6 – 2024-02-29
 ### Changed
 - Update translations

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>17.1.6</version>
+	<version>17.1.7</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk",
-	"version": "17.1.6",
+	"version": "17.1.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk",
-			"version": "17.1.6",
+			"version": "17.1.7",
 			"license": "agpl",
 			"dependencies": {
 				"@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "talk",
-	"version": "17.1.6",
+	"version": "17.1.7",
 	"private": true,
 	"description": "",
 	"author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
# 17.1.7 – 2024-04-04
## Changed
- Update translations
- Update several dependencies

## Fixed
- fix(conversation): skip unread marker increasing from notification [#11735](https://github.com/nextcloud/spreed/issues/11735)
- fix(modal): mount nested modals inside global modals [#11891](https://github.com/nextcloud/spreed/issues/11891)
