### PR TITLE
fix(chat): wrap Quote in RouterLink to handle in-app navigation

### DIFF
--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -9,10 +9,10 @@ components.
 </docs>
 
 <template>
-	<a href="#"
+	<router-link :to="{ hash, params: { skipLeaveWarning: true } }"
 		class="quote"
 		:class="{'quote-own-message': isOwnMessageQuoted}"
-		@click.prevent="handleQuoteClick">
+		@click.native="handleQuoteClick">
 		<div class="quote__main">
 			<div v-if="message.id"
 				class="quote__main__author"
@@ -50,7 +50,7 @@ components.
 				<Close :size="20" />
 			</template>
 		</NcButton>
-	</a>
+	</router-link>
 </template>
 
 <script>
@@ -211,6 +211,10 @@ export default {
 		cancelQuoteLabel() {
 			return t('spreed', 'Cancel quote')
 		},
+
+		hash() {
+			return '#message_' + this.message.id
+		},
 	},
 
 	methods: {
@@ -225,11 +229,7 @@ export default {
 		},
 
 		handleQuoteClick() {
-			const parentHash = '#message_' + this.message.id
-			if (this.$route.hash !== parentHash) {
-				// Change route to trigger message fetch, if not fetched yet
-				this.$router.replace(parentHash)
-			} else {
+			if (this.$route.hash === this.hash) {
 				// Already on this message route, just trigger highlight
 				EventBus.emit('focus-message', this.message.id)
 			}


### PR DESCRIPTION
### ☑️ Resolves

* Fix faulty dialog trigger when navigating to quoted message in the same chat
  *  Replace `<a>` with `<RouterLink>`

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before 

[Screencast from 08.07.2024 17:06:36.webm](https://github.com/nextcloud/spreed/assets/93392545/ba95b2bf-f535-4f17-8c18-4571ecb78992)

 🏡 After

[Screencast from 08.07.2024 17:03:48.webm](https://github.com/nextcloud/spreed/assets/93392545/7a111dc0-8de7-46b6-9e85-585d2cacebc6)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
