### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "ad39a84bcc13c8bcae5b160cbb8a115b26f6b8b1"
+                "reference": "bdeabb2fbb4691ac3d72dc27f56dd52aa6c61725"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/ad39a84bcc13c8bcae5b160cbb8a115b26f6b8b1",
-                "reference": "ad39a84bcc13c8bcae5b160cbb8a115b26f6b8b1",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/bdeabb2fbb4691ac3d72dc27f56dd52aa6c61725",
+                "reference": "bdeabb2fbb4691ac3d72dc27f56dd52aa6c61725",
                 "shasum": ""
             },
             "require": {
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-06-12T00:36:06+00:00"
+            "time": "2024-06-18T00:36:38+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency