### PR TITLE
fix(sharing): Don't repopulate query builder object

### DIFF
--- a/lib/Share/RoomShareProvider.php
+++ b/lib/Share/RoomShareProvider.php
@@ -1092,12 +1092,15 @@ class RoomShareProvider implements IShareProvider {
 		$cursor->closeCursor();
 
 		if (!empty($ids)) {
+			$delete = $this->dbConnection->getQueryBuilder();
+			$delete->delete('share')
+				->where($delete->expr()->eq('share_type', $delete->createNamedParameter(self::SHARE_TYPE_USERROOM)))
+				->andWhere($delete->expr()->in('parent', $delete->createParameter('ids')));
+
 			$chunks = array_chunk($ids, 100);
 			foreach ($chunks as $chunk) {
-				$qb->delete('share')
-					->where($qb->expr()->eq('share_type', $qb->createNamedParameter(self::SHARE_TYPE_USERROOM)))
-					->andWhere($qb->expr()->in('parent', $qb->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)));
-				$qb->executeStatement();
+				$delete->setParameter('ids', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
+				$delete->executeStatement();
 			}
 		}
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix 
```
Using where() on non-empty WHERE part, please verify it is intentional to not call andWhere() or orWhere() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first.
```

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
