### PR TITLE
style: adjust line-height usage after change from px value to unitless

### DIFF
--- a/css/talk-admin-settings.css
+++ b/css/talk-admin-settings.css
@@ -5,7 +5,7 @@
 
 .settings-section-placeholder {
 	--settings-section-placeholder-header-height: 30px;
-	--settings-section-placeholder-line-height: var(--default-line-height);
+	--settings-section-placeholder-line-height: 1lh;
 	--settings-section-placeholder-padding: 1em;
 	--settings-section-placeholder-image: linear-gradient(90deg, var(--color-placeholder-light) 65%, var(--color-placeholder-dark) 70%, var(--color-placeholder-light) 75%);
 	position: relative;
@@ -29,7 +29,7 @@
 
 .settings-section-placeholder::after {
 	max-width: 900px;
-	background: 
+	background:
 		var(--settings-section-placeholder-image) 0 calc(var(--settings-section-placeholder-header-height) + 1em + 0 * (var(--settings-section-placeholder-line-height) + 1em)) / 200vw var(--settings-section-placeholder-line-height) repeat-x content-box,
 		var(--settings-section-placeholder-image) 0 calc(var(--settings-section-placeholder-header-height) + 1em + 1 * (var(--settings-section-placeholder-line-height) + 1em)) / 200vw var(--settings-section-placeholder-line-height) repeat-x content-box,
 		var(--settings-section-placeholder-image) 0 calc(var(--settings-section-placeholder-header-height) + 1em + 2 * (var(--settings-section-placeholder-line-height) + 1em)) / 200vw var(--settings-section-placeholder-line-height) repeat-x content-box;

--- a/src/components/NewMessage/NewMessage.vue
+++ b/src/components/NewMessage/NewMessage.vue
@@ -1067,7 +1067,7 @@ export default {
 
 	// Override NcRichContenteditable styles
 	:deep(.rich-contenteditable__input) {
-		--contenteditable-space: calc((var(--default-clickable-area) - var(--default-line-height) - 4px) / 2);
+		--contenteditable-space: calc((var(--default-clickable-area) - 1lh - 4px) / 2);
 		border-radius: var(--border-radius-element, calc(var(--default-clickable-area) / 2));
 		padding: var(--contenteditable-space);
 		padding-left: calc(var(--contenteditable-space) + var(--default-clickable-area));


### PR DESCRIPTION
### ☑️ Resolves

* Fixup to  https://github.com/nextcloud/server/pull/46876


## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/dbb3c3f1-25a1-421c-a124-1381d69890c6) | ![image](https://github.com/user-attachments/assets/01f9a845-9136-49d8-ad03-9a18163e606b)


### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team