### PR TITLE
fix(MessageBody): pass actorId and actorType as props to the component

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -184,6 +184,14 @@ export default {
 			type: String,
 			required: true,
 		},
+		actorId: {
+			type: String,
+			required: true,
+		},
+		actorType: {
+			type: String,
+			required: true,
+		},
 		parent: {
 			type: Object,
 			default: undefined,


### PR DESCRIPTION
### ☑️ Resolves

* Pass actorId and actorType to MessageBody as props (not attrs)
* Allows to correctly check for message ownership

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 