### PR TITLE
fix(Quote): prevent button click event from propagation

### DIFF
--- a/src/components/Quote.vue
+++ b/src/components/Quote.vue
@@ -9,7 +9,8 @@ components.
 </docs>
 
 <template>
-	<router-link :to="{ hash, params: { skipLeaveWarning: true } }"
+	<component :is="component.tag"
+		:to="component.link"
 		class="quote"
 		:class="{'quote-own-message': isOwnMessageQuoted}"
 		@click.native="handleQuoteClick">
@@ -45,13 +46,14 @@ components.
 		<NcButton v-if="canCancel"
 			class="quote__close"
 			type="tertiary"
+			:title="cancelQuoteLabel"
 			:aria-label="cancelQuoteLabel"
 			@click="handleAbort">
 			<template #icon>
 				<Close :size="20" />
 			</template>
 		</NcButton>
-	</router-link>
+	</component>
 </template>
 
 <script>
@@ -127,6 +129,12 @@ export default {
 	},
 
 	computed: {
+		component() {
+			return this.canCancel
+				? { tag: 'div', link: undefined }
+				: { tag: 'router-link', link: { hash: this.hash, params: { skipLeaveWarning: true } } }
+		},
+
 		isOwnMessageQuoted() {
 			return this.message.actorId === this.$store.getters.getActorId()
 				&& this.message.actorType === this.$store.getters.getActorType()
@@ -215,6 +223,10 @@ export default {
 		},
 
 		handleQuoteClick() {
+			if (this.canCancel) {
+				return
+			}
+
 			if (this.$route.hash === this.hash) {
 				// Already on this message route, just trigger highlight
 				EventBus.emit('focus-message', this.message.id)


### PR DESCRIPTION
### ☑️ Resolves

* Follow up to #12651
* button is wrapped in `<a>` link, so bubbling click event doesn't get captured by router-link, and causes watning dialog to be shown (my humble assumption)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/b0bc77e9-9aec-40f4-970e-613d7033b870) | See URL hash is unchanged


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] ⛑️ Tests are included or not possible