### PR TITLE
refactor(OpenAPI): Use proper type inheritance for chat messages

### DIFF
--- a/lib/Model/ProxyCacheMessage.php
+++ b/lib/Model/ProxyCacheMessage.php
@@ -59,7 +59,7 @@ use OCP\AppFramework\Db\Entity;
  * @method void setMetaData(?string $metaData)
  * @method string|null getMetaData()
  *
- * @psalm-import-type TalkRoomProxyMessage from ResponseDefinitions
+ * @psalm-import-type TalkChatProxyMessage from ResponseDefinitions
  */
 class ProxyCacheMessage extends Entity implements \JsonSerializable {
 	public const METADATA_REPLY_TO_ACTOR_TYPE = 'replyToActorType';
@@ -108,7 +108,7 @@ class ProxyCacheMessage extends Entity implements \JsonSerializable {
 	}
 
 	/**
-	 * @return TalkRoomProxyMessage
+	 * @return TalkChatProxyMessage
 	 */
 	public function jsonSerialize(): array {
 		$expirationTimestamp = 0;

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -93,21 +93,24 @@ namespace OCA\Talk;
  *     conversation?: string,
  * }
  *
- * @psalm-type TalkChatMessage = array{
+ * @psalm-type TalkBaseMessage = array{
  *     actorDisplayName: string,
  *     actorId: string,
  *     actorType: string,
- *     deleted?: true,
  *     expirationTimestamp: int,
- *     id: int,
- *     isReplyable: bool,
- *     markdown: bool,
  *     message: string,
  *     messageParameters: array<string, TalkRichObjectParameter>,
  *     messageType: string,
+ *     systemMessage: string,
+ *  }
+ *
+ * @psalm-type TalkChatMessage = TalkBaseMessage&array{
+ *     deleted?: true,
+ *     id: int,
+ *     isReplyable: bool,
+ *     markdown: bool,
  *     reactions: array<string, integer>|\stdClass,
  *     referenceId: string,
- *     systemMessage: string,
  *     timestamp: int,
  *     token: string,
  *     lastEditActorDisplayName?: string,
@@ -117,18 +120,9 @@ namespace OCA\Talk;
  *     silent?: bool,
  * }
  *
- * @psalm-type TalkRoomProxyMessage = array{
- *     actorDisplayName: string,
- *     actorId: string,
- *     actorType: string,
- *     expirationTimestamp: int,
- *     message: string,
- *     messageParameters: array<string, TalkRichObjectParameter>,
- *     messageType: string,
- *     systemMessage: string,
- * }
+ * @psalm-type TalkChatProxyMessage = TalkBaseMessage
  *
- * @psalm-type TalkRoomLastMessage = TalkChatMessage|TalkRoomProxyMessage
+ * @psalm-type TalkRoomLastMessage = TalkChatMessage|TalkChatProxyMessage
  *
  * @psalm-type TalkChatMessageWithParent = TalkChatMessage&array{parent?: TalkChatMessage}
  *

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -20,6 +20,49 @@
             }
         },
         "schemas": {
+            "BaseMessage": {
+                "type": "object",
+                "required": [
+                    "actorDisplayName",
+                    "actorId",
+                    "actorType",
+                    "expirationTimestamp",
+                    "message",
+                    "messageParameters",
+                    "messageType",
+                    "systemMessage"
+                ],
+                "properties": {
+                    "actorDisplayName": {
+                        "type": "string"
+                    },
+                    "actorId": {
+                        "type": "string"
+                    },
+                    "actorType": {
+                        "type": "string"
+                    },
+                    "expirationTimestamp": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "messageParameters": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/RichObjectParameter"
+                        }
+                    },
+                    "messageType": {
+                        "type": "string"
+                    },
+                    "systemMessage": {
+                        "type": "string"
+                    }
+                }
+            },
             "Capabilities": {
                 "type": "object",
                 "required": [
@@ -209,103 +252,77 @@
                 }
             },
             "ChatMessage": {
-                "type": "object",
-                "required": [
-                    "actorDisplayName",
-                    "actorId",
-                    "actorType",
-                    "expirationTimestamp",
-                    "id",
-                    "isReplyable",
-                    "markdown",
-                    "message",
-                    "messageParameters",
-                    "messageType",
-                    "reactions",
-                    "referenceId",
-                    "systemMessage",
-                    "timestamp",
-                    "token"
-                ],
-                "properties": {
-                    "actorDisplayName": {
-                        "type": "string"
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/BaseMessage"
                     },
-                    "actorId": {
-                        "type": "string"
-                    },
-                    "actorType": {
-                        "type": "string"
-                    },
-                    "deleted": {
-                        "type": "boolean",
-                        "enum": [
-                            true
-                        ]
-                    },
-                    "expirationTimestamp": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "id": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "isReplyable": {
-                        "type": "boolean"
-                    },
-                    "markdown": {
-                        "type": "boolean"
-                    },
-                    "message": {
-                        "type": "string"
-                    },
-                    "messageParameters": {
+                    {
                         "type": "object",
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/RichObjectParameter"
+                        "required": [
+                            "id",
+                            "isReplyable",
+                            "markdown",
+                            "reactions",
+                            "referenceId",
+                            "timestamp",
+                            "token"
+                        ],
+                        "properties": {
+                            "deleted": {
+                                "type": "boolean",
+                                "enum": [
+                                    true
+                                ]
+                            },
+                            "id": {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            "isReplyable": {
+                                "type": "boolean"
+                            },
+                            "markdown": {
+                                "type": "boolean"
+                            },
+                            "reactions": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                }
+                            },
+                            "referenceId": {
+                                "type": "string"
+                            },
+                            "timestamp": {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            "token": {
+                                "type": "string"
+                            },
+                            "lastEditActorDisplayName": {
+                                "type": "string"
+                            },
+                            "lastEditActorId": {
+                                "type": "string"
+                            },
+                            "lastEditActorType": {
+                                "type": "string"
+                            },
+                            "lastEditTimestamp": {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            "silent": {
+                                "type": "boolean"
+                            }
                         }
-                    },
-                    "messageType": {
-                        "type": "string"
-                    },
-                    "reactions": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    "referenceId": {
-                        "type": "string"
-                    },
-                    "systemMessage": {
-                        "type": "string"
-                    },
-                    "timestamp": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "token": {
-                        "type": "string"
-                    },
-                    "lastEditActorDisplayName": {
-                        "type": "string"
-                    },
-                    "lastEditActorId": {
-                        "type": "string"
-                    },
-                    "lastEditActorType": {
-                        "type": "string"
-                    },
-                    "lastEditTimestamp": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "silent": {
-                        "type": "boolean"
                     }
-                }
+                ]
+            },
+            "ChatProxyMessage": {
+                "$ref": "#/components/schemas/BaseMessage"
             },
             "OCSMeta": {
                 "type": "object",
@@ -712,52 +729,9 @@
                         "$ref": "#/components/schemas/ChatMessage"
                     },
                     {
-                        "$ref": "#/components/schemas/RoomProxyMessage"
+                        "$ref": "#/components/schemas/ChatProxyMessage"
                     }
                 ]
-            },
-            "RoomProxyMessage": {
-                "type": "object",
-                "required": [
-                    "actorDisplayName",
-                    "actorId",
-                    "actorType",
-                    "expirationTimestamp",
-                    "message",
-                    "messageParameters",
-                    "messageType",
-                    "systemMessage"
-                ],
-                "properties": {
-                    "actorDisplayName": {
-                        "type": "string"
-                    },
-                    "actorId": {
-                        "type": "string"
-                    },
-                    "actorType": {
-                        "type": "string"
-                    },
-                    "expirationTimestamp": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "message": {
-                        "type": "string"
-                    },
-                    "messageParameters": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/RichObjectParameter"
-                        }
-                    },
-                    "messageType": {
-                        "type": "string"
-                    },
-                    "systemMessage": {
-                        "type": "string"
-                    }
-                }
             }
         }
     },

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -20,6 +20,49 @@
             }
         },
         "schemas": {
+            "BaseMessage": {
+                "type": "object",
+                "required": [
+                    "actorDisplayName",
+                    "actorId",
+                    "actorType",
+                    "expirationTimestamp",
+                    "message",
+                    "messageParameters",
+                    "messageType",
+                    "systemMessage"
+                ],
+                "properties": {
+                    "actorDisplayName": {
+                        "type": "string"
+                    },
+                    "actorId": {
+                        "type": "string"
+                    },
+                    "actorType": {
+                        "type": "string"
+                    },
+                    "expirationTimestamp": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "messageParameters": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/RichObjectParameter"
+                        }
+                    },
+                    "messageType": {
+                        "type": "string"
+                    },
+                    "systemMessage": {
+                        "type": "string"
+                    }
+                }
+            },
             "Capabilities": {
                 "type": "object",
                 "required": [
@@ -209,103 +252,77 @@
                 }
             },
             "ChatMessage": {
-                "type": "object",
-                "required": [
-                    "actorDisplayName",
-                    "actorId",
-                    "actorType",
-                    "expirationTimestamp",
-                    "id",
-                    "isReplyable",
-                    "markdown",
-                    "message",
-                    "messageParameters",
-                    "messageType",
-                    "reactions",
-                    "referenceId",
-                    "systemMessage",
-                    "timestamp",
-                    "token"
-                ],
-                "properties": {
-                    "actorDisplayName": {
-                        "type": "string"
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/BaseMessage"
                     },
-                    "actorId": {
-                        "type": "string"
-                    },
-                    "actorType": {
-                        "type": "string"
-                    },
-                    "deleted": {
-                        "type": "boolean",
-                        "enum": [
-                            true
-                        ]
-                    },
-                    "expirationTimestamp": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "id": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "isReplyable": {
-                        "type": "boolean"
-                    },
-                    "markdown": {
-                        "type": "boolean"
-                    },
-                    "message": {
-                        "type": "string"
-                    },
-                    "messageParameters": {
+                    {
                         "type": "object",
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/RichObjectParameter"
+                        "required": [
+                            "id",
+                            "isReplyable",
+                            "markdown",
+                            "reactions",
+                            "referenceId",
+                            "timestamp",
+                            "token"
+                        ],
+                        "properties": {
+                            "deleted": {
+                                "type": "boolean",
+                                "enum": [
+                                    true
+                                ]
+                            },
+                            "id": {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            "isReplyable": {
+                                "type": "boolean"
+                            },
+                            "markdown": {
+                                "type": "boolean"
+                            },
+                            "reactions": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                }
+                            },
+                            "referenceId": {
+                                "type": "string"
+                            },
+                            "timestamp": {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            "token": {
+                                "type": "string"
+                            },
+                            "lastEditActorDisplayName": {
+                                "type": "string"
+                            },
+                            "lastEditActorId": {
+                                "type": "string"
+                            },
+                            "lastEditActorType": {
+                                "type": "string"
+                            },
+                            "lastEditTimestamp": {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            "silent": {
+                                "type": "boolean"
+                            }
                         }
-                    },
-                    "messageType": {
-                        "type": "string"
-                    },
-                    "reactions": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    "referenceId": {
-                        "type": "string"
-                    },
-                    "systemMessage": {
-                        "type": "string"
-                    },
-                    "timestamp": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "token": {
-                        "type": "string"
-                    },
-                    "lastEditActorDisplayName": {
-                        "type": "string"
-                    },
-                    "lastEditActorId": {
-                        "type": "string"
-                    },
-                    "lastEditActorType": {
-                        "type": "string"
-                    },
-                    "lastEditTimestamp": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "silent": {
-                        "type": "boolean"
                     }
-                }
+                ]
+            },
+            "ChatProxyMessage": {
+                "$ref": "#/components/schemas/BaseMessage"
             },
             "FederationInvite": {
                 "type": "object",
@@ -766,52 +783,9 @@
                         "$ref": "#/components/schemas/ChatMessage"
                     },
                     {
-                        "$ref": "#/components/schemas/RoomProxyMessage"
+                        "$ref": "#/components/schemas/ChatProxyMessage"
                     }
                 ]
-            },
-            "RoomProxyMessage": {
-                "type": "object",
-                "required": [
-                    "actorDisplayName",
-                    "actorId",
-                    "actorType",
-                    "expirationTimestamp",
-                    "message",
-                    "messageParameters",
-                    "messageType",
-                    "systemMessage"
-                ],
-                "properties": {
-                    "actorDisplayName": {
-                        "type": "string"
-                    },
-                    "actorId": {
-                        "type": "string"
-                    },
-                    "actorType": {
-                        "type": "string"
-                    },
-                    "expirationTimestamp": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "message": {
-                        "type": "string"
-                    },
-                    "messageParameters": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/RichObjectParameter"
-                        }
-                    },
-                    "messageType": {
-                        "type": "string"
-                    },
-                    "systemMessage": {
-                        "type": "string"
-                    }
-                }
             }
         }
     },

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -20,6 +20,49 @@
             }
         },
         "schemas": {
+            "BaseMessage": {
+                "type": "object",
+                "required": [
+                    "actorDisplayName",
+                    "actorId",
+                    "actorType",
+                    "expirationTimestamp",
+                    "message",
+                    "messageParameters",
+                    "messageType",
+                    "systemMessage"
+                ],
+                "properties": {
+                    "actorDisplayName": {
+                        "type": "string"
+                    },
+                    "actorId": {
+                        "type": "string"
+                    },
+                    "actorType": {
+                        "type": "string"
+                    },
+                    "expirationTimestamp": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "messageParameters": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/RichObjectParameter"
+                        }
+                    },
+                    "messageType": {
+                        "type": "string"
+                    },
+                    "systemMessage": {
+                        "type": "string"
+                    }
+                }
+            },
             "Bot": {
                 "type": "object",
                 "required": [
@@ -370,103 +413,74 @@
                 }
             },
             "ChatMessage": {
-                "type": "object",
-                "required": [
-                    "actorDisplayName",
-                    "actorId",
-                    "actorType",
-                    "expirationTimestamp",
-                    "id",
-                    "isReplyable",
-                    "markdown",
-                    "message",
-                    "messageParameters",
-                    "messageType",
-                    "reactions",
-                    "referenceId",
-                    "systemMessage",
-                    "timestamp",
-                    "token"
-                ],
-                "properties": {
-                    "actorDisplayName": {
-                        "type": "string"
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/BaseMessage"
                     },
-                    "actorId": {
-                        "type": "string"
-                    },
-                    "actorType": {
-                        "type": "string"
-                    },
-                    "deleted": {
-                        "type": "boolean",
-                        "enum": [
-                            true
-                        ]
-                    },
-                    "expirationTimestamp": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "id": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "isReplyable": {
-                        "type": "boolean"
-                    },
-                    "markdown": {
-                        "type": "boolean"
-                    },
-                    "message": {
-                        "type": "string"
-                    },
-                    "messageParameters": {
+                    {
                         "type": "object",
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/RichObjectParameter"
+                        "required": [
+                            "id",
+                            "isReplyable",
+                            "markdown",
+                            "reactions",
+                            "referenceId",
+                            "timestamp",
+                            "token"
+                        ],
+                        "properties": {
+                            "deleted": {
+                                "type": "boolean",
+                                "enum": [
+                                    true
+                                ]
+                            },
+                            "id": {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            "isReplyable": {
+                                "type": "boolean"
+                            },
+                            "markdown": {
+                                "type": "boolean"
+                            },
+                            "reactions": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                }
+                            },
+                            "referenceId": {
+                                "type": "string"
+                            },
+                            "timestamp": {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            "token": {
+                                "type": "string"
+                            },
+                            "lastEditActorDisplayName": {
+                                "type": "string"
+                            },
+                            "lastEditActorId": {
+                                "type": "string"
+                            },
+                            "lastEditActorType": {
+                                "type": "string"
+                            },
+                            "lastEditTimestamp": {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            "silent": {
+                                "type": "boolean"
+                            }
                         }
-                    },
-                    "messageType": {
-                        "type": "string"
-                    },
-                    "reactions": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    "referenceId": {
-                        "type": "string"
-                    },
-                    "systemMessage": {
-                        "type": "string"
-                    },
-                    "timestamp": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "token": {
-                        "type": "string"
-                    },
-                    "lastEditActorDisplayName": {
-                        "type": "string"
-                    },
-                    "lastEditActorId": {
-                        "type": "string"
-                    },
-                    "lastEditActorType": {
-                        "type": "string"
-                    },
-                    "lastEditTimestamp": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "silent": {
-                        "type": "boolean"
                     }
-                }
+                ]
             },
             "ChatMessageWithParent": {
                 "allOf": [
@@ -482,6 +496,9 @@
                         }
                     }
                 ]
+            },
+            "ChatProxyMessage": {
+                "$ref": "#/components/schemas/BaseMessage"
             },
             "ChatReminder": {
                 "type": "object",
@@ -1231,52 +1248,9 @@
                         "$ref": "#/components/schemas/ChatMessage"
                     },
                     {
-                        "$ref": "#/components/schemas/RoomProxyMessage"
+                        "$ref": "#/components/schemas/ChatProxyMessage"
                     }
                 ]
-            },
-            "RoomProxyMessage": {
-                "type": "object",
-                "required": [
-                    "actorDisplayName",
-                    "actorId",
-                    "actorType",
-                    "expirationTimestamp",
-                    "message",
-                    "messageParameters",
-                    "messageType",
-                    "systemMessage"
-                ],
-                "properties": {
-                    "actorDisplayName": {
-                        "type": "string"
-                    },
-                    "actorId": {
-                        "type": "string"
-                    },
-                    "actorType": {
-                        "type": "string"
-                    },
-                    "expirationTimestamp": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "message": {
-                        "type": "string"
-                    },
-                    "messageParameters": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/RichObjectParameter"
-                        }
-                    },
-                    "messageType": {
-                        "type": "string"
-                    },
-                    "systemMessage": {
-                        "type": "string"
-                    }
-                }
             },
             "SignalingSession": {
                 "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -20,6 +20,49 @@
             }
         },
         "schemas": {
+            "BaseMessage": {
+                "type": "object",
+                "required": [
+                    "actorDisplayName",
+                    "actorId",
+                    "actorType",
+                    "expirationTimestamp",
+                    "message",
+                    "messageParameters",
+                    "messageType",
+                    "systemMessage"
+                ],
+                "properties": {
+                    "actorDisplayName": {
+                        "type": "string"
+                    },
+                    "actorId": {
+                        "type": "string"
+                    },
+                    "actorType": {
+                        "type": "string"
+                    },
+                    "expirationTimestamp": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "messageParameters": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/RichObjectParameter"
+                        }
+                    },
+                    "messageType": {
+                        "type": "string"
+                    },
+                    "systemMessage": {
+                        "type": "string"
+                    }
+                }
+            },
             "Bot": {
                 "type": "object",
                 "required": [
@@ -311,103 +354,74 @@
                 }
             },
             "ChatMessage": {
-                "type": "object",
-                "required": [
-                    "actorDisplayName",
-                    "actorId",
-                    "actorType",
-                    "expirationTimestamp",
-                    "id",
-                    "isReplyable",
-                    "markdown",
-                    "message",
-                    "messageParameters",
-                    "messageType",
-                    "reactions",
-                    "referenceId",
-                    "systemMessage",
-                    "timestamp",
-                    "token"
-                ],
-                "properties": {
-                    "actorDisplayName": {
-                        "type": "string"
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/BaseMessage"
                     },
-                    "actorId": {
-                        "type": "string"
-                    },
-                    "actorType": {
-                        "type": "string"
-                    },
-                    "deleted": {
-                        "type": "boolean",
-                        "enum": [
-                            true
-                        ]
-                    },
-                    "expirationTimestamp": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "id": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "isReplyable": {
-                        "type": "boolean"
-                    },
-                    "markdown": {
-                        "type": "boolean"
-                    },
-                    "message": {
-                        "type": "string"
-                    },
-                    "messageParameters": {
+                    {
                         "type": "object",
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/RichObjectParameter"
+                        "required": [
+                            "id",
+                            "isReplyable",
+                            "markdown",
+                            "reactions",
+                            "referenceId",
+                            "timestamp",
+                            "token"
+                        ],
+                        "properties": {
+                            "deleted": {
+                                "type": "boolean",
+                                "enum": [
+                                    true
+                                ]
+                            },
+                            "id": {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            "isReplyable": {
+                                "type": "boolean"
+                            },
+                            "markdown": {
+                                "type": "boolean"
+                            },
+                            "reactions": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                }
+                            },
+                            "referenceId": {
+                                "type": "string"
+                            },
+                            "timestamp": {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            "token": {
+                                "type": "string"
+                            },
+                            "lastEditActorDisplayName": {
+                                "type": "string"
+                            },
+                            "lastEditActorId": {
+                                "type": "string"
+                            },
+                            "lastEditActorType": {
+                                "type": "string"
+                            },
+                            "lastEditTimestamp": {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            "silent": {
+                                "type": "boolean"
+                            }
                         }
-                    },
-                    "messageType": {
-                        "type": "string"
-                    },
-                    "reactions": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    "referenceId": {
-                        "type": "string"
-                    },
-                    "systemMessage": {
-                        "type": "string"
-                    },
-                    "timestamp": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "token": {
-                        "type": "string"
-                    },
-                    "lastEditActorDisplayName": {
-                        "type": "string"
-                    },
-                    "lastEditActorId": {
-                        "type": "string"
-                    },
-                    "lastEditActorType": {
-                        "type": "string"
-                    },
-                    "lastEditTimestamp": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "silent": {
-                        "type": "boolean"
                     }
-                }
+                ]
             },
             "ChatMessageWithParent": {
                 "allOf": [
@@ -423,6 +437,9 @@
                         }
                     }
                 ]
+            },
+            "ChatProxyMessage": {
+                "$ref": "#/components/schemas/BaseMessage"
             },
             "ChatReminder": {
                 "type": "object",
@@ -1118,52 +1135,9 @@
                         "$ref": "#/components/schemas/ChatMessage"
                     },
                     {
-                        "$ref": "#/components/schemas/RoomProxyMessage"
+                        "$ref": "#/components/schemas/ChatProxyMessage"
                     }
                 ]
-            },
-            "RoomProxyMessage": {
-                "type": "object",
-                "required": [
-                    "actorDisplayName",
-                    "actorId",
-                    "actorType",
-                    "expirationTimestamp",
-                    "message",
-                    "messageParameters",
-                    "messageType",
-                    "systemMessage"
-                ],
-                "properties": {
-                    "actorDisplayName": {
-                        "type": "string"
-                    },
-                    "actorId": {
-                        "type": "string"
-                    },
-                    "actorType": {
-                        "type": "string"
-                    },
-                    "expirationTimestamp": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "message": {
-                        "type": "string"
-                    },
-                    "messageParameters": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/RichObjectParameter"
-                        }
-                    },
-                    "messageType": {
-                        "type": "string"
-                    },
-                    "systemMessage": {
-                        "type": "string"
-                    }
-                }
             },
             "SignalingSession": {
                 "type": "object",

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -40,6 +40,19 @@ export type webhooks = Record<string, never>;
 
 export type components = {
   schemas: {
+    BaseMessage: {
+      actorDisplayName: string;
+      actorId: string;
+      actorType: string;
+      /** Format: int64 */
+      expirationTimestamp: number;
+      message: string;
+      messageParameters: {
+        [key: string]: components["schemas"]["RichObjectParameter"];
+      };
+      messageType: string;
+      systemMessage: string;
+    };
     Capabilities: {
       features: string[];
       config: {
@@ -90,28 +103,17 @@ export type components = {
       };
       version: string;
     };
-    ChatMessage: {
-      actorDisplayName: string;
-      actorId: string;
-      actorType: string;
+    ChatMessage: components["schemas"]["BaseMessage"] & {
       /** @enum {boolean} */
       deleted?: true;
-      /** Format: int64 */
-      expirationTimestamp: number;
       /** Format: int64 */
       id: number;
       isReplyable: boolean;
       markdown: boolean;
-      message: string;
-      messageParameters: {
-        [key: string]: components["schemas"]["RichObjectParameter"];
-      };
-      messageType: string;
       reactions: {
         [key: string]: number;
       };
       referenceId: string;
-      systemMessage: string;
       /** Format: int64 */
       timestamp: number;
       token: string;
@@ -122,6 +124,7 @@ export type components = {
       lastEditTimestamp?: number;
       silent?: boolean;
     };
+    ChatProxyMessage: components["schemas"]["BaseMessage"];
     OCSMeta: {
       status: string;
       statuscode: number;
@@ -246,20 +249,7 @@ export type components = {
       /** Format: int64 */
       unreadMessages: number;
     };
-    RoomLastMessage: components["schemas"]["ChatMessage"] | components["schemas"]["RoomProxyMessage"];
-    RoomProxyMessage: {
-      actorDisplayName: string;
-      actorId: string;
-      actorType: string;
-      /** Format: int64 */
-      expirationTimestamp: number;
-      message: string;
-      messageParameters: {
-        [key: string]: components["schemas"]["RichObjectParameter"];
-      };
-      messageType: string;
-      systemMessage: string;
-    };
+    RoomLastMessage: components["schemas"]["ChatMessage"] | components["schemas"]["ChatProxyMessage"];
   };
   responses: never;
   parameters: never;

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -55,6 +55,19 @@ export type webhooks = Record<string, never>;
 
 export type components = {
   schemas: {
+    BaseMessage: {
+      actorDisplayName: string;
+      actorId: string;
+      actorType: string;
+      /** Format: int64 */
+      expirationTimestamp: number;
+      message: string;
+      messageParameters: {
+        [key: string]: components["schemas"]["RichObjectParameter"];
+      };
+      messageType: string;
+      systemMessage: string;
+    };
     Capabilities: {
       features: string[];
       config: {
@@ -105,28 +118,17 @@ export type components = {
       };
       version: string;
     };
-    ChatMessage: {
-      actorDisplayName: string;
-      actorId: string;
-      actorType: string;
+    ChatMessage: components["schemas"]["BaseMessage"] & {
       /** @enum {boolean} */
       deleted?: true;
-      /** Format: int64 */
-      expirationTimestamp: number;
       /** Format: int64 */
       id: number;
       isReplyable: boolean;
       markdown: boolean;
-      message: string;
-      messageParameters: {
-        [key: string]: components["schemas"]["RichObjectParameter"];
-      };
-      messageType: string;
       reactions: {
         [key: string]: number;
       };
       referenceId: string;
-      systemMessage: string;
       /** Format: int64 */
       timestamp: number;
       token: string;
@@ -137,6 +139,7 @@ export type components = {
       lastEditTimestamp?: number;
       silent?: boolean;
     };
+    ChatProxyMessage: components["schemas"]["BaseMessage"];
     FederationInvite: {
       /** Format: int64 */
       id: number;
@@ -277,20 +280,7 @@ export type components = {
       /** Format: int64 */
       unreadMessages: number;
     };
-    RoomLastMessage: components["schemas"]["ChatMessage"] | components["schemas"]["RoomProxyMessage"];
-    RoomProxyMessage: {
-      actorDisplayName: string;
-      actorId: string;
-      actorType: string;
-      /** Format: int64 */
-      expirationTimestamp: number;
-      message: string;
-      messageParameters: {
-        [key: string]: components["schemas"]["RichObjectParameter"];
-      };
-      messageType: string;
-      systemMessage: string;
-    };
+    RoomLastMessage: components["schemas"]["ChatMessage"] | components["schemas"]["ChatProxyMessage"];
   };
   responses: never;
   parameters: never;

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -532,6 +532,19 @@ export type webhooks = Record<string, never>;
 
 export type components = {
   schemas: {
+    BaseMessage: {
+      actorDisplayName: string;
+      actorId: string;
+      actorType: string;
+      /** Format: int64 */
+      expirationTimestamp: number;
+      message: string;
+      messageParameters: {
+        [key: string]: components["schemas"]["RichObjectParameter"];
+      };
+      messageType: string;
+      systemMessage: string;
+    };
     Bot: {
       description: string | null;
       /** Format: int64 */
@@ -624,28 +637,17 @@ export type components = {
       statusIcon: string | null;
       statusMessage: string | null;
     };
-    ChatMessage: {
-      actorDisplayName: string;
-      actorId: string;
-      actorType: string;
+    ChatMessage: components["schemas"]["BaseMessage"] & {
       /** @enum {boolean} */
       deleted?: true;
-      /** Format: int64 */
-      expirationTimestamp: number;
       /** Format: int64 */
       id: number;
       isReplyable: boolean;
       markdown: boolean;
-      message: string;
-      messageParameters: {
-        [key: string]: components["schemas"]["RichObjectParameter"];
-      };
-      messageType: string;
       reactions: {
         [key: string]: number;
       };
       referenceId: string;
-      systemMessage: string;
       /** Format: int64 */
       timestamp: number;
       token: string;
@@ -659,6 +661,7 @@ export type components = {
     ChatMessageWithParent: components["schemas"]["ChatMessage"] & {
       parent?: components["schemas"]["ChatMessage"];
     };
+    ChatProxyMessage: components["schemas"]["BaseMessage"];
     ChatReminder: {
       /** Format: int64 */
       messageId: number;
@@ -884,20 +887,7 @@ export type components = {
       /** Format: int64 */
       unreadMessages: number;
     };
-    RoomLastMessage: components["schemas"]["ChatMessage"] | components["schemas"]["RoomProxyMessage"];
-    RoomProxyMessage: {
-      actorDisplayName: string;
-      actorId: string;
-      actorType: string;
-      /** Format: int64 */
-      expirationTimestamp: number;
-      message: string;
-      messageParameters: {
-        [key: string]: components["schemas"]["RichObjectParameter"];
-      };
-      messageType: string;
-      systemMessage: string;
-    };
+    RoomLastMessage: components["schemas"]["ChatMessage"] | components["schemas"]["ChatProxyMessage"];
     SignalingSession: {
       /** Format: int64 */
       inCall: number;

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -385,6 +385,19 @@ export type webhooks = Record<string, never>;
 
 export type components = {
   schemas: {
+    BaseMessage: {
+      actorDisplayName: string;
+      actorId: string;
+      actorType: string;
+      /** Format: int64 */
+      expirationTimestamp: number;
+      message: string;
+      messageParameters: {
+        [key: string]: components["schemas"]["RichObjectParameter"];
+      };
+      messageType: string;
+      systemMessage: string;
+    };
     Bot: {
       description: string | null;
       /** Format: int64 */
@@ -463,28 +476,17 @@ export type components = {
       statusIcon: string | null;
       statusMessage: string | null;
     };
-    ChatMessage: {
-      actorDisplayName: string;
-      actorId: string;
-      actorType: string;
+    ChatMessage: components["schemas"]["BaseMessage"] & {
       /** @enum {boolean} */
       deleted?: true;
-      /** Format: int64 */
-      expirationTimestamp: number;
       /** Format: int64 */
       id: number;
       isReplyable: boolean;
       markdown: boolean;
-      message: string;
-      messageParameters: {
-        [key: string]: components["schemas"]["RichObjectParameter"];
-      };
-      messageType: string;
       reactions: {
         [key: string]: number;
       };
       referenceId: string;
-      systemMessage: string;
       /** Format: int64 */
       timestamp: number;
       token: string;
@@ -498,6 +500,7 @@ export type components = {
     ChatMessageWithParent: components["schemas"]["ChatMessage"] & {
       parent?: components["schemas"]["ChatMessage"];
     };
+    ChatProxyMessage: components["schemas"]["BaseMessage"];
     ChatReminder: {
       /** Format: int64 */
       messageId: number;
@@ -707,20 +710,7 @@ export type components = {
       /** Format: int64 */
       unreadMessages: number;
     };
-    RoomLastMessage: components["schemas"]["ChatMessage"] | components["schemas"]["RoomProxyMessage"];
-    RoomProxyMessage: {
-      actorDisplayName: string;
-      actorId: string;
-      actorType: string;
-      /** Format: int64 */
-      expirationTimestamp: number;
-      message: string;
-      messageParameters: {
-        [key: string]: components["schemas"]["RichObjectParameter"];
-      };
-      messageType: string;
-      systemMessage: string;
-    };
+    RoomLastMessage: components["schemas"]["ChatMessage"] | components["schemas"]["ChatProxyMessage"];
     SignalingSession: {
       /** Format: int64 */
       inCall: number;


### PR DESCRIPTION
### ☑️ Resolves

This makes it a lot easier to handle messages in clients because local and remote messages use the same base type with the same properties.

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
