### PR TITLE
fix(media): make an early request for userMedia to get permissions

### DIFF
--- a/src/composables/useDevices.js
+++ b/src/composables/useDevices.js
@@ -158,6 +158,17 @@ export function useDevices(video, initializeOnMounted) {
 			}
 		}
 
+		// Attempt to request permissions for camera and microphone
+		mediaDevicesManager.getUserMedia({ audio: true, video: true })
+			.then(stream => {
+				stream.getTracks().forEach(track => track.stop())
+			})
+			.catch(error => {
+				console.error('Error getting audio/video streams: ' + error.name + ': ' + error.message)
+				audioStreamError.value = error
+				videoStreamError.value = error
+			})
+
 		mediaDevicesManager.enableDeviceEvents()
 		updateAudioStream()
 		updateVideoStream()


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12122
 * initialisation is supposed to call getUserMedia in `updateAudioStream` and `updateVideoStream` separately for each device, but as it's a first attempt, we don't have a selected audioInputId or videoInputId, therefore -> early return
  * now we request permissions for both inputs at once beforehand, so don't have to wait several seconds for the second device
  * if permissions were reset at some point, and should be granted again, now media devices are selected correctly from preferences list


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/d2aed0d0-00dc-40e3-a53b-56c3d76d21be) | ![image](https://github.com/nextcloud/spreed/assets/93392545/ca621568-7324-4050-9e1f-9b34de65e8b1)

<!--
### 🚧 Tasks

- [ ] ...
-->

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possible