### PR TITLE
style: adjust variables and styles for Nc30 (part 2)

### DIFF
--- a/src/components/LeftSidebar/OpenConversationsList/OpenConversationsList.vue
+++ b/src/components/LeftSidebar/OpenConversationsList/OpenConversationsList.vue
@@ -5,6 +5,7 @@
 
 <template>
 	<RoomSelector v-if="modal"
+		:open.sync="modal"
 		:container="container"
 		list-open-conversations
 		show-postable-only

--- a/src/components/MediaSettings/MediaDevicesSelector.vue
+++ b/src/components/MediaSettings/MediaDevicesSelector.vue
@@ -5,14 +5,10 @@
 
 <template>
 	<div class="media-devices-selector">
-		<div class="media-devices-selector__icon">
-			<Microphone v-if="deviceIcon === 'microphone'"
-				title=""
-				:size="16" />
-			<VideoIcon v-if="deviceIcon === 'camera'"
-				title=""
-				:size="16" />
-		</div>
+		<component :is="deviceIcon"
+			class="media-devices-selector__icon"
+			title=""
+			:size="16" />
 
 		<NcSelect v-model="deviceSelectedOption"
 			:input-id="deviceSelectorId"
@@ -90,14 +86,12 @@ export default {
 
 		deviceIcon() {
 			if (this.kind === 'audioinput') {
-				return 'microphone'
+				return Microphone
+			} else if (this.kind === 'videoinput') {
+				return VideoIcon
+			} else {
+				return null
 			}
-
-			if (this.kind === 'videoinput') {
-				return 'camera'
-			}
-
-			return null
 		},
 
 		deviceOptionsAvailable() {
@@ -203,15 +197,14 @@ export default {
 <style lang="scss" scoped>
 .media-devices-selector {
 	display: flex;
-	margin: 16px 0;
+	margin: calc(var(--default-grid-baseline) * 2) 0;
+
 	&__icon {
 		display: flex;
-		justify-content: flex-start;
+		justify-content: center;
 		align-items: center;
-		width: 36px;
-	}
-	&__heading {
-		font-weight: bold;
+		width: var(--default-clickable-area);
+		flex-shrink: 0;
 	}
 
 	:deep(.v-select.select) {

--- a/src/components/MediaSettings/MediaDevicesSpeakerTest.vue
+++ b/src/components/MediaSettings/MediaDevicesSpeakerTest.vue
@@ -5,9 +5,7 @@
 
 <template>
 	<div class="media-devices-checker">
-		<div class="media-devices-checker__icon">
-			<VolumeHighIcon :size="16" />
-		</div>
+		<VolumeHighIcon class="media-devices-checker__icon" :size="16" />
 		<NcButton type="secondary" @click="playTestSound">
 			{{ buttonLabel }}
 		</NcButton>
@@ -82,13 +80,14 @@ export default {
 <style lang="scss" scoped>
 .media-devices-checker {
 	display: flex;
-	margin: 16px 0;
+	margin: calc(var(--default-grid-baseline) * 2) 0;
 
 	&__icon {
 		display: flex;
-		justify-content: flex-start;
+		justify-content: center;
 		align-items: center;
-		width: 36px;
+		width: var(--default-clickable-area);
+		flex-shrink: 0;
 	}
 
 	.equalizer {

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -4,13 +4,13 @@
 -->
 
 <template>
-	<NcModal v-if="modal"
+	<NcDialog :open.sync="modal"
 		:container="container"
+		:name="t('spreed', 'Media settings')"
+		size="normal"
+		close-on-click-outside
 		@close="closeModal">
 		<div class="media-settings">
-			<h2 class="media-settings__title">
-				{{ t('spreed', 'Media settings') }}
-			</h2>
 			<!-- Preview -->
 			<div class="media-settings__preview">
 				<video v-show="showVideo"
@@ -150,7 +150,9 @@
 					</NcCheckboxRadioSwitch>
 				</template>
 			</NcNoteCard>
+		</div>
 
+		<template #actions>
 			<!-- buttons bar at the bottom -->
 			<div class="media-settings__call-buttons">
 				<!-- Silent call -->
@@ -187,8 +189,8 @@
 					{{ t('spreed', 'Apply settings') }}
 				</NcButton>
 			</div>
-		</div>
-	</NcModal>
+		</template>
+	</NcDialog>
 </template>
 
 <script>
@@ -209,7 +211,7 @@ import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
-import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
+import NcDialog from '@nextcloud/vue/dist/Components/NcDialog.js'
 import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
@@ -248,7 +250,7 @@ export default {
 		NcActions,
 		NcButton,
 		NcCheckboxRadioSwitch,
-		NcModal,
+		NcDialog,
 		NcNoteCard,
 		MediaDevicesSelector,
 		MediaDevicesSpeakerTest,
@@ -698,12 +700,7 @@ export default {
 
 <style lang="scss" scoped>
 .media-settings {
-	padding: calc(var(--default-grid-baseline) * 5);
-	padding-bottom: 0;
-
-	&__title {
-		text-align: center;
-	}
+	padding: 0 calc(var(--default-grid-baseline) * 2);
 
 	&__preview {
 		position: relative;
@@ -746,14 +743,10 @@ export default {
 
 	&__call-buttons {
 		display: flex;
-		z-index: 1;
 		align-items: center;
 		justify-content: center;
 		gap: var(--default-grid-baseline);
-		position: sticky;
-		bottom: 0;
-		background-color: var(--color-main-background);
-		padding: 10px 0 20px;
+		width: 100%;
 	}
 }
 
@@ -790,7 +783,7 @@ export default {
 .checkbox {
 	display: flex;
 	justify-content: center;
-	margin: calc(var(--default-grid-baseline) * 2);
+	margin: calc(var(--default-grid-baseline) * 2) 0;
 
 	&--warning {
 		&:focus-within :deep(.checkbox-radio-switch__label),

--- a/src/components/MediaSettings/VideoBackgroundEditor.vue
+++ b/src/components/MediaSettings/VideoBackgroundEditor.vue
@@ -288,7 +288,7 @@ export default {
 	&__element {
 		border: none;
 		margin: 0 !important;
-		border-radius: calc(var(--border-radius-large) * 1.5);
+		border-radius: var(--border-radius-large);
 		height: calc(var(--default-grid-baseline) * 16);
 		display: flex;
 		flex-direction: column;

--- a/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageForwarder.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessageButtonsBar/MessageForwarder.vue
@@ -7,7 +7,8 @@
 	<div class="message-forwarder">
 		<!-- First step of the flow: selection of the room to which forward the
 		message to -->
-		<RoomSelector v-if="!showForwardedConfirmation"
+		<RoomSelector v-if="open"
+			:open.sync="open"
 			:container="container"
 			show-postable-only
 			:dialog-title="dialogTitle"
@@ -94,6 +95,10 @@ export default {
 	},
 
 	computed: {
+		open() {
+			return !this.showForwardedConfirmation
+		},
+
 		container() {
 			return this.$store.getters.getMainContainerSelector()
 		},

--- a/src/components/RoomSelector.vue
+++ b/src/components/RoomSelector.vue
@@ -4,12 +4,12 @@
 -->
 
 <template>
-	<NcModal size="small" :container="container" @close="close">
+	<NcDialog :name="dialogTitle"
+		:open="open"
+		:container="container"
+		close-on-click-outside
+		@close="close">
 		<div class="selector">
-			<!-- Heading, search field -->
-			<h2 class="selector__heading">
-				{{ dialogTitle }}
-			</h2>
 			<p v-if="dialogSubtitle" class="selector__subtitle">
 				{{ dialogSubtitle }}
 			</p>
@@ -26,24 +26,23 @@
 			<ConversationsSearchListVirtual v-if="loading || availableRooms.length > 0"
 				:conversations="availableRooms"
 				:loading="loading"
-				class="selector__list"
 				@select="onSelect" />
 			<NcEmptyContent v-else :name="noMatchFoundTitle" :description="noMatchFoundSubtitle">
 				<template #icon>
 					<MessageOutline :size="64" />
 				</template>
 			</NcEmptyContent>
+		</div>
 
-			<!-- Actions -->
+		<template #actions>
 			<NcButton v-if="!loading && availableRooms.length > 0"
-				class="selector__action"
 				type="primary"
 				:disabled="!selectedRoom"
 				@click="onSubmit">
 				{{ t('spreed', 'Select conversation') }}
 			</NcButton>
-		</div>
-	</NcModal>
+		</template>
+	</NcDialog>
 </template>
 
 <script>
@@ -55,8 +54,8 @@ import MessageOutline from 'vue-material-design-icons/MessageOutline.vue'
 import { t } from '@nextcloud/l10n'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcDialog from '@nextcloud/vue/dist/Components/NcDialog.js'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
-import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 
 import ConversationsSearchListVirtual from './LeftSidebar/ConversationsList/ConversationsSearchListVirtual.vue'
@@ -72,7 +71,7 @@ export default {
 		ConversationsSearchListVirtual,
 		NcButton,
 		NcEmptyContent,
-		NcModal,
+		NcDialog,
 		NcTextField,
 		// Icons
 		Magnify,
@@ -80,6 +79,11 @@ export default {
 	},
 
 	props: {
+		open: {
+			type: Boolean,
+			default: false,
+		},
+
 		container: {
 			type: String,
 			default: undefined,
@@ -120,7 +124,7 @@ export default {
 		},
 	},
 
-	emits: ['close', 'select'],
+	emits: ['close', 'select', 'update:open'],
 
 	setup() {
 		const selectedRoom = ref(null)
@@ -199,8 +203,10 @@ export default {
 		close() {
 			if (this.isPlugin) {
 				this.$root.$emit('close')
+				this.$root.$emit('update:open', false)
 			} else {
 				this.$emit('close')
+				this.$emit('update:open', false)
 			}
 		},
 
@@ -231,32 +237,17 @@ export default {
 }
 
 .selector {
-	width: 100%;
 	height: 100%;
 	display: flex;
 	flex-direction: column;
-	padding: 16px;
-
-	&__heading {
-		margin-bottom: 4px;
-	}
 
 	&__subtitle {
 		color: var(--color-text-maxcontrast);
-		margin-bottom: 8px;
+		margin-bottom: calc(var(--default-grid-baseline) * 2);
 	}
 
 	&__search {
-		margin-bottom: 10px;
-	}
-
-	&__list {
-		height: 100%;
-	}
-
-	&__action {
-		flex-shrink: 0;
-		margin-left: auto;
+		margin-bottom: calc(var(--default-grid-baseline) * 2);
 	}
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

* Based on #12662


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/nextcloud/spreed/assets/93392545/191f275d-f759-4820-af55-1ac50aa30069) | ![image](https://github.com/nextcloud/spreed/assets/93392545/00d562dc-c9ff-4dbc-8a09-679ae2a83d92)


### 🚧 Tasks

- [ ] Replace NcModal with NcDialog (a11y)
- [ ] Adjust cutted-off texts
- [ ] Adjust border-radiuses
- [ ] Adjust hover feedback

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

