### PR TITLE
fix(settings): don't allow guests when breakout rooms are set

### DIFF
--- a/src/components/ConversationSettings/LinkShareSettings.vue
+++ b/src/components/ConversationSettings/LinkShareSettings.vue
@@ -10,8 +10,11 @@
 		</h4>
 
 		<template v-if="canModerate">
+			<p v-if="hasBreakoutRooms" class="app-settings-section__hint">
+				{{ t('spreed', 'Breakout rooms are not allowed in public conversations.') }}
+			</p>
 			<NcCheckboxRadioSwitch :checked="isSharedPublicly"
-				:disabled="isSaving"
+				:disabled="hasBreakoutRooms || isSaving"
 				type="switch"
 				aria-describedby="link_share_settings_hint"
 				@update:checked="toggleGuests">
@@ -133,18 +136,16 @@ export default {
 			return this.$store.getters.conversation(this.token) || this.$store.getters.dummyConversation
 		},
 
+		hasBreakoutRooms() {
+			return this.conversation.breakoutRoomMode !== CONVERSATION.BREAKOUT_ROOM_MODE.NOT_CONFIGURED
+		},
+
 		isPasswordProtectionChecked() {
 			return this.conversation.hasPassword || this.showPasswordField
 		},
 	},
 
 	methods: {
-		focus() {
-			this.$nextTick(() => {
-				this.$refs.toggleGuests.focus()
-			})
-		},
-
 		async setConversationPassword(newPassword) {
 			this.isSaving = true
 			try {
@@ -169,27 +170,9 @@ export default {
 		},
 
 		async toggleGuests() {
-			const enabled = this.conversation.type !== CONVERSATION.TYPE.PUBLIC
+			const allowGuests = this.conversation.type !== CONVERSATION.TYPE.PUBLIC
 			this.isSaving = true
-			try {
-				await this.$store.dispatch('toggleGuests', {
-					token: this.token,
-					allowGuests: enabled,
-				})
-
-				if (enabled) {
-					showSuccess(t('spreed', 'You allowed guests'))
-				} else {
-					showSuccess(t('spreed', 'You disallowed guests'))
-				}
-			} catch (e) {
-				if (enabled) {
-					showError(t('spreed', 'Error occurred while allowing guests'))
-				} else {
-					showError(t('spreed', 'Error occurred while disallowing guests'))
-				}
-				console.error('Error toggling guest mode', e)
-			}
+			await this.$store.dispatch('toggleGuests', { token: this.token, allowGuests })
 			this.isSaving = false
 		},
 

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -471,17 +471,22 @@ const actions = {
 		}
 
 		try {
-			const conversation = Object.assign({}, getters.conversations[token])
+			const conversation = Object.assign({}, getters.conversation(token))
 			if (allowGuests) {
 				await makeConversationPublic(token)
 				conversation.type = CONVERSATION.TYPE.PUBLIC
+				showSuccess(t('spreed', 'You allowed guests'))
 			} else {
 				await makeConversationPrivate(token)
 				conversation.type = CONVERSATION.TYPE.GROUP
+				showSuccess(t('spreed', 'You disallowed guests'))
 			}
 			commit('addConversation', conversation)
 		} catch (error) {
 			console.error('Error while changing the conversation public status: ', error)
+			showError(allowGuests
+				? t('spreed', 'Error occurred while allowing guests')
+				: t('spreed', 'Error occurred while disallowing guests'))
 		}
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* keep error handling in the store only
* disable option in dialog window

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/387385d1-b74c-4239-b03e-101027aadc5a) | unreachable
![image](https://github.com/nextcloud/spreed/assets/93392545/bc574f00-e292-42c3-a2c3-09a52e47a0e1) | ![Screenshot from 2024-05-13 11-14-07](https://github.com/nextcloud/spreed/assets/93392545/79ad8f75-dbb1-4c1c-9b48-f69869600a64)


<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possible