### PR TITLE
Fix avatars in federated calls

### DIFF
--- a/lib/Controller/SignalingController.php
+++ b/lib/Controller/SignalingController.php
@@ -526,6 +526,8 @@ class SignalingController extends OCSController {
 				'sessionId' => $session->getSessionId(),
 				'inCall' => $session->getInCall(),
 				'participantPermissions' => $participant->getPermissions(),
+				'actorType' => $participant->getAttendee()->getActorType(),
+				'actorId' => $participant->getAttendee()->getActorId(),
 			];
 		}
 

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -275,6 +275,8 @@ namespace OCA\Talk;
  * }
  *
  * @psalm-type TalkSignalingSession = array{
+ *     actorId: string,
+ *     actorType: string,
  *     inCall: int,
  *     lastPing: int,
  *     participantPermissions: int,

--- a/lib/Signaling/BackendNotifier.php
+++ b/lib/Signaling/BackendNotifier.php
@@ -336,9 +336,10 @@ class BackendNotifier {
 				'participantType' => $attendee->getParticipantType(),
 				'participantPermissions' => Attendee::PERMISSIONS_CUSTOM,
 				'displayName' => $attendee->getDisplayName(),
+				'actorType' => $attendee->getActorType(),
+				'actorId' => $attendee->getActorId(),
 			];
-			if ($attendee->getActorType() === Attendee::ACTOR_USERS
-					|| $attendee->getActorType() === Attendee::ACTOR_FEDERATED_USERS) {
+			if ($attendee->getActorType() === Attendee::ACTOR_USERS) {
 				$data['userId'] = $attendee->getActorId();
 			}
 
@@ -428,9 +429,10 @@ class BackendNotifier {
 					'nextcloudSessionId' => $session->getSessionId(),
 					'participantType' => $attendee->getParticipantType(),
 					'participantPermissions' => $participant->getPermissions(),
+					'actorType' => $attendee->getActorType(),
+					'actorId' => $attendee->getActorId(),
 				];
-				if ($attendee->getActorType() === Attendee::ACTOR_USERS
-						|| $attendee->getActorType() === Attendee::ACTOR_FEDERATED_USERS) {
+				if ($attendee->getActorType() === Attendee::ACTOR_USERS) {
 					$data['userId'] = $attendee->getActorId();
 				}
 

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -1344,6 +1344,8 @@
             "SignalingSession": {
                 "type": "object",
                 "required": [
+                    "actorId",
+                    "actorType",
                     "inCall",
                     "lastPing",
                     "participantPermissions",
@@ -1352,6 +1354,12 @@
                     "userId"
                 ],
                 "properties": {
+                    "actorId": {
+                        "type": "string"
+                    },
+                    "actorType": {
+                        "type": "string"
+                    },
                     "inCall": {
                         "type": "integer",
                         "format": "int64"

--- a/openapi.json
+++ b/openapi.json
@@ -1231,6 +1231,8 @@
             "SignalingSession": {
                 "type": "object",
                 "required": [
+                    "actorId",
+                    "actorType",
                     "inCall",
                     "lastPing",
                     "participantPermissions",
@@ -1239,6 +1241,12 @@
                     "userId"
                 ],
                 "properties": {
+                    "actorId": {
+                        "type": "string"
+                    },
+                    "actorType": {
+                        "type": "string"
+                    },
                     "inCall": {
                         "type": "integer",
                         "format": "int64"

--- a/src/components/CallView/shared/VideoVue.vue
+++ b/src/components/CallView/shared/VideoVue.vue
@@ -358,7 +358,9 @@ export default {
 		},
 
 		participantActorType() {
-			if (this.participant?.actorType) {
+			if (this.model.attributes.actorType) {
+				return this.model.attributes.actorType
+			} else if (this.participant?.actorType) {
 				return this.participant.actorType
 			} else if (this.peerData?.actorType) {
 				return this.peerData.actorType
@@ -370,6 +372,10 @@ export default {
 		},
 
 		participantUserId() {
+			if (this.model.attributes.actorId) {
+				return this.model.attributes.actorId
+			}
+
 			if (this.model.attributes.userId) {
 				return this.model.attributes.userId
 			}

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -2168,6 +2168,8 @@ export type components = {
         };
         RoomLastMessage: components["schemas"]["ChatMessage"] | components["schemas"]["ChatProxyMessage"];
         SignalingSession: {
+            actorId: string;
+            actorType: string;
             /** Format: int64 */
             inCall: number;
             /** Format: int64 */

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1649,6 +1649,8 @@ export type components = {
         };
         RoomLastMessage: components["schemas"]["ChatMessage"] | components["schemas"]["ChatProxyMessage"];
         SignalingSession: {
+            actorId: string;
+            actorType: string;
             /** Format: int64 */
             inCall: number;
             /** Format: int64 */

--- a/src/utils/webrtc/models/CallParticipantModel.js
+++ b/src/utils/webrtc/models/CallParticipantModel.js
@@ -33,6 +33,8 @@ export default function CallParticipantModel(options) {
 		screenPeer: null,
 		// "undefined" is used for values not known yet; "null" or "false"
 		// are used for known but negative/empty values.
+		actorType: undefined,
+		actorId: undefined,
 		userId: undefined,
 		name: undefined,
 		internal: undefined,
@@ -347,6 +349,11 @@ CallParticipantModel.prototype = {
 		if (this._simulcastScreenQuality !== undefined) {
 			this.setSimulcastScreenQuality(this._simulcastScreenQuality)
 		}
+	},
+
+	setActor(actorType, actorId) {
+		this.set('actorType', actorType)
+		this.set('actorId', actorId)
 	},
 
 	setUserId(userId) {

--- a/src/utils/webrtc/webrtc.js
+++ b/src/utils/webrtc/webrtc.js
@@ -293,6 +293,7 @@ function usersChanged(signaling, newUsers, disconnectedSessionIds) {
 				webRtc: webrtc,
 			})
 		}
+		callParticipantModel.setActor(user.actorType, user.actorId)
 		callParticipantModel.setUserId(userId)
 		callParticipantModel.setNextcloudSessionId(nextcloudSessionId)
 		if (user.internal) {

--- a/tests/integration/features/callapi/update-call-flags.feature
+++ b/tests/integration/features/callapi/update-call-flags.feature
@@ -26,12 +26,12 @@ Feature: callapi/update-call-flags
     Then signaling server received the following requests
       | token | data |
       | public room | {"type":"message","message":{"data":{"type":"chat","chat":{"refresh":true}}}} |
-      | public room | {"type":"incall","incall":{"incall":7,"changed":[{"inCall":7,"lastPing":LAST_PING(),"sessionId":"SESSION(owner)","nextcloudSessionId":"SESSION(owner)","participantType":1,"participantPermissions":254,"userId":"owner"}],"users":[{"inCall":7,"lastPing":LAST_PING(),"sessionId":"SESSION(owner)","nextcloudSessionId":"SESSION(owner)","participantType":1,"participantPermissions":254,"userId":"owner"}]}} |
+      | public room | {"type":"incall","incall":{"incall":7,"changed":[{"inCall":7,"lastPing":LAST_PING(),"sessionId":"SESSION(owner)","nextcloudSessionId":"SESSION(owner)","participantType":1,"participantPermissions":254,"actorType":"users","actorId":"owner","userId":"owner"}],"users":[{"inCall":7,"lastPing":LAST_PING(),"sessionId":"SESSION(owner)","nextcloudSessionId":"SESSION(owner)","participantType":1,"participantPermissions":254,"actorType":"users","actorId":"owner","userId":"owner"}]}} |
     And reset signaling server requests
     When user "owner" updates call flags in room "public room" to "1" with 200 (v4)
     Then signaling server received the following requests
       | token | data |
-      | public room | {"type":"incall","incall":{"incall":1,"changed":[{"inCall":1,"lastPing":LAST_PING(),"sessionId":"SESSION(owner)","nextcloudSessionId":"SESSION(owner)","participantType":1,"participantPermissions":254,"userId":"owner"}],"users":[{"inCall":1,"lastPing":LAST_PING(),"sessionId":"SESSION(owner)","nextcloudSessionId":"SESSION(owner)","participantType":1,"participantPermissions":254,"userId":"owner"}]}} |
+      | public room | {"type":"incall","incall":{"incall":1,"changed":[{"inCall":1,"lastPing":LAST_PING(),"sessionId":"SESSION(owner)","nextcloudSessionId":"SESSION(owner)","participantType":1,"participantPermissions":254,"actorType":"users","actorId":"owner","userId":"owner"}],"users":[{"inCall":1,"lastPing":LAST_PING(),"sessionId":"SESSION(owner)","nextcloudSessionId":"SESSION(owner)","participantType":1,"participantPermissions":254,"actorType":"users","actorId":"owner","userId":"owner"}]}} |
     And user "moderator" joins call "public room" with 200 (v4)
     And user "invited user" joins call "public room" with 200 (v4)
     And user "not invited but joined user" joins call "public room" with 200 (v4)

--- a/tests/integration/features/conversation-4/promotion-demotion.feature
+++ b/tests/integration/features/conversation-4/promotion-demotion.feature
@@ -23,7 +23,7 @@ Feature: conversation-2/promotion-demotion
     # "participantsModified" once the clients no longer expect a
     # "roomModified" message for participant type changes.
       | room  | {"type":"update","update":{"userids":["participant1","participant2"],"properties":{"name":"Private conversation","type":3,"lobby-state":0,"lobby-timer":null,"read-only":0,"listable":0,"active-since":null,"sip-enabled":0,"description":""}}} |
-      | room  | {"type":"participants","participants":{"changed":[],"users":[{"inCall":0,"lastPing":0,"sessionId":"0","participantType":1,"participantPermissions":1,"displayName":"participant1-displayname","userId":"participant1"},{"inCall":0,"lastPing":0,"sessionId":"0","participantType":2,"participantPermissions":1,"displayName":"participant2-displayname","userId":"participant2"}]}} |
+      | room  | {"type":"participants","participants":{"changed":[],"users":[{"inCall":0,"lastPing":0,"sessionId":"0","participantType":1,"participantPermissions":1,"displayName":"participant1-displayname","actorType":"users","actorId":"participant1","userId":"participant1"},{"inCall":0,"lastPing":0,"sessionId":"0","participantType":2,"participantPermissions":1,"displayName":"participant2-displayname","actorType":"users","actorId":"participant2","userId":"participant2"}]}} |
     And user "participant2" is participant of the following rooms (v4)
       | id   | type | participantType |
       | room | 3    | 2               |


### PR DESCRIPTION
Follow up to #12668

Although the `userId` property in the `participants->update` signaling message, which is used by clients to know the participants in a call, [was set to the cloud ID for federated participants](https://github.com/nextcloud/spreed/pull/12668/commits/f91bdfa38ae5922fac15bd64353715bceac8d08a#diff-7ed631e9f04a0445d27e26f716dee988bd363d56cbfa4453ed74bd3605433f9aR433-R434) this was not enough to identify a federated user, as it was not possible to know for sure the actor type only based on the user ID (as [a local user could have a user ID that resembled a cloud ID](https://github.com/nextcloud/spreed/pull/12668#discussion_r1690234134), so looking for _@ remote_ would not be reliable).

Due to that now the `participants->update` signaling messages explicitly provide the `actorType` and `actorId` of each participant in the message (and `userId` is again provided only for regular users like it was always done). Knowing the actor type and id clients can now request the avatar from the right endpoint and with the right data.

In the WebUI now `actorType` and `actorId` take precedence over `userId` when identifying a participant in `VideoView`, which automatically causes `AvatarWrapper` to use the right endpoint (once the type and id are converted, see below).

## Converting actor type and id

Conversion of `actorType` and `actorId` in `participants->update` signaling messages will be automatically done by the external signaling server, so clients just need to use the received values as is (so the client of a federated user will see `actorType: users` for users in its own server and `actorType: federated_users` for users in the host server, in both cases with `actorId` adjusted as needed, just like when getting the participants from the API). However, this might become relevant again once/if federated calls are implemented in the internal signaling server, so leaving the section below for reference.

<details>
There is an important detail to keep in mind, though. The actor type and id in the signaling messages are from the point of view of the host Nextcloud server. Therefore, the client of a federated user would need to convert the actor type and id between local users and federated users, similarly to [how a federated Nextcloud server does it](https://github.com/nextcloud/spreed/blob/897c069d4ae80a5500e6dd0ac735bf3ebbc9e33a/lib/Federation/Proxy/TalkV1/UserConverter.php#L38-L53) when returning the list of participants (as a local user from the point of view of the host is a federated user from the point of view of the federated server, and a federated user from a specific remote server from the point of view of the host is a local user from the point of view of that specific remote server).

Note, however, that in order to get the avatars only converting from local users to federated users is strictly needed. Avatars can be got using two different API endpoints, one that accepts a user ID and another one that accepts a cloud ID; in the first case only avatars for local users are returned, while in the second case avatars are returned for both local and remote users. Therefore, if a federated user is not converted to a local user the proxy endpoint will be used, but [it will correctly return the avatar for the local user](https://github.com/nextcloud/spreed/blob/1ccbf67da231c37801c1406b10000144125aec35/lib/Controller/AvatarController.php#L247-L255). Nevertheless it might be better to do the conversion anyway for any other future use of the actor type and id.
</details>

## How to test

- Set up two Nextcloud servers with external signaling servers and federation
  - External signaling servers require support for converting the `actorType` and `actorId` in `participants->update` signaling messages
- Create a conversation in Nextcloud server A
- Add two users from Nextcloud server B
- In a private window, log in Nextcloud server B with one user
- Accept the invitation and join the conversation
- In another browser/device, log in Nextcloud server B with the other user
- Accept the invitation and join the conversation
- Start the call and join with all users

### Result with this pull request

The right avatars are shown for all users

### Result without this pull request

Broken avatars are shown for all users (except oneself)
