### PR TITLE
fix(LeftSidebar): small glitch on sidebar scroll

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -1014,9 +1014,10 @@ export default {
 	display: flex;
 	padding: 8px 4px 8px 12px;
 	align-items: center;
+	border-bottom: 1px solid transparent;
 
 	&--scrolled-down {
-		border-bottom: 1px solid var(--color-placeholder-dark);
+		border-bottom-color: var(--color-placeholder-dark);
 	}
 
 	.filters {


### PR DESCRIPTION
### ☑️ Resolves

* On scroll with debounce delay we add a 1px border
* It visually moves all the list after the scroll is finished or during the scroll
* When scroll position is 1px - it results in an infinite glitch

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![before](https://github.com/nextcloud/spreed/assets/25978914/4169b5dd-81aa-401b-87b7-0f9665874dd0) | ![after](https://github.com/nextcloud/spreed/assets/25978914/f1771282-af05-4ecc-bc5d-cdfdf1768565)
![border-bug](https://github.com/nextcloud/spreed/assets/25978914/33a78832-3eba-4f82-b9d3-b38d857b21b5) | ![image](https://github.com/nextcloud/spreed/assets/25978914/9a166801-b591-4ce9-ab49-fa070c731218)

### 🚧 Tasks

- [x] Add constant border to not change height during scrolling

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
