### PR TITLE
fix(sidebar): tab is not shown after switching a conversation

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -17,6 +17,7 @@
 		</template>
 		<NcAppSidebarTab v-if="isInCall"
 			id="chat"
+			key="chat"
 			:order="1"
 			:name="t('spreed', 'Chat')">
 			<template #icon>
@@ -26,6 +27,7 @@
 		</NcAppSidebarTab>
 		<NcAppSidebarTab v-if="showParticipantsTab"
 			id="participants"
+			key="participants"
 			ref="participantsTab"
 			:order="2"
 			:name="participantsText">
@@ -38,6 +40,7 @@
 		</NcAppSidebarTab>
 		<NcAppSidebarTab v-if="showBreakoutRoomsTab"
 			id="breakout-rooms"
+			key="breakout-rooms"
 			ref="breakout-rooms"
 			:order="3"
 			:name="breakoutRoomsText">
@@ -50,6 +53,7 @@
 		</NcAppSidebarTab>
 		<NcAppSidebarTab v-if="showDetailsTab"
 			id="details-tab"
+			key="details-tab"
 			:order="4"
 			:name="t('spreed', 'Details')">
 			<template #icon>
@@ -72,6 +76,7 @@
 		</NcAppSidebarTab>
 		<NcAppSidebarTab v-if="showSharedItemsTab"
 			id="shared-items"
+			key="shared-items"
 			ref="sharedItemsTab"
 			:order="5"
 			:name="t('spreed', 'Shared items')">


### PR DESCRIPTION
### ☑️ Resolves

0. Open Nextcloud Talk on `/apps/spreed`
1. Open a chat with one tab, for example, one-to-one with only **Shared Media** tab
2. Switch to a conversation with only one another tab, for example, Federation chat with only **Participants** tab
3. See no tab

Follow-up: add note to docs in `nextcloud-vue`.

### Why

`NcAppSidebar` registers tabs when they are created or destroyed.

But in this case, with Vue optimizing rendering, no tab has been destroyed or created. Instead, the only tab has been reused: it has received new content and `id` changed from `shared-media` to `participants`.

Supporting tab's `id` change in `NcAppSidebar` is not really possible and risky.

A solution - identify `NcAppSidebarTab`s with `key`, so Vue knows that `shared-items` and `participants` or other tabs are actually different tabs and doesn't try to reuse tabs.

The same solution is required in other cases where Vue has to identify nodes: KeepAlive, Transition, `v-for`.

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
