### PR TITLE
fix(a11y): provide aria-labels for screenshare buttons in every state

### DIFF
--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -112,6 +112,7 @@
 		<NcButton v-else-if="!isSidebar"
 			v-tooltip="screenSharingButtonTooltip"
 			type="tertiary"
+			:aria-label="screenSharingButtonAriaLabel"
 			@click.stop="toggleScreenSharingMenu">
 			<template #icon>
 				<MonitorShare :size="20" />
@@ -269,7 +270,7 @@ export default {
 
 		screenSharingButtonAriaLabel() {
 			if (this.screenSharingMenuOpen) {
-				return ''
+				return t('spreed', 'Screensharing options')
 			}
 
 			return this.isScreensharing


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12155 

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Vue warn from vue-lib | Clean console


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 