### PR TITLE
fix(public share): make trigger button color contrast to background

### DIFF
--- a/src/PublicShareSidebarTrigger.vue
+++ b/src/PublicShareSidebarTrigger.vue
@@ -10,7 +10,7 @@
 			:aria-label="ariaLabel"
 			@click="$emit('click')">
 			<template #icon>
-				<MessageText :size="20" />
+				<MessageText fill-color="var(--color-background-plain-text)" :size="20" />
 			</template>
 		</NcButton>
 	</div>


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12132
* I'm surprised it works with MDI icons

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/7a8191bf-7b28-4869-87e4-e013bb65e8b9) | ![image](https://github.com/user-attachments/assets/148fbc5c-e8ff-4db1-8489-00a2a80bc11c)

☀️ Light theme | 🌑 Dark Theme
-- | --
![image](https://github.com/user-attachments/assets/148fbc5c-e8ff-4db1-8489-00a2a80bc11c) | ![image](https://github.com/user-attachments/assets/a6f4c514-5b2b-488d-b01f-278a068f9b27)


### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required