### PR TITLE
feat(OpenConversationsList): expose description

### DIFF
--- a/lib/Service/RoomFormatter.php
+++ b/lib/Service/RoomFormatter.php
@@ -162,6 +162,7 @@ class RoomFormatter {
 			return array_merge($roomData, [
 				'name' => $room->getName(),
 				'displayName' => $room->getDisplayName($isListingBreakoutRooms || $isSIPBridgeRequest || $this->userId === null ? '' : $this->userId, $isListingBreakoutRooms || $isSIPBridgeRequest),
+				'description' => $room->getListable() !== Room::LISTABLE_NONE ? $room->getDescription() : '',
 				'objectType' => $room->getObjectType(),
 				'objectId' => $room->getObjectId(),
 				'readOnly' => $room->getReadOnly(),

--- a/src/App.vue
+++ b/src/App.vue
@@ -768,6 +768,10 @@ export default {
 body .modal-wrapper * {
 	box-sizing: border-box;
 }
+
+.modal-wrapper h2 {
+	margin-top: 0;
+}
 </style>
 
 <style lang="scss" scoped>

--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
@@ -161,10 +161,6 @@ export default {
 	justify-content: flex-start;
 	align-items: flex-start;
 
-	h2 {
-		margin-top: 0;
-	}
-
 	&__number-input{
 		display: block;
 		margin-bottom: calc(var(--default-grid-baseline)*4);

--- a/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
@@ -191,10 +191,11 @@ describe('Conversation.vue', () => {
 				testConversationLabel(item, 'Guest: hello')
 			})
 
-			test('displays last message for search results', () => {
+			test('displays description for search results', () => {
 				// search results have no actor id
 				item.actorId = null
-				testConversationLabel(item, 'Alice: hello', true)
+				item.description = 'This is a description'
+				testConversationLabel(item, 'This is a description', true)
 			})
 		})
 

--- a/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.spec.js
@@ -145,7 +145,7 @@ describe('Conversation.vue', () => {
 
 		test('displays nothing when there is no last chat message', () => {
 			item.lastMessage = {}
-			testConversationLabel(item, '')
+			testConversationLabel(item, 'No messages')
 		})
 
 		describe('author name', () => {

--- a/src/components/LeftSidebar/ConversationsList/ConversationSearchResult.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationSearchResult.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script>
-import { inject, toRefs } from 'vue'
+import { inject, toRefs, ref } from 'vue'
 
 import NcListItem from '@nextcloud/vue/dist/Components/NcListItem.js'
 
@@ -39,10 +39,6 @@ export default {
 	},
 
 	props: {
-		exposeMessages: {
-			type: Boolean,
-			default: false,
-		},
 		item: {
 			type: Object,
 			default() {
@@ -66,9 +62,10 @@ export default {
 	emits: ['click'],
 
 	setup(props) {
-		const { item, exposeMessages } = toRefs(props)
+		const { item } = toRefs(props)
 		const selectedRoom = inject('selectedRoom', null)
-		const { counterType, conversationInformation } = useConversationInfo({ item, exposeMessages })
+		const exposeDescriptionRef = inject('exposeDescription', ref(false))
+		const { counterType, conversationInformation } = useConversationInfo({ item, exposeDescriptionRef })
 
 		return {
 			selectedRoom,

--- a/src/components/LeftSidebar/ConversationsList/ConversationsSearchListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsSearchListVirtual.vue
@@ -10,7 +10,7 @@
 		:item-size="CONVERSATION_ITEM_SIZE"
 		key-field="token">
 		<template #default="{ item }">
-			<ConversationSearchResult :item="item" :expose-messages="exposeMessages" @click="onClick" />
+			<ConversationSearchResult :item="item" @click="onClick" />
 		</template>
 		<template #after>
 			<LoadingPlaceholder v-if="loading" type="conversations" />
@@ -42,10 +42,7 @@ export default {
 			type: Array,
 			required: true,
 		},
-		exposeMessages: {
-			type: Boolean,
-			default: false,
-		},
+
 		loading: {
 			type: Boolean,
 			default: false,

--- a/src/components/LeftSidebar/OpenConversationsList/OpenConversationsList.vue
+++ b/src/components/LeftSidebar/OpenConversationsList/OpenConversationsList.vue
@@ -14,6 +14,7 @@
 </template>
 
 <script>
+import { provide, ref } from 'vue'
 
 import RoomSelector from '../../RoomSelector.vue'
 
@@ -23,6 +24,10 @@ export default {
 
 	components: {
 		RoomSelector,
+	},
+
+	setup() {
+		provide('exposeDescription', ref(true))
 	},
 
 	data() {

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
@@ -296,10 +296,6 @@ export default {
 	&__editor {
 		height: 100%;
 		padding: 20px;
-
-		h2 {
-			margin-top: 0;
-		}
 	}
 }
 

--- a/src/composables/useConversationInfo.js
+++ b/src/composables/useConversationInfo.js
@@ -12,15 +12,20 @@ import { ATTENDEE, CONVERSATION } from '../constants.js'
  * @param {object} payload function payload
  * @param {import('vue').Ref} payload.item conversation item
  * @param {import('vue').Ref} [payload.isSearchResult] whether conversation item appears as search result
- * @param {import('vue').Ref} [payload.exposeMessages] whether to show messages in conversation item
+ * @param {import('vue').Ref} [payload.exposeMessagesRef] whether to show messages in conversation item
+ * @param {import('vue').Ref} [payload.exposeDescriptionRef] whether to show description in conversation item
  */
 export function useConversationInfo({
 	item,
 	isSearchResult = ref(null),
-	exposeMessages = ref(null),
+	exposeMessagesRef = ref(null),
+	exposeDescriptionRef = ref(null),
 }) {
+	const exposeMessages = exposeMessagesRef.value !== null ? exposeMessagesRef.value : !isSearchResult.value
+	const exposeDescription = exposeDescriptionRef.value !== null ? exposeDescriptionRef.value : isSearchResult.value
+
 	const counterType = computed(() => {
-		if (exposeMessages.value === false) {
+		if (!exposeMessages) {
 			return ''
 		} else if (item.value.unreadMentionDirect || (item.value.unreadMessages !== 0
 			&& [CONVERSATION.TYPE.ONE_TO_ONE, CONVERSATION.TYPE.ONE_TO_ONE_FORMER].includes(item.value.type)
@@ -43,7 +48,7 @@ export function useConversationInfo({
 	 * e.g. no avatars on mentions.
 	 */
 	const simpleLastChatMessage = computed(() => {
-		if (exposeMessages.value === false || !hasLastMessage.value) {
+		if (!exposeMessages || !hasLastMessage.value) {
 			return ''
 		}
 
@@ -62,7 +67,7 @@ export function useConversationInfo({
 	 * @return {string} Part of the name until the first space
 	 */
 	const shortLastChatMessageAuthor = computed(() => {
-		if (exposeMessages.value === false || !hasLastMessage.value || item.value.lastMessage.systemMessage.length) {
+		if (!exposeMessages || !hasLastMessage.value || item.value.lastMessage.systemMessage.length) {
 			return ''
 		}
 
@@ -81,8 +86,10 @@ export function useConversationInfo({
 			return t('spreed', 'Joining conversation …')
 		}
 
-		if (exposeMessages.value === false || !hasLastMessage.value) {
-			return ''
+		if (!exposeMessages) {
+			return exposeDescription ? item.value?.description : ''
+		} else if (!hasLastMessage.value) {
+			return t('spreed', 'No messages')
 		}
 
 		if (shortLastChatMessageAuthor.value === '') {

--- a/tests/integration/features/conversation-2/find-listed.feature
+++ b/tests/integration/features/conversation-2/find-listed.feature
@@ -28,12 +28,14 @@ Feature: conversation/find-listed
     And user "creator" creates room "public-room" (v4)
       | roomType | 3           |
       | roomName | public-room |
+    And user "creator" sets description for room "group-room" to "the group-room description" with 200 (v4)
+    And user "creator" sets description for room "public-room" to "the public-room description" with 200 (v4)
     When user "creator" allows listing room "group-room" for "users" with 200 (v4)
     And user "creator" allows listing room "public-room" for "users" with 200 (v4)
     Then user "regular-user" can find listed rooms (v4)
-      | name        | listable |
-      | group-room  | 1        |
-      | public-room | 1        |
+      | name        | listable | description                 |
+      | group-room  | 1        | the group-room description  |
+      | public-room | 1        | the public-room description |
     And user "user-guest@example.com" cannot find any listed rooms (v4)
 
   Scenario: All users can find all-listed rooms


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12209

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/84044328/1a93bdd4-0a7e-471d-b6a2-c8fd78cfd4ac) | ![image](https://github.com/nextcloud/spreed/assets/84044328/3a48498f-7780-4ee5-b505-4425d939e316)


### 🚧 Tasks

- [X] exposed description from backend  
- [X] added `exposeDescription` injection and it has a priority over `exposeMessage` -> maybe the opposite is better ? 
- [X] `exposeMessage` and `exposeDescription` are not needed to be reactive, simplified them to booleans
- [X] Adjust header styling

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
