### PR TITLE
fix(chat): focus submit on upload attachments without caption

### DIFF
--- a/src/components/NewMessage/NewMessageUploadEditor.vue
+++ b/src/components/NewMessage/NewMessageUploadEditor.vue
@@ -55,7 +55,7 @@
 				<NcButton type="tertiary" @click="handleDismiss">
 					{{ t('spreed', 'Dismiss') }}
 				</NcButton>
-				<NcButton type="primary" @click="handleUpload({ caption: null, options: null})">
+				<NcButton ref="submitButton" type="primary" @click="handleUpload({ caption: null, options: null})">
 					{{ t('spreed', 'Send') }}
 				</NcButton>
 			</div>
@@ -169,21 +169,25 @@ export default {
 
 	watch: {
 		async showModal(show) {
-			if (show && this.supportMediaCaption) {
+			if (show) {
+				// Wait for modal content to be rendered
 				await this.getContainerId()
-				this.$nextTick(() => {
-					this.$refs.newMessage?.focusInput()
-				})
+				if (this.supportMediaCaption) {
+					// Wait for NewMessage to be rendered after containerId is set
+					await this.$nextTick()
+					this.$refs.newMessage.focusInput()
+				} else {
+					this.$refs.submitButton.$el.focus()
+				}
 			}
 		},
 	},
 
 	methods: {
 		async getContainerId() {
-			this.$nextTick(() => {
-				// Postpone render of NewMessage until modal container is mounted
-				this.modalContainerId = `#modal-description-${this.$refs.modal.randId}`
-			})
+			await this.$nextTick()
+			// Postpone render of NewMessage until modal container is mounted
+			this.modalContainerId = `#modal-description-${this.$refs.modal.randId}`
 		},
 
 		handleDismiss() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/talk-desktop/issues/651
* Regression of https://github.com/nextcloud/spreed/pull/10730 for old servers:
  * When captions aren't supported submit button should be focus as it was before adding captions
  * Otherwise it is focused on "Close" button and `Enter` results in dismissing sending files
* Removed optional chaining `?.` to not miss error here
* Note, `getContainerId` did not returned actual promise from `nextTick`. It word because of `await` just as `await Promise.resolve()` but it is not guaranteed

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/25978914/d8402f27-9877-4565-8496-948a438cabdd) | ![image](https://github.com/nextcloud/spreed/assets/25978914/9301b950-b055-415d-b33c-f222f5b28faf)
![image](https://github.com/nextcloud/spreed/assets/25978914/19d638e0-d422-4b7f-a58d-c5a9eed6fec7) | ![image](https://github.com/nextcloud/spreed/assets/25978914/31551ef6-023f-4652-9a02-9dae84cbe49a)

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [x] Focus `submitButton` if there is no input

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required