### PR TITLE
Release 19.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 19.0.7 – 2024-07-15
+### Fixed
+- fix(federation): Fix missing notifications in https-federated conversations (Nextcloud Server 29.0.4 or later - Part 3)
+  [#12724](https://github.com/nextcloud/spreed/pull/12724)
+- fix(chat): Fix chat not loading new messages anymore in new conversation when switching quickly after writing a message
+  [#12721](https://github.com/nextcloud/spreed/pull/12721)
+- fix(chat): Fix missing parent message when a chained child message gets edited or deleted
+  [#12719](https://github.com/nextcloud/spreed/pull/12719)
+
 ## 19.0.6 – 2024-07-12
 ### Fixed
 - fix(chat): Fix broken widgets by updating nextcloud/vue library

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>19.0.6</version>
+	<version>19.0.7</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "19.0.6",
+  "version": "19.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "19.0.6",
+      "version": "19.0.7",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "19.0.6",
+  "version": "19.0.7",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
### Fixed
- fix(federation): Fix missing notifications in https-federated conversations (Nextcloud Server 29.0.4 or later - Part 3) [#12724](https://github.com/nextcloud/spreed/pull/12724)
- fix(chat): Fix chat not loading new messages anymore in new conversation when switching quickly after writing a message [#12721](https://github.com/nextcloud/spreed/pull/12721)
- fix(chat): Fix missing parent message when a chained child message gets edited or deleted [#12719](https://github.com/nextcloud/spreed/pull/12719)
