### PR TITLE
refactor(plugins): add reusable requestRoomSelection util to run room selector

### DIFF
--- a/src/collections.js
+++ b/src/collections.js
@@ -5,53 +5,51 @@
 
 import Vue from 'vue'
 
-// eslint-disable-next-line no-unexpected-multiline
-(function(OCP, OC) {
+import { t, n } from '@nextcloud/l10n'
 
-	// eslint-disable-next-line
-	__webpack_nonce__ = btoa(OC.requestToken)
-	// eslint-disable-next-line
-	__webpack_public_path__ = OC.linkTo('spreed', 'js/')
+// eslint-disable-next-line
+__webpack_nonce__ = btoa(OC.requestToken)
+// eslint-disable-next-line
+__webpack_public_path__ = OC.linkTo('spreed', 'js/')
 
-	Vue.prototype.t = t
-	Vue.prototype.n = n
-	Vue.prototype.OC = OC
+Vue.prototype.t = t
+Vue.prototype.n = n
+Vue.prototype.OC = window.OC
 
-	OCP.Collaboration.registerType('room', {
-		action: () => {
-			return new Promise((resolve, reject) => {
-				const container = document.createElement('div')
-				container.id = 'spreed-room-select'
-				const body = document.getElementById('body-user')
-				body.appendChild(container)
+window.OCP.Collaboration.registerType('room', {
+	action: () => {
+		return new Promise((resolve, reject) => {
+			const container = document.createElement('div')
+			container.id = 'spreed-room-select'
+			const body = document.getElementById('body-user')
+			body.appendChild(container)
 
-				const RoomSelector = () => import('./components/RoomSelector.vue')
-				const ComponentVM = new Vue({
-					el: container,
-					render: h => h(RoomSelector, {
-						props: {
-							// Even if it is used from Talk the Collections menu is
-							// independently loaded, so the properties that depend
-							// on the store need to be explicitly injected.
-							container: window.store ? window.store.getters.getMainContainerSelector() : undefined,
-							isPlugin: true,
-						},
-					}),
-				})
-
-				ComponentVM.$root.$on('close', () => {
-					ComponentVM.$el.remove()
-					ComponentVM.$destroy()
-					reject(new Error('User cancelled resource selection'))
-				})
-				ComponentVM.$root.$on('select', ({ token }) => {
-					resolve(token)
-					ComponentVM.$el.remove()
-					ComponentVM.$destroy()
-				})
+			const RoomSelector = () => import('./components/RoomSelector.vue')
+			const ComponentVM = new Vue({
+				el: container,
+				render: h => h(RoomSelector, {
+					props: {
+						// Even if it is used from Talk the Collections menu is
+						// independently loaded, so the properties that depend
+						// on the store need to be explicitly injected.
+						container: window.store ? window.store.getters.getMainContainerSelector() : undefined,
+						isPlugin: true,
+					},
+				}),
 			})
-		},
-		typeString: t('spreed', 'Link to a conversation'),
-		typeIconClass: 'icon-talk',
-	})
-})(window.OCP, window.OC)
+
+			ComponentVM.$root.$on('close', () => {
+				ComponentVM.$el.remove()
+				ComponentVM.$destroy()
+				reject(new Error('User cancelled resource selection'))
+			})
+			ComponentVM.$root.$on('select', ({ token }) => {
+				resolve(token)
+				ComponentVM.$el.remove()
+				ComponentVM.$destroy()
+			})
+		})
+	},
+	typeString: t('spreed', 'Link to a conversation'),
+	typeIconClass: 'icon-talk',
+})

--- a/src/collections.js
+++ b/src/collections.js
@@ -3,52 +3,27 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import Vue from 'vue'
+import { t } from '@nextcloud/l10n'
 
-import { t, n } from '@nextcloud/l10n'
+import { requestRoomSelection } from './utils/requestRoomSelection.js'
 
 // eslint-disable-next-line
 __webpack_nonce__ = btoa(OC.requestToken)
 // eslint-disable-next-line
 __webpack_public_path__ = OC.linkTo('spreed', 'js/')
 
-Vue.prototype.t = t
-Vue.prototype.n = n
-Vue.prototype.OC = window.OC
-
 window.OCP.Collaboration.registerType('room', {
-	action: () => {
-		return new Promise((resolve, reject) => {
-			const container = document.createElement('div')
-			container.id = 'spreed-room-select'
-			const body = document.getElementById('body-user')
-			body.appendChild(container)
-
-			const RoomSelector = () => import('./components/RoomSelector.vue')
-			const ComponentVM = new Vue({
-				el: container,
-				render: h => h(RoomSelector, {
-					props: {
-						// Even if it is used from Talk the Collections menu is
-						// independently loaded, so the properties that depend
-						// on the store need to be explicitly injected.
-						container: window.store ? window.store.getters.getMainContainerSelector() : undefined,
-						isPlugin: true,
-					},
-				}),
-			})
-
-			ComponentVM.$root.$on('close', () => {
-				ComponentVM.$el.remove()
-				ComponentVM.$destroy()
-				reject(new Error('User cancelled resource selection'))
-			})
-			ComponentVM.$root.$on('select', ({ token }) => {
-				resolve(token)
-				ComponentVM.$el.remove()
-				ComponentVM.$destroy()
-			})
+	action: async () => {
+		const conversation = await requestRoomSelection('spreed-room-select', {
+			// Even if it is used from Talk the Collections menu is
+			// independently loaded, so the properties that depend
+			// on the store need to be explicitly injected.
+			container: window.store ? window.store.getters.getMainContainerSelector() : undefined,
 		})
+		if (!conversation) {
+			throw new Error('User cancelled resource selection')
+		}
+		return conversation.token
 	},
 	typeString: t('spreed', 'Link to a conversation'),
 	typeIconClass: 'icon-talk',

--- a/src/deck.js
+++ b/src/deck.js
@@ -8,105 +8,102 @@ import Vue from 'vue'
 
 import { getRequestToken } from '@nextcloud/auth'
 import { showSuccess, showError } from '@nextcloud/dialogs'
-import { translate, translatePlural } from '@nextcloud/l10n'
+import { t, n } from '@nextcloud/l10n'
 import { generateFilePath, generateUrl } from '@nextcloud/router'
 
 import { postRichObjectToConversation } from './services/messagesService.ts'
 
 import '@nextcloud/dialogs/style.css'
 
-(function(OC, OCA, t, n) {
-	/**
-	 * @param {object} card The card object given by the deck app
-	 * @param {object} conversation The conversation object given by the RoomSelector
-	 * @param {string} conversation.token The conversation token
-	 * @param {string} conversation.displayName The conversation display name
-	 */
-	async function postCardToRoom(card, { token, displayName }) {
-		try {
-			const response = await postRichObjectToConversation(token, {
-				objectType: 'deck-card',
-				objectId: card.id,
-				metaData: JSON.stringify(card),
-			})
-
-			const messageId = response.data.ocs.data.id
-			const targetUrl = generateUrl('/call/{token}#message_{messageId}', { token, messageId })
-
-			showSuccess(t('spreed', 'Deck card has been posted to {conversation}')
-				.replace(/\{conversation}/g, `<a target="_blank" class="external" href="${targetUrl}">${escapeHtml(displayName)} ↗</a>`),
-			{
-				isHTML: true,
-			})
-		} catch (exception) {
-			console.error('Error posting deck card to conversation', exception, exception.response?.status)
-			if (exception.response?.status === 403) {
-				showError(t('spreed', 'No permission to post messages in this conversation'))
-			} else {
-				showError(t('spreed', 'An error occurred while posting deck card to conversation'))
-			}
-		}
-	}
-
-	/**
-	 *
-	 */
-	function init() {
-		if (!OCA.Deck) {
-			return
-		}
-
-		OCA.Deck.registerCardAction({
-			label: t('spreed', 'Post to a conversation'),
-			icon: 'icon-talk',
-			callback: (card) => {
-				const container = document.createElement('div')
-				container.id = 'spreed-post-card-to-room-select'
-				const body = document.getElementById('body-user')
-				body.appendChild(container)
-
-				const RoomSelector = () => import('./components/RoomSelector.vue')
-				const vm = new Vue({
-					el: container,
-					render: h => h(RoomSelector, {
-						props: {
-							dialogTitle: t('spreed', 'Post to conversation'),
-							showPostableOnly: true,
-							isPlugin: true,
-						},
-					}),
-				})
-
-				vm.$root.$on('close', () => {
-					vm.$el.remove()
-					vm.$destroy()
-				})
-				vm.$root.$on('select', (conversation) => {
-					vm.$el.remove()
-					vm.$destroy()
-
-					postCardToRoom(card, conversation)
-				})
-			},
+/**
+ * @param {object} card The card object given by the deck app
+ * @param {object} conversation The conversation object given by the RoomSelector
+ * @param {string} conversation.token The conversation token
+ * @param {string} conversation.displayName The conversation display name
+ */
+async function postCardToRoom(card, { token, displayName }) {
+	try {
+		const response = await postRichObjectToConversation(token, {
+			objectType: 'deck-card',
+			objectId: card.id,
+			metaData: JSON.stringify(card),
 		})
+
+		const messageId = response.data.ocs.data.id
+		const targetUrl = generateUrl('/call/{token}#message_{messageId}', { token, messageId })
+
+		showSuccess(t('spreed', 'Deck card has been posted to {conversation}')
+			.replace(/\{conversation}/g, `<a target="_blank" class="external" href="${targetUrl}">${escapeHtml(displayName)} ↗</a>`),
+		{
+			isHTML: true,
+		})
+	} catch (exception) {
+		console.error('Error posting deck card to conversation', exception, exception.response?.status)
+		if (exception.response?.status === 403) {
+			showError(t('spreed', 'No permission to post messages in this conversation'))
+		} else {
+			showError(t('spreed', 'An error occurred while posting deck card to conversation'))
+		}
+	}
+}
+
+/**
+	*
+	*/
+function init() {
+	if (!window.OCA.Deck) {
+		return
 	}
 
-	// CSP config for webpack dynamic chunk loading
-	// eslint-disable-next-line
-	__webpack_nonce__ = btoa(getRequestToken())
+	window.OCA.Deck.registerCardAction({
+		label: t('spreed', 'Post to a conversation'),
+		icon: 'icon-talk',
+		callback: (card) => {
+			const container = document.createElement('div')
+			container.id = 'spreed-post-card-to-room-select'
+			const body = document.getElementById('body-user')
+			body.appendChild(container)
 
-	// Correct the root of the app for chunk loading
-	// OC.linkTo matches the apps folders
-	// OC.generateUrl ensure the index.php (or not)
-	// We do not want the index.php since we're loading files
-	// eslint-disable-next-line
-	__webpack_public_path__ = generateFilePath('spreed', '', 'js/')
+			const RoomSelector = () => import('./components/RoomSelector.vue')
+			const vm = new Vue({
+				el: container,
+				render: h => h(RoomSelector, {
+					props: {
+						dialogTitle: t('spreed', 'Post to conversation'),
+						showPostableOnly: true,
+						isPlugin: true,
+					},
+				}),
+			})
 
-	Vue.prototype.t = translate
-	Vue.prototype.n = translatePlural
-	Vue.prototype.OC = OC
-	Vue.prototype.OCA = OCA
+			vm.$root.$on('close', () => {
+				vm.$el.remove()
+				vm.$destroy()
+			})
+			vm.$root.$on('select', (conversation) => {
+				vm.$el.remove()
+				vm.$destroy()
 
-	document.addEventListener('DOMContentLoaded', init)
+				postCardToRoom(card, conversation)
+			})
+		},
+	})
+}
 
-})(window.OC, window.OCA, t, n)
+// CSP config for webpack dynamic chunk loading
+// eslint-disable-next-line
+__webpack_nonce__ = btoa(getRequestToken())
+
+// Correct the root of the app for chunk loading
+// OC.linkTo matches the apps folders
+// OC.generateUrl ensure the index.php (or not)
+// We do not want the index.php since we're loading files
+// eslint-disable-next-line
+__webpack_public_path__ = generateFilePath('spreed', '', 'js/')
+
+Vue.prototype.t = t
+Vue.prototype.n = n
+Vue.prototype.OC = window.OC
+Vue.prototype.OCA = window.OCA
+
+document.addEventListener('DOMContentLoaded', init)

--- a/src/deck.js
+++ b/src/deck.js
@@ -4,14 +4,14 @@
  */
 
 import escapeHtml from 'escape-html'
-import Vue from 'vue'
 
 import { getRequestToken } from '@nextcloud/auth'
 import { showSuccess, showError } from '@nextcloud/dialogs'
-import { t, n } from '@nextcloud/l10n'
+import { t } from '@nextcloud/l10n'
 import { generateFilePath, generateUrl } from '@nextcloud/router'
 
 import { postRichObjectToConversation } from './services/messagesService.ts'
+import { requestRoomSelection } from './utils/requestRoomSelection.js'
 
 import '@nextcloud/dialogs/style.css'
 
@@ -58,34 +58,14 @@ function init() {
 	window.OCA.Deck.registerCardAction({
 		label: t('spreed', 'Post to a conversation'),
 		icon: 'icon-talk',
-		callback: (card) => {
-			const container = document.createElement('div')
-			container.id = 'spreed-post-card-to-room-select'
-			const body = document.getElementById('body-user')
-			body.appendChild(container)
-
-			const RoomSelector = () => import('./components/RoomSelector.vue')
-			const vm = new Vue({
-				el: container,
-				render: h => h(RoomSelector, {
-					props: {
-						dialogTitle: t('spreed', 'Post to conversation'),
-						showPostableOnly: true,
-						isPlugin: true,
-					},
-				}),
+		callback: async (card) => {
+			const conversation = await requestRoomSelection('spreed-post-card-to-room-select', {
+				dialogTitle: t('spreed', 'Post to conversation'),
+				showPostableOnly: true,
 			})
-
-			vm.$root.$on('close', () => {
-				vm.$el.remove()
-				vm.$destroy()
-			})
-			vm.$root.$on('select', (conversation) => {
-				vm.$el.remove()
-				vm.$destroy()
-
+			if (conversation) {
 				postCardToRoom(card, conversation)
-			})
+			}
 		},
 	})
 }
@@ -100,10 +80,5 @@ __webpack_nonce__ = btoa(getRequestToken())
 // We do not want the index.php since we're loading files
 // eslint-disable-next-line
 __webpack_public_path__ = generateFilePath('spreed', '', 'js/')
-
-Vue.prototype.t = t
-Vue.prototype.n = n
-Vue.prototype.OC = window.OC
-Vue.prototype.OCA = window.OCA
 
 document.addEventListener('DOMContentLoaded', init)

--- a/src/maps.js
+++ b/src/maps.js
@@ -8,104 +8,101 @@ import Vue from 'vue'
 
 import { getRequestToken } from '@nextcloud/auth'
 import { showSuccess, showError } from '@nextcloud/dialogs'
-import { translate, translatePlural } from '@nextcloud/l10n'
+import { t, n } from '@nextcloud/l10n'
 import { generateFilePath, generateUrl } from '@nextcloud/router'
 
 import { postRichObjectToConversation } from './services/messagesService.ts'
 
 import '@nextcloud/dialogs/style.css'
 
-(function(OC, OCA, t, n) {
-	/**
-	 * @param {object} location Geo location object
-	 * @param {object} conversation The conversation object given by the RoomSelector
-	 * @param {string} conversation.token The conversation token
-	 * @param {string} conversation.displayName The conversation display name
-	 */
-	async function postLocationToRoom(location, { token, displayName }) {
-		try {
-			const response = await postRichObjectToConversation(token, {
-				objectType: 'geo-location',
-				objectId: location.id,
-				metaData: JSON.stringify(location),
-			})
-			const messageId = response.data.ocs.data.id
-			const targetUrl = generateUrl('/call/{token}#message_{messageId}', { token, messageId })
+/**
+ * @param {object} location Geo location object
+ * @param {object} conversation The conversation object given by the RoomSelector
+ * @param {string} conversation.token The conversation token
+ * @param {string} conversation.displayName The conversation display name
+ */
+async function postLocationToRoom(location, { token, displayName }) {
+	try {
+		const response = await postRichObjectToConversation(token, {
+			objectType: 'geo-location',
+			objectId: location.id,
+			metaData: JSON.stringify(location),
+		})
+		const messageId = response.data.ocs.data.id
+		const targetUrl = generateUrl('/call/{token}#message_{messageId}', { token, messageId })
 
-			showSuccess(t('spreed', 'Location has been posted to {conversation}')
-				.replace(/\{conversation}/g, `<a target="_blank" class="external" href="${targetUrl}">${escapeHtml(displayName)} ↗</a>`),
+		showSuccess(t('spreed', 'Location has been posted to {conversation}')
+			.replace(/\{conversation}/g, `<a target="_blank" class="external" href="${targetUrl}">${escapeHtml(displayName)} ↗</a>`),
 			{
 				isHTML: true,
 			})
-		} catch (exception) {
-			console.error('Error posting location to conversation', exception, exception.response?.status)
-			if (exception.response?.status === 403) {
-				showError(t('spreed', 'No permission to post messages in this conversation'))
-			} else {
-				showError(t('spreed', 'An error occurred while posting location to conversation'))
-			}
+	} catch (exception) {
+		console.error('Error posting location to conversation', exception, exception.response?.status)
+		if (exception.response?.status === 403) {
+			showError(t('spreed', 'No permission to post messages in this conversation'))
+		} else {
+			showError(t('spreed', 'An error occurred while posting location to conversation'))
 		}
 	}
+}
 
-	/**
-	 * Initialise the maps action
-	 */
-	function init() {
-		if (!OCA.Maps?.registerMapsAction) {
-			return
-		}
-
-		OCA.Maps.registerMapsAction({
-			label: t('spreed', 'Share to a conversation'),
-			icon: 'icon-talk',
-			callback: (location) => {
-				const container = document.createElement('div')
-				container.id = 'spreed-post-location-to-room-select'
-				const body = document.getElementById('body-user')
-				body.appendChild(container)
-
-				const RoomSelector = () => import('./components/RoomSelector.vue')
-				const vm = new Vue({
-					el: container,
-					render: h => h(RoomSelector, {
-						props: {
-							dialogTitle: t('spreed', 'Share to conversation'),
-							showPostableOnly: true,
-							isPlugin: true,
-						},
-					}),
-				})
-
-				vm.$root.$on('close', () => {
-					vm.$el.remove()
-					vm.$destroy()
-				})
-				vm.$root.$on('select', (conversation) => {
-					vm.$el.remove()
-					vm.$destroy()
-
-					postLocationToRoom(location, conversation)
-				})
-			},
-		})
+/**
+ * Initialise the maps action
+ */
+function init() {
+	if (!window.OCA.Maps?.registerMapsAction) {
+		return
 	}
 
-	// CSP config for webpack dynamic chunk loading
-	// eslint-disable-next-line
-	__webpack_nonce__ = btoa(getRequestToken())
+	window.OCA.Maps.registerMapsAction({
+		label: t('spreed', 'Share to a conversation'),
+		icon: 'icon-talk',
+		callback: (location) => {
+			const container = document.createElement('div')
+			container.id = 'spreed-post-location-to-room-select'
+			const body = document.getElementById('body-user')
+			body.appendChild(container)
 
-	// Correct the root of the app for chunk loading
-	// OC.linkTo matches the apps folders
-	// OC.generateUrl ensure the index.php (or not)
-	// We do not want the index.php since we're loading files
-	// eslint-disable-next-line
-	__webpack_public_path__ = generateFilePath('spreed', '', 'js/')
+			const RoomSelector = () => import('./components/RoomSelector.vue')
+			const vm = new Vue({
+				el: container,
+				render: h => h(RoomSelector, {
+					props: {
+						dialogTitle: t('spreed', 'Share to conversation'),
+						showPostableOnly: true,
+						isPlugin: true,
+					},
+				}),
+			})
 
-	Vue.prototype.t = translate
-	Vue.prototype.n = translatePlural
-	Vue.prototype.OC = OC
-	Vue.prototype.OCA = OCA
+			vm.$root.$on('close', () => {
+				vm.$el.remove()
+				vm.$destroy()
+			})
+			vm.$root.$on('select', (conversation) => {
+				vm.$el.remove()
+				vm.$destroy()
 
-	document.addEventListener('DOMContentLoaded', init)
+				postLocationToRoom(location, conversation)
+			})
+		},
+	})
+}
 
-})(window.OC, window.OCA, t, n)
+// CSP config for webpack dynamic chunk loading
+// eslint-disable-next-line
+__webpack_nonce__ = btoa(getRequestToken())
+
+// Correct the root of the app for chunk loading
+// OC.linkTo matches the apps folders
+// OC.generateUrl ensure the index.php (or not)
+// We do not want the index.php since we're loading files
+// eslint-disable-next-line
+__webpack_public_path__ = generateFilePath('spreed', '', 'js/')
+
+Vue.prototype.t = t
+Vue.prototype.n = n
+Vue.prototype.OC = window.OC
+Vue.prototype.OCA = window.OCA
+
+document.addEventListener('DOMContentLoaded', init)

--- a/src/maps.js
+++ b/src/maps.js
@@ -4,14 +4,14 @@
  */
 
 import escapeHtml from 'escape-html'
-import Vue from 'vue'
 
 import { getRequestToken } from '@nextcloud/auth'
 import { showSuccess, showError } from '@nextcloud/dialogs'
-import { t, n } from '@nextcloud/l10n'
+import { t } from '@nextcloud/l10n'
 import { generateFilePath, generateUrl } from '@nextcloud/router'
 
 import { postRichObjectToConversation } from './services/messagesService.ts'
+import { requestRoomSelection } from './utils/requestRoomSelection.js'
 
 import '@nextcloud/dialogs/style.css'
 
@@ -33,9 +33,9 @@ async function postLocationToRoom(location, { token, displayName }) {
 
 		showSuccess(t('spreed', 'Location has been posted to {conversation}')
 			.replace(/\{conversation}/g, `<a target="_blank" class="external" href="${targetUrl}">${escapeHtml(displayName)} ↗</a>`),
-			{
-				isHTML: true,
-			})
+		{
+			isHTML: true,
+		})
 	} catch (exception) {
 		console.error('Error posting location to conversation', exception, exception.response?.status)
 		if (exception.response?.status === 403) {
@@ -57,34 +57,13 @@ function init() {
 	window.OCA.Maps.registerMapsAction({
 		label: t('spreed', 'Share to a conversation'),
 		icon: 'icon-talk',
-		callback: (location) => {
-			const container = document.createElement('div')
-			container.id = 'spreed-post-location-to-room-select'
-			const body = document.getElementById('body-user')
-			body.appendChild(container)
-
-			const RoomSelector = () => import('./components/RoomSelector.vue')
-			const vm = new Vue({
-				el: container,
-				render: h => h(RoomSelector, {
-					props: {
-						dialogTitle: t('spreed', 'Share to conversation'),
-						showPostableOnly: true,
-						isPlugin: true,
-					},
-				}),
+		callback: async (location) => {
+			const conversation = await requestRoomSelection('spreed-post-location-to-room-select', {
+				dialogTitle: t('spreed', 'Share to conversation'),
+				showPostableOnly: true,
 			})
 
-			vm.$root.$on('close', () => {
-				vm.$el.remove()
-				vm.$destroy()
-			})
-			vm.$root.$on('select', (conversation) => {
-				vm.$el.remove()
-				vm.$destroy()
-
-				postLocationToRoom(location, conversation)
-			})
+			postLocationToRoom(location, conversation)
 		},
 	})
 }
@@ -99,10 +78,5 @@ __webpack_nonce__ = btoa(getRequestToken())
 // We do not want the index.php since we're loading files
 // eslint-disable-next-line
 __webpack_public_path__ = generateFilePath('spreed', '', 'js/')
-
-Vue.prototype.t = t
-Vue.prototype.n = n
-Vue.prototype.OC = window.OC
-Vue.prototype.OCA = window.OCA
 
 document.addEventListener('DOMContentLoaded', init)

--- a/src/search.js
+++ b/src/search.js
@@ -7,78 +7,74 @@ import Vue from 'vue'
 
 import { getRequestToken } from '@nextcloud/auth'
 import { emit } from '@nextcloud/event-bus'
-import { translate, translatePlural } from '@nextcloud/l10n'
+import { t, n } from '@nextcloud/l10n'
 import { generateFilePath, imagePath } from '@nextcloud/router'
 
 import '@nextcloud/dialogs/style.css'
 
-(function(OC, OCA, t, n) {
-
-	/**
-	 *
-	 */
-	function init() {
-		if (!OCA.UnifiedSearch) {
-			return
-		}
-		console.debug('Initializing unified search plugin-filters from talk')
-		OCA.UnifiedSearch.registerFilterAction({
-			id: 'talk-message',
-			appId: 'spreed',
-			label: t('spreed', 'In conversation'),
-			icon: imagePath('spreed', 'app.svg'),
-			callback: () => {
-				const container = document.createElement('div')
-				container.id = 'spreed-unified-search-conversation-select'
-				const body = document.getElementById('body-user')
-				body.appendChild(container)
-
-				const RoomSelector = () => import('./components/RoomSelector.vue')
-				const vm = new Vue({
-					el: container,
-					render: h => h(RoomSelector, {
-						props: {
-							dialogTitle: t('spreed', 'Select conversation'),
-							isPlugin: true,
-						},
-					}),
-				})
-
-				vm.$root.$on('close', () => {
-					vm.$el.remove()
-					vm.$destroy()
-				})
-				vm.$root.$on('select', (conversation) => {
-					vm.$el.remove()
-					vm.$destroy()
-
-					emit('nextcloud:unified-search:add-filter', {
-						id: 'talk-message',
-						payload: conversation,
-						filterUpdateText: t('spreed', 'Search in conversation: {conversation}', { conversation: conversation.displayName }),
-						filterParams: { conversation: conversation.token }
-					})
-				})
-			},
-		})
+/**
+ *
+ */
+function init() {
+	if (!window.OCA.UnifiedSearch) {
+		return
 	}
+	console.debug('Initializing unified search plugin-filters from talk')
+	window.OCA.UnifiedSearch.registerFilterAction({
+		id: 'talk-message',
+		appId: 'spreed',
+		label: t('spreed', 'In conversation'),
+		icon: imagePath('spreed', 'app.svg'),
+		callback: () => {
+			const container = document.createElement('div')
+			container.id = 'spreed-unified-search-conversation-select'
+			const body = document.getElementById('body-user')
+			body.appendChild(container)
 
-	// CSP config for webpack dynamic chunk loading
-	// eslint-disable-next-line
-	__webpack_nonce__ = btoa(getRequestToken())
+			const RoomSelector = () => import('./components/RoomSelector.vue')
+			const vm = new Vue({
+				el: container,
+				render: h => h(RoomSelector, {
+					props: {
+						dialogTitle: t('spreed', 'Select conversation'),
+						isPlugin: true,
+					},
+				}),
+			})
 
-	// Correct the root of the app for chunk loading
-	// OC.linkTo matches the apps folders
-	// OC.generateUrl ensure the index.php (or not)
-	// We do not want the index.php since we're loading files
-	// eslint-disable-next-line
-	__webpack_public_path__ = generateFilePath('spreed', '', 'js/')
+			vm.$root.$on('close', () => {
+				vm.$el.remove()
+				vm.$destroy()
+			})
+			vm.$root.$on('select', (conversation) => {
+				vm.$el.remove()
+				vm.$destroy()
 
-	Vue.prototype.t = translate
-	Vue.prototype.n = translatePlural
-	Vue.prototype.OC = OC
-	Vue.prototype.OCA = OCA
+				emit('nextcloud:unified-search:add-filter', {
+					id: 'talk-message',
+					payload: conversation,
+					filterUpdateText: t('spreed', 'Search in conversation: {conversation}', { conversation: conversation.displayName }),
+					filterParams: { conversation: conversation.token }
+				})
+			})
+		},
+	})
+}
 
-	document.addEventListener('DOMContentLoaded', init)
+// CSP config for webpack dynamic chunk loading
+// eslint-disable-next-line
+__webpack_nonce__ = btoa(getRequestToken())
 
-})(window.OC, window.OCA, t, n)
+// Correct the root of the app for chunk loading
+// OC.linkTo matches the apps folders
+// OC.generateUrl ensure the index.php (or not)
+// We do not want the index.php since we're loading files
+// eslint-disable-next-line
+__webpack_public_path__ = generateFilePath('spreed', '', 'js/')
+
+Vue.prototype.t = t
+Vue.prototype.n = n
+Vue.prototype.OC = window.OC
+Vue.prototype.OCA = window.OCA
+
+document.addEventListener('DOMContentLoaded', init)

--- a/src/utils/requestRoomSelection.js
+++ b/src/utils/requestRoomSelection.js
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import Vue, { defineAsyncComponent } from 'vue'
+
+import { t, n } from '@nextcloud/l10n'
+
+Vue.prototype.t = t
+Vue.prototype.n = n
+Vue.prototype.OC = window.OC
+Vue.prototype.OCA = window.OCA
+Vue.prototype.OCP = window.OCP
+
+/**
+ *
+ * @param {string} containerId - id of the container to append the RoomSelector component to
+ * @param {object} roomSelectorProps - props data to pass to RoomSelector component
+ * @return {Promise<object|null>} - resolves with the conversation of the selected room or null if canceled
+ */
+export function requestRoomSelection(containerId, roomSelectorProps) {
+	return new Promise((resolve, reject) => {
+		const container = document.createElement('div')
+		container.id = containerId
+		const body = document.getElementById('body-user')
+		body.appendChild(container)
+
+		const RoomSelector = defineAsyncComponent(() => import('../components/RoomSelector.vue'))
+
+		const vm = new Vue({
+			render: h => h(RoomSelector, {
+				props: {
+					isPlugin: true,
+					...roomSelectorProps,
+				},
+			}),
+		}).$mount(container)
+
+		vm.$root.$on('close', () => {
+			container.remove()
+			vm.$destroy()
+			reject(new Error('User cancelled resource selection'))
+		})
+
+		vm.$root.$on('select', (conversation) => {
+			container.remove()
+			vm.$destroy()
+			resolve(conversation)
+		})
+	})
+}


### PR DESCRIPTION
### ☑️ Resolves

* 4 plugins have almost copy/past implementation of room selection
* Simplifies Vue 3 migration
* 👀 Review by commit with hide whitespaces

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes

### 🚧 Tasks

- [x] Get rid of unneeded IIFE
- [x] Add reusable util to mount `RoomSelector` and get the selected room

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required