### PR TITLE
fix(AdminSettings): remove PHP template

### DIFF
--- a/css/talk-admin-settings.css
+++ b/css/talk-admin-settings.css
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+.settings-section-placeholder {
+	--settings-section-placeholder-header-height: 30px;
+	--settings-section-placeholder-line-height: var(--default-line-height);
+	--settings-section-placeholder-padding: 1em;
+	--settings-section-placeholder-image: linear-gradient(90deg, var(--color-placeholder-light) 65%, var(--color-placeholder-dark) 70%, var(--color-placeholder-light) 75%);
+	position: relative;
+	height: calc(2 * (7 * var(--default-grid-baseline)) + var(--settings-section-placeholder-header-height) + 3 * (var(--settings-section-placeholder-line-height) + 1em));
+}
+
+.settings-section-placeholder::before,
+.settings-section-placeholder::after {
+	content: '';
+	position: absolute;
+	inset: calc(7 * var(--default-grid-baseline));
+	background-clip: content-box;
+	background-origin: content-box;
+	animation: loading-animation 3s forwards infinite linear;
+}
+
+.settings-section-placeholder::before {
+	max-width: 300px;
+	background: var(--settings-section-placeholder-image) 0 0 / 200vw var(--settings-section-placeholder-header-height) repeat-x content-box;
+}
+
+.settings-section-placeholder::after {
+	max-width: 900px;
+	background: 
+		var(--settings-section-placeholder-image) 0 calc(var(--settings-section-placeholder-header-height) + 1em + 0 * (var(--settings-section-placeholder-line-height) + 1em)) / 200vw var(--settings-section-placeholder-line-height) repeat-x content-box,
+		var(--settings-section-placeholder-image) 0 calc(var(--settings-section-placeholder-header-height) + 1em + 1 * (var(--settings-section-placeholder-line-height) + 1em)) / 200vw var(--settings-section-placeholder-line-height) repeat-x content-box,
+		var(--settings-section-placeholder-image) 0 calc(var(--settings-section-placeholder-header-height) + 1em + 2 * (var(--settings-section-placeholder-line-height) + 1em)) / 200vw var(--settings-section-placeholder-line-height) repeat-x content-box;
+}
+
+.settings-section-placeholder + .settings-section-placeholder {
+	border-top: 1px solid var(--color-border);
+}
+
+@keyframes loading-animation {
+	0% {
+		background-position-x: 0;
+	}
+	100% {
+		background-position-x: 140vw;
+	}
+}

--- a/lib/Settings/Admin/AdminSettings.php
+++ b/lib/Settings/Admin/AdminSettings.php
@@ -62,6 +62,7 @@ class AdminSettings implements ISettings {
 
 
 		Util::addScript('spreed', 'talk-admin-settings');
+		Util::addStyle('spreed', 'talk-admin-settings');
 
 		return new TemplateResponse('spreed', 'settings/admin-settings', [], '');
 	}

--- a/templates/settings/admin-settings.php
+++ b/templates/settings/admin-settings.php
@@ -10,45 +10,16 @@ declare(strict_types=1);
 ?>
 
 <div id="admin_settings">
-	<div class="videocalls section" id="general_settings">
-		<h2><?php p($l->t('General settings')) ?></h2>
-	</div>
-
-	<div class="videocalls section" id="allowed_groups">
-		<h2><?php p($l->t('Limit to groups')) ?></h2>
-		<p class="settings-hint"><?php p($l->t('When at least one group is selected, only people of the listed groups can be part of conversations.')); ?></p>
-		<p class="settings-hint"><?php p($l->t('Guests can still join public conversations.')); ?></p>
-		<p class="settings-hint"><?php p($l->t('Users that cannot use Talk anymore will still be listed as participants in their previous conversations and also their chat messages will be kept.')); ?></p>
-	</div>
-
-	<div id="stun_server" class="videocalls section">
-		<h2><?php p($l->t('STUN servers')) ?></h2>
-		<p class="settings-hint"><?php p($l->t('A STUN server is used to determine the public IP address of participants behind a router.')); ?></p>
-
-		<div class="stun-servers">
-		</div>
-	</div>
-
-	<div id="turn_server" class="videocalls section">
-		<h2><?php p($l->t('TURN server')) ?></h2>
-		<p class="settings-hint"><?php p($l->t('The TURN server is used to proxy the traffic from participants behind a firewall.')); ?></p>
-
-		<div class="turn-servers">
-		</div>
-	</div>
-
-	<div id="signaling_server" class="videocalls section">
-		<h2><?php p($l->t('Signaling servers')) ?></h2>
-		<p class="settings-hint"><?php p($l->t('An external signaling server can optionally be used for larger installations. Leave empty to use the internal signaling server.')) ?></p>
-
-		<div class="signaling-servers">
-		</div>
-
-		<div class="signaling-secret">
-			<h4><?php p($l->t('Shared secret')) ?></h4>
-			<input type="text" id="signaling_secret"
-				   name="signaling_secret" placeholder="<?php p($l->t('Shared secret')) ?>" aria-label="<?php p($l->t('Shared secret')) ?>"/>
-		</div>
-	</div>
-
+	<div class="settings-section-placeholder"></div>
+	<div class="settings-section-placeholder"></div>
+	<div class="settings-section-placeholder"></div>
+	<div class="settings-section-placeholder"></div>
+	<div class="settings-section-placeholder"></div>
+	<div class="settings-section-placeholder"></div>
+	<div class="settings-section-placeholder"></div>
+	<div class="settings-section-placeholder"></div>
+	<div class="settings-section-placeholder"></div>
+	<div class="settings-section-placeholder"></div>
+	<div class="settings-section-placeholder"></div>
+	<div class="settings-section-placeholder"></div>
 </div>


### PR DESCRIPTION
### ☑️ Resolves

* Likely from legacy, during admin settings loading, half of the settings are half-loaded
* On slow connection it feels weird because the settings are unusable
* On fast connection it looks like a layout shift glitch

Replaced with a placeholder

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/6cb62020-db0f-48ef-b89a-8e3575291ab5) | ![image](https://github.com/user-attachments/assets/ef395c4d-e1d1-45b7-a60f-12e34b234ad1)
![before-admin-settings-load](https://github.com/user-attachments/assets/692d5607-8872-4cbe-8c14-8240fb544941) | ![after-admin-settings-load](https://github.com/user-attachments/assets/ddea722c-9280-4ebc-bb10-0f70b3af2be6)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required