### PR TITLE
[stable28] fix(NewGroupConversation): bring back removed computed

### DIFF
--- a/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
+++ b/src/components/LeftSidebar/NewGroupConversation/NewGroupConversation.vue
@@ -299,6 +299,9 @@ export default {
 			}
 			return t('spreed', 'Maximum length exceeded ({maxlength} characters)', { maxlength: CONVERSATION.MAX_DESCRIPTION_LENGTH })
 		},
+		selectedParticipants() {
+			return this.$store.getters.selectedParticipants
+		},
 	},
 
 	watch: {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12040
* Regression from backport #11916, #11917
* stable29 and main isn't affected, as code was rewritten without store

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 