### PR TITLE
fix(FilesSidebarChaView): hide duplicated CallButton, when in call

### DIFF
--- a/src/views/FilesSidebarChatView.vue
+++ b/src/views/FilesSidebarChatView.vue
@@ -5,7 +5,7 @@
 
 <template>
 	<div class="talk-tab__wrapper">
-		<CallButton class="talk-tab__call-button" />
+		<CallButton v-if="!isInCall" class="talk-tab__call-button" />
 		<ChatView class="talk-tab__chat-view" />
 		<PollViewer />
 		<MediaSettings :recording-consent-given.sync="recordingConsentGiven" />
@@ -18,6 +18,8 @@ import MediaSettings from '../components/MediaSettings/MediaSettings.vue'
 import PollViewer from '../components/PollViewer/PollViewer.vue'
 import CallButton from '../components/TopBar/CallButton.vue'
 
+import { useIsInCall } from '../composables/useIsInCall.js'
+
 export default {
 
 	name: 'FilesSidebarChatView',
@@ -27,6 +29,12 @@ export default {
 		ChatView,
 		MediaSettings,
 		PollViewer,
+	},
+
+	setup() {
+		return {
+			isInCall: useIsInCall(),
+		}
 	},
 
 	data() {


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #12853
* Same changes as in PublicShareSidebar. but for registered users via Files app

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

See original PR

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
