### PR TITLE
fix(LeftSidebar): get rid of server styles for settings button

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.spec.js
+++ b/src/components/LeftSidebar/LeftSidebar.spec.js
@@ -18,7 +18,7 @@ import router from '../../__mocks__/router.js'
 import { searchPossibleConversations, searchListedConversations } from '../../services/conversationsService.js'
 import { EventBus } from '../../services/EventBus.js'
 import storeConfig from '../../store/storeConfig.js'
-import { findNcListItems, findNcActionButton } from '../../test-helpers.js'
+import { findNcListItems, findNcActionButton, findNcButton } from '../../test-helpers.js'
 import { requestTabLeadership } from '../../utils/requestTabLeadership.js'
 
 jest.mock('../../services/conversationsService', () => ({
@@ -742,7 +742,7 @@ describe('LeftSidebar.vue', () => {
 		subscribe('show-settings', eventHandler)
 		const wrapper = mountComponent()
 
-		const button = wrapper.find('.settings-button')
+		const button = findNcButton(wrapper, 'Talk settings')
 		expect(button.exists()).toBeTruthy()
 
 		await button.trigger('click')

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -280,12 +280,13 @@
 		</template>
 
 		<template #footer>
-			<div id="app-settings">
-				<div id="app-settings-header">
-					<NcButton class="settings-button" @click="showSettings">
-						{{ t('spreed', 'Talk settings') }}
-					</NcButton>
-				</div>
+			<div class="left-sidebar__settings-button-container">
+				<NcButton type="tertiary" wide @click="showSettings">
+					<template #icon>
+						<Cog :size="20" />
+					</template>
+					{{ t('spreed', 'Talk settings') }}
+				</NcButton>
 			</div>
 		</template>
 	</NcAppNavigation>
@@ -298,6 +299,7 @@ import { ref } from 'vue'
 import AccountMultiplePlus from 'vue-material-design-icons/AccountMultiplePlus.vue'
 import AtIcon from 'vue-material-design-icons/At.vue'
 import ChatPlus from 'vue-material-design-icons/ChatPlus.vue'
+import Cog from 'vue-material-design-icons/Cog.vue'
 import FilterIcon from 'vue-material-design-icons/Filter.vue'
 import FilterRemoveIcon from 'vue-material-design-icons/FilterRemove.vue'
 import List from 'vue-material-design-icons/FormatListBulleted.vue'
@@ -393,6 +395,7 @@ export default {
 		Phone,
 		Plus,
 		ChatPlus,
+		Cog,
 		List,
 		Note,
 		NcEmptyContent,
@@ -1087,13 +1090,13 @@ export default {
 	}
 }
 
+.left-sidebar__settings-button-container {
+	padding: calc(2 * var(--default-grid-baseline));
+}
+
 :deep(.empty-content) {
 	text-align: center;
 	padding: 20% 10px 0;
-}
-
-.settings-button {
-	justify-content: flex-start !important;
 }
 
 :deep(.app-navigation__list) {
@@ -1111,9 +1114,5 @@ export default {
 :deep(.list-item) {
 	overflow: hidden;
 	outline-offset: -2px;
-}
-
-:deep(#app-settings-header) {
-	padding-top: calc(var(--default-grid-baseline) * 2);
 }
 </style>

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -1027,14 +1027,14 @@ export default {
 
 	.filters {
 		position: absolute;
-		top: 8px;
-		right: 56px;
+		top: calc(var(--default-grid-baseline) * 2);
+		right: calc(var(--default-grid-baseline) * 3 + var(--default-clickable-area));
 	}
 
 	.actions {
 		position: absolute;
-		top: 8px;
-		right: 8px;
+		top: calc(var(--default-grid-baseline) * 2);
+		right: calc(var(--default-grid-baseline) * 2);
 	}
 }
 
@@ -1074,15 +1074,12 @@ export default {
 .conversations-search {
 	transition: all 0.15s ease;
 	z-index: 1;
-	// New conversation button width : 52 px
-	// Filters button width : 44 px
-	// Spacing : 3px + 1px
-	// Total : 100 px
-	width: calc(100% - 100px);
+	// TODO replace with NcAppNavigationSearch
+	width: calc(100% - var(--default-grid-baseline) * 2 - var(--default-clickable-area) * 2);
 	display: flex;
 
 	&--expanded {
-		width: calc(100% - 8px);
+		width: 100%;
 	}
 
 	:deep(.input-field) {


### PR DESCRIPTION
### ☑️ Resolves

* Settings button is a nix of global legacy server styles and `@nextcloud/vue`
  * It's style is a bit different from other buttons
  * It has double outline on focus
* Options 1: `secondary` - same as other similar apps - Mail, Calendar
* Options 2: `tertiary` - close to previous design
* Also, added a top padding

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After (secondary) | 🏡 After (tertiary)
-- | -- | --
![image](https://github.com/nextcloud/spreed/assets/25978914/86c7abe3-df72-442f-88f9-d3bf2a1cb7cb) | ![image](https://github.com/nextcloud/spreed/assets/25978914/c1e657c4-3b4e-4ba5-a291-1e0c07c2cb74) | ![image](https://github.com/nextcloud/spreed/assets/25978914/21ae1174-f944-4285-9ef5-2a89bf320d6b)
![image](https://github.com/nextcloud/spreed/assets/25978914/6387fc18-d1c7-4fb9-8fa2-1bd6615f0708) | ![image](https://github.com/nextcloud/spreed/assets/25978914/ba99368c-66db-4abc-b7d4-ed52c01059b4) | ![image](https://github.com/nextcloud/spreed/assets/25978914/f06b1b74-52cb-4b2f-89eb-593d54a1a22a)
![image](https://github.com/nextcloud/spreed/assets/25978914/2debb4fd-86c0-4042-bfb2-d3a3b5ca1724) | . | ![image](https://github.com/nextcloud/spreed/assets/25978914/e43e580a-4ab3-4003-9a31-7bd758028154)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required