### PR TITLE
fix(PublicShareSidebar): fix prop reactivity

### DIFF
--- a/src/mainPublicShareSidebar.js
+++ b/src/mainPublicShareSidebar.js
@@ -19,7 +19,7 @@
  */
 
 import { createPinia, PiniaVuePlugin } from 'pinia'
-import Vue from 'vue'
+import Vue, { reactive } from 'vue'
 import VueObserveVisibility from 'vue-observe-visibility'
 import vOutsideEvents from 'vue-outside-events'
 import VueShortKey from 'vue-shortkey'
@@ -84,9 +84,9 @@ adjustLayout()
 // An "isOpen" boolean should be passed to the component, but as it is a
 // primitive it would not be reactive; it needs to be wrapped in an object and
 // that object passed to the component to get reactivity.
-const sidebarState = {
+const sidebarState = reactive({
 	isOpen: false,
-}
+})
 
 // Open the sidebar by default based on the window width using the same
 // threshold as in the main Talk UI (in Talk 7).


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12132

Vue was not tracking the object changes in computed ( though in prop, it was changed), which means it's not reactive. 

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

