### PR TITLE
feat(CallView): introduce dynamic order

### DIFF
--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -266,6 +266,10 @@ const getters = {
 		}
 		return 0
 	},
+
+	getParticipantBySessionId: (state) => (token, sessionId) => {
+		return Object.values(Object(state.attendees[token])).find(attendee => attendee.sessionIds.includes(sessionId))
+	},
 }
 
 const mutations = {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11393

- [x] After following, go back to the view type that was on just before (done)
- [x] Default order :
1. user is screensharing
2. user is speaking
3. user has speaking rights and video with video ON
4. user has speaking rights and video with video OFF
5. user with no permissions

There is no differentiation between guests, users and moderators (hopefully in v2 😇)

## Tiles dynamic order

- [x] in Stripe (so it is Speaker view) and in grid view, last speaker should be placed first in their category (1. and 2.)
- [x] Same for screensharing
- [x] Re-ordering is only applicable when the speaker is not in the first page 


> [!TIP]
> For testing with a few tiles, make this condition always falsy
> and I suggest to review changes all at once and not by commit, it's messy..

```js
// if model is already in the first page, do nothing
	if (false && this.orderedVideos.slice(0, this.slots).find(video => video.attributes.peerId === model.attributes.peerId)) {
		return
	}
```

## Additional (follow-up): 

- [ ] Webinar mask: when it is switched on by a moderator the tiles of attendees who don't have permissions will be hidden (showing only total number in a tile).
- [ ] Styling the low-num-of-participants call as they are in one page and space should be minimized.
- [ ] When joining the call, It should be speaker view for the first tile and if another tile was added, it becomes a grid

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Screenshot before | Screenshot after

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

> [!CAUTION]
> This section for the side effects that I need to handle

- [x] waiting for participants to be fetched (around 3sec) is noticeable when joining, maybe I need to add to expand empty view for that case or add another view as tiles placeholders loading (we know how many participants at that time) 
- [x] skip any kind of ordering when user is guest as they don't have participants list thus, who has mic permissions/ moderator etc
### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

