### PR TITLE
fix(MessagesList): make sure to compare numeric values

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -425,7 +425,7 @@ export default {
 			Object.entries(newGroups).forEach(([id, newGroup]) => {
 				if (!oldGroups[id]) {
 					const oldId = Object.keys(oldGroups)
-						.find(key => id < key && oldGroups[key].nextMessageId <= newGroup.nextMessageId)
+						.find(key => +id < +key && oldGroups[key].nextMessageId <= newGroup.nextMessageId)
 					if (oldId) {
 						// newGroup includes oldGroup and more old messages, remove oldGroup
 						delete this.messagesGroupedByDateByAuthor[dateTimestamp][oldId]


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #11702
* It turns out, that `'226' < '55'` is true

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![Screenshot from 2024-04-17 15-15-34](https://github.com/nextcloud/spreed/assets/93392545/9da6f175-7bb9-43d7-8663-54606bdcb8eb) | ![image](https://github.com/nextcloud/spreed/assets/93392545/3ece49ff-3d97-49a8-a96d-ea400075c985)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possibl