### PR TITLE
fix(Reactions): integrate reactions into grid CSS layout

### DIFF
--- a/src/components/MessagesList/MessagesGroup/Message/Message.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/Message.vue
@@ -24,15 +24,15 @@
 				:is-deleting="isDeleting"
 				:has-call="conversation.hasCall"
 				:message="message"
-				:read-info="readInfo" />
-
-			<!-- reactions buttons and popover with details -->
-			<Reactions v-if="Object.keys(message.reactions).length"
-				:id="message.id"
-				:token="message.token"
-				:can-react="canReact"
-				:show-controls="isHovered || isFollowUpEmojiPickerOpen"
-				@emoji-picker-toggled="toggleFollowUpEmojiPicker" />
+				:read-info="readInfo">
+				<!-- reactions buttons and popover with details -->
+				<Reactions v-if="Object.keys(message.reactions).length"
+					:id="message.id"
+					:token="message.token"
+					:can-react="canReact"
+					:show-controls="isHovered || isFollowUpEmojiPickerOpen"
+					@emoji-picker-toggled="toggleFollowUpEmojiPicker" />
+			</MessageBody>
 		</div>
 
 		<!-- Message actions -->

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/MessageBody.vue
@@ -109,6 +109,9 @@
 				<CheckIcon :size="16" />
 			</div>
 		</div>
+
+		<!-- Reactions slot -->
+		<slot v-if="!isDeletedMessage" />
 	</div>
 </template>
 
@@ -450,6 +453,7 @@ export default {
 .message-main {
 	display: grid;
 	grid-template-columns: minmax(0, $messages-text-max-width) $messages-info-width;
+	grid-row-gap: var(--default-grid-baseline);
 	justify-content: space-between;
 	align-items: flex-start;
 	min-width: 100%;

--- a/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.vue
+++ b/src/components/MessagesList/MessagesGroup/Message/MessagePart/Reactions.vue
@@ -15,7 +15,7 @@
 			@after-show="fetchReactions">
 			<template #trigger>
 				<NcButton :type="userHasReacted(reaction) ? 'primary' : 'secondary'"
-					class="reaction-button"
+					size="small"
 					@click="handleReactionClick(reaction)">
 					{{ reaction }} {{ reactionsCount(reaction) }}
 				</NcButton>
@@ -39,11 +39,12 @@
 
 		<!-- all reactions button -->
 		<NcButton v-if="showControls"
-			class="reaction-button"
+			size="small"
 			:title="t('spreed', 'Show all reactions')"
 			@click="showAllReactions = true">
 			<HeartOutlineIcon :size="15" />
 		</NcButton>
+		<span v-else class="reaction-button--thumbnail" />
 
 		<!-- More reactions picker -->
 		<NcEmojiPicker v-if="canReact && showControls"
@@ -52,7 +53,7 @@
 			@select="handleReactionClick"
 			@after-show="emitEmojiPickerStatus"
 			@after-hide="emitEmojiPickerStatus">
-			<NcButton class="reaction-button"
+			<NcButton size="small"
 				:title="t('spreed', 'Add more reactions')"
 				:aria-label="t('spreed', 'Add more reactions')">
 				<template #icon>
@@ -60,6 +61,7 @@
 				</template>
 			</NcButton>
 		</NcEmojiPicker>
+		<span v-else-if="canReact" class="reaction-button--thumbnail" />
 
 		<!-- all reactions modal-->
 		<ReactionsList v-if="showAllReactions"
@@ -274,19 +276,23 @@ export default {
 </script>
 <style lang="scss" scoped>
 .reactions-wrapper {
+	--minimal-button-width: 48px;
 	display: flex;
 	flex-wrap: wrap;
-	margin: 4px 175px 4px -2px;
-}
-.reaction-button {
-	// Clear server rules
-	min-height: 0 !important;
-	margin: 2px;
-	height: 26px;
-	padding: 0 6px !important;
+	gap: var(--default-grid-baseline);
 
+	// Overwrite NcButton styles
+	:deep(.button-vue) {
+		min-width: var(--minimal-button-width);
+	}
 	:deep(.button-vue__text) {
 		font-weight: normal;
+	}
+
+	.reaction-button--thumbnail {
+		height: var(--clickable-area-small);
+		width: var(--minimal-button-width);
+		pointer-events: none;
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

* Based on top of  #12823 
* make reactions wrapper a part of message grid, so it is aware of available width (date deducted)
* rewrite styles to default 'small' NcButton
* add thumbnails to reserve space for appearing icons (to avoid chat jumping)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After |
-- | -- |
![react-before](https://github.com/user-attachments/assets/e59d29d4-5625-447c-a7bc-47efd16da4b0) | ![react-after](https://github.com/user-attachments/assets/a045df65-8308-4399-a9ac-0b36c3f67136)


### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
