### PR TITLE
fix: duplicate stun and turn servers cannot be added

### DIFF
--- a/lib/Command/Stun/Add.php
+++ b/lib/Command/Stun/Add.php
@@ -50,6 +50,14 @@ class Add extends Base {
 			$servers = [];
 		}
 
+		// check if the server is already in the list
+		foreach ($servers as $existingServer) {
+			if ($existingServer === "$host:$port") {
+				$output->writeln('<error>Server already exists.</error>');
+				return 1;
+			}
+		}
+
 		$servers[] = "$host:$port";
 
 		$this->config->setAppValue('spreed', 'stun_servers', json_encode($servers));

--- a/lib/Command/Turn/Add.php
+++ b/lib/Command/Turn/Add.php
@@ -98,6 +98,19 @@ class Add extends Base {
 			$servers = [];
 		}
 
+		//Checking if the server is already added
+		foreach ($servers as $existingServer) {
+			if (
+				$existingServer['schemes'] === $schemes &&
+				$existingServer['server'] === $server &&
+				$existingServer['protocols'] === $protocols
+			) {
+				$output->writeln('<error>Server already exists with the same configuration.</error>');
+				return 1;
+			}
+		}
+
+
 		$servers[] = [
 			'schemes' => $schemes,
 			'server' => $server,

--- a/tests/php/Command/Stun/AddTest.php
+++ b/tests/php/Command/Stun/AddTest.php
@@ -85,4 +85,20 @@ class AddTest extends TestCase {
 
 		self::invokePrivate($this->command, 'execute', [$this->input, $this->output]);
 	}
+
+	public function testAddDuplicateServer(): void {
+		$this->input->method('getArgument')
+			->with('server')
+			->willReturn('stun.test.com:443');
+		$this->config->method('getAppValue')
+			->with('spreed', 'stun_servers')
+			->willReturn(json_encode(['stun.test.com:443']));
+		$this->config->expects($this->never())
+			->method('setAppValue');
+		$this->output->expects($this->once())
+			->method('writeln')
+			->with($this->equalTo('<error>Server already exists.</error>'));
+	
+		$this->assertSame(1, self::invokePrivate($this->command, 'execute', [$this->input, $this->output]));
+	}
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11852

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Implemented logic to check if a TURN/STUN server is already added before adding a new one
- [x] Added a test case for checking duplicate servers

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
