### PR TITLE
fix: Fix broken audio in Safari after disconnecting node

### DIFF
--- a/src/utils/webrtc/CallParticipantsAudioPlayer.js
+++ b/src/utils/webrtc/CallParticipantsAudioPlayer.js
@@ -162,6 +162,10 @@ CallParticipantsAudioPlayer.prototype = {
 			} else if (!audioAvailable && audioNode.connected) {
 				audioNode.audioSource.disconnect(this._audioDestination)
 				audioNode.connected = false
+
+				// Force creating a new audio renderer to work around broken
+				// audio output in Safari after disconnecting a node.
+				this._audioElement.srcObject = this._audioDestination.stream
 			}
 
 			return


### PR DESCRIPTION
Follow up to #12497 (see https://github.com/nextcloud/spreed/pull/12497#pullrequestreview-2115081704)

It seems that Safari loops the audio buffer (or something like that) when disconnecting an audio node from a destination node being played, so if a remote participant mutes while speaking Safari plays weird noises. To work around that now the source of the output media element is set again whenever a node is disconnected to force creating a new audio renderer.

Kudos to @SystemKeeper for finding [this nugget](https://bugs.webkit.org/show_bug.cgi?id=198545#c16) in Safari bug tracker and thus avoiding a more complex work around :-)

**Reviewers:** please check the scenarios below without this pull request to ensure that the problem can be reproduced. Specially please check scenario 2, as the issue might occur only when disconnecting the last active node, rather than just when disconnecting any node (and it would be good to know that :-) ).

## How to test (scenario 1)

- Create a conversation
- In Safari, start a call
- In another browser/device, join the call with audio (Firefox with fake streams might be convenient, as it is required to "speak" to test this)
- Mute while speaking

### Result with this pull request

No strange noises are played in Safari

### Result without this pull request

Strange noises are played in Safari

## How to test (scenario 2)

- Create a conversation
- In Safari, start a call
- In another browser/device, join the call with audio (again Firefox might be convenient)
- In yet another browser/device, join the call with audio (a real microphone rather than fake streams would be convenient to be able to listen without muting)
- Mute while speaking on just one of the non-Safari clients (if you are using Firefox with fake streams then mute there)

### Result with this pull request

No strange noises are played in Safari

### Result without this pull request

Strange noises are played in Safari

## How to test (scenario 3)

- Create a conversation
- In Safari, start a call
- Change to another tab
- Wait a little
- In another browser/device, join the call with audio (Firefox with fake streams might be convenient, as it is required to "speak" to test this)
- Mute while speaking
- Unmute and speak again

### Result with this pull request

No strange noises were played in Safari while muted; after unmuting the other participant can be heard

### Result without this pull request

Strange noises are played in Safari while muted
