### PR TITLE
Add real federated server for integration tests

### DIFF
--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -839,7 +839,17 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 					$attendee['actorId'] = sha1(self::$userToSessionId[trim($attendee['actorId'], '"')]);
 				}
 
-				if (isset($attendee['actorId'], $attendee['actorType']) && $attendee['actorType'] === 'federated_users') {
+				if (isset($attendee['actorId']) && str_ends_with($attendee['actorId'], '@{$LOCAL_URL}')) {
+					$attendee['actorId'] = str_replace('{$LOCAL_URL}', rtrim($this->localServerUrl, '/'), $attendee['actorId']);
+				}
+				if (isset($attendee['actorId']) && str_ends_with($attendee['actorId'], '@{$LOCAL_REMOTE_URL}')) {
+					$attendee['actorId'] = str_replace('{$LOCAL_REMOTE_URL}', rtrim($this->localRemoteServerUrl, '/'), $attendee['actorId']);
+				}
+				if (isset($attendee['actorId']) && str_ends_with($attendee['actorId'], '@{$REMOTE_URL}')) {
+					$attendee['actorId'] = str_replace('{$REMOTE_URL}', rtrim($this->remoteServerUrl, '/'), $attendee['actorId']);
+				}
+
+				if (isset($attendee['actorId'], $attendee['actorType']) && $attendee['actorType'] === 'federated_users' && !str_contains($attendee['actorId'], '@')) {
 					$attendee['actorId'] .= '@' . rtrim($this->localRemoteServerUrl, '/');
 				}
 

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -88,7 +88,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 
 	protected string $localServerUrl;
 
-	protected string $remoteServerUrl;
+	protected string $localRemoteServerUrl;
 
 	protected string $baseUrl;
 
@@ -163,9 +163,9 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	public function __construct() {
 		$this->cookieJars = [];
 		$this->localServerUrl = getenv('TEST_SERVER_URL');
-		$this->remoteServerUrl = getenv('TEST_REMOTE_URL');
+		$this->localRemoteServerUrl = getenv('TEST_LOCAL_REMOTE_URL');
 		$this->baseUrl = $this->localServerUrl;
-		$this->baseRemoteUrl = $this->remoteServerUrl;
+		$this->baseRemoteUrl = $this->localRemoteServerUrl;
 	}
 
 	/**
@@ -500,7 +500,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			if (isset($expectedRoom['lastMessageActorId'])) {
 				$data['lastMessageActorId'] = $room['lastMessage'] ? $room['lastMessage']['actorId'] : '';
 				$data['lastMessageActorId'] = str_replace(rtrim($this->localServerUrl, '/'), '{$LOCAL_URL}', $data['lastMessageActorId']);
-				$data['lastMessageActorId'] = str_replace(rtrim($this->remoteServerUrl, '/'), '{$REMOTE_URL}', $data['lastMessageActorId']);
+				$data['lastMessageActorId'] = str_replace(rtrim($this->localRemoteServerUrl, '/'), '{$LOCAL_REMOTE_URL}', $data['lastMessageActorId']);
 			}
 			if (isset($expectedRoom['lastReadMessage'])) {
 				$data['lastReadMessage'] = self::$messageIdToText[(int) $room['lastReadMessage']] ?? (!$room['lastReadMessage'] ? 'ZERO': 'UNKNOWN_MESSAGE');
@@ -642,7 +642,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			return 'LOCAL';
 		}
 		if ($server === 'localhost:8180') {
-			return 'REMOTE';
+			return 'LOCAL_REMOTE';
 		}
 		return 'unknown-server';
 	}
@@ -798,7 +798,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 				}
 
 				if (isset($attendee['actorId'], $attendee['actorType']) && $attendee['actorType'] === 'federated_users') {
-					$attendee['actorId'] .= '@' . rtrim($this->baseRemoteUrl, '/');
+					$attendee['actorId'] .= '@' . rtrim($this->localRemoteServerUrl, '/');
 				}
 
 				if (isset($attendee['actorId'], $attendee['actorType'], $attendee['phoneNumber'])
@@ -1454,7 +1454,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			$attendeeId = 123456789;
 		} else {
 			if ($actorType === 'remote') {
-				$actorId .= '@' . rtrim($this->baseRemoteUrl, '/');
+				$actorId .= '@' . rtrim($this->localRemoteServerUrl, '/');
 				$actorType = 'federated_user';
 			}
 
@@ -1486,7 +1486,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			$actorId = '123456789';
 		} else {
 			if ($actorType === 'remote') {
-				$actorId .= '@' . rtrim($this->baseRemoteUrl, '/');
+				$actorId .= '@' . rtrim($this->localRemoteServerUrl, '/');
 				$actorType = 'federated_user';
 			}
 		}
@@ -1580,7 +1580,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			$actorId = '123456789';
 		} else {
 			if ($actorType === 'remote') {
-				$actorId .= '@' . rtrim($this->baseRemoteUrl, '/');
+				$actorId .= '@' . rtrim($this->localRemoteServerUrl, '/');
 				$actorType = 'federated_user';
 			}
 		}
@@ -1853,7 +1853,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->setCurrentUser($user);
 
 		if ($newType === 'federated_user') {
-			$newId .= '@' . $this->baseRemoteUrl;
+			$newId .= '@' . $this->localRemoteServerUrl;
 		}
 
 		$this->sendRequest(
@@ -2127,7 +2127,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$message = substr($message, 1, -1);
 		$message = str_replace('\n', "\n", $message);
 		$message = str_replace('{$LOCAL_URL}', $this->localServerUrl, $message);
-		$message = str_replace('{$REMOTE_URL}', $this->remoteServerUrl, $message);
+		$message = str_replace('{$LOCAL_REMOTE_URL}', $this->localRemoteServerUrl, $message);
 
 		if ($message === '413 Payload Too Large') {
 			$message .= "\n" . str_repeat('1', 32000);
@@ -2412,16 +2412,16 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		if (str_ends_with($expected['actorId'], '@{$LOCAL_URL}')) {
 			$expected['actorId'] = str_replace('{$LOCAL_URL}', rtrim($this->localServerUrl, '/'), $expected['actorId']);
 		}
-		if (str_ends_with($expected['actorId'], '@{$REMOTE_URL}')) {
-			$expected['actorId'] = str_replace('{$REMOTE_URL}', rtrim($this->remoteServerUrl, '/'), $expected['actorId']);
+		if (str_ends_with($expected['actorId'], '@{$LOCAL_REMOTE_URL}')) {
+			$expected['actorId'] = str_replace('{$LOCAL_REMOTE_URL}', rtrim($this->localRemoteServerUrl, '/'), $expected['actorId']);
 		}
 
 		if (isset($expected['details'])) {
 			if (str_contains($expected['details'], '@{$LOCAL_URL}')) {
 				$expected['details'] = str_replace('{$LOCAL_URL}', rtrim($this->localServerUrl, '/'), $expected['details']);
 			}
-			if (str_contains($expected['details'], '@{$REMOTE_URL}')) {
-				$expected['details'] = str_replace('{$REMOTE_URL}', rtrim($this->remoteServerUrl, '/'), $expected['details']);
+			if (str_contains($expected['details'], '@{$LOCAL_REMOTE_URL}')) {
+				$expected['details'] = str_replace('{$LOCAL_REMOTE_URL}', rtrim($this->localRemoteServerUrl, '/'), $expected['details']);
 			}
 		}
 
@@ -2874,23 +2874,23 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			if (str_ends_with($expected[$i]['actorId'], '@{$LOCAL_URL}')) {
 				$expected[$i]['actorId'] = str_replace('{$LOCAL_URL}', rtrim($this->localServerUrl, '/'), $expected[$i]['actorId']);
 			}
-			if (str_ends_with($expected[$i]['actorId'], '@{$REMOTE_URL}')) {
-				$expected[$i]['actorId'] = str_replace('{$REMOTE_URL}', rtrim($this->remoteServerUrl, '/'), $expected[$i]['actorId']);
+			if (str_ends_with($expected[$i]['actorId'], '@{$LOCAL_REMOTE_URL}')) {
+				$expected[$i]['actorId'] = str_replace('{$LOCAL_REMOTE_URL}', rtrim($this->localRemoteServerUrl, '/'), $expected[$i]['actorId']);
 			}
 
 			if (str_contains($expected[$i]['messageParameters'], '{$LOCAL_URL}')) {
 				$expected[$i]['messageParameters'] = str_replace('{$LOCAL_URL}', str_replace('/', '\/', rtrim($this->localServerUrl, '/')), $expected[$i]['messageParameters']);
 			}
-			if (str_contains($expected[$i]['messageParameters'], '{$REMOTE_URL}')) {
-				$expected[$i]['messageParameters'] = str_replace('{$REMOTE_URL}', str_replace('/', '\/', rtrim($this->remoteServerUrl, '/')), $expected[$i]['messageParameters']);
+			if (str_contains($expected[$i]['messageParameters'], '{$LOCAL_REMOTE_URL}')) {
+				$expected[$i]['messageParameters'] = str_replace('{$LOCAL_REMOTE_URL}', str_replace('/', '\/', rtrim($this->localRemoteServerUrl, '/')), $expected[$i]['messageParameters']);
 			}
 
 			if (isset($expected[$i]['lastEditActorId'])) {
 				if (str_ends_with($expected[$i]['lastEditActorId'], '@{$LOCAL_URL}')) {
 					$expected[$i]['lastEditActorId'] = str_replace('{$LOCAL_URL}', rtrim($this->localServerUrl, '/'), $expected[$i]['lastEditActorId']);
 				}
-				if (str_ends_with($expected[$i]['lastEditActorId'], '@{$REMOTE_URL}')) {
-					$expected[$i]['lastEditActorId'] = str_replace('{$REMOTE_URL}', rtrim($this->remoteServerUrl, '/'), $expected[$i]['lastEditActorId']);
+				if (str_ends_with($expected[$i]['lastEditActorId'], '@{$LOCAL_REMOTE_URL}')) {
+					$expected[$i]['lastEditActorId'] = str_replace('{$LOCAL_REMOTE_URL}', rtrim($this->localRemoteServerUrl, '/'), $expected[$i]['lastEditActorId']);
 				}
 			}
 
@@ -3122,14 +3122,14 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			if (str_ends_with($row['id'], '@{$LOCAL_URL}')) {
 				$row['id'] = str_replace('{$LOCAL_URL}', rtrim($this->localServerUrl, '/'), $row['id']);
 			}
-			if (str_ends_with($row['id'], '@{$REMOTE_URL}')) {
-				$row['id'] = str_replace('{$REMOTE_URL}', rtrim($this->remoteServerUrl, '/'), $row['id']);
+			if (str_ends_with($row['id'], '@{$LOCAL_REMOTE_URL}')) {
+				$row['id'] = str_replace('{$LOCAL_REMOTE_URL}', rtrim($this->localRemoteServerUrl, '/'), $row['id']);
 			}
 			if (str_ends_with($row['mentionId'], '@{$BASE_URL}')) {
 				$row['mentionId'] = str_replace('{$BASE_URL}', rtrim($this->localServerUrl, '/'), $row['mentionId']);
 			}
-			if (str_ends_with($row['mentionId'], '@{$REMOTE_URL}')) {
-				$row['mentionId'] = str_replace('{$REMOTE_URL}', rtrim($this->remoteServerUrl, '/'), $row['mentionId']);
+			if (str_ends_with($row['mentionId'], '@{$LOCAL_REMOTE_URL}')) {
+				$row['mentionId'] = str_replace('{$LOCAL_REMOTE_URL}', rtrim($this->localRemoteServerUrl, '/'), $row['mentionId']);
 			}
 			if (array_key_exists('avatar', $row)) {
 				Assert::assertMatchesRegularExpression('/' . self::$identifierToToken[$row['avatar']] . '\/avatar/', $mentions[$key]['avatar']);
@@ -3572,7 +3572,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 					$messageText = self::$messageIdToText[$message] ?? 'UNKNOWN_MESSAGE';
 
 					$messageText = str_replace($this->localServerUrl, '{$LOCAL_URL}', $messageText);
-					$messageText = str_replace($this->remoteServerUrl, '{$REMOTE_URL}', $messageText);
+					$messageText = str_replace($this->localRemoteServerUrl, '{$LOCAL_REMOTE_URL}', $messageText);
 
 					$data['object_id'] = self::$tokenToIdentifier[$roomToken] . '/' . $messageText;
 				} elseif (strpos($expectedNotification['object_id'], 'INVITE_ID') !== false) {
@@ -4060,7 +4060,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 				$reaction['actorId'] = ($reaction['actorType'] === 'guests') ? self::$sessionIdToUser[$reaction['actorId']] : (string) $reaction['actorId'];
 				if ($reaction['actorType'] === 'federated_users') {
 					$reaction['actorId'] = str_replace(rtrim($this->localServerUrl, '/'), '{$LOCAL_URL}', $reaction['actorId']);
-					$reaction['actorId'] = str_replace(rtrim($this->remoteServerUrl, '/'), '{$REMOTE_URL}', $reaction['actorId']);
+					$reaction['actorId'] = str_replace(rtrim($this->localRemoteServerUrl, '/'), '{$LOCAL_REMOTE_URL}', $reaction['actorId']);
 				}
 				return $reaction;
 			}, $list);

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -92,8 +92,6 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 
 	protected string $baseUrl;
 
-	protected string $baseRemoteUrl;
-
 	/** @var string[] */
 	protected array $createdUsers = [];
 
@@ -165,7 +163,6 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->localServerUrl = getenv('TEST_SERVER_URL');
 		$this->localRemoteServerUrl = getenv('TEST_LOCAL_REMOTE_URL');
 		$this->baseUrl = $this->localServerUrl;
-		$this->baseRemoteUrl = $this->localRemoteServerUrl;
 	}
 
 	/**
@@ -575,7 +572,9 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 
 		$this->setCurrentUser($user);
 		if ($server === 'LOCAL') {
-			$this->sendRemoteRequest($verb, '/apps/spreed/api/' . $apiVersion . '/federation/invitation/' . $inviteId);
+			$this->baseUrl = $this->localRemoteServerUrl;
+			$this->sendRequest($verb, '/apps/spreed/api/' . $apiVersion . '/federation/invitation/' . $inviteId);
+			$this->baseUrl = $this->localServerUrl;
 		}
 		$this->assertStatusCode($this->response, $status);
 		$response = $this->getDataFromResponse($this->response);
@@ -4667,17 +4666,6 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			])
 		);
 		$this->assertStatusCode($this->response, $statusCode);
-	}
-
-	/**
-	 * @param string $verb
-	 * @param string $url
-	 * @param TableNode|array|null $body
-	 * @param array $headers
-	 */
-	public function sendRemoteRequest($verb, $url, $body = null, array $headers = []) {
-		$fullUrl = $this->baseRemoteUrl . 'ocs/v2.php' . $url;
-		$this->sendRequestFullUrl($verb, $fullUrl, $body, $headers);
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -86,6 +86,10 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	/** @var CookieJar[] */
 	private array $cookieJars;
 
+	protected string $localServerUrl;
+
+	protected string $remoteServerUrl;
+
 	protected string $baseUrl;
 
 	protected string $baseRemoteUrl;
@@ -158,8 +162,10 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	 */
 	public function __construct() {
 		$this->cookieJars = [];
-		$this->baseUrl = getenv('TEST_SERVER_URL');
-		$this->baseRemoteUrl = getenv('TEST_REMOTE_URL');
+		$this->localServerUrl = getenv('TEST_SERVER_URL');
+		$this->remoteServerUrl = getenv('TEST_REMOTE_URL');
+		$this->baseUrl = $this->localServerUrl;
+		$this->baseRemoteUrl = $this->remoteServerUrl;
 	}
 
 	/**
@@ -493,8 +499,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			}
 			if (isset($expectedRoom['lastMessageActorId'])) {
 				$data['lastMessageActorId'] = $room['lastMessage'] ? $room['lastMessage']['actorId'] : '';
-				$data['lastMessageActorId'] = str_replace(rtrim($this->baseUrl, '/'), '{$BASE_URL}', $data['lastMessageActorId']);
-				$data['lastMessageActorId'] = str_replace(rtrim($this->baseRemoteUrl, '/'), '{$REMOTE_URL}', $data['lastMessageActorId']);
+				$data['lastMessageActorId'] = str_replace(rtrim($this->localServerUrl, '/'), '{$LOCAL_URL}', $data['lastMessageActorId']);
+				$data['lastMessageActorId'] = str_replace(rtrim($this->remoteServerUrl, '/'), '{$REMOTE_URL}', $data['lastMessageActorId']);
 			}
 			if (isset($expectedRoom['lastReadMessage'])) {
 				$data['lastReadMessage'] = self::$messageIdToText[(int) $room['lastReadMessage']] ?? (!$room['lastReadMessage'] ? 'ZERO': 'UNKNOWN_MESSAGE');
@@ -2120,8 +2126,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	public function userSendsMessageToRoom(string $user, string $sendingMode, string $message, string $identifier, string $statusCode, string $apiVersion = 'v1') {
 		$message = substr($message, 1, -1);
 		$message = str_replace('\n', "\n", $message);
-		$message = str_replace('{$BASE_URL}', $this->baseUrl, $message);
-		$message = str_replace('{$REMOTE_URL}', $this->baseRemoteUrl, $message);
+		$message = str_replace('{$LOCAL_URL}', $this->localServerUrl, $message);
+		$message = str_replace('{$REMOTE_URL}', $this->remoteServerUrl, $message);
 
 		if ($message === '413 Payload Too Large') {
 			$message .= "\n" . str_repeat('1', 32000);
@@ -2403,19 +2409,19 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			$expected['status'] = 1;
 		}
 
-		if (str_ends_with($expected['actorId'], '@{$BASE_URL}')) {
-			$expected['actorId'] = str_replace('{$BASE_URL}', rtrim($this->baseUrl, '/'), $expected['actorId']);
+		if (str_ends_with($expected['actorId'], '@{$LOCAL_URL}')) {
+			$expected['actorId'] = str_replace('{$LOCAL_URL}', rtrim($this->localServerUrl, '/'), $expected['actorId']);
 		}
 		if (str_ends_with($expected['actorId'], '@{$REMOTE_URL}')) {
-			$expected['actorId'] = str_replace('{$REMOTE_URL}', rtrim($this->baseRemoteUrl, '/'), $expected['actorId']);
+			$expected['actorId'] = str_replace('{$REMOTE_URL}', rtrim($this->remoteServerUrl, '/'), $expected['actorId']);
 		}
 
 		if (isset($expected['details'])) {
-			if (str_contains($expected['details'], '@{$BASE_URL}')) {
-				$expected['details'] = str_replace('{$BASE_URL}', rtrim($this->baseUrl, '/'), $expected['details']);
+			if (str_contains($expected['details'], '@{$LOCAL_URL}')) {
+				$expected['details'] = str_replace('{$LOCAL_URL}', rtrim($this->localServerUrl, '/'), $expected['details']);
 			}
 			if (str_contains($expected['details'], '@{$REMOTE_URL}')) {
-				$expected['details'] = str_replace('{$REMOTE_URL}', rtrim($this->baseRemoteUrl, '/'), $expected['details']);
+				$expected['details'] = str_replace('{$REMOTE_URL}', rtrim($this->remoteServerUrl, '/'), $expected['details']);
 			}
 		}
 
@@ -2865,26 +2871,26 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 			}
 			$expected[$i]['message'] = str_replace('\n', "\n", $expected[$i]['message']);
 
-			if (str_ends_with($expected[$i]['actorId'], '@{$BASE_URL}')) {
-				$expected[$i]['actorId'] = str_replace('{$BASE_URL}', rtrim($this->baseUrl, '/'), $expected[$i]['actorId']);
+			if (str_ends_with($expected[$i]['actorId'], '@{$LOCAL_URL}')) {
+				$expected[$i]['actorId'] = str_replace('{$LOCAL_URL}', rtrim($this->localServerUrl, '/'), $expected[$i]['actorId']);
 			}
 			if (str_ends_with($expected[$i]['actorId'], '@{$REMOTE_URL}')) {
-				$expected[$i]['actorId'] = str_replace('{$REMOTE_URL}', rtrim($this->baseRemoteUrl, '/'), $expected[$i]['actorId']);
+				$expected[$i]['actorId'] = str_replace('{$REMOTE_URL}', rtrim($this->remoteServerUrl, '/'), $expected[$i]['actorId']);
 			}
 
-			if (str_contains($expected[$i]['messageParameters'], '{$BASE_URL}')) {
-				$expected[$i]['messageParameters'] = str_replace('{$BASE_URL}', str_replace('/', '\/', rtrim($this->baseUrl, '/')), $expected[$i]['messageParameters']);
+			if (str_contains($expected[$i]['messageParameters'], '{$LOCAL_URL}')) {
+				$expected[$i]['messageParameters'] = str_replace('{$LOCAL_URL}', str_replace('/', '\/', rtrim($this->localServerUrl, '/')), $expected[$i]['messageParameters']);
 			}
 			if (str_contains($expected[$i]['messageParameters'], '{$REMOTE_URL}')) {
-				$expected[$i]['messageParameters'] = str_replace('{$REMOTE_URL}', str_replace('/', '\/', rtrim($this->baseRemoteUrl, '/')), $expected[$i]['messageParameters']);
+				$expected[$i]['messageParameters'] = str_replace('{$REMOTE_URL}', str_replace('/', '\/', rtrim($this->remoteServerUrl, '/')), $expected[$i]['messageParameters']);
 			}
 
 			if (isset($expected[$i]['lastEditActorId'])) {
-				if (str_ends_with($expected[$i]['lastEditActorId'], '@{$BASE_URL}')) {
-					$expected[$i]['lastEditActorId'] = str_replace('{$BASE_URL}', rtrim($this->baseUrl, '/'), $expected[$i]['lastEditActorId']);
+				if (str_ends_with($expected[$i]['lastEditActorId'], '@{$LOCAL_URL}')) {
+					$expected[$i]['lastEditActorId'] = str_replace('{$LOCAL_URL}', rtrim($this->localServerUrl, '/'), $expected[$i]['lastEditActorId']);
 				}
 				if (str_ends_with($expected[$i]['lastEditActorId'], '@{$REMOTE_URL}')) {
-					$expected[$i]['lastEditActorId'] = str_replace('{$REMOTE_URL}', rtrim($this->baseRemoteUrl, '/'), $expected[$i]['lastEditActorId']);
+					$expected[$i]['lastEditActorId'] = str_replace('{$REMOTE_URL}', rtrim($this->remoteServerUrl, '/'), $expected[$i]['lastEditActorId']);
 				}
 			}
 
@@ -3113,17 +3119,17 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 				Assert::assertMatchesRegularExpression('/^guest\/[0-9a-f]{40}$/', $mentions[$key]['mentionId']);
 				$mentions[$key]['mentionId'] = 'GUEST_ID';
 			}
-			if (str_ends_with($row['id'], '@{$BASE_URL}')) {
-				$row['id'] = str_replace('{$BASE_URL}', rtrim($this->baseUrl, '/'), $row['id']);
+			if (str_ends_with($row['id'], '@{$LOCAL_URL}')) {
+				$row['id'] = str_replace('{$LOCAL_URL}', rtrim($this->localServerUrl, '/'), $row['id']);
 			}
 			if (str_ends_with($row['id'], '@{$REMOTE_URL}')) {
-				$row['id'] = str_replace('{$REMOTE_URL}', rtrim($this->baseRemoteUrl, '/'), $row['id']);
+				$row['id'] = str_replace('{$REMOTE_URL}', rtrim($this->remoteServerUrl, '/'), $row['id']);
 			}
 			if (str_ends_with($row['mentionId'], '@{$BASE_URL}')) {
-				$row['mentionId'] = str_replace('{$BASE_URL}', rtrim($this->baseUrl, '/'), $row['mentionId']);
+				$row['mentionId'] = str_replace('{$BASE_URL}', rtrim($this->localServerUrl, '/'), $row['mentionId']);
 			}
 			if (str_ends_with($row['mentionId'], '@{$REMOTE_URL}')) {
-				$row['mentionId'] = str_replace('{$REMOTE_URL}', rtrim($this->baseRemoteUrl, '/'), $row['mentionId']);
+				$row['mentionId'] = str_replace('{$REMOTE_URL}', rtrim($this->remoteServerUrl, '/'), $row['mentionId']);
 			}
 			if (array_key_exists('avatar', $row)) {
 				Assert::assertMatchesRegularExpression('/' . self::$identifierToToken[$row['avatar']] . '\/avatar/', $mentions[$key]['avatar']);
@@ -3565,8 +3571,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 					[$roomToken, $message] = explode('/', $notification['object_id']);
 					$messageText = self::$messageIdToText[$message] ?? 'UNKNOWN_MESSAGE';
 
-					$messageText = str_replace($this->baseUrl, '{$BASE_URL}', $messageText);
-					$messageText = str_replace($this->baseRemoteUrl, '{$REMOTE_URL}', $messageText);
+					$messageText = str_replace($this->localServerUrl, '{$LOCAL_URL}', $messageText);
+					$messageText = str_replace($this->remoteServerUrl, '{$REMOTE_URL}', $messageText);
 
 					$data['object_id'] = self::$tokenToIdentifier[$roomToken] . '/' . $messageText;
 				} elseif (strpos($expectedNotification['object_id'], 'INVITE_ID') !== false) {
@@ -4053,8 +4059,8 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 				unset($reaction['timestamp']);
 				$reaction['actorId'] = ($reaction['actorType'] === 'guests') ? self::$sessionIdToUser[$reaction['actorId']] : (string) $reaction['actorId'];
 				if ($reaction['actorType'] === 'federated_users') {
-					$reaction['actorId'] = str_replace(rtrim($this->baseUrl, '/'), '{$BASE_URL}', $reaction['actorId']);
-					$reaction['actorId'] = str_replace(rtrim($this->baseRemoteUrl, '/'), '{$REMOTE_URL}', $reaction['actorId']);
+					$reaction['actorId'] = str_replace(rtrim($this->localServerUrl, '/'), '{$LOCAL_URL}', $reaction['actorId']);
+					$reaction['actorId'] = str_replace(rtrim($this->remoteServerUrl, '/'), '{$REMOTE_URL}', $reaction['actorId']);
 				}
 				return $reaction;
 			}, $list);

--- a/tests/integration/features/bootstrap/SharingContext.php
+++ b/tests/integration/features/bootstrap/SharingContext.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class SharingContext implements Context {
 	private string $baseUrl;
+	private string $currentServer;
 	private ?ResponseInterface $response = null;
 	private string $currentUser = '';
 	private array $adminUser;
@@ -29,6 +30,15 @@ class SharingContext implements Context {
 		if ($testServerUrl !== false) {
 			$this->baseUrl = $testServerUrl;
 		}
+	}
+
+	/**
+	 * @param string $currentServer
+	 * @param string $baseUrl
+	 */
+	public function setCurrentServer(string $currentServer, string $baseUrl) {
+		$this->currentServer = $currentServer;
+		$this->baseUrl = $baseUrl;
 	}
 
 	/**
@@ -165,7 +175,7 @@ class SharingContext implements Context {
 	 * @param int $statusCode
 	 */
 	public function userSharesWithTeamWithOcs(string $user, string $path, string $sharee, int $statusCode) {
-		$this->userSharesWithTeam($user, $path, FeatureContext::getTeamIdForLabel($sharee));
+		$this->userSharesWithTeam($user, $path, FeatureContext::getTeamIdForLabel($this->currentServer, $sharee));
 		$this->theOCSStatusCodeShouldBe($statusCode);
 	}
 

--- a/tests/integration/features/federation/chat.feature
+++ b/tests/integration/features/federation/chat.feature
@@ -22,10 +22,10 @@ Feature: federation/chat
       | id          | type |
       | LOCAL::room | 2    |
     And user "participant1" gets the following candidate mentions in room "room" for "" with 200
-      | source          | id                         | label                    | mentionId                                  |
-      | calls           | all                        | room                     | all                                        |
-      | federated_users | participant2@{$REMOTE_URL} | participant2-displayname | federated_user/participant2@{$REMOTE_URL}  |
-      | users           | participant3               | participant3-displayname | participant3                               |
+      | source          | id                               | label                    | mentionId                                        |
+      | calls           | all                              | room                     | all                                              |
+      | federated_users | participant2@{$LOCAL_REMOTE_URL} | participant2-displayname | federated_user/participant2@{$LOCAL_REMOTE_URL}  |
+      | users           | participant3                     | participant3-displayname | participant3                                     |
     And user "participant2" gets the following candidate mentions in room "LOCAL::room" for "" with 200
       | source          | id                        | label                    | mentionId    |
       | calls           | all                       | room                     | all          |
@@ -56,15 +56,15 @@ Feature: federation/chat
       | id          | type |
       | LOCAL::room | 2    |
     And user "participant1" gets the following candidate mentions in room "room" for "" with 200
-      | source          | id                         | label                    | mentionId                                 |
-      | calls           | all                        | room                     | all                                       |
-      | federated_users | participant2@{$REMOTE_URL} | participant2-displayname | federated_user/participant2@{$REMOTE_URL} |
-      | federated_users | participant3@{$REMOTE_URL} | participant3-displayname | federated_user/participant3@{$REMOTE_URL} |
+      | source          | id                               | label                    | mentionId                                       |
+      | calls           | all                              | room                     | all                                             |
+      | federated_users | participant2@{$LOCAL_REMOTE_URL} | participant2-displayname | federated_user/participant2@{$LOCAL_REMOTE_URL} |
+      | federated_users | participant3@{$LOCAL_REMOTE_URL} | participant3-displayname | federated_user/participant3@{$LOCAL_REMOTE_URL} |
     And user "participant2" gets the following candidate mentions in room "LOCAL::room" for "" with 200
-      | source          | id                        | label                    | mentionId                                 |
-      | calls           | all                       | room                     | all                                       |
-      | federated_users | participant1@{$LOCAL_URL} | participant1-displayname | participant1                              |
-      | users           | participant3              | participant3-displayname | federated_user/participant3@{$REMOTE_URL} |
+      | source          | id                        | label                    | mentionId                                       |
+      | calls           | all                       | room                     | all                                             |
+      | federated_users | participant1@{$LOCAL_URL} | participant1-displayname | participant1                                    |
+      | users           | participant3              | participant3-displayname | federated_user/participant3@{$LOCAL_REMOTE_URL} |
 
   Scenario: Basic chatting including posting, getting, editing and deleting
     Given the following "spreed" app config is set
@@ -98,9 +98,9 @@ Feature: federation/chat
       | id          | type | lastMessage |
       | LOCAL::room | 2    | Message 1-1 |
     Then user "participant1" sees the following messages in room "room" with 200
-      | room | actorType       | actorId                    | actorDisplayName         | message     | messageParameters | parentMessage |
-      | room | federated_users | participant2@{$REMOTE_URL} | participant2-displayname | Message 1-1 | []                | Message 1     |
-      | room | users           | participant1               | participant1-displayname | Message 1   | []                |               |
+      | room | actorType       | actorId                          | actorDisplayName         | message     | messageParameters | parentMessage |
+      | room | federated_users | participant2@{$LOCAL_REMOTE_URL} | participant2-displayname | Message 1-1 | []                | Message 1     |
+      | room | users           | participant1                     | participant1-displayname | Message 1   | []                |               |
     When next message request has the following parameters set
       | timeout                  | 0         |
     And user "participant2" sees the following messages in room "LOCAL::room" with 200
@@ -113,9 +113,9 @@ Feature: federation/chat
       | id          | type | lastMessage |
       | LOCAL::room | 2    | Message 1-1 - Edit 1 |
     Then user "participant1" sees the following messages in room "room" with 200
-      | room | actorType       | actorId                    | actorDisplayName         | message              | messageParameters | parentMessage      | lastEditActorType | lastEditActorId            | lastEditActorDisplayName |
-      | room | federated_users | participant2@{$REMOTE_URL} | participant2-displayname | Message 1-1 - Edit 1 | []                | Message 1 - Edit 1 | federated_users   | participant2@{$REMOTE_URL} | participant2-displayname |
-      | room | users           | participant1               | participant1-displayname | Message 1 - Edit 1   | []                |                    | users             | participant1               | participant1-displayname |
+      | room | actorType       | actorId                          | actorDisplayName         | message              | messageParameters | parentMessage      | lastEditActorType | lastEditActorId                  | lastEditActorDisplayName |
+      | room | federated_users | participant2@{$LOCAL_REMOTE_URL} | participant2-displayname | Message 1-1 - Edit 1 | []                | Message 1 - Edit 1 | federated_users   | participant2@{$LOCAL_REMOTE_URL} | participant2-displayname |
+      | room | users           | participant1                     | participant1-displayname | Message 1 - Edit 1   | []                |                    | users             | participant1                     | participant1-displayname |
     When next message request has the following parameters set
       | timeout                  | 0         |
     And user "participant2" sees the following messages in room "LOCAL::room" with 200
@@ -125,9 +125,9 @@ Feature: federation/chat
     And user "participant1" deletes message "Message 1 - Edit 1" from room "room" with 200
     And user "participant2" deletes message "Message 1-1 - Edit 1" from room "LOCAL::room" with 200
     Then user "participant1" sees the following messages in room "room" with 200
-      | room | actorType       | actorId                    | actorDisplayName         | message                   | messageParameters | parentMessage          |
-      | room | federated_users | participant2@{$REMOTE_URL} | participant2-displayname | Message deleted by author | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname","server":"{$REMOTE_URL}"}} | Message deleted by you |
-      | room | users           | participant1               | participant1-displayname | Message deleted by you    | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}}                          |                        |
+      | room | actorType       | actorId                          | actorDisplayName         | message                   | messageParameters | parentMessage          |
+      | room | federated_users | participant2@{$LOCAL_REMOTE_URL} | participant2-displayname | Message deleted by author | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname","server":"{$LOCAL_REMOTE_URL}"}} | Message deleted by you |
+      | room | users           | participant1                     | participant1-displayname | Message deleted by you    | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname"}}                          |                        |
     When next message request has the following parameters set
       | timeout                  | 0         |
     And user "participant2" sees the following messages in room "LOCAL::room" with 200
@@ -163,7 +163,7 @@ Feature: federation/chat
     When user "participant1" sends reply "Message 1-1" on message "Message 1" to room "LOCAL::room" with 201
     Then user "participant1" is participant of the following unordered rooms (v4)
       | id          | name | type | remoteServer | remoteToken | lastMessage | lastMessageActorType | lastMessageActorId |
-      | room        | room | 2    |              |             | Message 1-1 | federated_users      | participant1@{$REMOTE_URL} |
+      | room        | room | 2    |              |             | Message 1-1 | federated_users      | participant1@{$LOCAL_REMOTE_URL} |
       | LOCAL::room | room | 2    | LOCAL        | room        | Message 1-1 | users                | participant1       |
 
   Scenario: Read marker checking
@@ -258,12 +258,12 @@ Feature: federation/chat
     Then user "participant2" sees the following entries for dashboard widgets "spreed" (v2)
       | title | subtitle           | link        | iconUrl                                                               | sinceId | overlayIconUrl |
       | room  | You were mentioned | LOCAL::room | {$BASE_URL}ocs/v2.php/apps/spreed/api/v1/room/{token}/avatar{version} |         |                |
-    And user "participant1" sends message 'Hi @"federated_user/participant2@{$REMOTE_URL}" bye' to room "room" with 201
+    And user "participant1" sends message 'Hi @"federated_user/participant2@{$LOCAL_REMOTE_URL}" bye' to room "room" with 201
     And user "participant1" sends message 'Hi @all bye' to room "room" with 201
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                | subject                                                                | message     |
       | spreed | chat        | LOCAL::room/Hi @all bye         | participant1-displayname mentioned everyone in conversation room       | Hi room bye |
-      | spreed | chat        | LOCAL::room/Hi @"federated_user/participant2@{$REMOTE_URL}" bye | participant1-displayname mentioned you in conversation room | Hi @participant2-displayname bye |
+      | spreed | chat        | LOCAL::room/Hi @"federated_user/participant2@{$LOCAL_REMOTE_URL}" bye | participant1-displayname mentioned you in conversation room | Hi @participant2-displayname bye |
       | spreed | chat        | LOCAL::room/Message 1-1         | participant1-displayname replied to your message in conversation room  | Message 1-1 |
     When next message request has the following parameters set
       | timeout                  | 0         |
@@ -293,11 +293,11 @@ Feature: federation/chat
     Given user "participant2" joins room "LOCAL::room" with 200 (v4)
     Given user "participant2" leaves room "LOCAL::room" with 200 (v4)
     And user "guest" joins room "room" with 200 (v4)
-    When user "guest" sends message 'Hi @"federated_user/participant2@{$REMOTE_URL}" bye' to room "room" with 201
+    When user "guest" sends message 'Hi @"federated_user/participant2@{$LOCAL_REMOTE_URL}" bye' to room "room" with 201
     When user "guest" sends message "Message 2" to room "room" with 201
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                | subject                                                                | message     |
-      | spreed | chat        | LOCAL::room/Hi @"federated_user/participant2@{$REMOTE_URL}" bye | A guest mentioned you in conversation room | Hi @participant2-displayname bye |
+      | spreed | chat        | LOCAL::room/Hi @"federated_user/participant2@{$LOCAL_REMOTE_URL}" bye | A guest mentioned you in conversation room | Hi @participant2-displayname bye |
     Then user "participant2" reads message "Message 2" in room "LOCAL::room" with 200 (v1)
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                | subject                                                                | message     |
@@ -322,13 +322,13 @@ Feature: federation/chat
     Given user "participant2" joins room "LOCAL::room" with 200 (v4)
     Given user "participant2" sets session state to 1 in room "LOCAL::room" with 200 (v4)
     And user "guest" joins room "room" with 200 (v4)
-    When user "guest" sends message 'Sent to @"federated_user/participant2@{$REMOTE_URL}" while active' to room "room" with 201
+    When user "guest" sends message 'Sent to @"federated_user/participant2@{$LOCAL_REMOTE_URL}" while active' to room "room" with 201
     Given user "participant2" sets session state to 0 in room "LOCAL::room" with 200 (v4)
-    When user "guest" sends message 'User @"federated_user/participant2@{$REMOTE_URL}" is inactive' to room "room" with 201
+    When user "guest" sends message 'User @"federated_user/participant2@{$LOCAL_REMOTE_URL}" is inactive' to room "room" with 201
     When user "guest" sends message "Message 3" to room "room" with 201
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                | subject                                                                | message     |
-      | spreed | chat        | LOCAL::room/User @"federated_user/participant2@{$REMOTE_URL}" is inactive | A guest mentioned you in conversation room | User @participant2-displayname is inactive |
+      | spreed | chat        | LOCAL::room/User @"federated_user/participant2@{$LOCAL_REMOTE_URL}" is inactive | A guest mentioned you in conversation room | User @participant2-displayname is inactive |
     Then user "participant2" reads message "Message 3" in room "LOCAL::room" with 200 (v1)
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                | subject                                                                | message     |
@@ -362,10 +362,10 @@ Feature: federation/chat
     # Join and leave to clear the invite notification
     Given user "participant2" joins room "LOCAL::room" with 200 (v4)
     Given user "participant2" leaves room "LOCAL::room" with 200 (v4)
-    When user "participant3" sends message 'Hi @"federated_user/participant2@{$REMOTE_URL}" bye' to room "LOCAL::room" with 201
+    When user "participant3" sends message 'Hi @"federated_user/participant2@{$LOCAL_REMOTE_URL}" bye' to room "LOCAL::room" with 201
     Then user "participant2" has the following notifications
       | app    | object_type | object_id                | subject                                                                | message     |
-      | spreed | chat        | LOCAL::room/Hi @"federated_user/participant2@{$REMOTE_URL}" bye | participant3-displayname mentioned you in conversation room | Hi @participant2-displayname bye |
+      | spreed | chat        | LOCAL::room/Hi @"federated_user/participant2@{$LOCAL_REMOTE_URL}" bye | participant3-displayname mentioned you in conversation room | Hi @participant2-displayname bye |
 
   Scenario: Mentioning and replying to self does not do notifications
     Given the following "spreed" app config is set
@@ -396,7 +396,7 @@ Feature: federation/chat
     # Join and leave to clear the invite notification
     Given user "participant2" joins room "LOCAL::room" with 200 (v4)
     Given user "participant2" leaves room "LOCAL::room" with 200 (v4)
-    When user "participant2" sends message 'Hi @"federated_user/participant2@{$REMOTE_URL}" bye' to room "LOCAL::room" with 201
+    When user "participant2" sends message 'Hi @"federated_user/participant2@{$LOCAL_REMOTE_URL}" bye' to room "LOCAL::room" with 201
     And user "participant2" sends message "Message 1" to room "LOCAL::room" with 201
     When user "participant2" sends reply "Message 1-1" on message "Message 1" to room "LOCAL::room" with 201
     Then user "participant2" has the following notifications
@@ -455,4 +455,4 @@ Feature: federation/chat
     And user "participant1" retrieve reactions "all" of message "Message 1" in room "room" with 200
       | actorType       | actorId                    | actorDisplayName         | reaction |
       | users           | participant1               | participant1-displayname | 🚀       |
-      | federated_users | participant2@{$REMOTE_URL} | participant2-displayname | 🚀       |
+      | federated_users | participant2@{$LOCAL_REMOTE_URL} | participant2-displayname | 🚀       |

--- a/tests/integration/features/federation/chat.feature
+++ b/tests/integration/features/federation/chat.feature
@@ -27,10 +27,10 @@ Feature: federation/chat
       | federated_users | participant2@{$REMOTE_URL} | participant2-displayname | federated_user/participant2@{$REMOTE_URL}  |
       | users           | participant3               | participant3-displayname | participant3                               |
     And user "participant2" gets the following candidate mentions in room "LOCAL::room" for "" with 200
-      | source          | id                       | label                    | mentionId    |
-      | calls           | all                      | room                     | all          |
-      | federated_users | participant1@{$BASE_URL} | participant1-displayname | participant1 |
-      | federated_users | participant3@{$BASE_URL} | participant3-displayname | participant3 |
+      | source          | id                        | label                    | mentionId    |
+      | calls           | all                       | room                     | all          |
+      | federated_users | participant1@{$LOCAL_URL} | participant1-displayname | participant1 |
+      | federated_users | participant3@{$LOCAL_URL} | participant3-displayname | participant3 |
 
   Scenario: Get mention suggestions (translating federated users of the same server to local users)
     Given the following "spreed" app config is set
@@ -61,10 +61,10 @@ Feature: federation/chat
       | federated_users | participant2@{$REMOTE_URL} | participant2-displayname | federated_user/participant2@{$REMOTE_URL} |
       | federated_users | participant3@{$REMOTE_URL} | participant3-displayname | federated_user/participant3@{$REMOTE_URL} |
     And user "participant2" gets the following candidate mentions in room "LOCAL::room" for "" with 200
-      | source          | id                       | label                    | mentionId                                 |
-      | calls           | all                      | room                     | all                                       |
-      | federated_users | participant1@{$BASE_URL} | participant1-displayname | participant1                              |
-      | users           | participant3             | participant3-displayname | federated_user/participant3@{$REMOTE_URL} |
+      | source          | id                        | label                    | mentionId                                 |
+      | calls           | all                       | room                     | all                                       |
+      | federated_users | participant1@{$LOCAL_URL} | participant1-displayname | participant1                              |
+      | users           | participant3              | participant3-displayname | federated_user/participant3@{$REMOTE_URL} |
 
   Scenario: Basic chatting including posting, getting, editing and deleting
     Given the following "spreed" app config is set
@@ -104,9 +104,9 @@ Feature: federation/chat
     When next message request has the following parameters set
       | timeout                  | 0         |
     And user "participant2" sees the following messages in room "LOCAL::room" with 200
-      | room        | actorType       | actorId                  | actorDisplayName         | message     | messageParameters | parentMessage |
-      | LOCAL::room | users           | participant2             | participant2-displayname | Message 1-1 | []                | Message 1     |
-      | LOCAL::room | federated_users | participant1@{$BASE_URL} | participant1-displayname | Message 1   | []                |               |
+      | room        | actorType       | actorId                   | actorDisplayName         | message     | messageParameters | parentMessage |
+      | LOCAL::room | users           | participant2              | participant2-displayname | Message 1-1 | []                | Message 1     |
+      | LOCAL::room | federated_users | participant1@{$LOCAL_URL} | participant1-displayname | Message 1   | []                |               |
     And user "participant1" edits message "Message 1" in room "room" to "Message 1 - Edit 1" with 200
     And user "participant2" edits message "Message 1-1" in room "LOCAL::room" to "Message 1-1 - Edit 1" with 200
     Then user "participant2" is participant of the following rooms (v4)
@@ -119,9 +119,9 @@ Feature: federation/chat
     When next message request has the following parameters set
       | timeout                  | 0         |
     And user "participant2" sees the following messages in room "LOCAL::room" with 200
-      | room        | actorType       | actorId                  | actorDisplayName         | message              | messageParameters | parentMessage      | lastEditActorType | lastEditActorId          | lastEditActorDisplayName |
-      | LOCAL::room | users           | participant2             | participant2-displayname | Message 1-1 - Edit 1 | []                | Message 1 - Edit 1 | users             | participant2             | participant2-displayname |
-      | LOCAL::room | federated_users | participant1@{$BASE_URL} | participant1-displayname | Message 1 - Edit 1   | []                |                    | federated_users   | participant1@{$BASE_URL} | participant1-displayname |
+      | room        | actorType       | actorId                   | actorDisplayName         | message              | messageParameters | parentMessage      | lastEditActorType | lastEditActorId           | lastEditActorDisplayName |
+      | LOCAL::room | users           | participant2              | participant2-displayname | Message 1-1 - Edit 1 | []                | Message 1 - Edit 1 | users             | participant2              | participant2-displayname |
+      | LOCAL::room | federated_users | participant1@{$LOCAL_URL} | participant1-displayname | Message 1 - Edit 1   | []                |                    | federated_users   | participant1@{$LOCAL_URL} | participant1-displayname |
     And user "participant1" deletes message "Message 1 - Edit 1" from room "room" with 200
     And user "participant2" deletes message "Message 1-1 - Edit 1" from room "LOCAL::room" with 200
     Then user "participant1" sees the following messages in room "room" with 200
@@ -131,9 +131,9 @@ Feature: federation/chat
     When next message request has the following parameters set
       | timeout                  | 0         |
     And user "participant2" sees the following messages in room "LOCAL::room" with 200
-      | room        | actorType       | actorId                  | actorDisplayName         | message                   | messageParameters | parentMessage             |
-      | LOCAL::room | users           | participant2             | participant2-displayname | Message deleted by you    | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname"}}                        | Message deleted by author |
-      | LOCAL::room | federated_users | participant1@{$BASE_URL} | participant1-displayname | Message deleted by author | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname","server":"{$BASE_URL}"}} |                           |
+      | room        | actorType       | actorId                   | actorDisplayName         | message                   | messageParameters | parentMessage             |
+      | LOCAL::room | users           | participant2              | participant2-displayname | Message deleted by you    | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname"}}                        | Message deleted by author |
+      | LOCAL::room | federated_users | participant1@{$LOCAL_URL} | participant1-displayname | Message deleted by author | {"actor":{"type":"user","id":"participant1","name":"participant1-displayname","server":"{$LOCAL_URL}"}} |                           |
     Then user "participant2" is participant of the following rooms (v4)
       | id          | type | lastMessage |
       | LOCAL::room | 2    | Message deleted by author |
@@ -159,7 +159,7 @@ Feature: federation/chat
     Then user "participant1" is participant of the following unordered rooms (v4)
       | id          | name | type | remoteServer | remoteToken | lastMessage | lastMessageActorType | lastMessageActorId |
       | room        | room | 2    |              |             | Message 1   | users                | participant1       |
-      | LOCAL::room | room | 2    | LOCAL        | room        | Message 1   | federated_users      | participant1@{$BASE_URL} |
+      | LOCAL::room | room | 2    | LOCAL        | room        | Message 1   | federated_users      | participant1@{$LOCAL_URL} |
     When user "participant1" sends reply "Message 1-1" on message "Message 1" to room "LOCAL::room" with 201
     Then user "participant1" is participant of the following unordered rooms (v4)
       | id          | name | type | remoteServer | remoteToken | lastMessage | lastMessageActorType | lastMessageActorId |
@@ -449,9 +449,9 @@ Feature: federation/chat
       | actorType       | actorId                  | actorDisplayName         | reaction |
       | users           | participant1             | participant1-displayname | 🚀       |
     And user "participant2" react with "🚀" on message "Message 1" to room "LOCAL::room" with 201
-      | actorType       | actorId                  | actorDisplayName         | reaction |
-      | federated_users | participant1@{$BASE_URL} | participant1-displayname | 🚀       |
-      | users           | participant2             | participant2-displayname | 🚀       |
+      | actorType       | actorId                   | actorDisplayName         | reaction |
+      | federated_users | participant1@{$LOCAL_URL} | participant1-displayname | 🚀       |
+      | users           | participant2              | participant2-displayname | 🚀       |
     And user "participant1" retrieve reactions "all" of message "Message 1" in room "room" with 200
       | actorType       | actorId                    | actorDisplayName         | reaction |
       | users           | participant1               | participant1-displayname | 🚀       |

--- a/tests/integration/features/federation/poll.feature
+++ b/tests/integration/features/federation/poll.feature
@@ -26,7 +26,7 @@ Feature: federation/poll
       | maxVotes   | unlimited |
     Then user "participant1" sees the following messages in room "room" with 200
       | room | actorType | actorId      | actorDisplayName         | message   | messageParameters |
-      | room | federated_users | participant2@{$REMOTE_URL} | participant2-displayname | {object} | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname","server":"http:\/\/localhost:8180"},"object":{"type":"talk-poll","id":POLL_ID(What is the question?),"name":"What is the question?"}} |
+      | room | federated_users | participant2@{$LOCAL_REMOTE_URL} | participant2-displayname | {object} | {"actor":{"type":"user","id":"participant2","name":"participant2-displayname","server":"http:\/\/localhost:8180"},"object":{"type":"talk-poll","id":POLL_ID(What is the question?),"name":"What is the question?"}} |
     Then user "participant2" sees poll "What is the question?" in room "LOCAL::room" with 200
       | id         | POLL_ID(What is the question?) |
       | question   | What is the question? |
@@ -49,7 +49,7 @@ Feature: federation/poll
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | federated_users |
-      | actorId    | participant2@{$REMOTE_URL} |
+      | actorId    | participant2@{$LOCAL_REMOTE_URL} |
       | actorDisplayName    | participant2-displayname |
       | status     | open |
       | votedSelf  | [1] |
@@ -62,7 +62,7 @@ Feature: federation/poll
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | federated_users |
-      | actorId    | participant2@{$REMOTE_URL} |
+      | actorId    | participant2@{$LOCAL_REMOTE_URL} |
       | actorDisplayName    | participant2-displayname |
       | status     | open |
       | votedSelf  | [1] |
@@ -102,7 +102,7 @@ Feature: federation/poll
       | resultMode | public |
       | maxVotes   | unlimited |
       | actorType  | federated_users |
-      | actorId    | participant2@{$REMOTE_URL} |
+      | actorId    | participant2@{$LOCAL_REMOTE_URL} |
       | actorDisplayName    | participant2-displayname |
       | status     | closed |
       | votedSelf  | [1] |

--- a/tests/integration/features/federation/poll.feature
+++ b/tests/integration/features/federation/poll.feature
@@ -92,7 +92,7 @@ Feature: federation/poll
       | actorDisplayName    | participant2-displayname |
       | status     | closed |
       | votedSelf  | not voted |
-      | details    | [{"actorType":"federated_users","actorId":"participant1@{$BASE_URL}","actorDisplayName":"participant1-displayname","optionId":1}] |
+      | details    | [{"actorType":"federated_users","actorId":"participant1@{$LOCAL_URL}","actorDisplayName":"participant1-displayname","optionId":1}] |
     Then user "participant1" sees poll "What is the question?" in room "room" with 200
       | id         | POLL_ID(What is the question?) |
       | question   | What is the question? |

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -47,8 +47,10 @@ MAIN_SERVER_CONFIG_DIR=${ROOT_DIR}/config
 MAIN_SERVER_DATA_DIR=$(${ROOT_DIR}/occ config:system:get datadirectory)
 REAL_FEDERATED_SERVER_CONFIG_DIR="$MAIN_SERVER_DATA_DIR/tests-talk-real-federated-server/config"
 REAL_FEDERATED_SERVER_DATA_DIR="$MAIN_SERVER_DATA_DIR/tests-talk-real-federated-server/data"
+DESTROY_REAL_FEDERATED_SERVER=false
 
 if [ ! -d "$REAL_FEDERATED_SERVER_CONFIG_DIR" ] || NEXTCLOUD_CONFIG_DIR="$REAL_FEDERATED_SERVER_CONFIG_DIR" ${ROOT_DIR}/occ status | grep "installed: false"; then
+	DESTROY_REAL_FEDERATED_SERVER=true
 	echo ''
 	echo -e "\033[0;31mReal federated server not installed in $REAL_FEDERATED_SERVER_CONFIG_DIR\033[0m"
 	echo -e "\033[0;33mPerforming basic SQLite installation with data directory in $REAL_FEDERATED_SERVER_DATA_DIR\033[0m"
@@ -189,6 +191,11 @@ for CONFIG_DIR in $MAIN_SERVER_CONFIG_DIR $REAL_FEDERATED_SERVER_CONFIG_DIR; do
 		${ROOT_DIR}/occ config:system:set skeletondirectory --value "$SKELETON_DIR"
 	fi
 done
+
+if $DESTROY_REAL_FEDERATED_SERVER; then
+	rm -rf "$REAL_FEDERATED_SERVER_CONFIG_DIR" "$REAL_FEDERATED_SERVER_DATA_DIR"
+fi
+
 rm -rf ../../../spreedcheats
 
 wait $PHPPID1

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -50,7 +50,7 @@ trap 'pkill -P $PHPPID1; pkill -P $PHPPID2; pkill -P $PROCESS_ID; wait $PHPPID1;
 NEXTCLOUD_ROOT_DIR=${ROOT_DIR}
 export NEXTCLOUD_ROOT_DIR
 export TEST_SERVER_URL="http://localhost:8080/"
-export TEST_REMOTE_URL="http://localhost:8180/"
+export TEST_LOCAL_REMOTE_URL="http://localhost:8180/"
 
 OVERWRITE_CLI_URL=$(${ROOT_DIR}/occ config:system:get overwrite.cli.url)
 ${ROOT_DIR}/occ config:system:set overwrite.cli.url --value "http://localhost:8080/"

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -32,7 +32,6 @@ echo -e "Running on process ID: \033[1;35m$PHPPID1\033[0m"
 # Output filtered php server logs
 tail -f phpserver.log | grep --line-buffered -v -E ":[0-9]+ Accepted$" | grep --line-buffered -v -E ":[0-9]+ Closing$" &
 
-# The federated server is started and stopped by the tests themselves
 PORT_FED=8180
 export PORT_FED
 
@@ -44,22 +43,59 @@ echo -e "Running on process ID: \033[1;35m$PHPPID2\033[0m"
 # Output filtered federated php server logs
 tail -f phpserver_fed.log | grep --line-buffered -v -E ":[0-9]+ Accepted$" | grep --line-buffered -v -E ":[0-9]+ Closing$" &
 
+MAIN_SERVER_CONFIG_DIR=${ROOT_DIR}/config
+MAIN_SERVER_DATA_DIR=$(${ROOT_DIR}/occ config:system:get datadirectory)
+REAL_FEDERATED_SERVER_CONFIG_DIR="$MAIN_SERVER_DATA_DIR/tests-talk-real-federated-server/config"
+REAL_FEDERATED_SERVER_DATA_DIR="$MAIN_SERVER_DATA_DIR/tests-talk-real-federated-server/data"
+
+if [ ! -d "$REAL_FEDERATED_SERVER_CONFIG_DIR" ] || NEXTCLOUD_CONFIG_DIR="$REAL_FEDERATED_SERVER_CONFIG_DIR" ${ROOT_DIR}/occ status | grep "installed: false"; then
+	echo ''
+	echo -e "\033[0;31mReal federated server not installed in $REAL_FEDERATED_SERVER_CONFIG_DIR\033[0m"
+	echo -e "\033[0;33mPerforming basic SQLite installation with data directory in $REAL_FEDERATED_SERVER_DATA_DIR\033[0m"
+	mkdir --parents "$REAL_FEDERATED_SERVER_CONFIG_DIR" "$REAL_FEDERATED_SERVER_DATA_DIR"
+	NEXTCLOUD_CONFIG_DIR="$REAL_FEDERATED_SERVER_CONFIG_DIR" ${ROOT_DIR}/occ maintenance:install --admin-pass=admin --data-dir="$REAL_FEDERATED_SERVER_DATA_DIR"
+	echo ''
+fi
+
+PORT_FED_REAL=8280
+export PORT_FED_REAL
+
+echo "" > phpserver_fed_real.log
+PHP_CLI_SERVER_WORKERS=3 NEXTCLOUD_CONFIG_DIR="$REAL_FEDERATED_SERVER_CONFIG_DIR" php -S localhost:${PORT_FED_REAL} -t ${ROOT_DIR} &> phpserver_fed_real.log &
+PHPPID3=$!
+echo -e "Running on process ID: \033[1;35m$PHPPID3\033[0m"
+
+# Output filtered real federated php server logs
+tail -f phpserver_fed_real.log | grep --line-buffered -v -E ":[0-9]+ Accepted$" | grep --line-buffered -v -E ":[0-9]+ Closing$" &
+
 # Kill all sub-processes in case of ctrl+c
-trap 'pkill -P $PHPPID1; pkill -P $PHPPID2; pkill -P $PROCESS_ID; wait $PHPPID1; wait $PHPPID2;' INT TERM
+trap 'pkill -P $PHPPID1; pkill -P $PHPPID2; pkill -P $PHPPID3; pkill -P $PROCESS_ID; wait $PHPPID1; wait $PHPPID2; wait $PHPPID3;' INT TERM
 
 NEXTCLOUD_ROOT_DIR=${ROOT_DIR}
 export NEXTCLOUD_ROOT_DIR
 export TEST_SERVER_URL="http://localhost:8080/"
 export TEST_LOCAL_REMOTE_URL="http://localhost:8180/"
+export TEST_REMOTE_URL="http://localhost:8280/"
+export MAIN_SERVER_CONFIG_DIR
+export REAL_FEDERATED_SERVER_CONFIG_DIR
 
+export NEXTCLOUD_CONFIG_DIR="$MAIN_SERVER_CONFIG_DIR"
 OVERWRITE_CLI_URL=$(${ROOT_DIR}/occ config:system:get overwrite.cli.url)
 ${ROOT_DIR}/occ config:system:set overwrite.cli.url --value "http://localhost:8080/"
 
-SKELETON_DIR=$(${ROOT_DIR}/occ config:system:get skeletondirectory)
-if [[ "$SKELETON_DIR" ]]; then
-	echo "Resetting custom skeletondirectory so that tests pass"
-	${ROOT_DIR}/occ config:system:delete skeletondirectory
-fi
+export NEXTCLOUD_CONFIG_DIR="$REAL_FEDERATED_SERVER_CONFIG_DIR"
+OVERWRITE_CLI_URL=$(${ROOT_DIR}/occ config:system:get overwrite.cli.url)
+${ROOT_DIR}/occ config:system:set overwrite.cli.url --value "$TEST_REMOTE_URL"
+
+for CONFIG_DIR in $MAIN_SERVER_CONFIG_DIR $REAL_FEDERATED_SERVER_CONFIG_DIR; do
+	export NEXTCLOUD_CONFIG_DIR="$CONFIG_DIR"
+
+	SKELETON_DIR=$(${ROOT_DIR}/occ config:system:get skeletondirectory)
+	if [[ "$SKELETON_DIR" ]]; then
+		echo "Resetting custom skeletondirectory so that tests pass"
+		${ROOT_DIR}/occ config:system:delete skeletondirectory
+	fi
+done
 
 echo ''
 echo -e "\033[0;36m#\033[0m"
@@ -75,29 +111,40 @@ ${ROOT_DIR}/occ app:getpath guests || (cd ../../../ && git clone --depth 1 --bra
 ${ROOT_DIR}/occ app:getpath circles || (cd ../../../ && git clone --depth 1 --branch ${CIRCLES_BRANCH} https://github.com/nextcloud/circles)
 ${ROOT_DIR}/occ app:getpath call_summary_bot || (cd ../../../ && git clone --depth 1 --branch ${CSB_BRANCH} https://github.com/nextcloud/call_summary_bot)
 
-${ROOT_DIR}/occ app:enable spreed || exit 1
-${ROOT_DIR}/occ app:enable --force spreedcheats || exit 1
-${ROOT_DIR}/occ app:enable --force notifications || exit 1
-${ROOT_DIR}/occ app:enable --force guests || exit 1
-${ROOT_DIR}/occ app:enable --force circles || exit 1
-${ROOT_DIR}/occ app:enable --force call_summary_bot || exit 1
+for CONFIG_DIR in $MAIN_SERVER_CONFIG_DIR $REAL_FEDERATED_SERVER_CONFIG_DIR; do
+	export NEXTCLOUD_CONFIG_DIR="$CONFIG_DIR"
 
-${ROOT_DIR}/occ app:list | grep spreed
-${ROOT_DIR}/occ app:list | grep notifications
-${ROOT_DIR}/occ app:list | grep guests
-${ROOT_DIR}/occ app:list | grep circles
-${ROOT_DIR}/occ app:list | grep call_summary_bot
+	${ROOT_DIR}/occ app:enable spreed || exit 1
+	${ROOT_DIR}/occ app:enable --force spreedcheats || exit 1
+	${ROOT_DIR}/occ app:enable --force notifications || exit 1
+	${ROOT_DIR}/occ app:enable --force guests || exit 1
+	${ROOT_DIR}/occ app:enable --force circles || exit 1
+	${ROOT_DIR}/occ app:enable --force call_summary_bot || exit 1
+
+	${ROOT_DIR}/occ app:list | grep spreed
+	${ROOT_DIR}/occ app:list | grep notifications
+	${ROOT_DIR}/occ app:list | grep guests
+	${ROOT_DIR}/occ app:list | grep circles
+	${ROOT_DIR}/occ app:list | grep call_summary_bot
+done
 
 echo ''
 echo -e "\033[0;36m#\033[0m"
 echo -e "\033[0;36m# Optimizing configuration\033[0m"
 echo -e "\033[0;36m#\033[0m"
-# Disable bruteforce protection because the integration tests do trigger them
-${ROOT_DIR}/occ config:system:set auth.bruteforce.protection.enabled --value false --type bool
-# Disable rate limit protection because the integration tests do trigger them
-${ROOT_DIR}/occ config:system:set ratelimit.protection.enabled --value false --type bool
-# Allow local remote urls otherwise we can not share
-${ROOT_DIR}/occ config:system:set allow_local_remote_servers --value true --type bool
+for CONFIG_DIR in $MAIN_SERVER_CONFIG_DIR $REAL_FEDERATED_SERVER_CONFIG_DIR; do
+	export NEXTCLOUD_CONFIG_DIR="$CONFIG_DIR"
+
+	# Disable bruteforce protection because the integration tests do trigger them
+	${ROOT_DIR}/occ config:system:set auth.bruteforce.protection.enabled --value false --type bool
+	# Disable rate limit protection because the integration tests do trigger them
+	${ROOT_DIR}/occ config:system:set ratelimit.protection.enabled --value false --type bool
+	# Allow local remote urls otherwise we can not share
+	${ROOT_DIR}/occ config:system:set allow_local_remote_servers --value true --type bool
+done
+
+# Restore default config dir to local server in case it is used from the tests
+export NEXTCLOUD_CONFIG_DIR="$MAIN_SERVER_CONFIG_DIR"
 
 echo ''
 echo -e "\033[1;33m#\033[0m"
@@ -119,10 +166,12 @@ echo -e "\033[0;36m#\033[0m"
 # Kill child PHP processes
 pkill -P $PHPPID1;
 pkill -P $PHPPID2;
+pkill -P $PHPPID3;
 
 # Kill parent PHP processes
 kill -TERM $PHPPID1;
 kill -TERM $PHPPID2;
+kill -TERM $PHPPID3;
 
 # Kill child processes of this script (e.g. tail)
 pkill -P $PROCESS_ID;
@@ -131,14 +180,19 @@ echo ''
 echo -e "\033[0;36m#\033[0m"
 echo -e "\033[0;36m# Reverting configuration changes and disabling spreedcheats\033[0m"
 echo -e "\033[0;36m#\033[0m"
-${ROOT_DIR}/occ app:disable spreedcheats
-${ROOT_DIR}/occ config:system:set overwrite.cli.url --value $OVERWRITE_CLI_URL
-if [[ "$SKELETON_DIR" ]]; then
-	${ROOT_DIR}/occ config:system:set skeletondirectory --value "$SKELETON_DIR"
-fi
+for CONFIG_DIR in $MAIN_SERVER_CONFIG_DIR $REAL_FEDERATED_SERVER_CONFIG_DIR; do
+	export NEXTCLOUD_CONFIG_DIR="$CONFIG_DIR"
+
+	${ROOT_DIR}/occ app:disable spreedcheats
+	${ROOT_DIR}/occ config:system:set overwrite.cli.url --value $OVERWRITE_CLI_URL
+	if [[ "$SKELETON_DIR" ]]; then
+		${ROOT_DIR}/occ config:system:set skeletondirectory --value "$SKELETON_DIR"
+	fi
+done
 rm -rf ../../../spreedcheats
 
 wait $PHPPID1
 wait $PHPPID2
+wait $PHPPID3
 
 exit $RESULT

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -45,6 +45,7 @@ tail -f phpserver_fed.log | grep --line-buffered -v -E ":[0-9]+ Accepted$" | gre
 
 MAIN_SERVER_CONFIG_DIR=${ROOT_DIR}/config
 MAIN_SERVER_DATA_DIR=$(${ROOT_DIR}/occ config:system:get datadirectory)
+MAIN_SERVER_APPS_PATHS=$(${ROOT_DIR}/occ config:system:get apps_paths --output json)
 REAL_FEDERATED_SERVER_CONFIG_DIR="$MAIN_SERVER_DATA_DIR/tests-talk-real-federated-server/config"
 REAL_FEDERATED_SERVER_DATA_DIR="$MAIN_SERVER_DATA_DIR/tests-talk-real-federated-server/data"
 DESTROY_REAL_FEDERATED_SERVER=false
@@ -57,6 +58,12 @@ if [ ! -d "$REAL_FEDERATED_SERVER_CONFIG_DIR" ] || NEXTCLOUD_CONFIG_DIR="$REAL_F
 	mkdir --parents "$REAL_FEDERATED_SERVER_CONFIG_DIR" "$REAL_FEDERATED_SERVER_DATA_DIR"
 	NEXTCLOUD_CONFIG_DIR="$REAL_FEDERATED_SERVER_CONFIG_DIR" ${ROOT_DIR}/occ maintenance:install --admin-pass=admin --data-dir="$REAL_FEDERATED_SERVER_DATA_DIR"
 	echo ''
+	if [ $MAIN_SERVER_APPS_PATHS ]; then
+		echo -e "\033[0;33mCopying custom apps_paths\033[0m"
+		echo "{\"system\":{\"apps_paths\":$MAIN_SERVER_APPS_PATHS}}" > "$REAL_FEDERATED_SERVER_CONFIG_DIR/apps_paths.json"
+		NEXTCLOUD_CONFIG_DIR="$REAL_FEDERATED_SERVER_CONFIG_DIR" ${ROOT_DIR}/occ config:import < "$REAL_FEDERATED_SERVER_CONFIG_DIR/apps_paths.json"
+		echo ''
+	fi
 fi
 
 PORT_FED_REAL=8280


### PR DESCRIPTION
Split from https://github.com/nextcloud/spreed/pull/12604 for easier reviewing and to be able to backport it if needed to ease future backports of integration tests that could depend on these changes.

The real federated server uses the same code as the main server but a different configuration and data directory. For simplicity, the configuration directory is expected to be inside the data directory of the main server, specifically in `tests-talk-real-federated-server/config`.

If the federated server was not installed in the expected directory before the tests are run a basic installation using SQLite will be
performed, using `tests-talk-real-federated-server/data` as its data directory.

## Follow ups:

- Install the federated server in CI when using a database other than SQLite? Or just leave the main server with whatever database is used in the runner and the federated one with SQLite?