### PR TITLE
perf(participants): update participants session status from signaling

### DIFF
--- a/src/composables/useGetParticipants.js
+++ b/src/composables/useGetParticipants.js
@@ -47,6 +47,7 @@ export function useGetParticipants(isActive = ref(true), isTopBar = true) {
 			EventBus.on('signaling-users-joined', handleUsersUpdated)
 			EventBus.on('signaling-users-changed', handleUsersUpdated)
 			EventBus.on('signaling-users-left', handleUsersLeft)
+			EventBus.on('signaling-all-users-changed-in-call-to-disconnected', handleUsersDisconnected)
 		}
 
 		// FIXME this works only temporary until signaling is fixed to be only on the calls
@@ -65,7 +66,9 @@ export function useGetParticipants(isActive = ref(true), isTopBar = true) {
 	const handleUsersLeft = ([sessionIds]) => {
 		sessionStore.updateSessionsLeft(token.value, sessionIds)
 	}
-
+	const handleUsersDisconnected = () => {
+		sessionStore.updateParticipantsDisconnectedFromStandaloneSignaling(token.value)
+	}
 	/**
 	 * Stop the get participants listeners
 	 *
@@ -76,6 +79,7 @@ export function useGetParticipants(isActive = ref(true), isTopBar = true) {
 		EventBus.off('signaling-users-joined', handleUsersUpdated)
 		EventBus.off('signaling-users-changed', handleUsersUpdated)
 		EventBus.off('signaling-users-left', handleUsersLeft)
+		EventBus.off('signaling-all-users-changed-in-call-to-disconnected', handleUsersDisconnected)
 		EventBus.off('signaling-participant-list-changed', throttleUpdateParticipants)
 		unsubscribe('guest-promoted', onJoinedConversation)
 	}

--- a/src/composables/useGetParticipants.js
+++ b/src/composables/useGetParticipants.js
@@ -9,8 +9,12 @@ import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { useDocumentVisibility } from './useDocumentVisibility.ts'
 import { useIsInCall } from './useIsInCall.js'
 import { useStore } from './useStore.js'
-import { CONVERSATION } from '../constants.ts'
+import { CONFIG, CONVERSATION } from '../constants.ts'
+import { getTalkConfig } from '../services/CapabilitiesManager.ts'
 import { EventBus } from '../services/EventBus.ts'
+import { useSessionStore } from '../stores/session.ts'
+
+const experimentalUpdateParticipants = (getTalkConfig('local', 'experiments', 'enabled') ?? 0) & CONFIG.EXPERIMENTAL.UPDATE_PARTICIPANTS
 
 /**
  * @param {import('vue').Ref} isActive whether the participants tab is active
@@ -19,6 +23,7 @@ import { EventBus } from '../services/EventBus.ts'
 export function useGetParticipants(isActive = ref(true), isTopBar = true) {
 
 	// Encapsulation
+	const sessionStore = useSessionStore()
 	const store = useStore()
 	const token = computed(() => store.getters.getToken())
 	const conversation = computed(() => store.getters.conversation(token.value))
@@ -37,6 +42,12 @@ export function useGetParticipants(isActive = ref(true), isTopBar = true) {
 	 */
 	function initialiseGetParticipants() {
 		EventBus.on('joined-conversation', onJoinedConversation)
+		if (experimentalUpdateParticipants) {
+			EventBus.on('signaling-users-in-room', handleUsersUpdated)
+			EventBus.on('signaling-users-joined', handleUsersUpdated)
+			EventBus.on('signaling-users-changed', handleUsersUpdated)
+			EventBus.on('signaling-users-left', handleUsersLeft)
+		}
 
 		// FIXME this works only temporary until signaling is fixed to be only on the calls
 		// Then we have to search for another solution. Maybe the room list which we update
@@ -45,12 +56,26 @@ export function useGetParticipants(isActive = ref(true), isTopBar = true) {
 		subscribe('guest-promoted', onJoinedConversation)
 	}
 
+	const handleUsersUpdated = async ([users]) => {
+		if (sessionStore.updateSessions(token.value, users)) {
+			throttleUpdateParticipants()
+		}
+	}
+
+	const handleUsersLeft = ([sessionIds]) => {
+		sessionStore.updateSessionsLeft(token.value, sessionIds)
+	}
+
 	/**
 	 * Stop the get participants listeners
 	 *
 	 */
 	function stopGetParticipants() {
 		EventBus.off('joined-conversation', onJoinedConversation)
+		EventBus.off('signaling-users-in-room', handleUsersUpdated)
+		EventBus.off('signaling-users-joined', handleUsersUpdated)
+		EventBus.off('signaling-users-changed', handleUsersUpdated)
+		EventBus.off('signaling-users-left', handleUsersLeft)
 		EventBus.off('signaling-participant-list-changed', throttleUpdateParticipants)
 		unsubscribe('guest-promoted', onJoinedConversation)
 	}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,14 @@ export const CONFIG = {
 		REQUIRED: 1,
 		OPTIONAL: 2,
 	},
+	EXPERIMENTAL: {
+		/**
+		 * Since 21.1.0
+		 * Instead of refreshing the participant list repeatingly,
+		 * the data is generated from received signaling messages
+		 */
+		UPDATE_PARTICIPANTS: 1,
+	},
 } as const
 
 export const SIGNALING = {

--- a/src/services/EventBus.ts
+++ b/src/services/EventBus.ts
@@ -7,7 +7,14 @@ import mitt from 'mitt'
 import type { Emitter, EventType, Handler, WildcardHandler } from 'mitt'
 import type { Route } from 'vue-router'
 
-import type { ChatMessage, Conversation, Participant, SignalingSettings } from '../types/index.ts'
+import type {
+	ChatMessage,
+	Conversation,
+	InternalSignalingSession,
+	SignalingSettings,
+	StandaloneSignalingJoinSession,
+	StandaloneSignalingUpdateSession,
+} from '../types/index.ts'
 import type { components } from '../types/openapi/openapi-full.ts'
 
 // List of used events across the app
@@ -39,8 +46,11 @@ export type Events = {
 	'signaling-participant-list-changed': void,
 	'signaling-recording-status-changed': [string, number],
 	'signaling-settings-updated': [SignalingSettings],
-	'signaling-users-changed': [(Partial<Participant> & ({ sessionId: string } | { nextcloudSessionId: string }))[]],
-	'signaling-users-in-room': [{ sessionId: string, userId: string }[]],
+	'signaling-users-changed': [StandaloneSignalingUpdateSession[]],
+	'signaling-users-in-room': [InternalSignalingSession[]],
+	'signaling-users-joined': [StandaloneSignalingJoinSession[]],
+	'signaling-users-left': [string[]],
+	'signaling-all-users-changed-in-call-to-disconnected': void,
 	'smart-picker-open': void,
 	'switch-to-conversation': { token: string },
 	'talk:poll-added': { token: string, message: ChatMessage },

--- a/src/store/participantsStore.spec.js
+++ b/src/store/participantsStore.spec.js
@@ -35,6 +35,7 @@ import {
 	removeAllPermissionsFromParticipant,
 } from '../services/participantsService.js'
 import { useGuestNameStore } from '../stores/guestName.js'
+import { useSessionStore } from '../stores/session.ts'
 import { generateOCSErrorResponse, generateOCSResponse } from '../test-helpers.js'
 
 jest.mock('../services/participantsService', () => ({
@@ -397,9 +398,18 @@ describe('participantsStore', () => {
 			// Arrange
 			const payload = [{
 				attendeeId: 1,
-				sessionId: 'session-id-1',
+				sessionIds: ['session-id-1'],
 				inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
 			}]
+
+			const sessionStore = useSessionStore()
+			sessionStore.addSession({
+				attendeeId: undefined,
+				token: TOKEN,
+				signalingSessionId: 'signaling-session-id-1',
+				sessionId: 'session-id-1',
+				inCall: undefined,
+			})
 
 			fetchParticipants.mockResolvedValue(generateOCSResponse({ payload }))
 
@@ -408,6 +418,11 @@ describe('participantsStore', () => {
 
 			// Assert
 			expect(store.getters.participantsList(TOKEN)).toMatchObject(payload)
+			expect(sessionStore.getSession('signaling-session-id-1')).toMatchObject({
+				attendeeId: 1,
+				sessionId: 'session-id-1',
+				inCall: PARTICIPANT.CALL_FLAG.DISCONNECTED,
+			})
 		})
 
 		test('populates store for the fetched conversation', async () => {

--- a/src/stores/__tests__/session.spec.js
+++ b/src/stores/__tests__/session.spec.js
@@ -98,4 +98,203 @@ describe('sessionStore', () => {
 			expect(sessionStore.findOrCreateSession(TOKEN, {})).toBe(null)
 		})
 	})
+
+	describe('internal session', () => {
+		const participantsPayload = [
+			{
+				actorId: 'user1',
+				actorType: ATTENDEE.ACTOR_TYPE.USERS,
+				roomId: 1,
+				userId: 'user1',
+				sessionId: 'nextcloud-session-id-1',
+				inCall: 7,
+				lastPing: 1717192800,
+				participantPermissions: 254
+			},
+			{
+				actorId: 'user2',
+				actorType: ATTENDEE.ACTOR_TYPE.USERS,
+				roomId: 1,
+				userId: 'user2',
+				sessionId: 'nextcloud-session-id-2',
+				inCall: 7,
+				lastPing: 1717192800,
+				participantPermissions: 254
+			},
+			{
+				actorId: 'user2',
+				actorType: ATTENDEE.ACTOR_TYPE.USERS,
+				roomId: 1,
+				userId: 'user2',
+				sessionId: 'nextcloud-session-id-3',
+				inCall: 3,
+				lastPing: 1717192800,
+				participantPermissions: 254
+			},
+			{
+				actorId: 'hex',
+				actorType: ATTENDEE.ACTOR_TYPE.GUESTS,
+				roomId: 1,
+				userId: '',
+				sessionId: 'nextcloud-session-id-5',
+				inCall: 7,
+				lastPing: 1717192800,
+				participantPermissions: 254
+			},
+		]
+
+		it('should return a mapped object for a known session from participants store', () => {
+			// Arrange
+			populateParticipantsStore()
+
+			// Act
+			const unknownResults = sessionStore.updateSessions(TOKEN, participantsPayload)
+
+			// Assert
+			expect(unknownResults).toBeFalsy()
+			expect(Object.keys(sessionStore.sessions)).toHaveLength(4)
+			expect(sessionStore.getSession('nextcloud-session-id-1'))
+				.toMatchObject({
+					token: TOKEN,
+					attendeeId: 1,
+					sessionId: 'nextcloud-session-id-1',
+					signalingSessionId: 'nextcloud-session-id-1'
+				})
+			expect(sessionStore.getSession('nextcloud-session-id-2'))
+				.toMatchObject({
+					token: TOKEN,
+					attendeeId: 2,
+					sessionId: 'nextcloud-session-id-2',
+					signalingSessionId: 'nextcloud-session-id-2'
+				})
+			expect(sessionStore.getSession('nextcloud-session-id-3'))
+				.toMatchObject({
+					token: TOKEN,
+					attendeeId: 2,
+					sessionId: 'nextcloud-session-id-3',
+					signalingSessionId: 'nextcloud-session-id-3'
+				})
+			expect(sessionStore.getSession('nextcloud-session-id-5'))
+				.toMatchObject({
+					token: TOKEN,
+					attendeeId: 5,
+					sessionId: 'nextcloud-session-id-5',
+					signalingSessionId: 'nextcloud-session-id-5'
+				})
+		})
+
+		it('should update participant objects for a known session', () => {
+			// Arrange
+			populateParticipantsStore()
+
+			// Act
+			const unknownResults = sessionStore.updateSessions(TOKEN, participantsPayload)
+
+			// Assert
+			expect(unknownResults).toBeFalsy()
+			expect(vuexStore.commit).toHaveBeenCalledTimes(3)
+			expect(vuexStore.commit).toHaveBeenNthCalledWith(1, 'updateParticipant',
+				{
+					token: TOKEN,
+					attendeeId: 1,
+					updatedData: {
+						inCall: 7,
+						lastPing: 1717192800,
+						permissions: 254,
+						sessionIds: ['nextcloud-session-id-1']
+					}
+				})
+			expect(vuexStore.commit).toHaveBeenNthCalledWith(2, 'updateParticipant',
+				{
+					token: TOKEN,
+					attendeeId: 2,
+					updatedData: {
+						inCall: 7,
+						lastPing: 1717192800,
+						permissions: 254,
+						sessionIds: ['nextcloud-session-id-2', 'nextcloud-session-id-3']
+					}
+				})
+			expect(vuexStore.commit).toHaveBeenNthCalledWith(3, 'updateParticipant',
+				{
+					token: TOKEN,
+					attendeeId: 5,
+					updatedData: {
+						inCall: 7,
+						lastPing: 1717192800,
+						permissions: 254,
+						sessionIds: ['nextcloud-session-id-5']
+					}
+				})
+		})
+
+		it('should handle unknown sessions', () => {
+			// Arrange
+			populateParticipantsStore()
+			const sessionsPayload = [
+				...participantsPayload,
+				{
+					actorId: 'user-unknown',
+					actorType: ATTENDEE.ACTOR_TYPE.USERS,
+					roomId: 1,
+					userId: 'user-unknown',
+					sessionId: 'nextcloud-session-id-unknown'
+				}
+			]
+
+			// Act
+			const unknownResults = sessionStore.updateSessions(TOKEN, sessionsPayload)
+
+			// Assert
+			expect(unknownResults).toBeTruthy()
+			expect(sessionStore.orphanSessions).toHaveLength(1)
+			expect(Object.keys(sessionStore.sessions)).toHaveLength(5)
+			expect(sessionStore.getSession('nextcloud-session-id-unknown'))
+				.toMatchObject({
+					token: TOKEN,
+					attendeeId: undefined,
+					sessionId: 'nextcloud-session-id-unknown',
+					signalingSessionId: 'nextcloud-session-id-unknown'
+				})
+		})
+
+		it('should remove old sessions and update participant objects', () => {
+			// Arrange
+			populateParticipantsStore()
+			const newParticipantsPayload = [
+				{
+					roomId: 1,
+					userId: 'user2',
+					sessionId: 'nextcloud-session-id-3',
+					inCall: 3,
+					lastPing: 1717192800,
+					participantPermissions: 254
+				},
+			]
+			sessionStore.updateSessions(TOKEN, participantsPayload)
+
+			// Act
+			sessionStore.updateSessions(TOKEN, newParticipantsPayload)
+
+			// Assert
+			expect(Object.keys(sessionStore.sessions)).toHaveLength(1)
+			expect(sessionStore.getSession('nextcloud-session-id-1')).toBeUndefined()
+			expect(vuexStore.commit).toHaveBeenCalledTimes(6)
+			expect(vuexStore.commit).toHaveBeenNthCalledWith(4, 'updateParticipant',
+				{ token: TOKEN, attendeeId: 1, updatedData: { inCall: 0, sessionIds: [] } })
+			expect(vuexStore.commit).toHaveBeenNthCalledWith(5, 'updateParticipant',
+				{
+					token: TOKEN,
+					attendeeId: 2,
+					updatedData: {
+						inCall: 3,
+						lastPing: 1717192800,
+						permissions: 254,
+						sessionIds: ['nextcloud-session-id-3']
+					}
+				})
+			expect(vuexStore.commit).toHaveBeenNthCalledWith(6, 'updateParticipant',
+				{ token: TOKEN, attendeeId: 5, updatedData: { inCall: 0, sessionIds: [] } })
+		})
+	})
 })

--- a/src/stores/__tests__/session.spec.js
+++ b/src/stores/__tests__/session.spec.js
@@ -297,4 +297,252 @@ describe('sessionStore', () => {
 				{ token: TOKEN, attendeeId: 5, updatedData: { inCall: 0, sessionIds: [] } })
 		})
 	})
+
+	describe('standalone session', () => {
+		const participantsJoinedPayload = [
+			{
+				userid: 'user1',
+				user: { displayname: 'User 1' },
+				sessionid: 'session-id-1',
+				roomsessionid: 'nextcloud-session-id-1'
+			},
+			{
+				userid: 'user2',
+				user: { displayname: 'User 2' },
+				sessionid: 'session-id-2',
+				roomsessionid: 'nextcloud-session-id-2'
+			},
+			{
+				userid: 'user2',
+				sessionid: 'session-id-3',
+				roomsessionid: 'nextcloud-session-id-3'
+			},
+			{
+				userid: 'user4',
+				federated: true,
+				user: { displayname: 'User 4' },
+				sessionid: 'session-id-4',
+				roomsessionid: 'nextcloud-session-id-4'
+			},
+			{
+				userid: '',
+				user: { displayname: 'Guest' },
+				sessionid: 'session-id-5',
+				roomsessionid: 'nextcloud-session-id-5'
+			},
+		]
+
+		const participantsChangedPayload = [
+			{
+				userId: 'user1',
+				sessionId: 'session-id-1',
+				inCall: 7,
+				participantType: 1,
+				lastPing: 1717192800,
+				participantPermissions: 254
+			},
+			{
+				userId: 'user2',
+				sessionId: 'session-id-2',
+				inCall: 7,
+				participantType: 3,
+				lastPing: 1717192800,
+				participantPermissions: 254
+			},
+			{
+				userId: 'user2',
+				sessionId: 'session-id-3',
+				inCall: 3,
+				participantType: 3,
+				lastPing: 1717192800,
+				participantPermissions: 254
+			},
+			{
+				userId: 'user4',
+				sessionId: 'session-id-4',
+				inCall: 0,
+				participantType: 3,
+				lastPing: 1717192800,
+				participantPermissions: 254
+			},
+			{
+				userId: '',
+				displayName: 'Guest New',
+				sessionId: 'session-id-5',
+				inCall: 7,
+				participantType: 6,
+				lastPing: 1717192800,
+				participantPermissions: 254
+			},
+			{
+				userId: '',
+				sessionId: 'session-id-unknown',
+				inCall: 7,
+				participantType: 3,
+				lastPing: 1717192800,
+				participantPermissions: 254
+			},
+		]
+
+		it('should return a mapped object for a known session', () => {
+			// Arrange
+			populateParticipantsStore()
+
+			// Act
+			const unknownResults = sessionStore.updateSessions(TOKEN, participantsJoinedPayload)
+
+			// Assert
+			expect(unknownResults).toBeFalsy()
+			expect(Object.keys(sessionStore.sessions)).toHaveLength(5)
+			expect(sessionStore.getSession('session-id-1'))
+				.toMatchObject({
+					token: TOKEN,
+					attendeeId: 1,
+					sessionId: 'nextcloud-session-id-1',
+					signalingSessionId: 'session-id-1'
+				})
+			expect(sessionStore.getSession('session-id-2'))
+				.toMatchObject({
+					token: TOKEN,
+					attendeeId: 2,
+					sessionId: 'nextcloud-session-id-2',
+					signalingSessionId: 'session-id-2'
+				})
+			expect(sessionStore.getSession('session-id-3'))
+				.toMatchObject({
+					token: TOKEN,
+					attendeeId: 2,
+					sessionId: 'nextcloud-session-id-3',
+					signalingSessionId: 'session-id-3'
+				})
+			expect(sessionStore.getSession('session-id-4'))
+				.toMatchObject({
+					token: TOKEN,
+					attendeeId: 4,
+					sessionId: 'nextcloud-session-id-4',
+					signalingSessionId: 'session-id-4'
+				})
+			expect(sessionStore.getSession('session-id-5'))
+				.toMatchObject({
+					token: TOKEN,
+					attendeeId: 5,
+					sessionId: 'nextcloud-session-id-5',
+					signalingSessionId: 'session-id-5'
+				})
+		})
+
+		it('should update participant objects for a known session on join', () => {
+			// Arrange
+			populateParticipantsStore()
+
+			// Act
+			const unknownResults = sessionStore.updateSessions(TOKEN, participantsJoinedPayload)
+
+			// Assert
+			expect(unknownResults).toBeFalsy()
+			expect(vuexStore.commit).toHaveBeenCalledTimes(5)
+			expect(vuexStore.commit).toHaveBeenNthCalledWith(1, 'updateParticipant',
+				{
+					token: TOKEN,
+					attendeeId: 1,
+					updatedData: { displayName: 'User 1', sessionIds: ['nextcloud-session-id-1'] }
+				})
+			expect(vuexStore.commit).toHaveBeenNthCalledWith(2, 'updateParticipant',
+				{
+					token: TOKEN,
+					attendeeId: 2,
+					updatedData: { displayName: 'User 2', sessionIds: ['nextcloud-session-id-2'] }
+				})
+			expect(vuexStore.commit).toHaveBeenNthCalledWith(3, 'updateParticipant',
+				{
+					token: TOKEN,
+					attendeeId: 2,
+					updatedData: {
+						displayName: 'User 2',
+						sessionIds: ['nextcloud-session-id-2', 'nextcloud-session-id-3']
+					}
+				})
+			expect(vuexStore.commit).toHaveBeenNthCalledWith(4, 'updateParticipant',
+				{
+					token: TOKEN,
+					attendeeId: 4,
+					updatedData: { displayName: 'User 4', sessionIds: ['nextcloud-session-id-4'] }
+				})
+			expect(vuexStore.commit).toHaveBeenNthCalledWith(5, 'updateParticipant',
+				{
+					token: TOKEN,
+					attendeeId: 5,
+					updatedData: { displayName: 'Guest', sessionIds: ['nextcloud-session-id-5'] }
+				})
+		})
+
+		it('should handle unknown sessions on join', () => {
+			// Arrange
+			populateParticipantsStore()
+			const participantsPayload = [{
+				userid: 'user-unknown',
+				user: { displayName: 'User Unknown' },
+				sessionid: 'session-id-unknown',
+				roomsessionid: 'nextcloud-session-id-unknown'
+			}]
+
+			// Act
+			const unknownResults = sessionStore.updateSessions(TOKEN, participantsPayload)
+
+			// Assert
+			expect(unknownResults).toBeTruthy()
+			expect(Object.keys(sessionStore.sessions)).toHaveLength(1)
+			expect(sessionStore.getSession('session-id-unknown'))
+				.toMatchObject({
+					token: TOKEN,
+					attendeeId: undefined,
+					sessionId: 'nextcloud-session-id-unknown',
+					signalingSessionId: 'session-id-unknown'
+				})
+		})
+
+		it('should remove old sessions and update participant objects', () => {
+			// Arrange
+			populateParticipantsStore()
+			const participantsLeftPayload = [
+				'session-id-1',
+				'session-id-2',
+				'session-id-4',
+				'session-id-5',
+				'session-id-unknown',
+			]
+			const changedPayload = participantsChangedPayload.slice(0, 4).concat({
+				...participantsChangedPayload[4],
+				displayName: 'Guest New Name'
+			})
+			sessionStore.updateSessions(TOKEN, participantsJoinedPayload)
+			// Fake a session with missing inCall attribute
+			sessionStore.addSession({
+				attendeeId: 1,
+				token: TOKEN,
+				signalingSessionId: 'session-id-11',
+				sessionId: 'nextcloud-session-id-11',
+				inCall: undefined,
+			})
+			sessionStore.updateSessions(TOKEN, changedPayload)
+			expect(Object.keys(sessionStore.sessions)).toHaveLength(5 + 1)
+
+			// Act
+			sessionStore.updateSessionsLeft(TOKEN, participantsLeftPayload)
+
+			// Assert
+			expect(Object.keys(sessionStore.sessions)).toMatchObject(['session-id-3', 'session-id-11'])
+			expect(sessionStore.getSession('session-id-1')).toBeUndefined()
+			expect(vuexStore.commit).toHaveBeenCalledTimes(10 + 4)
+			expect(vuexStore.commit).toHaveBeenNthCalledWith(10 + 1, 'updateParticipant',
+				{ token: TOKEN, attendeeId: 1, updatedData: { inCall: 0, sessionIds: [] } })
+			expect(vuexStore.commit).toHaveBeenNthCalledWith(10 + 2, 'updateParticipant',
+				{ token: TOKEN, attendeeId: 2, updatedData: { inCall: 3, sessionIds: ['nextcloud-session-id-3'] } })
+			expect(vuexStore.commit).toHaveBeenNthCalledWith(10 + 3, 'updateParticipant',
+				{ token: TOKEN, attendeeId: 4, updatedData: { inCall: 0, sessionIds: [] } })
+			expect(vuexStore.commit).toHaveBeenNthCalledWith(10 + 4, 'updateParticipant',
+				{ token: TOKEN, attendeeId: 5, updatedData: { inCall: 0, sessionIds: [] } })
+
+		})
+	})
 })

--- a/src/stores/__tests__/session.spec.js
+++ b/src/stores/__tests__/session.spec.js
@@ -501,6 +501,22 @@ describe('sessionStore', () => {
 				})
 		})
 
+		it('should ignore ghost sessions', () => {
+			// Arrange
+			populateParticipantsStore()
+			const participantsPayload = [{
+				userid: '',
+				sessionid: 'session-id-recording',
+			}]
+
+			// Act
+			const unknownResults = sessionStore.updateSessions(TOKEN, participantsPayload)
+
+			// Assert
+			expect(unknownResults).toBeFalsy()
+			expect(Object.keys(sessionStore.sessions)).toHaveLength(0)
+		})
+
 		it('should remove old sessions and update participant objects', () => {
 			// Arrange
 			populateParticipantsStore()

--- a/src/stores/__tests__/session.spec.js
+++ b/src/stores/__tests__/session.spec.js
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { setActivePinia, createPinia } from 'pinia'
+
+import { ATTENDEE, PARTICIPANT } from '../../constants.ts'
+import vuexStore from '../../store/index.js'
+import { useGuestNameStore } from '../guestName.js'
+import { useSessionStore } from '../session.ts'
+
+describe('sessionStore', () => {
+	const TOKEN = 'TOKEN'
+	const participantsInStore = [
+		{
+			actorId: 'user1',
+			actorType: ATTENDEE.ACTOR_TYPE.USERS,
+			participantType: PARTICIPANT.TYPE.OWNER,
+			attendeeId: 1,
+			inCall: 0,
+			sessionIds: ['nextcloud-session-id-1']
+		},
+		{
+			actorId: 'user2',
+			actorType: ATTENDEE.ACTOR_TYPE.USERS,
+			participantType: PARTICIPANT.TYPE.USER,
+			attendeeId: 2,
+			inCall: 0,
+			sessionIds: []
+		},
+		{
+			actorId: 'user4',
+			actorType: ATTENDEE.ACTOR_TYPE.FEDERATED_USERS,
+			participantType: PARTICIPANT.TYPE.USER,
+			attendeeId: 4,
+			inCall: 0,
+			sessionIds: []
+		},
+		{
+			actorId: 'hex',
+			actorType: ATTENDEE.ACTOR_TYPE.GUESTS,
+			participantType: PARTICIPANT.TYPE.GUEST,
+			attendeeId: 5,
+			inCall: 0,
+			sessionIds: ['nextcloud-session-id-5']
+		},
+	]
+	const populateParticipantsStore = (participants = participantsInStore) => {
+		participants.forEach(participant => {
+			vuexStore.dispatch('addParticipant', { token: TOKEN, participant })
+		})
+	}
+
+	let sessionStore
+	let guestNameStore
+
+	beforeEach(() => {
+		setActivePinia(createPinia())
+		sessionStore = useSessionStore()
+		guestNameStore = useGuestNameStore()
+		jest.spyOn(vuexStore, 'commit')
+		jest.spyOn(guestNameStore, 'addGuestName')
+	})
+
+	afterEach(() => {
+		jest.clearAllMocks()
+		vuexStore.dispatch('purgeParticipantsStore', TOKEN)
+	})
+
+	describe('sessions handling', () => {
+		it('should return undefined for an unknown session', () => {
+			// Assert
+			expect(sessionStore.getSession('id')).toBeUndefined()
+		})
+
+		it('should update existing orphan session with new information', () => {
+			// Arrange
+			sessionStore.addSession({
+				token: TOKEN,
+				attendeeId: undefined,
+				sessionId: 'nextcloud-session-id-1',
+				signalingSessionId: 'session-id-1'
+			})
+			expect(sessionStore.getSession('session-id-1')).toBeDefined()
+			expect(sessionStore.getSession('session-id-1').attendeeId).toBeUndefined()
+
+			// Act
+			sessionStore.updateSession('session-id-1', { attendeeId: 1 })
+
+			// Assert
+			expect(sessionStore.getSession('session-id-1')).toBeDefined()
+			expect(sessionStore.getSession('session-id-1').attendeeId).toBe(1)
+		})
+
+		it('should handle correctly if sessionId is not defined', () => {
+			console.error = jest.fn()
+			// Assert
+			expect(sessionStore.findOrCreateSession(TOKEN, {})).toBe(null)
+		})
+	})
+})

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -99,6 +99,10 @@ export const useSessionStore = defineStore('session', {
 				return acc | (session.inCall ?? 0)
 			}, 0)
 		},
+
+		orphanSessions: (state) => {
+			return Object.values(state.sessions).filter(session => !session.attendeeId)
+		},
 	},
 
 	actions: {
@@ -110,6 +114,15 @@ export const useSessionStore = defineStore('session', {
 		deleteSession(signalingSessionId: string) {
 			if (this.sessions[signalingSessionId]) {
 				Vue.delete(this.sessions, signalingSessionId)
+			}
+		},
+
+		updateSession(signalingSessionId: string, updatedData: Partial<Session>) {
+			if (this.sessions[signalingSessionId]) {
+				Vue.set(this.sessions, signalingSessionId, {
+					...this.sessions[signalingSessionId],
+					...updatedData,
+				})
 			}
 		},
 

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -1,0 +1,209 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { defineStore } from 'pinia'
+import Vue from 'vue'
+
+import { ATTENDEE } from '../constants.ts'
+import store from '../store/index.js'
+import type {
+	InternalSignalingSession,
+	Participant,
+	StandaloneSignalingJoinSession,
+	StandaloneSignalingLeaveSession,
+	StandaloneSignalingUpdateSession,
+} from '../types/index.ts'
+
+type Session = {
+	attendeeId: number | undefined,
+	token: string,
+	signalingSessionId: string,
+	sessionId: string | undefined,
+	inCall: number | undefined,
+}
+
+type SignalingSessionPayload =
+	| InternalSignalingSession
+	| StandaloneSignalingJoinSession
+	| StandaloneSignalingUpdateSession
+
+type State = {
+	sessions: Record<string, Session>,
+}
+
+function isInternalSignalingSession(item: SignalingSessionPayload): item is InternalSignalingSession
+function isInternalSignalingSession(item: SignalingSessionPayload[]): item is InternalSignalingSession[]
+/**
+ *
+ * @param item user or array of users as it comes from signaling message
+ */
+function isInternalSignalingSession(item: SignalingSessionPayload | SignalingSessionPayload[]): item is InternalSignalingSession | InternalSignalingSession[] {
+	if (Array.isArray(item)) {
+		return 'roomId' in item[0]
+	}
+	return 'roomId' in item
+}
+
+/**
+ *
+ * @param item user as it comes from signaling message
+ */
+function isStandaloneSignalingJoinSession(item: SignalingSessionPayload): item is StandaloneSignalingJoinSession {
+	return 'sessionid' in item
+}
+
+/**
+ *
+ * @param item user as it comes from signaling message
+ */
+function isStandaloneSignalingUpdateSession(item: SignalingSessionPayload): item is StandaloneSignalingUpdateSession {
+	return !('roomId' in item) && 'sessionId' in item
+}
+
+export const useSessionStore = defineStore('session', {
+	state: (): State => ({
+		sessions: {},
+	}),
+
+	getters: {
+		getSession: (state) => (signalingSessionId?: string): Session | undefined => {
+			if (signalingSessionId) {
+				return state.sessions[signalingSessionId]
+			}
+		},
+	},
+
+	actions: {
+		addSession(session: Session) {
+			Vue.set(this.sessions, session.signalingSessionId, session)
+			return session
+		},
+
+		deleteSession(signalingSessionId: string) {
+			if (this.sessions[signalingSessionId]) {
+				Vue.delete(this.sessions, signalingSessionId)
+			}
+		},
+
+		findOrCreateSession(token: string, user: SignalingSessionPayload): Session {
+			const signalingSessionId = isStandaloneSignalingJoinSession(user) ? user.sessionid : user.sessionId
+			if (!signalingSessionId) {
+				console.error('Can not define sessionId from the payload: %s', JSON.stringify(user))
+				return null
+			}
+
+			const knownSession = this.getSession(signalingSessionId)
+			if (knownSession) {
+				return knownSession
+			}
+
+			let sessionId: Session['sessionId'] | undefined
+			if (isStandaloneSignalingJoinSession(user)) {
+				sessionId = user.roomsessionid
+			} else {
+				sessionId = isInternalSignalingSession(user) ? user.sessionId : user.nextcloudSessionId
+			}
+			if (!sessionId) {
+				/**
+				 * FIXME currently non-internal Nextcloud sessions are ignored. Examples:
+				 * - recording server joining as hidden participant
+				 * - dial-out phone number joining call
+				 */
+				console.debug('Ignored session: %s', JSON.stringify(user))
+				return null
+			}
+
+			let attendee: Participant | null
+			let inCall: Session['inCall']
+			if (isStandaloneSignalingJoinSession(user)) {
+				/**
+				 * FIXME it is currently impossible to define some Nextcloud actor types (e.g. emails)
+				 * from the signaling payload. Falling back to internal/federated users or guests
+				 */
+				const actorType = user.userid
+					? (user.federated ? ATTENDEE.ACTOR_TYPE.FEDERATED_USERS : ATTENDEE.ACTOR_TYPE.USERS)
+					: ATTENDEE.ACTOR_TYPE.GUESTS
+				attendee = store.getters.findParticipant(token, {
+					sessionId,
+					actorId: user.userid,
+					actorType,
+				}) as Participant | null
+				inCall = attendee?.inCall
+			} else {
+				attendee = store.getters.findParticipant(token, {
+					sessionId,
+					actorId: user.actorId,
+					actorType: user.actorType,
+				}) as Participant | null
+				inCall = user.inCall
+			}
+
+			return this.addSession({
+				attendeeId: attendee?.attendeeId,
+				token,
+				signalingSessionId,
+				sessionId,
+				inCall,
+			})
+		},
+
+		/**
+		 * Update sessions in store and participants object according to data from signaling messages
+		 *
+		 * @param token - Conversation token
+		 * @param users - Users payload from signaling message
+		 * @return {boolean} whether list has unknown sessions mapped to attendees list
+		 */
+		updateSessions(token: string, users: SignalingSessionPayload[]): boolean {
+			let hasUnknownSessions = false
+			const currentSessionIds = new Set<string>()
+
+			for (const user of users) {
+				const session = this.findOrCreateSession(token, user)
+				currentSessionIds.add(session.signalingSessionId)
+
+				// If we can not find an attendeeId for session - participant is missing from the list
+				if (!session.attendeeId) {
+					console.debug('Possible orphan session: %s', JSON.stringify(user))
+					hasUnknownSessions = true
+					continue
+				}
+
+				if (isStandaloneSignalingJoinSession(user)) {
+					// this.updateParticipantJoinedFromStandaloneSignaling(token, user)
+				} else if (isStandaloneSignalingUpdateSession(user)) {
+					// this.updateParticipantChangedFromStandaloneSignaling(token, user)
+				}
+			}
+
+			if (isInternalSignalingSession(users)) {
+				// this.updateParticipantsFromInternalSignaling(token, users)
+
+				// Internal signaling server always returns all current sessions,
+				// so if some participants are missing - they are 'offline'
+				for (const signalingSessionId of Object.keys(this.sessions)) {
+					if (!currentSessionIds.has(signalingSessionId)) {
+						this.deleteSession(signalingSessionId)
+					}
+				}
+			}
+
+			return hasUnknownSessions
+		},
+
+		/**
+		 * Delete sessions in store and update participants objects
+		 *
+		 * @param token - Conversation token
+		 * @param sessionIds - Left session ids from signaling message
+		 */
+		updateSessionsLeft(token: string, sessionIds: StandaloneSignalingLeaveSession[]) {
+			for (const sessionId of sessionIds) {
+				// this.updateParticipantLeftFromStandaloneSignaling(token, sessionId)
+				this.deleteSession(sessionId)
+			}
+		},
+	},
+})

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -23,7 +23,7 @@ type Session = {
 	attendeeId: number | undefined,
 	token: string,
 	signalingSessionId: string,
-	sessionId: string | undefined,
+	sessionId: string,
 	inCall: number | undefined,
 }
 
@@ -126,7 +126,7 @@ export const useSessionStore = defineStore('session', {
 			}
 		},
 
-		findOrCreateSession(token: string, user: SignalingSessionPayload): Session {
+		findOrCreateSession(token: string, user: SignalingSessionPayload): Session | null {
 			const signalingSessionId = isStandaloneSignalingJoinSession(user) ? user.sessionid : user.sessionId
 			if (!signalingSessionId) {
 				console.error('Can not define sessionId from the payload: %s', JSON.stringify(user))
@@ -201,6 +201,10 @@ export const useSessionStore = defineStore('session', {
 
 			for (const user of users) {
 				const session = this.findOrCreateSession(token, user)
+				if (!session) {
+					continue
+				}
+
 				currentSessionIds.add(session.signalingSessionId)
 
 				// If we can not find an attendeeId for session - participant is missing from the list

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,6 +105,44 @@ export type Notification<T = Record<string, RichObject & Record<string, unknown>
 // Signaling
 export type SignalingSettings = components['schemas']['SignalingSettings']
 
+export type InternalSignalingSession = components['schemas']['SignalingSession']
+
+// Based on https://github.com/strukturag/nextcloud-spreed-signaling/blob/master/api_signaling.go:
+// EventServerMessage - room - Join
+export type StandaloneSignalingJoinSession = {
+	userid: string,
+	user?:
+		| { displayname: string }
+		| { callid: string, number: string, type: string }, // Phone number
+	sessionid: string, // Standalone signaling id
+	roomsessionid?: string, // Nextcloud id
+	features?: string[],
+	federated?: boolean,
+}
+
+// EventServerMessage - room - Leave
+export type StandaloneSignalingLeaveSession = string // Standalone signaling id
+
+// EventServerMessage - participants - Update
+export type StandaloneSignalingUpdateSession = {
+	inCall: number,
+	lastPing: number,
+	sessionId: string, // Standalone signaling id
+	nextcloudSessionId?: string, // Nextcloud id
+	participantPermissions?: number,
+	participantType?: number,
+	userId?: string,
+	// Since Talk v20, treat as optional
+	actorId?: string,
+	actorType?: string,
+	displayName?: string,
+	// Internal participant (Recording server, phone number)
+	features?: string[],
+	internal?: boolean,
+	// Phone number only
+	virtual?: boolean,
+}
+
 // Conversations
 export type Conversation = components['schemas']['Room'] & {
 	// internal parameter up to mock a conversation object


### PR DESCRIPTION
### ☑️ Resolves

* Attempt to reduce the number of participants list updates

> [!IMPORTANT]
> 🍍Stores all sessions in Pinia store:
> - internal: by nextcloud sessionId
> - external: by signaling server sessionId
> If no attendee was mapped to the session, fetch participants and patch session later
>
> ♻️ Update participant object with data from signaling:
> - permissions
> - nextcloud sessionId
> - inCall
> - participantType
> - lastPing
> - displayName

> [!IMPORTANT]
> 🚧 Experimental feature: set config to enable:
> `occ config:app:set spreed experiments_users --value=1`

<details>
<summary> Examples of signaling messages inside: (was changed in Talk 20, have some new fields now) </summary>

### INTERNAL JOINED

```json
[
    [
        {
            "userId": "alice",
            "roomId": 7,
            "lastPing": 1718882327,
            "sessionId": "4eQPZvqBSnQ1AUb6DgO50JUgneyhx7K31c0qNZ7+M3gHEeU365NU0/1+jGueeO5oEboyJNG0cCA7xXkWxrK9dQzbNuY2ZjXdYhePoyh4j1M3h2F78DUocHvKF/I+Q56PNBT8QZts+XaswE2qW2gkm7pgr+3yD3+qaEKOZtptuE+m1JaKP7E4LGoE7ES8aD4GV+tKIgONhcurl1PNPzgMWj7NmWskJ44P/ZR3K0EYCoERCF6DLLcDXvldy4S4qqj",
            "inCall": 0,
            "participantPermissions": 246
        },
        {
            "userId": "antreesy", // Current user
            "roomId": 7,
            "lastPing": 1718882332,
            "sessionId": "0uf9N3nvaWKxz1Gn4mG5oHqnKu4N8XabhWHOSv+kmuPt8RFyK9tEk82+itf+iGflPyPzfeZr5SObW5PXDbXOO0y/wjt3O/xgoJrfI3qK7+7xmtz0WYZj0zdYaQXsv9jsEDpU6/QPXXMEoD9r+Alv4GlrzPwi0IMVo/Z4wtes2OM/jBXRhAU0AM7uwMlLfXS5ztA9QZRk8nT8sooBTiD0/D4y1rTkiXRBiX21YHNHVwVQfs38vOPnqxnNATX1Byh",
            "inCall": 0,
            "participantPermissions": 254
        }
    ]
]
```

### INTERNAL LEFT (`alice`)

```json
[
    [
        {
            "userId": "antreesy", // Current user
            "roomId": 7,
            "lastPing": 1718882333,
            "sessionId": "0uf9N3nvaWKxz1Gn4mG5oHqnKu4N8XabhWHOSv+kmuPt8RFyK9tEk82+itf+iGflPyPzfeZr5SObW5PXDbXOO0y/wjt3O/xgoJrfI3qK7+7xmtz0WYZj0zdYaQXsv9jsEDpU6/QPXXMEoD9r+Alv4GlrzPwi0IMVo/Z4wtes2OM/jBXRhAU0AM7uwMlLfXS5ztA9QZRk8nT8sooBTiD0/D4y1rTkiXRBiX21YHNHVwVQfs38vOPnqxnNATX1Byh",
            "inCall": 0,
            "participantPermissions": 254
        }
    ]
]
```

### EXTERNAL JOINED

```json
[
    [
        {
            "sessionid": "Li3jtK-0B4FW3m4eJDLajKQ7asilwKlxnUzc91Mnlrt8MVFnWnJQNlFpSFRvbkwxWGxoc3NxS19JMjNwUl9fLWNVb1FTSER4eFFnaHFFbUkyZFFWNWVzVFFRMGlMX003cVdaeWNGWXhDbWxlelR0UE5pZG1iTkcwZVdkVUJoZ2o4ZDRva2I5VERNSlcycW5iazFyMnVlX3JndkJkT1FKYzI2MGpIcHV4aUlhQWRHcGVVNWxYX2NTc0ZFMExvbGNJMFRWU19rU3I2fDI4OTE4ODgxNzE=",
            "userid": "bob",
            "user": {
                "displayname": "Bob Odenkirk"
            },
            "roomsessionid": "RnObY28zWT6p0tF84Jwlm0Xr8miMdUaCN0XBiqPuWdATkeVPxo7G7OFuIFkYft67vhDPXBpgeKRN4VUvvP8CTnNDRcsb9Xi+GDmFcV0jUxsIfZp/5PQuHpaZuWh7udfnmMc8nwC8rQWEDuH14G2OAvyJNtt5jQXeu08vt+h/gHBMboaETsEYgZZwNSSjmZHY5i/MvFu6gYHTLwojtrxIZp0iiyQmSDwPv8yjOLNxLV/eBRIySeeQzfFnDOgOMjl" // Nextcloud sessionId
        },
        {
            "sessionid": "hymgxogGWSihSgwbrtU58KVvZE073Hn0wSZM8mQDz2J8UzRMdl9IMVZDRVU2WXJpZDFCTm9SNENIMFhyNlNfM1Q3R0QxekkwLXNuMkNRenRCMDZ3ZE9Nb3EwVk5vaW1xOVdXem96Zk1DektJMmdJV2dLLWRwVW9YWjZTNE1pN2ZGT2RHeEdUVXFDa2RjRF9LZlNNQ3lHN3VuUlFXZl9qd2ZJNnI0a3VvZllWVWNYWDUzSVZxRGd4ZW1saTFEOTVDUWpXMV9QQU1RfDUyODA4ODgxNzE=",
            "userid": "alice",
            "user": {
                "displayname": "Alice Adair"
            },
            "roomsessionid": "ZljR8uqzJQYbi66LcM2z0sVFkNRtraNxQ8IfkDB0HIw1CB+lmeL8KXBO2OAoKOIoPW/enIsmsCs2fQPLP4g5rI8olyUrL3wv9bKMEJ1IdVjtaUbMXuA0GNqfzbxwr2+JfukhSecmjB7Rnf8OZGN76BXZtuXd90UKCOepoia4jXNZtg7ca4lZMpNZlWmMUueZd6IWMVvO/0Xoy4Nu/ePwTtB31DhCyIwfkwqHE6/3RlD6NHAeHKYwRv96R8IuWdN" // Nextcloud sessionId
        }
    ]
]
```

### EXTERNAL LEFT (`bob`)

```json
[
    [
        "Li3jtK-0B4FW3m4eJDLajKQ7asilwKlxnUzc91Mnlrt8MVFnWnJQNlFpSFRvbkwxWGxoc3NxS19JMjNwUl9fLWNVb1FTSER4eFFnaHFFbUkyZFFWNWVzVFFRMGlMX003cVdaeWNGWXhDbWxlelR0UE5pZG1iTkcwZVdkVUJoZ2o4ZDRva2I5VERNSlcycW5iazFyMnVlX3JndkJkT1FKYzI2MGpIcHV4aUlhQWRHcGVVNWxYX2NTc0ZFMExvbGNJMFRWU19rU3I2fDI4OTE4ODgxNzE="
    ]
]
```

### EXTERNAL CHANGED (`alice` joined call)

```json
[
    [
        {
            "lastPing": 1718962151,
            "sessionId": "cuFDIw8ygQQ29NMcr49-6WHTW7MZ4BCSdr16Vd6uvop8aXRYREVOYko2Mzg5LTBZM0NjSVB5REV0OEE2UXpMaEFxeklMVldEMEZyOGYwTHJMcmlfYjUwVlF4OXlrMU5iTEJlR0hvR1V4a2puZFdFeGlpcmhQZ1Q4R2JzdXFNbTNqMEIxTlF3QnNJWG9seHBvVFhTLTNqM0s1UUh3ekRrcWpTck9xaU9BWTUxY3dBcncxLW9Od1lhX09lME1vNWVuZmJzZExJY2lBfDI0MTI2OTgxNzE=",
            "nextcloudSessionId": "p8XiddHgLezUngrcg7GdkkTvrb+9kXzMNB2hd26YdImC5OmrTu3pPsZQ2atCvNEffYdMqyRTWuYt0OdIeZvFqGFztWNEveN5LJkXhlWiBElEedr6xZdJlDjwwnQn9O+pO3J8xivDyHrmvjDM+IwlLp/8etHLMxmLXauNHHfN1RlRXo/tlBu2AWGxqnFl54xJM8ip+4reyZckt5zQXucB3odU4x3VRP25G2NLkNDd0+42gwocfBPcxmO65Cr2IxX",
            "participantType": 3,
            "participantPermissions": 246,
            "userId": "alice",
            "inCall": 7
        }
    ]
]
```

### EXTERNAL END CALL FOR ALL

```json
undefined
```

</details>

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

[Screencast from 21.06.2024 13:04:46.webm](https://github.com/nextcloud/spreed/assets/93392545/b335c013-2a76-42de-ac57-436fce2dd968)


### 🚧 Tasks

- [x] Internal signaling
- [x] External signaling
- [ ] Reduce list updates -> follow-up

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
