### PR TITLE
chore(deps): replace vue-shortkey with vueuse directive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "vue-frag": "^1.4.3",
         "vue-material-design-icons": "^5.3.0",
         "vue-router": "^3.6.5",
-        "vue-shortkey": "^3.1.7",
         "vue-virtual-scroller": "^1.1.2",
         "vue2-leaflet": "^2.7.1",
         "vuex": "^3.6.2",
@@ -7790,11 +7789,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
       "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
-    "node_modules/custom-event-polyfill": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz",
-      "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w=="
-    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -8256,11 +8250,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.827.tgz",
       "integrity": "sha512-VY+J0e4SFcNfQy19MEoMdaIcZLmDCprqvBtkii1WTCTQHpRvf5N8+3kTYCgL/PcntvwQvmMJWTuDPsq+IlhWKQ==",
       "dev": true
-    },
-    "node_modules/element-matches": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/element-matches/-/element-matches-0.1.2.tgz",
-      "integrity": "sha512-yWh1otcs3OKUWDvu/IxyI36ZI3WNaRZlI0uG/DK6fu0pap0VYZ0J5pEGTk1zakme+hT0OKHwhlHc0N5TJhY6yQ=="
     },
     "node_modules/elliptic": {
       "version": "6.5.7",
@@ -20159,15 +20148,6 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.6.5.tgz",
       "integrity": "sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ=="
     },
-    "node_modules/vue-shortkey": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/vue-shortkey/-/vue-shortkey-3.1.7.tgz",
-      "integrity": "sha512-Wm/vPXXS+4Wl/LoYpD+cZc0J0HIoVlY8Ep0JLIqqswmAya3XUBtsqKbhzEf9sXo+3rZ5p1YsUyZfXas8XD7YjQ==",
-      "dependencies": {
-        "custom-event-polyfill": "^1.0.7",
-        "element-matches": "^0.1.2"
-      }
-    },
     "node_modules/vue-style-loader": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.3.tgz",
@@ -26825,11 +26805,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
       "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
-    "custom-event-polyfill": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz",
-      "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w=="
-    },
     "data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -27180,11 +27155,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.827.tgz",
       "integrity": "sha512-VY+J0e4SFcNfQy19MEoMdaIcZLmDCprqvBtkii1WTCTQHpRvf5N8+3kTYCgL/PcntvwQvmMJWTuDPsq+IlhWKQ==",
       "dev": true
-    },
-    "element-matches": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/element-matches/-/element-matches-0.1.2.tgz",
-      "integrity": "sha512-yWh1otcs3OKUWDvu/IxyI36ZI3WNaRZlI0uG/DK6fu0pap0VYZ0J5pEGTk1zakme+hT0OKHwhlHc0N5TJhY6yQ=="
     },
     "elliptic": {
       "version": "6.5.7",
@@ -35979,15 +35949,6 @@
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.6.5.tgz",
       "integrity": "sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ=="
-    },
-    "vue-shortkey": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/vue-shortkey/-/vue-shortkey-3.1.7.tgz",
-      "integrity": "sha512-Wm/vPXXS+4Wl/LoYpD+cZc0J0HIoVlY8Ep0JLIqqswmAya3XUBtsqKbhzEf9sXo+3rZ5p1YsUyZfXas8XD7YjQ==",
-      "requires": {
-        "custom-event-polyfill": "^1.0.7",
-        "element-matches": "^0.1.2"
-      }
     },
     "vue-style-loader": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "vue-frag": "^1.4.3",
     "vue-material-design-icons": "^5.3.0",
     "vue-router": "^3.6.5",
-    "vue-shortkey": "^3.1.7",
     "vue-virtual-scroller": "^1.1.2",
     "vue2-leaflet": "^2.7.1",
     "vuex": "^3.6.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,10 +4,8 @@
 -->
 
 <template>
-	<NcContent v-shortkey.once="disableKeyboardShortcuts ? null : ['ctrl', 'f']"
-		:class="{ 'icon-loading': loading, 'in-call': isInCall }"
-		app-name="talk"
-		@shortkey.native="handleAppSearch">
+	<NcContent :class="{ 'icon-loading': loading, 'in-call': isInCall }"
+		app-name="talk">
 		<LeftSidebar v-if="getUserId && !isFullscreen" ref="leftSidebar" />
 		<NcAppContent>
 			<router-view />
@@ -30,6 +28,7 @@ import { generateUrl } from '@nextcloud/router'
 
 import NcAppContent from '@nextcloud/vue/dist/Components/NcAppContent.js'
 import NcContent from '@nextcloud/vue/dist/Components/NcContent.js'
+import { useHotKey } from '@nextcloud/vue/dist/Composables/useHotKey.js'
 import { useIsMobile } from '@nextcloud/vue/dist/Composables/useIsMobile.js'
 
 import ConversationSettingsDialog from './components/ConversationSettings/ConversationSettingsDialog.vue'
@@ -186,10 +185,6 @@ export default {
 			return this.currentConversation?.type === CONVERSATION.TYPE.ONE_TO_ONE
 				|| this.currentConversation?.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER
 		},
-
-		disableKeyboardShortcuts() {
-			return OCP.Accessibility.disableKeyboardShortcuts()
-		},
 	},
 
 	watch: {
@@ -246,6 +241,7 @@ export default {
 
 	created() {
 		window.addEventListener('beforeunload', this.preventUnload)
+		useHotKey('f', this.handleAppSearch, { ctrl: true, stop: true, prevent: true })
 	},
 
 	beforeDestroy() {

--- a/src/PublicShareAuthRequestPasswordButton.vue
+++ b/src/PublicShareAuthRequestPasswordButton.vue
@@ -12,8 +12,7 @@
 				type="primary"
 				:wide="true"
 				:disabled="isRequestInProgress"
-				@click="requestPassword"
-				@keydown.enter="requestPassword">
+				@click="requestPassword">
 				{{ t('spreed', 'Request password') }}
 			</NcButton>
 		</div>

--- a/src/components/CallView/shared/LocalAudioControlButton.vue
+++ b/src/components/CallView/shared/LocalAudioControlButton.vue
@@ -4,12 +4,10 @@
 -->
 
 <template>
-	<NcButton v-shortkey.once="disableKeyboardShortcuts ? null : ['m']"
-		v-tooltip="audioButtonTooltip"
+	<NcButton v-tooltip="audioButtonTooltip"
 		:type="type"
 		:aria-label="audioButtonAriaLabel"
 		:class="{ 'no-audio-available': !isAudioAllowed || !model.attributes.audioAvailable }"
-		@shortkey="toggleAudio"
 		@click.stop="toggleAudio">
 		<template #icon>
 			<VolumeIndicator :audio-preview-available="model.attributes.audioAvailable"
@@ -26,6 +24,7 @@ import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import { useHotKey } from '@nextcloud/vue/dist/Composables/useHotKey.js'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import VolumeIndicator from '../../UIShared/VolumeIndicator.vue'
@@ -126,6 +125,11 @@ export default {
 				? t('spreed', 'Mute audio')
 				: t('spreed', 'Unmute audio')
 		},
+	},
+
+	created() {
+		useHotKey('m', this.toggleAudio)
+		useHotKey(' ', this.toggleAudio, { push: true })
 	},
 
 	mounted() {

--- a/src/components/CallView/shared/LocalVideoControlButton.vue
+++ b/src/components/CallView/shared/LocalVideoControlButton.vue
@@ -4,12 +4,10 @@
 -->
 
 <template>
-	<NcButton v-shortkey.once="disableKeyboardShortcuts ? null : ['v']"
-		v-tooltip="videoButtonTooltip"
+	<NcButton v-tooltip="videoButtonTooltip"
 		:type="type"
 		:aria-label="videoButtonAriaLabel"
 		:class="{ 'no-video-available': !isVideoAllowed || !model.attributes.videoAvailable }"
-		@shortkey="toggleVideo"
 		@click.stop="toggleVideo">
 		<template #icon>
 			<VideoIcon v-if="showVideoOn" :size="20" />
@@ -26,6 +24,7 @@ import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import { useHotKey } from '@nextcloud/vue/dist/Composables/useHotKey.js'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import { PARTICIPANT } from '../../../constants.js'
@@ -123,6 +122,10 @@ export default {
 		},
 	},
 
+	created() {
+		useHotKey('v', this.toggleVideo)
+	},
+
 	mounted() {
 		subscribe('local-video-control-button:toggle-video', this.updateDeviceState)
 	},
@@ -134,14 +137,6 @@ export default {
 	methods: {
 		t,
 		toggleVideo() {
-			/**
-			 * Abort toggling the video if the 'v' key is lifted when pasting an
-			 * image in the new message form.
-			 */
-			if (document.getElementsByClassName('upload-editor').length !== 0) {
-				return
-			}
-
 			if (!this.model.attributes.videoAvailable) {
 				emit('talk:media-settings:show')
 				return

--- a/src/components/ConversationSettings/LinkShareSettings.vue
+++ b/src/components/ConversationSettings/LinkShareSettings.vue
@@ -57,8 +57,7 @@
 
 		<div class="app-settings-subsection__buttons">
 			<NcButton ref="copyLinkButton"
-				@click="handleCopyLink"
-				@keydown.enter="handleCopyLink">
+				@click="handleCopyLink">
 				<template #icon>
 					<ClipboardTextOutline />
 				</template>
@@ -66,8 +65,7 @@
 			</NcButton>
 			<NcButton v-if="isSharedPublicly && canModerate"
 				:disabled="isSendingInvitations"
-				@click="handleResendInvitations"
-				@keydown.enter="handleResendInvitations">
+				@click="handleResendInvitations">
 				<template #icon>
 					<Email />
 				</template>

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -74,7 +74,6 @@
 					<p>{{ t('spreed','Adding a mention will only notify users who did not read the message.') }}</p>
 				</NcNoteCard>
 				<NcRichContenteditable ref="richContenteditable"
-					v-shortkey.once="$options.disableKeyboardShortcuts ? null : ['c']"
 					:value.sync="text"
 					:auto-complete="autoComplete"
 					:disabled="disabled"
@@ -83,7 +82,6 @@
 					:placeholder="placeholderText"
 					:aria-label="placeholderText"
 					dir="auto"
-					@shortkey="focusInput"
 					@keydown.esc="handleInputEsc"
 					@keydown.ctrl.up="handleEditLastMessage"
 					@input="handleTyping"
@@ -192,6 +190,7 @@ import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcEmojiPicker from '@nextcloud/vue/dist/Components/NcEmojiPicker.js'
 import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
 import NcRichContenteditable from '@nextcloud/vue/dist/Components/NcRichContenteditable.js'
+import { useHotKey } from '@nextcloud/vue/dist/Composables/useHotKey.js'
 
 import NewMessageAbsenceInfo from './NewMessageAbsenceInfo.vue'
 import NewMessageAttachments from './NewMessageAttachments.vue'
@@ -215,12 +214,8 @@ import { fetchClipboardContent } from '../../utils/clipboard.js'
 import { isDarkTheme } from '../../utils/isDarkTheme.js'
 import { parseSpecialSymbols } from '../../utils/textParse.ts'
 
-const disableKeyboardShortcuts = OCP.Accessibility.disableKeyboardShortcuts()
-
 export default {
 	name: 'NewMessage',
-
-	disableKeyboardShortcuts,
 
 	components: {
 		FilePickerVue,
@@ -535,6 +530,10 @@ export default {
 				this.checkAbsenceStatus()
 			}
 		},
+	},
+
+	created() {
+		useHotKey('c', this.focusInput, { stop: true, prevent: true })
 	},
 
 	mounted() {

--- a/src/components/TopBar/TopBarMediaControls.vue
+++ b/src/components/TopBar/TopBarMediaControls.vue
@@ -3,9 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div v-shortkey.push="disableKeyboardShortcuts ? null : ['space']"
-		class="buttons-bar"
-		@shortkey="handleShortkey">
+	<div class="buttons-bar">
 		<div class="network-connection-state">
 			<NcPopover v-if="qualityWarningTooltip"
 				:boundary="boundaryElement"
@@ -44,8 +42,7 @@
 			</NcPopover>
 		</div>
 
-		<LocalAudioControlButton ref="audioControl"
-			:token="token"
+		<LocalAudioControlButton :token="token"
 			:conversation="conversation"
 			:model="model"
 			type="tertiary" />
@@ -191,8 +188,6 @@ export default {
 			boundaryElement: document.querySelector('.main-view'),
 			mouseover: false,
 			qualityWarningInGracePeriodTimeout: null,
-			audioEnabledBeforeSpacebarKeydown: undefined,
-			spacebarKeyDown: false,
 		}
 	},
 
@@ -377,10 +372,6 @@ export default {
 
 			return tooltip
 		},
-
-		disableKeyboardShortcuts() {
-			return OCP.Accessibility.disableKeyboardShortcuts()
-		},
 	},
 
 	watch: {
@@ -409,29 +400,6 @@ export default {
 
 	methods: {
 		t,
-		/**
-		 * This method executes on spacebar keydown and keyup
-		 */
-		handleShortkey() {
-			if (!this.model.attributes.audioAvailable) {
-				return
-			}
-
-			if (!this.spacebarKeyDown) {
-				this.audioEnabledBeforeSpacebarKeydown = this.model.attributes.audioEnabled
-				this.spacebarKeyDown = true
-				this.$refs.audioControl.toggleAudio()
-			} else {
-				this.spacebarKeyDown = false
-				if (this.audioEnabledBeforeSpacebarKeydown) {
-					this.model.enableAudio()
-				} else {
-					this.model.disableAudio()
-				}
-				this.audioEnabledBeforeSpacebarKeydown = undefined
-			}
-
-		},
 
 		setSpeakingWhileMutedNotification(message) {
 			this.speakingWhileMutedNotification = message

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,6 @@
 import { createPinia, PiniaVuePlugin } from 'pinia'
 import Vue from 'vue'
 import VueRouter from 'vue-router'
-import VueShortKey from 'vue-shortkey'
 import Vuex from 'vuex'
 
 import { getRequestToken } from '@nextcloud/auth'
@@ -47,7 +46,6 @@ Vue.prototype.OCA = OCA
 Vue.use(PiniaVuePlugin)
 Vue.use(Vuex)
 Vue.use(VueRouter)
-Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
 
 const pinia = createPinia()
 

--- a/src/mainFilesSidebar.js
+++ b/src/mainFilesSidebar.js
@@ -5,7 +5,6 @@
 
 import { createPinia, PiniaVuePlugin } from 'pinia'
 import Vue from 'vue'
-import VueShortKey from 'vue-shortkey'
 import Vuex from 'vuex'
 
 import { getRequestToken } from '@nextcloud/auth'
@@ -40,7 +39,6 @@ Vue.prototype.OCA = OCA
 
 Vue.use(PiniaVuePlugin)
 Vue.use(Vuex)
-Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
 
 const pinia = createPinia()
 

--- a/src/mainPublicShareAuthSidebar.js
+++ b/src/mainPublicShareAuthSidebar.js
@@ -5,7 +5,6 @@
 
 import { createPinia, PiniaVuePlugin } from 'pinia'
 import Vue from 'vue'
-import VueShortKey from 'vue-shortkey'
 import Vuex from 'vuex'
 
 import { getRequestToken } from '@nextcloud/auth'
@@ -40,7 +39,6 @@ Vue.prototype.OCA = OCA
 
 Vue.use(PiniaVuePlugin)
 Vue.use(Vuex)
-Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
 
 const pinia = createPinia()
 store.dispatch('setMainContainerSelector', '#talk-sidebar')

--- a/src/mainPublicShareSidebar.js
+++ b/src/mainPublicShareSidebar.js
@@ -5,7 +5,6 @@
 
 import { createPinia, PiniaVuePlugin } from 'pinia'
 import Vue, { reactive } from 'vue'
-import VueShortKey from 'vue-shortkey'
 import Vuex from 'vuex'
 
 import { getRequestToken } from '@nextcloud/auth'
@@ -40,7 +39,6 @@ Vue.prototype.OCA = OCA
 
 Vue.use(PiniaVuePlugin)
 Vue.use(Vuex)
-Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
 
 const pinia = createPinia()
 

--- a/src/mainRecording.js
+++ b/src/mainRecording.js
@@ -7,7 +7,6 @@
 import { createPinia, PiniaVuePlugin } from 'pinia'
 import Vue from 'vue'
 import VueRouter from 'vue-router'
-import VueShortKey from 'vue-shortkey'
 import Vuex from 'vuex'
 
 import { getRequestToken } from '@nextcloud/auth'
@@ -50,7 +49,6 @@ Vue.prototype.OCA = OCA
 Vue.use(PiniaVuePlugin)
 Vue.use(Vuex)
 Vue.use(VueRouter)
-Vue.use(VueShortKey, { prevent: ['input', 'textarea', 'div'] })
 
 const pinia = createPinia()
 


### PR DESCRIPTION
### ☑️ Resolves

* drop `vue-shortkey` library
* use useHotKey composable (from vue-lib):

> [!IMPORTANT]
> * Ctrl+F doesn't work neither on main branch nor here

* replace shortcuts directive:
  * toggle audio / video / raised hand
  * toggle fullscreen
  * focus shorcuts
* drop `@keydown` listener from NcButton (it's same as click)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual or UX changes

### 🚧 Tasks

- [ ] Follow-up:
  - [ ] Ctrl+Up - edit last: move to directive
  - [ ] Esc - go to root: add directive
  - [ ] Settings KBD: refactor

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible