### PR TITLE
fix(media): Fix initial selection of devices

### DIFF
--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -209,12 +209,18 @@ MediaDevicesManager.prototype = {
 
 			// Selecting preferred device in case it was removed/unplugged, or it is a first initialization after reload,
 			// or we add/plug preferred device and overwriting automatic selection
+			// If the preference list is empty the default device falls back to
+			// the first device of that kind found. This can happen, for
+			// example, when no permissions were given yet. In that case,
+			// according to the spec, a single device of each kind (if at least
+			// one device of that kind is available) with an empty deviceId is
+			// returned, which will not be registered in the preference list.
 			if (this.attributes.audioInputId === undefined || this.attributes.audioInputId === previousFirstAvailableAudioInputId) {
-				this.attributes.audioInputId = getFirstAvailableMediaDevice(devices, this._preferenceAudioInputList)
+				this.attributes.audioInputId = getFirstAvailableMediaDevice(devices, this._preferenceAudioInputList) || devices.find(device => device.kind === 'audioinput')?.deviceId
 				console.debug(listMediaDevices(this.attributes, this._preferenceAudioInputList, this._preferenceVideoInputList))
 			}
 			if (this.attributes.videoInputId === undefined || this.attributes.videoInputId === previousFirstAvailableVideoInputId) {
-				this.attributes.videoInputId = getFirstAvailableMediaDevice(devices, this._preferenceVideoInputList)
+				this.attributes.videoInputId = getFirstAvailableMediaDevice(devices, this._preferenceVideoInputList) || devices.find(device => device.kind === 'videoinput')?.deviceId
 				console.debug(listMediaDevices(this.attributes, this._preferenceAudioInputList, this._preferenceVideoInputList))
 			}
 

--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -205,6 +205,8 @@ MediaDevicesManager.prototype = {
 				this._addDevice(addedDevice)
 			})
 
+			this._populatePreferences(devices)
+
 			// Selecting preferred device in case it was removed/unplugged, or it is a first initialization after reload,
 			// or we add/plug preferred device and overwriting automatic selection
 			if (this.attributes.audioInputId === undefined || this.attributes.audioInputId === previousFirstAvailableAudioInputId) {
@@ -226,8 +228,6 @@ MediaDevicesManager.prototype = {
 			}
 
 			this._pendingEnumerateDevicesPromise = null
-
-			this._populatePreferences(devices)
 		}).catch(function(error) {
 			console.error('Could not update known media devices: ' + error.name + ': ' + error.message)
 


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/spreed/pull/12108

@DorraJaouad After being working on this for quite some time I saw that [you fixed it](https://github.com/nextcloud/spreed/pull/12146) several hours ago already :cry:

Nevertheless, I took the freedom to push my version anyway as it also handles a special behaviour of Chromium*, and it is a pure fix rather than including an enhancement (showing the devices section when no preferences are set yet). While I think it that is a nice feature I would prefer to see the issue fixed first to then focus on the improvements :-) (specially given that the RC is so close).

*Actually it is in the spec, it is just that Firefox does not implement it yet, but [I forgot about it](https://github.com/nextcloud/spreed/commit/ec7fa54fafb326c111ce7a8c61a6d8e3b46c4093) :facepalm: Thanks @Antreesy for the digging :-)

## How to test
- Create a public conversation
- In a private window, open the conversation
- Show the media settings

### Result with this pull request

The media permissions are requested for and the first available devices selected and started

### Result without this pull request

The media permissions are not requested; no devices are selected nor started. Additionally, if the devices tab is shown you first need to choose _None_ and then a device for the permissions to be requested, just selecting the first device (_Default_ in Chromium) is not enough.