### PR TITLE
fix(MessagesList): show date separator when div is not scrollable

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -267,6 +267,8 @@ export default {
 			this.$store.dispatch('easeMessageList', { token: oldToken })
 			this.stopFetchingOldMessages = false
 			this.messagesGroupedByDateByAuthor = this.prepareMessagesGroups(this.messagesList)
+			this.stickyDate = null
+			this.checkSticky()
 		},
 
 		messagesList: {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12453

sticky date value was stored from the previous conversation and applied to the current conversation. 

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/84044328/a8b4ea72-4b31-4e6b-bd45-0323be3c7502) | ![image](https://github.com/nextcloud/spreed/assets/84044328/e9314241-572a-413b-bc50-3e06d915898a)


### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required