### PR TITLE
fix(Conversation): adjust design of icons

### DIFF
--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -39,8 +39,8 @@
 
 			<NcActionButton key="toggle-read" close-after-click @click="toggleReadConversation">
 				<template #icon>
-					<IconEyeOutline v-if="item.unreadMessages" :size="16" />
-					<IconEyeOffOutline v-else :size="16" />
+					<IconEye v-if="item.unreadMessages" :size="16" />
+					<IconEyeOff v-else :size="16" />
 				</template>
 				{{ labelRead }}
 			</NcActionButton>
@@ -115,8 +115,8 @@ import IconArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import IconCog from 'vue-material-design-icons/Cog.vue'
 import IconDelete from 'vue-material-design-icons/Delete.vue'
 import IconExitToApp from 'vue-material-design-icons/ExitToApp.vue'
-import IconEyeOffOutline from 'vue-material-design-icons/EyeOffOutline.vue'
-import IconEyeOutline from 'vue-material-design-icons/EyeOutline.vue'
+import IconEye from 'vue-material-design-icons/Eye.vue'
+import IconEyeOff from 'vue-material-design-icons/EyeOff.vue'
 import IconStar from 'vue-material-design-icons/Star.vue'
 
 import { showError } from '@nextcloud/dialogs'
@@ -147,8 +147,8 @@ export default {
 		IconCog,
 		IconDelete,
 		IconExitToApp,
-		IconEyeOffOutline,
-		IconEyeOutline,
+		IconEyeOff,
+		IconEye,
 		IconStar,
 
 	},

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -33,7 +33,10 @@
 				{{ labelFavorite }}
 			</NcActionButton>
 
-			<NcActionButton key="copy-link" icon="icon-clippy" @click.stop="handleCopyLink">
+			<NcActionButton key="copy-link" @click.stop="handleCopyLink">
+				<template #icon>
+					<IconContentCopy :size="16" />
+				</template>
 				{{ t('spreed', 'Copy link') }}
 			</NcActionButton>
 
@@ -82,7 +85,10 @@
 				{{ t('spreed', 'Join conversation') }}
 			</NcActionButton>
 
-			<NcActionButton key="copy-link" icon="icon-clippy" @click.stop="handleCopyLink">
+			<NcActionButton key="copy-link" @click.stop="handleCopyLink">
+				<template #icon>
+					<IconContentCopy :size="16" />
+				</template>
 				{{ t('spreed', 'Copy link') }}
 			</NcActionButton>
 		</template>
@@ -113,6 +119,7 @@ import { isNavigationFailure, NavigationFailureType } from 'vue-router'
 
 import IconArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import IconCog from 'vue-material-design-icons/Cog.vue'
+import IconContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 import IconDelete from 'vue-material-design-icons/Delete.vue'
 import IconExitToApp from 'vue-material-design-icons/ExitToApp.vue'
 import IconEye from 'vue-material-design-icons/Eye.vue'
@@ -145,6 +152,7 @@ export default {
 		NcListItem,
 		IconArrowRight,
 		IconCog,
+		IconContentCopy,
 		IconDelete,
 		IconExitToApp,
 		IconEyeOff,

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -28,7 +28,7 @@
 				close-after-click
 				@click="toggleFavoriteConversation">
 				<template #icon>
-					<Star :size="20" :fill-color="!item.isFavorite ? '#FFCC00' : undefined" />
+					<IconStar :size="20" :fill-color="!item.isFavorite ? '#FFCC00' : undefined" />
 				</template>
 				{{ labelFavorite }}
 			</NcActionButton>
@@ -39,15 +39,15 @@
 
 			<NcActionButton key="toggle-read" close-after-click @click="toggleReadConversation">
 				<template #icon>
-					<EyeOutline v-if="item.unreadMessages" :size="16" />
-					<EyeOffOutline v-else :size="16" />
+					<IconEyeOutline v-if="item.unreadMessages" :size="16" />
+					<IconEyeOffOutline v-else :size="16" />
 				</template>
 				{{ labelRead }}
 			</NcActionButton>
 
 			<NcActionButton key="show-settings" close-after-click @click="showConversationSettings">
 				<template #icon>
-					<Cog :size="20" />
+					<IconCog :size="20" />
 				</template>
 				{{ t('spreed', 'Conversation settings') }}
 			</NcActionButton>
@@ -57,7 +57,7 @@
 				close-after-click
 				@click="leaveConversation">
 				<template #icon>
-					<ExitToApp :size="16" />
+					<IconExitToApp :size="16" />
 				</template>
 				{{ t('spreed', 'Leave conversation') }}
 			</NcActionButton>
@@ -68,7 +68,7 @@
 				class="critical"
 				@click="isDialogOpen = true">
 				<template #icon>
-					<Delete :size="16" />
+					<IconDelete :size="16" />
 				</template>
 				{{ t('spreed', 'Delete conversation') }}
 			</NcActionButton>
@@ -77,7 +77,7 @@
 		<template v-else-if="item.token" #actions>
 			<NcActionButton key="join-conversation" close-after-click @click="onActionClick">
 				<template #icon>
-					<ArrowRight :size="16" />
+					<IconArrowRight :size="16" />
 				</template>
 				{{ t('spreed', 'Join conversation') }}
 			</NcActionButton>
@@ -111,13 +111,13 @@
 import { toRefs } from 'vue'
 import { isNavigationFailure, NavigationFailureType } from 'vue-router'
 
-import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
-import Cog from 'vue-material-design-icons/Cog.vue'
-import Delete from 'vue-material-design-icons/Delete.vue'
-import ExitToApp from 'vue-material-design-icons/ExitToApp.vue'
-import EyeOffOutline from 'vue-material-design-icons/EyeOffOutline.vue'
-import EyeOutline from 'vue-material-design-icons/EyeOutline.vue'
-import Star from 'vue-material-design-icons/Star.vue'
+import IconArrowRight from 'vue-material-design-icons/ArrowRight.vue'
+import IconCog from 'vue-material-design-icons/Cog.vue'
+import IconDelete from 'vue-material-design-icons/Delete.vue'
+import IconExitToApp from 'vue-material-design-icons/ExitToApp.vue'
+import IconEyeOffOutline from 'vue-material-design-icons/EyeOffOutline.vue'
+import IconEyeOutline from 'vue-material-design-icons/EyeOutline.vue'
+import IconStar from 'vue-material-design-icons/Star.vue'
 
 import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
@@ -143,14 +143,14 @@ export default {
 		NcActionButton,
 		NcDialog,
 		NcListItem,
-		// Icons
-		ArrowRight,
-		Cog,
-		Delete,
-		ExitToApp,
-		EyeOffOutline,
-		EyeOutline,
-		Star,
+		IconArrowRight,
+		IconCog,
+		IconDelete,
+		IconExitToApp,
+		IconEyeOffOutline,
+		IconEyeOutline,
+		IconStar,
+
 	},
 
 	props: {

--- a/src/components/LeftSidebar/ConversationsList/Conversation.vue
+++ b/src/components/LeftSidebar/ConversationsList/Conversation.vue
@@ -28,7 +28,7 @@
 				close-after-click
 				@click="toggleFavoriteConversation">
 				<template #icon>
-					<IconStar :size="20" :fill-color="!item.isFavorite ? '#FFCC00' : undefined" />
+					<IconStar :size="16" :fill-color="!item.isFavorite ? '#FFCC00' : undefined" />
 				</template>
 				{{ labelFavorite }}
 			</NcActionButton>
@@ -50,7 +50,7 @@
 
 			<NcActionButton key="show-settings" close-after-click @click="showConversationSettings">
 				<template #icon>
-					<IconCog :size="20" />
+					<IconCog :size="16" />
 				</template>
 				{{ t('spreed', 'Conversation settings') }}
 			</NcActionButton>


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/spreed/issues/12781

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/118be0da-8261-41fd-a3c4-27a8ef6c4940) | ![image](https://github.com/user-attachments/assets/9b7dbc3e-bd5b-4fb5-8f7e-8b2bf0129c9d)
![image](https://github.com/user-attachments/assets/3eff0f37-6b92-4f33-a3b1-8e00ccf942bf) | ![image](https://github.com/user-attachments/assets/5ddac035-41d5-41ff-9954-3c538002afa0)


### 🚧 Tasks

- [x] rename imported icons to Icon*
- [x] make "Mark as read" icons filled 
- [x] use `content-copy` icon for copy
- [x] make all icons in menu 16px

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [x] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required