### PR TITLE
fix(useViewer): initially define which type will be used to map objects

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/FilePreview.vue
@@ -255,7 +255,7 @@ export default {
 	emits: ['remove-file'],
 
 	setup() {
-		const { openViewer } = useViewer()
+		const { openViewer } = useViewer('talk')
 		const sharedItemsStore = useSharedItemsStore()
 
 		return {

--- a/src/components/NewMessage/NewMessageNewFileDialog.vue
+++ b/src/components/NewMessage/NewMessageNewFileDialog.vue
@@ -97,7 +97,7 @@ export default {
 	emits: ['dismiss'],
 
 	setup() {
-		const { openViewer } = useViewer()
+		const { openViewer } = useViewer('files')
 		return { openViewer }
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #12467
* Follow more strict logic when mapping an object for Viewer:
  * fileData from Files API goes as-is, only permissions converted;
  * fileData from Talk API converted completely to match expected value;

## 🖌️ UI Checklist

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possible