### PR TITLE
refactor(sidebar): stop relying on internal classes and rename class

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -20,7 +20,8 @@
 		<template v-if="isInCall" #toggle-icon>
 			<MessageText :size="20" />
 			<NcCounterBubble v-if="unreadMessagesCounter > 0"
-				class="chat-button__unread-messages-counter"
+				class="chat-button-unread-messages-counter"
+				:class="{ 'chat-button-unread-messages-counter--highlighted': hasUnreadMentions }"
 				:type="hasUnreadMentions ? 'highlighted' : 'outlined'">
 				{{ unreadMessagesCounter }}
 			</NcCounterBubble>
@@ -484,13 +485,13 @@ export default {
 	height: 100%;
 }
 
-.chat-button__unread-messages-counter {
+.chat-button-unread-messages-counter {
 	position: absolute;
 	bottom: 2px;
 	right: 2px;
 	pointer-events: none;
 
-	&.counter-bubble__counter--highlighted {
+	&.chat-button-unread-messages-counter--highlighted {
 		color: var(--color-primary-text);
 	}
 }


### PR DESCRIPTION
### ☑️ Resolves

* https://github.com/nextcloud/spreed/pull/12387

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes

### 🚧 Tasks

- [x] Don't rely on `NcCounterBubble` internal class
- [x] Rename class back to name from #12387 (probably was overwritten during force push)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required