### PR TITLE
fix: make more obvious that you can add Federated Cloud ID accounts

### DIFF
--- a/src/components/UIShared/SearchBox.vue
+++ b/src/components/UIShared/SearchBox.vue
@@ -7,6 +7,7 @@
 	<NcTextField ref="searchConversations"
 		:value="value"
 		:aria-label="placeholderText"
+		:aria-describedby="ariaDescribedby"
 		:placeholder="placeholderText"
 		:show-trailing-button="isFocused"
 		class="search-box"
@@ -61,6 +62,14 @@ export default {
 		listRef: {
 			type: Object,
 			default: null,
+		},
+
+		/**
+		 * Input's aria-describedby attribute
+		 */
+		ariaDescribedby: {
+			type: String,
+			default: undefined,
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/spreed/issues/12912

## 🖌️ UI Checklist

### 🖼️ Screenshots / Screencasts

🏚️ Before | 🏡 After
-- | --
![image](https://github.com/user-attachments/assets/9a674a96-c7a3-4fd9-8749-c4df573a32b7) | ![image](https://github.com/user-attachments/assets/1bd13647-71b3-4af5-a86a-b79c02da1b15)

### 🏁 Checklist

- [x] 🌏 Tested with Chrome, Firefox and Safari or should not be risky to browser differences
- [x] 🖥️ Tested with Desktop client or should not be risky for it 
- [x] 🖌️ Design was reviewed, approved or inspired by the design team
- [ ] ⛑️ Tests are included or not possible
- [x] 📗 User documentation in https://github.com/nextcloud/documentation/tree/master/user_manual/talk has been updated or is not required