### PR TITLE
Fix audio in inactive tab in Safari

### DIFF
--- a/src/utils/webrtc/CallParticipantsAudioPlayer.js
+++ b/src/utils/webrtc/CallParticipantsAudioPlayer.js
@@ -1,0 +1,113 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import attachMediaStream from '../attachmediastream.js'
+
+/**
+ * Player for audio of call participants.
+ *
+ * The player keeps track of the participants added and removed to the
+ * CallParticipantCollection and plays their audio as needed. Note that in the
+ * case of regular audio whether the audio is muted or not depends on
+ * "audioAvailable"; screen share audio, on the other hand, is always treated as
+ * unmuted.
+ *
+ * The audio or screen audio of each participant is played on its own audio
+ * element.
+ *
+ * Once the player is no longer needed "destroy()" must be called to stop
+ * tracking the participants and playing audio.
+ *
+ * @param {object} callParticipantCollection the CallParticipantCollection.
+ */
+export default function CallParticipantsAudioPlayer(callParticipantCollection) {
+	this._callParticipantCollection = callParticipantCollection
+
+	this._audioElements = new Map()
+
+	this._handleCallParticipantAddedBound = this._handleCallParticipantAdded.bind(this)
+	this._handleCallParticipantRemovedBound = this._handleCallParticipantRemoved.bind(this)
+	this._handleStreamChangedBound = this._handleStreamChanged.bind(this)
+	this._handleScreenChangedBound = this._handleScreenChanged.bind(this)
+	this._handleAudioAvailableChangedBound = this._handleAudioAvailableChanged.bind(this)
+
+	this._callParticipantCollection.on('add', this._handleCallParticipantAddedBound)
+	this._callParticipantCollection.on('remove', this._handleCallParticipantRemovedBound)
+
+	this._callParticipantCollection.callParticipantModels.value.forEach(callParticipantModel => {
+		this._handleCallParticipantAddedBound(this._callParticipantCollection, callParticipantModel)
+	})
+}
+
+CallParticipantsAudioPlayer.prototype = {
+
+	destroy() {
+		this._callParticipantCollection.off('add', this._handleCallParticipantAddedBound)
+		this._callParticipantCollection.off('remove', this._handleCallParticipantRemovedBound)
+
+		this._callParticipantCollection.callParticipantModels.value.forEach(callParticipantModel => {
+			this._handleCallParticipantRemovedBound(this._callParticipantCollection, callParticipantModel)
+		})
+	},
+
+	_handleCallParticipantAdded(callParticipantCollection, callParticipantModel) {
+		callParticipantModel.on('change:stream', this._handleStreamChangedBound)
+		callParticipantModel.on('change:screen', this._handleScreenChangedBound)
+		callParticipantModel.on('change:audioAvailable', this._handleAudioAvailableChangedBound)
+
+		this._handleStreamChangedBound(callParticipantModel, callParticipantModel.get('stream'))
+		this._handleScreenChangedBound(callParticipantModel, callParticipantModel.get('screen'))
+	},
+
+	_handleCallParticipantRemoved(callParticipantCollection, callParticipantModel) {
+		callParticipantModel.off('change:stream', this._handleStreamChangedBound)
+		callParticipantModel.off('change:screen', this._handleScreenChangedBound)
+		callParticipantModel.off('change:audioAvailable', this._handleAudioAvailableChangedBound)
+
+		this._handleStreamChangedBound(callParticipantModel, null)
+		this._handleScreenChangedBound(callParticipantModel, null)
+	},
+
+	_handleStreamChanged(callParticipantModel, stream) {
+		const id = callParticipantModel.get('peerId') + '-stream'
+		const mute = !callParticipantModel.get('audioAvailable')
+		this._setAudioElement(id, stream, mute)
+	},
+
+	_handleScreenChanged(callParticipantModel, screen) {
+		const id = callParticipantModel.get('peerId') + '-screen'
+		this._setAudioElement(id, screen)
+	},
+
+	_setAudioElement(id, stream, mute = false) {
+		let audioElement = this._audioElements.get(id)
+		if (audioElement) {
+			audioElement.srcObject = null
+
+			this._audioElements.delete(id)
+		}
+
+		if (!stream) {
+			return
+		}
+
+		audioElement = attachMediaStream(stream, null, { audio: true })
+		if (mute) {
+			audioElement.muted = true
+		}
+
+		this._audioElements.set(id, audioElement)
+	},
+
+	_handleAudioAvailableChanged(callParticipantModel, audioAvailable) {
+		const audioElement = this._audioElements.get(callParticipantModel.get('peerId') + '-stream')
+		if (!audioElement) {
+			return
+		}
+
+		audioElement.muted = !audioAvailable
+	},
+
+}

--- a/src/utils/webrtc/CallParticipantsAudioPlayer.spec.js
+++ b/src/utils/webrtc/CallParticipantsAudioPlayer.spec.js
@@ -1,0 +1,716 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { ref } from 'vue'
+
+import CallParticipantsAudioPlayer from './CallParticipantsAudioPlayer.js'
+import EmitterMixin from '../EmitterMixin.js'
+
+/**
+ * Stub of CallParticipantModel with just the attributes and methods used by
+ * CallParticipantsAudioPlayer.
+ *
+ * @param {string} peerId the ID of the peer
+ */
+function CallParticipantModelStub(peerId) {
+	this._superEmitterMixin()
+
+	this.attributes = {
+		peerId,
+	}
+
+	this.get = (key) => {
+		return this.attributes[key]
+	}
+
+	this.set = (key, value) => {
+		this.attributes[key] = value
+
+		this._trigger('change:' + key, [value])
+	}
+}
+EmitterMixin.apply(CallParticipantModelStub.prototype)
+
+/**
+ * Stub of CallParticipantCollection with just the attributes and methods used
+ * by CallParticipantsAudioPlayer.
+ */
+function CallParticipantCollectionStub() {
+	this._superEmitterMixin()
+
+	this.callParticipantModels = ref([])
+}
+EmitterMixin.apply(CallParticipantCollectionStub.prototype)
+
+/**
+ * Mock of MediaStream with an id for easier tracking in tests.
+ *
+ * HTMLAudioElement requires srcObject to conform to the MediaStream interface,
+ * but in jsdom anything can be assigned, so the mock is kept to a minimum.
+ *
+ * @param {string} id the id for the stream.
+ */
+function MediaStreamMock(id) {
+	this.id = id
+}
+
+describe('CallParticipantsAudioPlayer', () => {
+
+	let callParticipantCollection
+	let callParticipantsAudioPlayer
+
+	/**
+	 * Adds a CallParticipantModel to the collection.
+	 *
+	 * The participant must not be yet in the collection.
+	 *
+	 * @param {object} callParticipantModel the CallParticipantModel to add.
+	 */
+	function addCallParticipantModel(callParticipantModel) {
+		callParticipantCollection.callParticipantModels.value.push(callParticipantModel)
+
+		callParticipantCollection._trigger('add', [callParticipantModel])
+	}
+
+	/**
+	 * Removes a CallParticipantModel from the collection.
+	 *
+	 * The participant must be in the collection.
+	 *
+	 * @param {object} callParticipantModel the CallParticipantModel to remove.
+	 */
+	function removeCallParticipantModel(callParticipantModel) {
+		const index = callParticipantCollection.callParticipantModels.value.indexOf(callParticipantModel)
+		callParticipantCollection.callParticipantModels.value.splice(index, 1)
+
+		callParticipantCollection._trigger('remove', [callParticipantModel])
+	}
+
+	/**
+	 * Asserts that the audio element with the given id has the expected
+	 * srcObject and muted value.
+	 *
+	 * @param {string} audioElementId the id of the audio element in the player.
+	 * @param {object|null} expectedSrcObject the expected srcObject in the
+	 *        element.
+	 * @param {boolean} expectedMuted the expected muted value in the element.
+	 */
+	function assertAudioElement(audioElementId, expectedSrcObject, expectedMuted) {
+		expect(callParticipantsAudioPlayer._audioElements.get(audioElementId)).not.toBe(null)
+		expect(callParticipantsAudioPlayer._audioElements.get(audioElementId).tagName.toLowerCase()).toBe('audio')
+		expect(callParticipantsAudioPlayer._audioElements.get(audioElementId).srcObject).toBe(expectedSrcObject)
+		expect(callParticipantsAudioPlayer._audioElements.get(audioElementId).muted).toBe(expectedMuted)
+	}
+
+	beforeEach(() => {
+		callParticipantCollection = new CallParticipantCollectionStub()
+
+		callParticipantsAudioPlayer = new CallParticipantsAudioPlayer(callParticipantCollection)
+	})
+
+	afterEach(() => {
+		jest.clearAllMocks()
+	})
+
+	describe('constructor', () => {
+		test('without participants', () => {
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(0)
+		})
+
+		test('with several participants', () => {
+			const callParticipantModel1 = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel1)
+
+			const callParticipantModel2 = new CallParticipantModelStub('peerId2')
+			addCallParticipantModel(callParticipantModel2)
+
+			callParticipantModel2.attributes.audioAvailable = false
+
+			const stream2 = new MediaStreamMock('stream2')
+			callParticipantModel2.set('stream', stream2)
+
+			const callParticipantModel3 = new CallParticipantModelStub('peerId3')
+			addCallParticipantModel(callParticipantModel3)
+
+			callParticipantModel3.attributes.audioAvailable = true
+
+			const stream3 = new MediaStreamMock('stream3')
+			callParticipantModel3.set('stream', stream3)
+			const screen3 = new MediaStreamMock('screen3')
+			callParticipantModel3.set('screen', screen3)
+
+			callParticipantsAudioPlayer = new CallParticipantsAudioPlayer(callParticipantCollection)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(3)
+			assertAudioElement('peerId2-stream', stream2, true)
+			assertAudioElement('peerId3-stream', stream3, false)
+			assertAudioElement('peerId3-screen', screen3, false)
+		})
+
+		test('add stream and screen', () => {
+			const callParticipantModel1 = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel1)
+
+			callParticipantsAudioPlayer = new CallParticipantsAudioPlayer(callParticipantCollection)
+
+			const stream1 = new MediaStreamMock('stream1')
+			callParticipantModel1.set('stream', stream1)
+			const screen1 = new MediaStreamMock('screen1')
+			callParticipantModel1.set('screen', screen1)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(2)
+			assertAudioElement('peerId1-stream', stream1, true)
+			assertAudioElement('peerId1-screen', screen1, false)
+		})
+
+		test('change audio available', () => {
+			const callParticipantModel1 = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel1)
+
+			callParticipantModel1.attributes.audioAvailable = false
+
+			const stream1 = new MediaStreamMock('stream1')
+			callParticipantModel1.set('stream', stream1)
+			const screen1 = new MediaStreamMock('screen1')
+			callParticipantModel1.set('screen', screen1)
+
+			callParticipantsAudioPlayer = new CallParticipantsAudioPlayer(callParticipantCollection)
+
+			callParticipantModel1.set('audioAvailable', true)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(2)
+			assertAudioElement('peerId1-stream', stream1, false)
+			assertAudioElement('peerId1-screen', screen1, false)
+		})
+
+		test('remove participant, stream and screen', () => {
+			const callParticipantModel1 = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel1)
+
+			const stream1 = new MediaStreamMock('stream1')
+			callParticipantModel1.set('stream', stream1)
+			const screen1 = new MediaStreamMock('screen1')
+			callParticipantModel1.set('screen', screen1)
+
+			const callParticipantModel2 = new CallParticipantModelStub('peerId2')
+			addCallParticipantModel(callParticipantModel2)
+
+			const stream2 = new MediaStreamMock('stream2')
+			callParticipantModel2.set('stream', stream2)
+			const screen2 = new MediaStreamMock('screen2')
+			callParticipantModel2.set('screen', screen2)
+
+			callParticipantsAudioPlayer = new CallParticipantsAudioPlayer(callParticipantCollection)
+
+			callParticipantModel1.set('stream', null)
+			callParticipantModel1.set('screen', null)
+
+			removeCallParticipantModel(callParticipantModel2)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(0)
+		})
+	})
+
+	describe('add stream and screen', () => {
+		test('stream with available audio', () => {
+			const callParticipantModel = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel)
+
+			callParticipantModel.attributes.audioAvailable = true
+
+			const stream = new MediaStreamMock('stream1')
+			callParticipantModel.set('stream', stream)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(1)
+			assertAudioElement('peerId1-stream', stream, false)
+		})
+
+		test('stream without available audio', () => {
+			const callParticipantModel = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel)
+
+			callParticipantModel.attributes.audioAvailable = false
+
+			const stream = new MediaStreamMock('stream1')
+			callParticipantModel.set('stream', stream)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(1)
+			assertAudioElement('peerId1-stream', stream, true)
+		})
+
+		test('screen', () => {
+			const callParticipantModel = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel)
+
+			const screen = new MediaStreamMock('screen1')
+			callParticipantModel.set('screen', screen)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(1)
+			assertAudioElement('peerId1-screen', screen, false)
+		})
+
+		test('stream and screen', () => {
+			const callParticipantModel = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel)
+
+			callParticipantModel.attributes.audioAvailable = false
+
+			const stream = new MediaStreamMock('stream1')
+			callParticipantModel.set('stream', stream)
+			const screen = new MediaStreamMock('screen1')
+			callParticipantModel.set('screen', screen)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(2)
+			assertAudioElement('peerId1-stream', stream, true)
+			assertAudioElement('peerId1-screen', screen, false)
+		})
+
+		// This should not happen (the stream and screen are expected to be set
+		// once the participant is already in the collection), but test it just
+		// in case.
+		test('participant', () => {
+			const callParticipantModel = new CallParticipantModelStub('peerId1')
+
+			callParticipantModel.attributes.audioAvailable = false
+
+			const stream = new MediaStreamMock('stream1')
+			callParticipantModel.set('stream', stream)
+			const screen = new MediaStreamMock('screen1')
+			callParticipantModel.set('screen', screen)
+
+			addCallParticipantModel(callParticipantModel)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(2)
+			assertAudioElement('peerId1-stream', stream, true)
+			assertAudioElement('peerId1-screen', screen, false)
+		})
+
+		test('several participants, streams and screens', () => {
+			const callParticipantModel1 = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel1)
+			const callParticipantModel2 = new CallParticipantModelStub('peerId2')
+			addCallParticipantModel(callParticipantModel2)
+
+			callParticipantModel1.attributes.audioAvailable = false
+
+			const screen1 = new MediaStreamMock('screen1')
+			callParticipantModel1.set('screen', screen1)
+			const stream1 = new MediaStreamMock('stream1')
+			callParticipantModel1.set('stream', stream1)
+
+			const screen2 = new MediaStreamMock('screen2')
+			callParticipantModel2.set('screen', screen2)
+
+			const callParticipantModel3 = new CallParticipantModelStub('peerId3')
+			addCallParticipantModel(callParticipantModel3)
+
+			callParticipantModel3.attributes.audioAvailable = true
+
+			const stream3 = new MediaStreamMock('stream3')
+			callParticipantModel3.set('stream', stream3)
+
+			const callParticipantModel4 = new CallParticipantModelStub('peerId4')
+
+			callParticipantModel4.attributes.audioAvailable = true
+
+			const stream4 = new MediaStreamMock('stream4')
+			callParticipantModel4.set('stream', stream4)
+
+			addCallParticipantModel(callParticipantModel4)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(5)
+			assertAudioElement('peerId1-stream', stream1, true)
+			assertAudioElement('peerId1-screen', screen1, false)
+			assertAudioElement('peerId2-screen', screen2, false)
+			assertAudioElement('peerId3-stream', stream3, false)
+			assertAudioElement('peerId4-stream', stream4, false)
+		})
+
+		// This should not happen (the previous stream or screen is expected to
+		// be removed first), but test it just in case.
+		test('replace stream and screen', () => {
+			const callParticipantModel = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel)
+
+			callParticipantModel.attributes.audioAvailable = false
+
+			const stream1 = new MediaStreamMock('stream1')
+			callParticipantModel.set('stream', stream1)
+			const screen1 = new MediaStreamMock('screen1')
+			callParticipantModel.set('screen', screen1)
+
+			const audioElementStream1 = callParticipantsAudioPlayer._audioElements.get('peerId1-stream')
+			const audioElementScreen1 = callParticipantsAudioPlayer._audioElements.get('peerId1-screen')
+
+			callParticipantModel.attributes.audioAvailable = true
+
+			const stream2 = new MediaStreamMock('stream2')
+			callParticipantModel.set('stream', stream2)
+			const screen2 = new MediaStreamMock('screen2')
+			callParticipantModel.set('screen', screen2)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(2)
+			assertAudioElement('peerId1-stream', stream2, false)
+			assertAudioElement('peerId1-screen', screen2, false)
+			expect(audioElementStream1.srcObject).toBe(null)
+			expect(audioElementScreen1.srcObject).toBe(null)
+		})
+	})
+
+	describe('change audio available', () => {
+		test('not available with stream', () => {
+			const callParticipantModel = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel)
+
+			callParticipantModel.attributes.audioAvailable = true
+
+			const stream = new MediaStreamMock('stream1')
+			callParticipantModel.set('stream', stream)
+
+			callParticipantModel.set('audioAvailable', false)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(1)
+			assertAudioElement('peerId1-stream', stream, true)
+		})
+
+		test('not available without stream', () => {
+			const callParticipantModel = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel)
+
+			callParticipantModel.set('audioAvailable', false)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(0)
+		})
+
+		test('not available with screen', () => {
+			const callParticipantModel = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel)
+
+			callParticipantModel.attributes.audioAvailable = true
+
+			const screen = new MediaStreamMock('screen1')
+			callParticipantModel.set('screen', screen)
+
+			callParticipantModel.set('audioAvailable', false)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(1)
+			assertAudioElement('peerId1-screen', screen, false)
+		})
+
+		test('available with stream', () => {
+			const callParticipantModel = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel)
+
+			callParticipantModel.attributes.audioAvailable = false
+
+			const stream = new MediaStreamMock('stream1')
+			callParticipantModel.set('stream', stream)
+
+			callParticipantModel.set('audioAvailable', true)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(1)
+			assertAudioElement('peerId1-stream', stream, false)
+		})
+
+		test('available without stream', () => {
+			const callParticipantModel = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel)
+
+			callParticipantModel.set('audioAvailable', true)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(0)
+		})
+
+		test('several participants', () => {
+			const callParticipantModel1 = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel1)
+			const callParticipantModel2 = new CallParticipantModelStub('peerId2')
+			addCallParticipantModel(callParticipantModel2)
+
+			callParticipantModel1.attributes.audioAvailable = false
+
+			const stream1 = new MediaStreamMock('stream1')
+			callParticipantModel1.set('stream', stream1)
+			const screen1 = new MediaStreamMock('screen1')
+			callParticipantModel1.set('screen', screen1)
+
+			const screen2 = new MediaStreamMock('screen2')
+			callParticipantModel2.set('screen', screen2)
+
+			callParticipantModel1.set('audioAvailable', true)
+
+			const callParticipantModel3 = new CallParticipantModelStub('peerId3')
+			addCallParticipantModel(callParticipantModel3)
+
+			callParticipantModel3.attributes.audioAvailable = true
+
+			const stream3 = new MediaStreamMock('stream1')
+			callParticipantModel3.set('stream', stream3)
+
+			callParticipantModel3.set('audioAvailable', false)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(4)
+			assertAudioElement('peerId1-stream', stream1, false)
+			assertAudioElement('peerId1-screen', screen1, false)
+			assertAudioElement('peerId2-screen', screen2, false)
+			assertAudioElement('peerId3-stream', stream3, true)
+		})
+	})
+
+	describe('remove stream and screen', () => {
+		test('stream', () => {
+			const callParticipantModel = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel)
+
+			callParticipantModel.attributes.audioAvailable = true
+
+			const stream = new MediaStreamMock('stream1')
+			callParticipantModel.set('stream', stream)
+			const screen = new MediaStreamMock('screen1')
+			callParticipantModel.set('screen', screen)
+
+			const audioElementStream = callParticipantsAudioPlayer._audioElements.get('peerId1-stream')
+
+			callParticipantModel.set('stream', null)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(1)
+			assertAudioElement('peerId1-screen', screen, false)
+			expect(audioElementStream.srcObject).toBe(null)
+		})
+
+		test('screen', () => {
+			const callParticipantModel = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel)
+
+			callParticipantModel.attributes.audioAvailable = true
+
+			const stream = new MediaStreamMock('stream1')
+			callParticipantModel.set('stream', stream)
+			const screen = new MediaStreamMock('screen1')
+			callParticipantModel.set('screen', screen)
+
+			const audioElementScreen = callParticipantsAudioPlayer._audioElements.get('peerId1-screen')
+
+			callParticipantModel.set('screen', null)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(1)
+			assertAudioElement('peerId1-stream', stream, false)
+			expect(audioElementScreen.srcObject).toBe(null)
+		})
+
+		test('participant', () => {
+			const callParticipantModel = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel)
+
+			const stream = new MediaStreamMock('stream1')
+			callParticipantModel.set('stream', stream)
+			const screen = new MediaStreamMock('screen1')
+			callParticipantModel.set('screen', screen)
+
+			const audioElementStream = callParticipantsAudioPlayer._audioElements.get('peerId1-stream')
+			const audioElementScreen = callParticipantsAudioPlayer._audioElements.get('peerId1-screen')
+
+			removeCallParticipantModel(callParticipantModel)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(0)
+			expect(audioElementStream.srcObject).toBe(null)
+			expect(audioElementScreen.srcObject).toBe(null)
+		})
+
+		test('several participants, stream and screen', () => {
+			const callParticipantModel1 = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel1)
+
+			const stream1 = new MediaStreamMock('stream1')
+			callParticipantModel1.set('stream', stream1)
+			const screen1 = new MediaStreamMock('screen1')
+			callParticipantModel1.set('screen', screen1)
+
+			const callParticipantModel2 = new CallParticipantModelStub('peerId2')
+			addCallParticipantModel(callParticipantModel2)
+
+			const stream2 = new MediaStreamMock('stream2')
+			callParticipantModel2.set('stream', stream2)
+			const screen2 = new MediaStreamMock('screen2')
+			callParticipantModel2.set('screen', screen2)
+
+			const callParticipantModel3 = new CallParticipantModelStub('peerId3')
+			addCallParticipantModel(callParticipantModel3)
+
+			const stream3 = new MediaStreamMock('stream3')
+			callParticipantModel3.set('stream', stream3)
+			const screen3 = new MediaStreamMock('screen3')
+			callParticipantModel3.set('screen', screen3)
+
+			const audioElementStream1 = callParticipantsAudioPlayer._audioElements.get('peerId1-stream')
+			const audioElementScreen1 = callParticipantsAudioPlayer._audioElements.get('peerId1-screen')
+			const audioElementStream3 = callParticipantsAudioPlayer._audioElements.get('peerId3-stream')
+			const audioElementScreen3 = callParticipantsAudioPlayer._audioElements.get('peerId3-screen')
+
+			removeCallParticipantModel(callParticipantModel1)
+			callParticipantModel3.set('stream', null)
+			callParticipantModel3.set('screen', null)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(2)
+			assertAudioElement('peerId2-stream', stream2, true)
+			assertAudioElement('peerId2-screen', screen2, false)
+			expect(audioElementStream1.srcObject).toBe(null)
+			expect(audioElementScreen1.srcObject).toBe(null)
+			expect(audioElementStream3.srcObject).toBe(null)
+			expect(audioElementScreen3.srcObject).toBe(null)
+		})
+
+		// This should not happen, but test it just in case.
+		test('change stream and screen in removed participant', () => {
+			const callParticipantModel = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel)
+
+			removeCallParticipantModel(callParticipantModel)
+
+			const stream = new MediaStreamMock('stream1')
+			callParticipantModel.set('stream', stream)
+			const screen = new MediaStreamMock('screen1')
+			callParticipantModel.set('screen', screen)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(0)
+		})
+
+		// This should not happen, but test it just in case.
+		test('change audio available in removed participant', () => {
+			const callParticipantModel = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel)
+
+			callParticipantModel.attributes.audioAvailable = false
+
+			const stream = new MediaStreamMock('stream1')
+			callParticipantModel.set('stream', stream)
+			const screen = new MediaStreamMock('screen1')
+			callParticipantModel.set('screen', screen)
+
+			removeCallParticipantModel(callParticipantModel)
+
+			callParticipantModel.set('audioAvailable', true)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(0)
+		})
+	})
+
+	describe('destroy', () => {
+		test('without participants', () => {
+			callParticipantsAudioPlayer.destroy()
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(0)
+		})
+
+		test('with several participants', () => {
+			const callParticipantModel1 = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel1)
+
+			const callParticipantModel2 = new CallParticipantModelStub('peerId2')
+			addCallParticipantModel(callParticipantModel2)
+
+			const stream2 = new MediaStreamMock('stream2')
+			callParticipantModel2.set('stream', stream2)
+
+			const callParticipantModel3 = new CallParticipantModelStub('peerId3')
+			addCallParticipantModel(callParticipantModel3)
+
+			const stream3 = new MediaStreamMock('stream3')
+			callParticipantModel3.set('stream', stream3)
+			const screen3 = new MediaStreamMock('screen3')
+			callParticipantModel3.set('screen', screen3)
+
+			const audioElementStream2 = callParticipantsAudioPlayer._audioElements.get('peerId2-stream')
+			const audioElementStream3 = callParticipantsAudioPlayer._audioElements.get('peerId3-stream')
+			const audioElementScreen3 = callParticipantsAudioPlayer._audioElements.get('peerId3-screen')
+
+			callParticipantsAudioPlayer.destroy()
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(0)
+			expect(audioElementStream2.srcObject).toBe(null)
+			expect(audioElementStream3.srcObject).toBe(null)
+			expect(audioElementScreen3.srcObject).toBe(null)
+		})
+
+		test('add stream and screen after destroying', () => {
+			const callParticipantModel1 = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel1)
+
+			callParticipantsAudioPlayer.destroy()
+
+			const stream1 = new MediaStreamMock('stream1')
+			callParticipantModel1.set('stream', stream1)
+			const screen1 = new MediaStreamMock('screen1')
+			callParticipantModel1.set('screen', screen1)
+
+			const callParticipantModel2 = new CallParticipantModelStub('peerId2')
+			addCallParticipantModel(callParticipantModel2)
+
+			const stream2 = new MediaStreamMock('stream2')
+			callParticipantModel2.set('stream', stream2)
+			const screen2 = new MediaStreamMock('screen2')
+			callParticipantModel2.set('screen', screen2)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(0)
+		})
+
+		test('change audio available after destroying', () => {
+			const callParticipantModel1 = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel1)
+
+			callParticipantModel1.attributes.audioAvailable = false
+
+			const stream1 = new MediaStreamMock('stream1')
+			callParticipantModel1.set('stream', stream1)
+			const screen1 = new MediaStreamMock('screen1')
+			callParticipantModel1.set('screen', screen1)
+
+			callParticipantsAudioPlayer.destroy()
+
+			const callParticipantModel2 = new CallParticipantModelStub('peerId2')
+			addCallParticipantModel(callParticipantModel2)
+
+			callParticipantModel2.attributes.audioAvailable = false
+
+			const stream2 = new MediaStreamMock('stream2')
+			callParticipantModel2.set('stream', stream2)
+			const screen2 = new MediaStreamMock('screen2')
+			callParticipantModel2.set('screen', screen2)
+
+			callParticipantModel1.set('audioAvailable', true)
+
+			callParticipantModel2.set('audioAvailable', true)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(0)
+		})
+
+		test('remove stream and screen after destroying', () => {
+			const callParticipantModel1 = new CallParticipantModelStub('peerId1')
+			addCallParticipantModel(callParticipantModel1)
+
+			const stream1 = new MediaStreamMock('stream1')
+			callParticipantModel1.set('stream', stream1)
+			const screen1 = new MediaStreamMock('screen1')
+			callParticipantModel1.set('screen', screen1)
+
+			const callParticipantModel2 = new CallParticipantModelStub('peerId2')
+			addCallParticipantModel(callParticipantModel2)
+
+			const stream2 = new MediaStreamMock('stream2')
+			callParticipantModel2.set('stream', stream2)
+			const screen2 = new MediaStreamMock('screen2')
+			callParticipantModel2.set('screen', screen2)
+
+			callParticipantsAudioPlayer.destroy()
+
+			callParticipantModel1.set('stream', null)
+			callParticipantModel1.set('screen', null)
+
+			removeCallParticipantModel(callParticipantModel2)
+
+			expect(callParticipantsAudioPlayer._audioElements.size).toBe(0)
+		})
+	})
+})

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -7,6 +7,7 @@ import Axios from '@nextcloud/axios'
 import { getCapabilities } from '@nextcloud/capabilities'
 
 import CallAnalyzer from './analyzers/CallAnalyzer.js'
+import CallParticipantsAudioPlayer from './CallParticipantsAudioPlayer.js'
 import MediaDevicesManager from './MediaDevicesManager.js'
 import CallParticipantCollection from './models/CallParticipantCollection.js'
 import LocalCallParticipantModel from './models/LocalCallParticipantModel.js'
@@ -30,6 +31,7 @@ const localCallParticipantModel = new LocalCallParticipantModel()
 const localMediaModel = new LocalMediaModel()
 const mediaDevicesManager = new MediaDevicesManager()
 let callAnalyzer = null
+let callParticipantsAudioPlayer = null
 let sentVideoQualityThrottler = null
 let speakingStatusHandler = null
 
@@ -213,6 +215,8 @@ async function signalingJoinCall(token, flags, silent, recordingConsent) {
 			callAnalyzer = new CallAnalyzer(localMediaModel, null, callParticipantCollection)
 		}
 
+		callParticipantsAudioPlayer = new CallParticipantsAudioPlayer(callParticipantCollection)
+
 		const _signaling = signaling
 
 		return new Promise((resolve, reject) => {
@@ -366,6 +370,8 @@ async function signalingJoinCallForRecording(token, settings, internalClientAuth
 
 	setupWebRtc()
 
+	callParticipantsAudioPlayer = new CallParticipantsAudioPlayer(callParticipantCollection)
+
 	const _signaling = signaling
 
 	return new Promise((resolve, reject) => {
@@ -416,6 +422,9 @@ async function signalingLeaveCall(token, all = false) {
 
 	callAnalyzer.destroy()
 	callAnalyzer = null
+
+	callParticipantsAudioPlayer.destroy()
+	callParticipantsAudioPlayer = null
 
 	if (tokensInSignaling[token]) {
 		await signaling.leaveCall(token, false, all)

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -21,6 +21,7 @@ import { PARTICIPANT, PRIVACY, VIRTUAL_BACKGROUND } from '../../constants.js'
 import BrowserStorage from '../../services/BrowserStorage.js'
 import { fetchSignalingSettings } from '../../services/signalingService.js'
 import store from '../../store/index.js'
+import { isSafari } from '../browserCheck.js'
 import CancelableRequest from '../cancelableRequest.js'
 import Signaling from '../signaling.js'
 import SignalingTypingHandler from '../SignalingTypingHandler.js'
@@ -215,7 +216,8 @@ async function signalingJoinCall(token, flags, silent, recordingConsent) {
 			callAnalyzer = new CallAnalyzer(localMediaModel, null, callParticipantCollection)
 		}
 
-		callParticipantsAudioPlayer = new CallParticipantsAudioPlayer(callParticipantCollection)
+		const mixAudio = isSafari
+		callParticipantsAudioPlayer = new CallParticipantsAudioPlayer(callParticipantCollection, mixAudio)
 
 		const _signaling = signaling
 

--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import attachMediaStream from '../../../utils/attachmediastream.js'
 import EmitterMixin from '../../EmitterMixin.js'
 
 export const ConnectionState = {
@@ -43,9 +42,6 @@ export default function CallParticipantModel(options) {
 		initialConnection: true,
 		connectedAtLeastOnce: false,
 		stream: null,
-		// The audio element is part of the model to ensure that it can be
-		// played if needed even if there is no view for it.
-		audioElement: null,
 		audioAvailable: undefined,
 		speaking: undefined,
 		// "videoBlocked" is "true" only if the video is blocked and it would
@@ -53,9 +49,6 @@ export default function CallParticipantModel(options) {
 		videoBlocked: undefined,
 		videoAvailable: undefined,
 		screen: null,
-		// The audio element is part of the model to ensure that it can be
-		// played if needed even if there is no view for it.
-		screenAudioElement: null,
 		raisedHand: {
 			state: false,
 			timestamp: null,
@@ -124,8 +117,6 @@ CallParticipantModel.prototype = {
 	_handlePeerStreamAdded(peer) {
 		if (this.get('peer') === peer) {
 			this.set('stream', this.get('peer').stream || null)
-			this.set('audioElement', attachMediaStream(this.get('stream'), null, { audio: true }))
-			this.get('audioElement').muted = !this.get('audioAvailable')
 
 			// "peer.nick" is set only for users and when the MCU is not used.
 			if (this.get('peer').nick !== undefined) {
@@ -133,21 +124,16 @@ CallParticipantModel.prototype = {
 			}
 		} else if (this.get('screenPeer') === peer) {
 			this.set('screen', this.get('screenPeer').stream || null)
-			this.set('screenAudioElement', attachMediaStream(this.get('screen'), null, { audio: true }))
 		}
 	},
 
 	_handlePeerStreamRemoved(peer) {
 		if (this.get('peer') === peer) {
-			this.get('audioElement').srcObject = null
-			this.set('audioElement', null)
 			this.set('stream', null)
 			this.set('audioAvailable', undefined)
 			this.set('speaking', undefined)
 			this.set('videoAvailable', undefined)
 		} else if (this.get('screenPeer') === peer) {
-			this.get('screenAudioElement').srcObject = null
-			this.set('screenAudioElement', null)
 			this.set('screen', null)
 		}
 	},
@@ -169,9 +155,6 @@ CallParticipantModel.prototype = {
 		if (data.name === 'video') {
 			this.set('videoAvailable', false)
 		} else {
-			if (this.get('audioElement')) {
-				this.get('audioElement').muted = true
-			}
 			this.set('audioAvailable', false)
 			this.set('speaking', false)
 		}
@@ -200,9 +183,6 @@ CallParticipantModel.prototype = {
 		if (data.name === 'video') {
 			this.set('videoAvailable', true)
 		} else {
-			if (this.get('audioElement')) {
-				this.get('audioElement').muted = false
-			}
 			this.set('audioAvailable', true)
 		}
 	},


### PR DESCRIPTION
Fixes #12455

[Safari does not allow autoplaying on audio elements in inactive tabs](https://bugs.webkit.org/show_bug.cgi?id=262952), so if the user switched to another tab during a call the participants that join while the tab is inactive will not be heard until the user switches back to the Talk tab. To work around that now an audio element is created when the local participant joins the call and then the audio of all participants is mixed and played on that audio element.

This is applied only to Safari (although maybe it should be applied to any webkit browser? :thinking:); other browsers still play the audio in independent audio elements, just like before (although now they are all managed by a single object, rather than each `CallParticipantModel` managing audio elements specific to a single participant).

**Reviewers:** in theory the steps below should show the issue without this pull request, but I could not verify that, so please check that before testing the fix :-)

Besides testing it in desktop Safari please test it too in mobile Safari, as it seems to have its own quirks.

## How to test

- In Safari, create a conversation
- Start a call
- Switch to a different tab
- In another browser (a private window might work too, but who knows...), join the call

### Result with this pull request

Joined user can be heard in Safari

### Result without this pull request

Joined user can not be heard in Safari
