### PR TITLE
[stable29] perf(sharing): Use getFirstNodeById() which is more performant

### DIFF
--- a/lib/Chat/Parser/SystemMessage.php
+++ b/lib/Chat/Parser/SystemMessage.php
@@ -756,17 +756,18 @@ class SystemMessage implements IEventListener {
 		if ($participant && $participant->getAttendee()->getActorType() === Attendee::ACTOR_USERS) {
 			if ($share->getShareOwner() !== $participant->getAttendee()->getActorId()) {
 				$userFolder = $this->rootFolder->getUserFolder($participant->getAttendee()->getActorId());
-				if ($userFolder instanceof Node) {
-					$userNodes = $userFolder->getById($share->getNodeId());
+				if (!$userFolder instanceof Node) {
+					throw new ShareNotFound();
+				}
 
-					if (empty($userNodes)) {
-						// FIXME This should be much more sensible, e.g.
-						// 1. Only be executed on "Waiting for new messages"
-						// 2. Once per request
-						\OC_Util::tearDownFS();
-						\OC_Util::setupFS($participant->getAttendee()->getActorId());
-						$userNodes = $userFolder->getById($share->getNodeId());
-					}
+				$node = $userFolder->getFirstNodeById($share->getNodeId());
+				if (!$node instanceof Node) {
+					// FIXME This should be much more sensible, e.g.
+					// 1. Only be executed on "Waiting for new messages"
+					// 2. Once per request
+					\OC_Util::tearDownFS();
+					\OC_Util::setupFS($participant->getAttendee()->getActorId());
+					$userNodes = $userFolder->getById($share->getNodeId());
 
 					if (empty($userNodes)) {
 						throw new NotFoundException('File was not found');
@@ -774,12 +775,13 @@ class SystemMessage implements IEventListener {
 
 					/** @var Node $node */
 					$node = reset($userNodes);
-					$fullPath = $node->getPath();
-					$pathSegments = explode('/', $fullPath, 4);
-					$name = $node->getName();
-					$size = $node->getSize();
-					$path = $pathSegments[3] ?? $name;
 				}
+
+				$fullPath = $node->getPath();
+				$pathSegments = explode('/', $fullPath, 4);
+				$name = $node->getName();
+				$size = $node->getSize();
+				$path = $pathSegments[3] ?? $name;
 			} else {
 				$node = $share->getNode();
 				$name = $node->getName();

--- a/tests/php/Chat/Parser/SystemMessageTest.php
+++ b/tests/php/Chat/Parser/SystemMessageTest.php
@@ -873,7 +873,11 @@ class SystemMessageTest extends TestCase {
 			->willReturn($share);
 
 		$userFolder = $this->createMock(Folder::class);
-		$userFolder->expects($this->exactly(2))
+		$userFolder->expects($this->once())
+			->method('getFirstNodeById')
+			->with('54')
+			->willReturn(null);
+		$userFolder->expects($this->once())
 			->method('getById')
 			->with('54')
 			->willReturn([]);


### PR DESCRIPTION
As we don't care which node we get for rendering the message
As suggested by icewind

## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
