### PR TITLE
Release 20.0.0 beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 20.0.0-beta.2 – 2024-08-01
+### Fixed
+- fix(calls): Add notifications for federated calls
+  [#12845](https://github.com/nextcloud/spreed/issues/12845)
+  [#12856](https://github.com/nextcloud/spreed/issues/12856)
+  [#12874](https://github.com/nextcloud/spreed/issues/12874)
+- fix(calls): Fix broken avatar of remote users in calls
+  [#12863](https://github.com/nextcloud/spreed/issues/12863)
+- fix(videoverification): Fix design
+  [#12853](https://github.com/nextcloud/spreed/issues/12853)
+- fix(chat): Prevent leave call dialog when canceling quoting
+  [#12824](https://github.com/nextcloud/spreed/issues/12824)
+- fix(UI): More design adjustments for nextcloud/vue changes
+  [#12810](https://github.com/nextcloud/spreed/issues/12810)
+
 ## 20.0.0-beta.1 – 2024-07-26
 ### Added
 - Banning users and guests

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 * 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.
 ]]></description>
 
-	<version>20.0.0-beta.1</version>
+	<version>20.0.0-beta.2</version>
 	<licence>agpl</licence>
 
 	<author>Daniel Calviño Sánchez</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk",
-  "version": "20.0.0-beta.1",
+  "version": "20.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk",
-      "version": "20.0.0-beta.1",
+      "version": "20.0.0-beta.2",
       "license": "agpl",
       "dependencies": {
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "20.0.0-beta.1",
+  "version": "20.0.0-beta.2",
   "private": true,
   "description": "",
   "author": "Joas Schilling <coding@schilljs.com>",


### PR DESCRIPTION
## Fixed
- fix(calls): Add notifications for federated calls [#12845](https://github.com/nextcloud/spreed/issues/12845) [#12856](https://github.com/nextcloud/spreed/issues/12856) [#12874](https://github.com/nextcloud/spreed/issues/12874)
- fix(calls): Fix broken avatar of remote users in calls [#12863](https://github.com/nextcloud/spreed/issues/12863)
- fix(videoverification): Fix design [#12853](https://github.com/nextcloud/spreed/issues/12853)
- fix(chat): Prevent leave call dialog when canceling quoting [#12824](https://github.com/nextcloud/spreed/issues/12824)
- fix(UI): More design adjustments for nextcloud/vue changes [#12810](https://github.com/nextcloud/spreed/issues/12810)