### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "9af4248bbeff8ff43d45195d68530fd2674b12c8"
+                "reference": "1166f284566bbb6a7ceca6954c367504b87832f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/9af4248bbeff8ff43d45195d68530fd2674b12c8",
-                "reference": "9af4248bbeff8ff43d45195d68530fd2674b12c8",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/1166f284566bbb6a7ceca6954c367504b87832f4",
+                "reference": "1166f284566bbb6a7ceca6954c367504b87832f4",
                 "shasum": ""
             },
             "require": {
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-05-12T00:37:28+00:00"
+            "time": "2024-05-17T00:34:39+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency