### PR TITLE
fix(directive): unify tooltip registration

### DIFF
--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -95,7 +95,7 @@ export default {
 	name: 'TurnServer',
 
 	directives: {
-		tooltip: Tooltip,
+		Tooltip,
 	},
 
 	components: {

--- a/src/components/AdminSettings/WebServerSetupChecks.vue
+++ b/src/components/AdminSettings/WebServerSetupChecks.vue
@@ -53,7 +53,7 @@ export default {
 	name: 'WebServerSetupChecks',
 
 	directives: {
-		tooltip: Tooltip,
+		Tooltip,
 	},
 
 	components: {

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -144,7 +144,6 @@ import { loadState } from '@nextcloud/initial-state'
 import { generateFilePath } from '@nextcloud/router'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import TransitionWrapper from '../../UIShared/TransitionWrapper.vue'
 import EmptyCallView from '../shared/EmptyCallView.vue'
@@ -170,10 +169,6 @@ export default {
 		ChevronLeft,
 		ChevronUp,
 		ChevronDown,
-	},
-
-	directives: {
-		Tooltip,
 	},
 
 	props: {

--- a/src/components/CallView/shared/LocalAudioControlButton.vue
+++ b/src/components/CallView/shared/LocalAudioControlButton.vue
@@ -24,7 +24,8 @@
 <script>
 import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
 
-import { NcButton } from '@nextcloud/vue'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import VolumeIndicator from '../../UIShared/VolumeIndicator.vue'
 
@@ -37,6 +38,10 @@ export default {
 	components: {
 		NcButton,
 		VolumeIndicator,
+	},
+
+	directives: {
+		Tooltip,
 	},
 
 	props: {

--- a/src/components/CallView/shared/LocalVideoControlButton.vue
+++ b/src/components/CallView/shared/LocalVideoControlButton.vue
@@ -24,7 +24,8 @@ import VideoOff from 'vue-material-design-icons/VideoOff.vue'
 
 import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
 
-import { NcButton } from '@nextcloud/vue'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import { PARTICIPANT } from '../../../constants.js'
 import BrowserStorage from '../../../services/BrowserStorage.js'
@@ -36,6 +37,10 @@ export default {
 		NcButton,
 		VideoIcon,
 		VideoOff,
+	},
+
+	directives: {
+		Tooltip,
 	},
 
 	props: {

--- a/src/components/CallView/shared/VideoBottomBar.vue
+++ b/src/components/CallView/shared/VideoBottomBar.vue
@@ -120,7 +120,7 @@ export default {
 	},
 
 	directives: {
-		tooltip: Tooltip,
+		Tooltip,
 	},
 
 	inheritAttrs: false,

--- a/src/components/CallView/shared/ViewerOverlayCallView.vue
+++ b/src/components/CallView/shared/ViewerOverlayCallView.vue
@@ -115,7 +115,7 @@ import ArrowExpand from 'vue-material-design-icons/ArrowExpand.vue'
 import ChevronDown from 'vue-material-design-icons/ChevronDown.vue'
 import ChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 
-import { NcButton, Tooltip } from '@nextcloud/vue'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 
 import EmptyCallView from './EmptyCallView.vue'
 import LocalAudioControlButton from './LocalAudioControlButton.vue'
@@ -143,10 +143,6 @@ export default {
 		TransitionWrapper,
 		VideoVue,
 		ArrowExpand,
-	},
-
-	directives: {
-		tooltip: Tooltip,
 	},
 
 	props: {

--- a/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
+++ b/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
@@ -105,8 +105,6 @@ import {
 	getBridgeProcessState,
 } from '../../../services/matterbridgeService.js'
 
-Vue.directive('tooltip', Tooltip)
-
 export default {
 	name: 'MatterbridgeSettings',
 	components: {
@@ -120,10 +118,8 @@ export default {
 		Plus,
 	},
 
-	mixins: [
-	],
-
-	props: {
+	directives: {
+		Tooltip,
 	},
 
 	data() {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Contact.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Contact.vue
@@ -24,14 +24,8 @@
 </template>
 
 <script>
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
-
 export default {
 	name: 'Contact',
-
-	directives: {
-		tooltip: Tooltip,
-	},
 
 	props: {
 		name: {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/DeckCard.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/DeckCard.vue
@@ -24,14 +24,8 @@
 </template>
 
 <script>
-import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
-
 export default {
 	name: 'DeckCard',
-
-	directives: {
-		tooltip: Tooltip,
-	},
 
 	props: {
 		type: {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -94,7 +94,7 @@ export default {
 	},
 
 	directives: {
-		tooltip: Tooltip,
+		Tooltip,
 	},
 
 	props: {

--- a/src/components/NewMessage/NewMessageAudioRecorder.vue
+++ b/src/components/NewMessage/NewMessageAudioRecorder.vue
@@ -76,7 +76,7 @@ export default {
 	},
 
 	directives: {
-		tooltip: Tooltip,
+		Tooltip,
 	},
 
 	props: {

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -406,7 +406,7 @@ export default {
 	},
 
 	directives: {
-		tooltip: Tooltip,
+		Tooltip,
 	},
 
 	props: {

--- a/src/components/TopBar/ReactionMenu.vue
+++ b/src/components/TopBar/ReactionMenu.vue
@@ -36,6 +36,7 @@ import { emit } from '@nextcloud/event-bus'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import NcActionButtonGroup from '@nextcloud/vue/dist/Components/NcActionButtonGroup.js'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
+import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 export default {
 	name: 'ReactionMenu',
@@ -45,6 +46,10 @@ export default {
 		NcActionButton,
 		NcActionButtonGroup,
 		EmoticonOutline,
+	},
+
+	directives: {
+		Tooltip,
 	},
 
 	props: {

--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -139,7 +139,7 @@ export default {
 	name: 'TopBarMediaControls',
 
 	directives: {
-		tooltip: Tooltip,
+		Tooltip,
 	},
 	components: {
 		LocalAudioControlButton,

--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -170,6 +170,7 @@ import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcActionSeparator from '@nextcloud/vue/dist/Components/NcActionSeparator.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
+import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import { useIsInCall } from '../../composables/useIsInCall.js'
 import { CALL, CONVERSATION, PARTICIPANT } from '../../constants.js'
@@ -201,6 +202,10 @@ export default {
 		RecordCircle,
 		StopIcon,
 		VideoIcon,
+	},
+
+	directives: {
+		Tooltip,
 	},
 
 	props: {


### PR DESCRIPTION
### ☑️ Resolves

* Ref #9448
* Unify usage of tooltips across the app
* Remove the global registration of tooltip added in MatterbridgeSettings
* Remove outdated / no longer used imports


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts
No visual changes

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 