### PR TITLE
fix(MessageButtonsBar): Hide reply button if participant has no chat permission

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.spec.js
@@ -14,7 +14,7 @@ import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import MessageButtonsBar from './../MessageButtonsBar/MessageButtonsBar.vue'
 
 import * as useMessageInfoModule from '../../../../../composables/useMessageInfo.js'
-import { CONVERSATION, ATTENDEE } from '../../../../../constants.js'
+import { CONVERSATION, ATTENDEE, PARTICIPANT } from '../../../../../constants.js'
 import storeConfig from '../../../../../store/storeConfig.js'
 import { useIntegrationsStore } from '../../../../../stores/integrations.js'
 import { findNcActionButton, findNcButton } from '../../../../../test-helpers.js'
@@ -41,6 +41,7 @@ describe('MessageButtonsBar.vue', () => {
 			lastCommonReadMessage: 0,
 			type: CONVERSATION.TYPE.GROUP,
 			readOnly: CONVERSATION.STATE.READ_WRITE,
+			permissions: PARTICIPANT.PERMISSIONS.CHAT,
 		}
 
 		testStoreConfig = cloneDeep(storeConfig)
@@ -133,6 +134,25 @@ describe('MessageButtonsBar.vue', () => {
 
 			test('hides reply button when not replyable', async () => {
 				messageProps.message.isReplyable = false
+				store = new Store(testStoreConfig)
+
+				const wrapper = shallowMount(MessageButtonsBar, {
+					localVue,
+					store,
+					stubs: {
+						NcActionButton,
+						NcButton,
+					},
+					propsData: messageProps,
+					provide: injected,
+				})
+
+				const replyButton = findNcButton(wrapper, 'Reply')
+				expect(replyButton.exists()).toBe(false)
+			})
+
+			test('hides reply button when no chat permission', async () => {
+				conversationProps.permissions = 0
 				store = new Store(testStoreConfig)
 
 				const wrapper = shallowMount(MessageButtonsBar, {

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageButtonsBar.vue
@@ -16,7 +16,7 @@
 					<EmoticonOutline :size="20" />
 				</template>
 			</NcButton>
-			<NcButton v-if="message.isReplyable && !isConversationReadOnly"
+			<NcButton v-if="canReply"
 				type="tertiary"
 				:aria-label="t('spreed', 'Reply')"
 				:title="t('spreed', 'Reply')"
@@ -288,7 +288,7 @@ import NcEmojiPicker from '@nextcloud/vue/dist/Components/NcEmojiPicker.js'
 import { emojiSearch } from '@nextcloud/vue/dist/Functions/emoji.js'
 
 import { useMessageInfo } from '../../../../../composables/useMessageInfo.js'
-import { CONVERSATION, ATTENDEE } from '../../../../../constants.js'
+import { CONVERSATION, ATTENDEE, PARTICIPANT } from '../../../../../constants.js'
 import { hasTalkFeature } from '../../../../../services/CapabilitiesManager.ts'
 import { getMessageReminder, removeMessageReminder, setMessageReminder } from '../../../../../services/remindersService.js'
 import { useIntegrationsStore } from '../../../../../stores/integrations.js'
@@ -550,6 +550,10 @@ export default {
 				actor: this.message.lastEditActorDisplayName,
 			})
 		},
+
+		canReply() {
+			return this.message.isReplyable && !this.isConversationReadOnly && (this.conversation.permissions & PARTICIPANT.PERMISSIONS.CHAT) !== 0
+		}
 	},
 
 	watch: {


### PR DESCRIPTION
### ☑️ Resolves

The button was displayed, even when the user had no permissions to send a message to the chat.

## 🖌️ UI Checklist

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required