### PR TITLE
chore(vue3): replace $listeners with explicit emit

### DIFF
--- a/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
+++ b/src/components/BreakoutRoomsEditor/BreakoutRoomsEditor.vue
@@ -6,7 +6,7 @@
 <template>
 	<NcModal :container="container"
 		:class="{'modal-mask__participants-step': isEditingParticipants}"
-		v-on="$listeners">
+		@close="$emit('close')">
 		<div class="breakout-rooms-editor"
 			:class="{'breakout-rooms-editor__participants-step': isEditingParticipants}">
 			<h2>{{ modalTitle }}</h2>
@@ -64,12 +64,12 @@
 			<template v-else>
 				<BreakoutRoomsParticipantsEditor :token="token"
 					:room-number="amount"
-					v-on="$listeners"
+					@close="$emit('close')"
 					@back="isEditingParticipants = false"
 					@create-rooms="handleCreateRooms" />
 			</template>
 		</div>
-	</ncmodal>
+	</NcModal>
 </template>
 
 <script>

--- a/src/components/BreakoutRoomsEditor/SendMessageDialog.vue
+++ b/src/components/BreakoutRoomsEditor/SendMessageDialog.vue
@@ -6,7 +6,7 @@
 <template>
 	<NcModal ref="modal"
 		:container="container"
-		v-on="$listeners">
+		@close="$emit('close')">
 		<div class="send-message-dialog">
 			<h2 class="send-message-dialog__title">
 				{{ dialogTitle }}

--- a/src/components/NewMessage/NewMessagePollEditor.vue
+++ b/src/components/NewMessage/NewMessagePollEditor.vue
@@ -7,7 +7,7 @@
 	<NcModal size="small"
 		:close-on-click-outside="!isFilled"
 		:container="container"
-		v-on="$listeners">
+		@close="$emit('close')">
 		<div class="poll-editor">
 			<h2>{{ t('spreed', 'Create new poll') }}</h2>
 
@@ -15,7 +15,7 @@
 			<p class="poll-editor__caption">
 				{{ t('spreed', 'Question') }}
 			</p>
-			<NcTextField v-model="pollQuestion" :label="t('spreed', 'Ask a question')" v-on="$listeners" />
+			<NcTextField v-model="pollQuestion" :label="t('spreed', 'Ask a question')" />
 
 			<!-- Poll options -->
 			<p class="poll-editor__caption">

--- a/src/components/PermissionsEditor/PermissionsEditor.vue
+++ b/src/components/PermissionsEditor/PermissionsEditor.vue
@@ -6,7 +6,7 @@
 <template>
 	<NcModal size="small"
 		:container="container"
-		v-on="$listeners">
+		@close="$emit('close')">
 		<div class="wrapper">
 			<template v-if="!loading">
 				<!-- eslint-disable-next-line vue/no-v-html -->
@@ -116,7 +116,7 @@ export default {
 			default: false,
 		},
 	},
-	emits: ['submit'],
+	emits: ['close', 'submit'],
 
 	data() {
 		return {

--- a/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
+++ b/src/components/RightSidebar/BreakoutRooms/BreakoutRoomsActions.vue
@@ -97,8 +97,7 @@
 				<BreakoutRoomsParticipantsEditor :token="mainToken"
 					:breakout-rooms="breakoutRooms"
 					:is-creating-rooms="false"
-					@close="closeParticipantsEditor"
-					v-on="$listeners" />
+					@close="closeParticipantsEditor" />
 			</div>
 		</NcModal>
 

--- a/src/components/RightSidebar/Participants/ParticipantPermissionsEditor.vue
+++ b/src/components/RightSidebar/Participants/ParticipantPermissionsEditor.vue
@@ -7,7 +7,7 @@
 	<div class="wrapper">
 		<PermissionEditor :display-name="displayName"
 			:permissions="permissions"
-			v-on="$listeners"
+			@close="$emit('close')"
 			@submit="handleSubmitPermissions" />
 	</div>
 </template>

--- a/src/components/RightSidebar/SharedItems/SharedItemsBrowser.vue
+++ b/src/components/RightSidebar/SharedItems/SharedItemsBrowser.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<NcModal size="large" :container="container" v-on="$listeners">
+	<NcModal size="large" :container="container" @close="$emit('close')">
 		<div class="shared-items-browser">
 			<div class="shared-items-browser__navigation">
 				<template v-for="type in sharedItemsOrder">
@@ -64,7 +64,7 @@ export default {
 		},
 	},
 
-	emits: ['update:active-tab'],
+	emits: ['close', 'update:active-tab'],
 
 	setup() {
 		const sharedItemsStore = useSharedItemsStore()

--- a/src/components/UIShared/TransitionWrapper.vue
+++ b/src/components/UIShared/TransitionWrapper.vue
@@ -6,15 +6,11 @@
 <template>
 	<TransitionGroup v-if="group"
 		class="transition-group"
-		:name="name"
-		v-bind="$attrs"
-		v-on="$listeners">
+		:name="name">
 		<slot />
 	</TransitionGroup>
 	<Transition v-else
-		:name="name"
-		v-bind="$attrs"
-		v-on="$listeners">
+		:name="name">
 		<slot />
 	</Transition>
 </template>
@@ -22,8 +18,6 @@
 <script>
 export default {
 	name: 'TransitionWrapper',
-
-	inheritAttrs: false,
 
 	props: {
 		name: {


### PR DESCRIPTION
### ☑️ Resolves

* Ref: https://github.com/nextcloud/spreed/issues/12366
* [listeners has been removed / merged into $attrs](https://v3-migration.vuejs.org/breaking-changes/listeners-removed.html)

In most of the cases we used it only to get `close` from `NcModal`. Replaced with explicit `$emit('close')`