### PR TITLE
fix(vue3): use value from v-model (instead of event.target.value)

### DIFF
--- a/src/components/NewConversationDialog/NewConversationSetupPage.vue
+++ b/src/components/NewConversationDialog/NewConversationSetupPage.vue
@@ -113,8 +113,8 @@ export default {
 			get() {
 				return this.newConversation.displayName
 			},
-			set(event) {
-				this.updateNewConversation({ displayName: event.target.value })
+			set(value) {
+				this.updateNewConversation({ displayName: value })
 			},
 		},
 
@@ -122,8 +122,8 @@ export default {
 			get() {
 				return this.newConversation.description
 			},
-			set(event) {
-				this.updateNewConversation({ description: event.target.value })
+			set(value) {
+				this.updateNewConversation({ description: value })
 			},
 		},
 
@@ -170,8 +170,8 @@ export default {
 			get() {
 				return this.password
 			},
-			set(event) {
-				this.$emit('update:password', event.target.value)
+			set(value) {
+				this.$emit('update:password', value)
 			},
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Ref #12366
  * To test - create a new conversation with description and passport via dialog window

## 🖌️ UI Checklist

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 