### PR TITLE
fix(NewMessage): make silent chat button appearance more obvious

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -141,13 +141,16 @@
 			<!-- Send buttons -->
 			<template v-else>
 				<NcActions v-if="!broadcast" :container="container" force-menu>
+					<template #icon>
+						<BellOffIcon v-if="silentChat" :size="16" />
+					</template>
 					<NcActionButton close-after-click
+						:model-value="silentChat"
 						:name="silentSendLabel"
 						@click="toggleSilentChat">
 						{{ silentSendInfo }}
 						<template #icon>
-							<BellIcon v-if="silentChat" :size="16" />
-							<BellOffIcon v-else :size="16" />
+							<BellOffIcon :size="16" />
 						</template>
 					</NcActionButton>
 				</NcActions>
@@ -159,8 +162,7 @@
 					:aria-label="sendMessageLabel"
 					@click="handleSubmit">
 					<template #icon>
-						<SendVariantOutlineIcon v-if="silentChat" :size="18" />
-						<SendIcon v-else :size="16" />
+						<SendIcon :size="16" />
 					</template>
 				</NcButton>
 			</template>
@@ -190,13 +192,11 @@
 <script>
 import debounce from 'debounce'
 
-import BellIcon from 'vue-material-design-icons/Bell.vue'
 import BellOffIcon from 'vue-material-design-icons/BellOff.vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
 import CloseIcon from 'vue-material-design-icons/Close.vue'
 import EmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
 import SendIcon from 'vue-material-design-icons/Send.vue'
-import SendVariantOutlineIcon from 'vue-material-design-icons/SendVariantOutline.vue'
 
 import { getCapabilities } from '@nextcloud/capabilities'
 import { showError, showWarning } from '@nextcloud/dialogs'
@@ -258,13 +258,11 @@ export default {
 		NewMessageTypingIndicator,
 		Quote,
 		// Icons
-		BellIcon,
 		BellOffIcon,
 		CheckIcon,
 		CloseIcon,
 		EmoticonOutline,
 		SendIcon,
-		SendVariantOutlineIcon,
 	},
 
 	props: {
@@ -440,21 +438,13 @@ export default {
 		},
 
 		silentSendLabel() {
-			return this.silentChat
-				? t('spreed', 'Send with notification')
-				: t('spreed', 'Send without notification')
+			return t('spreed', 'Send without notification')
 		},
 
 		silentSendInfo() {
-			if (this.isOneToOne) {
-				return this.silentChat
-					? t('spreed', 'The participant will be notified about new messages')
-					: t('spreed', 'The participant will not be notified about new messages')
-			} else {
-				return this.silentChat
-					? t('spreed', 'Participants will be notified about new messages')
-					: t('spreed', 'Participants will not be notified about new messages')
-			}
+			return this.isOneToOne
+				? t('spreed', 'The participant will not be notified about new messages')
+				: t('spreed', 'Participants will not be notified about new messages')
 		},
 
 		showAttachmentsMenu() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12008
  * Same appearance as for filters in LeftSidebar
  * Less text changes, to describe only ENABLED behavior

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/7d2323e0-20cb-4256-a62a-83f5f14e595c)![image](https://github.com/nextcloud/spreed/assets/93392545/0f043bac-45ca-4a6c-b04d-2dd4be181dae) | ![image](https://github.com/nextcloud/spreed/assets/93392545/aca227b9-455f-4730-88f0-850968f7868a)![image](https://github.com/nextcloud/spreed/assets/93392545/e8afe4d3-6189-429a-9471-2fc28e478970)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required