### PR TITLE
fix: Cannot enable bots in former 1:1 rooms

### DIFF
--- a/lib/Controller/BotController.php
+++ b/lib/Controller/BotController.php
@@ -26,6 +26,7 @@ use OCA\Talk\Model\BotConversationMapper;
 use OCA\Talk\Model\BotServer;
 use OCA\Talk\Model\BotServerMapper;
 use OCA\Talk\ResponseDefinitions;
+use OCA\Talk\Room;
 use OCA\Talk\Service\BotService;
 use OCA\Talk\Service\ChecksumVerificationService;
 use OCA\Talk\Service\ParticipantService;
@@ -340,7 +341,7 @@ class BotController extends AEnvironmentAwareController {
 	#[NoAdminRequired]
 	#[RequireLoggedInModeratorParticipant]
 	public function enableBot(int $botId): DataResponse {
-		if ($this->room->isFederatedConversation()) {
+		if ($this->room->isFederatedConversation() || $this->room->getType() === ROOM::TYPE_ONE_TO_ONE_FORMER) {
 			return new DataResponse([
 				'error' => 'room',
 			], Http::STATUS_BAD_REQUEST);

--- a/tests/integration/features/chat-1/bots.feature
+++ b/tests/integration/features/chat-1/bots.feature
@@ -1,6 +1,7 @@
 Feature: chat/bots
   Background:
     Given user "participant1" exists
+    Given user "participant2" exists
 
   Scenario: Installing the call summary bot
     Given invoking occ with "talk:bot:list"
@@ -357,3 +358,25 @@ Feature: chat/bots
     Then the command failed with exit code 1
     And the command output contains the text "Bot not found"
 
+  Scenario: Cannot enable bots in a former one-to-one room
+    Given invoking occ with "talk:bot:list"
+    Then the command was successful
+    And the command output is empty
+    Given user "participant1" creates room "room" (v4)
+      | roomType | 1 |
+      | invite   | participant2 |
+    And user "participant1" is participant of room "room" (v4)
+    And user "participant2" is participant of room "room" (v4)
+    When user "participant2" is deleted
+    Then user "participant1" is participant of the following rooms (v4)
+      | id   | type | participantType |
+      | room | 5    | 1               |
+    And invoking occ with "app:enable call_summary_bot"
+    And the command was successful
+    And invoking occ with "talk:bot:list room-name:room"
+    Then the command was successful
+    And the command output is empty
+    And user "participant1" sets up bot "Call summary" for room "room" with 400 (v1)
+    Given invoking occ with "talk:bot:list room-name:room"
+    And the command was successful
+    And the command output is empty


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12883 


## 🛠️ API Checklist

### 🚧 Tasks

- [x] Cannot enable bots in former 1:1 rooms

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not possible
- [ ] 📘 API documentation in `docs/` has been updated or is not required
- [ ] 🔖 Capability is added or not needed 
