### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "c8c98085481bc485e101b0992f808bf82df705f7"
+                "reference": "dea7e6cd566796f983ef54bafaba860f529116f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/c8c98085481bc485e101b0992f808bf82df705f7",
-                "reference": "c8c98085481bc485e101b0992f808bf82df705f7",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/dea7e6cd566796f983ef54bafaba860f529116f3",
+                "reference": "dea7e6cd566796f983ef54bafaba860f529116f3",
                 "shasum": ""
             },
             "require": {
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-04-15T07:27:17+00:00"
+            "time": "2024-04-18T10:48:36+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency