### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "87b3c656978db13d16372d3bddc4117a0f1f273d"
+                "reference": "b8ae36e3e98db74bafd3dc7360cc758572e939b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/87b3c656978db13d16372d3bddc4117a0f1f273d",
-                "reference": "87b3c656978db13d16372d3bddc4117a0f1f273d",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b8ae36e3e98db74bafd3dc7360cc758572e939b0",
+                "reference": "b8ae36e3e98db74bafd3dc7360cc758572e939b0",
                 "shasum": ""
             },
             "require": {
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-03-28T10:47:18+00:00"
+            "time": "2024-04-03T00:32:10+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency