### PR TITLE
fix(MessageButtonsBar): pass props only

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
@@ -82,19 +82,20 @@ describe('Message.vue', () => {
 		testStoreConfig.modules.actorStore.getters.getActorType = getActorTypeMock
 
 		messageProps = {
-			message: 'test message',
-			actorType: ATTENDEE.ACTOR_TYPE.USERS,
-			actorId: 'user-id-1',
-			actorDisplayName: 'user-display-name-1',
-			messageParameters: {},
-			id: 123,
-			isTemporary: false,
-			isFirstMessage: true,
-			isReplyable: true,
-			timestamp: new Date('2020-05-07 09:23:00').getTime() / 1000,
-			token: TOKEN,
-			systemMessage: '',
-			messageType: 'comment',
+			message: {
+				message: 'test message',
+				actorType: ATTENDEE.ACTOR_TYPE.USERS,
+				actorId: 'user-id-1',
+				actorDisplayName: 'user-display-name-1',
+				messageParameters: {},
+				id: 123,
+				isReplyable: true,
+				timestamp: new Date('2020-05-07 09:23:00').getTime() / 1000,
+				token: TOKEN,
+				systemMessage: '',
+				messageType: 'comment',
+				reactions: [],
+			}
 		}
 	})
 
@@ -124,7 +125,7 @@ describe('Message.vue', () => {
 
 		test('renders emoji as single plain text', async () => {
 			messageProps.isSingleEmoji = true
-			messageProps.message = '🌧️'
+			messageProps.message.message = '🌧️'
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
@@ -157,9 +158,9 @@ describe('Message.vue', () => {
 			})
 
 			test('shows join call button on last message when a call is in progress', () => {
-				messageProps.id = 2
-				messageProps.systemMessage = 'call_started'
-				messageProps.message = 'message two'
+				messageProps.message.id = 2
+				messageProps.message.systemMessage = 'call_started'
+				messageProps.message.message = 'message two'
 				conversationProps.hasCall = true
 
 				const wrapper = shallowMount(Message, {
@@ -180,9 +181,9 @@ describe('Message.vue', () => {
 			})
 
 			test('does not show join call button on non-last message when a call is in progress', () => {
-				messageProps.id = 1
-				messageProps.systemMessage = 'call_started'
-				messageProps.message = 'message one'
+				messageProps.message.id = 1
+				messageProps.message.systemMessage = 'call_started'
+				messageProps.message.message = 'message one'
 				conversationProps.hasCall = true
 
 				const wrapper = shallowMount(Message, {
@@ -200,9 +201,9 @@ describe('Message.vue', () => {
 			})
 
 			test('does not show join call button when no call is in progress', () => {
-				messageProps.id = 2
-				messageProps.systemMessage = 'call_started'
-				messageProps.message = 'message two'
+				messageProps.message.id = 2
+				messageProps.message.systemMessage = 'call_started'
+				messageProps.message.message = 'message two'
 				conversationProps.hasCall = false
 
 				const wrapper = shallowMount(Message, {
@@ -220,9 +221,9 @@ describe('Message.vue', () => {
 			})
 
 			test('does not show join call button when self is in call', () => {
-				messageProps.id = 2
-				messageProps.systemMessage = 'call_started'
-				messageProps.message = 'message two'
+				messageProps.message.id = 2
+				messageProps.message.systemMessage = 'call_started'
+				messageProps.message.message = 'message two'
 				conversationProps.hasCall = true
 
 				jest.spyOn(useIsInCallModule, 'useIsInCall').mockReturnValue(() => true)
@@ -243,8 +244,8 @@ describe('Message.vue', () => {
 		})
 
 		test('renders deleted system message', () => {
-			messageProps.systemMessage = 'comment_deleted'
-			messageProps.message = 'message deleted'
+			messageProps.message.systemMessage = 'comment_deleted'
+			messageProps.message.message = 'message deleted'
 			conversationProps.hasCall = true
 
 			const wrapper = shallowMount(Message, {
@@ -288,7 +289,7 @@ describe('Message.vue', () => {
 				token: TOKEN,
 				reactions: '',
 			}
-			messageProps.parent = parentMessage
+			messageProps.message.parent = parentMessage
 
 			const messageGetterMock = jest.fn().mockReturnValue(parentMessage)
 			testStoreConfig.modules.messagesStore.getters.message = jest.fn(() => messageGetterMock)
@@ -316,9 +317,9 @@ describe('Message.vue', () => {
 			 * @param {object} expectedRichParameters The expected Vue objects for the parameters
 			 */
 			function renderRichObject(message, messageParameters, expectedRichParameters) {
-				messageProps.message = message
-				messageProps.messageParameters = messageParameters
-				store.dispatch('processMessage', { token: TOKEN, message: messageProps })
+				messageProps.message.message = message
+				messageProps.message.messageParameters = messageParameters
+				store.dispatch('processMessage', { token: TOKEN, message: messageProps.message })
 				const wrapper = shallowMount(Message, {
 					localVue,
 					store,
@@ -570,7 +571,7 @@ describe('Message.vue', () => {
 		})
 
 		test('does not render actions for system messages are available', async () => {
-			messageProps.systemMessage = 'this is a system message'
+			messageProps.message.systemMessage = 'this is a system message'
 
 			const wrapper = shallowMount(Message, {
 				localVue,
@@ -587,7 +588,7 @@ describe('Message.vue', () => {
 		})
 
 		test('does not render actions for temporary messages', async () => {
-			messageProps.isTemporary = true
+			messageProps.message.timestamp = 0
 
 			const wrapper = shallowMount(Message, {
 				localVue,
@@ -604,7 +605,7 @@ describe('Message.vue', () => {
 		})
 
 		test('does not render actions for deleted messages', async () => {
-			messageProps.messageType = 'comment_deleted'
+			messageProps.message.messageType = 'comment_deleted'
 
 			const wrapper = shallowMount(Message, {
 				localVue,
@@ -621,7 +622,7 @@ describe('Message.vue', () => {
 		})
 
 		test('Buttons bar is rendered on mouse over', async () => {
-			messageProps.sendingFailure = 'timeout'
+			messageProps.message.sendingFailure = 'timeout'
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
@@ -702,7 +703,7 @@ describe('Message.vue', () => {
 		})
 
 		test('lets user retry sending a timed out message', async () => {
-			messageProps.sendingFailure = 'timeout'
+			messageProps.message.sendingFailure = 'timeout'
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
@@ -733,7 +734,7 @@ describe('Message.vue', () => {
 		})
 
 		test('displays the message already with a spinner while sending it', () => {
-			messageProps.isTemporary = true
+			messageProps.message.timestamp = 0
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,
@@ -783,8 +784,8 @@ describe('Message.vue', () => {
 
 		test('does not displays check icon for other people\'s messages', () => {
 			conversationProps.lastCommonReadMessage = 123
-			messageProps.actorId = 'user-id-2'
-			messageProps.actorType = ATTENDEE.ACTOR_TYPE.USERS
+			messageProps.message.actorId = 'user-id-2'
+			messageProps.message.actorType = ATTENDEE.ACTOR_TYPE.USERS
 			const wrapper = shallowMount(Message, {
 				localVue,
 				store,

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -24,7 +24,7 @@
 				:is-deleting="isDeleting"
 				:has-call="conversation.hasCall"
 				:message="message"
-				v-bind="readInfoProps" />
+				:read-info="readInfo" />
 
 			<!-- reactions buttons and popover with details -->
 			<Reactions v-if="Object.keys(message.reactions).length"
@@ -48,7 +48,7 @@
 				:can-react="canReact"
 				:message="message"
 				:previous-message-id="previousMessageId"
-				v-bind="readInfoProps"
+				:read-info="readInfo"
 				@show-translate-dialog="isTranslateDialogOpen = true"
 				@reply="handleReply"
 				@edit="handleEdit"
@@ -317,7 +317,7 @@ export default {
 				&& this.isCombinedSystemMessage && (this.isHovered || !this.isCombinedSystemMessageCollapsed)
 		},
 
-		readInfoProps() {
+		readInfo() {
 			return {
 				showCommonReadIcon: this.showCommonReadIcon,
 				commonReadIconTooltip: t('spreed', 'Message read by everyone who shares their reading status'),

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
@@ -13,7 +13,7 @@ import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import MessageButtonsBar from './../MessageButtonsBar/MessageButtonsBar.vue'
 
 import * as useMessageInfoModule from '../../../../../composables/useMessageInfo.js'
-import { CONVERSATION, PARTICIPANT, ATTENDEE } from '../../../../../constants.js'
+import { CONVERSATION, ATTENDEE } from '../../../../../constants.js'
 import storeConfig from '../../../../../store/storeConfig.js'
 import { useIntegrationsStore } from '../../../../../stores/integrations.js'
 import { findNcActionButton, findNcButton } from '../../../../../test-helpers.js'
@@ -57,36 +57,30 @@ describe('MessageButtonsBar.vue', () => {
 		testStoreConfig.modules.actorStore.getters.isActorGuest = isActorGuestMock
 
 		messageProps = {
-			message: 'test message',
-			actorType: ATTENDEE.ACTOR_TYPE.USERS,
-			actorId: 'user-id-1',
-			actorDisplayName: 'user-display-name-1',
-			messageParameters: {},
-			id: 123,
-			isTemporary: false,
-			isFirstMessage: true,
-			isReplyable: true,
-			isTranslationAvailable: false,
-			canReact: true,
-			isReactionsMenuOpen: false,
+			previousMessageId: 100,
+			message: {
+				message: 'test message',
+				actorType: ATTENDEE.ACTOR_TYPE.USERS,
+				actorId: 'user-id-1',
+				actorDisplayName: 'user-display-name-1',
+				messageParameters: {},
+				id: 123,
+				isReplyable: true,
+				timestamp: new Date('2020-05-07 09:23:00').getTime() / 1000,
+				token: TOKEN,
+				systemMessage: '',
+				messageType: 'comment',
+			},
 			isActionMenuOpen: false,
 			isEmojiPickerOpen: false,
-			isLastRead: false,
+			isReactionsMenuOpen: false,
 			isForwarderOpen: false,
-			timestamp: new Date('2020-05-07 09:23:00').getTime() / 1000,
-			token: TOKEN,
-			systemMessage: '',
-			messageType: 'comment',
-			previousMessageId: 100,
-			participant: {
-				actorId: 'user-id-1',
-				actorType: ATTENDEE.ACTOR_TYPE.USERS,
-				participantType: PARTICIPANT.TYPE.USER,
-			},
+			canReact: true,
 			showCommonReadIcon: true,
 			showSentIcon: true,
 			commonReadIconTooltip: '',
 			sentIconTooltip: '',
+			isTranslationAvailable: false,
 		}
 	})
 
@@ -135,7 +129,7 @@ describe('MessageButtonsBar.vue', () => {
 			})
 
 			test('hides reply button when not replyable', async () => {
-				messageProps.isReplyable = false
+				messageProps.message.isReplyable = false
 				store = new Store(testStoreConfig)
 
 				const wrapper = shallowMount(MessageButtonsBar, {
@@ -161,7 +155,7 @@ describe('MessageButtonsBar.vue', () => {
 				testStoreConfig.modules.conversationsStore.actions.createOneToOneConversation = createOneToOneConversation
 				store = new Store(testStoreConfig)
 
-				messageProps.actorId = 'another-user'
+				messageProps.message.actorId = 'another-user'
 
 				const wrapper = shallowMount(MessageButtonsBar, {
 					localVue,
@@ -227,19 +221,19 @@ describe('MessageButtonsBar.vue', () => {
 			})
 
 			test('hides private reply action for one to one conversation type', async () => {
-				messageProps.actorId = 'another-user'
+				messageProps.message.actorId = 'another-user'
 				conversationProps.type = CONVERSATION.TYPE.ONE_TO_ONE
 				testPrivateReplyActionVisible(false)
 			})
 
 			test('hides private reply action for guest messages', async () => {
-				messageProps.actorId = 'guest-user'
-				messageProps.actorType = ATTENDEE.ACTOR_TYPE.GUESTS
+				messageProps.message.actorId = 'guest-user'
+				messageProps.message.actorType = ATTENDEE.ACTOR_TYPE.GUESTS
 				testPrivateReplyActionVisible(false)
 			})
 
 			test('hides private reply action when current user is a guest', async () => {
-				messageProps.actorId = 'another-user'
+				messageProps.message.actorId = 'another-user'
 				getActorTypeMock.mockClear().mockReturnValue(() => ATTENDEE.ACTOR_TYPE.GUESTS)
 				isActorUserMock.mockClear().mockReturnValue(() => false)
 				isActorGuestMock.mockClear().mockReturnValue(() => true)
@@ -315,12 +309,7 @@ describe('MessageButtonsBar.vue', () => {
 
 			// appears even with more restrictive conditions
 			conversationProps.readOnly = CONVERSATION.STATE.READ_ONLY
-			messageProps.actorId = 'another-user'
-			messageProps.participant = {
-				actorId: 'guest-id-1',
-				actorType: ATTENDEE.ACTOR_TYPE.GUESTS,
-				participantType: PARTICIPANT.TYPE.GUEST,
-			}
+			messageProps.message.actorId = 'another-user'
 
 			const wrapper = shallowMount(MessageButtonsBar, {
 				localVue,
@@ -353,12 +342,7 @@ describe('MessageButtonsBar.vue', () => {
 
 			// appears even with more restrictive conditions
 			conversationProps.readOnly = CONVERSATION.STATE.READ_ONLY
-			messageProps.actorId = 'another-user'
-			messageProps.participant = {
-				actorId: 'guest-id-1',
-				actorType: ATTENDEE.ACTOR_TYPE.GUESTS,
-				participantType: PARTICIPANT.TYPE.GUEST,
-			}
+			messageProps.message.actorId = 'another-user'
 
 			const wrapper = shallowMount(MessageButtonsBar, {
 				localVue,

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
@@ -76,10 +76,12 @@ describe('MessageButtonsBar.vue', () => {
 			isReactionsMenuOpen: false,
 			isForwarderOpen: false,
 			canReact: true,
-			showCommonReadIcon: true,
-			showSentIcon: true,
-			commonReadIconTooltip: '',
-			sentIconTooltip: '',
+			readInfo: {
+				showCommonReadIcon: true,
+				showSentIcon: true,
+				commonReadIconTooltip: '',
+				sentIconTooltip: '',
+			},
 			isTranslationAvailable: false,
 		}
 	})
@@ -396,7 +398,7 @@ describe('MessageButtonsBar.vue', () => {
 
 			expect(handler).toHaveBeenCalledWith({
 				apiVersion: 'v3',
-				message: messageProps,
+				message: messageProps.message,
 				metadata: conversationProps,
 			},)
 
@@ -406,7 +408,7 @@ describe('MessageButtonsBar.vue', () => {
 
 			expect(handler2).toHaveBeenCalledWith({
 				apiVersion: 'v3',
-				message: messageProps,
+				message: messageProps.message,
 				metadata: conversationProps,
 			})
 		})

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -16,7 +16,7 @@
 					<EmoticonOutline :size="20" />
 				</template>
 			</NcButton>
-			<NcButton v-if="isReplyable && !isConversationReadOnly"
+			<NcButton v-if="message.isReplyable && !isConversationReadOnly"
 				type="tertiary"
 				:aria-label="t('spreed', 'Reply')"
 				:title="t('spreed', 'Reply')"
@@ -50,7 +50,7 @@
 						{{ messageDateTime }}
 					</NcActionText>
 					<!-- Edited message timestamp -->
-					<NcActionText v-if="lastEditTimestamp"
+					<NcActionText v-if="message.lastEditTimestamp"
 						class="edit-timestamp"
 						:name="lastEditActorLabel">
 						<template #icon>
@@ -339,81 +339,15 @@ export default {
 
 	inject: ['getMessagesListScroller'],
 
-	inheritAttrs: false,
-
 	props: {
-		token: {
-			type: String,
-			required: true,
-		},
-
 		previousMessageId: {
 			type: [String, Number],
 			required: true,
 		},
 
-		isReplyable: {
-			type: Boolean,
-			required: true,
-		},
-
-		actorId: {
-			type: String,
-			required: true,
-		},
-
-		actorType: {
-			type: String,
-			required: true,
-		},
-
-		/**
-		 * The parameters of the rich object message
-		 */
-		messageParameters: {
-			type: [Array, Object],
-			required: true,
-		},
-
-		/**
-		 * The message timestamp.
-		 */
-		timestamp: {
-			type: Number,
-			default: 0,
-		},
-
-		/**
-		 * The message id.
-		 */
-		id: {
-			type: [String, Number],
-			required: true,
-		},
-
-		/**
-		 * The message or quote text.
-		 */
 		message: {
-			type: String,
+			type: Object,
 			required: true,
-		},
-
-		/**
-		 * The type of the message.
-		 */
-		messageType: {
-			type: String,
-			required: true,
-		},
-
-		lastEditActorDisplayName: {
-			type: String,
-			default: '',
-		},
-		lastEditTimestamp: {
-			type: Number,
-			default: 0,
 		},
 
 		isActionMenuOpen: {
@@ -466,7 +400,7 @@ export default {
 	emits: ['delete', 'update:isActionMenuOpen', 'update:isEmojiPickerOpen', 'update:isReactionsMenuOpen', 'update:isForwarderOpen', 'show-translate-dialog', 'reply', 'edit'],
 
 	setup(props) {
-		const { token, id } = toRefs(props)
+		const { message } = toRefs(props)
 		const reactionsStore = useReactionsStore()
 		const { messageActions } = useIntegrationsStore()
 		const {
@@ -477,7 +411,7 @@ export default {
 			isFileShareWithoutCaption,
 			isConversationReadOnly,
 			isConversationModifiable,
-		} = useMessageInfo(token, id)
+		} = useMessageInfo(message.value.token, message.value.id)
 
 		return {
 			messageActions,
@@ -504,7 +438,7 @@ export default {
 
 	computed: {
 		conversation() {
-			return this.$store.getters.conversation(this.token)
+			return this.$store.getters.conversation(this.message.token)
 		},
 
 		mainContainer() {
@@ -512,7 +446,7 @@ export default {
 		},
 
 		messageContainer() {
-			return `#message_${this.id}`
+			return `#message_${this.message.id}`
 		},
 
 		boundariesElement() {
@@ -520,18 +454,18 @@ export default {
 		},
 
 		isPrivateReplyable() {
-			return this.isReplyable
+			return this.message.isReplyable
 				&& (this.conversation.type === CONVERSATION.TYPE.PUBLIC
 					|| this.conversation.type === CONVERSATION.TYPE.GROUP)
 				&& !this.isCurrentUserOwnMessage
-				&& this.actorType === ATTENDEE.ACTOR_TYPE.USERS
+				&& this.message.actorType === ATTENDEE.ACTOR_TYPE.USERS
 				&& this.$store.getters.isActorUser()
 		},
 
 		linkToFile() {
 			if (this.isFileShare) {
-				const firstFileKey = (Object.keys(this.messageParameters).find(key => key.startsWith('file')))
-				return this.messageParameters?.[firstFileKey]?.link
+				const firstFileKey = (Object.keys(this.message.messageParameters).find(key => key.startsWith('file')))
+				return this.message.messageParameters?.[firstFileKey]?.link
 			} else {
 				return ''
 			}
@@ -542,12 +476,12 @@ export default {
 		},
 
 		isDeletedMessage() {
-			return this.messageType === 'comment_deleted'
+			return this.message.messageType === 'comment_deleted'
 		},
 
 		isPollMessage() {
-			return this.messageType === 'comment'
-				&& this.messageParameters?.object?.type === 'talk-poll'
+			return this.message.messageType === 'comment'
+				&& this.message.messageParameters?.object?.type === 'talk-poll'
 		},
 
 		isInNoteToSelf() {
@@ -562,11 +496,11 @@ export default {
 		},
 
 		messageDateTime() {
-			return moment(this.timestamp * 1000).format('lll')
+			return moment(this.message.timestamp * 1000).format('lll')
 		},
 
 		editedDateTime() {
-			return moment(this.lastEditTimestamp * 1000).format('lll')
+			return moment(this.message.lastEditTimestamp * 1000).format('lll')
 		},
 
 		reminderOptions() {
@@ -627,15 +561,15 @@ export default {
 
 		messageApiData() {
 			return {
-				message: this.$store.getters.message(this.token, this.id),
-				metadata: this.$store.getters.conversation(this.token),
+				message: this.$store.getters.message(this.message.token, this.message.id),
+				metadata: this.$store.getters.conversation(this.message.token),
 				apiVersion: 'v3',
 			}
 		},
 
 		lastEditActorLabel() {
 			return t('spreed', 'Edited by {actor}', {
-				actor: this.lastEditActorDisplayName,
+				actor: this.message.lastEditActorDisplayName,
 			})
 		},
 	},
@@ -655,12 +589,12 @@ export default {
 
 		async handlePrivateReply() {
 			// open the 1:1 conversation
-			const conversation = await this.$store.dispatch('createOneToOneConversation', this.actorId)
+			const conversation = await this.$store.dispatch('createOneToOneConversation', this.message.actorId)
 			this.$router.push({ name: 'conversation', params: { token: conversation.token } }).catch(err => console.debug(`Error while pushing the new conversation's route: ${err}`))
 		},
 
 		async handleCopyMessageText() {
-			const parsedText = parseMentions(this.message, this.messageParameters)
+			const parsedText = parseMentions(this.message.message, this.message.messageParameters)
 
 			try {
 				await navigator.clipboard.writeText(parsedText)
@@ -671,13 +605,13 @@ export default {
 		},
 
 		handleCopyMessageLink() {
-			copyConversationLinkToClipboard(this.token, this.id)
+			copyConversationLinkToClipboard(this.message.token, this.message.id)
 		},
 
 		async handleMarkAsUnread() {
 			// update in backend + visually
 			await this.$store.dispatch('updateLastReadMessage', {
-				token: this.token,
+				token: this.message.token,
 				id: this.previousMessageId,
 				updateVisually: true,
 			})
@@ -685,17 +619,17 @@ export default {
 
 		handleReactionClick(selectedEmoji) {
 			// Add reaction only if user hasn't reacted yet
-			if (!this.reactionsSelf?.includes(selectedEmoji)) {
+			if (!this.message.reactionsSelf?.includes(selectedEmoji)) {
 				this.reactionsStore.addReactionToMessage({
-					token: this.token,
-					messageId: this.id,
+					token: this.message.token,
+					messageId: this.message.id,
 					selectedEmoji,
 				})
 			} else {
 				console.debug('user has already reacted, removing reaction')
 				this.reactionsStore.removeReactionFromMessage({
-					token: this.token,
-					messageId: this.id,
+					token: this.message.token,
+					messageId: this.message.id,
 					selectedEmoji,
 				})
 			}
@@ -731,7 +665,7 @@ export default {
 		async forwardToNote() {
 			try {
 				await this.$store.dispatch('forwardMessage', {
-					messageToBeForwarded: this.$store.getters.message(this.token, this.id)
+					messageToBeForwarded: this.$store.getters.message(this.message.token, this.message.id)
 				})
 				showSuccess(t('spreed', 'Message forwarded to "Note to self"'))
 			} catch (error) {
@@ -771,7 +705,7 @@ export default {
 
 		async getReminder() {
 			try {
-				const response = await getMessageReminder(this.token, this.id)
+				const response = await getMessageReminder(this.message.token, this.message.id)
 				this.currentReminder = response.data.ocs.data
 			} catch (error) {
 				console.debug(error)
@@ -780,7 +714,7 @@ export default {
 
 		async removeReminder() {
 			try {
-				await removeMessageReminder(this.token, this.id)
+				await removeMessageReminder(this.message.token, this.message.id)
 				showSuccess(t('spreed', 'A reminder was successfully removed'))
 			} catch (error) {
 				console.error(error)
@@ -790,7 +724,7 @@ export default {
 
 		async setReminder(timestamp) {
 			try {
-				await setMessageReminder(this.token, this.id, timestamp / 1000)
+				await setMessageReminder(this.message.token, this.message.id, timestamp / 1000)
 				showSuccess(t('spreed', 'A reminder was successfully set at {datetime}', {
 					datetime: moment(timestamp).format('LLL'),
 				}))

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -35,14 +35,14 @@
 					<!-- Message timestamp -->
 					<NcActionText>
 						<template #icon>
-							<span v-if="showCommonReadIcon"
-								:title="commonReadIconTooltip"
-								:aria-label="commonReadIconTooltip">
+							<span v-if="readInfo.showCommonReadIcon"
+								:title="readInfo.commonReadIconTooltip"
+								:aria-label="readInfo.commonReadIconTooltip">
 								<CheckAll :size="16" />
 							</span>
-							<span v-else-if="showSentIcon"
-								:title="sentIconTooltip"
-								:aria-label="sentIconTooltip">
+							<span v-else-if="readInfo.showSentIcon"
+								:title="readInfo.sentIconTooltip"
+								:aria-label="readInfo.sentIconTooltip">
 								<Check :size="16" />
 							</span>
 							<ClockOutline v-else :size="16" />
@@ -135,7 +135,7 @@
 						:key="action.label"
 						:icon="action.icon"
 						close-after-click
-						@click="action.callback(messageApiData)">
+						@click="handleMessageAction(action)">
 						{{ action.label }}
 					</NcActionButton>
 					<NcActionButton v-if="isTranslationAvailable && !isFileShareWithoutCaption"
@@ -371,23 +371,9 @@ export default {
 			type: Boolean,
 			required: true,
 		},
-		/**
-		 * Message read information
-		 */
-		showCommonReadIcon: {
-			type: Boolean,
-			required: true,
-		},
-		showSentIcon: {
-			type: Boolean,
-			required: true,
-		},
-		commonReadIconTooltip: {
-			type: String,
-			required: true,
-		},
-		sentIconTooltip: {
-			type: String,
+
+		readInfo: {
+			type: Object,
 			required: true,
 		},
 
@@ -559,14 +545,6 @@ export default {
 			return t('spreed', 'Clear reminder – {timeLocale}', { timeLocale: moment(this.currentReminder.timestamp * 1000).format('ddd LT') })
 		},
 
-		messageApiData() {
-			return {
-				message: this.$store.getters.message(this.message.token, this.message.id),
-				metadata: this.$store.getters.conversation(this.message.token),
-				apiVersion: 'v3',
-			}
-		},
-
 		lastEditActorLabel() {
 			return t('spreed', 'Edited by {actor}', {
 				actor: this.message.lastEditActorDisplayName,
@@ -634,6 +612,10 @@ export default {
 				})
 			}
 			this.closeReactionsMenu()
+		},
+
+		handleMessageAction(action) {
+			action.callback({ message: this.message, metadata: this.conversation, apiVersion: 'v3' })
 		},
 
 		handleDelete() {

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -92,16 +92,16 @@
 				:title="loadingIconTooltip"
 				class="icon-loading-small message-status"
 				:aria-label="loadingIconTooltip" />
-			<div v-else-if="showCommonReadIcon"
-				:title="commonReadIconTooltip"
+			<div v-else-if="readInfo.showCommonReadIcon"
+				:title="readInfo.commonReadIconTooltip"
 				class="message-status"
-				:aria-label="commonReadIconTooltip">
+				:aria-label="readInfo.commonReadIconTooltip">
 				<CheckAllIcon :size="16" />
 			</div>
-			<div v-else-if="showSentIcon"
-				:title="sentIconTooltip"
+			<div v-else-if="readInfo.showSentIcon"
+				:title="readInfo.sentIconTooltip"
 				class="message-status"
-				:aria-label="sentIconTooltip">
+				:aria-label="readInfo.sentIconTooltip">
 				<CheckIcon :size="16" />
 			</div>
 		</div>
@@ -174,23 +174,8 @@ export default {
 			default: false,
 		},
 
-		/**
-		 * Message read information
-		 */
-		showCommonReadIcon: {
-			type: Boolean,
-			required: true,
-		},
-		commonReadIconTooltip: {
-			type: String,
-			required: true,
-		},
-		showSentIcon: {
-			type: Boolean,
-			required: true,
-		},
-		sentIconTooltip: {
-			type: String,
+		readInfo: {
+			type: Object,
 			required: true,
 		},
 	},

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.spec.js
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.spec.js
@@ -95,29 +95,33 @@ describe('MessagesGroup.vue', () => {
 		expect(authorEl.text()).toBe('actor one')
 
 		const messagesEl = wrapper.findAllComponents({ name: 'Message' })
-		let message = messagesEl.at(0)
-		expect(message.attributes('id')).toBe('100')
-		expect(message.attributes('message')).toBe('first')
-		expect(message.attributes('actorid')).toBe('actor-1')
-		expect(message.attributes('previousmessageid')).toBe('90')
-		expect(message.attributes('nextmessageid')).toBe('110')
-		expect(message.attributes('istemporary')).not.toBeDefined()
-
-		message = messagesEl.at(1)
-		expect(message.attributes('id')).toBe('110')
-		expect(message.attributes('message')).toBe('second')
-		expect(message.attributes('actorid')).toBe('actor-1')
-		expect(message.attributes('previousmessageid')).toBe('100')
-		expect(message.attributes('nextmessageid')).toBe('120')
-		expect(message.attributes('istemporary')).not.toBeDefined()
-
-		message = messagesEl.at(2)
-		expect(message.attributes('id')).toBe('120')
-		expect(message.attributes('message')).toBe('third')
-		expect(message.attributes('actorid')).toBe('actor-1')
-		expect(message.attributes('previousmessageid')).toBe('110')
-		expect(message.attributes('nextmessageid')).toBe('200')
-		expect(message.attributes('istemporary')).toBe('true')
+		expect(messagesEl.at(0).props()).toMatchObject({
+			message: {
+				id: 100,
+				message: 'first',
+				actorId: 'actor-1',
+			},
+			previousMessageId: 90,
+			nextMessageId: 110,
+		})
+		expect(messagesEl.at(1).props()).toMatchObject({
+			message: {
+				id: 110,
+				message: 'second',
+				actorId: 'actor-1',
+			},
+			previousMessageId: 100,
+			nextMessageId: 120,
+		})
+		expect(messagesEl.at(2).props()).toMatchObject({
+			message: {
+				id: 120,
+				message: 'third',
+				actorId: 'actor-1',
+			},
+			previousMessageId: 110,
+			nextMessageId: 200,
+		})
 	})
 
 	test('renders grouped system messages', () => {
@@ -163,26 +167,26 @@ describe('MessagesGroup.vue', () => {
 		expect(avatarEl.exists()).toBe(false)
 
 		const messagesEl = wrapper.findAllComponents({ name: 'Message' })
-
-		let message = messagesEl.at(0)
-		expect(message.props('id')).toBe(MESSAGES[0].id)
-		expect(message.props('message')).toBe(MESSAGES[0].message)
-		expect(message.props('actorid')).toBe(MESSAGES[0].actorid)
-		expect(message.props('actordisplayname')).toBe(MESSAGES[0].actordisplayname)
-		expect(message.props('previousmessageid')).toBe(MESSAGES[0].previousmessageid)
-		expect(message.props('nextmessageid')).toBe(MESSAGES[0].nextmessageid)
-		expect(message.props('isfirstmessage')).toBe(MESSAGES[0].isfirstmessage)
-		expect(message.props('showauthor')).not.toBeDefined()
-
-		message = messagesEl.at(1)
-		expect(message.props('id')).toBe(MESSAGES[1].id)
-		expect(message.props('message')).toBe(MESSAGES[1].message)
-		expect(message.props('actorid')).toBe(MESSAGES[1].actorid)
-		expect(message.props('actordisplayname')).toBe(MESSAGES[1].actordisplayname)
-		expect(message.props('previousmessageid')).toBe(MESSAGES[1].previousmessageid)
-		expect(message.props('nextmessageid')).toBe(MESSAGES[1].nextmessageid)
-		expect(message.props('isfirstmessage')).not.toBeDefined()
-		expect(message.props('showauthor')).not.toBeDefined()
+		expect(messagesEl.at(0).props()).toMatchObject({
+			message: {
+				id: MESSAGES[0].id,
+				message: MESSAGES[0].message,
+				actorId: MESSAGES[0].actorId,
+				actorDisplayName: MESSAGES[0].actorDisplayName,
+			},
+			previousMessageId: 90,
+			nextMessageId: 110,
+		})
+		expect(messagesEl.at(1).props()).toMatchObject({
+			message: {
+				id: MESSAGES[1].id,
+				message: MESSAGES[1].message,
+				actorId: MESSAGES[1].actorId,
+				actorDisplayName: MESSAGES[1].actorDisplayName,
+			},
+			previousMessageId: 100,
+			nextMessageId: 200,
+		})
 	})
 
 	test('renders guest display name', () => {
@@ -238,13 +242,18 @@ describe('MessagesGroup.vue', () => {
 		expect(authorEl.text()).toBe('guest-one-display-name')
 
 		const messagesEl = wrapper.findAllComponents({ name: 'Message' })
-		let message = messagesEl.at(0)
-		expect(message.attributes('id')).toBe('100')
-		expect(message.attributes('actorid')).toBe('actor-1')
-
-		message = messagesEl.at(1)
-		expect(message.attributes('id')).toBe('110')
-		expect(message.attributes('actorid')).toBe('actor-1')
+		expect(messagesEl.at(0).props()).toMatchObject({
+			message: {
+				id: 100,
+				actorId: 'actor-1',
+			},
+		})
+		expect(messagesEl.at(1).props()).toMatchObject({
+			message: {
+				id: 110,
+				actorId: 'actor-1',
+			},
+		})
 	})
 
 	test('renders deleted guest display name', () => {
@@ -293,12 +302,17 @@ describe('MessagesGroup.vue', () => {
 		expect(authorEl.text()).toBe('Deleted user')
 
 		const messagesEl = wrapper.findAllComponents({ name: 'Message' })
-		let message = messagesEl.at(0)
-		expect(message.attributes('id')).toBe('100')
-		expect(message.attributes('actorid')).toBe('actor-1')
-
-		message = messagesEl.at(1)
-		expect(message.attributes('id')).toBe('110')
-		expect(message.attributes('actorid')).toBe('actor-1')
+		expect(messagesEl.at(0).props()).toMatchObject({
+			message: {
+				id: 100,
+				actorId: 'actor-1',
+			},
+		})
+		expect(messagesEl.at(1).props()).toMatchObject({
+			message: {
+				id: 110,
+				actorId: 'actor-1',
+			},
+		})
 	})
 })

--- a/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesGroup.vue
@@ -22,13 +22,9 @@
 			</li>
 			<Message v-for="(message, index) of messages"
 				:key="message.id"
-				:token="token"
-				:is-temporary="message.timestamp === 0"
+				:message="message"
 				:next-message-id="(messages[index + 1] && messages[index + 1].id) || nextMessageId"
-				:previous-message-id="(index > 0 && messages[index - 1].id) || previousMessageId"
-				:actor-type="actorType"
-				:actor-id="actorId"
-				v-bind="message" />
+				:previous-message-id="(index > 0 && messages[index - 1].id) || previousMessageId" />
 		</ul>
 	</li>
 </template>

--- a/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
+++ b/src/components/MessagesList/MessagesGroup/MessagesSystemGroup.vue
@@ -10,13 +10,12 @@
 			class="messages-group__system">
 			<ul v-if="messagesCollapsed.messages?.length > 1"
 				class="messages messages--header">
-				<Message :token="token"
-					is-combined-system-message
+				<Message is-combined-system-message
 					:is-combined-system-message-collapsed="messagesCollapsed.collapsed"
 					:next-message-id="getNextMessageId(messagesCollapsed.messages.at(-1))"
 					:previous-message-id="getPrevMessageId(messagesCollapsed.messages.at(0))"
 					:last-collapsed-message-id="messagesCollapsed.lastId"
-					v-bind="createCombinedSystemMessage(messagesCollapsed)"
+					:message="createCombinedSystemMessage(messagesCollapsed)"
 					@toggle-combined-system-message="toggleCollapsed(messagesCollapsed)" />
 			</ul>
 			<ul v-show="messagesCollapsed.messages?.length === 1 || !messagesCollapsed.collapsed"
@@ -24,12 +23,11 @@
 				:class="{'messages--collapsed': messagesCollapsed.messages?.length > 1}">
 				<Message v-for="message in messagesCollapsed.messages"
 					:key="message.id"
-					:token="token"
+					:message="message"
 					:is-collapsed-system-message="messagesCollapsed.messages?.length > 1"
 					:last-collapsed-message-id="messagesCollapsed.lastId"
 					:next-message-id="getNextMessageId(message)"
-					:previous-message-id="getPrevMessageId(message)"
-					v-bind="message" />
+					:previous-message-id="getPrevMessageId(message)" />
 			</ul>
 		</div>
 	</li>


### PR DESCRIPTION
### ☑️ Resolves

* Related to #12380 and to avoid passing class as a prop in vue 3 

Tested with Vue3:
![image](https://github.com/nextcloud/spreed/assets/93392545/30022d7c-24e8-4d18-8452-58fffd5fa1e4)


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
