### PR TITLE
fix(chat): break message polling loop, if token has changed

### DIFF
--- a/src/components/MessagesList/MessagesList.vue
+++ b/src/components/MessagesList/MessagesList.vue
@@ -743,6 +743,11 @@ export default {
 			if (this.destroying) {
 				return
 			}
+			// Check that the token has not changed
+			if (this.token !== token) {
+				console.debug(`token has changed to ${this.token}, breaking the loop for ${token}`)
+				return
+			}
 			// Make the request
 			try {
 				// TODO: move polling logic to the store and also cancel timers on cancel

--- a/src/store/messagesStore.spec.js
+++ b/src/store/messagesStore.spec.js
@@ -1306,6 +1306,7 @@ describe('messagesStore', () => {
 
 			await store.dispatch('lookForNewMessages', {
 				token: TOKEN,
+				requestId: 'request1',
 				lastKnownMessageId: 100,
 				requestOptions: {
 					dummyOption: true,
@@ -1355,6 +1356,7 @@ describe('messagesStore', () => {
 
 			await store.dispatch('lookForNewMessages', {
 				token: TOKEN,
+				requestId: 'request1',
 				lastKnownMessageId: 100,
 				requestOptions: {
 					dummyOption: true,
@@ -1470,6 +1472,7 @@ describe('messagesStore', () => {
 
 				await store.dispatch('lookForNewMessages', {
 					token: TOKEN,
+					requestId: 'request1',
 					lastKnownMessageId: 100,
 				})
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12677 
* Regression from #12492 
  * To fix loading the chat from beginning, we incapsulate token from `handleStartGettingMessagesPreconditions` for all server requests (including the long polling loop)
  * Message polling lasts for 30 seconds, and starts again with 0.5 seconds timeout if successfull
https://github.com/nextcloud/spreed/blob/1c6e934b9cd78005f63000c0eee5b434b813b561/src/components/MessagesList/MessagesList.vue#L797-L799
  * If you're lucky enough to switch conversation in that moment, oldToken will cancel newToken request and 'hijack' the loop, sending the request to the old conversation under new `chatIdentifier`

> [!TIP]
> To test:
> - user1 and user2 are member of chat1 and chat2
> - as user1: be in chat1, have unread messages in chat2
> - as user2: be in chat1, send message_X in chat 1
> - as user1: as soon as message_X is received, switch to chat2 (increase mentioned timeout to have more chances)
> - as user1: make request for chat2, see it cancelled, see chat1 is still polling

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Doesn't work | Work

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] ⛑️ Tests are included or not possible