### PR TITLE
fix(NewConversationDialog): speed up conversation creation flow

### DIFF
--- a/src/components/ConversationSettings/ConversationAvatarEditor.vue
+++ b/src/components/ConversationSettings/ConversationAvatarEditor.vue
@@ -292,60 +292,50 @@ export default {
 			this.emojiAvatar = emoji
 		},
 
-		saveAvatar() {
+		async saveAvatar() {
 			this.loading = true
 
-			if (this.emojiAvatar) {
-				this.saveEmojiAvatar()
-			} else {
-				this.savePictureAvatar()
-			}
-		},
-
-		async saveEmojiAvatar() {
 			try {
-				await this.$store.dispatch('setConversationEmojiAvatarAction', {
-					token: this.conversation.token,
-					emoji: this.emojiAvatar,
-					color: this.backgroundColor ? this.backgroundColor.slice(1) : null,
-				})
-				this.emojiAvatar = ''
-				this.backgroundColor = ''
+				if (this.emojiAvatar) {
+					await this.saveEmojiAvatar()
+				} else {
+					await this.savePictureAvatar()
+				}
 			} catch (error) {
-				showError(t('spreed', 'Could not set the conversation picture: {error}',
-					{ error: error.message },
-				))
+				showError(t('spreed', 'Could not set the conversation picture: {error}', { error: error.message }))
+				this.cancel()
 			} finally {
 				this.loading = false
 			}
 		},
 
-		savePictureAvatar() {
+		async saveEmojiAvatar() {
+			await this.$store.dispatch('setConversationEmojiAvatarAction', {
+				token: this.conversation.token,
+				emoji: this.emojiAvatar,
+				color: this.backgroundColor ? this.backgroundColor.slice(1) : null,
+			})
+			this.emojiAvatar = ''
+			this.backgroundColor = ''
+		},
+
+		async savePictureAvatar() {
 			this.showCropper = false
 			const canvasData = this.$refs.cropper.getCroppedCanvas()
 			const scaleFactor = canvasData.width > 512 ? 512 / canvasData.width : 1
-			this.$refs.cropper.scale(scaleFactor, scaleFactor).getCroppedCanvas().toBlob(async (blob) => {
-				if (blob === null) {
-					showError(t('spreed', 'Error cropping conversation picture'))
-					this.cancel()
-					return
-				}
 
-				const formData = new FormData()
-				formData.append('file', blob)
+			const blob = await new Promise((resolve, reject) => {
+				this.$refs.cropper.scale(scaleFactor, scaleFactor).getCroppedCanvas()
+					.toBlob(blob => blob === null
+						? reject(new Error(t('spreed', 'Error cropping conversation picture')))
+						: resolve(blob))
+			})
+			const formData = new FormData()
+			formData.append('file', blob)
 
-				try {
-					await this.$store.dispatch('setConversationAvatarAction', {
-						token: this.conversation.token,
-						file: formData,
-					})
-				} catch (error) {
-					showError(t('spreed', 'Could not set the conversation picture: {error}',
-						{ error: error.message },
-					))
-				} finally {
-					this.loading = false
-				}
+			await this.$store.dispatch('setConversationAvatarAction', {
+				token: this.conversation.token,
+				file: formData,
 			})
 		},
 

--- a/src/components/NewConversationDialog/NewConversationDialog.vue
+++ b/src/components/NewConversationDialog/NewConversationDialog.vue
@@ -290,51 +290,42 @@ export default {
 					isPublic: this.isPublic,
 				})
 
+				// Gather all secondary requests to run in parallel
+				const promises = []
+
 				if (this.isPublic && this.password && this.newConversation.hasPassword) {
-					await setConversationPassword(this.newConversation.token, this.password)
+					promises.push(setConversationPassword(this.newConversation.token, this.password))
 				}
 
 				if (this.isAvatarEdited) {
-					await this.$refs.setupPage.$refs.conversationAvatar.saveAvatar()
+					promises.push(this.$refs.setupPage.$refs.conversationAvatar.saveAvatar)
 				}
 
 				if (this.newConversation.description) {
-					await this.$store.dispatch('setConversationDescription', {
+					promises.push(this.$store.dispatch('setConversationDescription', {
 						token: this.newConversation.token,
 						description: this.newConversation.description,
-					})
+					}))
 				}
+
+				if (this.listable !== CONVERSATION.LISTABLE.NONE) {
+					promises.push(this.$store.dispatch('setListable', {
+						token: this.newConversation.token,
+						listable: this.listable,
+					}))
+				}
+
+				for (const participant of this.selectedParticipants) {
+					promises.push(addParticipant(this.newConversation.token, participant.id, participant.source))
+				}
+
+				await Promise.all(promises)
 			} catch (exception) {
-				console.error(exception)
+				console.error('Error creating new conversation: ', exception)
 				this.isLoading = false
 				this.error = true
 				// Stop the execution of the method on exceptions.
 				return
-			}
-
-			try {
-				await this.$store.dispatch('setListable', {
-					token: this.newConversation.token,
-					listable: this.listable,
-				})
-			} catch (exception) {
-				console.error(exception)
-				this.isLoading = false
-				this.error = true
-				// Stop the execution of the method on exceptions.
-				return
-			}
-
-			for (const participant of this.selectedParticipants) {
-				try {
-					await addParticipant(this.newConversation.token, participant.id, participant.source)
-				} catch (exception) {
-					console.error(exception)
-					this.isLoading = false
-					this.error = true
-					// Stop the execution of the method on exceptions.
-					return
-				}
 			}
 
 			this.success = true

--- a/src/components/NewConversationDialog/NewConversationDialog.vue
+++ b/src/components/NewConversationDialog/NewConversationDialog.vue
@@ -333,18 +333,17 @@ export default {
 
 			if (!this.isInCall) {
 				// Push the newly created conversation's route.
-				this.pushNewRoute()
+				this.$router.push({ name: 'conversation', params: { token: this.newConversation.token } })
+					.catch(err => console.debug(`Error while pushing the new conversation's route: ${err}`))
+
+				// Get complete participant list in advance
+				this.$store.dispatch('fetchParticipants', { token: this.newConversation.token })
 			}
 
 			// Close the modal right away if the conversation is public.
 			if (!this.isPublic) {
 				this.closeModal()
 			}
-		},
-
-		pushNewRoute() {
-			this.$router.push({ name: 'conversation', params: { token: this.newConversation.token } })
-				.catch(err => console.debug(`Error while pushing the new conversation's route: ${err}`))
 		},
 
 		/** Handles the press of the enter key */

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -43,6 +43,8 @@ import {
 	setCallPermissions,
 	setMessageExpiration,
 	setConversationPassword,
+	createPublicConversation,
+	createPrivateConversation,
 } from '../services/conversationsService.js'
 import {
 	clearConversationHistory,
@@ -915,6 +917,29 @@ const actions = {
 			return response.data.ocs.data
 		} catch (error) {
 			console.error('Error creating new one to one conversation: ', error)
+		}
+	},
+
+	/**
+	 * Creates a new private or public conversation, adds it to the store
+	 *
+	 * @param {object} context default store context;
+	 * @param {object} payload action payload;
+	 * @param {string} payload.conversationName displayed name for a new conversation
+	 * @param {number} payload.isPublic whether a conversation is public or private
+	 * @return {string} token of new conversation
+	 */
+	async createGroupConversation(context, { conversationName, isPublic }) {
+		try {
+			const response = isPublic
+				? await createPublicConversation(conversationName)
+				: await createPrivateConversation(conversationName)
+			const conversation = response.data.ocs.data
+			context.dispatch('addConversation', conversation)
+			return conversation.token
+		} catch (error) {
+			console.error('Error creating new group conversation: ', error)
+			return ''
 		}
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12206 
* Only `createConversation` is mandatory to be completed first, rest request are secondary and could be done in parallel
* As owner of conversation definitely has all needed permissions and access to the conversation, we can fetch participants list (with statuses, permissions, e.t.c) much earlier
  * we don't need to wait to join conversation
  * we're the only one in the conversation yet, so don't need to debounce request (up to 3-15 sec)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Testing the time (with local server) from **submitting the form** with following:
- Description
- Avatar
- Password
- Listable
- 5 participants

to the time **participants are fetched** 

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/ebc6472c-cee9-43c1-913c-0dd7c8341860) | ![image](https://github.com/nextcloud/spreed/assets/93392545/6034882e-e17f-4ca7-85d9-8f2036874950)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required