### PR TITLE
fix(TopBar): align lines

### DIFF
--- a/src/components/CallView/CallView.vue
+++ b/src/components/CallView/CallView.vue
@@ -737,8 +737,8 @@ export default {
 #videos {
 	position: absolute;
 	width: 100%;
-	height: calc(100% - 60px);
-	top: 60px;
+	height: calc(100% - 50px);
+	top: 50px;
 	overflow: hidden;
 	display: -webkit-box;
 	display: -moz-box;

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -303,15 +303,13 @@ export default {
 <style lang="scss" scoped>
 .top-bar {
 	--border-width: 1px;
-	// hardcoded 1.5 value of line-height for compatibility with older versions
-	--text-height: calc(1.5 * (var(--default-font-size) + var(--font-size-small, 15px)));
 	display: flex;
 	flex-wrap: wrap;
 	z-index: 10;
 	gap: 3px;
 	align-items: center;
 	justify-content: flex-end;
-	min-height: calc(2 * var(--default-grid-baseline) + var(--text-height) + var(--border-width));
+	min-height: calc(var(--border-width) + 2 * (2 * var(--default-grid-baseline)) + var(--default-clickable-area));
 	padding-block: var(--default-grid-baseline);
 	// Reserve space for the sidebar toggle button
 	padding-inline: calc(2 * var(--default-grid-baseline)) calc(2 * var(--default-grid-baseline) + var(--app-sidebar-offset, 0));
@@ -361,6 +359,8 @@ export default {
 		justify-content: center;
 		width: 100%;
 		overflow: hidden;
+		// Text is guaranteed to be one line. Make line-height 1.2 to fit top bar
+		line-height: 1.2;
 		&--offline {
 			color: var(--color-text-maxcontrast);
 		}
@@ -371,7 +371,6 @@ export default {
 		text-overflow: ellipsis;
 	}
 	.description {
-		font-size: var(--font-size-small, 15px);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		max-width: fit-content;


### PR DESCRIPTION
### ☑️ Resolves

- With the default `line-height` one-line is 1.5 height of font
- In a limited spaces and with different font sizes, it looks a bit not aligned for me
  - The gap between lines is higher than between line and bottom border
  - Small text may look too small
- Using `normal` (about 1.2) line height ensures that the text is not cut off but also has no extra height even with normal font-size

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/c47d9e5c-dd86-43d6-aa49-7885f08b75f3) | ![image](https://github.com/user-attachments/assets/d0d6d023-b99d-4775-bf31-55d19badb6e4)
![image](https://github.com/user-attachments/assets/9bd0ffb0-1a83-4c81-938f-150b33485627) | ![image](https://github.com/user-attachments/assets/255a242c-9fe7-4c38-99b3-b1891ba626a3)
![image](https://github.com/user-attachments/assets/fc103350-2cc3-48ad-8104-b7b6da59850b) | ![image](https://github.com/user-attachments/assets/45ca2225-9ac3-480f-87e2-44663ed6134f)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required