### PR TITLE
chore(vue3): migrate renamed lifecycle hooks

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -247,7 +247,7 @@ export default {
 		window.addEventListener('beforeunload', this.preventUnload)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.debounceRefreshCurrentConversation.clear?.()
 		if (!getCurrentUser()) {
 			EventBus.off('should-refresh-conversations', this.debounceRefreshCurrentConversation)

--- a/src/FilesSidebarCallViewApp.vue
+++ b/src/FilesSidebarCallViewApp.vue
@@ -147,7 +147,7 @@ export default {
 		window.addEventListener('beforeunload', this.preventUnload)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('beforeunload', this.preventUnload)
 	},
 

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -139,7 +139,7 @@ export default {
 		})
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('beforeunload', this.preventUnload)
 	},
 

--- a/src/components/AdminSettings/AllowedGroups.vue
+++ b/src/components/AdminSettings/AllowedGroups.vue
@@ -162,7 +162,7 @@ export default {
 		this.debounceSearchGroup('')
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.debounceSearchGroup.clear?.()
 	},
 

--- a/src/components/AdminSettings/Federation.vue
+++ b/src/components/AdminSettings/Federation.vue
@@ -136,7 +136,7 @@ export default {
 		this.debounceSearchGroup('')
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.debounceSearchGroup.clear?.()
 	},
 

--- a/src/components/AdminSettings/RecordingServers.vue
+++ b/src/components/AdminSettings/RecordingServers.vue
@@ -149,7 +149,7 @@ export default {
 		this.uploadLimit = parseInt(state.uploadLimit, 10)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.debounceUpdateServers.clear?.()
 	},
 

--- a/src/components/AdminSettings/SIPBridge.vue
+++ b/src/components/AdminSettings/SIPBridge.vue
@@ -150,7 +150,7 @@ export default {
 		this.isDialoutSupported()
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.debounceSearchGroup.clear?.()
 	},
 

--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -118,7 +118,7 @@ export default {
 		this.hideWarning = state.hideWarning
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.debounceUpdateServers.clear?.()
 	},
 

--- a/src/components/AdminSettings/StunServers.vue
+++ b/src/components/AdminSettings/StunServers.vue
@@ -78,7 +78,7 @@ export default {
 		this.debounceUpdateServers = debounce(this.updateServers, 1000)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.debounceUpdateServers.clear?.()
 	},
 

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -200,7 +200,7 @@ export default {
 		this.testingSuccess = false
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.debounceTestServer.clear?.()
 	},
 

--- a/src/components/AdminSettings/TurnServers.vue
+++ b/src/components/AdminSettings/TurnServers.vue
@@ -89,7 +89,7 @@ export default {
 		this.servers = loadState('spreed', 'turn_servers')
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.debounceUpdateServers.clear?.()
 	},
 

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -429,7 +429,7 @@ export default {
 		subscribe('set-background-blurred', this.setBackgroundBlurred)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.debounceFetchPeers.clear?.()
 		this.$store.dispatch('isEmptyCallView', true)
 		EventBus.off('refresh-peer-list', this.debounceFetchPeers)

--- a/src/components/CallView/Grid/Grid.vue
+++ b/src/components/CallView/Grid/Grid.vue
@@ -532,7 +532,7 @@ export default {
 
 		window.OCA.Talk.gridDebugInformation = this.gridDebugInformation
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.debounceMakeGrid.clear?.()
 		window.OCA.Talk.gridDebugInformation = () => console.debug('Not in a call')
 

--- a/src/components/CallView/shared/LocalAudioControlButton.vue
+++ b/src/components/CallView/shared/LocalAudioControlButton.vue
@@ -131,7 +131,7 @@ export default {
 		subscribe('local-audio-control-button:toggle-audio', this.updateDeviceState)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		unsubscribe('local-audio-control-button:toggle-audio', this.updateDeviceState)
 	},
 

--- a/src/components/CallView/shared/LocalVideo.vue
+++ b/src/components/CallView/shared/LocalVideo.vue
@@ -287,13 +287,13 @@ export default {
 		}
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		if (this.resizeObserver) {
 			this.resizeObserver.disconnect()
 		}
 	},
 
-	destroyed() {
+	unmounted() {
 		if (this.notificationHandle) {
 			this.notificationHandle.hideToast()
 		}

--- a/src/components/CallView/shared/LocalVideoControlButton.vue
+++ b/src/components/CallView/shared/LocalVideoControlButton.vue
@@ -126,7 +126,7 @@ export default {
 		subscribe('local-video-control-button:toggle-video', this.updateDeviceState)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		unsubscribe('local-video-control-button:toggle-video', this.updateDeviceState)
 	},
 

--- a/src/components/CallView/shared/PresenterOverlay.vue
+++ b/src/components/CallView/shared/PresenterOverlay.vue
@@ -92,7 +92,7 @@ export default {
 		window.addEventListener('resize', this.updateSize)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('resize', this.updateSize)
 	},
 

--- a/src/components/CallView/shared/ReactionToaster.vue
+++ b/src/components/CallView/shared/ReactionToaster.vue
@@ -129,7 +129,7 @@ export default {
 		subscribe('send-reaction', this.handleOwnReaction)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		clearInterval(this.intervalId)
 		unsubscribe('send-reaction', this.handleOwnReaction)
 		Object.keys(this.registeredModels).forEach(modelId => {

--- a/src/components/CallView/shared/VideoVue.vue
+++ b/src/components/CallView/shared/VideoVue.vue
@@ -533,13 +533,13 @@ export default {
 		}
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		if (this.resizeObserver) {
 			this.resizeObserver.disconnect()
 		}
 	},
 
-	destroyed() {
+	unmounted() {
 		this.sharedData.remoteVideoBlocker.decreaseVisibleCounter()
 	},
 

--- a/src/components/CallView/shared/ViewerOverlayCallView.vue
+++ b/src/components/CallView/shared/ViewerOverlayCallView.vue
@@ -220,7 +220,7 @@ export default {
 		this.observer.observe(this.$refs.ghost)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.observer.disconnect()
 	},
 

--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -244,7 +244,7 @@ export default {
 
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		unsubscribe('show-conversation-settings', this.handleShowSettings)
 		unsubscribe('hide-conversation-settings', this.handleHideSettings)
 	},

--- a/src/components/ConversationSettings/ListableSettings.vue
+++ b/src/components/ConversationSettings/ListableSettings.vue
@@ -113,7 +113,7 @@ export default {
 		}
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		if (this.lastNotification) {
 			this.lastNotification.hideToast()
 			this.lastNotification = null

--- a/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
+++ b/src/components/ConversationSettings/Matterbridge/MatterbridgeSettings.vue
@@ -535,7 +535,7 @@ export default {
 	beforeMount() {
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 	},
 
 	methods: {

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -637,7 +637,7 @@ export default {
 		this.handleFilter(BrowserStorage.getItem('filterEnabled'))
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.debounceFetchSearchResults.clear?.()
 		this.debounceFetchConversations.clear?.()
 		this.debounceHandleScroll.clear?.()

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -480,7 +480,7 @@ export default {
 		}
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		unsubscribe('talk:media-settings:show', this.showModal)
 		unsubscribe('talk:media-settings:hide', this.closeModalAndApplySettings)
 	},

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -455,7 +455,7 @@ export default {
 		EventBus.on('highlight-message', this.highlightMessage)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		EventBus.off('highlight-message', this.highlightMessage)
 	},
 

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -568,7 +568,7 @@ export default {
 		img.src = this.previewUrl
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.uploadManager = null
 	},
 

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -308,7 +308,7 @@ export default {
 		}, 30000)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.debounceUpdateReadMarkerPosition.clear?.()
 		this.debounceHandleScroll.clear?.()
 

--- a/src/components/NewConversationDialog/NewConversationContactsPage.vue
+++ b/src/components/NewConversationDialog/NewConversationContactsPage.vue
@@ -170,7 +170,7 @@ export default {
 		})
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.debounceFetchSearchResults.clear?.()
 
 		this.cancelSearchPossibleConversations()

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -545,7 +545,7 @@ export default {
 		}
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		EventBus.off('focus-chat-input', this.focusInput)
 		EventBus.off('upload-start', this.handleUploadSideEffects)
 		EventBus.off('upload-discard', this.handleUploadSideEffects)

--- a/src/components/NewMessage/NewMessageAudioRecorder.vue
+++ b/src/components/NewMessage/NewMessageAudioRecorder.vue
@@ -167,7 +167,7 @@ export default {
 		this.$store.dispatch('initializeAudioEncoder')
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.killStreams()
 	},
 

--- a/src/components/PollViewer/PollViewer.vue
+++ b/src/components/PollViewer/PollViewer.vue
@@ -258,7 +258,7 @@ export default {
 		EventBus.on('talk:poll-added', this.showPollToast)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		EventBus.off('talk:poll-added', this.showPollToast)
 	},
 

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsTab.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsTab.vue
@@ -139,7 +139,7 @@ export default {
 		}
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		// Clear the interval
 		clearInterval(this.breakoutRoomsParticipantsInterval)
 	},

--- a/src/components/RightSidebar/Participants/ParticipantsTab.vue
+++ b/src/components/RightSidebar/Participants/ParticipantsTab.vue
@@ -209,7 +209,7 @@ export default {
 		subscribe('user_status:status.updated', this.updateUserStatus)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.debounceFetchSearchResults.clear?.()
 
 		EventBus.off('route-change', this.abortSearch)

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -351,7 +351,7 @@ export default {
 		subscribe('spreed:select-active-sidebar-tab', this.handleUpdateActive)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		unsubscribe('spreed:select-active-sidebar-tab', this.handleUpdateActive)
 	},
 

--- a/src/components/RightSidebar/SharedItems/SharedItemsBrowser.vue
+++ b/src/components/RightSidebar/SharedItems/SharedItemsBrowser.vue
@@ -106,7 +106,7 @@ export default {
 		this.firstFetchItems(this.activeTab)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.debounceHandleScroll.clear?.()
 	},
 

--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -347,7 +347,7 @@ export default {
 			this.showSettings = true
 		},
 
-		beforeDestroy() {
+		beforeUnmount() {
 			unsubscribe('show-settings', this.handleShowSettings)
 		},
 	},

--- a/src/components/TopBar/CallTime.vue
+++ b/src/components/TopBar/CallTime.vue
@@ -166,7 +166,7 @@ export default {
 		this.timer = setInterval(this.computeElapsedTime, 1000)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		clearInterval(this.timer)
 	},
 

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -340,7 +340,7 @@ export default {
 		document.addEventListener('webkitfullscreenchange', this.fullScreenChanged, false)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.notifyUnreadMessages(null)
 		document.removeEventListener('fullscreenchange', this.fullScreenChanged, false)
 		document.removeEventListener('mozfullscreenchange', this.fullScreenChanged, false)

--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -403,7 +403,7 @@ export default {
 		this.speakingWhileMutedWarner = new SpeakingWhileMutedWarner(this.model, this)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.speakingWhileMutedWarner.destroy()
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Ref: https://github.com/nextcloud/spreed/issues/12366

The destroyed lifecycle option has been renamed to unmounted
The beforeDestroy lifecycle option has been renamed to beforeUnmount