### PR TITLE
fix: Cannot set message expiration in former 1:1 rooms

### DIFF
--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -756,10 +756,10 @@ class RoomService {
 	}
 
 	/**
-	 * @throws InvalidArgumentException When the room is a breakout room
+	 * @throws InvalidArgumentException When the room is a breakout room or the room is a former one-to-one conversation
 	 */
 	public function setMessageExpiration(Room $room, int $seconds): void {
-		if ($room->getObjectType() === BreakoutRoom::PARENT_OBJECT_TYPE) {
+		if ($room->getObjectType() === BreakoutRoom::PARENT_OBJECT_TYPE || $room->getType() === Room::TYPE_ONE_TO_ONE_FORMER) {
 			throw new InvalidArgumentException('room');
 		}
 

--- a/tests/integration/features/chat-1/message-expiration.feature
+++ b/tests/integration/features/chat-1/message-expiration.feature
@@ -59,3 +59,18 @@ Feature: chat/message-expiration
       | room | actorType | actorId      | actorDisplayName         | message     | messageParameters | parentMessage |
     And user "participant1" gets last share
     And the OCS status code should be 404
+
+  Scenario: Cannot set message expiration in a former one to one room
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" is participant of room "room" (v4)
+    And user "participant2" is participant of room "room" (v4)
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | type | participantType |
+      | room | 1    | 1               |
+    When user "participant2" is deleted
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | type | participantType |
+      | room | 5    | 1               |
+    And user "participant1" set the message expiration to 3 of room "room" with 400 (v4)


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12882 


## 🛠️ API Checklist

### 🚧 Tasks

- [x] Cannot set message expiration in former 1:1 rooms

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
