### PR TITLE
fix(plugins): return null when room is not selected in plugin instead of throwing an exception

### DIFF
--- a/src/utils/requestRoomSelection.js
+++ b/src/utils/requestRoomSelection.js
@@ -20,7 +20,7 @@ Vue.prototype.OCP = window.OCP
  * @return {Promise<object|null>} - resolves with the conversation of the selected room or null if canceled
  */
 export function requestRoomSelection(containerId, roomSelectorProps) {
-	return new Promise((resolve, reject) => {
+	return new Promise((resolve) => {
 		const container = document.createElement('div')
 		container.id = containerId
 		const body = document.getElementById('body-user')
@@ -40,7 +40,7 @@ export function requestRoomSelection(containerId, roomSelectorProps) {
 		vm.$root.$on('close', () => {
 			container.remove()
 			vm.$destroy()
-			reject(new Error('User cancelled resource selection'))
+			resolve(null)
 		})
 
 		vm.$root.$on('select', (conversation) => {


### PR DESCRIPTION
### ☑️ Resolves

* Regression: https://github.com/nextcloud/spreed/pull/12356
* Fix: Actually do what util's documentation says and plugins expect
* Doesn't seem to really break anything, but annoying error in the console

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/25978914/709d8c18-c254-4e50-8fcb-d7471ee11be0) | ![image](https://github.com/nextcloud/spreed/assets/25978914/b900ba47-8bd4-4d92-a902-ddd998196b7f)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required