### PR TITLE
fix(editing): restore default behaviour of keyboard hotkeys `Ctrl+Up`

### DIFF
--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -962,8 +962,8 @@ export default {
 			this.blurInput()
 		},
 
-		handleEditLastMessage() {
-			if (!canEditMessage || this.upload || this.broadcast || this.isRecordingAudio) {
+		handleEditLastMessage(event) {
+			if (!canEditMessage || this.text || this.upload || this.broadcast || this.isRecordingAudio) {
 				return
 			}
 			const lastMessageByCurrentUser = this.$store.getters.messagesList(this.token).findLast(message => {
@@ -976,6 +976,7 @@ export default {
 				return
 			}
 
+			event.preventDefault()
 			this.chatExtrasStore.initiateEditingMessage({
 				token: this.token,
 				id: lastMessageByCurrentUser.id,


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #11451 
  `Ctrl + Arrow` is commonly used way to navigate (move cursor) through documents, text fields or inputs: https://www.w3schools.com/tags/ref_keyboardshortcuts.asp
  `Ctrl + Up` should move cursor to the beginning of the text line (if we have one), now it starts last message editing
* Now combination works only with empty input
  * event.preventDefault() added to set cursor to the end of edited text

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

 🏡 After - Navigation with  `Ctrl + Arrow`

[Screencast from 02.05.2024 12:55:44.webm](https://github.com/nextcloud/spreed/assets/93392545/60feda68-8f50-4ee9-b8a8-8c4e7691f498)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team