### PR TITLE
feat(MediaSettings): add option to mirror video preview

### DIFF
--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -13,12 +13,21 @@
 			</h2>
 			<!-- Preview -->
 			<div class="media-settings__preview">
-				<!-- eslint-disable-next-line -->
 				<video v-show="showVideo"
 					ref="video"
-					class="preview__video"
+					:class="['preview__video', {'preview__video--mirrored': isMirrored}]"
 					disable-picture-in-picture="true"
 					tabindex="-1" />
+				<NcButton v-if="showVideo"
+					type="secondary"
+					class="media-settings__preview-mirror"
+					:title="mirrorToggleLabel"
+					:aria-label="mirrorToggleLabel"
+					@click="isMirrored = !isMirrored">
+					<template #icon>
+						<ReflectHorizontal :size="20" />
+					</template>
+				</NcButton>
 				<div v-show="!showVideo"
 					class="preview__novideo">
 					<VideoBackground :display-name="displayName"
@@ -189,6 +198,7 @@ import Bell from 'vue-material-design-icons/Bell.vue'
 import BellOff from 'vue-material-design-icons/BellOff.vue'
 import Cog from 'vue-material-design-icons/Cog.vue'
 import Creation from 'vue-material-design-icons/Creation.vue'
+import ReflectHorizontal from 'vue-material-design-icons/ReflectHorizontal.vue'
 import VideoIcon from 'vue-material-design-icons/Video.vue'
 import VideoOff from 'vue-material-design-icons/VideoOff.vue'
 
@@ -242,6 +252,7 @@ export default {
 		NcNoteCard,
 		MediaDevicesSelector,
 		MediaDevicesSpeakerTest,
+		ReflectHorizontal,
 		VideoBackground,
 		VideoIcon,
 		VideoOff,
@@ -314,6 +325,7 @@ export default {
 			videoDeviceStateChanged: false,
 			isRecordingFromStart: false,
 			isPublicShareAuthSidebar: false,
+			isMirrored: false,
 		}
 	},
 
@@ -365,6 +377,12 @@ export default {
 				return t('spreed', 'No camera')
 			}
 			return this.videoOn ? t('spreed', 'Disable video') : t('spreed', 'Enable video')
+		},
+
+		mirrorToggleLabel() {
+			return this.isMirrored
+				? t('spreed', 'Display video as you will see it (mirrored)')
+				: t('spreed', 'Display video as others will see it')
 		},
 
 		conversation() {
@@ -505,6 +523,7 @@ export default {
 			this.videoDeviceStateChanged = false
 			this.isPublicShareAuthSidebar = false
 			this.isRecordingFromStart = false
+			this.isMirrored = false
 			// Update devices preferences
 			this.updatePreferences('audioinput')
 			this.updatePreferences('videoinput')
@@ -699,6 +718,12 @@ export default {
 		aspect-ratio: 4/3;
 	}
 
+	&__preview > &__preview-mirror {
+		position: absolute;
+		top: var(--default-grid-baseline);
+		right: var(--default-grid-baseline);
+	}
+
 	&__toggles-wrapper {
 		width: 100%;
 		display: flex;
@@ -746,6 +771,10 @@ export default {
 		max-width: 100%;
 		object-fit: contain;
 		max-height: 100%;
+
+		&--mirrored {
+			transform: none !important;
+		}
 	}
 
 	&__novideo {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12545
* I didn't like the idea of a long-text hint obstructing the video, so decided to try a toggle button:
  * title and aria-labels define the way video will be displayed for a user
  * users can check by himself, how others actually see them.

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

☀️ Light theme | 🌑 Dark Theme
-- | --
![Screenshot from 2024-06-26 11-09-39](https://github.com/nextcloud/spreed/assets/93392545/94ed1ae4-41e6-437b-a2c7-9222f8fa2154) | ![image](https://github.com/nextcloud/spreed/assets/93392545/dfa4cdd4-c707-4e04-b688-a97fe77852b8)
![Screenshot from 2024-06-26 11-09-23](https://github.com/nextcloud/spreed/assets/93392545/3ed7ca8d-e938-4d97-81ad-9b21ece7a382) | ![image](https://github.com/nextcloud/spreed/assets/93392545/fb309673-5f96-4520-ba60-d39067e76b34)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team