### PR TITLE
desktop: add screen sharing support

### DIFF
--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -458,16 +458,12 @@ export default {
 		},
 
 		toggleScreenSharingMenu() {
-			if (IS_DESKTOP) {
-				alert('Unfortunately, Screen sharing is not supported by Nextcloud Talk Preview')
-				return
-			}
-
 			if (!this.isScreensharingAllowed) {
 				return
 			}
 
-			if (!this.model.getWebRtc().capabilities.supportScreenSharing) {
+			// webrtcsupport considers screen share supported only via HTTPS, even if it is actually supported in the browser/desktop
+			if (!this.model.getWebRtc().capabilities.supportScreenSharing && !IS_DESKTOP) {
 				if (window.location.protocol === 'https:') {
 					showMessage(t('spreed', 'Screen sharing is not supported by your browser.'))
 				} else {

--- a/src/utils/webrtc/simplewebrtc/getscreenmedia.js
+++ b/src/utils/webrtc/simplewebrtc/getscreenmedia.js
@@ -34,13 +34,52 @@ export default function(mode, constraints, cb) {
 	const callback = hasConstraints ? cb : constraints
 	let error
 
-	if (typeof window === 'undefined' || window.location.protocol === 'http:') {
+	if (!IS_DESKTOP && (typeof window === 'undefined' || window.location.protocol === 'http:')) {
 		error = new Error('NavigatorUserMediaError')
 		error.name = 'HTTPS_REQUIRED'
 		return callback(error)
 	}
 
-	if (navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia) {
+	if (IS_DESKTOP) {
+		return window.OCA.Talk.Desktop.getDesktopMediaSource()
+			.then(({ sourceId }) => {
+				if (!sourceId) {
+					// User canceled
+					const error = new Error('NavigatorUserMediaError')
+					error.name = 'PERMISSION_DENIED'
+					throw error
+				}
+
+				// Special case for sharing all the screens with desktop audio in Electron
+				// In this case, it must have exactly these constraints
+				// "entire-desktop:0:0" is a custom sourceId for this specific case
+				const constraints = (sourceId === 'entire-desktop:0:0')
+					? {
+						audio: {
+							mandatory: {
+								chromeMediaSource: 'desktop',
+							},
+						},
+						video: {
+							mandatory: {
+								chromeMediaSource: 'desktop',
+							},
+						},
+					}
+					: {
+						audio: false,
+						video: {
+							mandatory: {
+								chromeMediaSource: 'desktop',
+								chromeMediaSourceId: sourceId,
+							},
+						},
+					}
+				return navigator.mediaDevices.getUserMedia(constraints)
+			})
+			.then((stream) => callback(null, stream))
+			.catch((error) => callback(error))
+	} else if (navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia) {
 		navigator.mediaDevices.getDisplayMedia({
 			video: true,
 			// Disable default audio optimizations, as they are meant to be used


### PR DESCRIPTION
### ☑️ Resolves

* Used for https://github.com/nextcloud/talk-desktop/pull/595

## 🖌️ UI Checklist

### 🚧 Tasks

- [x] On Desktop - do not consider screen share unsupported 
- [x] On Desktop on screen sharing - get media source to share from Talk Desktop API

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required