### PR TITLE
fix(chat): Rename circles to teams in system messages

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -416,19 +416,19 @@ class SystemMessage implements IEventListener {
 			}
 		} elseif ($message === 'circle_added') {
 			$parsedParameters['circle'] = $this->getCircle($parameters['circle']);
-			$parsedMessage = $this->l->t('{actor} added circle {circle}');
+			$parsedMessage = $this->l->t('{actor} added team {circle}');
 			if ($currentUserIsActor) {
-				$parsedMessage = $this->l->t('You added circle {circle}');
+				$parsedMessage = $this->l->t('You added team {circle}');
 			} elseif ($cliIsActor) {
-				$parsedMessage = $this->l->t('An administrator added circle {circle}');
+				$parsedMessage = $this->l->t('An administrator added team {circle}');
 			}
 		} elseif ($message === 'circle_removed') {
 			$parsedParameters['circle'] = $this->getCircle($parameters['circle']);
-			$parsedMessage = $this->l->t('{actor} removed circle {circle}');
+			$parsedMessage = $this->l->t('{actor} removed team {circle}');
 			if ($currentUserIsActor) {
-				$parsedMessage = $this->l->t('You removed circle {circle}');
+				$parsedMessage = $this->l->t('You removed team {circle}');
 			} elseif ($cliIsActor) {
-				$parsedMessage = $this->l->t('An administrator removed circle {circle}');
+				$parsedMessage = $this->l->t('An administrator removed team {circle}');
 			}
 		} elseif ($message === 'phone_added') {
 			$parsedParameters['phone'] = $this->getPhone($room, $parameters['phone'], $parameters['name']);


### PR DESCRIPTION
### ☑️ Resolves

- Fix #12101 

## 🛠️ API Checklist

- [ ] Backport only after 29 final

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
