### PR TITLE
fix(MessagesList): handle special case in scrolling

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -621,18 +621,21 @@ export default {
 			}
 
 			if (!isFocused) {
-				// Safeguard: scroll to before last read message
+				// Safeguard 1: scroll to first visible message before the read marker
 				const fallbackLastReadMessageId = this.$store.getters.getFirstDisplayableMessageIdBeforeReadMarker(this.token, this.visualLastReadMessageId)
 				if (fallbackLastReadMessageId) {
 					isFocused = this.focusMessage(fallbackLastReadMessageId, false, false)
+				}
+
+				if (!isFocused) {
+					// Safeguard 2: in case the fallback message is not found too
+					// scroll to bottom
+					this.scrollToBottom({ force: true })
+				} else {
 					this.$store.dispatch('setVisualLastReadMessageId', {
 						token: this.token,
 						id: fallbackLastReadMessageId,
 					})
-				} else {
-					// This is an ultimate safeguard in case the fallback message is not found too
-					// scroll to bottom
-					this.scrollToBottom({ force: true, smooth: true })
 				}
 			}
 
@@ -1083,13 +1086,18 @@ export default {
 		 * @return {boolean} true if element was found, false otherwise
 		 */
 		focusMessage(messageId, smooth = true, highlightAnimation = true) {
-			const element = document.getElementById(`message_${messageId}`)
+			let element = document.getElementById(`message_${messageId}`)
 			if (!element) {
 				// Message id doesn't exist
 				// TODO: in some cases might need to trigger a scroll up if this is an older message
 				// https://github.com/nextcloud/spreed/pull/10084
 				console.warn('Message to focus not found in DOM', messageId)
 				return false // element not found
+			}
+
+			if (element.offsetParent === null) {
+				console.debug('Message to focus is hidden, scrolling to its nearest visible parent', messageId)
+				element = element.closest('ul[style="display: none;"]').parentElement
 			}
 
 			console.debug('Scrolling to a focused message programmatically')

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -89,6 +89,17 @@ function hasMentionToSelf(context, message) {
 	return false
 }
 
+/**
+ * Returns whether the given message is presented in DOM and visible (none of the ancestors has `display: none`)
+ *
+ * @param {string} messageId store context
+ * @return {boolean} whether the message is visible in the UI
+ */
+function isMessageVisible(messageId) {
+	const element = document.getElementById(`message_${messageId}`)
+	return element !== null && element.offsetParent !== null
+}
+
 const state = {
 	/**
 	 * Map of conversation token to message list
@@ -243,6 +254,7 @@ const getters = {
 
 		return getters.messagesList(token).findLast(message => {
 			return message.id < readMessageId
+				&& isMessageVisible(message.id)
 				&& !String(message.id).startsWith('temp-')
 				&& message.systemMessage !== 'reaction'
 				&& message.systemMessage !== 'reaction_deleted'


### PR DESCRIPTION
### ☑️ Resolves

We use last read message to scroll to when opening conversation. When it is collapsed, there is nothing to scroll to and the conversation remains shown at the top. 

* Scroll to its nearest visible parent div
* Adjust the other safeguards

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
