### PR TITLE
fix(dashboard): Fix missing dashboard icon

### DIFF
--- a/lib/Dashboard/TalkWidget.php
+++ b/lib/Dashboard/TalkWidget.php
@@ -35,6 +35,7 @@ use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\Util;
 
 class TalkWidget implements IAPIWidget, IIconWidget, IButtonWidget, IOptionWidget, IConditionalWidget, IReloadableWidget {
 
@@ -124,6 +125,7 @@ class TalkWidget implements IAPIWidget, IIconWidget, IButtonWidget, IOptionWidge
 	 * @inheritDoc
 	 */
 	public function load(): void {
+		Util::addStyle('spreed', 'icons');
 	}
 
 	public function getItems(string $userId, ?string $since = null, int $limit = 7): array {


### PR DESCRIPTION
- Regression from #10250 

### 🖼️ Screenshots / Screencasts

🏚️ Before | ☀️ Light theme | 🌑 Dark Theme
--|--|--
![Bildschirmfoto vom 2024-07-11 10-52-03](https://github.com/nextcloud/spreed/assets/213943/004007de-e93c-4213-909e-0a3b52a6020d) | ![Bildschirmfoto vom 2024-07-11 10-50-19](https://github.com/nextcloud/spreed/assets/213943/830b37c8-787c-4653-8159-fe7fb8343323) | ![Bildschirmfoto vom 2024-07-11 10-51-12](https://github.com/nextcloud/spreed/assets/213943/dfbc0cca-a5dc-4461-adf8-367139cd336d)
![Bildschirmfoto vom 2024-07-11 10-53-49](https://github.com/nextcloud/spreed/assets/213943/e2617bdf-4011-454b-b078-a5ee65c6bed7) | ![Bildschirmfoto vom 2024-07-11 10-49-29](https://github.com/nextcloud/spreed/assets/213943/9558ce25-9d12-4ee1-809a-a47bd7565ecf) | ![Bildschirmfoto vom 2024-07-11 10-51-23](https://github.com/nextcloud/spreed/assets/213943/c3f098b2-ff11-4f0a-8d76-89b499b22c0d)
