### PR TITLE
fix: hide text on mobile for TopBar only

### DIFF
--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -23,7 +23,7 @@
 				<VideoOutlineIcon v-else-if="silentCall" :size="20" />
 				<VideoIcon v-else :size="20" />
 			</template>
-			<template v-if="!isMobile" #default>
+			<template v-if="showButtonText" #default>
 				{{ startCallLabel }}
 			</template>
 		</NcButton>
@@ -36,7 +36,7 @@
 			<template #icon>
 				<PhoneHangup :size="20" />
 			</template>
-			<template v-if="!isMobile" #default>
+			<template v-if="showButtonText" #default>
 				{{ endCallLabel }}
 			</template>
 		</NcButton>
@@ -49,14 +49,14 @@
 			<template #icon>
 				<VideoOff :size="20" />
 			</template>
-			<template v-if="!isMobile" #default>
+			<template v-if="showButtonText" #default>
 				{{ leaveCallLabel }}
 			</template>
 		</NcButton>
 		<NcActions v-else-if="showLeaveCallButton && (canEndForAll || isBreakoutRoom)"
 			:disabled="loading"
 			:aria-label="leaveCallCombinedLabel"
-			:menu-name="!isMobile ? leaveCallCombinedLabel : undefined"
+			:menu-name="showButtonText ? leaveCallCombinedLabel : undefined"
 			force-name
 			:container="container"
 			:type="isScreensharing ? 'tertiary' : 'error'">
@@ -176,7 +176,15 @@ export default {
 		isScreensharing: {
 			type: Boolean,
 			default: false,
-		}
+		},
+
+		/**
+		 * Whether the to use text on button at mobile view
+		 */
+		shrinkOnMobile: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	setup() {
@@ -209,7 +217,9 @@ export default {
 		conversation() {
 			return this.$store.getters.conversation(this.token) || this.$store.getters.dummyConversation
 		},
-
+		showButtonText() {
+			return !this.isMobile || !this.shrinkOnMobile
+		},
 		showRecordingWarning() {
 			return [CALL.RECORDING.VIDEO_STARTING, CALL.RECORDING.AUDIO_STARTING,
 				CALL.RECORDING.VIDEO, CALL.RECORDING.AUDIO].includes(this.conversation.callRecording)

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -78,7 +78,7 @@
 			:model="localMediaModel"
 			@open-breakout-rooms-editor="showBreakoutRoomsEditor = true" />
 
-		<CallButton :is-screensharing="!!localMediaModel.attributes.localScreen" />
+		<CallButton shrink-on-mobile :is-screensharing="!!localMediaModel.attributes.localScreen" />
 
 		<!-- sidebar toggle -->
 		<template v-if="showOpenSidebarButton">


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up for #12383 
*  Only button in TopBar was meant to be used without text on mobile, but we forgot that component is reusable :see_no_evil: 

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/a3856301-7495-4f16-a8ff-af3ef905a147) | ![image](https://github.com/nextcloud/spreed/assets/93392545/92129a4a-69e1-4cd6-a341-32eeb1f782e0)
![image](https://github.com/nextcloud/spreed/assets/93392545/7a1fff2e-ad13-4037-a0d4-444bba2753eb) | ![image](https://github.com/nextcloud/spreed/assets/93392545/651320bf-3604-4491-9249-8906426fbbca)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required