### PR TITLE
Propagate lobby state to federated servers

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -263,6 +263,7 @@ class Application extends App implements IBootstrap {
 
 		// Federation listeners
 		$context->registerEventListener(BeforeRoomDeletedEvent::class, TalkV1BeforeRoomDeletedListener::class);
+		$context->registerEventListener(LobbyModifiedEvent::class, TalkV1RoomModifiedListener::class);
 		$context->registerEventListener(RoomModifiedEvent::class, TalkV1RoomModifiedListener::class);
 		$context->registerEventListener(ChatMessageSentEvent::class, TalkV1MessageSentListener::class);
 		$context->registerEventListener(SystemMessageSentEvent::class, TalkV1MessageSentListener::class);

--- a/lib/Federation/BackendNotifier.php
+++ b/lib/Federation/BackendNotifier.php
@@ -241,6 +241,44 @@ class BackendNotifier {
 	}
 
 	/**
+	 * Send information to remote participants that the lobby was updated
+	 * Sent from Host server to Remote participant server
+	 */
+	public function sendRoomModifiedLobbyUpdate(
+		string $remoteServer,
+		int $localAttendeeId,
+		#[SensitiveParameter]
+		string $accessToken,
+		string $localToken,
+		string $changedProperty,
+		int $newValue,
+		int $oldValue,
+		?\DateTime $dateTime,
+		bool $timerReached,
+	): ?bool {
+		$remote = $this->prepareRemoteUrl($remoteServer);
+
+		$notification = $this->cloudFederationFactory->getCloudFederationNotification();
+		$notification->setMessage(
+			FederationManager::NOTIFICATION_ROOM_MODIFIED,
+			FederationManager::TALK_ROOM_RESOURCE,
+			(string) $localAttendeeId,
+			[
+				'remoteServerUrl' => $this->getServerRemoteUrl(),
+				'sharedSecret' => $accessToken,
+				'remoteToken' => $localToken,
+				'changedProperty' => $changedProperty,
+				'newValue' => $newValue,
+				'oldValue' => $oldValue,
+				'dateTime' => $dateTime ? (string) $dateTime->getTimestamp() : '',
+				'timerReached' => $timerReached,
+			],
+		);
+
+		return $this->sendUpdateToRemote($remote, $notification);
+	}
+
+	/**
 	 * Send information to remote participants that a message was posted
 	 * Sent from Host server to Remote participant server
 	 *

--- a/lib/Federation/CloudFederationProviderTalk.php
+++ b/lib/Federation/CloudFederationProviderTalk.php
@@ -288,7 +288,7 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 
 	/**
 	 * @param int $remoteAttendeeId
-	 * @param array{remoteServerUrl: string, sharedSecret: string, remoteToken: string, changedProperty: string, newValue: string|int|bool|null, oldValue: string|int|bool|null} $notification
+	 * @param array{remoteServerUrl: string, sharedSecret: string, remoteToken: string, changedProperty: string, newValue: string|int|bool|null, oldValue: string|int|bool|null, dateTime?: string, timerReached?: bool} $notification
 	 * @return array
 	 * @throws ActionNotSupportedException
 	 * @throws AuthenticationFailedException
@@ -311,6 +311,9 @@ class CloudFederationProviderTalk implements ICloudFederationProvider {
 			$this->roomService->setAvatar($room, $notification['newValue']);
 		} elseif ($notification['changedProperty'] === ARoomModifiedEvent::PROPERTY_DESCRIPTION) {
 			$this->roomService->setDescription($room, $notification['newValue']);
+		} elseif ($notification['changedProperty'] === ARoomModifiedEvent::PROPERTY_LOBBY) {
+			$dateTime = !empty($notification['dateTime']) ? \DateTime::createFromFormat('U', $notification['dateTime']) : null;
+			$this->roomService->setLobby($room, $notification['newValue'], $dateTime, $notification['timerReached'] ?? false);
 		} elseif ($notification['changedProperty'] === ARoomModifiedEvent::PROPERTY_NAME) {
 			$this->roomService->setName($room, $notification['newValue'], $notification['oldValue']);
 		} elseif ($notification['changedProperty'] === ARoomModifiedEvent::PROPERTY_READ_ONLY) {

--- a/lib/Federation/Proxy/TalkV1/Notifier/RoomModifiedListener.php
+++ b/lib/Federation/Proxy/TalkV1/Notifier/RoomModifiedListener.php
@@ -9,13 +9,17 @@ declare(strict_types=1);
 namespace OCA\Talk\Federation\Proxy\TalkV1\Notifier;
 
 use OCA\Talk\Events\AAttendeeRemovedEvent;
+use OCA\Talk\Events\ALobbyModifiedEvent;
 use OCA\Talk\Events\ARoomModifiedEvent;
+use OCA\Talk\Events\LobbyModifiedEvent;
 use OCA\Talk\Events\RoomModifiedEvent;
 use OCA\Talk\Federation\BackendNotifier;
 use OCA\Talk\Model\Attendee;
+use OCA\Talk\Participant;
 use OCA\Talk\Service\ParticipantService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\Federation\ICloudId;
 use OCP\Federation\ICloudIdManager;
 
 /**
@@ -30,13 +34,15 @@ class RoomModifiedListener implements IEventListener {
 	}
 
 	public function handle(Event $event): void {
-		if (!$event instanceof RoomModifiedEvent) {
+		if (!$event instanceof LobbyModifiedEvent
+				&& !$event instanceof RoomModifiedEvent) {
 			return;
 		}
 
 		if (!in_array($event->getProperty(), [
 			ARoomModifiedEvent::PROPERTY_AVATAR,
 			ARoomModifiedEvent::PROPERTY_DESCRIPTION,
+			ARoomModifiedEvent::PROPERTY_LOBBY,
 			ARoomModifiedEvent::PROPERTY_NAME,
 			ARoomModifiedEvent::PROPERTY_READ_ONLY,
 			ARoomModifiedEvent::PROPERTY_TYPE,
@@ -48,19 +54,41 @@ class RoomModifiedListener implements IEventListener {
 		foreach ($participants as $participant) {
 			$cloudId = $this->cloudIdManager->resolveCloudId($participant->getAttendee()->getActorId());
 
-			$success = $this->backendNotifier->sendRoomModifiedUpdate(
-				$cloudId->getRemote(),
-				$participant->getAttendee()->getId(),
-				$participant->getAttendee()->getAccessToken(),
-				$event->getRoom()->getToken(),
-				$event->getProperty(),
-				$event->getNewValue(),
-				$event->getOldValue(),
-			);
+			if ($event instanceof ALobbyModifiedEvent) {
+				$success = $this->notifyLobbyModified($cloudId, $participant, $event);
+			} else {
+				$success = $this->notifyRoomModified($cloudId, $participant, $event);
+			}
 
 			if ($success === null) {
 				$this->participantService->removeAttendee($event->getRoom(), $participant, AAttendeeRemovedEvent::REASON_LEFT);
 			}
 		}
+	}
+
+	private function notifyLobbyModified(ICloudId $cloudId, Participant $participant, ALobbyModifiedEvent $event) {
+		return $this->backendNotifier->sendRoomModifiedLobbyUpdate(
+			$cloudId->getRemote(),
+			$participant->getAttendee()->getId(),
+			$participant->getAttendee()->getAccessToken(),
+			$event->getRoom()->getToken(),
+			$event->getProperty(),
+			$event->getNewValue(),
+			$event->getOldValue(),
+			$event->getLobbyTimer(),
+			$event->isTimerReached(),
+		);
+	}
+
+	private function notifyRoomModified(ICloudId $cloudId, Participant $participant, ARoomModifiedEvent $event) {
+		return $this->backendNotifier->sendRoomModifiedUpdate(
+			$cloudId->getRemote(),
+			$participant->getAttendee()->getId(),
+			$participant->getAttendee()->getAccessToken(),
+			$event->getRoom()->getToken(),
+			$event->getProperty(),
+			$event->getNewValue(),
+			$event->getOldValue(),
+		);
 	}
 }

--- a/tests/integration/features/federation/lobby.feature
+++ b/tests/integration/features/federation/lobby.feature
@@ -1,0 +1,43 @@
+Feature: federation/lobby
+
+  Background:
+    Given user "participant1" exists
+    And user "participant2" exists
+    And the following "spreed" app config is set
+      | federation_enabled | yes |
+
+  Scenario: set lobby state
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room name |
+    And user "participant1" adds federated_user "participant2" to room "room" with 200 (v4)
+    And user "participant2" has the following invitations (v1)
+      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
+      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
+    And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room name | 2    | LOCAL        | room        |
+    When user "participant1" sets lobby state for room "room" to "non moderators" with 200 (v4)
+    Then user "participant2" is participant of room "LOCAL::room" (v4)
+      | lobbyState |
+      | 1          |
+
+  Scenario: reset lobby state
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 2 |
+      | roomName | room |
+    And user "participant1" adds federated_user "participant2" to room "room" with 200 (v4)
+    And user "participant2" has the following invitations (v1)
+      | remoteServerUrl | remoteToken | state | inviterCloudId                     | inviterDisplayName       |
+      | LOCAL           | room        | 0     | participant1@http://localhost:8080 | participant1-displayname |
+    And user "participant2" accepts invite to room "room" of server "LOCAL" with 200 (v1)
+      | id          | name | type | remoteServer | remoteToken |
+      | LOCAL::room | room | 2    | LOCAL        | room        |
+    When user "participant1" sets lobby state for room "room" to "non moderators" for 5 seconds with 200 (v4)
+    And user "participant2" is participant of room "LOCAL::room" (v4)
+      | lobbyState |
+      | 1          |
+    And wait for 10 second
+    Then user "participant2" is participant of room "LOCAL::room" (v4)
+      | lobbyState |
+      | 0          |


### PR DESCRIPTION
Should this be backported to _stable29_? I guess that mobile clients will properly show the lobby if the proxy conversation has the parameter set, but I have not tested it.

## How to test
- Create a conversation
- Add a federated user
- In a private window, log in as the federated user
- Accept the invitation
- In the original window, enable lobby
- In the private window, open the conversation

### Result with this pull request

The lobby is shown

### Result without this pull request

The conversation never ends to load