### PR TITLE
fix(conversations): Include rooms in "modified since" updates when at…

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>20.0.0-dev.0</version>
+	<version>20.0.0-dev.1</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/lib/Migration/Version19000Date20240416104656.php
+++ b/lib/Migration/Version19000Date20240416104656.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Add a column to track the last read marker update so conversations marked
+ * as (un)read on other devices are properly updated with the "lazy" update.
+ */
+class Version19000Date20240416104656 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('talk_attendees');
+		$table->addColumn('last_attendee_activity', Types::BIGINT, [
+			'default' => 0,
+			'unsigned' => true,
+		]);
+
+		return $schema;
+	}
+}

--- a/lib/Model/Attendee.php
+++ b/lib/Model/Attendee.php
@@ -70,6 +70,8 @@ use OCP\AppFramework\Db\Entity;
  * @method int getState()
  * @method void setUnreadMessages(int $unreadMessages)
  * @method int getUnreadMessages()
+ * @method void setLastAttendeeActivity(int $lastAttendeeActivity)
+ * @method int getLastAttendeeActivity()
  */
 class Attendee extends Entity {
 	public const ACTOR_USERS = 'users';
@@ -178,6 +180,9 @@ class Attendee extends Entity {
 	/** @var int */
 	protected $unreadMessages;
 
+	/** @var int */
+	protected $lastAttendeeActivity;
+
 	public function __construct() {
 		$this->addType('roomId', 'int');
 		$this->addType('actorType', 'string');
@@ -201,6 +206,7 @@ class Attendee extends Entity {
 		$this->addType('callId', 'string');
 		$this->addType('state', 'int');
 		$this->addType('unreadMessages', 'int');
+		$this->addType('lastAttendeeActivity', 'int');
 	}
 
 	public function getDisplayName(): string {
@@ -232,6 +238,7 @@ class Attendee extends Entity {
 			'invited_cloud_id' => $this->getInvitedCloudId(),
 			'phone_number' => $this->getPhoneNumber(),
 			'call_id' => $this->getCallId(),
+			'last_attendee_activity' => $this->getLastAttendeeActivity(),
 		];
 	}
 }

--- a/lib/Model/AttendeeMapper.php
+++ b/lib/Model/AttendeeMapper.php
@@ -301,6 +301,7 @@ class AttendeeMapper extends QBMapper {
 			'call_id' => $row['call_id'],
 			'state' => (int) $row['state'],
 			'unread_messages' => (int) $row['unread_messages'],
+			'last_attendee_activity' => (int) $row['last_attendee_activity'],
 		]);
 	}
 }

--- a/lib/Model/SelectHelper.php
+++ b/lib/Model/SelectHelper.php
@@ -90,6 +90,7 @@ class SelectHelper {
 			->addSelect($alias . 'call_id')
 			->addSelect($alias . 'state')
 			->addSelect($alias . 'unread_messages')
+			->addSelect($alias . 'last_attendee_activity')
 			->selectAlias($alias . 'id', 'a_id');
 	}
 

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -145,6 +145,7 @@ class ParticipantService {
 			$attendee->setPermissions(Attendee::PERMISSIONS_DEFAULT);
 		}
 
+		$attendee->setLastAttendeeActivity($this->timeFactory->getTime());
 		$this->attendeeMapper->update($attendee);
 
 		// XOR so we don't move the participant in and out when they are changed from moderator to owner or vice-versa
@@ -232,6 +233,7 @@ class ParticipantService {
 		if ($attendee->getParticipantType() === Participant::USER_SELF_JOINED) {
 			$attendee->setParticipantType(Participant::USER);
 		}
+		$attendee->setLastAttendeeActivity($this->timeFactory->getTime());
 		$this->attendeeMapper->update($attendee);
 
 		$event = new ParticipantModifiedEvent($room, $participant, AParticipantModifiedEvent::PROPERTY_PERMISSIONS, $newPermissions, $oldPermissions);
@@ -247,6 +249,7 @@ class ParticipantService {
 	public function updateLastReadMessage(Participant $participant, int $lastReadMessage): void {
 		$attendee = $participant->getAttendee();
 		$attendee->setLastReadMessage($lastReadMessage);
+		$attendee->setLastAttendeeActivity($this->timeFactory->getTime());
 		$this->attendeeMapper->update($attendee);
 	}
 
@@ -256,12 +259,14 @@ class ParticipantService {
 		$attendee->setLastReadMessage($lastReadMessageId);
 		$attendee->setLastMentionMessage($hasMention ? 1 : 0);
 		$attendee->setLastMentionDirect($hadDirectMention ? 1 : 0);
+		$attendee->setLastAttendeeActivity($this->timeFactory->getTime());
 		$this->attendeeMapper->update($attendee);
 	}
 
 	public function updateFavoriteStatus(Participant $participant, bool $isFavorite): void {
 		$attendee = $participant->getAttendee();
 		$attendee->setFavorite($isFavorite);
+		$attendee->setLastAttendeeActivity($this->timeFactory->getTime());
 		$this->attendeeMapper->update($attendee);
 	}
 
@@ -281,6 +286,7 @@ class ParticipantService {
 
 		$attendee = $participant->getAttendee();
 		$attendee->setNotificationLevel($level);
+		$attendee->setLastAttendeeActivity($this->timeFactory->getTime());
 		$this->attendeeMapper->update($attendee);
 	}
 
@@ -298,6 +304,7 @@ class ParticipantService {
 
 		$attendee = $participant->getAttendee();
 		$attendee->setNotificationCalls($level);
+		$attendee->setLastAttendeeActivity($this->timeFactory->getTime());
 		$this->attendeeMapper->update($attendee);
 	}
 
@@ -794,6 +801,7 @@ class ParticipantService {
 			&& ($attendee->getActorType() === Attendee::ACTOR_USERS || $attendee->getActorType() === Attendee::ACTOR_EMAILS)
 			&& !$attendee->getPin()) {
 			$attendee->setPin($this->generatePin());
+			$attendee->setLastAttendeeActivity($this->timeFactory->getTime());
 			$this->attendeeMapper->update($attendee);
 		}
 	}
@@ -1330,6 +1338,7 @@ class ParticipantService {
 			->set('last_read_message', $update->createNamedParameter(0, IQueryBuilder::PARAM_INT))
 			->set('last_mention_message', $update->createNamedParameter(0, IQueryBuilder::PARAM_INT))
 			->set('last_mention_direct', $update->createNamedParameter(0, IQueryBuilder::PARAM_INT))
+			->set('last_attendee_activity', $update->createNamedParameter($this->timeFactory->getTime(), IQueryBuilder::PARAM_INT))
 			->where($update->expr()->eq('room_id', $update->createNamedParameter($room->getId(), IQueryBuilder::PARAM_INT)));
 		$update->executeStatement();
 	}

--- a/tests/integration/features/chat-2/unread-messages.feature
+++ b/tests/integration/features/chat-2/unread-messages.feature
@@ -148,9 +148,24 @@ Feature: chat-2/unread-messages
     And user "participant1" sends message "Message 1" to room "group room" with 201
     And user "participant1" sends message "Message 2" to room "group room" with 201
     And user "participant1" sends message "Message 3" to room "group room" with 201
+    Then user "participant2" is participant of the following rooms (v4)
+      | id         | unreadMessages |
+      | group room | 3              |
+    And wait for 2 seconds
+    Then user "participant2" is participant of the following modified-since rooms (v4)
     And user "participant2" reads message "Message 3" in room "group room" with 200
+    And wait for 2 seconds
+    Then user "participant2" is participant of the following modified-since rooms (v4)
+      | id         | unreadMessages |
+      | group room | 0              |
+    Then user "participant2" is participant of the following modified-since rooms (v4)
     When user "participant1" marks room "group room" as unread with 200
     And user "participant2" marks room "group room" as unread with 200
+    And wait for 2 seconds
+    Then user "participant2" is participant of the following modified-since rooms (v4)
+      | id         | unreadMessages |
+      | group room | 1              |
+    Then user "participant2" is participant of the following modified-since rooms (v4)
     Then user "participant1" is participant of room "group room" (v4)
       | unreadMessages |
       | 1              |

--- a/tests/php/Chat/ChatManagerTest.php
+++ b/tests/php/Chat/ChatManagerTest.php
@@ -432,6 +432,7 @@ class ChatManagerTest extends TestCase {
 			'invited_cloud_id' => '',
 			'state' => Invitation::STATE_ACCEPTED,
 			'unread_messages' => 0,
+			'last_attendee_activity' => 0,
 		]);
 		$chat = $this->createMock(Room::class);
 		$chat->expects($this->any())
@@ -493,6 +494,7 @@ class ChatManagerTest extends TestCase {
 			'invited_cloud_id' => '',
 			'state' => Invitation::STATE_ACCEPTED,
 			'unread_messages' => 0,
+			'last_attendee_activity' => 0,
 		]);
 		$chat = $this->createMock(Room::class);
 		$chat->expects($this->any())
@@ -576,6 +578,7 @@ class ChatManagerTest extends TestCase {
 			'invited_cloud_id' => '',
 			'state' => Invitation::STATE_ACCEPTED,
 			'unread_messages' => 0,
+			'last_attendee_activity' => 0,
 		]);
 		$chat = $this->createMock(Room::class);
 		$chat->expects($this->any())


### PR DESCRIPTION
…tendee info changes

E.g. favorite, read-marker, notification settings, …

Fix #9590

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
