### PR TITLE
fix(MessagesList): clean up expired, removed messages from the chat

### DIFF
--- a/src/components/MessagesList/MessagesList.spec.js
+++ b/src/components/MessagesList/MessagesList.spec.js
@@ -73,6 +73,21 @@ describe('MessagesList.vue', () => {
 		isReplyable: true,
 	}]
 
+	const messagesGroup1OldMessage = {
+		id: 90,
+		token: TOKEN,
+		actorId: 'alice',
+		actorDisplayName: 'Alice',
+		actorType: ATTENDEE.ACTOR_TYPE.USERS,
+		message: 'old hello',
+		messageType: 'comment',
+		messageParameters: [],
+		systemMessage: '',
+		timestamp: fakeTimestamp('2024-05-01T12:04:00'),
+		isReplyable: true,
+	}
+	const messagesGroup1WithOld = [messagesGroup1OldMessage].concat(messagesGroup1)
+
 	const messagesGroup2 = [{
 		id: 200,
 		token: TOKEN,
@@ -98,6 +113,21 @@ describe('MessagesList.vue', () => {
 		timestamp: fakeTimestamp('2024-05-01T12:31:00'),
 		isReplyable: true,
 	}]
+
+	const messagesGroup2NewMessage = {
+		id: 220,
+		token: TOKEN,
+		actorId: 'bob',
+		actorDisplayName: 'Bob',
+		actorType: ATTENDEE.ACTOR_TYPE.USERS,
+		message: 'hello?',
+		messageType: 'comment',
+		messageParameters: [],
+		systemMessage: '',
+		timestamp: fakeTimestamp('2024-05-01T12:32:00'),
+		isReplyable: true,
+	}
+	const messagesGroup2WithNew = messagesGroup2.concat([messagesGroup2NewMessage])
 
 	const messagesGroup3 = [{
 		id: 'temp-300',
@@ -372,6 +402,23 @@ describe('MessagesList.vue', () => {
 	})
 
 	describe('message rendering', () => {
+		jest.useFakeTimers().setSystemTime(new Date('2024-05-01T17:00:00'))
+		/**
+		 *
+		 * @param {Array} messagesGroups initial messages groups
+		 */
+		function renderMessagesList(...messagesGroups) {
+			messagesGroups.flat().forEach(message => store.commit('addMessage', { token: TOKEN, message }))
+			return shallowMount(MessagesList, {
+				localVue,
+				store,
+				propsData: {
+					token: TOKEN,
+					isChatScrolledToBottom: true,
+				},
+			})
+		}
+
 		test('renders a placeholder while loading', () => {
 			const wrapper = shallowMount(MessagesList, {
 				localVue,
@@ -405,6 +452,195 @@ describe('MessagesList.vue', () => {
 
 			const placeholder = wrapper.findAllComponents({ name: 'NcEmptyContent' })
 			expect(placeholder.exists()).toBe(true)
+		})
+
+		test('renders initial group of messages', () => {
+			// Act
+			const wrapper = renderMessagesList(messagesGroup1)
+			const groups = wrapper.findAllComponents({ name: 'MessagesGroup' })
+
+			// Assert: groups are rendered
+			expect(groups.exists()).toBe(true)
+			expect(groups.at(0).props()).toMatchObject({
+				token: TOKEN,
+				messages: messagesGroup1,
+				previousMessageId: 0,
+				nextMessageId: 0,
+			})
+		})
+
+		test('updates rendered list of messages (add new group)', async () => {
+			// Arrange
+			const wrapper = renderMessagesList(messagesGroup1)
+
+			// Act: add new group to the store
+			messagesGroup2.forEach(message => store.commit('addMessage', { token: TOKEN, message }))
+			await wrapper.vm.$nextTick()
+
+			// Assert: old group nextMessageId is updated, new group is added
+			const groups = wrapper.findAllComponents({ name: 'MessagesGroup' })
+			expect(groups.at(0).props()).toMatchObject({
+				token: TOKEN,
+				messages: messagesGroup1,
+				previousMessageId: 0,
+				nextMessageId: 200,
+			})
+
+			expect(groups.at(1).props()).toMatchObject({
+				token: TOKEN,
+				messages: messagesGroup2,
+				previousMessageId: 110,
+				nextMessageId: 0,
+			})
+		})
+
+		test('updates rendered list of messages (add messages to existing groups)', async () => {
+			// Arrange
+			const wrapper = renderMessagesList(messagesGroup1, messagesGroup2)
+
+			// Act: add new messages to the store
+			store.commit('addMessage', { token: TOKEN, message: messagesGroup1OldMessage })
+			store.commit('addMessage', { token: TOKEN, message: messagesGroup2NewMessage })
+			await wrapper.vm.$nextTick()
+
+			// Assert: both groups are updated
+			const groups = wrapper.findAllComponents({ name: 'MessagesGroup' })
+			expect(groups.exists()).toBe(true)
+			expect(groups.length).toBe(2)
+			expect(groups.at(0).props()).toMatchObject({
+				token: TOKEN,
+				messages: messagesGroup1WithOld,
+				previousMessageId: 0,
+				nextMessageId: 200,
+			})
+
+			expect(groups.at(1).props()).toMatchObject({
+				token: TOKEN,
+				messages: messagesGroup2WithNew,
+				previousMessageId: 110,
+				nextMessageId: 0,
+			})
+		})
+
+		test('updates rendered list of messages (replace temporary message in separate group)', async () => {
+			// Arrange
+			const wrapper = renderMessagesList(messagesGroup1, messagesGroup3)
+
+			// Act: replace temporary message with returned from server
+			const message = {
+				...messagesGroup3[0],
+				id: 300,
+				timestamp: fakeTimestamp('2024-05-01T13:00:00'),
+			}
+			store.commit('deleteMessage', { token: TOKEN, id: messagesGroup3[0].id })
+			store.commit('addMessage', { token: TOKEN, message })
+			await wrapper.vm.$nextTick()
+
+			// Assert: old group nextMessageId is updated, new group is added
+			const groups = wrapper.findAllComponents({ name: 'MessagesGroup' })
+			expect(groups.exists()).toBe(true)
+			expect(groups.length).toBe(2)
+			expect(groups.at(0).props()).toMatchObject({
+				token: TOKEN,
+				messages: messagesGroup1,
+				previousMessageId: 0,
+				nextMessageId: 300,
+			})
+
+			expect(groups.at(1).props()).toMatchObject({
+				token: TOKEN,
+				messages: [message],
+				previousMessageId: 110,
+				nextMessageId: 0,
+			})
+		})
+
+		test('updates rendered list of messages (replace temporary message in same group)', async () => {
+			// Arrange
+			const messagesGroup2WithTemp = [messagesGroup2[0], {
+				...messagesGroup2[1],
+				id: 'temp-210',
+				timestamp: 0, // temporary
+			}]
+			const wrapper = renderMessagesList(messagesGroup1, messagesGroup2WithTemp)
+
+			// Act: replace temporary message with returned from server
+			store.commit('deleteMessage', { token: TOKEN, id: 'temp-210' })
+			store.commit('addMessage', { token: TOKEN, message: messagesGroup2[1] })
+			await wrapper.vm.$nextTick()
+
+			// Assert: old group nextMessageId is updated, new group is added
+			const groups = wrapper.findAllComponents({ name: 'MessagesGroup' })
+			expect(groups.exists()).toBe(true)
+			expect(groups.length).toBe(2)
+
+			expect(groups.at(1).props()).toMatchObject({
+				token: TOKEN,
+				messages: messagesGroup2,
+				previousMessageId: 110,
+				nextMessageId: 0,
+			})
+		})
+
+		test('updates rendered list of messages (clear history)', async () => {
+			// Arrange
+			const wrapper = renderMessagesList(messagesGroup1, messagesGroup2)
+
+			// Act: imitate clearing of history
+			const message = {
+				id: 400,
+				token: TOKEN,
+				actorId: 'alice',
+				actorDisplayName: 'Alice',
+				actorType: ATTENDEE.ACTOR_TYPE.USERS,
+				message: '{actor} cleared the history of the conversation',
+				messageType: 'system',
+				messageParameters: [],
+				systemMessage: 'history_cleared',
+				timestamp: fakeTimestamp('2024-05-01T13:00:00'),
+				isReplyable: false,
+			}
+			store.commit('purgeMessagesStore', TOKEN)
+			store.commit('addMessage', { token: TOKEN, message })
+			await wrapper.vm.$nextTick()
+
+			// Assert: old messages are removed, system message is added
+			const groups = wrapper.findAllComponents({ name: 'MessagesGroup' })
+			expect(groups.exists()).toBe(false)
+			const groupsSystem = wrapper.findAllComponents({ name: 'MessagesSystemGroup' })
+			expect(groupsSystem.length).toBe(1)
+			expect(groupsSystem.at(0).props()).toMatchObject({
+				token: TOKEN,
+				messages: [message],
+				previousMessageId: 0,
+				nextMessageId: 0,
+			})
+		})
+
+		test('updates rendered list of messages (remove messages from existing groups)', async () => {
+			// Arrange
+			const wrapper = renderMessagesList(messagesGroup1WithOld, messagesGroup2WithNew)
+
+			// Act: remove some messages from the store
+			store.commit('deleteMessage', { token: TOKEN, id: messagesGroup1OldMessage.id })
+			store.commit('deleteMessage', { token: TOKEN, id: messagesGroup2NewMessage.id })
+			await wrapper.vm.$nextTick()
+
+			const groups = wrapper.findAllComponents({ name: 'MessagesGroup' })
+			expect(groups.length).toBe(2)
+			expect(groups.at(0).props()).toMatchObject({
+				token: TOKEN,
+				messages: messagesGroup1,
+				previousMessageId: 0,
+				nextMessageId: 200,
+			})
+
+			expect(groups.at(1).props()).toMatchObject({
+				token: TOKEN,
+				messages: messagesGroup2,
+				previousMessageId: 110,
+				nextMessageId: 0,
+			})
 		})
 	})
 })

--- a/src/components/MessagesList/MessagesList.spec.js
+++ b/src/components/MessagesList/MessagesList.spec.js
@@ -11,12 +11,13 @@ import MessagesList from './MessagesList.vue'
 import { ATTENDEE } from '../../constants.js'
 import storeConfig from '../../store/storeConfig.js'
 
+const fakeTimestamp = (value) => new Date(value).getTime() / 1000
+
 describe('MessagesList.vue', () => {
 	const TOKEN = 'XXTOKENXX'
 	let store
 	let localVue
 	let testStoreConfig
-	const messagesListMock = jest.fn()
 	const getVisualLastReadMessageIdMock = jest.fn()
 
 	beforeEach(() => {
@@ -24,8 +25,6 @@ describe('MessagesList.vue', () => {
 		localVue.use(Vuex)
 
 		testStoreConfig = cloneDeep(storeConfig)
-		testStoreConfig.modules.messagesStore.getters.messagesList
-			= jest.fn().mockReturnValue(messagesListMock)
 		testStoreConfig.modules.messagesStore.getters.getVisualLastReadMessageId
 			= jest.fn().mockReturnValue(getVisualLastReadMessageIdMock)
 		// eslint-disable-next-line import/no-named-as-default-member
@@ -48,76 +47,103 @@ describe('MessagesList.vue', () => {
 		jest.clearAllMocks()
 	})
 
+	const messagesGroup1 = [{
+		id: 100,
+		token: TOKEN,
+		actorId: 'alice',
+		actorDisplayName: 'Alice',
+		actorType: ATTENDEE.ACTOR_TYPE.USERS,
+		message: 'hello',
+		messageType: 'comment',
+		messageParameters: [],
+		systemMessage: '',
+		timestamp: fakeTimestamp('2024-05-01T12:05:00'),
+		isReplyable: true,
+	}, {
+		id: 110,
+		token: TOKEN,
+		actorId: 'alice',
+		actorDisplayName: 'Alice',
+		actorType: ATTENDEE.ACTOR_TYPE.USERS,
+		message: 'how are you ?',
+		messageType: 'comment',
+		messageParameters: [],
+		systemMessage: '',
+		timestamp: fakeTimestamp('2024-05-01T12:06:00'),
+		isReplyable: true,
+	}]
+
+	const messagesGroup2 = [{
+		id: 200,
+		token: TOKEN,
+		actorId: 'bob',
+		actorDisplayName: 'Bob',
+		actorType: ATTENDEE.ACTOR_TYPE.USERS,
+		message: 'hello!',
+		messageType: 'comment',
+		messageParameters: [],
+		systemMessage: '',
+		timestamp: fakeTimestamp('2024-05-01T12:30:00'),
+		isReplyable: true,
+	}, {
+		id: 210,
+		token: TOKEN,
+		actorId: 'bob',
+		actorDisplayName: 'Bob',
+		actorType: ATTENDEE.ACTOR_TYPE.USERS,
+		message: 'fine... how about you ?',
+		messageType: 'comment',
+		messageParameters: [],
+		systemMessage: '',
+		timestamp: fakeTimestamp('2024-05-01T12:31:00'),
+		isReplyable: true,
+	}]
+
+	const messagesGroup3 = [{
+		id: 'temp-300',
+		token: TOKEN,
+		actorId: 'alice',
+		actorDisplayName: 'Alice',
+		actorType: ATTENDEE.ACTOR_TYPE.USERS,
+		message: 'fine as well, thanks!',
+		messageType: 'comment',
+		messageParameters: [],
+		systemMessage: '',
+		timestamp: 0, // temporary
+		isReplyable: true,
+	}]
+
 	describe('message grouping', () => {
-		test('groups consecutive messages by author', () => {
-			const messagesGroup1 = [{
-				id: 100,
-				token: TOKEN,
-				actorId: 'alice',
-				actorDisplayName: 'Alice',
-				actorType: ATTENDEE.ACTOR_TYPE.USERS,
-				message: 'hello',
-				messageType: 'comment',
-				messageParameters: {},
-				systemMessage: '',
-				timestamp: 100,
-				isReplyable: true,
-			}, {
-				id: 110,
-				token: TOKEN,
-				actorId: 'alice',
-				actorDisplayName: 'Alice',
-				actorType: ATTENDEE.ACTOR_TYPE.USERS,
-				message: 'how are you ?',
-				messageType: 'comment',
-				messageParameters: {},
-				systemMessage: '',
-				timestamp: 200,
-				isReplyable: true,
-			}]
+		/**
+		 * @param {Array} messagesGroups List of messages that should be grouped
+		 */
+		function testGrouped(...messagesGroups) {
+			messagesGroups.flat().forEach(message => store.commit('addMessage', { token: TOKEN, message }))
+			const wrapper = shallowMount(MessagesList, {
+				localVue,
+				store,
+				propsData: {
+					token: TOKEN,
+					isChatScrolledToBottom: true,
+				},
+			})
 
-			const messagesGroup2 = [{
-				id: 200,
-				token: TOKEN,
-				actorId: 'bob',
-				actorDisplayName: 'Bob',
-				actorType: ATTENDEE.ACTOR_TYPE.USERS,
-				message: 'hello!',
-				messageType: 'comment',
-				messageParameters: {},
-				systemMessage: '',
-				timestamp: 300,
-				isReplyable: true,
-			}, {
-				id: 210,
-				token: TOKEN,
-				actorId: 'bob',
-				actorDisplayName: 'Bob',
-				actorType: ATTENDEE.ACTOR_TYPE.USERS,
-				message: 'fine... how abouty you ?',
-				messageType: 'comment',
-				messageParameters: {},
-				systemMessage: '',
-				timestamp: 400,
-				isReplyable: true,
-			}]
+			const groups = wrapper.findAll('.messages-group')
 
-			const messagesGroup3 = [{
-				id: 300,
-				token: TOKEN,
-				actorId: 'alice',
-				actorDisplayName: 'Alice',
-				actorType: ATTENDEE.ACTOR_TYPE.USERS,
-				message: 'fine as well, thanks!',
-				messageType: 'comment',
-				messageParameters: {},
-				systemMessage: '',
-				timestamp: 0, // temporary
-				isReplyable: true,
-			}]
+			expect(groups.exists()).toBeTruthy()
 
-			const allMessages = messagesGroup1.concat(messagesGroup2.concat(messagesGroup3))
-			messagesListMock.mockReturnValue(allMessages)
+			groups.wrappers.forEach((group, index) => {
+				expect(group.props('messages')).toStrictEqual(messagesGroups[index])
+			})
+
+			return { wrapper, groups }
+		}
+
+		/**
+		 * @param {Array} messages List of messages that should not be grouped
+		 */
+		function testNotGrouped(messages) {
+			messages.forEach(message => store.commit('addMessage', { token: TOKEN, message }))
 
 			const wrapper = shallowMount(MessagesList, {
 				localVue,
@@ -128,30 +154,34 @@ describe('MessagesList.vue', () => {
 				},
 			})
 
-			const groups = wrapper.findAllComponents({ name: 'MessagesGroup' })
+			const groups = wrapper.findAll('.messages-group')
 
-			expect(groups.exists()).toBe(true)
+			expect(groups.exists()).toBeTruthy()
 
-			let group = groups.at(0)
-			expect(group.props('messages')).toStrictEqual(messagesGroup1)
-			expect(group.props('previousMessageId')).toBe(0)
-			expect(group.props('nextMessageId')).toBe(200)
+			groups.wrappers.forEach((group, index) => {
+				expect(group.props('messages')).toStrictEqual([messages[index]])
+			})
 
-			group = groups.at(1)
-			expect(group.props('messages')).toStrictEqual(messagesGroup2)
-			expect(group.props('previousMessageId')).toBe(110)
-			expect(group.props('nextMessageId')).toBe(300)
+			return { wrapper, groups }
+		}
 
-			group = groups.at(2)
-			expect(group.props('messages')).toStrictEqual(messagesGroup3)
-			expect(group.props('previousMessageId')).toBe(210)
-			expect(group.props('nextMessageId')).toBe(0)
+		test('groups consecutive messages by author', () => {
+			const { groups } = testGrouped(messagesGroup1, messagesGroup2, messagesGroup3)
 
-			expect(messagesListMock).toHaveBeenCalledWith(TOKEN)
+			expect(groups.at(0).props('previousMessageId')).toBe(0)
+			expect(groups.at(0).props('nextMessageId')).toBe(200)
+
+			expect(groups.at(1).props('previousMessageId')).toBe(110)
+			expect(groups.at(1).props('nextMessageId')).toBe('temp-300')
+
+			expect(groups.at(2).props('previousMessageId')).toBe(210)
+			expect(groups.at(2).props('nextMessageId')).toBe(0)
 		})
 
 		test('displays a date separator between days', () => {
-			const messages = [{
+			jest.useFakeTimers().setSystemTime(new Date('2020-05-11T13:00:00'))
+
+			const { wrapper } = testNotGrouped([{
 				id: 100,
 				token: TOKEN,
 				actorId: 'alice',
@@ -159,9 +189,9 @@ describe('MessagesList.vue', () => {
 				actorType: ATTENDEE.ACTOR_TYPE.USERS,
 				message: 'hello',
 				messageType: 'comment',
-				messageParameters: {},
+				messageParameters: [],
 				systemMessage: '',
-				timestamp: new Date('2020-05-09 13:00:00').getTime() / 1000,
+				timestamp: fakeTimestamp('2020-05-09T13:00:00'),
 				isReplyable: true,
 			}, {
 				id: 110,
@@ -171,9 +201,9 @@ describe('MessagesList.vue', () => {
 				actorType: ATTENDEE.ACTOR_TYPE.USERS,
 				message: 'no one here ?',
 				messageType: 'comment',
-				messageParameters: {},
+				messageParameters: [],
 				systemMessage: '',
-				timestamp: new Date('2020-05-10 13:00:00').getTime() / 1000,
+				timestamp: fakeTimestamp('2020-05-10T13:00:00'),
 				isReplyable: true,
 			}, {
 				id: 'temp-120',
@@ -183,45 +213,21 @@ describe('MessagesList.vue', () => {
 				actorType: ATTENDEE.ACTOR_TYPE.USERS,
 				message: 'seems no one is there...',
 				messageType: 'comment',
-				messageParameters: {},
+				messageParameters: [],
 				systemMessage: '',
 				timestamp: 0, // temporary, matches current date
 				isReplyable: true,
-			}]
-
-			const mockDate = new Date('2020-05-11 13:00:00')
-			jest.spyOn(global.Date, 'now').mockImplementation(() => mockDate)
-
-			messagesListMock.mockReturnValue(messages)
-
-			const wrapper = shallowMount(MessagesList, {
-				localVue,
-				store,
-				propsData: {
-					token: TOKEN,
-					isChatScrolledToBottom: true,
-				},
-			})
-
-			const groups = wrapper.findAllComponents({ name: 'MessagesGroup' })
-
-			expect(groups.exists()).toBeTruthy()
-
-			groups.wrappers.forEach((group, index) => {
-				expect(group.props('messages')).toStrictEqual([messages[index]])
-			})
+			}])
 
 			const dateSeparators = wrapper.findAll('.messages-group__date')
 			expect(dateSeparators).toHaveLength(3)
 			expect(dateSeparators.at(0).text()).toBe('2 days ago, May 9, 2020')
 			expect(dateSeparators.at(1).text()).toBe('Yesterday, May 10, 2020')
 			expect(dateSeparators.at(2).text()).toBe('Today, May 11, 2020')
-
-			expect(messagesListMock).toHaveBeenCalledWith(TOKEN)
 		})
 
 		test('groups system messages with each other', () => {
-			const messages = [{
+			testGrouped([{
 				id: 100,
 				token: TOKEN,
 				actorId: 'alice',
@@ -229,9 +235,9 @@ describe('MessagesList.vue', () => {
 				actorType: ATTENDEE.ACTOR_TYPE.USERS,
 				message: 'Alice has entered the call',
 				messageType: 'comment',
-				messageParameters: {},
+				messageParameters: [],
 				systemMessage: 'call_started',
-				timestamp: 100,
+				timestamp: fakeTimestamp('2020-05-09T13:00:00'),
 				isReplyable: true,
 			}, {
 				id: 110,
@@ -241,56 +247,12 @@ describe('MessagesList.vue', () => {
 				actorType: ATTENDEE.ACTOR_TYPE.USERS,
 				message: 'Alice has exited the call',
 				messageType: 'comment',
-				messageParameters: {},
+				messageParameters: [],
 				systemMessage: 'call_ended',
-				timestamp: 200,
+				timestamp: fakeTimestamp('2020-05-09T13:02:00'),
 				isReplyable: true,
-			}]
-
-			messagesListMock.mockReturnValue(messages)
-
-			const wrapper = shallowMount(MessagesList, {
-				localVue,
-				store,
-				propsData: {
-					token: TOKEN,
-					isChatScrolledToBottom: true,
-				},
-			})
-
-			const groups = wrapper.findAll('.messages-group')
-
-			expect(groups.exists()).toBe(true)
-
-			const group = groups.at(0)
-			expect(group.props('messages')).toStrictEqual(messages)
-
-			expect(messagesListMock).toHaveBeenCalledWith(TOKEN)
+			}])
 		})
-
-		/**
-		 * @param {Array} messages List of messages that should not be grouped
-		 */
-		function testNotGrouped(messages) {
-			messagesListMock.mockReturnValue(messages)
-
-			const wrapper = shallowMount(MessagesList, {
-				localVue,
-				store,
-				propsData: {
-					token: TOKEN,
-					isChatScrolledToBottom: true,
-				},
-			})
-
-			const groups = wrapper.findAll('.messages-group')
-
-			expect(groups.exists()).toBeTruthy()
-
-			groups.wrappers.forEach((group, index) => {
-				expect(group.props('messages')).toStrictEqual([messages[index]])
-			})
-		}
 
 		test('does not group system messages with regular messages from the same author', () => {
 			testNotGrouped([{
@@ -301,9 +263,9 @@ describe('MessagesList.vue', () => {
 				actorType: ATTENDEE.ACTOR_TYPE.USERS,
 				message: 'Alice has entered the call',
 				messageType: 'comment',
-				messageParameters: {},
+				messageParameters: [],
 				systemMessage: 'call_started',
-				timestamp: 100,
+				timestamp: fakeTimestamp('2020-05-09T13:00:00'),
 				isReplyable: true,
 			}, {
 				id: 110,
@@ -313,37 +275,37 @@ describe('MessagesList.vue', () => {
 				actorType: ATTENDEE.ACTOR_TYPE.USERS,
 				message: 'hello',
 				messageType: 'comment',
-				messageParameters: {},
+				messageParameters: [],
 				systemMessage: '',
-				timestamp: 200,
+				timestamp: fakeTimestamp('2020-05-09T13:02:00'),
 				isReplyable: true,
 			}])
 		})
 
-		test('does not group messages of changelog bot', () => {
-			testNotGrouped([{
+		test('groups messages of changelog bot', () => {
+			testGrouped([{
 				id: 100,
 				token: TOKEN,
 				actorId: ATTENDEE.CHANGELOG_BOT_ID,
-				actorDisplayName: 'Changelog bot',
+				actorDisplayName: 'Talk updates \u2705',
 				actorType: ATTENDEE.ACTOR_TYPE.BOTS,
-				message: 'Alice has entered the call',
+				message: 'New in Talk 16',
 				messageType: 'comment',
-				messageParameters: {},
-				systemMessage: 'call_started',
-				timestamp: 100,
+				messageParameters: [],
+				systemMessage: '',
+				timestamp: fakeTimestamp('2020-05-09T13:00:00'),
 				isReplyable: true,
 			}, {
 				id: 110,
 				token: TOKEN,
 				actorId: ATTENDEE.CHANGELOG_BOT_ID,
-				actorDisplayName: 'Changelog bot',
+				actorDisplayName: 'Talk updates \u2705',
 				actorType: ATTENDEE.ACTOR_TYPE.BOTS,
-				message: 'hello',
+				message: '- Calls can now be recorded',
 				messageType: 'comment',
-				messageParameters: {},
+				messageParameters: [],
 				systemMessage: '',
-				timestamp: 200,
+				timestamp: fakeTimestamp('2020-05-09T13:02:00'),
 				isReplyable: true,
 			}])
 		})
@@ -357,9 +319,9 @@ describe('MessagesList.vue', () => {
 				actorType: ATTENDEE.ACTOR_TYPE.USERS,
 				message: 'Alice has entered the call',
 				messageType: 'comment',
-				messageParameters: {},
+				messageParameters: [],
 				systemMessage: 'call_started',
-				timestamp: 100,
+				timestamp: fakeTimestamp('2020-05-09T13:00:00'),
 				isReplyable: true,
 			}, {
 				id: 110,
@@ -369,16 +331,48 @@ describe('MessagesList.vue', () => {
 				actorType: ATTENDEE.ACTOR_TYPE.GUESTS,
 				message: 'hello',
 				messageType: 'comment',
-				messageParameters: {},
+				messageParameters: [],
 				systemMessage: '',
-				timestamp: 200,
+				timestamp: fakeTimestamp('2020-05-09T13:02:00'),
 				isReplyable: true,
 			}])
 		})
 
-		test('renders a placeholder while loading', () => {
-			messagesListMock.mockReturnValue([])
+		test('does not group edited messages', () => {
+			testNotGrouped([{
+				id: 100,
+				token: TOKEN,
+				actorId: 'alice',
+				actorDisplayName: 'Alice',
+				actorType: ATTENDEE.ACTOR_TYPE.USERS,
+				message: 'hello',
+				messageType: 'comment',
+				messageParameters: [],
+				systemMessage: '',
+				timestamp: fakeTimestamp('2024-05-01T12:05:00'),
+				isReplyable: true,
+			}, {
+				id: 110,
+				token: TOKEN,
+				actorId: 'alice',
+				actorDisplayName: 'Alice',
+				actorType: ATTENDEE.ACTOR_TYPE.USERS,
+				lastEditActorType: ATTENDEE.ACTOR_TYPE.USERS,
+				lastEditActorId: 'alice',
+				lastEditActorDisplayName: 'Alice',
+				lastEditTimestamp: fakeTimestamp('2024-05-01T12:07:00'),
+				message: 'how are you doing?',
+				messageType: 'comment',
+				messageParameters: [],
+				systemMessage: '',
+				timestamp: fakeTimestamp('2024-05-01T12:06:00'),
+				isReplyable: true,
+			}])
+		})
+	})
 
+	describe('message rendering', () => {
+		test('renders a placeholder while loading', () => {
 			const wrapper = shallowMount(MessagesList, {
 				localVue,
 				store,
@@ -392,6 +386,24 @@ describe('MessagesList.vue', () => {
 			expect(groups.exists()).toBe(false)
 
 			const placeholder = wrapper.findAllComponents({ name: 'LoadingPlaceholder' })
+			expect(placeholder.exists()).toBe(true)
+		})
+
+		test('renders an empty content after loading', () => {
+			store.commit('loadedMessagesOfConversation', { token: TOKEN })
+			const wrapper = shallowMount(MessagesList, {
+				localVue,
+				store,
+				propsData: {
+					token: TOKEN,
+					isChatScrolledToBottom: true,
+				},
+			})
+
+			const groups = wrapper.findAllComponents({ name: 'MessagesGroup' })
+			expect(groups.exists()).toBe(false)
+
+			const placeholder = wrapper.findAllComponents({ name: 'NcEmptyContent' })
 			expect(placeholder.exists()).toBe(true)
 		})
 	})

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -432,7 +432,7 @@ const mutations = {
 
 		if (state.messages[token]) {
 			for (const messageId of Object.keys(state.messages[token])) {
-				if (messageId < id) {
+				if (+messageId < id) {
 					Vue.delete(state.messages[token], messageId)
 				}
 			}


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #11592
  * Messages that are no longer persisted in the store, should be cleared from rendered list

Tested cases:
// group is older than any known newGroup
`[1][2,3],[4,5]` => `[6]` (6 - clear history) - remove all old groups
// at least one message from group is no longer in the store
`[1][2,3],[temp-4]` => `[1][2,3],[4]` - replace temporary message
`[1][2,3],[4],[5,6]` => `[1][2,3],[4]` (4 - message expiration, all messages after 4 were removed)
`[1][2,3],[4,5]` => `[1][2,3],[6]` (mocked case, whole group was removed)
`[1][2,3],[4,5]` => `[1][2,3],[4],[6]` (mocked case, non-first message was removed)
`[1][2,3],[4,5]` => `[1][2,3],[5],[6]` (mocked case, first message was removed)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/82051c81-85d7-489b-a437-4141907c95aa) | ![image](https://github.com/nextcloud/spreed/assets/93392545/01777cd0-dab6-42b4-8b46-1ffde6ca2460)

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [x] clear expired and purged messages:
  - [x] from the top of the list
  - [x] from the middle of the list
- [x] Add test coverage for soft update
  - [ ] Follow-up: move soft-update logic to test-able composable

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] ⛑️ Tests are included or not possible