### PR TITLE
feat(bots): Add events for enabling and disabling bots

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -176,6 +176,20 @@ listen to the `OCA\Talk\Events\SystemMessagesMultipleSentEvent` event instead.
 * After event: *Not available*
 * Since: 18.0.0
 
+### Bot enabled
+
+Sends a request to the bot server, informing it was added in a chat.
+
+* Event: `OCA\Talk\Events\BotEnabledEvent`
+* Since: 20.0.0
+
+### Bot disabled
+
+Sends a request to the bot server, informing it was removed from a chat.
+
+* Event: `OCA\Talk\Events\BotDisabledEvent`
+* Since: 20.0.0
+
 ## Inbound events to invoke Talk
 
 ### Bot install

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -43,6 +43,8 @@ use OCA\Talk\Events\BeforeRoomDeletedEvent;
 use OCA\Talk\Events\BeforeRoomsFetchEvent;
 use OCA\Talk\Events\BeforeSessionLeftRoomEvent;
 use OCA\Talk\Events\BeforeUserJoinedRoomEvent;
+use OCA\Talk\Events\BotDisabledEvent;
+use OCA\Talk\Events\BotEnabledEvent;
 use OCA\Talk\Events\BotInstallEvent;
 use OCA\Talk\Events\BotUninstallEvent;
 use OCA\Talk\Events\CallEndedForEveryoneEvent;
@@ -174,6 +176,8 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(SessionLeftRoomEvent::class, ActivityListener::class, -100);
 
 		// Bot listeners
+		$context->registerEventListener(BotDisabledEvent::class, BotListener::class);
+		$context->registerEventListener(BotEnabledEvent::class, BotListener::class);
 		$context->registerEventListener(BotInstallEvent::class, BotListener::class);
 		$context->registerEventListener(BotUninstallEvent::class, BotListener::class);
 		$context->registerEventListener(ChatMessageSentEvent::class, BotListener::class);

--- a/lib/Events/BotDisabledEvent.php
+++ b/lib/Events/BotDisabledEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Events;
+
+use OCA\Talk\Model\BotServer;
+use OCA\Talk\Room;
+
+class BotDisabledEvent extends ARoomEvent {
+
+	public function __construct(
+		Room $room,
+		protected BotServer $botServer,
+	) {
+		parent::__construct($room);
+	}
+
+	public function getBotServer(): BotServer {
+		return $this->botServer;
+	}
+}

--- a/lib/Events/BotEnabledEvent.php
+++ b/lib/Events/BotEnabledEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Events;
+
+use OCA\Talk\Model\BotServer;
+use OCA\Talk\Room;
+
+class BotEnabledEvent extends ARoomEvent {
+
+	public function __construct(
+		Room $room,
+		protected BotServer $botServer,
+	) {
+		parent::__construct($room);
+	}
+
+	public function getBotServer(): BotServer {
+		return $this->botServer;
+	}
+}

--- a/lib/Listener/BotListener.php
+++ b/lib/Listener/BotListener.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace OCA\Talk\Listener;
 
 use OCA\Talk\Chat\MessageParser;
+use OCA\Talk\Events\BotDisabledEvent;
+use OCA\Talk\Events\BotEnabledEvent;
 use OCA\Talk\Events\BotInstallEvent;
 use OCA\Talk\Events\BotUninstallEvent;
 use OCA\Talk\Events\ChatMessageSentEvent;
@@ -47,17 +49,24 @@ class BotListener implements IEventListener {
 			return;
 		}
 
-		/** @var BotService $service */
-		$service = Server::get(BotService::class);
+		if ($event instanceof BotEnabledEvent) {
+			$this->botService->afterBotEnabled($event);
+			return;
+		}
+		if ($event instanceof BotDisabledEvent) {
+			$this->botService->afterBotDisabled($event);
+			return;
+		}
+
 		/** @var MessageParser $messageParser */
 		$messageParser = Server::get(MessageParser::class);
 
 		if ($event instanceof ChatMessageSentEvent) {
-			$service->afterChatMessageSent($event, $messageParser);
+			$this->botService->afterChatMessageSent($event, $messageParser);
 			return;
 		}
 		if ($event instanceof SystemMessageSentEvent) {
-			$service->afterSystemMessageSent($event, $messageParser);
+			$this->botService->afterSystemMessageSent($event, $messageParser);
 		}
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11461 

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## Overview
* The PR introduces BotEnabledEvent and BotDisabledEvent.
* These events are dispatched when a bot is enabled or disabled through controller or occ. 
* And sends an asynchronous request to the bot server when these events occur.

This allows the bot server to be notified when a bot is enabled or disabled, enabling it to take appropriate action.

### Demo Example

https://github.com/nextcloud/spreed/assets/88997516/2b555435-3eea-4e95-aefd-f6d159222c9c



### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
