### PR TITLE
fix(viewer): fix creation of file from template

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -255,12 +255,11 @@ export default {
 	emits: ['remove-file'],
 
 	setup() {
-		const { openViewer, generateViewerObject } = useViewer()
+		const { openViewer } = useViewer()
 		const sharedItemsStore = useSharedItemsStore()
 
 		return {
 			openViewer,
-			generateViewerObject,
 			sharedItemsStore,
 		}
 	},
@@ -584,11 +583,9 @@ export default {
 			event.stopPropagation()
 			event.preventDefault()
 
-			const fileInfo = this.generateViewerObject(this)
-
 			if (this.itemType === SHARED_ITEM.TYPES.MEDIA) {
 				const getRevertedList = (items) => Object.values(items).reverse()
-					.map(item => this.generateViewerObject(item.messageParameters.file))
+					.map(item => item.messageParameters.file)
 
 				// Get available media files from store and put them to the list to navigate through slides
 				const mediaFiles = this.sharedItemsStore.sharedItems(this.token).media
@@ -598,9 +595,9 @@ export default {
 					return getRevertedList(messages)
 				}
 
-				this.openViewer(this.internalAbsolutePath, list, fileInfo, loadMore)
+				this.openViewer(this.internalAbsolutePath, list, this, loadMore)
 			} else {
-				this.openViewer(this.internalAbsolutePath, [fileInfo], fileInfo)
+				this.openViewer(this.internalAbsolutePath, [this], this)
 
 			}
 		},

--- a/src/components/NewMessage/NewMessageNewFileDialog.vue
+++ b/src/components/NewMessage/NewMessageNewFileDialog.vue
@@ -40,7 +40,11 @@
 
 				<div class="new-text-file__buttons">
 					<NcButton type="primary"
+						:disabled="loading"
 						@click="handleCreateNewFile">
+						<template v-if="loading" #icon>
+							<NcLoadingIcon />
+						</template>
 						{{ t('spreed', 'Create file') }}
 					</NcButton>
 				</div>
@@ -53,6 +57,7 @@
 import { showError } from '@nextcloud/dialogs'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 
@@ -66,9 +71,10 @@ export default {
 
 	components: {
 		NcButton,
-		NewMessageTemplatePreview,
+		NcLoadingIcon,
 		NcModal,
 		NcTextField,
+		NewMessageTemplatePreview,
 	},
 
 	props: {
@@ -100,6 +106,7 @@ export default {
 			newFileTitle: t('spreed', 'New file'),
 			newFileError: '',
 			checked: -1,
+			loading: false,
 		}
 	},
 
@@ -183,6 +190,7 @@ export default {
 
 		// Create text file and share it to a conversation
 		async handleCreateNewFile() {
+			this.loading = true
 			this.newFileError = ''
 			let filePath = this.$store.getters.getAttachmentFolder() + '/' + this.newFileTitle.replace('/', '')
 
@@ -208,10 +216,12 @@ export default {
 				} else {
 					showError(t('spreed', 'Error while creating file'))
 				}
+				this.loading = false
 				return
 			}
 
 			await shareFile(filePath, this.token, '', '')
+			this.loading = false
 
 			this.openViewer(filePath, [fileData], fileData)
 

--- a/src/composables/useViewer.js
+++ b/src/composables/useViewer.js
@@ -105,13 +105,13 @@ export function useViewer() {
 	})
 
 	const generateViewerObject = (file) => ({
-		fileid: parseInt(file.id, 10),
-		filename: generateAbsolutePath(file.path),
-		basename: file.name,
-		mime: file.mimetype,
-		hasPreview: file.previewAvailable === 'yes' || file['preview-available'] === 'yes',
+		fileid: file.fileid ?? parseInt(file.id, 10),
+		filename: file.filename ?? generateAbsolutePath(file.path),
+		basename: file.basename ?? file.name,
+		mime: file.mime ?? file.mimetype,
+		hasPreview: file.hasPreview ?? (file.previewAvailable === 'yes' || file['preview-available'] === 'yes'),
 		etag: file.etag,
-		permissions: generatePermissions(file.permissions),
+		permissions: generatePermissions(file.permissions), // Viewer expects a String instead of Bitmask
 	})
 
 	/**
@@ -133,8 +133,8 @@ export function useViewer() {
 
 		OCA.Viewer.open({
 			path,
-			list,
-			fileInfo,
+			list: list.map(generateViewerObject),
+			fileInfo: generateViewerObject(fileInfo),
 			onClose: () => {
 				isViewerOpen.value = false
 				store.dispatch('setCallViewMode', { isViewerOverlay: false })
@@ -156,6 +156,5 @@ export function useViewer() {
 	return {
 		isViewerOpen,
 		openViewer,
-		generateViewerObject,
 	}
 }


### PR DESCRIPTION
### ☑️ Resolves

- pass permissions to Viewer as a string instead of Bitmask
- add visual indicator of loading

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/bd5f9fcf-e796-4a43-a6d2-32e078cb524e) | ![image](https://github.com/nextcloud/spreed/assets/93392545/7207cd2d-791b-4ac6-b10e-64f4d4db8cf0)


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required