### PR TITLE
feat: add selector for Audio Output 🔈

### DIFF
--- a/src/components/MediaSettings/MediaDevicesSelector.vue
+++ b/src/components/MediaSettings/MediaDevicesSelector.vue
@@ -35,11 +35,17 @@ const emit = defineEmits<{
 	(event: 'update:deviceId', value: string | null | undefined): void
 }>()
 
-const deviceOptions = computed<NcSelectOption[]>(() => ([
-	...props.devices.filter(device => device.kind === props.kind)
-		.map(device => ({ id: device.deviceId, label: device.label ? device.label : device.fallbackLabel })),
-	{ id: null, label: t('spreed', 'None') },
-]))
+const deviceOptions = computed<NcSelectOption[]>(() => {
+	const kindDevices = props.devices.filter(device => device.kind === props.kind)
+		.map(device => ({
+			id: device.deviceId,
+			label: device.label ? device.label : device.fallbackLabel,
+		}))
+	if (props.kind === 'audiooutput') {
+		return kindDevices
+	}
+	return [...kindDevices, { id: null, label: t('spreed', 'None') }]
+})
 const deviceOptionsAvailable = computed(() => deviceOptions.value.length > 1)
 
 const deviceIcon = computed<ComponentPublicInstance | null>(() => {

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -85,6 +85,12 @@
 						:device-id="videoInputId"
 						@refresh="updateDevices"
 						@update:deviceId="handleVideoInputIdChange" />
+					<MediaDevicesSelector v-if="audioOutputSupported"
+						kind="audiooutput"
+						:devices="devices"
+						:device-id="audioOutputId"
+						@refresh="updateDevices"
+						@update:deviceId="handleAudioOutputIdChange" />
 					<MediaDevicesSpeakerTest />
 				</template>
 
@@ -263,7 +269,9 @@ export default {
 			audioPreviewAvailable,
 			videoPreviewAvailable,
 			audioInputId,
+			audioOutputId,
 			videoInputId,
+			audioOutputSupported,
 			initializeDevices,
 			stopDevices,
 			virtualBackground,
@@ -298,7 +306,9 @@ export default {
 			audioPreviewAvailable,
 			videoPreviewAvailable,
 			audioInputId,
+			audioOutputId,
 			videoInputId,
+			audioOutputSupported,
 			initializeDevices,
 			stopDevices,
 			virtualBackground,
@@ -545,6 +555,7 @@ export default {
 			this.isMirrored = false
 			// Update devices preferences
 			this.updatePreferences('audioinput')
+			this.updatePreferences('audiooutput')
 			this.updatePreferences('videoinput')
 		},
 
@@ -705,6 +716,11 @@ export default {
 		handleAudioInputIdChange(audioInputId) {
 			this.audioInputId = audioInputId
 			this.updatePreferences('audioinput')
+		},
+
+		handleAudioOutputIdChange(audioOutputId) {
+			this.audioOutputId = audioOutputId
+			this.updatePreferences('audiooutput')
 		},
 
 		handleVideoInputIdChange(videoInputId) {

--- a/src/components/SettingsDialog/MediaDevicesPreview.vue
+++ b/src/components/SettingsDialog/MediaDevicesPreview.vue
@@ -69,6 +69,13 @@
 			@update:model-value="setBlurVirtualBackgroundEnabled">
 			{{ t('spreed', 'Enable blur background by default for all conversation') }}
 		</NcCheckboxRadioSwitch>
+		<MediaDevicesSelector v-if="audioOutputSupported"
+			kind="audiooutput"
+			:devices="devices"
+			:device-id="audioOutputId"
+			@refresh="updateDevices"
+			@update:deviceId="handleAudioOutputIdChange" />
+		<MediaDevicesSpeakerTest />
 	</div>
 </template>
 
@@ -84,6 +91,7 @@ import { t } from '@nextcloud/l10n'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 
 import MediaDevicesSelector from '../MediaSettings/MediaDevicesSelector.vue'
+import MediaDevicesSpeakerTest from '../MediaSettings/MediaDevicesSpeakerTest.vue'
 import VolumeIndicator from '../UIShared/VolumeIndicator.vue'
 
 import { useDevices } from '../../composables/useDevices.js'
@@ -98,6 +106,7 @@ export default {
 	name: 'MediaDevicesPreview',
 
 	components: {
+		MediaDevicesSpeakerTest,
 		AlertCircle,
 		MediaDevicesSelector,
 		MicrophoneOff,
@@ -117,7 +126,9 @@ export default {
 			audioPreviewAvailable,
 			videoPreviewAvailable,
 			audioInputId,
+			audioOutputId,
 			videoInputId,
+			audioOutputSupported,
 			audioStream,
 			audioStreamError,
 			videoStream,
@@ -135,7 +146,9 @@ export default {
 			audioPreviewAvailable,
 			videoPreviewAvailable,
 			audioInputId,
+			audioOutputId,
 			videoInputId,
+			audioOutputSupported,
 			audioStream,
 			audioStreamError,
 			videoStream,
@@ -228,6 +241,11 @@ export default {
 		handleVideoInputIdChange(videoInputId) {
 			this.videoInputId = videoInputId
 			this.updatePreferences('videoinput')
+		},
+
+		handleAudioOutputIdChange(audioOutputId) {
+			this.audioOutputId = audioOutputId
+			this.updatePreferences('audiooutput')
 		},
 
 		async setBlurVirtualBackgroundEnabled(value) {

--- a/src/composables/useDevices.js
+++ b/src/composables/useDevices.js
@@ -6,6 +6,7 @@
 import createHark from 'hark'
 import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 
+import { useSoundsStore } from '../stores/sounds.js'
 import attachMediaStream from '../utils/attachmediastream.js'
 import TrackToStream from '../utils/media/pipeline/TrackToStream.js'
 import VirtualBackground from '../utils/media/pipeline/VirtualBackground.js'
@@ -23,6 +24,9 @@ export function useDevices(video, initializeOnMounted) {
 	let initialized = false
 	let pendingGetUserMediaAudioCount = 0
 	let pendingGetUserMediaVideoCount = 0
+
+	const soundsStore = useSoundsStore()
+
 	const hark = ref(null)
 	const videoTrackToStream = ref(null)
 	const mediaDevicesManager = reactive(mediaDevicesManagerInstance)
@@ -103,6 +107,12 @@ export function useDevices(video, initializeOnMounted) {
 		}
 	})
 
+	watch(audioOutputId, (deviceId) => {
+		if (initialized && deviceId !== undefined) {
+			soundsStore.setGeneralAudioOutput(deviceId)
+		}
+	})
+
 	watch(videoInputId, () => {
 		if (initialized) {
 			updateVideoStream()
@@ -156,6 +166,10 @@ export function useDevices(video, initializeOnMounted) {
 		mediaDevicesManager.enableDeviceEvents()
 		updateAudioStream()
 		updateVideoStream()
+
+		if (mediaDevicesManager.attributes.audioOutputId !== undefined) {
+			soundsStore.setGeneralAudioOutput(mediaDevicesManager.attributes.audioOutputId)
+		}
 	}
 
 	/**

--- a/src/composables/useDevices.js
+++ b/src/composables/useDevices.js
@@ -63,6 +63,19 @@ export function useDevices(video, initializeOnMounted) {
 		return audioTracks.length < 1 ? null : audioTracks[0].getSettings().deviceId
 	})
 
+	const audioOutputId = computed({
+		get() {
+			return mediaDevicesManager.attributes.audioOutputId
+		},
+		set(value) {
+			mediaDevicesManager.set('audioOutputId', value)
+		},
+	})
+
+	const audioOutputSupported = computed(() => {
+		return mediaDevicesManager.isAudioOutputSelectSupported
+	})
+
 	const videoInputId = computed({
 		get() {
 			return mediaDevicesManager.attributes.videoInputId
@@ -155,7 +168,7 @@ export function useDevices(video, initializeOnMounted) {
 
 	/**
 	 * Update preference counters for devices (audio and video)
-	 * @param {string} kind the kind of the input stream to update ('audioinput' or 'videoinput')
+	 * @param {string} kind the kind of the input stream to update ('audioinput', 'audiooutput' or 'videoinput')
 	 * @public
 	 */
 	function updatePreferences(kind) {
@@ -376,7 +389,9 @@ export function useDevices(video, initializeOnMounted) {
 		audioPreviewAvailable,
 		videoPreviewAvailable,
 		audioInputId,
+		audioOutputId,
 		videoInputId,
+		audioOutputSupported,
 		// MediaDevicesPreview only
 		audioStream,
 		audioStreamError,

--- a/src/composables/useDevices.js
+++ b/src/composables/useDevices.js
@@ -10,7 +10,7 @@ import { useSoundsStore } from '../stores/sounds.js'
 import attachMediaStream from '../utils/attachmediastream.js'
 import TrackToStream from '../utils/media/pipeline/TrackToStream.js'
 import VirtualBackground from '../utils/media/pipeline/VirtualBackground.js'
-import { mediaDevicesManager as mediaDevicesManagerInstance } from '../utils/webrtc/index.js'
+import { callParticipantsAudioPlayer, mediaDevicesManager as mediaDevicesManagerInstance } from '../utils/webrtc/index.js'
 
 /**
  * Check whether the user joined the call of the current token in this PHP session or not
@@ -110,6 +110,10 @@ export function useDevices(video, initializeOnMounted) {
 	watch(audioOutputId, (deviceId) => {
 		if (initialized && deviceId !== undefined) {
 			soundsStore.setGeneralAudioOutput(deviceId)
+
+			if (callParticipantsAudioPlayer) {
+				callParticipantsAudioPlayer.setGeneralAudioOutput(deviceId)
+			}
 		}
 	})
 

--- a/src/services/__tests__/mediaDevicePreferences.spec.js
+++ b/src/services/__tests__/mediaDevicePreferences.spec.js
@@ -32,12 +32,13 @@ describe('mediaDevicePreferences', () => {
 		videoInputDeviceDefault, videoInputDeviceA, videoInputDeviceB,
 		audioOutputDeviceDefault, audioOutputDeviceA, audioOutputDeviceB]
 	const audioInputPreferenceList = [audioInputDeviceDefault, audioInputDeviceA, audioInputDeviceB]
+	const audioOutputPreferenceList = [audioOutputDeviceDefault, audioOutputDeviceA, audioOutputDeviceB]
 	const videoInputPreferenceList = [videoInputDeviceDefault, videoInputDeviceA, videoInputDeviceB]
 
 	describe('listMediaDevices', () => {
 		it('list all input devices from preference lists', () => {
-			const attributes = { devices: allDevices, audioInputId: undefined, videoInputId: undefined }
-			const output = listMediaDevices(attributes, audioInputPreferenceList, videoInputPreferenceList)
+			const attributes = { devices: allDevices, audioInputId: undefined, audioOutputId: undefined, videoInputId: undefined }
+			const output = listMediaDevices(attributes, audioInputPreferenceList, audioOutputPreferenceList, videoInputPreferenceList)
 
 			// Assert: should show all registered devices, apart from default / outputs
 			const inputDevices = allDevices.filter(device => device.kind !== 'audiooutput' && device.deviceId !== 'default')
@@ -47,8 +48,8 @@ describe('mediaDevicePreferences', () => {
 		})
 
 		it('show selected devices from preference lists', () => {
-			const attributes = { devices: allDevices, audioInputId: audioInputDeviceA.deviceId, videoInputId: videoInputDeviceA.deviceId }
-			const output = listMediaDevices(attributes, audioInputPreferenceList, videoInputPreferenceList)
+			const attributes = { devices: allDevices, audioInputId: audioInputDeviceA.deviceId, audioOutputId: audioOutputDeviceA.deviceId, videoInputId: videoInputDeviceA.deviceId }
+			const output = listMediaDevices(attributes, audioInputPreferenceList, audioOutputPreferenceList, videoInputPreferenceList)
 
 			// Assert: should show a label next to selected registered devices
 			const selectedDeviceIds = [audioInputDeviceA.deviceId, videoInputDeviceA.deviceId]
@@ -64,7 +65,7 @@ describe('mediaDevicePreferences', () => {
 				audioInputId: undefined,
 				videoInputId: undefined,
 			}
-			const output = listMediaDevices(attributes, audioInputPreferenceList, videoInputPreferenceList)
+			const output = listMediaDevices(attributes, audioInputPreferenceList, audioOutputPreferenceList, videoInputPreferenceList)
 
 			// Assert: should show a label next to unplugged registered devices
 			unpluggedDeviceIds.forEach(deviceId => {
@@ -108,14 +109,14 @@ describe('mediaDevicePreferences', () => {
 		})
 
 		it('returns preference lists with all available devices', () => {
-			const output = populateMediaDevicesPreferences(allDevices, [], [])
+			const output = populateMediaDevicesPreferences(allDevices, [], [], [])
 
 			// Assert: should contain all available devices, apart from default / outputs
-			expect(output).toMatchObject({ newAudioInputList: audioInputPreferenceList, newVideoInputList: videoInputPreferenceList })
+			expect(output).toMatchObject({ newAudioInputList: audioInputPreferenceList, newAudioOutputList: audioOutputPreferenceList, newVideoInputList: videoInputPreferenceList })
 		})
 
 		it('returns null if preference lists were not updated', () => {
-			const output = populateMediaDevicesPreferences(allDevices, audioInputPreferenceList, videoInputPreferenceList)
+			const output = populateMediaDevicesPreferences(allDevices, audioInputPreferenceList, audioOutputPreferenceList, videoInputPreferenceList)
 
 			// Assert
 			expect(output).toMatchObject({ newAudioInputList: null, newVideoInputList: null })

--- a/src/stores/sounds.js
+++ b/src/stores/sounds.js
@@ -25,6 +25,7 @@ const shouldPlaySounds = hasUserAccount
  * Preferred version is the .ogg, with .flac fallback if .ogg is not supported (Safari)
  */
 const fileExtension = new Audio().canPlayType('audio/ogg') ? '.ogg' : '.flac'
+const isAudioOutputSelectSupported = !!(new Audio().setSinkId)
 
 export const useSoundsStore = defineStore('sounds', {
 	state: () => ({
@@ -105,6 +106,21 @@ export const useSoundsStore = defineStore('sounds', {
 			this.createAudioObject('leave', 'leave_call', 0.75)
 			this.createAudioObject('wait', 'LibremPhoneCall', 0.5)
 			this.audioObjectsCreated = true
+		},
+
+		async setGeneralAudioOutput(deviceId) {
+			if (!isAudioOutputSelectSupported) {
+				return
+			}
+
+			try {
+				for (const key in this.audioObjects) {
+					this.pauseAudio(key)
+					await this.audioObjects[key].setSinkId(deviceId)
+				}
+			} catch (error) {
+				console.error(error)
+			}
 		},
 	}
 })

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -32,6 +32,8 @@ jest.mock('@nextcloud/capabilities', () => ({
 	getCapabilities: jest.fn(() => mockedCapabilities),
 }))
 
+HTMLAudioElement.prototype.setSinkId = jest.fn()
+
 window.IntersectionObserver = jest.fn(() => ({
 	observe: jest.fn(),
 	unobserve: jest.fn(),

--- a/src/utils/webrtc/index.js
+++ b/src/utils/webrtc/index.js
@@ -514,6 +514,8 @@ export {
 
 	mediaDevicesManager,
 
+	callParticipantsAudioPlayer,
+
 	callAnalyzer,
 
 	signalingGetSettingsForRecording,


### PR DESCRIPTION
### ☑️ Resolves

* Fix #7125
* Fix #14405
* Fix #14404
* Current POC: works when selecting device before start of the call

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="354" alt="image" src="https://github.com/user-attachments/assets/6e40896e-0a4b-4574-9439-38275cd9b50c" /> | <img width="355" alt="image" src="https://github.com/user-attachments/assets/ba890a33-4f60-48ae-ade3-13ce7eeff7bf" />

### 🚧 Tasks

- [x] Media selector for output
  - [x] Migrate to TS https://github.com/nextcloud/spreed/pull/14511
- [x] Device preferences handling
- [x] Store handling
- [x] ~Mixer usage~
- [x] Safari warning (not supported) or hide the element
- [x] CallParticipants* proper update on change
- [x] Switch to default sinkId `''`
  - [x] replace None with Default in NcSelect
  - [ ] faulty cases
- [ ] Firefox usage

### 🏁 Checklist

- [ ] 🌏 Tested with different browsers / clients:
  - [x] Chromium (Chrome / Edge / Opera / Brave)
  - [ ] Firefox ❓ less devices, need to test
  - [x] ~Safari~ ⚠️ not supported
  - [x] Talk Desktop
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required