### PR TITLE
fix(ChatView): mark when used in sidebar, simplify templates

### DIFF
--- a/src/PublicShareAuthSidebar.vue
+++ b/src/PublicShareAuthSidebar.vue
@@ -11,10 +11,9 @@
 				<h2>{{ t('spreed', 'This conversation has ended') }}</h2>
 			</div>
 			<template v-else>
-				<TopBar :is-in-call="true"
-					:is-sidebar="true" />
-				<CallView :token="token" :is-sidebar="true" />
-				<ChatView />
+				<TopBar is-in-call is-sidebar />
+				<CallView :token="token" is-sidebar />
+				<ChatView is-sidebar />
 				<PollViewer />
 				<MediaSettings :recording-consent-given.sync="recordingConsentGiven" />
 			</template>

--- a/src/PublicShareSidebar.vue
+++ b/src/PublicShareSidebar.vue
@@ -20,14 +20,10 @@
 				</NcButton>
 			</div>
 			<template v-else>
-				<TopBar v-if="isInCall"
-					:is-in-call="true"
-					:is-sidebar="true" />
-				<CallView v-if="isInCall"
-					:token="token"
-					:is-sidebar="true" />
+				<TopBar v-if="isInCall" is-in-call is-sidebar />
+				<CallView v-if="isInCall" :token="token" is-sidebar />
 				<CallButton v-if="!isInCall" class="call-button" />
-				<ChatView />
+				<ChatView is-sidebar />
 				<PollViewer />
 				<MediaSettings :recording-consent-given.sync="recordingConsentGiven" />
 			</template>

--- a/src/components/ChatView.vue
+++ b/src/components/ChatView.vue
@@ -95,6 +95,11 @@ export default {
 			type: Boolean,
 			default: true,
 		},
+
+		isSidebar: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	setup() {

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -37,7 +37,7 @@
 			<template #icon>
 				<Message :size="20" />
 			</template>
-			<ChatView :is-visible="opened" />
+			<ChatView :is-visible="opened" is-sidebar />
 		</NcAppSidebarTab>
 		<NcAppSidebarTab v-if="showParticipantsTab"
 			id="participants"

--- a/src/views/FilesSidebarChatView.vue
+++ b/src/views/FilesSidebarChatView.vue
@@ -6,7 +6,7 @@
 <template>
 	<div class="talk-tab__wrapper">
 		<CallButton v-if="!isInCall" class="talk-tab__call-button" />
-		<ChatView class="talk-tab__chat-view" />
+		<ChatView class="talk-tab__chat-view" is-sidebar />
 		<PollViewer />
 		<MediaSettings :recording-consent-given.sync="recordingConsentGiven" />
 	</div>

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -7,12 +7,10 @@
 	<div class="main-view">
 		<LobbyScreen v-if="isInLobby" />
 		<template v-else>
-			<TopBar :is-in-call="showChatInSidebar" />
+			<TopBar :is-in-call="isInCall" />
 			<TransitionWrapper name="fade">
-				<ChatView v-if="!showChatInSidebar" />
-				<template v-else>
-					<CallView :token="token" />
-				</template>
+				<ChatView v-if="!isInCall" />
+				<CallView v-else :token="token" />
 			</TransitionWrapper>
 			<PollViewer />
 		</template>
@@ -55,10 +53,6 @@ export default {
 	computed: {
 		conversation() {
 			return this.$store.getters.conversation(this.token)
-		},
-
-		showChatInSidebar() {
-			return this.isInCall
 		},
 
 		isInLobby() {


### PR DESCRIPTION
### ☑️ Resolves

* Separated from #12823 (unrelated mostly)
* `isSidebar` isn't used in this PR, but I'd keep it for future ones (if we ever need to distinct)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
