### PR TITLE
chore(deps): bump nextcloud/vue from 8.13.0 to 8.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "lodash": "^4.17.21",
         "mitt": "^3.0.1",
         "mockconsole": "0.0.1",
-        "nextcloud-vue-collections": "^0.13.0",
         "pinia": "^2.1.7",
         "ua-parser-js": "^1.0.38",
         "util": "^0.12.5",
@@ -13457,11 +13456,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -14762,25 +14756,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/nested-property/-/nested-property-4.0.0.tgz",
       "integrity": "sha512-yFehXNWRs4cM0+dz7QxCd06hTbWbSkV0ISsqBfkntU6TOY4Qm3Q88fRRLOddkGh2Qq6dZvnKVAahfhjcUvLnyA=="
-    },
-    "node_modules/nextcloud-vue-collections": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/nextcloud-vue-collections/-/nextcloud-vue-collections-0.13.0.tgz",
-      "integrity": "sha512-J5n2Kf9h/HVKFM0YdcHnNcbbqSossq7ocQwC9fHFs87/5iKgkUMPmVmla6uTKZHUKYCNnKSJtG7pDOWD4AP47A==",
-      "dependencies": {
-        "@nextcloud/axios": "^2.5.0",
-        "@nextcloud/l10n": "^3.1.0",
-        "@nextcloud/router": "^3.0.1",
-        "@nextcloud/vue": "^8.12.0",
-        "lodash-es": "^4.17.21"
-      },
-      "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
-      },
-      "peerDependencies": {
-        "vue": "^2.7.16"
-      }
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -30403,11 +30378,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -31329,18 +31299,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/nested-property/-/nested-property-4.0.0.tgz",
       "integrity": "sha512-yFehXNWRs4cM0+dz7QxCd06hTbWbSkV0ISsqBfkntU6TOY4Qm3Q88fRRLOddkGh2Qq6dZvnKVAahfhjcUvLnyA=="
-    },
-    "nextcloud-vue-collections": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/nextcloud-vue-collections/-/nextcloud-vue-collections-0.13.0.tgz",
-      "integrity": "sha512-J5n2Kf9h/HVKFM0YdcHnNcbbqSossq7ocQwC9fHFs87/5iKgkUMPmVmla6uTKZHUKYCNnKSJtG7pDOWD4AP47A==",
-      "requires": {
-        "@nextcloud/axios": "^2.5.0",
-        "@nextcloud/l10n": "^3.1.0",
-        "@nextcloud/router": "^3.0.1",
-        "@nextcloud/vue": "^8.12.0",
-        "lodash-es": "^4.17.21"
-      }
     },
     "node-domexception": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/upload": "^1.4.1",
-        "@nextcloud/vue": "^8.13.0",
+        "@nextcloud/vue": "^8.14.0",
         "@vueuse/components": "^10.11.0",
         "crypto-js": "^4.2.0",
         "debounce": "^2.1.0",
@@ -3864,9 +3864,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.13.0.tgz",
-      "integrity": "sha512-FV0GWSbxkaDQ8S/bWc4XcCXzJfpHzJn4xj0pK/jEwSwdSleBdBFsFFGo+wLCAGoXH5Xf5mHE+LtATFh6wnX7VA==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.14.0.tgz",
+      "integrity": "sha512-hB3dG7tZWpItC74PfbTLW02754qYXFDH+h7Ksq6b7e8WlhnKLWrhNGKhSpNDt9/g+vb5bSIOxbiDZIJZ63hAuQ==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -23138,9 +23138,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.13.0.tgz",
-      "integrity": "sha512-FV0GWSbxkaDQ8S/bWc4XcCXzJfpHzJn4xj0pK/jEwSwdSleBdBFsFFGo+wLCAGoXH5Xf5mHE+LtATFh6wnX7VA==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.14.0.tgz",
+      "integrity": "sha512-hB3dG7tZWpItC74PfbTLW02754qYXFDH+h7Ksq6b7e8WlhnKLWrhNGKhSpNDt9/g+vb5bSIOxbiDZIJZ63hAuQ==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "lodash": "^4.17.21",
     "mitt": "^3.0.1",
     "mockconsole": "0.0.1",
-    "nextcloud-vue-collections": "^0.13.0",
     "pinia": "^2.1.7",
     "ua-parser-js": "^1.0.38",
     "util": "^0.12.5",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/upload": "^1.4.1",
-    "@nextcloud/vue": "^8.13.0",
+    "@nextcloud/vue": "^8.14.0",
     "@vueuse/components": "^10.11.0",
     "crypto-js": "^4.2.0",
     "debounce": "^2.1.0",

--- a/src/components/RightSidebar/SharedItems/SharedItemsTab.vue
+++ b/src/components/RightSidebar/SharedItems/SharedItemsTab.vue
@@ -39,7 +39,7 @@
 			<!-- Shared from "Projects" app -->
 			<template v-if="projectsEnabled">
 				<NcAppNavigationCaption :name="t('spreed', 'Projects')" />
-				<CollectionList v-if="getUserId && token"
+				<NcCollectionList v-if="getUserId && token"
 					:id="token"
 					type="room"
 					:name="conversation.displayName"
@@ -66,8 +66,6 @@
 </template>
 
 <script>
-import { CollectionList } from 'nextcloud-vue-collections'
-
 import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 import FolderMultipleImage from 'vue-material-design-icons/FolderMultipleImage.vue'
 
@@ -76,6 +74,7 @@ import { t } from '@nextcloud/l10n'
 
 import NcAppNavigationCaption from '@nextcloud/vue/dist/Components/NcAppNavigationCaption.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcCollectionList from '@nextcloud/vue/dist/Components/NcCollectionList.js'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import NcRelatedResourcesPanel from '@nextcloud/vue/dist/Components/NcRelatedResourcesPanel.js'
 
@@ -96,12 +95,12 @@ export default {
 	name: 'SharedItemsTab',
 
 	components: {
-		CollectionList,
 		DotsHorizontal,
 		FolderMultipleImage,
 		LoadingComponent,
 		NcAppNavigationCaption,
 		NcButton,
+		NcCollectionList,
 		NcEmptyContent,
 		NcRelatedResourcesPanel,
 		SharedItems,


### PR DESCRIPTION
### ☑️ Resolves

* Ref https://github.com/nextcloud-libraries/nextcloud-vue/releases/tag/v8.14.0
* Drop `nextcloud-vue-collections` in favor of migrated component

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Ton on visual changes with interactive elements sizes and border radiuses

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team