### PR TITLE
feat(mobile): use button without text if on mobile

### DIFF
--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -14,6 +14,7 @@
 				autoHide: false,
 				html: true
 			}"
+			:aria-label="startCallLabel"
 			:disabled="startCallButtonDisabled || loading"
 			:type="startCallButtonType"
 			@click="handleClick">
@@ -22,31 +23,40 @@
 				<VideoOutlineIcon v-else-if="silentCall" :size="20" />
 				<VideoIcon v-else :size="20" />
 			</template>
-			{{ startCallLabel }}
+			<template v-if="!isMobile" #default>
+				{{ startCallLabel }}
+			</template>
 		</NcButton>
 		<NcButton v-else-if="showLeaveCallButton && canEndForAll && isPhoneRoom"
 			id="call_button"
+			:aria-label="endCallLabel"
 			type="error"
 			:disabled="loading"
 			@click="leaveCall(true)">
 			<template #icon>
 				<PhoneHangup :size="20" />
 			</template>
-			{{ t('spreed', 'End call') }}
+			<template v-if="!isMobile" #default>
+				{{ endCallLabel }}
+			</template>
 		</NcButton>
 		<NcButton v-else-if="showLeaveCallButton && !canEndForAll && !isBreakoutRoom"
 			id="call_button"
+			:aria-label="leaveCallLabel"
 			:type="isScreensharing ? 'tertiary' : 'error'"
 			:disabled="loading"
 			@click="leaveCall(false)">
 			<template #icon>
 				<VideoOff :size="20" />
 			</template>
-			{{ leaveCallLabel }}
+			<template v-if="!isMobile" #default>
+				{{ leaveCallLabel }}
+			</template>
 		</NcButton>
 		<NcActions v-else-if="showLeaveCallButton && (canEndForAll || isBreakoutRoom)"
 			:disabled="loading"
-			:menu-name="leaveCallCombinedLabel"
+			:aria-label="leaveCallCombinedLabel"
+			:menu-name="!isMobile ? leaveCallCombinedLabel : undefined"
 			force-name
 			:container="container"
 			:type="isScreensharing ? 'tertiary' : 'error'">
@@ -94,6 +104,7 @@ import { loadState } from '@nextcloud/initial-state'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import { useIsMobile } from '@nextcloud/vue/dist/Composables/useIsMobile.js'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import { useIsInCall } from '../../composables/useIsInCall.js'
@@ -174,6 +185,7 @@ export default {
 			breakoutRoomsStore: useBreakoutRoomsStore(),
 			talkHashStore: useTalkHashStore(),
 			settingsStore: useSettingsStore(),
+			isMobile: useIsMobile(),
 		}
 	},
 
@@ -251,6 +263,10 @@ export default {
 			}
 
 			return this.silentCall ? t('spreed', 'Start call silently') : t('spreed', 'Start call')
+		},
+
+		endCallLabel() {
+			return t('spreed', 'End call')
 		},
 
 		startCallToolTip() {


### PR DESCRIPTION
For https://github.com/nextcloud/spreed/issues/10358

| Before | After |
|---|---|
| ![image](https://github.com/nextcloud/spreed/assets/42591237/81a63177-68c0-4b2d-88d1-40ea071c239f) | ![image](https://github.com/nextcloud/spreed/assets/42591237/f60bd8ca-7092-4432-ab9e-69e6c8b2a05a) |

<details>
<summary>For my own testing</summary>

```
docker run -it --rm ^
--name nextcloud-easy-test1 ^
-p 8443:443 ^
-e TALK_BRANCH=enh/noid/shrink-button ^
--volume="nextcloud_easy_test_npm_cache_volume:/var/www/.npm" ^
ghcr.io/szaimen/nextcloud-easy-test:latest

```

</details>