### PR TITLE
fix(conversation): adjust broadcasted data between tabs

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -614,6 +614,7 @@ export default {
 						conversations: event.data.conversations,
 						withRemoving: event.data.withRemoving,
 					})
+					this.federationStore.updatePendingSharesCount(event.data.invites)
 					break
 				case 'update-nextcloud-talk-hash':
 					this.talkHashStore.setNextcloudTalkHash(event.data.hash)

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -441,7 +441,7 @@ const actions = {
 			await deleteConversation(token)
 			// upon success, also delete from store
 			await context.dispatch('deleteConversation', token)
-			talkBroadcastChannel.postMessage({ message: 'force-fetch-all-conversations' })
+			talkBroadcastChannel.postMessage({ message: 'force-fetch-all-conversations', options: { all: true } })
 		} catch (error) {
 			console.error('Error while deleting the conversation: ', error)
 		}

--- a/src/store/conversationsStore.js
+++ b/src/store/conversationsStore.js
@@ -878,6 +878,7 @@ const actions = {
 			talkBroadcastChannel.postMessage({
 				message: 'update-conversations',
 				conversations: response.data.ocs.data,
+				invites: response.headers['x-nextcloud-talk-federation-invites'],
 				withRemoving: modifiedSince === 0,
 			})
 			return response

--- a/src/store/participantsStore.js
+++ b/src/store/participantsStore.js
@@ -972,7 +972,7 @@ const actions = {
 		await removeCurrentUserFromConversation(token)
 		// If successful, deletes the conversation from the store
 		await context.dispatch('deleteConversation', token)
-		talkBroadcastChannel.postMessage({ message: 'force-fetch-all-conversations' })
+		talkBroadcastChannel.postMessage({ message: 'force-fetch-all-conversations', options: { all: true } })
 	},
 
 	/**


### PR DESCRIPTION
### ☑️ Resolves

Fix #12548

- pass `options: { all }` to leader tab, when force refresh;
- do not fetch anything on secondary tabs, pass message to force refresh via broadcast channel;
- do not fetch anything on leaving conversation;
- broadcast federation invites count to secondary tabs;

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏡 After

[Screencast from 21.06.2024 15:58:27.webm](https://github.com/nextcloud/spreed/assets/93392545/95a7d3e8-26d8-406f-9bce-5b7244f2ab9f)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required