### PR TITLE
Add support for external signaling federation

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>20.0.0-dev.7</version>
+	<version>20.0.0-dev.8</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/appinfo/routes/routesRoomController.php
+++ b/appinfo/routes/routesRoomController.php
@@ -71,6 +71,8 @@ return [
 		['name' => 'Room#resendInvitations', 'url' => '/api/{apiVersion}/room/{token}/participants/resend-invitations', 'verb' => 'POST', 'requirements' => $requirementsWithToken],
 		/** @see \OCA\Talk\Controller\RoomController::leaveRoom() */
 		['name' => 'Room#leaveRoom', 'url' => '/api/{apiVersion}/room/{token}/participants/active', 'verb' => 'DELETE', 'requirements' => $requirementsWithToken],
+		/** @see \OCA\Talk\Controller\RoomController::leaveFederatedRoom() */
+		['name' => 'Room#leaveFederatedRoom', 'url' => '/api/{apiVersion}/room/{token}/federation/active', 'verb' => 'DELETE', 'requirements' => $requirementsWithToken],
 		/** @see \OCA\Talk\Controller\RoomController::setSessionState() */
 		['name' => 'Room#setSessionState', 'url' => '/api/{apiVersion}/room/{token}/participants/state', 'verb' => 'PUT', 'requirements' => $requirementsWithToken],
 		/** @see \OCA\Talk\Controller\RoomController::promoteModerator() */

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -153,3 +153,4 @@
 ## 20
 * `ban-v1` - Whether the API to ban attendees is available
 * `mention-permissions` - Whether non-moderators are allowed to mention `@all`
+* `federation-v2` - Whether federated session ids are used and calls are possible with federation

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -98,6 +98,7 @@ class Capabilities implements IPublicCapability {
 		'silent-send-state',
 		'chat-read-last',
 		'federation-v1',
+		'federation-v2',
 		'ban-v1',
 		'chat-reference-id',
 		'mention-permissions',

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -15,6 +15,7 @@ use OCA\Talk\Vendor\Firebase\JWT\JWT;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Federation\ICloudIdManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
@@ -46,6 +47,7 @@ class Config {
 		private ISecureRandom $secureRandom,
 		private IGroupManager $groupManager,
 		private IUserManager $userManager,
+		private ICloudIdManager $cloudIdManager,
 		private IURLGenerator $urlGenerator,
 		protected ITimeFactory $timeFactory,
 		private IEventDispatcher $dispatcher,
@@ -572,7 +574,8 @@ class Config {
 	}
 
 	/**
-	 * @param string|null $userId
+	 * @param string|null $userId if given, the id of a user in this instance or
+	 *        a cloud id.
 	 * @return string
 	 */
 	private function getSignalingTicketV2(?string $userId): string {
@@ -586,6 +589,8 @@ class Config {
 		if ($user instanceof IUser) {
 			$data['sub'] = $user->getUID();
 			$data['userdata'] = $this->getSignalingUserData($user);
+		} elseif (!empty($userId) && $this->cloudIdManager->isValidCloudId($userId)) {
+			$data['sub'] = $userId;
 		}
 
 		$alg = $this->getSignalingTokenAlgorithm();

--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -1902,7 +1902,6 @@ class RoomController extends AEnvironmentAwareController {
 		$this->session->removeSessionForRoom($token);
 
 		try {
-			// The participant is just joining, so enforce to not load any session
 			if (!$this->federationAuthenticator->isFederationRequest()) {
 				$room = $this->manager->getRoomForUserByToken($token, $this->userId, $sessionId);
 				$participant = $this->participantService->getParticipantBySession($room, $sessionId);

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -189,13 +189,14 @@ class SignalingController extends OCSController {
 		$signalingMode = $this->talkConfig->getSignalingMode();
 		$signaling = $this->signalingManager->getSignalingServerLinkForConversation($room);
 
+		$helloAuthParams20UserId = $isTalkFederation ? $this->federationAuthenticator->getCloudId() : $this->userId;
 		$helloAuthParams = [
 			'1.0' => [
 				'userid' => $this->userId,
 				'ticket' => $this->talkConfig->getSignalingTicket(Config::SIGNALING_TICKET_V1, $this->userId),
 			],
 			'2.0' => [
-				'token' => $this->talkConfig->getSignalingTicket(Config::SIGNALING_TICKET_V2, $this->userId),
+				'token' => $this->talkConfig->getSignalingTicket(Config::SIGNALING_TICKET_V2, $helloAuthParams20UserId),
 			],
 		];
 		$data = [

--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -15,6 +15,7 @@ use OCA\Talk\Events\BeforeSignalingResponseSentEvent;
 use OCA\Talk\Exceptions\ForbiddenException;
 use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Exceptions\RoomNotFoundException;
+use OCA\Talk\Federation\Authenticator;
 use OCA\Talk\Manager;
 use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\Session;
@@ -69,6 +70,7 @@ class SignalingController extends OCSController {
 		private IClientService $clientService,
 		private BanService $banService,
 		private LoggerInterface $logger,
+		protected Authenticator $federationAuthenticator,
 		private ?string $userId,
 	) {
 		parent::__construct($appName, $request);
@@ -114,6 +116,7 @@ class SignalingController extends OCSController {
 	#[PublicPage]
 	#[BruteForceProtection(action: 'talkRoomToken')]
 	#[BruteForceProtection(action: 'talkRecordingSecret')]
+	#[BruteForceProtection(action: 'talkFederationAccess')]
 	#[OpenAPI(tags: ['internal_signaling', 'external_signaling'])]
 	public function getSettings(string $token = ''): DataResponse {
 		$isRecordingRequest = false;
@@ -128,9 +131,20 @@ class SignalingController extends OCSController {
 			$isRecordingRequest = true;
 		}
 
+		$isTalkFederation = $this->federationAuthenticator->isFederationRequest();
+
 		try {
+			$action = 'talkRoomToken';
 			if ($token !== '' && $isRecordingRequest) {
 				$room = $this->manager->getRoomByToken($token);
+			} elseif ($token !== '' && $isTalkFederation) {
+				$action = 'talkFederationAccess';
+				$room = $this->manager->getRoomByRemoteAccess(
+					$token,
+					Attendee::ACTOR_FEDERATED_USERS,
+					$this->federationAuthenticator->getCloudId(),
+					$this->federationAuthenticator->getAccessToken(),
+				);
 			} elseif ($token !== '') {
 				$room = $this->manager->getRoomForUserByToken($token, $this->userId);
 			} else {
@@ -139,7 +153,7 @@ class SignalingController extends OCSController {
 			}
 		} catch (RoomNotFoundException $e) {
 			$response = new DataResponse([], Http::STATUS_NOT_FOUND);
-			$response->throttle(['token' => $token, 'action' => 'talkRoomToken']);
+			$response->throttle(['token' => $token, 'action' => $action]);
 			return $response;
 		}
 
@@ -191,12 +205,45 @@ class SignalingController extends OCSController {
 			'server' => $signaling,
 			'ticket' => $helloAuthParams['1.0']['ticket'],
 			'helloAuthParams' => $helloAuthParams,
+			'federation' => $this->getFederationSettings($room),
 			'stunservers' => $stun,
 			'turnservers' => $turn,
 			'sipDialinInfo' => $this->talkConfig->isSIPConfigured() ? $this->talkConfig->getDialInInfo() : '',
 		];
 
 		return new DataResponse($data);
+	}
+
+	private function getFederationSettings(?Room $room): array {
+		if ($room === null || !$room->isFederatedConversation()) {
+			return [];
+		}
+
+		try {
+			$participant = $this->participantService->getParticipant($room, $this->userId);
+		} catch (ParticipantNotFoundException $e) {
+			return [];
+		}
+
+		/** @var \OCA\Talk\Federation\Proxy\TalkV1\Controller\SignalingController $proxy */
+		$proxy = \OCP\Server::get(\OCA\Talk\Federation\Proxy\TalkV1\Controller\SignalingController::class);
+		$response = $proxy->getSettings($room, $participant);
+
+		if ($response->getStatus() === Http::STATUS_NOT_FOUND) {
+			return [];
+		}
+
+		/** @var TalkSignalingSettings $data */
+		$data = $response->getData();
+
+		return [
+			'server' => $data['server'],
+			'nextcloudServer' => $room->getRemoteServer(),
+			'helloAuthParams' => [
+				'token' => $data['helloAuthParams']['2.0']['token'],
+			],
+			'roomId' => $room->getRemoteToken(),
+		];
 	}
 
 	/**

--- a/lib/Federation/Proxy/TalkV1/Controller/RoomController.php
+++ b/lib/Federation/Proxy/TalkV1/Controller/RoomController.php
@@ -11,6 +11,7 @@ namespace OCA\Talk\Federation\Proxy\TalkV1\Controller;
 use OCA\Talk\Exceptions\CannotReachRemoteException;
 use OCA\Talk\Federation\Proxy\TalkV1\ProxyRequest;
 use OCA\Talk\Federation\Proxy\TalkV1\UserConverter;
+use OCA\Talk\Model\Session;
 use OCA\Talk\Participant;
 use OCA\Talk\ResponseDefinitions;
 use OCA\Talk\Room;
@@ -63,17 +64,25 @@ class RoomController {
 	/**
 	 * @see \OCA\Talk\Controller\RoomController::joinFederatedRoom()
 	 *
+	 * @param Room $room the federated room to join
+	 * @param Participant $participant the federated user to will join the room;
+	 *        the participant must have a session
 	 * @return DataResponse<Http::STATUS_OK|Http::STATUS_NOT_FOUND, array<empty>, array{X-Nextcloud-Talk-Proxy-Hash: string}>
 	 * @throws CannotReachRemoteException
 	 *
-	 * 200: Federated user is still part of the room
+	 * 200: Federated user joined the room
 	 * 404: Room not found
 	 */
 	public function joinFederatedRoom(Room $room, Participant $participant): DataResponse {
+		$options = [
+			'sessionId' => $participant->getSession()->getSessionId(),
+		];
+
 		$proxy = $this->proxy->post(
 			$participant->getAttendee()->getInvitedCloudId(),
 			$participant->getAttendee()->getAccessToken(),
 			$room->getRemoteServer() . '/ocs/v2.php/apps/spreed/api/v4/room/' . $room->getRemoteToken() . '/federation/active',
+			$options,
 		);
 
 		$statusCode = $proxy->getStatusCode();
@@ -85,6 +94,40 @@ class RoomController {
 		$headers = ['X-Nextcloud-Talk-Proxy-Hash' => $this->proxy->overwrittenRemoteTalkHash($proxy->getHeader('X-Nextcloud-Talk-Hash'))];
 
 		return new DataResponse([], $statusCode, $headers);
+	}
+
+	/**
+	 * @see \OCA\Talk\Controller\RoomController::leaveFederatedRoom()
+	 *
+	 * @param Room $room the federated room to leave
+	 * @param Participant $participant the federated user that will leave the
+	 *        room; the participant must have a session
+	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
+	 * @throws CannotReachRemoteException
+	 *
+	 * 200: Federated user left the room
+	 */
+	public function leaveFederatedRoom(Room $room, Participant $participant): DataResponse {
+		$options = [
+			'sessionId' => $participant->getSession()->getSessionId(),
+		];
+
+		$proxy = $this->proxy->delete(
+			$participant->getAttendee()->getInvitedCloudId(),
+			$participant->getAttendee()->getAccessToken(),
+			$room->getRemoteServer() . '/ocs/v2.php/apps/spreed/api/v4/room/' . $room->getRemoteToken() . '/federation/active',
+			$options,
+		);
+
+		// STATUS_NOT_FOUND is not taken into account, as it should happen only
+		// for non-federation requests.
+		$statusCode = $proxy->getStatusCode();
+		if (!in_array($statusCode, [Http::STATUS_OK], true)) {
+			$this->proxy->logUnexpectedStatusCode(__METHOD__, $proxy->getStatusCode());
+			throw new CannotReachRemoteException();
+		}
+
+		return new DataResponse([], $statusCode);
 	}
 
 	/**

--- a/lib/Federation/Proxy/TalkV1/Controller/SignalingController.php
+++ b/lib/Federation/Proxy/TalkV1/Controller/SignalingController.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Federation\Proxy\TalkV1\Controller;
+
+use OCA\Talk\Exceptions\CannotReachRemoteException;
+use OCA\Talk\Federation\Proxy\TalkV1\ProxyRequest;
+use OCA\Talk\Participant;
+use OCA\Talk\ResponseDefinitions;
+use OCA\Talk\Room;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+
+/**
+ * @psalm-import-type TalkSignalingSettings from ResponseDefinitions
+ */
+class SignalingController {
+	public function __construct(
+		protected ProxyRequest  $proxy,
+	) {
+	}
+
+	/**
+	 * @see \OCA\Talk\Controller\SignalingController::getSettings()
+	 *
+	 * @return DataResponse<Http::STATUS_OK, TalkSignalingSettings, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array<empty>, array{}>
+	 * @throws CannotReachRemoteException
+	 *
+	 * 200: Signaling settings returned
+	 * 404: Room not found
+	 */
+	public function getSettings(Room $room, Participant $participant): DataResponse {
+		$proxy = $this->proxy->get(
+			$participant->getAttendee()->getInvitedCloudId(),
+			$participant->getAttendee()->getAccessToken(),
+			$room->getRemoteServer() . '/ocs/v2.php/apps/spreed/api/v3/signaling/settings',
+			[
+				'token' => $room->getRemoteToken(),
+			],
+		);
+
+		$statusCode = $proxy->getStatusCode();
+		if (!in_array($statusCode, [Http::STATUS_OK, Http::STATUS_NOT_FOUND], true)) {
+			$this->proxy->logUnexpectedStatusCode(__METHOD__, $proxy->getStatusCode());
+			throw new CannotReachRemoteException();
+		}
+
+		/** @var TalkSignalingSettings|array<empty> $data */
+		$data = $this->proxy->getOCSData($proxy);
+
+		return new DataResponse($data, $statusCode);
+	}
+}

--- a/lib/Migration/Version20000Date20240718031959.php
+++ b/lib/Migration/Version20000Date20240718031959.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adjust session id length in internal signaling messages to maximum Nextcloud
+ * session id length.
+ */
+class Version20000Date20240718031959 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('talk_internalsignaling')) {
+			$table = $schema->getTable('talk_internalsignaling');
+
+			$modified = false;
+
+			$sender = $table->getColumn('sender');
+			if ($sender->getLength() !== 512) {
+				$sender->setLength(512);
+				$modified = true;
+			}
+
+			$recipient = $table->getColumn('recipient');
+			if ($recipient->getLength() !== 512) {
+				$recipient->setLength(512);
+				$modified = true;
+			}
+
+			if ($modified) {
+				return $schema;
+			}
+		}
+
+		return null;
+	}
+}

--- a/lib/Model/AttendeeMapper.php
+++ b/lib/Model/AttendeeMapper.php
@@ -103,6 +103,26 @@ class AttendeeMapper extends QBMapper {
 
 	/**
 	 * @param int $roomId
+	 * @param array $actorTypes
+	 * @param int|null $lastJoinedCall
+	 * @return Attendee[]
+	 */
+	public function getActorsByTypes(int $roomId, array $actorTypes, ?int $lastJoinedCall = null): array {
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->eq('room_id', $query->createNamedParameter($roomId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->in('actor_type', $query->createNamedParameter($actorTypes, IQueryBuilder::PARAM_STR_ARRAY)));
+
+		if ($lastJoinedCall !== null) {
+			$query->andWhere($query->expr()->gte('last_joined_call', $query->createNamedParameter($lastJoinedCall, IQueryBuilder::PARAM_INT)));
+		}
+
+		return $this->findEntities($query);
+	}
+
+	/**
+	 * @param int $roomId
 	 * @param array $participantType
 	 * @return Attendee[]
 	 * @throws DBException

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -282,6 +282,14 @@ namespace OCA\Talk;
  * }
  *
  * @psalm-type TalkSignalingSettings = array{
+ *     federation: array{
+ *         server: string,
+ *         nextcloudServer: string,
+ *         helloAuthParams: array{
+ *             token: string,
+ *         },
+ *         roomId: string,
+ *     }|array<empty>,
  *     helloAuthParams: array{
  *         "1.0": array{
  *             userid: ?string,

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -363,7 +363,7 @@ class ParticipantService {
 	/**
 	 * @throws UnauthorizedException
 	 */
-	public function joinRoomAsFederatedUser(Room $room, string $actorType, string $actorId): Participant {
+	public function joinRoomAsFederatedUser(Room $room, string $actorType, string $actorId, string $sessionId): Participant {
 		$event = new BeforeFederatedUserJoinedRoomEvent($room, $actorId);
 		$this->dispatcher->dispatchTyped($event);
 
@@ -379,7 +379,7 @@ class ParticipantService {
 			throw new UnauthorizedException('Participant is not allowed to join');
 		}
 
-		$session = $this->sessionService->createSessionForAttendee($attendee);
+		$session = $this->sessionService->createSessionForAttendee($attendee, $sessionId);
 
 		$event = new FederatedUserJoinedRoomEvent($room, $actorId);
 		$this->dispatcher->dispatchTyped($event);

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1619,11 +1619,18 @@ class ParticipantService {
 	 * @return string[]
 	 */
 	public function getParticipantUserIds(Room $room, ?\DateTime $maxLastJoined = null): array {
+		return $this->getParticipantActorIdsByActorType($room, [Attendee::ACTOR_USERS], $maxLastJoined);
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getParticipantActorIdsByActorType(Room $room, array $actorTypes, ?\DateTime $maxLastJoined = null): array {
 		$maxLastJoinedTimestamp = null;
 		if ($maxLastJoined !== null) {
 			$maxLastJoinedTimestamp = $maxLastJoined->getTimestamp();
 		}
-		$attendees = $this->attendeeMapper->getActorsByType($room->getId(), Attendee::ACTOR_USERS, $maxLastJoinedTimestamp);
+		$attendees = $this->attendeeMapper->getActorsByTypes($room->getId(), $actorTypes, $maxLastJoinedTimestamp);
 
 		return array_map(static function (Attendee $attendee) {
 			return $attendee->getActorId();

--- a/lib/Service/ParticipantService.php
+++ b/lib/Service/ParticipantService.php
@@ -1625,6 +1625,13 @@ class ParticipantService {
 	/**
 	 * @return string[]
 	 */
+	public function getParticipantUserIdsAndFederatedUserCloudIds(Room $room, ?\DateTime $maxLastJoined = null): array {
+		return $this->getParticipantActorIdsByActorType($room, [Attendee::ACTOR_USERS, Attendee::ACTOR_FEDERATED_USERS], $maxLastJoined);
+	}
+
+	/**
+	 * @return string[]
+	 */
 	public function getParticipantActorIdsByActorType(Room $room, array $actorTypes, ?\DateTime $maxLastJoined = null): array {
 		$maxLastJoinedTimestamp = null;
 		if ($maxLastJoined !== null) {

--- a/lib/Service/SessionService.php
+++ b/lib/Service/SessionService.php
@@ -94,6 +94,9 @@ class SessionService {
 		} else {
 			while (true) {
 				$sessionId = $this->secureRandom->generate(255);
+				if (!empty($attendee->getInvitedCloudId())) {
+					$sessionId = $this->extendSessionIdWithCloudId($sessionId, $attendee->getInvitedCloudId());
+				}
 				$session->setSessionId($sessionId);
 				try {
 					$this->sessionMapper->insert($session);
@@ -108,5 +111,25 @@ class SessionService {
 		}
 
 		return $session;
+	}
+
+	/**
+	 * Adds the given cloud id to the given session id.
+	 *
+	 * The session id and the cloud id are separated by '#'.
+	 *
+	 * If the resulting session id is longer than the column length it is
+	 * trimmed at the end as needed.
+	 *
+	 * @param string $sessionId
+	 * @param string $invitedCloudId
+	 * @return string
+	 */
+	public function extendSessionIdWithCloudId(string $sessionId, string $invitedCloudId): string {
+		// Session id column length is 512, while generated session ids are 255
+		// characters.
+		$invitedCloudId = substr($invitedCloudId, 0, 256);
+
+		return $sessionId . '#' . $invitedCloudId;
 	}
 }

--- a/lib/Signaling/BackendNotifier.php
+++ b/lib/Signaling/BackendNotifier.php
@@ -155,7 +155,7 @@ class BackendNotifier {
 				'userids' => $userIds,
 				// TODO(fancycode): We should try to get rid of 'alluserids' and
 				// find a better way to notify existing users to update the room.
-				'alluserids' => $this->participantService->getParticipantUserIds($room),
+				'alluserids' => $this->participantService->getParticipantUserIdsAndFederatedUserCloudIds($room),
 				'properties' => $room->getPropertiesForSignaling('', false),
 			],
 		]);
@@ -176,7 +176,7 @@ class BackendNotifier {
 	 * @throws \Exception
 	 */
 	public function roomsDisinvited(Room $room, array $attendees): void {
-		$allUserIds = $this->participantService->getParticipantUserIds($room);
+		$allUserIds = $this->participantService->getParticipantUserIdsAndFederatedUserCloudIds($room);
 		sort($allUserIds);
 		$userIds = [];
 		foreach ($attendees as $attendee) {
@@ -212,7 +212,7 @@ class BackendNotifier {
 	 * @throws \Exception
 	 */
 	public function roomSessionsRemoved(Room $room, array $sessionIds): void {
-		$allUserIds = $this->participantService->getParticipantUserIds($room);
+		$allUserIds = $this->participantService->getParticipantUserIdsAndFederatedUserCloudIds($room);
 		sort($allUserIds);
 		$start = microtime(true);
 		$this->backendRequest($room, [
@@ -245,6 +245,9 @@ class BackendNotifier {
 		$this->backendRequest($room, [
 			'type' => 'update',
 			'update' => [
+				// Message not sent for federated users, as they will receive
+				// the message from their federated Nextcloud server once the
+				// property change is propagated.
 				'userids' => $this->participantService->getParticipantUserIds($room),
 				'properties' => $room->getPropertiesForSignaling(''),
 			],

--- a/lib/Signaling/Manager.php
+++ b/lib/Signaling/Manager.php
@@ -36,6 +36,7 @@ class Manager {
 		$features = explode(',', $featureHeader);
 		$features = array_map('trim', $features);
 		return in_array('audio-video-permissions', $features, true)
+			&& in_array('federation', $features, true)
 			&& in_array('incall-all', $features, true)
 			&& in_array('hello-v2', $features, true)
 			&& in_array('switchto', $features, true);

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -1635,7 +1635,8 @@
         "/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/federation/active": {
             "post": {
                 "operationId": "room-join-federated-room",
-                "summary": "Fake join a room on the host server to verify the federated user is still part of it",
+                "summary": "Join room on the host server using the session id of the federated user.",
+                "description": "The session id can be null only for requests from Talk < 20.",
                 "tags": [
                     "room"
                 ],
@@ -1648,6 +1649,25 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "sessionId"
+                                ],
+                                "properties": {
+                                    "sessionId": {
+                                        "type": "string",
+                                        "description": "Federated session id to join with"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
                     {
                         "name": "apiVersion",
@@ -1684,7 +1704,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Federated user is still part of the room",
+                        "description": "Federated user joined the room",
                         "headers": {
                             "X-Nextcloud-Talk-Hash": {
                                 "schema": {
@@ -1720,6 +1740,135 @@
                     },
                     "404": {
                         "description": "Room not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "room-leave-federated-room",
+                "summary": "Leave room on the host server using the session id of the federated user.",
+                "tags": [
+                    "room"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "sessionId"
+                                ],
+                                "properties": {
+                                    "sessionId": {
+                                        "type": "string",
+                                        "description": "Federated session id to leave with"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v4"
+                            ],
+                            "default": "v4"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "description": "Token of the room",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully left the room",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Room not found (non-federation request)",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -1373,6 +1373,7 @@
             "SignalingSettings": {
                 "type": "object",
                 "required": [
+                    "federation",
                     "helloAuthParams",
                     "hideWarning",
                     "server",
@@ -1384,6 +1385,45 @@
                     "userId"
                 ],
                 "properties": {
+                    "federation": {
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "required": [
+                                    "server",
+                                    "nextcloudServer",
+                                    "helloAuthParams",
+                                    "roomId"
+                                ],
+                                "properties": {
+                                    "server": {
+                                        "type": "string"
+                                    },
+                                    "nextcloudServer": {
+                                        "type": "string"
+                                    },
+                                    "helloAuthParams": {
+                                        "type": "object",
+                                        "required": [
+                                            "token"
+                                        ],
+                                        "properties": {
+                                            "token": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "roomId": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "array",
+                                "maxItems": 0
+                            }
+                        ]
+                    },
                     "helloAuthParams": {
                         "type": "object",
                         "required": [
@@ -16844,7 +16884,8 @@
         "/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/federation/active": {
             "post": {
                 "operationId": "room-join-federated-room",
-                "summary": "Fake join a room on the host server to verify the federated user is still part of it",
+                "summary": "Join room on the host server using the session id of the federated user.",
+                "description": "The session id can be null only for requests from Talk < 20.",
                 "tags": [
                     "room"
                 ],
@@ -16857,6 +16898,25 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "sessionId"
+                                ],
+                                "properties": {
+                                    "sessionId": {
+                                        "type": "string",
+                                        "description": "Federated session id to join with"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
                     {
                         "name": "apiVersion",
@@ -16893,7 +16953,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Federated user is still part of the room",
+                        "description": "Federated user joined the room",
                         "headers": {
                             "X-Nextcloud-Talk-Hash": {
                                 "schema": {
@@ -16929,6 +16989,135 @@
                     },
                     "404": {
                         "description": "Room not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "room-leave-federated-room",
+                "summary": "Leave room on the host server using the session id of the federated user.",
+                "tags": [
+                    "room"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "sessionId"
+                                ],
+                                "properties": {
+                                    "sessionId": {
+                                        "type": "string",
+                                        "description": "Federated session id to leave with"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v4"
+                            ],
+                            "default": "v4"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "description": "Token of the room",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9]{4,30}$"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully left the room",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Room not found (non-federation request)",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/openapi.json
+++ b/openapi.json
@@ -1260,6 +1260,7 @@
             "SignalingSettings": {
                 "type": "object",
                 "required": [
+                    "federation",
                     "helloAuthParams",
                     "hideWarning",
                     "server",
@@ -1271,6 +1272,45 @@
                     "userId"
                 ],
                 "properties": {
+                    "federation": {
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "required": [
+                                    "server",
+                                    "nextcloudServer",
+                                    "helloAuthParams",
+                                    "roomId"
+                                ],
+                                "properties": {
+                                    "server": {
+                                        "type": "string"
+                                    },
+                                    "nextcloudServer": {
+                                        "type": "string"
+                                    },
+                                    "helloAuthParams": {
+                                        "type": "object",
+                                        "required": [
+                                            "token"
+                                        ],
+                                        "properties": {
+                                            "token": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "roomId": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "array",
+                                "maxItems": 0
+                            }
+                        ]
+                    },
                     "helloAuthParams": {
                         "type": "object",
                         "required": [

--- a/src/components/RightSidebar/Participants/Participant.vue
+++ b/src/components/RightSidebar/Participants/Participant.vue
@@ -785,7 +785,7 @@ export default {
 		isOffline() {
 			return !this.sessionIds.length && !this.isSearched
 				&& (this.isUserActor || this.isFederatedActor || this.isGuestActor)
-				&& (!hasTalkFeature(this.token, 'federation-v1') || (!this.conversation.remoteServer && !this.isFederatedActor))
+				&& (hasTalkFeature(this.token, 'federation-v2') || !hasTalkFeature(this.token, 'federation-v1') || (!this.conversation.remoteServer && !this.isFederatedActor))
 		},
 
 		isGuest() {

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -125,9 +125,13 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Fake join a room on the host server to verify the federated user is still part of it */
+        /**
+         * Join room on the host server using the session id of the federated user.
+         * @description The session id can be null only for requests from Talk < 20.
+         */
         post: operations["room-join-federated-room"];
-        delete?: never;
+        /** Leave room on the host server using the session id of the federated user. */
+        delete: operations["room-leave-federated-room"];
         options?: never;
         head?: never;
         patch?: never;
@@ -719,9 +723,16 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Federated session id to join with */
+                    sessionId: string;
+                };
+            };
+        };
         responses: {
-            /** @description Federated user is still part of the room */
+            /** @description Federated user joined the room */
             200: {
                 headers: {
                     "X-Nextcloud-Talk-Hash"?: string;
@@ -737,6 +748,59 @@ export interface operations {
                 };
             };
             /** @description Room not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "room-leave-federated-room": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v4";
+                /** @description Token of the room */
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Federated session id to leave with */
+                    sessionId: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Successfully left the room */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Room not found (non-federation request) */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1391,9 +1391,13 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Fake join a room on the host server to verify the federated user is still part of it */
+        /**
+         * Join room on the host server using the session id of the federated user.
+         * @description The session id can be null only for requests from Talk < 20.
+         */
         post: operations["room-join-federated-room"];
-        delete?: never;
+        /** Leave room on the host server using the session id of the federated user. */
+        delete: operations["room-leave-federated-room"];
         options?: never;
         head?: never;
         patch?: never;
@@ -2155,6 +2159,14 @@ export type components = {
             userId: string;
         };
         SignalingSettings: {
+            federation: {
+                server: string;
+                nextcloudServer: string;
+                helloAuthParams: {
+                    token: string;
+                };
+                roomId: string;
+            } | unknown[];
             helloAuthParams: {
                 "1.0": {
                     userid: string | null;
@@ -8583,9 +8595,16 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Federated session id to join with */
+                    sessionId: string;
+                };
+            };
+        };
         responses: {
-            /** @description Federated user is still part of the room */
+            /** @description Federated user joined the room */
             200: {
                 headers: {
                     "X-Nextcloud-Talk-Hash"?: string;
@@ -8601,6 +8620,59 @@ export interface operations {
                 };
             };
             /** @description Room not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "room-leave-federated-room": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v4";
+                /** @description Token of the room */
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Federated session id to leave with */
+                    sessionId: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Successfully left the room */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Room not found (non-federation request) */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1640,6 +1640,14 @@ export type components = {
             userId: string;
         };
         SignalingSettings: {
+            federation: {
+                server: string;
+                nextcloudServer: string;
+                helloAuthParams: {
+                    token: string;
+                };
+                roomId: string;
+            } | unknown[];
             helloAuthParams: {
                 "1.0": {
                     userid: string | null;

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -1083,6 +1083,7 @@ Signaling.Standalone.prototype.helloResponseReceived = function(data) {
 
 	if (!this.settings.helloAuthParams.internal
 			&& (!this.hasFeature('audio-video-permissions')
+				|| !this.hasFeature('federation')
 				|| !this.hasFeature('incall-all')
 				|| !this.hasFeature('switchto'))) {
 		showError(

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -1081,7 +1081,10 @@ Signaling.Standalone.prototype.helloResponseReceived = function(data) {
 		}
 	}
 
-	if (!this.settings.helloAuthParams.internal && (!this.hasFeature('audio-video-permissions') || !this.hasFeature('incall-all') || !this.hasFeature('switchto'))) {
+	if (!this.settings.helloAuthParams.internal
+			&& (!this.hasFeature('audio-video-permissions')
+				|| !this.hasFeature('incall-all')
+				|| !this.hasFeature('switchto'))) {
 		showError(
 			t('spreed', 'The configured signaling server needs to be updated to be compatible with this version of Talk. Please contact your administration.'),
 			{

--- a/src/utils/signaling.js
+++ b/src/utils/signaling.js
@@ -977,8 +977,8 @@ Signaling.Standalone.prototype.doSend = function(msg, callback) {
 	this.socket.send(JSON.stringify(msg))
 }
 
-Signaling.Standalone.prototype._getBackendUrl = function() {
-	return generateOcsUrl('apps/spreed/api/v3/signaling/backend')
+Signaling.Standalone.prototype._getBackendUrl = function(baseURL = undefined) {
+	return generateOcsUrl('apps/spreed/api/v3/signaling/backend', {}, { baseURL })
 }
 
 Signaling.Standalone.prototype.sendHello = function() {
@@ -1165,7 +1165,7 @@ Signaling.Standalone.prototype._joinRoomSuccess = function(token, nextcloudSessi
 	}
 
 	console.debug('Join room', token)
-	this.doSend({
+	const message = {
 		type: 'room',
 		room: {
 			roomid: token,
@@ -1174,7 +1174,18 @@ Signaling.Standalone.prototype._joinRoomSuccess = function(token, nextcloudSessi
 			// the (Nextcloud) user is allowed to join the room.
 			sessionid: nextcloudSessionId,
 		},
-	}, function(data) {
+	}
+
+	if (this.settings.federation?.server) {
+		message.room.federation = {
+			signaling: this.settings.federation.server,
+			url: this._getBackendUrl(this.settings.federation.nextcloudServer),
+			roomid: this.settings.federation.roomId,
+			token: this.settings.federation.helloAuthParams.token,
+		}
+	}
+
+	this.doSend(message, function(data) {
 		this.joinResponseReceived(data, token)
 	}.bind(this))
 }

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -125,6 +125,8 @@ async function connectSignaling(token) {
 		})
 
 		signalingTypingHandler?.setSignaling(signaling)
+	} else {
+		signaling.setSettings(settings)
 	}
 
 	tokensInSignaling[token] = true

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -820,6 +820,19 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 				if (isset($expectedKeys['callId'])) {
 					$data['callId'] = (string) $attendee['callId'];
 				}
+				if (isset($expectedKeys['sessionIds'])) {
+					$sessionIds = '[';
+					foreach ($attendee['sessionIds'] as $sessionId) {
+						if (str_contains($sessionId, '#')) {
+							$sessionIds .= 'SESSION' . substr($sessionId, strpos($sessionId, '#')) . ',';
+						} else {
+							$sessionIds .= 'SESSION,';
+						}
+					}
+					$sessionIds .= ']';
+
+					$data['sessionIds'] = $sessionIds;
+				}
 
 				if (!isset(self::$userToAttendeeId[$identifier][$attendee['actorType']])) {
 					self::$userToAttendeeId[$identifier][$attendee['actorType']] = [];
@@ -851,6 +864,16 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 
 				if (isset($attendee['actorId'], $attendee['actorType']) && $attendee['actorType'] === 'federated_users' && !str_contains($attendee['actorId'], '@')) {
 					$attendee['actorId'] .= '@' . rtrim($this->localRemoteServerUrl, '/');
+				}
+
+				if (isset($attendee['sessionIds']) && str_contains($attendee['sessionIds'], '@{$LOCAL_URL}')) {
+					$attendee['sessionIds'] = str_replace('{$LOCAL_URL}', rtrim($this->localServerUrl, '/'), $attendee['sessionIds']);
+				}
+				if (isset($attendee['sessionIds']) && str_contains($attendee['sessionIds'], '@{$LOCAL_REMOTE_URL}')) {
+					$attendee['sessionIds'] = str_replace('{$LOCAL_REMOTE_URL}', rtrim($this->localRemoteServerUrl, '/'), $attendee['sessionIds']);
+				}
+				if (isset($attendee['sessionIds']) && str_contains($attendee['sessionIds'], '@{$REMOTE_URL}')) {
+					$attendee['sessionIds'] = str_replace('{$REMOTE_URL}', rtrim($this->remoteServerUrl, '/'), $attendee['sessionIds']);
 				}
 
 				if (isset($attendee['actorId'], $attendee['actorType'], $attendee['phoneNumber'])

--- a/tests/integration/features/federation/join-leave.feature
+++ b/tests/integration/features/federation/join-leave.feature
@@ -1,0 +1,110 @@
+Feature: federation/join-leave
+
+  Background:
+    Given using server "REMOTE"
+    And user "participant2" exists
+    And the following "spreed" app config is set
+      | federation_enabled | yes |
+    And using server "LOCAL"
+    And user "participant1" exists
+    And the following "spreed" app config is set
+      | federation_enabled | yes |
+
+  Scenario: join a group room
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds federated_user "participant2@REMOTE" to room "room" with 200 (v4)
+    And using server "REMOTE"
+    And user "participant2" has the following invitations (v1)
+      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
+      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
+    And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
+    When using server "LOCAL"
+    And user "participant1" joins room "room" with 200 (v4)
+    And using server "REMOTE"
+    And user "participant2" joins room "LOCAL::room" with 200 (v4)
+    Then using server "LOCAL"
+    And user "participant1" is participant of room "room" (v4)
+    And user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | actorType       | actorId                    | participantType | sessionIds                            |
+      | users           | participant1               | 1               | [SESSION,]                            |
+      | federated_users | participant2@{$REMOTE_URL} | 3               | [SESSION#participant2@{$REMOTE_URL},] |
+    And using server "REMOTE"
+    And user "participant2" is participant of room "LOCAL::room" (v4)
+    And user "participant2" sees the following attendees in room "LOCAL::room" with 200 (v4)
+      | actorType       | actorId                   | participantType | sessionIds                            |
+      | federated_users | participant1@{$LOCAL_URL} | 1               | [SESSION,]                            |
+      | users           | participant2              | 3               | [SESSION#participant2@{$REMOTE_URL},] |
+
+  Scenario: join a group room again without leaving it first
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds federated_user "participant2@REMOTE" to room "room" with 200 (v4)
+    And using server "REMOTE"
+    And user "participant2" has the following invitations (v1)
+      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
+      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
+    And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
+    And using server "LOCAL"
+    And user "participant1" joins room "room" with 200 (v4)
+    And using server "REMOTE"
+    And user "participant2" joins room "LOCAL::room" with 200 (v4)
+    When user "participant2" joins room "LOCAL::room" with 200 (v4)
+    Then using server "LOCAL"
+    And user "participant1" is participant of room "room" (v4)
+    And user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | actorType       | actorId                    | participantType | sessionIds                            |
+      | users           | participant1               | 1               | [SESSION,]                            |
+      | federated_users | participant2@{$REMOTE_URL} | 3               | [SESSION#participant2@{$REMOTE_URL},] |
+    And using server "REMOTE"
+    And user "participant2" is participant of room "LOCAL::room" (v4)
+    And user "participant2" sees the following attendees in room "LOCAL::room" with 200 (v4)
+      | actorType       | actorId                   | participantType | sessionIds                            |
+      | federated_users | participant1@{$LOCAL_URL} | 1               | [SESSION,]                            |
+      | users           | participant2              | 3               | [SESSION#participant2@{$REMOTE_URL},] |
+
+  Scenario: leave a group room
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds federated_user "participant2@REMOTE" to room "room" with 200 (v4)
+    And using server "REMOTE"
+    And user "participant2" has the following invitations (v1)
+      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
+      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
+    And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
+    And using server "LOCAL"
+    And user "participant1" joins room "room" with 200 (v4)
+    And using server "REMOTE"
+    And user "participant2" joins room "LOCAL::room" with 200 (v4)
+    And using server "LOCAL"
+    And user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | actorType       | actorId                    | participantType | sessionIds                            |
+      | users           | participant1               | 1               | [SESSION,]                            |
+      | federated_users | participant2@{$REMOTE_URL} | 3               | [SESSION#participant2@{$REMOTE_URL},] |
+    And using server "REMOTE"
+    And user "participant2" sees the following attendees in room "LOCAL::room" with 200 (v4)
+      | actorType       | actorId                    | participantType | sessionIds                            |
+      | federated_users | participant1@{$LOCAL_URL}  | 1               | [SESSION,]                            |
+      | users           | participant2               | 3               | [SESSION#participant2@{$REMOTE_URL},] |
+    When user "participant2" leaves room "LOCAL::room" with 200 (v4)
+    Then using server "LOCAL"
+    And user "participant1" is participant of room "room" (v4)
+    And user "participant1" sees the following attendees in room "room" with 200 (v4)
+      | actorType       | actorId                    | participantType | sessionIds |
+      | users           | participant1               | 1               | [SESSION,] |
+      | federated_users | participant2@{$REMOTE_URL} | 3               | []         |
+    And using server "REMOTE"
+    And user "participant2" is participant of room "LOCAL::room" (v4)
+    And user "participant2" sees the following attendees in room "LOCAL::room" with 200 (v4)
+      | actorType       | actorId                   | participantType | sessionIds |
+      | federated_users | participant1@{$LOCAL_URL} | 1               | [SESSION,] |
+      | users           | participant2              | 3               | []         |

--- a/tests/integration/features/federation/reminder.feature
+++ b/tests/integration/features/federation/reminder.feature
@@ -1,17 +1,25 @@
 Feature: federation/reminder
   Background:
+    Given using server "REMOTE"
+    And user "participant2" exists
+    And using server "LOCAL"
     Given user "participant1" exists
     Given user "participant2" exists
     Given user "participant3" exists
 
   Scenario: Get mention suggestions (translating local users to federated users)
-    Given the following "spreed" app config is set
+    Given using server "REMOTE"
+    And the following "spreed" app config is set
+      | federation_enabled | yes |
+    And using server "LOCAL"
+    And the following "spreed" app config is set
       | federation_enabled | yes |
     Given user "participant1" creates room "room" (v4)
       | roomType | 2 |
       | roomName | room |
     And user "participant1" sends message "Message 1" to room "room" with 201
-    And user "participant1" adds federated_user "participant2" to room "room" with 200 (v4)
+    And user "participant1" adds federated_user "participant2@REMOTE" to room "room" with 200 (v4)
+    And using server "REMOTE"
     And user "participant2" has the following invitations (v1)
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
@@ -24,37 +32,52 @@ Feature: federation/reminder
     And user "participant2" joins room "LOCAL::room" with 200 (v4)
     And user "participant2" leaves room "LOCAL::room" with 200 (v4)
     And user "participant2" sends message "Message 2" to room "LOCAL::room" with 201
-    When user "participant1" sets reminder for message "Message 2" in room "room" for time 2133349024 with 201 (v1)
+    When using server "LOCAL"
+    And user "participant1" sets reminder for message "Message 2" in room "room" for time 2133349024 with 201 (v1)
+    And using server "REMOTE"
     And user "participant2" sets reminder for message "Message 1" in room "LOCAL::room" for time 1234567 with 201 (v1)
+    And using server "LOCAL"
     And user "participant1" has the following notifications
       | app | object_type | object_id | subject |
+    And using server "REMOTE"
     And user "participant2" has the following notifications
       | app | object_type | object_id | subject |
     And force run "OCA\Talk\BackgroundJob\Reminder" background jobs
+    And using server "LOCAL"
+    And force run "OCA\Talk\BackgroundJob\Reminder" background jobs
     Then user "participant1" has the following notifications
       | app | object_type | object_id | subject |
+    And using server "REMOTE"
     And user "participant2" has the following notifications
       | app    | object_type | object_id      | subject                                                 |
       | spreed | reminder    | LOCAL::room/Message 1 | Reminder: participant1-displayname in conversation room |
     # Participant1 sets timestamp to past so it should trigger now
-    When user "participant1" sets reminder for message "Message 2" in room "room" for time 1234567 with 201 (v1)
+    When using server "LOCAL"
+    And user "participant1" sets reminder for message "Message 2" in room "room" for time 1234567 with 201 (v1)
     And force run "OCA\Talk\BackgroundJob\Reminder" background jobs
     Then user "participant1" has the following notifications
       | app    | object_type | object_id      | subject                                                 |
       | spreed | reminder    | room/Message 2 | Reminder: participant2-displayname in conversation room |
+    When using server "REMOTE"
+    And force run "OCA\Talk\BackgroundJob\Reminder" background jobs
     And user "participant2" deletes reminder for message "Message 1" in room "LOCAL::room" with 200 (v1)
     And user "participant2" has the following notifications
       | app | object_type | object_id | subject |
 
   Scenario: Deleting reminder before the job is executed never triggers a notification
-    Given the following "spreed" app config is set
+    Given using server "REMOTE"
+    And the following "spreed" app config is set
+      | federation_enabled | yes |
+    And using server "LOCAL"
+    And the following "spreed" app config is set
       | federation_enabled | yes |
     Given user "participant1" creates room "room" (v4)
       | roomType | 2 |
       | roomName | room |
     And user "participant1" sends message "Message 1" to room "room" with 201
-    And user "participant1" adds federated_user "participant2" to room "room" with 200 (v4)
+    And user "participant1" adds federated_user "participant2@REMOTE" to room "room" with 200 (v4)
     And user "participant1" adds user "participant3" to room "room" with 200 (v4)
+    And using server "REMOTE"
     And user "participant2" has the following invitations (v1)
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |

--- a/tests/integration/mocks/FakeSignalingServer.php
+++ b/tests/integration/mocks/FakeSignalingServer.php
@@ -57,6 +57,7 @@ if (preg_match('/\/api\/v1\/room\/([^\/]+)/', $_SERVER['REQUEST_URI'], $matches)
 
 	header('X-Spreed-Signaling-Features: ' . implode(',', [
 		'audio-video-permissions',
+		'federation',
 		'incall-all',
 		'hello-v2',
 		'switchto',

--- a/tests/php/ConfigTest.php
+++ b/tests/php/ConfigTest.php
@@ -15,6 +15,7 @@ use OCA\Talk\Vendor\Firebase\JWT\Key;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Federation\ICloudIdManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
@@ -36,12 +37,14 @@ class ConfigTest extends TestCase {
 		$groupManager = $this->createMock(IGroupManager::class);
 		/** @var MockObject|IUserManager $userManager */
 		$userManager = $this->createMock(IUserManager::class);
+		/** @var MockObject|ICloudIdManager $cloudIdManager */
+		$cloudIdManager = $this->createMock(ICloudIdManager::class);
 		/** @var MockObject|IURLGenerator $urlGenerator */
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		/** @var MockObject|IEventDispatcher $dispatcher */
 		$dispatcher = $this->createMock(IEventDispatcher::class);
 
-		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher);
+		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $cloudIdManager, $urlGenerator, $timeFactory, $dispatcher);
 		return $helper;
 	}
 
@@ -145,6 +148,8 @@ class ConfigTest extends TestCase {
 		$groupManager = $this->createMock(IGroupManager::class);
 		/** @var MockObject|IUserManager $userManager */
 		$userManager = $this->createMock(IUserManager::class);
+		/** @var MockObject|ICloudIdManager $cloudIdManager */
+		$cloudIdManager = $this->createMock(ICloudIdManager::class);
 		/** @var MockObject|IURLGenerator $urlGenerator */
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		/** @var MockObject|IEventDispatcher $dispatcher */
@@ -157,7 +162,7 @@ class ConfigTest extends TestCase {
 			->method('generate')
 			->with(16)
 			->willReturn('abcdefghijklmnop');
-		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher);
+		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $cloudIdManager, $urlGenerator, $timeFactory, $dispatcher);
 
 		//
 		$settings = $helper->getTurnSettings();
@@ -221,6 +226,9 @@ class ConfigTest extends TestCase {
 		/** @var MockObject|IUserManager $userManager */
 		$userManager = $this->createMock(IUserManager::class);
 
+		/** @var MockObject|ICloudIdManager $cloudIdManager */
+		$cloudIdManager = $this->createMock(ICloudIdManager::class);
+
 		/** @var MockObject|IURLGenerator $urlGenerator */
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 
@@ -249,7 +257,7 @@ class ConfigTest extends TestCase {
 
 		$dispatcher->addServiceListener(BeforeTurnServersGetEvent::class, GetTurnServerListener::class);
 
-		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher);
+		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $cloudIdManager, $urlGenerator, $timeFactory, $dispatcher);
 
 		$settings = $helper->getTurnSettings();
 		$this->assertSame($servers, $settings);
@@ -354,6 +362,8 @@ class ConfigTest extends TestCase {
 		$groupManager = $this->createMock(IGroupManager::class);
 		/** @var MockObject|IUserManager $userManager */
 		$userManager = $this->createMock(IUserManager::class);
+		/** @var MockObject|ICloudIdManager $cloudIdManager */
+		$cloudIdManager = $this->createMock(ICloudIdManager::class);
 		/** @var MockObject|IURLGenerator $urlGenerator */
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		/** @var MockObject|IEventDispatcher $dispatcher */
@@ -385,7 +395,7 @@ class ConfigTest extends TestCase {
 			->method('getDisplayName')
 			->willReturn('Jane Doe');
 
-		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher);
+		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $cloudIdManager, $urlGenerator, $timeFactory, $dispatcher);
 
 		$config->setAppValue('spreed', 'signaling_token_alg', $algo);
 		// Make sure new keys are generated.
@@ -419,6 +429,8 @@ class ConfigTest extends TestCase {
 		$groupManager = $this->createMock(IGroupManager::class);
 		/** @var MockObject|IUserManager $userManager */
 		$userManager = $this->createMock(IUserManager::class);
+		/** @var MockObject|ICloudIdManager $cloudIdManager */
+		$cloudIdManager = $this->createMock(ICloudIdManager::class);
 		/** @var MockObject|IURLGenerator $urlGenerator */
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		/** @var MockObject|IEventDispatcher $dispatcher */
@@ -435,7 +447,7 @@ class ConfigTest extends TestCase {
 			->with('')
 			->willReturn('https://domain.invalid/nextcloud');
 
-		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $urlGenerator, $timeFactory, $dispatcher);
+		$helper = new Config($config, $appConfig, $secureRandom, $groupManager, $userManager, $cloudIdManager, $urlGenerator, $timeFactory, $dispatcher);
 
 		$config->setAppValue('spreed', 'signaling_token_alg', $algo);
 		// Make sure new keys are generated.

--- a/tests/php/Controller/SignalingControllerTest.php
+++ b/tests/php/Controller/SignalingControllerTest.php
@@ -30,6 +30,7 @@ use OCP\App\IAppManager;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Federation\ICloudIdManager;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -70,6 +71,7 @@ class SignalingControllerTest extends TestCase {
 	protected SessionService&MockObject $sessionService;
 	protected Messages&MockObject $messages;
 	protected IUserManager&MockObject $userManager;
+	protected ICloudIdManager&MockObject $cloudIdManager;
 	protected ITimeFactory&MockObject $timeFactory;
 	protected IClientService&MockObject $clientService;
 	protected IThrottler&MockObject $throttler;
@@ -101,9 +103,10 @@ class SignalingControllerTest extends TestCase {
 		$this->serverConfig->setAppValue('spreed', 'signaling_ticket_secret', 'the-app-ticket-secret');
 		$this->serverConfig->setUserValue($this->userId, 'spreed', 'signaling_ticket_secret', 'the-user-ticket-secret');
 		$this->userManager = $this->createMock(IUserManager::class);
+		$this->cloudIdManager = $this->createMock(ICloudIdManager::class);
 		$this->dispatcher = \OCP\Server::get(IEventDispatcher::class);
 		$urlGenerator = $this->createMock(IURLGenerator::class);
-		$this->config = new Config($this->serverConfig, $appConfig, $this->secureRandom, $groupManager, $this->userManager, $urlGenerator, $timeFactory, $this->dispatcher);
+		$this->config = new Config($this->serverConfig, $appConfig, $this->secureRandom, $groupManager, $this->userManager, $this->cloudIdManager, $urlGenerator, $timeFactory, $this->dispatcher);
 		$this->session = $this->createMock(TalkSession::class);
 		$this->dbConnection = \OCP\Server::get(IDBConnection::class);
 		$this->signalingManager = $this->createMock(\OCA\Talk\Signaling\Manager::class);

--- a/tests/php/Controller/SignalingControllerTest.php
+++ b/tests/php/Controller/SignalingControllerTest.php
@@ -75,6 +75,7 @@ class SignalingControllerTest extends TestCase {
 	protected IThrottler&MockObject $throttler;
 	protected BanService&MockObject $banService;
 	protected LoggerInterface&MockObject $logger;
+	protected Authenticator&MockObject $authenticator;
 	protected IDBConnection $dbConnection;
 	protected IConfig $serverConfig;
 	protected ?Config $config = null;
@@ -115,6 +116,7 @@ class SignalingControllerTest extends TestCase {
 		$this->clientService = $this->createMock(IClientService::class);
 		$this->banService = $this->createMock(BanService::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->authenticator = $this->createMock(Authenticator::class);
 		$this->recreateSignalingController();
 	}
 
@@ -137,6 +139,7 @@ class SignalingControllerTest extends TestCase {
 			$this->clientService,
 			$this->banService,
 			$this->logger,
+			$this->authenticator,
 			$this->userId,
 		);
 	}
@@ -975,7 +978,7 @@ class SignalingControllerTest extends TestCase {
 			$this->timeFactory,
 			$this->createMock(IHasher::class),
 			$this->createMock(IL10N::class),
-			$this->createMock(Authenticator::class),
+			$this->authenticator,
 		);
 		$this->recreateSignalingController();
 

--- a/tests/php/Recording/BackendNotifierTest.php
+++ b/tests/php/Recording/BackendNotifierTest.php
@@ -23,6 +23,7 @@ use OCP\App\IAppManager;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Federation\ICloudIdManager;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -90,10 +91,11 @@ class BackendNotifierTest extends TestCase {
 		$appConfig = $this->createMock(IAppConfig::class);
 		$groupManager = $this->createMock(IGroupManager::class);
 		$userManager = $this->createMock(IUserManager::class);
+		$cloudIdManager = $this->createMock(ICloudIdManager::class);
 		$timeFactory = $this->createMock(ITimeFactory::class);
 		$dispatcher = \OCP\Server::get(IEventDispatcher::class);
 
-		$this->config = new Config($config, $appConfig, $this->secureRandom, $groupManager, $userManager, $this->urlGenerator, $timeFactory, $dispatcher);
+		$this->config = new Config($config, $appConfig, $this->secureRandom, $groupManager, $userManager, $cloudIdManager, $this->urlGenerator, $timeFactory, $dispatcher);
 
 		$this->recreateBackendNotifier();
 


### PR DESCRIPTION
For external signaling federation the federated signaling server joins the host room in the host Nextcloud server, and establishes a connection against the host signaling server, proxying the messags from the host signaling server to the federated clients connected to it; it does not join the room in the federated Nextcloud server (from the point of view of the federated signaling server; the client does join the conversation in the federated Nextcloud server and the federated Nextcloud server proxies the join to the host Nextcloud server), although the federated Nextcloud server will anyway send some notifications to it (as it is the configured signaling server).

Unfortunately, as the session id of the participant in the federated server is used to join the conversation in the remote server, federation no longer works with local federated participants (as the session id would be duplicated).

Requires https://github.com/strukturag/nextcloud-spreed-signaling/pull/776
  - Pre-built binary: [signaling.zip](https://github.com/user-attachments/files/16285230/signaling.zip) (https://github.com/strukturag/nextcloud-spreed-signaling/pull/776/commits/55aa055187d555c703008fd20362fb7e7ddcee86)

## Client changes

**Note:** this section is subject to change before the pull request is merged.

Clients for federated users send requests to the federated Nextcloud server, and the federated Nextcloud server proxies them as needed to the remote Nextcloud server; the clients do not directly connect to the remote Nextcloud server. In the case of the signaling server the same approach is used: the clients establish a connection to the federated signaling server, and the signaling server in turn establishes a connection with the remote signaling server.

Note, however, that the federated signaling server authenticates against the remote Nextcloud server, not the federated one, and it directly joins the remote room, not the federated one.

Besides adjusting the UI to the new features (for example, federated users now have a session in the remote server, so they can be shown as active or inactive in the conversation) the clients need to:
- Provide some additional parameters to the external signaling server when joining a room in a federated conversation
- ~~Convert the `roomid` parameter from the remote conversation token to the federated conversation token when receiving messages in a federated conversation~~ Not needed if both `roomid` and `federation.roomid` parameters are provided to the signaling server

### Joining a room

Note that the signaling settings, for legacy reasons, can be got [without specifiying the token of the conversation](https://github.com/nextcloud/spreed/blob/1ccbf67da231c37801c1406b10000144125aec35/lib/Controller/SignalingController.php#L134-L135). This is not supported for federated conversations; when getting the signaling settings of a federated conversation the token of the federated conversation must be provided.

When the token of a federated conversation is provided the returned settings will contain the additional parameters that need to be passed to the signaling server when joining the federated room. Those parameters will be under the `federation` key. If no token is provided, or if the token does not belong to a federated conversation, the `federation` key will be still included in the settings, although with an empty value (this could change to not provide a `federation` key at all, as mentioned in the TODO section below).

The signaling settings must be refreshed before joining a federated conversation, as [the authentication token is valid only for one minute](https://github.com/nextcloud/spreed/blob/1ccbf67da231c37801c1406b10000144125aec35/lib/Config.php#L583). This also implies that, unless the connection to the local signaling server is kept open, the signaling settings will need to be fetched again when switching to a non-federated conversation and thus connecting again to the local signaling server, as any authentication token previously got for the local signaling server would be probably expired (except on very quick changes between conversations).

When joining a normal room the clients send a `room` message to the signaling server with the following format:
```
type: 'room',
room: {
    roomid: the-token-of-the-room,
    sessionid: the-nextcloud-session-id,
},
```

When joining a federated room the clients should send a `room` message with the following format instead:
```
type: 'room',
room: {
    roomid: conversation-token,
    sessionid: the-nextcloud-session-id,
    federation: {
        signaling: settings.federation.server,
        url: settings.federation.nextcloudServer + '/ocs/v2.php/apps/spreed/api/v3/signaling/backend',
        roomid: settings.federation.roomId,
        token: settings.federation.helloAuthParams.token,
},
```
- The `roomid` is the token of the federated conversation (that is, the token of the conversation that the participant is directly joining, so probably nothing needs to be changed in the code)
- The url is similar to the URL sent in `hello` messages, but in this case for the remote Nextcloud server (as the federated signaling server will authenticate against the remote Nextcloud server, not the federated one)
- The `federation.roomid` in this case is the token of the remote room, not the federated room, so its value is provided in the settings. Also note the different casing in `roomid` in `message.room.federation.roomid` and in `settings.federation.roomId`

## `room` and `roomlist` signaling messages

**Note:** after a quick look to the code in the Talk Android and Talk iOS apps this does not seem to be currently relevant. For the WebUI [it works as expected without changes](https://github.com/nextcloud/spreed/blob/1ccbf67da231c37801c1406b10000144125aec35/src/utils/signaling.js#L1416-L1472).

TL;DR;: for federated users ignore the properties in `room` signaling messages and use the ones from `roomlist` events instead. `roomlist` events with property `participant-list: "refresh"` are also sent if local users were added to or removed from the remote room.

When certain properties of a room are modified and a participant is active in the room (has joined it) that participant receives a `room` message from the signaling server with [the updated properties](https://github.com/nextcloud/spreed/blob/1ccbf67da231c37801c1406b10000144125aec35/lib/Room.php#L416-L437):
```
{
    type: 'room',
    room: {
        properties: {
            active-since: ...,
            ...
        },
        roomid: THE-CONVERSATION-TOKEN,
    },
}
```
This is true too for federated participants when the remote room is modified.

However, federated participants get their room data from the proxy/federated room, not from the remote one. Currently [only a subset of the remote room properties is proxied to the federated rooms](https://github.com/nextcloud/spreed/blob/1ccbf67da231c37801c1406b10000144125aec35/lib/Federation/Proxy/TalkV1/Notifier/RoomModifiedListener.php#L38-L42), and some of the properties notified by the signaling server are not proxied to the federated rooms (for example, whether the conversation is listable or not, as that is not used in federated rooms).

Due to all that a federated user can receive a `room` message with updated properties that will never be reflected in the room data. Therefore the properties in `room` signaling messages should not be used to update the data of a federated room in clients.

The `room` message [is sent by the signaling server](https://github.com/strukturag/nextcloud-spreed-signaling/blob/2a1fd2e01875babf3cad299c2ae860aed0f72a2d/backend_server.go#L860) to all active participants when it is notified by the Nextcloud server that the room was modified. However, [a `roomlist` message is also sent](https://github.com/strukturag/nextcloud-spreed-signaling/blob/2a1fd2e01875babf3cad299c2ae860aed0f72a2d/backend_server.go#L861) to all the users (not participants, users) in the conversation ([as instructed by the Nextcloud server in the notification](https://github.com/nextcloud/spreed/blob/a6aa9f6c6225670cee278e4cc9cdd685a745ab4b/lib/Signaling/BackendNotifier.php#L248), no matter if they are active or not:
```
{
    type: 'event',
    event: {
        target: 'roomlist',
        type: 'update',
        update: {
            properties: {
                active-since: ...,
                ...
            },
            roomid: THE-CONVERSATION-TOKEN,
        },
    },
}
```

As the participants that are notified are only local users the federated users do not receive a `roomlist` event from the remote Nextcloud server. However, as soon as the properties are propagated to the federated Nextcloud server the federated Nexcloud server will notify its own signaling server, so the federated signaling server will in turn notify the federated users in the federated/proxy room (as, for that room, they are the local users). In this case the `roomlist` event received by the federated users will always match the federated room properties, so it can be used to update the data of the federated room in clients.

`roomlist` events with updated properties are also sent when [a user is invited](https://github.com/nextcloud/spreed/blob/a6aa9f6c6225670cee278e4cc9cdd685a745ab4b/lib/Signaling/BackendNotifier.php#L147-L149) or [disinvited](https://github.com/nextcloud/spreed/blob/a6aa9f6c6225670cee278e4cc9cdd685a745ab4b/lib/Signaling/BackendNotifier.php#L183-L185) to the conversation. In this case invited/disvinted user receives a `roomlist` event with type `invite` or `disinvite`, while the rest of users receive a `roomlist` event with type `update`, and the properties include [`participant-list: "refresh"`](https://github.com/nextcloud/spreed/blob/1ccbf67da231c37801c1406b10000144125aec35/lib/Room.php#L431)

Now federated users will receive the `roomlist` update as well when another user is invited/disinvited to the conversation (or a session is removed). Note that the federated users will not receive `roomlist` events with type `invite` or `disinvite`, as the process to add them to the conversation is different than for local users. Another detail is that, in this case, the `roomlist` update is sent by the remote Nextcloud server (as the participants are modified in the remote Nextcloud server, not the federated one), but this is just an implementation detail that clients should not be concerned about.

### Converting `roomid` parameters

This would be needed only if `roomid` in the previous parameters is set to the token of the remote room and `federation.roomid` is not given. So... just set them and let the signaling server do the conversion :-) (but please notify it if [some roomid is not converted](https://github.com/strukturag/nextcloud-spreed-signaling/pull/776#pullrequestreview-2186044849))

<details>
Given that the federated signaling server joins the room in the remote Nextcloud server the `roomid` parameter in the proxied signaling messages will be the token of the remote room, not the federated one. Due to that the clients need to translate the received `roomid` parameter from the remote room to the federated room.

The `roomid` parameter appears in these messages:
```
type: 'room',
room: {
    roomid: 'REMOTE-TOKEN',
    ...
}
```
and:
```
type: 'event',
event: {
    type: 'message|update|disintive|switchto',
    message|update|disintive|switchto: {
        roomid: 'REMOTE-TOKEN',
        ...
    }
}
```

For reference this is how it was implemented in the WebUI in [`signaling.js`](https://github.com/nextcloud/spreed/blob/e9b9cf49022521291fce0386c78f6df1e70fb731/src/utils/signaling.js#L744):
```
		if (this.settings.federation?.roomId) {
			const remoteRoomId = this.settings.federation.roomId

			let roomIdConverted = false

			if (data.room?.roomid === remoteRoomId) {
				data.room.roomid = this.signalingRoomJoined
				roomIdConverted = true
			}
			if (data.event?.message?.roomid === remoteRoomId) {
				data.event.message.roomid = this.signalingRoomJoined
				roomIdConverted = true
			}
			if (data.event?.update?.roomid === remoteRoomId) {
				data.event.update.roomid = this.signalingRoomJoined
				roomIdConverted = true
			}
			if (data.event?.disinvite?.roomid === remoteRoomId) {
				data.event.disinvite.roomid = this.signalingRoomJoined
				roomIdConverted = true
			}
			if (data.event?.switchto?.roomid === remoteRoomId) {
				data.event.switchto.roomid = this.signalingRoomJoined
				roomIdConverted = true
			}

			if (OC.debug && roomIdConverted) {
				console.debug('Received, roomid converted', data)
			}
		}
```
</details>

## Notes

- [The federated users are not included in the Nextcloud server message sent to the signaling when participants are modified](https://github.com/nextcloud/spreed/blob/a6aa9f6c6225670cee278e4cc9cdd685a745ab4b/lib/Signaling/BackendNotifier.php#L323-L326) or [their `inCall` status changes](https://github.com/nextcloud/spreed/blob/a6aa9f6c6225670cee278e4cc9cdd685a745ab4b/lib/Signaling/BackendNotifier.php#L413-L416). This will need to be changed when adding support for calls, as otherwise other clients would not know that the `inCall` flag of those federated participants changed.
  - Note, however, that the federated users do receive the signaling message (`{"target":"participants", "type":"update"}`) when non federated participants are modified

## TODO (could be moved to follow ups as needed)

- [ ] Does any API version need to be bumped?
- [ ] Reset throttling when joining a remote room, just like done [when joining a room](https://github.com/nextcloud/spreed/blob/ba276d686a4ffe38286d8838822f990bfc346e2d/lib/Controller/RoomController.php#L1597-L1598)?
- [ ] If a room is not a federated room the signaling settings still include the `federation` key with an empty value for consistency with other properties like `stunServers`. But would it be better to fully remove the key in that case?
  - If the empty key is kept it could be used to differentiate between Talk 19 and Talk 20, although not sure if that could be useful
- [ ] Handle incompatible server versions
  - A federated Talk 19 should be able to join against a Talk 20 host, although it would not be shown as active.
  - A federated Talk 20 might be able to join against a Talk 19 host, although it should be tested.
  - Getting the settings by a federated Talk 20 from a Talk 19 host would fail, and the request would be throttled. Maybe a new endpoint like _settings/federation_ should be added to get the settings from the remote server, so in case a bad request is returned the federated server can know that the remote server is not Talk >= 20 and return federation settings?
- [ ] Handle incompatible signaling server versions
  - Between a federated Talk 20 and a remote Talk 20 the `federation` settings could be empty if both signaling modes are different, so clients would behave just like in Talk 19 (they will connect to the federated signaling server, and it would connect to the federated Nextcloud server, ignoring the remote one).
- [X] Add capability
  - [ ] Should an additional configuration capability to know if both the remote and the federated servers are using the same signaling server mode (external or internal, as they are not compatible)? Or just rely on the signaling settings as described above?
- [ ] Handle errors in proxied requests (also related to incompatible server versions)
- [ ] Throttled requests due to bruteforce protection could make the proxied request to timeout, is it possible to show an explicit error in that case?
- [ ] Adjust to possible changes in https://github.com/strukturag/nextcloud-spreed-signaling/tree/federation
- [x] Cleanup
- [x] Make CI happy
- [ ] Add tests
- [ ] Documentation

## Done

- [X] The `to` field in messages of type `message` (for example, `startedTyping`) is the session ID of the internal connection made from the federated signaling to the host signaling. However, [this field is part of a free format](https://github.com/strukturag/nextcloud-spreed-signaling/blob/fdb4d74dd63eb94a0a0e59267daf5f515cf27248/docs/standalone-signaling-api-v1.md?plain=1#L757), it is not explicitly known to the signaling server, which just relays it, so in this case it will probably need to be handled by the clients. Also note that (at least in the web) the [`to` field is used to set the recipient of the message](https://github.com/nextcloud/spreed/blob/e9b9cf49022521291fce0386c78f6df1e70fb731/src/utils/signaling.js#L935-L938) so it would not be enough to simply change the `to` field to the _native_ signaling session in the federated signaling server (which, on the other hand, is not currently known to the rest of participants anyway)
  - In the end this is done by the signaling server. Even if for some messages it is a free format field the signaling server is aware of the `to` and `from` fields for `offer`, `answer` and `candidate` messages, and the rest of messages use the same fields with the same semantic, so it can convert them as well. Moreover, having to do the conversion is an internal detail due to how the federation is currently implemented in the signaling server, but with some changes it may not be even necessary.
- [X] Fix joining a federated conversation again - Right now an `Integrity constraint violation: 1062 Duplicate entry 'XXX...' for key 'ts_session'"` exception happens
- [X] Ensure that federated session IDs are never longer than the column length in the database
- [X] Leaving a room as a federated user does not cause a `{ target: "room", type: "leave" }` signaling message to be sent to other participants. This will probably need to be fixed in the signaling server to leave the room when a federated client closes the connection, in a similar way to how [the room is currently joined when establishing the federated connection](https://github.com/strukturag/nextcloud-spreed-signaling/blob/8eb0c3ca49892046a615c425b0aac62fe528ca21/federation.go#L296) (but this is just my guess, @fancycode will know the right way :-) ).
  - Fixed in https://github.com/strukturag/nextcloud-spreed-signaling/commit/eb2c1cbd49b44620f01c0c2f85172e356f9cfe54, thanks!
- [X] Adjust length of [`sender` and `recipient` columns in `talk_internalsignaling` table](https://github.com/nextcloud/spreed/blob/1ccbf67da231c37801c1406b10000144125aec35/lib/Migration/Version11000Date20201209142525.php#L38-L45) to match the maximum session id length (512); otherwise when the cloud id is appended to the session id it overflows the column length and federation fails with an internal signaling server (including in tests).
- [X] `roomid` in proxy signaling messages received by the federated clients (for example, `{"target":"participants", "type":"update"}`) include the token of the conversation in the host. Should the proxy message include the token of the proxied conversation in the federated server instead? Or should the federated clients do the conversion themselves?
  - The signaling server now does it :-)
- [X] Events like changes in the room name or description [are notified from the host server to the federated server](https://github.com/nextcloud/spreed/blob/1ccbf67da231c37801c1406b10000144125aec35/lib/Federation/Proxy/TalkV1/Notifier/RoomModifiedListener.php#L51-L59); this modifies the proxy conversation in the federated server, which in turn causes [a message to be sent](https://github.com/nextcloud/spreed/blob/a6aa9f6c6225670cee278e4cc9cdd685a745ab4b/lib/Signaling/BackendNotifier.php#L237-L258) by the federated Nextcloud server to the federated signaling server (just like in a normal server), so the federated participant receives a signaling message. However, [the events that are notified from the host Nextcloud server to the federated Nextcloud server](https://github.com/nextcloud/spreed/blob/1ccbf67da231c37801c1406b10000144125aec35/lib/Federation/Proxy/TalkV1/Notifier/RoomModifiedListener.php#L38-L42) are a subset of [the events that cause a message to be sent to the signaling server](https://github.com/nextcloud/spreed/blob/1ccbf67da231c37801c1406b10000144125aec35/lib/Signaling/Listener.php#L126-L138), so the federated participant does not receive all the signaling events when a room is modified and that participant is not active in the room (if the participant is in the room it will receive `room` messages from the host server relayed by the signaling server and `roomlist` messages from the federated Nextcloud server, if not active in the room only `roomlist` messages from the federated Nextcloud server, see below for details on `roomlist` messages from the host Nextcloud server relayed by the signaling server).
  - `room` messages are not sent by the federated signaling server to the clients when the federated Nextcloud server notifies the federated signaling server because, from the point of view of the federated signaling server, the clients are not in the federated room, they are in the host room
  - Documented in `Client changes` above
- [X] `roomlist` signaling messages are currently not proxied to the federated participants. Besides being used to [notify clients](https://github.com/strukturag/nextcloud-spreed-signaling/blob/2a1fd2e01875babf3cad299c2ae860aed0f72a2d/backend_server.go#L861) when the Nextcloud server notifies a room update (like described above) they are also used (with `type: "update"`) to notify other clients when another participant is [invited](https://github.com/strukturag/nextcloud-spreed-signaling/blob/2a1fd2e01875babf3cad299c2ae860aed0f72a2d/backend_server.go#L851) or [disinvited](https://github.com/strukturag/nextcloud-spreed-signaling/blob/2a1fd2e01875babf3cad299c2ae860aed0f72a2d/backend_server.go#L854) to the room, so federated participants do not receive those events. Maybe it will be enough to add the federated user id to the `alluserids` property in [`invite`](https://github.com/nextcloud/spreed/blob/a6aa9f6c6225670cee278e4cc9cdd685a745ab4b/lib/Signaling/BackendNotifier.php#L158) and [`disinvite`](https://github.com/nextcloud/spreed/blob/a6aa9f6c6225670cee278e4cc9cdd685a745ab4b/lib/Signaling/BackendNotifier.php#L194) messages sent from the Nextcloud server to the signaling server, maybe something else will be needed :-)
  - [X] In the case of room updates the property would be [`userids`](https://github.com/nextcloud/spreed/blob/a6aa9f6c6225670cee278e4cc9cdd685a745ab4b/lib/Signaling/BackendNotifier.php#L248), but it might not be needed if all the events are proxied from the host Nextcloud server to the federated Nextcloud server
  - `invite`/`disinvite` events are also notified to federated users; remote room modifications are not, as they may include data not propagated to the federated server, and it is also enough if the federated server does the notification

## Follow-ups

- Joining/leaving with the federated session IDs seems to work with internal signaling too (and the participant status is eventually updated in the sidebar), but is something else needed? For example, relaying the ping from the federated server to the host or something like that
- Verify if [cleaning participants](https://github.com/nextcloud/spreed/blob/3cda633a5f019c0f47a88bfc12b6e90e49ec5bee/lib/Controller/RoomController.php#L944-L952) works as intended (it seems that only secondary sessions are cleaned when inactive, but if a single session is kept in the room without a ping it is not cleaned) (unrelated to this pull request, but could be relevant for internal signaling if the behaviour is changed)
  - Related: https://github.com/nextcloud/spreed/pull/12741

## How to test

- Setup Nextcloud server A
- Setup signaling server (in the federation branch) for server A
  - You may need to set `federation->skipverify = false` in the signaling server settings
- Setup Nextcloud server B
- Setup signaling server (in the federation branch) for server B
  - You may need to set `federation->skipverify = false` in the signaling server settings
- In both Nextcloud servers, enable federation in Talk settings
- "/ocm-provider" should be available in both severs; depending on your setup you may need to enable `mod_rewrite` and `mod_env` in Apache (`a2enmod rewrite` and `a2enmod env`) and set `AllowOverride All` for the Nextcloud directory in the main site configuration of both servers
- If using self-signed certificates, you will need to allow them in both servers with `occ config:system:set sharing.federation.allowSelfSignedCertificates --value true --type bool`
- Create a conversation in Nextcloud server A
- Add a user from Nextcloud server B
- In a private window, log in Nextcloud server B
- Accept the invitation and join the conversation
- Type a message; _XXX is typing_ should be shown in the other window
