### PR TITLE
fix: hide Translate option for files without caption

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -138,7 +138,7 @@
 						@click="action.callback(messageApiData)">
 						{{ action.label }}
 					</NcActionButton>
-					<NcActionButton v-if="isTranslationAvailable"
+					<NcActionButton v-if="isTranslationAvailable && !isFileShareWithoutCaption"
 						close-after-click
 						@click.stop="$emit('show-translate-dialog', true)"
 						@close="$emit('show-translate-dialog', false)">


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12347


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

 🏡 After
![Screenshot from 2024-05-14 11-44-42](https://github.com/nextcloud/spreed/assets/93392545/5d7b90bd-fc3a-47f5-98de-eb6223eca32f)
![Screenshot from 2024-05-14 11-44-37](https://github.com/nextcloud/spreed/assets/93392545/b7281a63-65e1-4b66-beb7-318225ead4b5)
![Screenshot from 2024-05-14 11-44-33](https://github.com/nextcloud/spreed/assets/93392545/2453179f-d657-41ef-933e-3aab54c6015d)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possible