### PR TITLE
fix(NewMessage): clear debounce queue when posting a message

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -660,6 +660,7 @@ export default {
 			}
 
 			// Clear input content from store
+			this.debouncedUpdateChatInput.clear()
 			this.chatExtrasStore.removeChatInput(this.token)
 
 			if (this.upload) {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12061
  * after typing and hitting enter, debounces update of store (200 ms), might still be in the queue, we need to clear it from there

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before

[Screencast from 22.04.2024 09:15:08.webm](https://github.com/nextcloud/spreed/assets/93392545/7c4584cf-324b-4c7e-8ccc-cee2723494c4)

🏡 After

[Screencast from 22.04.2024 09:18:29.webm](https://github.com/nextcloud/spreed/assets/93392545/e775c587-c840-4461-94dc-de04eb6665bf)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possible
