### PR TITLE
fix(media): improve the default selection before preferences

### DIFF
--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -489,6 +489,11 @@ export default {
 	mounted() {
 		subscribe('talk:media-settings:show', this.showModal)
 		subscribe('talk:media-settings:hide', this.closeModalAndApplySettings)
+
+		const devicesPreferred = BrowserStorage.getItem('devicesPreferred')
+		if (!devicesPreferred) {
+			this.tabContent = 'devices'
+		}
 	},
 
 	beforeDestroy() {

--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -267,6 +267,12 @@ MediaDevicesManager.prototype = {
 			this._preferenceVideoInputList = newVideoInputList
 			BrowserStorage.setItem('videoInputPreferences', JSON.stringify(newVideoInputList))
 		}
+
+		const devicesPreferred = BrowserStorage.getItem('devicesPreferred')
+		if (!devicesPreferred) {
+			BrowserStorage.setItem('devicesPreferred', true)
+		}
+
 	},
 
 	/**


### PR DESCRIPTION
### ☑️ Resolves

- It shows Devices section when no preferences are set yet
- It fixes the issue when there is no prefs yet, no device is selected.

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

---