### PR TITLE
chore(deps): bump nextcloud/vue from 8.11.1 to 8.11.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^3.0.0",
         "@nextcloud/upload": "^1.1.0",
-        "@nextcloud/vue": "^8.11.1",
+        "@nextcloud/vue": "^8.11.2",
         "crypto-js": "^4.2.0",
         "debounce": "^2.0.0",
         "emoji-mart-vue-fast": "^15.0.0",
@@ -3837,9 +3837,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.11.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.1.tgz",
-      "integrity": "sha512-tK/OpRasvjVwKBe8k7T5WfvNbeimYPF7TGNq3P2UO8ir6mDoO0aymAW8qKfPU56elH7bqqr8qk0d8rC/jZuLaQ==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.2.tgz",
+      "integrity": "sha512-mjA3Ni2CB3gOkKFMYFhQUjqaUos8hnwglfvz3lPp5LVrORsXaHa3C2ZudVp+hAKslVsRKkjfMYOKrlquw8vxQw==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -23549,9 +23549,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.11.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.1.tgz",
-      "integrity": "sha512-tK/OpRasvjVwKBe8k7T5WfvNbeimYPF7TGNq3P2UO8ir6mDoO0aymAW8qKfPU56elH7bqqr8qk0d8rC/jZuLaQ==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.2.tgz",
+      "integrity": "sha512-mjA3Ni2CB3gOkKFMYFhQUjqaUos8hnwglfvz3lPp5LVrORsXaHa3C2ZudVp+hAKslVsRKkjfMYOKrlquw8vxQw==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^3.0.0",
     "@nextcloud/upload": "^1.1.0",
-    "@nextcloud/vue": "^8.11.1",
+    "@nextcloud/vue": "^8.11.2",
     "crypto-js": "^4.2.0",
     "debounce": "^2.0.0",
     "emoji-mart-vue-fast": "^15.0.0",


### PR DESCRIPTION
### ☑️ Resolves

* Changelog: https://github.com/nextcloud-libraries/nextcloud-vue/releases/tag/v8.11.2
* Fix #12009

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | ![image](https://github.com/nextcloud/spreed/assets/93392545/73a1fadf-c548-436a-b562-f65e95c43867)


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 