### PR TITLE
fix(chat): keep message parents in the store after update

### DIFF
--- a/src/store/messagesStore.js
+++ b/src/store/messagesStore.js
@@ -290,7 +290,14 @@ const mutations = {
 		if (!state.messages[token]) {
 			Vue.set(state.messages, token, {})
 		}
-		Vue.set(state.messages[token], message.id, message)
+		// TODO split adding and updating message in the store to different actions
+		// message.parent doesn't contain grand-parent, so we should keep it
+		// when updating message in store from new message.parent object
+		const storedMessage = state.messages[token][message.id]
+		const preparedMessage = !message.parent && storedMessage?.parent
+			? { ...message, parent: storedMessage.parent }
+			: message
+		Vue.set(state.messages[token], message.id, preparedMessage)
 	},
 	/**
 	 * Deletes a message from the store.

--- a/src/store/messagesStore.spec.js
+++ b/src/store/messagesStore.spec.js
@@ -219,6 +219,45 @@ describe('messagesStore', () => {
 			store.dispatch('processMessage', { token: TOKEN, message: message2 })
 			expect(store.getters.messagesList(TOKEN)).toStrictEqual([message2])
 		})
+
+		test('replaces existing message from system message and drops outdated properties, apart from parent', () => {
+			const message1 = {
+				id: 2,
+				token: TOKEN,
+				message: 'helo-helo',
+				'outdated-property': 'outdated-value',
+				parent: {
+					id: 1,
+					token: TOKEN,
+					message: 'hello',
+					timestamp: 100,
+				},
+				timestamp: 200,
+			}
+			const message2 = {
+				id: 4,
+				token: TOKEN,
+				message: '👍',
+				messageType: 'system',
+				systemMessage: 'reaction',
+				parent: {
+					id: 2,
+					token: TOKEN,
+					message: 'hello-hello',
+					lastEditTimestamp: 300,
+					timestamp: 200,
+					reactions: { '👍': 1 },
+				},
+				timestamp: 400,
+			}
+
+			store.dispatch('processMessage', { token: TOKEN, message: message1 })
+			store.dispatch('processMessage', { token: TOKEN, message: message2 })
+			expect(store.getters.messagesList(TOKEN)).toStrictEqual([{
+				...message2.parent,
+				parent: message1.parent,
+			}])
+		})
 	})
 
 	test('message list', () => {


### PR DESCRIPTION
### ☑️ Resolves

Fix lost replies
  - a fix from e815ef2dd0cd37e8fde5a3f8cff652dc1277970b works for plain values, but we don't propagate nested parents to parents
  - see backend reference:
https://github.com/nextcloud/spreed/blob/1ccbf67da231c37801c1406b10000144125aec35/lib/Controller/ChatController.php#L551-L552


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![reply-before](https://github.com/user-attachments/assets/b264a65b-6d5c-4224-9958-f6f2c6807ba4) | ![reply-after](https://github.com/user-attachments/assets/0dc2c20c-d26f-4b0f-a415-b53d0a15f0af)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] ⛑️ Tests are included or not possible
