### PR TITLE
fix(tests): Sort attendees before using them when preparing the expec…

### DIFF
--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -768,6 +768,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 
 				$result[] = $data;
 			}
+			usort($result, [self::class, 'sortAttendees']);
 
 			$expected = array_map(function ($attendee, $actual) {
 				if (isset($attendee['actorId']) && substr($attendee['actorId'], 0, strlen('"guest')) === '"guest') {
@@ -813,7 +814,6 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			}, $result);
 
 			usort($expected, [self::class, 'sortAttendees']);
-			usort($result, [self::class, 'sortAttendees']);
 
 			Assert::assertEquals($expected, $result, print_r([
 				'original' => $formData->getHash(),


### PR DESCRIPTION
…ted result

Finally happened: https://github.com/nextcloud/spreed/actions/runs/9064151772/job/24901861969?pr=12319#step:14:3405

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
