### PR TITLE
fix: chat jumping when reference widgets are rendered

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -295,6 +295,7 @@ export default {
 		EventBus.on('scroll-chat-to-bottom', this.scrollToBottom)
 		EventBus.on('focus-message', this.focusMessage)
 		EventBus.on('route-change', this.onRouteChange)
+		EventBus.on('message-height-changed', this.onMessageHeightChanged)
 		subscribe('networkOffline', this.handleNetworkOffline)
 		subscribe('networkOnline', this.handleNetworkOnline)
 		window.addEventListener('focus', this.onWindowFocus)
@@ -315,7 +316,7 @@ export default {
 		EventBus.off('scroll-chat-to-bottom', this.scrollToBottom)
 		EventBus.off('focus-message', this.focusMessage)
 		EventBus.off('route-change', this.onRouteChange)
-
+		EventBus.off('message-height-changed', this.onMessageHeightChanged)
 		this.$store.dispatch('cancelLookForNewMessages', { requestId: this.chatIdentifier })
 		this.destroying = true
 
@@ -1223,6 +1224,11 @@ export default {
 		messagesGroupComponent(group) {
 			return group.isSystemMessagesGroup ? MessagesSystemGroup : MessagesGroup
 		},
+
+		onMessageHeightChanged({ heightDiff }) {
+			// scroll down by the height difference
+			this.$refs.scroller.scrollTop += heightDiff
+		}
 	},
 }
 </script>


### PR DESCRIPTION
### ☑️ Resolves

* Fix #10627 

During testing, this fix seems smooth when joining, during scrolling and on message link (yet, needs some conditions for this case). 

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts


Before

https://github.com/nextcloud/spreed/assets/84044328/b79aae8a-cce2-4881-8941-2b8d48bc9796




After


https://github.com/nextcloud/spreed/assets/84044328/974a84ec-e357-4ecf-a637-758800ffb2a8




### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
