### PR TITLE
fix(tests): Make tests more reliable on PostgreSQL by also sorting on stop

### DIFF
--- a/lib/Service/BreakoutRoomService.php
+++ b/lib/Service/BreakoutRoomService.php
@@ -439,7 +439,7 @@ class BreakoutRoomService {
 
 		$this->roomService->setBreakoutRoomStatus($parent, BreakoutRoom::STATUS_STOPPED);
 
-		$breakoutRooms = $this->manager->getMultipleRoomsByObject(BreakoutRoom::PARENT_OBJECT_TYPE, $parent->getToken());
+		$breakoutRooms = $this->manager->getMultipleRoomsByObject(BreakoutRoom::PARENT_OBJECT_TYPE, $parent->getToken(), true);
 		foreach ($breakoutRooms as $breakoutRoom) {
 			$this->roomService->setLobby($breakoutRoom, Webinary::LOBBY_NON_MODERATORS, null);
 

--- a/lib/Signaling/Listener.php
+++ b/lib/Signaling/Listener.php
@@ -395,7 +395,7 @@ class Listener implements IEventListener {
 	}
 
 	protected function notifyBreakoutRoomStopped(Room $room): void {
-		$breakoutRooms = $this->manager->getMultipleRoomsByObject(BreakoutRoom::PARENT_OBJECT_TYPE, $room->getToken());
+		$breakoutRooms = $this->manager->getMultipleRoomsByObject(BreakoutRoom::PARENT_OBJECT_TYPE, $room->getToken(), true);
 
 		foreach ($breakoutRooms as $breakoutRoom) {
 			$sessionIds = [];


### PR DESCRIPTION
## 🛠️ API Checklist

- We had sorting in place already, but for some reason only on start breakout rooms, not on stop....

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
