### PR TITLE
fix(fileUpload): don't share files in parallel, harden checks

### DIFF
--- a/src/store/fileUploadStore.js
+++ b/src/store/fileUploadStore.js
@@ -428,7 +428,11 @@ const actions = {
 	 * @param {object|null} data.options The share options
 	 */
 	async shareFiles(context, { token, uploadId, lastIndex, caption, options }) {
-		const performShare = async ([index, shareableFile]) => {
+		const performShare = async (share) => {
+			if (!Array.isArray(share)) {
+				return
+			}
+			const [index, shareableFile] = share
 			const { id, messageType, parent, referenceId } = shareableFile.temporaryMessage || {}
 
 			const metadata = JSON.stringify(Object.assign({ messageType },
@@ -453,22 +457,7 @@ const actions = {
 		}
 
 		const shares = context.getters.getShareableFiles(uploadId)
-
-		// Check if caption message for share was provided
-		if (caption) {
-			const captionShareIndex = shares.findIndex(([index]) => index === lastIndex)
-
-			// Share all files in parallel, except for last one
-			await Promise.all(shares
-				.filter((_item, index) => index !== captionShareIndex)
-				.map(performShare))
-
-			// Share a last file, where caption is attached
-			await performShare(shares.at(captionShareIndex))
-		} else {
-			// Share all files in parallel
-			await Promise.all(shares.map(performShare))
-		}
+		shares.forEach(share => performShare(share))
 	},
 
 	/**


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11948 
* Files are shared one by one (but propfind and upload still done in parallel, so process is expected to be fast)
* Fix `undefined is not iterable`
* Don't proceed with share if it's not valid (should be pair of index/file)

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

No visual changes

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [ ] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required
