### PR TITLE
fix: Broken links in documentation

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -2,14 +2,14 @@
 
 ### Short version
 
- * The [**issue template can be found here**](https://raw.github.com/nextcloud/spreed/main/.github/issue_template.md) but be aware of the different repositories! See list below. Please always use the issue template when reporting issues.
+ * Here you can find the [**bug report template**](https://raw.github.com/nextcloud/spreed/main/.github/ISSUE_TEMPLATE/1_bug_report.md) and [**feature request template**](https://raw.github.com/nextcloud/spreed/main/.github/ISSUE_TEMPLATE/2_feature_request.md), but be aware of the different repositories! See list below. Please always use the issue template when reporting issues.
 
 ### Guidelines
 * Please search the existing issues first, it's likely that your issue was already reported or even fixed.
   - Go to one of the repositories, click "issues" and type any word in the top search/command bar.
   - You can also filter by appending e. g. "state:open" to the search string.
   - More info on [search syntax within github](https://help.github.com/articles/searching-issues)
-* Report the issue using our [template](https://raw.github.com/nextcloud/spreed/main/.github/issue_template.md), it includes all the informations we need to track down the issue.
+* Report the issue using our template for [bugs](https://raw.github.com/nextcloud/spreed/main/.github/ISSUE_TEMPLATE/1_bug_report.md) and [features](https://raw.github.com/nextcloud/spreed/main/.github/ISSUE_TEMPLATE/2_feature_request.md), it includes all the informations we need to track down the issue.
 
 If your issue appears to be a bug, and hasn't been reported, open a new issue.
 

--- a/docs/TURN.md
+++ b/docs/TURN.md
@@ -96,7 +96,7 @@ This test only verifies that your TURN server is accessible from the outside, bu
 
 For _eturnal_:
 
-The easiest way is to refer to eturnal's Quick-Start guide, e.g. [in a shell](https://github.com/processone/eturnal/blob/master/QUICK-TEST.md) or with [Docker](https://github.com/processone/eturnal/blob/master/docker-k8s/QUICK-TEST.md).
+The easiest way is to refer to eturnal's Quick-Start guide, e.g. [in a shell](https://github.com/processone/eturnal/blob/master/doc/QUICK-TEST.md) or with [Docker](https://github.com/processone/eturnal/blob/master/doc/CONTAINER-QUICK-TEST.md).
 
 ##### Test the TURN server connection from within Talk
 


### PR DESCRIPTION
Added correct links to documentation in spreed\docs\TURN.md
Minor changes to documentation and correct links added to spreed\.github\contributing.md

### ☑️ Resolves

* Fix #11489

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->
### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
