### PR TITLE
fix(capabilities): store remote capabilities based on remoteServer

### DIFF
--- a/src/__mocks__/capabilities.ts
+++ b/src/__mocks__/capabilities.ts
@@ -79,7 +79,10 @@ export const mockedCapabilities: Capabilities = {
 			'silent-send-state',
 			'chat-read-last',
 			'federation-v1',
+			'federation-v2',
 			'ban-v1',
+			'chat-reference-id',
+			'mention-permissions',
 		],
 		'features-local': [
 			'favorites',
@@ -156,4 +159,9 @@ export const mockedCapabilities: Capabilities = {
 		},
 		version: '20.0.0-dev.0',
 	}
+}
+
+export const mockedRemotes = {
+	'https://nextcloud1.local': { ...mockedCapabilities, hash: 'abc123', tokens: ['TOKEN3FED1'] },
+	'https://nextcloud2.local': { ...mockedCapabilities, hash: 'def123', tokens: ['TOKEN5FED2'] },
 }

--- a/src/components/LeftSidebar/InvitationHandler.vue
+++ b/src/components/LeftSidebar/InvitationHandler.vue
@@ -153,6 +153,8 @@ export default {
 			const conversation = await this.federationStore.acceptShare(id)
 			if (conversation?.token) {
 				this.$store.dispatch('addConversation', conversation)
+				// TODO move cacheConversations to the store action
+				this.$store.dispatch('cacheConversations')
 			}
 			this.checkIfNoMoreInvitations()
 		},

--- a/src/services/CapabilitiesManager.ts
+++ b/src/services/CapabilitiesManager.ts
@@ -40,6 +40,16 @@ function generateTokenMap() {
 }
 
 /**
+ * Patch token map with new / updated remote conversation
+ * @param conversation conversation object from join response
+ */
+function patchTokenMap(conversation: Conversation) {
+	if (conversation.remoteServer) {
+		remoteTokenMap[conversation.token] = conversation.remoteServer
+	}
+}
+
+/**
  * Check whether the feature is presented (in case of federation - on both servers)
  * @param token conversation token
  * @param feature feature capability in string format
@@ -119,6 +129,7 @@ export async function setRemoteCapabilities(joinRoomResponse: JoinRoomFullRespon
 	remoteCapabilities[remoteServer] = { spreed: response.data.ocs.data }
 	remoteCapabilities[remoteServer].hash = joinRoomResponse.headers['x-nextcloud-talk-proxy-hash']
 	BrowserStorage.setItem('remoteCapabilities', JSON.stringify(remoteCapabilities))
+	patchTokenMap(joinRoomResponse.data.ocs.data)
 
 	// As normal capabilities update, requires a reload to take effect
 	showError(t('spreed', 'Nextcloud Talk Federation was updated, please reload the page'), {

--- a/src/services/__tests__/CapabilitiesManager.spec.js
+++ b/src/services/__tests__/CapabilitiesManager.spec.js
@@ -1,0 +1,161 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { createPinia, setActivePinia } from 'pinia'
+
+import { mockedCapabilities, mockedRemotes } from '../../__mocks__/capabilities.ts'
+import { useTalkHashStore } from '../../stores/talkHash.js'
+import { generateOCSResponse } from '../../test-helpers.js'
+import BrowserStorage from '../BrowserStorage.js'
+import {
+	hasTalkFeature,
+	getTalkConfig,
+	setRemoteCapabilities,
+} from '../CapabilitiesManager.ts'
+import { getRemoteCapabilities } from '../federationService.ts'
+
+jest.mock('../BrowserStorage', () => ({
+	getItem: jest.fn(key => {
+		const mockedConversations = [
+			{ token: 'TOKEN1', remoteServer: undefined },
+			{ token: 'TOKEN2', remoteServer: undefined },
+			{ token: 'TOKEN3FED1', remoteServer: 'https://nextcloud1.local' },
+			{ token: 'TOKEN4FED1', remoteServer: 'https://nextcloud1.local' },
+			{ token: 'TOKEN5FED2', remoteServer: 'https://nextcloud2.local' },
+			{ token: 'TOKEN6FED2', remoteServer: 'https://nextcloud2.local' },
+		]
+
+		if (key === 'remoteCapabilities') {
+			return JSON.stringify(mockedRemotes)
+		} else if (key === 'cachedConversations') {
+			return JSON.stringify(mockedConversations)
+		}
+		return null
+	}),
+	setItem: jest.fn(),
+	removeItem: jest.fn(),
+}))
+
+jest.mock('../federationService', () => ({
+	getRemoteCapabilities: jest.fn(),
+}))
+
+describe('CapabilitiesManager', () => {
+	let talkHashStore
+
+	beforeEach(() => {
+		setActivePinia(createPinia())
+		talkHashStore = useTalkHashStore()
+	})
+
+	afterEach(() => {
+		jest.clearAllMocks()
+	})
+
+	describe('hasTalkFeature - local conversation', () => {
+		it('should return false if the feature is not in the capabilities', () => {
+			expect(hasTalkFeature('TOKEN1', 'never-existed')).toBeFalsy()
+		})
+
+		it('should return true if the feature is in the capabilities', () => {
+			expect(hasTalkFeature('TOKEN1', 'federation-v1')).toBeTruthy()
+		})
+
+		it('should return true if the feature is in the local capabilities', () => {
+			expect(hasTalkFeature('local', 'favorites')).toBeTruthy()
+		})
+
+		it('should return true if the feature is in the features-local list', () => {
+			expect(hasTalkFeature('TOKEN1', 'favorites')).toBeTruthy()
+		})
+	})
+
+	describe('hasTalkFeature - remote conversation', () => {
+		it('should return false if the feature is not in the capabilities', () => {
+			expect(hasTalkFeature('TOKEN3FED1', 'never-existed')).toBeFalsy()
+		})
+
+		it('should return true if the feature is in the capabilities', () => {
+			expect(hasTalkFeature('TOKEN3FED1', 'federation-v1')).toBeTruthy()
+		})
+	})
+
+	describe('getTalkConfig - local conversation', () => {
+		it('should return false if the feature is not in the capabilities', () => {
+			expect(getTalkConfig('TOKEN1', 'never', 'existed')).toBeFalsy()
+		})
+
+		it('should return true if the feature is in the capabilities', () => {
+			expect(getTalkConfig('TOKEN1', 'call', 'enabled')).toBeTruthy()
+		})
+
+		it('should return true if the feature is in the local capabilities', () => {
+			expect(getTalkConfig('local', 'call', 'enabled')).toBeTruthy()
+		})
+
+		it('should return true if the feature is in the features-local list', () => {
+			expect(getTalkConfig('TOKEN1', 'attachments', 'allowed')).toBeTruthy()
+		})
+	})
+
+	describe('getTalkConfig - remote conversation', () => {
+		it('should return false if the feature is not in the capabilities', () => {
+			expect(getTalkConfig('TOKEN3FED1', 'never', 'existed')).toBeFalsy()
+		})
+
+		it('should return true if the feature is in the capabilities', () => {
+			expect(getTalkConfig('TOKEN3FED1', 'call', 'enabled')).toBeTruthy()
+		})
+	})
+
+	describe('getRemoteCapability', () => {
+		it('should return true for known remoteServer and unknown token capabilities', () => {
+			expect(hasTalkFeature('TOKEN4FED1', 'ban-v1')).toBeTruthy()
+		})
+		it('should try to regenerate tokenMap for unknown token', () => {
+			hasTalkFeature('TOKEN7FED1', 'ban-v1')
+			expect(BrowserStorage.getItem).toHaveBeenCalledTimes(1) // retry once
+			expect(BrowserStorage.getItem).toHaveBeenCalledWith('cachedConversations')
+		})
+	})
+
+	describe('setRemoteCapability', () => {
+		const [remoteServer, remoteCapabilities] = Object.entries(mockedRemotes)[0]
+		const token = remoteCapabilities.tokens[0]
+
+		it('should early return if proxy hash unchanged', async () => {
+			const joinRoomResponseMock = generateOCSResponse({
+				headers: { 'x-nextcloud-talk-proxy-hash': remoteCapabilities.hash },
+				payload: { token, remoteServer },
+			})
+			await setRemoteCapabilities(joinRoomResponseMock)
+			expect(talkHashStore.isNextcloudTalkProxyHashDirty[token]).toBeUndefined()
+			expect(BrowserStorage.setItem).toHaveBeenCalledTimes(0)
+		})
+
+		it('should early return if no capabilities received from server', async () => {
+			const joinRoomResponseMock = generateOCSResponse({
+				headers: { 'x-nextcloud-talk-proxy-hash': `${remoteCapabilities.hash}001` },
+				payload: { token, remoteServer },
+			})
+			const responseMock = generateOCSResponse({ payload: [] })
+			getRemoteCapabilities.mockReturnValue(responseMock)
+			await setRemoteCapabilities(joinRoomResponseMock)
+			expect(talkHashStore.isNextcloudTalkProxyHashDirty[token]).toBeTruthy()
+			expect(BrowserStorage.setItem).toHaveBeenCalledTimes(0)
+		})
+
+		it('should update capabilities from server response and mark talk proxy hash as dirty', async () => {
+			const joinRoomResponseMock = generateOCSResponse({
+				headers: { 'x-nextcloud-talk-proxy-hash': `${remoteCapabilities.hash}002` },
+				payload: { token, remoteServer }
+			})
+			const responseMock = generateOCSResponse({ payload: mockedCapabilities.spreed })
+			getRemoteCapabilities.mockReturnValue(responseMock)
+			await setRemoteCapabilities(joinRoomResponseMock)
+			expect(talkHashStore.isNextcloudTalkProxyHashDirty[token]).toBeTruthy()
+			expect(BrowserStorage.setItem).toHaveBeenCalledTimes(1)
+		})
+	})
+})


### PR DESCRIPTION
### ☑️ Resolves

* Fix duplicated requests and reloads, if different federated rooms belong to the same remote server

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

Added some logs for visibility:
- for clean storage or new server - works as before, asking to reload the page
- for next, if server matches - update token map, cache new token for future
- in Network - no new requests for 'capabilities'

[Screencast from 31.07.2024 13:50:16.webm](https://github.com/user-attachments/assets/17f8c52c-e07f-433b-a30f-91dc1d6fd5a1)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] ⛑️ Tests are included or not possible