### PR TITLE
fix(CallTime): stop showing hint for participants who joined after 1 hour. 

### DIFF
--- a/src/components/TopBar/CallTime.vue
+++ b/src/components/TopBar/CallTime.vue
@@ -70,6 +70,8 @@ import NcPopover from '@nextcloud/vue/dist/Components/NcPopover.js'
 import { CALL } from '../../constants.js'
 import { formattedTime } from '../../utils/formattedTime.ts'
 
+const ONE_HOUR_MS = 60 * 60 * 1000
+
 export default {
 	name: 'CallTime',
 
@@ -97,7 +99,6 @@ export default {
 			showPopover: false,
 			isCallDurationHintShown: false,
 			timer: null,
-			untilCallDurationHintShown: null,
 		}
 	},
 
@@ -154,11 +155,8 @@ export default {
 
 	watch: {
 		callTime(value) {
-			if (value && !this.untilCallDurationHintShown) {
-				this.untilCallDurationHintShown = (1000 * 60 * 60) - value + 1000
-				setTimeout(() => {
-					this.showCallDurationHint()
-				}, this.untilCallDurationHintShown)
+			if (value > ONE_HOUR_MS && value < (ONE_HOUR_MS + 10000) && !this.isCallDurationHintShown) {
+				this.showCallDurationHint()
 			}
 		},
 	},


### PR DESCRIPTION
### ☑️ Resolves

It makes sense if attendees who joined after 1h and 10 sec to not see the hint. 

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

