### PR TITLE
fix: Fix generating session id again if duplicated

### DIFF
--- a/lib/Service/SessionService.php
+++ b/lib/Service/SessionService.php
@@ -100,7 +100,7 @@ class SessionService {
 					break;
 				} catch (Exception $e) {
 					// 255 chars are not unique? Try again...
-					if ($e->getReason() === Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+					if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
 						throw $e;
 					}
 				}

--- a/tests/php/Service/SessionServiceTest.php
+++ b/tests/php/Service/SessionServiceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Tests\php\Service;
+
+use OCA\Talk\Model\Attendee;
+use OCA\Talk\Model\SessionMapper;
+use OCA\Talk\Service\SessionService;
+use OCP\IDBConnection;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class SessionServiceTest extends TestCase {
+	protected ?SessionMapper $sessionMapper = null;
+	protected ISecureRandom&MockObject $secureRandom;
+	private ?SessionService $service = null;
+
+	private const RANDOM_254 = '123456789abcdef0123456789abcdef1123456789abcdef2123456789abcdef3123456789abcdef4123456789abcdef5123456789abcdef6123456789abcdef7123456789abcdef8123456789abcdef9123456789abcdefa123456789abcdefb123456789abcdefc123456789abcdefd123456789abcdefe123456789abcde';
+
+	private array $attendeeIds = [];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sessionMapper = \OCP\Server::get(SessionMapper::class);
+		$this->secureRandom = $this->createMock(ISecureRandom::class);
+		$this->service = new SessionService(
+			$this->sessionMapper,
+			\OCP\Server::get(IDBConnection::class),
+			$this->secureRandom,
+		);
+	}
+
+	public function tearDown(): void {
+		foreach ($this->attendeeIds as $attendeeId) {
+			try {
+				$this->sessionMapper->deleteByAttendeeId($attendeeId);
+			} catch (DoesNotExistException $exception) {
+			}
+		}
+
+		parent::tearDown();
+	}
+
+	public function testCreateSessionForAttendee() {
+		$attendee = new Attendee();
+		$attendee->setId(42);
+		$attendee->setActorType(Attendee::ACTOR_USERS);
+		$attendee->setActorId('test');
+		$this->attendeeIds[] = $attendee->getId();
+
+		$random = self::RANDOM_254 . 'x';
+
+		$this->secureRandom->expects($this->once())
+			->method('generate')
+			->with(255)
+			->willReturn($random);
+
+		$session = $this->service->createSessionForAttendee($attendee);
+
+		self::assertEquals($random, $session->getSessionId());
+	}
+
+	public function testCreateSessionForAttendeeWithDuplicatedSessionId() {
+		$attendee1 = new Attendee();
+		$attendee1->setId(42);
+		$attendee1->setActorType(Attendee::ACTOR_USERS);
+		$attendee1->setActorId('test1');
+		$this->attendeeIds[] = $attendee1->getId();
+
+		$attendee2 = new Attendee();
+		$attendee2->setId(108);
+		$attendee2->setActorType(Attendee::ACTOR_USERS);
+		$attendee2->setActorId('test2');
+		$this->attendeeIds[] = $attendee2->getId();
+
+		$random1 = self::RANDOM_254 . 'x';
+		$random2 = self::RANDOM_254 . 'y';
+
+		$this->secureRandom->expects($this->exactly(3))
+			->method('generate')
+			->with(255)
+			->willReturn(
+				$random1,
+				$random1,
+				$random2,
+			);
+
+		$session1 = $this->service->createSessionForAttendee($attendee1);
+		$session2 = $this->service->createSessionForAttendee($attendee2);
+
+		self::assertEquals($random1, $session1->getSessionId());
+		self::assertEquals($random2, $session2->getSessionId());
+	}
+
+	public function testCreateSessionForAttendeeWithoutId() {
+		$attendee = new Attendee();
+		$attendee->setActorType(Attendee::ACTOR_USERS);
+		$attendee->setActorId('test');
+
+		$random = self::RANDOM_254 . 'x';
+
+		$this->secureRandom->expects($this->once())
+			->method('generate')
+			->with(255)
+			->willReturn($random);
+
+		$this->expectException(\OC\DB\Exceptions\DbalException::class);
+
+		$session = $this->service->createSessionForAttendee($attendee);
+	}
+}


### PR DESCRIPTION
## 🛠️ API Checklist

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
