### PR TITLE
chore(release): Fix build action while there is no latest-29 package

### DIFF
--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -68,10 +68,10 @@ jobs:
         with:
           filename: ${{ env.APP_NAME }}/appinfo/info.xml
 
-      - name: Set up php ${{ steps.php-versions.outputs.php-min }}
+      - name: Set up php 8.1
         uses: shivammathur/setup-php@a4e22b60bbb9c1021113f2860347b0759f66fe5d # v2
         with:
-          php-version: ${{ steps.php-versions.outputs.php-min }}
+          php-version: 8.1
           coverage: none
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ref https://github.com/nextcloud-releases/spreed/actions/runs/8653875091/job/23729990728#step:20:1335

> This version of Nextcloud requires at least PHP 8.1<br/>You are currently running 8.0.30. Please update your PHP version.

As there is no latest-29 package, master is cloned, but that is no longer compatible with 8.0, so hard coding the version to 8.1 for now.
We can revert this once the 29 final is in place.