### PR TITLE
Release 18.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 18.0.10 – 2024-07-11
+### Fixed
+- fix(sharing): Fix share detection within object stores
+  [#12628](https://github.com/nextcloud/spreed/pull/12628)
+
 ## 18.0.9 – 2024-06-27
 ### Fixed
 - fix(bots): Fix bots with self-signed certificates

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/spreed/m
 
 	]]></description>
 
-	<version>18.0.9</version>
+	<version>18.0.10</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "18.0.9",
+  "version": "18.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "18.0.9",
+      "version": "18.0.10",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "18.0.9",
+  "version": "18.0.10",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## 18.0.10 – 2024-07-11
### Fixed
- fix(sharing): Fix share detection within object stores [#12628](https://github.com/nextcloud/spreed/pull/12628)
