### PR TITLE
fix(RightSidebar): discard unread messages toast on conversation change

### DIFF
--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -391,6 +391,9 @@ export default {
 
 	beforeDestroy() {
 		unsubscribe('spreed:select-active-sidebar-tab', this.handleUpdateActive)
+
+		// Discard current chat notifications
+		this.notifyUnreadMessages(null)
 	},
 
 	methods: {

--- a/src/components/RightSidebar/RightSidebar.vue
+++ b/src/components/RightSidebar/RightSidebar.vue
@@ -369,6 +369,9 @@ export default {
 			if (this.$refs.participantsTab) {
 				this.$refs.participantsTab.$el.scrollTop = 0
 			}
+
+			// Discard notification if the conversation changes or closed
+			this.notifyUnreadMessages(null)
 		},
 
 		isModeratorOrUser(newValue) {
@@ -391,9 +394,6 @@ export default {
 
 	beforeDestroy() {
 		unsubscribe('spreed:select-active-sidebar-tab', this.handleUpdateActive)
-
-		// Discard current chat notifications
-		this.notifyUnreadMessages(null)
 	},
 
 	methods: {

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -268,7 +268,6 @@ export default {
 	},
 
 	beforeDestroy() {
-		this.notifyUnreadMessages(null)
 		document.removeEventListener('fullscreenchange', this.fullScreenChanged, false)
 		document.removeEventListener('mozfullscreenchange', this.fullScreenChanged, false)
 		document.removeEventListener('MSFullscreenChange', this.fullScreenChanged, false)


### PR DESCRIPTION
### ☑️ Resolves

* Fix `[Vue warn]: Error in beforeDestroy hook: "TypeError: this.notifyUnreadMessages is not a function"`
  * Leftover from moving it from `TopBar` to `RightSidebar`
* Also discard the notification on conversation switch

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required