### PR TITLE
fix(attachments): allow null expireDate in createShare

### DIFF
--- a/lib/Share/Helper/ShareAPIController.php
+++ b/lib/Share/Helper/ShareAPIController.php
@@ -78,14 +78,14 @@ class ShareAPIController {
 	 * @param IShare $share
 	 * @param string $shareWith
 	 * @param int $permissions
-	 * @param string $expireDate
+	 * @param ?string $expireDate
 	 * @throws OCSNotFoundException
 	 */
-	public function createShare(IShare $share, string $shareWith, int $permissions, string $expireDate): void {
+	public function createShare(IShare $share, string $shareWith, int $permissions, ?string $expireDate = null): void {
 		$share->setSharedWith($shareWith);
 		$share->setPermissions($permissions);
 
-		if ($expireDate !== '') {
+		if ($expireDate !== null && $expireDate !== '') {
 			try {
 				$expireDateTime = $this->parseDate($expireDate);
 				$share->setExpirationDate($expireDateTime);


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from: https://github.com/nextcloud/server/pull/44485
* `$expireDate` is now `null` by default and can be not only `string`
* Or is it better to fix on server side?

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Make `expireDate` nullable and check for null on setting date

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
