### PR TITLE
fix(OpenAPI): Add missing reactionsSelf to ChatMessage

### DIFF
--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -103,6 +103,7 @@ namespace OCA\Talk;
  *     isReplyable: bool,
  *     markdown: bool,
  *     reactions: array<string, integer>|\stdClass,
+ *     reactionsSelf?: string[],
  *     referenceId: string,
  *     timestamp: int,
  *     token: string,

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -308,6 +308,12 @@
                                     "format": "int64"
                                 }
                             },
+                            "reactionsSelf": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
                             "referenceId": {
                                 "type": "string"
                             },

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -308,6 +308,12 @@
                                     "format": "int64"
                                 }
                             },
+                            "reactionsSelf": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
                             "referenceId": {
                                 "type": "string"
                             },

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -506,6 +506,12 @@
                                     "format": "int64"
                                 }
                             },
+                            "reactionsSelf": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
                             "referenceId": {
                                 "type": "string"
                             },

--- a/openapi.json
+++ b/openapi.json
@@ -447,6 +447,12 @@
                                     "format": "int64"
                                 }
                             },
+                            "reactionsSelf": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
                             "referenceId": {
                                 "type": "string"
                             },

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -117,6 +117,7 @@ export type components = {
       reactions: {
         [key: string]: number;
       };
+      reactionsSelf?: string[];
       referenceId: string;
       /** Format: int64 */
       timestamp: number;

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -132,6 +132,7 @@ export type components = {
       reactions: {
         [key: string]: number;
       };
+      reactionsSelf?: string[];
       referenceId: string;
       /** Format: int64 */
       timestamp: number;

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -679,6 +679,7 @@ export type components = {
       reactions: {
         [key: string]: number;
       };
+      reactionsSelf?: string[];
       referenceId: string;
       /** Format: int64 */
       timestamp: number;

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -518,6 +518,7 @@ export type components = {
       reactions: {
         [key: string]: number;
       };
+      reactionsSelf?: string[];
       referenceId: string;
       /** Format: int64 */
       timestamp: number;


### PR DESCRIPTION
Psalm probably didn't catch the missing field because the logic for setting it is too complicated and it can't figure out what is happening.
https://github.com/nextcloud/spreed/blob/704a0727ddc1c798a1f2ba8120cb17316a9995c6/lib/Controller/ChatController.php#L680-L694

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
