### PR TITLE
fix(MessagesButtonsBar): exclude click on emoji picker from outside click event listener

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -791,6 +791,11 @@ export default {
 
 		// Making sure that the click is outside the MessageButtonsBar
 		handleClickOutside(event) {
+			// check if click is inside the emoji picker
+			if (event.composedPath().some(element => element.classList?.contains('v-popper__popper--shown'))) {
+				return
+			}
+
 			if (event.composedPath().includes(this.$el)) {
 				return
 			}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12046

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░



Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

https://github.com/nextcloud/spreed/assets/84044328/5b827f80-6c2f-487a-a869-9addd002603a


### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required