### PR TITLE
fix(messagesStore): compare message ids as numeric values

### DIFF
--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -504,15 +504,15 @@ const mutations = {
 			return
 		}
 
-		const messagesToRemove = messageIds.sort().reverse().slice(199)
+		const messagesToRemove = messageIds.sort((a, b) => b - a).slice(199)
 		const newFirstKnown = messagesToRemove.shift()
 
 		messagesToRemove.forEach((messageId) => {
 			Vue.delete(state.messages[token], messageId)
 		})
 
-		if (state.firstKnown[token] && messagesToRemove.includes(state.firstKnown[token])) {
-			Vue.set(state.firstKnown, token, newFirstKnown)
+		if (state.firstKnown[token] && messagesToRemove.includes(state.firstKnown[token].toString())) {
+			Vue.set(state.firstKnown, token, +newFirstKnown)
 		}
 	},
 }


### PR DESCRIPTION
### ☑️ Resolves

* Ref #11994
  * Not sure if that fixes this issue, but should fix another:

```js
const messageIds = Object.keys(state.messages[token])
// Array<string>
...
const messagesToRemove = messageIds.sort().reverse().slice(199)
// Sort strings by characters, so '100' < '99'
...
if (state.firstKnown[token] && messagesToRemove.includes(state.firstKnown[token]))
// state.firstKnown[token] is number, so Array<string>.includes(number) is always false
```

Because of that, firstKnown is not updated after list, and after opening the chat again, user couldn't load old messages 

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possible