### PR TITLE
chore(deps): bump nextcloud/vue lib from 8.15.1 to 8.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@nextcloud/paths": "^2.2.1",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/upload": "^1.4.2",
-        "@nextcloud/vue": "^8.15.1",
+        "@nextcloud/vue": "^8.16.0",
         "@vueuse/components": "^10.11.0",
         "crypto-js": "^4.2.0",
         "debounce": "^2.1.0",
@@ -3868,9 +3868,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.15.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.15.1.tgz",
-      "integrity": "sha512-gZEcXPNhRGYhjSd/IeTs0jQ5P8tPIv9BJm5A8qsdpB1Mb/Xb9suhJv1xHaeGcOGoUCcs7A66coPkCgv1zcSJ2w==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.16.0.tgz",
+      "integrity": "sha512-xkoR2VeWk+WTTmXC01Z7hI0yztSf222XMPXhy9OkDNQBXmCl/idEjNnMWmxezJMyqALtFD/csouW+GS7JUVoFw==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -23631,9 +23631,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.15.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.15.1.tgz",
-      "integrity": "sha512-gZEcXPNhRGYhjSd/IeTs0jQ5P8tPIv9BJm5A8qsdpB1Mb/Xb9suhJv1xHaeGcOGoUCcs7A66coPkCgv1zcSJ2w==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.16.0.tgz",
+      "integrity": "sha512-xkoR2VeWk+WTTmXC01Z7hI0yztSf222XMPXhy9OkDNQBXmCl/idEjNnMWmxezJMyqALtFD/csouW+GS7JUVoFw==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@nextcloud/paths": "^2.2.1",
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/upload": "^1.4.2",
-    "@nextcloud/vue": "^8.15.1",
+    "@nextcloud/vue": "^8.16.0",
     "@vueuse/components": "^10.11.0",
     "crypto-js": "^4.2.0",
     "debounce": "^2.1.0",


### PR DESCRIPTION
### ☑️ Resolves

[Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/releases/tag/v8.16.0)

<!--
░░░░░░░░░░░░░░░░░░░░
░█████░░█████░█████░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░███░░░░███░░░███░░
░░░████████░░░█████░
░░░░░░░░░░░░░░░░░░░░

Feel free to remove this section when your PR is only touching backend/API code
-->

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

![image](https://github.com/user-attachments/assets/9e035aaa-9049-43ed-a712-01e079d18676)

### 🏁 Checklist

- [ ] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [ ] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [ ] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
