### PR TITLE
fix(openapi): add remote* fields to Room definition

### DIFF
--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -259,6 +259,8 @@ namespace OCA\Talk;
  *     permissions: int,
  *     readOnly: int,
  *     recordingConsent: int,
+ *     remoteServer?: string,
+ *     remoteToken?: string,
  *     sessionId: string,
  *     sipEnabled: int,
  *     status?: string,

--- a/openapi-backend-sipbridge.json
+++ b/openapi-backend-sipbridge.json
@@ -721,6 +721,12 @@
                         "type": "integer",
                         "format": "int64"
                     },
+                    "remoteServer": {
+                        "type": "string"
+                    },
+                    "remoteToken": {
+                        "type": "string"
+                    },
                     "sessionId": {
                         "type": "string"
                     },

--- a/openapi-federation.json
+++ b/openapi-federation.json
@@ -775,6 +775,12 @@
                         "type": "integer",
                         "format": "int64"
                     },
+                    "remoteServer": {
+                        "type": "string"
+                    },
+                    "remoteToken": {
+                        "type": "string"
+                    },
                     "sessionId": {
                         "type": "string"
                     },

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -1283,6 +1283,12 @@
                         "type": "integer",
                         "format": "int64"
                     },
+                    "remoteServer": {
+                        "type": "string"
+                    },
+                    "remoteToken": {
+                        "type": "string"
+                    },
                     "sessionId": {
                         "type": "string"
                     },

--- a/openapi.json
+++ b/openapi.json
@@ -1170,6 +1170,12 @@
                         "type": "integer",
                         "format": "int64"
                     },
+                    "remoteServer": {
+                        "type": "string"
+                    },
+                    "remoteToken": {
+                        "type": "string"
+                    },
                     "sessionId": {
                         "type": "string"
                     },

--- a/src/types/openapi/openapi-backend-sipbridge.ts
+++ b/src/types/openapi/openapi-backend-sipbridge.ts
@@ -314,6 +314,8 @@ export type components = {
             readOnly: number;
             /** Format: int64 */
             recordingConsent: number;
+            remoteServer?: string;
+            remoteToken?: string;
             sessionId: string;
             /** Format: int64 */
             sipEnabled: number;

--- a/src/types/openapi/openapi-federation.ts
+++ b/src/types/openapi/openapi-federation.ts
@@ -361,6 +361,8 @@ export type components = {
             readOnly: number;
             /** Format: int64 */
             recordingConsent: number;
+            remoteServer?: string;
+            remoteToken?: string;
             sessionId: string;
             /** Format: int64 */
             sipEnabled: number;

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -2148,6 +2148,8 @@ export type components = {
             readOnly: number;
             /** Format: int64 */
             recordingConsent: number;
+            remoteServer?: string;
+            remoteToken?: string;
             sessionId: string;
             /** Format: int64 */
             sipEnabled: number;

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1629,6 +1629,8 @@ export type components = {
             readOnly: number;
             /** Format: int64 */
             recordingConsent: number;
+            remoteServer?: string;
+            remoteToken?: string;
             sessionId: string;
             /** Format: int64 */
             sipEnabled: number;


### PR DESCRIPTION
### ☑️ Resolves

* Add two fields in Room schema:
```php
 * @psalm-type TalkRoom = array{
 *     remoteServer?: string,
 *     remoteToken?: string,
 }
 ```

## 🛠️ API Checklist

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
