### PR TITLE
fix(ban): Limit query for participants when they actually can be a moderator

### DIFF
--- a/lib/Controller/BanController.php
+++ b/lib/Controller/BanController.php
@@ -41,7 +41,7 @@ class BanController extends AEnvironmentAwareController {
 	 * @param 'users'|'groups'|'circles'|'emails'|'federated_users'|'phones'|'ip' $actorType Type of actor to ban, or `ip` when banning a clients remote address
 	 * @psalm-param Attendee::ACTOR_*|'ip' $actorType Type of actor to ban, or `ip` when banning a clients remote address
 	 * @param string $actorId Actor ID or the IP address or range in case of type `ip`
-	 * @param string $internalNote Optional internal note
+	 * @param string $internalNote Optional internal note (max. 4000 characters)
 	 * @return DataResponse<Http::STATUS_OK, TalkBan, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: 'bannedActor'|'internalNote'}, array{}>
 	 *
 	 * 200: Ban successfully

--- a/lib/Controller/BanController.php
+++ b/lib/Controller/BanController.php
@@ -38,11 +38,11 @@ class BanController extends AEnvironmentAwareController {
 	 *
 	 * Required capability: `ban-v1`
 	 *
-	 * @param 'users'|'groups'|'circles'|'emails'|'federated_users'|'phones'|'ip' $actorType Type of actor to ban, or `ip` when banning a clients remote address
+	 * @param 'users'|'groups'|'guests'|'circles'|'emails'|'federated_users'|'phones'|'ip' $actorType Type of actor to ban, or `ip` when banning a clients remote address
 	 * @psalm-param Attendee::ACTOR_*|'ip' $actorType Type of actor to ban, or `ip` when banning a clients remote address
 	 * @param string $actorId Actor ID or the IP address or range in case of type `ip`
 	 * @param string $internalNote Optional internal note (max. 4000 characters)
-	 * @return DataResponse<Http::STATUS_OK, TalkBan, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: 'bannedActor'|'internalNote'}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, TalkBan, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: 'bannedActor'|'internalNote'|'moderator'|'self'}, array{}>
 	 *
 	 * 200: Ban successfully
 	 * 400: Actor information is invalid
@@ -56,9 +56,9 @@ class BanController extends AEnvironmentAwareController {
 			$moderatorActorId = $moderator->getActorId();
 
 			$ban = $this->banService->createBan(
+				$this->room,
 				$moderatorActorId,
 				$moderatorActorType,
-				$this->room->getId(),
 				$actorId,
 				$actorType,
 				$this->timeFactory->getDateTime(),
@@ -67,7 +67,7 @@ class BanController extends AEnvironmentAwareController {
 
 			return new DataResponse($ban->jsonSerialize(), Http::STATUS_OK);
 		} catch (\InvalidArgumentException $e) {
-			/** @var 'bannedActor'|'internalNote' $message */
+			/** @var 'bannedActor'|'internalNote'|'moderator'|'self' $message */
 			$message = $e->getMessage();
 			return new DataResponse([
 				'error' => $message,

--- a/lib/Model/Ban.php
+++ b/lib/Model/Ban.php
@@ -32,6 +32,8 @@ use OCP\AppFramework\Db\Entity;
  * @method null|string getInternalNote()
  */
 class Ban extends Entity implements \JsonSerializable {
+	public const NOTE_MAX_LENGTH = 4000;
+
 	protected string $actorType = '';
 	protected string $actorId = '';
 	protected int $roomId = 0;

--- a/lib/Service/BanService.php
+++ b/lib/Service/BanService.php
@@ -33,7 +33,7 @@ class BanService {
 			throw new \InvalidArgumentException('bannedActor');
 		}
 
-		if (empty($internalNote)) {
+		if (strlen($internalNote) > Ban::NOTE_MAX_LENGTH) {
 			throw new \InvalidArgumentException('internalNote');
 		}
 

--- a/lib/Service/BanService.php
+++ b/lib/Service/BanService.php
@@ -9,9 +9,12 @@ declare(strict_types=1);
 namespace OCA\Talk\Service;
 
 use DateTime;
+use OCA\Talk\Exceptions\ParticipantNotFoundException;
 use OCA\Talk\Manager;
+use OCA\Talk\Model\Attendee;
 use OCA\Talk\Model\Ban;
 use OCA\Talk\Model\BanMapper;
+use OCA\Talk\Room;
 use OCP\AppFramework\Db\DoesNotExistException;
 
 class BanService {
@@ -28,7 +31,7 @@ class BanService {
 	 *
 	 * @throws \InvalidArgumentException
 	 */
-	public function createBan(string $actorId, string $actorType, int $roomId, string $bannedId, string $bannedType, DateTime $bannedTime, string $internalNote): Ban {
+	public function createBan(Room $room, string $actorId, string $actorType, string $bannedId, string $bannedType, DateTime $bannedTime, string $internalNote): Ban {
 		if (empty($bannedId) || empty($bannedType)) {
 			throw new \InvalidArgumentException('bannedActor');
 		}
@@ -37,16 +40,25 @@ class BanService {
 			throw new \InvalidArgumentException('internalNote');
 		}
 
-		$bannedParticipant = $this->participantService->getParticipantByActor($this->manager->getRoomById($roomId), $bannedType, $bannedId);
+		if ($bannedType === $actorType && $bannedId === $actorId) {
+			throw new \InvalidArgumentException('self');
+		}
 
-		if ($bannedParticipant->hasModeratorPermissions()) {
-			throw new \InvalidArgumentException('moderator');
+		if (in_array($bannedType, [Attendee::ACTOR_GUESTS, Attendee::ACTOR_USERS, Attendee::ACTOR_FEDERATED_USERS], true)) {
+			try {
+				$bannedParticipant = $this->participantService->getParticipantByActor($room, $bannedType, $bannedId);
+				if ($bannedParticipant->hasModeratorPermissions()) {
+					throw new \InvalidArgumentException('moderator');
+				}
+			} catch (ParticipantNotFoundException) {
+				// No failure if the banned actor is not in the room yet/anymore
+			}
 		}
 
 		$ban = new Ban();
 		$ban->setActorId($actorId);
 		$ban->setActorType($actorType);
-		$ban->setRoomId($roomId);
+		$ban->setRoomId($room->getId());
 		$ban->setBannedId($bannedId);
 		$ban->setBannedType($bannedType);
 		$ban->setBannedTime($bannedTime);

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -1983,6 +1983,7 @@
                             "enum": [
                                 "users",
                                 "groups",
+                                "guests",
                                 "circles",
                                 "emails",
                                 "federated_users",
@@ -2102,7 +2103,9 @@
                                                             "type": "string",
                                                             "enum": [
                                                                 "bannedActor",
-                                                                "internalNote"
+                                                                "internalNote",
+                                                                "moderator",
+                                                                "self"
                                                             ]
                                                         }
                                                     }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -2003,7 +2003,7 @@
                     {
                         "name": "internalNote",
                         "in": "query",
-                        "description": "Optional internal note",
+                        "description": "Optional internal note (max. 4000 characters)",
                         "schema": {
                             "type": "string",
                             "default": ""

--- a/openapi.json
+++ b/openapi.json
@@ -1890,7 +1890,7 @@
                     {
                         "name": "internalNote",
                         "in": "query",
-                        "description": "Optional internal note",
+                        "description": "Optional internal note (max. 4000 characters)",
                         "schema": {
                             "type": "string",
                             "default": ""

--- a/openapi.json
+++ b/openapi.json
@@ -1870,6 +1870,7 @@
                             "enum": [
                                 "users",
                                 "groups",
+                                "guests",
                                 "circles",
                                 "emails",
                                 "federated_users",
@@ -1989,7 +1990,9 @@
                                                             "type": "string",
                                                             "enum": [
                                                                 "bannedActor",
-                                                                "internalNote"
+                                                                "internalNote",
+                                                                "moderator",
+                                                                "self"
                                                             ]
                                                         }
                                                     }

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -2386,7 +2386,7 @@ export interface operations {
         parameters: {
             query: {
                 /** @description Type of actor to ban, or `ip` when banning a clients remote address */
-                actorType: "users" | "groups" | "circles" | "emails" | "federated_users" | "phones" | "ip";
+                actorType: "users" | "groups" | "guests" | "circles" | "emails" | "federated_users" | "phones" | "ip";
                 /** @description Actor ID or the IP address or range in case of type `ip` */
                 actorId: string;
                 /** @description Optional internal note (max. 4000 characters) */
@@ -2429,7 +2429,7 @@ export interface operations {
                             meta: components["schemas"]["OCSMeta"];
                             data: {
                                 /** @enum {string} */
-                                error: "bannedActor" | "internalNote";
+                                error: "bannedActor" | "internalNote" | "moderator" | "self";
                             };
                         };
                     };

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -2389,7 +2389,7 @@ export interface operations {
                 actorType: "users" | "groups" | "circles" | "emails" | "federated_users" | "phones" | "ip";
                 /** @description Actor ID or the IP address or range in case of type `ip` */
                 actorId: string;
-                /** @description Optional internal note */
+                /** @description Optional internal note (max. 4000 characters) */
                 internalNote?: string;
             };
             header: {

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1874,7 +1874,7 @@ export interface operations {
                 actorType: "users" | "groups" | "circles" | "emails" | "federated_users" | "phones" | "ip";
                 /** @description Actor ID or the IP address or range in case of type `ip` */
                 actorId: string;
-                /** @description Optional internal note */
+                /** @description Optional internal note (max. 4000 characters) */
                 internalNote?: string;
             };
             header: {

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1871,7 +1871,7 @@ export interface operations {
         parameters: {
             query: {
                 /** @description Type of actor to ban, or `ip` when banning a clients remote address */
-                actorType: "users" | "groups" | "circles" | "emails" | "federated_users" | "phones" | "ip";
+                actorType: "users" | "groups" | "guests" | "circles" | "emails" | "federated_users" | "phones" | "ip";
                 /** @description Actor ID or the IP address or range in case of type `ip` */
                 actorId: string;
                 /** @description Optional internal note (max. 4000 characters) */
@@ -1914,7 +1914,7 @@ export interface operations {
                             meta: components["schemas"]["OCSMeta"];
                             data: {
                                 /** @enum {string} */
-                                error: "bannedActor" | "internalNote";
+                                error: "bannedActor" | "internalNote" | "moderator" | "self";
                             };
                         };
                     };

--- a/tests/integration/features/conversation-1/ban.feature
+++ b/tests/integration/features/conversation-1/ban.feature
@@ -63,7 +63,7 @@ Feature: conversation/ban
         | roomType | 3 |
         | roomName | room |
         And user "participant2" joins room "room" with 200 (v4)
-        And user "participant1" bans user "participant3" from room "room" with 404 (v1)
+        And user "participant1" bans user "participant3" from room "room" with 200 (v1)
             | internalNote | BannedInvalid |
 
     Scenario: Moderator trying to ban themselves
@@ -73,7 +73,7 @@ Feature: conversation/ban
         And user "participant1" joins room "room" with 200 (v4)
         And user "participant1" bans user "participant1" from room "room" with 400 (v1)
             | internalNote | BannedP1 |
-    
+
     Scenario: Moderator trying to ban moderator
         Given user "participant1" creates room "room" (v4)
         | roomType | 3 |
@@ -93,7 +93,7 @@ Feature: conversation/ban
 
 
 
-    
+
 
 
 


### PR DESCRIPTION
## 🛠️ API Checklist

### 🚧 Tasks

- Allow empty internal note (its marked optional)
- Use existing room object (save a query)
- Skip moderator check when not needed
- Allow banning former and future users

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
