### PR TITLE
fix(federation): Fix federation with Nextcloud 29.0.4 or later

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>20.0.0-dev.1</version>
+	<version>20.0.0-dev.2</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/lib/Federation/BackendNotifier.php
+++ b/lib/Federation/BackendNotifier.php
@@ -395,10 +395,6 @@ class BackendNotifier {
 			$server = substr($server, 0, -10);
 		}
 
-		if (str_starts_with($server, 'https://')) {
-			return substr($server, strlen('https://'));
-		}
-
 		return $server;
 	}
 }

--- a/lib/Federation/CloudFederationProviderTalk.php
+++ b/lib/Federation/CloudFederationProviderTalk.php
@@ -137,6 +137,12 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 		$ownerFederatedId = $share->getOwner();
 		[, $remote] = $this->addressHandler->splitUserRemote($ownerFederatedId);
 
+		if (!$this->addressHandler->urlContainProtocol($remote)) {
+			// Heal federation from before Nextcloud 29.0.4 which sends requests
+			// without the protocol on the remote in case it is https://
+			$remote = 'https://' . $remote;
+		}
+
 		// if no explicit information about the person who created the share was sent
 		// we assume that the share comes from the owner
 		if ($sharedByFederatedId === null) {
@@ -505,6 +511,12 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 
 		if (!$sharedSecret) {
 			throw new AuthenticationFailedException();
+		}
+
+		if (!$this->addressHandler->urlContainProtocol($remoteServerUrl)) {
+			// Heal federation from before Nextcloud 29.0.4 which sends requests
+			// without the protocol on the remote in case it is https://
+			$remoteServerUrl = 'https://' . $remoteServerUrl;
 		}
 
 		try {

--- a/lib/Migration/Version19000Date20240709183937.php
+++ b/lib/Migration/Version19000Date20240709183937.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Heal federation from before Nextcloud 29.0.4 which sends requests
+ * without the protocol on the remote in case it is https://
+ */
+class Version19000Date20240709183937 extends SimpleMigrationStep {
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
+	}
+
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$query = $this->connection->getQueryBuilder();
+		$query->update('talk_invitations')
+			->set('remote_server_url', $query->func()->concat($query->createNamedParameter('https://'), 'remote_server_url'))
+			->where($query->expr()->notLike('remote_server_url', $query->createNamedParameter(
+				$this->connection->escapeLikeParameter('http://'). '%'
+			)))
+			->andWhere($query->expr()->notLike('remote_server_url', $query->createNamedParameter(
+				$this->connection->escapeLikeParameter('https://'). '%'
+			)));
+		$query->executeStatement();
+	}
+}

--- a/tests/php/Federation/FederationTest.php
+++ b/tests/php/Federation/FederationTest.php
@@ -252,7 +252,7 @@ class FederationTest extends TestCase {
 		$ownerFederatedId = 'owner@test.local';
 		$sharedBy = 'Owner\'s name';
 		$sharedByFederatedId = 'owner@test.local';
-		$remote = 'test.local';
+		$remote = 'https://test.local';
 		$shareType = 'user';
 		$roomType = Room::TYPE_GROUP;
 		$roomName = 'Room name';
@@ -311,6 +311,10 @@ class FederationTest extends TestCase {
 			->method('splitUserRemote')
 			->with($ownerFederatedId)
 			->willReturn(['owner', $remote]);
+
+		$this->addressHandler->expects($this->once())
+			->method('urlContainProtocol')
+			->willReturnCallback(static fn (string $url) => str_starts_with($url, 'http://') || str_starts_with($url, 'https://'));
 
 		$this->userManager->expects($this->once())
 			->method('get')
@@ -429,7 +433,7 @@ class FederationTest extends TestCase {
 				[
 					'sharedSecret' => $token,
 					'message' => 'Recipient declined the share',
-					'remoteServerUrl' => 'example.tld',
+					'remoteServerUrl' => 'https://example.tld',
 				]
 			);
 


### PR DESCRIPTION
Since [Nextcloud 29.0.4 ICloudID::getRemote() contains the protocol](https://github.com/nextcloud/server/pull/46133). Therefore we can no longer find the federation invites by the server URL, as the protocol was missing in the database.
To be more aligned with the future expectation of the handling, the protocol is added and now always expected.

### ☑️ Resolves

* Fix #12654 

## 🛠️ API Checklist

- Can not be covered by integration tests as they use http and therefore always have the protocol anyway.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
