### PR TITLE
feat(RightSidebar): enforce tab navigation, show chat description in sidebar

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -12,6 +12,7 @@
 		:class="'active-tab-' + activeTab"
 		:toggle-classes="{ 'chat-button-sidebar-toggle': isInCall }"
 		:toggle-attrs="isInCall ? inCallToggleAttrs : undefined"
+		force-tabs
 		@update:open="handleUpdateOpen"
 		@update:active="handleUpdateActive"
 		@closed="handleClosed"
@@ -27,6 +28,12 @@
 			</NcCounterBubble>
 		</template>
 		<template #description>
+			<NcRichText v-if="conversation.description"
+				class="rich-text-description"
+				:text="conversation.description"
+				dir="auto"
+				autolink
+				use-extended-markdown />
 			<LobbyStatus v-if="canFullModerate && hasLobbyEnabled" :token="token" />
 		</template>
 		<NcAppSidebarTab v-if="isInCall"
@@ -119,6 +126,7 @@ import NcAppSidebar from '@nextcloud/vue/dist/Components/NcAppSidebar.js'
 import NcAppSidebarTab from '@nextcloud/vue/dist/Components/NcAppSidebarTab.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcCounterBubble from '@nextcloud/vue/dist/Components/NcCounterBubble.js'
+import NcRichText from '@nextcloud/vue/dist/Components/NcRichText.js'
 
 import BreakoutRoomsTab from './BreakoutRooms/BreakoutRoomsTab.vue'
 import LobbyStatus from './LobbyStatus.vue'
@@ -142,6 +150,7 @@ export default {
 		NcAppSidebarTab,
 		NcButton,
 		NcCounterBubble,
+		NcRichText,
 		ParticipantsTab,
 		SetGuestUsername,
 		SharedItemsTab,
@@ -450,7 +459,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-
+@import '../../assets/markdown';
 /* Override style set in server for "#app-sidebar" to match the style set in
  * nextcloud-vue for ".app-sidebar". */
 #app-sidebar {
@@ -483,6 +492,14 @@ export default {
 	/* Remove padding to maximize the space for the chat view. */
 	padding: 0;
 	height: 100%;
+}
+
+:deep(.app-sidebar-header__description) {
+	.rich-text-description {
+		width: 100%;
+		text-align: start;
+		@include markdown;
+	}
 }
 
 .chat-button-unread-messages-counter {

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -17,30 +17,14 @@
 		<!-- conversation header -->
 		<a role="button"
 			class="conversation-header"
+			:class="{ 'conversation-header--offline': isPeerInactive }"
 			@click="openConversationSettings">
-			<div class="conversation-header__text"
-				:class="{'conversation-header__text--offline': isPeerInactive}">
-				<p class="title">
-					{{ conversation.displayName }}
-				</p>
-				<p v-if="showUserStatusAsDescription"
-					class="description"
-					:class="{'description__in-chat' : !isInCall }">
-					{{ statusMessage }}
-				</p>
-				<template v-if="conversation.description">
-					<p v-tooltip.bottom="{
-							content: renderedDescription,
-							delay: { show: 500, hide: 500 },
-							autoHide: false,
-							html: true,
-						}"
-						class="description"
-						:class="{'description__in-chat' : !isInCall }">
-						{{ conversation.description }}
-					</p>
-				</template>
-			</div>
+			<span class="conversation-header__name">
+				{{ conversation.displayName }}
+			</span>
+			<span v-if="showUserStatus" class="conversation-header__status">
+				{{ statusMessage }}
+			</span>
 		</a>
 
 		<!-- Call time -->
@@ -190,16 +174,12 @@ export default {
 			return this.$store.getters.conversation(this.token) || this.$store.getters.dummyConversation
 		},
 
-		showUserStatusAsDescription() {
+		showUserStatus() {
 			return this.isOneToOneConversation && this.statusMessage
 		},
 
 		statusMessage() {
 			return getStatusMessage(this.conversation)
-		},
-
-		renderedDescription() {
-			return this.renderContent(this.conversation.description)
 		},
 
 		/**
@@ -332,38 +312,31 @@ export default {
 .conversation-header {
 	position: relative;
 	display: flex;
+	margin: 0 calc(2 * var(--default-grid-baseline));
 	overflow-x: hidden;
 	overflow-y: clip;
 	white-space: nowrap;
-	width: 0;
+	align-self: center;
 	flex-grow: 1;
+	text-overflow: ellipsis;
+	line-height: var(--default-line-height);
 	cursor: pointer;
-	&__text {
-		display: flex;
-		flex-direction:column;
-		flex-grow: 1;
-		margin-left: 8px;
-		justify-content: center;
-		width: 100%;
-		overflow: hidden;
-		min-height: var(--default-clickable-area);
-		line-height: calc(var(--default-clickable-area) / 2);
-		&--offline {
-			color: var(--color-text-maxcontrast);
-		}
+
+	&--offline {
+		color: var(--color-text-maxcontrast);
 	}
-	.title {
+
+	&__name {
+		flex-shrink: 0;
+		padding-inline: var(--default-grid-baseline);
 		font-weight: bold;
 		overflow: hidden;
-		text-overflow: ellipsis;
 	}
-	.description {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		max-width: fit-content;
-		&__in-chat {
-			color: var(--color-text-maxcontrast);
-		}
+
+	&__status {
+		padding-inline: var(--default-grid-baseline);
+		border-left: 1px solid var(--color-border-maxcontrast);
+		color: var(--color-text-maxcontrast);
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

* Ref #12800
* Follow-up of discussion in https://github.com/nextcloud/spreed/pull/12810#discussion_r1691396919


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
Group chat | --
![image](https://github.com/user-attachments/assets/a27d6e49-4190-4b24-b1da-f857ce6be7d1) | ![image](https://github.com/user-attachments/assets/6203fa34-9a8b-47fa-848a-d9ba275ea207)
![image](https://github.com/user-attachments/assets/240fca0e-f1a0-4a71-a7ca-4fe6cd933ba5) | ![image](https://github.com/user-attachments/assets/c2c59ab1-f0ac-4332-842a-0d924593089f)
Federated chat | --
![image](https://github.com/user-attachments/assets/1ba151f6-6691-4942-864b-2bd5d9679153) | ![image](https://github.com/user-attachments/assets/404ba10a-7daf-4f08-8f00-24eeb37475e1)
![image](https://github.com/user-attachments/assets/b2bc4225-a297-4cc8-8584-11d1ba048e39) | ![image](https://github.com/user-attachments/assets/6de41342-42fd-4137-b403-6a4143fb663e)
1-1 chat | --
![image](https://github.com/user-attachments/assets/7e3bc785-7d1c-4c11-ab42-eaceee21e8b8) | ![image](https://github.com/user-attachments/assets/7d9b6509-872d-45de-a78f-73ddf570eb01)
![image](https://github.com/user-attachments/assets/bc4f546a-93d6-42d0-b248-1a2a439ef7ab) | ![image](https://github.com/user-attachments/assets/daccc4d2-a665-4c49-89ed-9bf165bb3d81)

<!-- ☀️ Light theme | 🌑 Dark Theme -->

### 🚧 Tasks

- [x] Top bar title is cut off - keep it one line only

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
