### PR TITLE
fix: check for `note-to-self` capability on frontend

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -73,7 +73,7 @@
 						{{ t('spreed', 'Create a new conversation') }}
 					</NcActionButton>
 
-					<NcActionButton v-if="!hasNoteToSelf"
+					<NcActionButton v-if="canNoteToSelf && !hasNoteToSelf"
 						close-after-click
 						@click="restoreNoteToSelfConversation">
 						<template #icon>
@@ -357,6 +357,7 @@ const canModerateSipDialOut = getCapabilities()?.spreed?.features?.includes('sip
 	&& getCapabilities()?.spreed?.config.call['sip-enabled']
 	&& getCapabilities()?.spreed?.config.call['sip-dialout-enabled']
 	&& getCapabilities()?.spreed?.config.call['can-enable-sip']
+const canNoteToSelf = getCapabilities()?.spreed?.features?.includes('note-to-self')
 
 export default {
 	name: 'LeftSidebar',
@@ -417,6 +418,7 @@ export default {
 			isMobile,
 			canModerateSipDialOut,
 			isFederationEnabled,
+			canNoteToSelf,
 		}
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix: there is always `New personal note` button even on `stable27` without this feature

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/25978914/31f8cb63-4e6e-4330-b528-209d48683563) | ![image](https://github.com/nextcloud/spreed/assets/25978914/d0c23734-af40-4b9f-9d1f-dc815acbb896)

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [x] Check for capabilities

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required