### PR TITLE
fix(LobbySettings): convert to string before passing it to translation

### DIFF
--- a/src/components/ConversationSettings/LobbySettings.vue
+++ b/src/components/ConversationSettings/LobbySettings.vue
@@ -145,7 +145,7 @@ export default {
 				return ''
 			}
 			const date = new Date(this.lobbyTimer)
-			return t('spreed', 'Start time: {date}', { date })
+			return t('spreed', 'Start time: {date}', { date: date.toString() })
 		},
 
 		getRelativeTime() {


### PR DESCRIPTION
### ☑️ Resolves

It seems that placeholders in [translation](https://github.com/nextcloud-libraries/nextcloud-l10n/blob/main/lib/translation.ts#L70) are not converted to strings, at least to minimize [unhandled cases](https://github.com/nextcloud-libraries/nextcloud-l10n/blob/e0b16b54fc946273e31e99e0b16d5e85b4ff9560/lib/translation.ts#L88)  :')  

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/84044328/6f3fe389-689f-4b02-be76-0ae3f5b4dbee) | ![image](https://github.com/nextcloud/spreed/assets/84044328/43b8f25f-9439-4430-8b1a-29f43bb484f6)

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
