### PR TITLE
Release 18.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 18.0.8 – 2024-05-23
+### Fixed
+- fix(polls): Remove actor info from system message
+  [#12343](https://github.com/nextcloud/spreed/pull/12343)
+- fix(recording): Stop broken recording backend
+  [#12402](https://github.com/nextcloud/spreed/pull/12402)
+
+## 17.1.9 – 2024-05-23
+### Fixed
+- fix(polls): Remove actor info from system message
+  [#12342](https://github.com/nextcloud/spreed/pull/12342)
+- fix(recording): Stop broken recording backend
+  [#12401](https://github.com/nextcloud/spreed/pull/12401)
+
 ## 18.0.7 – 2024-04-12
 ### Changed
 - Update translations

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>18.0.7</version>
+	<version>18.0.8</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "18.0.7",
+  "version": "18.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "18.0.7",
+      "version": "18.0.8",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "18.0.7",
+  "version": "18.0.8",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 18.0.8 – 2024-05-23
### Fixed
- fix(polls): Remove actor info from system message [#12343](https://github.com/nextcloud/spreed/pull/12343)
- fix(recording): Stop broken recording backend [#12402](https://github.com/nextcloud/spreed/pull/12402)

## 17.1.9 – 2024-05-23
### Fixed
- fix(polls): Remove actor info from system message [#12342](https://github.com/nextcloud/spreed/pull/12342)
- fix(recording): Stop broken recording backend [#12401](https://github.com/nextcloud/spreed/pull/12401)
