### PR TITLE
fix(MessageBody): restrict checkbox editing in one-to-one conversation

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -519,9 +519,14 @@ export default {
 			return !this.isConversationReadOnly && this.conversation.participantType !== PARTICIPANT.TYPE.GUEST
 		},
 
+		isOneToOne() {
+			return this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE
+				|| this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER
+		},
+
 		isEditable() {
 			if (!canEditMessage || !this.isModifiable || this.isObjectShare
-					|| (!this.$store.getters.isModerator && !this.isMyMsg)) {
+					|| ((!this.$store.getters.isModerator || this.isOneToOne) && !this.isMyMsg)) {
 				return false
 			}
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -320,9 +320,14 @@ export default {
 				&& this.actorType === this.$store.getters.getActorType()
 		},
 
+		isOneToOne() {
+			return this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE
+				|| this.conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER
+		},
+
 		isEditable() {
 			if (!canEditMessage || !this.isModifiable || this.isObjectShare
-				|| (!this.$store.getters.isModerator && !this.isMyMsg)) {
+				|| ((!this.$store.getters.isModerator || this.isOneToOne) && !this.isMyMsg)) {
 				return false
 			}
 


### PR DESCRIPTION
### ☑️ Resolves

Checkboxes should be disabled in other user messages for one to one conversation.

![image](https://github.com/nextcloud/spreed/assets/93392545/522ce552-c347-491c-abb6-ac1d148a788e)


<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
