### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -258,12 +258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "a19e1b3d3ca65c22b5cef74c2de01cc362d624a1"
+                "reference": "d8e950ec7bbd1c02f1ef7fc984f09325e1dc565b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/a19e1b3d3ca65c22b5cef74c2de01cc362d624a1",
-                "reference": "a19e1b3d3ca65c22b5cef74c2de01cc362d624a1",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/d8e950ec7bbd1c02f1ef7fc984f09325e1dc565b",
+                "reference": "d8e950ec7bbd1c02f1ef7fc984f09325e1dc565b",
                 "shasum": ""
             },
             "require": {
@@ -295,7 +295,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-07-20T00:36:41+00:00"
+            "time": "2024-07-22T08:25:24+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency