### PR TITLE
fix(directive): replace v-observe-visibility with vIntersectionObserver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "vue-draggable-resizable": "^2.3.0",
         "vue-frag": "^1.4.3",
         "vue-material-design-icons": "^5.3.0",
-        "vue-observe-visibility": "^1.0.0",
         "vue-router": "^3.6.5",
         "vue-shortkey": "^3.1.7",
         "vue-virtual-scroller": "^1.1.2",
@@ -19700,11 +19699,6 @@
       "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.3.0.tgz",
       "integrity": "sha512-wnbRh+48RwX/Gt+iqwCSdWpm0hPBwwv9F7MSouUzZ2PsphYVMJB9KkG9iGs+tgBiT57ZiurFEK07Y/rFKx+Ekg=="
     },
-    "node_modules/vue-observe-visibility": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-1.0.0.tgz",
-      "integrity": "sha512-s5TFh3s3h3Mhd3jaz3zGzkVHKHnc/0C/gNr30olO99+yw2hl3WBhK3ng3/f9OF+qkW4+l7GkmwfAzDAcY3lCFg=="
-    },
     "node_modules/vue-resize": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-1.0.1.tgz",
@@ -35175,11 +35169,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.3.0.tgz",
       "integrity": "sha512-wnbRh+48RwX/Gt+iqwCSdWpm0hPBwwv9F7MSouUzZ2PsphYVMJB9KkG9iGs+tgBiT57ZiurFEK07Y/rFKx+Ekg=="
-    },
-    "vue-observe-visibility": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-1.0.0.tgz",
-      "integrity": "sha512-s5TFh3s3h3Mhd3jaz3zGzkVHKHnc/0C/gNr30olO99+yw2hl3WBhK3ng3/f9OF+qkW4+l7GkmwfAzDAcY3lCFg=="
     },
     "vue-resize": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "vue-draggable-resizable": "^2.3.0",
     "vue-frag": "^1.4.3",
     "vue-material-design-icons": "^5.3.0",
-    "vue-observe-visibility": "^1.0.0",
     "vue-router": "^3.6.5",
     "vue-shortkey": "^3.1.7",
     "vue-virtual-scroller": "^1.1.2",

--- a/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.spec.js
@@ -507,7 +507,7 @@ describe('Message.vue', () => {
 		test('displays unread message marker that marks the message seen when visible', () => {
 			getVisualLastReadMessageIdMock.mockReturnValue(123)
 			messageProps.nextMessageId = 333
-			const observeVisibility = jest.fn()
+			const IntersectionObserver = jest.fn()
 
 			const wrapper = shallowMount(Message, {
 				localVue,
@@ -516,7 +516,7 @@ describe('Message.vue', () => {
 					MessageBody,
 				},
 				directives: {
-					observeVisibility,
+					IntersectionObserver,
 				},
 				propsData: messageProps,
 				provide: injected,
@@ -525,26 +525,26 @@ describe('Message.vue', () => {
 			const marker = wrapper.find('.new-message-marker')
 			expect(marker.exists()).toBe(true)
 
-			expect(observeVisibility).toHaveBeenCalled()
-			const directiveValue = observeVisibility.mock.calls[0][1]
+			expect(IntersectionObserver).toHaveBeenCalled()
+			const directiveValue = IntersectionObserver.mock.calls[0][1]
 
 			expect(wrapper.vm.seen).toEqual(false)
 
-			directiveValue.value(false)
+			directiveValue.value([{ isIntersecting: false }])
 			expect(wrapper.vm.seen).toEqual(false)
 
-			directiveValue.value(true)
+			directiveValue.value([{ isIntersecting: true }])
 			expect(wrapper.vm.seen).toEqual(true)
 
 			// stays true if it was visible once
-			directiveValue.value(false)
+			directiveValue.value([{ isIntersecting: false }])
 			expect(wrapper.vm.seen).toEqual(true)
 		})
 
 		test('does not display read marker on the very last message', () => {
 			messageProps.lastReadMessageId = 123
 			messageProps.nextMessageId = null // last message
-			const observeVisibility = jest.fn()
+			const IntersectionObserver = jest.fn()
 
 			const wrapper = shallowMount(Message, {
 				localVue,
@@ -553,7 +553,7 @@ describe('Message.vue', () => {
 					MessageBody,
 				},
 				directives: {
-					observeVisibility,
+					IntersectionObserver,
 				},
 				propsData: messageProps,
 				provide: injected,

--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -78,7 +78,7 @@
 			@close="isTranslateDialogOpen = false" />
 
 		<div v-if="isLastReadMessage"
-			v-observe-visibility="lastReadMessageVisibilityChanged"
+			v-intersection-observer="lastReadMessageVisibilityChanged"
 			class="new-message-marker">
 			<span>{{ t('spreed', 'Unread messages') }}</span>
 		</div>
@@ -86,6 +86,8 @@
 </template>
 
 <script>
+import { vIntersectionObserver as IntersectionObserver } from '@vueuse/components'
+
 import UnfoldLess from 'vue-material-design-icons/UnfoldLessHorizontal.vue'
 import UnfoldMore from 'vue-material-design-icons/UnfoldMoreHorizontal.vue'
 
@@ -126,6 +128,10 @@ export default {
 		// Icons
 		UnfoldLess,
 		UnfoldMore,
+	},
+
+	directives: {
+		IntersectionObserver,
 	},
 
 	props: {
@@ -346,8 +352,8 @@ export default {
 
 	methods: {
 		t,
-		lastReadMessageVisibilityChanged(isVisible) {
-			if (isVisible) {
+		lastReadMessageVisibilityChanged([{ isIntersecting }]) {
+			if (isIntersecting) {
 				this.seen = true
 			}
 		},

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Poll.vue
@@ -6,7 +6,7 @@
 <template>
 	<!-- Poll card -->
 	<a v-if="!showAsButton"
-		v-observe-visibility="getPollData"
+		v-intersection-observer="getPollData"
 		:aria-label="t('spreed', 'Poll')"
 		class="poll-card"
 		role="button"
@@ -30,6 +30,8 @@
 </template>
 
 <script>
+import { vIntersectionObserver as IntersectionObserver } from '@vueuse/components'
+
 import PollIcon from 'vue-material-design-icons/Poll.vue'
 
 import { t } from '@nextcloud/l10n'
@@ -44,6 +46,10 @@ export default {
 	components: {
 		NcButton,
 		PollIcon,
+	},
+
+	directives: {
+		IntersectionObserver,
 	},
 
 	props: {

--- a/src/components/NewConversationDialog/NewConversationContactsPage.vue
+++ b/src/components/NewConversationDialog/NewConversationContactsPage.vue
@@ -8,7 +8,7 @@
 		<!-- Search -->
 		<div class="set-contacts__form">
 			<NcTextField ref="setContacts"
-				v-observe-visibility="visibilityChanged"
+				v-intersection-observer="visibilityChanged"
 				:value.sync="searchText"
 				type="text"
 				class="set-contacts__form-input"
@@ -57,6 +57,7 @@
 </template>
 
 <script>
+import { vIntersectionObserver as IntersectionObserver } from '@vueuse/components'
 import debounce from 'debounce'
 import { ref } from 'vue'
 
@@ -91,6 +92,10 @@ export default {
 		// Icons
 		Close,
 		Magnify,
+	},
+
+	directives: {
+		IntersectionObserver,
 	},
 
 	props: {
@@ -225,12 +230,14 @@ export default {
 				this.contactsLoading = false
 			}
 		},
-		visibilityChanged(isVisible) {
-			if (isVisible) {
+
+		visibilityChanged([{ isIntersecting }]) {
+			if (isIntersecting) {
 				// Focus the input field of the current component.
 				this.focusInput()
 			}
 		},
+
 		focusInput() {
 			this.setContacts.focus()
 		},

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,6 @@
 
 import { createPinia, PiniaVuePlugin } from 'pinia'
 import Vue from 'vue'
-import VueObserveVisibility from 'vue-observe-visibility'
 import VueRouter from 'vue-router'
 import VueShortKey from 'vue-shortkey'
 import Vuex from 'vuex'
@@ -48,7 +47,6 @@ Vue.prototype.OCA = OCA
 Vue.use(PiniaVuePlugin)
 Vue.use(Vuex)
 Vue.use(VueRouter)
-Vue.use(VueObserveVisibility)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
 
 const pinia = createPinia()

--- a/src/mainFilesSidebar.js
+++ b/src/mainFilesSidebar.js
@@ -5,7 +5,6 @@
 
 import { createPinia, PiniaVuePlugin } from 'pinia'
 import Vue from 'vue'
-import VueObserveVisibility from 'vue-observe-visibility'
 import VueShortKey from 'vue-shortkey'
 import Vuex from 'vuex'
 
@@ -42,7 +41,6 @@ Vue.prototype.OCA = OCA
 Vue.use(PiniaVuePlugin)
 Vue.use(Vuex)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
-Vue.use(VueObserveVisibility)
 
 const pinia = createPinia()
 

--- a/src/mainPublicShareAuthSidebar.js
+++ b/src/mainPublicShareAuthSidebar.js
@@ -5,7 +5,6 @@
 
 import { createPinia, PiniaVuePlugin } from 'pinia'
 import Vue from 'vue'
-import VueObserveVisibility from 'vue-observe-visibility'
 import VueShortKey from 'vue-shortkey'
 import Vuex from 'vuex'
 
@@ -42,7 +41,6 @@ Vue.prototype.OCA = OCA
 Vue.use(PiniaVuePlugin)
 Vue.use(Vuex)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
-Vue.use(VueObserveVisibility)
 
 const pinia = createPinia()
 store.dispatch('setMainContainerSelector', '#talk-sidebar')

--- a/src/mainPublicShareSidebar.js
+++ b/src/mainPublicShareSidebar.js
@@ -5,7 +5,6 @@
 
 import { createPinia, PiniaVuePlugin } from 'pinia'
 import Vue, { reactive } from 'vue'
-import VueObserveVisibility from 'vue-observe-visibility'
 import VueShortKey from 'vue-shortkey'
 import Vuex from 'vuex'
 
@@ -42,7 +41,6 @@ Vue.prototype.OCA = OCA
 Vue.use(PiniaVuePlugin)
 Vue.use(Vuex)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
-Vue.use(VueObserveVisibility)
 
 const pinia = createPinia()
 

--- a/src/mainRecording.js
+++ b/src/mainRecording.js
@@ -6,7 +6,6 @@
 
 import { createPinia, PiniaVuePlugin } from 'pinia'
 import Vue from 'vue'
-import VueObserveVisibility from 'vue-observe-visibility'
 import VueRouter from 'vue-router'
 import VueShortKey from 'vue-shortkey'
 import Vuex from 'vuex'
@@ -51,7 +50,6 @@ Vue.prototype.OCA = OCA
 Vue.use(PiniaVuePlugin)
 Vue.use(Vuex)
 Vue.use(VueRouter)
-Vue.use(VueObserveVisibility)
 Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
 
 const pinia = createPinia()


### PR DESCRIPTION
### ☑️ Resolves

* Drop dependency lib `vue-observe-visibility`, as it's using the same browser API
  * `vue-virtual-scroller` still has it in deps, but different version anyway

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No changes

### 🚧 Tasks

- [ ] Polls might be fetched several times, from component and messageStore
  - [ ] Follow-up when fixing pollStore

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possible