### PR TITLE
fix(Message): adjust toast message on delete to align with API

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -397,7 +397,7 @@ export default {
 				})
 
 				if (statusCode === 202) {
-					showWarning(t('spreed', 'Message deleted successfully, but Matterbridge is configured and the message might already be distributed to other services'), {
+					showWarning(t('spreed', 'Message deleted successfully, but a bot or Matterbridge is configured and the message might already be distributed to other services'), {
 						timeout: TOAST_DEFAULT_TIMEOUT * 2,
 					})
 				} else if (statusCode === 200) {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12500

Ref: https://github.com/nextcloud/spreed/blob/eb45b2eb8787207d072e5399da50f24f000df658/docs/chat.md?plain=1#L297
Didn't find an easy way to distinguish between bot or Matterbridge, but siince it's in the docs, should be fine to show the same text

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

![image](https://github.com/nextcloud/spreed/assets/93392545/38a01258-e625-4902-811b-c1e500a6ca39)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
