### PR TITLE
fix(federation): use a value from response header to count invites

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -534,7 +534,7 @@ export default {
 
 		pendingInvitationsCount() {
 			return isFederationEnabled
-				? Object.keys(this.federationStore.pendingShares).length
+				? this.federationStore.pendingSharesCount
 				: 0
 		},
 
@@ -593,10 +593,6 @@ export default {
 			this.refreshTimer = window.setInterval(() => {
 				this.fetchConversations()
 			}, 30000)
-
-			if (isFederationEnabled) {
-				this.federationStore.getShares()
-			}
 		})
 
 		talkBroadcastChannel.addEventListener('message', (event) => {

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -55,6 +55,7 @@ import {
 import { talkBroadcastChannel } from '../services/talkBroadcastChannel.js'
 import { useBreakoutRoomsStore } from '../stores/breakoutRooms.ts'
 import { useChatExtrasStore } from '../stores/chatExtras.js'
+import { useFederationStore } from '../stores/federation.ts'
 import { useReactionsStore } from '../stores/reactions.js'
 import { useTalkHashStore } from '../stores/talkHash.js'
 
@@ -845,6 +846,7 @@ const actions = {
 
 	async fetchConversations({ dispatch }, { modifiedSince }) {
 		const talkHashStore = useTalkHashStore()
+		const federationStore = useFederationStore()
 		try {
 			talkHashStore.clearMaintenanceMode()
 			modifiedSince = modifiedSince || 0
@@ -860,6 +862,7 @@ const actions = {
 
 			const response = await fetchConversations(options)
 			talkHashStore.updateTalkVersionHash(response)
+			federationStore.updatePendingSharesCount(response.headers['x-nextcloud-talk-federation-invites'])
 
 			dispatch('patchConversations', {
 				conversations: response.data.ocs.data,

--- a/src/store/conversationsStore.spec.js
+++ b/src/store/conversationsStore.spec.js
@@ -546,13 +546,7 @@ describe('conversationsStore', () => {
 			// add conversation that should be removed
 			store.dispatch('addConversation', testConversation)
 
-			const response = {
-				data: {
-					ocs: {
-						data: testConversations,
-					},
-				},
-			}
+			const response = generateOCSResponse({ payload: testConversations })
 
 			fetchConversations.mockResolvedValue(response)
 
@@ -594,13 +588,7 @@ describe('conversationsStore', () => {
 			}
 			const modifiedSince = 1675209600 // 2023-02-01T00:00:00.000Z
 
-			const response = {
-				data: {
-					ocs: {
-						data: [newConversation1, newConversation2],
-					},
-				},
-			}
+			const response = generateOCSResponse({ payload: [newConversation1, newConversation2] })
 
 			fetchConversations.mockResolvedValue(response)
 

--- a/src/stores/__tests__/federation.spec.js
+++ b/src/stores/__tests__/federation.spec.js
@@ -124,6 +124,23 @@ describe('federationStore', () => {
 		expect(federationStore.pendingSharesCount).toBe(1)
 	})
 
+	it('processes a response from server and remove outdated invites', async () => {
+		// Arrange
+		const response = generateOCSResponse({ payload: invites })
+		getShares.mockResolvedValueOnce(response)
+		await federationStore.getShares()
+
+		// Act: load empty response from server
+		const responseEmpty = generateOCSResponse({ payload: [] })
+		getShares.mockResolvedValueOnce(responseEmpty)
+		await federationStore.getShares()
+
+		// Assert
+		expect(federationStore.pendingShares).toStrictEqual({})
+		expect(federationStore.acceptedShares).toStrictEqual({})
+		expect(federationStore.pendingSharesCount).toBe(0)
+	})
+
 	it('handles error in server request for getShares', async () => {
 		// Arrange
 		const response = generateOCSErrorResponse({ status: 404, payload: [] })

--- a/src/stores/__tests__/federation.spec.js
+++ b/src/stores/__tests__/federation.spec.js
@@ -121,6 +121,7 @@ describe('federationStore', () => {
 		expect(getShares).toHaveBeenCalled()
 		expect(federationStore.pendingShares).toMatchObject({ [invites[0].id]: invites[0] })
 		expect(federationStore.acceptedShares).toMatchObject({ [invites[1].id]: invites[1] })
+		expect(federationStore.pendingSharesCount).toBe(1)
 	})
 
 	it('handles error in server request for getShares', async () => {
@@ -135,6 +136,7 @@ describe('federationStore', () => {
 		// Assert: store hasn't changed
 		expect(federationStore.pendingShares).toStrictEqual({})
 		expect(federationStore.acceptedShares).toStrictEqual({})
+		expect(federationStore.pendingSharesCount).toBe(0)
 	})
 
 	it('updates invites in the store after receiving a notification', async () => {
@@ -152,6 +154,7 @@ describe('federationStore', () => {
 			[notifications[1].objectId]: { id: notifications[1].objectId },
 		})
 		expect(federationStore.acceptedShares).toMatchObject({ [invites[1].id]: invites[1] })
+		expect(federationStore.pendingSharesCount).toBe(2)
 	})
 
 	it('accepts invitation and modify store', async () => {
@@ -178,6 +181,7 @@ describe('federationStore', () => {
 			[invites[0].id]: { ...invites[0], state: 1 },
 			[invites[1].id]: invites[1],
 		})
+		expect(federationStore.pendingSharesCount).toBe(0)
 	})
 
 	it('skip already accepted invitations', async () => {
@@ -228,6 +232,7 @@ describe('federationStore', () => {
 		expect(rejectShare).toHaveBeenCalledWith(invites[0].id)
 		expect(federationStore.pendingShares).toStrictEqual({})
 		expect(federationStore.acceptedShares).toMatchObject({ [invites[1].id]: invites[1] })
+		expect(federationStore.pendingSharesCount).toBe(1)
 	})
 
 	it('skip already rejected invitations', async () => {

--- a/src/stores/federation.ts
+++ b/src/stores/federation.ts
@@ -32,13 +32,17 @@ export const useFederationStore = defineStore('federation', {
 		async getShares() {
 			try {
 				const response = await getShares()
+				const acceptedShares: State['acceptedShares'] = {}
+				const pendingShares: State['pendingShares'] = {}
 				response.data.ocs.data.forEach(item => {
 					if (item.state === FEDERATION.STATE.ACCEPTED) {
-						Vue.set(this.acceptedShares, item.id, item)
+						acceptedShares[item.id] = item
 					} else {
-						Vue.set(this.pendingShares, item.id, item)
+						pendingShares[item.id] = item
 					}
 				})
+				Vue.set(this, 'acceptedShares', acceptedShares)
+				Vue.set(this, 'pendingShares', pendingShares)
 				this.updatePendingSharesCount(Object.keys(this.pendingShares).length)
 			} catch (error) {
 				console.error(error)
@@ -110,6 +114,11 @@ export const useFederationStore = defineStore('federation', {
 			} catch (error) {
 				console.error(error)
 				showError(t('spreed', 'An error occurred while accepting an invitation'))
+				// Dismiss the loading state, refresh the list
+				await this.getShares()
+				if (this.pendingShares[id]) {
+					Vue.delete(this.pendingShares[id], 'loading')
+				}
 			}
 		},
 
@@ -130,6 +139,11 @@ export const useFederationStore = defineStore('federation', {
 			} catch (error) {
 				console.error(error)
 				showError(t('spreed', 'An error occurred while rejecting an invitation'))
+				// Dismiss the loading state, refresh the list
+				await this.getShares()
+				if (this.pendingShares[id]) {
+					Vue.delete(this.pendingShares[id], 'loading')
+				}
 			}
 		},
 

--- a/src/stores/federation.ts
+++ b/src/stores/federation.ts
@@ -16,11 +16,13 @@ import type { Conversation, FederationInvite, NotificationInvite } from '../type
 type State = {
 	pendingShares: Record<string, FederationInvite & { loading?: 'accept' | 'reject' }>,
 	acceptedShares: Record<string, FederationInvite>,
+	pendingSharesCount: number,
 }
 export const useFederationStore = defineStore('federation', {
 	state: (): State => ({
 		pendingShares: {},
 		acceptedShares: {},
+		pendingSharesCount: 0,
 	}),
 
 	actions: {
@@ -37,6 +39,7 @@ export const useFederationStore = defineStore('federation', {
 						Vue.set(this.pendingShares, item.id, item)
 					}
 				})
+				this.updatePendingSharesCount(Object.keys(this.pendingShares).length)
 			} catch (error) {
 				console.error(error)
 			}
@@ -67,6 +70,7 @@ export const useFederationStore = defineStore('federation', {
 				inviterDisplayName: name,
 			}
 			Vue.set(this.pendingShares, invitation.id, invitation)
+			this.updatePendingSharesCount(Object.keys(this.pendingShares).length)
 		},
 
 		/**
@@ -101,6 +105,7 @@ export const useFederationStore = defineStore('federation', {
 				Vue.set(this.pendingShares[id], 'loading', 'accept')
 				const response = await acceptShare(id)
 				this.markInvitationAccepted(id, response.data.ocs.data)
+				this.updatePendingSharesCount(Object.keys(this.pendingShares).length)
 				return response.data.ocs.data
 			} catch (error) {
 				console.error(error)
@@ -120,11 +125,21 @@ export const useFederationStore = defineStore('federation', {
 			try {
 				Vue.set(this.pendingShares[id], 'loading', 'reject')
 				await rejectShare(id)
+				this.updatePendingSharesCount(Object.keys(this.pendingShares).length)
 				Vue.delete(this.pendingShares, id)
 			} catch (error) {
 				console.error(error)
 				showError(t('spreed', 'An error occurred while rejecting an invitation'))
 			}
+		},
+
+		/**
+		 * Update pending shares count.
+		 *
+		 * @param value amount of pending shares
+		 */
+		updatePendingSharesCount(value?: string|number) {
+			Vue.set(this, 'pendingSharesCount', value ? +value : 0)
 		},
 	},
 })


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up #11944
  * Use header `x-nextcloud-talk-federation-invites` to update counter within 30-sec interval
  * Also update manually while accpeting/dismissing
  * Rely on that number to show 'Pending invites' button
  * Fetch pending invites from server on-demand (if number mismatches)

## 🖌️ UI Checklist

Loading | Placeholder
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/fe0cbffb-6720-4585-a096-3f85c2dc1cb0) | ![image](https://github.com/nextcloud/spreed/assets/93392545/f59fa64e-4c9b-419f-8aab-3011a6a91285)


### 🚧 Tasks

- [ ] Manual test

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] ⛑️ Tests are included or not possible