### PR TITLE
fix(breakout-rooms): enforce rooms order, minor fixes

### DIFF
--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
@@ -177,6 +177,10 @@ export default {
 	justify-content: flex-start;
 	align-items: flex-start;
 
+	h2 {
+		margin-top: 0;
+	}
+
 	&__number-input{
 		display: block;
 		margin-bottom: calc(var(--default-grid-baseline)*4);
@@ -207,13 +211,6 @@ export default {
 		justify-content: flex-end;
 		gap: calc(var(--default-grid-baseline) * 2);
 		width: 100%;
-	}
-}
-
-.modal-mask__participants-step {
-	:deep(.modal-container) {
-		overflow: hidden !important;
-		height: 100% !important;
 	}
 }
 </style>

--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
@@ -22,7 +22,8 @@
 <template>
 	<div class="participants-editor">
 		<ul class="participants-editor__scroller">
-			<BreakoutRoomItem class="participants-editor__section"
+			<BreakoutRoomItem key="unassigned"
+				class="participants-editor__section"
 				:name="t('spreed', 'Unassigned participants')">
 				<SelectableParticipant v-for="participant in unassignedParticipants"
 					:key="participant.attendeeId"
@@ -30,17 +31,16 @@
 					:checked.sync="selectedParticipants"
 					:participant="participant" />
 			</BreakoutRoomItem>
-			<template v-for="(item, index) in assignments">
-				<BreakoutRoomItem :key="index"
-					class="participants-editor__section"
-					:name="roomName(index)">
-					<SelectableParticipant v-for="attendeeId in item"
-						:key="attendeeId"
-						:value="assignments"
-						:checked.sync="selectedParticipants"
-						:participant="attendeesById[attendeeId]" />
-				</BreakoutRoomItem>
-			</template>
+			<BreakoutRoomItem v-for="(item, index) in assignments"
+				:key="index"
+				class="participants-editor__section"
+				:name="roomName(index)">
+				<SelectableParticipant v-for="attendeeId in item"
+					:key="attendeeId"
+					:value="assignments"
+					:checked.sync="selectedParticipants"
+					:participant="attendeesById[attendeeId]" />
+			</BreakoutRoomItem>
 		</ul>
 		<div class="participants-editor__buttons">
 			<NcButton v-if="breakoutRoomsConfigured"
@@ -74,7 +74,7 @@
 				:menu-name="t('spreed', 'Assign')">
 				<NcActionButton v-for="(item, index) in assignments"
 					:key="index"
-					:close-after-click="true"
+					close-after-click
 					@click="assignAttendees(index)">
 					<template #icon>
 						<DotsCircle :size="20" />
@@ -294,8 +294,8 @@ export default {
 		},
 
 		roomName(index) {
-			const roomNumber = index + 1
-			return t('spreed', 'Room {roomNumber}', { roomNumber })
+			return this.breakoutRooms[index]?.displayName
+				?? t('spreed', 'Room {roomNumber}', { roomNumber: index + 1 })
 		},
 
 		resetAssignments() {

--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsParticipantsEditor.vue
@@ -88,7 +88,8 @@
 				{{ confirmButtonLabel }}
 			</NcButton>
 		</div>
-		<NcDialog :open.sync="showDialog"
+		<NcDialog v-if="showDialog"
+			:open.sync="showDialog"
 			:name="t('spreed','Delete breakout rooms')"
 			:message="dialogMessage"
 			container=".participants-editor">
@@ -357,10 +358,10 @@ export default {
 	width: 100%;
 	flex-direction: column;
 	gap: var(--default-grid-baseline);
-	height: calc(100% - 42px);
+	height: calc(100% - 57px); // heading 30px * 1.5 line-height + 12px margin-bottom
 
 	&__section {
-		margin: calc(var(--default-grid-baseline) * 2) 0 var(--default-grid-baseline) 0;
+		margin: calc(var(--default-grid-baseline) * 2) 0 calc(var(--default-grid-baseline) * 4);
 
 	}
 
@@ -373,6 +374,7 @@ export default {
 		display: flex;
 		justify-content: flex-end;
 		gap: calc(var(--default-grid-baseline) * 2);
+		padding-top: 10px;
 	}
 }
 

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomItem.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomItem.vue
@@ -159,15 +159,15 @@ export default {
 		},
 
 		participantType() {
-			return this.breakoutRoom.participantType
+			return this.breakoutRoom?.participantType
 		},
 
 		roomName() {
-			return this.isParticipantsEditor ? this.name : this.breakoutRoom.displayName
+			return this.isParticipantsEditor ? this.name : this.breakoutRoom?.displayName
 		},
 
 		roomToken() {
-			return this.breakoutRoom.token
+			return this.breakoutRoom?.token
 		},
 
 		showJoinButton() {
@@ -189,7 +189,7 @@ export default {
 			if (this.isParticipantsEditor) {
 				return false
 			}
-			return this.canModerate && this.breakoutRoom.breakoutRoomStatus === CONVERSATION.BREAKOUT_ROOM_STATUS.STATUS_ASSISTANCE_REQUESTED
+			return this.canModerate && this.breakoutRoom?.breakoutRoomStatus === CONVERSATION.BREAKOUT_ROOM_STATUS.STATUS_ASSISTANCE_REQUESTED
 		},
 
 		toggleParticipantsListLabel() {

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
@@ -291,6 +291,10 @@ export default {
 	&__editor {
 		height: 100%;
 		padding: 20px;
+
+		h2 {
+			margin-top: 0;
+		}
 	}
 }
 

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsTab.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsTab.vue
@@ -28,15 +28,14 @@
 			:breakout-rooms-configured="breakoutRoomsConfigured" />
 		<!-- Breakout rooms list -->
 		<ul v-if="showBreakoutRoomsList">
-			<template v-for="breakoutRoom in breakoutRooms">
-				<BreakoutRoomItem :key="breakoutRoom.token"
-					:breakout-room="breakoutRoom"
-					:main-conversation="mainConversation">
-					<template v-for="participant in $store.getters.participantsList(breakoutRoom.token)">
-						<Participant :key="participant.actorId" :participant="participant" />
-					</template>
-				</BreakoutRoomItem>
-			</template>
+			<BreakoutRoomItem v-for="breakoutRoom in breakoutRooms"
+				:key="breakoutRoom.token"
+				:breakout-room="breakoutRoom"
+				:main-conversation="mainConversation">
+				<Participant v-for="participant in $store.getters.participantsList(breakoutRoom.token)"
+					:key="participant.actorId"
+					:participant="participant" />
+			</BreakoutRoomItem>
 		</ul>
 		<NcEmptyContent v-else
 			class="breakout-rooms__empty-content"

--- a/src/stores/breakoutRooms.ts
+++ b/src/stores/breakoutRooms.ts
@@ -62,7 +62,8 @@ export const useBreakoutRoomsStore = defineStore('breakoutRooms', {
 
 	getters: {
 		breakoutRooms: (state) => (token: string): BreakoutRoom[] => {
-			return Object.values(Object(state.rooms[token]))
+			const roomsArray: BreakoutRoom[] = Object.values(Object(state.rooms[token]))
+			return roomsArray.sort((roomA, roomB) => roomA.id - roomB.id)
 		},
 
 		getParentRoomToken: (state) => (token: string): string | undefined => {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11921
  * sort rooms in getter by id (order of creation, so 1 -> 2 -> 3) _hard to reproduce_
  * use server-provided room names where possible _ParticipantsEditor_
  * ease template in Vue SFC files 
  * add some ?. conditions to avoid TypeErrors _Vue devtools_
  * fix styles to avoid double scrollbar in dialogs _screenshot_
  * don't mount NcDialog for deletion if not called explicitly _console_

TODO:
 - [ ] find another way to restrict image sizes (now it affects user_status)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/dc54163a-b19d-4e3c-9b25-dffb7efffc77) | ![image](https://github.com/nextcloud/spreed/assets/93392545/c7e7429c-fa6f-4016-9e3a-9b623101a4ed)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possible