### PR TITLE
fix(RightSidebar): refactor, add 'Participants' to 1-1 calls

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -5,11 +5,10 @@
 
 <template>
 	<NcAppSidebar v-show="opened"
-		:name="name"
-		:title="name"
-		:active="activeTab"
+		:name="conversation.displayName"
+		:title="conversation.displayName"
+		:active.sync="activeTab"
 		:class="'active-tab-' + activeTab"
-		@update:active="handleUpdateActive"
 		@closed="handleClosed"
 		@close="handleClose">
 		<template #description>
@@ -190,10 +189,6 @@ export default {
 				|| (this.conversation.type === CONVERSATION.TYPE.PUBLIC && this.conversation.objectType !== CONVERSATION.OBJECT_TYPE.VIDEO_VERIFICATION))
 		},
 
-		isSearching() {
-			return this.searchText !== ''
-		},
-
 		participantType() {
 			return this.conversation.participantType
 		},
@@ -202,33 +197,12 @@ export default {
 			return this.participantType === PARTICIPANT.TYPE.OWNER || this.participantType === PARTICIPANT.TYPE.MODERATOR
 		},
 
-		canModerate() {
-			return !this.isOneToOne && (this.canFullModerate || this.participantType === PARTICIPANT.TYPE.GUEST_MODERATOR)
-		},
-
 		isModeratorOrUser() {
 			return this.$store.getters.isModeratorOrUser
 		},
 
 		isInLobby() {
 			return this.$store.getters.isInLobby
-		},
-
-		/**
-		 * The conversation name value passed into the NcAppSidebar component.
-		 *
-		 * @return {string} The conversation's name.
-		 */
-		name() {
-			if (this.isRenamingConversation) {
-				return this.conversationName
-			} else {
-				return this.conversation.displayName
-			}
-		},
-
-		isRenamingConversation() {
-			return this.$store.getters.isRenamingConversation
 		},
 
 		showSIPSettings() {
@@ -287,10 +261,6 @@ export default {
 
 	watch: {
 		conversation(newConversation, oldConversation) {
-			if (!this.isRenamingConversation) {
-				this.conversationName = this.conversation.displayName
-			}
-
 			if (newConversation.token === oldConversation.token || !this.showParticipantsTab) {
 				return
 			}

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -239,7 +239,7 @@ export default {
 		},
 
 		showParticipantsTab() {
-			return (this.getUserId || this.isModeratorOrUser) && !this.isOneToOne && !this.isNoteToSelf
+			return (this.getUserId || this.isModeratorOrUser) && (!this.isOneToOne || this.isInCall) && !this.isNoteToSelf
 		},
 
 		showSharedItemsTab() {

--- a/src/store/sidebarStore.js
+++ b/src/store/sidebarStore.js
@@ -5,17 +5,11 @@
 
 const state = {
 	show: true,
-	isRenamingConversation: false,
-	sidebarOpenBeforeEditing: null,
-
 }
 
 const getters = {
 	getSidebarStatus: (state) => {
 		return state.show
-	},
-	isRenamingConversation: (state) => {
-		return state.isRenamingConversation
 	},
 }
 
@@ -36,23 +30,6 @@ const mutations = {
 	hideSidebar(state) {
 		state.show = false
 	},
-	/**
-	 * Renaming state of the conversation
-	 *
-	 * @param {object} state current store state;
-	 * @param {boolean} boolean the state of the renaming action;
-	 */
-	isRenamingConversation(state, boolean) {
-		if (boolean) {
-			// Record sidebar status before starting editing process
-			state.sidebarOpenBeforeEditing = state.show
-			state.isRenamingConversation = true
-		} else {
-			state.isRenamingConversation = false
-			// Go back to the previous sidebar state
-			state.show = state.sidebarOpenBeforeEditing
-		}
-	},
 }
 
 const actions = {
@@ -72,15 +49,6 @@ const actions = {
 	 */
 	hideSidebar(context) {
 		context.commit('hideSidebar')
-	},
-	/**
-	 * Renaming state of the conversation
-	 *
-	 * @param {object} context default store context;
-	 * @param {boolean} boolean the state of the renaming action;
-	 */
-	isRenamingConversation(context, boolean) {
-		context.commit('isRenamingConversation', boolean)
 	},
 }
 

--- a/src/store/sidebarStore.spec.js
+++ b/src/store/sidebarStore.spec.js
@@ -26,7 +26,6 @@ describe('sidebarStore', () => {
 
 	test('defaults are off', () => {
 		expect(store.getters.getSidebarStatus).toBe(true)
-		expect(store.getters.isRenamingConversation).toBe(false)
 	})
 
 	test('toggle sidebar', () => {
@@ -37,39 +36,5 @@ describe('sidebarStore', () => {
 		store.dispatch('showSidebar')
 
 		expect(store.getters.getSidebarStatus).toBe(true)
-	})
-
-	test('toggling renaming mode and remembers sidebar hidden state', () => {
-		store.dispatch('hideSidebar')
-		store.dispatch('isRenamingConversation', true)
-
-		expect(store.getters.getSidebarStatus).toBe(false)
-		expect(store.getters.isRenamingConversation).toBe(true)
-
-		store.dispatch('showSidebar')
-
-		expect(store.getters.getSidebarStatus).toBe(true)
-
-		store.dispatch('isRenamingConversation', false)
-
-		expect(store.getters.getSidebarStatus).toBe(false)
-		expect(store.getters.isRenamingConversation).toBe(false)
-	})
-
-	test('toggling renaming mode and remembers sidebar shown state', () => {
-		store.dispatch('showSidebar')
-		store.dispatch('isRenamingConversation', true)
-
-		expect(store.getters.getSidebarStatus).toBe(true)
-		expect(store.getters.isRenamingConversation).toBe(true)
-
-		store.dispatch('hideSidebar')
-
-		expect(store.getters.getSidebarStatus).toBe(false)
-
-		store.dispatch('isRenamingConversation', false)
-
-		expect(store.getters.getSidebarStatus).toBe(true)
-		expect(store.getters.isRenamingConversation).toBe(false)
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

* Remove some outdated code
* Add 'Participants' tab for 1-1 calls




## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/c40dcfd1-2025-434b-9079-1246294eb602) | ![image](https://github.com/nextcloud/spreed/assets/93392545/fa14cc70-1b8b-47a3-a55f-e4facd9a19fc)

### 🚧 Tasks

- [ ] Headers are sometime incorrect: wrong `activeTab` assignment, follow-up with it
- [x] Tab is empty: assignment of `activeTab` when tab is not ready yet, upstream: fixed with `:key` by @ShGKme 
- [ ] Add a header for a single tab - upstream to vue-lib

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
