### PR TITLE
fix(tests): Limit notification testing to `app='spreed'`

### DIFF
--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -3653,15 +3653,19 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		);
 
 		$data = $this->getDataFromResponse($this->response);
+		$filteredNotifications = array_filter($data, static fn (array $notification) => $notification['app'] === 'spreed');
+		if (count($data) !== count($filteredNotifications)) {
+			echo 'Notifications were filtered by app=spreed';
+		}
 
 		if ($body === null) {
 			self::$lastNotifications = [];
-			Assert::assertCount(0, $data, json_encode($data, JSON_PRETTY_PRINT));
+			Assert::assertCount(0, $filteredNotifications, json_encode($data, JSON_PRETTY_PRINT));
 			return;
 		}
 
-		$this->assertNotifications($data, $body);
-		self::$lastNotifications = $data;
+		$this->assertNotifications($filteredNotifications, $body);
+		self::$lastNotifications = $filteredNotifications;
 	}
 
 	private function assertNotifications($notifications, TableNode $formData) {


### PR DESCRIPTION
### ☑️ Resolves

* To avoid bugs like https://github.com/nextcloud/circles/pull/1650 ruining our tests

## 🛠️ API Checklist

![Bildschirmfoto vom 2024-07-31 11-01-25](https://github.com/user-attachments/assets/9e97bc26-91de-4eb6-8757-151b0413ecb5)


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not possible
- [x] 📘 API documentation in `docs/` has been updated or is not required
- [x] 🔖 Capability is added or not needed 
