### PR TITLE
fix: replace emoji-mart-vue-fast lib usage with nextcloud/vue function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@nextcloud/vue": "^8.11.3",
         "crypto-js": "^4.2.0",
         "debounce": "^2.0.0",
-        "emoji-mart-vue-fast": "^15.0.2",
         "emoji-regex": "^10.3.0",
         "escape-html": "^1.0.3",
         "extendable-media-recorder": "^9.2.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@nextcloud/vue": "^8.11.3",
     "crypto-js": "^4.2.0",
     "debounce": "^2.0.0",
-    "emoji-mart-vue-fast": "^15.0.2",
     "emoji-regex": "^10.3.0",
     "escape-html": "^1.0.3",
     "extendable-media-recorder": "^9.2.2",

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -248,8 +248,6 @@
 </template>
 
 <script>
-import { frequently, EmojiIndex as EmojiIndexFactory } from 'emoji-mart-vue-fast'
-import data from 'emoji-mart-vue-fast/data/all.json'
 import { toRefs } from 'vue'
 
 import AccountIcon from 'vue-material-design-icons/Account.vue'
@@ -286,6 +284,7 @@ import NcActionSeparator from '@nextcloud/vue/dist/Components/NcActionSeparator.
 import NcActionText from '@nextcloud/vue/dist/Components/NcActionText.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcEmojiPicker from '@nextcloud/vue/dist/Components/NcEmojiPicker.js'
+import { emojiSearch } from '@nextcloud/vue/dist/Functions/emoji.js'
 
 import { useMessageInfo } from '../../../../../composables/useMessageInfo.js'
 import { CONVERSATION, ATTENDEE } from '../../../../../constants.js'
@@ -295,7 +294,6 @@ import { useReactionsStore } from '../../../../../stores/reactions.js'
 import { copyConversationLinkToClipboard } from '../../../../../utils/handleUrl.ts'
 import { parseMentions } from '../../../../../utils/textParse.ts'
 
-const EmojiIndex = new EmojiIndexFactory(data)
 const supportReminders = getCapabilities()?.spreed?.features?.includes('remind-me-later')
 
 export default {
@@ -759,9 +757,7 @@ export default {
 		},
 
 		updateFrequentlyUsedEmojis() {
-			this.frequentlyUsedEmojis = frequently.get(5).map(emojiStrings => {
-				return EmojiIndex.emoji(emojiStrings).native
-			})
+			this.frequentlyUsedEmojis = emojiSearch('', 5).map(emoji => emoji.native)
 		},
 
 		getTimestamp(momentObject) {


### PR DESCRIPTION
### ☑️ Resolves

* Required https://github.com/nextcloud-libraries/nextcloud-vue/pull/5553
  * Reduce dependencies list (bundle size if different versions) by reusing available function from `nextcloud/vue` library
  * Supports skin tone

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/cc9782f7-038c-454b-8038-027690a9898d) | ![image](https://github.com/nextcloud/spreed/assets/93392545/b7312a7a-c7a4-4272-994f-7a43d62cff04)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 