### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "bdeabb2fbb4691ac3d72dc27f56dd52aa6c61725"
+                "reference": "6a23d33b2cfd8660aa2a23ee377329773451dcf7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/bdeabb2fbb4691ac3d72dc27f56dd52aa6c61725",
-                "reference": "bdeabb2fbb4691ac3d72dc27f56dd52aa6c61725",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6a23d33b2cfd8660aa2a23ee377329773451dcf7",
+                "reference": "6a23d33b2cfd8660aa2a23ee377329773451dcf7",
                 "shasum": ""
             },
             "require": {
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-06-18T00:36:38+00:00"
+            "time": "2024-06-28T00:36:28+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency