### PR TITLE
fix(tests): Adjust expected share type attributes after server change

### DIFF
--- a/tests/integration/features/sharing-2/get.feature
+++ b/tests/integration/features/sharing-2/get.feature
@@ -1149,8 +1149,12 @@ Feature: get
       | roomName | room |
     And user "participant1" adds user "participant2" to room "group room" with 200 (v4)
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
+    When user "participant1" gets the share-type DAV property for "/welcome.txt"
+    Then the response contains a share-types DAV property with
+      | 10 |
     When user "participant2" gets the share-type DAV property for "Talk/welcome.txt"
     Then the response contains a share-types DAV property with
+      | 10 |
 
   Scenario: get DAV properties for a room share reshared with a user
     Given user "participant1" creates room "group room" (v4)
@@ -1166,6 +1170,10 @@ Feature: get
     When user "participant1" gets the share-type DAV property for "/welcome.txt"
     Then the response contains a share-types DAV property with
       | 10 |
+    When user "participant2" gets the share-type DAV property for "Talk/welcome.txt"
+    Then the response contains a share-types DAV property with
+      | 0  |
+      | 10 |
 
   Scenario: get DAV properties for a user share reshared with a room
     Given user "participant1" creates room "group room" (v4)
@@ -1180,7 +1188,12 @@ Feature: get
     And user "participant2" shares "welcome (2).txt" with room "group room" with OCS 100
     When user "participant1" gets the share-type DAV property for "/welcome.txt"
     Then the response contains a share-types DAV property with
-      | 0 |
+      | 0  |
+      | 10 |
+    When user "participant2" gets the share-type DAV property for "welcome (2).txt"
+    Then the response contains a share-types DAV property with
+      | 0  |
+      | 10 |
 
   Scenario: get DAV properties for a room share reshared with a user as the resharer
     Given user "participant1" creates room "group room" (v4)
@@ -1193,9 +1206,13 @@ Feature: get
     And user "participant1" shares "welcome.txt" with room "group room" with OCS 100
     And user "participant2" shares "Talk/welcome.txt" with user "participant3" with OCS 100
     And user "participant3" accepts last share
+    When user "participant1" gets the share-type DAV property for "welcome.txt"
+    Then the response contains a share-types DAV property with
+      | 10 |
     When user "participant2" gets the share-type DAV property for "/Talk/welcome.txt"
     Then the response contains a share-types DAV property with
-      | 0 |
+      | 0  |
+      | 10 |
 
   Scenario: get DAV properties for a user share reshared with a room as the resharer
     Given user "participant1" creates room "group room" (v4)
@@ -1208,8 +1225,13 @@ Feature: get
     And user "participant1" shares "welcome.txt" with user "participant2" with OCS 100
     And user "participant2" accepts last share
     And user "participant2" shares "welcome (2).txt" with room "group room" with OCS 100
+    When user "participant1" gets the share-type DAV property for "welcome.txt"
+    Then the response contains a share-types DAV property with
+      | 0  |
+      | 10 |
     When user "participant2" gets the share-type DAV property for "/welcome (2).txt"
     Then the response contains a share-types DAV property with
+      | 0  |
       | 10 |
 
   # Reshares are taken into account only for the files in the folder, not the


### PR DESCRIPTION
### ☑️ Resolves

* Close #12504
* Adjusting test expectations after server changes (loading incoming and outgoing shares now) https://github.com/nextcloud/server/pull/45698


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
