### PR TITLE
Fix conversations layout

### DIFF
--- a/src/components/ConversationIcon.vue
+++ b/src/components/ConversationIcon.vue
@@ -129,7 +129,7 @@ export default {
 
 		size: {
 			type: Number,
-			default: AVATAR.SIZE.TWO_LINES,
+			default: AVATAR.SIZE.DEFAULT,
 		},
 	},
 

--- a/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
+++ b/src/components/LeftSidebar/ConversationsList/ConversationsListVirtual.vue
@@ -27,11 +27,11 @@ import LoadingPlaceholder from '../../UIShared/LoadingPlaceholder.vue'
 import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'
 
 /* Consider:
- * 48 = 2 * var(--default-line-height) - 2 lines of text
+ * 45 = 2lh - 2 lines of text
  * 8 = 2 * var(--default-grid-baseline) - item padding
- * 8 = 2 * var(--default-grid-baseline) - focus offset
+ * 4 = var(--default-grid-baseline) - item outline (collapsed)
  */
-const CONVERSATION_ITEM_SIZE = 64
+const CONVERSATION_ITEM_SIZE = 61
 
 export default {
 	name: 'ConversationsListVirtual',

--- a/src/components/LeftSidebar/LeftSidebar.vue
+++ b/src/components/LeftSidebar/LeftSidebar.vue
@@ -180,7 +180,7 @@
 					data-nav-id="conversation_create_new"
 					@click="createConversation(searchText)">
 					<template #icon>
-						<ChatPlus :size="AVATAR.SIZE.TWO_LINES" />
+						<ChatPlus :size="44" />
 					</template>
 					<template #subname>
 						{{ t('spreed', 'New group conversation') }}
@@ -206,7 +206,7 @@
 						:name="item.label"
 						@click="createAndJoinConversation(item)">
 						<template #icon>
-							<AvatarWrapper v-bind="iconData(item)" :size="AVATAR.SIZE.TWO_LINES" />
+							<AvatarWrapper v-bind="iconData(item)" />
 						</template>
 						<template #subname>
 							{{ t('spreed', 'New private conversation') }}
@@ -259,7 +259,7 @@
 							:name="item.label"
 							@click="createAndJoinConversation(item)">
 							<template #icon>
-								<AvatarWrapper v-bind="iconData(item)" :size="AVATAR.SIZE.TWO_LINES" />
+								<AvatarWrapper v-bind="iconData(item)" />
 							</template>
 							<template #subname>
 								{{ t('spreed', 'New group conversation') }}
@@ -336,7 +336,7 @@ import SearchBox from '../UIShared/SearchBox.vue'
 import TransitionWrapper from '../UIShared/TransitionWrapper.vue'
 
 import { useArrowNavigation } from '../../composables/useArrowNavigation.js'
-import { ATTENDEE, AVATAR, CONVERSATION } from '../../constants.js'
+import { ATTENDEE, CONVERSATION } from '../../constants.js'
 import BrowserStorage from '../../services/BrowserStorage.js'
 import { getTalkConfig, hasTalkFeature } from '../../services/CapabilitiesManager.ts'
 import {
@@ -410,7 +410,6 @@ export default {
 		const isMobile = useIsMobile()
 
 		return {
-			AVATAR,
 			initializeNavigation,
 			resetNavigation,
 			leftSidebar,

--- a/src/constants.js
+++ b/src/constants.js
@@ -274,7 +274,6 @@ export const AVATAR = {
 		EXTRA_SMALL: 22,
 		SMALL: 32,
 		DEFAULT: 44,
-		TWO_LINES: 48, // 2 * var(--default-line-height)
 		MEDIUM: 64,
 		LARGE: 128,
 		EXTRA_LARGE: 180,


### PR DESCRIPTION
- [x] Revert commit 12ec9babcb3f3bef763db380bfc1c32ab271f947
- [x] Reduce space between elements to 4px (outline)
- [x] Return avatar size to 44px

<img width="306" alt="Screenshot 2024-07-31 at 18 01 44" src="https://github.com/user-attachments/assets/4986b67e-9185-4f75-bb3b-4891c1cca84a">
