### PR TITLE
fix: Moderators no longer able to ban themselves or other moderators

### DIFF
--- a/lib/Service/BanService.php
+++ b/lib/Service/BanService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Talk\Service;
 
 use DateTime;
+use OCA\Talk\Manager;
 use OCA\Talk\Model\Ban;
 use OCA\Talk\Model\BanMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -17,6 +18,8 @@ class BanService {
 
 	public function __construct(
 		protected BanMapper $banMapper,
+		protected Manager $manager,
+		protected ParticipantService $participantService,
 	) {
 	}
 
@@ -32,6 +35,12 @@ class BanService {
 
 		if (empty($internalNote)) {
 			throw new \InvalidArgumentException('internalNote');
+		}
+
+		$bannedParticipant = $this->participantService->getParticipantByActor($this->manager->getRoomById($roomId), $bannedType, $bannedId);
+
+		if ($bannedParticipant->hasModeratorPermissions()) {
+			throw new \InvalidArgumentException('moderator');
 		}
 
 		$ban = new Ban();

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1838,6 +1838,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->assertStatusCode($this->response, $statusCode);
 	}
 
+
+
 	/**
 	 * @Then /^user "([^"]*)" (promotes|demotes) "([^"]*)" in room "([^"]*)" with (\d+) \((v4)\)$/
 	 *

--- a/tests/integration/features/conversation-1/ban.feature
+++ b/tests/integration/features/conversation-1/ban.feature
@@ -63,27 +63,35 @@ Feature: conversation/ban
         | roomType | 3 |
         | roomName | room |
         And user "participant2" joins room "room" with 200 (v4)
-        And user "participant1" bans user "participant3" from room "room" with 200 (v1)
+        And user "participant1" bans user "participant3" from room "room" with 404 (v1)
             | internalNote | BannedInvalid |
 
-    # Scenario: Moderator trying to ban moderator
-    #     Given user "participant1" creates room "room" (v4)
-    #     | roomType | 3 |
-    #     | roomName | room |
-    #     And user "participant1" joins room "room" with 200 (v4)
-    #     And user "participant2" joins room "room" with 200 (v4)
-    #     And user "participant1" adds user "participant2" to room "room" with 200 (v4)
-    #     And user "participant1" promotes "participant2" in room "room" with 200 (v4)
-    #     And user "participant1" bans user "participant2" from room "room" with 403 (v1)
-    #         | internalNote | BannedP2 |
+    Scenario: Moderator trying to ban themselves
+        Given user "participant1" creates room "room" (v4)
+        | roomType | 3 |
+        | roomName | room |
+        And user "participant1" joins room "room" with 200 (v4)
+        And user "participant1" bans user "participant1" from room "room" with 400 (v1)
+            | internalNote | BannedP1 |
+    
+    Scenario: Moderator trying to ban moderator
+        Given user "participant1" creates room "room" (v4)
+        | roomType | 3 |
+        | roomName | room |
+        And user "participant1" joins room "room" with 200 (v4)
+        And user "participant2" joins room "room" with 200 (v4)
+        And user "participant1" adds user "participant2" to room "room" with 200 (v4)
+        And user "participant1" promotes "participant2" in room "room" with 200 (v4)
+        And user "participant1" bans user "participant2" from room "room" with 400 (v1)
+            | internalNote | BannedP2 |
+        And user "participant1" demotes "participant2" in room "room" with 200 (v4)
+        And user "participant1" bans user "participant2" from room "room" with 200 (v1)
+            | internalNote | BannedP2 |
+        And user "participant1" sees the following bans in room "room" with 200 (v1)
+          | actorType | actorId      | bannedType | bannedId     | internalNote |
+          | users     | participant1 | users      | participant2 | BannedP2     |
 
-    # Scenario: Moderator trying to ban themselves
-    #     Given user "participant1" creates room "room" (v4)
-    #     | roomType | 3 |
-    #     | roomName | room |
-    #     And user "participant1" joins room "room" with 200 (v4)
-    #     And user "participant1" bans user "participant1" from room "room" with 403 (v1)
-    #         | internalNote | BannedP1 |
+
 
     
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12670 

<!--
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
░░░███████░░░█████████░░█████░
░░███░░░███░░░███░░░███░░███░░
░░█████████░░░████████░░░███░░
░░███░░░███░░░███░░░░░░░░███░░
░█████░█████░█████░░░░░░█████░
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching frontend/UI code
-->

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Moderators no longer able to ban themselves or other moderators

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
