### PR TITLE
[vue3] fix: fix unmount issues and call reactivity

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -376,9 +376,16 @@ export default {
 		},
 
 		screens() {
+			console.log('screens watcher')
 			this._setScreenVisible()
 
 		},
+		// screens: {
+		// 	deep: true,
+		// 	handler() {
+		// 		this._setScreenVisible()
+		// 	}
+		// },
 
 		callParticipantModelsWithScreen(newValue, previousValue) {
 			// Everytime a new screen is shared, switch to promoted view
@@ -455,6 +462,7 @@ export default {
 		 * @param {Array} models the array of CallParticipantModels
 		 */
 		updateDataFromCallParticipantModels(models) {
+			console.log('updateDataFromCallParticipantModels', models)
 			const addedModels = models.filter(model => !this.sharedDatas[model.attributes.peerId])
 			const removedModelIds = Object.keys(this.sharedDatas).filter(sharedDataId => models.find(model => model.attributes.peerId === sharedDataId) === undefined)
 
@@ -464,15 +472,15 @@ export default {
 				delete this.sharedDatas[removedModelId]
 
 				this.speakingUnwatchers[removedModelId]()
-				// Not reactive, but not a problem
+				// FIXME Not reactive, but not a problem?
 				delete this.speakingUnwatchers[removedModelId]
 
 				this.screenUnwatchers[removedModelId]()
-				// Not reactive, but not a problem
+				// FIXME Not reactive, but not a problem?
 				delete this.screenUnwatchers[removedModelId]
 
 				this.raisedHandUnwatchers[removedModelId]()
-				// Not reactive, but not a problem
+				// FIXME Not reactive, but not a problem?
 				delete this.raisedHandUnwatchers[removedModelId]
 
 				const index = this.speakers.findIndex(speaker => speaker.id === removedModelId)
@@ -490,7 +498,7 @@ export default {
 
 				this.sharedDatas[addedModel.attributes.peerId] = sharedData
 
-				// Not reactive, but not a problem
+				// FIXME Not reactive, but not a problem?
 				this.speakingUnwatchers[addedModel.attributes.peerId] = this.$watch(function() {
 					return addedModel.attributes.speaking
 				}, function(speaking) {
@@ -502,14 +510,14 @@ export default {
 					active: false,
 				})
 
-				// Not reactive, but not a problem
+				// FIXME Not reactive, but not a problem?
 				this.screenUnwatchers[addedModel.attributes.peerId] = this.$watch(function() {
 					return addedModel.attributes.screen
 				}, function(screen) {
 					this._setScreenAvailable(addedModel.attributes.peerId, screen)
 				})
 
-				// Not reactive, but not a problem
+				// FIXME Not reactive, but not a problem? - at least works
 				this.raisedHandUnwatchers[addedModel.attributes.peerId] = this.$watch(function() {
 					return addedModel.attributes.raisedHand
 				}, function(raisedHand) {
@@ -578,6 +586,7 @@ export default {
 		},
 
 		_setScreenAvailable(id, screen) {
+			console.log('_setScreenAvailable', id, screen)
 			if (screen) {
 				this.screens.unshift(id)
 
@@ -625,6 +634,7 @@ export default {
 		},
 
 		_setScreenVisible() {
+			console.log('_setScreenVisible', this.sharedDatas)
 			this.localSharedData.screenVisible = false
 
 			Object.values(this.sharedDatas).forEach(sharedData => {

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -360,9 +360,12 @@ export default {
 			this.adjustSimulcastQuality()
 		},
 
-		speakers(value) {
-			if (value) {
-				this._setPromotedParticipant()
+		speakers: {
+			deep: true,
+			handler(value) {
+				if (value) {
+					this._setPromotedParticipant()
+				}
 			}
 		},
 

--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -206,7 +206,7 @@ export default {
 		},
 
 		callParticipantModels() {
-			return callParticipantCollection.callParticipantModels.value.filter(callParticipantModel => !callParticipantModel.attributes.internal)
+			return callParticipantCollection.callParticipantModels.filter(callParticipantModel => !callParticipantModel.attributes.internal)
 		},
 
 		callParticipantModelsWithScreen() {

--- a/src/components/CallView/shared/VideoVue.vue
+++ b/src/components/CallView/shared/VideoVue.vue
@@ -575,7 +575,7 @@ export default {
 		},
 
 		updateVideoAspectRatio() {
-			if (!this.isBig) {
+			if (!this.isBig || !this.model.attributes.stream) {
 				return
 			}
 

--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -791,6 +791,10 @@ export default {
 		},
 
 		checkSticky() {
+			if (!this.$refs.scroller) {
+				return
+			}
+
 			const ulElements = this.$refs['dateGroup-' + this.token]
 			if (!ulElements) {
 				return
@@ -813,7 +817,7 @@ export default {
 			this.isScrolling = true
 			this.endScrollTimeout = setTimeout(this.endScroll, 3000)
 			// handle sticky date
-			if (this.$refs.scroller.scrollTop === 0) {
+			if (this.$refs.scroller?.scrollTop === 0) {
 				this.stickyDate = null
 			} else {
 				this.checkSticky()

--- a/src/components/TopBar/TopBarMenu.vue
+++ b/src/components/TopBar/TopBarMenu.vue
@@ -383,7 +383,7 @@ export default {
 
 	methods: {
 		forceMuteOthers() {
-			callParticipantCollection.callParticipantModels.value.forEach(callParticipantModel => {
+			callParticipantCollection.callParticipantModels.forEach(callParticipantModel => {
 				callParticipantModel.forceMute()
 			})
 		},

--- a/src/utils/webrtc/SentVideoQualityThrottler.js
+++ b/src/utils/webrtc/SentVideoQualityThrottler.js
@@ -84,7 +84,7 @@ SentVideoQualityThrottler.prototype = {
 		this._callParticipantCollection.on('add', this._handleAddParticipantBound)
 		this._callParticipantCollection.on('remove', this._handleRemoveParticipantBound)
 
-		this._callParticipantCollection.callParticipantModels.value.forEach(callParticipantModel => {
+		this._callParticipantCollection.callParticipantModels.forEach(callParticipantModel => {
 			callParticipantModel.on('change:videoAvailable', this._adjustVideoQualityIfNeededBound)
 			callParticipantModel.on('change:audioAvailable', this._adjustVideoQualityIfNeededBound)
 		})
@@ -103,7 +103,7 @@ SentVideoQualityThrottler.prototype = {
 		this._callParticipantCollection.off('add', this._handleAddParticipantBound)
 		this._callParticipantCollection.off('remove', this._handleRemoveParticipantBound)
 
-		this._callParticipantCollection.callParticipantModels.value.forEach(callParticipantModel => {
+		this._callParticipantCollection.callParticipantModels.forEach(callParticipantModel => {
 			callParticipantModel.off('change:videoAvailable', this._adjustVideoQualityIfNeededBound)
 			callParticipantModel.off('change:audioAvailable', this._adjustVideoQualityIfNeededBound)
 		})
@@ -171,7 +171,7 @@ SentVideoQualityThrottler.prototype = {
 
 		let availableVideosCount = 0
 		let availableAudiosCount = 0
-		this._callParticipantCollection.callParticipantModels.value.forEach(callParticipantModel => {
+		this._callParticipantCollection.callParticipantModels.forEach(callParticipantModel => {
 			if (callParticipantModel.get('videoAvailable')) {
 				availableVideosCount++
 			}

--- a/src/utils/webrtc/SpeakingStatusHandler.js
+++ b/src/utils/webrtc/SpeakingStatusHandler.js
@@ -58,7 +58,7 @@ export default class SpeakingStatusHandler {
 		this.#callParticipantCollection.off('add', this.#handleAddParticipantBound)
 		this.#callParticipantCollection.off('remove', this.#handleRemoveParticipantBound)
 
-		this.#callParticipantCollection.callParticipantModels.value.forEach(callParticipantModel => {
+		this.#callParticipantCollection.callParticipantModels.forEach(callParticipantModel => {
 			callParticipantModel.off('change:speaking', this.#handleSpeakingBound)
 			callParticipantModel.off('change:stoppedSpeaking', this.#handleSpeakingBound)
 		})

--- a/src/utils/webrtc/models/CallParticipantCollection.js
+++ b/src/utils/webrtc/models/CallParticipantCollection.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { ref } from 'vue'
+import { reactive } from 'vue'
 
 import CallParticipantModel from './CallParticipantModel.js'
 import EmitterMixin from '../../EmitterMixin.js'
@@ -15,8 +15,7 @@ export default function CallParticipantCollection() {
 
 	this._superEmitterMixin()
 
-	// FIXME: use reactive instead of ref after migration to vue 3
-	this.callParticipantModels = ref([])
+	this.callParticipantModels = reactive([])
 
 }
 
@@ -24,7 +23,7 @@ CallParticipantCollection.prototype = {
 
 	add(options) {
 		const callParticipantModel = new CallParticipantModel(options)
-		this.callParticipantModels.value.push(callParticipantModel)
+		this.callParticipantModels.push(callParticipantModel)
 
 		this._trigger('add', [callParticipantModel])
 
@@ -32,19 +31,19 @@ CallParticipantCollection.prototype = {
 	},
 
 	get(peerId) {
-		return this.callParticipantModels.value.find(function(callParticipantModel) {
+		return this.callParticipantModels.find(function(callParticipantModel) {
 			return callParticipantModel.attributes.peerId === peerId
 		})
 	},
 
 	remove(peerId) {
-		const index = this.callParticipantModels.value.findIndex(function(callParticipantModel) {
+		const index = this.callParticipantModels.findIndex(function(callParticipantModel) {
 			return callParticipantModel.attributes.peerId === peerId
 		})
 		if (index !== -1) {
-			const callParticipantModel = this.callParticipantModels.value[index]
+			const callParticipantModel = this.callParticipantModels[index]
 
-			this.callParticipantModels.value.splice(index, 1)
+			this.callParticipantModels.splice(index, 1)
 
 			this._trigger('remove', [callParticipantModel])
 

--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -148,15 +148,19 @@ CallParticipantModel.prototype = {
 
 	_handlePeerStreamRemoved(peer) {
 		if (this._isSameProxy(this.get('peer'), peer)) {
-			this.get('audioElement').srcObject = null
-			this.set('audioElement', null)
+			if (this.get('audioElement') !== null) {
+				this.get('audioElement').srcObject = null
+				this.set('audioElement', null)
+			}
 			this.set('stream', null)
 			this.set('audioAvailable', undefined)
 			this.set('speaking', undefined)
 			this.set('videoAvailable', undefined)
 		} else if (this._isSameProxy(this.get('screenPeer'), peer)) {
-			this.get('screenAudioElement').srcObject = null
-			this.set('screenAudioElement', null)
+			if (this.get('screenAudioElement') !== null) {
+				this.get('screenAudioElement').srcObject = null
+				this.set('screenAudioElement', null)
+			}
 			this.set('screen', null)
 		}
 	},

--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -2,6 +2,7 @@
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+import { reactive } from 'vue'
 
 import attachMediaStream from '../../../utils/attachmediastream.js'
 import EmitterMixin from '../../EmitterMixin.js'
@@ -27,7 +28,7 @@ export default function CallParticipantModel(options) {
 
 	this._superEmitterMixin()
 
-	this.attributes = {
+	this.attributes = reactive({
 		peerId: null,
 		nextcloudSessionId: null,
 		peer: null,
@@ -60,7 +61,7 @@ export default function CallParticipantModel(options) {
 			state: false,
 			timestamp: null,
 		},
-	}
+	})
 
 	this.set('peerId', options.peerId)
 

--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -122,8 +122,16 @@ CallParticipantModel.prototype = {
 		this._trigger('change:' + key, [value])
 	},
 
+	// Compare Object and Proxy(Object), whether they refer to the same object
+	_isSameProxy(obj1, obj2) {
+		if (typeof obj1 !== 'object' || obj1 === null || typeof obj2 !== 'object' || obj2 === null) {
+			return obj1 === obj2
+		}
+		return Reflect.getPrototypeOf(obj1) === Reflect.getPrototypeOf(obj2)
+	},
+
 	_handlePeerStreamAdded(peer) {
-		if (this.get('peer') === peer) {
+		if (this._isSameProxy(this.get('peer'), peer)) {
 			this.set('stream', this.get('peer').stream || null)
 			this.set('audioElement', attachMediaStream(this.get('stream'), null, { audio: true }))
 			this.get('audioElement').muted = !this.get('audioAvailable')
@@ -132,21 +140,21 @@ CallParticipantModel.prototype = {
 			if (this.get('peer').nick !== undefined) {
 				this.set('name', this.get('peer').nick)
 			}
-		} else if (this.get('screenPeer') === peer) {
+		} else if (this._isSameProxy(this.get('screenPeer'), peer)) {
 			this.set('screen', this.get('screenPeer').stream || null)
 			this.set('screenAudioElement', attachMediaStream(this.get('screen'), null, { audio: true }))
 		}
 	},
 
 	_handlePeerStreamRemoved(peer) {
-		if (this.get('peer') === peer) {
+		if (this._isSameProxy(this.get('peer'), peer)) {
 			this.get('audioElement').srcObject = null
 			this.set('audioElement', null)
 			this.set('stream', null)
 			this.set('audioAvailable', undefined)
 			this.set('speaking', undefined)
 			this.set('videoAvailable', undefined)
-		} else if (this.get('screenPeer') === peer) {
+		} else if (this._isSameProxy(this.get('screenPeer'), peer)) {
 			this.get('screenAudioElement').srcObject = null
 			this.set('screenAudioElement', null)
 			this.set('screen', null)


### PR DESCRIPTION
### ☑️ Resolves

* Reactivity doesn't work correctly for callParticipantModels, this leads to missed updates / re-renders, which worked in Vue2


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

### 🚧 Tasks

- [x] replace ref with reactive
  - :warning:  doesn't work deeply (or works, but flacky), if we push models later in the reactive array, and then update some properties null -> object (stream, peer, speaking)
- [x] Minor TypeErrors in console.log
- [x] Participant join with video
- [ ] Participant join with screenshare (don't see)
- [ ] Participant and speaking indicator (don't see)
- [ ] Participant stops screenshare (main peer video is missing for several seconds)

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required