### PR TITLE
fix(AdminSettings): server buttons visual interactivity

### DIFF
--- a/src/components/AdminSettings/RecordingServer.vue
+++ b/src/components/AdminSettings/RecordingServer.vue
@@ -22,7 +22,7 @@
 		</NcCheckboxRadioSwitch>
 
 		<NcButton v-show="!loading"
-			type="tertiary-no-background"
+			type="tertiary"
 			:aria-label="t('spreed', 'Delete this server')"
 			@click="removeServer">
 			<template #icon>

--- a/src/components/AdminSettings/SignalingServer.vue
+++ b/src/components/AdminSettings/SignalingServer.vue
@@ -21,7 +21,7 @@
 		</NcCheckboxRadioSwitch>
 
 		<NcButton v-show="!loading"
-			type="tertiary-no-background"
+			type="tertiary"
 			:aria-label="t('spreed', 'Delete this server')"
 			@click="removeServer">
 			<template #icon>

--- a/src/components/AdminSettings/StunServer.vue
+++ b/src/components/AdminSettings/StunServer.vue
@@ -27,7 +27,7 @@
 			fill-color="#E9322D" />
 
 		<NcButton v-show="!loading"
-			type="tertiary-no-background"
+			type="tertiary"
 			:aria-label="t('spreed', 'Delete this server')"
 			@click="removeServer">
 			<template #icon>
@@ -111,6 +111,7 @@ export default {
 	display: flex;
 	align-items: center;
 	margin-bottom: calc(var(--default-grid-baseline) * 2);
+	gap: var(--default-grid-baseline);
 
 	&__wrapper {
 		display: flex;

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -387,6 +387,7 @@ export default {
 	display: grid;
 	grid-template-columns: minmax(100px, 180px) 1fr 1fr minmax(100px, 180px) var(--default-clickable-area) var(--default-clickable-area);
 	grid-column-gap: 4px;
+	align-items: center;
 	margin-bottom: 4px;
 
 	& &__textfield {

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -53,7 +53,7 @@
 			@input="updateProtocols" />
 
 		<NcButton v-show="!loading"
-			type="tertiary-no-background"
+			type="tertiary"
 			:aria-label="testResult"
 			@click="testServer">
 			<template #icon>
@@ -64,7 +64,7 @@
 			</template>
 		</NcButton>
 		<NcButton v-show="!loading"
-			type="tertiary-no-background"
+			type="tertiary"
 			:aria-label="t('spreed', 'Delete this server')"
 			@click="removeServer">
 			<template #icon>

--- a/src/components/AdminSettings/TurnServer.vue
+++ b/src/components/AdminSettings/TurnServer.vue
@@ -55,6 +55,7 @@
 		<NcButton v-show="!loading"
 			type="tertiary"
 			:aria-label="testResult"
+			:disabled="!testAvailable"
 			@click="testServer">
 			<template #icon>
 				<span v-if="testing" class="icon icon-loading-small" />
@@ -196,6 +197,11 @@ export default {
 			}
 			return t('spreed', 'Test this server')
 		},
+		testAvailable() {
+			const schemes = this.schemes.split(',')
+			const protocols = this.protocols.split(',')
+			return !!(schemes.length && this.server && this.secret && protocols.length)
+		},
 	},
 
 	mounted() {
@@ -212,15 +218,16 @@ export default {
 	methods: {
 		t,
 		testServer() {
-			this.testing = true
 			this.testingError = false
 			this.testingSuccess = false
 
 			const schemes = this.schemes.split(',')
 			const protocols = this.protocols.split(',')
-			if (!schemes.length || !this.server || !this.secret || !protocols.length) {
+			if (!this.testAvailable) {
 				return
 			}
+
+			this.testing = true
 
 			const urls = []
 			for (let i = 0; i < schemes.length; i++) {


### PR DESCRIPTION
### ☑️ Resolves

* A part of: https://github.com/nextcloud/spreed/issues/12800

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![before](https://github.com/user-attachments/assets/990b2165-b73d-4ada-8300-04a38ae455e2) | ![after](https://github.com/user-attachments/assets/2f1663cc-d888-471c-b679-95227cab599c)

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [x] Replace `tertiary-no-background` -> `tertiary`
  - Recording server - delete
  - Signaling server - delete
  - STUN server - delete (+ add a missing gap here)
  - TURN server - delete + test. 
- [x] Prevent infinite loading in TURN server testing
  - Don't switch to "testing" (loading) state if testing is not happening
    ![image](https://github.com/user-attachments/assets/6dd9cfeb-d6c8-4542-91b7-8ffaf61a3744)
  - Disable the testing button when testing is not possible
    ![image](https://github.com/user-attachments/assets/c3ae3dc5-30e9-4118-945b-2e895795b1ae)
- [x] Align turn settings on center to avoid button stretch
  Before | After
  ---|---  
  ![image](https://github.com/user-attachments/assets/207b44ee-b345-4bb4-a29b-c31f2db7cc59) | ![image](https://github.com/user-attachments/assets/65d810fe-38f8-41bc-931c-e529bef25d30)


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required