### PR TITLE
fix(NewMessage): typing indicator alignment for wide screens

### DIFF
--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -11,6 +11,7 @@
 $messages-text-max-width: calc(70 * var(--default-font-size));
 $message-utils-width: calc(52px + 4 * var(--default-grid-baseline) + 120px);
 $messages-list-max-width: calc($messages-text-max-width + $message-utils-width + 3 * var(--default-grid-baseline));
+$message-input-max-width: calc($messages-list-max-width - 100px);
 
 // background color of call container
 $color-call-background: rgba(34, 34, 34, 0.8);

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -1032,7 +1032,7 @@ export default {
 	display: flex;
 	gap: 4px;
 	position: relative;
-	max-width: calc($messages-list-max-width - 100px);
+	max-width: $message-input-max-width;
 	margin: 0 auto;
 
 	&__emoji-picker {

--- a/src/components/NewMessage/NewMessageTypingIndicator.vue
+++ b/src/components/NewMessage/NewMessageTypingIndicator.vue
@@ -131,13 +131,15 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '../../assets/variables';
+
 .indicator {
 	width: 100%;
 	padding-right: 12px;
 	margin-bottom: 4px;
 
 	&__wrapper {
-		max-width: 800px;
+		max-width: $message-input-max-width;
 		display: flex;
 		align-items: center;
 		margin: auto;


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12466 

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![240613_09h49m00s_screenshot](https://github.com/nextcloud/spreed/assets/88997516/5b830e95-0fc1-4d3e-9a15-828b6af4cd37) | ![240613_09h06m05s_screenshot](https://github.com/nextcloud/spreed/assets/88997516/513e121b-e439-45cf-a979-5f3c4804fff9)


<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required