### PR TITLE
fix(call): open chat sidebar in call by click on toast

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -1125,4 +1125,8 @@ export default {
 	overflow: hidden;
 	outline-offset: -2px;
 }
+
+:deep(#app-settings-header) {
+	padding-top: calc(var(--default-grid-baseline) * 2);
+}
 </style>

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -738,6 +738,8 @@ export default {
 				})
 				this.chatExtrasStore.removeMessageIdToEdit(this.token)
 				this.resetTypingIndicator()
+				// refocus input as the user might want to type further
+				this.focusInput()
 			} catch {
 				this.$emit('failure')
 				showError(t('spreed', 'The message could not be edited'))

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -370,7 +370,11 @@ export default {
 				this.unreadNotificationHandle = null
 			}
 			if (message) {
-				this.unreadNotificationHandle = showMessage(message)
+				this.unreadNotificationHandle = showMessage(message, {
+					onClick: () => {
+						this.openSidebar('chat')
+					},
+				})
 			}
 		},
 


### PR DESCRIPTION
Signed-off-by: Maksim Sukharev <antreesy.web@gmail.com>### ☑️ Resolves

* Fix #12114:
  * onClick was added, to open sidebar with 'chat' tab
* Additional minor fixes:
  * padding-top for LeftSidebar footer increased
  * after editing the message, focus the input field back to continue typing

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/d9bf320f-b27a-4bfa-92e1-c58e14ab3cdb) | ![image](https://github.com/nextcloud/spreed/assets/93392545/ef13b9d0-5f58-4a24-a303-a8f62be59ff5)

🏡 After

[Screencast from 23.04.2024 15:29:29.webm](https://github.com/nextcloud/spreed/assets/93392545/2936d19a-74f4-4d00-bbd8-4fc9d2d3d47c)

[Screencast from 23.04.2024 15:31:00.webm](https://github.com/nextcloud/spreed/assets/93392545/d2cf5d22-d0f5-42d6-950d-ff8d780a16f5)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 