### PR TITLE
fix(MediaSettings): remove PiP and increase mirror toggle margin

### DIFF
--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -719,8 +719,8 @@ export default {
 
 	&__preview > &__preview-mirror {
 		position: absolute;
-		top: var(--default-grid-baseline);
-		right: var(--default-grid-baseline);
+		top: calc(var(--default-grid-baseline) * 2);
+		right: calc(var(--default-grid-baseline) * 2);
 	}
 
 	&__toggles {

--- a/src/components/MediaSettings/MediaSettings.vue
+++ b/src/components/MediaSettings/MediaSettings.vue
@@ -16,7 +16,7 @@
 				<video v-show="showVideo"
 					ref="video"
 					:class="['preview__video', {'preview__video--mirrored': isMirrored}]"
-					disable-picture-in-picture="true"
+					disablePictureInPicture
 					tabindex="-1" />
 				<NcButton v-if="showVideo"
 					type="secondary"


### PR DESCRIPTION
### ☑️ Resolves

* Minor UI changes:
  * Remove Picture-In-Picture
    * It must be exactly `disablePictureInPicture`, it cannot be `disable-picture-in-picture`
  * Use base * 2 padding for the toggle button
    * Inline with other paddings on the modal

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/9fdf4ada-fce1-49ae-a4be-8d6c1900fd43) | ![image](https://github.com/user-attachments/assets/0dc3a494-2817-4da3-b2c4-60155021337a)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required