### PR TITLE
chore(vue3): migrate async component registration and remove $children

### DIFF
--- a/src/FilesSidebarCallViewApp.vue
+++ b/src/FilesSidebarCallViewApp.vue
@@ -15,6 +15,8 @@
 </template>
 
 <script>
+import { defineComponent, defineAsyncComponent, h } from 'vue'
+
 import LoadingComponent from './components/LoadingComponent.vue'
 
 import { useHashCheck } from './composables/useHashCheck.js'
@@ -22,17 +24,14 @@ import { useIsInCall } from './composables/useIsInCall.js'
 import { useSessionIssueHandler } from './composables/useSessionIssueHandler.js'
 
 export default {
-
 	name: 'FilesSidebarCallViewApp',
 
 	components: {
-		CallView: () => ({
-			component: import(/* webpackChunkName: "files-sidebar-call-chunk" */'./components/CallView/CallView.vue'),
-			loading: {
-				render: (h) => h(LoadingComponent, { class: 'call-loading' }),
-			},
+		CallView: defineAsyncComponent({
+			loader: () => import(/* webpackChunkName: "files-sidebar-call-chunk" */'./components/CallView/CallView.vue'),
+			loadingComponent: defineComponent(() => h(LoadingComponent, { class: 'call-loading' })),
 		}),
-		TopBar: () => import(/* webpackChunkName: "files-sidebar-call-chunk" */'./components/TopBar/TopBar.vue'),
+		TopBar: defineAsyncComponent(() => import(/* webpackChunkName: "files-sidebar-call-chunk" */'./components/TopBar/TopBar.vue')),
 	},
 
 	setup() {

--- a/src/FilesSidebarTabApp.vue
+++ b/src/FilesSidebarTabApp.vue
@@ -27,6 +27,7 @@
 </template>
 
 <script>
+import { defineComponent, defineAsyncComponent, h } from 'vue'
 
 import { getCurrentUser } from '@nextcloud/auth'
 import Axios from '@nextcloud/axios'
@@ -51,11 +52,9 @@ export default {
 	name: 'FilesSidebarTabApp',
 
 	components: {
-		FilesSidebarChatView: () => ({
-			component: import(/* webpackChunkName: "files-sidebar-tab-chunk" */'./views/FilesSidebarChatView.vue'),
-			loading: {
-				render: (h) => h(LoadingComponent, { class: 'tab-loading' }),
-			},
+		FilesSidebarChatView: defineAsyncComponent({
+			loader: () => import(/* webpackChunkName: "files-sidebar-tab-chunk" */'./views/FilesSidebarChatView.vue'),
+			loadingComponent: defineComponent(() => h(LoadingComponent, { class: 'tab-loading' })),
 		}),
 		NcButton,
 	},

--- a/src/views/FilesSidebarCallView.js
+++ b/src/views/FilesSidebarCallView.js
@@ -17,12 +17,12 @@
 export default class FilesSidebarCallView {
 
 	constructor() {
-		this.callViewInstance = OCA.Talk.newCallView()
+		const callViewApp = OCA.Talk.newCallView()
 
-		this.$el = document.createElement('div')
-		this.id = 'FilesSidebarCallView'
+		const container = document.createElement('div')
+		container.id = 'FilesSidebarCallView'
 
-		this.callViewInstance.mount(this.$el)
+		this.callViewInstance = callViewApp.mount(container)
 		this.$el = this.callViewInstance.$el
 
 		this.$el.replaceAll = function(target) {
@@ -33,7 +33,7 @@ export default class FilesSidebarCallView {
 	setFileInfo(fileInfo) {
 		// The FilesSidebarCallViewApp is the first (and only) child of the Vue
 		// instance.
-		this.callViewInstance.$children[0].setFileInfo(fileInfo)
+		this.callViewInstance.setFileInfo(fileInfo)
 	}
 
 }


### PR DESCRIPTION
### ☑️ Resolves

* Ref: https://github.com/nextcloud/spreed/issues/12366
* [Async components now require defineAsyncComponent method to be created](https://v3-migration.vuejs.org/breaking-changes/async-components.html)
* [$children instance property](https://v3-migration.vuejs.org/breaking-changes/children.html)
* Note: sidebar is still half broken but can be fixed separately on `main`. This PR only fixes breaking changes.
  * Styles has been lost
  * Reactivity is lost

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/25978914/62461967-8141-41fe-8c6a-71a03b0c9c30) | ![image](https://github.com/nextcloud/spreed/assets/25978914/e1d6715d-e15c-4c70-a454-0cc7ef64e341)
