### PR TITLE
fix(MessageList): Workaround rendering issue on safari when unread marker is removed

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -1193,7 +1193,10 @@ export default {
 		},
 
 		onWindowFocus() {
-			this.refreshReadMarkerPosition()
+			// setTimeout is needed here for Safari to correctly remove the unread marker
+			setTimeout(() => {
+				this.refreshReadMarkerPosition()
+			}, 2)
 		},
 
 		messagesGroupComponent(group) {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12595

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

See screencast in original issue.

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required