### PR TITLE
[stable29] debug: long polling messages

### DIFF
--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -1141,6 +1141,7 @@ const actions = {
 		console.debug(`chat_debug: ${requestId.split(':').shift()} | polling start`, {
 			time: new Date().toLocaleString(),
 			requestId,
+			lastKnownMessageId,
 			marker: `polling from ${lastKnownMessageId}`,
 		})
 		const response = await request({
@@ -1153,7 +1154,10 @@ const actions = {
 		console.debug(`chat_debug: ${requestId.split(':').shift()} | polling end`, {
 			time: new Date().toLocaleString(),
 			requestId,
+			lastKnownMessageId,
 			marker: `${response.data.ocs.data?.length} messages received`,
+			'x-chat-last-common-read': response.headers['x-chat-last-common-read'],
+			'x-chat-last-given': response.headers['x-chat-last-given'],
 		})
 		if ('x-chat-last-common-read' in response.headers) {
 			const lastCommonReadMessage = parseInt(response.headers['x-chat-last-common-read'], 10)

--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -1119,6 +1119,11 @@ const actions = {
 	 * @param {number} data.lastKnownMessageId The id of the last message in the store.
 	 */
 	async lookForNewMessages(context, { token, lastKnownMessageId, requestId, requestOptions }) {
+		console.debug(`chat_debug: ${requestId.split(':').shift()} | cancel`, {
+			time: new Date().toLocaleString(),
+			requestId,
+			marker: 'lookForNewMessages action',
+		})
 		context.dispatch('cancelLookForNewMessages', { requestId })
 
 		if (!lastKnownMessageId) {
@@ -1132,14 +1137,24 @@ const actions = {
 
 		// Assign the new cancel function to our data value
 		context.commit('setCancelLookForNewMessages', { cancelFunction: cancel, requestId })
-
+		console.time(`chat_debug: ${requestId.split(':').shift()} | polling time`)
+		console.debug(`chat_debug: ${requestId.split(':').shift()} | polling start`, {
+			time: new Date().toLocaleString(),
+			requestId,
+			marker: `polling from ${lastKnownMessageId}`,
+		})
 		const response = await request({
 			token,
 			lastKnownMessageId,
 			limit: CHAT.FETCH_LIMIT,
 		}, requestOptions)
 		context.commit('setCancelLookForNewMessages', { requestId })
-
+		console.timeEnd(`chat_debug: ${requestId.split(':').shift()} | polling time`)
+		console.debug(`chat_debug: ${requestId.split(':').shift()} | polling end`, {
+			time: new Date().toLocaleString(),
+			requestId,
+			marker: `${response.data.ocs.data?.length} messages received`,
+		})
 		if ('x-chat-last-common-read' in response.headers) {
 			const lastCommonReadMessage = parseInt(response.headers['x-chat-last-common-read'], 10)
 			context.dispatch('updateLastCommonReadMessage', {

--- a/src/store/messagesStore.spec.js
+++ b/src/store/messagesStore.spec.js
@@ -1300,6 +1300,7 @@ describe('messagesStore', () => {
 
 			await store.dispatch('lookForNewMessages', {
 				token: TOKEN,
+				requestId: 'request1',
 				lastKnownMessageId: 100,
 				requestOptions: {
 					dummyOption: true,
@@ -1349,6 +1350,7 @@ describe('messagesStore', () => {
 
 			await store.dispatch('lookForNewMessages', {
 				token: TOKEN,
+				requestId: 'request1',
 				lastKnownMessageId: 100,
 				requestOptions: {
 					dummyOption: true,
@@ -1464,6 +1466,7 @@ describe('messagesStore', () => {
 
 				await store.dispatch('lookForNewMessages', {
 					token: TOKEN,
+					requestId: 'request1',
 					lastKnownMessageId: 100,
 				})
 


### PR DESCRIPTION
[skip ci]

### ☑️ Resolves

- marks all cancelling calls for polling requests
- marks all polling requests:
  - counts completing time
  - show message to start polling from
  - amount of new messages received
  
> [!TIP]
> Build desktop client on it