### PR TITLE
fix(AdminSettings): Require HPB for recording server configuration

### DIFF
--- a/src/components/AdminSettings/HostedSignalingServer.vue
+++ b/src/components/AdminSettings/HostedSignalingServer.vue
@@ -129,6 +129,8 @@ import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 
+import { EventBus } from '../../services/EventBus.js'
+
 export default {
 	name: 'HostedSignalingServer',
 
@@ -209,8 +211,12 @@ export default {
 		this.hostedHPBCountry = this.countries.find(country => country.code === state.country) ?? this.countries[0]
 
 		const signaling = loadState('spreed', 'signaling_servers')
-		this.showForm = this.trialAccount.length !== 0
-			|| signaling.servers.length === 0
+		this.updateSignalingServers(signaling.servers)
+		EventBus.on('signaling-servers-updated', this.updateSignalingServers)
+	},
+
+	beforeDestroy() {
+		EventBus.off('signaling-servers-updated', this.updateSignalingServers)
 	},
 
 	methods: {
@@ -249,6 +255,10 @@ export default {
 			} finally {
 				this.loading = false
 			}
+		},
+
+		updateSignalingServers(servers) {
+			this.showForm = this.trialAccount.length !== 0 || servers.length === 0
 		},
 	},
 }

--- a/src/components/AdminSettings/RecordingServers.vue
+++ b/src/components/AdminSettings/RecordingServers.vue
@@ -98,6 +98,7 @@ import TransitionWrapper from '../UIShared/TransitionWrapper.vue'
 
 import { CALL } from '../../constants.js'
 import { hasTalkFeature } from '../../services/CapabilitiesManager.ts'
+import { EventBus } from '../../services/EventBus.js'
 
 const recordingConsentCapability = hasTalkFeature('local', 'recording-consent')
 const recordingConsentOptions = [
@@ -152,19 +153,20 @@ export default {
 
 	beforeMount() {
 		this.debounceUpdateServers = debounce(this.updateServers, 1000)
+
 		const state = loadState('spreed', 'recording_servers')
 		this.servers = state.servers
 		this.secret = state.secret
 		this.uploadLimit = parseInt(state.uploadLimit, 10)
-	},
 
-	mounted() {
 		const signaling = loadState('spreed', 'signaling_servers')
-		this.showForm = signaling.servers.length > 0
+		this.updateSignalingServers(signaling.servers)
+		EventBus.on('signaling-servers-updated', this.updateSignalingServers)
 	},
 
 	beforeDestroy() {
 		this.debounceUpdateServers.clear?.()
+		EventBus.off('signaling-servers-updated', this.updateSignalingServers)
 	},
 
 	methods: {
@@ -229,6 +231,10 @@ export default {
 			setTimeout(() => {
 				this.saved = false
 			}, 3000)
+		},
+
+		updateSignalingServers(servers) {
+			this.showForm = servers.length > 0
 		},
 	},
 }

--- a/src/components/AdminSettings/SIPBridge.vue
+++ b/src/components/AdminSettings/SIPBridge.vue
@@ -94,6 +94,7 @@ import NcPasswordField from '@nextcloud/vue/dist/Components/NcPasswordField.js'
 import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
 import NcTextArea from '@nextcloud/vue/dist/Components/NcTextArea.js'
 
+import { EventBus } from '../../services/EventBus.js'
 import { setSIPSettings } from '../../services/settingsService.js'
 import { getWelcomeMessage } from '../../services/signalingService.js'
 
@@ -147,13 +148,17 @@ export default {
 		this.debounceSearchGroup('')
 		this.loading = false
 		this.saveCurrentSetup()
+
 		const signaling = loadState('spreed', 'signaling_servers')
-		this.showForm = signaling.servers.length > 0
+		this.updateSignalingServers(signaling.servers)
+		EventBus.on('signaling-servers-updated', this.updateSignalingServers)
+
 		this.isDialoutSupported()
 	},
 
 	beforeDestroy() {
 		this.debounceSearchGroup.clear?.()
+		EventBus.off('signaling-servers-updated', this.updateSignalingServers)
 	},
 
 	methods: {
@@ -218,6 +223,10 @@ export default {
 					this.dialOutSupported = false
 				}
 			}
+		},
+
+		updateSignalingServers(servers) {
+			this.showForm = servers.length > 0
 		},
 	},
 }

--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -84,6 +84,7 @@ import SignalingServer from '../../components/AdminSettings/SignalingServer.vue'
 import TransitionWrapper from '../UIShared/TransitionWrapper.vue'
 
 import { SIGNALING } from '../../constants.js'
+import { EventBus } from '../../services/EventBus.js'
 
 export default {
 	name: 'SignalingServers',
@@ -165,6 +166,7 @@ export default {
 			}), {
 				success: () => {
 					showSuccess(t('spreed', 'High-performance backend settings saved'))
+					EventBus.emit('signaling-servers-updated', this.servers)
 					this.loading = false
 					this.toggleSave()
 				},


### PR DESCRIPTION
### ☑️ Resolves

* Fixes https://github.com/nextcloud/spreed/issues/10486
Same as we currently do for the SIP configuration: https://github.com/nextcloud/spreed/blob/main/src/components/AdminSettings/SIPBridge.vue.
* Add emitter to promprtly update all sections (see screencast)

Changes are best reviewed as https://github.com/nextcloud/spreed/pull/12771/files?diff=unified&w=1

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
<img width="554" alt="Bildschirmfoto 2024-07-21 um 10 30 06" src="https://github.com/user-attachments/assets/3378f44c-092b-41a4-99e4-12d203ad7614"> | <img width="703" alt="Bildschirmfoto 2024-07-21 um 10 30 18" src="https://github.com/user-attachments/assets/8b497c16-a1ee-4408-958b-1e6cf24d1dab">

[Screencast from 22.07.2024 20:44:11.webm](https://github.com/user-attachments/assets/99d619f6-793d-4582-b2bd-0dbe28008a9f)


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

