### PR TITLE
fix: pass both arguments to the method

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -1182,7 +1182,7 @@ export default {
 							token: this.token,
 							id: focusedId,
 						})
-						await this.getMessageContext(focusedId)
+						await this.getMessageContext(this.token, focusedId)
 						this.focusMessage(focusedId, true)
 					}
 				}


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #12492
  * first argument (token) was added to the method

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/2a969246-f385-4353-b070-006dc28f8563) | ![image](https://github.com/nextcloud/spreed/assets/93392545/c2161fc0-2f0e-4a34-a562-22b75d27c31c)
