### PR TITLE
fix(vue3): keep wrapper in transition group for styles

### DIFF
--- a/src/components/UIShared/TransitionWrapper.vue
+++ b/src/components/UIShared/TransitionWrapper.vue
@@ -5,6 +5,7 @@
 
 <template>
 	<TransitionGroup v-if="group"
+		tag="span"
 		class="transition-group"
 		:name="name">
 		<slot />


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12396

