### PR TITLE
fix(federation): update counter after invites store update

### DIFF
--- a/src/stores/__tests__/federation.spec.js
+++ b/src/stores/__tests__/federation.spec.js
@@ -249,7 +249,7 @@ describe('federationStore', () => {
 		expect(rejectShare).toHaveBeenCalledWith(invites[0].id)
 		expect(federationStore.pendingShares).toStrictEqual({})
 		expect(federationStore.acceptedShares).toMatchObject({ [invites[1].id]: invites[1] })
-		expect(federationStore.pendingSharesCount).toBe(1)
+		expect(federationStore.pendingSharesCount).toBe(0)
 	})
 
 	it('skip already rejected invitations', async () => {

--- a/src/stores/federation.ts
+++ b/src/stores/federation.ts
@@ -135,8 +135,8 @@ export const useFederationStore = defineStore('federation', {
 			try {
 				Vue.set(this.pendingShares[id], 'loading', 'reject')
 				await rejectShare(id)
-				this.updatePendingSharesCount(Object.keys(this.pendingShares).length)
 				Vue.delete(this.pendingShares, id)
+				this.updatePendingSharesCount(Object.keys(this.pendingShares).length)
 			} catch (error) {
 				console.error(error)
 				showError(t('spreed', 'An error occurred while rejecting an invitation'))


### PR DESCRIPTION
### ☑️ Resolves

Ref #12340: we should remove update the object records count after updating themselves.

