### PR TITLE
fix(AdminSettings): hide secrets in password fields

### DIFF
--- a/src/components/AdminSettings/RecordingServers.vue
+++ b/src/components/AdminSettings/RecordingServers.vue
@@ -40,9 +40,10 @@
 			{{ t('spreed', 'Add a new recording backend server') }}
 		</NcButton>
 
-		<NcTextField class="form__textfield additional-top-margin"
+		<NcPasswordField class="form__textfield additional-top-margin"
 			:value="secret"
 			name="recording_secret"
+			autocomplete="new-password"
 			:disabled="loading"
 			:placeholder="t('spreed', 'Shared secret')"
 			:label="t('spreed', 'Shared secret')"
@@ -84,7 +85,7 @@ import { t } from '@nextcloud/l10n'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
-import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
+import NcPasswordField from '@nextcloud/vue/dist/Components/NcPasswordField.js'
 
 import RecordingServer from '../../components/AdminSettings/RecordingServer.vue'
 import TransitionWrapper from '../UIShared/TransitionWrapper.vue'
@@ -106,7 +107,7 @@ export default {
 		NcButton,
 		NcCheckboxRadioSwitch,
 		NcNoteCard,
-		NcTextField,
+		NcPasswordField,
 		Plus,
 		RecordingServer,
 		TransitionWrapper,

--- a/src/components/AdminSettings/SIPBridge.vue
+++ b/src/components/AdminSettings/SIPBridge.vue
@@ -45,9 +45,11 @@
 			<label for="sip-shared-secret" class="form__label additional-top-margin">
 				{{ t('spreed', 'Shared secret') }}
 			</label>
-			<NcTextField id="sip-shared-secret"
+			<NcPasswordField id="sip-shared-secret"
 				:value.sync="sharedSecret"
 				class="form"
+				name="sip-shared-secret"
+				autocomplete="new-password"
 				:disabled="loading"
 				:placeholder="t('spreed', 'Shared secret')"
 				label-outside />
@@ -88,9 +90,9 @@ import { generateOcsUrl } from '@nextcloud/router'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
+import NcPasswordField from '@nextcloud/vue/dist/Components/NcPasswordField.js'
 import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
 import NcTextArea from '@nextcloud/vue/dist/Components/NcTextArea.js'
-import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 
 import { setSIPSettings } from '../../services/settingsService.js'
 import { getWelcomeMessage } from '../../services/signalingService.js'
@@ -104,7 +106,7 @@ export default {
 		NcNoteCard,
 		NcSelect,
 		NcTextArea,
-		NcTextField,
+		NcPasswordField,
 	},
 
 	data() {

--- a/src/components/AdminSettings/SignalingServers.vue
+++ b/src/components/AdminSettings/SignalingServers.vue
@@ -54,9 +54,10 @@
 			</NcCheckboxRadioSwitch>
 		</template>
 
-		<NcTextField class="form__textfield additional-top-margin"
+		<NcPasswordField class="form__textfield additional-top-margin"
 			:value="secret"
 			name="signaling_secret"
+			autocomplete="new-password"
 			:disabled="loading"
 			:placeholder="t('spreed', 'Shared secret')"
 			:label="t('spreed', 'Shared secret')"
@@ -77,7 +78,7 @@ import { t } from '@nextcloud/l10n'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
-import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
+import NcPasswordField from '@nextcloud/vue/dist/Components/NcPasswordField.js'
 
 import SignalingServer from '../../components/AdminSettings/SignalingServer.vue'
 import TransitionWrapper from '../UIShared/TransitionWrapper.vue'
@@ -91,7 +92,7 @@ export default {
 		NcButton,
 		NcCheckboxRadioSwitch,
 		NcNoteCard,
-		NcTextField,
+		NcPasswordField,
 		Plus,
 		SignalingServer,
 		TransitionWrapper,

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -29,8 +29,9 @@
 			:label="t('spreed', 'TURN server URL')"
 			@update:value="updateServer" />
 
-		<NcTextField ref="turn_secret"
+		<NcPasswordField ref="turn_secret"
 			name="turn_secret"
+			autocomplete="new-password"
 			placeholder="secret"
 			class="turn-server__textfield"
 			:value="secret"
@@ -87,6 +88,7 @@ import Pulse from 'vue-material-design-icons/Pulse.vue'
 import { t } from '@nextcloud/l10n'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcPasswordField from '@nextcloud/vue/dist/Components/NcPasswordField.js'
 import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
@@ -107,6 +109,7 @@ export default {
 		NcButton,
 		NcSelect,
 		NcTextField,
+		NcPasswordField,
 		Pulse,
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* A part of: https://github.com/nextcloud/spreed/issues/12800

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/32d72136-7aba-4355-9e1f-d4065a4c211c) | ![image](https://github.com/user-attachments/assets/72f8fc14-55e3-4bb2-b4ce-6c4a5314b532)
. | ![image](https://github.com/user-attachments/assets/8e21a49a-ebf2-4e57-8498-637c5872beec)
. | ![image](https://github.com/user-attachments/assets/40a7e5d4-da07-4a7c-9d8e-d71692489e11)
. | ![image](https://github.com/user-attachments/assets/26b5f021-7a85-47d9-ba3b-b653253d6322)

### 🚧 Tasks

- [x] Replace Text fields with password fields for shared secrets
- [x] Add `autocomplete="new-password"` to not save the password
  - Completely disable is not possible with `type="password"`, forced by web-browsers
- [x] Add names just in case, so browsers and tools may know these are not user passwords and are different values

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required