### PR TITLE
style: update CSS specificity for fallback mention icons

### DIFF
--- a/css/icons.css
+++ b/css/icons.css
@@ -92,29 +92,46 @@
  * .app-Talk rules above.
  * "forced-white" needs to be included in the class name as the Avatar does
  * not accept several classes. */
-.user-bubble__avatar .icon-group-forced-white,
-.user-bubble__avatar .icon-user-forced-white,
-.autocomplete-result .icon-group-forced-white,
-.autocomplete-result .icon-user-forced-white,
-.mention-bubble .icon-group-forced-white,
-.mention-bubble .icon-user-forced-white {
-	background-color: var(--color-text-maxcontrast-default) !important;
-}
-
-body[data-theme-dark] .icon-group-forced-white,
-body[data-theme-dark] .icon-user-forced-white {
-	background-color: #3B3B3B !important;
-}
-
-.user-bubble__avatar .icon-group-forced-white,
-.user-bubble__avatar .icon-user-forced-white {
-	background-size: 75%;
-}
-
+.user-bubble__avatar .icon-group-forced-white.avatar-class-icon,
+.user-bubble__avatar .icon-user-forced-white.avatar-class-icon,
 .autocomplete-result .icon-group-forced-white.autocomplete-result__icon--,
 .autocomplete-result .icon-user-forced-white.autocomplete-result__icon--,
 .mention-bubble .icon-group-forced-white.mention-bubble__icon--,
 .mention-bubble .icon-user-forced-white.mention-bubble__icon-- {
+	background-color: #6B6B6B;
+}
+
+/* System default: dark theme */
+@media (prefers-color-scheme: dark) {
+	.user-bubble__avatar .icon-group-forced-white.avatar-class-icon,
+	.user-bubble__avatar .icon-user-forced-white.avatar-class-icon,
+	.autocomplete-result .icon-group-forced-white.autocomplete-result__icon--,
+	.autocomplete-result .icon-user-forced-white.autocomplete-result__icon--,
+	.mention-bubble .icon-group-forced-white.mention-bubble__icon--,
+	.mention-bubble .icon-user-forced-white.mention-bubble__icon-- {
+		background-color: #3B3B3B;
+	}
+}
+
+/* Manually set dark theme */
+body[data-theme-dark] .user-bubble__avatar .icon-group-forced-white.avatar-class-icon,
+body[data-theme-dark] .user-bubble__avatar .icon-user-forced-white.avatar-class-icon,
+body[data-theme-dark] .autocomplete-result .icon-group-forced-white.autocomplete-result__icon--,
+body[data-theme-dark] .autocomplete-result .icon-user-forced-white.autocomplete-result__icon--,
+body[data-theme-dark] .mention-bubble .icon-group-forced-white.mention-bubble__icon--,
+body[data-theme-dark] .mention-bubble .icon-user-forced-white.mention-bubble__icon-- {
+	background-color: #3B3B3B;
+}
+
+.user-bubble__avatar .icon-group-forced-white.avatar-class-icon,
+.user-bubble__avatar .icon-user-forced-white.avatar-class-icon,
+.mention-bubble .icon-group-forced-white.mention-bubble__icon--,
+.mention-bubble .icon-user-forced-white.mention-bubble__icon-- {
+	background-size: 75%;
+}
+
+.autocomplete-result .icon-group-forced-white.autocomplete-result__icon--,
+.autocomplete-result .icon-user-forced-white.autocomplete-result__icon-- {
 	background-size: 50% !important;
 }
 

--- a/css/icons.css
+++ b/css/icons.css
@@ -103,12 +103,12 @@
 
 /* System default: dark theme */
 @media (prefers-color-scheme: dark) {
-	.user-bubble__avatar .icon-group-forced-white.avatar-class-icon,
-	.user-bubble__avatar .icon-user-forced-white.avatar-class-icon,
-	.autocomplete-result .icon-group-forced-white.autocomplete-result__icon--,
-	.autocomplete-result .icon-user-forced-white.autocomplete-result__icon--,
-	.mention-bubble .icon-group-forced-white.mention-bubble__icon--,
-	.mention-bubble .icon-user-forced-white.mention-bubble__icon-- {
+	body[data-theme-default] .user-bubble__avatar .icon-group-forced-white.avatar-class-icon,
+	body[data-theme-default] .user-bubble__avatar .icon-user-forced-white.avatar-class-icon,
+	body[data-theme-default] .autocomplete-result .icon-group-forced-white.autocomplete-result__icon--,
+	body[data-theme-default] .autocomplete-result .icon-user-forced-white.autocomplete-result__icon--,
+	body[data-theme-default] .mention-bubble .icon-group-forced-white.mention-bubble__icon--,
+	body[data-theme-default] .mention-bubble .icon-user-forced-white.mention-bubble__icon-- {
 		background-color: #3B3B3B;
 	}
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #11811
* For BG color specifity was increased, so it follows:
  * server/component styles (0.2.0);
  * light theme in-Talk styles (0.3.0);
  * dark theme in-Talk styles (0.4.1);
  * system dark theme in-Talk styles (0.3.0 `@media`);
* Increase size for mention bubble (see screenshots)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

☀️ Light theme | 🌑 Dark Theme
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/09927d59-1c32-41bb-9c47-c101a4173984) | ![image](https://github.com/nextcloud/spreed/assets/93392545/577a7800-de56-47ef-92ee-4116f79fb265)

Before | After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/455c1d26-1c1f-4ff2-ad27-a3d2ec6ab7ef) | ![image](https://github.com/nextcloud/spreed/assets/93392545/915ec02f-440f-4ffc-8cc5-bce58f11b825)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 