### PR TITLE
chore(deps): Bump @nextcloud/vue from 8.11.2 to 8.11.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/upload": "^1.1.1",
-        "@nextcloud/vue": "^8.11.2",
+        "@nextcloud/vue": "^8.11.3",
         "crypto-js": "^4.2.0",
         "debounce": "^2.0.0",
         "emoji-mart-vue-fast": "^15.0.2",
@@ -3742,15 +3742,15 @@
       }
     },
     "node_modules/@nextcloud/l10n": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.0.0.tgz",
-      "integrity": "sha512-m1RqUuIM6Ms0S+clXvO7rcra/XOF38wVUM00sn55jsSSbJ3CMLdanX7vpgIVEF4V5UxS8IZvhEppSC1XgOe7XQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.1.0.tgz",
+      "integrity": "sha512-unciqr8QSJ29vFBw9S1bquyoj1PTWHszNL8tcUNuxUAYpq0hX+8o7rpB5gimELA4sj4m9+VCJwgLtBZd1Yj0lg==",
       "dependencies": {
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/typings": "^1.8.0",
         "@types/dompurify": "^3.0.5",
         "@types/escape-html": "^1.0.4",
-        "dompurify": "^3.1.1",
+        "dompurify": "^3.1.2",
         "escape-html": "^1.0.3",
         "node-gettext": "^3.0.0"
       },
@@ -3923,21 +3923,21 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.2.tgz",
-      "integrity": "sha512-mjA3Ni2CB3gOkKFMYFhQUjqaUos8hnwglfvz3lPp5LVrORsXaHa3C2ZudVp+hAKslVsRKkjfMYOKrlquw8vxQw==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.3.tgz",
+      "integrity": "sha512-W+0zsu8JIvHDI+DD+suYRBRqEGotgE4aBIPTLx7AxiL9CMTEzKP8g3hrEnpen9P7DBs6JpxIzsAWN7yyRzkP4w==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
         "@nextcloud/auth": "^2.2.1",
         "@nextcloud/axios": "^2.4.0",
-        "@nextcloud/browser-storage": "^0.3.0",
+        "@nextcloud/browser-storage": "^0.4.0",
         "@nextcloud/calendar-js": "^6.1.0",
         "@nextcloud/capabilities": "^1.1.0",
         "@nextcloud/event-bus": "^3.1.0",
         "@nextcloud/initial-state": "^2.1.0",
-        "@nextcloud/l10n": "^2.2.0",
-        "@nextcloud/logger": "^2.7.0",
+        "@nextcloud/l10n": "^3.0.1",
+        "@nextcloud/logger": "^3.0.1",
         "@nextcloud/router": "^3.0.0",
         "@nextcloud/vue-select": "^3.25.0",
         "@vueuse/components": "^10.9.0",
@@ -4002,18 +4002,6 @@
         "@floating-ui/utils": "^0.1.3"
       }
     },
-    "node_modules/@nextcloud/vue/node_modules/@nextcloud/browser-storage": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.3.0.tgz",
-      "integrity": "sha512-vqc26T4WQ3y9EbFpHh4dl/FN7ahEfEoc0unQmsdJ2YSZNTxTvAXAasWI6HFNcHi10b5rEYxxEYjAwKF34th3Aw==",
-      "dependencies": {
-        "core-js": "3.33.0"
-      },
-      "engines": {
-        "node": "^20.0.0",
-        "npm": "^9.0.0"
-      }
-    },
     "node_modules/@nextcloud/vue/node_modules/@nextcloud/calendar-js": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.1.0.tgz",
@@ -4027,33 +4015,16 @@
         "uuid": "^9.0.0"
       }
     },
-    "node_modules/@nextcloud/vue/node_modules/@nextcloud/l10n": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-2.2.0.tgz",
-      "integrity": "sha512-UAM2NJcl/NR46MANSF7Gr7q8/Up672zRyGrxLpN3k4URNmWQM9upkbRME+1K3T29wPrUyOIbQu710ZjvZafqFA==",
+    "node_modules/@nextcloud/vue/node_modules/@nextcloud/logger": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-3.0.1.tgz",
+      "integrity": "sha512-Q/c3WNp2BaXJ8sBWHsZaQ6I3k/gWMDW0ikP1vCLYq55xPxmRWwNN+X1dgUeMG3iPvQQgsjOoz+JiaZ8Mej15aA==",
       "dependencies": {
-        "@nextcloud/router": "^2.1.2",
-        "@nextcloud/typings": "^1.7.0",
-        "dompurify": "^3.0.3",
-        "escape-html": "^1.0.3",
-        "node-gettext": "^3.0.0"
+        "@nextcloud/auth": "^2.3.0"
       },
       "engines": {
         "node": "^20.0.0",
-        "npm": "^9.0.0"
-      }
-    },
-    "node_modules/@nextcloud/vue/node_modules/@nextcloud/l10n/node_modules/@nextcloud/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-M4AVGnB5tt3MYO5RpH/R2jq7z/nW05AmRhk4Lh68krVwRIYGo8pgNikKrPGogHd2Q3UgzF5Py1drHz3uuV99bQ==",
-      "dependencies": {
-        "@nextcloud/typings": "^1.7.0",
-        "core-js": "^3.6.4"
-      },
-      "engines": {
-        "node": "^20.0.0",
-        "npm": "^9.0.0"
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/vue/node_modules/@types/unist": {
@@ -4070,16 +4041,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@nextcloud/vue/node_modules/core-js": {
-      "version": "3.33.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.0.tgz",
-      "integrity": "sha512-HoZr92+ZjFEKar5HS6MC776gYslNOKHt75mEBKWKnPeFDpZ6nH5OeF3S6HFT1mUAUZKrzkez05VboaX8myjSuw==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/@nextcloud/vue/node_modules/is-plain-obj": {
@@ -23302,15 +23263,15 @@
       "integrity": "sha512-cDW98L5KGGgpS8pzd+05304/p80cyu8U2xSDQGa+kGPTpUFmCbv2qnO5WrwwGTauyjYijCal2bmw82VddSH+Pg=="
     },
     "@nextcloud/l10n": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.0.0.tgz",
-      "integrity": "sha512-m1RqUuIM6Ms0S+clXvO7rcra/XOF38wVUM00sn55jsSSbJ3CMLdanX7vpgIVEF4V5UxS8IZvhEppSC1XgOe7XQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.1.0.tgz",
+      "integrity": "sha512-unciqr8QSJ29vFBw9S1bquyoj1PTWHszNL8tcUNuxUAYpq0hX+8o7rpB5gimELA4sj4m9+VCJwgLtBZd1Yj0lg==",
       "requires": {
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/typings": "^1.8.0",
         "@types/dompurify": "^3.0.5",
         "@types/escape-html": "^1.0.4",
-        "dompurify": "^3.1.1",
+        "dompurify": "^3.1.2",
         "escape-html": "^1.0.3",
         "node-gettext": "^3.0.0"
       }
@@ -23437,21 +23398,21 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.2.tgz",
-      "integrity": "sha512-mjA3Ni2CB3gOkKFMYFhQUjqaUos8hnwglfvz3lPp5LVrORsXaHa3C2ZudVp+hAKslVsRKkjfMYOKrlquw8vxQw==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.11.3.tgz",
+      "integrity": "sha512-W+0zsu8JIvHDI+DD+suYRBRqEGotgE4aBIPTLx7AxiL9CMTEzKP8g3hrEnpen9P7DBs6JpxIzsAWN7yyRzkP4w==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
         "@nextcloud/auth": "^2.2.1",
         "@nextcloud/axios": "^2.4.0",
-        "@nextcloud/browser-storage": "^0.3.0",
+        "@nextcloud/browser-storage": "^0.4.0",
         "@nextcloud/calendar-js": "^6.1.0",
         "@nextcloud/capabilities": "^1.1.0",
         "@nextcloud/event-bus": "^3.1.0",
         "@nextcloud/initial-state": "^2.1.0",
-        "@nextcloud/l10n": "^2.2.0",
-        "@nextcloud/logger": "^2.7.0",
+        "@nextcloud/l10n": "^3.0.1",
+        "@nextcloud/logger": "^3.0.1",
         "@nextcloud/router": "^3.0.0",
         "@nextcloud/vue-select": "^3.25.0",
         "@vueuse/components": "^10.9.0",
@@ -23501,41 +23462,18 @@
             "@floating-ui/utils": "^0.1.3"
           }
         },
-        "@nextcloud/browser-storage": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.3.0.tgz",
-          "integrity": "sha512-vqc26T4WQ3y9EbFpHh4dl/FN7ahEfEoc0unQmsdJ2YSZNTxTvAXAasWI6HFNcHi10b5rEYxxEYjAwKF34th3Aw==",
-          "requires": {
-            "core-js": "3.33.0"
-          }
-        },
         "@nextcloud/calendar-js": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.1.0.tgz",
           "integrity": "sha512-thVS6Bz+TV7rUB+LO5yFbOhdm65zICDRKcHDUquaZiWL9r6TyV9hCYDcP7cDRV+62wZJh8QPmf1E+d7ZFUOVeA==",
           "requires": {}
         },
-        "@nextcloud/l10n": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-2.2.0.tgz",
-          "integrity": "sha512-UAM2NJcl/NR46MANSF7Gr7q8/Up672zRyGrxLpN3k4URNmWQM9upkbRME+1K3T29wPrUyOIbQu710ZjvZafqFA==",
+        "@nextcloud/logger": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-3.0.1.tgz",
+          "integrity": "sha512-Q/c3WNp2BaXJ8sBWHsZaQ6I3k/gWMDW0ikP1vCLYq55xPxmRWwNN+X1dgUeMG3iPvQQgsjOoz+JiaZ8Mej15aA==",
           "requires": {
-            "@nextcloud/router": "^2.1.2",
-            "@nextcloud/typings": "^1.7.0",
-            "dompurify": "^3.0.3",
-            "escape-html": "^1.0.3",
-            "node-gettext": "^3.0.0"
-          },
-          "dependencies": {
-            "@nextcloud/router": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.0.tgz",
-              "integrity": "sha512-M4AVGnB5tt3MYO5RpH/R2jq7z/nW05AmRhk4Lh68krVwRIYGo8pgNikKrPGogHd2Q3UgzF5Py1drHz3uuV99bQ==",
-              "requires": {
-                "@nextcloud/typings": "^1.7.0",
-                "core-js": "^3.6.4"
-              }
-            }
+            "@nextcloud/auth": "^2.3.0"
           }
         },
         "@types/unist": {
@@ -23547,11 +23485,6 @@
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
           "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
-        },
-        "core-js": {
-          "version": "3.33.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.0.tgz",
-          "integrity": "sha512-HoZr92+ZjFEKar5HS6MC776gYslNOKHt75mEBKWKnPeFDpZ6nH5OeF3S6HFT1mUAUZKrzkez05VboaX8myjSuw=="
         },
         "is-plain-obj": {
           "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/upload": "^1.1.1",
-    "@nextcloud/vue": "^8.11.2",
+    "@nextcloud/vue": "^8.11.3",
     "crypto-js": "^4.2.0",
     "debounce": "^2.0.0",
     "emoji-mart-vue-fast": "^15.0.2",


### PR DESCRIPTION
### ☑️ Resolves

* Fix #…
* Changelog: https://github.com/nextcloud-libraries/nextcloud-vue/releases/tag/v8.11.3

## 🖌️ UI Checklist
<!--
### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

### 🚧 Tasks

- [ ] ...
-->

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 