### PR TITLE
fix(chat): show iconSvgInline in attachments

### DIFF
--- a/src/components/NewMessage/NewMessageAttachments.vue
+++ b/src/components/NewMessage/NewMessageAttachments.vue
@@ -56,6 +56,9 @@
 				close-after-click
 				:icon="provider.iconClass"
 				@click="$emit('update-new-file-dialog', index)">
+				<template v-if="provider.iconSvgInline" #icon>
+					<NcIconSvgWrapper :svg="provider.iconSvgInline" :size="20" />
+				</template>
 				{{ provider.label }}
 			</NcActionButton>
 		</template>
@@ -79,6 +82,7 @@ import Upload from 'vue-material-design-icons/Upload.vue'
 
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
+import NcIconSvgWrapper from '@nextcloud/vue/dist/Components/NcIconSvgWrapper.js'
 
 export default {
 	name: 'NewMessageAttachments',
@@ -86,6 +90,7 @@ export default {
 	components: {
 		NcActionButton,
 		NcActions,
+		NcIconSvgWrapper,
 		// Icons
 		Folder,
 		Paperclip,


### PR DESCRIPTION
### ☑️ Resolves

* Fix: icon is not shown for some attachments 
* Fix: https://github.com/nextcloud/talk-desktop/issues/63
* See: https://github.com/nextcloud/server/blob/a86c1131d7092b4abb1abac8a55f2e71f7a2bbaa/apps/files/lib/ResponseDefinitions.php#L42-L52

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/25978914/7256f3e0-364d-470d-acf7-b753b20eccbf) | ![image](https://github.com/nextcloud/spreed/assets/25978914/4711977c-670b-446a-9252-56164f8c9097)

### 🚧 Tasks

- [ ] Show `provider.iconSvgInline` if it is available instead of `provider.iconClass`

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required


