### PR TITLE
fix: pass returned promise instead of function

### DIFF
--- a/src/components/NewConversationDialog/NewConversationDialog.vue
+++ b/src/components/NewConversationDialog/NewConversationDialog.vue
@@ -300,7 +300,7 @@ export default {
 				}
 
 				if (this.isAvatarEdited) {
-					promises.push(this.$refs.setupPage.$refs.conversationAvatar.saveAvatar)
+					promises.push(this.$refs.setupPage.$refs.conversationAvatar.saveAvatar())
 				}
 
 				if (this.newConversation.description) {


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #12431 
  * we should push a result `function()`, not a `function` itself 

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

| 🏡 After |
| -- |
![image](https://github.com/nextcloud/spreed/assets/93392545/7248c33c-3aa3-4290-95e1-017ce8a254eb)
