### PR TITLE
Fix mapping of token to identifier for federated rooms

### DIFF
--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -577,7 +577,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		if ($formData) {
 			if ($status === 200) {
 				if (!isset(self::$tokenToIdentifier[$response['token']])) {
-					self::$identifierToToken[$server . '::' . $identifier] = $response['token'];
+					self::$tokenToIdentifier[$response['token']] = $server . '::' . $identifier;
 				}
 
 				$this->assertRooms([$response], $formData);

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -557,13 +557,13 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	 * @Then /^user "([^"]*)" (accepts|declines) invite to room "([^"]*)" of server "([^"]*)" with (\d+) \((v1)\)$/
 	 *
 	 * @param string $user
-	 * @param string $roomName
+	 * @param string $identifier
 	 * @param string $server
 	 * @param string $apiVersion
 	 * @param TableNode|null $formData
 	 */
-	public function userAcceptsDeclinesRemoteInvite(string $user, string $acceptsDeclines, string $roomName, string $server, int $status, string $apiVersion, ?TableNode $formData = null): void {
-		$inviteId = self::$remoteToInviteId[$server . '::' . $roomName];
+	public function userAcceptsDeclinesRemoteInvite(string $user, string $acceptsDeclines, string $identifier, string $server, int $status, string $apiVersion, ?TableNode $formData = null): void {
+		$inviteId = self::$remoteToInviteId[$server . '::' . $identifier];
 
 		$verb = $acceptsDeclines === 'accepts' ? 'POST' : 'DELETE';
 
@@ -577,7 +577,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		if ($formData) {
 			if ($status === 200) {
 				if (!isset(self::$tokenToIdentifier[$response['token']])) {
-					self::$identifierToToken[$server . '::' . $roomName] = $response['token'];
+					self::$identifierToToken[$server . '::' . $identifier] = $response['token'];
 				}
 
 				$this->assertRooms([$response], $formData);

--- a/tests/integration/features/federation/chat.feature
+++ b/tests/integration/features/federation/chat.feature
@@ -16,11 +16,11 @@ Feature: federation/chat
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type |
-      | room | 2    |
+      | id          | type |
+      | LOCAL::room | 2    |
     And user "participant1" gets the following candidate mentions in room "room" for "" with 200
       | source          | id                         | label                    | mentionId                                  |
       | calls           | all                        | room                     | all                                        |
@@ -44,17 +44,17 @@ Feature: federation/chat
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
     And user "participant3" has the following invitations (v1)
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant3" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type |
-      | room | 2    |
+      | id          | type |
+      | LOCAL::room | 2    |
     And user "participant1" gets the following candidate mentions in room "room" for "" with 200
       | source          | id                         | label                    | mentionId                                 |
       | calls           | all                        | room                     | all                                       |
@@ -78,25 +78,25 @@ Feature: federation/chat
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
     And user "participant3" has the following invitations (v1)
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant3" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type | lastMessage |
-      | room | 2    | {federated_user} accepted the invitation |
+      | id          | type | lastMessage |
+      | LOCAL::room | 2    | {federated_user} accepted the invitation |
     And user "participant1" sends message "Message 1" to room "room" with 201
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type | lastMessage |
-      | room | 2    | Message 1 |
+      | id          | type | lastMessage |
+      | LOCAL::room | 2    | Message 1 |
     When user "participant2" sends reply "Message 1-1" on message "Message 1" to room "LOCAL::room" with 201
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type | lastMessage |
-      | room | 2    | Message 1-1 |
+      | id          | type | lastMessage |
+      | LOCAL::room | 2    | Message 1-1 |
     Then user "participant1" sees the following messages in room "room" with 200
       | room | actorType       | actorId                    | actorDisplayName         | message     | messageParameters | parentMessage |
       | room | federated_users | participant2@{$REMOTE_URL} | participant2-displayname | Message 1-1 | []                | Message 1     |
@@ -104,14 +104,14 @@ Feature: federation/chat
     When next message request has the following parameters set
       | timeout                  | 0         |
     And user "participant2" sees the following messages in room "LOCAL::room" with 200
-      | room | actorType       | actorId                  | actorDisplayName         | message     | messageParameters | parentMessage |
-      | room | users           | participant2             | participant2-displayname | Message 1-1 | []                | Message 1     |
-      | room | federated_users | participant1@{$BASE_URL} | participant1-displayname | Message 1   | []                |               |
+      | room        | actorType       | actorId                  | actorDisplayName         | message     | messageParameters | parentMessage |
+      | LOCAL::room | users           | participant2             | participant2-displayname | Message 1-1 | []                | Message 1     |
+      | LOCAL::room | federated_users | participant1@{$BASE_URL} | participant1-displayname | Message 1   | []                |               |
     And user "participant1" edits message "Message 1" in room "room" to "Message 1 - Edit 1" with 200
     And user "participant2" edits message "Message 1-1" in room "LOCAL::room" to "Message 1-1 - Edit 1" with 200
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type | lastMessage |
-      | room | 2    | Message 1-1 - Edit 1 |
+      | id          | type | lastMessage |
+      | LOCAL::room | 2    | Message 1-1 - Edit 1 |
     Then user "participant1" sees the following messages in room "room" with 200
       | room | actorType       | actorId                    | actorDisplayName         | message              | messageParameters | parentMessage      | lastEditActorType | lastEditActorId            | lastEditActorDisplayName |
       | room | federated_users | participant2@{$REMOTE_URL} | participant2-displayname | Message 1-1 - Edit 1 | []                | Message 1 - Edit 1 | federated_users   | participant2@{$REMOTE_URL} | participant2-displayname |
@@ -119,9 +119,9 @@ Feature: federation/chat
     When next message request has the following parameters set
       | timeout                  | 0         |
     And user "participant2" sees the following messages in room "LOCAL::room" with 200
-      | room | actorType       | actorId                  | actorDisplayName         | message              | messageParameters | parentMessage      | lastEditActorType | lastEditActorId          | lastEditActorDisplayName |
-      | room | users           | participant2             | participant2-displayname | Message 1-1 - Edit 1 | []                | Message 1 - Edit 1 | users             | participant2             | participant2-displayname |
-      | room | federated_users | participant1@{$BASE_URL} | participant1-displayname | Message 1 - Edit 1   | []                |                    | federated_users   | participant1@{$BASE_URL} | participant1-displayname |
+      | room        | actorType       | actorId                  | actorDisplayName         | message              | messageParameters | parentMessage      | lastEditActorType | lastEditActorId          | lastEditActorDisplayName |
+      | LOCAL::room | users           | participant2             | participant2-displayname | Message 1-1 - Edit 1 | []                | Message 1 - Edit 1 | users             | participant2             | participant2-displayname |
+      | LOCAL::room | federated_users | participant1@{$BASE_URL} | participant1-displayname | Message 1 - Edit 1   | []                |                    | federated_users   | participant1@{$BASE_URL} | participant1-displayname |
     And user "participant1" deletes message "Message 1 - Edit 1" from room "room" with 200
     And user "participant2" deletes message "Message 1-1 - Edit 1" from room "LOCAL::room" with 200
     Then user "participant1" sees the following messages in room "room" with 200
@@ -131,12 +131,12 @@ Feature: federation/chat
     When next message request has the following parameters set
       | timeout                  | 0         |
     And user "participant2" sees the following messages in room "LOCAL::room" with 200
-      | room | actorType       | actorId                  | actorDisplayName         | message                   | messageParameters | parentMessage             |
-      | room | users           | participant2             | participant2-displayname | Message deleted by you    | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname"}}                        | Message deleted by author |
-      | room | federated_users | participant1@{$BASE_URL} | participant1-displayname | Message deleted by author | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname","server":"{$BASE_URL}"}} |                           |
+      | room        | actorType       | actorId                  | actorDisplayName         | message                   | messageParameters | parentMessage             |
+      | LOCAL::room | users           | participant2             | participant2-displayname | Message deleted by you    | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname"}}                        | Message deleted by author |
+      | LOCAL::room | federated_users | participant1@{$BASE_URL} | participant1-displayname | Message deleted by author | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname","server":"{$BASE_URL}"}} |                           |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type | lastMessage |
-      | room | 2    | Message deleted by author |
+      | id          | type | lastMessage |
+      | LOCAL::room | 2    | Message deleted by author |
 
   Scenario: Last message actor when the same user ID is present
     Given the following "spreed" app config is set
@@ -149,22 +149,22 @@ Feature: federation/chat
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant1" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
     Then user "participant1" is participant of the following unordered rooms (v4)
-      | id   | name | type | remoteServer | remoteToken | lastMessage |
-      | room | room | 2    |              |             | {actor} invited you |
-      | room | room | 2    | LOCAL        | room        | {federated_user} accepted the invitation |
+      | id          | name | type | remoteServer | remoteToken | lastMessage |
+      | room        | room | 2    |              |             | {actor} invited you |
+      | LOCAL::room | room | 2    | LOCAL        | room        | {federated_user} accepted the invitation |
     And user "participant1" sends message "Message 1" to room "room" with 201
     Then user "participant1" is participant of the following unordered rooms (v4)
-      | id   | name | type | remoteServer | remoteToken | lastMessage | lastMessageActorType | lastMessageActorId |
-      | room | room | 2    |              |             | Message 1   | users                | participant1       |
-      | room | room | 2    | LOCAL        | room        | Message 1   | federated_users      | participant1@{$BASE_URL} |
+      | id          | name | type | remoteServer | remoteToken | lastMessage | lastMessageActorType | lastMessageActorId |
+      | room        | room | 2    |              |             | Message 1   | users                | participant1       |
+      | LOCAL::room | room | 2    | LOCAL        | room        | Message 1   | federated_users      | participant1@{$BASE_URL} |
     When user "participant1" sends reply "Message 1-1" on message "Message 1" to room "LOCAL::room" with 201
     Then user "participant1" is participant of the following unordered rooms (v4)
-      | id   | name | type | remoteServer | remoteToken | lastMessage | lastMessageActorType | lastMessageActorId |
-      | room | room | 2    |              |             | Message 1-1 | federated_users      | participant1@{$REMOTE_URL} |
-      | room | room | 2    | LOCAL        | room        | Message 1-1 | users                | participant1       |
+      | id          | name | type | remoteServer | remoteToken | lastMessage | lastMessageActorType | lastMessageActorId |
+      | room        | room | 2    |              |             | Message 1-1 | federated_users      | participant1@{$REMOTE_URL} |
+      | LOCAL::room | room | 2    | LOCAL        | room        | Message 1-1 | users                | participant1       |
 
   Scenario: Read marker checking
     Given the following "spreed" app config is set
@@ -178,35 +178,35 @@ Feature: federation/chat
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
     And user "participant3" has the following invitations (v1)
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant3" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type | lastReadMessage      | unreadMessages | unreadMention | unreadMentionDirect |
-      | room | 2    | UNKNOWN_MESSAGE      | 0              | 0             | 0                   |
+      | id          | type | lastReadMessage      | unreadMessages | unreadMention | unreadMentionDirect |
+      | LOCAL::room | 2    | UNKNOWN_MESSAGE      | 0              | 0             | 0                   |
     And user "participant1" sends message "Message 1" to room "room" with 201
     And user "participant1" sends message "Message 2" to room "room" with 201
     When user "participant2" marks room "LOCAL::room" as unread with 200 (v1)
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type | lastReadMessage      | unreadMessages | unreadMention | unreadMentionDirect |
-      | room | 2    | Message 1            | 1              | 0             | 0                   |
+      | id          | type | lastReadMessage      | unreadMessages | unreadMention | unreadMentionDirect |
+      | LOCAL::room | 2    | Message 1            | 1              | 0             | 0                   |
     When user "participant2" reads message "NULL" in room "LOCAL::room" with 200 (v1)
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type | lastReadMessage      | unreadMessages | unreadMention | unreadMentionDirect |
-      | room | 2    | Message 2            | 0              | 0             | 0                   |
+      | id          | type | lastReadMessage      | unreadMessages | unreadMention | unreadMentionDirect |
+      | LOCAL::room | 2    | Message 2            | 0              | 0             | 0                   |
     When user "participant2" reads message "Message 1" in room "LOCAL::room" with 200 (v1)
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type | lastReadMessage      | unreadMessages | unreadMention | unreadMentionDirect |
-      | room | 2    | Message 1            | 1              | 0             | 0                   |
+      | id          | type | lastReadMessage      | unreadMessages | unreadMention | unreadMentionDirect |
+      | LOCAL::room | 2    | Message 1            | 1              | 0             | 0                   |
     When user "participant2" reads message "Message 2" in room "LOCAL::room" with 200 (v1)
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type | lastReadMessage      | unreadMessages | unreadMention | unreadMentionDirect |
-      | room | 2    | Message 2            | 0              | 0             | 0                   |
+      | id          | type | lastReadMessage      | unreadMessages | unreadMention | unreadMentionDirect |
+      | LOCAL::room | 2    | Message 2            | 0              | 0             | 0                   |
 
   Scenario: Error handling of chatting (posting a too long message)
     Given the following "spreed" app config is set
@@ -219,11 +219,11 @@ Feature: federation/chat
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type |
-      | room | 2    |
+      | id          | type |
+      | LOCAL::room | 2    |
     And user "participant2" sends message "413 Payload Too Large" to room "LOCAL::room" with 413
 
   Scenario: Mentioning a federated user triggers a notification for them
@@ -237,11 +237,11 @@ Feature: federation/chat
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type |
-      | room | 2    |
+      | id          | type |
+      | LOCAL::room | 2    |
     # Join and leave to clear the invite notification
     Given user "participant2" joins room "LOCAL::room" with 200 (v4)
     Given user "participant2" leaves room "LOCAL::room" with 200 (v4)
@@ -262,9 +262,9 @@ Feature: federation/chat
     And user "participant1" sends message 'Hi @all bye' to room "room" with 201
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                | subject                                                                | message     |
-      | spreed | chat        | room/Hi @all bye         | participant1-displayname mentioned everyone in conversation room       | Hi room bye |
-      | spreed | chat        | room/Hi @"federated_user/participant2@{$REMOTE_URL}" bye | participant1-displayname mentioned you in conversation room | Hi @participant2-displayname bye |
-      | spreed | chat        | room/Message 1-1         | participant1-displayname replied to your message in conversation room  | Message 1-1 |
+      | spreed | chat        | LOCAL::room/Hi @all bye         | participant1-displayname mentioned everyone in conversation room       | Hi room bye |
+      | spreed | chat        | LOCAL::room/Hi @"federated_user/participant2@{$REMOTE_URL}" bye | participant1-displayname mentioned you in conversation room | Hi @participant2-displayname bye |
+      | spreed | chat        | LOCAL::room/Message 1-1         | participant1-displayname replied to your message in conversation room  | Message 1-1 |
     When next message request has the following parameters set
       | timeout                  | 0         |
       | lookIntoFuture           | 1         |
@@ -284,11 +284,11 @@ Feature: federation/chat
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 3    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 3    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type |
-      | room | 3    |
+      | id          | type |
+      | LOCAL::room | 3    |
     # Join and leave to clear the invite notification
     Given user "participant2" joins room "LOCAL::room" with 200 (v4)
     Given user "participant2" leaves room "LOCAL::room" with 200 (v4)
@@ -297,7 +297,7 @@ Feature: federation/chat
     When user "guest" sends message "Message 2" to room "room" with 201
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                | subject                                                                | message     |
-      | spreed | chat        | room/Hi @"federated_user/participant2@{$REMOTE_URL}" bye | A guest mentioned you in conversation room | Hi @participant2-displayname bye |
+      | spreed | chat        | LOCAL::room/Hi @"federated_user/participant2@{$REMOTE_URL}" bye | A guest mentioned you in conversation room | Hi @participant2-displayname bye |
     Then user "participant2" reads message "Message 2" in room "LOCAL::room" with 200 (v1)
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                | subject                                                                | message     |
@@ -313,11 +313,11 @@ Feature: federation/chat
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 3    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 3    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type |
-      | room | 3    |
+      | id          | type |
+      | LOCAL::room | 3    |
     # Join and leave to clear the invite notification
     Given user "participant2" joins room "LOCAL::room" with 200 (v4)
     Given user "participant2" sets session state to 1 in room "LOCAL::room" with 200 (v4)
@@ -328,7 +328,7 @@ Feature: federation/chat
     When user "guest" sends message "Message 3" to room "room" with 201
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                | subject                                                                | message     |
-      | spreed | chat        | room/User @"federated_user/participant2@{$REMOTE_URL}" is inactive | A guest mentioned you in conversation room | User @participant2-displayname is inactive |
+      | spreed | chat        | LOCAL::room/User @"federated_user/participant2@{$REMOTE_URL}" is inactive | A guest mentioned you in conversation room | User @participant2-displayname is inactive |
     Then user "participant2" reads message "Message 3" in room "LOCAL::room" with 200 (v1)
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                | subject                                                                | message     |
@@ -344,28 +344,28 @@ Feature: federation/chat
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 3    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 3    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type |
-      | room | 3    |
+      | id          | type |
+      | LOCAL::room | 3    |
     And user "participant1" adds federated_user "participant3" to room "room" with 200 (v4)
     And user "participant3" has the following invitations (v1)
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant3" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 3    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 3    | LOCAL        | room        |
     Then user "participant3" is participant of the following rooms (v4)
-      | id   | type |
-      | room | 3    |
+      | id          | type |
+      | LOCAL::room | 3    |
     # Join and leave to clear the invite notification
     Given user "participant2" joins room "LOCAL::room" with 200 (v4)
     Given user "participant2" leaves room "LOCAL::room" with 200 (v4)
     When user "participant3" sends message 'Hi @"federated_user/participant2@{$REMOTE_URL}" bye' to room "LOCAL::room" with 201
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                | subject                                                                | message     |
-      | spreed | chat        | room/Hi @"federated_user/participant2@{$REMOTE_URL}" bye | participant3-displayname mentioned you in conversation room | Hi @participant2-displayname bye |
+      | spreed | chat        | LOCAL::room/Hi @"federated_user/participant2@{$REMOTE_URL}" bye | participant3-displayname mentioned you in conversation room | Hi @participant2-displayname bye |
 
   Scenario: Mentioning and replying to self does not do notifications
     Given the following "spreed" app config is set
@@ -378,21 +378,21 @@ Feature: federation/chat
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 3    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 3    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type |
-      | room | 3    |
+      | id          | type |
+      | LOCAL::room | 3    |
     And user "participant1" adds federated_user "participant3" to room "room" with 200 (v4)
     And user "participant3" has the following invitations (v1)
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant3" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 3    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 3    | LOCAL        | room        |
     Then user "participant3" is participant of the following rooms (v4)
-      | id   | type |
-      | room | 3    |
+      | id          | type |
+      | LOCAL::room | 3    |
     # Join and leave to clear the invite notification
     Given user "participant2" joins room "LOCAL::room" with 200 (v4)
     Given user "participant2" leaves room "LOCAL::room" with 200 (v4)
@@ -413,11 +413,11 @@ Feature: federation/chat
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 3    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 3    | LOCAL        | room        |
     And user "participant2" is participant of the following rooms (v4)
-      | id   | type |
-      | room | 3    |
+      | id          | type |
+      | LOCAL::room | 3    |
     And user "participant1" sends message "Message 1" to room "room" with 201
     When user "participant2" sets notifications to all for room "LOCAL::room" (v4)
     And user "participant1" sets description for room "room" to "the description" with 200 (v4)
@@ -436,11 +436,11 @@ Feature: federation/chat
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type |
-      | room | 2    |
+      | id          | type |
+      | LOCAL::room | 2    |
     # Join and leave to clear the invite notification
     Given user "participant2" joins room "LOCAL::room" with 200 (v4)
     Given user "participant2" leaves room "LOCAL::room" with 200 (v4)

--- a/tests/integration/features/federation/invite.feature
+++ b/tests/integration/features/federation/invite.feature
@@ -60,11 +60,11 @@ Feature: federation/invite
       | app    | object_type       | object_id              | subject                                                           | message                                                                     |
       | spreed | remote_talk_share | INVITE_ID(LOCAL::room) | @participant1-displayname invited you to a federated conversation | @participant1-displayname invited you to join room on http://localhost:8080 |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 3    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 3    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 3    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 3    | LOCAL        | room        |
     Then last response has federation invites header set to "NULL"
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 400 (v1)
       | error | state |
@@ -128,8 +128,8 @@ Feature: federation/invite
       | app    | object_type       | object_id              | subject                                                           | message                                                                     |
       | spreed | remote_talk_share | INVITE_ID(LOCAL::room) | @participant1-displayname invited you to a federated conversation | @participant1-displayname invited you to join room on http://localhost:8080 |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 3    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 3    | LOCAL        | room        |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 400 (v1)
       | error | state |
     And user "participant2" declines invite to room "room" of server "LOCAL" with 400 (v1)
@@ -261,8 +261,8 @@ Feature: federation/invite
       | app    | object_type       | object_id              | subject                                                           | message                                                                     |
       | spreed | remote_talk_share | INVITE_ID(LOCAL::room) | @participant1-displayname invited you to a federated conversation | @participant1-displayname invited you to join room on http://localhost:8080 |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 3    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 3    | LOCAL        | room        |
     And user "participant2" has the following invitations (v1)
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 1     | participant1@http://localhost:8080 | participant1-displayname |
@@ -291,15 +291,15 @@ Feature: federation/invite
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | name | type |
-      | room | room | 2    |
+      | id          | name | type |
+      | LOCAL::room | room | 2    |
     And user "participant1" renames room "room" to "Federated room" with 200 (v4)
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | name           | type |
-      | room | Federated room | 2    |
+      | id          | name           | type |
+      | LOCAL::room | Federated room | 2    |
 
   Scenario: Allow accessing conversation and room avatars for invited users
     Given the following "spreed" app config is set
@@ -314,8 +314,8 @@ Feature: federation/invite
     When as user "participant2"
     Then the room "LOCAL::room" has an avatar with 200
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
     When as user "participant2"
     Then the room "LOCAL::room" has an avatar with 200
     And user "participant2" removes themselves from room "LOCAL::room" with 200 (v4)

--- a/tests/integration/features/federation/poll.feature
+++ b/tests/integration/features/federation/poll.feature
@@ -14,11 +14,11 @@ Feature: federation/poll
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type |
-      | room | 2    |
+      | id          | type |
+      | LOCAL::room | 2    |
     When user "participant2" creates a poll in room "LOCAL::room" with 201
       | question   | What is the question? |
       | options    | ["Where are you?","How much is the fish?"] |

--- a/tests/integration/features/federation/reminder.feature
+++ b/tests/integration/features/federation/reminder.feature
@@ -16,11 +16,11 @@ Feature: federation/reminder
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type |
-      | room | 2    |
+      | id          | type |
+      | LOCAL::room | 2    |
     And user "participant2" joins room "LOCAL::room" with 200 (v4)
     And user "participant2" leaves room "LOCAL::room" with 200 (v4)
     And user "participant2" sends message "Message 2" to room "LOCAL::room" with 201
@@ -35,7 +35,7 @@ Feature: federation/reminder
       | app | object_type | object_id | subject |
     And user "participant2" has the following notifications
       | app    | object_type | object_id      | subject                                                 |
-      | spreed | reminder    | room/Message 1 | Reminder: participant1-displayname in conversation room |
+      | spreed | reminder    | LOCAL::room/Message 1 | Reminder: participant1-displayname in conversation room |
     # Participant1 sets timestamp to past so it should trigger now
     When user "participant1" sets reminder for message "Message 2" in room "room" for time 1234567 with 201 (v1)
     And force run "OCA\Talk\BackgroundJob\Reminder" background jobs
@@ -59,11 +59,11 @@ Feature: federation/reminder
       | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
       | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
     And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
-      | id   | name | type | remoteServer | remoteToken |
-      | room | room | 2    | LOCAL        | room        |
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
     Then user "participant2" is participant of the following rooms (v4)
-      | id   | type |
-      | room | 2    |
+      | id          | type |
+      | LOCAL::room | 2    |
     And user "participant2" joins room "LOCAL::room" with 200 (v4)
     And user "participant2" leaves room "LOCAL::room" with 200 (v4)
     When user "participant2" sets reminder for message "Message 1" in room "LOCAL::room" for time 1234567 with 201 (v1)


### PR DESCRIPTION
The remote room identifier happened to work in the tests just because it matched the room name, and [unmapped tokens are automatically mapped to their room name in `assertRooms()`](https://github.com/nextcloud/spreed/blob/da33a4436cf423472008b85445d282ee559f56f4/tests/integration/features/bootstrap/FeatureContext.php#L423-L425).
