### PR TITLE
fix(federation): disable call buton if talk proxy hash is dirty

### DIFF
--- a/src/components/TopBar/CallButton.vue
+++ b/src/components/TopBar/CallButton.vue
@@ -217,6 +217,7 @@ export default {
 		},
 		isNextcloudTalkHashDirty() {
 			return this.talkHashStore.isNextcloudTalkHashDirty
+				|| this.talkHashStore.isNextcloudTalkProxyHashDirty[this.token]
 		},
 		container() {
 			return this.$store.getters.getMainContainerSelector()

--- a/src/services/CapabilitiesManager.ts
+++ b/src/services/CapabilitiesManager.ts
@@ -40,7 +40,7 @@ export function hasTalkFeature(token: string = 'local', feature: string): boolea
  * @param key2 second-level key (e.g. 'allowed')
  */
 export function getTalkConfig(token: string = 'local', key1: keyof Config, key2: keyof Config[keyof Config]) {
-	if (localCapabilities?.spreed?.['config-local']?.[key1]?.[key2]) {
+	if (localCapabilities?.spreed?.['config-local']?.[key1]?.includes(key2)) {
 		return localCapabilities?.spreed?.config?.[key1]?.[key2]
 	} else if (token === 'local' || !remoteCapabilities[token]) {
 		return localCapabilities?.spreed?.config?.[key1]?.[key2]

--- a/src/services/CapabilitiesManager.ts
+++ b/src/services/CapabilitiesManager.ts
@@ -9,6 +9,7 @@ import { t } from '@nextcloud/l10n'
 
 import { getRemoteCapabilities } from './federationService.ts'
 import BrowserStorage from '../services/BrowserStorage.js'
+import { useTalkHashStore } from '../stores/talkHash.js'
 import type { Capabilities, JoinRoomFullResponse } from '../types'
 
 type Config = Capabilities['spreed']['config']
@@ -61,6 +62,10 @@ export async function setRemoteCapabilities(joinRoomResponse: JoinRoomFullRespon
 	if (joinRoomResponse.headers['x-nextcloud-talk-proxy-hash'] === remoteCapabilities[token]?.hash) {
 		return
 	}
+
+	// Mark the hash as dirty to prevent any activity in the conversation
+	const talkHashStore = useTalkHashStore()
+	talkHashStore.setTalkProxyHashDirty(token)
 
 	const response = await getRemoteCapabilities(token)
 	if (Array.isArray(response.data.ocs.data)) {

--- a/src/stores/talkHash.js
+++ b/src/stores/talkHash.js
@@ -4,6 +4,7 @@
  */
 
 import { defineStore } from 'pinia'
+import Vue from 'vue'
 
 import { showError, TOAST_PERMANENT_TIMEOUT } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
@@ -12,9 +13,10 @@ import { talkBroadcastChannel } from '../services/talkBroadcastChannel.js'
 
 /**
  * @typedef {object} State
- * @property {string} initialNextcloudTalkHash - The absence status per conversation.
- * @property {boolean} isNextcloudTalkHashDirty - The parent message id to reply per conversation.
- * @property {object|null} maintenanceWarningToast -The input value per conversation.
+ * @property {string} initialNextcloudTalkHash - the 'default' Talk hash to compare with.
+ * @property {boolean} isNextcloudTalkHashDirty - whether Talk hash was updated and requires a reload.
+ * @property {object} isNextcloudTalkProxyHashDirty - whether Talk hash in federated conversation was updated.
+ * @property {object|null} maintenanceWarningToast - a toast object.
  */
 
 /**
@@ -27,6 +29,7 @@ export const useTalkHashStore = defineStore('talkHash', {
 	state: () => ({
 		initialNextcloudTalkHash: '',
 		isNextcloudTalkHashDirty: false,
+		isNextcloudTalkProxyHashDirty: {},
 		maintenanceWarningToast: null,
 	}),
 
@@ -44,6 +47,16 @@ export const useTalkHashStore = defineStore('talkHash', {
 				console.debug('X-Nextcloud-Talk-Hash marked dirty: ', hash)
 				this.isNextcloudTalkHashDirty = true
 			}
+		},
+
+		/**
+		 * Mark the current Talk Federation hash as dirty
+		 *
+		 * @param {string} token federated conversation token
+		 */
+		setTalkProxyHashDirty(token) {
+			console.debug('X-Nextcloud-Talk-Proxy-Hash marked dirty: ', token)
+			Vue.set(this.isNextcloudTalkProxyHashDirty, token, true)
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12864
* Not sure if we should allow chat with dirty hash (as we did before), but feels like we need to

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts
Moved toast to the top to see call button on th screenshot

![image](https://github.com/user-attachments/assets/49f09683-b1d0-47a7-92d4-efde4eee6df4)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible - in follow-up
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
