### PR TITLE
fix(ConversationSettings): hide ban section in note to self

### DIFF
--- a/src/components/ConversationSettings/ConversationSettingsDialog.vue
+++ b/src/components/ConversationSettings/ConversationSettingsDialog.vue
@@ -208,8 +208,8 @@ export default {
 
 		canFullModerate() {
 			return this.selfIsOwnerOrModerator
-				&& this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE
-				&& this.conversation.type !== CONVERSATION.TYPE.ONE_TO_ONE_FORMER
+				&& (this.conversation.type === CONVERSATION.TYPE.GROUP
+				|| this.conversation.type === CONVERSATION.TYPE.PUBLIC)
 		},
 
 		canDeleteConversation() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12880

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/6f26084a-5d65-4947-bf97-cc1a2cae5182) | ![image](https://github.com/user-attachments/assets/d0e4a7ce-974e-4a95-aec1-35c598b5a17e)

<!-- ☀️ Light theme | 🌑 Dark Theme -->


### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required

