### PR TITLE
feat(Vue3): nextcloud vue lib breaking changes

### DIFF
--- a/src/components/AdminSettings/AllowedGroups.vue
+++ b/src/components/AdminSettings/AllowedGroups.vue
@@ -82,7 +82,7 @@
 				:clearable="false"
 				no-wrap
 				:disabled="loading || loadingStartCalls"
-				@input="saveStartCalls" />
+				@update:modelValue="saveStartCalls" />
 		</div>
 		<p>
 			<em>{{ t('spreed', 'When a call has started, everyone with access to the conversation can join the call.') }}</em>

--- a/src/components/AdminSettings/BotsSettings.vue
+++ b/src/components/AdminSettings/BotsSettings.vue
@@ -85,7 +85,6 @@ import Lock from 'vue-material-design-icons/Lock.vue'
 import moment from '@nextcloud/moment'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 import NcPopover from '@nextcloud/vue/dist/Components/NcPopover.js'
 
 import { BOT } from '../../constants.js'
@@ -97,7 +96,6 @@ export default {
 	components: {
 		NcPopover,
 		NcButton,
-		NcCheckboxRadioSwitch,
 	},
 
 	data() {

--- a/src/components/AdminSettings/Federation.vue
+++ b/src/components/AdminSettings/Federation.vue
@@ -10,34 +10,34 @@
 			<small>{{ t('spreed', 'Beta') }}</small>
 		</h2>
 
-		<NcCheckboxRadioSwitch :checked="isFederationEnabled"
+		<NcCheckboxRadioSwitch :model-value="isFederationEnabled"
 			:disabled="loading"
 			type="switch"
-			@update:checked="saveFederationEnabled">
+			@update:modelValue="saveFederationEnabled">
 			{{ t('spreed', 'Enable Federation in Talk app') }}
 		</NcCheckboxRadioSwitch>
 
 		<template v-if="isFederationEnabled">
 			<h3>{{ t('spreed', 'Permissions') }}</h3>
 
-			<NcCheckboxRadioSwitch :checked="isFederationIncomingEnabled"
+			<NcCheckboxRadioSwitch :model-value="isFederationIncomingEnabled"
 				:disabled="loading"
 				type="switch"
-				@update:checked="saveFederationIncomingEnabled">
+				@update:modelValue="saveFederationIncomingEnabled">
 				{{ t('spreed', 'Allow users to be invited to federated conversations') }}
 			</NcCheckboxRadioSwitch>
 
-			<NcCheckboxRadioSwitch :checked="isFederationOutgoingEnabled"
+			<NcCheckboxRadioSwitch :model-value="isFederationOutgoingEnabled"
 				:disabled="loading"
 				type="switch"
-				@update:checked="saveFederationOutgoingEnabled">
+				@update:modelValue="saveFederationOutgoingEnabled">
 				{{ t('spreed', 'Allow users to invite federated users into conversation') }}
 			</NcCheckboxRadioSwitch>
 
-			<NcCheckboxRadioSwitch :checked="isFederationOnlyTrustedServersEnabled"
+			<NcCheckboxRadioSwitch :model-value="isFederationOnlyTrustedServersEnabled"
 				:disabled="loading"
 				type="switch"
-				@update:checked="saveFederationOnlyTrustedServersEnabled">
+				@update:modelValue="saveFederationOnlyTrustedServersEnabled">
 				{{ t('spreed', 'Only allow to federate with trusted servers') }}
 			</NcCheckboxRadioSwitch>
 			<!-- eslint-disable-next-line vue/no-v-html -->

--- a/src/components/AdminSettings/GeneralSettings.vue
+++ b/src/components/AdminSettings/GeneralSettings.vue
@@ -21,7 +21,7 @@
 			track-by="value"
 			no-wrap
 			:disabled="loading || loadingDefaultGroupNotification"
-			@input="saveDefaultGroupNotification" />
+			@update:modelValue="saveDefaultGroupNotification" />
 
 		<h3>{{ t('spreed', 'Integration into other apps') }}</h3>
 

--- a/src/components/AdminSettings/GeneralSettings.vue
+++ b/src/components/AdminSettings/GeneralSettings.vue
@@ -25,15 +25,15 @@
 
 		<h3>{{ t('spreed', 'Integration into other apps') }}</h3>
 
-		<NcCheckboxRadioSwitch :checked="isConversationsFilesChecked"
+		<NcCheckboxRadioSwitch :model-value="isConversationsFilesChecked"
 			:disabled="loading || loadingConversationsFiles"
-			@update:checked="saveConversationsFiles">
+			@update:modelValue="saveConversationsFiles">
 			{{ t('spreed', 'Allow conversations on files') }}
 		</NcCheckboxRadioSwitch>
 
-		<NcCheckboxRadioSwitch :checked="isConversationsFilesPublicSharesChecked"
+		<NcCheckboxRadioSwitch :model-value="isConversationsFilesPublicSharesChecked"
 			:disabled="loading || loadingConversationsFiles || !isConversationsFilesChecked"
-			@update:checked="saveConversationsFilesPublicShares">
+			@update:modelValue="saveConversationsFilesPublicShares">
 			{{ t('spreed', 'Allow conversations on public shares for files') }}
 		</NcCheckboxRadioSwitch>
 	</section>

--- a/src/components/AdminSettings/HostedSignalingServer.vue
+++ b/src/components/AdminSettings/HostedSignalingServer.vue
@@ -16,7 +16,7 @@
 		</p>
 
 		<template v-if="!trialAccount.status">
-			<NcTextField :value.sync="hostedHPBNextcloudUrl"
+			<NcTextField v-model="hostedHPBNextcloudUrl"
 				class="form__textfield"
 				name="hosted_hpb_nextcloud_url"
 				placeholder="https://cloud.example.org/"
@@ -24,7 +24,7 @@
 				:label="t('spreed', 'URL of this Nextcloud instance')"
 				label-visible />
 
-			<NcTextField :value.sync="hostedHPBFullName"
+			<NcTextField v-model="hostedHPBFullName"
 				class="form__textfield"
 				name="full_name"
 				placeholder="Jane Doe"
@@ -32,7 +32,7 @@
 				:label="t('spreed', 'Full name of the user requesting the trial')"
 				label-visible />
 
-			<NcTextField :value.sync="hostedHPBEmail"
+			<NcTextField v-model="hostedHPBEmail"
 				class="form__textfield"
 				name="hosted_hpb_email"
 				placeholder="jane@example.org"

--- a/src/components/AdminSettings/MatterbridgeIntegration.vue
+++ b/src/components/AdminSettings/MatterbridgeIntegration.vue
@@ -15,8 +15,8 @@
 				{{ installedVersion }}
 			</p>
 
-			<NcCheckboxRadioSwitch :checked="isEnabled"
-				@update:checked="saveMatterbridgeEnabled">
+			<NcCheckboxRadioSwitch :model-value="isEnabled"
+				@update:modelValue="saveMatterbridgeEnabled">
 				{{ t('spreed', 'Enable Matterbridge integration') }}
 			</NcCheckboxRadioSwitch>
 		</template>

--- a/src/components/AdminSettings/RecordingServer.vue
+++ b/src/components/AdminSettings/RecordingServer.vue
@@ -10,10 +10,10 @@
 			class="recording-server__textfield"
 			name="recording_server"
 			placeholder="https://recording.example.org"
-			:value="server"
+			:model-value="server"
 			:disabled="loading"
 			:label="t('spreed', 'Recording backend URL')"
-			@update:value="updateServer" />
+			@update:modelValue="updateServer" />
 
 		<NcCheckboxRadioSwitch :checked="verify"
 			class="recording-server__checkbox"

--- a/src/components/AdminSettings/RecordingServer.vue
+++ b/src/components/AdminSettings/RecordingServer.vue
@@ -15,9 +15,9 @@
 			:label="t('spreed', 'Recording backend URL')"
 			@update:modelValue="updateServer" />
 
-		<NcCheckboxRadioSwitch :checked="verify"
+		<NcCheckboxRadioSwitch :model-value="verify"
 			class="recording-server__checkbox"
-			@update:checked="updateVerify">
+			@update:modelValue="updateVerify">
 			{{ t('spreed', 'Validate SSL certificate') }}
 		</NcCheckboxRadioSwitch>
 

--- a/src/components/AdminSettings/RecordingServers.vue
+++ b/src/components/AdminSettings/RecordingServers.vue
@@ -54,11 +54,11 @@
 
 			<template v-for="level in recordingConsentOptions" :key="level.value">
 				<NcCheckboxRadioSwitch :value="level.value.toString()"
-					:checked.sync="recordingConsentSelected"
+					v-model="recordingConsentSelected"
 					name="recording-consent"
 					type="radio"
 					:disabled="loading"
-					@update:checked="setRecordingConsent">
+					@update:modelValue="setRecordingConsent">
 					{{ level.label }}
 				</NcCheckboxRadioSwitch>
 

--- a/src/components/AdminSettings/RecordingServers.vue
+++ b/src/components/AdminSettings/RecordingServers.vue
@@ -41,13 +41,13 @@
 		</NcButton>
 
 		<NcTextField class="form__textfield additional-top-margin"
-			:value="secret"
+			:model-value="secret"
 			name="recording_secret"
 			:disabled="loading"
 			:placeholder="t('spreed', 'Shared secret')"
 			:label="t('spreed', 'Shared secret')"
 			label-visible
-			@update:value="updateSecret" />
+			@update:modelValue="updateSecret" />
 
 		<template v-if="servers.length && recordingConsentCapability">
 			<h3>{{ t('spreed', 'Recording consent') }}</h3>

--- a/src/components/AdminSettings/SIPBridge.vue
+++ b/src/components/AdminSettings/SIPBridge.vue
@@ -13,7 +13,7 @@
 
 		<template v-else>
 			<NcCheckboxRadioSwitch type="switch"
-				:checked.sync="dialOutEnabled"
+				v-model="dialOutEnabled"
 				:disabled="loading || !dialOutSupported">
 				{{ t('spreed', 'Enable SIP Dial-out option') }}
 			</NcCheckboxRadioSwitch>

--- a/src/components/AdminSettings/SIPBridge.vue
+++ b/src/components/AdminSettings/SIPBridge.vue
@@ -46,7 +46,7 @@
 				{{ t('spreed', 'Shared secret') }}
 			</label>
 			<NcTextField id="sip-shared-secret"
-				:value.sync="sharedSecret"
+				v-model="sharedSecret"
 				class="form"
 				:disabled="loading"
 				:placeholder="t('spreed', 'Shared secret')"
@@ -56,7 +56,7 @@
 				{{ t('spreed', 'Dial-in information') }}
 			</label>
 			<NcTextArea id="dial-in-info"
-				:value.sync="dialInInfo"
+				v-model="dialInInfo"
 				name="message"
 				class="form form__textarea"
 				rows="4"

--- a/src/components/AdminSettings/SignalingServer.vue
+++ b/src/components/AdminSettings/SignalingServer.vue
@@ -14,9 +14,9 @@
 			:label="t('spreed', 'High-performance backend URL')"
 			@update:modelValue="updateServer" />
 
-		<NcCheckboxRadioSwitch :checked="verify"
+		<NcCheckboxRadioSwitch :model-value="verify"
 			class="signaling-server__checkbox"
-			@update:checked="updateVerify">
+			@update:modelValue="updateVerify">
 			{{ t('spreed', 'Validate SSL certificate') }}
 		</NcCheckboxRadioSwitch>
 

--- a/src/components/AdminSettings/SignalingServer.vue
+++ b/src/components/AdminSettings/SignalingServer.vue
@@ -9,10 +9,10 @@
 			class="signaling-server__textfield"
 			name="signaling_server"
 			placeholder="wss://signaling.example.org"
-			:value="server"
+			:model-value="server"
 			:disabled="loading"
 			:label="t('spreed', 'High-performance backend URL')"
-			@update:value="updateServer" />
+			@update:modelValue="updateServer" />
 
 		<NcCheckboxRadioSwitch :checked="verify"
 			class="signaling-server__checkbox"

--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -47,9 +47,9 @@
 			<p class="settings-hint additional-top-margin">
 				{{ t('spreed', 'Please note that in calls with more than 4 participants without external signaling server, participants can experience connectivity issues and cause high load on participating devices.') }}
 			</p>
-			<NcCheckboxRadioSwitch :checked.sync="hideWarning"
+			<NcCheckboxRadioSwitch v-model="hideWarning"
 				:disabled="loading"
-				@update:checked="updateHideWarning">
+				@update:modelValue="updateHideWarning">
 				{{ t('spreed', 'Don\'t warn about connectivity issues in calls with more than 4 participants') }}
 			</NcCheckboxRadioSwitch>
 		</template>

--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -55,13 +55,13 @@
 		</template>
 
 		<NcTextField class="form__textfield additional-top-margin"
-			:value="secret"
+			:model-value="secret"
 			name="signaling_secret"
 			:disabled="loading"
 			:placeholder="t('spreed', 'Shared secret')"
 			:label="t('spreed', 'Shared secret')"
 			label-visible
-			@update:value="updateSecret" />
+			@update:modelValue="updateSecret" />
 	</section>
 </template>
 

--- a/src/components/AdminSettings/StunServer.vue
+++ b/src/components/AdminSettings/StunServer.vue
@@ -13,10 +13,10 @@
 				:input-id="`stun_server_${index}`"
 				name="stun_server"
 				placeholder="stunserver:port"
-				:value="server"
+				:model-value="server"
 				:disabled="loading"
 				:aria-label="t('spreed', 'STUN server URL')"
-				@update:value="update" />
+				@update:modelValue="update" />
 		</div>
 
 		<AlertCircle v-show="!isValidServer"

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -7,7 +7,7 @@
 	<li class="turn-server">
 		<NcSelect class="turn-server__select"
 			name="turn_schemes"
-			:value="schemesOptions.find(i => i.value === schemes)"
+			:model-value="schemesOptions.find(i => i.value === schemes)"
 			:disabled="loading"
 			:aria-label-combobox="t('spreed', 'TURN server schemes')"
 			:options="schemesOptions"
@@ -16,7 +16,7 @@
 			label="label"
 			track-by="value"
 			no-wrap
-			@input="updateSchemes" />
+			@update:modelValue="updateSchemes" />
 
 		<NcTextField ref="turn_server"
 			v-tooltip.auto="turnServerError"
@@ -24,23 +24,23 @@
 			placeholder="turnserver:port"
 			class="turn-server__textfield"
 			:class="{ error: turnServerError }"
-			:value="server"
+			:model-value="server"
 			:disabled="loading"
 			:label="t('spreed', 'TURN server URL')"
-			@update:value="updateServer" />
+			@update:modelValue="updateServer" />
 
 		<NcTextField ref="turn_secret"
 			name="turn_secret"
 			placeholder="secret"
 			class="turn-server__textfield"
-			:value="secret"
+			:model-value="secret"
 			:disabled="loading"
 			:label="t('spreed', 'TURN server secret')"
-			@update:value="updateSecret" />
+			@update:modelValue="updateSecret" />
 
 		<NcSelect class="turn-server__select"
 			name="turn_protocols"
-			:value="protocolOptions.find(i => i.value === protocols)"
+			:model-value="protocolOptions.find(i => i.value === protocols)"
 			:disabled="loading"
 			:aria-label-combobox="t('spreed', 'TURN server protocols')"
 			:options="protocolOptions"
@@ -49,7 +49,7 @@
 			label="label"
 			track-by="value"
 			no-wrap
-			@input="updateProtocols" />
+			@update:modelValue="updateProtocols" />
 
 		<NcButton v-show="!loading"
 			type="tertiary-no-background"

--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
@@ -18,7 +18,7 @@
 					</p>
 					<NcInputField id="room-number"
 						ref="inputField"
-						:value.sync="amount"
+						v-model="amount"
 						class="breakout-rooms-editor__number-input"
 						type="number"
 						min="1"

--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
@@ -26,19 +26,19 @@
 
 					<label class="breakout-rooms-editor__caption">{{ t('spreed', 'Assignment method') }}</label>
 					<fieldset>
-						<NcCheckboxRadioSwitch :checked.sync="mode"
+						<NcCheckboxRadioSwitch v-model="mode"
 							value="1"
 							name="mode_radio"
 							type="radio">
 							{{ t('spreed', 'Automatically assign participants') }}
 						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch :checked.sync="mode"
+						<NcCheckboxRadioSwitch v-model="mode"
 							value="2"
 							name="mode_radio"
 							type="radio">
 							{{ t('spreed', 'Manually assign participants') }}
 						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch :checked.sync="mode"
+						<NcCheckboxRadioSwitch v-model="mode"
 							value="3"
 							name="mode_radio"
 							type="radio">

--- a/src/components/ConversationSettings/ConversationPermissionsSettings.vue
+++ b/src/components/ConversationSettings/ConversationPermissionsSettings.vue
@@ -17,12 +17,12 @@
 
 		<!-- All permissions -->
 		<div class="conversation-permissions-editor__setting">
-			<NcCheckboxRadioSwitch :checked.sync="radioValue"
+			<NcCheckboxRadioSwitch v-model="radioValue"
 				:disabled="loading"
 				value="all"
 				name="permission_radio"
 				type="radio"
-				@update:checked="handleSubmitPermissions">
+				@update:modelValue="handleSubmitPermissions">
 				{{ t('spreed', 'All permissions') }}
 			</NcCheckboxRadioSwitch>
 			<span v-show="loading && radioValue === 'all'" class="icon-loading-small" />
@@ -33,12 +33,12 @@
 
 		<!-- No permissions -->
 		<div class="conversation-permissions-editor__setting">
-			<NcCheckboxRadioSwitch :checked.sync="radioValue"
+			<NcCheckboxRadioSwitch v-model="radioValue"
 				value="restricted"
 				:disabled="loading"
 				name="permission_radio"
 				type="radio"
-				@update:checked="handleSubmitPermissions">
+				@update:modelValue="handleSubmitPermissions">
 				{{ t('spreed', 'Restricted') }}
 			</NcCheckboxRadioSwitch>
 			<span v-show="loading && radioValue === 'restricted'" class="icon-loading-small" />
@@ -49,12 +49,12 @@
 
 		<!-- Advanced permissions -->
 		<div class="conversation-permissions-editor__setting--advanced">
-			<NcCheckboxRadioSwitch :checked.sync="radioValue"
+			<NcCheckboxRadioSwitch v-model="radioValue"
 				value="advanced"
 				:disabled="loading"
 				name="permission_radio"
 				type="radio"
-				@update:checked="showPermissionsEditor = true">
+				@update:modelValue="showPermissionsEditor = true">
 				{{ t('spreed', 'Advanced permissions') }}
 			</NcCheckboxRadioSwitch>
 

--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -24,8 +24,8 @@
 				<NcCheckboxRadioSwitch v-if="showMediaSettingsToggle"
 					type="switch"
 					:disabled="recordingConsentRequired"
-					:checked="showMediaSettings"
-					@update:checked="setShowMediaSettings">
+					:model-value="showMediaSettings"
+					@update:modelValue="setShowMediaSettings">
 					{{ t('spreed', 'Always show the device preview screen before joining a call in this conversation.') }}
 				</NcCheckboxRadioSwitch>
 				<p v-if="recordingConsentRequired">

--- a/src/components/ConversationSettings/ExpirationSettings.vue
+++ b/src/components/ConversationSettings/ExpirationSettings.vue
@@ -15,7 +15,7 @@
 		<template v-if="canModerate">
 			<NcSelect id="moderation_settings_message_expiration"
 				:input-label="t('spreed', 'Set message expiration')"
-				:value="selectedOption"
+				:model-value="selectedOption"
 				:options="expirationOptions"
 				label="label"
 				close-on-select

--- a/src/components/ConversationSettings/LinkShareSettings.vue
+++ b/src/components/ConversationSettings/LinkShareSettings.vue
@@ -13,26 +13,26 @@
 			<p v-if="hasBreakoutRooms" class="app-settings-section__hint">
 				{{ t('spreed', 'Breakout rooms are not allowed in public conversations.') }}
 			</p>
-			<NcCheckboxRadioSwitch :checked="isSharedPublicly"
+			<NcCheckboxRadioSwitch :model-value="isSharedPublicly"
 				:disabled="hasBreakoutRooms || isSaving"
 				type="switch"
 				aria-describedby="link_share_settings_hint"
-				@update:checked="toggleGuests">
+				@update:modelValue="toggleGuests">
 				{{ t('spreed', 'Allow guests to join this conversation via link') }}
 			</NcCheckboxRadioSwitch>
 
 			<NcCheckboxRadioSwitch v-show="isSharedPublicly"
-				:checked="isPasswordProtectionChecked"
+				:model-value="isPasswordProtectionChecked"
 				:disabled="isSaving"
 				type="switch"
 				aria-describedby="link_share_settings_password_hint"
-				@update:checked="togglePassword">
+				@update:modelValue="togglePassword">
 				{{ t('spreed', 'Password protection') }}
 			</NcCheckboxRadioSwitch>
 
 			<form v-if="showPasswordField" class="password-form" @submit.prevent="handleSetNewPassword">
 				<NcPasswordField ref="passwordField"
-					:value.sync="password"
+					v-model="password"
 					autocomplete="new-password"
 					check-password-strength
 					:disabled="isSaving"

--- a/src/components/ConversationSettings/ListableSettings.vue
+++ b/src/components/ConversationSettings/ListableSettings.vue
@@ -5,18 +5,18 @@
 
 <template>
 	<div v-if="canModerate">
-		<NcCheckboxRadioSwitch :checked="listable !== LISTABLE.NONE"
+		<NcCheckboxRadioSwitch :model-value="listable !== LISTABLE.NONE"
 			:disabled="isListableLoading"
 			type="switch"
-			@update:checked="toggleListableUsers">
+			@update:modelValue="toggleListableUsers">
 			{{ t('spreed', 'Open conversation to registered users, showing it in search results') }}
 		</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch v-if="listable !== LISTABLE.NONE && isGuestsAccountsEnabled"
 			class="additional-top-margin"
-			:checked="listable === LISTABLE.ALL"
+			:model-value="listable === LISTABLE.ALL"
 			:disabled="isListableLoading"
 			type="switch"
-			@update:checked="toggleListableGuests">
+			@update:modelValue="toggleListableGuests">
 			{{ t('spreed', 'Also open to users created with the Guests app') }}
 		</NcCheckboxRadioSwitch>
 	</div>

--- a/src/components/ConversationSettings/LobbySettings.vue
+++ b/src/components/ConversationSettings/LobbySettings.vue
@@ -10,10 +10,10 @@
 				{{ t('spreed', 'Enabling the lobby will remove non-moderators from the ongoing call.') }}
 			</NcNoteCard>
 			<div>
-				<NcCheckboxRadioSwitch :checked="hasLobbyEnabled"
+				<NcCheckboxRadioSwitch :model-value="hasLobbyEnabled"
 					type="switch"
 					:disabled="isLobbyStateLoading"
-					@update:checked="toggleLobby">
+					@update:modelValue="toggleLobby">
 					{{ t('spreed', 'Enable lobby, restricting the conversation to moderators') }}
 				</NcCheckboxRadioSwitch>
 			</div>

--- a/src/components/ConversationSettings/LobbySettings.vue
+++ b/src/components/ConversationSettings/LobbySettings.vue
@@ -27,7 +27,7 @@
 				</div>
 				<NcDateTimePicker id="moderation_settings_lobby_timer_field"
 					aria-describedby="moderation_settings_lobby_timer_hint"
-					:value="lobbyTimer"
+					:model-value="lobbyTimer"
 					:default-value="defaultLobbyTimer"
 					:placeholder="t('spreed', 'Start time (optional)')"
 					:disabled="lobbyTimerFieldDisabled"

--- a/src/components/ConversationSettings/LockingSettings.vue
+++ b/src/components/ConversationSettings/LockingSettings.vue
@@ -14,11 +14,11 @@
 			</p>
 		</NcNoteCard>
 		<div>
-			<NcCheckboxRadioSwitch :checked="isReadOnly"
+			<NcCheckboxRadioSwitch :model-value="isReadOnly"
 				type="switch"
 				aria-describedby="moderation_settings_lock_conversation_hint"
 				:disabled="isReadOnlyStateLoading"
-				@update:checked="toggleReadOnly">
+				@update:modelValue="toggleReadOnly">
 				{{ t('spreed', 'Lock the conversation to prevent anyone to post messages or start calls') }}
 			</NcCheckboxRadioSwitch>
 		</div>

--- a/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
+++ b/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
@@ -36,9 +36,9 @@
 				</div>
 				<div v-show="parts.length > 0"
 					class="enable-switch-line">
-					<NcCheckboxRadioSwitch :checked="enabled"
+					<NcCheckboxRadioSwitch :model-value="enabled"
 						type="switch"
-						@update:checked="onEnabled">
+						@update:modelValue="onEnabled">
 						{{ t('spreed', 'Enable bridge') }}
 						({{ processStateText }})
 					</NcCheckboxRadioSwitch>

--- a/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
+++ b/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
@@ -25,7 +25,7 @@
 						:aria-label-combobox="t('spreed', 'Messaging systems')"
 						:placeholder="newPartPlaceholder"
 						:options="formatedTypes"
-						@input="clickAddPart">
+						@update:modelValue="clickAddPart">
 						<template #option="option">
 							<img class="icon-multiselect-service"
 								:src="option.iconUrl"
@@ -55,7 +55,7 @@
 						container=".matterbridge-settings"
 						@close="closeLogModal">
 						<div class="modal__content">
-							<NcTextArea :value="processLog"
+							<NcTextArea :model-value="processLog"
 								class="log-content"
 								:label="t('spreed', 'Log content')"
 								rows="29"

--- a/src/components/ConversationSettings/NotificationsSettings.vue
+++ b/src/components/ConversationSettings/NotificationsSettings.vue
@@ -12,10 +12,10 @@
 		<NcCheckboxRadioSwitch v-for="level in notificationLevels"
 			:key="level.value"
 			:value="level.value.toString()"
-			:checked.sync="notificationLevel"
+			v-model="notificationLevel"
 			name="notification_level"
 			type="radio"
-			@update:checked="setNotificationLevel">
+			@update:modelValue="setNotificationLevel">
 			<span class="radio-button">
 				<component :is="notificationLevelIcon(level.value)" />
 				{{ level.label }}
@@ -25,8 +25,8 @@
 		<NcCheckboxRadioSwitch v-if="showCallNotificationSettings"
 			id="notification_calls"
 			type="switch"
-			:checked.sync="notifyCalls"
-			@update:checked="setNotificationCalls">
+			v-model="notifyCalls"
+			@update:modelValue="setNotificationCalls">
 			{{ t('spreed', 'Notify about calls in this conversation') }}
 		</NcCheckboxRadioSwitch>
 	</div>

--- a/src/components/ConversationSettings/RecordingConsentSettings.vue
+++ b/src/components/ConversationSettings/RecordingConsentSettings.vue
@@ -13,9 +13,9 @@
 		</div>
 		<NcCheckboxRadioSwitch v-if="canModerate && !isGlobalConsent"
 			type="switch"
-			:checked.sync="recordingConsentSelected"
+			v-model="recordingConsentSelected"
 			:disabled="disabled"
-			@update:checked="setRecordingConsent">
+			@update:modelValue="setRecordingConsent">
 			{{ t('spreed', 'Require recording consent before joining call in this conversation') }}
 		</NcCheckboxRadioSwitch>
 		<p v-else-if="isGlobalConsent">

--- a/src/components/ConversationSettings/SipSettings.vue
+++ b/src/components/ConversationSettings/SipSettings.vue
@@ -10,19 +10,19 @@
 		</h4>
 
 		<div>
-			<NcCheckboxRadioSwitch :checked="hasSIPEnabled"
+			<NcCheckboxRadioSwitch :model-value="hasSIPEnabled"
 				type="switch"
 				aria-describedby="sip_settings_hint"
 				:disabled="isSipLoading"
-				@update:checked="toggleSetting('enable')">
+				@update:modelValue="toggleSetting('enable')">
 				{{ t('spreed', 'Enable phone and SIP dial-in') }}
 			</NcCheckboxRadioSwitch>
 		</div>
 		<div v-if="hasSIPEnabled">
-			<NcCheckboxRadioSwitch :checked="noPinRequired"
+			<NcCheckboxRadioSwitch :model-value="noPinRequired"
 				type="switch"
 				:disabled="isSipLoading || !hasSIPEnabled"
-				@update:checked="toggleSetting('nopin')">
+				@update:modelValue="toggleSetting('nopin')">
 				{{ t('spreed', 'Allow to dial-in without a PIN') }}
 			</NcCheckboxRadioSwitch>
 		</div>

--- a/src/components/GuestWelcomeWindow.vue
+++ b/src/components/GuestWelcomeWindow.vue
@@ -19,7 +19,7 @@
 
 			<label for="textField">{{ t('spreed', 'Enter your name') }}</label>
 			<NcTextField id="textField"
-				:value.sync="guestUserName"
+				v-model="guestUserName"
 				:placeholder="t('spreed', 'Guest')"
 				class="username-form__input"
 				:show-trailing-button="false"

--- a/src/components/LeftSidebar/CallPhoneDialog/CallPhoneDialog.vue
+++ b/src/components/LeftSidebar/CallPhoneDialog/CallPhoneDialog.vue
@@ -18,7 +18,7 @@
 					class="call-phone__form-input"
 					:label="t('spreed', 'Search participants or phone numbers')"
 					label-visible
-					:value.sync="searchText"
+					v-model="searchText"
 					@keydown.enter="createConversation(participantPhoneItem)" />
 				<DialpadPanel container=".call-phone__form"
 					:value.sync="searchText"

--- a/src/components/LeftSidebar/LeftSidebar.spec.js
+++ b/src/components/LeftSidebar/LeftSidebar.spec.js
@@ -639,7 +639,7 @@ describe('LeftSidebar.vue', () => {
 				expect(ncModalComponent.exists()).toBeTruthy()
 
 				const input = ncModalComponent.findComponent({ name: 'NcTextField', ref: 'conversationName' })
-				expect(input.props('value')).toBe(groupsResults[1].label)
+				expect(input.props('modelValue')).toBe(groupsResults[1].label)
 
 				// nothing created yet
 				expect(createOneToOneConversationAction).not.toHaveBeenCalled()
@@ -661,7 +661,7 @@ describe('LeftSidebar.vue', () => {
 				const ncModalComponent = wrapper.findComponent({ name: 'NcModal' })
 				expect(ncModalComponent.exists()).toBeTruthy()
 				const input = ncModalComponent.findComponent({ name: 'NcTextField', ref: 'conversationName' })
-				expect(input.props('value')).toBe(circlesResults[1].label)
+				expect(input.props('modelValue')).toBe(circlesResults[1].label)
 
 				// nothing created yet
 				expect(createOneToOneConversationAction).not.toHaveBeenCalled()

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -109,16 +109,16 @@
 			<!-- "Always show" setting -->
 			<NcCheckboxRadioSwitch v-if="!isPublicShareAuthSidebar"
 				class="checkbox"
-				:checked="showMediaSettings || showRecordingWarning"
+				:model-value="showMediaSettings || showRecordingWarning"
 				:disabled="showRecordingWarning"
-				@update:checked="setShowMediaSettings">
+				@update:modelValue="setShowMediaSettings">
 				{{ t('spreed', 'Always show preview for this conversation') }}
 			</NcCheckboxRadioSwitch>
 
 			<!-- Moderator options before starting a call-->
 			<NcCheckboxRadioSwitch v-if="!hasCall && canModerateRecording"
 				class="checkbox"
-				:checked.sync="isRecordingFromStart">
+				v-model="isRecordingFromStart">
 				{{ t('spreed', 'Start recording immediately with the call') }}
 			</NcCheckboxRadioSwitch>
 
@@ -135,8 +135,8 @@
 						{{ t('spreed', 'The recording might include your voice, video from camera, and screen share. Your consent is required before joining the call.') }}
 					</p>
 					<NcCheckboxRadioSwitch class="checkbox--warning"
-						:checked="recordingConsentGiven"
-						@update:checked="setRecordingConsentGiven">
+						:model-value="recordingConsentGiven"
+						@update:modelValue="setRecordingConsentGiven">
 						{{ t('spreed', 'Give consent to the recording of this call') }}
 					</NcCheckboxRadioSwitch>
 				</template>

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -192,7 +192,7 @@
 
 					<NcActionInput type="datetime-local"
 						is-native-picker
-						:value="customReminderDateTime"
+						:model-value="customReminderDateTime"
 						:min="new Date()"
 						@change="setCustomReminderDateTime">
 						<template #icon>

--- a/src/components/NewConversationDialog/NewConversationContactsPage.vue
+++ b/src/components/NewConversationDialog/NewConversationContactsPage.vue
@@ -9,7 +9,7 @@
 		<div class="set-contacts__form">
 			<NcTextField ref="setContacts"
 				v-observe-visibility="visibilityChanged"
-				:value.sync="searchText"
+				v-model="searchText"
 				type="text"
 				class="set-contacts__form-input"
 				:label="textFieldLabel"

--- a/src/components/NewConversationDialog/NewConversationSetupPage.vue
+++ b/src/components/NewConversationDialog/NewConversationSetupPage.vue
@@ -38,12 +38,12 @@
 		<label class="new-group-conversation__label">
 			{{ t('spreed', 'Conversation visibility') }}
 		</label>
-		<NcCheckboxRadioSwitch :checked.sync="isPublic"
+		<NcCheckboxRadioSwitch v-model="isPublic"
 			type="switch">
 			{{ t('spreed', 'Allow guests to join via link') }}
 		</NcCheckboxRadioSwitch>
 		<div class="new-group-conversation__wrapper">
-			<NcCheckboxRadioSwitch :checked.sync="hasPassword"
+			<NcCheckboxRadioSwitch v-model="hasPassword"
 				type="switch"
 				:disabled="!isPublic">
 				<span class="checkbox__label">{{ t('spreed', 'Password protect') }}</span>

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -75,7 +75,7 @@
 				</NcNoteCard>
 				<NcRichContenteditable ref="richContenteditable"
 					v-shortkey.once="$options.disableKeyboardShortcuts ? null : ['c']"
-					:value.sync="text"
+					v-model="text"
 					:auto-complete="autoComplete"
 					:disabled="disabled"
 					:user-data="userData"
@@ -86,7 +86,7 @@
 					@shortkey="focusInput"
 					@keydown.esc="handleInputEsc"
 					@keydown.ctrl.up="handleEditLastMessage"
-					@input="handleTyping"
+					@update:modelValue="handleTyping"
 					@paste="handlePastedFiles"
 					@submit="handleSubmit" />
 			</div>

--- a/src/components/NewMessage/NewMessageNewFileDialog.vue
+++ b/src/components/NewMessage/NewMessageNewFileDialog.vue
@@ -21,8 +21,8 @@
 					:helper-text="newFileError"
 					:label="t('spreed', 'Name of the new file')"
 					:placeholder="newFileTitle"
-					:value="newFileTitle"
-					@update:value="updateNewFileTitle" />
+					:model-value="newFileTitle"
+					@update:modelValue="updateNewFileTitle" />
 
 				<ul v-if="templates.length > 1" class="templates-picker__list">
 					<NewMessageTemplatePreview v-for="template in templates"

--- a/src/components/NewMessage/NewMessageNewFileDialog.vue
+++ b/src/components/NewMessage/NewMessageNewFileDialog.vue
@@ -28,7 +28,7 @@
 					<NewMessageTemplatePreview v-for="template in templates"
 						:key="template.fileid"
 						:basename="template.basename"
-						:checked="checked === template.fileid"
+						:model-value="checked === template.fileid"
 						:fileid="template.fileid"
 						:filename="template.filename"
 						:preview-url="template.previewUrl"

--- a/src/components/NewMessage/NewMessagePollEditor.vue
+++ b/src/components/NewMessage/NewMessagePollEditor.vue
@@ -15,7 +15,7 @@
 			<p class="poll-editor__caption">
 				{{ t('spreed', 'Question') }}
 			</p>
-			<NcTextField :value.sync="pollQuestion" :label="t('spreed', 'Ask a question')" v-on="$listeners" />
+			<NcTextField v-model="pollQuestion" :label="t('spreed', 'Ask a question')" v-on="$listeners" />
 
 			<!-- Poll options -->
 			<p class="poll-editor__caption">
@@ -25,7 +25,7 @@
 				:key="index"
 				class="poll-editor__option">
 				<NcTextField ref="pollOption"
-					:value.sync="pollOptions[index]"
+					v-model="pollOptions[index]"
 					:label="t('spreed', 'Answer {option}', {option: index + 1})" />
 				<NcButton v-if="pollOptions.length > 2"
 					type="tertiary-no-background"

--- a/src/components/NewMessage/NewMessagePollEditor.vue
+++ b/src/components/NewMessage/NewMessagePollEditor.vue
@@ -50,10 +50,10 @@
 				{{ t('spreed', 'Settings') }}
 			</p>
 			<div class="poll-editor__settings">
-				<NcCheckboxRadioSwitch :checked.sync="isPrivate" type="checkbox">
+				<NcCheckboxRadioSwitch v-model="isPrivate" type="checkbox">
 					{{ t('spreed', 'Private poll') }}
 				</NcCheckboxRadioSwitch>
-				<NcCheckboxRadioSwitch :checked.sync="isMultipleAnswer" type="checkbox">
+				<NcCheckboxRadioSwitch v-model="isMultipleAnswer" type="checkbox">
 					{{ t('spreed', 'Multiple answers') }}
 				</NcCheckboxRadioSwitch>
 			</div>

--- a/src/components/PermissionsEditor/PermissionsEditor.vue
+++ b/src/components/PermissionsEditor/PermissionsEditor.vue
@@ -13,32 +13,32 @@
 				<p class="title" v-html="modalTitle" />
 				<form @submit.prevent="handleSubmitPermissions">
 					<NcCheckboxRadioSwitch ref="callStart"
-						:checked.sync="callStart"
+						v-model="callStart"
 						class="checkbox">
 						{{ t('spreed', 'Start a call') }}
 					</NcCheckboxRadioSwitch>
 					<NcCheckboxRadioSwitch ref="lobbyIgnore"
-						:checked.sync="lobbyIgnore"
+						v-model="lobbyIgnore"
 						class="checkbox">
 						{{ t('spreed', 'Skip the lobby') }}
 					</NcCheckboxRadioSwitch>
 					<NcCheckboxRadioSwitch ref="chatMessagesAndReactions"
-						:checked.sync="chatMessagesAndReactions"
+						v-model="chatMessagesAndReactions"
 						class="checkbox">
 						{{ t('spreed', 'Can post messages and reactions') }}
 					</NcCheckboxRadioSwitch>
 					<NcCheckboxRadioSwitch ref="publishAudio"
-						:checked.sync="publishAudio"
+						v-model="publishAudio"
 						class="checkbox">
 						{{ t('spreed', 'Enable the microphone') }}
 					</NcCheckboxRadioSwitch>
 					<NcCheckboxRadioSwitch ref="publishVideo"
-						:checked.sync="publishVideo"
+						v-model="publishVideo"
 						class="checkbox">
 						{{ t('spreed', 'Enable the camera') }}
 					</NcCheckboxRadioSwitch>
 					<NcCheckboxRadioSwitch ref="publishScreen"
-						:checked.sync="publishScreen"
+						v-model="publishScreen"
 						class="checkbox">
 						{{ t('spreed', 'Share the screen') }}
 					</NcCheckboxRadioSwitch>

--- a/src/components/PollViewer/PollViewer.vue
+++ b/src/components/PollViewer/PollViewer.vue
@@ -23,7 +23,7 @@
 			<div v-if="modalPage === 'voting'" class="poll-modal__options">
 				<NcCheckboxRadioSwitch v-for="(option, index) in poll.options"
 					:key="'option-' + index"
-					:checked.sync="checked"
+					v-model="checked"
 					:value="index.toString()"
 					:type="isMultipleAnswers ? 'checkbox' : 'radio'"
 					name="answerType">

--- a/src/components/RoomSelector.spec.js
+++ b/src/components/RoomSelector.spec.js
@@ -168,7 +168,7 @@ describe('RoomSelector', () => {
 
 			// Act: type 'conversation'
 			const input = wrapper.findComponent({ name: 'NcTextField' })
-			await input.vm.$emit('update:value', 'conversation')
+			await input.vm.$emit('update:modelValue', 'conversation')
 
 			// Assert
 			const list = wrapper.findAllComponents({ name: 'NcListItem' })
@@ -182,7 +182,7 @@ describe('RoomSelector', () => {
 
 			// Act: type 'conversation'
 			const input = wrapper.findComponent({ name: 'NcTextField' })
-			await input.vm.$emit('update:value', 'qwerty')
+			await input.vm.$emit('update:modelValue', 'qwerty')
 
 			// Assert
 			const list = wrapper.findAllComponents({ name: 'NcListItem' })
@@ -195,7 +195,7 @@ describe('RoomSelector', () => {
 
 			// Act: type 'conversation'
 			const input = wrapper.findComponent({ name: 'NcTextField' })
-			await input.vm.$emit('update:value', 'qwerty')
+			await input.vm.$emit('update:modelValue', 'qwerty')
 
 			// Assert
 			const list = wrapper.findAllComponents({ name: 'NcListItem' })
@@ -208,7 +208,7 @@ describe('RoomSelector', () => {
 			// Arrange
 			const wrapper = await mountRoomSelector()
 			const input = wrapper.findComponent({ name: 'NcTextField' })
-			await input.vm.$emit('update:value', 'conversation')
+			await input.vm.$emit('update:modelValue', 'conversation')
 
 			// Act: click trailing button
 			await input.vm.$emit('trailing-button-click')

--- a/src/components/RoomSelector.vue
+++ b/src/components/RoomSelector.vue
@@ -13,7 +13,7 @@
 			<p v-if="dialogSubtitle" class="selector__subtitle">
 				{{ dialogSubtitle }}
 			</p>
-			<NcTextField :value.sync="searchText"
+			<NcTextField v-model="searchText"
 				trailing-button-icon="close"
 				class="selector__search"
 				:label="t('spreed', 'Search conversations or users')"

--- a/src/components/SetGuestUsername.vue
+++ b/src/components/SetGuestUsername.vue
@@ -18,7 +18,7 @@
 
 		<NcTextField v-else
 			ref="usernameInput"
-			:value.sync="guestUserName"
+			v-model="guestUserName"
 			:placeholder="t('spreed', 'Guest')"
 			class="username-form__input"
 			:show-trailing-button="!!guestUserName"

--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -45,20 +45,20 @@
 			:name="t('spreed', 'Privacy')"
 			class="app-settings-section">
 			<NcCheckboxRadioSwitch id="read_status_privacy"
-				:checked="readStatusPrivacyIsPublic"
+				:model-value="readStatusPrivacyIsPublic"
 				:disabled="privacyLoading"
 				type="switch"
 				class="checkbox"
-				@update:checked="toggleReadStatusPrivacy">
+				@update:modelValue="toggleReadStatusPrivacy">
 				{{ t('spreed', 'Share my read-status and show the read-status of others') }}
 			</NcCheckboxRadioSwitch>
 			<NcCheckboxRadioSwitch v-if="supportTypingStatus"
 				id="typing_status_privacy"
-				:checked="typingStatusPrivacyIsPublic"
+				:model-value="typingStatusPrivacyIsPublic"
 				:disabled="privacyLoading"
 				type="switch"
 				class="checkbox"
-				@update:checked="toggleTypingStatusPrivacy">
+				@update:modelValue="toggleTypingStatusPrivacy">
 				{{ t('spreed', 'Share my typing-status and show the typing-status of others') }}
 			</NcCheckboxRadioSwitch>
 		</NcAppSettingsSection>
@@ -66,11 +66,11 @@
 			:name="t('spreed', 'Sounds')"
 			class="app-settings-section">
 			<NcCheckboxRadioSwitch id="play_sounds"
-				:checked="playSounds"
+				:model-value="playSounds"
 				:disabled="playSoundsLoading"
 				type="switch"
 				class="checkbox"
-				@update:checked="togglePlaySounds">
+				@update:modelValue="togglePlaySounds">
 				{{ t('spreed', 'Play sounds when participants join or leave a call') }}
 			</NcCheckboxRadioSwitch>
 			<em>{{ t('spreed', 'Sounds can currently not be played on iPad and iPhone devices due to technical restrictions by the manufacturer.') }}</em>
@@ -86,10 +86,10 @@
 			:name="t('spreed', 'Performance')"
 			class="app-settings-section">
 			<NcCheckboxRadioSwitch id="blur-call-background"
-				:checked="isBackgroundBlurred"
+				:model-value="isBackgroundBlurred"
 				type="switch"
 				class="checkbox"
-				@update:checked="toggleBackgroundBlurred">
+				@update:modelValue="toggleBackgroundBlurred">
 				{{ t('spreed', 'Blur background image in the call (may increase GPU load)') }}
 			</NcCheckboxRadioSwitch>
 		</NcAppSettingsSection>

--- a/src/components/UIShared/DialpadPanel.vue
+++ b/src/components/UIShared/DialpadPanel.vue
@@ -26,7 +26,7 @@
 			<NcSelect v-if="!dialing"
 				ref="regionSelect"
 				class="dial-panel__select"
-				:value="region"
+				:model-value="region"
 				:options="options"
 				:append-to-body="false"
 				:clearable="false"

--- a/src/components/UIShared/EditableTextField.vue
+++ b/src/components/UIShared/EditableTextField.vue
@@ -14,7 +14,7 @@
 		<NcRichContenteditable v-else
 			ref="richContenteditable"
 			dir="auto"
-			:value.sync="text"
+			v-model="text"
 			:auto-complete="()=>{}"
 			:maxlength="maxLength"
 			:multiline="multiline"

--- a/src/components/UIShared/SearchBox.vue
+++ b/src/components/UIShared/SearchBox.vue
@@ -5,7 +5,7 @@
 
 <template>
 	<NcTextField ref="searchConversations"
-		:value="value"
+		:model-value="value"
 		:aria-label="placeholderText"
 		:placeholder="placeholderText"
 		:show-trailing-button="isFocused"
@@ -14,7 +14,7 @@
 		pill
 		@focus="handleFocus"
 		@blur="handleBlur"
-		@update:value="updateValue"
+		@update:modelValue="updateValue"
 		@trailing-button-click="abortSearch"
 		@keydown.esc="abortSearch">
 		<Magnify :size="16" />

--- a/src/views/FlowPostToConversation.vue
+++ b/src/views/FlowPostToConversation.vue
@@ -5,17 +5,17 @@
 
 <template>
 	<div>
-		<NcSelect :value="currentRoom"
+		<NcSelect :model-value="currentRoom"
 			:options="roomOptions"
 			:aria-label-combobox="t('spreed', 'Select a conversation')"
 			label="displayName"
-			@input="(newValue) => newValue !== null && $emit('input', JSON.stringify({'m': currentMode.id, 't': newValue.token }))" />
+			@update:modelValue="(newValue) => newValue !== null && $emit('input', JSON.stringify({'m': currentMode.id, 't': newValue.token }))" />
 
-		<NcSelect :value="currentMode"
+		<NcSelect :model-value="currentMode"
 			:options="modeOptions"
 			:aria-label-combobox="t('spreed', 'Select a mode')"
 			label="text"
-			@input="(newValue) => newValue !== null && $emit('input', JSON.stringify({'m': newValue.id, 't': currentRoom.token }))" />
+			@update:modelValue="(newValue) => newValue !== null && $emit('input', JSON.stringify({'m': newValue.id, 't': currentRoom.token }))" />
 	</div>
 </template>
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix: #12359

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [x] [NOTHING TO DO] The package now uses Vue 3 instead of Vue 2.7
- [x] [NOTHING TO DO?] The package is now a native ESM package
- [x] The checked prop was renamed to modelValue, the update:checked event was renamed to update:modelValue.
- [x] The value prop was renamed to modelValue, the update:value or input events were renamed to update:modelValue
- [x] [NOT USED]  The exact prop was removed. This affects the following components
- [x] [ALREADY MIGRATED]  The isFullscreen and isMobile mixins were removed. Use the according composables instead.

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
