### PR TITLE
fix(MediaSettings): sync preferences with devices direct selection

### DIFF
--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -92,12 +92,12 @@
 					:devices="devices"
 					:device-id="audioInputId"
 					@refresh="updateDevices"
-					@update:deviceId="audioInputId = $event" />
+					@update:deviceId="handleAudioInputIdChange" />
 				<MediaDevicesSelector kind="videoinput"
 					:devices="devices"
 					:device-id="videoInputId"
 					@refresh="updateDevices"
-					@update:deviceId="videoInputId = $event" />
+					@update:deviceId="handleVideoInputIdChange" />
 				<MediaDevicesSpeakerTest />
 			</div>
 
@@ -312,7 +312,6 @@ export default {
 			videoOn: undefined,
 			silentCall: false,
 			updatedBackground: undefined,
-			deviceIdChanged: false,
 			audioDeviceStateChanged: false,
 			videoDeviceStateChanged: false,
 			isRecordingFromStart: false,
@@ -422,7 +421,7 @@ export default {
 		},
 
 		showUpdateChangesButton() {
-			return this.updatedBackground || this.deviceIdChanged || this.audioDeviceStateChanged
+			return this.updatedBackground || this.audioDeviceStateChanged
 				|| this.videoDeviceStateChanged
 		},
 	},
@@ -452,14 +451,12 @@ export default {
 		},
 
 		audioInputId(audioInputId) {
-			this.deviceIdChanged = true
 			if (this.showDeviceSelection && audioInputId && !this.audioOn) {
 				this.toggleAudio()
 			}
 		},
 
 		videoInputId(videoInputId) {
-			this.deviceIdChanged = true
 			if (this.showDeviceSelection && videoInputId && !this.videoOn) {
 				this.toggleVideo()
 			}
@@ -495,7 +492,6 @@ export default {
 		closeModal() {
 			this.modal = false
 			this.updatedBackground = undefined
-			this.deviceIdChanged = false
 			this.audioDeviceStateChanged = false
 			this.videoDeviceStateChanged = false
 			this.isPublicShareAuthSidebar = false
@@ -544,7 +540,6 @@ export default {
 				emit('local-video-control-button:toggle-video')
 			}
 
-			this.updatePreferences()
 			this.closeModal()
 		},
 
@@ -655,7 +650,21 @@ export default {
 
 		setRecordingConsentGiven(value) {
 			this.$emit('update:recording-consent-given', value)
-		}
+		},
+
+		handleAudioInputIdChange(audioInputId) {
+			this.audioInputId = audioInputId
+			if (audioInputId !== null) {
+				this.updatePreferences()
+			}
+		},
+
+		handleVideoInputIdChange(videoInputId) {
+			this.videoInputId = videoInputId
+			if (videoInputId !== null) {
+				this.updatePreferences()
+			}
+		},
 	},
 }
 </script>

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -473,11 +473,6 @@ export default {
 	mounted() {
 		subscribe('talk:media-settings:show', this.showModal)
 		subscribe('talk:media-settings:hide', this.closeModalAndApplySettings)
-
-		const devicesPreferred = BrowserStorage.getItem('devicesPreferred')
-		if (!devicesPreferred) {
-			this.tabContent = 'devices'
-		}
 	},
 
 	beforeDestroy() {
@@ -490,6 +485,10 @@ export default {
 			this.modal = true
 			if (page === 'video-verification') {
 				this.isPublicShareAuthSidebar = true
+			}
+
+			if (!BrowserStorage.getItem('devicesPreferred')) {
+				this.tabContent = 'devices'
 			}
 		},
 

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -674,6 +674,7 @@ export default {
 <style lang="scss" scoped>
 .media-settings {
 	padding: calc(var(--default-grid-baseline) * 5);
+	padding-bottom: 0;
 
 	&__title {
 		text-align: center;
@@ -723,9 +724,14 @@ export default {
 
 	&__call-buttons {
 		display: flex;
+		z-index: 1;
 		align-items: center;
 		justify-content: center;
 		gap: var(--default-grid-baseline);
+		position: sticky;
+		bottom: 0;
+		background-color: var(--color-main-background);
+		padding: 10px 0 20px;
 	}
 }
 

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -484,7 +484,7 @@ export default {
 				this.isPublicShareAuthSidebar = true
 			}
 
-			if (!BrowserStorage.getItem('devicesPreferred')) {
+			if (!BrowserStorage.getItem('audioInputDevicePreferred') || !BrowserStorage.getItem('videoInputDevicePreferred')) {
 				this.tabContent = 'devices'
 			}
 		},
@@ -654,16 +654,12 @@ export default {
 
 		handleAudioInputIdChange(audioInputId) {
 			this.audioInputId = audioInputId
-			if (audioInputId !== null) {
-				this.updatePreferences()
-			}
+			this.updatePreferences('audioinput')
 		},
 
 		handleVideoInputIdChange(videoInputId) {
 			this.videoInputId = videoInputId
-			if (videoInputId !== null) {
-				this.updatePreferences()
-			}
+			this.updatePreferences('videoinput')
 		},
 	},
 }

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -470,6 +470,12 @@ export default {
 	mounted() {
 		subscribe('talk:media-settings:show', this.showModal)
 		subscribe('talk:media-settings:hide', this.closeModalAndApplySettings)
+
+		// FIXME: this is a workaround to remove the old key from the browser storage
+		// To be removed in the future
+		if (BrowserStorage.getItem('devicesPreferred')) {
+			BrowserStorage.removeItem('devicesPreferred')
+		}
 	},
 
 	beforeDestroy() {

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -502,6 +502,9 @@ export default {
 			this.videoDeviceStateChanged = false
 			this.isPublicShareAuthSidebar = false
 			this.isRecordingFromStart = false
+			// Update devices preferences
+			this.updatePreferences('audioinput')
+			this.updatePreferences('videoinput')
 		},
 
 		toggleAudio() {

--- a/src/components/SettingsDialog/MediaDevicesPreview.vue
+++ b/src/components/SettingsDialog/MediaDevicesPreview.vue
@@ -9,7 +9,7 @@
 			:devices="devices"
 			:device-id="audioInputId"
 			@refresh="updateDevices"
-			@update:deviceId="audioInputId = $event" />
+			@update:deviceId="handleAudioInputIdChange" />
 		<div class="preview preview-audio">
 			<div v-if="!audioPreviewAvailable"
 				class="preview-not-available">
@@ -38,7 +38,7 @@
 			:devices="devices"
 			:device-id="videoInputId"
 			@refresh="updateDevices"
-			@update:deviceId="videoInputId = $event" />
+			@update:deviceId="handleVideoInputIdChange" />
 		<div class="preview preview-video">
 			<div v-if="!videoPreviewAvailable"
 				class="preview-not-available">
@@ -95,6 +95,7 @@ export default {
 		const {
 			devices,
 			updateDevices,
+			updatePreferences,
 			currentVolume,
 			currentThreshold,
 			audioPreviewAvailable,
@@ -111,6 +112,7 @@ export default {
 			video,
 			devices,
 			updateDevices,
+			updatePreferences,
 			currentVolume,
 			currentThreshold,
 			audioPreviewAvailable,
@@ -176,7 +178,24 @@ export default {
 
 			return t('spreed', 'Error while accessing camera')
 		},
-	}
+	},
+
+	methods: {
+		handleAudioInputIdChange(audioInputId) {
+			this.audioInputId = audioInputId
+			if (audioInputId !== null) {
+				this.updatePreferences()
+			}
+		},
+
+		handleVideoInputIdChange(videoInputId) {
+			this.videoInputId = videoInputId
+			if (videoInputId !== null) {
+				this.updatePreferences()
+			}
+		},
+
+	},
 }
 </script>
 

--- a/src/components/SettingsDialog/MediaDevicesPreview.vue
+++ b/src/components/SettingsDialog/MediaDevicesPreview.vue
@@ -183,16 +183,12 @@ export default {
 	methods: {
 		handleAudioInputIdChange(audioInputId) {
 			this.audioInputId = audioInputId
-			if (audioInputId !== null) {
-				this.updatePreferences()
-			}
+			this.updatePreferences('audioinput')
 		},
 
 		handleVideoInputIdChange(videoInputId) {
 			this.videoInputId = videoInputId
-			if (videoInputId !== null) {
-				this.updatePreferences()
-			}
+			this.updatePreferences('videoinput')
 		},
 
 	},

--- a/src/composables/useDevices.js
+++ b/src/composables/useDevices.js
@@ -155,10 +155,11 @@ export function useDevices(video, initializeOnMounted) {
 
 	/**
 	 * Update preference counters for devices (audio and video)
+	 * @param {string} kind the kind of the input stream to update ('audioinput' or 'videoinput')
 	 * @public
 	 */
-	function updatePreferences() {
-		mediaDevicesManager.updatePreferences()
+	function updatePreferences(kind) {
+		mediaDevicesManager.updatePreferences(kind)
 	}
 
 	/**

--- a/src/services/__tests__/mediaDevicePreferences.spec.js
+++ b/src/services/__tests__/mediaDevicePreferences.spec.js
@@ -6,7 +6,7 @@ import {
 	getFirstAvailableMediaDevice,
 	listMediaDevices,
 	populateMediaDevicesPreferences,
-	updateMediaDevicesPreferences,
+	promoteMediaDevice,
 } from '../mediaDevicePreferences.ts'
 
 describe('mediaDevicePreferences', () => {
@@ -122,42 +122,38 @@ describe('mediaDevicePreferences', () => {
 		})
 	})
 
-	describe('updateMediaDevicesPreferences', () => {
+	describe('promoteMediaDevice', () => {
 		it('returns null if preference lists were not updated (no id or default id provided)', () => {
 			const ids = [null, undefined, 'default']
 
 			const getOutput = (id) => {
-				const attributes = { devices: allDevices, audioInputId: id, videoInputId: id }
-				return updateMediaDevicesPreferences(attributes, audioInputPreferenceList, videoInputPreferenceList)
+				const attributes = { devices: allDevices, audioInputId: id }
+				return promoteMediaDevice('audioinput', attributes.devices, audioInputPreferenceList, attributes.audioInputId)
 			}
 
 			// Assert
 			ids.forEach(id => {
-				expect(getOutput(id)).toMatchObject({ newAudioInputList: null, newVideoInputList: null })
+				expect(getOutput(id)).toEqual(null)
 			})
 		})
 
 		it('returns updated preference lists (device A id provided)', () => {
-			const attributes = { devices: allDevices, audioInputId: audioInputDeviceA.deviceId, videoInputId: videoInputDeviceA.deviceId }
-			const output = updateMediaDevicesPreferences(attributes, audioInputPreferenceList, videoInputPreferenceList)
+			const attributes = { devices: allDevices, audioInputId: audioInputDeviceA.deviceId }
+			const output = promoteMediaDevice('audioinput', attributes.devices, audioInputPreferenceList, attributes.audioInputId)
 
 			// Assert: should put device A on top of default device
-			expect(output).toMatchObject({
-				newAudioInputList: [audioInputDeviceA, audioInputDeviceDefault, audioInputDeviceB],
-				newVideoInputList: [videoInputDeviceA, videoInputDeviceDefault, videoInputDeviceB],
-			})
+			expect(output).toEqual([audioInputDeviceA, audioInputDeviceDefault, audioInputDeviceB])
 		})
 
 		it('returns null if preference lists were not updated (device A id provided but not available)', () => {
 			const attributes = {
 				devices: allDevices.filter(device => !['da1234567890', 'da4567890123'].includes(device.deviceId)),
 				audioInputId: audioInputDeviceA.deviceId,
-				videoInputId: videoInputDeviceA.deviceId,
 			}
-			const output = updateMediaDevicesPreferences(attributes, audioInputPreferenceList, videoInputPreferenceList)
+			const output = promoteMediaDevice('audioinput', attributes.devices, audioInputPreferenceList, attributes.audioInputId)
 
 			// Assert
-			expect(output).toMatchObject({ newAudioInputList: null, newVideoInputList: null })
+			expect(output).toEqual(null)
 		})
 
 		it('returns null if preference lists were not updated (all devices are not available)', () => {
@@ -166,29 +162,22 @@ describe('mediaDevicePreferences', () => {
 				audioInputId: audioInputDeviceA.deviceId,
 				videoInputId: videoInputDeviceA.deviceId,
 			}
-			const output = updateMediaDevicesPreferences(attributes, audioInputPreferenceList, videoInputPreferenceList)
+			const output = promoteMediaDevice('audioinput', attributes.devices, audioInputPreferenceList, attributes.audioInputId)
 
 			// Assert
-			expect(output).toMatchObject({ newAudioInputList: null, newVideoInputList: null })
+			expect(output).toEqual(null)
 		})
 
 		it('returns updated preference lists (device B id provided, but not registered, default device and device A not available)', () => {
 			const attributes = {
 				devices: allDevices.filter(device => !['default', 'da1234567890', 'da4567890123'].includes(device.deviceId)),
 				audioInputId: audioInputDeviceB.deviceId,
-				videoInputId: videoInputDeviceB.deviceId,
 			}
-			const output = updateMediaDevicesPreferences(
-				attributes,
-				[audioInputDeviceDefault, audioInputDeviceA],
-				[videoInputDeviceDefault, videoInputDeviceA],
-			)
+
+			const output = promoteMediaDevice('audioinput', attributes.devices, [audioInputDeviceDefault, audioInputDeviceA], attributes.audioInputId)
 
 			// Assert: should put device C on top of device B, but not the device A
-			expect(output).toMatchObject({
-				newAudioInputList: [audioInputDeviceDefault, audioInputDeviceA, audioInputDeviceB],
-				newVideoInputList: [videoInputDeviceDefault, videoInputDeviceA, videoInputDeviceB],
-			})
+			expect(output).toEqual([audioInputDeviceDefault, audioInputDeviceA, audioInputDeviceB])
 		})
 	})
 })

--- a/src/services/__tests__/mediaDevicePreferences.spec.js
+++ b/src/services/__tests__/mediaDevicePreferences.spec.js
@@ -127,8 +127,12 @@ describe('mediaDevicePreferences', () => {
 			const ids = [null, undefined, 'default']
 
 			const getOutput = (id) => {
-				const attributes = { devices: allDevices, audioInputId: id }
-				return promoteMediaDevice('audioinput', attributes.devices, audioInputPreferenceList, attributes.audioInputId)
+				return promoteMediaDevice({
+					kind: 'audioinput',
+					devices: allDevices,
+					inputList: audioInputPreferenceList,
+					inputId: id
+				})
 			}
 
 			// Assert
@@ -138,43 +142,48 @@ describe('mediaDevicePreferences', () => {
 		})
 
 		it('returns updated preference lists (device A id provided)', () => {
-			const attributes = { devices: allDevices, audioInputId: audioInputDeviceA.deviceId }
-			const output = promoteMediaDevice('audioinput', attributes.devices, audioInputPreferenceList, attributes.audioInputId)
+			const output = promoteMediaDevice({
+				kind: 'audioinput',
+				devices: allDevices,
+				inputList: audioInputPreferenceList,
+				inputId: audioInputDeviceA.deviceId
+			})
 
 			// Assert: should put device A on top of default device
 			expect(output).toEqual([audioInputDeviceA, audioInputDeviceDefault, audioInputDeviceB])
 		})
 
 		it('returns null if preference lists were not updated (device A id provided but not available)', () => {
-			const attributes = {
+			const output = promoteMediaDevice({
+				kind: 'audioinput',
 				devices: allDevices.filter(device => !['da1234567890', 'da4567890123'].includes(device.deviceId)),
-				audioInputId: audioInputDeviceA.deviceId,
-			}
-			const output = promoteMediaDevice('audioinput', attributes.devices, audioInputPreferenceList, attributes.audioInputId)
+				inputList: audioInputPreferenceList,
+				inputId: audioInputDeviceA.deviceId
+			})
 
 			// Assert
 			expect(output).toEqual(null)
 		})
 
 		it('returns null if preference lists were not updated (all devices are not available)', () => {
-			const attributes = {
+			const output = promoteMediaDevice({
+				kind: 'audioinput',
 				devices: allDevices.filter(device => !['audioinput', 'videoinput'].includes(device.kind)),
-				audioInputId: audioInputDeviceA.deviceId,
-				videoInputId: videoInputDeviceA.deviceId,
-			}
-			const output = promoteMediaDevice('audioinput', attributes.devices, audioInputPreferenceList, attributes.audioInputId)
+				inputList: audioInputPreferenceList,
+				inputId: audioInputDeviceA.deviceId
+			})
 
 			// Assert
 			expect(output).toEqual(null)
 		})
 
 		it('returns updated preference lists (device B id provided, but not registered, default device and device A not available)', () => {
-			const attributes = {
+			const output = promoteMediaDevice({
+				kind: 'audioinput',
 				devices: allDevices.filter(device => !['default', 'da1234567890', 'da4567890123'].includes(device.deviceId)),
-				audioInputId: audioInputDeviceB.deviceId,
-			}
-
-			const output = promoteMediaDevice('audioinput', attributes.devices, [audioInputDeviceDefault, audioInputDeviceA], attributes.audioInputId)
+				inputList: [audioInputDeviceDefault, audioInputDeviceA],
+				inputId: audioInputDeviceB.deviceId
+			})
 
 			// Assert: should put device C on top of device B, but not the device A
 			expect(output).toEqual([audioInputDeviceDefault, audioInputDeviceA, audioInputDeviceB])

--- a/src/services/mediaDevicePreferences.ts
+++ b/src/services/mediaDevicePreferences.ts
@@ -164,27 +164,9 @@ function populateMediaDevicesPreferences(devices: MediaDeviceInfo[], audioInputL
 	}
 }
 
-/**
- * Update devices preferences. Assuming that preferred devices were selected, should be called after applying the selection:
- * so either with joining the call or changing device during the call
- *
- * Returns changed preference lists for audio / video devices (null, if it hasn't been changed)
- *
- * @param attributes MediaDeviceManager attributes
- * @param audioInputList list of registered audio devices in order of preference
- * @param videoInputList list of registered video devices in order of preference
- * @return {InputLists} object with updated devices lists (null, if they have not been changed)
- */
-function updateMediaDevicesPreferences(attributes: Attributes, audioInputList: MediaDeviceInfo[], videoInputList: MediaDeviceInfo[]): InputLists {
-	return {
-		newAudioInputList: promoteMediaDevice(DeviceKind.AudioInput, attributes.devices, audioInputList, attributes.audioInputId),
-		newVideoInputList: promoteMediaDevice(DeviceKind.VideoInput, attributes.devices, videoInputList, attributes.videoInputId),
-	}
-}
-
 export {
 	getFirstAvailableMediaDevice,
 	listMediaDevices,
 	populateMediaDevicesPreferences,
-	updateMediaDevicesPreferences,
+	promoteMediaDevice,
 }

--- a/src/services/mediaDevicePreferences.ts
+++ b/src/services/mediaDevicePreferences.ts
@@ -21,6 +21,13 @@ enum DeviceKind {
 	AudioOutput = 'audiooutput',
 }
 
+type PromotePayload = {
+	kind: DeviceKind,
+	devices: MediaDeviceInfo[],
+	inputList: MediaDeviceInfo[],
+	inputId: InputId
+}
+
 /**
  * List all registered devices in order of their preferences
  * Show whether device is currently unplugged or selected, if information is available
@@ -90,13 +97,14 @@ function registerNewMediaDevice(device: MediaDeviceInfo, devicesList: MediaDevic
  *
  * Returns changed preference lists for audio / video devices (null, if it hasn't been changed)
  *
- * @param kind kind of device
- * @param devices list of available devices
- * @param inputList list of registered audio/video devices in order of preference
- * @param inputId id of currently selected input
+ * @param data the wrapping object
+ * @param data.kind kind of device
+ * @param data.devices list of available devices
+ * @param data.inputList list of registered audio/video devices in order of preference
+ * @param data.inputId id of currently selected input
  * @return {InputListUpdated} updated devices list (null, if it has not been changed)
  */
-function promoteMediaDevice(kind: DeviceKind, devices: MediaDeviceInfo[], inputList: MediaDeviceInfo[], inputId: InputId): InputListUpdated {
+function promoteMediaDevice({ kind, devices, inputList, inputId } : PromotePayload) : InputListUpdated {
 	if (!inputId) {
 		return null
 	}

--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -8,7 +8,7 @@ import {
 	getFirstAvailableMediaDevice,
 	listMediaDevices,
 	populateMediaDevicesPreferences,
-	updateMediaDevicesPreferences,
+	promoteMediaDevice,
 } from '../../services/mediaDevicePreferences.ts'
 import EmitterMixin from '../EmitterMixin.js'
 
@@ -247,24 +247,25 @@ MediaDevicesManager.prototype = {
 		}
 	},
 
-	updatePreferences() {
-		const { newAudioInputList, newVideoInputList } = updateMediaDevicesPreferences(
-			this.attributes,
-			this._preferenceAudioInputList,
-			this._preferenceVideoInputList,
-		)
-
-		if (newAudioInputList) {
-			this._preferenceAudioInputList = newAudioInputList
-			BrowserStorage.setItem('audioInputPreferences', JSON.stringify(newAudioInputList))
-		}
-		if (newVideoInputList) {
-			this._preferenceVideoInputList = newVideoInputList
-			BrowserStorage.setItem('videoInputPreferences', JSON.stringify(newVideoInputList))
-		}
-
-		if (!BrowserStorage.getItem('devicesPreferred')) {
-			BrowserStorage.setItem('devicesPreferred', true)
+	updatePreferences(kind) {
+		if (kind === 'audioinput') {
+			const newAudioInputList = promoteMediaDevice('audioinput', this.attributes.devices, this._preferenceAudioInputList, this.attributes.audioInputId)
+			if (newAudioInputList) {
+				this._preferenceAudioInputList = newAudioInputList
+				BrowserStorage.setItem('audioInputPreferences', JSON.stringify(newAudioInputList))
+			}
+			if (!BrowserStorage.getItem('audioInputDevicePreferred')) {
+				BrowserStorage.setItem('audioInputDevicePreferred', true)
+			}
+		} else if (kind === 'videoinput') {
+			const newVideoInputList = promoteMediaDevice('videoinput', this.attributes.devices, this._preferenceVideoInputList, this.attributes.videoInputId)
+			if (newVideoInputList) {
+				this._preferenceVideoInputList = newVideoInputList
+				BrowserStorage.setItem('videoInputPreferences', JSON.stringify(newVideoInputList))
+			}
+			if (!BrowserStorage.getItem('videoInputDevicePreferred')) {
+				BrowserStorage.setItem('videoInputDevicePreferred', true)
+			}
 		}
 
 	},

--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -199,12 +199,17 @@ MediaDevicesManager.prototype = {
 			// according to the spec, a single device of each kind (if at least
 			// one device of that kind is available) with an empty deviceId is
 			// returned, which will not be registered in the preference list.
+			let deviceIdChanged = false
 			if (this.attributes.audioInputId === undefined || this.attributes.audioInputId === previousFirstAvailableAudioInputId) {
 				this.attributes.audioInputId = getFirstAvailableMediaDevice(devices, this._preferenceAudioInputList) || devices.find(device => device.kind === 'audioinput')?.deviceId
-				console.debug(listMediaDevices(this.attributes, this._preferenceAudioInputList, this._preferenceVideoInputList))
+				deviceIdChanged = true
 			}
 			if (this.attributes.videoInputId === undefined || this.attributes.videoInputId === previousFirstAvailableVideoInputId) {
 				this.attributes.videoInputId = getFirstAvailableMediaDevice(devices, this._preferenceVideoInputList) || devices.find(device => device.kind === 'videoinput')?.deviceId
+				deviceIdChanged = true
+			}
+
+			if (deviceIdChanged) {
 				console.debug(listMediaDevices(this.attributes, this._preferenceAudioInputList, this._preferenceVideoInputList))
 			}
 
@@ -258,8 +263,7 @@ MediaDevicesManager.prototype = {
 			BrowserStorage.setItem('videoInputPreferences', JSON.stringify(newVideoInputList))
 		}
 
-		const devicesPreferred = BrowserStorage.getItem('devicesPreferred')
-		if (!devicesPreferred) {
+		if (!BrowserStorage.getItem('devicesPreferred')) {
 			BrowserStorage.setItem('devicesPreferred', true)
 		}
 

--- a/src/utils/webrtc/MediaDevicesManager.js
+++ b/src/utils/webrtc/MediaDevicesManager.js
@@ -249,7 +249,13 @@ MediaDevicesManager.prototype = {
 
 	updatePreferences(kind) {
 		if (kind === 'audioinput') {
-			const newAudioInputList = promoteMediaDevice('audioinput', this.attributes.devices, this._preferenceAudioInputList, this.attributes.audioInputId)
+			const newAudioInputList = promoteMediaDevice({
+				kind,
+				devices: this.attributes.devices,
+				inputList: this._preferenceAudioInputList,
+				inputId: this.attributes.audioInputId
+			})
+
 			if (newAudioInputList) {
 				this._preferenceAudioInputList = newAudioInputList
 				BrowserStorage.setItem('audioInputPreferences', JSON.stringify(newAudioInputList))
@@ -258,7 +264,13 @@ MediaDevicesManager.prototype = {
 				BrowserStorage.setItem('audioInputDevicePreferred', true)
 			}
 		} else if (kind === 'videoinput') {
-			const newVideoInputList = promoteMediaDevice('videoinput', this.attributes.devices, this._preferenceVideoInputList, this.attributes.videoInputId)
+			const newVideoInputList = promoteMediaDevice({
+				kind,
+				devices: this.attributes.devices,
+				inputList: this._preferenceVideoInputList,
+				inputId: this.attributes.videoInputId
+			})
+
 			if (newVideoInputList) {
 				this._preferenceVideoInputList = newVideoInputList
 				BrowserStorage.setItem('videoInputPreferences', JSON.stringify(newVideoInputList))


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12185
* Fix #12120

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![before-sticky](https://github.com/nextcloud/spreed/assets/84044328/5d94d5aa-49fd-4708-8519-1a4a1f29be9c)| ![After-sticky](https://github.com/nextcloud/spreed/assets/84044328/4c9f9f64-528c-45ee-a827-c99d0b765bf3)

### 🚧 Tasks

- [x] Do not show "Apply Settings" on changes that touch devices only.
- [x] Update preferences needs to be called `@update:deviceId` event. This will cover both media settings and Talk settings devices changes.
- [x] To move ["check if preferences update is called at least once"](https://github.com/nextcloud/spreed/pull/12146/files) to `showModal()`, because user may open and close media settings without any pref update and without reload. It makes more sense to also force it next time they open it.
- [x] Split audio and video preferences update

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
