### PR TITLE
feat: Added database migration for banning users

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>20.0.0-dev.2</version>
+	<version>20.0.0-dev.3</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/appinfo/routes/routesBanController.php
+++ b/appinfo/routes/routesBanController.php
@@ -17,6 +17,6 @@ return [
 		/** @see \OCA\Talk\Controller\BanController::listBans() */
 		['name' => 'Ban#listBans', 'url' => '/api/{apiVersion}/ban/{token}', 'verb' => 'GET', 'requirements' => $requirements],
 		/** @see \OCA\Talk\Controller\BanController::unbanActor() */
-		['name' => 'Ban#unbanActor', 'url' => '/api/{apiVersion}/ban/{token}', 'verb' => 'DELETE', 'requirements' => $requirements],
+		['name' => 'Ban#unbanActor', 'url' => '/api/{apiVersion}/ban/{token}/{banId}', 'verb' => 'DELETE', 'requirements' => $requirements],
 	],
 ];

--- a/lib/Controller/BanController.php
+++ b/lib/Controller/BanController.php
@@ -48,17 +48,16 @@ class BanController extends AEnvironmentAwareController {
 	#[RequireModeratorParticipant]
 	public function banActor(string $actorType, string $actorId, string $internalNote = ''): DataResponse {
 		try {
-			$attendee = $this->participant->getAttendee();
-			$roomId = $attendee->getRoomId();
-			$bannedId = $attendee->getActorId();
-			$bannedType = $attendee->getActorType();
+			$moderator = $this->participant->getAttendee();
+			$moderatorActorType = $moderator->getActorType();
+			$moderatorActorId = $moderator->getActorId();
 
 			$ban = $this->banService->createBan(
+				$moderatorActorId,
+				$moderatorActorType,
+				$this->room->getId(),
 				$actorId,
 				$actorType,
-				$roomId,
-				$bannedId,
-				$bannedType,
 				null,
 				$internalNote
 			);

--- a/lib/Controller/BanController.php
+++ b/lib/Controller/BanController.php
@@ -111,19 +111,4 @@ class BanController extends AEnvironmentAwareController {
 		$this->banService->findAndDeleteBanByIdForRoom($banId, $this->room->getId());
 		return new DataResponse([], Http::STATUS_OK);
 	}
-
-	/**
-	 * @psalm-return TalkBan
-	 */
-	protected function randomBan(string $actorType, string $actorId): array {
-		return [
-			'id' => random_int(1, 1337),
-			'actorType' => $this->participant->getAttendee()->getActorType(),
-			'actorId' => $this->participant->getAttendee()->getActorId(),
-			'bannedType' => $actorType,
-			'bannedId' => $actorId,
-			'bannedTime' => random_int(1514747958, 1714747958),
-			'internalNote' => '#NOTE#' . $actorType . '#' . $actorId . '#' . sha1($actorType . $actorId),
-		];
-	}
 }

--- a/lib/Controller/BanController.php
+++ b/lib/Controller/BanController.php
@@ -104,7 +104,7 @@ class BanController extends AEnvironmentAwareController {
 	#[PublicPage]
 	#[RequireModeratorParticipant]
 	public function unbanActor(int $banId): DataResponse {
-		$this->banService->findAndDeleteBanById($banId);
+		$this->banService->findAndDeleteBanByIdForRoom($banId, $this->room->getId());
 		return new DataResponse([], Http::STATUS_OK);
 	}
 

--- a/lib/Controller/BanController.php
+++ b/lib/Controller/BanController.php
@@ -103,16 +103,8 @@ class BanController extends AEnvironmentAwareController {
 	 */
 	#[PublicPage]
 	#[RequireModeratorParticipant]
-	public function unbanActor(): DataResponse {
-		$banId = $this->request->getParam('id');
-		if ($banId === null) {
-			return new DataResponse([
-				'error' => 'Missing ban ID',
-			], Http::STATUS_BAD_REQUEST);
-		}
-		echo "Ban ID!!!: $banId\n";
-		$this->banService->findAndDeleteBanById((int)$banId);
-		echo "Unbanned successfully\n";
+	public function unbanActor(int $banId): DataResponse {
+		$this->banService->findAndDeleteBanById($banId);
 		return new DataResponse([], Http::STATUS_OK);
 	}
 

--- a/lib/Controller/BanController.php
+++ b/lib/Controller/BanController.php
@@ -11,6 +11,7 @@ namespace OCA\Talk\Controller;
 
 use OCA\Talk\Middleware\Attribute\RequireModeratorParticipant;
 use OCA\Talk\Model\Attendee;
+use OCA\Talk\Model\Ban;
 use OCA\Talk\ResponseDefinitions;
 use OCA\Talk\Service\BanService;
 use OCP\AppFramework\Http;
@@ -79,7 +80,7 @@ class BanController extends AEnvironmentAwareController {
 	 *
 	 * Required capability: `ban-v1`
 	 *
-	 * @return DataResponse<Http::STATUS_OK, list<TalkBan>, array{}>
+	 * @return DataResponse<Http::STATUS_OK, TalkBan[], array{}>
 	 *
 	 * 200: List all bans
 	 */
@@ -87,11 +88,7 @@ class BanController extends AEnvironmentAwareController {
 	#[RequireModeratorParticipant]
 	public function listBans(): DataResponse {
 		$bans = $this->banService->getBansForRoom($this->room->getId());
-		$result = array_map(function ($ban) {
-			return $ban->jsonSerialize();
-		}, $bans);
-
-		/** @psalm-var list<array{actorId: string, actorType: string, bannedId: string, bannedTime: int, bannedType: string, id: int, internalNote: string}> $result */
+		$result = array_map(static fn (Ban $ban): array => $ban->jsonSerialize(), $bans);
 		return new DataResponse($result, Http::STATUS_OK);
 	}
 

--- a/lib/Controller/BanController.php
+++ b/lib/Controller/BanController.php
@@ -82,8 +82,8 @@ class BanController extends AEnvironmentAwareController {
 	 */
 	#[PublicPage]
 	#[RequireModeratorParticipant]
-	public function listBans(int $roomId): DataResponse {
-		$bans = $this->banService->getBansForRoom($roomId);
+	public function listBans(): DataResponse {
+		$bans = $this->banService->getBansForRoom($this->room->getId());
 		$result = array_map(function ($ban) {
 			return $ban->jsonSerialize();
 		}, $bans);
@@ -104,8 +104,16 @@ class BanController extends AEnvironmentAwareController {
 	 */
 	#[PublicPage]
 	#[RequireModeratorParticipant]
-	public function unbanActor(int $banId): DataResponse {
-		$this->banService->findAndDeleteBanById($banId);
+	public function unbanActor(): DataResponse {
+		$banId = $this->request->getParam('id');
+		if ($banId === null) {
+			return new DataResponse([
+				'error' => 'Missing ban ID',
+			], Http::STATUS_BAD_REQUEST);
+		}
+		echo "Ban ID!!!: $banId\n";
+		$this->banService->findAndDeleteBanById((int)$banId);
+		echo "Unbanned successfully\n";
 		return new DataResponse([], Http::STATUS_OK);
 	}
 

--- a/lib/Migration/Version20000Date20240621150333.php
+++ b/lib/Migration/Version20000Date20240621150333.php
@@ -53,7 +53,7 @@ class Version20000Date20240621150333 extends SimpleMigrationStep {
 				'notnull' => true,
 			]);
 			$table->addColumn('banned_at', Types::DATETIME, [
-				'notnull' => true,
+				'notnull' => false,
 			]);
 			$table->addColumn('reason', Types::TEXT, [
 				'notnull' => false,

--- a/lib/Migration/Version20000Date20240621150333.php
+++ b/lib/Migration/Version20000Date20240621150333.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version20000Date20240621150333 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('talk_bans')) {
+			$table = $schema->createTable('talk_bans');
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 20,
+			]);
+			$table->addColumn('actor_id', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('actor_type', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('room_id', Types::BIGINT, [
+				'notnull' => true,
+				'unsigned' => true,
+			]);
+			$table->addColumn('banned_by_actor_id', Types::STRING, [
+				'length' => 64,
+				'notnull' => true,
+			]);
+			$table->addColumn('banned_by_actor_type', Types::STRING, [
+				'length' => 64,
+				'notnull' => true,
+			]);
+			$table->addColumn('banned_at', Types::DATETIME, [
+				'notnull' => false,
+			]);
+			$table->addColumn('reason', Types::TEXT, [
+				'notnull' => false,
+			]);
+
+			// $table->setPrimaryKey(['id']);
+			// $table->addUniqueIndex(['user_id', 'room_id'], 'talk_ban_user_room'); //A user should not be banned from the same room more than once
+			// $table->addIndex(['banned_at'], 'talk_ban_banned_at');
+			return $schema;
+		}
+
+		return null;
+	}
+}

--- a/lib/Migration/Version20000Date20240621150333.php
+++ b/lib/Migration/Version20000Date20240621150333.php
@@ -55,7 +55,7 @@ class Version20000Date20240621150333 extends SimpleMigrationStep {
 			$table->addColumn('banned_at', Types::DATETIME, [
 				'notnull' => false,
 			]);
-			$table->addColumn('reason', Types::TEXT, [
+			$table->addColumn('internalNote', Types::TEXT, [
 				'notnull' => false,
 			]);
 

--- a/lib/Migration/Version20000Date20240621150333.php
+++ b/lib/Migration/Version20000Date20240621150333.php
@@ -32,11 +32,11 @@ class Version20000Date20240621150333 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 20,
 			]);
-			$table->addColumn('actor_id', Types::STRING, [
+			$table->addColumn('actor_type', Types::STRING, [
 				'notnull' => true,
 				'length' => 64,
 			]);
-			$table->addColumn('actor_type', Types::STRING, [
+			$table->addColumn('actor_id', Types::STRING, [
 				'notnull' => true,
 				'length' => 64,
 			]);
@@ -44,11 +44,11 @@ class Version20000Date20240621150333 extends SimpleMigrationStep {
 				'notnull' => true,
 				'unsigned' => true,
 			]);
-			$table->addColumn('banned_id', Types::STRING, [
+			$table->addColumn('banned_type', Types::STRING, [
 				'length' => 64,
 				'notnull' => true,
 			]);
-			$table->addColumn('banned_type', Types::STRING, [
+			$table->addColumn('banned_id', Types::STRING, [
 				'length' => 64,
 				'notnull' => true,
 			]);
@@ -60,8 +60,8 @@ class Version20000Date20240621150333 extends SimpleMigrationStep {
 			]);
 
 			$table->setPrimaryKey(['id']);
-			// $table->addUniqueIndex(['user_id', 'room_id'], 'talk_ban_user_room'); //A user should not be banned from the same room more than once
-			// $table->addIndex(['banned_at'], 'talk_ban_banned_at');
+			$table->addUniqueIndex(['banned_type', 'banned_id', 'room_id'], 'talk_bans_unique_actor_room'); //A user should not be banned from the same room more than once
+			$table->addIndex(['room_id']);
 			return $schema;
 		}
 

--- a/lib/Migration/Version20000Date20240621150333.php
+++ b/lib/Migration/Version20000Date20240621150333.php
@@ -53,13 +53,13 @@ class Version20000Date20240621150333 extends SimpleMigrationStep {
 				'notnull' => true,
 			]);
 			$table->addColumn('banned_at', Types::DATETIME, [
-				'notnull' => false,
+				'notnull' => true,
 			]);
 			$table->addColumn('reason', Types::TEXT, [
 				'notnull' => false,
 			]);
 
-			// $table->setPrimaryKey(['id']);
+			$table->setPrimaryKey(['id']);
 			// $table->addUniqueIndex(['user_id', 'room_id'], 'talk_ban_user_room'); //A user should not be banned from the same room more than once
 			// $table->addIndex(['banned_at'], 'talk_ban_banned_at');
 			return $schema;

--- a/lib/Migration/Version20000Date20240621150333.php
+++ b/lib/Migration/Version20000Date20240621150333.php
@@ -44,18 +44,18 @@ class Version20000Date20240621150333 extends SimpleMigrationStep {
 				'notnull' => true,
 				'unsigned' => true,
 			]);
-			$table->addColumn('banned_by_actor_id', Types::STRING, [
+			$table->addColumn('banned_id', Types::STRING, [
 				'length' => 64,
 				'notnull' => true,
 			]);
-			$table->addColumn('banned_by_actor_type', Types::STRING, [
+			$table->addColumn('banned_type', Types::STRING, [
 				'length' => 64,
 				'notnull' => true,
 			]);
-			$table->addColumn('banned_at', Types::DATETIME, [
+			$table->addColumn('banned_time', Types::DATETIME, [
 				'notnull' => false,
 			]);
-			$table->addColumn('internalNote', Types::TEXT, [
+			$table->addColumn('internal_note', Types::TEXT, [
 				'notnull' => false,
 			]);
 

--- a/lib/Model/Ban.php
+++ b/lib/Model/Ban.php
@@ -17,32 +17,32 @@ use OCP\AppFramework\Db\Entity;
  * @method string getActorType()
  * @method void setRoomId(int $roomId)
  * @method int getRoomId()
- * @method void setBannedByActorId(string $bannedByActorId)
- * @method string getBannedByActorId()
- * @method void setBannedByActorType(string $bannedByActorType)
- * @method string getBannedByActorType()
- * @method void setBannedAt(\DateTime $bannedAt)
- * @method \DateTime getBannedAt()
- * @method void setReason(string $reason)
- * @method string getReason()
+ * @method void setBannedId(string $bannedId)
+ * @method string getBannedId()
+ * @method void setBannedType(string $bannedType)
+ * @method string getBannedType()
+ * @method void setBannedTime(\DateTime $bannedTime)
+ * @method \DateTime getBannedTime()
+ * @method void setInternalNote(string $internalNote)
+ * @method string getInternalNote()
  */
 class Ban extends Entity implements \JsonSerializable {
 	protected string $actorId = '';
 	protected string $actorType = '';
 	protected int $roomId = 0;
-	protected string $bannedByActorId = '';
-	protected string $bannedByActorType = '';
-	protected ?\DateTime $bannedAt = null;
-	protected ?string $reason = null;
+	protected string $bannedId = '';
+	protected string $bannedType = '';
+	protected ?\DateTime $bannedTime = null;
+	protected ?string $internalNote = null;
 
 	public function __construct() {
 		$this->addType('actorId', 'string');
 		$this->addType('actorType', 'string');
 		$this->addType('roomId', 'int');
-		$this->addType('bannedByActorId', 'string');
-		$this->addType('bannedByActorType', 'string');
-		$this->addType('bannedAt', 'datetime');
-		$this->addType('reason', 'string');
+		$this->addType('bannedId', 'string');
+		$this->addType('bannedType', 'string');
+		$this->addType('bannedTime', 'datetime');
+		$this->addType('internalNote', 'string');
 	}
 
 	public function jsonSerialize(): array {
@@ -50,10 +50,10 @@ class Ban extends Entity implements \JsonSerializable {
 			'actorId' => $this->getActorId(),
 			'actorType' => $this->getActorType(),
 			'roomId' => $this->getRoomId(),
-			'bannedByActorId' => $this->getBannedByActorId(),
-			'bannedByActorType' => $this->getBannedByActorType(),
-			'bannedAt' => $this->getBannedAt() ? $this->getBannedAt()->getTimestamp() : null,
-			'reason' => $this->getReason(),
+			'bannedId' => $this->getBannedId(),
+			'bannedType' => $this->getBannedType(),
+			'bannedTime' => $this->getBannedTime() ? $this->getBannedTime()->getTimestamp() : null,
+			'internalNote' => $this->getInternalNote(),
 		];
 	}
 }

--- a/lib/Model/Ban.php
+++ b/lib/Model/Ban.php
@@ -28,8 +28,8 @@ use OCP\AppFramework\Db\Entity;
  * @method string getBannedId()
  * @method void setBannedTime(\DateTime $bannedTime)
  * @method \DateTime getBannedTime()
- * @method void setInternalNote(string $internalNote)
- * @method string getInternalNote()
+ * @method void setInternalNote(null|string $internalNote)
+ * @method null|string getInternalNote()
  */
 class Ban extends Entity implements \JsonSerializable {
 	protected string $actorType = '';
@@ -62,7 +62,7 @@ class Ban extends Entity implements \JsonSerializable {
 			'bannedType' => $this->getBannedType(),
 			'bannedId' => $this->getBannedId(),
 			'bannedTime' => $this->getBannedTime()->getTimestamp(),
-			'internalNote' => $this->getInternalNote(),
+			'internalNote' => $this->getInternalNote() ?? '',
 		];
 	}
 }

--- a/lib/Model/Ban.php
+++ b/lib/Model/Ban.php
@@ -27,7 +27,7 @@ use OCP\AppFramework\Db\Entity;
  * @method string getReason()
  */
 class Ban extends Entity implements \JsonSerializable {
-	protected $actorId = '';
+	protected string $actorId = '';
 	protected string $actorType = '';
 	protected int $roomId = 0;
 	protected string $bannedByActorId = '';

--- a/lib/Model/Ban.php
+++ b/lib/Model/Ban.php
@@ -13,37 +13,37 @@ use OCP\AppFramework\Db\Entity;
 /**
  * @method void setId(int $id)
  * @method int getId()
- * @method void setActorId(string $actorId)
- * @method string getActorId()
  * @method void setActorType(string $actorType)
  * @method string getActorType()
+ * @method void setActorId(string $actorId)
+ * @method string getActorId()
  * @method void setRoomId(int $roomId)
  * @method int getRoomId()
- * @method void setBannedId(string $bannedId)
- * @method string getBannedId()
  * @method void setBannedType(string $bannedType)
  * @method string getBannedType()
+ * @method void setBannedId(string $bannedId)
+ * @method string getBannedId()
  * @method void setBannedTime(\DateTime $bannedTime)
  * @method \DateTime getBannedTime()
  * @method void setInternalNote(string $internalNote)
  * @method string getInternalNote()
  */
 class Ban extends Entity implements \JsonSerializable {
-	protected string $actorId = '';
 	protected string $actorType = '';
+	protected string $actorId = '';
 	protected int $roomId = 0;
-	protected string $bannedId = '';
 	protected string $bannedType = '';
+	protected string $bannedId = '';
 	protected ?\DateTime $bannedTime = null;
 	protected ?string $internalNote = null;
 
 	public function __construct() {
 		$this->addType('id', 'int');
-		$this->addType('actorId', 'string');
 		$this->addType('actorType', 'string');
+		$this->addType('actorId', 'string');
 		$this->addType('roomId', 'int');
-		$this->addType('bannedId', 'string');
 		$this->addType('bannedType', 'string');
+		$this->addType('bannedId', 'string');
 		$this->addType('bannedTime', 'datetime');
 		$this->addType('internalNote', 'string');
 	}
@@ -51,11 +51,11 @@ class Ban extends Entity implements \JsonSerializable {
 	public function jsonSerialize(): array {
 		return [
 			'id' => $this->getId(),
-			'actorId' => $this->getActorId(),
 			'actorType' => $this->getActorType(),
+			'actorId' => $this->getActorId(),
 			'roomId' => $this->getRoomId(),
-			'bannedId' => $this->getBannedId(),
 			'bannedType' => $this->getBannedType(),
+			'bannedId' => $this->getBannedId(),
 			'bannedTime' => $this->getBannedTime() ? $this->getBannedTime()->getTimestamp() : null,
 			'internalNote' => $this->getInternalNote(),
 		];

--- a/lib/Model/Ban.php
+++ b/lib/Model/Ban.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Model;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method void setActorId(string $actorId)
+ * @method string getActorId()
+ * @method void setActorType(string $actorType)
+ * @method string getActorType()
+ * @method void setRoomId(int $roomId)
+ * @method int getRoomId()
+ * @method void setBannedByActorId(string $bannedByActorId)
+ * @method string getBannedByActorId()
+ * @method void setBannedByActorType(string $bannedByActorType)
+ * @method string getBannedByActorType()
+ * @method void setBannedAt(\DateTime $bannedAt)
+ * @method \DateTime getBannedAt()
+ * @method void setReason(string $reason)
+ * @method string getReason()
+ */
+class Ban extends Entity implements \JsonSerializable {
+	protected $actorId = '';
+	protected string $actorType = '';
+	protected int $roomId = 0;
+	protected string $bannedByActorId = '';
+	protected string $bannedByActorType = '';
+	protected ?\DateTime $bannedAt = null;
+	protected ?string $reason = null;
+
+	public function __construct() {
+		$this->addType('actorId', 'string');
+		$this->addType('actorType', 'string');
+		$this->addType('roomId', 'int');
+		$this->addType('bannedByActorId', 'string');
+		$this->addType('bannedByActorType', 'string');
+		$this->addType('bannedAt', 'datetime');
+		$this->addType('reason', 'string');
+	}
+
+	public function jsonSerialize(): array {
+		return [
+			'actorId' => $this->getActorId(),
+			'actorType' => $this->getActorType(),
+			'roomId' => $this->getRoomId(),
+			'bannedByActorId' => $this->getBannedByActorId(),
+			'bannedByActorType' => $this->getBannedByActorType(),
+			'bannedAt' => $this->getBannedAt() ? $this->getBannedAt()->getTimestamp() : null,
+			'reason' => $this->getReason(),
+		];
+	}
+}

--- a/lib/Model/Ban.php
+++ b/lib/Model/Ban.php
@@ -11,6 +11,8 @@ namespace OCA\Talk\Model;
 use OCP\AppFramework\Db\Entity;
 
 /**
+ * @method void setId(int $id)
+ * @method int getId()
  * @method void setActorId(string $actorId)
  * @method string getActorId()
  * @method void setActorType(string $actorType)
@@ -36,6 +38,7 @@ class Ban extends Entity implements \JsonSerializable {
 	protected ?string $internalNote = null;
 
 	public function __construct() {
+		$this->addType('id', 'int');
 		$this->addType('actorId', 'string');
 		$this->addType('actorType', 'string');
 		$this->addType('roomId', 'int');
@@ -47,6 +50,7 @@ class Ban extends Entity implements \JsonSerializable {
 
 	public function jsonSerialize(): array {
 		return [
+			'id' => $this->getId(),
 			'actorId' => $this->getActorId(),
 			'actorType' => $this->getActorType(),
 			'roomId' => $this->getRoomId(),

--- a/lib/Model/Ban.php
+++ b/lib/Model/Ban.php
@@ -8,9 +8,12 @@ declare(strict_types=1);
 
 namespace OCA\Talk\Model;
 
+use OCA\Talk\ResponseDefinitions;
 use OCP\AppFramework\Db\Entity;
 
 /**
+ * @psalm-import-type TalkBan from ResponseDefinitions
+ *
  * @method void setId(int $id)
  * @method int getId()
  * @method void setActorType(string $actorType)
@@ -48,15 +51,17 @@ class Ban extends Entity implements \JsonSerializable {
 		$this->addType('internalNote', 'string');
 	}
 
+	/**
+	 * @return TalkBan
+	 */
 	public function jsonSerialize(): array {
 		return [
 			'id' => $this->getId(),
 			'actorType' => $this->getActorType(),
 			'actorId' => $this->getActorId(),
-			'roomId' => $this->getRoomId(),
 			'bannedType' => $this->getBannedType(),
 			'bannedId' => $this->getBannedId(),
-			'bannedTime' => $this->getBannedTime() ? $this->getBannedTime()->getTimestamp() : null,
+			'bannedTime' => $this->getBannedTime()->getTimestamp(),
 			'internalNote' => $this->getInternalNote(),
 		];
 	}

--- a/lib/Model/BanMapper.php
+++ b/lib/Model/BanMapper.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Model;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\AppFramework\Db\TTransactional;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * @method Ban mapRowToEntity(array $row)
+ * @method Ban findEntity(IQueryBuilder $query)
+ * @method Ban[] findEntities(IQueryBuilder $query)
+ * @template-extends QBMapper<Ban>
+ */
+class BanMapper extends QBMapper {
+	use TTransactional;
+
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'talk_bans', Ban::class);
+	}
+
+	/**
+	 * @throws DoesNotExistException
+	 */
+	public function findForActorAndRoom(string $actorId, string $actorType, int $roomId): Ban {
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->eq('actor_id', $query->createNamedParameter($actorId, IQueryBuilder::PARAM_STR)))
+			->andWhere($query->expr()->eq('actor_type', $query->createNamedParameter($actorType, IQueryBuilder::PARAM_STR)))
+			->andWhere($query->expr()->eq('room_id', $query->createNamedParameter($roomId, IQueryBuilder::PARAM_INT)));
+
+		return $this->findEntity($query);
+	}
+
+	public function deleteBanForActorAndRoom(string $actorId, string $actorType, int $roomId): void {
+		$query = $this->db->getQueryBuilder();
+		$query->delete($this->getTableName())
+			->where($query->expr()->eq('actor_id', $query->createNamedParameter($actorId, IQueryBuilder::PARAM_STR)))
+			->andWhere($query->expr()->eq('actor_type', $query->createNamedParameter($actorType, IQueryBuilder::PARAM_STR)))
+			->andWhere($query->expr()->eq('room_id', $query->createNamedParameter($roomId, IQueryBuilder::PARAM_INT)));
+
+		$query->executeStatement();
+	}
+}

--- a/lib/Model/BanMapper.php
+++ b/lib/Model/BanMapper.php
@@ -61,15 +61,4 @@ class BanMapper extends QBMapper {
 
 		return $this->findEntity($query);
 	}
-
-	public function deleteBanForActorAndRoom(string $actorId, string $actorType, int $roomId): void {
-		$query = $this->db->getQueryBuilder();
-		$query->delete($this->getTableName())
-			->where($query->expr()->eq('actor_id', $query->createNamedParameter($actorId, IQueryBuilder::PARAM_STR)))
-			->andWhere($query->expr()->eq('actor_type', $query->createNamedParameter($actorType, IQueryBuilder::PARAM_STR)))
-			->andWhere($query->expr()->eq('room_id', $query->createNamedParameter($roomId, IQueryBuilder::PARAM_INT)));
-
-		$query->executeStatement();
-	}
-
 }

--- a/lib/Model/BanMapper.php
+++ b/lib/Model/BanMapper.php
@@ -52,11 +52,12 @@ class BanMapper extends QBMapper {
 	/**
 	 * @throws DoesNotExistException
 	 */
-	public function findByBanId(int $banId): Ban {
+	public function findByBanIdAndRoom(int $banId, int $roomId): Ban {
 		$query = $this->db->getQueryBuilder();
 		$query->select('*')
 			->from($this->getTableName())
-			->where($query->expr()->eq('id', $query->createNamedParameter($banId, IQueryBuilder::PARAM_INT)));
+			->where($query->expr()->eq('id', $query->createNamedParameter($banId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('room_id', $query->createNamedParameter($roomId, IQueryBuilder::PARAM_INT)));
 
 		return $this->findEntity($query);
 	}

--- a/lib/Model/BanMapper.php
+++ b/lib/Model/BanMapper.php
@@ -41,6 +41,15 @@ class BanMapper extends QBMapper {
 		return $this->findEntity($query);
 	}
 
+	public function findByRoomId(int $roomId): array {
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->eq('room_id', $query->createNamedParameter($roomId, IQueryBuilder::PARAM_INT)));
+
+		return $this->findEntities($query);
+	}
+
 	public function deleteBanForActorAndRoom(string $actorId, string $actorType, int $roomId): void {
 		$query = $this->db->getQueryBuilder();
 		$query->delete($this->getTableName())
@@ -50,4 +59,5 @@ class BanMapper extends QBMapper {
 
 		$query->executeStatement();
 	}
+
 }

--- a/lib/Model/BanMapper.php
+++ b/lib/Model/BanMapper.php
@@ -50,6 +50,15 @@ class BanMapper extends QBMapper {
 		return $this->findEntities($query);
 	}
 
+	public function findByBanId(int $banId): Ban {
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->eq('id', $query->createNamedParameter($banId, IQueryBuilder::PARAM_INT)));
+
+		return $this->findEntity($query);
+	}
+
 	public function deleteBanForActorAndRoom(string $actorId, string $actorType, int $roomId): void {
 		$query = $this->db->getQueryBuilder();
 		$query->delete($this->getTableName())

--- a/lib/Model/BanMapper.php
+++ b/lib/Model/BanMapper.php
@@ -10,7 +10,6 @@ namespace OCA\Talk\Model;
 
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\QBMapper;
-use OCP\AppFramework\Db\TTransactional;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
@@ -21,7 +20,6 @@ use OCP\IDBConnection;
  * @template-extends QBMapper<Ban>
  */
 class BanMapper extends QBMapper {
-	use TTransactional;
 
 	public function __construct(IDBConnection $db) {
 		parent::__construct($db, 'talk_bans', Ban::class);
@@ -45,11 +43,15 @@ class BanMapper extends QBMapper {
 		$query = $this->db->getQueryBuilder();
 		$query->select('*')
 			->from($this->getTableName())
-			->where($query->expr()->eq('room_id', $query->createNamedParameter($roomId, IQueryBuilder::PARAM_INT)));
+			->where($query->expr()->eq('room_id', $query->createNamedParameter($roomId, IQueryBuilder::PARAM_INT)))
+			->orderBy('id', 'ASC');
 
 		return $this->findEntities($query);
 	}
 
+	/**
+	 * @throws DoesNotExistException
+	 */
 	public function findByBanId(int $banId): Ban {
 		$query = $this->db->getQueryBuilder();
 		$query->select('*')

--- a/lib/Service/BanService.php
+++ b/lib/Service/BanService.php
@@ -25,30 +25,30 @@ class BanService {
 	/**
 	 * Validate the ban data.
 	 */
-	private function validateBanData(string $actorId, string $actorType, int $roomId, string $bannedByActorId, string $bannedByActorType, ?DateTime $bannedAt, ?string $reason): void {
-		if (empty($actorId) || empty($actorType) || empty($roomId) || empty($bannedByActorId) || empty($bannedByActorType)) {
+	private function validateBanData(string $actorId, string $actorType, int $roomId, string $bannedId, string $bannedType, ?DateTime $bannedTime, ?string $internalNote): void {
+		if (empty($actorId) || empty($actorType) || empty($roomId) || empty($bannedId) || empty($bannedType)) {
 			throw new \InvalidArgumentException("Invalid ban data provided.");
 		}
 
-		if ($bannedAt !== null && !$bannedAt instanceof DateTime) {
-			throw new \InvalidArgumentException("Invalid date format for bannedAt.");
+		if ($bannedTime !== null && !$bannedTime instanceof DateTime) {
+			throw new \InvalidArgumentException("Invalid date format for bannedTime.");
 		}
 	}
 
 	/**
 	 * Create a new ban
 	 */
-	public function createBan(string $actorId, string $actorType, int $roomId, string $bannedByActorId, string $bannedByActorType, ?DateTime $bannedAt, ?string $reason): Ban {
-		$this->validateBanData($actorId, $actorType, $roomId, $bannedByActorId, $bannedByActorType, $bannedAt, $reason);
+	public function createBan(string $actorId, string $actorType, int $roomId, string $bannedId, string $bannedType, ?DateTime $bannedTime, ?string $internalNote): Ban {
+		$this->validateBanData($actorId, $actorType, $roomId, $bannedId, $bannedType, $bannedTime, $internalNote);
 
 		$ban = new Ban();
 		$ban->setActorId($actorId);
 		$ban->setActorType($actorType);
 		$ban->setRoomId($roomId);
-		$ban->setBannedByActorId($bannedByActorId);
-		$ban->setBannedByActorType($bannedByActorType);
-		$ban->setBannedAt($bannedAt ?? $this->timeFactory->getTime());
-		$ban->setReason($reason);
+		$ban->setBannedId($bannedId);
+		$ban->setBannedType($bannedType);
+		$ban->setBannedTime($bannedTime ?? $this->timeFactory->getTime());
+		$ban->setInternalNote($internalNote);
 
 		return $this->banMapper->insert($ban);
 	}
@@ -84,5 +84,17 @@ class BanService {
 	 */
 	public function getBansForRoom(int $roomId): array {
 		return $this->banMapper->findByRoomId($roomId);
+	}
+
+	/**
+	 * Retrieve a ban by its ID and delete it.
+	 */
+	public function findAndDeleteBanById(int $banId): void {
+		try {
+			$ban = $this->banMapper->findByBanId($banId);
+			$this->banMapper->delete($ban);
+		} catch (DoesNotExistException $e) {
+			// Ban does not exist
+		}
 	}
 }

--- a/lib/Service/BanService.php
+++ b/lib/Service/BanService.php
@@ -37,7 +37,7 @@ class BanService {
 		if (empty($internalNote)) {
 			throw new \InvalidArgumentException("invalid_internalNote.");
 		}
-		
+
 		if ($bannedTime !== null && !$bannedTime instanceof DateTime) {
 			throw new \InvalidArgumentException("invalid_bannedTime.");
 		}
@@ -97,9 +97,9 @@ class BanService {
 	/**
 	 * Retrieve a ban by its ID and delete it.
 	 */
-	public function findAndDeleteBanById(int $banId): void {
+	public function findAndDeleteBanByIdForRoom(int $banId, int $roomId): void {
 		try {
-			$ban = $this->banMapper->findByBanId($banId);
+			$ban = $this->banMapper->findByBanIdAndRoom($banId, $roomId);
 			$this->banMapper->delete($ban);
 		} catch (DoesNotExistException $e) {
 			// Ban does not exist

--- a/lib/Service/BanService.php
+++ b/lib/Service/BanService.php
@@ -12,42 +12,27 @@ use DateTime;
 use OCA\Talk\Model\Ban;
 use OCA\Talk\Model\BanMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Utility\ITimeFactory;
 
 class BanService {
 
 	public function __construct(
 		protected BanMapper $banMapper,
-		protected ITimeFactory $timeFactory,
 	) {
 	}
 
 	/**
-	 * Validate the ban data.
+	 * Create a new ban
+	 *
+	 * @throws \InvalidArgumentException
 	 */
-	private function validateBanData(string $actorId, string $actorType, int $roomId, string $bannedId, string $bannedType, ?DateTime $bannedTime, ?string $internalNote): void {
-		if (empty($bannedId)) {
-			throw new \InvalidArgumentException("invalid_bannedId.");
-		}
-
-		if (empty($bannedType)) {
-			throw new \InvalidArgumentException("invalid_bannedType.");
+	public function createBan(string $actorId, string $actorType, int $roomId, string $bannedId, string $bannedType, DateTime $bannedTime, string $internalNote): Ban {
+		if (empty($bannedId) || empty($bannedType)) {
+			throw new \InvalidArgumentException('bannedActor');
 		}
 
 		if (empty($internalNote)) {
-			throw new \InvalidArgumentException("invalid_internalNote.");
+			throw new \InvalidArgumentException('internalNote');
 		}
-
-		if ($bannedTime !== null && !$bannedTime instanceof DateTime) {
-			throw new \InvalidArgumentException("invalid_bannedTime.");
-		}
-	}
-
-	/**
-	 * Create a new ban
-	 */
-	public function createBan(string $actorId, string $actorType, int $roomId, string $bannedId, string $bannedType, ?DateTime $bannedTime, ?string $internalNote): Ban {
-		$this->validateBanData($actorId, $actorType, $roomId, $bannedId, $bannedType, $bannedTime, $internalNote);
 
 		$ban = new Ban();
 		$ban->setActorId($actorId);
@@ -55,7 +40,7 @@ class BanService {
 		$ban->setRoomId($roomId);
 		$ban->setBannedId($bannedId);
 		$ban->setBannedType($bannedType);
-		$ban->setBannedTime($bannedTime ?? new \DateTime());
+		$ban->setBannedTime($bannedTime);
 		$ban->setInternalNote($internalNote);
 
 		return $this->banMapper->insert($ban);

--- a/lib/Service/BanService.php
+++ b/lib/Service/BanService.php
@@ -47,7 +47,7 @@ class BanService {
 		$ban->setRoomId($roomId);
 		$ban->setBannedId($bannedId);
 		$ban->setBannedType($bannedType);
-		$ban->setBannedTime($bannedTime ?? $this->timeFactory->getTime());
+		$ban->setBannedTime($bannedTime ?? new \DateTime());
 		$ban->setInternalNote($internalNote);
 
 		return $this->banMapper->insert($ban);

--- a/lib/Service/BanService.php
+++ b/lib/Service/BanService.php
@@ -48,6 +48,8 @@ class BanService {
 
 	/**
 	 * Retrieve a ban for a specific actor and room.
+	 *
+	 * @throws DoesNotExistException
 	 */
 	public function getBanForActorAndRoom(string $actorId, string $actorType, int $roomId): Ban {
 		return $this->banMapper->findForActorAndRoom($actorId, $actorType, $roomId);
@@ -55,6 +57,8 @@ class BanService {
 
 	/**
 	 * Retrieve all bans for a specific room.
+	 *
+	 * @return Ban[]
 	 */
 	public function getBansForRoom(int $roomId): array {
 		return $this->banMapper->findByRoomId($roomId);
@@ -67,7 +71,7 @@ class BanService {
 		try {
 			$ban = $this->banMapper->findByBanIdAndRoom($banId, $roomId);
 			$this->banMapper->delete($ban);
-		} catch (DoesNotExistException $e) {
+		} catch (DoesNotExistException) {
 			// Ban does not exist
 		}
 	}

--- a/lib/Service/BanService.php
+++ b/lib/Service/BanService.php
@@ -54,25 +54,6 @@ class BanService {
 	}
 
 	/**
-	 * Delete a ban for a specific actor and room.
-	 */
-	public function deleteBanForActorAndRoom(string $actorId, string $actorType, int $roomId): void {
-		$this->banMapper->deleteBanForActorAndRoom($actorId, $actorType, $roomId);
-	}
-
-	/**
-	 * Find and delete a ban for a specific actor and room.
-	 */
-	public function findAndDeleteBanForActorAndRoom(string $actorId, string $actorType, int $roomId): void {
-		try {
-			$ban = $this->getBanForActorAndRoom($actorId, $actorType, $roomId);
-			$this->deleteBanForActorAndRoom($actorId, $actorType, $roomId);
-		} catch (DoesNotExistException $e) {
-			// Ban does not exist
-		}
-	}
-
-	/**
 	 * Retrieve all bans for a specific room.
 	 */
 	public function getBansForRoom(int $roomId): array {

--- a/lib/Service/BanService.php
+++ b/lib/Service/BanService.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Service;
+
+use DateTime;
+use OCA\Talk\Model\Ban;
+use OCA\Talk\Model\BanMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+
+class BanService {
+	
+	public function __construct(
+		protected BanMapper $banMapper,
+		protected ITimeFactory $timeFactory,
+	) {
+	}
+
+	/**
+	 * Validate the ban data.
+	 */
+	private function validateBanData(string $actorId, string $actorType, int $roomId, string $bannedByActorId, string $bannedByActorType, ?DateTime $bannedAt, ?string $reason): void {
+		if (empty($actorId) || empty($actorType) || empty($roomId) || empty($bannedByActorId) || empty($bannedByActorType)) {
+			throw new \InvalidArgumentException("Invalid ban data provided.");
+		}
+
+		if ($bannedAt !== null && !$bannedAt instanceof DateTime) {
+			throw new \InvalidArgumentException("Invalid date format for bannedAt.");
+		}
+	}
+
+	/**
+	 * Create a new ban
+	 */
+	public function createBan(string $actorId, string $actorType, int $roomId, string $bannedByActorId, string $bannedByActorType, ?DateTime $bannedAt, ?string $reason): Ban {
+		$this->validateBanData($actorId, $actorType, $roomId, $bannedByActorId, $bannedByActorType, $bannedAt, $reason);
+
+		$ban = new Ban();
+		$ban->setActorId($actorId);
+		$ban->setActorType($actorType);
+		$ban->setRoomId($roomId);
+		$ban->setBannedByActorId($bannedByActorId);
+		$ban->setBannedByActorType($bannedByActorType);
+		$ban->setBannedAt($bannedAt ?? $this->timeFactory->getTime());
+		$ban->setReason($reason);
+
+		return $this->banMapper->insert($ban);
+	}
+
+	/**
+	 * Retrieve a ban for a specific actor and room.
+	 */
+	public function getBanForActorAndRoom(string $actorId, string $actorType, int $roomId): Ban {
+		return $this->banMapper->findForActorAndRoom($actorId, $actorType, $roomId);
+	}
+
+	/**
+	 * Delete a ban for a specific actor and room.
+	 */
+	public function deleteBanForActorAndRoom(string $actorId, string $actorType, int $roomId): void {
+		$this->banMapper->deleteBanForActorAndRoom($actorId, $actorType, $roomId);
+	}
+
+	/**
+	 * Find and delete a ban for a specific actor and room.
+	 */
+	public function findAndDeleteBanForActorAndRoom(string $actorId, string $actorType, int $roomId): void {
+		try {
+			$ban = $this->getBanForActorAndRoom($actorId, $actorType, $roomId);
+			$this->deleteBanForActorAndRoom($actorId, $actorType, $roomId);
+		} catch (DoesNotExistException $e) {
+			// Ban does not exist
+		}
+	}
+
+	/**
+	 * Retrieve all bans for a specific room.
+	 */
+	public function getBansForRoom(int $roomId): array {
+		return $this->banMapper->findByRoomId($roomId);
+	}
+}

--- a/lib/Service/BanService.php
+++ b/lib/Service/BanService.php
@@ -15,7 +15,7 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 
 class BanService {
-	
+
 	public function __construct(
 		protected BanMapper $banMapper,
 		protected ITimeFactory $timeFactory,
@@ -26,12 +26,20 @@ class BanService {
 	 * Validate the ban data.
 	 */
 	private function validateBanData(string $actorId, string $actorType, int $roomId, string $bannedId, string $bannedType, ?DateTime $bannedTime, ?string $internalNote): void {
-		if (empty($actorId) || empty($actorType) || empty($roomId) || empty($bannedId) || empty($bannedType)) {
-			throw new \InvalidArgumentException("Invalid ban data provided.");
+		if (empty($bannedId)) {
+			throw new \InvalidArgumentException("invalid_bannedId.");
 		}
 
+		if (empty($bannedType)) {
+			throw new \InvalidArgumentException("invalid_bannedType.");
+		}
+
+		if (empty($internalNote)) {
+			throw new \InvalidArgumentException("invalid_internalNote.");
+		}
+		
 		if ($bannedTime !== null && !$bannedTime instanceof DateTime) {
-			throw new \InvalidArgumentException("Invalid date format for bannedTime.");
+			throw new \InvalidArgumentException("invalid_bannedTime.");
 		}
 	}
 

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -2196,7 +2196,9 @@
                         }
                     }
                 }
-            },
+            }
+        },
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/ban/{token}/{banId}": {
             "delete": {
                 "operationId": "ban-unban-actor",
                 "summary": "Unban an actor or IP address",
@@ -2214,16 +2216,6 @@
                     }
                 ],
                 "parameters": [
-                    {
-                        "name": "banId",
-                        "in": "query",
-                        "description": "ID of the ban to be removed",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -2243,6 +2235,16 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "banId",
+                        "in": "path",
+                        "description": "ID of the ban to be removed",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
                         }
                     },
                     {

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -2099,7 +2099,11 @@
                                                     ],
                                                     "properties": {
                                                         "error": {
-                                                            "type": "string"
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "bannedActor",
+                                                                "internalNote"
+                                                            ]
                                                         }
                                                     }
                                                 }

--- a/openapi.json
+++ b/openapi.json
@@ -2083,7 +2083,9 @@
                         }
                     }
                 }
-            },
+            }
+        },
+        "/ocs/v2.php/apps/spreed/api/{apiVersion}/ban/{token}/{banId}": {
             "delete": {
                 "operationId": "ban-unban-actor",
                 "summary": "Unban an actor or IP address",
@@ -2101,16 +2103,6 @@
                     }
                 ],
                 "parameters": [
-                    {
-                        "name": "banId",
-                        "in": "query",
-                        "description": "ID of the ban to be removed",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -2130,6 +2122,16 @@
                         "schema": {
                             "type": "string",
                             "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "banId",
+                        "in": "path",
+                        "description": "ID of the ban to be removed",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
                         }
                     },
                     {

--- a/openapi.json
+++ b/openapi.json
@@ -1986,7 +1986,11 @@
                                                     ],
                                                     "properties": {
                                                         "error": {
-                                                            "type": "string"
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "bannedActor",
+                                                                "internalNote"
+                                                            ]
                                                         }
                                                     }
                                                 }

--- a/src/services/banService.ts
+++ b/src/services/banService.ts
@@ -42,11 +42,8 @@ const banActor = async function(token: string, payload: banActorParams, options?
  * @param banId - ban id
  * @param [options] - request options
  */
-const unbanActor = async function(token: string, banId: unbanActorParams['banId'], options?: object): unbanActorResponse {
-	return axios.delete(generateOcsUrl('/apps/spreed/api/v1/ban/{token}', { token }, options), {
-		...options,
-		params: { banId } as unbanActorParams,
-	})
+const unbanActor = async function(token: string, banId: number, options?: object): unbanActorResponse {
+	return axios.delete(generateOcsUrl('/apps/spreed/api/v1/ban/{token}/{banId}', { token, banId }, options), options)
 }
 
 export {

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -2428,7 +2428,8 @@ export interface operations {
                         ocs: {
                             meta: components["schemas"]["OCSMeta"];
                             data: {
-                                error: string;
+                                /** @enum {string} */
+                                error: "bannedActor" | "internalNote";
                             };
                         };
                     };

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -75,6 +75,22 @@ export type paths = {
          * @description Required capability: `ban-v1`
          */
         post: operations["ban-ban-actor"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ocs/v2.php/apps/spreed/api/{apiVersion}/ban/{token}/{banId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
         /**
          * Unban an actor or IP address
          * @description Required capability: `ban-v1`
@@ -2422,10 +2438,7 @@ export interface operations {
     };
     "ban-unban-actor": {
         parameters: {
-            query: {
-                /** @description ID of the ban to be removed */
-                banId: number;
-            };
+            query?: never;
             header: {
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
@@ -2433,6 +2446,8 @@ export interface operations {
             path: {
                 apiVersion: "v1";
                 token: string;
+                /** @description ID of the ban to be removed */
+                banId: number;
             };
             cookie?: never;
         };

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -75,6 +75,22 @@ export type paths = {
          * @description Required capability: `ban-v1`
          */
         post: operations["ban-ban-actor"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ocs/v2.php/apps/spreed/api/{apiVersion}/ban/{token}/{banId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
         /**
          * Unban an actor or IP address
          * @description Required capability: `ban-v1`
@@ -1907,10 +1923,7 @@ export interface operations {
     };
     "ban-unban-actor": {
         parameters: {
-            query: {
-                /** @description ID of the ban to be removed */
-                banId: number;
-            };
+            query?: never;
             header: {
                 /** @description Required to be true for the API request to pass */
                 "OCS-APIRequest": boolean;
@@ -1918,6 +1931,8 @@ export interface operations {
             path: {
                 apiVersion: "v1";
                 token: string;
+                /** @description ID of the ban to be removed */
+                banId: number;
             };
             cookie?: never;
         };

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1913,7 +1913,8 @@ export interface operations {
                         ocs: {
                             meta: components["schemas"]["OCSMeta"];
                             data: {
-                                error: string;
+                                /** @enum {string} */
+                                error: "bannedActor" | "internalNote";
                             };
                         };
                     };

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1456,6 +1456,38 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" bans (user|group|email|remote) "([^"]*)" from room "([^"]*)" with (\d+) \((v4)\)$/
+	 *
+	 * @param string $user
+	 * @param string $actorType
+	 * @param string $actorId
+	 * @param string $identifier
+	 * @param int $statusCode
+	 * @param string $apiVersion
+	 */
+	public function userBansUserFromRoom(string $user, string $actorType, string $actorId, string $identifier, int $statusCode, string $apiVersion): void {
+		if ($actorId === 'stranger') {
+			$actorId = '123456789';
+		} else {
+			if ($actorType === 'remote') {
+				$actorId .= '@' . rtrim($this->baseRemoteUrl, '/');
+				$actorType = 'federated_user';
+			}
+		}
+
+		$this->setCurrentUser($user);
+		$this->sendRequest(
+			'POST', '/apps/spreed/api/' . $apiVersion . '/ban/' . self::$identifierToToken[$identifier], new TableNode([
+				['actorType', $actorType],
+				['actorId', $actorId],
+			])
+		);
+		$this->assertStatusCode($this->response, $statusCode);
+	}
+
+
+
+	/**
 	 * @Then /^user "([^"]*)" deletes room "([^"]*)" with (\d+) \((v4)\)$/
 	 *
 	 * @param string $user
@@ -4560,5 +4592,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			Assert::assertEquals($statusCode, $response->getStatusCode(), $message);
 		}
 	}
+
+
 
 }

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -151,26 +151,6 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		return self::$userToAttendeeId[$room][$type][$id];
 	}
 
-	public function getBanId(string $type, string $id, string $room, string $user = null) {
-		if (!isset(self::$userToBanId[$room][$type][$id])) {
-			if ($user !== null) {
-				echo "userLoadsBanIdsInRoom\n";
-				$this->userLoadsBanIdsInRoom($user, $room, 'v1');
-			} else {
-				throw new \Exception('Ban id unknown, please call userLoadsBanIdsInRoom with a user that has access before');
-			}
-		}
-	
-		echo "userToBanId\n";
-		echo self::$userToBanId[$room][$type][$id];
-		if (!isset(self::$userToBanId[$room][$type][$id])) {
-			throw new \Exception('Ban id unknown, please call userLoadsBanIdsInRoom with a user that has access before 1');
-		}
-	
-		echo "returned correct banId\n";
-		return self::$userToBanId[$room][$type][$id];
-	}
-
 	/**
 	 * FeatureContext constructor.
 	 */
@@ -194,6 +174,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		];
 		self::$userToSessionId = [];
 		self::$userToAttendeeId = [];
+		self::$userToBanId = [];
 		self::$textToMessageId = [];
 		self::$messageIdToText = [];
 		self::$questionToPollId = [];
@@ -891,33 +872,6 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		}
 		return $a1['actorId'] <=> $a2['actorId'];
 	}
-	
-	/**
-	 * @Then /^user "([^"]*)" loads ban ids in room "([^"]*)" \((v1)\)$/
-	 *
-	 * @param string $user
-	 * @param string $identifier
-	 * @param string $apiVersion
-	 */
-	public function userLoadsBanIdsInRoom(string $user, string $identifier, string $apiVersion = 'v1'): void {
-		$this->setCurrentUser($user);
-		echo "SENDING GET REQUEST\n";
-		echo "selftoken: " . self::$identifierToToken[$identifier] . "\n";
-		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/ban/' . self::$identifierToToken[$identifier]);
-		$this->assertStatusCode($this->response, 200);
-		$bans = $this->getDataFromResponse($this->response);
-
-		echo "BANS: " . print_r($bans, true) . "\n";
-
-		foreach ($bans as $ban) {
-			if (!isset(self::$userToBanId[$identifier][$ban['actorType']])) {
-				self::$userToBanId[$identifier][$ban['actorType']] = [];
-			}
-			self::$userToBanId[$identifier][$ban['actorType']][$ban['actorId']] = $ban['id'];
-		}
-		echo "print the user to ban id array\n";
-		echo print_r(self::$userToBanId, true) . "\n";
-	}
 
 	private function mapParticipantTypeTestInput($participantType) {
 		if (is_numeric($participantType)) {
@@ -1538,15 +1492,38 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			}
 		}
 
-		//echo "Request Body: " . json_encode($body) . "\n";
-		echo "self" . self::$identifierToToken[$identifier] . "\n";
-
 		$this->sendRequest(
 			'POST', '/apps/spreed/api/' . $apiVersion . '/ban/' . self::$identifierToToken[$identifier], $body
 		);
 
-		echo "Response: " . $this->response->getBody()->getContents() . "\n";
 		$this->assertStatusCode($this->response, $statusCode);
+
+		if ($statusCode === 200) {
+			$data = $this->getDataFromResponse($this->response);
+			self::$userToBanId[self::$identifierToToken[$identifier]] ??= [];
+			self::$userToBanId[self::$identifierToToken[$identifier]][$actorType] ??= [];
+			self::$userToBanId[self::$identifierToToken[$identifier]][$actorType][$actorId] = $data['id'];
+		}
+	}
+
+	/**
+	 * @Then /^user "([^"]*)" sees the following bans in room "([^"]*)" with (\d+) \((v1)\)$/
+	 */
+	public function userLoadsBanIdsInRoom(string $user, string $identifier, int $statusCode, string $apiVersion, ?TableNode $tableNode): void {
+		$this->setCurrentUser($user);
+		$this->sendRequest('GET', '/apps/spreed/api/' . $apiVersion . '/ban/' . self::$identifierToToken[$identifier]);
+		$this->assertStatusCode($this->response, $statusCode);
+
+		if ($statusCode !== 200) {
+			return;
+		}
+
+		$bans = $this->getDataFromResponse($this->response);
+
+		var_dump($bans);
+		var_dump($tableNode->getColumnsHash());
+
+		// FIXME compare the 2 arrays
 	}
 
 	/**
@@ -1567,23 +1544,13 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 				$actorId .= '@' . rtrim($this->baseRemoteUrl, '/');
 				$actorType = 'federated_user';
 			}
-
-			echo "Getting banID\n";
-			$banId = $this->getBanId($actorType, $actorId, $identifier, $statusCode === 200 ? $user : null);
 		}
+		$banId = self::$userToBanId[self::$identifierToToken[$identifier]][$actorType][$actorId];
 
-		echo "starting to delete this ban\n";
 		$this->setCurrentUser($user);
-
-		echo "self: " . self::$identifierToToken[$identifier] . "\n";
-		echo "banId: " . $banId . "\n";
-
 		$this->sendRequest(
-			'DELETE', '/apps/spreed/api/' . $apiVersion . '/ban/' . self::$identifierToToken[$identifier], ['id' => $banId]
+			'DELETE', '/apps/spreed/api/' . $apiVersion . '/ban/' . self::$identifierToToken[$identifier] . '/' . $banId
 		);
-
-		echo "Response Status Code: " . $this->response->getStatusCode() . "\n";
-		echo "Response Body: " . $this->response->getBody()->getContents() . "\n";
 
 		$this->assertStatusCode($this->response, $statusCode);
 	}

--- a/tests/integration/features/conversation-1/ban.feature
+++ b/tests/integration/features/conversation-1/ban.feature
@@ -2,13 +2,30 @@ Feature: conversation/ban
     Background:
         Given user "participant1" exists
         Given user "participant2" exists
+        Given user "participant3" exists
         And guest accounts can be created
         And user "user-guest@example.com" is a guest account user
 
-    Scenario: Ban a user from a room
+    Scenario: Moderator banning and unbanning multiple users
         Given user "participant1" creates room "room" (v4)
         | roomType | 3 |
         | roomName | room |
         And user "participant2" joins room "room" with 200 (v4)
-        When user "participant1" bans user "participant2" from room "room" with 200 (v4)
-        Then user "participant2" joins room "room" with 403 (v4)
+        And user "participant3" joins room "room" with 200 (v4)
+        And user "participant1" bans user "participant2" from room "room" with 200 (v1)
+            | internalNote | BannedP1 |
+        And user "participant1" bans user "participant3" from room "room" with 200 (v1)
+            | internalNote | BannedP2 |
+        #And user "participant2" joins room "room" with 403 (v4)
+        #And user "participant3" joins room "room" with 403 (v4)
+        And user "participant1" unbans user "participant2" from room "room" with 200 (v1)
+        And user "participant1" unbans user "participant3" from room "room" with 200 (v1)
+    
+    # Scenario: Moderator banning and unbanning guest account
+    #     Given user "participant1" creates room "room" (v4)
+    #     | roomType | 3 |
+    #     | roomName | room |
+    #     And user "user-guest@example.com" joins room "room" with 200 (v4)
+    #     And user "participant1" bans user "user-guest@example.com" from room "room" with 200 (v1)
+    #         | internalNote | BannedG1 |
+    #     And user "participant1" unbans user "user-guest@exmaple.com" from room "room" with 200 (v1)

--- a/tests/integration/features/conversation-1/ban.feature
+++ b/tests/integration/features/conversation-1/ban.feature
@@ -13,23 +13,80 @@ Feature: conversation/ban
         And user "participant2" joins room "room" with 200 (v4)
         And user "participant3" joins room "room" with 200 (v4)
         And user "participant1" bans user "participant2" from room "room" with 200 (v1)
-            | internalNote | BannedP1 |
-        And user "participant1" bans user "participant3" from room "room" with 200 (v1)
             | internalNote | BannedP2 |
+        And user "participant1" bans user "participant3" from room "room" with 200 (v1)
+            | internalNote | BannedP3 |
         And user "participant1" sees the following bans in room "room" with 200 (v1)
           | actorType | actorId      | bannedType | bannedId     | internalNote |
-          | users     | participant1 | users      | participant2 | BannedP1     |
-          | users     | participant1 | users      | participant3 | BannedP2     |
+          | users     | participant1 | users      | participant2 | BannedP2     |
+          | users     | participant1 | users      | participant3 | BannedP3     |
         And user "participant2" joins room "room" with 403 (v4)
         And user "participant3" joins room "room" with 403 (v4)
         And user "participant1" unbans user "participant2" from room "room" with 200 (v1)
         And user "participant1" unbans user "participant3" from room "room" with 200 (v1)
+        And user "participant2" joins room "room" with 200 (v4)
+        And user "participant3" joins room "room" with 200 (v4)
 
-    # Scenario: Moderator banning and unbanning guest account
+    Scenario: Users trying to ban moderator
+        Given user "participant1" creates room "room" (v4)
+        | roomType | 3 |
+        | roomName | room |
+        And user "participant2" joins room "room" with 200 (v4)
+        And user "participant3" joins room "room" with 200 (v4)
+        And user "participant2" bans user "participant1" from room "room" with 403 (v1)
+            | internalNote | BannedP1 |
+        And user "participant3" bans user "participant1" from room "room" with 403 (v1)
+            | internalNote | BannedP1 |
+
+    Scenario: Users trying to ban other users
+        Given user "participant1" creates room "room" (v4)
+        | roomType | 3 |
+        | roomName | room |
+        And user "participant2" joins room "room" with 200 (v4)
+        And user "participant3" joins room "room" with 200 (v4)
+        And user "participant2" bans user "participant3" from room "room" with 403 (v1)
+            | internalNote | BannedP3 |
+        And user "participant3" bans user "participant2" from room "room" with 403 (v1)
+            | internalNote | BannedP2 |
+
+    Scenario: User trying to ban themselves
+        Given user "participant1" creates room "room" (v4)
+        | roomType | 3 |
+        | roomName | room |
+        And user "participant1" joins room "room" with 200 (v4)
+        And user "participant2" joins room "room" with 200 (v4)
+        And user "participant2" bans user "participant2" from room "room" with 403 (v1)
+            | internalNote | BannedP2 |
+
+    Scenario: Moderator trying to ban an invalid user
+        Given user "participant1" creates room "room" (v4)
+        | roomType | 3 |
+        | roomName | room |
+        And user "participant2" joins room "room" with 200 (v4)
+        And user "participant1" bans user "participant3" from room "room" with 200 (v1)
+            | internalNote | BannedInvalid |
+
+    # Scenario: Moderator trying to ban moderator
     #     Given user "participant1" creates room "room" (v4)
     #     | roomType | 3 |
     #     | roomName | room |
-    #     And user "user-guest@example.com" joins room "room" with 200 (v4)
-    #     And user "participant1" bans user "user-guest@example.com" from room "room" with 200 (v1)
-    #         | internalNote | BannedG1 |
-    #     And user "participant1" unbans user "user-guest@exmaple.com" from room "room" with 200 (v1)
+    #     And user "participant1" joins room "room" with 200 (v4)
+    #     And user "participant2" joins room "room" with 200 (v4)
+    #     And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+    #     And user "participant1" promotes "participant2" in room "room" with 200 (v4)
+    #     And user "participant1" bans user "participant2" from room "room" with 403 (v1)
+    #         | internalNote | BannedP2 |
+
+    # Scenario: Moderator trying to ban themselves
+    #     Given user "participant1" creates room "room" (v4)
+    #     | roomType | 3 |
+    #     | roomName | room |
+    #     And user "participant1" joins room "room" with 200 (v4)
+    #     And user "participant1" bans user "participant1" from room "room" with 403 (v1)
+    #         | internalNote | BannedP1 |
+
+    
+
+
+
+

--- a/tests/integration/features/conversation-1/ban.feature
+++ b/tests/integration/features/conversation-1/ban.feature
@@ -16,11 +16,15 @@ Feature: conversation/ban
             | internalNote | BannedP1 |
         And user "participant1" bans user "participant3" from room "room" with 200 (v1)
             | internalNote | BannedP2 |
-        #And user "participant2" joins room "room" with 403 (v4)
-        #And user "participant3" joins room "room" with 403 (v4)
+        And user "participant1" sees the following bans in room "room" with 200 (v1)
+          | actorType | actorId      | bannedType | bannedId     | internalNote |
+          | users     | participant1 | users      | participant2 | BannedP1     |
+          | users     | participant1 | users      | participant3 | BannedP2     |
+        And user "participant2" joins room "room" with 403 (v4)
+        And user "participant3" joins room "room" with 403 (v4)
         And user "participant1" unbans user "participant2" from room "room" with 200 (v1)
         And user "participant1" unbans user "participant3" from room "room" with 200 (v1)
-    
+
     # Scenario: Moderator banning and unbanning guest account
     #     Given user "participant1" creates room "room" (v4)
     #     | roomType | 3 |

--- a/tests/integration/features/conversation-1/ban.feature
+++ b/tests/integration/features/conversation-1/ban.feature
@@ -1,0 +1,14 @@
+Feature: conversation/ban
+    Background:
+        Given user "participant1" exists
+        Given user "participant2" exists
+        And guest accounts can be created
+        And user "user-guest@example.com" is a guest account user
+
+    Scenario: Ban a user from a room
+        Given user "participant1" creates room "room" (v4)
+        | roomType | 3 |
+        | roomName | room |
+        And user "participant2" joins room "room" with 200 (v4)
+        When user "participant1" bans user "participant2" from room "room" with 200 (v4)
+        Then user "participant2" joins room "room" with 403 (v4)


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12292 

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Create the API contracts, already done with https://github.com/nextcloud/spreed/pull/12259
- [x] Create the database migration in lib/Migration/ (create a skeleton file with matching name by using `occ migrations:generate spreed 20000`)
   1. Check the contract for needed fields
   2. Get inspired from `Version18000Date20230808120823` how to define the `oc_talk_bans` table, columns and indixes
- [x] Create the entity and basic mapper in lib/Model/ (Reminder and ReminderMapper look like they have all data types you need aswell). The base class QBMapper has quite some methods and involves magic methods, so it can be a bit confusing to work with in the beginning.
- [x] Create a service (or put the methods into the BanMapper) to handle validating, creating, retrieving and deleting bans
- [x] Use the service or mapper in the controller and other code blocks that were touched for the contract in step 1
- [x] Write integration tests (I'd put them into `tests/integration/features/conversation-1/ban.feature`)
- [x] Ensure all queries are covered by indexes 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
