### PR TITLE
fix: Removed redundant database indices

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>20.0.0-dev.5</version>
+	<version>20.0.0-dev.6</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/lib/Migration/Version10000Date20201015134000.php
+++ b/lib/Migration/Version10000Date20201015134000.php
@@ -108,7 +108,7 @@ class Version10000Date20201015134000 extends SimpleMigrationStep {
 
 			$table->addUniqueIndex(['room_id', 'actor_type', 'actor_id'], 'ta_ident');
 			$table->addIndex(['room_id', 'pin'], 'ta_roompin');
-			$table->addIndex(['room_id'], 'ta_room');
+			//$table->addIndex(['room_id'], 'ta_room'); Removed in Version20000Date20240717180417
 			$table->addIndex(['actor_type', 'actor_id'], 'ta_actor');
 		}
 

--- a/lib/Migration/Version18000Date20230504205823.php
+++ b/lib/Migration/Version18000Date20230504205823.php
@@ -93,7 +93,7 @@ class Version18000Date20230504205823 extends SimpleMigrationStep {
 
 			$table->setPrimaryKey(['id']);
 			$table->addIndex(['token', 'state'], 'talk_bots_convo_token');
-			$table->addIndex(['bot_id'], 'talk_bots_convo_id');
+			//$table->addIndex(['bot_id'], 'talk_bots_convo_id'); Removed in Version20000Date20240717180417
 			$table->addUniqueIndex(['bot_id', 'token'], 'talk_bots_convo_uniq');
 			return $schema;
 		}

--- a/lib/Migration/Version20000Date20240717180417.php
+++ b/lib/Migration/Version20000Date20240717180417.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Talk\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version20000Date20240717180417 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		// Remove redundant index ta_room from talk_attendees
+		$table = $schema->getTable('talk_attendees');
+		if ($table->hasIndex('ta_room')) {
+			$table->dropIndex('ta_room');
+		}
+
+		// Remove redundant index talk_bots_convo_id from talk_bots_conversation
+		$table = $schema->getTable('talk_bots_conversation');
+		if ($table->hasIndex('talk_bots_convo_id')) {
+			$table->dropIndex('talk_bots_convo_id');
+		}
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11442 

## 🛠️ API Checklist

### 🚧 Tasks

- [x] Removed redundant database indices of ta_room and talk_bots_convo_id

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 