### PR TITLE
fix(chat): show spinner for temporary / edited messages

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -66,7 +66,7 @@
 
 		<!-- Additional message info-->
 		<div v-if="!isDeletedMessage" class="message-main__info">
-			<span v-if="!hideDate" class="date" :title="messageDate">{{ messageTime }}</span>
+			<span :class="['date', { 'date--hidden': hideDate }]" :title="messageDate">{{ messageTime }}</span>
 
 			<!-- Message delivery status indicators -->
 			<div v-if="message.sendingFailure"
@@ -237,17 +237,11 @@ export default {
 		},
 
 		messageTime() {
-			if (this.hideDate) {
-				return null
-			}
-			return moment(this.message.timestamp * 1000).format('LT')
+			return moment(this.isTemporary ? undefined : this.message.timestamp * 1000).format('LT')
 		},
 
 		messageDate() {
-			if (this.hideDate) {
-				return null
-			}
-			return moment(this.message.timestamp * 1000).format('LL')
+			return moment(this.isTemporary ? undefined : this.message.timestamp * 1000).format('LL')
 		},
 
 		isLastCallStartedMessage() {
@@ -481,8 +475,15 @@ export default {
 		flex: 1 0 auto;
 		padding: 0 calc(2 * var(--default-grid-baseline));
 
-		.date:last-child {
-			margin-right: var(--default-clickable-area);
+		.date {
+			&--hidden {
+				pointer-events: none;
+				opacity: 0;
+			}
+
+			&:last-child {
+				margin-right: var(--default-clickable-area);
+			}
 		}
 	}
 }

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -195,6 +195,7 @@ export default {
 
 	data() {
 		return {
+			isEditing: false,
 			showReloadButton: false,
 			codeBlocks: null,
 			currentCodeBlock: null,
@@ -267,7 +268,7 @@ export default {
 		},
 
 		showLoadingIcon() {
-			return (this.isTemporary && !this.isFileShare) || this.isDeleting
+			return this.isTemporary || this.isDeleting || this.isEditing
 		},
 
 		loadingIconTooltip() {
@@ -303,6 +304,7 @@ export default {
 	},
 
 	mounted() {
+		EventBus.on('editing-message-processing', this.setIsEditing)
 		if (!this.containsCodeBlocks) {
 			return
 		}
@@ -395,7 +397,13 @@ export default {
 				console.error(error)
 				showError(t('spreed', 'Could not update the message'))
 			}
-		}
+		},
+
+		setIsEditing({ messageId, value }) {
+			if (messageId === this.message.id) {
+				this.isEditing = value
+			}
+		},
 	},
 }
 </script>

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -638,6 +638,7 @@ const actions = {
 	 * @param {string} payload.updatedMessage The modified text of the message / file share caption
 	 */
 	async editMessage(context, { token, messageId, updatedMessage }) {
+		EventBus.emit('editing-message-processing', { messageId, value: true })
 		const message = Object.assign({}, context.getters.message(token, messageId))
 		context.commit('addMessage', {
 			token,
@@ -651,10 +652,12 @@ const actions = {
 				updatedMessage,
 			})
 			context.dispatch('processMessage', { token, message: response.data.ocs.data })
+			EventBus.emit('editing-message-processing', { messageId, value: false })
 		} catch (error) {
 			console.error(error)
 			// Restore the previous message state
 			context.commit('addMessage', { token, message })
+			EventBus.emit('editing-message-processing', { messageId, value: false })
 			throw error
 		}
 	},


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12454
  * Reserve space for time element for all processed messages:
    * file uploads
    * edited messages
    * new messages
  * Show spinner for:
    * file uploads
    * edited messages

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/09057090-ad39-4ac3-98e9-8010e3e8e8d8) | ![image](https://github.com/nextcloud/spreed/assets/93392545/251477de-0492-404e-8221-7fed372729c5)
![image](https://github.com/nextcloud/spreed/assets/93392545/f55a4c5f-4693-4553-9079-fd72e571c645) | ![image](https://github.com/nextcloud/spreed/assets/93392545/623c929c-aa47-4493-bcbe-01b0d5f35ad6)
![image](https://github.com/nextcloud/spreed/assets/93392545/02655dd8-10c6-4111-b5e0-01c3f63a9f9f) | ![image](https://github.com/nextcloud/spreed/assets/93392545/a862285f-cdd4-40e8-a214-f4491e5e4734)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible